### PR TITLE
Add lock acquisition to make `test_callbacks` test thread-safe.

### DIFF
--- a/tests/test_study.py
+++ b/tests/test_study.py
@@ -21,6 +21,8 @@ if type_checking.TYPE_CHECKING:
     from typing import Dict  # NOQA
     from typing import Optional  # NOQA
 
+    CallbackFuncType = Callable[[optuna.study.Study, optuna.structs.FrozenTrial], None]
+
 STORAGE_MODES = [
     'none',  # We give `None` to storage argument, so InMemoryStorage is used.
     'new',  # We always create a new sqlite DB file for each experiment.
@@ -705,6 +707,19 @@ def test_optimize_without_gc(collect_mock):
 def test_callbacks(n_jobs):
     # type: (int) -> None
 
+    lock = threading.Lock()
+
+    def with_lock(f):
+        # type: (CallbackFuncType) -> CallbackFuncType
+
+        def callback(study, trial):
+            # type: (optuna.study.Study, optuna.structs.FrozenTrial) -> None
+
+            with lock:
+                f(study, trial)
+
+        return callback
+
     study = optuna.create_study()
 
     def objective(trial):
@@ -717,7 +732,7 @@ def test_callbacks(n_jobs):
 
     # A callback.
     values = []
-    callbacks = [lambda study, trial: values.append(trial.value)]
+    callbacks = [with_lock(lambda study, trial: values.append(trial.value))]
     study.optimize(objective, callbacks=callbacks, n_trials=10, n_jobs=n_jobs)
     assert values == [1] * 10
 
@@ -725,8 +740,8 @@ def test_callbacks(n_jobs):
     values = []
     params = []
     callbacks = [
-        lambda study, trial: values.append(trial.value),
-        lambda study, trial: params.append(trial.params)
+        with_lock(lambda study, trial: values.append(trial.value)),
+        with_lock(lambda study, trial: params.append(trial.params))
     ]
     study.optimize(objective, callbacks=callbacks, n_trials=10, n_jobs=n_jobs)
     assert values == [1] * 10
@@ -735,7 +750,7 @@ def test_callbacks(n_jobs):
     # If a trial is failed with an exception and the exception is caught by the study,
     # callbacks are invoked.
     states = []
-    callbacks = [lambda study, trial: states.append(trial.state)]
+    callbacks = [with_lock(lambda study, trial: states.append(trial.state))]
     study.optimize(
         lambda t: 1/0, callbacks=callbacks, n_trials=10, n_jobs=n_jobs,
         catch=(ZeroDivisionError,))
@@ -744,7 +759,7 @@ def test_callbacks(n_jobs):
     # If a trial is failed with an exception and the exception isn't caught by the study,
     # callbacks aren't invoked.
     states = []
-    callbacks = [lambda study, trial: states.append(trial.state)]
+    callbacks = [with_lock(lambda study, trial: states.append(trial.state))]
     with pytest.raises(ZeroDivisionError):
         study.optimize(lambda t: 1/0, callbacks=callbacks,
                        n_trials=10, n_jobs=n_jobs, catch=())


### PR DESCRIPTION
This PR makes the callback functions used in unit test thread-safe.