### PR TITLE
Add 'attrs' option to `Study.trials_dataframe()`.

### DIFF
--- a/optuna/study.py
+++ b/optuna/study.py
@@ -359,10 +359,6 @@ class Study(BaseStudy):
                 assert df.shape[0] == 3  # n_trials.
 
         Args:
-            include_internal_fields:
-                By default, internal fields of :class:`~optuna.structs.FrozenTrial` are excluded
-                from a DataFrame of trials. If this argument is :obj:`True`, they will be included
-                in the DataFrame.
             attrs:
                 Specifies field names of :class:`~optuna.structs.FrozenTrial` to include them to a
                 DataFrame of trials.

--- a/tests/test_study.py
+++ b/tests/test_study.py
@@ -453,11 +453,14 @@ def test_study_trials_dataframe_with_no_trials():
 
 
 @pytest.mark.parametrize('storage_mode', STORAGE_MODES)
-@pytest.mark.parametrize('include_internal_fields', [True, False])
-@pytest.mark.parametrize('exclude_fields', [('intermediate_values', ), ()])
+@pytest.mark.parametrize('attrs', [
+    ('number', 'state', 'value', 'datetime_start', 'datetime_complete', 'params', 'user_attrs',
+     'system_attrs'),
+    ('number', 'state', 'value', 'datetime_start', 'datetime_complete', 'params', 'user_attrs',
+     'system_attrs', 'intermediate_values', '_trial_id', 'distributions')])
 @pytest.mark.parametrize('multi_index', [True, False])
-def test_trials_dataframe(storage_mode, include_internal_fields, exclude_fields, multi_index):
-    # type: (str, bool, Tuple[str], bool) -> None
+def test_trials_dataframe(storage_mode, attrs, multi_index):
+    # type: (str, Tuple[str], bool) -> None
 
     def f(trial):
         # type: (optuna.trial.Trial) -> float
@@ -475,10 +478,7 @@ def test_trials_dataframe(storage_mode, include_internal_fields, exclude_fields,
     with StorageSupplier(storage_mode) as storage:
         study = optuna.create_study(storage=storage)
         study.optimize(f, n_trials=3)
-        df = study.trials_dataframe(
-            include_internal_fields=include_internal_fields,
-            exclude_fields=exclude_fields,
-            multi_index=multi_index)
+        df = study.trials_dataframe(attrs=attrs, multi_index=multi_index)
         # Change index to access rows via trial number.
         if multi_index:
             df.set_index(('number', ''), inplace=True, drop=False)
@@ -486,18 +486,18 @@ def test_trials_dataframe(storage_mode, include_internal_fields, exclude_fields,
             df.set_index('number', inplace=True, drop=False)
         assert len(df) == 3
         # TODO(Yanase): Remove number from system_attrs after adding TrialModel.number.
-        # Number expected columns are as follows (total of 10):
-        #   non-nested: 5
+        # Number columns are as follows (total of 10):
+        #   non-nested: 5 (number, value, state, datetime_start, datetime_complete)
         #   params: 2
+        #   distributions: 2
         #   user_attrs: 1
         #   system_attrs: 1
         #   intermediate_values: 1
-        expected_n_columns = 10
-        if include_internal_fields:
-            # distributions: 2
-            # trial_id: 1
-            expected_n_columns += 3
-        expected_n_columns -= len(exclude_fields)
+        expected_n_columns = len(attrs)
+        if 'params' in attrs:
+            expected_n_columns += 1
+        if 'distributions' in attrs:
+            expected_n_columns += 1
         assert len(df.columns) == expected_n_columns
 
         for i in range(3):
@@ -508,9 +508,10 @@ def test_trials_dataframe(storage_mode, include_internal_fields, exclude_fields,
             assert isinstance(df.datetime_complete[i], pd.Timestamp)
 
             if multi_index:
-                if include_internal_fields:
+                if 'distributions' in attrs:
                     assert ('distributions', 'x') in df.columns
                     assert ('distributions', 'y') in df.columns
+                if '_trial_id' in attrs:
                     assert ('trial_id', '') in df.columns  # trial_id depends on other tests.
 
                 assert df.params.x[i] == 1
@@ -518,9 +519,10 @@ def test_trials_dataframe(storage_mode, include_internal_fields, exclude_fields,
                 assert df.user_attrs.train_loss[i] == 3
                 assert df.system_attrs._number[i] == i
             else:
-                if include_internal_fields:
+                if 'distributions' in attrs:
                     assert 'distributions_x' in df.columns
                     assert 'distributions_y' in df.columns
+                if '_trial_id' in attrs:
                     assert 'trial_id' in df.columns  # trial_id depends on other tests.
 
                 assert df.params_x[i] == 1

--- a/tests/test_study.py
+++ b/tests/test_study.py
@@ -462,7 +462,7 @@ def test_study_trials_dataframe_with_no_trials():
      'system_attrs', 'state', 'intermediate_values', '_trial_id', 'distributions')])
 @pytest.mark.parametrize('multi_index', [True, False])
 def test_trials_dataframe(storage_mode, attrs, multi_index):
-    # type: (str, Tuple[str], bool) -> None
+    # type: (str, Tuple[str, ...], bool) -> None
 
     def f(trial):
         # type: (optuna.trial.Trial) -> float


### PR DESCRIPTION
[Updated]
This PR adds an `attrs` option of `Study.trials_dataframe()` to select attributes of `FrozenTrial`. It also removes `include_intermediate_field` because the functionality can be covered by `attrs`.

[Original description]
This PR adds an option to exclude fields of `FrozenTrial` from dataframes.
`intermediate_values` is a bit noisy when it has many steps, and it will be excluded by default.
