### PR TITLE
Move sessionmaker instance to global

### DIFF
--- a/pfnopt/storage/rdb.py
+++ b/pfnopt/storage/rdb.py
@@ -19,6 +19,7 @@ import pfnopt.trial as trial_module
 from pfnopt.trial import State
 
 Base = declarative_base()  # type: Any
+Session = orm.sessionmaker()
 
 
 class Study(Base):
@@ -74,7 +75,7 @@ class RDBStorage(BaseStorage):
     def __init__(self, url):
         # type: (str) -> None
         self.engine = create_engine(url)
-        self.session = orm.sessionmaker(bind=self.engine)()
+        self.session = Session(bind=self.engine)
         Base.metadata.create_all(self.engine)
 
     def create_new_study_id(self):


### PR DESCRIPTION
http://docs.sqlalchemy.org/en/latest/orm/session_api.html#session-and-sessionmaker

SQLAlchemy's document claims `sessionmaker` should be called once and the result should be put at the global scope.