### PR TITLE
Use Joblib to parallelize optimization

### DIFF
--- a/optuna/samplers/random.py
+++ b/optuna/samplers/random.py
@@ -33,16 +33,19 @@ class RandomSampler(BaseSampler):
 
     def __init__(self, seed=None):
         # type: (Optional[int]) -> None
+
         self._rng = numpy.random.RandomState(seed)
 
     def __getstate__(self):
         # type: () -> Dict[Any, Any]
+
         state = self.__dict__.copy()
         del state['_rng']
         return state
 
     def __setstate__(self, state):
         # type: (Dict[Any, Any]) -> None
+
         self.__dict__.update(state)
         self._rng = numpy.random.RandomState(None)
 

--- a/optuna/samplers/random.py
+++ b/optuna/samplers/random.py
@@ -33,8 +33,19 @@ class RandomSampler(BaseSampler):
 
     def __init__(self, seed=None):
         # type: (Optional[int]) -> None
+        self._seed = seed
+        self._rng = numpy.random.RandomState(self._seed)
 
-        self._rng = numpy.random.RandomState(seed)
+    def __getstate__(self):
+        # type: () -> Dict[Any, Any]
+        state = self.__dict__.copy()
+        del state['_rng']
+        return state
+
+    def __setstate__(self, state):
+        # type: (Dict[Any, Any]) -> None
+        self.__dict__.update(state)
+        self._rng = numpy.random.RandomState(self._seed)
 
     def infer_relative_search_space(self, study, trial):
         # type: (Study, FrozenTrial) -> Dict[str, BaseDistribution]

--- a/optuna/samplers/random.py
+++ b/optuna/samplers/random.py
@@ -33,19 +33,21 @@ class RandomSampler(BaseSampler):
 
     def __init__(self, seed=None):
         # type: (Optional[int]) -> None
-        self._seed = seed
-        self._rng = numpy.random.RandomState(self._seed)
+        self._rng = numpy.random.RandomState(seed)
 
     def __getstate__(self):
         # type: () -> Dict[Any, Any]
         state = self.__dict__.copy()
+        uii32 = numpy.iinfo(numpy.uint32)
+        state['seed'] = self._rng.randint(uii32.max)
         del state['_rng']
         return state
 
     def __setstate__(self, state):
         # type: (Dict[Any, Any]) -> None
+        seed = state.pop("seed")
         self.__dict__.update(state)
-        self._rng = numpy.random.RandomState(self._seed)
+        self._rng = numpy.random.RandomState(seed)
 
     def infer_relative_search_space(self, study, trial):
         # type: (Study, FrozenTrial) -> Dict[str, BaseDistribution]

--- a/optuna/samplers/random.py
+++ b/optuna/samplers/random.py
@@ -38,16 +38,13 @@ class RandomSampler(BaseSampler):
     def __getstate__(self):
         # type: () -> Dict[Any, Any]
         state = self.__dict__.copy()
-        uii32 = numpy.iinfo(numpy.uint32)
-        state['seed'] = self._rng.randint(uii32.max)
         del state['_rng']
         return state
 
     def __setstate__(self, state):
         # type: (Dict[Any, Any]) -> None
-        seed = state.pop("seed")
         self.__dict__.update(state)
-        self._rng = numpy.random.RandomState(seed)
+        self._rng = numpy.random.RandomState(None)
 
     def infer_relative_search_space(self, study, trial):
         # type: (Study, FrozenTrial) -> Dict[str, BaseDistribution]

--- a/optuna/storages/rdb/storage.py
+++ b/optuna/storages/rdb/storage.py
@@ -108,6 +108,7 @@ class RDBStorage(BaseStorage):
 
     def __getstate__(self):
         # type: () -> Dict[Any, Any]
+
         state = self.__dict__.copy()
         del state['scoped_session']
         del state['engine']

--- a/optuna/storages/rdb/storage.py
+++ b/optuna/storages/rdb/storage.py
@@ -83,12 +83,13 @@ class RDBStorage(BaseStorage):
 
         self._check_python_version()
 
-        engine_kwargs = engine_kwargs or {}
-
-        url = self._fill_storage_url_template(url)
+        self.engine_kwargs = engine_kwargs or {}
+        self.url = self._fill_storage_url_template(url)
+        self.enable_cache = enable_cache
+        self.skip_compatibility_check = skip_compatibility_check
 
         try:
-            self.engine = create_engine(url, **engine_kwargs)
+            self.engine = create_engine(self.url, **self.engine_kwargs)
         except ImportError as e:
             raise ImportError('Failed to import DB access module for the specified storage URL. '
                               'Please install appropriate one. (The actual import error is: ' +
@@ -99,11 +100,39 @@ class RDBStorage(BaseStorage):
 
         self.logger = optuna.logging.get_logger(__name__)
 
-        self._version_manager = _VersionManager(url, self.engine, self.scoped_session)
+        self._version_manager = _VersionManager(self.url, self.engine, self.scoped_session)
         if not skip_compatibility_check:
             self._version_manager.check_table_schema_compatibility()
 
         self._finished_trials_cache = _FinishedTrialsCache(enable_cache)
+
+    def __getstate__(self):
+        # type: () -> Dict[Any, Any]
+        state = self.__dict__.copy()
+        del state['scoped_session']
+        del state['engine']
+        del state['logger']
+        del state['_version_manager']
+        del state['_finished_trials_cache']
+        return state
+
+    def __setstate__(self, state):
+        # type: (Dict[Any, Any]) -> None
+        self.__dict__.update(state)
+        try:
+            self.engine = create_engine(self.url, **self.engine_kwargs)
+        except ImportError as e:
+            raise ImportError('Failed to import DB access module for the specified storage URL. '
+                              'Please install appropriate one. (The actual import error is: ' +
+                              str(e) + '.)')
+
+        self.scoped_session = orm.scoped_session(orm.sessionmaker(bind=self.engine))
+        models.BaseModel.metadata.create_all(self.engine)
+        self.logger = optuna.logging.get_logger(__name__)
+        self._version_manager = _VersionManager(self.url, self.engine, self.scoped_session)
+        if not self.skip_compatibility_check:
+            self._version_manager.check_table_schema_compatibility()
+        self._finished_trials_cache = _FinishedTrialsCache(self.enable_cache)
 
     @staticmethod
     def _check_python_version():
@@ -115,7 +144,7 @@ class RDBStorage(BaseStorage):
         if sys.version_info.minor != 4:
             return
 
-        if 0 <= sys.version_info.micro and sys.version_info.micro < 4:
+        if 0 <= sys.version_info.micro < 4:
             raise RuntimeError('RDBStorage does not support Python 3.4.0 to 3.4.3.')
 
     def create_new_study(self, study_name=None):

--- a/optuna/study.py
+++ b/optuna/study.py
@@ -280,8 +280,17 @@ class Study(BaseStudy):
                                           gc_after_trial, None)
             else:
                 time_start = datetime.datetime.now()
+                
+                if n_trials is not None:
+                    _iter = range(n_trials)
+                elif timeout is not None:
+                    is_timeout = lambda: (datetime.datetime.now() - time_start).total_seconds() > timeout
+                    _iter = iter(is_timeout, True)
+                else:
+                    # The following expression makes an iterator that never ends.
+                    _iter = iter(int, 1)
+
                 with Parallel(n_jobs=n_jobs, prefer="threads") as parallel:
-                    _iter = range(n_trials) if n_trials is not None else iter(int, 0)
                     parallel(
                         delayed(self._optimize_sequential)
                         (func, 1, timeout, catch, callbacks, gc_after_trial, time_start)

--- a/optuna/study.py
+++ b/optuna/study.py
@@ -15,8 +15,8 @@ import threading
 import warnings
 
 from joblib import delayed
-from joblib import Parallel
 from joblib import effective_n_jobs
+from joblib import Parallel
 
 from optuna import exceptions
 from optuna import logging

--- a/optuna/study.py
+++ b/optuna/study.py
@@ -15,7 +15,6 @@ import threading
 import warnings
 
 from joblib import delayed
-from joblib import effective_n_jobs
 from joblib import Parallel
 
 from optuna import exceptions

--- a/optuna/study.py
+++ b/optuna/study.py
@@ -280,12 +280,14 @@ class Study(BaseStudy):
                                           gc_after_trial, None)
             else:
                 time_start = datetime.datetime.now()
-                
+
                 if n_trials is not None:
-                    _iter = range(n_trials)
+                    _iter = iter(range(n_trials))
                 elif timeout is not None:
-                    is_timeout = lambda: (datetime.datetime.now() - time_start).total_seconds() > timeout
-                    _iter = iter(is_timeout, True)
+                    # This is needed for mypy
+                    actual_timeout = timeout  # type: float
+                    _iter = iter(lambda: (datetime.datetime.now() -
+                                          time_start).total_seconds() > actual_timeout, True)
                 else:
                     # The following expression makes an iterator that never ends.
                     _iter = iter(int, 1)

--- a/optuna/study.py
+++ b/optuna/study.py
@@ -231,7 +231,7 @@ class Study(BaseStudy):
             func,  # type: ObjectiveFuncType
             n_trials=None,  # type: Optional[int]
             timeout=None,  # type: Optional[float]
-            n_jobs=1,  # type: Optional[int]
+            n_jobs=1,  # type: int
             catch=(),  # type: Union[Tuple[()], Tuple[Type[Exception]]]
             callbacks=None,  # type: Optional[List[Callable[[Study, structs.FrozenTrial], None]]]
             gc_after_trial=True  # type: bool
@@ -254,8 +254,7 @@ class Study(BaseStudy):
                 termination signal such as Ctrl+C or SIGTERM.
             n_jobs:
                 The number of parallel jobs. If this argument is set to :obj:`-1`, the number is
-                set to CPU counts. If instead it is set to :obj:`None`, then the behaviour will
-                depend on the parallel backend.
+                set to CPU count.
             catch:
                 A study continues to run even when a trial raises one of the exceptions specified
                 in this argument. Default is an empty tuple, i.e. the study will stop for any

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ def get_install_requires():
         'sqlalchemy>=1.1.0',
         'tqdm',
         'typing',
+        'joblib',
     ]
 
 

--- a/tests/samplers_tests/test_samplers.py
+++ b/tests/samplers_tests/test_samplers.py
@@ -42,13 +42,6 @@ def test_pickle_random_sampler(seed):
     restored_sampler = pickle.loads(pickle.dumps(sampler))
     assert sampler._rng != restored_sampler._rng
     assert sampler._rng.bytes(10) != restored_sampler._rng.bytes(10)
-    if seed:
-        # We have to create a new random number generator
-        # because the one from `sampler` was already used
-        rng = np.random.RandomState(seed)
-        next_rng = np.random.RandomState(rng.randint(2**32-1))
-        next_rng.bytes(10)
-        assert next_rng.bytes(10) == restored_sampler._rng.bytes(10)
 
 
 @parametrize_sampler

--- a/tests/samplers_tests/test_samplers.py
+++ b/tests/samplers_tests/test_samplers.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pickle
 import pytest
 
 import optuna
@@ -28,6 +29,21 @@ parametrize_sampler = pytest.mark.parametrize(
         lambda: optuna.integration.SkoptSampler(skopt_kwargs={'n_initial_points': 1}),
         lambda: optuna.integration.CmaEsSampler()
     ])
+
+
+@pytest.mark.parametrize(
+    'seed',
+    [None, 0, 169208]
+)
+def test_pickle_random_sampler(seed):
+    sampler = optuna.samplers.RandomSampler(seed)
+    restored_sampler = pickle.loads(pickle.dumps(sampler))
+    assert sampler.seed == restored_sampler.seed
+    assert sampler.rng != restored_sampler.rng
+    if seed is None:
+        assert sampler.rng.bytes(10) != restored_sampler.rng.bytes(10)
+    else:
+        assert sampler.rng.bytes(10) == restored_sampler.rng.bytes(10)
 
 
 @parametrize_sampler

--- a/tests/samplers_tests/test_samplers.py
+++ b/tests/samplers_tests/test_samplers.py
@@ -38,6 +38,7 @@ parametrize_sampler = pytest.mark.parametrize(
 )
 def test_pickle_random_sampler(seed):
     # type: (Optional[int]) -> None
+
     sampler = optuna.samplers.RandomSampler(seed)
     restored_sampler = pickle.loads(pickle.dumps(sampler))
     assert sampler._rng != restored_sampler._rng

--- a/tests/samplers_tests/test_samplers.py
+++ b/tests/samplers_tests/test_samplers.py
@@ -14,6 +14,7 @@ if optuna.type_checking.TYPE_CHECKING:
     import typing  # NOQA
     from typing import Any  # NOQA
     from typing import Dict  # NOQA
+    from typing import Optional  # NOQA
 
     from optuna.distributions import BaseDistribution  # NOQA
     from optuna.structs import FrozenTrial  # NOQA
@@ -36,6 +37,7 @@ parametrize_sampler = pytest.mark.parametrize(
     [None, 0, 169208]
 )
 def test_pickle_random_sampler(seed):
+    # type: (Optional[int]) -> None
     sampler = optuna.samplers.RandomSampler(seed)
     restored_sampler = pickle.loads(pickle.dumps(sampler))
     assert sampler.seed == restored_sampler.seed

--- a/tests/samplers_tests/test_samplers.py
+++ b/tests/samplers_tests/test_samplers.py
@@ -40,12 +40,12 @@ def test_pickle_random_sampler(seed):
     # type: (Optional[int]) -> None
     sampler = optuna.samplers.RandomSampler(seed)
     restored_sampler = pickle.loads(pickle.dumps(sampler))
-    assert sampler.seed == restored_sampler.seed
-    assert sampler.rng != restored_sampler.rng
+    assert sampler._seed == restored_sampler._seed
+    assert sampler._rng != restored_sampler._rng
     if seed is None:
-        assert sampler.rng.bytes(10) != restored_sampler.rng.bytes(10)
+        assert sampler._rng.bytes(10) != restored_sampler._rng.bytes(10)
     else:
-        assert sampler.rng.bytes(10) == restored_sampler.rng.bytes(10)
+        assert sampler._rng.bytes(10) == restored_sampler._rng.bytes(10)
 
 
 @parametrize_sampler

--- a/tests/samplers_tests/test_samplers.py
+++ b/tests/samplers_tests/test_samplers.py
@@ -40,12 +40,15 @@ def test_pickle_random_sampler(seed):
     # type: (Optional[int]) -> None
     sampler = optuna.samplers.RandomSampler(seed)
     restored_sampler = pickle.loads(pickle.dumps(sampler))
-    assert sampler._seed == restored_sampler._seed
     assert sampler._rng != restored_sampler._rng
-    if seed is None:
-        assert sampler._rng.bytes(10) != restored_sampler._rng.bytes(10)
-    else:
-        assert sampler._rng.bytes(10) == restored_sampler._rng.bytes(10)
+    assert sampler._rng.bytes(10) != restored_sampler._rng.bytes(10)
+    if seed:
+        # We have to create a new random number generator
+        # because the one from `sampler` was already used
+        rng = np.random.RandomState(seed)
+        next_rng = np.random.RandomState(rng.randint(2**32-1))
+        next_rng.bytes(10)
+        assert next_rng.bytes(10) == restored_sampler._rng.bytes(10)
 
 
 @parametrize_sampler

--- a/tests/storages_tests/rdb_tests/test_storage.py
+++ b/tests/storages_tests/rdb_tests/test_storage.py
@@ -2,6 +2,7 @@ from mock import patch
 import pytest
 import sys
 import tempfile
+import pickle
 
 from optuna.distributions import CategoricalDistribution
 from optuna.distributions import json_to_distribution
@@ -246,6 +247,20 @@ def create_test_storage(enable_cache=True, engine_kwargs=None):
                          enable_cache=enable_cache,
                          engine_kwargs=engine_kwargs)
     return storage
+
+
+def test_pickle_storage():
+    # type: () -> None
+    storage = create_test_storage()
+    restored_storage = pickle.loads(pickle.dumps(storage))
+    assert storage.url == restored_storage.url
+    assert storage.enable_cache == restored_storage.enable_cache
+    assert storage.engine_kwargs == restored_storage.engine_kwargs
+    assert storage.skip_compatibility_check == restored_storage.skip_compatibility_check
+    assert storage.engine != restored_storage.engine
+    assert storage.scoped_session != restored_storage.scoped_session
+    assert storage._version_manager != restored_storage._version_manager
+    assert storage._finished_trials_cache != restored_storage._finished_trials_cache
 
 
 def test_commit():

--- a/tests/storages_tests/rdb_tests/test_storage.py
+++ b/tests/storages_tests/rdb_tests/test_storage.py
@@ -251,7 +251,7 @@ def create_test_storage(enable_cache=True, engine_kwargs=None):
 
 def test_pickle_storage():
     # type: () -> None
-    
+
     storage = create_test_storage()
     restored_storage = pickle.loads(pickle.dumps(storage))
     assert storage.url == restored_storage.url

--- a/tests/storages_tests/rdb_tests/test_storage.py
+++ b/tests/storages_tests/rdb_tests/test_storage.py
@@ -1,8 +1,8 @@
 from mock import patch
+import pickle
 import pytest
 import sys
 import tempfile
-import pickle
 
 from optuna.distributions import CategoricalDistribution
 from optuna.distributions import json_to_distribution

--- a/tests/storages_tests/rdb_tests/test_storage.py
+++ b/tests/storages_tests/rdb_tests/test_storage.py
@@ -251,6 +251,7 @@ def create_test_storage(enable_cache=True, engine_kwargs=None):
 
 def test_pickle_storage():
     # type: () -> None
+    
     storage = create_test_storage()
     restored_storage = pickle.loads(pickle.dumps(storage))
     assert storage.url == restored_storage.url


### PR DESCRIPTION
This PR is currently a work in-progress that I wanted to share before proceeding further.
It's better to get feedback at early stage, because maybe the Optuna team does not think that is a good addition to the project.

Using Joblib allows the use of different backends to run the optimization:
 - Threading
 - Multiprocessing
 - Loky
 - Dask

Including any future backends that will be added.

This currently only works with the Threading backend due to the presence of unpicklable Locks in the Study and RDBStorage classes.

The one in the Study class be replaced by a variable that keeps track of the nesting level, which is both cheaper and simpler.

As for the one in the RDBStorage class it is used in the finished trial cache and I haven't figured yet a way to change it.

Feedback would be greatly appreciated.
