### PR TITLE
Remove StudySummary.__ne__.

### DIFF
--- a/optuna/structs.py
+++ b/optuna/structs.py
@@ -299,14 +299,6 @@ class StudySummary(object):
 
         return other.__dict__ == self.__dict__
 
-    def __ne__(self, other):
-        # type: (Any) -> bool
-
-        if not isinstance(other, StudySummary):
-            return NotImplemented
-
-        return not self.__eq__(other)
-
     def __lt__(self, other):
         # type: (Any) -> bool
 

--- a/tests/test_structs.py
+++ b/tests/test_structs.py
@@ -188,6 +188,9 @@ def test_study_summary_eq_ne():
     assert len(summaries) == 2
 
     assert summaries[0] == copy.deepcopy(summaries[0])
+    assert not summaries[0] != copy.deepcopy(summaries[0])
+
+    assert not summaries[0] == summaries[1]
     assert summaries[0] != summaries[1]
 
     assert not summaries[0] == 1


### PR DESCRIPTION
Following to the discussion in https://github.com/optuna/optuna/pull/726#discussion_r349994303, this PR removes `StudySummary.__ne__` and implicitly uses results of `StudySummary.__eq__`.