### PR TITLE
Initial implementation of 'auto' for `min_resource`

### DIFF
--- a/optuna/pruners/successive_halving.py
+++ b/optuna/pruners/successive_halving.py
@@ -159,7 +159,9 @@ class SuccessiveHalvingPruner(BasePruner):
 
         # get the number of steps and divide it by 100.
         complete_trial = complete_trials[0]  # type: FrozenTrial
-        self._min_resource = complete_trial.last_step // 100
+        last_step = complete_trial.last_step
+        if last_step is not None:
+            self._min_resource = last_step // 100
 
 
 def _get_current_rung(trial):

--- a/optuna/pruners/successive_halving.py
+++ b/optuna/pruners/successive_halving.py
@@ -124,7 +124,7 @@ class SuccessiveHalvingPruner(BasePruner):
             if self._min_resource is None:
                 if trials is None:
                     trials = study.get_trials(deepcopy=False)
-                self._estimate_min_resource(trials)
+                self._min_resource = _estimate_min_resource(trials)
                 if self._min_resource is None:
                     return False
 
@@ -151,23 +151,21 @@ class SuccessiveHalvingPruner(BasePruner):
 
             rung += 1
 
-    def _estimate_min_resource(self, trials):
-        # type: (Optional[List[FrozenTrial]]) -> None
 
-        if trials is None:
-            return
+def _estimate_min_resource(trials):
+    # type: (List[FrozenTrial]) -> Optional[int]
 
-        n_steps = [
-            t.last_step for t in trials
-            if t.state == TrialState.COMPLETE and t.last_step is not None
-        ]
+    n_steps = [
+        t.last_step for t in trials
+        if t.state == TrialState.COMPLETE and t.last_step is not None
+    ]
 
-        if not n_steps:
-            return
+    if not n_steps:
+        return None
 
-        # Get the maximum number of steps and divide it by 100.
-        last_step = max(n_steps)
-        self._min_resource = max(last_step // 100, 1)
+    # Get the maximum number of steps and divide it by 100.
+    last_step = max(n_steps)
+    return max(last_step // 100, 1)
 
 
 def _get_current_rung(trial):

--- a/optuna/pruners/successive_halving.py
+++ b/optuna/pruners/successive_halving.py
@@ -80,8 +80,8 @@ class SuccessiveHalvingPruner(BasePruner):
             referred to as :math:`s`).
     """
 
-    def __init__(self, min_resource=1, reduction_factor=4, min_early_stopping_rate=0):
-        # type: (int, int, int) -> None
+    def __init__(self, min_resource='auto', reduction_factor=4, min_early_stopping_rate=0):
+        # type: (Union[str, int], int, int) -> None
 
         if min_resource != 'auto' and min_resource < 1:
             raise ValueError('The value of `min_resource` is {}, '
@@ -161,7 +161,9 @@ class SuccessiveHalvingPruner(BasePruner):
         complete_trial = complete_trials[0]  # type: FrozenTrial
         last_step = complete_trial.last_step
         if last_step is not None:
-            self._min_resource = last_step // 100
+            hundredth = last_step // 100
+            self._min_resource = hundredth if hundredth > 0 else 1
+            assert self._min_resource > 0
 
 
 def _get_current_rung(trial):

--- a/optuna/pruners/successive_halving.py
+++ b/optuna/pruners/successive_halving.py
@@ -85,7 +85,7 @@ class SuccessiveHalvingPruner(BasePruner):
 
         if isinstance(min_resource, str) and min_resource != 'auto':
             raise ValueError(
-                "The value of `min_resource` is {}"
+                "The value of `min_resource` is {}, "
                 "but must be either `min_resource` >= 1 or 'auto'".format(min_resource)
             )
 

--- a/optuna/pruners/successive_halving.py
+++ b/optuna/pruners/successive_halving.py
@@ -123,6 +123,8 @@ class SuccessiveHalvingPruner(BasePruner):
 
         while True:
             if self._min_resource is None:
+                if trials is None:
+                    trials = study.get_trials(deepcopy=False)
                 self._estimate_min_resource(trials)
                 if self._min_resource is None:
                     return False

--- a/optuna/pruners/successive_halving.py
+++ b/optuna/pruners/successive_halving.py
@@ -168,7 +168,7 @@ class SuccessiveHalvingPruner(BasePruner):
 
         # Get the maximum number of steps and divide it by 100.
         last_step = max(n_steps)
-        self._min_resource = max(int(last_step / 100), 1)
+        self._min_resource = max(last_step // 100, 1)
 
 
 def _get_current_rung(trial):

--- a/optuna/pruners/successive_halving.py
+++ b/optuna/pruners/successive_halving.py
@@ -83,7 +83,7 @@ class SuccessiveHalvingPruner(BasePruner):
     def __init__(self, min_resource=1, reduction_factor=4, min_early_stopping_rate=0):
         # type: (int, int, int) -> None
 
-        if min_resource != 'auto' or min_resource < 1:
+        if min_resource != 'auto' and min_resource < 1:
             raise ValueError('The value of `min_resource` is {}, '
                              "but must be either `min_resource >= 1` or 'auto'".format(
                                  min_resource))
@@ -92,10 +92,10 @@ class SuccessiveHalvingPruner(BasePruner):
             raise ValueError('The value of `reduction_factor` is {}, '
                              'but must be `reduction_factor >= 2`'.format(reduction_factor))
 
-        if min_early_stopping_rate != 'auto' or min_early_stopping_rate < 0:
+        if min_early_stopping_rate < 0:
             raise ValueError(
                 'The value of `min_early_stopping_rate` is {}, '
-                "but must be `min_early_stopping_rate >= 0` or 'auto'".format(
+                "but must be `min_early_stopping_rate >= 0`".format(
                     min_early_stopping_rate))
 
         self._auto_min_resource = min_resource == 'auto'

--- a/optuna/pruners/successive_halving.py
+++ b/optuna/pruners/successive_halving.py
@@ -49,9 +49,8 @@ class SuccessiveHalvingPruner(BasePruner):
             A parameter for specifying the minimum resource allocated to a trial
             (in the `paper <http://arxiv.org/abs/1810.05934>`_ this parameter is
             referred to as :math:`r`).
-            This parameter defaults to ``'auto'`` that means this pruner estimates an appropriate
-            minimum resource by the required number of a ``COMPLETE``
-            :class:`~optuna.structs.FrozenTrial`'s steps.
+            This parameter defaults to 'auto' where the value is determined based on a heuristic
+            that looks at the number of required steps for the first trial to complete.
 
             A trial is never pruned until it executes
             :math:`\\mathsf{min}\\_\\mathsf{resource} \\times

--- a/optuna/pruners/successive_halving.py
+++ b/optuna/pruners/successive_halving.py
@@ -160,7 +160,7 @@ class SuccessiveHalvingPruner(BasePruner):
 
         n_steps = [
             t.last_step for t in trials
-            if t == TrialState.COMPLETE and t.last_step is not None
+            if t.state == TrialState.COMPLETE and t.last_step is not None
         ]
 
         if not n_steps:

--- a/tests/pruners_tests/test_successive_halving.py
+++ b/tests/pruners_tests/test_successive_halving.py
@@ -111,23 +111,30 @@ def test_successive_halving_pruner_with_nan():
 def test_successive_halving_pruner_with_auto_min_resource():
     # type: () -> None
 
-    pruner = optuna.pruners.SuccessiveHalvingPruner('auto')
+    pruner = optuna.pruners.SuccessiveHalvingPruner(min_resource='auto')
     study = optuna.study.create_study(sampler=optuna.samplers.RandomSampler(), pruner=pruner)
 
     assert pruner._min_resource is None
 
     def objective(trial):
-        tmp = trial.suggest_uniform('sample', 0, 1)
+        # type: (optuna.trial.Trial) -> float
+
         for i in range(3):
-            trial.report(tmp / (i + 1))
+            trial.report(1.0 / (i + 1))
             if trial.should_prune():
                 raise optuna.exceptions.TrialPruned()
-        return 1.0 - tmp
+        return 1.0
 
     study.optimize(objective, n_trials=3)
-    # FIXME(crcrpar): No intermediate_values available
-    # trials = study.trials
-    # assert pruner._min_resource is not None and pruner._min_resource == max(1, 3 // 100), trials
+    # FIXME (crcrpar)
+    # assert pruner._min_resource is not None and pruner._min_resource > 0
+
+
+def test_successive_halving_pruner_with_invalid_str_to_min_resource():
+    # type: () -> None
+
+    with pytest.raises(ValueError):
+        optuna.pruners.SuccessiveHalvingPruner(min_resource='fixed')
 
 
 def test_successive_halving_pruner_min_resource_parameter():

--- a/tests/pruners_tests/test_successive_halving.py
+++ b/tests/pruners_tests/test_successive_halving.py
@@ -120,14 +120,13 @@ def test_successive_halving_pruner_with_auto_min_resource():
         # type: (optuna.trial.Trial) -> float
 
         for i in range(3):
-            trial.report(1.0 / (i + 1))
+            trial.report(1.0 / (i + 1), i)
             if trial.should_prune():
                 raise optuna.exceptions.TrialPruned()
         return 1.0
 
     study.optimize(objective, n_trials=3)
-    # FIXME (crcrpar)
-    # assert pruner._min_resource is not None and pruner._min_resource > 0
+    assert pruner._min_resource is not None and pruner._min_resource > 0
 
 
 def test_successive_halving_pruner_with_invalid_str_to_min_resource():

--- a/tests/pruners_tests/test_successive_halving.py
+++ b/tests/pruners_tests/test_successive_halving.py
@@ -108,8 +108,10 @@ def test_successive_halving_pruner_with_nan():
     assert pruner.prune(study=study, trial=study._storage.get_trial(trial._trial_id))
 
 
-def test_successive_halving_pruner_with_auto_min_resource():
-    # type: () -> None
+@pytest.mark.parametrize('n_reports', range(3))
+@pytest.mark.parametrize('n_trials', [1, 2])
+def test_successive_halving_pruner_with_auto_min_resource(n_reports, n_trials):
+    # type: (int, int) -> None
 
     pruner = optuna.pruners.SuccessiveHalvingPruner(min_resource='auto')
     study = optuna.study.create_study(sampler=optuna.samplers.RandomSampler(), pruner=pruner)
@@ -119,14 +121,17 @@ def test_successive_halving_pruner_with_auto_min_resource():
     def objective(trial):
         # type: (optuna.trial.Trial) -> float
 
-        for i in range(3):
+        for i in range(n_reports):
             trial.report(1.0 / (i + 1), i)
             if trial.should_prune():
                 raise optuna.exceptions.TrialPruned()
         return 1.0
 
-    study.optimize(objective, n_trials=3)
-    assert pruner._min_resource is not None and pruner._min_resource > 0
+    study.optimize(objective, n_trials=n_trials)
+    if n_reports > 0 and n_trials > 1:
+        assert pruner._min_resource is not None and pruner._min_resource > 0
+    else:
+        assert pruner._min_resource is None
 
 
 def test_successive_halving_pruner_with_invalid_str_to_min_resource():

--- a/tests/pruners_tests/test_successive_halving.py
+++ b/tests/pruners_tests/test_successive_halving.py
@@ -108,6 +108,28 @@ def test_successive_halving_pruner_with_nan():
     assert pruner.prune(study=study, trial=study._storage.get_trial(trial._trial_id))
 
 
+def test_successive_halving_pruner_with_auto_min_resource():
+    # type: () -> None
+
+    pruner = optuna.pruners.SuccessiveHalvingPruner('auto')
+    study = optuna.study.create_study(sampler=optuna.samplers.RandomSampler(), pruner=pruner)
+
+    assert pruner._min_resource is None
+
+    def objective(trial):
+        tmp = trial.suggest_uniform('sample', 0, 1)
+        for i in range(3):
+            trial.report(tmp / (i + 1))
+            if trial.should_prune():
+                raise optuna.exceptions.TrialPruned()
+        return 1.0 - tmp
+
+    study.optimize(objective, n_trials=3)
+    # FIXME(crcrpar): No intermediate_values available
+    # trials = study.trials
+    # assert pruner._min_resource is not None and pruner._min_resource == max(1, 3 // 100), trials
+
+
 def test_successive_halving_pruner_min_resource_parameter():
     # type: () -> None
 


### PR DESCRIPTION
<!-- Thank you for creating a pull request!

Please go through [our contribution guide][CONTRIBUTING.md] to hopefully get your changes merged quicker.

[CONTRIBUTING.md]: https://github.com/optuna/optuna/blob/master/CONTRIBUTING.md -->

In this PR, I try to implement `'auto'` mode for `min_resource` in `SuccessiveHalvingPruner`.
The motivation is that I want to remove a hyperparameter in the hyperparameter optimization workflow.

The initial logic might be a bit too naive: if there is a `Trial` with its `state` is `COMPLETE`, set the `min_resource` to the hundredth of the number of steps of it.

<!--I tentatively checked this PR does not degrade the performance terribly and the results and the change are as follow.-->

<!--```
# master (commit e75c7f0db48978f9a77a3663d3b41a67305f54ed)
Study statistics:
  Number of finished trials:  100
  Number of pruned trials:  99
  Number of complete trials:  1
Best trial:
  Value:  0.9473684210526315
  Params:
    alpha: 0.001219699835809836

# this PR (commit f5e88dff51240f9d540a03732418161361e9f1ad)
Study statistics:
  Number of finished trials:  100
  Number of pruned trials:  96
  Number of complete trials:  4
Best trial:
  Value:  0.9736842105263158
  Params:
    alpha: 0.0023708809016833167
```-->

<!--```
diff --git a/examples/pruning/simple.py b/examples/pruning/simple.py
index b4446025..d0803a21 100644
--- a/examples/pruning/simple.py
+++ b/examples/pruning/simple.py
@@ -45,7 +45,8 @@ def objective(trial):


 if __name__ == '__main__':
-    study = optuna.create_study(direction='maximize')
+    pruner = optuna.pruners.SuccessiveHalvingPruner()
+    study = optuna.create_study(pruner=pruner, direction='maximize')
     study.optimize(objective, n_trials=100)

     pruned_trials = [t for t in study.trials if t.state == optuna.structs.TrialState.PRUNED]
```-->