### PR TITLE
Enhance study tests

### DIFF
--- a/tests/test_study.py
+++ b/tests/test_study.py
@@ -48,6 +48,7 @@ class StorageSupplier(object):
 
     def __enter__(self):
         # type: () -> Optional[pfnopt.storages.BaseStorage]
+
         if self.storage_specifier == 'none':
             return None
         elif self.storage_specifier == 'new':
@@ -69,6 +70,7 @@ class StorageSupplier(object):
 
 def func(client, x_max=1.0):
     # type: (pfnopt.client.BaseClient, float) -> float
+
     x = client.sample_uniform('x', -x_max, x_max)
     y = client.sample_loguniform('y', 20, 30)
     z = client.sample_categorical('z', (-1.0, 1.0))
@@ -79,6 +81,7 @@ class Func(object):
 
     def __init__(self, sleep_sec=None):
         # type: (Optional[float]) -> None
+
         self.n_calls = 0
         self.sleep_sec = sleep_sec
         self.lock = threading.Lock()
@@ -86,6 +89,7 @@ class Func(object):
 
     def __call__(self, client):
         # type: (pfnopt.client.BaseClient) -> float
+
         with self.lock:
             self.n_calls += 1
             x_max = self.x_max
@@ -100,11 +104,13 @@ class Func(object):
 
 def check_params(params):
     # type: (Dict[str, Any]) -> None
+
     assert sorted(params.keys()) == ['x', 'y', 'z']
 
 
 def check_value(value):
     # type: (float) -> None
+
     assert isinstance(value, float)
     assert -1.0 <= value <= 12.0 ** 2 + 5.0 ** 2 + 1.0
 


### PR DESCRIPTION
This PR aims to enhance tests to find bugs like #72. Without #72, the new tests correctly fails as follows:

```
========================================================= test session starts =========================================================
tests/test_study.py::test_minimize_trivial_in_memory_new PASSED
tests/test_study.py::test_minimize_trivial_in_memory_resume PASSED
tests/test_study.py::test_minimize_trivial_rdb_new PASSED
tests/test_study.py::test_minimize_trivial_rdb_resume_study PASSED
tests/test_study.py::test_minimize_trivial_rdb_resume_uuid PASSED
tests/test_study.py::test_minimize_parallel[0-1-none] PASSED
tests/test_study.py::test_minimize_parallel[0-1-new] PASSED
tests/test_study.py::test_minimize_parallel[0-1-common] PASSED
tests/test_study.py::test_minimize_parallel[0-2-none] PASSED
tests/test_study.py::test_minimize_parallel[0-2-new] PASSED
tests/test_study.py::test_minimize_parallel[0-2-common] PASSED
tests/test_study.py::test_minimize_parallel[0-10-none] PASSED
tests/test_study.py::test_minimize_parallel[0-10-new] PASSED
tests/test_study.py::test_minimize_parallel[0-10-common] PASSED
tests/test_study.py::test_minimize_parallel[0--1-none] PASSED
tests/test_study.py::test_minimize_parallel[0--1-new] PASSED
tests/test_study.py::test_minimize_parallel[0--1-common] PASSED
tests/test_study.py::test_minimize_parallel[1-1-none] PASSED
tests/test_study.py::test_minimize_parallel[1-1-new] PASSED
tests/test_study.py::test_minimize_parallel[1-1-common] FAILED
tests/test_study.py::test_minimize_parallel[1-2-none] PASSED
tests/test_study.py::test_minimize_parallel[1-2-new] PASSED
tests/test_study.py::test_minimize_parallel[1-2-common] PASSED
tests/test_study.py::test_minimize_parallel[1-10-none] PASSED
tests/test_study.py::test_minimize_parallel[1-10-new] PASSED
tests/test_study.py::test_minimize_parallel[1-10-common] PASSED
tests/test_study.py::test_minimize_parallel[1--1-none] PASSED
tests/test_study.py::test_minimize_parallel[1--1-new] PASSED
tests/test_study.py::test_minimize_parallel[1--1-common] PASSED
tests/test_study.py::test_minimize_parallel[2-1-none] PASSED
tests/test_study.py::test_minimize_parallel[2-1-new] PASSED
tests/test_study.py::test_minimize_parallel[2-1-common] FAILED
tests/test_study.py::test_minimize_parallel[2-2-none] PASSED
tests/test_study.py::test_minimize_parallel[2-2-new] PASSED
tests/test_study.py::test_minimize_parallel[2-2-common] PASSED
tests/test_study.py::test_minimize_parallel[2-10-none] PASSED
tests/test_study.py::test_minimize_parallel[2-10-new] PASSED
tests/test_study.py::test_minimize_parallel[2-10-common] PASSED
tests/test_study.py::test_minimize_parallel[2--1-none] PASSED
tests/test_study.py::test_minimize_parallel[2--1-new] PASSED
...
```
