### PR TITLE
Remove study argument from minimize().

### DIFF
--- a/examples/quadratic.py
+++ b/examples/quadratic.py
@@ -35,10 +35,10 @@ if __name__ == '__main__':
 
     # We can continue the optimization as follows.
     print('Running 20 additional trials...')
-    optuna.minimize(objective, n_trials=20, study=study)
+    study.run(objective, n_trials=20)
     print('Best value: {} (params: {})\n'.format(study.best_value, study.best_params))
 
     # We can specify the timeout instead of a number of trials.
     print('Running additional trials in 2 seconds...')
-    optuna.minimize(objective, timeout=2.0, study=study)
+    study.run(objective, timeout_seconds=2.0)
     print('Best value: {} (params: {})\n'.format(study.best_value, study.best_params))

--- a/optuna/cli.py
+++ b/optuna/cli.py
@@ -189,10 +189,9 @@ class Minimize(BaseCommand):
                 parsed_args.method, parsed_args.file))
             return 1
 
-        optuna.minimize(
+        study.run(
             target_method, n_trials=parsed_args.n_trials,
-            timeout=parsed_args.timeout, n_jobs=parsed_args.n_jobs,
-            study=study)
+            timeout_seconds=parsed_args.timeout, n_jobs=parsed_args.n_jobs)
         return 0
 
 

--- a/optuna/integration/chainermn.py
+++ b/optuna/integration/chainermn.py
@@ -6,7 +6,6 @@ from typing import Optional  # NOQA
 from optuna.pruners import BasePruner  # NOQA
 from optuna.samplers import BaseSampler  # NOQA
 from optuna.storages import InMemoryStorage
-from optuna.study import minimize
 from optuna.study import Study  # NOQA
 from optuna.trial import Trial  # NOQA
 
@@ -58,9 +57,9 @@ def minimize_chainermn(
         raise ValueError('Please make sure an identical study name is shared among workers.')
 
     if comm.rank == 0:
-        minimize(
+        study.run(
             ObjectiveFuncChainerMN(func, comm),
-            n_trials=n_trials, timeout=timeout, n_jobs=1, study=study)
+            n_trials=n_trials, timeout_seconds=timeout, n_jobs=1)
         comm.mpi_comm.bcast((False, None))
     else:
         while True:

--- a/optuna/study.py
+++ b/optuna/study.py
@@ -63,6 +63,9 @@ class Study(object):
         self.study_id = self.storage.get_study_id_from_name(study_name)
         self.logger = logging.get_logger(__name__)
 
+        # TODO(Yanase): Add `task` as an argument of Study() and check inconsistency of tasks.
+        self.storage.set_study_task(self.study_id, structs.StudyTask.MINIMIZE)
+
     def __getstate__(self):
         # type: () -> Dict[Any, Any]
         state = self.__dict__.copy()
@@ -349,7 +352,6 @@ def minimize(
         n_jobs=1,  # type: int
         sampler=None,  # type: samplers.BaseSampler
         pruner=None,  # type: pruners.BasePruner
-        study=None,  # type: Optional[Study]
         catch=(Exception,)  # type: Tuple[Type[Exception]]
 ):
     # type: (...) -> Study
@@ -371,8 +373,6 @@ def minimize(
             Sampler object that implements background algorithm for value suggestion.
         pruner:
             Pruner object that decides early stopping of unpromising trials.
-        study:
-            Study object. If this argument is set to None, a new study is created.
         catch:
             A study continues to run even when a trial raises one of exceptions specified in this
             argument. Default is (Exception,), where all non-exit exceptions are handled by this
@@ -383,16 +383,8 @@ def minimize(
 
     """
 
-    if study is None:
-        # We start a new study with a new in-memory storage.
-        study = create_study(sampler=sampler, pruner=pruner)
-
-    # Set up StudyTask as MINIMIZE.
-    if study.task == structs.StudyTask.MAXIMIZE:
-        raise ValueError(
-            'Cannot run minimize task with study name {} because it already has been set up as a '
-            'maximize task.'.format(study.study_name))
-    study.storage.set_study_task(study.study_id, structs.StudyTask.MINIMIZE)
+    # We start a new study with a new in-memory storage.
+    study = create_study(sampler=sampler, pruner=pruner)
 
     study.run(func, n_trials, timeout, n_jobs, catch)
     return study

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -153,7 +153,7 @@ def test_studies_command(options):
 
         # Second study.
         study_2 = optuna.create_study(storage, study_name='study_2')
-        optuna.minimize(objective_func, n_trials=10, study=study_2)
+        study_2.run(objective_func, n_trials=10)
 
         # Run command.
         command = ['optuna', 'studies']

--- a/tests/test_study.py
+++ b/tests/test_study.py
@@ -126,7 +126,7 @@ def test_minimize_trivial_in_memory_resume():
     # type: () -> None
 
     study = optuna.minimize(func, n_trials=10)
-    optuna.minimize(func, n_trials=10, study=study)
+    study.run(func, n_trials=10)
     check_study(study)
 
 
@@ -134,7 +134,7 @@ def test_minimize_trivial_rdb_resume_study():
     # type: () -> None
 
     study = optuna.create_study('sqlite:///:memory:')
-    optuna.minimize(func, n_trials=10, study=study)
+    study.run(func, n_trials=10)
     check_study(study)
 
 
@@ -150,7 +150,7 @@ def test_minimize_parallel(n_trials, n_jobs, storage_mode):
 
     with StorageSupplier(storage_mode) as storage:
         study = optuna.create_study(storage=storage)
-        optuna.minimize(f, n_trials=n_trials, n_jobs=n_jobs, study=study)
+        study.run(f, n_trials=n_trials, n_jobs=n_jobs)
         assert f.n_calls == len(study.trials) == n_trials
         check_study(study)
 
@@ -169,8 +169,8 @@ def test_minimize_parallel_timeout(n_trials, n_jobs, storage_mode):
 
     with StorageSupplier(storage_mode) as storage:
         study = optuna.create_study(storage=storage)
-        study = optuna.minimize(
-            f, n_trials=n_trials, n_jobs=n_jobs, timeout=timeout_sec, study=study)
+        study.run(
+            f, n_trials=n_trials, n_jobs=n_jobs, timeout_seconds=timeout_sec)
 
         assert f.n_calls == len(study.trials)
 
@@ -186,15 +186,6 @@ def test_minimize_parallel_timeout(n_trials, n_jobs, storage_mode):
 
 
 @pytest.mark.parametrize('storage_mode', STORAGE_MODES)
-def test_minimize_with_incompatible_task(storage_mode):
-    with StorageSupplier(storage_mode) as storage:
-        study = optuna.create_study(storage=storage)
-        study.storage.set_study_task(study.study_id, optuna.structs.StudyTask.MAXIMIZE)
-        with pytest.raises(ValueError):
-            optuna.minimize(Func(), n_trials=1, n_jobs=1, study=study)
-
-
-@pytest.mark.parametrize('storage_mode', STORAGE_MODES)
 def test_minimize_with_catch(storage_mode):
     # type: (str) -> None
 
@@ -205,12 +196,12 @@ def test_minimize_with_catch(storage_mode):
             raise ValueError
 
         # Test acceptable exception.
-        optuna.minimize(func_value_error, n_trials=20, study=study, catch=(ValueError,))
+        study.run(func_value_error, n_trials=20, catch=(ValueError,))
 
         # Test trial with unacceptable exception.
         with pytest.raises(ValueError):
-            optuna.minimize(
-                func_value_error, n_trials=20, study=study, catch=(ArithmeticError,))
+            study.run(
+                func_value_error, n_trials=20, catch=(ArithmeticError,))
 
 
 @pytest.mark.parametrize('storage_mode', STORAGE_MODES)
@@ -248,7 +239,7 @@ def test_trial_set_and_get_user_attrs(storage_mode):
 
     with StorageSupplier(storage_mode) as storage:
         study = optuna.create_study(storage=storage)
-        optuna.minimize(f, n_trials=1, study=study)
+        study.run(f, n_trials=1)
         frozen_trial = study.trials[0]
         assert frozen_trial.user_attrs['train_accuracy'] == 1
 
@@ -266,7 +257,7 @@ def test_trial_set_and_get_system_attrs(storage_mode):
 
     with StorageSupplier(storage_mode) as storage:
         study = optuna.create_study(storage=storage)
-        optuna.minimize(f, n_trials=1, study=study)
+        study.run(f, n_trials=1)
         frozen_trial = study.trials[0]
         assert frozen_trial.system_attrs['system_message'] == 'test'
 
@@ -277,7 +268,7 @@ def test_get_all_study_summaries(storage_mode):
 
     with StorageSupplier(storage_mode) as storage:
         study = optuna.create_study(storage=storage)
-        optuna.minimize(Func(), n_trials=5, study=study)
+        study.run(Func(), n_trials=5)
 
         summaries = optuna.get_all_study_summaries(study.storage)
         summary = [s for s in summaries if s.study_id == study.study_id][0]
@@ -366,7 +357,7 @@ def test_study_pickle():
     check_study(study_2)
     assert len(study_2.trials) == 10
 
-    optuna.minimize(func, n_trials=10, study=study_2)
+    study_2.run(func, n_trials=10)
     check_study(study_2)
     assert len(study_2.trials) == 20
 
@@ -385,7 +376,7 @@ def test_trials_dataframe(storage_mode):
 
     with StorageSupplier(storage_mode) as storage:
         study = optuna.create_study(storage=storage)
-        optuna.minimize(f, n_trials=3, study=study)
+        study.run(f, n_trials=3)
         df = study.trials_dataframe()
         assert len(df) == 3
         # non-nested: 5, params: 2, user_attrs: 1
@@ -416,7 +407,7 @@ def test_trials_dataframe_with_failure(storage_mode):
 
     with StorageSupplier(storage_mode) as storage:
         study = optuna.create_study(storage=storage)
-        optuna.minimize(f, n_trials=3, study=study)
+        study.run(f, n_trials=3)
         df = study.trials_dataframe()
         assert len(df) == 3
         # non-nested: 5, params: 2, user_attrs: 1 system_attrs: 1


### PR DESCRIPTION
This PR is based on the offline  discussion of #177. In this PR, we strictly restrict the storage of `minimize()` to `InMemoryDB`.

Changes:
- Remove `--study` from `minimize()`
- Use `study.run()` instead of minimize(study=study)

Notes:
- The names of some test functions still have the word `minimize`, but it will be fixed when we integrate `minimize()` and `maximize()` into `optimize()`.
- The interface of `minimize_chainermn` seems inconsistent to `minimize()` in this PR. It will be re-design and rewritten as a subclass of `Study` in near future.