### PR TITLE
Git ignore `.DS_Store`.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# macOS metadata
+.DS_Store
+
 # Ignore files that examples create
 t10k-images-idx3-ubyte*
 t10k-labels-idx1-ubyte*


### PR DESCRIPTION
Adds the `.DS_Store` metadata file unique to macOS to the git ignore list. This file should in general not be included in the repository.