### PR TITLE
Improving usability of TrialState in trials dataframes.

### DIFF
--- a/optuna/structs.py
+++ b/optuna/structs.py
@@ -119,8 +119,8 @@ class FrozenTrial(object):
     # Ordered list of fields required for `__repr__`, `__hash__` and dataframe creation.
     # TODO(hvy): Remove this list in Python 3.6 as the order of `self.__dict__` is preserved.
     _ordered_fields = [
-        'number', 'state', 'value', 'datetime_start', 'datetime_complete', 'params',
-        '_distributions', 'user_attrs', 'system_attrs', 'intermediate_values', '_trial_id', ]
+        'number', 'value', 'datetime_start', 'datetime_complete', 'params', '_distributions',
+        'user_attrs', 'system_attrs', 'intermediate_values', '_trial_id', 'state', ]
 
     def __eq__(self, other):
         # type: (Any) -> bool

--- a/optuna/study.py
+++ b/optuna/study.py
@@ -388,6 +388,9 @@ class Study(BaseStudy):
             record = {}
             for field, df_column in fields_to_df_columns.items():
                 value = getattr(trial, field)
+                if isinstance(value, structs.TrialState):
+                    # Convert TrialState to str and remove the common prefix.
+                    value = str(value).split('.')[-1]
                 if isinstance(value, dict):
                     for nested_field, nested_value in value.items():
                         record[(df_column, nested_field)] = nested_value

--- a/tests/test_study.py
+++ b/tests/test_study.py
@@ -510,7 +510,7 @@ def test_trials_dataframe(storage_mode, cache_mode, include_internal_fields, mul
 
         for i in range(3):
             assert df.number[i] == i
-            assert df.state[i] == optuna.structs.TrialState.COMPLETE
+            assert df.state[i] == 'COMPLETE'
             assert df.value[i] == 3.5
             assert isinstance(df.datetime_start[i], pd.Timestamp)
             assert isinstance(df.datetime_complete[i], pd.Timestamp)
@@ -563,7 +563,7 @@ def test_trials_dataframe_with_failure(storage_mode, cache_mode):
         assert len(df.columns) == 10
         for i in range(3):
             assert df.number[i] == i
-            assert df.state[i] == optuna.structs.TrialState.FAIL
+            assert df.state[i] == 'FAIL'
             assert df.value[i] is None
             assert isinstance(df.datetime_start[i], pd.Timestamp)
             assert isinstance(df.datetime_complete[i], pd.Timestamp)


### PR DESCRIPTION
This PR changes the type of `TrialState` to `str` and re-orders the columns.
Currently, `TrialState` instances are directly put into dataframes, and it is a bit confusing to use them as shown in the following example:

```python
>>> study.trials_dataframe()
   number                state     value             datetime_start          datetime_complete  params_x  system_attrs__number
0       0  TrialState.COMPLETE  0.695242 2019-12-05 15:07:34.973166 2019-12-05 15:07:35.009297  0.695242                     0
1       1  TrialState.COMPLETE  0.518207 2019-12-05 15:07:35.009687 2019-12-05 15:07:35.053692  0.518207                     1
2       2  TrialState.COMPLETE  0.342652 2019-12-05 15:07:35.054039 2019-12-05 15:07:35.101730  0.342652                     2
3       3  TrialState.COMPLETE  0.277671 2019-12-05 15:07:35.102118 2019-12-05 15:07:35.148646  0.277671                     3
4       4  TrialState.COMPLETE  0.511689 2019-12-05 15:07:35.149014 2019-12-05 15:07:35.194713  0.511689                     4
>>> study.trials_dataframe().state[0] == optuna.structs.TrialState.COMPLETE
True
>>> study.trials_dataframe().state[0] == 'TrialState.COMPLETE'
False
```

This PR converts `TrialState` instances to `str` to make the comparison easy. And also, I moved the `state` column to the last, so that users easily find both `value` and `state` when users print the dataframes.


![image](https://user-images.githubusercontent.com/3255979/70209032-77b0af80-1772-11ea-8979-2579066da956.png)
