### PR TITLE
Add to FAQ dynamically altering search spaces.

### DIFF
--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -194,7 +194,7 @@ What happens when I dynamically alter a search space?
 -----------------------------------------------------
 
 Since parameters search spaces are specified in each call to the suggestion API, e.g.
-:func:`~optuna.trial.Trial.suggest_uniform` and :func:`~optuna.trial.Trial.suggest_categorical`,
+:func:`~optuna.trial.Trial.suggest_uniform` and :func:`~optuna.trial.Trial.suggest_int`,
 it is possible to in a single study alter the range by sampling parameters from different search
 spaces in different trials.
 The behavior when altered is defined by each sampler individually.

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -190,6 +190,20 @@ You can also find the failed trials by checking the trial states as follows:
     1,TrialState.COMPLETE,1269,...,1,
 
 
+What happens when I dynamically alter a search space?
+-----------------------------------------------------
+
+Since parameters search spaces are specified in each call to the suggestion API, e.g.
+:func:`~optuna.trial.Trial.suggest_uniform` and :func:`~optuna.trial.Trial.suggest_categorical`,
+it is possible to in a single study alter the range by sampling parameters from different search
+spaces in different trials.
+The behavior when altered is defined by each sampler individually.
+
+.. note::
+
+    Discussion about the TPE sampler. https://github.com/optuna/optuna/issues/822
+
+
 How can I use two GPUs for evaluating two trials simultaneously?
 ----------------------------------------------------------------
 


### PR DESCRIPTION
An addition to the FAQ in the documentation about altering search spaces dynamically. C.f. https://github.com/optuna/optuna/issues/822.