### PR TITLE
Rename task to direction.

### DIFF
--- a/optuna/cli.py
+++ b/optuna/cli.py
@@ -91,7 +91,7 @@ class StudySetUserAttribute(BaseCommand):
 class Studies(Lister):
 
     _datetime_format = '%Y-%m-%d %H:%M:%S'
-    _study_list_header = ('NAME', 'TASK', 'N_TRIALS', 'DATETIME_START')
+    _study_list_header = ('NAME', 'DIRECTION', 'N_TRIALS', 'DATETIME_START')
 
     def get_parser(self, prog_name):
         # type: (str) -> ArgumentParser

--- a/optuna/storages/base.py
+++ b/optuna/storages/base.py
@@ -31,8 +31,8 @@ class BaseStorage(object):
         raise NotImplementedError
 
     @ abc.abstractmethod
-    def set_study_task(self, study_id, task):
-        # type: (int, structs.StudyTask) -> None
+    def set_study_direction(self, study_id, direction):
+        # type: (int, structs.StudyDirection) -> None
 
         raise NotImplementedError
 
@@ -57,8 +57,8 @@ class BaseStorage(object):
         raise NotImplementedError
 
     @ abc.abstractmethod
-    def get_study_task(self, study_id):
-        # type: (int) -> structs.StudyTask
+    def get_study_direction(self, study_id):
+        # type: (int) -> structs.StudyDirection
 
         raise NotImplementedError
 
@@ -159,7 +159,7 @@ class BaseStorage(object):
         if len(all_trials) == 0:
             raise ValueError('No trials are completed yet.')
 
-        # TODO(sano): Deal with maximize task.
+        # TODO(sano): Deal with maximize direction.
         return min(all_trials, key=lambda t: t.value)
 
     def get_trial_params(self, trial_id):

--- a/optuna/storages/in_memory.py
+++ b/optuna/storages/in_memory.py
@@ -22,7 +22,7 @@ class InMemoryStorage(base.BaseStorage):
         # type: () -> None
         self.trials = []  # type: List[structs.FrozenTrial]
         self.param_distribution = {}  # type: Dict[str, distributions.BaseDistribution]
-        self.task = structs.StudyTask.NOT_SET
+        self.direction = structs.StudyDirection.NOT_SET
         self.study_user_attrs = {}  # type: Dict[str, Any]
         self.study_system_attrs = {}  # type: Dict[str, Any]
         self.study_name = DEFAULT_STUDY_NAME_PREFIX + IN_MEMORY_STORAGE_STUDY_UUID  # type: str
@@ -48,14 +48,15 @@ class InMemoryStorage(base.BaseStorage):
 
         return IN_MEMORY_STORAGE_STUDY_ID  # TODO(akiba)
 
-    def set_study_task(self, study_id, task):
-        # type: (int, structs.StudyTask) -> None
+    def set_study_direction(self, study_id, direction):
+        # type: (int, structs.StudyDirection) -> None
 
         with self._lock:
-            if self.task != structs.StudyTask.NOT_SET and self.task != task:
+            if self.direction != structs.StudyDirection.NOT_SET and self.direction != direction:
                 raise ValueError(
-                    'Cannot overwrite study task from {} to {}.'.format(self.task, task))
-            self.task = task
+                    'Cannot overwrite study direction from {} to {}.'.format(
+                        self.direction, direction))
+            self.direction = direction
 
     def set_study_user_attr(self, study_id, key, value):
         # type: (int, str, Any) -> None
@@ -83,10 +84,10 @@ class InMemoryStorage(base.BaseStorage):
         self._check_study_id(study_id)
         return self.study_name
 
-    def get_study_task(self, study_id):
-        # type: (int) -> structs.StudyTask
+    def get_study_direction(self, study_id):
+        # type: (int) -> structs.StudyDirection
 
-        return self.task
+        return self.direction
 
     def get_study_user_attrs(self, study_id):
         # type: (int) -> Dict[str, Any]
@@ -115,7 +116,7 @@ class InMemoryStorage(base.BaseStorage):
         return [structs.StudySummary(
             study_id=IN_MEMORY_STORAGE_STUDY_ID,
             study_name=self.study_name,
-            direction=self.task,
+            direction=self.direction,
             best_trial=best_trial,
             user_attrs=copy.deepcopy(self.study_user_attrs),
             system_attrs=copy.deepcopy(self.study_system_attrs),

--- a/optuna/storages/rdb/models.py
+++ b/optuna/storages/rdb/models.py
@@ -15,7 +15,7 @@ from typing import List  # NOQA
 from typing import Optional  # NOQA
 
 from optuna import distributions
-from optuna.structs import StudyTask
+from optuna.structs import StudyDirection
 from optuna.structs import TrialState
 
 SCHEMA_VERSION = 10
@@ -29,7 +29,7 @@ class StudyModel(BaseModel):
     __tablename__ = 'studies'
     study_id = Column(Integer, primary_key=True)
     study_name = Column(String(255), unique=True, nullable=False)
-    task = Column(Enum(StudyTask), nullable=False)
+    direction = Column(Enum(StudyDirection), nullable=False)
 
     @classmethod
     def find_by_id(cls, study_id, session):

--- a/optuna/structs.py
+++ b/optuna/structs.py
@@ -19,7 +19,7 @@ class TrialState(enum.Enum):
         return self == TrialState.COMPLETE or self == TrialState.PRUNED
 
 
-class StudyTask(enum.Enum):
+class StudyDirection(enum.Enum):
 
     NOT_SET = 0
     MINIMIZE = 1
@@ -48,7 +48,7 @@ StudySummary = NamedTuple(
     'StudySummary',
     [('study_id', int),
      ('study_name', str),
-     ('direction', StudyTask),
+     ('direction', StudyDirection),
      ('best_trial', Optional[FrozenTrial]),
      ('user_attrs', Dict[str, Any]),
      ('system_attrs', Dict[str, Any]),

--- a/optuna/study.py
+++ b/optuna/study.py
@@ -67,20 +67,19 @@ class Study(object):
         self.logger = logging.get_logger(__name__)
 
         if direction == 'minimize':
-            _direction = structs.StudyTask.MINIMIZE
+            _direction = structs.StudyDirection.MINIMIZE
         elif direction == 'maximize':
-            _direction = structs.StudyTask.MAXIMIZE
+            _direction = structs.StudyDirection.MAXIMIZE
         else:
             raise ValueError('Please set either \'minimize\' or \'maximize\' to direction.')
 
         # TODO(Yanase): Implement maximization.
-        if _direction == structs.StudyTask.MAXIMIZE:
+        if _direction == structs.StudyDirection.MAXIMIZE:
             raise ValueError(
                 'Optimization direction of study {} is set to `MAXIMIZE`. '
                 'Currently, Optuna supports `MINIMIZE` only.'.format(study_name))
 
-        # TODO(Yanase): Change `task` in storages to `direction`.
-        self.storage.set_study_task(self.study_id, _direction)
+        self.storage.set_study_direction(self.study_id, _direction)
 
     def __getstate__(self):
         # type: () -> Dict[Any, Any]
@@ -117,9 +116,9 @@ class Study(object):
 
     @property
     def direction(self):
-        # type: () -> structs.StudyTask
+        # type: () -> structs.StudyDirection
 
-        return self.storage.get_study_task(self.study_id)
+        return self.storage.get_study_direction(self.study_id)
 
     @property
     def trials(self):

--- a/tests/storages_tests/rdb_tests/test_models.py
+++ b/tests/storages_tests/rdb_tests/test_models.py
@@ -11,7 +11,7 @@ from optuna.storages.rdb.models import TrialModel
 from optuna.storages.rdb.models import TrialSystemAttributeModel
 from optuna.storages.rdb.models import TrialUserAttributeModel
 from optuna.storages.rdb.models import VersionInfoModel
-from optuna.structs import StudyTask
+from optuna.structs import StudyDirection
 from optuna.structs import TrialState
 
 
@@ -108,7 +108,7 @@ class TestTrialUserAttributeModel(object):
     def test_where_study(session):
         # type: (Session) -> None
 
-        study = StudyModel(study_id=1, study_name='test-study', task=StudyTask.MINIMIZE)
+        study = StudyModel(study_id=1, study_name='test-study', direction=StudyDirection.MINIMIZE)
         trial = TrialModel(trial_id=1, study_id=study.study_id, state=TrialState.COMPLETE)
 
         session.add(study)
@@ -126,7 +126,7 @@ class TestTrialUserAttributeModel(object):
     def test_where_trial(session):
         # type: (Session) -> None
 
-        study = StudyModel(study_id=1, study_name='test-study', task=StudyTask.MINIMIZE)
+        study = StudyModel(study_id=1, study_name='test-study', direction=StudyDirection.MINIMIZE)
         trial = TrialModel(trial_id=1, study_id=study.study_id, state=TrialState.COMPLETE)
 
         session.add(TrialUserAttributeModel(trial_id=trial.trial_id, key='sample-key',
@@ -142,7 +142,7 @@ class TestTrialUserAttributeModel(object):
     def test_all(session):
         # type: (Session) -> None
 
-        study = StudyModel(study_id=1, study_name='test-study', task=StudyTask.MINIMIZE)
+        study = StudyModel(study_id=1, study_name='test-study', direction=StudyDirection.MINIMIZE)
         trial = TrialModel(trial_id=1, study_id=study.study_id, state=TrialState.COMPLETE)
 
         session.add(TrialUserAttributeModel(trial_id=trial.trial_id, key='sample-key',
@@ -177,7 +177,7 @@ class TestTrialSystemAttributeModel(object):
     def test_where_study(session):
         # type: (Session) -> None
 
-        study = StudyModel(study_id=1, study_name='test-study', task=StudyTask.MINIMIZE)
+        study = StudyModel(study_id=1, study_name='test-study', direction=StudyDirection.MINIMIZE)
         trial = TrialModel(trial_id=1, study_id=study.study_id, state=TrialState.COMPLETE)
 
         session.add(study)
@@ -195,7 +195,7 @@ class TestTrialSystemAttributeModel(object):
     def test_where_trial(session):
         # type: (Session) -> None
 
-        study = StudyModel(study_id=1, study_name='test-study', task=StudyTask.MINIMIZE)
+        study = StudyModel(study_id=1, study_name='test-study', direction=StudyDirection.MINIMIZE)
         trial = TrialModel(trial_id=1, study_id=study.study_id, state=TrialState.COMPLETE)
 
         session.add(TrialSystemAttributeModel(trial_id=trial.trial_id, key='sample-key',
@@ -211,7 +211,7 @@ class TestTrialSystemAttributeModel(object):
     def test_all(session):
         # type: (Session) -> None
 
-        study = StudyModel(study_id=1, study_name='test-study', task=StudyTask.MINIMIZE)
+        study = StudyModel(study_id=1, study_name='test-study', direction=StudyDirection.MINIMIZE)
         trial = TrialModel(trial_id=1, study_id=study.study_id, state=TrialState.COMPLETE)
 
         session.add(TrialSystemAttributeModel(trial_id=trial.trial_id, key='sample-key',

--- a/tests/storages_tests/rdb_tests/test_storage.py
+++ b/tests/storages_tests/rdb_tests/test_storage.py
@@ -14,8 +14,8 @@ from optuna.storages.rdb.models import TrialParamModel
 from optuna.storages.rdb.models import VersionInfoModel
 from optuna.storages import RDBStorage
 from optuna.structs import StorageInternalError
+from optuna.structs import StudyDirection
 from optuna.structs import StudySummary
-from optuna.structs import StudyTask
 from optuna.structs import TrialState
 from optuna import version
 
@@ -109,7 +109,7 @@ def test_get_all_study_summaries_with_multiple_studies():
 
     # Set up a MINIMIZE study.
     study_id_1 = storage.create_new_study_id()
-    storage.set_study_task(study_id_1, StudyTask.MINIMIZE)
+    storage.set_study_direction(study_id_1, StudyDirection.MINIMIZE)
 
     trial_id_1_1 = storage.create_new_trial_id(study_id_1)
     trial_id_1_2 = storage.create_new_trial_id(study_id_1)
@@ -122,7 +122,7 @@ def test_get_all_study_summaries_with_multiple_studies():
 
     # Set up a MAXIMIZE study.
     study_id_2 = storage.create_new_study_id()
-    storage.set_study_task(study_id_2, StudyTask.MAXIMIZE)
+    storage.set_study_direction(study_id_2, StudyDirection.MAXIMIZE)
 
     # TODO(sano): Add more trials after implementing maximize.
     trial_id_2_1 = storage.create_new_trial_id(study_id_2)
@@ -140,7 +140,7 @@ def test_get_all_study_summaries_with_multiple_studies():
     expected_summary_1 = StudySummary(
         study_id=study_id_1,
         study_name=storage.get_study_name_from_id(study_id_1),
-        direction=StudyTask.MINIMIZE,
+        direction=StudyDirection.MINIMIZE,
         user_attrs={},
         system_attrs={},
         best_trial=summaries[0].best_trial,  # This always passes.
@@ -150,7 +150,7 @@ def test_get_all_study_summaries_with_multiple_studies():
     expected_summary_2 = StudySummary(
         study_id=study_id_2,
         study_name=storage.get_study_name_from_id(study_id_2),
-        direction=StudyTask.MAXIMIZE,
+        direction=StudyDirection.MAXIMIZE,
         user_attrs={},
         system_attrs={},
         best_trial=summaries[1].best_trial,  # This always passes.
@@ -160,7 +160,7 @@ def test_get_all_study_summaries_with_multiple_studies():
     expected_summary_3 = StudySummary(
         study_id=study_id_3,
         study_name=storage.get_study_name_from_id(study_id_3),
-        direction=StudyTask.NOT_SET,
+        direction=StudyDirection.NOT_SET,
         user_attrs={},
         system_attrs={},
         best_trial=None,

--- a/tests/storages_tests/test_storages.py
+++ b/tests/storages_tests/test_storages.py
@@ -16,7 +16,7 @@ from optuna.storages import BaseStorage  # NOQA
 from optuna.storages import InMemoryStorage
 from optuna.storages import RDBStorage
 from optuna.structs import FrozenTrial
-from optuna.structs import StudyTask
+from optuna.structs import StudyDirection
 from optuna.structs import TrialState
 from optuna.testing.storage import StorageSupplier
 
@@ -134,26 +134,26 @@ def test_get_study_id_from_name_and_get_study_name_from_id(storage_mode):
 
 
 @parametrize_storage
-def test_set_and_get_study_task(storage_init_func):
+def test_set_and_get_study_direction(storage_init_func):
     # type: (Callable[[], BaseStorage]) -> None
 
     storage = storage_init_func()
     study_id = storage.create_new_study_id()
 
-    def check_set_and_get(task):
-        # type: (StudyTask) -> None
+    def check_set_and_get(direction):
+        # type: (StudyDirection) -> None
 
-        storage.set_study_task(study_id, task)
-        assert storage.get_study_task(study_id) == task
+        storage.set_study_direction(study_id, direction)
+        assert storage.get_study_direction(study_id) == direction
 
-    assert storage.get_study_task(study_id) == StudyTask.NOT_SET
+    assert storage.get_study_direction(study_id) == StudyDirection.NOT_SET
 
     # Test setting value.
-    check_set_and_get(StudyTask.MINIMIZE)
+    check_set_and_get(StudyDirection.MINIMIZE)
 
     # Test overwriting value.
     with pytest.raises(ValueError):
-        storage.set_study_task(study_id, StudyTask.MAXIMIZE)
+        storage.set_study_direction(study_id, StudyDirection.MAXIMIZE)
 
 
 @parametrize_storage
@@ -411,7 +411,7 @@ def test_get_all_study_summaries(storage_init_func):
     storage = storage_init_func()
     study_id = storage.create_new_study_id()
 
-    storage.set_study_task(study_id, StudyTask.MINIMIZE)
+    storage.set_study_direction(study_id, StudyDirection.MINIMIZE)
 
     datetime_1 = datetime.now()
 
@@ -433,7 +433,7 @@ def test_get_all_study_summaries(storage_init_func):
     assert len(summaries) == 1
     assert summaries[0].study_id == study_id
     assert summaries[0].study_name == storage.get_study_name_from_id(study_id)
-    assert summaries[0].direction == StudyTask.MINIMIZE
+    assert summaries[0].direction == StudyDirection.MINIMIZE
     assert summaries[0].user_attrs == EXAMPLE_ATTRS
     assert summaries[0].n_trials == 2
     assert summaries[0].datetime_start is not None

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -125,7 +125,7 @@ def test_create_study_command_with_direction():
         command = ['optuna', 'create-study', '--storage', storage_url, '--direction', 'minimize']
         study_name = str(subprocess.check_output(command).decode().strip())
         study_id = storage.get_study_id_from_name(study_name)
-        assert storage.get_study_task(study_id) == optuna.structs.StudyTask.MINIMIZE
+        assert storage.get_study_direction(study_id) == optuna.structs.StudyDirection.MINIMIZE
 
         command = ['optuna', 'create-study', '--storage', storage_url, '--direction', 'maximize']
 

--- a/tests/test_study.py
+++ b/tests/test_study.py
@@ -138,14 +138,14 @@ def test_optimize_with_direction():
 
     study = optuna.create_study(direction='minimize')
     study.optimize(func, n_trials=10)
-    assert study.direction == optuna.structs.StudyTask.MINIMIZE
+    assert study.direction == optuna.structs.StudyDirection.MINIMIZE
     check_study(study)
 
     # Currently, maximization is not implemented.
     with pytest.raises(ValueError):
         study = optuna.create_study(direction='maximize')
         study.optimize(func, n_trials=10)
-        assert study.direction == optuna.structs.StudyTask.MAXIMIZE
+        assert study.direction == optuna.structs.StudyDirection.MAXIMIZE
         check_study(study)
 
     with pytest.raises(ValueError):


### PR DESCRIPTION
This PR renames `task` to `storage` regarding `StudyModel.task` and `StudyTask`.