### PR TITLE
[WIP] Adding number attribute to FixedTrial class

### DIFF
--- a/optuna/trial.py
+++ b/optuna/trial.py
@@ -120,11 +120,13 @@ class Trial(BaseTrial):
             self,
             study,  # type: Study
             trial_id,  # type: int
+            number,    # type: int
     ):
         # type: (...) -> None
 
         self.study = study
         self._trial_id = trial_id
+        self.number = number
 
         self.study_id = self.study.study_id
         self.storage = self.study.storage


### PR DESCRIPTION
Suggestion from @caprest
> When saving machine learning models, Trial.number are suggested to be used to identify the trial.
However, FixedTrial don't have number/trial_id feature which prevents testing of objective.
Thus adding mock function of number might be helpful for testing.

Changes
- [ ] add number method (property) to classes
    - [ ] `BaseTrial`
    - [ ] `FixedTrial`
- [ ] remove `trial_id` property from `Trial` class in the future as direct access to the ID by users has been deprecated

References issue #426