### PR TITLE
Fix indentation in tutorial/index.rst

### DIFF
--- a/docs/source/tutorial/index.rst
+++ b/docs/source/tutorial/index.rst
@@ -4,7 +4,7 @@ Tutorial
 ========
 
 .. toctree::
-    :maxdepth: 2
+   :maxdepth: 2
 
    first
    configurations


### PR DESCRIPTION
This PR aligns indentation in `tutorial/index.rst` to fix the following error.

```
optuna/docs/source/tutorial/index.rst:6: WARNING: toctree contains reference to nonexisting document 'tutorial/ :maxdepth: 2'
```

<img width="1132" alt="Screen Shot 2019-12-27 at 10 42 48" src="https://user-images.githubusercontent.com/17039389/71496248-a4e60e80-2895-11ea-8a7d-5c8e327d6d6f.png">

https://circleci.com/gh/optuna/optuna/24947#tests/containers/0
