### PR TITLE
Avoid redundant sort (reverse) in successive halving

### DIFF
--- a/optuna/pruners/successive_halving.py
+++ b/optuna/pruners/successive_halving.py
@@ -140,7 +140,7 @@ class SuccessiveHalvingPruner(BasePruner):
             promotable_idx = 0
 
         if study_direction == StudyDirection.MAXIMIZE:
-            return value >= competing_values[len(competing_values) - 1 - promotable_idx]
+            return value >= competing_values[-(promotable_idx + 1)]
         return value <= competing_values[promotable_idx]
 
 

--- a/optuna/pruners/successive_halving.py
+++ b/optuna/pruners/successive_halving.py
@@ -140,9 +140,7 @@ class SuccessiveHalvingPruner(BasePruner):
             promotable_idx = 0
 
         if study_direction == StudyDirection.MAXIMIZE:
-            competing_values.reverse()
-            return value >= competing_values[promotable_idx]
-
+            return value >= competing_values[len(competing_values) - 1 - promotable_idx]
         return value <= competing_values[promotable_idx]
 
 


### PR DESCRIPTION
Avoid unnecessary in-place sort (`list.reverse`) in successive halving.