### PR TITLE
Fix keras pruning example code

### DIFF
--- a/optuna/integration/keras.py
+++ b/optuna/integration/keras.py
@@ -24,7 +24,7 @@ class KerasPruningCallback(Callback):
 
         .. code::
 
-            model.fit(X, y, callbacks=KerasPruningCallback(trial, 'val_loss'))
+            model.fit(X, y, callbacks=[KerasPruningCallback(trial, 'val_loss')])
 
     Args:
         trial:


### PR DESCRIPTION
Fixed a sample code in the docstring of `KerasPruningCallback`. `callbacks` should be a list.

Before:
<img width="727" alt="Screen Shot 2020-01-10 at 22 19 47" src="https://user-images.githubusercontent.com/17039389/72155936-96e8cf80-33f7-11ea-8329-577a5119ef44.png">

After:
<img width="727" alt="Screen Shot 2020-01-10 at 22 24 08" src="https://user-images.githubusercontent.com/17039389/72156102-052d9200-33f8-11ea-8744-c3320eb14e31.png">
