### PR TITLE
Remove Google Colab preinstalled library from `quickstart.ipynb`

### DIFF
--- a/examples/quickstart.ipynb
+++ b/examples/quickstart.ipynb
@@ -13,7 +13,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install --quiet optuna plotly"
+    "!pip install --quiet optuna"
    ]
   },
   {


### PR DESCRIPTION
Might be open for discussions but as `quickstart.ipynb` is mostly meant to be used through Google Colab where `plotly` is preinstalled, we could omit it from the installation to simplify the example. Cc. @harupy (https://github.com/optuna/optuna/pull/741)