### PR TITLE
Implement study list command

### DIFF
--- a/pfnopt/cli.py
+++ b/pfnopt/cli.py
@@ -17,10 +17,6 @@ from typing import Tuple  # NOQA
 import pfnopt
 
 
-_DATETIME_FORMAT = '%Y-%m-%d %H:%M:%S'
-_STUDY_LIST_HEADER = ('UUID', 'TASK', 'N_TRIALS', 'DATETIME_START')
-
-
 class BaseCommand(Command):
 
     def __init__(self, *args, **kwargs):
@@ -70,6 +66,9 @@ class StudySetUserAttribute(BaseCommand):
 
 class Studies(Lister):
 
+    _datetime_format = '%Y-%m-%d %H:%M:%S'
+    _study_list_header = ('UUID', 'TASK', 'N_TRIALS', 'DATETIME_START')
+
     def get_parser(self, prog_name):
         # type: (str) -> ArgumentParser
 
@@ -84,11 +83,12 @@ class Studies(Lister):
 
         rows = []
         for s in summaries:
-            start = s.datetime_start if s.datetime_start is not None else None
+            start = s.datetime_start.strftime(self._datetime_format) \
+                if s.datetime_start is not None else None
             row = (s.study_uuid, s.task.name, s.n_trials, start)
             rows.append(row)
 
-        return _STUDY_LIST_HEADER, tuple(rows)
+        return self._study_list_header, tuple(rows)
 
 
 class Dashboard(BaseCommand):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,7 +5,7 @@ import tempfile
 from typing import List  # NOQA
 
 import pfnopt
-from pfnopt.cli import _STUDY_LIST_HEADER
+from pfnopt.cli import Studies
 from pfnopt.storages import RDBStorage
 from pfnopt.trial import Trial  # NOQA
 
@@ -79,7 +79,7 @@ def test_studies_command():
             return [r.strip() for r in rows[row_index].split('|')[1: -1]]
 
         assert len(rows) == 6
-        assert tuple(get_row_elements(1)) == _STUDY_LIST_HEADER
+        assert tuple(get_row_elements(1)) == Studies._study_list_header
 
         # Check study_uuid and n_trials for the first study.
         elms = get_row_elements(3)


### PR DESCRIPTION
This PR implements `study list` command, which shows list of all studies and their basic information.

An example usage below:

```console
$ pfnopt study list --storage sqlite:///tmp.db
+--------------------------------------+----------+----------+----------------------------+
| UUID                                 | TASK     | N_TRIALS | DATETIME_START             |
+--------------------------------------+----------+----------+----------------------------+
| beaffd9b-662f-4a02-b887-339cb50a7931 | MINIMIZE |       13 | 2018-05-07 11:14:43.967880 |
| 0da639df-5ab0-4a91-8587-ef894d8920df | MINIMIZE |       10 | 2018-05-07 13:26:33.709694 |
+--------------------------------------+----------+----------+----------------------------+
```