### PR TITLE
Remove a temporary workaround in the `test_callbacks` function.

### DIFF
--- a/tests/test_study.py
+++ b/tests/test_study.py
@@ -741,22 +741,14 @@ def test_callbacks(n_jobs):
         catch=(ZeroDivisionError,))
     assert states == [optuna.structs.TrialState.FAIL] * 10
 
-    # NOTE: Because `Study.optimize` blocks forever if `n_jobs` is more than `1` and
-    #       an uncaught exception is raised during an optimization,
-    #       we test the following scenario only when `n_jobs==1`.
-    #       For further details, please see https://github.com/optuna/optuna/issues/538.
-    #
-    # TODO(ohta): Fix `Study.optimize`
-
-    if n_jobs == 1:
-        # If a trial is failed with an exception and the exception isn't caught by the study,
-        # callbacks aren't invoked.
-        states = []
-        callbacks = [lambda study, trial: states.append(trial.state)]
-        with pytest.raises(ZeroDivisionError):
-            study.optimize(lambda t: 1/0, callbacks=callbacks,
-                           n_trials=10, n_jobs=n_jobs, catch=())
-        assert states == []
+    # If a trial is failed with an exception and the exception isn't caught by the study,
+    # callbacks aren't invoked.
+    states = []
+    callbacks = [lambda study, trial: states.append(trial.state)]
+    with pytest.raises(ZeroDivisionError):
+        study.optimize(lambda t: 1/0, callbacks=callbacks,
+                       n_trials=10, n_jobs=n_jobs, catch=())
+    assert states == []
 
 
 def test_study_id():


### PR DESCRIPTION
This PR removes a no longer needed workaround in the `test_callbacks` function.
The aim of the workaround was to avoid the issue #538, but it was resolved by #692.