### PR TITLE
Validate report step

### DIFF
--- a/optuna/trial.py
+++ b/optuna/trial.py
@@ -388,6 +388,9 @@ class Trial(BaseTrial):
                 type(value).__name__)
             raise TypeError(message)
 
+        if step is not None and step < 0:
+            raise ValueError('The `step` argument is {} but cannot be negative.'.format(step))
+
         self.storage.set_trial_value(self._trial_id, value)
         if step is not None:
             self.storage.set_trial_intermediate_value(self._trial_id, step, value)

--- a/tests/integration_tests/test_pytorch_ignite.py
+++ b/tests/integration_tests/test_pytorch_ignite.py
@@ -1,5 +1,4 @@
 from ignite.engine import Engine
-from mock import Mock
 from mock import patch
 import pytest
 
@@ -27,7 +26,7 @@ def test_pytorch_ignite_pruning_handler():
     trial = create_running_trial(study, 1.0)
 
     handler = optuna.integration.PyTorchIgnitePruningHandler(trial, 'accuracy', trainer)
-    with patch.object(trainer, 'state', epoch=Mock(return_value=1), metrics={'accuracy': 1}):
+    with patch.object(trainer, 'state', epoch=1, metrics={'accuracy': 1}):
         with pytest.raises(optuna.exceptions.TrialPruned):
             handler(trainer)
 
@@ -36,5 +35,5 @@ def test_pytorch_ignite_pruning_handler():
     trial = create_running_trial(study, 1.0)
 
     handler = optuna.integration.PyTorchIgnitePruningHandler(trial, 'accuracy', trainer)
-    with patch.object(trainer, 'state', epoch=Mock(return_value=1), metrics={'accuracy': 1}):
+    with patch.object(trainer, 'state', epoch=1, metrics={'accuracy': 1}):
         handler(trainer)

--- a/tests/test_trial.py
+++ b/tests/test_trial.py
@@ -416,7 +416,7 @@ def test_trial_report():
     trial.report(1)
     trial.report(np.array([1], dtype=np.float32)[0])
 
-    # Report values that cannot be cast to `float` (Error).
+    # Report values that cannot be cast to `float` or steps that are negative (Error).
     with pytest.raises(TypeError):
         trial.report(None)  # type: ignore
 
@@ -425,3 +425,9 @@ def test_trial_report():
 
     with pytest.raises(TypeError):
         trial.report([1, 2, 3])  # type: ignore
+
+    with pytest.raises(TypeError):
+        trial.report('foo', -1)  # type: ignore
+
+    with pytest.raises(ValueError):
+        trial.report(1.23, -1)  # type: ignore

--- a/tests/test_trial.py
+++ b/tests/test_trial.py
@@ -430,4 +430,4 @@ def test_trial_report():
         trial.report('foo', -1)  # type: ignore
 
     with pytest.raises(ValueError):
-        trial.report(1.23, -1)  # type: ignore
+        trial.report(1.23, -1)


### PR DESCRIPTION
Validates the report step to avoid unexpected behaviors and catch early errors as it makes little sense to report negative steps and it'll break e.g. `{Median,Percentile}Pruner`. Open for discussions.