### PR TITLE
Remove deprecated `product_search_space` function.

### DIFF
--- a/docs/source/reference/samplers.rst
+++ b/docs/source/reference/samplers.rst
@@ -15,4 +15,3 @@ Samplers
     :exclude-members: infer_relative_search_space, sample_relative, sample_independent
 
 .. autofunction:: intersection_search_space
-.. autofunction:: product_search_space

--- a/optuna/integration/cma.py
+++ b/optuna/integration/cma.py
@@ -374,7 +374,7 @@ class _Optimizer(object):
         # the parameters of complete trials are always compatible with the search space.
         #
         # However, in distributed optimization, incompatible trials may complete on a worker
-        # just after a product search space is calculated on another worker.
+        # just after an intersection search space is calculated on another worker.
 
         for name, distribution in self._search_space.items():
             if name not in trial.params:

--- a/optuna/integration/skopt.py
+++ b/optuna/integration/skopt.py
@@ -213,7 +213,7 @@ class _Optimizer(object):
         # the parameters of complete trials are always compatible with the search space.
         #
         # However, in distributed optimization, incompatible trials may complete on a worker
-        # just after a product search space is calculated on another worker.
+        # just after an intersection search space is calculated on another worker.
 
         for name, distribution in self._search_space.items():
             if name not in trial.params:

--- a/optuna/samplers/__init__.py
+++ b/optuna/samplers/__init__.py
@@ -1,7 +1,4 @@
-import warnings
-
 import optuna
-from optuna import logging
 from optuna.samplers.base import BaseSampler  # NOQA
 from optuna.samplers.random import RandomSampler  # NOQA
 from optuna.samplers.tpe import TPESampler  # NOQA

--- a/optuna/samplers/__init__.py
+++ b/optuna/samplers/__init__.py
@@ -47,22 +47,3 @@ def intersection_search_space(study):
             del search_space[param_name]
 
     return search_space or {}
-
-
-def product_search_space(study):
-    # type: (BaseStudy) -> Dict[str, BaseDistribution]
-    """Return the product search space of the :class:`~optuna.study.BaseStudy`.
-
-    .. deprecated:: 0.14.0
-        Please use :func:`~optuna.samplers.intersection_search_space` instead.
-    """
-
-    warnings.warn(
-        '`product_search_space` function is deprecated. '
-        'Please use `intersection_search_space` function instead.', DeprecationWarning)
-
-    logger = logging.get_logger(__name__)
-    logger.warning('`product_search_space` function is deprecated. '
-                   'Please use `intersection_search_space` function instead.')
-
-    return intersection_search_space(study)

--- a/tests/samplers_tests/test_samplers.py
+++ b/tests/samplers_tests/test_samplers.py
@@ -245,7 +245,8 @@ def test_intersection_search_space():
         'y': UniformDistribution(low=-3, high=3)
     }
 
-    # Failed or pruned trials are not considered in the calculation of a product search space.
+    # Failed or pruned trials are not considered in the calculation of
+    # an intersection search space.
     def objective(trial, exception):
         # type: (optuna.trial.Trial, Exception) -> float
 

--- a/tests/samplers_tests/test_samplers.py
+++ b/tests/samplers_tests/test_samplers.py
@@ -264,46 +264,6 @@ def test_intersection_search_space():
     assert optuna.samplers.intersection_search_space(study) == {}
 
 
-def test_product_search_space():
-    # type: () -> None
-
-    study = optuna.create_study()
-
-    # No trial.
-    assert optuna.samplers.product_search_space(study) == {}
-
-    # First trial.
-    study.optimize(lambda t: t.suggest_int('x', 0, 10) + t.suggest_uniform('y', -3, 3), n_trials=1)
-    assert optuna.samplers.product_search_space(study) == {
-        'x': IntUniformDistribution(low=0, high=10),
-        'y': UniformDistribution(low=-3, high=3)
-    }
-
-    # Second trial (only 'y' parameter is suggested in this trial).
-    study.optimize(lambda t: t.suggest_uniform('y', -3, 3), n_trials=1)
-    assert optuna.samplers.product_search_space(study) == {
-        'y': UniformDistribution(low=-3, high=3)
-    }
-
-    # Failed or pruned trials are not considered in the calculation of a product search space.
-    def objective(trial, exception):
-        # type: (optuna.trial.Trial, Exception) -> float
-
-        trial.suggest_uniform('z', 0, 1)
-        raise exception
-
-    study.optimize(lambda t: objective(t, RuntimeError()), n_trials=1, catch=(RuntimeError,))
-    study.optimize(lambda t: objective(t, optuna.exceptions.TrialPruned()), n_trials=1)
-    assert optuna.samplers.product_search_space(study) == {
-        'y': UniformDistribution(low=-3, high=3)
-    }
-
-    # If two parameters have the same name but different distributions,
-    # those are regarded as different trials.
-    study.optimize(lambda t: t.suggest_uniform('y', -1, 1), n_trials=1)
-    assert optuna.samplers.product_search_space(study) == {}
-
-
 @parametrize_sampler
 def test_nan_objective_value(sampler_class):
     # type: (typing.Callable[[], BaseSampler]) -> None


### PR DESCRIPTION
This PR removes `optuna.samplers.product_search_space` function that has been deprecated since v0.14.0.
I believe that this function isn't used anybody and can be safely removed.