### PR TITLE
Follow Google Analytics Privacy Disclosure Policy

### DIFF
--- a/docs/source/_templates/footer.html
+++ b/docs/source/_templates/footer.html
@@ -1,0 +1,5 @@
+{% extends "!footer.html" %}
+{% block extrafooter %}
+    {% trans path=pathto('privacy') %}<a href="{{ path }}">Privacy Policy</a>{{ privacy }}.{% endtrans %}
+    {{ super() }}
+{% endblock %}

--- a/docs/source/privacy.rst
+++ b/docs/source/privacy.rst
@@ -1,0 +1,11 @@
+Privacy Policy
+==============
+
+Google Analytics
+----------------
+
+To collect information about how visitors use our website and to improve our services, we are using Google Analytics on this website. You can find out more about how Google Analytics works and about how information is collected on the Google Analytics terms of services and on Google's privacy policy.
+
+- Google Analytics Terms of Service: http://www.google.com/analytics/terms/us.html
+- Google Privacy Policy: https://policies.google.com/privacy?hl=en
+- Google Analytics Opt-out Add-on: https://tools.google.com/dlpage/gaoptout?hl=en


### PR DESCRIPTION
Adds a page in the documentation about the usage of Google Analytics, to be open about the usage and to follow its [disclosure policy](https://support.google.com/analytics/answer/7318509). Please refer to the diff as it is quite self explanatory.

The page is rendered as follows and will be accessible from the footer.

<img width="1112" alt="Screen Shot 2019-12-06 at 15 48 36" src="https://user-images.githubusercontent.com/5983694/70305568-165b1000-1848-11ea-9f95-5bb922fdec46.png">
