### PR TITLE
Change `logger` to study's module variable

### DIFF
--- a/optuna/study.py
+++ b/optuna/study.py
@@ -44,7 +44,7 @@ if type_checking.TYPE_CHECKING:
     ObjectiveFuncType = Callable[[trial_module.Trial], float]
 
 
-logger = logging.get_logger(__name__)
+_logger = logging.get_logger(__name__)
 
 
 class BaseStudy(object):
@@ -133,9 +133,9 @@ class BaseStudy(object):
                       "(e.g., `Study.set_user_attr`)",
                       DeprecationWarning)
 
-        logger.warning("The direct use of storage is deprecated. "
-                       "Please access to storage via study's public methods "
-                       "(e.g., `Study.set_user_attr`)")
+        _logger.warning("The direct use of storage is deprecated. "
+                        "Please access to storage via study's public methods "
+                        "(e.g., `Study.set_user_attr`)")
 
         return self._storage
 
@@ -200,7 +200,7 @@ class Study(BaseStudy):
         message = 'The use of `Study.study_id` is deprecated. ' \
                   'Please use `Study.study_name` instead.'
         warnings.warn(message, DeprecationWarning)
-        logger.warning(message)
+        _logger.warning(message)
 
         return self._study_id
 
@@ -578,13 +578,13 @@ class Study(BaseStudy):
             message = 'Setting status of trial#{} as {}. {}'.format(trial_number,
                                                                     structs.TrialState.PRUNED,
                                                                     str(e))
-            logger.info(message)
+            _logger.info(message)
             self._storage.set_trial_state(trial_id, structs.TrialState.PRUNED)
             return trial
         except Exception as e:
             message = 'Setting status of trial#{} as {} because of the following error: {}'\
                 .format(trial_number, structs.TrialState.FAIL, repr(e))
-            logger.warning(message, exc_info=True)
+            _logger.warning(message, exc_info=True)
             self._storage.set_trial_system_attr(trial_id, 'fail_reason', message)
             self._storage.set_trial_state(trial_id, structs.TrialState.FAIL)
 
@@ -608,7 +608,7 @@ class Study(BaseStudy):
             message = 'Setting status of trial#{} as {} because the returned value from the ' \
                       'objective function cannot be casted to float. Returned value is: ' \
                       '{}'.format(trial_number, structs.TrialState.FAIL, repr(result))
-            logger.warning(message)
+            _logger.warning(message)
             self._storage.set_trial_system_attr(trial_id, 'fail_reason', message)
             self._storage.set_trial_state(trial_id, structs.TrialState.FAIL)
             return trial
@@ -616,7 +616,7 @@ class Study(BaseStudy):
         if math.isnan(result):
             message = 'Setting status of trial#{} as {} because the objective function ' \
                       'returned {}.'.format(trial_number, structs.TrialState.FAIL, result)
-            logger.warning(message)
+            _logger.warning(message)
             self._storage.set_trial_system_attr(trial_id, 'fail_reason', message)
             self._storage.set_trial_state(trial_id, structs.TrialState.FAIL)
             return trial
@@ -630,9 +630,9 @@ class Study(BaseStudy):
     def _log_completed_trial(self, trial_number, value):
         # type: (int, float) -> None
 
-        logger.info('Finished trial#{} resulted in value: {}. '
-                    'Current best value is {} with parameters: {}.'.format(
-                        trial_number, value, self.best_value, self.best_params))
+        _logger.info('Finished trial#{} resulted in value: {}. '
+                     'Current best value is {} with parameters: {}.'.format(
+                         trial_number, value, self.best_value, self.best_params))
 
 
 def create_study(
@@ -695,8 +695,8 @@ def create_study(
         if load_if_exists:
             assert study_name is not None
 
-            logger.info("Using an existing study with name '{}' instead of "
-                        "creating a new one.".format(study_name))
+            _logger.info("Using an existing study with name '{}' instead of "
+                         "creating a new one.".format(study_name))
             study_id = storage.get_study_id_from_name(study_name)
         else:
             raise


### PR DESCRIPTION
<!-- Thank you for creating a pull request!

Please go through [our contribution guide][CONTRIBUTING.md] to hopefully get your changes merged quicker.

[CONTRIBUTING.md]: https://github.com/optuna/optuna/blob/master/CONTRIBUTING.md -->

Personally, there is no specific reason for `Study` to have `logger` as its attribute and the below code block does not look solid.

https://github.com/optuna/optuna/blob/dab63878bf348b16713df23691c2fe9bb467dcdf/optuna/study.py#L172-L185