### PR TITLE
Add `FrozenTrial.__lt__` to sort trials without key.

### DIFF
--- a/optuna/structs.py
+++ b/optuna/structs.py
@@ -143,6 +143,14 @@ class FrozenTrial(object):
 
         return self.number < other.number
 
+    def __le__(self, other):
+        # type: (Any) -> bool
+
+        if not isinstance(other, FrozenTrial):
+            return NotImplemented
+
+        return self.number <= other.number
+
     def __hash__(self):
         # type: () -> int
 

--- a/optuna/structs.py
+++ b/optuna/structs.py
@@ -138,7 +138,7 @@ class FrozenTrial(object):
     def __lt__(self, other):
         # type: (Any) -> bool
 
-        if not isinstance(other, type(self)):
+        if not isinstance(other, FrozenTrial):
             return NotImplemented
 
         return self.number < other.number

--- a/optuna/structs.py
+++ b/optuna/structs.py
@@ -139,8 +139,7 @@ class FrozenTrial(object):
         # type: (Any) -> bool
 
         if not isinstance(other, type(self)):
-            raise TypeError('\'<\' not supported between instances of {} and {}'.format(
-                type(self.__class__.__name__), type(other)))
+            return NotImplemented
 
         return self.number < other.number
 

--- a/optuna/structs.py
+++ b/optuna/structs.py
@@ -135,6 +135,15 @@ class FrozenTrial(object):
 
         return not self.__eq__(other)
 
+    def __lt__(self, other):
+        # type: (Any) -> bool
+
+        if not isinstance(other, type(self)):
+            raise TypeError('\'<\' not supported between instances of {} and {}'.format(
+                type(self.__class__.__name__), type(other)))
+
+        return self.number < other.number
+
     def __hash__(self):
         # type: () -> int
 

--- a/tests/test_structs.py
+++ b/tests/test_structs.py
@@ -108,6 +108,9 @@ def test_frozen_trial_lt():
     assert trial < trial_other
     assert not trial_other < trial
 
+    with pytest.raises(TypeError):
+        trial < 1
+
     # A list of FrozenTrials is sortable.
     trials = [trial_other, trial]
     trials.sort()

--- a/tests/test_structs.py
+++ b/tests/test_structs.py
@@ -96,6 +96,8 @@ def test_frozen_trial_eq_ne():
     assert trial != trial_other
 
 
+# TODO(Yanase): Remove version check after Python 2.7 is retired.
+@pytest.mark.skipif('sys.version_info < (3, 5)')
 def test_frozen_trial_lt():
     # type: () -> None
 

--- a/tests/test_structs.py
+++ b/tests/test_structs.py
@@ -120,8 +120,8 @@ def test_frozen_trial_lt():
     # A list of FrozenTrials is sortable.
     trials = [trial_other, trial]
     trials.sort()
-    assert trials[0] == trial
-    assert trials[1] == trial_other
+    assert trials[0] is trial
+    assert trials[1] is trial_other
 
 
 def _create_frozen_trial():

--- a/tests/test_structs.py
+++ b/tests/test_structs.py
@@ -21,17 +21,7 @@ def test_frozen_trial_validate():
     # type: () -> None
 
     # Valid.
-    valid_trial = FrozenTrial(number=0,
-                              trial_id=0,
-                              state=TrialState.COMPLETE,
-                              value=0.2,
-                              datetime_start=datetime.datetime.now(),
-                              datetime_complete=datetime.datetime.now(),
-                              params={'x': 10},
-                              distributions={'x': UniformDistribution(5, 12)},
-                              user_attrs={},
-                              system_attrs={},
-                              intermediate_values={})
+    valid_trial = _create_frozen_trial()
     valid_trial._validate()
 
     # Invalid: `datetime_start` is not set.
@@ -97,23 +87,48 @@ def test_frozen_trial_validate():
 def test_frozen_trial_eq_ne():
     # type: () -> None
 
-    trial = FrozenTrial(number=0,
-                        trial_id=0,
-                        state=TrialState.COMPLETE,
-                        value=0.2,
-                        datetime_start=datetime.datetime.now(),
-                        datetime_complete=datetime.datetime.now(),
-                        params={'x': 10},
-                        distributions={'x': UniformDistribution(5, 12)},
-                        user_attrs={},
-                        system_attrs={},
-                        intermediate_values={})
+    trial = _create_frozen_trial()
 
     trial_other = copy.copy(trial)
     assert trial == trial_other
 
     trial_other.value = 0.3
     assert trial != trial_other
+
+
+def test_frozen_trial_lt():
+    # type: () -> None
+
+    trial = _create_frozen_trial()
+
+    trial_other = copy.copy(trial)
+    assert not trial < trial_other
+
+    trial_other.number = trial.number + 1
+    assert trial < trial_other
+    assert not trial_other < trial
+
+    # A list of FrozenTrials is sortable.
+    trials = [trial_other, trial]
+    trials.sort()
+    assert trials[0] == trial
+    assert trials[1] == trial_other
+
+
+def _create_frozen_trial():
+    # type: () -> FrozenTrial
+
+    return FrozenTrial(number=0,
+                       trial_id=0,
+                       state=TrialState.COMPLETE,
+                       value=0.2,
+                       datetime_start=datetime.datetime.now(),
+                       datetime_complete=datetime.datetime.now(),
+                       params={'x': 10},
+                       distributions={'x': UniformDistribution(5, 12)},
+                       user_attrs={},
+                       system_attrs={},
+                       intermediate_values={})
 
 
 # TODO(hvy): Remove version check after Python 2.7 is retired.

--- a/tests/test_structs.py
+++ b/tests/test_structs.py
@@ -113,6 +113,12 @@ def test_frozen_trial_lt():
     with pytest.raises(TypeError):
         trial < 1
 
+    assert trial <= trial_other
+    assert not trial_other <= trial
+
+    with pytest.raises(TypeError):
+        trial <= 1
+
     # A list of FrozenTrials is sortable.
     trials = [trial_other, trial]
     trials.sort()

--- a/tests/test_structs.py
+++ b/tests/test_structs.py
@@ -97,7 +97,8 @@ def test_frozen_trial_eq_ne():
 
 
 # TODO(Yanase): Remove version check after Python 2.7 is retired.
-@pytest.mark.skipif('sys.version_info < (3, 5)')
+@pytest.mark.skipif('sys.version_info < (3, 5)',
+                    reason='NotImplemented does not raise TypeError in Python 2.7.')
 def test_frozen_trial_lt():
     # type: () -> None
 


### PR DESCRIPTION
This PR makes `FrozenTrial.__lt__` sortable by `number` to improve backward compatibility with the `FrozenTrial` in `v0.18.x`.

The previous implementation of `FrozenTrial` was based on `NamedTuple` and it was implicitly sorted as a tuple (i.e., the first key is `number` and the second key is `state` and so on). In this PR, I only used `number` because it is unique in a study.

I'm not fully confident with this design of `sort`. Please close PR if the current behavior is expected.