### PR TITLE
Fix implementations of `__eq__`

### DIFF
--- a/optuna/distributions.py
+++ b/optuna/distributions.py
@@ -84,13 +84,15 @@ class BaseDistribution(object, metaclass=abc.ABCMeta):
     def __eq__(self, other):
         # type: (Any) -> bool
 
-        if not isinstance(other, BaseDistribution):
+        if not type(self) is type(other):
             return NotImplemented
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):
         # type: (Any) -> bool
 
+        if not type(self) is type(other):
+            return NotImplemented
         return not self.__eq__(other)
 
     def __hash__(self):

--- a/optuna/distributions.py
+++ b/optuna/distributions.py
@@ -85,14 +85,12 @@ class BaseDistribution(object, metaclass=abc.ABCMeta):
         # type: (Any) -> bool
 
         if not type(self) is type(other):
-            return NotImplemented
+            return False
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):
         # type: (Any) -> bool
 
-        if not type(self) is type(other):
-            return NotImplemented
         return not self.__eq__(other)
 
     def __hash__(self):

--- a/optuna/distributions.py
+++ b/optuna/distributions.py
@@ -84,9 +84,8 @@ class BaseDistribution(object, metaclass=abc.ABCMeta):
     def __eq__(self, other):
         # type: (Any) -> bool
 
-        if not isinstance(other, type(self)):
-            return False
-
+        if not isinstance(other, BaseDistribution):
+            return NotImplemented
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/optuna/distributions.py
+++ b/optuna/distributions.py
@@ -90,13 +90,6 @@ class BaseDistribution(object, metaclass=abc.ABCMeta):
             return False
         return self.__dict__ == other.__dict__
 
-    def __ne__(self, other):
-        # type: (Any) -> bool
-
-        if not isinstance(other, BaseDistribution):
-            return NotImplemented
-        return not self.__eq__(other)
-
     def __hash__(self):
         # type: () -> int
 

--- a/optuna/distributions.py
+++ b/optuna/distributions.py
@@ -84,6 +84,8 @@ class BaseDistribution(object, metaclass=abc.ABCMeta):
     def __eq__(self, other):
         # type: (Any) -> bool
 
+        if not isinstance(other, BaseDistribution):
+            return NotImplemented
         if not type(self) is type(other):
             return False
         return self.__dict__ == other.__dict__
@@ -91,6 +93,8 @@ class BaseDistribution(object, metaclass=abc.ABCMeta):
     def __ne__(self, other):
         # type: (Any) -> bool
 
+        if not isinstance(other, BaseDistribution):
+            return NotImplemented
         return not self.__eq__(other)
 
     def __hash__(self):

--- a/optuna/structs.py
+++ b/optuna/structs.py
@@ -133,6 +133,8 @@ class FrozenTrial(object):
     def __ne__(self, other):
         # type: (Any) -> bool
 
+        if not isinstance(other, FrozenTrial):
+            return NotImplemented
         return not self.__eq__(other)
 
     def __hash__(self):

--- a/optuna/structs.py
+++ b/optuna/structs.py
@@ -126,9 +126,9 @@ class FrozenTrial(object):
     def __eq__(self, other):
         # type: (Any) -> bool
 
-        if isinstance(other, type(self)):
-            return other.__dict__ == self.__dict__
-        return False
+        if not isinstance(other, FrozenTrial):
+            return NotImplemented
+        return other.__dict__ == self.__dict__
 
     def __ne__(self, other):
         # type: (Any) -> bool

--- a/optuna/structs.py
+++ b/optuna/structs.py
@@ -130,13 +130,6 @@ class FrozenTrial(object):
             return NotImplemented
         return other.__dict__ == self.__dict__
 
-    def __ne__(self, other):
-        # type: (Any) -> bool
-
-        if not isinstance(other, FrozenTrial):
-            return NotImplemented
-        return not self.__eq__(other)
-
     def __hash__(self):
         # type: () -> int
 

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -193,8 +193,10 @@ def test_eq_ne_hash():
 
     # Two instances of a class are regarded as equivalent if the fields have the same values.
     for d in EXAMPLE_DISTRIBUTIONS.values():
-        assert d == copy.deepcopy(d)
-        assert hash(d) == hash(copy.deepcopy(d))
+        d_copy = copy.deepcopy(d)
+        assert d == d_copy
+        assert not d != d_copy
+        assert hash(d) == hash(d_copy)
 
     # Different field values.
     d0 = distributions.UniformDistribution(low=1, high=2)
@@ -208,14 +210,14 @@ def test_eq_ne_hash():
     assert d0 != d2
     assert not d0 == d2
 
+    # In the implementation of `__hash__`, only attributes are considered.
+    assert hash(d0) != hash(d2)
+
     # Different types.
     assert d0 != 1
     assert not d0 == 1
     assert d0 != 'foo'
     assert not d0 == 'foo'
-
-    # In the implementation of `__hash__`, only attributes are considered.
-    assert hash(d0) == hash(d2)
 
 
 def test_repr():

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -211,7 +211,7 @@ def test_eq_ne_hash():
     assert not d0 == d2
 
     # In the implementation of `__hash__`, only attributes are considered.
-    assert hash(d0) != hash(d2)
+    assert hash(d0) == hash(d2)
 
     # Different types.
     assert d0 != 1

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -200,11 +200,19 @@ def test_eq_ne_hash():
     d0 = distributions.UniformDistribution(low=1, high=2)
     d1 = distributions.UniformDistribution(low=1, high=3)
     assert d0 != d1
+    assert not d0 == d1
     assert hash(d0) != hash(d1)
 
-    # Different classes.
+    # Different distribution classes.
     d2 = distributions.IntUniformDistribution(low=1, high=2)
     assert d0 != d2
+    assert not d0 == d2
+
+    # Different types.
+    assert d0 != 1
+    assert not d0 == 1
+    assert d0 != 'foo'
+    assert not d0 == 'foo'
 
     # In the implementation of `__hash__`, only attributes are considered.
     assert hash(d0) == hash(d2)


### PR DESCRIPTION
Fixes implementations of `__eq__` to correctly handle equality comparisons between classes in a class hierarchy and also to prefer returning the `NotImplemented` singleton. Though the `__eq__` resolution seems to different between Python 2 and 3. C.f. https://stackoverflow.com/questions/3588776/how-is-eq-handled-in-python-and-in-what-order