### PR TITLE
Make plot functions return Plotly graph object.

### DIFF
--- a/optuna/visualization.py
+++ b/optuna/visualization.py
@@ -53,7 +53,7 @@ def is_available():
 
 
 def plot_intermediate_values(study, update_layout_params=None):
-    # type: (Study, Optional[Dict[Any, Any]]) -> None
+    # type: (Study, Optional[Dict[str, Any]]) -> None
     """Plot intermediate values of all trials in a study.
 
     Example:
@@ -79,8 +79,8 @@ def plot_intermediate_values(study, update_layout_params=None):
             values.
 
         update_layout_params:
-            Parameters to customize the layout of Plotly's figure graph object. Please see the
-            document of `update_layout <https://plot.ly/python/creating-and-updating-figures/
+            Parameters to customize the layout of Plotly's figure graph object. Please check the
+            document of `update_layout() <https://plot.ly/python/creating-and-updating-figures/
             #the-update-layout-method>`_ method for more details.
     """
 

--- a/optuna/visualization.py
+++ b/optuna/visualization.py
@@ -13,7 +13,9 @@ logger = get_logger(__name__)
 if type_checking.TYPE_CHECKING:
     from plotly.graph_objs import Contour  # NOQA
     from plotly.graph_objs import Scatter  # NOQA
+    from typing import Any  # NOQA
     from typing import DefaultDict  # NOQA
+    from typing import Dict  # NOQA
     from typing import List  # NOQA
     from typing import Optional  # NOQA
     from typing import Tuple  # NOQA
@@ -50,8 +52,8 @@ def is_available():
     return _available
 
 
-def plot_intermediate_values(study):
-    # type: (Study) -> None
+def plot_intermediate_values(study, update_layout_params=None):
+    # type: (Study, Optional[Dict[Any, Any]]) -> None
     """Plot intermediate values of all trials in a study.
 
     Example:
@@ -75,10 +77,17 @@ def plot_intermediate_values(study):
         study:
             A :class:`~optuna.study.Study` object whose trials are plotted for their intermediate
             values.
+
+        update_layout_params:
+            Parameters to customize the layout of Plotly's figure graph object. Please see the
+            document of `update_layout <https://plot.ly/python/creating-and-updating-figures/
+            #the-update-layout-method>`_ method for more details.
     """
 
     _check_plotly_availability()
     figure = _get_intermediate_plot(study)
+    if update_layout_params:
+        figure.update_layout(update_layout_params)
     figure.show()
 
 

--- a/optuna/visualization.py
+++ b/optuna/visualization.py
@@ -23,7 +23,6 @@ if type_checking.TYPE_CHECKING:
 try:
     import plotly
     import plotly.graph_objs as go
-    from plotly.graph_objs._figure import Figure  # NOQA
     from plotly.subplots import make_subplots
     _available = True
 except ImportError as e:
@@ -85,7 +84,7 @@ def plot_intermediate_values(study):
 
 
 def _get_intermediate_plot(study):
-    # type: (Study) -> Figure
+    # type: (Study) -> go.Figure
 
     layout = go.Layout(
         title='Intermediate Values Plot',
@@ -126,7 +125,7 @@ def _get_intermediate_plot(study):
 
 
 def plot_optimization_history(study):
-    # type: (Study) -> Figure
+    # type: (Study) -> go.Figure
     """Plot optimization history of all trials in a study.
 
     Example:
@@ -159,7 +158,7 @@ def plot_optimization_history(study):
 
 
 def _get_optimization_history_plot(study):
-    # type: (Study) -> Figure
+    # type: (Study) -> go.Figure
 
     layout = go.Layout(
         title='Optimization History Plot',
@@ -198,7 +197,7 @@ def _get_optimization_history_plot(study):
 
 
 def plot_contour(study, params=None):
-    # type: (Study, Optional[List[str]]) -> Figure
+    # type: (Study, Optional[List[str]]) -> go.Figure
     """Plot the parameter relationship as contour plot in a study.
 
         Note that, If a parameter contains missing values, a trial with missing values is not
@@ -236,7 +235,7 @@ def plot_contour(study, params=None):
 
 
 def _get_contour_plot(study, params=None):
-    # type: (Study, Optional[List[str]]) -> Figure
+    # type: (Study, Optional[List[str]]) -> go.Figure
 
     layout = go.Layout(
         title='Contour Plot',
@@ -376,7 +375,7 @@ def _generate_contour_subplot(trials, x_param, y_param, direction):
 
 
 def plot_parallel_coordinate(study, params=None):
-    # type: (Study, Optional[List[str]]) -> Figure
+    # type: (Study, Optional[List[str]]) -> go.Figure
     """Plot the high-dimentional parameter relationships in a study.
 
         Note that, If a parameter contains missing values, a trial with missing values is not
@@ -414,7 +413,7 @@ def plot_parallel_coordinate(study, params=None):
 
 
 def _get_parallel_coordinate_plot(study, params=None):
-    # type: (Study, Optional[List[str]]) -> Figure
+    # type: (Study, Optional[List[str]]) -> go.Figure
 
     layout = go.Layout(
         title='Parallel Coordinate Plot',
@@ -482,7 +481,7 @@ def _get_parallel_coordinate_plot(study, params=None):
 
 
 def plot_slice(study, params=None):
-    # type: (Study, Optional[List[str]]) -> Figure
+    # type: (Study, Optional[List[str]]) -> go.Figure
     """Plot the parameter relationship as slice plot in a study.
 
         Note that, If a parameter contains missing values, a trial with missing values is not
@@ -520,7 +519,7 @@ def plot_slice(study, params=None):
 
 
 def _get_slice_plot(study, params=None):
-    # type: (Study, Optional[List[str]]) -> Figure
+    # type: (Study, Optional[List[str]]) -> go.Figure
 
     layout = go.Layout(
         title='Slice Plot',

--- a/optuna/visualization.py
+++ b/optuna/visualization.py
@@ -5,7 +5,6 @@ from optuna.distributions import LogUniformDistribution
 from optuna.logging import get_logger
 from optuna.structs import StudyDirection
 from optuna.structs import TrialState
-from optuna.study import Study  # NOQA
 from optuna import type_checking
 
 logger = get_logger(__name__)
@@ -21,6 +20,7 @@ if type_checking.TYPE_CHECKING:
     from typing import Tuple  # NOQA
 
     from optuna.structs import FrozenTrial  # NOQA
+    from optuna.study import Study  # NOQA
 
 try:
     import plotly
@@ -52,8 +52,8 @@ def is_available():
     return _available
 
 
-def plot_intermediate_values(study, update_layout_params=None):
-    # type: (Study, Optional[Dict[str, Any]]) -> None
+def plot_intermediate_values(study):
+    # type: (Study) -> Figure
     """Plot intermediate values of all trials in a study.
 
     Example:
@@ -78,17 +78,12 @@ def plot_intermediate_values(study, update_layout_params=None):
             A :class:`~optuna.study.Study` object whose trials are plotted for their intermediate
             values.
 
-        update_layout_params:
-            Parameters to customize the layout of Plotly's figure graph object. Please check the
-            document of `update_layout() <https://plot.ly/python/creating-and-updating-figures/
-            #the-update-layout-method>`_ method for more details.
+    Returns:
+        A :class:`plotly.graph_objs._figure.Figure` object.
     """
 
     _check_plotly_availability()
-    figure = _get_intermediate_plot(study)
-    if update_layout_params:
-        figure.update_layout(update_layout_params)
-    figure.show()
+    return _get_intermediate_plot(study)
 
 
 def _get_intermediate_plot(study):
@@ -133,7 +128,7 @@ def _get_intermediate_plot(study):
 
 
 def plot_optimization_history(study):
-    # type: (Study) -> None
+    # type: (Study) -> Figure
     """Plot optimization history of all trials in a study.
 
     Example:
@@ -156,11 +151,13 @@ def plot_optimization_history(study):
         study:
             A :class:`~optuna.study.Study` object whose trials are plotted for their objective
             values.
+
+    Returns:
+        A :class:`plotly.graph_objs._figure.Figure` object.
     """
 
     _check_plotly_availability()
-    figure = _get_optimization_history_plot(study)
-    figure.show()
+    return _get_optimization_history_plot(study)
 
 
 def _get_optimization_history_plot(study):
@@ -203,7 +200,7 @@ def _get_optimization_history_plot(study):
 
 
 def plot_contour(study, params=None):
-    # type: (Study, Optional[List[str]]) -> None
+    # type: (Study, Optional[List[str]]) -> Figure
     """Plot the parameter relationship as contour plot in a study.
 
         Note that, If a parameter contains missing values, a trial with missing values is not
@@ -231,11 +228,13 @@ def plot_contour(study, params=None):
             values.
         params:
             Parameter list to visualize. The default is all parameters.
+
+    Returns:
+        A :class:`plotly.graph_objs._figure.Figure` object.
     """
 
     _check_plotly_availability()
-    figure = _get_contour_plot(study, params)
-    figure.show()
+    return _get_contour_plot(study, params)
 
 
 def _get_contour_plot(study, params=None):
@@ -379,7 +378,7 @@ def _generate_contour_subplot(trials, x_param, y_param, direction):
 
 
 def plot_parallel_coordinate(study, params=None):
-    # type: (Study, Optional[List[str]]) -> None
+    # type: (Study, Optional[List[str]]) -> Figure
     """Plot the high-dimentional parameter relationships in a study.
 
         Note that, If a parameter contains missing values, a trial with missing values is not
@@ -407,11 +406,13 @@ def plot_parallel_coordinate(study, params=None):
             values.
         params:
             Parameter list to visualize. The default is all parameters.
+
+    Returns:
+        A :class:`plotly.graph_objs._figure.Figure` object.
     """
 
     _check_plotly_availability()
-    figure = _get_parallel_coordinate_plot(study, params)
-    figure.show()
+    return _get_parallel_coordinate_plot(study, params)
 
 
 def _get_parallel_coordinate_plot(study, params=None):
@@ -483,7 +484,7 @@ def _get_parallel_coordinate_plot(study, params=None):
 
 
 def plot_slice(study, params=None):
-    # type: (Study, Optional[List[str]]) -> None
+    # type: (Study, Optional[List[str]]) -> Figure
     """Plot the parameter relationship as slice plot in a study.
 
         Note that, If a parameter contains missing values, a trial with missing values is not
@@ -511,11 +512,13 @@ def plot_slice(study, params=None):
             values.
         params:
             Parameter list to visualize. The default is all parameters.
+
+    Returns:
+        A :class:`plotly.graph_objs._figure.Figure` object.
     """
 
     _check_plotly_availability()
-    figure = _get_slice_plot(study, params)
-    figure.show()
+    return _get_slice_plot(study, params)
 
 
 def _get_slice_plot(study, params=None):

--- a/optuna/visualization.py
+++ b/optuna/visualization.py
@@ -51,7 +51,7 @@ def is_available():
 
 
 def plot_intermediate_values(study):
-    # type: (Study) -> Figure
+    # type: (Study) -> go.Figure
     """Plot intermediate values of all trials in a study.
 
     Example:
@@ -77,7 +77,7 @@ def plot_intermediate_values(study):
             values.
 
     Returns:
-        A :class:`plotly.graph_objs._figure.Figure` object.
+        A :class:`plotly.graph_objs.Figure` object.
     """
 
     _check_plotly_availability()
@@ -151,7 +151,7 @@ def plot_optimization_history(study):
             values.
 
     Returns:
-        A :class:`plotly.graph_objs._figure.Figure` object.
+        A :class:`plotly.graph_objs.Figure` object.
     """
 
     _check_plotly_availability()
@@ -228,7 +228,7 @@ def plot_contour(study, params=None):
             Parameter list to visualize. The default is all parameters.
 
     Returns:
-        A :class:`plotly.graph_objs._figure.Figure` object.
+        A :class:`plotly.graph_objs.Figure` object.
     """
 
     _check_plotly_availability()
@@ -406,7 +406,7 @@ def plot_parallel_coordinate(study, params=None):
             Parameter list to visualize. The default is all parameters.
 
     Returns:
-        A :class:`plotly.graph_objs._figure.Figure` object.
+        A :class:`plotly.graph_objs.Figure` object.
     """
 
     _check_plotly_availability()
@@ -512,7 +512,7 @@ def plot_slice(study, params=None):
             Parameter list to visualize. The default is all parameters.
 
     Returns:
-        A :class:`plotly.graph_objs._figure.Figure` object.
+        A :class:`plotly.graph_objs.Figure` object.
     """
 
     _check_plotly_availability()

--- a/optuna/visualization.py
+++ b/optuna/visualization.py
@@ -12,9 +12,7 @@ logger = get_logger(__name__)
 if type_checking.TYPE_CHECKING:
     from plotly.graph_objs import Contour  # NOQA
     from plotly.graph_objs import Scatter  # NOQA
-    from typing import Any  # NOQA
     from typing import DefaultDict  # NOQA
-    from typing import Dict  # NOQA
     from typing import List  # NOQA
     from typing import Optional  # NOQA
     from typing import Tuple  # NOQA


### PR DESCRIPTION
## Summary

I want to plot intermediate values with log-scale yaxis. I once designed APIs of plotting utilities like `plot_intermediate_values(study, yaxis_logscale=True)` but this approach might need a lot of parameters if we want to provide more flexible options. In this PR, I added option to pass parameters into `update_layout` method.

## Usage

Prepare a dummy study.

```python
import optuna

study = optuna.create_study()

values = [
    [10000, 1000, 100, 10, 1, 0.1, 0.01],
    [7500, None],
    [5000, 500, 50, 5, 0.5, 0.05, 0.005],
    [6000, None],
]
    
for intermediate_values in values:
    trial_id = study._storage.create_new_trial(study.study_id)
    trial = optuna.trial.Trial(study, trial_id)

    for i, v in enumerate(intermediate_values):
        if v is None:
            study._storage.set_trial_state(trial_id, optuna.structs.TrialState.PRUNED)
            break
        trial.report(v, step=i)
    else:
        study._storage.set_trial_state(trial_id, optuna.structs.TrialState.COMPLETE)
```

Then plotting without params:

```python
from optuna.visualization import plot_intermediate_values

plot_intermediate_values(study)
```

![newplot (2)](https://user-images.githubusercontent.com/5564044/68834074-49522e00-06f8-11ea-9e50-8e294776c47a.png)

Then plotting in log-scale yaxis:

```python
from optuna.visualization import plot_intermediate_values

plot_intermediate_values(study, {'yaxis_type': 'log'})
```

![newplot (1)](https://user-images.githubusercontent.com/5564044/68834034-33dd0400-06f8-11ea-83d1-fc229d09bd19.png)
