### PR TITLE
Move common storage tests to test_storages.py

### DIFF
--- a/pfnopt/storages/rdb/storage.py
+++ b/pfnopt/storages/rdb/storage.py
@@ -154,20 +154,6 @@ class RDBStorage(BaseStorage):
 
         return study_sumarries
 
-    def set_trial_param_distribution(self, trial_id, param_name, distribution):
-        # type: (int, str, distributions.BaseDistribution) -> None
-
-        session = self.scoped_session()
-
-        param_distribution = models.TrialParamDistributionModel(
-            trial_id=trial_id,
-            param_name=param_name,
-            distribution_json=distributions.distribution_to_json(distribution)
-        )
-
-        param_distribution.check_and_add(session)
-        session.commit()
-
     def create_new_trial_id(self, study_id):
         # type: (int) -> int
 
@@ -183,6 +169,20 @@ class RDBStorage(BaseStorage):
         session.commit()
 
         return trial.trial_id
+
+    def set_trial_param_distribution(self, trial_id, param_name, distribution):
+        # type: (int, str, distributions.BaseDistribution) -> None
+
+        session = self.scoped_session()
+
+        param_distribution = models.TrialParamDistributionModel(
+            trial_id=trial_id,
+            param_name=param_name,
+            distribution_json=distributions.distribution_to_json(distribution)
+        )
+
+        param_distribution.check_and_add(session)
+        session.commit()
 
     def set_trial_state(self, trial_id, state):
         # type: (int, structs.TrialState) -> None

--- a/tests/storages_tests/rdb_tests/test_storage.py
+++ b/tests/storages_tests/rdb_tests/test_storage.py
@@ -3,7 +3,6 @@ from mock import patch
 import pytest
 from sqlalchemy.exc import IntegrityError
 from typing import Dict  # NOQA
-import unittest
 import uuid
 
 from pfnopt.distributions import BaseDistribution  # NOQA
@@ -21,170 +20,147 @@ from pfnopt.structs import StudyTask
 from pfnopt import version
 
 
-class TestRDBStorage(unittest.TestCase):
+def test_init():
+    # type: () -> None
 
-    def test_init(self):
-        # type: () -> None
+    storage = create_test_storage()
+    session = storage.scoped_session()
 
-        storage = RDBStorage('sqlite:///:memory:')
+    version_info = session.query(VersionInfoModel).first()
+    assert version_info.schema_version == SCHEMA_VERSION
+    assert version_info.library_version == version.__version__
+
+
+def test_create_new_study_id_multiple_studies():
+    # type: () -> None
+
+    storage = create_test_storage()
+    session = storage.scoped_session()
+
+    study_id_1 = storage.create_new_study_id()
+    study_id_2 = storage.create_new_study_id()
+
+    result = session.query(StudyModel).all()
+    result = sorted(result, key=lambda x: x.study_id)
+    assert len(result) == 2
+    assert result[0].study_id == study_id_1
+    assert result[1].study_id == study_id_2
+
+
+def test_create_new_study_id_duplicated_uuid():
+    # type: () -> None
+
+    mock = Mock()
+    mock.side_effect = ['uuid1', 'uuid1', 'uuid2', 'uuid3']
+
+    with patch.object(uuid, 'uuid4', mock) as mock_object:
+        storage = create_test_storage()
         session = storage.scoped_session()
 
-        version_info = session.query(VersionInfoModel).first()
-        assert version_info.schema_version == SCHEMA_VERSION
-        assert version_info.library_version == version.__version__
-
-    def test_create_new_study_id(self):
-        # type: () -> None
-
-        storage = self.create_test_storage()
-        session = storage.scoped_session()
-
+        storage.create_new_study_id()
         study_id = storage.create_new_study_id()
 
-        result = session.query(StudyModel).all()
-        assert len(result) == 1
-        assert result[0].study_id == study_id
+        result = session.query(StudyModel).filter(StudyModel.study_id == study_id).one()
+        assert result.study_uuid == 'uuid2'
+        assert mock_object.call_count == 3
 
-    def test_create_new_study_id_duplicated_uuid(self):
-        # type: () -> None
 
-        mock = Mock()
-        mock.side_effect = ['uuid1', 'uuid1', 'uuid2', 'uuid3']
+def test_set_trial_param_distribution():
+    # type: () -> None
 
-        with patch.object(uuid, 'uuid4', mock) as mock_object:
-            storage = self.create_test_storage()
-            session = storage.scoped_session()
+    example_distributions = {
+        'x': UniformDistribution(low=1., high=2.),
+        'y': CategoricalDistribution(choices=('Otemachi', 'Tokyo', 'Ginza'))
+    }  # type: Dict[str, BaseDistribution]
 
-            storage.create_new_study_id()
-            study_id = storage.create_new_study_id()
+    storage = create_test_storage()
+    session = storage.scoped_session()
+    study_id = storage.create_new_study_id()
 
-            result = session.query(StudyModel).filter(StudyModel.study_id == study_id).one()
-            assert result.study_uuid == 'uuid2'
-            assert mock_object.call_count == 3
+    trial_id = storage.create_new_trial_id(study_id)
+    storage.set_trial_param_distribution(trial_id, 'x', example_distributions['x'])
+    storage.set_trial_param_distribution(trial_id, 'y', example_distributions['y'])
 
-    def test_get_study_id_from_uuid(self):
-        # type: () -> None
+    # test setting new name
+    result_1 = session.query(TrialParamDistributionModel). \
+        filter(TrialParamDistributionModel.param_name == 'x').one()
+    assert result_1.trial_id == trial_id
+    assert json_to_distribution(result_1.distribution_json) == example_distributions['x']
 
-        storage = self.create_test_storage()
-        session = storage.scoped_session()
+    result_2 = session.query(TrialParamDistributionModel). \
+        filter(TrialParamDistributionModel.param_name == 'y').one()
+    assert result_2.trial_id == trial_id
+    assert json_to_distribution(result_2.distribution_json) == example_distributions['y']
 
-        # test not existing study
-        self.assertRaises(ValueError, lambda: storage.get_study_id_from_uuid('dummy-uuid'))
+    # test setting a duplicated pair of trial and parameter name
+    with pytest.raises(IntegrityError):
+        storage.set_trial_param_distribution(
+            trial_id,  # existing trial_id
+            'x',
+            example_distributions['x'])
 
-        # test existing study
-        storage.create_new_study_id()
-        study = session.query(StudyModel).one()
-        assert storage.get_study_id_from_uuid(study.study_uuid) == study.study_id
 
-    def test_get_study_uuid_from_id(self):
-        # type: () -> None
+def test_get_all_study_summaries_with_multiple_studies():
+    # type: () -> None
 
-        storage = self.create_test_storage()
-        session = storage.scoped_session()
+    storage = create_test_storage()
 
-        # test not existing study
-        self.assertRaises(ValueError, lambda: storage.get_study_uuid_from_id(0))
+    study_id_1 = storage.create_new_study_id()
+    study_id_2 = storage.create_new_study_id()
 
-        # test existing study
-        storage.create_new_study_id()
-        study = session.query(StudyModel).one()
-        assert storage.get_study_uuid_from_id(study.study_id) == study.study_uuid
+    storage.set_study_task(study_id_1, StudyTask.MINIMIZE)
+    storage.set_study_task(study_id_2, StudyTask.MAXIMIZE)
 
-    def test_set_trial_param_distribution(self):
-        # type: () -> None
+    storage.create_new_trial_id(study_id_1)
+    storage.create_new_trial_id(study_id_1)
+    storage.create_new_trial_id(study_id_2)
 
-        example_distributions = {
-            'x': UniformDistribution(low=1., high=2.),
-            'y': CategoricalDistribution(choices=('Otemachi', 'Tokyo', 'Ginza'))
-        }  # type: Dict[str, BaseDistribution]
+    summaries = storage.get_all_study_summaries()
+    summaries = sorted(summaries, key=lambda x: x.study_id)
 
-        storage = self.create_test_storage()
-        session = storage.scoped_session()
-        study_id = storage.create_new_study_id()
+    expected_summary_1 = StudySummary(
+        study_id=study_id_1,
+        study_uuid=storage.get_study_uuid_from_id(study_id_1),
+        task=StudyTask.MINIMIZE,
+        user_attrs={SYSTEM_ATTRS_KEY: {}},
+        best_trial=None,
+        n_trials=2,
+        datetime_start=summaries[0].datetime_start  # This always passes.
+    )
+    expected_summary_2 = StudySummary(
+        study_id=study_id_2,
+        study_uuid=storage.get_study_uuid_from_id(study_id_2),
+        task=StudyTask.MAXIMIZE,
+        user_attrs={SYSTEM_ATTRS_KEY: {}},
+        best_trial=None,
+        n_trials=1,
+        datetime_start=summaries[1].datetime_start  # This always passes.
+    )
 
-        trial_id = storage.create_new_trial_id(study_id)
-        storage.set_trial_param_distribution(trial_id, 'x', example_distributions['x'])
-        storage.set_trial_param_distribution(trial_id, 'y', example_distributions['y'])
+    assert summaries[0] == expected_summary_1
+    assert summaries[1] == expected_summary_2
 
-        # test setting new name
-        result_1 = session.query(TrialParamDistributionModel). \
-            filter(TrialParamDistributionModel.param_name == 'x').one()
-        assert result_1.trial_id == trial_id
-        assert json_to_distribution(result_1.distribution_json) == example_distributions['x']
 
-        result_2 = session.query(TrialParamDistributionModel). \
-            filter(TrialParamDistributionModel.param_name == 'y').one()
-        assert result_2.trial_id == trial_id
-        assert json_to_distribution(result_2.distribution_json) == example_distributions['y']
+def test_check_table_schema_compatibility():
+    # type: () -> None
 
-        # test setting a duplicated pair of trial and parameter name
-        self.assertRaises(
-            IntegrityError,
-            lambda: storage.set_trial_param_distribution(
-                trial_id,  # existing trial_id
-                'x',
-                example_distributions['x']))
+    storage = create_test_storage()
+    session = storage.scoped_session()
 
-    def test_get_all_study_summaries_with_multiple_studies(self):
-        # type: () -> None
+    # test not raising error for out of date schema type
+    storage._check_table_schema_compatibility()
 
-        storage = self.create_test_storage()
+    # test raising error for out of date schema type
+    version_info = session.query(VersionInfoModel).one()
+    version_info.schema_version = SCHEMA_VERSION - 1
+    session.commit()
 
-        study_id_1 = storage.create_new_study_id()
-        study_id_2 = storage.create_new_study_id()
-
-        storage.set_study_task(study_id_1, StudyTask.MINIMIZE)
-        storage.set_study_task(study_id_2, StudyTask.MAXIMIZE)
-
-        storage.create_new_trial_id(study_id_1)
-        storage.create_new_trial_id(study_id_1)
-        storage.create_new_trial_id(study_id_2)
-
-        summaries = storage.get_all_study_summaries()
-        summaries = sorted(summaries, key=lambda x: x.study_id)
-
-        expected_summary_1 = StudySummary(
-            study_id=study_id_1,
-            study_uuid=storage.get_study_uuid_from_id(study_id_1),
-            task=StudyTask.MINIMIZE,
-            user_attrs={SYSTEM_ATTRS_KEY: {}},
-            best_trial=None,
-            n_trials=2,
-            datetime_start=summaries[0].datetime_start  # This always passes.
-        )
-        expected_summary_2 = StudySummary(
-            study_id=study_id_2,
-            study_uuid=storage.get_study_uuid_from_id(study_id_2),
-            task=StudyTask.MAXIMIZE,
-            user_attrs={SYSTEM_ATTRS_KEY: {}},
-            best_trial=None,
-            n_trials=1,
-            datetime_start=summaries[1].datetime_start  # This always passes.
-        )
-
-        assert summaries[0] == expected_summary_1
-        assert summaries[1] == expected_summary_2
-
-    def test_check_table_schema_compatibility(self):
-        # type: () -> None
-
-        storage = self.create_test_storage()
-        session = storage.scoped_session()
-
-        # test not raising error for out of date schema type
+    with pytest.raises(RuntimeError):
         storage._check_table_schema_compatibility()
 
-        # test raising error for out of date schema type
-        version_info = session.query(VersionInfoModel).one()
-        version_info.schema_version = SCHEMA_VERSION - 1
-        session.commit()
 
-        with pytest.raises(RuntimeError):
-            storage._check_table_schema_compatibility()
+def create_test_storage():
+    # type: () -> RDBStorage
 
-    @staticmethod
-    def create_test_storage():
-        # type: () -> RDBStorage
-
-        storage = RDBStorage('sqlite:///:memory:')
-        return storage
+    storage = RDBStorage('sqlite:///:memory:')
+    return storage

--- a/tests/storages_tests/test_storages.py
+++ b/tests/storages_tests/test_storages.py
@@ -63,6 +63,40 @@ parametrize_storage = pytest.mark.parametrize(
 
 
 @parametrize_storage
+def test_create_new_study_id(storage_init_func):
+    # type: (Callable[[], BaseStorage]) -> None
+
+    storage = storage_init_func()
+    study_id = storage.create_new_study_id()
+
+    summaries = storage.get_all_study_summaries()
+    assert len(summaries) == 1
+    assert summaries[0].study_id == study_id
+
+
+@parametrize_storage
+def test_get_study_id_from_uuid_and_get_study_uuid_from_id(storage_init_func):
+    # type: (Callable[[], BaseStorage]) -> None
+
+    storage = storage_init_func()
+
+    # Test not existing study.
+    with pytest.raises(ValueError):
+        storage.get_study_id_from_uuid('dummy-uuid')
+
+    with pytest.raises(ValueError):
+        storage.get_study_uuid_from_id(-1)
+
+    # Test existing study.
+    study_id = storage.create_new_study_id()
+    summary = storage.get_all_study_summaries()[0]
+
+    assert study_id == summary.study_id
+    assert storage.get_study_uuid_from_id(summary.study_id) == summary.study_uuid
+    assert storage.get_study_id_from_uuid(summary.study_uuid) == summary.study_id
+
+
+@parametrize_storage
 def test_set_and_get_study_task(storage_init_func):
     # type: (Callable[[], BaseStorage]) -> None
 


### PR DESCRIPTION
- Move common storage tests to test_storages.py.
- Modify order of a method in rdb/storage.py.
- Eliminate unittest from test_rdb/test_storage.py.