### PR TITLE
Implement `Hyperband` pruner

### DIFF
--- a/docs/source/reference/pruners.rst
+++ b/docs/source/reference/pruners.rst
@@ -21,3 +21,7 @@ Pruners
 .. autoclass:: SuccessiveHalvingPruner
     :members:
     :exclude-members: prune
+
+.. autoclass:: HyperbandPruner
+    :members:
+    :exclude-members: prune

--- a/examples/samplers/simulated_annealing_sampler.py
+++ b/examples/samplers/simulated_annealing_sampler.py
@@ -33,13 +33,13 @@ class SimulatedAnnealingSampler(BaseSampler):
     def infer_relative_search_space(self, study, trial):
         return optuna.samplers.intersection_search_space(study)
 
-    def sample_relative(self, study, trial, search_space):
+    def sample_relative(self, study, trial, search_space, trials):
         if search_space == {}:
             # The relative search space is empty (it means this is the first trial of a study).
             return {}
 
         # The rest of this method is an implementation of Simulated Annealing (SA) algorithm.
-        prev_trial = self._get_last_complete_trial(study)
+        prev_trial = self._get_last_complete_trial(study, trials)
 
         # Update the current state of SA if the transition is accepted.
         if self._rng.uniform(0, 1) <= self._transition_probability(study, prev_trial):
@@ -93,15 +93,17 @@ class SimulatedAnnealingSampler(BaseSampler):
         return np.exp(-abs(current_value - prev_value) / self._temperature)
 
     @staticmethod
-    def _get_last_complete_trial(study):
-        complete_trials = [t for t in study.trials if t.state == structs.TrialState.COMPLETE]
+    def _get_last_complete_trial(study, trials=None):
+        if trials is None:
+            trials = study.trials
+        complete_trials = [t for t in trials if t.state == structs.TrialState.COMPLETE]
         return complete_trials[-1]
 
-    def sample_independent(self, study, trial, param_name, param_distribution):
+    def sample_independent(self, study, trial, param_name, param_distribution, trials):
         # In this example, this method is invoked only in the first trial of a study.
         # The parameters of the trial are sampled by using `RandomSampler` as follows.
-        return self._independent_sampler.sample_independent(study, trial, param_name,
-                                                            param_distribution)
+        return self._independent_sampler.sample_independent(
+            study, trial, param_name, param_distribution, trials)
 
 
 # Define a simple 2-dimensional objective function whose minimum value is -1 when (x, y) = (0, -1).

--- a/optuna/integration/lightgbm_tuner/optimize.py
+++ b/optuna/integration/lightgbm_tuner/optimize.py
@@ -52,8 +52,14 @@ class _GridSamplerUniform1D(optuna.samplers.BaseSampler):
         self.param_values = tuple(param_values)
         self.value_idx = 0
 
-    def sample_relative(self, study, trial, search_space):
-        # type: (Study, FrozenTrial, Dict[str, BaseDistribution]) -> Dict[str, float]
+    def sample_relative(
+            self,
+            study,  # type: Study
+            trial,  # type: FrozenTrial
+            search_space,  # type: Dict[str, BaseDistribution]
+            trials=None  # type: Optional[List[FrozenTrial]]
+    ):
+        # type: (...) -> Dict[str, float]
 
         # todo (g-votte): Take care of distributed optimization.
         assert self.value_idx < len(self.param_values)
@@ -61,8 +67,8 @@ class _GridSamplerUniform1D(optuna.samplers.BaseSampler):
         self.value_idx += 1
         return {self.param_name: param_value}
 
-    def sample_independent(self, study, trial, param_name, param_distribution):
-        # type: (Study, FrozenTrial, str, BaseDistribution) -> None
+    def sample_independent(self, study, trial, param_name, param_distribution, trials=None):
+        # type: (Study, FrozenTrial, str, BaseDistribution, Optional[List[FrozenTrial]]) -> None
 
         raise ValueError(
             'Suggest method is called for an invalid parameter: {}.'.format(param_name))

--- a/optuna/integration/skopt.py
+++ b/optuna/integration/skopt.py
@@ -110,8 +110,14 @@ class SkoptSampler(BaseSampler):
 
         return search_space
 
-    def sample_relative(self, study, trial, search_space):
-        # type: (Study, FrozenTrial, Dict[str, BaseDistribution]) -> Dict[str, Any]
+    def sample_relative(
+            self,
+            study,  # type: Study
+            trial,  # type: FrozenTrial
+            search_space,  # type: Dict[str, BaseDistribution]
+            trials=None  # type: Optional[List[FrozenTrial]]
+    ):
+        # type: (...) -> Dict[str, Any]
 
         if len(search_space) == 0:
             return {}
@@ -120,8 +126,8 @@ class SkoptSampler(BaseSampler):
         optimizer.tell(study)
         return optimizer.ask()
 
-    def sample_independent(self, study, trial, param_name, param_distribution):
-        # type: (Study, FrozenTrial, str, BaseDistribution) -> Any
+    def sample_independent(self, study, trial, param_name, param_distribution, trials=None):
+        # type: (Study, FrozenTrial, str, BaseDistribution, Optional[List[FrozenTrial]]) -> Any
 
         if self._warn_independent_sampling:
             complete_trials = [t for t in study.trials if t.state == structs.TrialState.COMPLETE]

--- a/optuna/pruners/__init__.py
+++ b/optuna/pruners/__init__.py
@@ -1,4 +1,5 @@
 from optuna.pruners.base import BasePruner  # NOQA
+from optuna.pruners.hyperband import HyperbandPruner  # NOQA
 from optuna.pruners.median import MedianPruner  # NOQA
 from optuna.pruners.nop import NopPruner  # NOQA
 from optuna.pruners.percentile import PercentilePruner  # NOQA

--- a/optuna/pruners/base.py
+++ b/optuna/pruners/base.py
@@ -42,6 +42,7 @@ class BasePruner(object, metaclass=abc.ABCMeta):
     def should_filter_trials(self):
         # type: () -> bool
         """Returns whether the sampler can use all of :func:`~optuna.study.Study.trials`.
+
         This method tells :class:`~optuna.study.Study` whether it needs to filters out trials
         that have different ``pruner_metadata`` of :func:`optuna.trial.Trial.user_attrs`.
         One use-case of this method is :class:`~optuna.pruners.HyperbandPruner` that runs and

--- a/optuna/pruners/base.py
+++ b/optuna/pruners/base.py
@@ -30,3 +30,25 @@ class BasePruner(object, metaclass=abc.ABCMeta):
         """
 
         raise NotImplementedError
+
+    @abc.abstractmethod
+    def get_trial_pruner_auxiliary_data(self, study_name, trial_number):
+        # type: (str, int) -> str
+        """Return appropriate pruner's metadata for a trial."""
+
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def should_filter_trials(self):
+        # type: () -> bool
+        """Returns whether the sampler can use all of :func:`~optuna.study.Study.trials`.
+        This method tells :class:`~optuna.study.Study` whether it needs to filters out trials
+        that have different ``pruner_metadata`` of :func:`optuna.trial.Trial.user_attrs`.
+        One use-case of this method is :class:`~optuna.pruners.HyperbandPruner` that runs and
+        manages multiple :class:`~optuna.pruners.SuccessiveHalvingPruner`\\s called ``bracket``\\s
+        by indexing its brackets.
+        Therefore, the sampler of the study should use the history of trials that is monitored by
+        the pruner of the same index.
+        """
+
+        raise NotImplementedError

--- a/optuna/pruners/hyperband.py
+++ b/optuna/pruners/hyperband.py
@@ -23,6 +23,7 @@ class HyperbandPruner(BasePruner):
     by trying different :math:`n` values for a fixed budget.
     Note that this implementation does not take as inputs the maximum amount of resource to
     a single SHA noted as :math:`R` in the paper.
+
     Args:
         min_resource:
             A parameter for specifying the minimum resource allocated to a trial noted as :math:`r`
@@ -79,7 +80,7 @@ class HyperbandPruner(BasePruner):
     def prune(self, study, trial):
         # type: (Study, FrozenTrial) -> bool
 
-        i = self.get_bracket_id(study.study_id, trial.number)
+        i = self.get_bracket_id(study.study_name, trial.number)
         _logger.debug('{}th bracket is selected'.format(i))
         return self._pruners[i].prune(study, trial)
 
@@ -105,6 +106,7 @@ class HyperbandPruner(BasePruner):
     def get_bracket_id(self, study_name, trial_number):
         # type: (str, int) -> int
         """Computes the index of bracket for a trial of ``trial_number``.
+
         The index of a bracket is noted as :math:`s` in
         `Hyperband paper <http://www.jmlr.org/papers/volume18/16-558/16-558.pdf>`_.
         """
@@ -121,6 +123,7 @@ class HyperbandPruner(BasePruner):
     def resource_budget(self):
         # type: () -> int
         """The total amount of resource.
+
         This value is a proxy for :math:`B` in the
         `Hyperband paper <http://www.jmlr.org/papers/volume18/16-558/16-558.pdf>`_.
         """
@@ -131,6 +134,7 @@ class HyperbandPruner(BasePruner):
     def n_pruners(self):
         # type: () -> int
         """The number of pruners.
+
         The number of pruners is calculated by the following equation:
         :math:`
         \\mathsf{min}\\_\\mathsf{early}\\_\\mathsf{stopping}\\_\\mathsf{rate}\\_\\mathsf{high} -

--- a/optuna/pruners/hyperband.py
+++ b/optuna/pruners/hyperband.py
@@ -1,0 +1,140 @@
+from optuna import logging
+from optuna.pruners.base import BasePruner
+from optuna.pruners.successive_halving import SuccessiveHalvingPruner
+from optuna import type_checking
+
+if type_checking.TYPE_CHECKING:
+    from typing import List  # NOQA
+
+    from optuna.structs import FrozenTrial  # NOQA
+    from optuna.study import Study  # NOQA
+
+_logger = logging.get_logger(__name__)
+
+
+class HyperbandPruner(BasePruner):
+    """Pruner using Hyperband.
+
+    As SuccessiveHalving (SHA) requires the number of configurations
+    :math:`n` as its hyperparameter.  For a given finite budget :math:`B`,
+    all the configurations have the resources of :math:`B \\over n` on average.
+    As you can see, there will be a trade-off of :math:`B` and :math:`B \\over n`.
+    `Hyperband <http://www.jmlr.org/papers/volume18/16-558/16-558.pdf>`_ attacks this trade-off
+    by trying different :math:`n` values for a fixed budget.
+    Note that this implementation does not take as inputs the maximum amount of resource to
+    a single SHA noted as :math:`R` in the paper.
+    Args:
+        min_resource:
+            A parameter for specifying the minimum resource allocated to a trial noted as :math:`r`
+            in the paper.
+            See the details for :class:`~optuna.pruners.SuccessiveHalvingPruner`.
+        reduction_factor:
+            A parameter for specifying reduction factor of promotable trials noted as
+            :math:`\\eta` in the paper. See the details for
+            :class:`~optuna.pruners.SuccessiveHalvingPruner`.
+        min_early_stopping_rate_low:
+            The start point of the minimum early stopping rate for ``SuccessiveHalvingPruner``.
+        min_early_stopping_rate_high:
+            The end point of the minimum early stopping rate for ``SuccessiveHalvingPruner``.
+    """
+
+    def __init__(
+            self,
+            min_resource=1,
+            reduction_factor=3,
+            min_early_stopping_rate_low=0,
+            min_early_stopping_rate_high=4
+    ):
+        # type: (int, int, int, int) -> None
+        self._pruners = []  # type: List[SuccessiveHalvingPruner]
+        self._reduction_factor = reduction_factor
+        self._resource_budget = 0
+        n_pruners = min_early_stopping_rate_high - min_early_stopping_rate_low + 1
+        self._n_pruners = n_pruners
+        self._bracket_resource_budgets = []  # type: List[int]
+
+        _logger.debug('Hyperband has {} brackets'.format(self.n_pruners))
+
+        for i in range(n_pruners):
+            bracket_resource_budget = self._calc_bracket_resource_budget(i, n_pruners)
+            self._resource_budget += bracket_resource_budget
+            self._bracket_resource_budgets.append(bracket_resource_budget)
+
+            # N.B. (crcrpar): `min_early_stopping_rate` has the information of `bracket_index`.
+            min_early_stopping_rate = min_early_stopping_rate_low + i
+            rung_key_prefix = 'bracket{}_'.format(i)
+
+            _logger.debug(
+                '{}th bracket has minimum early stopping rate of {}'.format(
+                    i, min_early_stopping_rate))
+
+            pruner = SuccessiveHalvingPruner(
+                min_resource=min_resource,
+                reduction_factor=reduction_factor,
+                min_early_stopping_rate=min_early_stopping_rate,
+                rung_key_prefix=rung_key_prefix
+            )
+            self._pruners.append(pruner)
+
+    def prune(self, study, trial):
+        # type: (Study, FrozenTrial) -> bool
+
+        i = self.get_bracket_id(study.study_id, trial.number)
+        _logger.debug('{}th bracket is selected'.format(i))
+        return self._pruners[i].prune(study, trial)
+
+    def get_trial_pruner_auxiliary_data(self, study_name, trial_number):
+        # type: (str, int) -> str
+
+        bracket_index = self.get_bracket_id(study_name, trial_number)
+        return '_{}'.format(bracket_index)
+
+    def should_filter_trials(self):
+        # type: () -> bool
+
+        return True
+
+    def _calc_bracket_resource_budget(self, pruner_index, n_pruners):
+        # type: (int, int) -> int
+        n = self._reduction_factor ** (n_pruners - 1)
+        budget = n
+        for i in range(pruner_index, n_pruners - 1):
+            budget += n / 2
+        return budget
+
+    def get_bracket_id(self, study_name, trial_number):
+        # type: (str, int) -> int
+        """Computes the index of bracket for a trial of ``trial_number``.
+        The index of a bracket is noted as :math:`s` in
+        `Hyperband paper <http://www.jmlr.org/papers/volume18/16-558/16-558.pdf>`_.
+        """
+
+        n = hash('{}_{}'.format(study_name, trial_number)) % self._resource_budget
+        for i in range(self.n_pruners):
+            n -= self._bracket_resource_budgets[i]
+            if n < 0:
+                return i
+
+        raise RuntimeError
+
+    @property
+    def resource_budget(self):
+        # type: () -> int
+        """The total amount of resource.
+        This value is a proxy for :math:`B` in the
+        `Hyperband paper <http://www.jmlr.org/papers/volume18/16-558/16-558.pdf>`_.
+        """
+
+        return self._resource_budget
+
+    @property
+    def n_pruners(self):
+        # type: () -> int
+        """The number of pruners.
+        The number of pruners is calculated by the following equation:
+        :math:`
+        \\mathsf{min}\\_\\mathsf{early}\\_\\mathsf{stopping}\\_\\mathsf{rate}\\_\\mathsf{high} -
+        \\mathsf{min}\\_\\mathsf{early}\\_\\mathsf{stopping}\\_\\mathsf{rate}\\_\\mathsf{low} + 1`
+        """
+
+        return self._n_pruners

--- a/optuna/pruners/nop.py
+++ b/optuna/pruners/nop.py
@@ -27,3 +27,13 @@ class NopPruner(BasePruner):
         # type: (Study, structs.FrozenTrial) -> bool
 
         return False
+
+    def get_trial_pruner_auxiliary_data(self, study_name, trial_number):
+        # type: (str, int) -> str
+
+        return ''
+
+    def should_filter_trials(self):
+        # type: () -> bool
+
+        return False

--- a/optuna/pruners/percentile.py
+++ b/optuna/pruners/percentile.py
@@ -150,3 +150,13 @@ class PercentilePruner(BasePruner):
         if direction == structs.StudyDirection.MAXIMIZE:
             return best_intermediate_result < p
         return best_intermediate_result > p
+
+    def get_trial_pruner_auxiliary_data(self, study_name, trial_number):
+        # type: (str, int) -> str
+
+        return ''
+
+    def should_filter_trials(self):
+        # type: () -> bool
+
+        return False

--- a/optuna/pruners/successive_halving.py
+++ b/optuna/pruners/successive_halving.py
@@ -93,6 +93,17 @@ class SuccessiveHalvingPruner(BasePruner):
         self._min_resource = min_resource
         self._reduction_factor = reduction_factor
         self._min_early_stopping_rate = min_early_stopping_rate
+        self._rung_key_prefix = rung_key_prefix
+
+    def get_trial_pruner_auxiliary_data(self, study_name, trial_number):
+        # type: (str, int) -> str
+
+        return ''
+
+    def should_filter_trials(self):
+        # type: () -> bool
+
+        return False
 
     def prune(self, study, trial):
         # type: (Study, FrozenTrial) -> bool

--- a/optuna/samplers/base.py
+++ b/optuna/samplers/base.py
@@ -5,6 +5,8 @@ from optuna import type_checking
 if type_checking.TYPE_CHECKING:
     from typing import Any  # NOQA
     from typing import Dict  # NOQA
+    from typing import List  # NOQA
+    from typing import Optional  # NOQA
 
     from optuna.distributions import BaseDistribution  # NOQA
     from optuna.structs import FrozenTrial  # NOQA
@@ -70,8 +72,14 @@ class BaseSampler(object, metaclass=abc.ABCMeta):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def sample_relative(self, study, trial, search_space):
-        # type: (Study, FrozenTrial, Dict[str, BaseDistribution]) -> Dict[str, Any]
+    def sample_relative(
+            self,
+            study,  # type: Study
+            trial,  # type: FrozenTrial
+            search_space,  # type: Dict[str, BaseDistribution]
+            trials=None  # type: Optional[List[FrozenTrial]]
+    ):
+        # type: (...) -> Dict[str, Any]
         """Sample parameters in a given search space.
 
         This method is called once at the beginning of each trial, i.e., right before the
@@ -86,6 +94,9 @@ class BaseSampler(object, metaclass=abc.ABCMeta):
             search_space:
                 The search space returned by
                 :func:`~optuna.samplers.BaseSampler.infer_relative_search_space`.
+            trials:
+                The list of trials that have the same value for the key of `pruner_metadata`
+                in `user_attrs` as the given `trial`.
 
         Returns:
             A dictionary containing the parameter names and the values.
@@ -95,8 +106,15 @@ class BaseSampler(object, metaclass=abc.ABCMeta):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def sample_independent(self, study, trial, param_name, param_distribution):
-        # type: (Study, FrozenTrial, str, BaseDistribution) -> Any
+    def sample_independent(
+            self,
+            study,  # type: Study
+            trial,  # type: FrozenTrial
+            param_name,  # type: str
+            param_distribution,  # type: BaseDistribution
+            trials=None  # type: Optional[List[FrozenTrial]]
+    ):
+        # type: (...) -> Any
         """Sample a parameter for a given distribution.
 
         This method is called only for the parameters not contained in the search space returned
@@ -113,6 +131,9 @@ class BaseSampler(object, metaclass=abc.ABCMeta):
                 Name of the sampled parameter.
             param_distribution:
                 Distribution object that specifies a prior and/or scale of the sampling algorithm.
+            trials:
+                The list of trials that have the same value for the key of `pruner_metadata`
+                in `user_attrs` as the given `trial`.
 
         Returns:
             A parameter value.

--- a/optuna/samplers/random.py
+++ b/optuna/samplers/random.py
@@ -7,6 +7,7 @@ from optuna import type_checking
 if type_checking.TYPE_CHECKING:
     from typing import Any  # NOQA
     from typing import Dict  # NOQA
+    from typing import List  # NOQA
     from typing import Optional  # NOQA
 
     from optuna.distributions import BaseDistribution  # NOQA
@@ -54,13 +55,26 @@ class RandomSampler(BaseSampler):
 
         return {}
 
-    def sample_relative(self, study, trial, search_space):
-        # type: (Study, FrozenTrial, Dict[str, BaseDistribution]) -> Dict[str, Any]
+    def sample_relative(
+            self,
+            study,  # type: Study
+            trial,  # type: FrozenTrial
+            search_space,  # type: Dict[str, BaseDistribution]
+            trials=None  # type: Optional[List[FrozenTrial]]
+    ):
+        # type: (...) -> Dict[str, Any]
 
         return {}
 
-    def sample_independent(self, study, trial, param_name, param_distribution):
-        # type: (Study, FrozenTrial, str, distributions.BaseDistribution) -> Any
+    def sample_independent(
+            self,
+            study,  # type: Study
+            trial,  # type: FrozenTrial
+            param_name,  # type: str
+            param_distribution,  # type: BaseDistribution
+            trials=None  # type: Optional[List[FrozenTrial]]
+    ):
+        # type: (...) -> Any
 
         if isinstance(param_distribution, distributions.UniformDistribution):
             return self._rng.uniform(param_distribution.low, param_distribution.high)

--- a/optuna/samplers/tpe/sampler.py
+++ b/optuna/samplers/tpe/sampler.py
@@ -116,13 +116,26 @@ class TPESampler(base.BaseSampler):
 
         return {}
 
-    def sample_relative(self, study, trial, search_space):
-        # type: (Study, FrozenTrial, Dict[str, BaseDistribution]) -> Dict[str, Any]
+    def sample_relative(
+            self,
+            study,  # type: Study
+            trial,  # type: FrozenTrial
+            search_space,  # type: Dict[str, BaseDistribution]
+            trials=None  # type: Optional[List[FrozenTrial]]
+    ):
+        # type: (...) -> Dict[str, Any]
 
         return {}
 
-    def sample_independent(self, study, trial, param_name, param_distribution):
-        # type: (Study, FrozenTrial, str, BaseDistribution) -> Any
+    def sample_independent(
+            self,
+            study,  # type: Study
+            trial,  # type: FrozenTrial
+            param_name,  # type: str
+            param_distribution,  # type: BaseDistribution
+            trials=None  # type: Optional[List[FrozenTrial]]
+    ):
+        # type: (...) -> Any
 
         values, scores = _get_observation_pairs(study, param_name)
 

--- a/optuna/study.py
+++ b/optuna/study.py
@@ -565,6 +565,9 @@ class Study(BaseStudy):
         trial = trial_module.Trial(self, trial_id)
         trial_number = trial.number
 
+        trials = self.trials
+        trial._set_friend_trials(trials)
+
         try:
             result = func(trial)
         except exceptions.TrialPruned as e:
@@ -585,6 +588,8 @@ class Study(BaseStudy):
                 return trial
             raise
         finally:
+            trial._clear_friend_trials()
+            del trials
             # The following line mitigates memory problems that can be occurred in some
             # environments (e.g., services that use computing containers such as CircleCI).
             # Please refer to the following PR for further details:

--- a/optuna/testing/integration.py
+++ b/optuna/testing/integration.py
@@ -12,6 +12,16 @@ class DeterministicPruner(optuna.pruners.BasePruner):
 
         return self.is_pruning
 
+    def get_trial_pruner_auxiliary_data(self, study_name, trial_number):
+        # type: (str, int) -> str
+
+        return ''
+
+    def should_filter_trials(self):
+        # type: () -> bool
+
+        return False
+
 
 def create_running_trial(study, value):
     # type: (optuna.study.Study, float) -> optuna.trial.Trial

--- a/optuna/testing/sampler.py
+++ b/optuna/testing/sampler.py
@@ -4,6 +4,8 @@ from optuna import distributions
 if optuna.type_checking.TYPE_CHECKING:
     from typing import Any  # NOQA
     from typing import Dict  # NOQA
+    from typing import List  # NOQA
+    from typing import Optional  # NOQA
 
     from optuna.distributions import BaseDistribution  # NOQA
     from optuna.structs import FrozenTrial  # NOQA
@@ -22,13 +24,19 @@ class DeterministicRelativeSampler(optuna.samplers.BaseSampler):
 
         return self.relative_search_space
 
-    def sample_relative(self, study, trial, search_space):
-        # type: (Study, FrozenTrial, Dict[str, BaseDistribution]) -> Dict[str, Any]
+    def sample_relative(
+            self,
+            study,  # type: Study
+            trial,  # type: FrozenTrial
+            search_space,  # type: Dict[str, BaseDistribution]
+            trials=None  # type: Optional[List[FrozenTrial]]
+    ):
+        # type: (...) -> Dict[str, Any]
 
         return self.relative_params
 
-    def sample_independent(self, study, trial, param_name, param_distribution):
-        # type: (Study, FrozenTrial, str, BaseDistribution) -> Any
+    def sample_independent(self, study, trial, param_name, param_distribution, trials=None):
+        # type: (Study, FrozenTrial, str, BaseDistribution, Optional[List[FrozenTrial]]) -> Any
 
         if isinstance(param_distribution, distributions.UniformDistribution):
             param_value = param_distribution.low  # type: Any
@@ -47,16 +55,22 @@ class DeterministicRelativeSampler(optuna.samplers.BaseSampler):
 
 
 class FirstTrialOnlyRandomSampler(optuna.samplers.RandomSampler):
-    def sample_relative(self, study, trial, search_space):
-        # type: (Study, FrozenTrial, Dict[str, BaseDistribution]) -> Dict[str, float]
+    def sample_relative(
+            self,
+            study,  # type: Study
+            trial,  # type: FrozenTrial
+            search_space,  # type: Dict[str, Any]
+            trials=None  # type: Optional[List[FrozenTrial]]
+    ):
+        # type: (...) -> Dict[str, float]
 
         if len(study.trials) > 1:
             raise RuntimeError("`FirstTrialOnlyRandomSampler` only works on the first trial.")
 
         return super(FirstTrialOnlyRandomSampler, self).sample_relative(study, trial, search_space)
 
-    def sample_independent(self, study, trial, param_name, param_distribution):
-        # type: (Study, FrozenTrial, str, BaseDistribution) -> float
+    def sample_independent(self, study, trial, param_name, param_distribution, trials=None):
+        # type: (Study, FrozenTrial, str, BaseDistribution, Optional[List[FrozenTrial]]) -> float
 
         if len(study.trials) > 1:
             raise RuntimeError("`FirstTrialOnlyRandomSampler` only works on the first trial.")

--- a/tests/pruners_tests/test_hyperband.py
+++ b/tests/pruners_tests/test_hyperband.py
@@ -1,0 +1,55 @@
+import optuna
+from optuna import type_checking
+
+if type_checking.TYPE_CHECKING:
+    from typing import Dict  # NOQA
+    from typing import List  # NOQA
+    from typing import Tuple  # NOQA
+
+    from optuna.structs import FrozenTrial  # NOQA
+    from optuna.trial import Trial  # NOQA
+
+MIN_RESOURCE = 1
+REDUCTION_FACTOR = 2
+EARLY_STOPPING_RATE_LOW = 0
+EARLY_STOPPING_RATE_HIGH = 3
+N_REPORTS = 10
+EXPECTED_N_TRIALS_PER_BRACKET = 10
+
+
+def test_hyperband_pruner_intermediate_values():
+    # type: () -> None
+
+    pruner = optuna.pruners.HyperbandPruner(
+        min_resource=MIN_RESOURCE,
+        reduction_factor=REDUCTION_FACTOR,
+        min_early_stopping_rate_low=EARLY_STOPPING_RATE_LOW,
+        min_early_stopping_rate_high=EARLY_STOPPING_RATE_HIGH
+    )
+    assert pruner.n_pruners == EARLY_STOPPING_RATE_HIGH - EARLY_STOPPING_RATE_LOW + 1
+    n_pruners = pruner.n_pruners
+
+    study = optuna.study.create_study(pruner=pruner)
+
+    def objective(trial):
+        # type: (Trial) -> float
+
+        for i in range(N_REPORTS):
+            trial.report(i)
+
+        return 1.0
+
+    study.optimize(objective, n_trials=n_pruners * EXPECTED_N_TRIALS_PER_BRACKET)
+
+    trials = study.trials
+    bracket_user_attrs = [pruner.__class__.__name__ + '_{}'.format(i) for i in range(n_pruners)]
+
+    assert len(trials) == n_pruners * EXPECTED_N_TRIALS_PER_BRACKET
+
+    bracket_trials = {
+        key: [t for t in trials if t.user_attrs['pruner_metadata'] == key]
+        for key in bracket_user_attrs
+    }  # type: Dict[str, List[FrozenTrial]]
+
+    for key, value in bracket_trials.items():
+        assert len(value) > 0

--- a/tests/samplers_tests/test_samplers.py
+++ b/tests/samplers_tests/test_samplers.py
@@ -15,6 +15,7 @@ if optuna.type_checking.TYPE_CHECKING:
     import typing  # NOQA
     from typing import Any  # NOQA
     from typing import Dict  # NOQA
+    from typing import List  # NOQA
     from typing import Optional  # NOQA
     from typing import Sequence  # NOQA
 
@@ -178,13 +179,19 @@ class FixedSampler(BaseSampler):
 
         return self.relative_search_space
 
-    def sample_relative(self, study, trial, search_space):
-        # type: (Study, FrozenTrial, Dict[str, BaseDistribution]) -> Dict[str, Any]
+    def sample_relative(
+            self,
+            study,  # type: Study
+            trial,  # type: FrozenTrial
+            search_space,  # type: Dict[str, BaseDistribution]
+            trials=None  # type: Optional[List[FrozenTrial]]
+    ):
+        # type: (...) -> Dict[str, Any]
 
         return self.relative_params
 
-    def sample_independent(self, study, trial, param_name, param_distribution):
-        # type: (Study, FrozenTrial, str, BaseDistribution) -> Any
+    def sample_independent(self, study, trial, param_name, param_distribution, trials=None):
+        # type: (Study, FrozenTrial, str, BaseDistribution, Optional[List[FrozenTrial]]) -> Any
 
         return self.unknown_param_value
 

--- a/tests/test_study.py
+++ b/tests/test_study.py
@@ -505,10 +505,10 @@ def test_trials_dataframe(storage_mode, attrs, multi_index):
         #   non-nested: 5 (number, value, state, datetime_start, datetime_complete)
         #   params: 2
         #   distributions: 2
-        #   user_attrs: 1
+        #   user_attrs: 2
         #   system_attrs: 1
         #   intermediate_values: 1
-        expected_n_columns = len(attrs)
+        expected_n_columns = len(attrs) + 1
         if 'params' in attrs:
             expected_n_columns += 1
         if 'distributions' in attrs:
@@ -568,7 +568,7 @@ def test_trials_dataframe_with_failure(storage_mode):
         assert len(df) == 3
         # TODO(Yanase): Remove number from system_attrs after adding TrialModel.number.
         # non-nested: 5, params: 2, user_attrs: 1 system_attrs: 2
-        assert len(df.columns) == 10
+        assert len(df.columns) == 11
         for i in range(3):
             assert df.number[i] == i
             assert df.state[i] == 'FAIL'

--- a/tests/test_trial.py
+++ b/tests/test_trial.py
@@ -144,7 +144,7 @@ def test_suggest_discrete_uniform_range(storage_init_func, range_config):
 
     # Check upper endpoints.
     mock = Mock()
-    mock.side_effect = lambda study, trial, param_name, distribution: distribution.high
+    mock.side_effect = lambda study, trial, param_name, distribution, trials: distribution.high
     with patch.object(sampler, 'sample_independent', mock) as mock_object:
         study = create_study(storage_init_func(), sampler=sampler)
         trial = Trial(study, study._storage.create_new_trial(study._study_id))
@@ -156,7 +156,7 @@ def test_suggest_discrete_uniform_range(storage_init_func, range_config):
 
     # Check lower endpoints.
     mock = Mock()
-    mock.side_effect = lambda study, trial, param_name, distribution: distribution.low
+    mock.side_effect = lambda study, trial, param_name, distribution, trials: distribution.low
     with patch.object(sampler, 'sample_independent', mock) as mock_object:
         study = create_study(storage_init_func(), sampler=sampler)
         trial = Trial(study, study._storage.create_new_trial(study._study_id))


### PR DESCRIPTION
<!-- Thank you for creating a pull request!

Please go through [our contribution guide][CONTRIBUTING.md] to hopefully get your changes merged quicker.

[CONTRIBUTING.md]: https://github.com/optuna/optuna/blob/master/CONTRIBUTING.md -->

**UPDATE**
The original version is separated into #805 and this PR.

---

This PR is based on #301.

Intuitively, Hyperband (HB) eliminates the dependency on parameters of SuccessiveHalving (SH) by internally executes multiple SHs with different configurations.

## Design
`Study` with `HyperbandPruner` runs in the same way as with other pruners. `HyperbandPruner` class maintains some number of `SuccessiveHalvingPruner`s (= brackets) and selects a pruner for each `Trial`. So, the algorithm would be different from the paper to some extent. There're two challenges, 1) different trials of the same `Study` have to be pruned by different brackets, and 2) When sampling for a new trial, `Sampler` can only use the trials of the same bracket.

## Major Changes
- `Study` collects the list of trials (= `friend_trials` in the code) and set it as a `Trial`'s attribute
    - To filter trials with some metadata, study sets the information of pruner as `user_attr` to `Trial` and uses it as a filter. 
- `Trial` passes its `friend_trial` to `study.sampler`
- `Sampler`'s sampling methods accept the list of trials as their argument

An alternative design, a new class that manages multiple `Study`s is implemented in https://github.com/crcrpar/optuna/tree/dev/study-manager.