### PR TITLE
Update the PyTorch Lightning example to support pytorch_lightning==0.6.0.

### DIFF
--- a/examples/pytorch_lightning_simple.py
+++ b/examples/pytorch_lightning_simple.py
@@ -19,6 +19,7 @@ We have the following two ways to execute this example:
 
 import argparse
 import os
+import pkg_resources
 import shutil
 
 import pytorch_lightning as pl
@@ -33,6 +34,9 @@ from torchvision import transforms
 
 import optuna
 from optuna.integration import PyTorchLightningPruningCallback
+
+if pkg_resources.parse_version(pl.__version__) < pkg_resources.parse_version('0.6.0'):
+    raise RuntimeError('PyTorch Lightning>=0.6.0 is required for this example.')
 
 PERCENT_TEST_EXAMPLES = 0.1
 BATCHSIZE = 128


### PR DESCRIPTION
PyTorch Lightning v0.6.0 has been released on January 22, 2020.

It includes interface changes and this PR update the PyTorch Lightning example as follows:
- the built-in `logging` module of Python is imported in `pytorch_lightning/__init__.py`,  and we cannot access `LightningLoggerBase` class via `pl.logging.LightningLoggerBase`.
- The `step_num` option of `LightningLoggerBase.log_metrics` was renamed to `step`.
- The `save_best_only` option of `pl.callbacks.ModelCheckpoint.__init__` was removed.
- The default metric monitored by `pl.callbacks.ModelCheckpoint` is `val_loss`, but the target metric of this example is validation accuracy. So, I changed the metric using `monitor` option.
- The `max_nb_epochs ` option of `pl.Trainer` was renamed to `max_epochs`.

I think it would help users If we put the version number of pytorch_lightning supported by this example.

## Updates

- Added version checking of pytorch_lightning: https://github.com/optuna/optuna/pull/858/commits/cf6f02dde0e470da603d7158430a51ff59d87d85