### PR TITLE
`BaseDistribution.__hash__` to take `__class__` into account

### DIFF
--- a/optuna/distributions.py
+++ b/optuna/distributions.py
@@ -93,7 +93,7 @@ class BaseDistribution(object, metaclass=abc.ABCMeta):
     def __hash__(self):
         # type: () -> int
 
-        return hash(tuple(sorted(self.__dict__.items())))
+        return hash((self.__class__,) + tuple(sorted(self.__dict__.items())))
 
     def __repr__(self):
         # type: () -> str

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -209,9 +209,7 @@ def test_eq_ne_hash():
     d2 = distributions.IntUniformDistribution(low=1, high=2)
     assert d0 != d2
     assert not d0 == d2
-
-    # In the implementation of `__hash__`, only attributes are considered.
-    assert hash(d0) == hash(d2)
+    assert hash(d0) != hash(d2)
 
     # Different types.
     assert d0 != 1


### PR DESCRIPTION
Changes `BaseDistribution.__hash__` to take `__class__` into account similar to `__eq__`. 

If the current behavior really is expected, please close this ticket. There's more context in https://github.com/optuna/optuna/pull/726#discussion_r351102361.