### PR TITLE
Add MLflow example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -55,6 +55,10 @@ In addition, integration modules are available for the following libraries, prov
 
 * [Visualizing study](https://nbviewer.jupyter.org/github/optuna/optuna/blob/master/examples/visualization/plot_study.ipynb)
 
+### Examples of MLflow
+
+* [Tracking optimization process with MLflow](./mlflow/keras_mlflow.py)
+
 ### Examples of Distributed Optimization
 
 * [Optimizing on Kubernetes](./distributed/kubernetes/README.md)

--- a/examples/mlflow/keras_mlflow.py
+++ b/examples/mlflow/keras_mlflow.py
@@ -1,0 +1,98 @@
+"""
+Optuna example that optimizes a neural network regressor configuration for the
+wine quality dataset using Keras and records hyperparamters and metrics using MLflow
+
+In this example, we optimize the learning rate and momentum of
+stochastic gradient descent optimizer to minimize the validation mean squared error
+for the wine quality regression.
+
+You can run this example as follows:
+    $ python keras_simple.py
+
+"""
+
+from sklearn.datasets import load_wine
+from sklearn.preprocessing import StandardScaler
+from sklearn.model_selection import train_test_split
+from keras.backend import clear_session
+from keras.models import Sequential
+from keras.layers import Dense
+from keras.optimizers import SGD
+
+import optuna
+import mlflow
+
+
+TEST_SIZE = 0.25
+BATCHSIZE = 16
+EPOCHS = 100
+
+
+def standardize(data):
+    return StandardScaler().fit_transform(data)
+
+
+def create_model(num_features, trial):
+    model = Sequential()
+    model.add(Dense(num_features,
+                    activation='relu',
+                    kernel_initializer='normal',
+                    input_shape=(num_features,))),
+    model.add(Dense(16,
+                    activation='relu',
+                    kernel_initializer='normal'))
+    model.add(Dense(16,
+                    activation='relu',
+                    kernel_initializer='normal'))
+    model.add(Dense(1,
+                    kernel_initializer='normal',
+                    activation='linear'))
+
+    optimizer = SGD(lr=trial.suggest_loguniform('lr', 1e-5, 1e-1),
+                    momentum=trial.suggest_uniform('momentum', 0.0, 1.0))
+    model.compile(loss='mean_squared_error',
+                  optimizer=optimizer,
+                  metrics=['accuracy'])
+    return model
+
+
+def objective(trial):
+    # Clear clutter from previous Keras session graphs.
+    clear_session()
+
+    X, y = load_wine(return_X_y=True)
+    X = standardize(X)
+    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=TEST_SIZE, random_state=42)
+
+    model = create_model(X.shape[1], trial)
+    model.fit(X_train,
+              y_train,
+              shuffle=True,
+              batch_size=BATCHSIZE,
+              epochs=EPOCHS,
+              verbose=False)
+
+    scores = model.evaluate(X_test, y_test, verbose=0)
+    metrics = dict(zip(model.metrics_names, scores))
+
+    with mlflow.start_run() as run:
+        mlflow.log_params(trial.params)
+        mlflow.log_metrics(metrics)
+
+    return scores[1]
+
+
+if __name__ == '__main__':
+    study = optuna.create_study(direction='maximize')
+    study.optimize(objective, n_trials=100, timeout=600)
+
+    print('Number of finished trials: {}'.format(len(study.trials)))
+
+    print('Best trial:')
+    trial = study.best_trial
+
+    print('  Value: {}'.format(trial.value))
+
+    print('  Params: ')
+    for key, value in trial.params.items():
+        print('    {}: {}'.format(key, value))

--- a/examples/mlflow/keras_mlflow.py
+++ b/examples/mlflow/keras_mlflow.py
@@ -19,17 +19,16 @@ We have the following two ways to execute this example:
 
 """
 
-from sklearn.datasets import load_wine
-from sklearn.preprocessing import StandardScaler
-from sklearn.model_selection import train_test_split
 from keras.backend import clear_session
-from keras.models import Sequential
 from keras.layers import Dense
+from keras.models import Sequential
 from keras.optimizers import SGD
+import mlflow
+from sklearn.datasets import load_wine
+from sklearn.model_selection import train_test_split
+from sklearn.preprocessing import StandardScaler
 
 import optuna
-import mlflow
-
 
 TEST_SIZE = 0.25
 BATCHSIZE = 16

--- a/examples/mlflow/keras_mlflow.py
+++ b/examples/mlflow/keras_mlflow.py
@@ -1,6 +1,6 @@
 """
-Optuna example that optimizes a neural network regressor configuration for the
-wine quality dataset using Keras and records hyperparamters and metrics using MLflow
+Optuna example that optimizes a neural network regressor for the
+wine quality dataset using Keras and records hyperparamters and metrics using MLflow.
 
 In this example, we optimize the learning rate and momentum of
 stochastic gradient descent optimizer to minimize the validation mean squared error
@@ -51,8 +51,7 @@ def create_model(num_features, trial):
     optimizer = SGD(lr=trial.suggest_loguniform('lr', 1e-5, 1e-1),
                     momentum=trial.suggest_uniform('momentum', 0.0, 1.0))
     model.compile(loss='mean_squared_error',
-                  optimizer=optimizer,
-                  metrics=['accuracy'])
+                  optimizer=optimizer)
     return model
 
 
@@ -72,18 +71,17 @@ def objective(trial):
               epochs=EPOCHS,
               verbose=False)
 
-    scores = model.evaluate(X_test, y_test, verbose=0)
-    metrics = dict(zip(model.metrics_names, scores))
+    score = model.evaluate(X_test, y_test, verbose=0)
 
     with mlflow.start_run() as run:
         mlflow.log_params(trial.params)
-        mlflow.log_metrics(metrics)
+        mlflow.log_metrics({'mean_squared_error': score})
 
-    return scores[1]
+    return score
 
 
 if __name__ == '__main__':
-    study = optuna.create_study(direction='maximize')
+    study = optuna.create_study(direction='minimize')
     study.optimize(objective, n_trials=100, timeout=600)
 
     print('Number of finished trials: {}'.format(len(study.trials)))

--- a/examples/mlflow/keras_mlflow.py
+++ b/examples/mlflow/keras_mlflow.py
@@ -81,7 +81,7 @@ def objective(trial):
 
     score = model.evaluate(X_test, y_test, verbose=0)
 
-    with mlflow.start_run() as run:
+    with mlflow.start_run():
         mlflow.log_params(trial.params)
         mlflow.log_metrics({'mean_squared_error': score})
 

--- a/examples/mlflow/keras_mlflow.py
+++ b/examples/mlflow/keras_mlflow.py
@@ -7,7 +7,7 @@ stochastic gradient descent optimizer to minimize the validation mean squared er
 for the wine quality regression.
 
 You can run this example as follows:
-    $ python keras_simple.py
+    $ python keras_mlflow.py
 
 """
 

--- a/examples/mlflow/keras_mlflow.py
+++ b/examples/mlflow/keras_mlflow.py
@@ -17,6 +17,11 @@ We have the following two ways to execute this example:
     $ optuna study optimize keras_mlflow.py objective --n-trials=100 \
       --study $STUDY_NAME --storage sqlite:///example.db
 
+
+After the script finishes, run the MLflow UI:
+    $ mlflow ui
+
+and view the optimization results at http://127.0.0.1:5000.
 """
 
 from keras.backend import clear_session

--- a/examples/mlflow/keras_mlflow.py
+++ b/examples/mlflow/keras_mlflow.py
@@ -6,8 +6,16 @@ In this example, we optimize the learning rate and momentum of
 stochastic gradient descent optimizer to minimize the validation mean squared error
 for the wine quality regression.
 
-You can run this example as follows:
+We have the following two ways to execute this example:
+
+(1) Execute this code directly.
     $ python keras_mlflow.py
+
+
+(2) Execute through CLI.
+    $ STUDY_NAME=`optuna create-study --direction minimize --storage sqlite:///example.db`
+    $ optuna study optimize keras_mlflow.py objective --n-trials=100 \
+      --study $STUDY_NAME --storage sqlite:///example.db
 
 """
 

--- a/setup.py
+++ b/setup.py
@@ -76,6 +76,7 @@ def get_extras_require():
             'catboost',
             'chainer',
             'lightgbm',
+            'mlflow',
             'mxnet',
             'scikit-image',
             'scikit-learn',


### PR DESCRIPTION
This PR adds an example that shows how to use Optuna with MLflow. The example employs similar experimental settings to examples in the [MLFlow repository](https://github.com/mlflow/mlflow/tree/master/examples/hyperparam).

How to run:
```
# install mlflow (if not installed)
pip install mlflow

# run the example
python keras_mflow.py

# run the MLflow UI to view the optimization result
mlflow ui

# open http://127.0.0.1:5000 on your browser
```

![optuna-mlflow](https://user-images.githubusercontent.com/17039389/70850501-4cdefd80-1ece-11ea-9018-e47363c81f08.gif)
