### PR TITLE
CLI optimize

### DIFF
--- a/examples/chainer_mnist.py
+++ b/examples/chainer_mnist.py
@@ -14,7 +14,7 @@ We have the following two ways to execute this example:
 
 (2) Execute through CLI.
     $ STUDY_NAME=`optuna create-study --storage sqlite:///example.db`
-    $ optuna optimize chainer_mnist.py objective --n-trials=100 --study $STUDY_NAME \
+    $ optuna study optimize chainer_mnist.py objective --n-trials=100 --study $STUDY_NAME \
       --storage sqlite:///example.db
 
 """

--- a/examples/quadratic.py
+++ b/examples/quadratic.py
@@ -12,7 +12,7 @@ We have the following two ways to execute this example:
 
 (2) Execute through CLI.
     $ STUDY_NAME=`optuna create-study --storage sqlite:///example.db`
-    $ optuna optimize quadratic.py objective --n-trials=100 --study $STUDY_NAME \
+    $ optuna study optimize quadratic.py objective --n-trials=100 --study $STUDY_NAME \
       --storage sqlite:///example.db
 
 """

--- a/examples/sklearn_iris.py
+++ b/examples/sklearn_iris.py
@@ -13,7 +13,7 @@ We have the following two ways to execute this example:
 
 (2) Execute through CLI.
     $ STUDY_NAME=`optuna create-study --storage sqlite:///example.db`
-    $ optuna optimize sklearn_iris.py objective --n-trials=100 --study $STUDY_NAME \
+    $ optuna study optimize sklearn_iris.py objective --n-trials=100 --study $STUDY_NAME \
       --storage sqlite:///example.db
 
 """

--- a/examples/xgboost_cancer.py
+++ b/examples/xgboost_cancer.py
@@ -14,7 +14,7 @@ We have following two ways to execute this example:
 
 (2) Execute through CLI.
     $ STUDY_NAME=`optuna create-study --storage sqlite:///example.db`
-    $ optuna optimize xgboost_cancer.py objective --n-trials=100 --study $STUDY_NAME \
+    $ optuna study optimize xgboost_cancer.py objective --n-trials=100 --study $STUDY_NAME \
       --storage sqlite:///example.db
 
 """

--- a/optuna/cli.py
+++ b/optuna/cli.py
@@ -142,12 +142,12 @@ class Dashboard(BaseCommand):
             self.logger.info('Report successfully written to: {}'.format(parsed_args.out))
 
 
-class Optimize(BaseCommand):
+class StudyOptimize(BaseCommand):
 
     def get_parser(self, prog_name):
         # type: (str) -> ArgumentParser
 
-        parser = super(Optimize, self).get_parser(prog_name)
+        parser = super(StudyOptimize, self).get_parser(prog_name)
         parser.add_argument('--n-trials', type=int,
                             help='The number of trials. If this argument is not given, as many '
                                  'trials run as possible.')
@@ -194,7 +194,7 @@ _COMMANDS = {
     'study set-user-attr': StudySetUserAttribute,
     'studies': Studies,
     'dashboard': Dashboard,
-    'optimize': Optimize,
+    'study optimize': StudyOptimize,
 }
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -227,7 +227,7 @@ def test_dashboard_command(options):
             assert 'bokeh' in html
 
 
-# An example of objective functions for testing optimize command
+# An example of objective functions for testing study optimize command
 def objective_func(trial):
     # type: (Trial) -> float
 
@@ -236,14 +236,14 @@ def objective_func(trial):
 
 
 @pytest.mark.parametrize('options', [['storage'], ['config'], ['storage', 'config']])
-def test_optimize_command(options):
+def test_study_optimize_command(options):
     # type: (List[str]) -> None
 
     with StorageConfigSupplier(TEST_CONFIG_TEMPLATE) as (storage_url, config_path):
         storage = RDBStorage(storage_url)
 
         study_name = storage.get_study_name_from_id(storage.create_new_study_id())
-        command = ['optuna', 'optimize', '--study', study_name, '--n-trials', '10',
+        command = ['optuna', 'study', 'optimize', '--study', study_name, '--n-trials', '10',
                    __file__, 'objective_func']
         command = _add_option(command, '--storage', storage_url, 'storage' in options)
         command = _add_option(command, '--config', config_path, 'config' in options)
@@ -257,16 +257,16 @@ def test_optimize_command(options):
         assert storage.get_study_name_from_id(study.study_id).startswith(DEFAULT_STUDY_NAME_PREFIX)
 
 
-def test_optimize_command_inconsistent_args():
+def test_study_optimize_command_inconsistent_args():
     # type: () -> None
 
     with tempfile.NamedTemporaryFile() as tf:
         db_url = 'sqlite:///{}'.format(tf.name)
 
-        # Missing --study
+        # --study argument is missing.
         with pytest.raises(subprocess.CalledProcessError):
-            subprocess.check_call(['optuna', 'optimize', '--storage', db_url, '--n-trials', '10',
-                                   __file__, 'objective_func'])
+            subprocess.check_call(['optuna', 'study', 'optimize', '--storage', db_url,
+                                   '--n-trials', '10', __file__, 'objective_func'])
 
 
 def test_empty_argv():


### PR DESCRIPTION
This PR renames minimize subcommand of CLI. It depends on PR #184.

Changes:
- minimize is renamed to optimize.
- `--direction` option is added. It works with `--create-study` option and is ignored when `--study` option is specified.
- A test case is added to check `--direction` option.