### PR TITLE
Fix warnings in the documentation build

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    =
+SPHINXOPTS    = -W
 SPHINXBUILD   = sphinx-build
 SPHINXPROJ    = Optuna
 SOURCEDIR     = source

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    = -W
+SPHINXOPTS    = -W --keep-going
 SPHINXBUILD   = sphinx-build
 SPHINXPROJ    = Optuna
 SOURCEDIR     = source

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -98,7 +98,7 @@ html_favicon = '../image/favicon.ico'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+# html_static_path = ['_static']
 
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.

--- a/docs/source/privacy.rst
+++ b/docs/source/privacy.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 Privacy Policy
 ==============
 

--- a/docs/source/reference/index.rst
+++ b/docs/source/reference/index.rst
@@ -1,5 +1,3 @@
-.. module:: optuna
-
 API Reference
 =============
 

--- a/docs/source/tutorial/index.rst
+++ b/docs/source/tutorial/index.rst
@@ -1,5 +1,3 @@
-.. module:: optuna
-
 Tutorial
 ========
 

--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,7 @@ def get_extras_require():
             'scikit-learn>=0.19.0',
         ],
         'document': [
+            'lightgbm',
             'sphinx',
             'sphinx_rtd_theme',
         ],


### PR DESCRIPTION
This PR:
- Fixes the existing warnings in the documentation build.
- Adds the option `-W` to `SPHINXOPTS` in `Makefile` to treat warnings as errors and make the CI fail when warnings are raised ([ref](https://www.sphinx-doc.org/en/master/man/sphinx-build.html#id6)).
- Addresses #817 and #818 