### PR TITLE
Explicitly terminate thread pool

### DIFF
--- a/pfnopt/study.py
+++ b/pfnopt/study.py
@@ -117,6 +117,8 @@ class Study(object):
             except (StopIteration, multiprocessing.TimeoutError):  # type: ignore
                 break
 
+        pool.terminate()
+
 
 def minimize(
         func,  # type: ObjectiveFuncType


### PR DESCRIPTION
I found that threads are not properly killed for some reason, which causes unexpected memory consumption, etc. This PR adds explicit termination of thread pool to address that issue.