### PR TITLE
Early commit after RDB session creation

### DIFF
--- a/optuna/storages/rdb/storage.py
+++ b/optuna/storages/rdb/storage.py
@@ -713,6 +713,9 @@ class RDBStorage(BaseStorage):
         else:
             trial = models.TrialModel.find_min_value_trial(study_id, session)
 
+        # Terminate transaction explicitly to avoid connection timeout during transaction.
+        self._commit(session)
+
         return self.get_trial(trial.trial_id)
 
     def _get_all_trial_ids(self, study_id):


### PR DESCRIPTION
Follow-up on https://github.com/optuna/optuna/pull/729.

Adds an early explicit commit to not have to rely on the internal logic of `get_trial` (and to align with existing conventions).