### PR TITLE
Drop CI jobs for Python 2.7.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,6 @@ workflows:
       - tests-python37
       - tests-python36
       - tests-python35
-      - tests-python27
       - codecov
   daily-build:
     triggers:
@@ -25,11 +24,9 @@ workflows:
       - tests-python37-full
       - tests-python36-full
       - tests-python35-full
-      - tests-python27-full
       - examples-python37
       - examples-python36
       - examples-python35
-      - examples-python27
 
 jobs:
 
@@ -66,7 +63,6 @@ jobs:
           command: |
             . venv/bin/activate
             mypy --disallow-untyped-defs --ignore-missing-imports .
-            mypy --py2 --disallow-untyped-defs --ignore-missing-imports .
 
   document:
     docker:
@@ -154,22 +150,6 @@ jobs:
 
       - run: *tests-mn
 
-  tests-python27:
-    docker:
-      - image: circleci/python:2.7
-    steps:
-      - checkout
-
-      - run: *install
-
-      - run:
-          <<: *tests
-          command: |
-            . venv/bin/activate
-            pytest tests --ignore tests/integration_tests/test_pytorch_lightning.py --ignore tests/integration_tests/test_xgboost.py --ignore tests/integration_tests/test_fastai.py
-
-      - run: *tests-mn
-
   tests-python37-full:
     docker:
       - image: circleci/python:3.7
@@ -211,22 +191,6 @@ jobs:
           command: |
             . venv/bin/activate
             pytest tests --ignore tests/integration_tests/test_pytorch_lightning.py --ignore tests/integration_tests/test_fastai.py
-
-      - run: *tests-mn-full
-
-  tests-python27-full:
-    docker:
-      - image: circleci/python:2.7
-    steps:
-      - checkout
-
-      - run: *install
-
-      - run:
-          <<: *tests-full
-          command: |
-            . venv/bin/activate
-            pytest tests --ignore tests/integration_tests/test_pytorch_lightning.py --ignore tests/integration_tests/test_xgboost.py --ignore tests/integration_tests/test_fastai.py
 
       - run: *tests-mn-full
 
@@ -320,23 +284,5 @@ jobs:
           environment:
             OMP_NUM_THREADS: 1
             IGNORES: chainermn_.*|pytorch_lightning.*
-
-      - run: *examples-mn
-
-  examples-python27:
-    docker:
-      - image: circleci/python:2.7
-    steps:
-      - checkout
-
-      - run: *install
-
-      - run: *install-examples
-
-      - run:
-          <<: *examples
-          environment:
-            OMP_NUM_THREADS: 1
-            IGNORES: chainermn_.*|pytorch_lightning.*|xgboost_.*|dask_ml_.*
 
       - run: *examples-mn

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,11 +57,9 @@ $ circleci build --job tests-python37
 
 You can run tests and examples for each Python version using the following jobs:
 
-- `tests-python27`
 - `tests-python35`
 - `tests-python36`
 - `tests-python37`
-- `examples-python27`
 - `examples-python35`
 - `examples-python36`
 - `examples-python37`

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ To install Optuna, use `pip` as follows:
 $ pip install optuna
 ```
 
-Optuna supports Python 2.7 and Python 3.5 or newer.
+Optuna supports Python 3.5 or newer.
 
 
 ## Contribution

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -1,7 +1,7 @@
 Installation
 ============
 
-Optuna supports Python 2.7 and Python 3.5 or newer.
+Optuna supports Python 3.5 or newer.
 
 We recommend to install Optuna via pip:
 

--- a/tests/test_structs.py
+++ b/tests/test_structs.py
@@ -116,10 +116,6 @@ def test_frozen_trial_eq_ne():
     assert trial != trial_other
 
 
-# TODO(hvy): Remove version check after Python 2.7 is retired.
-@pytest.mark.skipif(
-    'sys.version_info < (3, 5)',
-    reason='Cannot eval/reconstruct namedtuple distributions in Python 2.7.')
 def test_frozen_trial_repr():
     # type: () -> None
 

--- a/tests/test_trial.py
+++ b/tests/test_trial.py
@@ -86,8 +86,6 @@ def test_suggest_low_equals_high(storage_init_func):
         assert mock_object.call_count == 0
 
 
-# TODO(Yanase): Remove version check after Python 2.7 is retired.
-@pytest.mark.skipif('sys.version_info < (3, 5)')
 @parametrize_storage
 @pytest.mark.parametrize(
     'range_config',


### PR DESCRIPTION
Since we will drop Python 2 support in the coming December, this PR deletes all CI jobs for Python 2.7.