### PR TITLE
Add FastAI example with `FastAIPruningCallback`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -302,7 +302,7 @@ jobs:
           <<: *examples
           environment:
             OMP_NUM_THREADS: 1
-            IGNORES: chainermn_.*|dask_ml_.*|keras_.*|pytorch_.*|tensorflow_.*|tfkeras_.*
+            IGNORES: chainermn_.*|dask_ml_.*|keras_.*|pytorch_.*|tensorflow_.*|tfkeras_.*|fastai_.*
 
       - run: *examples-mn
 
@@ -328,6 +328,6 @@ jobs:
           <<: *examples
           environment:
             OMP_NUM_THREADS: 1
-            IGNORES: chainermn_.*|pytorch_lightning.*
+            IGNORES: chainermn_.*|pytorch_lightning.*|fastai_.*
 
       - run: *examples-mn

--- a/examples/README.md
+++ b/examples/README.md
@@ -24,6 +24,7 @@ This page contains a list of example codes written with Optuna.
 * [Tensorflow](./tensorflow_estimator_simple.py)
 * [Tensorflow(eager)](./tensorflow_eager_simple.py)
 * [Keras](./keras_simple.py)
+* [FastAI](./fastai_simple.py)
 
 ### An example where an objective function uses additional arguments
 
@@ -47,6 +48,7 @@ In addition, integration modules are available for the following libraries, prov
 * [Pruning with MXNet integration module](./pruning/mxnet_integration.py)
 * [Pruning with PyTorch Ignite integration module](./pytorch_ignite_simple.py)
 * [Pruning with PyTorch Lightning integration module](./pytorch_lightning_simple.py)
+* [Pruning with FastAI integration module](./fastai_simple.py)
 
 ### Examples of User-Defined Sampler
 

--- a/examples/fastai_simple.py
+++ b/examples/fastai_simple.py
@@ -16,12 +16,7 @@ argument.
 import argparse
 from functools import partial
 
-from fastai.vision import ImageDataBunch
-from fastai.vision import Learner
-from fastai.vision import URLs
-from fastai.vision import accuracy
-from fastai.vision import simple_cnn
-from fastai.vision import untar_data
+from fastai import vision
 
 import optuna
 from optuna.integration import FastAIPruningCallback
@@ -31,8 +26,8 @@ BATCHSIZE = 128
 EPOCHS = 10
 
 
-path = untar_data(URLs.MNIST_SAMPLE)
-data = ImageDataBunch.from_folder(path, bs=BATCHSIZE)
+path = vision.untar_data(vision.URLs.MNIST_SAMPLE)
+data = vision.ImageDataBunch.from_folder(path, bs=BATCHSIZE)
 
 
 def objective(trial):
@@ -44,10 +39,10 @@ def objective(trial):
         n_channels.append(out_channels)
     n_channels.append(2)
 
-    model = simple_cnn(n_channels)
+    model = vision.simple_cnn(n_channels)
 
-    learn = Learner(
-        data, model, silent=True, metrics=[accuracy],
+    learn = vision.Learner(
+        data, model, silent=True, metrics=[vision.accuracy],
         callback_fns=[partial(FastAIPruningCallback, trial=trial, monitor='valid_loss')])
     learn.fit(EPOCHS)
 

--- a/examples/fastai_simple.py
+++ b/examples/fastai_simple.py
@@ -1,0 +1,50 @@
+"""
+Optuna example that demonstrates a pruner for fastai.
+
+In this example, we optimize the hyperparameters of a convolutional neural network for hand-written
+digit recognition in terms of validation loss. The network is implemented by fastai and evaluated
+on MNIST dataset. Throughout the training of neural networks, a pruner observes intermediate
+results and stops unpromising trials.
+
+You can run this example as follows:
+    $ python fastai_integration.py
+
+"""
+
+from functools import partial
+
+from fastai.vision import ImageDataBunch
+from fastai.vision import Learner
+from fastai.vision import URLs
+from fastai.vision import simple_cnn
+from fastai.vision import untar_data
+import optuna
+from optuna.integration import FastAIPruningCallback
+
+
+path = untar_data(URLs.MNIST_SAMPLE)
+data = ImageDataBunch.from_folder(path)
+
+
+def objective(trial: optuna.trial.Trial) -> float:
+    n_layers = trial.suggest_int('n_layers', 2, 5)
+
+    n_channels = [3]
+    for i in range(n_layers):
+        out_channels = trial.suggest_int('n_channels_{}'.format(i), 3, 32)
+        n_channels.append(out_channels)
+    n_channels.append(2)
+
+    model = simple_cnn(n_channels)
+
+    learn = Learner(
+        data, model, silent=True,
+        callback_fns=[partial(FastAIPruningCallback, trial=trial, monitor='valid_loss')])
+    learn.fit(10)
+
+    return learn.validate()[-1].item()
+
+
+if __name__ == '__main__':
+    study = optuna.create_study()
+    study.optimize(objective, n_trials=100, timeout=600)

--- a/examples/fastai_simple.py
+++ b/examples/fastai_simple.py
@@ -2,28 +2,37 @@
 Optuna example that demonstrates a pruner for fastai.
 
 In this example, we optimize the hyperparameters of a convolutional neural network for hand-written
-digit recognition in terms of validation loss. The network is implemented by fastai and evaluated
-on MNIST dataset. Throughout the training of neural networks, a pruner observes intermediate
-results and stops unpromising trials.
+digit recognition in terms of validation accuracy. The network is implemented by fastai and
+evaluated on MNIST dataset. Throughout the training of neural networks, a pruner observes
+intermediate results and stops unpromising trials.
+Note that this example will take longer than the other examples
+as this uses the entire MNIST dataset.
 
-You can run this example as follows:
-    $ python fastai_integration.py
-
+You can run this example as follows, pruning can be turned on and off with the `--pruning`
+argument.
+    $ python fastai_integration.py [--pruning]
 """
 
+import argparse
 from functools import partial
 
 from fastai.vision import ImageDataBunch
 from fastai.vision import Learner
+from fastai.vision import URLs
+from fastai.vision import accuracy
 from fastai.vision import simple_cnn
 from fastai.vision import untar_data
-from fastai.vision import URLs
+
 import optuna
 from optuna.integration import FastAIPruningCallback
 
 
+BATCHSIZE = 128
+EPOCHS = 10
+
+
 path = untar_data(URLs.MNIST_SAMPLE)
-data = ImageDataBunch.from_folder(path)
+data = ImageDataBunch.from_folder(path, bs=BATCHSIZE)
 
 
 def objective(trial: optuna.trial.Trial) -> float:
@@ -38,13 +47,32 @@ def objective(trial: optuna.trial.Trial) -> float:
     model = simple_cnn(n_channels)
 
     learn = Learner(
-        data, model, silent=True,
+        data, model, silent=True, metrics=[accuracy],
         callback_fns=[partial(FastAIPruningCallback, trial=trial, monitor='valid_loss')])
-    learn.fit(10)
+    learn.fit(EPOCHS)
 
     return learn.validate()[-1].item()
 
 
 if __name__ == '__main__':
-    study = optuna.create_study()
+    parser = argparse.ArgumentParser(description='FastAI example.')
+    parser.add_argument(
+        '--pruning', '-p', action='store_true',
+        help='Activate the pruning feature. `MedianPruner` stops unpromising '
+             'trials at the early stages of training.')
+    args = parser.parse_args()
+
+    pruner = optuna.pruners.MedianPruner() if args.pruning else optuna.pruners.NopPruner()
+    study = optuna.create_study(direction='maximize', pruner=pruner)
     study.optimize(objective, n_trials=100, timeout=600)
+
+    print('Number of finished trials: {}'.format(len(study.trials)))
+
+    print('Best trial:')
+    trial = study.best_trial
+
+    print('  Value: {}'.format(trial.value))
+
+    print('  Params: ')
+    for key, value in trial.params.items():
+        print('    {}: {}'.format(key, value))

--- a/examples/fastai_simple.py
+++ b/examples/fastai_simple.py
@@ -35,7 +35,7 @@ path = untar_data(URLs.MNIST_SAMPLE)
 data = ImageDataBunch.from_folder(path, bs=BATCHSIZE)
 
 
-def objective(trial: optuna.trial.Trial) -> float:
+def objective(trial):
     n_layers = trial.suggest_int('n_layers', 2, 5)
 
     n_channels = [3]

--- a/examples/fastai_simple.py
+++ b/examples/fastai_simple.py
@@ -15,9 +15,9 @@ from functools import partial
 
 from fastai.vision import ImageDataBunch
 from fastai.vision import Learner
-from fastai.vision import URLs
 from fastai.vision import simple_cnn
 from fastai.vision import untar_data
+from fastai.vision import URLs
 import optuna
 from optuna.integration import FastAIPruningCallback
 

--- a/examples/fastai_simple.py
+++ b/examples/fastai_simple.py
@@ -1,8 +1,9 @@
 """
-Optuna example that demonstrates a pruner for fastai.
+Optuna example that optimizes convolutional neural network and data augmentation using FastAI.
 
-In this example, we optimize the hyperparameters of a convolutional neural network for hand-written
-digit recognition in terms of validation accuracy. The network is implemented by fastai and
+In this example, we optimize the hyperparameters of a convolutional neural network and
+data augmentation for hand-written digit recognition in terms of validation accuracy.
+The network is implemented by fastai and
 evaluated on MNIST dataset. Throughout the training of neural networks, a pruner observes
 intermediate results and stops unpromising trials.
 Note that this example will take longer than the other examples


### PR DESCRIPTION
<!-- Thank you for creating a pull request!

Please go through [our contribution guide][CONTRIBUTING.md] to hopefully get your changes merged quicker.

[CONTRIBUTING.md]: https://github.com/optuna/optuna/blob/master/CONTRIBUTING.md -->

__UPDATE__: According to [fastai's quickstart](https://docs.fast.ai/vision.data.html#Quickly-get-your-data-ready-for-training), we can easily change the combination of data augmentation algorithms like rotation and zooming in/out. How about handling data augmentation as a hyperparameter?