### PR TITLE
Add `trials` to `*Sampler.sample_{independent, relative}`

### DIFF
--- a/examples/samplers/simulated_annealing_sampler.py
+++ b/examples/samplers/simulated_annealing_sampler.py
@@ -33,13 +33,13 @@ class SimulatedAnnealingSampler(BaseSampler):
     def infer_relative_search_space(self, study, trial):
         return optuna.samplers.intersection_search_space(study)
 
-    def sample_relative(self, study, trial, search_space):
+    def sample_relative(self, study, trial, search_space, trials):
         if search_space == {}:
             # The relative search space is empty (it means this is the first trial of a study).
             return {}
 
         # The rest of this method is an implementation of Simulated Annealing (SA) algorithm.
-        prev_trial = self._get_last_complete_trial(study)
+        prev_trial = self._get_last_complete_trial(study, trials)
 
         # Update the current state of SA if the transition is accepted.
         if self._rng.uniform(0, 1) <= self._transition_probability(study, prev_trial):
@@ -93,15 +93,17 @@ class SimulatedAnnealingSampler(BaseSampler):
         return np.exp(-abs(current_value - prev_value) / self._temperature)
 
     @staticmethod
-    def _get_last_complete_trial(study):
-        complete_trials = [t for t in study.trials if t.state == structs.TrialState.COMPLETE]
+    def _get_last_complete_trial(study, trials=None):
+        if trials is None:
+            trials = study.trials
+        complete_trials = [t for t in trials if t.state == structs.TrialState.COMPLETE]
         return complete_trials[-1]
 
-    def sample_independent(self, study, trial, param_name, param_distribution):
+    def sample_independent(self, study, trial, param_name, param_distribution, trials):
         # In this example, this method is invoked only in the first trial of a study.
         # The parameters of the trial are sampled by using `RandomSampler` as follows.
-        return self._independent_sampler.sample_independent(study, trial, param_name,
-                                                            param_distribution)
+        return self._independent_sampler.sample_independent(
+            study, trial, param_name, param_distribution, trials)
 
 
 # Define a simple 2-dimensional objective function whose minimum value is -1 when (x, y) = (0, -1).

--- a/optuna/integration/lightgbm_tuner/optimize.py
+++ b/optuna/integration/lightgbm_tuner/optimize.py
@@ -52,8 +52,14 @@ class _GridSamplerUniform1D(optuna.samplers.BaseSampler):
         self.param_values = tuple(param_values)
         self.value_idx = 0
 
-    def sample_relative(self, study, trial, search_space):
-        # type: (Study, FrozenTrial, Dict[str, BaseDistribution]) -> Dict[str, float]
+    def sample_relative(
+            self,
+            study,  # type: Study
+            trial,  # type: FrozenTrial
+            search_space,  # type: Dict[str, BaseDistribution]
+            trials=None  # type: Optional[List[FrozenTrial]]
+    ):
+        # type: (...) -> Dict[str, float]
 
         # todo (g-votte): Take care of distributed optimization.
         assert self.value_idx < len(self.param_values)
@@ -61,8 +67,8 @@ class _GridSamplerUniform1D(optuna.samplers.BaseSampler):
         self.value_idx += 1
         return {self.param_name: param_value}
 
-    def sample_independent(self, study, trial, param_name, param_distribution):
-        # type: (Study, FrozenTrial, str, BaseDistribution) -> None
+    def sample_independent(self, study, trial, param_name, param_distribution, trials=None):
+        # type: (Study, FrozenTrial, str, BaseDistribution, Optional[List[FrozenTrial]]) -> None
 
         raise ValueError(
             'Suggest method is called for an invalid parameter: {}.'.format(param_name))

--- a/optuna/integration/skopt.py
+++ b/optuna/integration/skopt.py
@@ -110,8 +110,14 @@ class SkoptSampler(BaseSampler):
 
         return search_space
 
-    def sample_relative(self, study, trial, search_space):
-        # type: (Study, FrozenTrial, Dict[str, BaseDistribution]) -> Dict[str, Any]
+    def sample_relative(
+            self,
+            study,  # type: Study
+            trial,  # type: FrozenTrial
+            search_space,  # type: Dict[str, BaseDistribution]
+            trials=None  # type: Optional[List[FrozenTrial]]
+    ):
+        # type: (...) -> Dict[str, Any]
 
         if len(search_space) == 0:
             return {}
@@ -120,8 +126,8 @@ class SkoptSampler(BaseSampler):
         optimizer.tell(study)
         return optimizer.ask()
 
-    def sample_independent(self, study, trial, param_name, param_distribution):
-        # type: (Study, FrozenTrial, str, BaseDistribution) -> Any
+    def sample_independent(self, study, trial, param_name, param_distribution, trials=None):
+        # type: (Study, FrozenTrial, str, BaseDistribution, Optional[List[FrozenTrial]]) -> Any
 
         if self._warn_independent_sampling:
             complete_trials = [t for t in study.trials if t.state == structs.TrialState.COMPLETE]

--- a/optuna/samplers/base.py
+++ b/optuna/samplers/base.py
@@ -5,6 +5,8 @@ from optuna import type_checking
 if type_checking.TYPE_CHECKING:
     from typing import Any  # NOQA
     from typing import Dict  # NOQA
+    from typing import List  # NOQA
+    from typing import Optional  # NOQA
 
     from optuna.distributions import BaseDistribution  # NOQA
     from optuna.structs import FrozenTrial  # NOQA
@@ -70,8 +72,14 @@ class BaseSampler(object, metaclass=abc.ABCMeta):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def sample_relative(self, study, trial, search_space):
-        # type: (Study, FrozenTrial, Dict[str, BaseDistribution]) -> Dict[str, Any]
+    def sample_relative(
+            self,
+            study,  # type: Study
+            trial,  # type: FrozenTrial
+            search_space,  # type: Dict[str, BaseDistribution]
+            trials=None  # type: Optional[List[FrozenTrial]]
+    ):
+        # type: (...) -> Dict[str, Any]
         """Sample parameters in a given search space.
 
         This method is called once at the beginning of each trial, i.e., right before the
@@ -86,6 +94,9 @@ class BaseSampler(object, metaclass=abc.ABCMeta):
             search_space:
                 The search space returned by
                 :func:`~optuna.samplers.BaseSampler.infer_relative_search_space`.
+            trials:
+                The list of trials that have the same value for the key of `pruner_metadata`
+                in `user_attrs` as the given `trial`.
 
         Returns:
             A dictionary containing the parameter names and the values.
@@ -95,8 +106,15 @@ class BaseSampler(object, metaclass=abc.ABCMeta):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def sample_independent(self, study, trial, param_name, param_distribution):
-        # type: (Study, FrozenTrial, str, BaseDistribution) -> Any
+    def sample_independent(
+            self,
+            study,  # type: Study
+            trial,  # type: FrozenTrial
+            param_name,  # type: str
+            param_distribution,  # type: BaseDistribution
+            trials=None  # type: Optional[List[FrozenTrial]]
+    ):
+        # type: (...) -> Any
         """Sample a parameter for a given distribution.
 
         This method is called only for the parameters not contained in the search space returned
@@ -113,6 +131,9 @@ class BaseSampler(object, metaclass=abc.ABCMeta):
                 Name of the sampled parameter.
             param_distribution:
                 Distribution object that specifies a prior and/or scale of the sampling algorithm.
+            trials:
+                The list of trials that have the same value for the key of `pruner_metadata`
+                in `user_attrs` as the given `trial`.
 
         Returns:
             A parameter value.

--- a/optuna/samplers/random.py
+++ b/optuna/samplers/random.py
@@ -7,6 +7,7 @@ from optuna import type_checking
 if type_checking.TYPE_CHECKING:
     from typing import Any  # NOQA
     from typing import Dict  # NOQA
+    from typing import List  # NOQA
     from typing import Optional  # NOQA
 
     from optuna.distributions import BaseDistribution  # NOQA
@@ -54,13 +55,26 @@ class RandomSampler(BaseSampler):
 
         return {}
 
-    def sample_relative(self, study, trial, search_space):
-        # type: (Study, FrozenTrial, Dict[str, BaseDistribution]) -> Dict[str, Any]
+    def sample_relative(
+            self,
+            study,  # type: Study
+            trial,  # type: FrozenTrial
+            search_space,  # type: Dict[str, BaseDistribution]
+            trials=None  # type: Optional[List[FrozenTrial]]
+    ):
+        # type: (...) -> Dict[str, Any]
 
         return {}
 
-    def sample_independent(self, study, trial, param_name, param_distribution):
-        # type: (Study, FrozenTrial, str, distributions.BaseDistribution) -> Any
+    def sample_independent(
+            self,
+            study,  # type: Study
+            trial,  # type: FrozenTrial
+            param_name,  # type: str
+            param_distribution,  # type: BaseDistribution
+            trials=None  # type: Optional[List[FrozenTrial]]
+    ):
+        # type: (...) -> Any
 
         if isinstance(param_distribution, distributions.UniformDistribution):
             return self._rng.uniform(param_distribution.low, param_distribution.high)

--- a/optuna/samplers/tpe/sampler.py
+++ b/optuna/samplers/tpe/sampler.py
@@ -116,13 +116,26 @@ class TPESampler(base.BaseSampler):
 
         return {}
 
-    def sample_relative(self, study, trial, search_space):
-        # type: (Study, FrozenTrial, Dict[str, BaseDistribution]) -> Dict[str, Any]
+    def sample_relative(
+            self,
+            study,  # type: Study
+            trial,  # type: FrozenTrial
+            search_space,  # type: Dict[str, BaseDistribution]
+            trials=None  # type: Optional[List[FrozenTrial]]
+    ):
+        # type: (...) -> Dict[str, Any]
 
         return {}
 
-    def sample_independent(self, study, trial, param_name, param_distribution):
-        # type: (Study, FrozenTrial, str, BaseDistribution) -> Any
+    def sample_independent(
+            self,
+            study,  # type: Study
+            trial,  # type: FrozenTrial
+            param_name,  # type: str
+            param_distribution,  # type: BaseDistribution
+            trials=None  # type: Optional[List[FrozenTrial]]
+    ):
+        # type: (...) -> Any
 
         values, scores = _get_observation_pairs(study, param_name)
 

--- a/optuna/study.py
+++ b/optuna/study.py
@@ -565,6 +565,9 @@ class Study(BaseStudy):
         trial = trial_module.Trial(self, trial_id)
         trial_number = trial.number
 
+        trials = self.trials
+        trial._set_friend_trials(trials)
+
         try:
             result = func(trial)
         except exceptions.TrialPruned as e:
@@ -585,6 +588,8 @@ class Study(BaseStudy):
                 return trial
             raise
         finally:
+            trial._clear_friend_trials()
+            del trials
             # The following line mitigates memory problems that can be occurred in some
             # environments (e.g., services that use computing containers such as CircleCI).
             # Please refer to the following PR for further details:

--- a/optuna/testing/sampler.py
+++ b/optuna/testing/sampler.py
@@ -4,6 +4,8 @@ from optuna import distributions
 if optuna.type_checking.TYPE_CHECKING:
     from typing import Any  # NOQA
     from typing import Dict  # NOQA
+    from typing import List  # NOQA
+    from typing import Optional  # NOQA
 
     from optuna.distributions import BaseDistribution  # NOQA
     from optuna.structs import FrozenTrial  # NOQA
@@ -22,13 +24,19 @@ class DeterministicRelativeSampler(optuna.samplers.BaseSampler):
 
         return self.relative_search_space
 
-    def sample_relative(self, study, trial, search_space):
-        # type: (Study, FrozenTrial, Dict[str, BaseDistribution]) -> Dict[str, Any]
+    def sample_relative(
+            self,
+            study,  # type: Study
+            trial,  # type: FrozenTrial
+            search_space,  # type: Dict[str, BaseDistribution]
+            trials=None  # type: Optional[List[FrozenTrial]]
+    ):
+        # type: (...) -> Dict[str, Any]
 
         return self.relative_params
 
-    def sample_independent(self, study, trial, param_name, param_distribution):
-        # type: (Study, FrozenTrial, str, BaseDistribution) -> Any
+    def sample_independent(self, study, trial, param_name, param_distribution, trials=None):
+        # type: (Study, FrozenTrial, str, BaseDistribution, Optional[List[FrozenTrial]]) -> Any
 
         if isinstance(param_distribution, distributions.UniformDistribution):
             param_value = param_distribution.low  # type: Any
@@ -47,16 +55,22 @@ class DeterministicRelativeSampler(optuna.samplers.BaseSampler):
 
 
 class FirstTrialOnlyRandomSampler(optuna.samplers.RandomSampler):
-    def sample_relative(self, study, trial, search_space):
-        # type: (Study, FrozenTrial, Dict[str, BaseDistribution]) -> Dict[str, float]
+    def sample_relative(
+            self,
+            study,  # type: Study
+            trial,  # type: FrozenTrial
+            search_space,  # type: Dict[str, Any]
+            trials=None  # type: Optional[List[FrozenTrial]]
+    ):
+        # type: (...) -> Dict[str, float]
 
         if len(study.trials) > 1:
             raise RuntimeError("`FirstTrialOnlyRandomSampler` only works on the first trial.")
 
         return super(FirstTrialOnlyRandomSampler, self).sample_relative(study, trial, search_space)
 
-    def sample_independent(self, study, trial, param_name, param_distribution):
-        # type: (Study, FrozenTrial, str, BaseDistribution) -> float
+    def sample_independent(self, study, trial, param_name, param_distribution, trials=None):
+        # type: (Study, FrozenTrial, str, BaseDistribution, Optional[List[FrozenTrial]]) -> float
 
         if len(study.trials) > 1:
             raise RuntimeError("`FirstTrialOnlyRandomSampler` only works on the first trial.")

--- a/tests/samplers_tests/test_samplers.py
+++ b/tests/samplers_tests/test_samplers.py
@@ -15,6 +15,7 @@ if optuna.type_checking.TYPE_CHECKING:
     import typing  # NOQA
     from typing import Any  # NOQA
     from typing import Dict  # NOQA
+    from typing import List  # NOQA
     from typing import Optional  # NOQA
     from typing import Sequence  # NOQA
 
@@ -178,13 +179,19 @@ class FixedSampler(BaseSampler):
 
         return self.relative_search_space
 
-    def sample_relative(self, study, trial, search_space):
-        # type: (Study, FrozenTrial, Dict[str, BaseDistribution]) -> Dict[str, Any]
+    def sample_relative(
+            self,
+            study,  # type: Study
+            trial,  # type: FrozenTrial
+            search_space,  # type: Dict[str, BaseDistribution]
+            trials=None  # type: Optional[List[FrozenTrial]]
+    ):
+        # type: (...) -> Dict[str, Any]
 
         return self.relative_params
 
-    def sample_independent(self, study, trial, param_name, param_distribution):
-        # type: (Study, FrozenTrial, str, BaseDistribution) -> Any
+    def sample_independent(self, study, trial, param_name, param_distribution, trials=None):
+        # type: (Study, FrozenTrial, str, BaseDistribution, Optional[List[FrozenTrial]]) -> Any
 
         return self.unknown_param_value
 

--- a/tests/test_trial.py
+++ b/tests/test_trial.py
@@ -144,7 +144,7 @@ def test_suggest_discrete_uniform_range(storage_init_func, range_config):
 
     # Check upper endpoints.
     mock = Mock()
-    mock.side_effect = lambda study, trial, param_name, distribution: distribution.high
+    mock.side_effect = lambda study, trial, param_name, distribution, trials: distribution.high
     with patch.object(sampler, 'sample_independent', mock) as mock_object:
         study = create_study(storage_init_func(), sampler=sampler)
         trial = Trial(study, study._storage.create_new_trial(study._study_id))
@@ -156,7 +156,7 @@ def test_suggest_discrete_uniform_range(storage_init_func, range_config):
 
     # Check lower endpoints.
     mock = Mock()
-    mock.side_effect = lambda study, trial, param_name, distribution: distribution.low
+    mock.side_effect = lambda study, trial, param_name, distribution, trials: distribution.low
     with patch.object(sampler, 'sample_independent', mock) as mock_object:
         study = create_study(storage_init_func(), sampler=sampler)
         trial = Trial(study, study._storage.create_new_trial(study._study_id))


### PR DESCRIPTION
<!-- Thank you for creating a pull request!

Please go through [our contribution guide][CONTRIBUTING.md] to hopefully get your changes merged quicker.

[CONTRIBUTING.md]: https://github.com/optuna/optuna/blob/master/CONTRIBUTING.md -->

Context: This PR derives from #785.
#785 is not trivial and composed of two major changes: hyperband implementation and new argument.
But the changes related to the new argument is independent from hyperband implementation.

This PR changes `BaseSampler.sample_{independent, relative}` to take `trials`, a list of trials as an argument.