### PR TITLE
setup: remove typing external dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,6 @@ def get_install_requires():
         'scipy<1.4.0',
         'sqlalchemy>=1.1.0',
         'tqdm',
-        'typing',
         'joblib',
     ]
 


### PR DESCRIPTION
`typing` is part of Python standard library since 3.5.

It should therefore be removed from `optuna` requirements, as `typing` external library might break things for future Python version: 

"Also note that most improvements to the typing module in Python 3.7 will not be included in this package, since Python 3.7 has some built-in support that is not present in older versions (See PEP 560.)" -- https://pypi.org/project/typing/