### PR TITLE
Set OMP_NUM_THREADS to 1 to solve performance issues on CircleCI.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,15 +76,17 @@ jobs:
           name: tests
           command: |
             . venv/bin/activate
-            export OMP_NUM_THREADS=1
             pytest tests
+          environment:
+            OMP_NUM_THREADS: 1
 
       - run: &tests-mn
           name: tests-mn
           command: |
             . venv/bin/activate
-            export OMP_NUM_THREADS=1
             mpirun -n 2 -- pytest tests/integration_tests/test_chainermn.py
+          environment:
+            OMP_NUM_THREADS: 1
 
   tests-python35:
     docker:
@@ -124,20 +126,22 @@ jobs:
           name: examples
           command: |
             . venv/bin/activate
-            export OMP_NUM_THREADS=1
             for file in `find examples -name '*.py' -not -name 'chainermn_mnist.py'`
             do
                python $file
             done
+          environment:
+            OMP_NUM_THREADS: 1
 
       - run: &examples-mn
           name: examples-mn
           command: |
             . venv/bin/activate
-            export OMP_NUM_THREADS=1
             STORAGE_URL=sqlite:///example.db
             STUDY_UUID=`pfnopt create-study --storage $STORAGE_URL`
             mpirun -n 2 -- python examples/chainermn_mnist.py $STUDY_UUID $STORAGE_URL
+          environment:
+            OMP_NUM_THREADS: 1
 
   examples-python35:
     docker:


### PR DESCRIPTION
This configuration reduces execution time of example tests from 40 mins to 10 mins.