### PR TITLE
Fix deprecated property access.

### DIFF
--- a/optuna/study.py
+++ b/optuna/study.py
@@ -442,7 +442,7 @@ class Study(BaseStudy):
 
         trial._validate()
 
-        self.storage.create_new_trial(self._study_id, template_trial=trial)
+        self._storage.create_new_trial(self._study_id, template_trial=trial)
 
     def _optimize_sequential(
             self,


### PR DESCRIPTION
Now, when `Study._append_trial` method is called, a deprecated warning message is emitted due to the access to the deprecated `storage` property.
This PR fixes this issue.
