### PR TITLE
Add CI jobs for Python 3.8.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -158,31 +158,7 @@ jobs:
     steps:
       - checkout
 
-      # Some libraries have not provided wheel packages for Python 3.8 yet, and additional
-      # dependencies are required to build them.
-      - run: &install-python38
-          <<: *install
-          command: |
-            sudo apt-get update
-            sudo apt-get -y install openmpi-bin libopenmpi-dev
-            python -m venv venv || virtualenv venv
-            . venv/bin/activate
-            pip install -U pip
-            pip install --progress-bar off -U setuptools
-            python setup.py sdist
-
-            # Install minimal dependencies and confirm that `import optuna` is successful.
-            pip install --progress-bar off $(ls dist/*.tar.gz)
-            python -c 'import optuna'
-
-            # Additional dependencies for Python 3.8.
-            # cython is required by scikit-learn.
-            pip install --progress-bar off cython
-            # libhdf5.so is required by keras.
-            sudo apt-get -y install libhdf5-dev
-
-            # Install all dependencies needed for testing.
-            pip install --progress-bar off $(ls dist/*.tar.gz)[testing]
+      - run: *install
 
       - run:
           <<: *tests
@@ -247,7 +223,7 @@ jobs:
     steps:
       - checkout
 
-      - run: *install-python38
+      - run: *install
 
       - run:
           <<: *tests-full
@@ -359,7 +335,7 @@ jobs:
     steps:
       - checkout
 
-      - run: *install-python38
+      - run: *install
 
       - run: *install-examples
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,7 @@ workflows:
       - checks
       - document
       - doctest
+      - tests-python38
       - tests-python37
       - tests-python36
       - tests-python35
@@ -22,9 +23,11 @@ workflows:
     jobs:
       - checks
       - document
+      - tests-python38-full
       - tests-python37-full
       - tests-python36-full
       - tests-python35-full
+      - examples-python38
       - examples-python37
       - examples-python36
       - examples-python35
@@ -149,6 +152,51 @@ jobs:
           environment:
             OMP_NUM_THREADS: 1
 
+  tests-python38:
+    docker:
+      - image: circleci/python:3.8
+    steps:
+      - checkout
+
+      # Some libraries have not provided wheel packages for Python 3.8 yet, and additional
+      # dependencies are required to build them.
+      - run: &install-python38
+          <<: *install
+          command: |
+            sudo apt-get update
+            sudo apt-get -y install openmpi-bin libopenmpi-dev
+            python -m venv venv || virtualenv venv
+            . venv/bin/activate
+            pip install -U pip
+            pip install --progress-bar off -U setuptools
+            python setup.py sdist
+
+            # Install minimal dependencies and confirm that `import optuna` is successful.
+            pip install --progress-bar off $(ls dist/*.tar.gz)
+            python -c 'import optuna'
+
+            # Additional dependencies for Python 3.8.
+            # cython is required by scikit-learn.
+            pip install --progress-bar off cython
+            # libhdf5.so is required by keras.
+            sudo apt-get -y install libhdf5-dev
+
+            # Install all dependencies needed for testing.
+            pip install --progress-bar off $(ls dist/*.tar.gz)[testing]
+
+      - run:
+          <<: *tests
+          command: |
+            . venv/bin/activate
+            pytest tests --ignore tests/integration_tests/test_fastai.py \
+                --ignore tests/integration_tests/test_keras.py \
+                --ignore tests/integration_tests/test_pytorch_lightning.py \
+                --ignore tests/integration_tests/test_pytorch_ignite.py \
+                --ignore tests/integration_tests/test_tensorflow.py \
+                --ignore tests/integration_tests/test_tfkeras.py
+
+      - run: *tests-mn
+
   tests-python36:
     docker:
       - image: circleci/python:3.6
@@ -192,6 +240,27 @@ jobs:
           environment:
             OMP_NUM_THREADS: 1
             INCLUDE_SLOW_TESTS: 1
+
+  tests-python38-full:
+    docker:
+      - image: circleci/python:3.8
+    steps:
+      - checkout
+
+      - run: *install-python38
+
+      - run:
+          <<: *tests-full
+          command: |
+            . venv/bin/activate
+            pytest tests --ignore tests/integration_tests/test_fastai.py \
+                --ignore tests/integration_tests/test_keras.py \
+                --ignore tests/integration_tests/test_pytorch_lightning.py \
+                --ignore tests/integration_tests/test_pytorch_ignite.py \
+                --ignore tests/integration_tests/test_tensorflow.py \
+                --ignore tests/integration_tests/test_tfkeras.py
+
+      - run: *tests-mn-full
 
   tests-python36-full:
     docker:
@@ -283,6 +352,24 @@ jobs:
             done
           environment:
             OMP_NUM_THREADS: 1
+
+  examples-python38:
+    docker:
+      - image: circleci/python:3.8
+    steps:
+      - checkout
+
+      - run: *install-python38
+
+      - run: *install-examples
+
+      - run:
+          <<: *examples
+          environment:
+            OMP_NUM_THREADS: 1
+            IGNORES: chainermn_.*|dask_ml_.*|keras_.*|pytorch_.*|tensorflow_.*|tfkeras_.*
+
+      - run: *examples-mn
 
   examples-python36:
     docker:

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ def get_tests_require():
 def get_extras_require():
     # type: () -> Dict[str, List[str]]
 
-    return {
+    requirements = {
         'checking': [
             'autopep8',
             'hacking',
@@ -90,12 +90,11 @@ def get_extras_require():
             'tensorflow<2.0.0',
             'torch',
             'torchvision'
-        ] if sys.version_info[:2] < (3, 8) else []),
+        ] if sys.version_info[:2] < (3, 8) else []) ,
         'testing': [
             'bokeh',
             'chainer>=5.0.0',
             'cma',
-            'keras',
             'lightgbm',
             'mock',
             'mpi4py',
@@ -108,6 +107,7 @@ def get_extras_require():
             'xgboost',
         ] + (['fastai<2'] if (3, 5) < sys.version_info[:2] < (3, 8) else [])
         + ([
+            'keras',
             'pytorch-ignite',
             'pytorch-lightning',
             'tensorflow',
@@ -116,6 +116,14 @@ def get_extras_require():
             'torchvision'
         ] if sys.version_info[:2] < (3, 8) else []),
     }
+
+    # TODO(Yanase): Remove cython from dependencies after wheel packages of scikit-learn are
+    # released for Python 3.8.
+    if sys.version_info[:2] == (3, 8):
+        requirements['testing'].insert(0, 'cython')
+        requirements['example'].insert(0, 'cython')
+
+    return requirements
 
 
 def find_any_distribution(pkgs):

--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,7 @@ def get_extras_require():
             'tensorflow<2.0.0',
             'torch',
             'torchvision'
-        ] if sys.version_info[:2] < (3, 8) else []) ,
+        ] if sys.version_info[:2] < (3, 8) else []),
         'testing': [
             'bokeh',
             'chainer>=5.0.0',

--- a/setup.py
+++ b/setup.py
@@ -74,21 +74,23 @@ def get_extras_require():
         'example': [
             'catboost',
             'chainer',
+            'lightgbm',
+            'mxnet',
+            'scikit-learn',
+            'xgboost',
+        ] + (['fastai<2'] if (3, 5) < sys.version_info[:2] < (3, 8) else [])
+        + ([
             'dask[dataframe]',
             'dask-ml',
             'keras',
-            'lightgbm',
-            'mxnet',
             'pytorch-ignite',
             'pytorch-lightning',
-            'scikit-learn',
             # TODO(Yanase): Update examples to support TensorFlow 2.0.
             # See https://github.com/optuna/optuna/issues/565 for further details.
             'tensorflow<2.0.0',
             'torch',
-            'torchvision',
-            'xgboost',
-        ] + (['fastai<2'] if sys.version_info[:2] > (3, 5) else []),
+            'torchvision'
+        ] if sys.version_info[:2] < (3, 8) else []),
         'testing': [
             'bokeh',
             'chainer>=5.0.0',
@@ -101,16 +103,18 @@ def get_extras_require():
             'pandas',
             'plotly>=4.0.0',
             'pytest',
-            'pytorch-ignite',
-            'pytorch-lightning',
             'scikit-learn>=0.19.0',
             'scikit-optimize',
+            'xgboost',
+        ] + (['fastai<2'] if (3, 5) < sys.version_info[:2] < (3, 8) else [])
+        + ([
+            'pytorch-ignite',
+            'pytorch-lightning',
             'tensorflow',
             'tensorflow-datasets',
             'torch',
-            'torchvision',
-            'xgboost',
-        ] + (['fastai<2'] if sys.version_info[:2] > (3, 5) else []),
+            'torchvision'
+        ] if sys.version_info[:2] < (3, 8) else []),
     }
 
 


### PR DESCRIPTION
This PR adds CI jobs for Python 3.8.
For now, the following libraries were ignored in the jobs because their wheel packages haven't been provided yet:
- dask-ml
- keras
- tensorflow
- torch

No wheel packages are provided for `scikit-learn`, but I keep it with its dependency (cython) for build because some other libraries like lightgbm require it.