### PR TITLE
WIP: Enhancement proposal of SuccessiveHalvingPruner

### DIFF
--- a/examples/pruning/caching_model.py
+++ b/examples/pruning/caching_model.py
@@ -53,6 +53,7 @@ def objective(trial):
         if trial.should_suspend():
             serialized = pickle.dumps(clf)
             trial.save_model(step, serialized)
+            raise optuna.structs.TrialSuspended()
 
     return 1.0 - clf.score(test_x, test_y)
 

--- a/examples/pruning/caching_model.py
+++ b/examples/pruning/caching_model.py
@@ -46,10 +46,11 @@ def objective(trial):
         trial.report(intermediate_value, step)
 
         # Handle pruning based on the intermediate value.
+        # TODO(c-bata): remove step argument after rebased on #398.
         if trial.should_prune(step):
             raise optuna.structs.TrialPruned()
 
-        if trial.should_suspend(step):
+        if trial.should_suspend():
             serialized = pickle.dumps(clf)
             trial.save_model(step, serialized)
 

--- a/examples/pruning/caching_model.py
+++ b/examples/pruning/caching_model.py
@@ -1,0 +1,78 @@
+"""
+Optuna example that demonstrates a pruner.
+
+In this example, we optimize a classifier configuration using scikit-learn. Note that, to enable
+the pruning feature, the following 2 methods are invoked after each step of the iterative training.
+
+(1) :func:`optuna.trial.Trial.report`
+(2) :func:`optuna.trial.Trial.should_prune`
+
+You can run this example as follows:
+    $ python simple.py
+
+"""
+import pickle
+
+import sklearn.datasets
+import sklearn.linear_model
+import sklearn.model_selection
+
+import optuna
+
+
+# FYI: Objective functions can take additional arguments
+# (https://optuna.readthedocs.io/en/stable/faq.html#objective-func-additional-args).
+def objective(trial):
+    serialized_model, previous_step = trial.get_saved_model()
+    if serialized_model:
+        clf = pickle.loads(serialized_model)
+    else:
+        alpha = trial.suggest_loguniform('alpha', 1e-5, 1e-1)
+        clf = sklearn.linear_model.SGDClassifier(alpha=alpha)
+
+    iris = sklearn.datasets.load_iris()
+    classes = list(set(iris.target))
+    train_x, test_x, train_y, test_y = \
+        sklearn.model_selection.train_test_split(iris.data, iris.target, test_size=0.25)
+
+    for step in range(100):
+        if previous_step > step:
+            continue
+
+        clf.partial_fit(train_x, train_y, classes=classes)
+
+        # Report intermediate objective value.
+        intermediate_value = 1.0 - clf.score(test_x, test_y)
+        trial.report(intermediate_value, step)
+
+        # Handle pruning based on the intermediate value.
+        if trial.should_prune(step):
+            raise optuna.structs.TrialPruned()
+
+        if trial.should_suspend(step):
+            serialized = pickle.dumps(clf)
+            trial.save_model(step, serialized)
+
+    return 1.0 - clf.score(test_x, test_y)
+
+
+if __name__ == '__main__':
+    study = optuna.create_study()
+    study.optimize(objective, n_trials=100)
+
+    pruned_trials = [t for t in study.trials if t.state == optuna.structs.TrialState.PRUNED]
+    complete_trials = [t for t in study.trials if t.state == optuna.structs.TrialState.COMPLETE]
+
+    print('Study statistics: ')
+    print('  Number of finished trials: ', len(study.trials))
+    print('  Number of pruned trials: ', len(pruned_trials))
+    print('  Number of complete trials: ', len(complete_trials))
+
+    print('Best trial:')
+    trial = study.best_trial
+
+    print('  Value: ', trial.value)
+
+    print('  Params: ')
+    for key, value in trial.params.items():
+        print('    {}: {}'.format(key, value))

--- a/optuna/pruners/base.py
+++ b/optuna/pruners/base.py
@@ -32,3 +32,28 @@ class BasePruner(object):
         """
 
         raise NotImplementedError
+
+    @abc.abstractmethod
+    def suspend(self, storage, study_id, trial_id, step):
+        # type: (BaseStorage, int, int, int) -> bool
+        """Judge whether the trial should be pruned.
+
+        Note that this method is not supposed to be called by library users. Instead,
+        :func:`opotuna.trial.Trial.should_suspend` provide user interfaces to suspend
+        trials.
+
+        Args:
+            storage:
+                Storage object.
+            study_id:
+                Identifier of the target study.
+            trial_id:
+                Identifier of the target trial.
+            step:
+                Step number.
+
+        Returns:
+            A boolean value representing whether the trial should be suspended.
+        """
+
+        raise NotImplementedError

--- a/optuna/pruners/median.py
+++ b/optuna/pruners/median.py
@@ -69,3 +69,8 @@ class MedianPruner(BasePruner):
         if storage.get_study_direction(study_id) == StudyDirection.MAXIMIZE:
             return best_intermediate_result < median
         return best_intermediate_result > median
+
+    def suspend(self, storage, study_id, trial_id, step):
+        # type: (BaseStorage, int, int, int) -> bool
+        """Please consult the documentation for :func:`BasePruner.suspend`."""
+        return False

--- a/optuna/storages/base.py
+++ b/optuna/storages/base.py
@@ -105,6 +105,12 @@ class BaseStorage(object):
         raise NotImplementedError
 
     @abc.abstractmethod
+    def resume_promotable_trial(self, study_id):
+        # type: (int) -> Optional[structs.FrozenTrial]
+
+        raise NotImplementedError
+
+    @abc.abstractmethod
     def set_trial_state(self, trial_id, state):
         # type: (int, structs.TrialState) -> None
 

--- a/optuna/storages/in_memory.py
+++ b/optuna/storages/in_memory.py
@@ -157,6 +157,23 @@ class InMemoryStorage(base.BaseStorage):
                     trial_id=trial_id))
         return trial_id
 
+    def resume_promotable_trial(self, study_id):
+        # type: (int) -> Optional[structs.FrozenTrial]
+
+        self._check_study_id(study_id)
+
+        with self._lock:
+            for trial in self.trials:
+                if trial.state != structs.TrialState.PROMOTABLE:
+                    continue
+
+                trial_id = trial.trial_id
+                self.trials[trial_id] = self.trials[trial_id]._replace(
+                    state=structs.TrialState.RUNNING,
+                )
+                return self.trials[trial_id]
+        return None
+
     def set_trial_state(self, trial_id, state):
         # type: (int, structs.TrialState) -> None
 

--- a/optuna/storages/rdb/models.py
+++ b/optuna/storages/rdb/models.py
@@ -174,6 +174,21 @@ class TrialModel(BaseModel):
         return trials
 
     @classmethod
+    def resume_one(cls, study_id, session):
+        # type: (int, orm.Session) -> Optional[TrialModel]
+
+        trial = session.query(cls) \
+            .filter(cls.study_id == study_id) \
+            .filter(cls.state == TrialState.PROMOTABLE) \
+            .limit(1).one_or_none()
+
+        if trial is None:
+            return None
+
+        trial.state = TrialState.RUNNING
+        return trial
+
+    @classmethod
     def count(cls, session, study=None, state=None):
         # type: (orm.Session, Optional[StudyModel], Optional[TrialState]) -> int
 

--- a/optuna/storages/rdb/storage.py
+++ b/optuna/storages/rdb/storage.py
@@ -326,6 +326,30 @@ class RDBStorage(BaseStorage):
 
         return trial_number
 
+    def resume_promotable_trial(self, study_id):
+        # type: (int) -> Optional[structs.FrozenTrial]
+
+        session = self.scoped_session()
+
+        trial = models.TrialModel.resume_one(study_id, session)
+        if trial is None:
+            return None
+
+        # TODO(c-bata): Convert all attributes
+        return structs.FrozenTrial(
+                    number=trial.trial_id,
+                    state=trial.state,
+                    params=trial.params,
+                    distributions={},
+                    user_attrs={},
+                    system_attrs={},
+                    value=trial.value,
+                    intermediate_values={},
+                    params_in_internal_repr={},
+                    datetime_start=trial.datetime_start,
+                    datetime_complete=trial.datetime_complete,
+                    trial_id=trial.trial_id)
+
     def set_trial_state(self, trial_id, state):
         # type: (int, structs.TrialState) -> None
 

--- a/optuna/structs.py
+++ b/optuna/structs.py
@@ -171,6 +171,28 @@ class TrialPruned(OptunaError):
     pass
 
 
+class TrialSuspended(OptunaError):
+    """Exception for suspended trials.
+
+    This error tells a trainer that the current :class:`~optuna.trial.Trial` was suspended. It is
+    supposed to be raised after :func:`optuna.trial.Trial.should_suspend` as shown in the following
+    example.
+
+    Example:
+
+        .. code::
+
+            >>> def objective(trial):
+            >>>     ...
+            >>>     for step in range(n_train_iter):
+            >>>         ...
+            >>>         if trial.should_suspend():
+            >>>             raise TrialSuspended()
+    """
+
+    pass
+
+
 class CLIUsageError(OptunaError):
     """Exception for CLI.
 

--- a/optuna/structs.py
+++ b/optuna/structs.py
@@ -20,12 +20,15 @@ class TrialState(enum.Enum):
             The :class:`~optuna.trial.Trial` has been pruned with :class:`TrialPruned`.
         FAIL:
             The :class:`~optuna.trial.Trial` has failed due to an uncaught error.
+        SUSPEND:
+            The :class:`~optuna.trial.Trial` has been suspended. It may be resume.
     """
 
     RUNNING = 0
     COMPLETE = 1
     PRUNED = 2
     FAIL = 3
+    SUSPEND = 4
 
     def is_finished(self):
         # type: () -> bool

--- a/optuna/structs.py
+++ b/optuna/structs.py
@@ -21,7 +21,10 @@ class TrialState(enum.Enum):
         FAIL:
             The :class:`~optuna.trial.Trial` has failed due to an uncaught error.
         SUSPEND:
-            The :class:`~optuna.trial.Trial` has been suspended. It may be resume.
+            The :class:`~optuna.trial.Trial` has been suspended.
+            It will turn promotable or pruned.
+        PROMOTABLE:
+            The :class:`~optuna.trial.Trial` has been promotable. It may be resume.
     """
 
     RUNNING = 0
@@ -29,6 +32,7 @@ class TrialState(enum.Enum):
     PRUNED = 2
     FAIL = 3
     SUSPEND = 4
+    PROMOTABLE = 5
 
     def is_finished(self):
         # type: () -> bool

--- a/optuna/study.py
+++ b/optuna/study.py
@@ -391,7 +391,11 @@ class Study(object):
     def _run_trial(self, func, catch):
         # type: (ObjectiveFuncType, Union[Tuple[()], Tuple[Type[Exception]]]) -> trial_module.Trial
 
-        trial_id = self.storage.create_new_trial_id(self.study_id)
+        resumed_trial = self.storage.resume_promotable_trial(self.study_id)
+        if resumed_trial is None:
+            trial_id = self.storage.create_new_trial_id(self.study_id)
+        else:
+            trial_id = resumed_trial.trial_id
         trial = trial_module.Trial(self, trial_id)
         trial_number = trial.number
 

--- a/optuna/study.py
+++ b/optuna/study.py
@@ -408,6 +408,13 @@ class Study(object):
             self.logger.info(message)
             self.storage.set_trial_state(trial_id, structs.TrialState.PRUNED)
             return trial
+        except structs.TrialSuspended as e:
+            message = 'Setting status of trial#{} as {}. {}'.format(trial_number,
+                                                                    structs.TrialState.SUSPEND,
+                                                                    str(e))
+            self.logger.info(message)
+            self.storage.set_trial_state(trial_id, structs.TrialState.SUSPEND)
+            return trial
         except catch as e:
             message = 'Setting status of trial#{} as {} because of the following error: {}'\
                 .format(trial_number, structs.TrialState.FAIL, repr(e))

--- a/optuna/trial.py
+++ b/optuna/trial.py
@@ -383,6 +383,17 @@ class Trial(BaseTrial):
 
         return self.study.pruner.prune(self.storage, self.study_id, self._trial_id, step)
 
+    def should_suspend(self):
+        # type: () -> bool
+        """Judge whether the trial should be pruned.
+
+        This method calls suspend method of the pruner, which judges whether the trial
+        should be suspended at the given step. Please refer to the example code of
+        :func:`optuna.trial.Trial.report`.
+        """
+        step = max(self.storage.get_trial(self._trial_id).intermediate_values.keys())
+        return self.study.pruner.suspend(self.storage, self.study_id, self._trial_id, step)
+
     def set_user_attr(self, key, value):
         # type: (str, Any) -> None
         """Set user attributes to the trial.

--- a/tests/storages_tests/rdb_tests/test_models.py
+++ b/tests/storages_tests/rdb_tests/test_models.py
@@ -110,6 +110,25 @@ class TestTrialModel(object):
         session.commit()
         assert 0 == trial_2_1.count_past_trials(session)
 
+    @staticmethod
+    def test_resume_one(session):
+        # type: (Session) -> None
+
+        study_id = 1
+        trial_1 = TrialModel(study_id=study_id, state=TrialState.COMPLETE)
+        session.add(trial_1)
+        session.commit()
+
+        # Returns None when there is no suspended trials.
+        assert TrialModel.resume_one(study_id, session) is None
+
+        trial_2 = TrialModel(study_id=study_id, state=TrialState.PROMOTABLE)
+        session.add(trial_2)
+        session.commit()
+
+        resumed = TrialModel.resume_one(study_id, session)
+        assert resumed.state == TrialState.RUNNING
+
 
 class TestTrialUserAttributeModel(object):
     @staticmethod


### PR DESCRIPTION
## Preface

SuccessiveHalvingPruner take different behaviors depending on the order of trial's performances.  In #388, it pruned a trial which is 2nd-best score (and 23/25 trials are pruned at rung 0). On the other hand, as [this benchmark](https://gist.github.com/sile/d4befbe5a3b1ec9711cb5dcd5dbc4538) shows the average of required budgets are relatively expensive. These results shows current implementation is completely different algorithm from the original paper.

The reason why SuccessiveHalvingPruner behaves like this is that it's difficult to provide user-friendly api to saving/restoring trained models of each trials at the increases of the rung. So optuna couldn't implement exactly the same behavior with the original paper.

## Proposal

My proposal is simple, when the rung increases, it suspends the running trial without saving trained models, then start training the model over from the beginning.

This proposal looks inefficient because of the waste of training. But it's better not only this proposal is robust against the performance order of each trials but also it's better in the viewpoint of calculation costs.

### Does my proposal makes the total required budgets bigger?

No. The step count of my proposal is fewer than current SuccessiveHalvingPruner.

| reduction_factor | SHA steps | ASHA steps (SD) | Optuna steps (SD) | Proposal method(SD) |
|------------------:|------------:|--------------:|----------------:|------------:|
| 2                        | 376           |  564 (74)       | 1363 (603)        | 1099 (171) |
| 3                        |  340          | 445 (65)        | 818 (275)        |  654 (129) |
| 4                        |  295          | 389 (66)        | 763 (243)        | 496 (104)  |

The benchmark is [here](https://gist.github.com/c-bata/b3ec610b896533729846059bb42459f1), which is based on [@sile's benchmark](https://gist.github.com/sile/d4befbe5a3b1ec9711cb5dcd5dbc4538).

The required budgets on each rung is exponentially increased with increases of the rung. Optuna always consumes 100 steps to evaluate first trial in the benchmark. This budget equals how much we need to execute rung 0 on all trials. We need to estimate the cost of proceeding the rung to the end more expensive. This is the reason why step count of my proposal is fewer than the ones of the current implementation.

The another advantage of this method is low standard deviation. This means we can easily expect the execution time of optimization.

###  Can we provide APIs to save/restore trained models?

Probably yes. There are several approaches, But I have no definitive solutions. It seems we need to discuss more. Now I think following interface might be good in the viewpoint of usability.

<img width="1680" src="https://user-images.githubusercontent.com/5564044/58378875-45114780-7fd6-11e9-9c04-3045cfab0f8e.png">

The most important thing is we can use SuccessiveHalvingPruner even if we don't use these apis. I think it should be optional.


### Is it Asynchronous Successive Halving Algorithm?

Yes. The original paper of 'Massively Parallel Hyperparameter Optimization' doesn't mention whether we should suspend/resume trials. The GIF animation in the blog post of Liam Li (1st author of the ASHA's paper) behaves the same with my proposal.

> ![asha](https://lh6.googleusercontent.com/ncYQXlFoVzhEsun2I-0LfTySEySc-uwEAd2vdPXGHvwprwXApuHuU4o17uJ1ITgHw9_sxId0995xOdfs-r7K3lWB4QQ7v9s33GnBs-EZ7cECIqj9Cq_eDQapJSAEG6P6A0oLZxm6)
> 
> https://blog.ml.cmu.edu/2018/12/12/massively-parallel-hyperparameter-optimization/


## Discussion

I think there are no disadvantages very much in this proposal, but it seems we need to discuss the design of each components to keep clean (ex:  pruner's interface). This PR is still WIP. I want your feedbacks on this proposal before the implementation is ready for review.

Another things I want to consider.

* How we provide the apis to suspend training. Should we provide `should_suspend` method and `TrialSuspended` ?
* It might be better to define Interface for storage backend for serialized models. We may not want to use RDB because the parameters of modern machine learning models (like deep neural-network) tends to be bigger.
* It might be better to benchmark this method by more realistic problems.


## Implementation status

This PR depends #464, ~~#424~~ , #493 and #520.