### PR TITLE
Fix Colab badge on visualization example notebook

### DIFF
--- a/examples/visualization/plot_study.ipynb
+++ b/examples/visualization/plot_study.ipynb
@@ -46,7 +46,7 @@
         "colab_type": "text"
       },
       "source": [
-        "<a href=\"https://colab.research.google.com/github/harupy/optuna/blob/fix-colab-badge/examples/visualization/plot_study.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+        "<a href=\"https://colab.research.google.com/github/optuna/optuna/blob/master/examples/visualization/plot_study.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
       ]
     },
     {

--- a/examples/visualization/plot_study.ipynb
+++ b/examples/visualization/plot_study.ipynb
@@ -1,294 +1,382 @@
 {
- "cells": [
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](http://colab.research.google.com/github/optuna/optuna/blob/master/examples/visualization/plot_study.ipynb)\n",
-    "Colab must be opened in a new tab or window if you are on GitHub.\n",
-    "\n",
-    "# Visualizing High-dimensional Parameter Relationships\n",
-    "\n",
-    "This notebook demonstrates various visualizations of studies in Optuna.\n",
-    "The hyperparameters of a neural network trained to classify images are optimized and the resulting study is then visualized using these features.\n",
-    "\n",
-    "**Note:** If a parameter contains missing values, a trial with missing values is not plotted."
-   ]
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.7.4"
+    },
+    "toc": {
+      "base_numbering": 1,
+      "nav_menu": {},
+      "number_sections": true,
+      "sideBar": true,
+      "skip_h1_title": false,
+      "title_cell": "Table of Contents",
+      "title_sidebar": "Contents",
+      "toc_cell": false,
+      "toc_position": {},
+      "toc_section_display": true,
+      "toc_window_display": false
+    },
+    "colab": {
+      "name": "plot_study.ipynb",
+      "provenance": [],
+      "include_colab_link": true
+    }
   },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# If you run this notebook on Google Colaboratory, uncomment the below to install Optuna.\n",
-    "#! pip install --quiet optuna"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Preparing the Dataset"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
-   "outputs": [],
-   "source": [
-    "from sklearn.datasets import fetch_openml\n",
-    "from sklearn.model_selection import train_test_split\n",
-    "\n",
-    "mnist = fetch_openml(name='Fashion-MNIST', version=1)\n",
-    "classes = list(set(mnist.target))\n",
-    "\n",
-    "# For demonstrational purpose, only use a subset of the dataset.\n",
-    "n_samples = 4000\n",
-    "data = mnist.data[:n_samples]\n",
-    "target = mnist.target[:n_samples]\n",
-    "\n",
-    "x_train, x_test, y_train, y_test = train_test_split(data, target)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Defining the Objective Function"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from sklearn.neural_network import MLPClassifier\n",
-    "\n",
-    "def objective(trial):\n",
-    "    \n",
-    "    clf = MLPClassifier(\n",
-    "        hidden_layer_sizes=tuple([trial.suggest_int(f'n_units_l{i}', 32, 64) for i in range(3)]),\n",
-    "        learning_rate_init=trial.suggest_loguniform('lr_init', 1e-5, 1e-1),\n",
-    "    )\n",
-    "\n",
-    "    for step in range(100):\n",
-    "        clf.partial_fit(x_train, y_train, classes=classes)\n",
-    "        value = clf.score(x_test, y_test)  \n",
-    "        \n",
-    "        # Report intermediate objective value.\n",
-    "        trial.report(value, step)\n",
-    "\n",
-    "        # Handle pruning based on the intermediate value.\n",
-    "        if trial.should_prune(step):\n",
-    "            raise optuna.exceptions.TrialPruned()  \n",
-    "\n",
-    "    return value"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Running the Optimization"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import optuna\n",
-    "\n",
-    "optuna.logging.set_verbosity(optuna.logging.WARNING)  # This verbosity change is just to simplify the notebook output.\n",
-    "\n",
-    "study = optuna.create_study(direction='maximize', pruner=optuna.pruners.MedianPruner())\n",
-    "study.optimize(objective, n_trials=100)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Visualizing the Optimization History"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from optuna.visualization import plot_optimization_history\n",
-    "\n",
-    "plot_optimization_history(study)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Visualizing the Learning Curves of the Trials"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from optuna.visualization import plot_intermediate_values\n",
-    "\n",
-    "plot_intermediate_values(study)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Visualizing High-dimensional Parameter Relationships"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from optuna.visualization import plot_parallel_coordinate\n",
-    "\n",
-    "plot_parallel_coordinate(study)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Selecting Parameters to Visualize"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "plot_parallel_coordinate(study, params=['lr_init', 'n_units_l0'])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Visualizing Hyperparameter Relationships"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from optuna.visualization import plot_contour\n",
-    "\n",
-    "plot_contour(study)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Selecting Parameters to Visualize"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "plot_contour(study, params=['n_units_l0', 'n_units_l1'])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Visualizing Individual Hyperparameters"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from optuna.visualization import plot_slice\n",
-    "\n",
-    "plot_slice(study)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Selecting Parameters to Visualize"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "plot_slice(study, params=['n_units_l0', 'n_units_l1'])"
-   ]
-  }
- ],
- "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.7.4"
-  },
-  "toc": {
-   "base_numbering": 1,
-   "nav_menu": {},
-   "number_sections": true,
-   "sideBar": true,
-   "skip_h1_title": false,
-   "title_cell": "Table of Contents",
-   "title_sidebar": "Contents",
-   "toc_cell": false,
-   "toc_position": {},
-   "toc_section_display": true,
-   "toc_window_display": false
-  },
-  "widgets": {
-   "application/vnd.jupyter.widget-state+json": {
-    "state": {},
-    "version_major": 2,
-    "version_minor": 0
-   }
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 2
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "view-in-github",
+        "colab_type": "text"
+      },
+      "source": [
+        "<a href=\"https://colab.research.google.com/github/harupy/optuna/blob/fix-colab-badge/examples/visualization/plot_study.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "-YU0qvAUUoPD",
+        "colab_type": "text"
+      },
+      "source": [
+        "# Visualizing High-dimensional Parameter Relationships\n",
+        "\n",
+        "This notebook demonstrates various visualizations of studies in Optuna.\n",
+        "The hyperparameters of a neural network trained to classify images are optimized and the resulting study is then visualized using these features.\n",
+        "\n",
+        "**Note:** If a parameter contains missing values, a trial with missing values is not plotted."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "M3Nw2LeUUoPG",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "# If you run this notebook on Google Colaboratory, uncomment the below to install Optuna.\n",
+        "#! pip install --quiet optuna"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "MuXQ4o1IUoPI",
+        "colab_type": "text"
+      },
+      "source": [
+        "## Preparing the Dataset"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "scrolled": false,
+        "id": "Rd6d39oiUoPJ",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "from sklearn.datasets import fetch_openml\n",
+        "from sklearn.model_selection import train_test_split\n",
+        "\n",
+        "mnist = fetch_openml(name='Fashion-MNIST', version=1)\n",
+        "classes = list(set(mnist.target))\n",
+        "\n",
+        "# For demonstrational purpose, only use a subset of the dataset.\n",
+        "n_samples = 4000\n",
+        "data = mnist.data[:n_samples]\n",
+        "target = mnist.target[:n_samples]\n",
+        "\n",
+        "x_train, x_test, y_train, y_test = train_test_split(data, target)"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "TLAXcsikUoPL",
+        "colab_type": "text"
+      },
+      "source": [
+        "## Defining the Objective Function"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "muYLe1cnUoPL",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "from sklearn.neural_network import MLPClassifier\n",
+        "\n",
+        "def objective(trial):\n",
+        "    \n",
+        "    clf = MLPClassifier(\n",
+        "        hidden_layer_sizes=tuple([trial.suggest_int(f'n_units_l{i}', 32, 64) for i in range(3)]),\n",
+        "        learning_rate_init=trial.suggest_loguniform('lr_init', 1e-5, 1e-1),\n",
+        "    )\n",
+        "\n",
+        "    for step in range(100):\n",
+        "        clf.partial_fit(x_train, y_train, classes=classes)\n",
+        "        value = clf.score(x_test, y_test)  \n",
+        "        \n",
+        "        # Report intermediate objective value.\n",
+        "        trial.report(value, step)\n",
+        "\n",
+        "        # Handle pruning based on the intermediate value.\n",
+        "        if trial.should_prune(step):\n",
+        "            raise optuna.exceptions.TrialPruned()  \n",
+        "\n",
+        "    return value"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "LiOUN44QUoPN",
+        "colab_type": "text"
+      },
+      "source": [
+        "## Running the Optimization"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "S4uHKpGBUoPO",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "import optuna\n",
+        "\n",
+        "optuna.logging.set_verbosity(optuna.logging.WARNING)  # This verbosity change is just to simplify the notebook output.\n",
+        "\n",
+        "study = optuna.create_study(direction='maximize', pruner=optuna.pruners.MedianPruner())\n",
+        "study.optimize(objective, n_trials=100)"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "xVaPfRIvUoPP",
+        "colab_type": "text"
+      },
+      "source": [
+        "## Visualizing the Optimization History"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "3CrP76NHUoPQ",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "from optuna.visualization import plot_optimization_history\n",
+        "\n",
+        "plot_optimization_history(study)"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "OJKHKl40UoPR",
+        "colab_type": "text"
+      },
+      "source": [
+        "## Visualizing the Learning Curves of the Trials"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "i3CiV88pUoPS",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "from optuna.visualization import plot_intermediate_values\n",
+        "\n",
+        "plot_intermediate_values(study)"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "zgAqVidnUoPU",
+        "colab_type": "text"
+      },
+      "source": [
+        "## Visualizing High-dimensional Parameter Relationships"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "3k0c4Ts6UoPU",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "from optuna.visualization import plot_parallel_coordinate\n",
+        "\n",
+        "plot_parallel_coordinate(study)"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "h2aog7OOUoPV",
+        "colab_type": "text"
+      },
+      "source": [
+        "### Selecting Parameters to Visualize"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "KgWhMGcSUoPW",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "plot_parallel_coordinate(study, params=['lr_init', 'n_units_l0'])"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "2xes8EzPUoPX",
+        "colab_type": "text"
+      },
+      "source": [
+        "## Visualizing Hyperparameter Relationships"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "pCO5UdbIUoPY",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "from optuna.visualization import plot_contour\n",
+        "\n",
+        "plot_contour(study)"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "v9_Y6HybUoPZ",
+        "colab_type": "text"
+      },
+      "source": [
+        "### Selecting Parameters to Visualize"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "VP5xtXPUUoPa",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "plot_contour(study, params=['n_units_l0', 'n_units_l1'])"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "MN_DaQN7UoPb",
+        "colab_type": "text"
+      },
+      "source": [
+        "## Visualizing Individual Hyperparameters"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "joZlYv6QUoPb",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "from optuna.visualization import plot_slice\n",
+        "\n",
+        "plot_slice(study)"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "sqsM_Z3gUoPd",
+        "colab_type": "text"
+      },
+      "source": [
+        "### Selecting Parameters to Visualize"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "dFHizY0nUoPd",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "plot_slice(study, params=['n_units_l0', 'n_units_l1'])"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    }
+  ]
 }


### PR DESCRIPTION
I figured out a proper way to include a Colab badge on the notebook.
With this fix, we can open the notebook on Colab without opening a new tab.

https://github.com/harupy/optuna/blob/fix-colab-badge/examples/visualization/plot_study.ipynb

Here's what I did:

1. Opened the notebook on Coalb.
2. Clicked "File" and select "Save a copy in GitHub".

<img width="429" alt="Screen Shot 2019-12-11 at 23 24 31" src="https://user-images.githubusercontent.com/17039389/70629617-9ed51880-1c6d-11ea-97e0-84aebb4e224f.png">


3. Checked  "Inlucde a link to Colaboratory" (bottom left) and saved.

<img width="872" alt="Screen Shot 2019-12-11 at 23 24 49" src="https://user-images.githubusercontent.com/17039389/70629653-aac0da80-1c6d-11ea-8947-2c1a48f70da8.png">
