### PR TITLE
Show stacktrace of an error during a trial.

### DIFF
--- a/pfnopt/study.py
+++ b/pfnopt/study.py
@@ -267,7 +267,7 @@ class Study(object):
         except catch as e:
             message = 'Setting trial status as {} because of the following error: {}'.format(
                 structs.TrialState.FAIL, repr(e))
-            self.logger.warning(message)
+            self.logger.warning(message, exc_info=True)
             self.storage.set_trial_state(trial_id, structs.TrialState.FAIL)
             self.storage.set_trial_system_attr(trial_id, 'fail_reason', message)
             return trial


### PR DESCRIPTION
- Used an option of `Logger.debug` to show stacktrace.
- Do we need an option to show/hide stacktrace?

A sample error message:
```shell
[W 2018-09-07 17:56:04,125] Setting trial status as TrialState.FAIL because of the following error: ValueError('y = 0',)
Traceback (most recent call last):
  File "./pfnopt/pfnopt/study.py", line 260, in _run_trial
    result = func(trial)
  File "./quadratic_value_error.py", line 28, in objective
    raise ValueError('y = {}'.format(y))
ValueError: y = 0
[I 2018-09-07 17:56:04,208] Finished a trial resulted in value: 14.949627600278257. Current best value is 14.9496276002783 with parameters: {'x'
: -3.73492002595481, 'y': 1}.
```

The objective function for this experiment:
```python
def objective(trial):
    x = trial.suggest_uniform('x', -100, 100)
    y = trial.suggest_categorical('y', (-1, 0, 1))
    if y == 0:
        raise ValueError('y = {}'.format(y))
    return x ** 2 + y
```