### PR TITLE
Only allow `float`, `str` and castable to `float` in categorical distribution

### DIFF
--- a/optuna/distributions.py
+++ b/optuna/distributions.py
@@ -11,6 +11,8 @@ if type_checking.TYPE_CHECKING:
     from typing import Sequence  # NOQA
     from typing import Union  # NOQA
 
+    CategoricalChoiceType = Union[None, bool, int, float, str]
+
 
 class BaseDistribution(object, metaclass=abc.ABCMeta):
     """Base class for distributions.
@@ -285,7 +287,7 @@ class CategoricalDistribution(BaseDistribution):
     """
 
     def __init__(self, choices):
-        # type: (Sequence[Any]) -> None
+        # type: (Sequence[CategoricalChoiceType]) -> None
 
         if len(choices) == 0:
             raise ValueError("The `choices` must contains one or more elements.")
@@ -303,12 +305,12 @@ class CategoricalDistribution(BaseDistribution):
         self.choices = choices
 
     def to_external_repr(self, param_value_in_internal_repr):
-        # type: (float) -> Any
+        # type: (float) -> CategoricalChoiceType
 
         return self.choices[int(param_value_in_internal_repr)]
 
     def to_internal_repr(self, param_value_in_external_repr):
-        # type: (Any) -> float
+        # type: (CategoricalChoiceType) -> float
 
         return self.choices.index(param_value_in_external_repr)
 

--- a/optuna/distributions.py
+++ b/optuna/distributions.py
@@ -269,7 +269,8 @@ class CategoricalDistribution(BaseDistribution):
 
     Attributes:
         choices:
-            Candidates of parameter values.
+            Candidates of parameter values. Candidates must be :class:`float`, :class:`str` and
+            castable to :class:`float`.
     """
 
     def __init__(self, choices):
@@ -277,8 +278,7 @@ class CategoricalDistribution(BaseDistribution):
 
         if len(choices) == 0:
             raise ValueError("The `choices` must contains one or more elements.")
-
-        self.choices = choices
+        self.choices = tuple(map(lambda c: self._to_valid_choice(c), choices))
 
     def to_external_repr(self, param_value_in_internal_repr):
         # type: (float) -> Union[float, str]
@@ -300,6 +300,20 @@ class CategoricalDistribution(BaseDistribution):
 
         index = int(param_value_in_internal_repr)
         return 0 <= index and index < len(self.choices)
+
+    @staticmethod
+    def _to_valid_choice(choice):
+        # type: (Union[float, str]) -> Union[float, str]
+
+        if isinstance(choice, (float, str)):
+            return choice
+        try:
+            return float(choice)
+        except TypeError:
+            raise TypeError(
+                "Choices to the categorical distribution must be a tuple of float, str "
+                f"and castable to float but contains {choice} which is of type "
+                f"{type(choice).__name__}.")
 
 
 DISTRIBUTION_CLASSES = (UniformDistribution, LogUniformDistribution, DiscreteUniformDistribution,

--- a/optuna/distributions.py
+++ b/optuna/distributions.py
@@ -311,9 +311,9 @@ class CategoricalDistribution(BaseDistribution):
             return float(choice)
         except TypeError:
             raise TypeError(
-                "Choices to the categorical distribution must be a tuple of float, str "
-                f"and castable to float but contains {choice} which is of type "
-                f"{type(choice).__name__}.")
+                "Choices to the categorical distribution must be a tuple of float, str and "
+                "castable to float but contains {} which is of type {}.".format(
+                    choice, type(choice).__name__))
 
 
 DISTRIBUTION_CLASSES = (UniformDistribution, LogUniformDistribution, DiscreteUniformDistribution,

--- a/optuna/integration/chainermn.py
+++ b/optuna/integration/chainermn.py
@@ -17,14 +17,11 @@ if type_checking.TYPE_CHECKING:
     from typing import Sequence  # NOQA
     from typing import Tuple  # NOQA
     from typing import Type  # NOQA
-    from typing import TypeVar  # NOQA
     from typing import Union  # NOQA
 
     from optuna.distributions import BaseDistribution  # NOQA
     from optuna.study import Study  # NOQA
     from optuna.trial import Trial  # NOQA
-
-    T = TypeVar('T', float, str)
 
 try:
     from chainermn.communicators.communicator_base import CommunicatorBase  # NOQA
@@ -233,10 +230,10 @@ class ChainerMNTrial(BaseTrial):
         return self._call_with_mpi(func)
 
     def suggest_categorical(self, name, choices):
-        # type: (str, Sequence[T]) -> T
+        # type: (str, Tuple[Union[float, str], ...]) -> Union[float, str]
 
         def func():
-            # type: () -> T
+            # type: () -> Union[float, str]
 
             assert self.delegate is not None
             return self.delegate.suggest_categorical(name, choices)

--- a/optuna/integration/chainermn.py
+++ b/optuna/integration/chainermn.py
@@ -230,10 +230,10 @@ class ChainerMNTrial(BaseTrial):
         return self._call_with_mpi(func)
 
     def suggest_categorical(self, name, choices):
-        # type: (str, Tuple[Union[float, str], ...]) -> Union[float, str]
+        # type: (str, Sequence[Any]) -> Any
 
         def func():
-            # type: () -> Union[float, str]
+            # type: () -> Any
 
             assert self.delegate is not None
             return self.delegate.suggest_categorical(name, choices)

--- a/optuna/integration/chainermn.py
+++ b/optuna/integration/chainermn.py
@@ -20,6 +20,7 @@ if type_checking.TYPE_CHECKING:
     from typing import Union  # NOQA
 
     from optuna.distributions import BaseDistribution  # NOQA
+    from optuna.distributions import CategoricalChoiceType  # NOQA
     from optuna.study import Study  # NOQA
     from optuna.trial import Trial  # NOQA
 
@@ -230,10 +231,10 @@ class ChainerMNTrial(BaseTrial):
         return self._call_with_mpi(func)
 
     def suggest_categorical(self, name, choices):
-        # type: (str, Sequence[Any]) -> Any
+        # type: (str, Sequence[CategoricalChoiceType]) -> Any
 
         def func():
-            # type: () -> Any
+            # type: () -> CategoricalChoiceType
 
             assert self.delegate is not None
             return self.delegate.suggest_categorical(name, choices)

--- a/optuna/testing/sampler.py
+++ b/optuna/testing/sampler.py
@@ -4,7 +4,6 @@ from optuna import distributions
 if optuna.type_checking.TYPE_CHECKING:
     from typing import Any  # NOQA
     from typing import Dict  # NOQA
-    from typing import Union  # NOQA
 
     from optuna.distributions import BaseDistribution  # NOQA
     from optuna.structs import FrozenTrial  # NOQA
@@ -32,7 +31,7 @@ class DeterministicRelativeSampler(optuna.samplers.BaseSampler):
         # type: (Study, FrozenTrial, str, BaseDistribution) -> Any
 
         if isinstance(param_distribution, distributions.UniformDistribution):
-            param_value = param_distribution.low  # type: Union[float, str]
+            param_value = param_distribution.low  # type: Any
         elif isinstance(param_distribution, distributions.LogUniformDistribution):
             param_value = param_distribution.low
         elif isinstance(param_distribution, distributions.DiscreteUniformDistribution):

--- a/optuna/trial.py
+++ b/optuna/trial.py
@@ -12,8 +12,6 @@ if type_checking.TYPE_CHECKING:
     from typing import Dict  # NOQA
     from typing import Optional  # NOQA
     from typing import Sequence  # NOQA
-    from typing import Tuple  # NOQA
-    from typing import Union  # NOQA
 
     from optuna.distributions import BaseDistribution  # NOQA
     from optuna.study import Study  # NOQA
@@ -46,7 +44,7 @@ class BaseTrial(object, metaclass=abc.ABCMeta):
         raise NotImplementedError
 
     def suggest_categorical(self, name, choices):
-        # type: (str, Tuple[Union[float, str], ...]) -> Union[float, str]
+        # type: (str, Sequence[Any]) -> Any
 
         raise NotImplementedError
 
@@ -311,7 +309,7 @@ class Trial(BaseTrial):
         return int(self._suggest(name, distribution))
 
     def suggest_categorical(self, name, choices):
-        # type: (str, Tuple[Union[float, str], ...]) -> Union[float, str]
+        # type: (str, Sequence[Any]) -> Any
         """Suggest a value for the categorical parameter.
 
         The value is sampled from ``choices``.
@@ -333,8 +331,10 @@ class Trial(BaseTrial):
             name:
                 A parameter name.
             choices:
-                Candidates of parameter values. Candidates must be :class:`float`, :class:`str` and
-                castable to :class:`float`.
+                Parameter value candidates.
+
+        .. seealso::
+            :class:`~optuna.distributions.CategoricalDistribution`.
 
         Returns:
             A suggested value.
@@ -687,7 +687,7 @@ class FixedTrial(BaseTrial):
         return int(self._suggest(name, distributions.IntUniformDistribution(low=low, high=high)))
 
     def suggest_categorical(self, name, choices):
-        # type: (str, Tuple[Union[float, str], ...]) -> Union[float, str]
+        # type: (str, Sequence[Any]) -> Any
 
         choices = tuple(choices)
         return self._suggest(name, distributions.CategoricalDistribution(choices=choices))

--- a/optuna/trial.py
+++ b/optuna/trial.py
@@ -12,12 +12,11 @@ if type_checking.TYPE_CHECKING:
     from typing import Dict  # NOQA
     from typing import Optional  # NOQA
     from typing import Sequence  # NOQA
-    from typing import TypeVar  # NOQA
+    from typing import Tuple  # NOQA
+    from typing import Union  # NOQA
 
     from optuna.distributions import BaseDistribution  # NOQA
     from optuna.study import Study  # NOQA
-
-    T = TypeVar('T', float, str)
 
 
 class BaseTrial(object, metaclass=abc.ABCMeta):
@@ -47,7 +46,7 @@ class BaseTrial(object, metaclass=abc.ABCMeta):
         raise NotImplementedError
 
     def suggest_categorical(self, name, choices):
-        # type: (str, Sequence[T]) -> T
+        # type: (str, Tuple[Union[float, str], ...]) -> Union[float, str]
 
         raise NotImplementedError
 
@@ -312,7 +311,7 @@ class Trial(BaseTrial):
         return int(self._suggest(name, distribution))
 
     def suggest_categorical(self, name, choices):
-        # type: (str, Sequence[T]) -> T
+        # type: (str, Tuple[Union[float, str], ...]) -> Union[float, str]
         """Suggest a value for the categorical parameter.
 
         The value is sampled from ``choices``.
@@ -687,7 +686,7 @@ class FixedTrial(BaseTrial):
         return int(self._suggest(name, distributions.IntUniformDistribution(low=low, high=high)))
 
     def suggest_categorical(self, name, choices):
-        # type: (str, Sequence[T]) -> T
+        # type: (str, Tuple[Union[float, str], ...]) -> Union[float, str]
 
         choices = tuple(choices)
         return self._suggest(name, distributions.CategoricalDistribution(choices=choices))

--- a/optuna/trial.py
+++ b/optuna/trial.py
@@ -14,6 +14,7 @@ if type_checking.TYPE_CHECKING:
     from typing import Sequence  # NOQA
 
     from optuna.distributions import BaseDistribution  # NOQA
+    from optuna.distributions import CategoricalChoiceType  # NOQA
     from optuna.study import Study  # NOQA
 
 
@@ -44,7 +45,7 @@ class BaseTrial(object, metaclass=abc.ABCMeta):
         raise NotImplementedError
 
     def suggest_categorical(self, name, choices):
-        # type: (str, Sequence[Any]) -> Any
+        # type: (str, Sequence[CategoricalChoiceType]) -> CategoricalChoiceType
 
         raise NotImplementedError
 
@@ -309,7 +310,7 @@ class Trial(BaseTrial):
         return int(self._suggest(name, distribution))
 
     def suggest_categorical(self, name, choices):
-        # type: (str, Sequence[Any]) -> Any
+        # type: (str, Sequence[CategoricalChoiceType]) -> CategoricalChoiceType
         """Suggest a value for the categorical parameter.
 
         The value is sampled from ``choices``.
@@ -687,7 +688,7 @@ class FixedTrial(BaseTrial):
         return int(self._suggest(name, distributions.IntUniformDistribution(low=low, high=high)))
 
     def suggest_categorical(self, name, choices):
-        # type: (str, Sequence[Any]) -> Any
+        # type: (str, Sequence[CategoricalChoiceType]) -> CategoricalChoiceType
 
         choices = tuple(choices)
         return self._suggest(name, distributions.CategoricalDistribution(choices=choices))

--- a/optuna/trial.py
+++ b/optuna/trial.py
@@ -333,7 +333,8 @@ class Trial(BaseTrial):
             name:
                 A parameter name.
             choices:
-                Candidates of parameter values.
+                Candidates of parameter values. Candidates must be :class:`float`, :class:`str` and
+                castable to :class:`float`.
 
         Returns:
             A suggested value.

--- a/tests/integration_tests/test_chainermn.py
+++ b/tests/integration_tests/test_chainermn.py
@@ -421,9 +421,6 @@ class TestChainerMNTrial(object):
                 x2 = mn_trial.suggest_categorical('x', choices)
                 assert x1 == x2
 
-                with pytest.raises(TypeError):
-                    mn_trial.suggest_categorical('x', [{'foo': 'bar'}])
-
                 with pytest.raises(ValueError):
                     mn_trial.suggest_uniform('x', 0., 1.)
 

--- a/tests/integration_tests/test_chainermn.py
+++ b/tests/integration_tests/test_chainermn.py
@@ -421,6 +421,9 @@ class TestChainerMNTrial(object):
                 x2 = mn_trial.suggest_categorical('x', choices)
                 assert x1 == x2
 
+                with pytest.raises(TypeError):
+                    mn_trial.suggest_categorical('x', [{'foo': 'bar'}])
+
                 with pytest.raises(ValueError):
                     mn_trial.suggest_uniform('x', 0., 1.)
 

--- a/tests/integration_tests/test_sampler.py
+++ b/tests/integration_tests/test_sampler.py
@@ -61,6 +61,7 @@ def test_sample_independent(sampler_class):
         p2 = trial.suggest_int('p2', 0, 10)
         p3 = trial.suggest_discrete_uniform('p3', 0, 9, 3)
         p4 = trial.suggest_categorical('p4', ['10', '20', '30'])
+        assert isinstance(p4, str)
         return p0 + p1 + p2 + p3 + int(p4)
 
     with patch.object(sampler, 'sample_independent') as mock_object:
@@ -161,5 +162,6 @@ def _objective(trial):
     p7 = trial.suggest_discrete_uniform('p7', 0.1, 1.0, 0.1)
     p8 = trial.suggest_discrete_uniform('p8', 2.2, 2.2, 0.5)
     p9 = trial.suggest_categorical('p9', ['9', '3', '0', '8'])
+    assert isinstance(p9, str)
 
     return p0 + p1 + p2 + p3 + p4 + p5 + p6 + p7 + p8 + int(p9)

--- a/tests/integration_tests/test_skopt.py
+++ b/tests/integration_tests/test_skopt.py
@@ -143,6 +143,7 @@ def _objective(trial):
     p7 = trial.suggest_discrete_uniform('p7', 0.1, 1.0, 0.1)
     p8 = trial.suggest_discrete_uniform('p8', 2.2, 2.2, 0.5)
     p9 = trial.suggest_categorical('p9', ['9', '3', '0', '8'])
+    assert isinstance(p9, str)
 
     return p0 + p1 + p2 + p3 + p4 + p5 + p6 + p7 + p8 + int(p9)
 

--- a/tests/samplers_tests/test_samplers.py
+++ b/tests/samplers_tests/test_samplers.py
@@ -17,7 +17,6 @@ if optuna.type_checking.TYPE_CHECKING:
     from optuna.distributions import BaseDistribution  # NOQA
     from optuna.structs import FrozenTrial  # NOQA
     from optuna.study import Study  # NOQA
-    from optuna.trial import T  # NOQA
     from optuna.trial import Trial  # NOQA
 
 parametrize_sampler = pytest.mark.parametrize(
@@ -119,7 +118,7 @@ def test_int(sampler_class, distribution):
 @parametrize_sampler
 @pytest.mark.parametrize('choices', [(1, 2, 3), ('a', 'b', 'c'), (1, 'a')])
 def test_categorical(sampler_class, choices):
-    # type: (typing.Callable[[], BaseSampler], typing.Tuple[T, ...]) -> None
+    # type: (typing.Callable[[], BaseSampler], typing.Tuple[Any]) -> None
 
     distribution = CategoricalDistribution(choices)
 

--- a/tests/samplers_tests/test_samplers.py
+++ b/tests/samplers_tests/test_samplers.py
@@ -13,8 +13,10 @@ if optuna.type_checking.TYPE_CHECKING:
     import typing  # NOQA
     from typing import Any  # NOQA
     from typing import Dict  # NOQA
+    from typing import Sequence  # NOQA
 
     from optuna.distributions import BaseDistribution  # NOQA
+    from optuna.distributions import CategoricalChoiceType  # NOQA
     from optuna.structs import FrozenTrial  # NOQA
     from optuna.study import Study  # NOQA
     from optuna.trial import Trial  # NOQA
@@ -118,7 +120,7 @@ def test_int(sampler_class, distribution):
 @parametrize_sampler
 @pytest.mark.parametrize('choices', [(1, 2, 3), ('a', 'b', 'c'), (1, 'a')])
 def test_categorical(sampler_class, choices):
-    # type: (typing.Callable[[], BaseSampler], typing.Tuple[Any]) -> None
+    # type: (typing.Callable[[], BaseSampler], Sequence[CategoricalChoiceType]) -> None
 
     distribution = CategoricalDistribution(choices)
 

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -12,7 +12,8 @@ def _create_some_study():
 
         x = trial.suggest_uniform('x', -10, 10)
         y = trial.suggest_loguniform('y', 10, 20)
-        z = trial.suggest_categorical('z', (10, 20.5, 30))
+        z = trial.suggest_categorical('z', (10.0, 20.5, 30.0))
+        assert isinstance(z, float)
 
         return x**2 + y**2 + z
 

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -192,7 +192,7 @@ def test_invalid_distribution():
     # type: () -> None
 
     with pytest.warns(UserWarning):
-        distributions.CategoricalDistribution(choices=({'foo': 'bar'},))
+        distributions.CategoricalDistribution(choices=({'foo': 'bar'},))  # type: ignore
 
 
 def test_eq_ne_hash():

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -188,6 +188,13 @@ def test_empty_distribution():
         distributions.CategoricalDistribution(choices=()),
 
 
+def test_invalid_distribution():
+    # type: () -> None
+
+    with pytest.raises(TypeError):
+        distributions.CategoricalDistribution(choices=[{'foo': 'bar'}])
+
+
 def test_eq_ne_hash():
     # type: () -> None
 

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -191,8 +191,8 @@ def test_empty_distribution():
 def test_invalid_distribution():
     # type: () -> None
 
-    with pytest.raises(TypeError):
-        distributions.CategoricalDistribution(choices=[{'foo': 'bar'}])
+    with pytest.warns(UserWarning):
+        distributions.CategoricalDistribution(choices=({'foo': 'bar'},))
 
 
 def test_eq_ne_hash():

--- a/tests/test_study.py
+++ b/tests/test_study.py
@@ -55,6 +55,7 @@ def func(trial, x_max=1.0):
     x = trial.suggest_uniform('x', -x_max, x_max)
     y = trial.suggest_loguniform('y', 20, 30)
     z = trial.suggest_categorical('z', (-1.0, 1.0))
+    assert isinstance(z, float)
     return (x - 2)**2 + (y - 25)**2 + z
 
 
@@ -474,6 +475,7 @@ def test_trials_dataframe(storage_mode, cache_mode, include_internal_fields):
 
         x = trial.suggest_int('x', 1, 1)
         y = trial.suggest_categorical('y', (2.5, ))
+        assert isinstance(y, float)
         trial.set_user_attr('train_loss', 3)
         return x + y  # 3.5
 

--- a/tests/test_trial.py
+++ b/tests/test_trial.py
@@ -277,13 +277,14 @@ def test_fixed_trial_suggest_categorical():
     trial = FixedTrial({'x': 'baz'})
     assert trial.suggest_categorical('x', ['foo', 'bar', 'baz']) == 'baz'
 
-    # Dict category.
-    with pytest.raises(TypeError):
-        trial.suggest_categorical('x', [{'foo': 'bar'}])
-
     # Unknown parameter.
     with pytest.raises(ValueError):
         trial.suggest_categorical('y', ['foo', 'bar', 'baz'])
+
+    # Unkown parameter and bad category type.
+    with pytest.warns(UserWarning):
+        with pytest.raises(ValueError):  # Must come after `pytest.warns` to catch failures.
+            trial.suggest_categorical('x', [{'foo': 'bar'}])
 
 
 def test_fixed_trial_user_attrs():

--- a/tests/test_trial.py
+++ b/tests/test_trial.py
@@ -277,6 +277,11 @@ def test_fixed_trial_suggest_categorical():
     trial = FixedTrial({'x': 'baz'})
     assert trial.suggest_categorical('x', ['foo', 'bar', 'baz']) == 'baz'
 
+    # Dict category.
+    with pytest.raises(TypeError):
+        trial.suggest_categorical('x', [{'foo': 'bar'}])
+
+    # Unknown parameter.
     with pytest.raises(ValueError):
         trial.suggest_categorical('y', ['foo', 'bar', 'baz'])
 

--- a/tests/test_trial.py
+++ b/tests/test_trial.py
@@ -284,7 +284,7 @@ def test_fixed_trial_suggest_categorical():
     # Unkown parameter and bad category type.
     with pytest.warns(UserWarning):
         with pytest.raises(ValueError):  # Must come after `pytest.warns` to catch failures.
-            trial.suggest_categorical('x', [{'foo': 'bar'}])
+            trial.suggest_categorical('x', [{'foo': 'bar'}])  # type: ignore
 
 
 def test_fixed_trial_user_attrs():


### PR DESCRIPTION
Limits the types of items allowed as the choices to the categorical distribution to `float`, `str` and castable to `float`. Raises an error in case of unexpected types.

The motivation is partially to simplify the behavior. 

This change breaks compatibility. Previously, basically any type could be passed, when used in conjunction with the RDB storage, any type that used to be JSON serializable. While I am assuming that such use cases are rase, for instance having `dict`s in the list of choices (such use cases have not been encouraged via documentations nor samples AFAIK), we could change the behavior to raise a warning as well. Open for discussions.