### PR TITLE
Add --storage option to example usages.

### DIFF
--- a/examples/chainer_mnist.py
+++ b/examples/chainer_mnist.py
@@ -13,7 +13,8 @@ We have the following two ways to execute this example:
 
 
 (2) Execute through CLI.
-    $ pfnopt minimize chainer_mnist.py objective --create-study --n-trials=100
+    $ pfnopt minimize chainer_mnist.py objective --create-study --n-trials=100 \
+      --storage sqlite:///example.db
 
 """
 

--- a/examples/quadratic.py
+++ b/examples/quadratic.py
@@ -11,7 +11,8 @@ We have the following two ways to execute this example:
 
 
 (2) Execute through CLI.
-    $ pfnopt minimize quadratic.py objective --create-study --n-trials=100
+    $ pfnopt minimize quadratic.py objective --create-study --n-trials=100 \
+      --storage sqlite:///example.db
 
 """
 

--- a/examples/sklearn_iris.py
+++ b/examples/sklearn_iris.py
@@ -12,7 +12,8 @@ We have the following two ways to execute this example:
 
 
 (2) Execute through CLI.
-    $ pfnopt minimize sklearn_iris.py objective --create-study --n-trials=100
+    $ pfnopt minimize sklearn_iris.py objective --create-study --n-trials=100 \
+      --storage sqlite:///example.db
 
 """
 

--- a/examples/xgboost_cancer.py
+++ b/examples/xgboost_cancer.py
@@ -11,8 +11,10 @@ We have following two ways to execute this example:
 (1) Execute this code directly.
     $ python xgboost_cancer.py
 
-(2) Execute throurgh CLI.
-    $ pfnopt minimize xgboost_cancer.py objective --create-study --n-trials=100
+
+(2) Execute through CLI.
+    $ pfnopt minimize xgboost_cancer.py objective --create-study --n-trials=100 \
+      --storage sqlite:///example.db
 
 """
 


### PR DESCRIPTION
Fix usages of pfnopt/examples. `--storage` option is necessary to run a study via pfnopt CLI.