### PR TITLE
Revise quickstart Jupyter notebook

### DIFF
--- a/examples/quickstart.ipynb
+++ b/examples/quickstart.ipynb
@@ -121,7 +121,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "It is possible to condition hyperparameters using Python `if`s. We can for instance include another classifier, a support vector machine, in our HPO and define hyperparameters specific to the random forest model and the support vector machine."
+    "It is possible to condition hyperparameters using Python `if` statements. We can for instance include another classifier, a support vector machine, in our HPO and define hyperparameters specific to the random forest model and the support vector machine."
    ]
   },
   {

--- a/examples/quickstart.ipynb
+++ b/examples/quickstart.ipynb
@@ -11,7 +11,7 @@
     "- Install Optuna\n",
     "- Write a training algorithm that involves hyperparameters\n",
     "  - Read train/test data\n",
-    "  - Defina and train model\n",
+    "  - Define and train model\n",
     "  - Evaluate model\n",
     "- Use Optuna to tune the hyperparameters (hyperparameter optimization, HPO)\n",
     "- Visualize HPO"
@@ -52,7 +52,7 @@
    "source": [
     "## Optimize Hyperparameters\n",
     "\n",
-    "### Defina a simple scikit-learn model\n",
+    "### Define a simple scikit-learn model\n",
     "\n",
     "We start with a simple random forest model to classify flowers in the Iris dataset. We define a function called `objective` that encapsulates the whole training process and outputs the accuracy of the model."
    ]

--- a/examples/quickstart.ipynb
+++ b/examples/quickstart.ipynb
@@ -54,7 +54,7 @@
     "\n",
     "### Defina a simple scikit-learn model\n",
     "\n",
-    "We start with a simple random forest ensemble model to classify flowers in the Iris dataset. We define a function called `objective` that encapsulates the whole training process and outputs the accuracy of the model."
+    "We start with a simple random forest model to classify flowers in the Iris dataset. We define a function called `objective` that encapsulates the whole training process and outputs the accuracy of the model."
    ]
   },
   {
@@ -121,7 +121,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "It is possible to condition hyperparameters using Python `if`s. We can for instance include another classifier, a vector machine, in our HPO and define hyperparameters specific to the random forest ensemble model and the support vector machine."
+    "It is possible to condition hyperparameters using Python `if`s. We can for instance include another classifier, a support vector machine, in our HPO and define hyperparameters specific to the random forest model and the support vector machine."
    ]
   },
   {
@@ -198,7 +198,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Plotting the accuracy surface for the hyperparameters involved in the random forest ensemble model."
+    "Plotting the accuracy surface for the hyperparameters involved in the random forest model."
    ]
   },
   {

--- a/examples/quickstart.ipynb
+++ b/examples/quickstart.ipynb
@@ -4,7 +4,26 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Install Optuna and Plotly"
+    "# A Quick Introduction to Optuna\n",
+    "\n",
+    "This Jupyter notebook goes through the basic usage of Optuna.\n",
+    "\n",
+    "- Install Optuna\n",
+    "- Write a training algorithm that involves hyperparameters\n",
+    "  - Read train/test data\n",
+    "  - Defina and train model\n",
+    "  - Evaluate model\n",
+    "- Use Optuna to tune the hyperparameters (hyperparameter optimization, HPO)\n",
+    "- Visualize HPO"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Install `optuna`\n",
+    "\n",
+    "Optuna can be installed via `pip` or `conda`."
    ]
   },
   {
@@ -17,10 +36,25 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import optuna\n",
+    "\n",
+    "optuna.__version__"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Defining Objective Function"
+    "## Optimize Hyperparameters\n",
+    "\n",
+    "### Defina a simple scikit-learn model\n",
+    "\n",
+    "We start with a simple random forest ensemble model to classify flowers in the Iris dataset. We define a function called `objective` that encapsulates the whole training process and outputs the accuracy of the model."
    ]
   },
   {
@@ -32,53 +66,62 @@
     "import sklearn.datasets\n",
     "import sklearn.ensemble\n",
     "import sklearn.model_selection\n",
-    "import sklearn.svm\n",
     "\n",
-    "def objective(trial):\n",
-    "    iris = sklearn.datasets.load_iris()\n",
-    "    x, y = iris.data, iris.target\n",
+    "def objective():\n",
+    "    iris = sklearn.datasets.load_iris()  # Prepare the data.\n",
+    "    \n",
+    "    clf = sklearn.ensemble.RandomForestClassifier(    \n",
+    "        n_estimators=5, max_depth=3)  # Define the model.\n",
+    "    \n",
+    "    return sklearn.model_selection.cross_val_score(\n",
+    "        clf, iris.data, iris.target, n_jobs=-1, cv=3).mean()  # Train and evaluate the model.\n",
     "\n",
-    "    classifier_name = trial.suggest_categorical('classifier', ['SVC', 'RandomForest'])\n",
-    "    if classifier_name == 'SVC':\n",
-    "        svc_c = trial.suggest_loguniform('svc_c', 1e-10, 1e10)\n",
-    "        classifier_obj = sklearn.svm.SVC(C=svc_c, gamma='auto')\n",
-    "    else:\n",
-    "        rf_max_depth = int(trial.suggest_loguniform('rf_max_depth', 2, 32))\n",
-    "        classifier_obj = sklearn.ensemble.RandomForestClassifier(\n",
-    "            max_depth=rf_max_depth, n_estimators=10)\n",
-    "\n",
-    "    score = sklearn.model_selection.cross_val_score(classifier_obj, x, y, n_jobs=-1, cv=3)\n",
-    "    accuracy = score.mean()\n",
-    "    return accuracy"
+    "print('Accuracy: {}'.format(objective()))"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Running Optimization"
+    "### Optimize hyperparameters of the model\n",
+    "\n",
+    "The hyperparameters of the above algorithm are `n_estimators` and `max_depth` for which we can try different values to see if the model accuracy can be improved. The `objective` function is modified to accept a trial object. This trial has several methods for sampling hyperparameters. We create a study to run the hyperparameter optimization and finally read the best hyperparameters."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import optuna\n",
     "\n",
+    "def objective(trial):\n",
+    "    iris = sklearn.datasets.load_iris()\n",
+    "    \n",
+    "    n_estimators = trial.suggest_int('n_estimators', 2, 20)\n",
+    "    max_depth = int(trial.suggest_loguniform('max_depth', 1, 32))\n",
+    "    \n",
+    "    clf = sklearn.ensemble.RandomForestClassifier(\n",
+    "        n_estimators=n_estimators, max_depth=max_depth)\n",
+    "    \n",
+    "    return sklearn.model_selection.cross_val_score(\n",
+    "        clf, iris.data, iris.target, n_jobs=-1, cv=3).mean()\n",
+    "\n",
     "study = optuna.create_study(direction='maximize')\n",
     "study.optimize(objective, n_trials=100)\n",
-    "print(study.best_trial)"
+    "\n",
+    "trial = study.best_trial\n",
+    "\n",
+    "print('Accuracy: {}'.format(trial.value))\n",
+    "print(\"Best hyperparameters: {}\".format(trial.params))"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Plotting Optimization History of Study"
+    "It is possible to condition hyperparameters using Python `if`s. We can for instance include another classifier, a vector machine, in our HPO and define hyperparameters specific to the random forest ensemble model and the support vector machine."
    ]
   },
   {
@@ -87,16 +130,43 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from optuna.visualization import plot_optimization_history\n",
+    "import sklearn.svm\n",
     "\n",
-    "plot_optimization_history(study)"
+    "def objective(trial):\n",
+    "    iris = sklearn.datasets.load_iris()\n",
+    "\n",
+    "    classifier = trial.suggest_categorical('classifier', ['RandomForest', 'SVC'])\n",
+    "    \n",
+    "    if classifier == 'RandomForest':\n",
+    "        n_estimators = trial.suggest_int('n_estimators', 2, 20)\n",
+    "        max_depth = int(trial.suggest_loguniform('max_depth', 1, 32))\n",
+    "\n",
+    "        clf = sklearn.ensemble.RandomForestClassifier(\n",
+    "            n_estimators=n_estimators, max_depth=max_depth)\n",
+    "    else:\n",
+    "        c = trial.suggest_loguniform('svc_c', 1e-10, 1e10)\n",
+    "        \n",
+    "        clf = sklearn.svm.SVC(C=c, gamma='auto')\n",
+    "\n",
+    "    return sklearn.model_selection.cross_val_score(\n",
+    "        clf, iris.data, iris.target, n_jobs=-1, cv=3).mean()\n",
+    "\n",
+    "study = optuna.create_study(direction='maximize')\n",
+    "study.optimize(objective, n_trials=100)\n",
+    "\n",
+    "trial = study.best_trial\n",
+    "\n",
+    "print('Accuracy: {}'.format(trial.value))\n",
+    "print(\"Best hyperparameters: {}\".format(trial.params))"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Plotting Hyper-parameter Relationship of Trials"
+    "### Plotting the study\n",
+    "\n",
+    "Plotting the optimization history of the study."
    ]
   },
   {
@@ -105,9 +175,39 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from optuna.visualization import plot_slice\n",
-    "\n",
-    "plot_slice(study)"
+    "optuna.visualization.plot_optimization_history(study)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Plotting the accuracies for each hyperparameter for each trial."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "optuna.visualization.plot_slice(study)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Plotting the accuracy surface for the hyperparameters involved in the random forest ensemble model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "optuna.visualization.plot_contour(study, params=['n_estimators', 'max_depth'])"
    ]
   }
  ],
@@ -127,7 +227,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.7.4"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
The quickstart Jupyter notebook is minimal, which is good to some extent but it's lacking explanations to guide the reader. This PR aims to improve the notebook. More precisely it
- in a chronological order explains the process of turning a regular training script into one that utilizes Optuna
- adds explanatory markdown cells