### PR TITLE
Make `PyTorchIgnitePruningHandler` report correct epoch.

### DIFF
--- a/optuna/integration/pytorch_ignite.py
+++ b/optuna/integration/pytorch_ignite.py
@@ -54,7 +54,7 @@ class PyTorchIgnitePruningHandler(object):
         # type: (Engine) -> None
 
         score = engine.state.metrics[self._metric]
-        self._trial.report(score, engine.state.epoch)
+        self._trial.report(score, self._trainer.state.epoch)
         if self._trial.should_prune():
             message = "Trial was pruned at {} epoch.".format(engine.state.epoch)
             raise optuna.exceptions.TrialPruned(message)

--- a/optuna/integration/pytorch_ignite.py
+++ b/optuna/integration/pytorch_ignite.py
@@ -56,7 +56,7 @@ class PyTorchIgnitePruningHandler(object):
         score = engine.state.metrics[self._metric]
         self._trial.report(score, self._trainer.state.epoch)
         if self._trial.should_prune():
-            message = "Trial was pruned at {} epoch.".format(engine.state.epoch)
+            message = "Trial was pruned at {} epoch.".format(self._trainer.state.epoch)
             raise optuna.exceptions.TrialPruned(message)
 
 

--- a/tests/integration_tests/test_pytorch_ignite.py
+++ b/tests/integration_tests/test_pytorch_ignite.py
@@ -20,17 +20,17 @@ def test_pytorch_ignite_pruning_handler():
         pass
 
     trainer = Engine(update)
-    pruning_evaluator = Engine(update)
+    evaluator = Engine(update)
 
     # The pruner is activated.
     study = optuna.create_study(pruner=DeterministicPruner(True))
     trial = create_running_trial(study, 1.0)
 
     handler = optuna.integration.PyTorchIgnitePruningHandler(trial, 'accuracy', trainer)
-    with patch.object(trainer, 'state', epoch=3, metrics={}):
-        with patch.object(pruning_evaluator, 'state', epoch=1, metrics={'accuracy': 1}):
+    with patch.object(trainer, 'state', epoch=3):
+        with patch.object(evaluator, 'state', metrics={'accuracy': 1}):
             with pytest.raises(optuna.exceptions.TrialPruned):
-                handler(pruning_evaluator)
+                handler(evaluator)
             assert study.trials[0].intermediate_values == {3: 1}
 
     # The pruner is not activated.
@@ -38,7 +38,7 @@ def test_pytorch_ignite_pruning_handler():
     trial = create_running_trial(study, 1.0)
 
     handler = optuna.integration.PyTorchIgnitePruningHandler(trial, 'accuracy', trainer)
-    with patch.object(trainer, 'state', epoch=5, metrics={}):
-        with patch.object(pruning_evaluator, 'state', epoch=1, metrics={'accuracy': 2}):
-            handler(pruning_evaluator)
+    with patch.object(trainer, 'state', epoch=5):
+        with patch.object(evaluator, 'state', metrics={'accuracy': 2}):
+            handler(evaluator)
             assert study.trials[0].intermediate_values == {5: 2}


### PR DESCRIPTION
The current implementation of `PyTorchIgnitePruningHandler` reports **the epoch number of evaluator**, which means the value is always `1`. This PR fixes it to use **the epoch number of trainer** to match the expected behavior of the pruning handler.