### PR TITLE
Fix: XGBoostPruningCallback is not compatible with xgboost.cv

### DIFF
--- a/optuna/integration/xgboost.py
+++ b/optuna/integration/xgboost.py
@@ -11,9 +11,9 @@ except ImportError as e:
 
 def _get_callback_context(env):
     # type: (xgb.core.CallbackEnv) -> str
-    """return whether the current callback context is cv or train
+    """Return whether the current callback context is cv or train.
 
-    Note:
+    .. note::
         `Reference
         <https://github.com/dmlc/xgboost/blob/master/python-package/xgboost/callback.py>`_.
     """
@@ -75,6 +75,7 @@ class XGBoostPruningCallback(object):
 
     def __call__(self, env):
         # type: (xgb.core.CallbackEnv) -> None
+
         context = _get_callback_context(env)
         if context == 'cv':
             _remove_std_from_evaluation_result_list(env)

--- a/optuna/integration/xgboost.py
+++ b/optuna/integration/xgboost.py
@@ -17,8 +17,6 @@ def _get_callback_context(env):
         `Reference
         <https://github.com/dmlc/xgboost/blob/master/python-package/xgboost/callback.py>`_.
     """
-    # if env.model is not None and env.cvfolds is None:
-    #     context = 'train'
     if env.model is None and env.cvfolds is not None:
         context = 'cv'
     else:

--- a/optuna/integration/xgboost.py
+++ b/optuna/integration/xgboost.py
@@ -77,7 +77,7 @@ class XGBoostPruningCallback(object):
         context = _get_callback_context(env)
         if context == 'cv':
             _remove_std_from_evaluation_result_list(env)
-        print(env.evaluation_result_list)
+
         current_score = dict(env.evaluation_result_list)[self._observation_key]
         self._trial.report(current_score, step=env.iteration)
         if self._trial.should_prune():

--- a/optuna/integration/xgboost.py
+++ b/optuna/integration/xgboost.py
@@ -17,6 +17,7 @@ def _get_callback_context(env):
         `Reference
         <https://github.com/dmlc/xgboost/blob/master/python-package/xgboost/callback.py>`_.
     """
+
     if env.model is None and env.cvfolds is not None:
         context = 'cv'
     else:
@@ -32,7 +33,7 @@ def _remove_std_from_evaluation_result_list(xgb_callback_env):
     It expects the observation_key and the evaluation metric only, but XGBoost is also providing
     a third element: the stddev of the metric across the cross-valdation folds.
     """
-    # drop the 3rd element (stddev) from each evaluation_result_list item.
+
     erl_orig = xgb_callback_env.evaluation_result_list
     erl_no_std = [(key, metric) for key, metric, std in erl_orig]
     erl_orig.clear()

--- a/tests/integration_tests/test_xgboost.py
+++ b/tests/integration_tests/test_xgboost.py
@@ -76,6 +76,7 @@ def test_xgboost_pruning_callback_cv():
             'silent': 1,
             'objective': 'binary:logistic',
         }
+
         pruning_callback = optuna.integration.XGBoostPruningCallback(trial, 'test-error')
         xgb.cv(
             params,

--- a/tests/integration_tests/test_xgboost.py
+++ b/tests/integration_tests/test_xgboost.py
@@ -77,7 +77,7 @@ def test_xgboost_pruning_callback_cv():
             'objective': 'binary:logistic',
         }
         pruning_callback = optuna.integration.XGBoostPruningCallback(trial, 'test-error')
-        history = xgb.cv(
+        xgb.cv(
             params,
             dtrain,
             callbacks=[pruning_callback],

--- a/tests/integration_tests/test_xgboost.py
+++ b/tests/integration_tests/test_xgboost.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pytest
 import xgboost as xgb
 
@@ -52,6 +53,36 @@ def test_xgboost_pruning_callback():
             evals=[(dtest, 'validation')],
             verbose_eval=False,
             callbacks=[pruning_callback])
+        return 1.0
+
+    study = optuna.create_study(pruner=DeterministicPruner(True))
+    study.optimize(objective, n_trials=1)
+    assert study.trials[0].state == optuna.structs.TrialState.PRUNED
+
+    study = optuna.create_study(pruner=DeterministicPruner(False))
+    study.optimize(objective, n_trials=1)
+    assert study.trials[0].state == optuna.structs.TrialState.COMPLETE
+    assert study.trials[0].value == 1.
+
+
+def test_xgboost_pruning_callback_cv():
+    # type: () -> None
+
+    def objective(trial):
+        # type: (optuna.trial.Trial) -> float
+
+        dtrain = xgb.DMatrix(np.ones((2, 1)), label=[1., 1.])
+        params = {
+            'silent': 1,
+            'objective': 'binary:logistic',
+        }
+        pruning_callback = optuna.integration.XGBoostPruningCallback(trial, 'test-error')
+        history = xgb.cv(
+            params,
+            dtrain,
+            callbacks=[pruning_callback],
+            nfold=2
+        )
         return 1.0
 
     study = optuna.create_study(pruner=DeterministicPruner(True))


### PR DESCRIPTION
- Related issue https://github.com/optuna/optuna/issues/810  
- I added to two functions to resolve this issue.
  - `_get_callback_context` is used to detect the context `xgboost.train` or `xgboost.cv`.
  - `_remove_std_from_evaluation_result_list` removes std in `xgboost.core.CallbackEnv.evaluation_result_list`  to parse as dictionary in `XGBoostPruningCallback` .