### PR TITLE
Update `TPESampler` to support `HyperbandPruner`

### DIFF
--- a/optuna/pruners/hyperband.py
+++ b/optuna/pruners/hyperband.py
@@ -24,6 +24,21 @@ class HyperbandPruner(BasePruner):
     Note that this implementation does not take as inputs the maximum amount of resource to
     a single SHA noted as :math:`R` in the paper.
 
+    .. note::
+        If you use ``HyperbandPruner`` with :class:`~optuna.samplers.TPESampler`,
+        it's recommended to consider to set larger ``n_trials`` or ``timeout`` to make full use of
+        the characteristics of :class:`~optuna.samplers.TPESampler`
+        because :class:`~optuna.samplers.TPESampler` uses some (by default, :math:`10`)
+        :class:`~optuna.trial.Trial`s for its startup.
+
+        As Hyperband runs multiple :class:`~optuna.pruners.SuccessiveHalvingPruner` and collect
+        trials based on the current :class:`~optuna.trial.Trial`'s bracket ID, each bracket
+        needs to observe more than :math:`10` :class:`~optuna.trial.Trial`s
+        for :class:`~optuna.samplers.TPESampler` to adapt its search space.
+
+        Thus, for example, if ``HyperbandPruner`` has :math:`4` pruners in it,
+        at least :math:`4 \times 10` pruners are consumed for startup.
+
     Args:
         min_resource:
             A parameter for specifying the minimum resource allocated to a trial noted as :math:`r`

--- a/optuna/pruners/hyperband.py
+++ b/optuna/pruners/hyperband.py
@@ -29,11 +29,11 @@ class HyperbandPruner(BasePruner):
         it's recommended to consider to set larger ``n_trials`` or ``timeout`` to make full use of
         the characteristics of :class:`~optuna.samplers.TPESampler`
         because :class:`~optuna.samplers.TPESampler` uses some (by default, :math:`10`)
-        :class:`~optuna.trial.Trial`\s for its startup.
+        :class:`~optuna.trial.Trial`\\ s for its startup.
 
         As Hyperband runs multiple :class:`~optuna.pruners.SuccessiveHalvingPruner` and collect
-        trials based on the current :class:`~optuna.trial.Trial`'s bracket ID, each bracket
-        needs to observe more than :math:`10` :class:`~optuna.trial.Trial`s
+        trials based on the current :class:`~optuna.trial.Trial`\\ 's bracket ID, each bracket
+        needs to observe more than :math:`10` :class:`~optuna.trial.Trial`\\ s
         for :class:`~optuna.samplers.TPESampler` to adapt its search space.
 
         Thus, for example, if ``HyperbandPruner`` has :math:`4` pruners in it,
@@ -49,7 +49,7 @@ class HyperbandPruner(BasePruner):
             :math:`\\eta` in the paper. See the details for
             :class:`~optuna.pruners.SuccessiveHalvingPruner`.
         n_brackets:
-            The number of :class:`~optuna.pruners.SuccessiveHalvingPruner`\\s (brackets).
+            The number of :class:`~optuna.pruners.SuccessiveHalvingPruner`\\ s (brackets).
         min_early_stopping_rate_low:
             A parameter for specifying the minimum early-stopping rate.
             This parameter is related to a parameter that is referred to as :math:`r` and used in

--- a/optuna/pruners/hyperband.py
+++ b/optuna/pruners/hyperband.py
@@ -29,7 +29,7 @@ class HyperbandPruner(BasePruner):
         it's recommended to consider to set larger ``n_trials`` or ``timeout`` to make full use of
         the characteristics of :class:`~optuna.samplers.TPESampler`
         because :class:`~optuna.samplers.TPESampler` uses some (by default, :math:`10`)
-        :class:`~optuna.trial.Trial`s for its startup.
+        :class:`~optuna.trial.Trial`\s for its startup.
 
         As Hyperband runs multiple :class:`~optuna.pruners.SuccessiveHalvingPruner` and collect
         trials based on the current :class:`~optuna.trial.Trial`'s bracket ID, each bracket

--- a/optuna/pruners/hyperband.py
+++ b/optuna/pruners/hyperband.py
@@ -37,7 +37,7 @@ class HyperbandPruner(BasePruner):
         for :class:`~optuna.samplers.TPESampler` to adapt its search space.
 
         Thus, for example, if ``HyperbandPruner`` has :math:`4` pruners in it,
-        at least :math:`4 \times 10` pruners are consumed for startup.
+        at least :math:`4 \\times 10` pruners are consumed for startup.
 
     Args:
         min_resource:

--- a/optuna/samplers/tpe/sampler.py
+++ b/optuna/samplers/tpe/sampler.py
@@ -535,15 +535,14 @@ def _get_observation_pairs(study, param_name, trial):
     if study.direction == StudyDirection.MAXIMIZE:
         sign = -1
 
-    _study = study
     if isinstance(study.pruner, HyperbandPruner):
         # Create `_BracketStudy` to use trials that have the same bracket id.
         pruner = study.pruner  # type: HyperbandPruner
-        _study = pruner._create_bracket_study(study, pruner._get_bracket_id(study, trial))
+        study = pruner._create_bracket_study(study, pruner._get_bracket_id(study, trial))
 
     values = []
     scores = []
-    for trial in _study.get_trials(deepcopy=False):
+    for trial in study.get_trials(deepcopy=False):
         if param_name not in trial.params:
             continue
 

--- a/optuna/study.py
+++ b/optuna/study.py
@@ -191,16 +191,6 @@ class Study(BaseStudy):
         self.sampler = sampler or samplers.TPESampler()
         self.pruner = pruner or pruners.MedianPruner()
 
-        if (
-                isinstance(self.sampler, samplers.TPESampler) and
-                isinstance(self.pruner, pruners.HyperbandPruner)):
-            msg = (
-                "The algorithm of TPESampler and HyperbandPruner might behave in a different way "
-                "from the paper of Hyperband because the sampler uses all the trials including "
-                "ones of brackets other than that of currently running trial")
-            warnings.warn(msg, UserWarning)
-            _logger.warning(msg)
-
         self._optimize_lock = threading.Lock()
 
     def __getstate__(self):

--- a/tests/pruners_tests/test_hyperband.py
+++ b/tests/pruners_tests/test_hyperband.py
@@ -15,13 +15,6 @@ N_REPORTS = 10
 EXPECTED_N_TRIALS_PER_BRACKET = 10
 
 
-def test_warn_on_TPESampler():
-    # type: () -> None
-
-    with pytest.warns(UserWarning):
-        optuna.study.create_study(pruner=optuna.pruners.HyperbandPruner())
-
-
 def test_hyperband_pruner_intermediate_values():
     # type: () -> None
 

--- a/tests/samplers_tests/tpe_tests/test_sampler.py
+++ b/tests/samplers_tests/tpe_tests/test_sampler.py
@@ -1,3 +1,5 @@
+import pytest
+
 import optuna
 from optuna.exceptions import TrialPruned
 from optuna.samplers import tpe
@@ -7,11 +9,13 @@ if optuna.type_checking.TYPE_CHECKING:
     from optuna.trial import Trial  # NOQA
 
 
-def test_hyperopt_parameters():
-    # type: () -> None
+@pytest.mark.parametrize('use_hyperband', [False, True])
+def test_hyperopt_parameters(use_hyperband):
+    # type: (bool) -> None
 
     sampler = TPESampler(**TPESampler.hyperopt_parameters())
-    study = optuna.create_study(sampler=sampler)
+    study = optuna.create_study(
+        sampler=sampler, pruner=optuna.pruners.HyperbandPruner() if use_hyperband else None)
     study.optimize(lambda t: t.suggest_uniform('x', 10, 20), n_trials=50)
 
 

--- a/tests/samplers_tests/tpe_tests/test_sampler.py
+++ b/tests/samplers_tests/tpe_tests/test_sampler.py
@@ -39,9 +39,10 @@ def test_get_observation_pairs():
     # direction=minimize.
     study = optuna.create_study(direction='minimize')
     study.optimize(objective, n_trials=5, catch=(RuntimeError,))
-    study._storage.create_new_trial(study._study_id)  # Create a running trial.
+    trial_number = study._storage.create_new_trial(study._study_id)  # Create a running trial.
+    trial = study._storage.get_trial(trial_number)
 
-    assert tpe.sampler._get_observation_pairs(study, 'x') == (
+    assert tpe.sampler._get_observation_pairs(study, 'x', trial) == (
         [5.0, 5.0, 5.0, 5.0],
         [
             (-float('inf'), 5.0),   # COMPLETE
@@ -49,14 +50,14 @@ def test_get_observation_pairs():
             (-3, float('inf')),  # PRUNED (with a NaN intermediate value; it's treated as infinity)
             (float('inf'), 0.0)  # PRUNED (without intermediate values)
         ])
-    assert tpe.sampler._get_observation_pairs(study, 'y') == ([], [])
+    assert tpe.sampler._get_observation_pairs(study, 'y', trial) == ([], [])
 
     # direction=maximize.
     study = optuna.create_study(direction='maximize')
     study.optimize(objective, n_trials=4)
     study._storage.create_new_trial(study._study_id)  # Create a running trial.
 
-    assert tpe.sampler._get_observation_pairs(study, 'x') == (
+    assert tpe.sampler._get_observation_pairs(study, 'x', trial) == (
         [5.0, 5.0, 5.0, 5.0],
         [
             (-float('inf'), -5.0),   # COMPLETE
@@ -64,4 +65,4 @@ def test_get_observation_pairs():
             (-3, float('inf')),  # PRUNED (with a NaN intermediate value; it's treated as infinity)
             (float('inf'), 0.0)  # PRUNED (without intermediate values)
         ])
-    assert tpe.sampler._get_observation_pairs(study, 'y') == ([], [])
+    assert tpe.sampler._get_observation_pairs(study, 'y', trial) == ([], [])


### PR DESCRIPTION
<!-- Thank you for creating a pull request!

Please go through [our contribution guide][CONTRIBUTING.md] to hopefully get your changes merged quicker.

[CONTRIBUTING.md]: https://github.com/optuna/optuna/blob/master/CONTRIBUTING.md -->

~~This PR depends on #809.~~

~~__EDIT__: Until #809 is merged, I'd like reviewers to check and comment on https://github.com/crcrpar/optuna/pull/1. After you think crcrpar#1 OK, I'll cherry-pick the new commits.~~

In this PR, I modified `_get_observation_pairs` in `optuna/samplers/tpe/sampler.py` to use trials that have the same bracket index as the running trial by using `_BracketStudy`.