### PR TITLE
Remove description about CLI execution of MLFlow example.

### DIFF
--- a/examples/mlflow/README.md
+++ b/examples/mlflow/README.md
@@ -9,20 +9,10 @@ In this example, we optimize the learning rate and momentum of
 a stochastic gradient descent optimizer to minimize the validation mean squared error
 for the wine quality regression.
 
-We have the following two ways to execute this example:
-
-(1) Excute code directly.
+You can run this example as follows:
 
 ```
 $ python keras_mlflow.py
-```
-
-(2) Execute through CLI.
-
-```
-$ STUDY_NAME=`optuna create-study --direction minimize --storage sqlite:///example.db`
-$ optuna study optimize keras_mlflow.py objective --n-trials=100 \
-         --study $STUDY_NAME --storage sqlite:///example.db
 ```
 
 After the script finishes, run the MLflow UI:

--- a/examples/mlflow/keras_mlflow.py
+++ b/examples/mlflow/keras_mlflow.py
@@ -6,17 +6,8 @@ In this example, we optimize the learning rate and momentum of
 stochastic gradient descent optimizer to minimize the validation mean squared error
 for the wine quality regression.
 
-We have the following two ways to execute this example:
-
-(1) Execute this code directly.
+You can run this example as follows:
     $ python keras_mlflow.py
-
-
-(2) Execute through CLI.
-    $ STUDY_NAME=`optuna create-study --direction minimize --storage sqlite:///example.db`
-    $ optuna study optimize keras_mlflow.py objective --n-trials=100 \
-      --study $STUDY_NAME --storage sqlite:///example.db
-
 
 After the script finishes, run the MLflow UI:
     $ mlflow ui


### PR DESCRIPTION
When we execute `examples/mlflow/keras_mlflow.py` via CLI, no values are reported to MLFlow. 
 The example uses `mlflow_callback` but the CLI does not support the callback feature of `Study.optimize`.

This PR removes the description about CLI from the MLFlow example.