### PR TITLE
Make `study_id` private.

### DIFF
--- a/optuna/integration/lightgbm.py
+++ b/optuna/integration/lightgbm.py
@@ -97,14 +97,14 @@ class LightGBMPruningCallback(object):
                 continue
 
             if is_higher_better:
-                if self.trial.storage.get_study_direction(self.trial._study_id) != \
+                if self.trial.storage.get_study_direction(self.trial.study._study_id) != \
                         optuna.structs.StudyDirection.MAXIMIZE:
                     raise ValueError(
                         "The intermediate values are inconsistent with the objective values in "
                         "terms of study directions. Please specify a metric to be minimized for "
                         "LightGBMPruningCallback.")
             else:
-                if self.trial.storage.get_study_direction(self.trial._study_id) != \
+                if self.trial.storage.get_study_direction(self.trial.study._study_id) != \
                         optuna.structs.StudyDirection.MINIMIZE:
                     raise ValueError(
                         "The intermediate values are inconsistent with the objective values in "

--- a/optuna/integration/lightgbm.py
+++ b/optuna/integration/lightgbm.py
@@ -97,14 +97,14 @@ class LightGBMPruningCallback(object):
                 continue
 
             if is_higher_better:
-                if self.trial.storage.get_study_direction(self.trial.study_id) != \
+                if self.trial.storage.get_study_direction(self.trial._study_id) != \
                         optuna.structs.StudyDirection.MAXIMIZE:
                     raise ValueError(
                         "The intermediate values are inconsistent with the objective values in "
                         "terms of study directions. Please specify a metric to be minimized for "
                         "LightGBMPruningCallback.")
             else:
-                if self.trial.storage.get_study_direction(self.trial.study_id) != \
+                if self.trial.storage.get_study_direction(self.trial._study_id) != \
                         optuna.structs.StudyDirection.MINIMIZE:
                     raise ValueError(
                         "The intermediate values are inconsistent with the objective values in "

--- a/optuna/storages/in_memory.py
+++ b/optuna/storages/in_memory.py
@@ -139,14 +139,15 @@ class InMemoryStorage(base.BaseStorage):
 
         return [
             structs.StudySummary(
-                study_id=IN_MEMORY_STORAGE_STUDY_ID,
                 study_name=self.study_name,
                 direction=self.direction,
                 best_trial=best_trial,
                 user_attrs=copy.deepcopy(self.study_user_attrs),
                 system_attrs=copy.deepcopy(self.study_system_attrs),
                 n_trials=len(self.trials),
-                datetime_start=datetime_start)
+                datetime_start=datetime_start,
+                study_id=IN_MEMORY_STORAGE_STUDY_ID
+            )
         ]
 
     def create_new_trial(self, study_id, template_trial=None):

--- a/optuna/storages/rdb/storage.py
+++ b/optuna/storages/rdb/storage.py
@@ -364,14 +364,14 @@ class RDBStorage(BaseStorage):
             # Consolidate StudySummary.
             study_sumarries.append(
                 structs.StudySummary(
-                    study_id=study_model.study_id,
                     study_name=study_model.study_name,
                     direction=self.get_study_direction(study_model.study_id),
                     best_trial=best_trial,
                     user_attrs=self.get_study_user_attrs(study_model.study_id),
                     system_attrs=system_attrs,
                     n_trials=len(study_trial_models),
-                    datetime_start=datetime_start))
+                    datetime_start=datetime_start,
+                    study_id=study_model.study_id))
 
         # Terminate transaction explicitly to avoid connection timeout during transaction.
         self._commit(session)

--- a/optuna/structs.py
+++ b/optuna/structs.py
@@ -1,17 +1,17 @@
-from datetime import datetime
 import enum
 import warnings
 
-from typing import Any
-from typing import Dict
-from typing import NamedTuple
-from typing import Optional
 
 from optuna import exceptions
 from optuna import logging
 from optuna import type_checking
 
 if type_checking.TYPE_CHECKING:
+    from datetime import datetime  # NOQA
+    from typing import Any  # NOQA
+    from typing import Dict  # NOQA
+    from typing import Optional  # NOQA
+
     from optuna.distributions import BaseDistribution  # NOQA
 
 
@@ -235,20 +235,12 @@ class FrozenTrial(object):
             return max(self.intermediate_values.keys())
 
 
-class StudySummary(
-        NamedTuple('StudySummary', [('study_id', int), ('study_name', str),
-                                    ('direction', StudyDirection),
-                                    ('best_trial', Optional[FrozenTrial]),
-                                    ('user_attrs', Dict[str, Any]),
-                                    ('system_attrs', Dict[str, Any]), ('n_trials', int),
-                                    ('datetime_start', Optional[datetime])])):
+class StudySummary(object):
     """Basic attributes and aggregated results of a :class:`~optuna.study.Study`.
 
     See also :func:`optuna.study.get_all_study_summaries`.
 
     Attributes:
-        study_id:
-            Identifier of the :class:`~optuna.study.Study`.
         study_name:
             Name of the :class:`~optuna.study.Study`.
         direction:
@@ -266,6 +258,67 @@ class StudySummary(
         datetime_start:
             Datetime where the :class:`~optuna.study.Study` started.
     """
+
+    def __init__(
+            self,
+            study_name,  # type: str
+            direction,  # type: StudyDirection
+            best_trial,  # type: Optional[FrozenTrial]
+            user_attrs,  # type: Dict[str, Any]
+            system_attrs,  # type: Dict[str, Any]
+            n_trials,  # type: int
+            datetime_start,  # type: Optional[datetime]
+            study_id,  # type: int
+    ):
+        # type: (...) -> None
+
+        self.study_name = study_name
+        self.direction = direction
+        self.best_trial = best_trial
+        self.user_attrs = user_attrs
+        self.system_attrs = system_attrs
+        self.n_trials = n_trials
+        self.datetime_start = datetime_start
+        self._study_id = study_id
+
+    def __eq__(self, other):
+        # type: (Any) -> bool
+
+        if isinstance(other, type(self)):
+            return other.__dict__ == self.__dict__
+        return False
+
+    def __ne__(self, other):
+        # type: (Any) -> bool
+
+        return not self.__eq__(other)
+
+    def __hash__(self):
+        # type: () -> int
+
+        return hash(tuple(sorted(self.__dict__.items())))
+
+    @property
+    def study_id(self):
+        # type: () -> int
+        """Return the study ID.
+
+        .. deprecated:: 0.20.0
+            The direct use of this attribute is deprecated and it is recommended that you use
+            :attr:`~optuna.structs.StudySummary.study_name` instead.
+
+        Returns:
+            The study ID.
+        """
+
+        message = 'The use of `StudySummary.study_id` is deprecated. ' \
+                  'Please use `StudySummary.study_name` instead.'
+        warnings.warn(message, DeprecationWarning)
+
+        logger = logging._get_library_root_logger()
+        logger.warning(message)
+
+        return self._study_id
 
 
 class TrialPruned(exceptions.TrialPruned):

--- a/optuna/structs.py
+++ b/optuna/structs.py
@@ -296,9 +296,8 @@ class StudySummary(object):
     def __lt__(self, other):
         # type: (Any) -> bool
 
-        if not isinstance(other, type(self)):
-            raise TypeError('\'<\' not supported between instances of {} and {}'.format(
-                type(self.__class__.__name__), type(other)))
+        if not isinstance(other, StudySummary):
+            return NotImplemented
 
         return self._study_id < other._study_id
 

--- a/optuna/structs.py
+++ b/optuna/structs.py
@@ -1,5 +1,4 @@
 import enum
-from functools import total_ordering
 import warnings
 
 from optuna import exceptions
@@ -235,7 +234,6 @@ class FrozenTrial(object):
             return max(self.intermediate_values.keys())
 
 
-@total_ordering
 class StudySummary(object):
     """Basic attributes and aggregated results of a :class:`~optuna.study.Study`.
 
@@ -301,6 +299,14 @@ class StudySummary(object):
             return NotImplemented
 
         return self._study_id < other._study_id
+
+    def __le__(self, other):
+        # type: (Any) -> bool
+
+        if not isinstance(other, StudySummary):
+            return NotImplemented
+
+        return self._study_id <= other._study_id
 
     @property
     def study_id(self):

--- a/optuna/structs.py
+++ b/optuna/structs.py
@@ -291,6 +291,9 @@ class StudySummary(object):
     def __ne__(self, other):
         # type: (Any) -> bool
 
+        if not isinstance(other, StudySummary):
+            return NotImplemented
+
         return not self.__eq__(other)
 
     def __lt__(self, other):

--- a/optuna/structs.py
+++ b/optuna/structs.py
@@ -283,9 +283,10 @@ class StudySummary(object):
     def __eq__(self, other):
         # type: (Any) -> bool
 
-        if isinstance(other, type(self)):
-            return other.__dict__ == self.__dict__
-        return False
+        if not isinstance(other, StudySummary):
+            return NotImplemented
+
+        return other.__dict__ == self.__dict__
 
     def __ne__(self, other):
         # type: (Any) -> bool

--- a/optuna/structs.py
+++ b/optuna/structs.py
@@ -1,6 +1,6 @@
 import enum
+from functools import total_ordering
 import warnings
-
 
 from optuna import exceptions
 from optuna import logging
@@ -235,6 +235,7 @@ class FrozenTrial(object):
             return max(self.intermediate_values.keys())
 
 
+@total_ordering
 class StudySummary(object):
     """Basic attributes and aggregated results of a :class:`~optuna.study.Study`.
 

--- a/optuna/structs.py
+++ b/optuna/structs.py
@@ -293,10 +293,14 @@ class StudySummary(object):
 
         return not self.__eq__(other)
 
-    def __hash__(self):
-        # type: () -> int
+    def __lt__(self, other):
+        # type: (Any) -> bool
 
-        return hash(tuple(sorted(self.__dict__.items())))
+        if not isinstance(other, type(self)):
+            raise TypeError('\'<\' not supported between instances of {} and {}'.format(
+                type(self.__class__.__name__), type(other)))
+
+        return self._study_id < other._study_id
 
     @property
     def study_id(self):

--- a/optuna/study.py
+++ b/optuna/study.py
@@ -48,7 +48,7 @@ class BaseStudy(object):
     def __init__(self, study_id, storage):
         # type: (int, storages.BaseStorage) -> None
 
-        self.study_id = study_id
+        self._study_id = study_id
         self._storage = storage
 
     @property
@@ -85,7 +85,7 @@ class BaseStudy(object):
             A :class:`~optuna.structs.FrozenTrial` object of the best trial.
         """
 
-        return self._storage.get_best_trial(self.study_id)
+        return self._storage.get_best_trial(self._study_id)
 
     @property
     def direction(self):
@@ -96,7 +96,7 @@ class BaseStudy(object):
             A :class:`~optuna.structs.StudyDirection` object.
         """
 
-        return self._storage.get_study_direction(self.study_id)
+        return self._storage.get_study_direction(self._study_id)
 
     @property
     def trials(self):
@@ -109,7 +109,7 @@ class BaseStudy(object):
             A list of :class:`~optuna.structs.FrozenTrial` objects.
         """
 
-        return self._storage.get_all_trials(self.study_id)
+        return self._storage.get_all_trials(self._study_id)
 
     @property
     def storage(self):
@@ -195,7 +195,7 @@ class Study(BaseStudy):
             A dictionary containing all user attributes.
         """
 
-        return self._storage.get_study_user_attrs(self.study_id)
+        return self._storage.get_study_user_attrs(self._study_id)
 
     @property
     def system_attrs(self):
@@ -206,7 +206,7 @@ class Study(BaseStudy):
             A dictionary containing all system attributes.
         """
 
-        return self._storage.get_study_system_attrs(self.study_id)
+        return self._storage.get_study_system_attrs(self._study_id)
 
     def optimize(
             self,
@@ -275,7 +275,7 @@ class Study(BaseStudy):
 
         """
 
-        self._storage.set_study_user_attr(self.study_id, key, value)
+        self._storage.set_study_user_attr(self._study_id, key, value)
 
     def set_system_attr(self, key, value):
         # type: (str, Any) -> None
@@ -290,7 +290,7 @@ class Study(BaseStudy):
 
         """
 
-        self._storage.set_study_system_attr(self.study_id, key, value)
+        self._storage.set_study_system_attr(self._study_id, key, value)
 
     def trials_dataframe(self, include_internal_fields=False):
         # type: (bool) -> pd.DataFrame
@@ -414,7 +414,7 @@ class Study(BaseStudy):
 
         trial._validate()
 
-        self.storage.create_new_trial(self.study_id, template_trial=trial)
+        self.storage.create_new_trial(self._study_id, template_trial=trial)
 
     def _optimize_sequential(
             self,
@@ -531,7 +531,7 @@ class Study(BaseStudy):
     ):
         # type: (...) -> trial_module.Trial
 
-        trial_id = self._storage.create_new_trial(self.study_id)
+        trial_id = self._storage.create_new_trial(self._study_id)
         trial = trial_module.Trial(self, trial_id)
         trial_number = trial.number
 

--- a/optuna/study.py
+++ b/optuna/study.py
@@ -187,6 +187,26 @@ class Study(BaseStudy):
         self._optimize_lock = threading.Lock()
 
     @property
+    def study_id(self):
+        # type: () -> int
+        """Return the study ID.
+
+        .. deprecated:: 0.20.0
+            The direct use of this attribute is deprecated and it is recommended that you use
+            :attr:`~optuna.study.Study.study_name` instead.
+
+        Returns:
+            The study ID.
+        """
+
+        message = 'The use of `Study.study_id` is deprecated. ' \
+                  'Please use `Study.study_name` instead.'
+        warnings.warn(message, DeprecationWarning)
+        self.logger.warning(message)
+
+        return self._study_id
+
+    @property
     def user_attrs(self):
         # type: () -> Dict[str, Any]
         """Return user attributes.

--- a/optuna/testing/integration.py
+++ b/optuna/testing/integration.py
@@ -16,6 +16,6 @@ class DeterministicPruner(optuna.pruners.BasePruner):
 def create_running_trial(study, value):
     # type: (optuna.study.Study, float) -> optuna.trial.Trial
 
-    trial_id = study._storage.create_new_trial(study.study_id)
+    trial_id = study._storage.create_new_trial(study._study_id)
     study._storage.set_trial_value(trial_id, value)
     return optuna.trial.Trial(study, trial_id)

--- a/optuna/trial.py
+++ b/optuna/trial.py
@@ -133,7 +133,7 @@ class Trial(BaseTrial):
         self.study = study
         self._trial_id = trial_id
 
-        self.study_id = self.study.study_id
+        self._study_id = self.study._study_id
         self.storage = self.study._storage
         self.logger = logging.get_logger(__name__)
 

--- a/optuna/trial.py
+++ b/optuna/trial.py
@@ -133,6 +133,7 @@ class Trial(BaseTrial):
         self.study = study
         self._trial_id = trial_id
 
+        # TODO(Yanase): Remove _study_id attribute, and use study._study_id instead.
         self._study_id = self.study._study_id
         self.storage = self.study._storage
         self.logger = logging.get_logger(__name__)
@@ -601,6 +602,26 @@ class Trial(BaseTrial):
             Datetime where the :class:`~optuna.trial.Trial` started.
         """
         return self.storage.get_trial(self._trial_id).datetime_start
+
+    @property
+    def study_id(self):
+        # type: () -> int
+        """Return the study ID.
+
+        .. deprecated:: 0.20.0
+            The direct use of this attribute is deprecated and it is recommended that you use
+            :attr:`~optuna.trial.Trial.study` instead.
+
+        Returns:
+            The study ID.
+        """
+
+        message = 'The use of `Trial.study_id` is deprecated. ' \
+                  'Please use `Trial.study` instead.'
+        warnings.warn(message, DeprecationWarning)
+        self.logger.warning(message)
+
+        return self.study._study_id
 
 
 class FixedTrial(BaseTrial):

--- a/tests/integration_tests/test_chainermn.py
+++ b/tests/integration_tests/test_chainermn.py
@@ -526,7 +526,7 @@ def _create_new_chainermn_trial(study, comm):
     # type: (Study, CommunicatorBase) -> integration.chainermn.ChainerMNTrial
 
     if comm.rank == 0:
-        trial_id = study._storage.create_new_trial(study.study_id)
+        trial_id = study._storage.create_new_trial(study._study_id)
         trial = Trial(study, trial_id)
         mn_trial = integration.chainermn.ChainerMNTrial(trial, comm)
     else:

--- a/tests/integration_tests/test_tensorflow.py
+++ b/tests/integration_tests/test_tensorflow.py
@@ -83,7 +83,7 @@ def test_init_with_is_higher_better(is_higher_better):
     )
 
     study = optuna.create_study()
-    trial_id = study._storage.create_new_trial(study.study_id)
+    trial_id = study._storage.create_new_trial(study._study_id)
 
     with pytest.raises(ValueError):
         TensorFlowPruningHook(

--- a/tests/pruners_tests/test_median.py
+++ b/tests/pruners_tests/test_median.py
@@ -13,7 +13,7 @@ def test_median_pruner_with_one_trial():
     # type: () -> None
 
     study = optuna.study.create_study()
-    trial = optuna.trial.Trial(study, study._storage.create_new_trial(study.study_id))
+    trial = optuna.trial.Trial(study, study._storage.create_new_trial(study._study_id))
     trial.report(1, 1)
     pruner = optuna.pruners.MedianPruner(0, 0)
 
@@ -30,11 +30,11 @@ def test_median_pruner_intermediate_values(direction_value):
     pruner = optuna.pruners.MedianPruner(0, 0)
     study = optuna.study.create_study(direction=direction)
 
-    trial = optuna.trial.Trial(study, study._storage.create_new_trial(study.study_id))
+    trial = optuna.trial.Trial(study, study._storage.create_new_trial(study._study_id))
     trial.report(1, 1)
     study._storage.set_trial_state(trial._trial_id, TrialState.COMPLETE)
 
-    trial = optuna.trial.Trial(study, study._storage.create_new_trial(study.study_id))
+    trial = optuna.trial.Trial(study, study._storage.create_new_trial(study._study_id))
     # A pruner is not activated if a trial has no intermediate values.
     assert not pruner.prune(
         study=study, trial=study._storage.get_trial(trial._trial_id))
@@ -51,21 +51,21 @@ def test_median_pruner_intermediate_values_nan():
     pruner = optuna.pruners.MedianPruner(0, 0)
     study = optuna.study.create_study()
 
-    trial = optuna.trial.Trial(study, study._storage.create_new_trial(study.study_id))
+    trial = optuna.trial.Trial(study, study._storage.create_new_trial(study._study_id))
     trial.report(float('nan'), 1)
     # A pruner is not activated if the study does not have any previous trials.
     assert not pruner.prune(
         study=study, trial=study._storage.get_trial(trial._trial_id))
     study._storage.set_trial_state(trial._trial_id, TrialState.COMPLETE)
 
-    trial = optuna.trial.Trial(study, study._storage.create_new_trial(study.study_id))
+    trial = optuna.trial.Trial(study, study._storage.create_new_trial(study._study_id))
     trial.report(float('nan'), 1)
     # A pruner is activated if the best intermediate value of this trial is NaN.
     assert pruner.prune(
         study=study, trial=study._storage.get_trial(trial._trial_id))
     study._storage.set_trial_state(trial._trial_id, TrialState.COMPLETE)
 
-    trial = optuna.trial.Trial(study, study._storage.create_new_trial(study.study_id))
+    trial = optuna.trial.Trial(study, study._storage.create_new_trial(study._study_id))
     trial.report(1, 1)
     # A pruner is not activated if the median intermediate value is NaN.
     assert not pruner.prune(
@@ -78,18 +78,18 @@ def test_median_pruner_n_startup_trials():
     pruner = optuna.pruners.MedianPruner(2, 0)
     study = optuna.study.create_study()
 
-    trial = optuna.trial.Trial(study, study._storage.create_new_trial(study.study_id))
+    trial = optuna.trial.Trial(study, study._storage.create_new_trial(study._study_id))
     trial.report(1, 1)
     study._storage.set_trial_state(trial._trial_id, TrialState.COMPLETE)
 
-    trial = optuna.trial.Trial(study, study._storage.create_new_trial(study.study_id))
+    trial = optuna.trial.Trial(study, study._storage.create_new_trial(study._study_id))
     trial.report(2, 1)
     # A pruner is not activated during startup trials.
     assert not pruner.prune(
         study=study, trial=study._storage.get_trial(trial._trial_id))
     study._storage.set_trial_state(trial._trial_id, TrialState.COMPLETE)
 
-    trial = optuna.trial.Trial(study, study._storage.create_new_trial(study.study_id))
+    trial = optuna.trial.Trial(study, study._storage.create_new_trial(study._study_id))
     trial.report(3, 1)
     # A pruner is activated after startup trials.
     assert pruner.prune(
@@ -102,12 +102,12 @@ def test_median_pruner_n_warmup_steps():
     pruner = optuna.pruners.MedianPruner(0, 1)
     study = optuna.study.create_study()
 
-    trial = optuna.trial.Trial(study, study._storage.create_new_trial(study.study_id))
+    trial = optuna.trial.Trial(study, study._storage.create_new_trial(study._study_id))
     trial.report(1, 1)
     trial.report(1, 2)
     study._storage.set_trial_state(trial._trial_id, TrialState.COMPLETE)
 
-    trial = optuna.trial.Trial(study, study._storage.create_new_trial(study.study_id))
+    trial = optuna.trial.Trial(study, study._storage.create_new_trial(study._study_id))
     trial.report(2, 1)
     # A pruner is not activated during warm-up steps.
     assert not pruner.prune(
@@ -134,14 +134,14 @@ def test_median_pruner_interval_steps(
     pruner = optuna.pruners.MedianPruner(0, n_warmup_steps, interval_steps)
     study = optuna.study.create_study()
 
-    trial = optuna.trial.Trial(study, study._storage.create_new_trial(study.study_id))
+    trial = optuna.trial.Trial(study, study._storage.create_new_trial(study._study_id))
     n_steps = max(expected_prune_steps)
     base_index = 1
     for i in range(base_index, base_index + n_steps):
         trial.report(base_index, i)
     study._storage.set_trial_state(trial._trial_id, TrialState.COMPLETE)
 
-    trial = optuna.trial.Trial(study, study._storage.create_new_trial(study.study_id))
+    trial = optuna.trial.Trial(study, study._storage.create_new_trial(study._study_id))
     for i in range(base_index, base_index + n_steps):
         if (i - base_index) % report_steps == 0:
             trial.report(2, i)

--- a/tests/pruners_tests/test_nop.py
+++ b/tests/pruners_tests/test_nop.py
@@ -5,7 +5,7 @@ def test_nop_pruner():
     # type: () -> None
 
     study = optuna.study.create_study()
-    trial = optuna.trial.Trial(study, study._storage.create_new_trial(study.study_id))
+    trial = optuna.trial.Trial(study, study._storage.create_new_trial(study._study_id))
     trial.report(1, 1)
     pruner = optuna.pruners.NopPruner()
 

--- a/tests/pruners_tests/test_percentile.py
+++ b/tests/pruners_tests/test_percentile.py
@@ -65,7 +65,7 @@ def test_percentile_pruner_with_one_trial():
     # type: () -> None
 
     study = optuna.study.create_study()
-    trial = optuna.trial.Trial(study, study._storage.create_new_trial(study.study_id))
+    trial = optuna.trial.Trial(study, study._storage.create_new_trial(study._study_id))
     trial.report(1, 1)
     pruner = optuna.pruners.PercentilePruner(25.0, 0, 0)
 
@@ -86,11 +86,11 @@ def test_25_percentile_pruner_intermediate_values(direction_value):
     study = optuna.study.create_study(direction=direction)
 
     for v in intermediate_values:
-        trial = optuna.trial.Trial(study, study._storage.create_new_trial(study.study_id))
+        trial = optuna.trial.Trial(study, study._storage.create_new_trial(study._study_id))
         trial.report(v, 1)
         study._storage.set_trial_state(trial._trial_id, TrialState.COMPLETE)
 
-    trial = optuna.trial.Trial(study, study._storage.create_new_trial(study.study_id))
+    trial = optuna.trial.Trial(study, study._storage.create_new_trial(study._study_id))
     # A pruner is not activated if a trial has no intermediate values.
     assert not pruner.prune(
         study=study, trial=study._storage.get_trial(trial._trial_id))
@@ -107,21 +107,21 @@ def test_25_percentile_pruner_intermediate_values_nan():
     pruner = optuna.pruners.PercentilePruner(25.0, 0, 0)
     study = optuna.study.create_study()
 
-    trial = optuna.trial.Trial(study, study._storage.create_new_trial(study.study_id))
+    trial = optuna.trial.Trial(study, study._storage.create_new_trial(study._study_id))
     trial.report(float('nan'), 1)
     # A pruner is not activated if the study does not have any previous trials.
     assert not pruner.prune(
         study=study, trial=study._storage.get_trial(trial._trial_id))
     study._storage.set_trial_state(trial._trial_id, TrialState.COMPLETE)
 
-    trial = optuna.trial.Trial(study, study._storage.create_new_trial(study.study_id))
+    trial = optuna.trial.Trial(study, study._storage.create_new_trial(study._study_id))
     trial.report(float('nan'), 1)
     # A pruner is activated if the best intermediate value of this trial is NaN.
     assert pruner.prune(
         study=study, trial=study._storage.get_trial(trial._trial_id))
     study._storage.set_trial_state(trial._trial_id, TrialState.COMPLETE)
 
-    trial = optuna.trial.Trial(study, study._storage.create_new_trial(study.study_id))
+    trial = optuna.trial.Trial(study, study._storage.create_new_trial(study._study_id))
     trial.report(1, 1)
     # A pruner is not activated if the 25 percentile intermediate value is NaN.
     assert not pruner.prune(
@@ -141,14 +141,14 @@ def test_get_best_intermediate_result_over_steps(direction_expected):
         study = optuna.study.create_study(direction="maximize")
 
     # FrozenTrial.intermediate_values has no elements.
-    trial_id_empty = study._storage.create_new_trial(study.study_id)
+    trial_id_empty = study._storage.create_new_trial(study._study_id)
     trial_empty = study._storage.get_trial(trial_id_empty)
 
     with pytest.raises(ValueError):
         percentile._get_best_intermediate_result_over_steps(trial_empty, direction)
 
     # Input value has no NaNs but float values.
-    trial_id_float = study._storage.create_new_trial(study.study_id)
+    trial_id_float = study._storage.create_new_trial(study._study_id)
     trial_float = optuna.trial.Trial(study, trial_id_float)
     trial_float.report(0.1, step=0)
     trial_float.report(0.2, step=1)
@@ -157,7 +157,7 @@ def test_get_best_intermediate_result_over_steps(direction_expected):
         frozen_trial_float, direction)
 
     # Input value has a float value and a NaN.
-    trial_id_float_nan = study._storage.create_new_trial(study.study_id)
+    trial_id_float_nan = study._storage.create_new_trial(study._study_id)
     trial_float_nan = optuna.trial.Trial(study, trial_id_float_nan)
     trial_float_nan.report(0.3, step=0)
     trial_float_nan.report(float('nan'), step=1)
@@ -166,7 +166,7 @@ def test_get_best_intermediate_result_over_steps(direction_expected):
         frozen_trial_float_nan, direction)
 
     # Input value has a NaN only.
-    trial_id_nan = study._storage.create_new_trial(study.study_id)
+    trial_id_nan = study._storage.create_new_trial(study._study_id)
     trial_nan = optuna.trial.Trial(study, trial_id_nan)
     trial_nan.report(float('nan'), step=0)
     frozen_trial_nan = study._storage.get_trial(trial_id_nan)
@@ -182,13 +182,13 @@ def test_get_percentile_intermediate_result_over_trials():
 
         _study = optuna.study.create_study(direction="minimize")
         trial_ids = [_study._storage.create_new_trial(
-            _study.study_id) for _ in range(trial_num)]
+            _study._study_id) for _ in range(trial_num)]
 
         for step, values in enumerate(_intermediate_values):
             # Study does not have any trials.
             with pytest.raises(ValueError):
-                _all_trials = _study._storage.get_all_trials(_study.study_id)
-                _direction = _study._storage.get_study_direction(_study.study_id)
+                _all_trials = _study._storage.get_all_trials(_study._study_id)
+                _direction = _study._storage.get_study_direction(_study._study_id)
                 percentile._get_percentile_intermediate_result_over_trials(
                     _all_trials, _direction, step, 25)
 
@@ -206,8 +206,8 @@ def test_get_percentile_intermediate_result_over_trials():
     # Input value has no NaNs but float values (step=0).
     intermediate_values = [[0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]]
     study = setup_study(9, intermediate_values)
-    all_trials = study._storage.get_all_trials(study.study_id)
-    direction = study._storage.get_study_direction(study.study_id)
+    all_trials = study._storage.get_all_trials(study._study_id)
+    direction = study._storage.get_study_direction(study._study_id)
     assert 0.3 == percentile._get_percentile_intermediate_result_over_trials(
         all_trials, direction, 0, 25.0)
 
@@ -216,8 +216,8 @@ def test_get_percentile_intermediate_result_over_trials():
         0.1, 0.2, 0.3, 0.4, 0.5,
         float('nan'), float('nan'), float('nan'), float('nan')])
     study = setup_study(9, intermediate_values)
-    all_trials = study._storage.get_all_trials(study.study_id)
-    direction = study._storage.get_study_direction(study.study_id)
+    all_trials = study._storage.get_all_trials(study._study_id)
+    direction = study._storage.get_study_direction(study._study_id)
     assert 0.2 == percentile._get_percentile_intermediate_result_over_trials(
         all_trials, direction, 1, 25.0)
 
@@ -226,7 +226,7 @@ def test_get_percentile_intermediate_result_over_trials():
         float('nan'), float('nan'), float('nan'), float('nan'), float('nan'),
         float('nan'), float('nan'), float('nan'), float('nan')])
     study = setup_study(9, intermediate_values)
-    all_trials = study._storage.get_all_trials(study.study_id)
-    direction = study._storage.get_study_direction(study.study_id)
+    all_trials = study._storage.get_all_trials(study._study_id)
+    direction = study._storage.get_study_direction(study._study_id)
     assert math.isnan(percentile._get_percentile_intermediate_result_over_trials(
         all_trials, direction, 2, 75))

--- a/tests/pruners_tests/test_successive_halving.py
+++ b/tests/pruners_tests/test_successive_halving.py
@@ -16,13 +16,13 @@ def test_successive_halving_pruner_intermediate_values(direction_value):
         min_resource=1, reduction_factor=2, min_early_stopping_rate=0)
     study = optuna.study.create_study(direction=direction)
 
-    trial = optuna.trial.Trial(study, study._storage.create_new_trial(study.study_id))
+    trial = optuna.trial.Trial(study, study._storage.create_new_trial(study._study_id))
     trial.report(1, 1)
 
     # A pruner is not activated at a first trial.
     assert not pruner.prune(study=study, trial=study._storage.get_trial(trial._trial_id))
 
-    trial = optuna.trial.Trial(study, study._storage.create_new_trial(study.study_id))
+    trial = optuna.trial.Trial(study, study._storage.create_new_trial(study._study_id))
     # A pruner is not activated if a trial has no intermediate values.
     assert not pruner.prune(study=study, trial=study._storage.get_trial(trial._trial_id))
 
@@ -40,26 +40,26 @@ def test_successive_halving_pruner_rung_check():
 
     # Report 7 trials in advance.
     for i in range(7):
-        trial = optuna.trial.Trial(study, study._storage.create_new_trial(study.study_id))
+        trial = optuna.trial.Trial(study, study._storage.create_new_trial(study._study_id))
         trial.report(0.1 * (i + 1), step=7)
         pruner.prune(study=study, trial=study._storage.get_trial(trial._trial_id))
 
     # Report a trial that has the 7-th value from bottom.
-    trial = optuna.trial.Trial(study, study._storage.create_new_trial(study.study_id))
+    trial = optuna.trial.Trial(study, study._storage.create_new_trial(study._study_id))
     trial.report(0.75, step=7)
     pruner.prune(study=study, trial=study._storage.get_trial(trial._trial_id))
     assert 'completed_rung_0' in trial.system_attrs
     assert 'completed_rung_1' not in trial.system_attrs
 
     # Report a trial that has the third value from bottom.
-    trial = optuna.trial.Trial(study, study._storage.create_new_trial(study.study_id))
+    trial = optuna.trial.Trial(study, study._storage.create_new_trial(study._study_id))
     trial.report(0.25, step=7)
     pruner.prune(study=study, trial=study._storage.get_trial(trial._trial_id))
     assert 'completed_rung_1' in trial.system_attrs
     assert 'completed_rung_2' not in trial.system_attrs
 
     # Report a trial that has the lowest value.
-    trial = optuna.trial.Trial(study, study._storage.create_new_trial(study.study_id))
+    trial = optuna.trial.Trial(study, study._storage.create_new_trial(study._study_id))
     trial.report(0.05, step=7)
     pruner.prune(study=study, trial=study._storage.get_trial(trial._trial_id))
     assert 'completed_rung_2' in trial.system_attrs
@@ -73,7 +73,7 @@ def test_successive_halving_pruner_first_trial_is_not_pruned():
         min_resource=1, reduction_factor=2, min_early_stopping_rate=0)
     study = optuna.study.create_study()
 
-    trial = optuna.trial.Trial(study, study._storage.create_new_trial(study.study_id))
+    trial = optuna.trial.Trial(study, study._storage.create_new_trial(study._study_id))
     for i in range(10):
         trial.report(1, step=i)
 
@@ -96,7 +96,7 @@ def test_successive_halving_pruner_with_nan():
         min_resource=2, reduction_factor=2, min_early_stopping_rate=0)
     study = optuna.study.create_study()
 
-    trial = optuna.trial.Trial(study, study._storage.create_new_trial(study.study_id))
+    trial = optuna.trial.Trial(study, study._storage.create_new_trial(study._study_id))
 
     # A pruner is not activated if the step is not a rung completion point.
     trial.report(float('nan'), step=1)
@@ -121,7 +121,7 @@ def test_successive_halving_pruner_min_resource_parameter():
     # min_resource=1: The rung 0 ends at step 1.
     pruner = optuna.pruners.SuccessiveHalvingPruner(
         min_resource=1, reduction_factor=2, min_early_stopping_rate=0)
-    trial = optuna.trial.Trial(study, study._storage.create_new_trial(study.study_id))
+    trial = optuna.trial.Trial(study, study._storage.create_new_trial(study._study_id))
 
     trial.report(1, step=1)
     assert not pruner.prune(study=study, trial=study._storage.get_trial(trial._trial_id))
@@ -131,7 +131,7 @@ def test_successive_halving_pruner_min_resource_parameter():
     # min_resource=2: The rung 0 ends at step 2.
     pruner = optuna.pruners.SuccessiveHalvingPruner(
         min_resource=2, reduction_factor=2, min_early_stopping_rate=0)
-    trial = optuna.trial.Trial(study, study._storage.create_new_trial(study.study_id))
+    trial = optuna.trial.Trial(study, study._storage.create_new_trial(study._study_id))
 
     trial.report(1, step=1)
     assert not pruner.prune(study=study, trial=study._storage.get_trial(trial._trial_id))
@@ -156,7 +156,7 @@ def test_successive_halving_pruner_reduction_factor_parameter():
     # reduction_factor=2: The rung 0 ends at step 1.
     pruner = optuna.pruners.SuccessiveHalvingPruner(
         min_resource=1, reduction_factor=2, min_early_stopping_rate=0)
-    trial = optuna.trial.Trial(study, study._storage.create_new_trial(study.study_id))
+    trial = optuna.trial.Trial(study, study._storage.create_new_trial(study._study_id))
 
     trial.report(1, step=1)
     assert not pruner.prune(study=study, trial=study._storage.get_trial(trial._trial_id))
@@ -166,7 +166,7 @@ def test_successive_halving_pruner_reduction_factor_parameter():
     # reduction_factor=3: The rung 1 ends at step 3.
     pruner = optuna.pruners.SuccessiveHalvingPruner(
         min_resource=1, reduction_factor=3, min_early_stopping_rate=0)
-    trial = optuna.trial.Trial(study, study._storage.create_new_trial(study.study_id))
+    trial = optuna.trial.Trial(study, study._storage.create_new_trial(study._study_id))
 
     trial.report(1, step=1)
     assert not pruner.prune(study=study, trial=study._storage.get_trial(trial._trial_id))
@@ -196,7 +196,7 @@ def test_successive_halving_pruner_min_early_stopping_rate_parameter():
     # min_early_stopping_rate=0: The rung 0 ends at step 1.
     pruner = optuna.pruners.SuccessiveHalvingPruner(
         min_resource=1, reduction_factor=2, min_early_stopping_rate=0)
-    trial = optuna.trial.Trial(study, study._storage.create_new_trial(study.study_id))
+    trial = optuna.trial.Trial(study, study._storage.create_new_trial(study._study_id))
 
     trial.report(1, step=1)
     assert not pruner.prune(study=study, trial=study._storage.get_trial(trial._trial_id))
@@ -205,7 +205,7 @@ def test_successive_halving_pruner_min_early_stopping_rate_parameter():
     # min_early_stopping_rate=1: The rung 0 ends at step 2.
     pruner = optuna.pruners.SuccessiveHalvingPruner(
         min_resource=1, reduction_factor=2, min_early_stopping_rate=1)
-    trial = optuna.trial.Trial(study, study._storage.create_new_trial(study.study_id))
+    trial = optuna.trial.Trial(study, study._storage.create_new_trial(study._study_id))
 
     trial.report(1, step=1)
     assert not pruner.prune(study=study, trial=study._storage.get_trial(trial._trial_id))

--- a/tests/samplers_tests/test_samplers.py
+++ b/tests/samplers_tests/test_samplers.py
@@ -144,7 +144,7 @@ def test_categorical(sampler_class, choices):
 def _create_new_trial(study):
     # type: (Study) -> FrozenTrial
 
-    trial_id = study._storage.create_new_trial(study.study_id)
+    trial_id = study._storage.create_new_trial(study._study_id)
     return study._storage.get_trial(trial_id)
 
 

--- a/tests/samplers_tests/tpe_tests/test_sampler.py
+++ b/tests/samplers_tests/tpe_tests/test_sampler.py
@@ -40,7 +40,7 @@ def test_get_observation_pairs():
     # direction=minimize.
     study = optuna.create_study(direction='minimize')
     study.optimize(objective, n_trials=5, catch=(RuntimeError,))
-    study._storage.create_new_trial(study.study_id)  # Create a running trial.
+    study._storage.create_new_trial(study._study_id)  # Create a running trial.
 
     assert tpe.sampler._get_observation_pairs(study, 'x') == (
         [5.0, 5.0, 5.0, 5.0],
@@ -55,7 +55,7 @@ def test_get_observation_pairs():
     # direction=maximize.
     study = optuna.create_study(direction='maximize')
     study.optimize(objective, n_trials=4)
-    study._storage.create_new_trial(study.study_id)  # Create a running trial.
+    study._storage.create_new_trial(study._study_id)  # Create a running trial.
 
     assert tpe.sampler._get_observation_pairs(study, 'x') == (
         [5.0, 5.0, 5.0, 5.0],

--- a/tests/storages_tests/rdb_tests/test_storage.py
+++ b/tests/storages_tests/rdb_tests/test_storage.py
@@ -174,7 +174,7 @@ def test_get_all_study_summaries_with_multiple_studies():
     study_id_3 = storage.create_new_study()
 
     summaries = storage.get_all_study_summaries()
-    summaries = sorted(summaries, key=lambda x: x.study_id)
+    summaries = sorted(summaries, key=lambda x: x._study_id)
 
     expected_summary_1 = StudySummary(
         study_id=study_id_1,

--- a/tests/storages_tests/rdb_tests/test_storage.py
+++ b/tests/storages_tests/rdb_tests/test_storage.py
@@ -174,7 +174,7 @@ def test_get_all_study_summaries_with_multiple_studies():
     study_id_3 = storage.create_new_study()
 
     summaries = storage.get_all_study_summaries()
-    summaries = sorted(summaries, key=lambda x: x._study_id)
+    summaries = sorted(summaries)
 
     expected_summary_1 = StudySummary(
         study_id=study_id_1,

--- a/tests/storages_tests/test_storages.py
+++ b/tests/storages_tests/test_storages.py
@@ -185,8 +185,8 @@ def test_get_study_id_from_name_and_get_study_name_from_id(storage_mode, cache_m
         study = optuna.create_study(storage=storage, study_name=study_name)
 
         # Test existing study.
-        assert storage.get_study_name_from_id(study.study_id) == study_name
-        assert storage.get_study_id_from_name(study_name) == study.study_id
+        assert storage.get_study_name_from_id(study._study_id) == study_name
+        assert storage.get_study_id_from_name(study_name) == study._study_id
 
         # Test not existing study.
         with pytest.raises(ValueError):

--- a/tests/storages_tests/test_storages.py
+++ b/tests/storages_tests/test_storages.py
@@ -119,7 +119,7 @@ def test_create_new_study(storage_init_func):
 
     summaries = storage.get_all_study_summaries()
     assert len(summaries) == 1
-    assert summaries[0].study_id == study_id
+    assert summaries[0]._study_id == study_id
     assert summaries[0].study_name.startswith(DEFAULT_STUDY_NAME_PREFIX)
 
 
@@ -165,7 +165,7 @@ def test_delete_study_after_create_multiple_studies():
 
     storage.delete_study(study_id2)
 
-    studies = {s.study_id: s for s in storage.get_all_study_summaries()}
+    studies = {s._study_id: s for s in storage.get_all_study_summaries()}
     assert study_id1 in studies
     assert study_id2 not in studies
     assert study_id3 in studies
@@ -601,7 +601,7 @@ def test_get_all_study_summaries(storage_init_func):
     summaries = storage.get_all_study_summaries()
 
     assert len(summaries) == 1
-    assert summaries[0].study_id == study_id
+    assert summaries[0]._study_id == study_id
     assert summaries[0].study_name == storage.get_study_name_from_id(study_id)
     assert summaries[0].direction == StudyDirection.MINIMIZE
     assert summaries[0].user_attrs == EXAMPLE_ATTRS

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -277,7 +277,8 @@ def test_study_optimize_command():
         assert 'x' in study.best_params
 
         # Check if a default value of study_name is stored in the storage.
-        assert storage.get_study_name_from_id(study.study_id).startswith(DEFAULT_STUDY_NAME_PREFIX)
+        assert storage.get_study_name_from_id(
+            study._study_id).startswith(DEFAULT_STUDY_NAME_PREFIX)
 
 
 def test_study_optimize_command_inconsistent_args():

--- a/tests/test_structs.py
+++ b/tests/test_structs.py
@@ -1,6 +1,7 @@
 import copy
 import datetime
 import pytest
+import warnings
 
 import optuna
 from optuna.distributions import LogUniformDistribution
@@ -147,7 +148,10 @@ def test_study_summary_study_id():
 
     summary = summaries[0]
 
-    assert summary.study_id == summary._study_id
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore', category=DeprecationWarning)
+        assert summary.study_id == summary._study_id
+
     with pytest.warns(DeprecationWarning):
         summary.study_id
 

--- a/tests/test_structs.py
+++ b/tests/test_structs.py
@@ -170,6 +170,9 @@ def test_study_summary_eq_ne():
     assert summaries[0] == copy.deepcopy(summaries[0])
     assert summaries[0] != summaries[1]
 
+    assert not summaries[0] == 1
+    assert summaries[0] != 1
+
 
 # TODO(Yanase): Remove version check after Python 2.7 is retired.
 @pytest.mark.skipif('sys.version_info < (3, 5)',

--- a/tests/test_structs.py
+++ b/tests/test_structs.py
@@ -136,3 +136,43 @@ def test_frozen_trial_repr():
                         intermediate_values={})
 
     assert trial == eval(repr(trial))
+
+
+def test_study_summary_study_id():
+    # type: () -> None
+
+    study = optuna.create_study()
+    summaries = study._storage.get_all_study_summaries()
+    assert len(summaries) == 1
+
+    summary = summaries[0]
+
+    assert summary.study_id == summary._study_id
+    with pytest.warns(DeprecationWarning):
+        summary.study_id
+
+
+def test_study_summary_eq_ne_lt():
+    # type: () -> None
+
+    storage = optuna.storages.RDBStorage('sqlite:///:memory:')
+
+    optuna.create_study(storage=storage)
+    study = optuna.create_study(storage=storage)
+
+    summaries = study._storage.get_all_study_summaries()
+    assert len(summaries) == 2
+
+    summary_0 = summaries[0]
+    summary_1 = summaries[1]
+
+    assert summary_0 == copy.deepcopy(summary_0)
+    assert summary_0 != summary_1
+    assert summary_0 < summary_1
+    assert not summary_1 < summary_0
+
+    # A list of StudySummaries is sortable.
+    summaries.reverse()
+    summaries.sort()
+    assert summaries[0] == summary_0
+    assert summaries[1] == summary_1

--- a/tests/test_structs.py
+++ b/tests/test_structs.py
@@ -172,7 +172,8 @@ def test_study_summary_eq_ne():
 
 
 # TODO(Yanase): Remove version check after Python 2.7 is retired.
-@pytest.mark.skipif('sys.version_info < (3, 5)')
+@pytest.mark.skipif('sys.version_info < (3, 5)',
+                    reason='NotImplemented does not raise TypeError in Python 2.7.')
 def test_study_summary_lt():
     # type: () -> None
 

--- a/tests/test_structs.py
+++ b/tests/test_structs.py
@@ -152,7 +152,7 @@ def test_study_summary_study_id():
         summary.study_id
 
 
-def test_study_summary_eq_ne_lt():
+def test_study_summary_eq_ne():
     # type: () -> None
 
     storage = optuna.storages.RDBStorage('sqlite:///:memory:')

--- a/tests/test_structs.py
+++ b/tests/test_structs.py
@@ -194,13 +194,11 @@ def test_study_summary_lt_le():
     with pytest.raises(TypeError):
         summary_0 < 1
 
-    # Skip type checking as mypy does not support functools.total_ordering.
-    # See https://github.com/python/mypy/issues/4610.
-    assert summary_0 <= summary_0  # type: ignore
-    assert not summary_1 <= summary_0  # type: ignore
+    assert summary_0 <= summary_0
+    assert not summary_1 <= summary_0
 
     with pytest.raises(TypeError):
-        summary_0 <= 1  # type: ignore
+        summary_0 <= 1
 
     # A list of StudySummaries is sortable.
     summaries.reverse()

--- a/tests/test_structs.py
+++ b/tests/test_structs.py
@@ -170,9 +170,6 @@ def test_study_summary_eq_ne():
     assert summaries[0] != 1
 
 
-# TODO(Yanase): Remove version check after Python 2.7 is retired.
-@pytest.mark.skipif('sys.version_info < (3, 5)',
-                    reason='NotImplemented does not raise TypeError in Python 2.7.')
 def test_study_summary_lt_le():
     # type: () -> None
 

--- a/tests/test_structs.py
+++ b/tests/test_structs.py
@@ -163,13 +163,31 @@ def test_study_summary_eq_ne_lt():
     summaries = study._storage.get_all_study_summaries()
     assert len(summaries) == 2
 
+    assert summaries[0] == copy.deepcopy(summaries[0])
+    assert summaries[0] != summaries[1]
+
+
+# TODO(Yanase): Remove version check after Python 2.7 is retired.
+@pytest.mark.skipif('sys.version_info < (3, 5)')
+def test_study_summary_lt():
+    # type: () -> None
+
+    storage = optuna.storages.RDBStorage('sqlite:///:memory:')
+
+    optuna.create_study(storage=storage)
+    study = optuna.create_study(storage=storage)
+
+    summaries = study._storage.get_all_study_summaries()
+    assert len(summaries) == 2
+
     summary_0 = summaries[0]
     summary_1 = summaries[1]
 
-    assert summary_0 == copy.deepcopy(summary_0)
-    assert summary_0 != summary_1
     assert summary_0 < summary_1
     assert not summary_1 < summary_0
+
+    with pytest.raises(TypeError):
+        summary_0 < 1
 
     # A list of StudySummaries is sortable.
     summaries.reverse()

--- a/tests/test_structs.py
+++ b/tests/test_structs.py
@@ -174,7 +174,7 @@ def test_study_summary_eq_ne():
 # TODO(Yanase): Remove version check after Python 2.7 is retired.
 @pytest.mark.skipif('sys.version_info < (3, 5)',
                     reason='NotImplemented does not raise TypeError in Python 2.7.')
-def test_study_summary_lt():
+def test_study_summary_lt_le():
     # type: () -> None
 
     storage = optuna.storages.RDBStorage('sqlite:///:memory:')
@@ -193,6 +193,14 @@ def test_study_summary_lt():
 
     with pytest.raises(TypeError):
         summary_0 < 1
+
+    # Skip type checking as mypy does not support functools.total_ordering.
+    # See https://github.com/python/mypy/issues/4610.
+    assert summary_0 <= summary_0  # type: ignore
+    assert not summary_1 <= summary_0  # type: ignore
+
+    with pytest.raises(TypeError):
+        summary_0 <= 1  # type: ignore
 
     # A list of StudySummaries is sortable.
     summaries.reverse()

--- a/tests/test_study.py
+++ b/tests/test_study.py
@@ -336,7 +336,7 @@ def test_get_all_study_summaries(storage_mode, cache_mode):
         study.optimize(Func(), n_trials=5)
 
         summaries = optuna.get_all_study_summaries(study._storage)
-        summary = [s for s in summaries if s.study_id == study.study_id][0]
+        summary = [s for s in summaries if s.study_id == study._study_id][0]
 
         assert summary.study_name == study.study_name
         assert summary.n_trials == 5
@@ -351,7 +351,7 @@ def test_get_all_study_summaries_with_no_trials(storage_mode, cache_mode):
         study = optuna.create_study(storage=storage)
 
         summaries = optuna.get_all_study_summaries(study._storage)
-        summary = [s for s in summaries if s.study_id == study.study_id][0]
+        summary = [s for s in summaries if s.study_id == study._study_id][0]
 
         assert summary.study_name == study.study_name
         assert summary.n_trials == 0
@@ -590,7 +590,7 @@ def test_load_study(storage_mode, cache_mode):
 
         # Test loading an existing study.
         loaded_study = optuna.study.load_study(study_name=study_name, storage=storage)
-        assert created_study.study_id == loaded_study.study_id
+        assert created_study._study_id == loaded_study._study_id
 
 
 @pytest.mark.parametrize('storage_mode', STORAGE_MODES)

--- a/tests/test_study.py
+++ b/tests/test_study.py
@@ -729,3 +729,13 @@ def test_callbacks(n_jobs):
             study.optimize(lambda t: 1/0, callbacks=callbacks,
                            n_trials=10, n_jobs=n_jobs, catch=())
         assert states == []
+
+
+def test_study_id():
+    # type: () -> None
+
+    study = optuna.create_study()
+    assert study.study_id == study._study_id
+
+    with pytest.warns(DeprecationWarning):
+        study.study_id

--- a/tests/test_study.py
+++ b/tests/test_study.py
@@ -9,6 +9,7 @@ import pytest
 import threading
 import time
 import uuid
+import warnings
 
 import optuna
 from optuna.testing.storage import StorageSupplier
@@ -735,7 +736,10 @@ def test_study_id():
     # type: () -> None
 
     study = optuna.create_study()
-    assert study.study_id == study._study_id
+
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore', category=DeprecationWarning)
+        assert study.study_id == study._study_id
 
     with pytest.warns(DeprecationWarning):
         study.study_id

--- a/tests/test_study.py
+++ b/tests/test_study.py
@@ -336,7 +336,7 @@ def test_get_all_study_summaries(storage_mode, cache_mode):
         study.optimize(Func(), n_trials=5)
 
         summaries = optuna.get_all_study_summaries(study._storage)
-        summary = [s for s in summaries if s.study_id == study._study_id][0]
+        summary = [s for s in summaries if s._study_id == study._study_id][0]
 
         assert summary.study_name == study.study_name
         assert summary.n_trials == 5
@@ -351,7 +351,7 @@ def test_get_all_study_summaries_with_no_trials(storage_mode, cache_mode):
         study = optuna.create_study(storage=storage)
 
         summaries = optuna.get_all_study_summaries(study._storage)
-        summary = [s for s in summaries if s.study_id == study._study_id][0]
+        summary = [s for s in summaries if s._study_id == study._study_id][0]
 
         assert summary.study_name == study.study_name
         assert summary.n_trials == 0

--- a/tests/test_trial.py
+++ b/tests/test_trial.py
@@ -33,7 +33,7 @@ def test_suggest_uniform(storage_init_func):
 
     with patch.object(sampler, 'sample_independent', mock) as mock_object:
         study = create_study(storage_init_func(), sampler=sampler)
-        trial = Trial(study, study._storage.create_new_trial(study.study_id))
+        trial = Trial(study, study._storage.create_new_trial(study._study_id))
         distribution = distributions.UniformDistribution(low=0., high=3.)
 
         assert trial._suggest('x', distribution) == 1.  # Test suggesting a param.
@@ -53,7 +53,7 @@ def test_suggest_discrete_uniform(storage_init_func):
 
     with patch.object(sampler, 'sample_independent', mock) as mock_object:
         study = create_study(storage_init_func(), sampler=sampler)
-        trial = Trial(study, study._storage.create_new_trial(study.study_id))
+        trial = Trial(study, study._storage.create_new_trial(study._study_id))
         distribution = distributions.DiscreteUniformDistribution(low=0., high=3., q=1.)
 
         assert trial._suggest('x', distribution) == 1.  # Test suggesting a param.
@@ -68,7 +68,7 @@ def test_suggest_low_equals_high(storage_init_func):
     # type: (typing.Callable[[], storages.BaseStorage]) -> None
 
     study = create_study(storage_init_func(), sampler=samplers.TPESampler(n_startup_trials=0))
-    trial = Trial(study, study._storage.create_new_trial(study.study_id))
+    trial = Trial(study, study._storage.create_new_trial(study._study_id))
 
     # Parameter values are determined without suggestion when low == high.
     with patch.object(trial, '_suggest', wraps=trial._suggest) as mock_object:
@@ -147,7 +147,7 @@ def test_suggest_discrete_uniform_range(storage_init_func, range_config):
     mock.side_effect = lambda study, trial, param_name, distribution: distribution.high
     with patch.object(sampler, 'sample_independent', mock) as mock_object:
         study = create_study(storage_init_func(), sampler=sampler)
-        trial = Trial(study, study._storage.create_new_trial(study.study_id))
+        trial = Trial(study, study._storage.create_new_trial(study._study_id))
 
         x = trial.suggest_discrete_uniform('x', range_config['low'], range_config['high'],
                                            range_config['q'])
@@ -159,7 +159,7 @@ def test_suggest_discrete_uniform_range(storage_init_func, range_config):
     mock.side_effect = lambda study, trial, param_name, distribution: distribution.low
     with patch.object(sampler, 'sample_independent', mock) as mock_object:
         study = create_study(storage_init_func(), sampler=sampler)
-        trial = Trial(study, study._storage.create_new_trial(study.study_id))
+        trial = Trial(study, study._storage.create_new_trial(study._study_id))
 
         x = trial.suggest_discrete_uniform('x', range_config['low'], range_config['high'],
                                            range_config['q'])
@@ -177,7 +177,7 @@ def test_suggest_int(storage_init_func):
 
     with patch.object(sampler, 'sample_independent', mock) as mock_object:
         study = create_study(storage_init_func(), sampler=sampler)
-        trial = Trial(study, study._storage.create_new_trial(study.study_id))
+        trial = Trial(study, study._storage.create_new_trial(study._study_id))
         distribution = distributions.IntUniformDistribution(low=0, high=3)
 
         assert trial._suggest('x', distribution) == 1  # Test suggesting a param.
@@ -219,7 +219,7 @@ def test_trial_should_prune():
 
     pruner = DeterministicPruner(True)
     study = create_study(pruner=pruner)
-    trial = Trial(study, study._storage.create_new_trial(study.study_id))
+    trial = Trial(study, study._storage.create_new_trial(study._study_id))
     trial.report(1, 1)
     assert trial.should_prune()
 
@@ -354,7 +354,7 @@ def test_relative_parameters(storage_init_func):
     def create_trial():
         # type: () -> Trial
 
-        return Trial(study, study._storage.create_new_trial(study.study_id))
+        return Trial(study, study._storage.create_new_trial(study._study_id))
 
     # Suggested from `relative_params`.
     trial0 = create_trial()
@@ -406,7 +406,7 @@ def test_trial_report():
     # type: () -> None
 
     study = create_study()
-    trial = Trial(study, study._storage.create_new_trial(study.study_id))
+    trial = Trial(study, study._storage.create_new_trial(study._study_id))
 
     # Report values that can be cast to `float` (OK).
     trial.report(1.23)

--- a/tests/test_trial.py
+++ b/tests/test_trial.py
@@ -3,6 +3,7 @@ from mock import Mock
 from mock import patch
 import numpy as np
 import pytest
+import warnings
 
 from optuna import distributions
 from optuna import samplers
@@ -431,3 +432,17 @@ def test_trial_report():
 
     with pytest.raises(ValueError):
         trial.report(1.23, -1)
+
+
+def test_study_id():
+    # type: () -> None
+
+    study = create_study()
+    trial = Trial(study, study._storage.create_new_trial(study._study_id))
+
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore', category=DeprecationWarning)
+        assert trial.study_id == trial.study._study_id
+
+    with pytest.warns(DeprecationWarning):
+        trial.study_id


### PR DESCRIPTION
This PR makes the `study_id` attribute of `Study` and `StudySummary` private. It also renames `study_id` to `_study_id`. The original attribute is maintained with `DeprecationWarning`.

Similarly to the change of `FrozenTrial`, `StudySummary` will be mutable because `NamedTuple` can not have attributes prefixed with `_` (see #663 for further details). The new `StudySummary` will be sorted `_study_id` to keep the backward compatibility with the original implementation. Please note that the order is undefined if two instances have the same `_study_id` although such a situation is not usually happened.

[Opinion Wanted]
`StudySummary.__hash__` is not implemented because the original implementation does not support it. `StudySummary` is not expected to be a dictionary key (Updated on 20 Nov.). ~~I think sorting a huge list of StudySummaries is not usual, and the lack of `__hash__` is not critical to most of the users.~~ If you have any ideas about it, please let me know.