### PR TITLE
Add `HyperbandPruner`

### DIFF
--- a/docs/source/reference/pruners.rst
+++ b/docs/source/reference/pruners.rst
@@ -21,3 +21,7 @@ Pruners
 .. autoclass:: SuccessiveHalvingPruner
     :members:
     :exclude-members: prune
+
+.. autoclass:: HyperbandPruner
+    :members:
+    :exclude-members: prune

--- a/optuna/pruners/__init__.py
+++ b/optuna/pruners/__init__.py
@@ -1,4 +1,5 @@
 from optuna.pruners.base import BasePruner  # NOQA
+from optuna.pruners.hyperband import HyperbandPruner  # NOQA
 from optuna.pruners.median import MedianPruner  # NOQA
 from optuna.pruners.nop import NopPruner  # NOQA
 from optuna.pruners.percentile import PercentilePruner  # NOQA

--- a/optuna/pruners/hyperband.py
+++ b/optuna/pruners/hyperband.py
@@ -39,7 +39,7 @@ class HyperbandPruner(BasePruner):
             A parameter for specifying the minimum early-stopping rate.
             This parameter is related to a parameter that is referred to as :math:`r` and used in
             `Asynchronous SuccessiveHalving paper <http://arxiv.org/abs/1810.05934>`_.
-            The minimum early stopping rate for ``i``th bracket is :math:`i + s`.
+            The minimum early stopping rate for :math:`i` th bracket is :math:`i + s`.
     """
 
     def __init__(

--- a/optuna/pruners/hyperband.py
+++ b/optuna/pruners/hyperband.py
@@ -110,7 +110,12 @@ class HyperbandPruner(BasePruner):
         raise RuntimeError
 
 
+# N.B. This class is assumed to be passed to `SuccessiveHalvingPruner.prune` in which `get_trials`,
+# `direction`, and `storage` are used.
+# But for safety, prohibit the other attributes explicitly.
 class _BracketStudy(Study):
+
+    _VALID_ATTRS = ('get_trials', 'direction', '_storage')
 
     def __init__(self, study, bracket_id) -> None:
         # type: (Study, int) -> None
@@ -129,6 +134,12 @@ class _BracketStudy(Study):
         trials = super().get_trials(deepcopy=deepcopy)
         trials = [
             t for t in trials
-            if self.pruner.get_bracket_id(self.study_name, t.number) == self._bracket_id
+            if self.pruner._get_bracket_id(self.study_name, t.number) == self._bracket_id
         ]
         return trials
+
+    def __getattribute__(self, attr_name):
+        if attr_name not in _BracketStudy._VALID_ATTRS:
+            raise NotImplementedError
+        else:
+            return getattr(self, attr_name)

--- a/optuna/pruners/hyperband.py
+++ b/optuna/pruners/hyperband.py
@@ -1,3 +1,4 @@
+import optuna
 from optuna import logging
 from optuna.pruners.base import BasePruner
 from optuna.pruners.successive_halving import SuccessiveHalvingPruner
@@ -7,7 +8,6 @@ if type_checking.TYPE_CHECKING:
     from typing import List  # NOQA
 
     from optuna import structs  # NOQA
-    from optuna.study import Study  # NOQA
 
 _logger = logging.get_logger(__name__)
 
@@ -79,7 +79,7 @@ class HyperbandPruner(BasePruner):
             self._pruners.append(pruner)
 
     def prune(self, study, trial):
-        # type: (Study, structs.FrozenTrial) -> bool
+        # type: (optuna.study.Study, structs.FrozenTrial) -> bool
 
         i = self._get_bracket_id(study, trial)
         _logger.debug('{}th bracket is selected'.format(i))
@@ -93,7 +93,7 @@ class HyperbandPruner(BasePruner):
         return n + (n / 2) * (n_brackets - 1 - pruner_index)
 
     def _get_bracket_id(self, study, trial):
-        # type: (Study, structs.FrozenTrial) -> int
+        # type: (optuna.study.Study, structs.FrozenTrial) -> int
         """Computes the index of bracket for a trial of ``trial_number``.
 
         The index of a bracket is noted as :math:`s` in
@@ -109,19 +109,13 @@ class HyperbandPruner(BasePruner):
         assert False, 'This line should be unreachable.'
 
     def _create_bracket_study(self, study, bracket_index):
-        # type: (Study, int) -> Study
-
-        # NOTE(crcrpar): The below import is workaround (optuna/optuna#809).
-        # The below import violates PEP8 (https://www.python.org/dev/peps/pep-0008/#imports),
-        # however, if we follow that here, ImportError occurs.
-
-        from optuna.study import Study
+        # type: (optuna.study.Study, int) -> optuna.study.Study
 
         # This class is assumed to be passed to
         # `SuccessiveHalvingPruner.prune` in which `get_trials`,
         # `direction`, and `storage` are used.
         # But for safety, prohibit the other attributes explicitly.
-        class _BracketStudy(Study):
+        class _BracketStudy(optuna.study.Study):
 
             _VALID_ATTRS = (
                 'get_trials', 'direction', '_storage', '_study_id',
@@ -129,7 +123,7 @@ class HyperbandPruner(BasePruner):
             )
 
             def __init__(self, study, bracket_id):
-                # type: (Study, int) -> None
+                # type: (optuna.study.Study, int) -> None
 
                 super().__init__(
                     study_name=study.study_name,

--- a/optuna/pruners/hyperband.py
+++ b/optuna/pruners/hyperband.py
@@ -8,6 +8,7 @@ if type_checking.TYPE_CHECKING:
     from typing import List  # NOQA
 
     from optuna.structs import FrozenTrial  # NOQA
+    from optuna.trial import Trial  # NOQA
 
 _logger = logging.get_logger(__name__)
 
@@ -47,6 +48,7 @@ class HyperbandPruner(BasePruner):
             min_early_stopping_rate_high=4
     ):
         # type: (int, int, int, int) -> None
+
         self._pruners = []  # type: List[SuccessiveHalvingPruner]
         self._reduction_factor = reduction_factor
         self._resource_budget = 0
@@ -106,30 +108,6 @@ class HyperbandPruner(BasePruner):
                 return i
 
         raise RuntimeError
-
-    @property
-    def resource_budget(self):
-        # type: () -> int
-        """The total amount of resource.
-
-        This value is a proxy for :math:`B` in the
-        `Hyperband paper <http://www.jmlr.org/papers/volume18/16-558/16-558.pdf>`_.
-        """
-
-        return self._resource_budget
-
-    @property
-    def n_pruners(self):
-        # type: () -> int
-        """The number of pruners.
-
-        The number of pruners is calculated by the following equation:
-        :math:`
-        \\mathsf{min}\\_\\mathsf{early}\\_\\mathsf{stopping}\\_\\mathsf{rate}\\_\\mathsf{high} -
-        \\mathsf{min}\\_\\mathsf{early}\\_\\mathsf{stopping}\\_\\mathsf{rate}\\_\\mathsf{low} + 1`
-        """
-
-        return self._n_pruners
 
 
 class _BracketStudy(Study):

--- a/optuna/pruners/hyperband.py
+++ b/optuna/pruners/hyperband.py
@@ -80,7 +80,7 @@ class HyperbandPruner(BasePruner):
     def prune(self, study, trial):
         # type: (Study, FrozenTrial) -> bool
 
-        i = self.get_bracket_id(study.study_name, trial.number)
+        i = self._get_bracket_id(study, trial)
         _logger.debug('{}th bracket is selected'.format(i))
         bracket_study = _BracketStudy(study, i)
         return self._pruners[i].prune(bracket_study, trial)
@@ -93,21 +93,21 @@ class HyperbandPruner(BasePruner):
             budget += n / 2
         return budget
 
-    def get_bracket_id(self, study_name, trial_number):
-        # type: (str, int) -> int
+    def _get_bracket_id(self, study, trial):
+        # type: (Study, FrozenTrial) -> int
         """Computes the index of bracket for a trial of ``trial_number``.
 
         The index of a bracket is noted as :math:`s` in
         `Hyperband paper <http://www.jmlr.org/papers/volume18/16-558/16-558.pdf>`_.
         """
 
-        n = hash('{}_{}'.format(study_name, trial_number)) % self._resource_budget
+        n = hash('{}_{}'.format(study.study_name, trial.number)) % self._resource_budget
         for i in range(self.n_pruners):
             n -= self._bracket_resource_budgets[i]
             if n < 0:
                 return i
 
-        raise RuntimeError
+        assert False
 
 
 # N.B. This class is assumed to be passed to `SuccessiveHalvingPruner.prune` in which `get_trials`,

--- a/optuna/pruners/hyperband.py
+++ b/optuna/pruners/hyperband.py
@@ -1,7 +1,7 @@
 from optuna import logging
 from optuna.pruners.base import BasePruner
-from optuna import Study
 from optuna.pruners.successive_halving import SuccessiveHalvingPruner
+from optuna import Study
 from optuna import type_checking
 
 if type_checking.TYPE_CHECKING:

--- a/optuna/pruners/hyperband.py
+++ b/optuna/pruners/hyperband.py
@@ -132,7 +132,7 @@ class HyperbandPruner(BasePruner):
 
                 super().__init__(
                     study_name=study.study_name,
-                    storage=study.storage,
+                    storage=study._storage,
                     sampler=study.sampler,
                     pruner=study.pruner
                 )

--- a/optuna/pruners/hyperband.py
+++ b/optuna/pruners/hyperband.py
@@ -88,6 +88,7 @@ class HyperbandPruner(BasePruner):
 
     def _calc_bracket_resource_budget(self, pruner_index, n_brackets):
         # type: (int, int) -> int
+
         n = self._reduction_factor ** (n_brackets - 1)
         budget = n
         for i in range(pruner_index, n_brackets - 1):

--- a/optuna/pruners/hyperband.py
+++ b/optuna/pruners/hyperband.py
@@ -1,0 +1,156 @@
+from optuna import logging
+from optuna.pruners.base import BasePruner
+from optuna import Study
+from optuna.pruners.successive_halving import SuccessiveHalvingPruner
+from optuna import type_checking
+
+if type_checking.TYPE_CHECKING:
+    from typing import List  # NOQA
+
+    from optuna.structs import FrozenTrial  # NOQA
+
+_logger = logging.get_logger(__name__)
+
+
+class HyperbandPruner(BasePruner):
+    """Pruner using Hyperband.
+
+    As SuccessiveHalving (SHA) requires the number of configurations
+    :math:`n` as its hyperparameter.  For a given finite budget :math:`B`,
+    all the configurations have the resources of :math:`B \\over n` on average.
+    As you can see, there will be a trade-off of :math:`B` and :math:`B \\over n`.
+    `Hyperband <http://www.jmlr.org/papers/volume18/16-558/16-558.pdf>`_ attacks this trade-off
+    by trying different :math:`n` values for a fixed budget.
+    Note that this implementation does not take as inputs the maximum amount of resource to
+    a single SHA noted as :math:`R` in the paper.
+
+    Args:
+        min_resource:
+            A parameter for specifying the minimum resource allocated to a trial noted as :math:`r`
+            in the paper.
+            See the details for :class:`~optuna.pruners.SuccessiveHalvingPruner`.
+        reduction_factor:
+            A parameter for specifying reduction factor of promotable trials noted as
+            :math:`\\eta` in the paper. See the details for
+            :class:`~optuna.pruners.SuccessiveHalvingPruner`.
+        min_early_stopping_rate_low:
+            The start point of the minimum early stopping rate for ``SuccessiveHalvingPruner``.
+        min_early_stopping_rate_high:
+            The end point of the minimum early stopping rate for ``SuccessiveHalvingPruner``.
+    """
+
+    def __init__(
+            self,
+            min_resource=1,
+            reduction_factor=3,
+            min_early_stopping_rate_low=0,
+            min_early_stopping_rate_high=4
+    ):
+        # type: (int, int, int, int) -> None
+        self._pruners = []  # type: List[SuccessiveHalvingPruner]
+        self._reduction_factor = reduction_factor
+        self._resource_budget = 0
+        n_pruners = min_early_stopping_rate_high - min_early_stopping_rate_low + 1
+        self._n_pruners = n_pruners
+        self._bracket_resource_budgets = []  # type: List[int]
+
+        _logger.debug('Hyperband has {} brackets'.format(self.n_pruners))
+
+        for i in range(n_pruners):
+            bracket_resource_budget = self._calc_bracket_resource_budget(i, n_pruners)
+            self._resource_budget += bracket_resource_budget
+            self._bracket_resource_budgets.append(bracket_resource_budget)
+
+            # N.B. (crcrpar): `min_early_stopping_rate` has the information of `bracket_index`.
+            min_early_stopping_rate = min_early_stopping_rate_low + i
+
+            _logger.debug(
+                '{}th bracket has minimum early stopping rate of {}'.format(
+                    i, min_early_stopping_rate))
+
+            pruner = SuccessiveHalvingPruner(
+                min_resource=min_resource,
+                reduction_factor=reduction_factor,
+                min_early_stopping_rate=min_early_stopping_rate,
+            )
+            self._pruners.append(pruner)
+
+    def prune(self, study, trial):
+        # type: (Study, FrozenTrial) -> bool
+
+        i = self.get_bracket_id(study.study_name, trial.number)
+        _logger.debug('{}th bracket is selected'.format(i))
+        bracket_study = _BracketStudy(study, i)
+        return self._pruners[i].prune(bracket_study, trial)
+
+    def _calc_bracket_resource_budget(self, pruner_index, n_pruners):
+        # type: (int, int) -> int
+        n = self._reduction_factor ** (n_pruners - 1)
+        budget = n
+        for i in range(pruner_index, n_pruners - 1):
+            budget += n / 2
+        return budget
+
+    def get_bracket_id(self, study_name, trial_number):
+        # type: (str, int) -> int
+        """Computes the index of bracket for a trial of ``trial_number``.
+
+        The index of a bracket is noted as :math:`s` in
+        `Hyperband paper <http://www.jmlr.org/papers/volume18/16-558/16-558.pdf>`_.
+        """
+
+        n = hash('{}_{}'.format(study_name, trial_number)) % self._resource_budget
+        for i in range(self.n_pruners):
+            n -= self._bracket_resource_budgets[i]
+            if n < 0:
+                return i
+
+        raise RuntimeError
+
+    @property
+    def resource_budget(self):
+        # type: () -> int
+        """The total amount of resource.
+
+        This value is a proxy for :math:`B` in the
+        `Hyperband paper <http://www.jmlr.org/papers/volume18/16-558/16-558.pdf>`_.
+        """
+
+        return self._resource_budget
+
+    @property
+    def n_pruners(self):
+        # type: () -> int
+        """The number of pruners.
+
+        The number of pruners is calculated by the following equation:
+        :math:`
+        \\mathsf{min}\\_\\mathsf{early}\\_\\mathsf{stopping}\\_\\mathsf{rate}\\_\\mathsf{high} -
+        \\mathsf{min}\\_\\mathsf{early}\\_\\mathsf{stopping}\\_\\mathsf{rate}\\_\\mathsf{low} + 1`
+        """
+
+        return self._n_pruners
+
+
+class _BracketStudy(Study):
+
+    def __init__(self, study, bracket_id) -> None:
+        # type: (Study, int) -> None
+
+        super().__init__(
+            study_name=study.study_name,
+            storage=study.storage,
+            sampler=study.sampler,
+            pruner=study.pruner
+        )
+        self._bracket_id = bracket_id
+
+    def get_trials(self, deepcopy):
+        # type: (bool) -> List[FrozenTrial]
+
+        trials = super().get_trials(deepcopy=deepcopy)
+        trials = [
+            t for t in trials
+            if self.pruner.get_bracket_id(self.study_name, t.number) == self._bracket_id
+        ]
+        return trials

--- a/optuna/pruners/hyperband.py
+++ b/optuna/pruners/hyperband.py
@@ -90,10 +90,7 @@ class HyperbandPruner(BasePruner):
         # type: (int, int) -> int
 
         n = self._reduction_factor ** (n_brackets - 1)
-        budget = n
-        for i in range(pruner_index, n_brackets - 1):
-            budget += n / 2
-        return budget
+        return n + (n / 2) * (n_brackets - 1 - pruner_index)
 
     def _get_bracket_id(self, study, trial):
         # type: (Study, structs.FrozenTrial) -> int
@@ -114,13 +111,13 @@ class HyperbandPruner(BasePruner):
     def _create_bracket_study(self, study, bracket_index):
         # type: (Study, int) -> Study
 
-        # NOTE(crcrpar): The below import is workaround.
+        # NOTE(crcrpar): The below import is workaround (optuna/optuna#809).
         # The below import violates PEP8 (https://www.python.org/dev/peps/pep-0008/#imports),
         # however, if we follow that here, ImportError occurs.
 
         from optuna.study import Study
 
-        # N.B. This class is assumed to be passed to
+        # This class is assumed to be passed to
         # `SuccessiveHalvingPruner.prune` in which `get_trials`,
         # `direction`, and `storage` are used.
         # But for safety, prohibit the other attributes explicitly.

--- a/optuna/pruners/hyperband.py
+++ b/optuna/pruners/hyperband.py
@@ -122,7 +122,10 @@ class HyperbandPruner(BasePruner):
         # But for safety, prohibit the other attributes explicitly.
         class _BracketStudy(Study):
 
-            _VALID_ATTRS = ('get_trials', 'direction', '_storage')
+            _VALID_ATTRS = (
+                'get_trials', 'direction', '_storage', '_study_id',
+                'pruner', 'study_name', '_bracket_id'
+            )
 
             def __init__(self, study, bracket_id):
                 # type: (Study, int) -> None
@@ -150,6 +153,6 @@ class HyperbandPruner(BasePruner):
                 if attr_name not in _BracketStudy._VALID_ATTRS:
                     raise NotImplementedError
                 else:
-                    return getattr(self, attr_name)
+                    return object.__getattribute__(self, attr_name)
 
         return _BracketStudy(study, bracket_index)

--- a/optuna/pruners/hyperband.py
+++ b/optuna/pruners/hyperband.py
@@ -86,6 +86,7 @@ class HyperbandPruner(BasePruner):
         bracket_study = self._create_bracket_study(study, i)
         return self._pruners[i].prune(bracket_study, trial)
 
+    # TODO(crcrpar): Improve resource computation/allocation algorithm.
     def _calc_bracket_resource_budget(self, pruner_index, n_brackets):
         # type: (int, int) -> int
 

--- a/optuna/pruners/hyperband.py
+++ b/optuna/pruners/hyperband.py
@@ -128,7 +128,7 @@ class HyperbandPruner(BasePruner):
 
             _VALID_ATTRS = (
                 'get_trials', 'direction', '_storage', '_study_id',
-                'pruner', 'study_name', '_bracket_id'
+                'pruner', 'study_name', '_bracket_id', 'sampler'
             )
 
             def __init__(self, study, bracket_id):
@@ -155,7 +155,8 @@ class HyperbandPruner(BasePruner):
 
             def __getattribute__(self, attr_name):  # type: ignore
                 if attr_name not in _BracketStudy._VALID_ATTRS:
-                    raise NotImplementedError
+                    raise AttributeError(
+                        "_BracketStudy does not have attribute of '{}'".format(attr_name))
                 else:
                     return object.__getattribute__(self, attr_name)
 

--- a/optuna/pruners/hyperband.py
+++ b/optuna/pruners/hyperband.py
@@ -114,6 +114,10 @@ class HyperbandPruner(BasePruner):
     def _create_bracket_study(self, study, bracket_index):
         # type: (Study, int) -> Study
 
+        # NOTE(crcrpar): The below import is workaround.
+        # The below import violates PEP8 (https://www.python.org/dev/peps/pep-0008/#imports),
+        # however, if we follow that here, ImportError occurs.
+
         from optuna.study import Study
 
         # N.B. This class is assumed to be passed to

--- a/optuna/pruners/hyperband.py
+++ b/optuna/pruners/hyperband.py
@@ -109,7 +109,7 @@ class HyperbandPruner(BasePruner):
             if n < 0:
                 return i
 
-        assert False
+        assert False, 'This line should be unreachable.'
 
     def _create_bracket_study(self, study, bracket_index):
         # type: (Study, int) -> Study

--- a/optuna/study.py
+++ b/optuna/study.py
@@ -196,8 +196,8 @@ class Study(BaseStudy):
                 isinstance(self.pruner, pruners.HyperbandPruner)):
             msg = (
                 "The algorithm of TPESampler and HyperbandPruner might behave in a different way "
-                "from the paper because the sampler uses all the trials including ones of "
-                "brackets other than that of currently running trial")
+                "from the paper of Hyperband because the sampler uses all the trials including "
+                "ones of brackets other than that of currently running trial")
             warnings.warn(msg, UserWarning)
 
         self._optimize_lock = threading.Lock()

--- a/optuna/study.py
+++ b/optuna/study.py
@@ -199,6 +199,7 @@ class Study(BaseStudy):
                 "from the paper of Hyperband because the sampler uses all the trials including "
                 "ones of brackets other than that of currently running trial")
             warnings.warn(msg, UserWarning)
+            _logger.warning(msg)
 
         self._optimize_lock = threading.Lock()
 

--- a/optuna/study.py
+++ b/optuna/study.py
@@ -191,6 +191,15 @@ class Study(BaseStudy):
         self.sampler = sampler or samplers.TPESampler()
         self.pruner = pruner or pruners.MedianPruner()
 
+        if (
+                isinstance(self.sampler, samplers.TPESampler) and
+                isinstance(self.pruner, pruners.HyperbandPruner)):
+            msg = (
+                "The algorithm of TPESampler and HyperbandPruner might behave in a different way "
+                "from the paper because the sampler uses all the trials including ones of "
+                "brackets other than that of currently running trial")
+            warnings.warn(msg, UserWarning)
+
         self._optimize_lock = threading.Lock()
 
     def __getstate__(self):

--- a/tests/pruners_tests/test_hyperband.py
+++ b/tests/pruners_tests/test_hyperband.py
@@ -1,0 +1,49 @@
+import pytest
+
+import optuna
+from optuna import type_checking
+
+if type_checking.TYPE_CHECKING:
+    from optuna.trial import Trial  # NOQA
+
+MIN_RESOURCE = 1
+REDUCTION_FACTOR = 2
+EARLY_STOPPING_RATE_LOW = 0
+EARLY_STOPPING_RATE_HIGH = 3
+N_REPORTS = 10
+EXPECTED_N_TRIALS_PER_BRACKET = 10
+
+
+def test_hyperband_pruner_intermediate_values():
+    # type: () -> None
+
+    pruner = optuna.pruners.HyperbandPruner(
+        min_resource=MIN_RESOURCE,
+        reduction_factor=REDUCTION_FACTOR,
+        min_early_stopping_rate_low=EARLY_STOPPING_RATE_LOW,
+        min_early_stopping_rate_high=EARLY_STOPPING_RATE_HIGH
+    )
+    assert pruner.n_pruners == EARLY_STOPPING_RATE_HIGH - EARLY_STOPPING_RATE_LOW + 1
+    n_pruners = pruner.n_pruners
+
+    study = optuna.study.create_study(sampler=optuna.samplers.RandomSampler(), pruner=pruner)
+
+    def objective(trial):
+        # type: (Trial) -> float
+
+        for i in range(N_REPORTS):
+            trial.report(i)
+
+        return 1.0
+
+    study.optimize(objective, n_trials=n_pruners * EXPECTED_N_TRIALS_PER_BRACKET)
+
+    trials = study.trials
+    assert len(trials) == n_pruners * EXPECTED_N_TRIALS_PER_BRACKET
+
+
+def test_warn_on_TPESampler():
+    # type: () -> None
+
+    with pytest.warns(UserWarning):
+        optuna.study.create_study(pruner=optuna.pruners.HyperbandPruner())

--- a/tests/pruners_tests/test_hyperband.py
+++ b/tests/pruners_tests/test_hyperband.py
@@ -15,6 +15,13 @@ N_REPORTS = 10
 EXPECTED_N_TRIALS_PER_BRACKET = 10
 
 
+def test_warn_on_TPESampler():
+    # type: () -> None
+
+    with pytest.warns(UserWarning):
+        optuna.study.create_study(pruner=optuna.pruners.HyperbandPruner())
+
+
 def test_hyperband_pruner_intermediate_values():
     # type: () -> None
 
@@ -24,7 +31,7 @@ def test_hyperband_pruner_intermediate_values():
         n_brackets=N_BRACKETS
     )
 
-    study = optuna.study.create_study(pruner=pruner)
+    study = optuna.study.create_study(sampler=optuna.samplers.RandomSampler(), pruner=pruner)
 
     def objective(trial):
         # type: (Trial) -> float
@@ -48,21 +55,21 @@ def test_bracket_study():
         reduction_factor=REDUCTION_FACTOR,
         n_brackets=N_BRACKETS
     )
-    study = optuna.study.create_study(pruner=pruner)
+    study = optuna.study.create_study(sampler=optuna.samplers.RandomSampler(), pruner=pruner)
     bracket_study = pruner._create_bracket_study(study, 0)
 
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(AttributeError):
         bracket_study.optimize(lambda *args: 1.0)
 
     for attr in ('set_user_attr', 'set_system_attr'):
-        with pytest.raises(NotImplementedError):
+        with pytest.raises(AttributeError):
             getattr(bracket_study, attr)('abc', 100)
 
     for attr in ('user_attrs', 'system_attrs'):
-        with pytest.raises(NotImplementedError):
+        with pytest.raises(AttributeError):
             getattr(bracket_study, attr)
 
-    with pytest.raises(Exception):
+    with pytest.raises(AttributeError):
         bracket_study.trials_dataframe()
 
     bracket_study.get_trials()
@@ -75,10 +82,3 @@ def test_bracket_study():
     # we cannot do `assert isinstance(bracket_study, _BracketStudy)`.
     # This is why the below line is ignored by mypy checks.
     bracket_study._bracket_id  # type: ignore
-
-
-def test_warn_on_TPESampler():
-    # type: () -> None
-
-    with pytest.warns(UserWarning):
-        optuna.study.create_study(pruner=optuna.pruners.HyperbandPruner())

--- a/tests/pruners_tests/test_hyperband.py
+++ b/tests/pruners_tests/test_hyperband.py
@@ -51,8 +51,8 @@ def test_bracket_study():
         min_early_stopping_rate_low=EARLY_STOPPING_RATE_LOW,
         min_early_stopping_rate_high=EARLY_STOPPING_RATE_HIGH
     )
-    study = optuna.study.create_study(sampler=optuna.samplers.RandomSampler(), pruner=pruner)
-    bracket_study = study.pruner._create_bracket_study(study, 0)
+    study = optuna.study.create_study(pruner=pruner)
+    bracket_study = pruner._create_bracket_study(study, 0)
 
     with pytest.raises(Exception):
-        bracket_study.optimize(objective=lambda *args: 1.0)
+        bracket_study.optimize(lambda *args: 1.0)

--- a/tests/pruners_tests/test_hyperband.py
+++ b/tests/pruners_tests/test_hyperband.py
@@ -1,5 +1,3 @@
-import pytest
-
 import optuna
 from optuna import type_checking
 
@@ -23,8 +21,8 @@ def test_hyperband_pruner_intermediate_values():
         min_early_stopping_rate_low=EARLY_STOPPING_RATE_LOW,
         min_early_stopping_rate_high=EARLY_STOPPING_RATE_HIGH
     )
-    assert pruner.n_pruners == EARLY_STOPPING_RATE_HIGH - EARLY_STOPPING_RATE_LOW + 1
-    n_pruners = pruner.n_pruners
+    assert pruner._n_pruners == EARLY_STOPPING_RATE_HIGH - EARLY_STOPPING_RATE_LOW + 1
+    n_pruners = pruner._n_pruners
 
     study = optuna.study.create_study(sampler=optuna.samplers.RandomSampler(), pruner=pruner)
 

--- a/tests/pruners_tests/test_hyperband.py
+++ b/tests/pruners_tests/test_hyperband.py
@@ -51,5 +51,27 @@ def test_bracket_study():
     study = optuna.study.create_study(pruner=pruner)
     bracket_study = pruner._create_bracket_study(study, 0)
 
-    with pytest.raises(Exception):
+    with pytest.raises(NotImplementedError):
         bracket_study.optimize(lambda *args: 1.0)
+
+    for attr in ('set_user_attr', 'set_system_attr'):
+        with pytest.raises(NotImplementedError):
+            getattr(bracket_study, attr)('abc', 100)
+
+    for attr in ('user_attrs', 'system_attrs'):
+        with pytest.raises(NotImplementedError):
+            getattr(bracket_study, attr)
+
+    with pytest.raises(Exception):
+        bracket_study.trials_dataframe()
+
+    bracket_study.get_trials()
+    bracket_study.direction
+    bracket_study._storage
+    bracket_study._study_id
+    bracket_study.pruner
+    bracket_study.study_name
+    # As `_BracketStudy` is defined inside `HyperbandPruner`,
+    # we cannot do `assert isinstance(bracket_study, _BracketStudy)`.
+    # This is why the below line is ignored by mypy checks.
+    bracket_study._bracket_id  # type: ignore

--- a/tests/pruners_tests/test_hyperband.py
+++ b/tests/pruners_tests/test_hyperband.py
@@ -1,5 +1,8 @@
+import pytest
+
 import optuna
 from optuna import type_checking
+from optuna.pruners.hyperband import _BracketStudy
 
 if type_checking.TYPE_CHECKING:
     from optuna.trial import Trial  # NOQA
@@ -38,3 +41,19 @@ def test_hyperband_pruner_intermediate_values():
 
     trials = study.trials
     assert len(trials) == n_pruners * EXPECTED_N_TRIALS_PER_BRACKET
+
+
+def test_bracket_study():
+    # type: () -> None
+
+    pruner = optuna.pruners.HyperbandPruner(
+        min_resource=MIN_RESOURCE,
+        reduction_factor=REDUCTION_FACTOR,
+        min_early_stopping_rate_low=EARLY_STOPPING_RATE_LOW,
+        min_early_stopping_rate_high=EARLY_STOPPING_RATE_HIGH
+    )
+    study = optuna.study.create_study(sampler=optuna.samplers.RandomSampler(), pruner=pruner)
+    bracket_study = _BracketStudy(study, 0)
+
+    with pytest.raises(Exception):
+        bracket_study.optimize(objective=lambda *args: 1.0)

--- a/tests/pruners_tests/test_hyperband.py
+++ b/tests/pruners_tests/test_hyperband.py
@@ -8,6 +8,7 @@ if type_checking.TYPE_CHECKING:
 
 MIN_RESOURCE = 1
 REDUCTION_FACTOR = 2
+N_BRACKETS = 4
 EARLY_STOPPING_RATE_LOW = 0
 EARLY_STOPPING_RATE_HIGH = 3
 N_REPORTS = 10
@@ -20,13 +21,10 @@ def test_hyperband_pruner_intermediate_values():
     pruner = optuna.pruners.HyperbandPruner(
         min_resource=MIN_RESOURCE,
         reduction_factor=REDUCTION_FACTOR,
-        min_early_stopping_rate_low=EARLY_STOPPING_RATE_LOW,
-        min_early_stopping_rate_high=EARLY_STOPPING_RATE_HIGH
+        n_brackets=N_BRACKETS
     )
-    assert pruner._n_pruners == EARLY_STOPPING_RATE_HIGH - EARLY_STOPPING_RATE_LOW + 1
-    n_pruners = pruner._n_pruners
 
-    study = optuna.study.create_study(sampler=optuna.samplers.RandomSampler(), pruner=pruner)
+    study = optuna.study.create_study(pruner=pruner)
 
     def objective(trial):
         # type: (Trial) -> float
@@ -36,10 +34,10 @@ def test_hyperband_pruner_intermediate_values():
 
         return 1.0
 
-    study.optimize(objective, n_trials=n_pruners * EXPECTED_N_TRIALS_PER_BRACKET)
+    study.optimize(objective, n_trials=N_BRACKETS * EXPECTED_N_TRIALS_PER_BRACKET)
 
     trials = study.trials
-    assert len(trials) == n_pruners * EXPECTED_N_TRIALS_PER_BRACKET
+    assert len(trials) == N_BRACKETS * EXPECTED_N_TRIALS_PER_BRACKET
 
 
 def test_bracket_study():
@@ -48,8 +46,7 @@ def test_bracket_study():
     pruner = optuna.pruners.HyperbandPruner(
         min_resource=MIN_RESOURCE,
         reduction_factor=REDUCTION_FACTOR,
-        min_early_stopping_rate_low=EARLY_STOPPING_RATE_LOW,
-        min_early_stopping_rate_high=EARLY_STOPPING_RATE_HIGH
+        n_brackets=N_BRACKETS
     )
     study = optuna.study.create_study(pruner=pruner)
     bracket_study = pruner._create_bracket_study(study, 0)

--- a/tests/pruners_tests/test_hyperband.py
+++ b/tests/pruners_tests/test_hyperband.py
@@ -40,10 +40,3 @@ def test_hyperband_pruner_intermediate_values():
 
     trials = study.trials
     assert len(trials) == n_pruners * EXPECTED_N_TRIALS_PER_BRACKET
-
-
-def test_warn_on_TPESampler():
-    # type: () -> None
-
-    with pytest.warns(UserWarning):
-        optuna.study.create_study(pruner=optuna.pruners.HyperbandPruner())

--- a/tests/pruners_tests/test_hyperband.py
+++ b/tests/pruners_tests/test_hyperband.py
@@ -75,3 +75,10 @@ def test_bracket_study():
     # we cannot do `assert isinstance(bracket_study, _BracketStudy)`.
     # This is why the below line is ignored by mypy checks.
     bracket_study._bracket_id  # type: ignore
+
+
+def test_warn_on_TPESampler():
+    # type: () -> None
+
+    with pytest.warns(UserWarning):
+        optuna.study.create_study(pruner=optuna.pruners.HyperbandPruner())

--- a/tests/pruners_tests/test_hyperband.py
+++ b/tests/pruners_tests/test_hyperband.py
@@ -2,7 +2,6 @@ import pytest
 
 import optuna
 from optuna import type_checking
-from optuna.pruners.hyperband import _BracketStudy
 
 if type_checking.TYPE_CHECKING:
     from optuna.trial import Trial  # NOQA
@@ -53,7 +52,7 @@ def test_bracket_study():
         min_early_stopping_rate_high=EARLY_STOPPING_RATE_HIGH
     )
     study = optuna.study.create_study(sampler=optuna.samplers.RandomSampler(), pruner=pruner)
-    bracket_study = _BracketStudy(study, 0)
+    bracket_study = study.pruner._create_bracket_study(study, 0)
 
     with pytest.raises(Exception):
         bracket_study.optimize(objective=lambda *args: 1.0)


### PR DESCRIPTION
<!-- Thank you for creating a pull request!

Please go through [our contribution guide][CONTRIBUTING.md] to hopefully get your changes merged quicker.

[CONTRIBUTING.md]: https://github.com/optuna/optuna/blob/master/CONTRIBUTING.md -->

~~This depends on #808~~
The algorithm would behave differently from the paper if the sampler is `TPESampler` because there is no way to filter out the trials of brackets other than that of the running trial.

---

~~Although #785 and #805 are for Hyperband, this PR follows another design policy.
The core design of #785 is to realize filtering by adding an attribute that represents pruner to Trial.
It will make `Study` more complex while it can keep the current loosely connected relationship between `Sampler` and `Pruner`.~~

~~On the other hand, the policy of this PR does not implement any filtering of trials.
This means that we will need to add some interaction between `HyperbandPruner` and `Sampler`, especially `TPESampler`.~~

EDIT:
In this implementation, trials are filtered by `bracket_id` that is computed by `HyperbandPruner._get_bracket_id` and this filtering is enabled by implementing `_BracketStudy` which just wraps `Study` for the `HyperbandPruner` use only. The idea is suggested in https://github.com/optuna/optuna/pull/809#discussion_r359688632.