### PR TITLE
Add CircleCI jobs for Python 3.7.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,7 @@ workflows:
     jobs:
       - checks
       - document
+      - tests-python37
       - tests-python36
       - tests-python35
       - tests-python34
@@ -21,10 +22,12 @@ workflows:
     jobs:
       - checks
       - document
+      - tests-python37
       - tests-python36
       - tests-python35
       - tests-python34
       - tests-python27
+      - examples-python37
       - examples-python36
       - examples-python35
       - examples-python34
@@ -36,7 +39,7 @@ jobs:
 
   checks:
     docker:
-      - image: circleci/python:3.6
+      - image: circleci/python:3.7
     steps:
       - checkout
 
@@ -83,9 +86,9 @@ jobs:
 
   # Unit tests
 
-  tests-python36:
+  tests-python37:
     docker:
-      - image: circleci/python:3.6
+      - image: circleci/python:3.7
     steps:
       - checkout
 
@@ -115,6 +118,12 @@ jobs:
           environment:
             OMP_NUM_THREADS: 1
 
+  tests-python36:
+    docker:
+      - image: circleci/python:3.6
+    steps:
+      [checkout, run: *install, run: *tests, run: *tests-mn]
+
   tests-python35:
     docker:
       - image: circleci/python:3.5
@@ -135,9 +144,9 @@ jobs:
 
   # Examples
 
-  examples-python36:
+  examples-python37:
     docker:
-      - image: circleci/python:3.6
+      - image: circleci/python:3.7
     steps:
       - checkout
 
@@ -169,6 +178,12 @@ jobs:
             mpirun -n 2 -- python examples/chainermn_mnist.py $STUDY_NAME $STORAGE_URL
           environment:
             OMP_NUM_THREADS: 1
+
+  examples-python36:
+    docker:
+      - image: circleci/python:3.6
+    steps:
+      [checkout, run: *install, run: *install-examples, run: *examples, run: *examples-mn]
 
   examples-python35:
     docker:


### PR DESCRIPTION
This PR adds add CircleCI jobs to test Optuna on Python.

Changes:
- Add `tests-python37` to execute unit tests.
- Add `examples-python37` to run all examples.
- Update the image of `checks` job from 3.6 to 3.7.
