### PR TITLE
FAQ documentation bullet list

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -44,6 +44,7 @@ release = __version__
 # ones.
 extensions = [
     'sphinx.ext.autodoc',
+    'sphinx.ext.autosectionlabel',
     'sphinx.ext.doctest',
     'sphinx.ext.intersphinx',
     'sphinx.ext.mathjax',

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -44,7 +44,6 @@ release = __version__
 # ones.
 extensions = [
     'sphinx.ext.autodoc',
-    'sphinx.ext.autosectionlabel',
     'sphinx.ext.doctest',
     'sphinx.ext.intersphinx',
     'sphinx.ext.mathjax',

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -1,15 +1,8 @@
 FAQ
 ===
 
-- :ref:`Can I use Optuna with X? (where X is your favorite ML library)`
-- :ref:`How to define objective functions that have own arguments?`
-- :ref:`Can I use Optuna without remote RDB servers?`
-- :ref:`How to suppress log messages of Optuna?`
-- :ref:`How to save machine learning models trained in objective functions?`
-- :ref:`How can I obtain reproducible optimization results?`
-- :ref:`How does Optuna handle NaNs and exceptions reported by the objective function?`
-- :ref:`How can I use two GPUs for evaluating two trials simultaneously?`
-- :ref:`How can I test my objective functions?`
+.. contents::
+    :local:
 
 Can I use Optuna with X? (where X is your favorite ML library)
 --------------------------------------------------------------

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -1,6 +1,16 @@
 FAQ
 ===
 
+- :ref:`Can I use Optuna with X? (where X is your favorite ML library)`
+- :ref:`How to define objective functions that have own arguments?`
+- :ref:`Can I use Optuna without remote RDB servers?`
+- :ref:`How to suppress log messages of Optuna?`
+- :ref:`How to save machine learning models trained in objective functions?`
+- :ref:`How can I obtain reproducible optimization results?`
+- :ref:`How does Optuna handle NaNs and exceptions reported by the objective function?`
+- :ref:`How can I use two GPUs for evaluating two trials simultaneously?`
+- :ref:`How can I test my objective functions?`
+
 Can I use Optuna with X? (where X is your favorite ML library)
 --------------------------------------------------------------
 


### PR DESCRIPTION
Adds a bullet list at the top of the FAQ section in the documentation for quick overview. This bullet list is easier to go through than the list on the sidebar as long sentences on the sidebar are wrapped.

![Screen Shot 2020-01-23 at 12 37 17](https://user-images.githubusercontent.com/5983694/72954853-279eb280-3ddd-11ea-9403-26e21574ac59.png)
