### PR TITLE
Fix: TensorFlow estimator pruning example with TensorFlow 2.X.

### DIFF
--- a/examples/pruning/tensorflow_estimator_integration.py
+++ b/examples/pruning/tensorflow_estimator_integration.py
@@ -34,9 +34,9 @@ def create_network(trial, features):
     n_layers = trial.suggest_int('n_layers', 1, 3)
     for i in range(n_layers):
         n_units = trial.suggest_int('n_units_l{}'.format(i), 1, 128)
-        prev_layer = tf.layers.dense(inputs=prev_layer, units=n_units, activation=tf.nn.relu)
+        prev_layer = tf.keras.layers.Dense(units=n_units, activation=tf.nn.relu)(prev_layer)
 
-    logits = tf.layers.dense(inputs=prev_layer, units=10)
+    logits = tf.keras.layers.Dense(units=10)(prev_layer)
     return logits
 
 
@@ -51,15 +51,17 @@ def model_fn(trial, features, labels, mode):
     if mode == tf.estimator.ModeKeys.PREDICT:
         return tf.estimator.EstimatorSpec(mode=mode, predictions=predictions)
 
-    loss = tf.losses.sparse_softmax_cross_entropy(labels=labels, logits=logits)
+    loss = tf.compat.v1.losses.sparse_softmax_cross_entropy(labels=labels, logits=logits)
 
     if mode == tf.estimator.ModeKeys.TRAIN:
-        optimizer = tf.train.GradientDescentOptimizer(learning_rate=0.001)
-        train_op = optimizer.minimize(loss=loss, global_step=tf.train.get_global_step())
+        optimizer = tf.compat.v1.train.GradientDescentOptimizer(learning_rate=0.001)
+        train_op = optimizer.minimize(
+            loss=loss, global_step=tf.compat.v1.train.get_or_create_global_step())
         return tf.estimator.EstimatorSpec(mode=mode, loss=loss, train_op=train_op)
 
     eval_metric_ops = {
-        "accuracy": tf.metrics.accuracy(labels=labels, predictions=predictions["classes"])
+        "accuracy": tf.compat.v1.metrics.accuracy(
+            labels=labels, predictions=predictions["classes"])
     }
     return tf.estimator.EstimatorSpec(mode=mode, loss=loss, eval_metric_ops=eval_metric_ops)
 
@@ -89,13 +91,13 @@ def objective(trial):
         run_every_steps=PRUNING_INTERVAL_STEPS,
     )
 
-    train_input_fn = tf.estimator.inputs.numpy_input_fn(
+    train_input_fn = tf.compat.v1.estimator.inputs.numpy_input_fn(
         x={"x": train_data}, y=train_labels, batch_size=BATCH_SIZE, num_epochs=None, shuffle=True)
 
     train_spec = tf.estimator.TrainSpec(
         input_fn=train_input_fn, max_steps=TRAIN_STEPS, hooks=[optuna_pruning_hook])
 
-    eval_input_fn = tf.estimator.inputs.numpy_input_fn(
+    eval_input_fn = tf.compat.v1.estimator.inputs.numpy_input_fn(
         x={"x": eval_data}, y=eval_labels, num_epochs=1, shuffle=False)
 
     eval_spec = tf.estimator.EvalSpec(
@@ -128,4 +130,4 @@ def main(unused_argv):
 
 
 if __name__ == "__main__":
-    tf.app.run()
+    tf.compat.v1.app.run()


### PR DESCRIPTION
Updates `examples/pruning/tensorflow_estimator_integration.py` to work with TensorFlow versions v1 (verified with v.1.15.0) and v2.

C.f. https://github.com/optuna/optuna/pull/868 and https://github.com/optuna/optuna/pull/855#issuecomment-579591353.

This PR blocks #855.