### PR TITLE
Cosmetic fix for GitHub templates.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -7,11 +7,11 @@ assignees: ''
 
 ---
 
-Please write a clear and concise description of what the bug is.
+<!-- Please write a clear and concise description of what the bug is. -->
 
 ## Expected behavior
 
-Please write a clear and concise description of what you expected to happen.
+<!-- Please write a clear and concise description of what you expected to happen. -->
 
 ## Environment
 
@@ -40,4 +40,4 @@ Please write a clear and concise description of what you expected to happen.
 
 ## Additional context (optional)
 
-Please add any other context or screenshots about the problem here.
+<!-- Please add any other context or screenshots about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -7,4 +7,4 @@ assignees: ''
 
 ---
 
-Please write a clear and concise description of what content in https://optuna.readthedocs.io/ is an issue.
+<!-- Please write a clear and concise description of what content in https://optuna.readthedocs.io/ is an issue. -->

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -7,22 +7,22 @@ assignees: ''
 
 ---
 
-Please write a clear and concise description of the feature proposal.
+<!-- Please write a clear and concise description of the feature proposal. -->
 
 ## Motivation
 
-Please write the motivation for the proposal.
+<!-- Please write the motivation for the proposal.
 
-If your feature request is related to a problem, please describe a clear and concise description of what the problem is.
+If your feature request is related to a problem, please describe a clear and concise description of what the problem is. -->
 
 ## Description
 
-Please write a detailed description of the new feature.
+<!-- Please write a detailed description of the new feature. -->
 
 ## Alternatives (optional)
 
-Please write a clear and concise description of any alternative solutions or features you've considered.
+<!-- Please write a clear and concise description of any alternative solutions or features you've considered. -->
 
 ## Additional context (optional)
 
-Please add any other context or screenshots about the feature request here.
+<!-- Please add any other context or screenshots about the feature request here. -->

--- a/.github/ISSUE_TEMPLATE/questions-help-support.md
+++ b/.github/ISSUE_TEMPLATE/questions-help-support.md
@@ -7,7 +7,7 @@ assignees: ''
 
 ---
 
-Please write your question here.
+<!-- Please write your question here. -->
 
 ## Note to the questioner
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,5 @@
-Thank you for creating a pull request!
+<!-- Thank you for creating a pull request!
 
 Please go through [our contribution guide][CONTRIBUTING.md] to hopefully get your changes merged quicker.
 
-[CONTRIBUTING.md]: https://github.com/optuna/optuna/blob/master/CONTRIBUTING.md
+[CONTRIBUTING.md]: https://github.com/optuna/optuna/blob/master/CONTRIBUTING.md -->


### PR DESCRIPTION
This PR comments out some notes for contributors in GitHub templates in order for users not to think of the need to delete those notes.

I also think it better to move the contents of "Note to the questioner" of `.github/ISSUE_TEMPLATE/questions-help-support.md` to README.md.

Any comment is welcomed.
