### PR TITLE
Fix: TensorFlow estimator example with TensorFlow 2.X

### DIFF
--- a/examples/tensorflow_estimator_simple.py
+++ b/examples/tensorflow_estimator_simple.py
@@ -40,10 +40,10 @@ def create_network(trial, features):
     n_layers = trial.suggest_int('n_layers', 1, 3)
     for i in range(n_layers):
         n_units = trial.suggest_int('n_units_l{}'.format(i), 1, 128)
-        prev_layer = tf.compat.v1.layers.dense(
-            inputs=prev_layer, units=n_units, activation=tf.nn.relu)
+        prev_layer = tf.keras.layers.Dense(
+            units=n_units, activation=tf.nn.relu)(prev_layer)
 
-    logits = tf.compat.v1.layers.dense(inputs=prev_layer, units=10)
+    logits = tf.keras.layers.Dense(units=10)(prev_layer)
     return logits
 
 

--- a/examples/tensorflow_estimator_simple.py
+++ b/examples/tensorflow_estimator_simple.py
@@ -82,7 +82,8 @@ def model_fn(trial, features, labels, mode):
         return tf.estimator.EstimatorSpec(mode=mode, loss=loss, train_op=train_op)
 
     eval_metric_ops = {
-        "accuracy": tf.compat.v1.metrics.accuracy(labels=labels, predictions=predictions["classes"])
+        "accuracy": tf.compat.v1.metrics.accuracy(labels=labels,
+                                                  predictions=predictions["classes"])
     }
     return tf.estimator.EstimatorSpec(mode=mode, loss=loss, eval_metric_ops=eval_metric_ops)
 

--- a/examples/tensorflow_estimator_simple.py
+++ b/examples/tensorflow_estimator_simple.py
@@ -24,7 +24,6 @@ import tempfile
 
 import numpy as np
 import tensorflow as tf
-import tensorflow_addons as tfe
 
 import optuna
 

--- a/examples/tensorflow_estimator_simple.py
+++ b/examples/tensorflow_estimator_simple.py
@@ -40,7 +40,8 @@ def create_network(trial, features):
     n_layers = trial.suggest_int('n_layers', 1, 3)
     for i in range(n_layers):
         n_units = trial.suggest_int('n_units_l{}'.format(i), 1, 128)
-        prev_layer = tf.compat.v1.layers.dense(inputs=prev_layer, units=n_units, activation=tf.nn.relu)
+        prev_layer = tf.compat.v1.layers.dense(
+            inputs=prev_layer, units=n_units, activation=tf.nn.relu)
 
     logits = tf.compat.v1.layers.dense(inputs=prev_layer, units=10)
     return logits
@@ -56,7 +57,8 @@ def create_optimizer(trial):
     else:
         sgd_lr = trial.suggest_loguniform('sgd_lr', 1e-5, 1e-1)
         sgd_momentum = trial.suggest_loguniform('sgd_momentum', 1e-5, 1e-1)
-        optimizer = tf.compat.v1.train.MomentumOptimizer(learning_rate=sgd_lr, momentum=sgd_momentum)
+        optimizer = tf.compat.v1.train.MomentumOptimizer(
+            learning_rate=sgd_lr, momentum=sgd_momentum)
 
     return optimizer
 

--- a/examples/tensorflow_estimator_simple.py
+++ b/examples/tensorflow_estimator_simple.py
@@ -24,6 +24,7 @@ import tempfile
 
 import numpy as np
 import tensorflow as tf
+import tensorflow_addons as tfe
 
 import optuna
 
@@ -40,25 +41,24 @@ def create_network(trial, features):
     n_layers = trial.suggest_int('n_layers', 1, 3)
     for i in range(n_layers):
         n_units = trial.suggest_int('n_units_l{}'.format(i), 1, 128)
-        prev_layer = tf.layers.dense(inputs=prev_layer, units=n_units, activation=tf.nn.relu)
+        prev_layer = tf.compat.v1.layers.dense(inputs=prev_layer, units=n_units, activation=tf.nn.relu)
 
-    logits = tf.layers.dense(inputs=prev_layer, units=10)
+    logits = tf.compat.v1.layers.dense(inputs=prev_layer, units=10)
     return logits
 
 
 def create_optimizer(trial):
     # We optimize the choice of optimizers as well as their parameters.
-    weight_decay = trial.suggest_loguniform('weight_decay', 1e-10, 1e-3)
 
-    optimizer_name = trial.suggest_categorical('optimizer', ['Adam', 'MomentumSGD'])
+    optimizer_name = trial.suggest_categorical('optimizer', ['Adam', 'SGD'])
     if optimizer_name == 'Adam':
         adam_lr = trial.suggest_loguniform('adam_lr', 1e-5, 1e-1)
-        optimizer = tf.contrib.opt.AdamWOptimizer(learning_rate=adam_lr, weight_decay=weight_decay)
+        optimizer = tf.compat.v1.train.AdamOptimizer(learning_rate=adam_lr)
     else:
-        momentum_sgd_lr = trial.suggest_loguniform('momentum_sgd_lr', 1e-5, 1e-1)
-        momentum = trial.suggest_loguniform('momentum', 1e-5, 1e-1)
-        optimizer = tf.contrib.opt.MomentumWOptimizer(
-            learning_rate=momentum_sgd_lr, momentum=momentum, weight_decay=weight_decay)
+        sgd_lr = trial.suggest_loguniform('sgd_lr', 1e-5, 1e-1)
+        sgd_momentum = trial.suggest_loguniform('sgd_momentum', 1e-5, 1e-1)
+        optimizer = tf.compat.v1.train.MomentumOptimizer(
+            learning_rate=sgd_lr, momentum=sgd_momentum)
 
     return optimizer
 
@@ -74,15 +74,15 @@ def model_fn(trial, features, labels, mode):
     if mode == tf.estimator.ModeKeys.PREDICT:
         return tf.estimator.EstimatorSpec(mode=mode, predictions=predictions)
 
-    loss = tf.losses.sparse_softmax_cross_entropy(labels=labels, logits=logits)
+    loss = tf.compat.v1.losses.sparse_softmax_cross_entropy(labels=labels, logits=logits)
 
     if mode == tf.estimator.ModeKeys.TRAIN:
         optimizer = create_optimizer(trial)
-        train_op = optimizer.minimize(loss=loss, global_step=tf.train.get_global_step())
+        train_op = optimizer.minimize(loss, tf.compat.v1.train.get_or_create_global_step())
         return tf.estimator.EstimatorSpec(mode=mode, loss=loss, train_op=train_op)
 
     eval_metric_ops = {
-        "accuracy": tf.metrics.accuracy(labels=labels, predictions=predictions["classes"])
+        "accuracy": tf.compat.v1.metrics.accuracy(labels=labels, predictions=predictions["classes"])
     }
     return tf.estimator.EstimatorSpec(mode=mode, loss=loss, eval_metric_ops=eval_metric_ops)
 
@@ -101,12 +101,12 @@ def objective(trial):
         model_fn=lambda features, labels, mode: model_fn(trial, features, labels, mode),
         model_dir=model_dir)
 
-    train_input_fn = tf.estimator.inputs.numpy_input_fn(
+    train_input_fn = tf.compat.v1.estimator.inputs.numpy_input_fn(
         x={"x": train_data}, y=train_labels, batch_size=BATCH_SIZE, num_epochs=None, shuffle=True)
 
     mnist_classifier.train(input_fn=train_input_fn, steps=TRAIN_STEPS)
 
-    eval_input_fn = tf.estimator.inputs.numpy_input_fn(
+    eval_input_fn = tf.compat.v1.estimator.inputs.numpy_input_fn(
         x={"x": eval_data}, y=eval_labels, num_epochs=1, shuffle=False)
 
     eval_results = mnist_classifier.evaluate(input_fn=eval_input_fn)
@@ -132,4 +132,4 @@ def main(unused_argv):
 
 
 if __name__ == "__main__":
-    tf.app.run()
+    tf.compat.v1.app.run()

--- a/examples/tensorflow_estimator_simple.py
+++ b/examples/tensorflow_estimator_simple.py
@@ -56,8 +56,7 @@ def create_optimizer(trial):
     else:
         sgd_lr = trial.suggest_loguniform('sgd_lr', 1e-5, 1e-1)
         sgd_momentum = trial.suggest_loguniform('sgd_momentum', 1e-5, 1e-1)
-        optimizer = tf.compat.v1.train.MomentumOptimizer(
-            learning_rate=sgd_lr, momentum=sgd_momentum)
+        optimizer = tf.compat.v1.train.MomentumOptimizer(learning_rate=sgd_lr, momentum=sgd_momentum)
 
     return optimizer
 


### PR DESCRIPTION
This PR fixes TensorFlow estimator example for TensorFlow 2.X (Related to #855 )

`tf.compat.v1` module is used in this script to call v1 API required for TensorFlow estimator.