### PR TITLE
Replace slack with gitter in the issue template.

### DIFF
--- a/.github/ISSUE_TEMPLATE/questions-help-support.md
+++ b/.github/ISSUE_TEMPLATE/questions-help-support.md
@@ -13,8 +13,8 @@ assignees: ''
 
 If you are more comfortable with [Stack Overflow], you may consider posting your question there instead.
 Alternatively, for issues that would benefit from more of an interactive session with the developers,
-you may refer to the `#general` channel in the [chainer slack] or the [chainer-jp slack] (Japanese) Slack workspaces.
+you may refer to the [optuna/optuna chat] or the [optuna/optuna-jp chat] (Japanese) on Gitter.
 
 [Stack Overflow]: https://stackoverflow.com/questions/tagged/optuna
-[chainer slack]: https://bit.ly/join-chainer-slack
-[chainer-jp slack]: https://bit.ly/join-chainer-jp-slack
+[optuna/optuna chat]: https://gitter.im/optuna/optuna
+[optuna/optuna-jp chat]: https://gitter.im/optuna/optuna-jp

--- a/.github/ISSUE_TEMPLATE/questions-help-support.md
+++ b/.github/ISSUE_TEMPLATE/questions-help-support.md
@@ -13,7 +13,7 @@ assignees: ''
 
 If you are more comfortable with [Stack Overflow], you may consider posting your question there instead.
 Alternatively, for issues that would benefit from more of an interactive session with the developers,
-you may refer to the [optuna/optuna chat] or the [optuna/optuna-jp chat] (Japanese) on Gitter.
+you may refer to the [optuna/optuna chat] on Gitter.
 
 [Stack Overflow]: https://stackoverflow.com/questions/tagged/optuna
 [optuna/optuna chat]: https://gitter.im/optuna/optuna

--- a/.github/ISSUE_TEMPLATE/questions-help-support.md
+++ b/.github/ISSUE_TEMPLATE/questions-help-support.md
@@ -17,4 +17,3 @@ you may refer to the [optuna/optuna chat] on Gitter.
 
 [Stack Overflow]: https://stackoverflow.com/questions/tagged/optuna
 [optuna/optuna chat]: https://gitter.im/optuna/optuna
-[optuna/optuna-jp chat]: https://gitter.im/optuna/optuna-jp


### PR DESCRIPTION
This PR replaces the links to the slack channels with those to the gitter rooms.

(We may move the section modified in this PR to README.md as suggested by https://github.com/optuna/optuna/pull/749#issuecomment-559698921.)