### PR TITLE
Make `bokeh-allow-websocket-origins` required.

### DIFF
--- a/optuna/dashboard.py
+++ b/optuna/dashboard.py
@@ -252,8 +252,8 @@ def _get_this_source_path():
     return path
 
 
-def _serve(study, bokeh_allow_websocket_origins=None):
-    # type: (optuna.study.Study, Optional[List[str]]) -> None
+def _serve(study, bokeh_allow_websocket_origins):
+    # type: (optuna.study.Study, List[str]) -> None
 
     global _mode, _study
 
@@ -276,9 +276,8 @@ def _serve(study, bokeh_allow_websocket_origins=None):
     # version 0.12.15. In addition, we will need to do many configuration to servers, which can be
     # done automatically with the following one line. So, for now, we decided to use this way.
     command = ['bokeh', 'serve', '--show', _get_this_source_path()]
-    if bokeh_allow_websocket_origins is not None:
-        for bokeh_allow_websocket_origin in bokeh_allow_websocket_origins:
-            command.extend(['--allow-websocket-origin', bokeh_allow_websocket_origin])
+    for bokeh_allow_websocket_origin in bokeh_allow_websocket_origins:
+        command.extend(['--allow-websocket-origin', bokeh_allow_websocket_origin])
     bokeh.command.bootstrap.main(command)
 
 


### PR DESCRIPTION
This is a followup PR for #698. According to [the suggestion](https://github.com/optuna/optuna/pull/698#discussion_r346746741) by @hvy, `bokeh-allow-websocket-origins` will be a required option of `_serve`. This change simplifies both code and type hint.