### PR TITLE
Followup #681.

### DIFF
--- a/optuna/visualization/contour.py
+++ b/optuna/visualization/contour.py
@@ -3,7 +3,6 @@ import math
 from optuna.logging import get_logger
 from optuna.structs import StudyDirection
 from optuna.structs import TrialState
-from optuna.study import Study  # NOQA
 from optuna import type_checking
 from optuna.visualization.utils import _check_plotly_availability
 from optuna.visualization.utils import _is_log_scale
@@ -15,8 +14,8 @@ if type_checking.TYPE_CHECKING:
     from typing import Tuple  # NOQA
 
     from optuna.structs import FrozenTrial  # NOQA
+    from optuna.study import Study  # NOQA
     from optuna.visualization.plotly_imports import Contour  # NOQA
-    from optuna.visualization.plotly_imports import Figure  # NOQA
     from optuna.visualization.plotly_imports import Scatter  # NOQA
 
 if is_available():
@@ -28,7 +27,7 @@ logger = get_logger(__name__)
 
 
 def plot_contour(study, params=None):
-    # type: (Study, Optional[List[str]]) -> None
+    # type: (Study, Optional[List[str]]) -> go.Figure
     """Plot the parameter relationship as contour plot in a study.
 
         Note that, If a parameter contains missing values, a trial with missing values is not
@@ -56,15 +55,17 @@ def plot_contour(study, params=None):
             values.
         params:
             Parameter list to visualize. The default is all parameters.
+
+    Returns:
+        A :class:`plotly.graph_objs.Figure` object.
     """
 
     _check_plotly_availability()
-    figure = _get_contour_plot(study, params)
-    figure.show()
+    return _get_contour_plot(study, params)
 
 
 def _get_contour_plot(study, params=None):
-    # type: (Study, Optional[List[str]]) -> Figure
+    # type: (Study, Optional[List[str]]) -> go.Figure
 
     layout = go.Layout(
         title='Contour Plot',

--- a/optuna/visualization/intermediate_values.py
+++ b/optuna/visualization/intermediate_values.py
@@ -1,12 +1,11 @@
 from optuna.logging import get_logger
 from optuna.structs import TrialState
-from optuna.study import Study  # NOQA
 from optuna import type_checking
 from optuna.visualization.utils import _check_plotly_availability
 from optuna.visualization.utils import is_available
 
 if type_checking.TYPE_CHECKING:
-    from optuna.visualization.plotly_imports import Figure  # NOQA
+    from optuna.study import Study  # NOQA
 
 if is_available():
     from optuna.visualization.plotly_imports import go
@@ -15,7 +14,7 @@ logger = get_logger(__name__)
 
 
 def plot_intermediate_values(study):
-    # type: (Study) -> None
+    # type: (Study) -> go.Figure
     """Plot intermediate values of all trials in a study.
 
     Example:
@@ -39,15 +38,17 @@ def plot_intermediate_values(study):
         study:
             A :class:`~optuna.study.Study` object whose trials are plotted for their intermediate
             values.
+
+    Returns:
+        A :class:`plotly.graph_objs.Figure` object.
     """
 
     _check_plotly_availability()
-    figure = _get_intermediate_plot(study)
-    figure.show()
+    return _get_intermediate_plot(study)
 
 
 def _get_intermediate_plot(study):
-    # type: (Study) -> Figure
+    # type: (Study) -> go.Figure
 
     layout = go.Layout(
         title='Intermediate Values Plot',

--- a/optuna/visualization/optimization_history.py
+++ b/optuna/visualization/optimization_history.py
@@ -1,13 +1,12 @@
 from optuna.logging import get_logger
 from optuna.structs import StudyDirection
 from optuna.structs import TrialState
-from optuna.study import Study  # NOQA
 from optuna import type_checking
 from optuna.visualization.utils import _check_plotly_availability
 from optuna.visualization.utils import is_available
 
 if type_checking.TYPE_CHECKING:
-    from optuna.visualization.plotly_imports import Figure  # NOQA
+    from optuna.study import Study  # NOQA
 
 if is_available():
     from optuna.visualization.plotly_imports import go
@@ -16,7 +15,7 @@ logger = get_logger(__name__)
 
 
 def plot_optimization_history(study):
-    # type: (Study) -> None
+    # type: (Study) -> go.Figure
     """Plot optimization history of all trials in a study.
 
     Example:
@@ -39,15 +38,17 @@ def plot_optimization_history(study):
         study:
             A :class:`~optuna.study.Study` object whose trials are plotted for their objective
             values.
+
+    Returns:
+        A :class:`plotly.graph_objs.Figure` object.
     """
 
     _check_plotly_availability()
-    figure = _get_optimization_history_plot(study)
-    figure.show()
+    return _get_optimization_history_plot(study)
 
 
 def _get_optimization_history_plot(study):
-    # type: (Study) -> Figure
+    # type: (Study) -> go.Figure
 
     layout = go.Layout(
         title='Optimization History Plot',

--- a/optuna/visualization/parallel_coordinate.py
+++ b/optuna/visualization/parallel_coordinate.py
@@ -3,7 +3,6 @@ from collections import defaultdict
 from optuna.logging import get_logger
 from optuna.structs import StudyDirection
 from optuna.structs import TrialState
-from optuna.study import Study  # NOQA
 from optuna import type_checking
 from optuna.visualization.utils import _check_plotly_availability
 from optuna.visualization.utils import is_available
@@ -13,7 +12,7 @@ if type_checking.TYPE_CHECKING:
     from typing import List  # NOQA
     from typing import Optional  # NOQA
 
-    from optuna.visualization.plotly_imports import Figure  # NOQA
+    from optuna.study import Study  # NOQA
 
 if is_available():
     from optuna.visualization.plotly_imports import go
@@ -22,7 +21,7 @@ logger = get_logger(__name__)
 
 
 def plot_parallel_coordinate(study, params=None):
-    # type: (Study, Optional[List[str]]) -> None
+    # type: (Study, Optional[List[str]]) -> go.Figure
     """Plot the high-dimentional parameter relationships in a study.
 
         Note that, If a parameter contains missing values, a trial with missing values is not
@@ -50,15 +49,17 @@ def plot_parallel_coordinate(study, params=None):
             values.
         params:
             Parameter list to visualize. The default is all parameters.
+
+    Returns:
+        A :class:`plotly.graph_objs.Figure` object.
     """
 
     _check_plotly_availability()
-    figure = _get_parallel_coordinate_plot(study, params)
-    figure.show()
+    return _get_parallel_coordinate_plot(study, params)
 
 
 def _get_parallel_coordinate_plot(study, params=None):
-    # type: (Study, Optional[List[str]]) -> Figure
+    # type: (Study, Optional[List[str]]) -> go.Figure
 
     layout = go.Layout(
         title='Parallel Coordinate Plot',

--- a/optuna/visualization/plotly_imports.py
+++ b/optuna/visualization/plotly_imports.py
@@ -2,7 +2,6 @@ try:
     import plotly  # NOQA
     import plotly.graph_objs as go  # NOQA
     from plotly.graph_objs import Contour, Scatter  # NOQA
-    from plotly.graph_objs._figure import Figure  # NOQA
     from plotly.subplots import make_subplots  # NOQA
     _available = True
 except ImportError as e:

--- a/optuna/visualization/slice.py
+++ b/optuna/visualization/slice.py
@@ -1,6 +1,5 @@
 from optuna.logging import get_logger
 from optuna.structs import TrialState
-from optuna.study import Study  # NOQA
 from optuna import type_checking
 from optuna.visualization.utils import _check_plotly_availability
 from optuna.visualization.utils import _is_log_scale
@@ -11,7 +10,7 @@ if type_checking.TYPE_CHECKING:
     from typing import Optional  # NOQA
 
     from optuna.structs import FrozenTrial  # NOQA
-    from optuna.visualization.plotly_imports import Figure  # NOQA
+    from optuna.study import Study  # NOQA
     from optuna.visualization.plotly_imports import Scatter  # NOQA
 
 if is_available():
@@ -22,7 +21,7 @@ logger = get_logger(__name__)
 
 
 def plot_slice(study, params=None):
-    # type: (Study, Optional[List[str]]) -> None
+    # type: (Study, Optional[List[str]]) -> go.Figure
     """Plot the parameter relationship as slice plot in a study.
 
         Note that, If a parameter contains missing values, a trial with missing values is not
@@ -50,15 +49,17 @@ def plot_slice(study, params=None):
             values.
         params:
             Parameter list to visualize. The default is all parameters.
+
+    Returns:
+        A :class:`plotly.graph_objs.Figure` object.
     """
 
     _check_plotly_availability()
-    figure = _get_slice_plot(study, params)
-    figure.show()
+    return _get_slice_plot(study, params)
 
 
 def _get_slice_plot(study, params=None):
-    # type: (Study, Optional[List[str]]) -> Figure
+    # type: (Study, Optional[List[str]]) -> go.Figure
 
     layout = go.Layout(
         title='Slice Plot',

--- a/tests/visualization_tests/test_contour.py
+++ b/tests/visualization_tests/test_contour.py
@@ -6,7 +6,7 @@ from optuna.study import create_study
 from optuna.testing.visualization import prepare_study_with_trials
 from optuna import type_checking
 from optuna.visualization.contour import _generate_contour_subplot
-from optuna.visualization.contour import _get_contour_plot
+from optuna.visualization.contour import plot_contour
 
 if type_checking.TYPE_CHECKING:
     from typing import List, Optional  # NOQA
@@ -24,12 +24,12 @@ if type_checking.TYPE_CHECKING:
         None,
     ]
 )
-def test_get_contour_plot(params):
+def test_plot_contour(params):
     # type: (Optional[List[str]]) -> None
 
     # Test with no trial.
     study_without_trials = prepare_study_with_trials(no_trials=True)
-    figure = _get_contour_plot(study_without_trials, params=params)
+    figure = plot_contour(study_without_trials, params=params)
     assert len(figure.data) == 0
 
     # Test whether trials with `ValueError`s are ignored.
@@ -41,7 +41,7 @@ def test_get_contour_plot(params):
 
     study = create_study()
     study.optimize(fail_objective, n_trials=1, catch=(ValueError, ))
-    figure = _get_contour_plot(study, params=params)
+    figure = plot_contour(study, params=params)
     assert len(figure.data) == 0
 
     # Test with some trials.
@@ -49,9 +49,9 @@ def test_get_contour_plot(params):
 
     # Test ValueError due to wrong params.
     with pytest.raises(ValueError):
-        _get_contour_plot(study, ['optuna', 'Optuna'])
+        plot_contour(study, ['optuna', 'Optuna'])
 
-    figure = _get_contour_plot(study, params=params)
+    figure = plot_contour(study, params=params)
     if params is not None and len(params) < 3:
         if len(params) <= 1:
             assert not figure.data
@@ -89,10 +89,10 @@ def test_generate_contour_plot_for_few_observations():
     assert contour.x is None and contour.y is None and scatter.x is None and scatter.y is None
 
 
-def test_get_contour_plot_log_scale():
+def test_plot_contour_log_scale():
     # type: () -> None
 
-    # If the search space has two parameters, _get_contour_plot generates a single plot.
+    # If the search space has two parameters, plot_contour generates a single plot.
     study = create_study()
     study._append_trial(
         value=0.0,
@@ -117,13 +117,13 @@ def test_get_contour_plot_log_scale():
         }
     )
 
-    figure = _get_contour_plot(study)
+    figure = plot_contour(study)
     assert figure.layout['xaxis']['range'] == (-6, -5)
     assert figure.layout['yaxis']['range'] == (-4, -3)
     assert figure.layout['xaxis_type'] == 'log'
     assert figure.layout['yaxis_type'] == 'log'
 
-    # If the search space has three parameters, _get_contour_plot generates nine plots.
+    # If the search space has three parameters, plot_contour generates nine plots.
     study = create_study()
     study._append_trial(
         value=0.0,
@@ -152,7 +152,7 @@ def test_get_contour_plot_log_scale():
         }
     )
 
-    figure = _get_contour_plot(study)
+    figure = plot_contour(study)
     param_a_range = (-6, -5)
     param_b_range = (-4, -3)
     param_c_range = (-2, -1)

--- a/tests/visualization_tests/test_intermediate_plot.py
+++ b/tests/visualization_tests/test_intermediate_plot.py
@@ -1,18 +1,18 @@
 from optuna.study import create_study
 from optuna.testing.visualization import prepare_study_with_trials
 from optuna import type_checking
-from optuna.visualization.intermediate_values import _get_intermediate_plot
+from optuna.visualization.intermediate_values import plot_intermediate_values
 
 if type_checking.TYPE_CHECKING:
     from optuna.trial import Trial  # NOQA
 
 
-def test_get_intermediate_plot():
+def test_plot_intermediate_values():
     # type: () -> None
 
     # Test with no trials.
     study = prepare_study_with_trials(no_trials=True)
-    figure = _get_intermediate_plot(study)
+    figure = plot_intermediate_values(study)
     assert not figure.data
 
     def objective(trial, report_intermediate_values):
@@ -26,7 +26,7 @@ def test_get_intermediate_plot():
     # Test with a trial with intermediate values.
     study = create_study()
     study.optimize(lambda t: objective(t, True), n_trials=1)
-    figure = _get_intermediate_plot(study)
+    figure = plot_intermediate_values(study)
     assert len(figure.data) == 1
     assert figure.data[0].x == (0, 1)
     assert figure.data[0].y == (1.0, 2.0)
@@ -36,7 +36,7 @@ def test_get_intermediate_plot():
     # Expect the trial with no intermediate values to be ignored.
     study.optimize(lambda t: objective(t, False), n_trials=1)
     assert len(study.trials) == 2
-    figure = _get_intermediate_plot(study)
+    figure = plot_intermediate_values(study)
     assert len(figure.data) == 1
     assert figure.data[0].x == (0, 1)
     assert figure.data[0].y == (1.0, 2.0)
@@ -44,7 +44,7 @@ def test_get_intermediate_plot():
     # Test a study of only one trial that has no intermediate values.
     study = create_study()
     study.optimize(lambda t: objective(t, False), n_trials=1)
-    figure = _get_intermediate_plot(study)
+    figure = plot_intermediate_values(study)
     assert not figure.data
 
     # Ignore failed trials.
@@ -55,5 +55,5 @@ def test_get_intermediate_plot():
 
     study = create_study()
     study.optimize(fail_objective, n_trials=1, catch=(ValueError, ))
-    figure = _get_intermediate_plot(study)
+    figure = plot_intermediate_values(study)
     assert not figure.data

--- a/tests/visualization_tests/test_optimization_history.py
+++ b/tests/visualization_tests/test_optimization_history.py
@@ -2,19 +2,19 @@ import pytest
 
 from optuna.study import create_study
 from optuna import type_checking
-from optuna.visualization.optimization_history import _get_optimization_history_plot
+from optuna.visualization.optimization_history import plot_optimization_history
 
 if type_checking.TYPE_CHECKING:
     from optuna.trial import Trial  # NOQA
 
 
 @pytest.mark.parametrize('direction', ['minimize', 'maximize'])
-def test_get_optimization_history_plot(direction):
+def test_plot_optimization_history(direction):
     # type: (str) -> None
 
     # Test with no trial.
     study = create_study(direction=direction)
-    figure = _get_optimization_history_plot(study)
+    figure = plot_optimization_history(study)
     assert len(figure.data) == 0
 
     def objective(trial):
@@ -31,7 +31,7 @@ def test_get_optimization_history_plot(direction):
     # Test with a trial.
     study = create_study(direction=direction)
     study.optimize(objective, n_trials=3)
-    figure = _get_optimization_history_plot(study)
+    figure = plot_optimization_history(study)
     assert len(figure.data) == 2
     assert figure.data[0].x == (0, 1, 2)
     assert figure.data[0].y == (1.0, 2.0, 0.0)
@@ -50,5 +50,5 @@ def test_get_optimization_history_plot(direction):
     study = create_study(direction=direction)
     study.optimize(fail_objective, n_trials=1, catch=(ValueError, ))
 
-    figure = _get_optimization_history_plot(study)
+    figure = plot_optimization_history(study)
     assert len(figure.data) == 0

--- a/tests/visualization_tests/test_parallel_coordinate.py
+++ b/tests/visualization_tests/test_parallel_coordinate.py
@@ -4,24 +4,24 @@ from optuna.distributions import CategoricalDistribution
 from optuna.study import create_study
 from optuna.testing.visualization import prepare_study_with_trials
 from optuna import type_checking
-from optuna.visualization.parallel_coordinate import _get_parallel_coordinate_plot
+from optuna.visualization.parallel_coordinate import plot_parallel_coordinate
 
 if type_checking.TYPE_CHECKING:
     from optuna.trial import Trial  # NOQA
 
 
-def test_get_parallel_coordinate_plot():
+def test_plot_parallel_coordinate():
     # type: () -> None
 
     # Test with no trial.
     study = create_study()
-    figure = _get_parallel_coordinate_plot(study)
+    figure = plot_parallel_coordinate(study)
     assert len(figure.data) == 0
 
     study = prepare_study_with_trials(with_c_d=False)
 
     # Test with a trial.
-    figure = _get_parallel_coordinate_plot(study)
+    figure = plot_parallel_coordinate(study)
     assert len(figure.data[0]['dimensions']) == 3
     assert figure.data[0]['dimensions'][0]['label'] == 'Objective Value'
     assert figure.data[0]['dimensions'][0]['range'] == (0.0, 2.0)
@@ -34,7 +34,7 @@ def test_get_parallel_coordinate_plot():
     assert figure.data[0]['dimensions'][2]['values'] == (2.0, 0.0, 1.0)
 
     # Test with a trial to select parameter.
-    figure = _get_parallel_coordinate_plot(study, params=['param_a'])
+    figure = plot_parallel_coordinate(study, params=['param_a'])
     assert len(figure.data[0]['dimensions']) == 2
     assert figure.data[0]['dimensions'][0]['label'] == 'Objective Value'
     assert figure.data[0]['dimensions'][0]['range'] == (0.0, 2.0)
@@ -45,7 +45,7 @@ def test_get_parallel_coordinate_plot():
 
     # Test with wrong params that do not exist in trials
     with pytest.raises(ValueError):
-        _get_parallel_coordinate_plot(study, params=['optuna', 'optuna'])
+        plot_parallel_coordinate(study, params=['optuna', 'optuna'])
 
     # Ignore failed trials.
     def fail_objective(_):
@@ -55,7 +55,7 @@ def test_get_parallel_coordinate_plot():
 
     study = create_study()
     study.optimize(fail_objective, n_trials=1, catch=(ValueError, ))
-    figure = _get_parallel_coordinate_plot(study)
+    figure = plot_parallel_coordinate(study)
     assert len(figure.data) == 0
 
     # Test with categorical params that cannot be converted to numeral.
@@ -82,7 +82,7 @@ def test_get_parallel_coordinate_plot():
             'category_b': CategoricalDistribution(('net', 'una')),
         }
     )
-    figure = _get_parallel_coordinate_plot(study_categorical_params)
+    figure = plot_parallel_coordinate(study_categorical_params)
     assert len(figure.data[0]['dimensions']) == 3
     assert figure.data[0]['dimensions'][0]['label'] == 'Objective Value'
     assert figure.data[0]['dimensions'][0]['range'] == (0.0, 2.0)

--- a/tests/visualization_tests/test_slice.py
+++ b/tests/visualization_tests/test_slice.py
@@ -5,24 +5,24 @@ from optuna.distributions import UniformDistribution
 from optuna.study import create_study
 from optuna.testing.visualization import prepare_study_with_trials
 from optuna import type_checking
-from optuna.visualization.slice import _get_slice_plot
+from optuna.visualization.slice import plot_slice
 
 if type_checking.TYPE_CHECKING:
     from optuna.trial import Trial  # NOQA
 
 
-def test_get_slice_plot():
+def test_plot_slice():
     # type: () -> None
 
     # Test with no trial.
     study = prepare_study_with_trials(no_trials=True)
-    figure = _get_slice_plot(study)
+    figure = plot_slice(study)
     assert len(figure.data) == 0
 
     study = prepare_study_with_trials(with_c_d=False)
 
     # Test with a trial.
-    figure = _get_slice_plot(study)
+    figure = plot_slice(study)
     assert len(figure.data) == 2
     assert figure.data[0]['x'] == (1.0, 2.5)
     assert figure.data[0]['y'] == (0.0, 1.0)
@@ -30,14 +30,14 @@ def test_get_slice_plot():
     assert figure.data[1]['y'] == (0.0, 2.0, 1.0)
 
     # Test with a trial to select parameter.
-    figure = _get_slice_plot(study, params=['param_a'])
+    figure = plot_slice(study, params=['param_a'])
     assert len(figure.data) == 1
     assert figure.data[0]['x'] == (1.0, 2.5)
     assert figure.data[0]['y'] == (0.0, 1.0)
 
     # Test with wrong parameters.
     with pytest.raises(ValueError):
-        _get_slice_plot(study, params=['optuna'])
+        plot_slice(study, params=['optuna'])
 
     # Ignore failed trials.
     def fail_objective(_):
@@ -47,11 +47,11 @@ def test_get_slice_plot():
 
     study = create_study()
     study.optimize(fail_objective, n_trials=1, catch=(ValueError, ))
-    figure = _get_slice_plot(study)
+    figure = plot_slice(study)
     assert len(figure.data) == 0
 
 
-def test_get_slice_plot_log_scale():
+def test_plot_slice_log_scale():
     # type: () -> None
 
     study = create_study()
@@ -68,12 +68,12 @@ def test_get_slice_plot_log_scale():
     )
 
     # Plot a parameter.
-    figure = _get_slice_plot(study, params=['y_log'])
+    figure = plot_slice(study, params=['y_log'])
     assert figure.layout['xaxis_type'] == 'log'
-    figure = _get_slice_plot(study, params=['x_linear'])
+    figure = plot_slice(study, params=['x_linear'])
     assert figure.layout['xaxis_type'] is None
 
     # Plot multiple parameters.
-    figure = _get_slice_plot(study)
+    figure = plot_slice(study)
     assert figure.layout['xaxis_type'] is None
     assert figure.layout['xaxis2_type'] == 'log'


### PR DESCRIPTION
This is a followup PR for #681. It reverts the changes introduced by #704. 

Changes:
- Make plot functions return Plotly's figure objects.
- Remove redundant module import for type checking.
- Update test cases to check if the plot functions return the figure objects.