### PR TITLE
Require torchvision>=0.5.0 with Pillow version fix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -83,9 +83,6 @@ def get_extras_require():
             'lightgbm',
             'mlflow',
             'mxnet',
-            # TODO(Yanase): Remove pillow from dependencies after torchvision includes the
-            # following change: https://github.com/pytorch/vision/pull/1501.
-            'pillow<7',
             'scikit-image',
             # TODO(Yanase): Update sklearn integration to support v0.22.1 or newer.
             # See https://github.com/optuna/optuna/issues/825 for further details.
@@ -102,7 +99,7 @@ def get_extras_require():
             # See https://github.com/optuna/optuna/issues/565 for further details.
             'tensorflow<2.0.0',
             'torch',
-            'torchvision'
+            'torchvision>=0.5.0'
         ] if sys.version_info[:2] < (3, 8) else []),
         'testing': [
             'bokeh',
@@ -113,9 +110,6 @@ def get_extras_require():
             'mpi4py',
             'mxnet',
             'pandas',
-            # TODO(Yanase): Remove pillow from dependencies after torchvision includes the
-            # following change: https://github.com/pytorch/vision/pull/1501.
-            'pillow<7',
             'plotly>=4.0.0',
             'pytest',
             # TODO(Yanase): Update sklearn integration to support v0.22.1 or newer.
@@ -131,7 +125,7 @@ def get_extras_require():
             'tensorflow',
             'tensorflow-datasets',
             'torch',
-            'torchvision'
+            'torchvision>=0.5.0'
         ] if sys.version_info[:2] < (3, 8) else []),
     }
 


### PR DESCRIPTION
<!-- Thank you for creating a pull request!

Please go through [our contribution guide][CONTRIBUTING.md] to hopefully get your changes merged quicker.

[CONTRIBUTING.md]: https://github.com/optuna/optuna/blob/master/CONTRIBUTING.md -->

[torchvision v0.5.0](https://github.com/pytorch/vision/releases/tag/v0.5.0) has been released with the fix for https://github.com/optuna/optuna/pull/827:

1. Require `torchvision>=0.5.0`
2. Remove the temporary Pillow pin
