### PR TITLE
Add version constraint of pillow to avoid torchvision's issue.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -78,14 +78,14 @@ def get_extras_require():
             'sphinx_rtd_theme',
         ],
         'example': [
-            # TODO(Yanase): Remove pillow from dependencies after torchvision includes the
-            # following change: https://github.com/pytorch/vision/pull/1501.
-            'pillow<7',
             'catboost',
             'chainer',
             'lightgbm',
             'mlflow',
             'mxnet',
+            # TODO(Yanase): Remove pillow from dependencies after torchvision includes the
+            # following change: https://github.com/pytorch/vision/pull/1501.
+            'pillow<7',
             'scikit-image',
             # TODO(Yanase): Update sklearn integration to support v0.22.1 or newer.
             # See https://github.com/optuna/optuna/issues/825 for further details.
@@ -105,9 +105,6 @@ def get_extras_require():
             'torchvision'
         ] if sys.version_info[:2] < (3, 8) else []),
         'testing': [
-            # TODO(Yanase): Remove pillow from dependencies after torchvision includes the
-            # following change: https://github.com/pytorch/vision/pull/1501.
-            'pillow<7',
             'bokeh',
             'chainer>=5.0.0',
             'cma',
@@ -116,6 +113,9 @@ def get_extras_require():
             'mpi4py',
             'mxnet',
             'pandas',
+            # TODO(Yanase): Remove pillow from dependencies after torchvision includes the
+            # following change: https://github.com/pytorch/vision/pull/1501.
+            'pillow<7',
             'plotly>=4.0.0',
             'pytest',
             # TODO(Yanase): Update sklearn integration to support v0.22.1 or newer.

--- a/setup.py
+++ b/setup.py
@@ -78,6 +78,9 @@ def get_extras_require():
             'sphinx_rtd_theme',
         ],
         'example': [
+            # TODO(Yanase): Remove pillow from dependencies after torchvision includes the
+            # following change: https://github.com/pytorch/vision/pull/1501.
+            'pillow<7',
             'catboost',
             'chainer',
             'lightgbm',
@@ -102,6 +105,9 @@ def get_extras_require():
             'torchvision'
         ] if sys.version_info[:2] < (3, 8) else []),
         'testing': [
+            # TODO(Yanase): Remove pillow from dependencies after torchvision includes the
+            # following change: https://github.com/pytorch/vision/pull/1501.
+            'pillow<7',
             'bokeh',
             'chainer>=5.0.0',
             'cma',


### PR DESCRIPTION
This PR will fix the CI failure of daily build (i.e., https://circleci.com/workflow-run/ae35c239-ec79-4b39-8c7f-da60b816b307.). 

It restricts the version of pillow (<7) to avoid the torchvision's issue reported in  https://github.com/pytorch/vision/issues/1712. A new `torchvision` which resolves the issue will be released soon, and we can remove this version constraint after that.