### PR TITLE
Fix a typo.

### DIFF
--- a/docs/source/tutorial/attributes.rst
+++ b/docs/source/tutorial/attributes.rst
@@ -36,7 +36,7 @@ We can access annotated attributes with :attr:`~optuna.study.Study.user_attr` pr
     study_summaries[0].user_attrs  # {'contributors': ['Akiba', 'Sano'], 'dataset': 'MNIST'}
 
 .. seealso::
-    ``optuna study set-user-attr`` command, which set an attribute via command line interface.
+    ``optuna study set-user-attr`` command, which sets an attribute via command line interface.
 
 
 Adding User Attributes to Trials


### PR DESCRIPTION
This PR fixes a typo in the User Attributes page of the tutorial.