### PR TITLE
Show a message to uninstall old pfnopt.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ pfnopt_pkg = find_any_distribution(['pfnopt'])
 if pfnopt_pkg is not None:
     msg = 'We detected that PFNOpt is installed in your environment.\n' \
         'PFNOpt has been renamed Optuna. Please uninstall the old\n' \
-        'PFNOpt in advance (e.g. pip uninstall pfnopt).'
+        'PFNOpt in advance (e.g. by executing `$ pip uninstall pfnopt`).'
     print(msg)
     exit(1)
 


### PR DESCRIPTION
This PR adds a message for PFNOpt users to migrate from `pfnopt` to `optuna`. If `pfnopt` is found in environment, the following error message will be shown to users:

```shell
% pip install .
Processing ./optuna
    Complete output from command python setup.py egg_info:

    We detected that PFNOpt is installed in your environment.
    PFNOpt has been renamed Optuna. Please uninstall the old
    PFNOpt in advance.


    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /private/var/folders/3b/rzc1tk0s1r38cgjysjxjw9qm0000gn/T/pip-iwhnrvmg-build/
```