### PR TITLE
Restrict pip version tentatively.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,8 @@ jobs:
           command: |
             python -m venv venv || virtualenv venv
             . venv/bin/activate
-            pip install -U pip
+            # TODO(Yanase): Remove version constraint after lightgbm and mxnet support pip>=20.
+            pip install -U 'pip<20'
             pip install --progress-bar off .[checking]
 
       - run:
@@ -87,7 +88,8 @@ jobs:
           command: |
             python -m venv venv || virtualenv venv --python=python3
             . venv/bin/activate
-            pip install -U pip
+            # TODO(Yanase): Remove version constraint after lightgbm and mxnet support pip>=20.
+            pip install -U 'pip<20'
             pip install --progress-bar off .[document]
 
       - run:
@@ -110,7 +112,8 @@ jobs:
           command: |
             python -m venv venv || virtualenv venv --python=python3
             . venv/bin/activate
-            pip install -U pip
+            # TODO(Yanase): Remove version constraint after lightgbm and mxnet support pip>=20.
+            pip install -U 'pip<20'
             pip install --progress-bar off .[doctest,document]
 
       - run:
@@ -137,7 +140,8 @@ jobs:
             sudo apt-get -y install openmpi-bin libopenmpi-dev
             python -m venv venv || virtualenv venv
             . venv/bin/activate
-            pip install -U pip
+            # TODO(Yanase): Remove version constraint after lightgbm and mxnet support pip>=20.
+            pip install -U 'pip<20'
             pip install --progress-bar off -U setuptools
             python setup.py sdist
 
@@ -225,7 +229,6 @@ jobs:
           name: install-codecov
           command: |
             . venv/bin/activate
-            pip install -U pip
             pip install --progress-bar off .[codecov]
 
       - run:
@@ -253,7 +256,6 @@ jobs:
           name: install-examples
           command: |
             . venv/bin/activate
-            pip install -U pip
             pip install --progress-bar off $(ls dist/*.tar.gz)[example]
 
       - run: &examples


### PR DESCRIPTION
This PR is a hotfix that adds a version constraint of pip.

CI fails due to the update of pip from 19.3.1 to 20.0.1. Wheel packages of mxnet and lightgbm cannot be installed using pip>=20.

1. Failed to install mxnet

```
ERROR: Could not find a version that satisfies the requirement mxnet (from optuna==1.0.0) (from versions: none)
ERROR: No matching distribution found for mxnet (from optuna==1.0.0)
```
https://circleci.com/gh/optuna/optuna/25903

2. Failed to install lightgbm

```
Collecting lightgbm
  Downloading lightgbm-2.3.1.tar.gz (679 kB)
    Running setup.py install for lightgbm ... - error
    ERROR: Command errored out with exit status 1:
     command: /home/circleci/project/venv/bin/python -u -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-aw7jy8kg/lightgbm/setup.py'"'"'; __file__='"'"'/tmp/pip-install-aw7jy8kg/lightgbm/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' install --record /tmp/pip-record-q_dusfhf/install-record.txt --single-version-externally-managed --compile --install-headers /home/circleci/project/venv/include/site/python3.5/lightgbm
```
https://circleci.com/gh/optuna/optuna/25900