### PR TITLE
Fix docstrings of visualization functions.

### DIFF
--- a/optuna/visualization/contour.py
+++ b/optuna/visualization/contour.py
@@ -30,8 +30,7 @@ def plot_contour(study, params=None):
     # type: (Study, Optional[List[str]]) -> go.Figure
     """Plot the parameter relationship as contour plot in a study.
 
-    Note that, If a parameter contains missing values, a trial with missing values is not
-    plotted.
+    Note that, If a parameter contains missing values, a trial with missing values is not plotted.
 
     Example:
 

--- a/optuna/visualization/contour.py
+++ b/optuna/visualization/contour.py
@@ -30,8 +30,8 @@ def plot_contour(study, params=None):
     # type: (Study, Optional[List[str]]) -> go.Figure
     """Plot the parameter relationship as contour plot in a study.
 
-        Note that, If a parameter contains missing values, a trial with missing values is not
-        plotted.
+    Note that, If a parameter contains missing values, a trial with missing values is not
+    plotted.
 
     Example:
 

--- a/optuna/visualization/parallel_coordinate.py
+++ b/optuna/visualization/parallel_coordinate.py
@@ -24,8 +24,7 @@ def plot_parallel_coordinate(study, params=None):
     # type: (Study, Optional[List[str]]) -> go.Figure
     """Plot the high-dimentional parameter relationships in a study.
 
-    Note that, If a parameter contains missing values, a trial with missing values is not
-    plotted.
+    Note that, If a parameter contains missing values, a trial with missing values is not plotted.
 
     Example:
 

--- a/optuna/visualization/parallel_coordinate.py
+++ b/optuna/visualization/parallel_coordinate.py
@@ -24,8 +24,8 @@ def plot_parallel_coordinate(study, params=None):
     # type: (Study, Optional[List[str]]) -> go.Figure
     """Plot the high-dimentional parameter relationships in a study.
 
-        Note that, If a parameter contains missing values, a trial with missing values is not
-        plotted.
+    Note that, If a parameter contains missing values, a trial with missing values is not
+    plotted.
 
     Example:
 

--- a/optuna/visualization/slice.py
+++ b/optuna/visualization/slice.py
@@ -24,8 +24,8 @@ def plot_slice(study, params=None):
     # type: (Study, Optional[List[str]]) -> go.Figure
     """Plot the parameter relationship as slice plot in a study.
 
-        Note that, If a parameter contains missing values, a trial with missing values is not
-        plotted.
+    Note that, If a parameter contains missing values, a trial with missing values is not
+    plotted.
 
     Example:
 

--- a/optuna/visualization/slice.py
+++ b/optuna/visualization/slice.py
@@ -24,8 +24,7 @@ def plot_slice(study, params=None):
     # type: (Study, Optional[List[str]]) -> go.Figure
     """Plot the parameter relationship as slice plot in a study.
 
-    Note that, If a parameter contains missing values, a trial with missing values is not
-    plotted.
+    Note that, If a parameter contains missing values, a trial with missing values is not plotted.
 
     Example:
 


### PR DESCRIPTION
Fixed unaligned docstrings in:
- `plot_contour `
- `plot_parallel_coordinate`
- `plot_slice `


Before:

<img width="573" alt="Screen Shot 2020-01-14 at 22 35 46" src="https://user-images.githubusercontent.com/17039389/72348708-530b0880-371e-11ea-8cf5-c8dfb9046795.png">


After:
<img width="573" alt="Screen Shot 2020-01-14 at 22 35 53" src="https://user-images.githubusercontent.com/17039389/72348730-6322e800-371e-11ea-8eb8-de135d366a65.png">
