### PR TITLE
Add an example for LightGBM Tuner

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -15,6 +15,7 @@ This page contains a list of example codes written with Optuna.
 * [ChainerMN](./chainermn_simple.py)
 * [Dask-ML](./dask_ml_simple.py)
 * [LightGBM](./lightgbm_simple.py)
+* [LightGBM Tuner](./lightgbm_tuner_simple.py)
 * [CatBoost](./catboost_simple.py)
 * [MXNet](./mxnet_simple.py)
 * [PyTorch](./pytorch_simple.py)

--- a/examples/lightgbm_tuner_simple.py
+++ b/examples/lightgbm_tuner_simple.py
@@ -14,15 +14,14 @@ import sklearn.datasets
 from sklearn.metrics import accuracy_score
 from sklearn.model_selection import train_test_split
 
-import lightgbm as lgb_original
 import optuna.integration.lightgbm as lgb
 
 
 if __name__ == '__main__':
     data, target = sklearn.datasets.load_breast_cancer(return_X_y=True)
     train_x, val_x, train_y, val_y = train_test_split(data, target, test_size=0.25)
-    dtrain = lgb_original.Dataset(train_x, label=train_y)
-    dval = lgb_original.Dataset(val_x, label=val_y)
+    dtrain = lgb.Dataset(train_x, label=train_y)
+    dval = lgb.Dataset(val_x, label=val_y)
 
     params = {
         'objective': 'binary',

--- a/examples/lightgbm_tuner_simple.py
+++ b/examples/lightgbm_tuner_simple.py
@@ -1,0 +1,63 @@
+"""
+Optuna example that optimizes a classifier configuration for cancer dataset using LightGBM tuner.
+
+In this example, we optimize the validation accuracy of cancer detection.
+We optimize both the choice of booster model and their hyperparameters.
+
+You can execute this code directly.
+    $ python lightgbm_tuner_simple.py
+
+"""
+
+import numpy as np
+import sklearn.datasets
+from sklearn.metrics import accuracy_score
+from sklearn.model_selection import train_test_split
+
+import lightgbm as lgb_original
+import optuna.integration.lightgbm as lgb
+
+
+if __name__ == '__main__':
+    data, target = sklearn.datasets.load_breast_cancer(return_X_y=True)
+    train_x, val_x, train_y, val_y = train_test_split(data, target, test_size=0.25)
+    dtrain = lgb_original.Dataset(train_x, label=train_y)
+    dval = lgb_original.Dataset(val_x, label=val_y)
+
+    params = {
+        'objective': 'binary',
+        'metric': 'binary_logloss',
+        'verbosity': -1,
+        'boosting_type': 'gbdt',
+    }
+
+    best_params, tuning_history = dict(), list()
+
+    search = lgb.train(params,
+                       dtrain,
+                       valid_sets=[dtrain, dval],
+                       best_params=best_params,
+                       tuning_history=tuning_history,
+                       verbose_eval=100,
+                       early_stopping_rounds=100,
+                       )
+
+    print('Number of finished trials: {}'.format(len(tuning_history)))
+    print('Best Params:', best_params)
+
+    model = lgb_original.train(best_params,
+                               dtrain,
+                               valid_sets=[dtrain, dval],
+                               early_stopping_rounds=1000,
+                               verbose_eval=100,
+                               )
+
+    prediction = np.rint(model.predict(val_x, num_iteration=model.best_iteration))
+
+    accuracy = accuracy_score(val_y, prediction)
+
+    print('Accuracy = {}'.format(accuracy))
+
+    print('  Params: ')
+    for key, value in best_params.items():
+        print('    {}: {}'.format(key, value))

--- a/examples/lightgbm_tuner_simple.py
+++ b/examples/lightgbm_tuner_simple.py
@@ -33,31 +33,21 @@ if __name__ == '__main__':
 
     best_params, tuning_history = dict(), list()
 
-    search = lgb.train(params,
-                       dtrain,
-                       valid_sets=[dtrain, dval],
-                       best_params=best_params,
-                       tuning_history=tuning_history,
-                       verbose_eval=100,
-                       early_stopping_rounds=100,
-                       )
-
-    print('Number of finished trials: {}'.format(len(tuning_history)))
-    print('Best Params:', best_params)
-
-    model = lgb_original.train(best_params,
-                               dtrain,
-                               valid_sets=[dtrain, dval],
-                               early_stopping_rounds=1000,
-                               verbose_eval=100,
-                               )
+    model = lgb.train(params,
+                      dtrain,
+                      valid_sets=[dtrain, dval],
+                      best_params=best_params,
+                      tuning_history=tuning_history,
+                      verbose_eval=100,
+                      early_stopping_rounds=100,
+                      )
 
     prediction = np.rint(model.predict(val_x, num_iteration=model.best_iteration))
-
     accuracy = accuracy_score(val_y, prediction)
 
-    print('Accuracy = {}'.format(accuracy))
-
+    print('Number of finished trials: {}'.format(len(tuning_history)))
+    print('Best params:', best_params)
+    print('  Accuracy = {}'.format(accuracy))
     print('  Params: ')
     for key, value in best_params.items():
         print('    {}: {}'.format(key, value))

--- a/examples/lightgbm_tuner_simple.py
+++ b/examples/lightgbm_tuner_simple.py
@@ -1,8 +1,7 @@
 """
 Optuna example that optimizes a classifier configuration for cancer dataset using LightGBM tuner.
 
-In this example, we optimize the validation accuracy of cancer detection.
-We optimize both the choice of booster model and their hyperparameters.
+In this example, we optimize the validation log loss of cancer detection.
 
 You can execute this code directly.
     $ python lightgbm_tuner_simple.py


### PR DESCRIPTION
This PR adds a simple example to show the usage of LightGBM Tuner (#846).
Following lightgbm_simple.py, catboost_simple.py, and xgboost_simple.py, the breast cancer dataset is used.

Let me know if there is any way to improve this example.