### PR TITLE
Remove redundant study_id arguments

### DIFF
--- a/pfnopt/client.py
+++ b/pfnopt/client.py
@@ -72,10 +72,9 @@ class LocalClient(BaseClient):
         self.study_id = self.study.study_id
         self.storage = self.study.storage
 
-        system_attrs = self.storage.get_trial_system_attrs(
-            self.study_id, self.trial_id)
+        system_attrs = self.storage.get_trial_system_attrs(self.trial_id)
         self.storage.set_trial_system_attrs(
-            self.study_id, self.trial_id,
+            self.trial_id,
             system_attrs._replace(datetime_start=datetime.datetime.now()))
 
     def _sample(self, name, distribution):
@@ -89,45 +88,37 @@ class LocalClient(BaseClient):
 
         param_value_in_internal_repr = self.study.sampler.sample(
             self.storage, self.study_id, name, distribution)
-        self.storage.set_trial_param(
-            self.study_id, self.trial_id, name, param_value_in_internal_repr)
+        self.storage.set_trial_param(self.trial_id, name, param_value_in_internal_repr)
         param_value = distribution.to_external_repr(param_value_in_internal_repr)
         return param_value
 
     def complete(self, result):
         # type: (float) -> None
 
-        self.storage.set_trial_value(
-            self.study_id, self.trial_id, result)
-        self.storage.set_trial_state(
-            self.study_id, self.trial_id, trial.State.COMPLETE)
+        self.storage.set_trial_value(self.trial_id, result)
+        self.storage.set_trial_state(self.trial_id, trial.State.COMPLETE)
 
-        system_attrs = self.storage.get_trial_system_attrs(
-            self.study_id, self.trial_id)
+        system_attrs = self.storage.get_trial_system_attrs(self.trial_id)
         self.storage.set_trial_system_attrs(
-            self.study_id, self.trial_id,
+            self.trial_id,
             system_attrs._replace(datetime_complete=datetime.datetime.now()))
 
     def prune(self, step, current_result):
         # type: (int, float) -> bool
 
-        self.storage.set_trial_intermediate_value(
-            self.study_id, self.trial_id, step, current_result)
-        ret = self.study.pruner.prune(
-            self.storage, self.study_id, self.trial_id, step)
+        self.storage.set_trial_intermediate_value(self.trial_id, step, current_result)
+        ret = self.study.pruner.prune(self.storage, self.study_id, self.trial_id, step)
         return ret
 
     @property
     def params(self):
         # type: () -> Dict[str, Any]
 
-        return self.storage.get_trial_params(
-            self.study_id, self.trial_id)
+        return self.storage.get_trial_params(self.trial_id)
 
     @property
     def info(self):
         # type: () -> trial.SystemAttributes
 
         # TODO(Akiba): info -> system_attrs
-        return self.storage.get_trial_system_attrs(
-            self.study_id, self.trial_id)
+        return self.storage.get_trial_system_attrs(self.trial_id)

--- a/pfnopt/pruners.py
+++ b/pfnopt/pruners.py
@@ -29,8 +29,7 @@ class MedianPruner(BasePruner):
         if trial_id < self.n_startup_trials:
             return False
 
-        best_intermediate_result = storage.get_best_intermediate_result_over_steps(
-            study_id, trial_id)
+        best_intermediate_result = storage.get_best_intermediate_result_over_steps(trial_id)
         median = storage.get_median_intermediate_result_over_trials(
             study_id, step)
 

--- a/pfnopt/storage/base.py
+++ b/pfnopt/storage/base.py
@@ -29,36 +29,36 @@ class BaseStorage(object):
     # Basic trial manipulation
 
     @abc.abstractmethod
-    def set_trial_state(self, study_id, trial_id, state):
-        # type: (int, int, trial.State) -> None
+    def set_trial_state(self, trial_id, state):
+        # type: (int, trial.State) -> None
         raise NotImplementedError
 
     @abc.abstractmethod
-    def set_trial_param(self, study_id, trial_id, param_name, param_value_in_internal_repr):
-        # type: (int, int, str, float) -> None
+    def set_trial_param(self, trial_id, param_name, param_value_in_internal_repr):
+        # type: (int, str, float) -> None
         # TODO(Akiba): float? how about categorical?
         raise NotImplementedError
 
     @abc.abstractmethod
-    def set_trial_value(self, study_id, trial_id, value):
+    def set_trial_value(self, trial_id, value):
+        # type: (int, float) -> None
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def set_trial_intermediate_value(self, trial_id, step, intermediate_value):
         # type: (int, int, float) -> None
         raise NotImplementedError
 
     @abc.abstractmethod
-    def set_trial_intermediate_value(self, study_id, trial_id, step, intermediate_value):
-        # type: (int, int, int, float) -> None
-        raise NotImplementedError
-
-    @abc.abstractmethod
-    def set_trial_system_attrs(self, study_id, trial_id, system_attrs):
-        # type: (int, int, trial.SystemAttributes) -> None
+    def set_trial_system_attrs(self, trial_id, system_attrs):
+        # type: (int, trial.SystemAttributes) -> None
         raise NotImplementedError
 
     # Basic trial access
 
     @abc.abstractmethod
-    def get_trial(self, study_id, trial_id):
-        # type: (int, int) -> trial.Trial
+    def get_trial(self, trial_id):
+        # type: (int) -> trial.Trial
         raise NotImplementedError
 
     @abc.abstractmethod
@@ -78,13 +78,13 @@ class BaseStorage(object):
 
         return copy.deepcopy(best_trial)
 
-    def get_trial_params(self, study_id, trial_id):
-        # type: (int, int) -> Dict[str, Any]
-        return self.get_trial(study_id, trial_id).params
+    def get_trial_params(self, trial_id):
+        # type: (int) -> Dict[str, Any]
+        return self.get_trial(trial_id).params
 
-    def get_trial_system_attrs(self, study_id, trial_id):
-        # type: (int, int) -> trial.SystemAttributes
-        return self.get_trial(study_id, trial_id).system_attrs
+    def get_trial_system_attrs(self, trial_id):
+        # type: (int) -> trial.SystemAttributes
+        return self.get_trial(trial_id).system_attrs
 
     # Methods for the TPE sampler
 
@@ -102,9 +102,9 @@ class BaseStorage(object):
 
     # Methods for the median pruner
 
-    def get_best_intermediate_result_over_steps(self, study_id, trial_id):
-        # type: (int, int) -> float
-        return min(self.get_trial(study_id, trial_id).intermediate_values.values())
+    def get_best_intermediate_result_over_steps(self, trial_id):
+        # type: (int) -> float
+        return min(self.get_trial(trial_id).intermediate_values.values())
 
     def get_median_intermediate_result_over_trials(self, study_id, step):
         # type: (int, int) -> float

--- a/pfnopt/storage/in_memory.py
+++ b/pfnopt/storage/in_memory.py
@@ -29,38 +29,32 @@ class InMemoryStorage(base.BaseStorage):
         assert study_id == 0
         self.param_distribution[param_name] = distribution
 
-    def set_trial_state(self, study_id, trial_id, state):
-        # type: (int, int, trial.State) -> None
-        assert study_id == 0  # TODO(Akiba)
+    def set_trial_state(self, trial_id, state):
+        # type: (int, trial.State) -> None
         self.trials[trial_id].state = state
 
-    def set_trial_param(self, study_id, trial_id, param_name, param_value_in_internal_repr):
-        # type: (int, int, str, float) -> None
-        assert study_id == 0  # TODO(Akiba)
+    def set_trial_param(self, trial_id, param_name, param_value_in_internal_repr):
+        # type: (int, str, float) -> None
         self.trials[trial_id].params_in_internal_repr[param_name] = param_value_in_internal_repr
 
         distribution = self.param_distribution[param_name]
         param_value_actual = distribution.to_external_repr(param_value_in_internal_repr)
         self.trials[trial_id].params[param_name] = param_value_actual
 
-    def set_trial_value(self, study_id, trial_id, value):
-        # type: (int, int, float) -> None
-        assert study_id == 0  # TODO(Akiba)
+    def set_trial_value(self, trial_id, value):
+        # type: (int, float) -> None
         self.trials[trial_id].value = value
 
-    def set_trial_intermediate_value(self, study_id, trial_id, step, intermediate_value):
-        # type: (int, int, int, float) -> None
-        assert study_id == 0  # TODO(Akiba)
+    def set_trial_intermediate_value(self, trial_id, step, intermediate_value):
+        # type: (int, int, float) -> None
         self.trials[trial_id].intermediate_values[step] = intermediate_value
 
-    def set_trial_system_attrs(self, study_id, trial_id, system_attrs):
-        # type: (int, int, trial.SystemAttributes) -> None
-        assert study_id == 0  # TODO(Akiba)
+    def set_trial_system_attrs(self, trial_id, system_attrs):
+        # type: (int, trial.SystemAttributes) -> None
         self.trials[trial_id].system_attrs = system_attrs
 
-    def get_trial(self, study_id, trial_id):
-        # type: (int, int) -> trial.Trial
-        assert study_id == 0  # TODO(Akiba)
+    def get_trial(self, trial_id):
+        # type: (int) -> trial.Trial
         return copy.deepcopy(self.trials[trial_id])
 
     def get_all_trials(self, study_id):


### PR DESCRIPTION
There are no use of study_id parameter but just asserting it is 0, in several Storage methods. This PR removes them.