### PR TITLE
Add a note for JupyterLab users.

### DIFF
--- a/docs/source/reference/visualization.rst
+++ b/docs/source/reference/visualization.rst
@@ -4,6 +4,14 @@
 Visualization
 =============
 
+.. note::
+    :mod:`~optuna.visualization` module uses plotly to create figures, but `JupyterLab`_ cannot
+    render them by default. Please follow this `installation guide`_ to show figures in
+    `JupyterLab`_.
+
+    .. _JupyterLab: https://github.com/jupyterlab/jupyterlab
+    .. _installation guide: https://github.com/plotly/plotly.py#jupyterlab-support-python-35
+
 .. autofunction:: plot_contour
 
 .. autofunction:: plot_intermediate_values


### PR DESCRIPTION
As reported in #837, JupyterLab cannot render figures generated by Optuna's visualization features. This PR adds a guide to solve the issue.

In #837, @srizvan suggested that such documentation should be written in the installation, but I place it in the visualization document since the issue is only related to the visualization features and JupyterLab users can use other features without the extra installation step.

![image](https://user-images.githubusercontent.com/3255979/72589230-f8e88e00-393d-11ea-8b1d-630c4d137147.png)
