### PR TITLE
Add FAQ entry on how to save/resume studies using in-memory storage

### DIFF
--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -86,11 +86,13 @@ If you want to save and resume studies,  it's handy to use SQLite as the local s
 Please see :ref:`rdb` for more details.
 
 
-How do I save and resume studies without a database?
+How can I save and resume studies?
 ----------------------------------------------------
 
-You can also save and load studies like usual Python objects using ``pickle``
-or ``joblib``. For example, using ``joblib``:
+There are two ways of persisting studies, which depends if you are using
+in-memory storage (default) or remote databases (RDB). In-memory studies can be
+saved and loaded like usual Python objects using ``pickle`` or ``joblib``. For
+example, using ``joblib``:
 
 .. code-block:: python
 
@@ -108,11 +110,7 @@ And to resume the study:
     for key, value in study.best_trial.params.items():
         print(f'    {key}: {value}')
 
-.. warning::
-    Dump and load is recommended only for in-memory storage (i.e., without a
-    RDB), since an RDB requires to handle two files to be consistent, the DB
-    file and the dumped-study file.
-
+If you are using RDBs, see :ref:`rdb` for more details.
 
 How to suppress log messages of Optuna?
 ---------------------------------------

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -86,6 +86,29 @@ If you want to save and resume studies,  it's handy to use SQLite as the local s
 Please see :ref:`rdb` for more details.
 
 
+How do I save and resume studies?
+---------------------------------
+
+You can save and load studies like usual Python objects using `pickle` or `joblib`. Example using `joblib`:
+
+.. code-block:: python
+
+    study = optuna.create_study()
+    joblib.dump(study, 'study.pkl')
+
+
+And to resume the study:
+
+.. code-block:: python
+
+    study = joblib.load('study.pkl')
+	print('Best trial until now:')
+	print(' Value: ', study.trial.value)
+	print(' Params: ')
+	for key, value in study.trial.params.items():
+		print(f'    {key}: {value}')
+
+
 How to suppress log messages of Optuna?
 ---------------------------------------
 

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -86,27 +86,32 @@ If you want to save and resume studies,  it's handy to use SQLite as the local s
 Please see :ref:`rdb` for more details.
 
 
-How do I save and resume studies?
----------------------------------
+How do I save and resume studies without a database?
+----------------------------------------------------
 
-You can save and load studies like usual Python objects using `pickle` or `joblib`. Example using `joblib`:
+You can also save and load studies like usual Python objects using ``pickle``
+or ``joblib``. For example, using ``joblib``:
 
 .. code-block:: python
 
     study = optuna.create_study()
     joblib.dump(study, 'study.pkl')
 
-
 And to resume the study:
 
 .. code-block:: python
 
     study = joblib.load('study.pkl')
-	print('Best trial until now:')
-	print(' Value: ', study.trial.value)
-	print(' Params: ')
-	for key, value in study.trial.params.items():
-		print(f'    {key}: {value}')
+    print('Best trial until now:')
+    print(' Value: ', study.best_trial.value)
+    print(' Params: ')
+    for key, value in study.best_trial.params.items():
+        print(f'    {key}: {value}')
+
+.. warning::
+    Dump and load is recommended only for in-memory storage (i.e., without a
+    RDB), since an RDB requires to handle two files to be consistent, the DB
+    file and the dumped-study file.
 
 
 How to suppress log messages of Optuna?


### PR DESCRIPTION
It's also possible with a RDB storage, but it requires to handle two files to be consistent, the database and the dumped study file. Thus, @toshihikoyanase recommended that it would be better to leave this out to avoid confusion. An example he shared in [colab](https://colab.research.google.com/drive/1Ax88pweMOnpRFzqwHEi3B9Ch5LtAZ__u#scrollTo=8MyFtHFkog1W):

```python
# using dump/load with RDBStorage
study = optuna.create_study('sqlite:///example.db')
study.optimize(objective, n_trials=5)

joblib.dump(study, 'study_rdb_storage.dump')
dumped_study = joblib.load('study_rdb_storage.dump')
dumped_study.trials_dataframe()
```
Thus, if one file is missing, it won't work properly, as in the following that `example2.db` is removed:

```python
# using dump/load with RDBStorage (2)
# Please note that the db file (i.e., 'example2.db') is required in addition to the dumped study.
study = optuna.create_study('sqlite:///example2.db')
study.optimize(objective, n_trials=5)

joblib.dump(study, 'study_rdb_storage2.dump')
!rm example2.db
dumped_study = joblib.load('study_rdb_storage2.dump')
# An error occurs due to the db file does not exist.
dumped_study.trials_dataframe()
```