### PR TITLE
Add "Open In Colab" badge to visualization example

### DIFF
--- a/examples/visualization/plot_study.ipynb
+++ b/examples/visualization/plot_study.ipynb
@@ -5,7 +5,7 @@
    "metadata": {},
    "source": [
     "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](http://colab.research.google.com/github/optuna/optuna/blob/master/examples/visualization/plot_study.ipynb)\n",
-    "It's recommended to right-click \"Open In Colab\" to open this notebook if you are on GitHub.\n",
+    "Colab must be opened in a new tab or window if you are on GitHub.\n",
     "\n",
     "# Visualizing High-dimensional Parameter Relationships\n",
     "\n",

--- a/examples/visualization/plot_study.ipynb
+++ b/examples/visualization/plot_study.ipynb
@@ -5,6 +5,7 @@
    "metadata": {},
    "source": [
     "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](http://colab.research.google.com/github/optuna/optuna/blob/master/examples/visualization/plot_study.ipynb)\n",
+    "It's recommended to right-click \"Open In Colab\" to open this notebook if you are on GitHub.\n",
     "\n",
     "# Visualizing High-dimensional Parameter Relationships\n",
     "\n",
@@ -21,7 +22,7 @@
    "outputs": [],
    "source": [
     "# If you run this notebook on Google Colaboratory, uncomment the below to install Optuna.\n",
-    "#! pip install git+https://github.com/optuna/optuna.git"
+    "#! pip install --quiet optuna"
    ]
   },
   {

--- a/examples/visualization/plot_study.ipynb
+++ b/examples/visualization/plot_study.ipynb
@@ -4,12 +4,24 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](http://colab.research.google.com/github/optuna/optuna/blob/master/examples/visualization/plot_study.ipynb)\n",
+    "\n",
     "# Visualizing High-dimensional Parameter Relationships\n",
     "\n",
     "This notebook demonstrates various visualizations of studies in Optuna.\n",
     "The hyperparameters of a neural network trained to classify images are optimized and the resulting study is then visualized using these features.\n",
     "\n",
     "**Note:** If a parameter contains missing values, a trial with missing values is not plotted."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# If you run this notebook on Google Colaboratory, uncomment the below to install Optuna.\n",
+    "#! pip install git+https://github.com/optuna/optuna.git"
    ]
   },
   {
@@ -254,6 +266,19 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.7.4"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": false,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": false
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {


### PR DESCRIPTION
Merge after #735.

This PR adds a badge of "Open In Colab" which navigates users from GitHub to Colab as the capture shows.

<img width="927" alt="image" src="https://user-images.githubusercontent.com/16191443/69689157-87dde480-110b-11ea-99c2-66ce06cdd8f4.png">
