### PR TITLE
Update example dataframe in tutorial.

### DIFF
--- a/docs/source/tutorial/rdb.rst
+++ b/docs/source/tutorial/rdb.rst
@@ -61,14 +61,13 @@ The method :func:`~optuna.study.Study.trials_dataframe` returns a pandas datafra
 
 .. code-block:: bash
 
-    number                state       value             datetime_start          datetime_complete    params system_attrs
-                                                                                                          x      _number
-         0  TrialState.COMPLETE   25.301959 2019-03-14 10:57:27.716141 2019-03-14 10:57:27.746354 -3.030105            0
-         1  TrialState.COMPLETE    1.406223 2019-03-14 10:57:27.774461 2019-03-14 10:57:27.835520  0.814157            1
-         2  TrialState.COMPLETE   44.010366 2019-03-14 10:57:27.871365 2019-03-14 10:57:27.926247 -4.634031            2
-         3  TrialState.COMPLETE   55.872181 2019-03-14 10:59:00.845565 2019-03-14 10:59:00.899305  9.474770            3
-         4  TrialState.COMPLETE  113.039223 2019-03-14 10:59:00.921534 2019-03-14 10:59:00.947233 -8.631991            4
-         5  TrialState.COMPLETE   57.319570 2019-03-14 10:59:00.985909 2019-03-14 10:59:01.028819  9.570969            5
+    number       value             datetime_start          datetime_complete  params_x system_attrs__number     state
+         0   25.301959 2019-03-14 10:57:27.716141 2019-03-14 10:57:27.746354 -3.030105                    0  COMPLETE
+         1    1.406223 2019-03-14 10:57:27.774461 2019-03-14 10:57:27.835520  0.814157                    1  COMPLETE
+         2   44.010366 2019-03-14 10:57:27.871365 2019-03-14 10:57:27.926247 -4.634031                    2  COMPLETE
+         3   55.872181 2019-03-14 10:59:00.845565 2019-03-14 10:59:00.899305  9.474770                    3  COMPLETE
+         4  113.039223 2019-03-14 10:59:00.921534 2019-03-14 10:59:00.947233 -8.631991                    4  COMPLETE
+         5   57.319570 2019-03-14 10:59:00.985909 2019-03-14 10:59:01.028819  9.570969                    5  COMPLETE
 
 A :class:`~optuna.study.Study` object also provides properties such as :attr:`~optuna.study.Study.trials`, :attr:`~optuna.study.Study.best_value`, :attr:`~optuna.study.Study.best_params` (see also :ref:`firstopt`).
 

--- a/docs/source/tutorial/rdb.rst
+++ b/docs/source/tutorial/rdb.rst
@@ -55,19 +55,19 @@ For example, we can get all trials of ``example-study`` as:
 
     import optuna
     study = optuna.create_study(study_name='example-study', storage='sqlite:///example.db', load_if_exists=True)
-    df = study.trials_dataframe()
+    df = study.trials_dataframe(attrs=('number', 'value', 'params', 'state'))
 
 The method :func:`~optuna.study.Study.trials_dataframe` returns a pandas dataframe like:
 
 .. code-block:: bash
 
-    number       value             datetime_start          datetime_complete  params_x system_attrs__number     state
-         0   25.301959 2019-03-14 10:57:27.716141 2019-03-14 10:57:27.746354 -3.030105                    0  COMPLETE
-         1    1.406223 2019-03-14 10:57:27.774461 2019-03-14 10:57:27.835520  0.814157                    1  COMPLETE
-         2   44.010366 2019-03-14 10:57:27.871365 2019-03-14 10:57:27.926247 -4.634031                    2  COMPLETE
-         3   55.872181 2019-03-14 10:59:00.845565 2019-03-14 10:59:00.899305  9.474770                    3  COMPLETE
-         4  113.039223 2019-03-14 10:59:00.921534 2019-03-14 10:59:00.947233 -8.631991                    4  COMPLETE
-         5   57.319570 2019-03-14 10:59:00.985909 2019-03-14 10:59:01.028819  9.570969                    5  COMPLETE
+    number       value  params_x     state
+         0   25.301959 -3.030105  COMPLETE
+         1    1.406223  0.814157  COMPLETE
+         2   44.010366 -4.634031  COMPLETE
+         3   55.872181  9.474770  COMPLETE
+         4  113.039223 -8.631991  COMPLETE
+         5   57.319570  9.570969  COMPLETE
 
 A :class:`~optuna.study.Study` object also provides properties such as :attr:`~optuna.study.Study.trials`, :attr:`~optuna.study.Study.best_value`, :attr:`~optuna.study.Study.best_params` (see also :ref:`firstopt`).
 


### PR DESCRIPTION
This PR updates the example of dataframes in [the RDB page](https://optuna.readthedocs.io/en/stable/tutorial/rdb.html#experimental-history) of the tutorial.

Before 
![image](https://user-images.githubusercontent.com/3255979/70586420-5c2e2480-1c0a-11ea-91c1-c6920b95256c.png)

After
![image](https://user-images.githubusercontent.com/3255979/70586513-9f889300-1c0a-11ea-8b12-6973504d42a9.png)
![image](https://user-images.githubusercontent.com/3255979/70586564-cb0b7d80-1c0a-11ea-803f-af1c9fa9ddb1.png)

This is just a comment, but the updated dataframe still is busy due to the `datetime_start`, `datetime_complete` and `system_attrs`.

Although the command will be more complicated, we can simplify the output like

![image](https://user-images.githubusercontent.com/3255979/70586731-4b31e300-1c0b-11ea-9325-d3b0b591a998.png)

or 

![image](https://user-images.githubusercontent.com/3255979/70588235-70285500-1c0f-11ea-9edd-4c64e952aa24.png).

