### PR TITLE
Update SciPy version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ def get_install_requires():
         'cliff',
         'colorlog',
         'numpy',
-        'scipy<1.4.0,>=1.4.1',
+        'scipy!=1.4.0',
         'sqlalchemy>=1.1.0',
         'tqdm',
         'typing',

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ def get_install_requires():
         'cliff',
         'colorlog',
         'numpy',
-        'scipy>=1.4.1',
+        'scipy<1.4.0,>=1.4.1',
         'sqlalchemy>=1.1.0',
         'tqdm',
         'typing',

--- a/setup.py
+++ b/setup.py
@@ -37,9 +37,7 @@ def get_install_requires():
         'cliff',
         'colorlog',
         'numpy',
-        # TODO(Yanase): Remove the version constraint when the CI error is solved by new versions.
-        # See https://github.com/optuna/optuna/issues/800 for further details.
-        'scipy<1.4.0',
+        'scipy>=1.4.1',
         'sqlalchemy>=1.1.0',
         'tqdm',
         'typing',


### PR DESCRIPTION
Related to #800
In SciPy 1.4.1, segmentation faults no longer occur.
https://github.com/scipy/scipy/releases/tag/v1.4.1
（Confirmed to pass the CI on my local environment）
Let's bump the version of SciPy.