### PR TITLE
Add integration modules list to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,16 +79,16 @@ study.optimize(objective, n_trials=100)  # Invoke optimization of the objective 
 
 [Integrations modules](https://optuna.readthedocs.io/en/stable/tutorial/pruning.html), which allow pruning, or early stopping, of unpromising trials are available for the following libraries:
 
-XGBoost
-LightGBM
-Chainer 
-Keras
-TensorFlow
-tf.keras
-MXNet
-PyTorch Ignite
-PyTorch Lightning
-FastAI
+* XGBoost
+* LightGBM
+* Chainer 
+* Keras
+* TensorFlow
+* tf.keras
+* MXNet
+* PyTorch Ignite
+* PyTorch Lightning
+* FastAI
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,21 @@ study.optimize(objective, n_trials=100)  # Invoke optimization of the objective 
 ```
 
 
+## Integrations
+
+[Integrations modules](https://optuna.readthedocs.io/en/stable/tutorial/pruning.html), which allow pruning, or early stopping, of unpromising trials are available for the following libraries:
+
+XGBoost
+LightGBM
+Chainer 
+Keras
+TensorFlow
+tf.keras
+MXNet
+PyTorch Ignite
+PyTorch Lightning
+FastAI
+
 ## Installation
 
 Optuna is available at [the Python Package Index](https://pypi.org/project/optuna/) and on [Anaconda Cloud](https://anaconda.org/conda-forge/optuna).


### PR DESCRIPTION
Add the modules that we have created integration modules for to the top of the README.md. We will be reaching out to these libraries and asking for cross-referencing on their README's as well, so we should have this list on the Optuna README as well.