### PR TITLE
Revise description of study.optimize()

### DIFF
--- a/optuna/study.py
+++ b/optuna/study.py
@@ -155,13 +155,14 @@ class Study(object):
             func:
                 A callable that implements objective function.
             n_trials:
-                The number of trials. If both timeout and n_trials are set to None, the study
-                continues to create trials until it receives a termination signal such as Ctrl+C
-                or SIGTERM.
+                The number of trials. If n_trials is set to None, there is no limitation on the
+                number of trials. If timeout is also set to None, the study continues to create
+                trials until it receives a termination signal such as Ctrl+C or SIGTERM.
             timeout:
-                Stop study after the given number of second(s). If both timeout and n_trials are
-                set to None, the study continues to create trials until it receives a termination
-                signal such as Ctrl+C or SIGTERM.
+                Stop study after the given number of second(s). If timeout is set to None, the
+                study is executed without time limitation. If n_trials is also set to None, the
+                study continues to create trials until it receives a termination signal such as
+                Ctrl+C or SIGTERM.
             n_jobs:
                 The number of parallel jobs. If this argument is set to -1, the number is set to
                 CPU counts.


### PR DESCRIPTION
This PR revises the description for n_trials and timeout arguments of study.optimize(). Note that this PR depends on #187. The revised comments may be too specific (e.g. Ctrl+C or SIGTERM), so any feedback will be welcomed.

Before
```
If this argument is set to None, as many trials run as possible.
```

After
```
If both timeout and n_trials are set to None, the study continues to create trials
until it receives a termination signal such as Ctrl+C or SIGTERM.
```