### PR TITLE
Refactoring of successive halving

### DIFF
--- a/optuna/pruners/successive_halving.py
+++ b/optuna/pruners/successive_halving.py
@@ -150,7 +150,6 @@ def _get_competing_values(trials, value, rung_key):
 
     competing_values = [t.system_attrs[rung_key] for t in trials if rung_key in t.system_attrs]
     competing_values.append(value)
-    competing_values.sort()
     return competing_values
 
 
@@ -165,6 +164,7 @@ def _is_trial_promotable_to_next_rung(value, competing_values, reduction_factor,
         # smallest one among the competing values.
         promotable_idx = 0
 
+    competing_values.sort()
     if study_direction == StudyDirection.MAXIMIZE:
         return value >= competing_values[-(promotable_idx + 1)]
     return value <= competing_values[promotable_idx]

--- a/optuna/pruners/successive_halving.py
+++ b/optuna/pruners/successive_halving.py
@@ -121,7 +121,7 @@ class SuccessiveHalvingPruner(BasePruner):
 
             study._storage.set_trial_system_attr(trial._trial_id, rung_key, value)
 
-            if not _is_value_promotable_to_next_rung(
+            if not _is_trial_promotable_to_next_rung(
                     value, _get_competing_values(trials, value, rung_key),
                     self._reduction_factor, study.direction):
                 return True
@@ -154,16 +154,15 @@ def _get_competing_values(trials, value, rung_key):
     return competing_values
 
 
-def _is_value_promotable_to_next_rung(value, competing_values, reduction_factor, study_direction):
+def _is_trial_promotable_to_next_rung(value, competing_values, reduction_factor, study_direction):
     # type: (float, List[float], int, StudyDirection) -> bool
 
     promotable_idx = (len(competing_values) // reduction_factor) - 1
 
     if promotable_idx == -1:
-        # Optuna does not support to suspend/resume ongoing trials.
-        #
-        # For the first `eta - 1` trials, this implementation promotes a trial if its
-        # intermediate value is the smallest one among the trials that have completed the rung.
+        # Optuna does not support suspending or resuming ongoing trials. Therefore, for the first
+        # `eta - 1` trials, this implementation instead promotes the trial if its value is the
+        # smallest one among the competing values.
         promotable_idx = 0
 
     if study_direction == StudyDirection.MAXIMIZE:


### PR DESCRIPTION
~_This PR can probably wait until https://github.com/optuna/optuna/pull/785 is merged. I was mostly looking through the code and made these changes for my own readability._~

A minor refactoring of the successive halving pruner that reduces calls to `_completed_rung_key`, changes some variable named and introduces indirections.

If you find the indirections to increase the complexity, please feel free to close this PR.