### PR TITLE
Convert None to NaN before reporting to MLFlow.

### DIFF
--- a/examples/mlflow/keras_mlflow.py
+++ b/examples/mlflow/keras_mlflow.py
@@ -68,9 +68,10 @@ def create_model(num_features, trial):
 
 
 def mlflow_callback(study, trial):
+    trial_value = trial.value if trial.value is not None else float('nan')
     with mlflow.start_run(run_name=study.study_name):
         mlflow.log_params(trial.params)
-        mlflow.log_metrics({'mean_squared_error': trial.value})
+        mlflow.log_metrics({'mean_squared_error': trial_value})
 
 
 def objective(trial):


### PR DESCRIPTION
This PR fixes the following error during the execution of `examples/mlflow/keras_mlflow.py`.

https://circleci.com/gh/optuna/optuna/26217
```console
[W 2020-01-26 16:06:02,184] Setting status of trial#48 as TrialState.FAIL because the objective function returned nan.
Traceback (most recent call last):
  File "examples/mlflow/keras_mlflow.py", line 97, in <module>
    study.optimize(objective, n_trials=100, timeout=600, callbacks=[mlflow_callback])
...
  File "/home/circleci/project/venv/lib/python3.6/site-packages/mlflow/utils/validation.py", line 70, in _validate_metric
    INVALID_PARAMETER_VALUE)
mlflow.exceptions.MlflowException: Got invalid value None for metric 'mean_squared_error' (timestamp=1580054762270). Please specify value as a valid double (64-bit floating point)
```

MLFlow does not allow users to report non-numerical values like `None` and raises `mlflow.exceptions.MlflowException` (c.f., [implementation](https://github.com/mlflow/mlflow/blob/master/mlflow/utils/validation.py#L60-L82)). This PR converts `None` to `NaN` to prevent such errors.

The NaN values are shown in the MLFlow UI as follows:

![image](https://user-images.githubusercontent.com/3255979/73153295-9f8b1680-4116-11ea-9ad4-2450218c3252.png)
