### PR TITLE
Add minimum width to subplots in slice plot

### DIFF
--- a/optuna/visualization.py
+++ b/optuna/visualization.py
@@ -585,7 +585,11 @@ def _generate_slice_subplot(study, trials, param):
             },
             'color': [t.number for t in trials if param in t.params],
             'colorscale': 'Blues',
-            'colorbar': {'title': '#Trials'}
+            'colorbar': {
+                'title': '#Trials',
+                'x': 1.0,  # Offset the colorbar position with a fixed width `xpad`.
+                'xpad': 40,
+            }
         },
         showlegend=False,
     )

--- a/optuna/visualization.py
+++ b/optuna/visualization.py
@@ -531,7 +531,9 @@ def _get_slice_plot(study, params=None):
                 raise ValueError('Parameter {} does not exist in your study.'.format(input_p_name))
         sorted_params = sorted(list(set(params)))
 
-    if len(sorted_params) == 1:
+    n_params = len(sorted_params)
+
+    if n_params == 1:
         figure = go.Figure(
             data=[_generate_slice_subplot(study, trials, sorted_params[0])],
             layout=layout
@@ -555,6 +557,9 @@ def _get_slice_plot(study, params=None):
                 figure.update_yaxes(title_text='Objective Value', row=1, col=1)
             if _is_log_scale(trials, param):
                 figure.update_xaxes(type='log', row=1, col=i + 1)
+        if n_params > 3:
+            # Ensure that each subplot has a minimum width without relying on autosizing.
+            figure.update_layout(width=300 * n_params)
 
     return figure
 


### PR DESCRIPTION
Fixes https://github.com/optuna/optuna/issues/628.

Best effort resizes the overall figure horizontally if the number of subplots are above a certain threshold to keep a minimum subplot width. 