### PR TITLE
Remove `cache_mode` argument to fix a broken test.

### DIFF
--- a/tests/test_study.py
+++ b/tests/test_study.py
@@ -753,11 +753,10 @@ def test_callbacks(n_jobs):
 
 
 @pytest.mark.parametrize('storage_mode', STORAGE_MODES)
-@pytest.mark.parametrize('cache_mode', CACHE_MODES)
-def test_get_trials(storage_mode, cache_mode):
-    # type: (str, bool) -> None
+def test_get_trials(storage_mode):
+    # type: (str) -> None
 
-    with StorageSupplier(storage_mode, cache_mode) as storage:
+    with StorageSupplier(storage_mode) as storage:
         storage = optuna.storages.get_storage(storage=storage)
 
         study = optuna.create_study(storage=storage)


### PR DESCRIPTION
`test_get_trials` test takes `cache_mode` argument that refers to `CACHE_MODES` constant. However the constant has been deleted by https://github.com/optuna/optuna/pull/706, so this PR removes the argument to fix the broken test.