### PR TITLE
Use default parameter when tuned parameter doesn't improve

### DIFF
--- a/optuna/integration/lightgbm_tuner/optimize.py
+++ b/optuna/integration/lightgbm_tuner/optimize.py
@@ -302,6 +302,17 @@ class LightGBMTuner(BaseTuner):
         self.best_params = {} if best_params is None else best_params
         self.tuning_history = [] if tuning_history is None else tuning_history
 
+        # Set default parameters as best.
+        self.best_params.update({
+            'lambda_l1': 0.0,
+            'lambda_l2': 0.0,
+            'num_leaves': 31,
+            'feature_fraction': 1.0,
+            'bagging_fraction': 1.0,
+            'bagging_freq': 0,
+            'min_child_samples': 20,
+        })
+
         if valid_sets is None:
             raise ValueError("`valid_sets` is required.")
 
@@ -335,10 +346,6 @@ class LightGBMTuner(BaseTuner):
         self.train_set = args[1]
         self.train_subset = None  # Use for sampling.
         self.lgbm_kwargs = kwargs
-
-        # Keep original kwargs.
-        self.original_lgbm_kwargs = kwargs.copy()
-        self.original_lgbm_params = self.lgbm_params.copy()
 
     def run(self):
         # type: () -> lgb.Booster

--- a/optuna/integration/lightgbm_tuner/optimize.py
+++ b/optuna/integration/lightgbm_tuner/optimize.py
@@ -32,6 +32,17 @@ if type_checking.TYPE_CHECKING:
 # EPS is used to ensure that a sampled parameter value is in pre-defined value range.
 EPS = 1e-12
 
+# Default parameter values described in the official webpage.
+DEFAULT_LIGHTGBM_PARAMETERS = {
+    'lambda_l1': 0.0,
+    'lambda_l2': 0.0,
+    'num_leaves': 31,
+    'feature_fraction': 1.0,
+    'bagging_fraction': 1.0,
+    'bagging_freq': 0,
+    'min_child_samples': 20,
+}
+
 
 class _GridSamplerUniform1D(optuna.samplers.BaseSampler):
 
@@ -303,15 +314,7 @@ class LightGBMTuner(BaseTuner):
         self.tuning_history = [] if tuning_history is None else tuning_history
 
         # Set default parameters as best.
-        self.best_params.update({
-            'lambda_l1': 0.0,
-            'lambda_l2': 0.0,
-            'num_leaves': 31,
-            'feature_fraction': 1.0,
-            'bagging_fraction': 1.0,
-            'bagging_freq': 0,
-            'min_child_samples': 20,
-        })
+        self.best_params.update(DEFAULT_LIGHTGBM_PARAMETERS)
 
         if valid_sets is None:
             raise ValueError("`valid_sets` is required.")

--- a/tests/integration_tests/lightgbm_tuner_tests/test_optimize.py
+++ b/tests/integration_tests/lightgbm_tuner_tests/test_optimize.py
@@ -400,7 +400,7 @@ class TestLightGBMTuner(object):
             assert runner.lgbm_params['min_child_samples'] != unexpected_value
             assert len(tuning_history) == 5
 
-    def test_when_tuning_num_leaves_doesnt_improve_best_score(self):
+    def test_when_a_step_does_not_improve_best_score(self):
         # type: () -> None
 
         params = {}  # type: Dict

--- a/tests/integration_tests/lightgbm_tuner_tests/test_optimize.py
+++ b/tests/integration_tests/lightgbm_tuner_tests/test_optimize.py
@@ -295,12 +295,10 @@ class TestLightGBMTuner(object):
                 best_params=best_params,
             ))
             assert len(tuning_history) == 0
-            assert len(best_params) == 0
             runner.tune_feature_fraction()
 
             assert runner.lgbm_params['feature_fraction'] != unexpected_value
             assert len(tuning_history) == 7
-            assert len(best_params) == 1
 
     def test_tune_num_leaves(self):
         # type: () -> None
@@ -465,6 +463,6 @@ class TestLightGBMTuner(object):
 
             fake_study.optimize.assert_called()
 
-        # `num_leaves` should not be included since default is better.
-        assert 'num_leaves' not in tuner.best_params
+        # `num_leaves` should not be same as default.
+        assert tuner.best_params['num_leaves'] == 31
         assert tuner.best_score == 0.9

--- a/tests/integration_tests/lightgbm_tuner_tests/test_optimize.py
+++ b/tests/integration_tests/lightgbm_tuner_tests/test_optimize.py
@@ -403,7 +403,9 @@ class TestLightGBMTuner(object):
             assert len(tuning_history) == 5
 
     def test_when_tuning_num_leaves_doesnt_improve_best_score(self):
-        params = {}
+        # type: () -> None
+
+        params = {}  # type: Dict
         valid_data = np.zeros((10, 10))
         valid_sets = lgb.Dataset(valid_data)
         tuner = LightGBMTuner(params, None, valid_sets=valid_sets)
@@ -447,7 +449,7 @@ class TestLightGBMTuner(object):
             fake_objective.best_booster = None
             objective_mock.return_value = fake_objective
 
-            # Assume thattuning `num_leaves` doesn't improve the `best_score`.
+            # Assume that tuning `num_leaves` doesn't improve the `best_score`.
             fake_study = mock.MagicMock(spec=Study)
             fake_study._storage = mock.MagicMock()
             fake_study.best_value = 1.1


### PR DESCRIPTION
LightGBMTuner tunes parameters in groups step by step. The current implementation adopts parameters that are worse than the default when the result of tuning at one stage is worse than at the previous stage. This PR resolves it.