### PR TITLE
Fix: LightGBM tuner raises exception when max_depth=-1

### DIFF
--- a/optuna/integration/lightgbm_tuner/optimize.py
+++ b/optuna/integration/lightgbm_tuner/optimize.py
@@ -31,6 +31,9 @@ if type_checking.TYPE_CHECKING:
 # EPS is used to ensure that a sampled parameter value is in pre-defined value range.
 EPS = 1e-12
 
+# Default value of tree_depth, used for upper bound of num_leaves
+DEFAULT_TUNER_TREE_DEPTH = 8
+
 # Default parameter values described in the official webpage.
 DEFAULT_LIGHTGBM_PARAMETERS = {
     'lambda_l1': 0.0,
@@ -213,9 +216,10 @@ class OptunaObjective(BaseTuner):
         if 'lambda_l2' in self.target_param_names:
             self.lgbm_params['lambda_l2'] = trial.suggest_loguniform('lambda_l2', 1e-8, 10.0)
         if 'num_leaves' in self.target_param_names:
-            max_depth = self.lgbm_params.get('max_depth', 8)
+            tree_depth = self.lgbm_params.get('max_depth', DEFAULT_TUNER_TREE_DEPTH)
+            max_num_leaves = 2 ** tree_depth if tree_depth > 0 else 2 ** DEFAULT_TUNER_TREE_DEPTH
             self.lgbm_params['num_leaves'] = trial.suggest_int(
-                'num_leaves', 2, 2 ** max_depth)
+                'num_leaves', 2, max_num_leaves)
         if 'feature_fraction' in self.target_param_names:
             # `_GridSamplerUniform1D` is used for sampling feature_fraction value.
             # The value 1.0 for the hyperparameter is always sampled.

--- a/optuna/integration/lightgbm_tuner/optimize.py
+++ b/optuna/integration/lightgbm_tuner/optimize.py
@@ -217,7 +217,7 @@ class OptunaObjective(BaseTuner):
             self.lgbm_params['lambda_l2'] = trial.suggest_loguniform('lambda_l2', 1e-8, 10.0)
         if 'num_leaves' in self.target_param_names:
             tree_depth = self.lgbm_params.get('max_depth', DEFAULT_TUNER_TREE_DEPTH)
-            max_num_leaves = 2 ** tree_depth if tree_depth > 0 else 2 ** DEFAULT_TUNER_TREE_DEPTH
+            max_num_leaves = 2**tree_depth if tree_depth > 0 else 2**DEFAULT_TUNER_TREE_DEPTH
             self.lgbm_params['num_leaves'] = trial.suggest_int(
                 'num_leaves', 2, max_num_leaves)
         if 'feature_fraction' in self.target_param_names:

--- a/tests/integration_tests/lightgbm_tuner_tests/test_optimize.py
+++ b/tests/integration_tests/lightgbm_tuner_tests/test_optimize.py
@@ -319,6 +319,28 @@ class TestLightGBMTuner(object):
             assert runner.lgbm_params['num_leaves'] != unexpected_value
             assert len(tuning_history) == 20
 
+    def test_tune_num_leaves_negative_max_depth(self):
+        # type: () -> None
+
+        params = {
+            'metric': 'binary_logloss',
+            'max_depth': -1,
+        }  # type: Dict[str, Any]
+        X_trn = np.random.uniform(10, size=50).reshape((10, 5))
+        y_trn = np.random.randint(2, size=10)
+        train_dataset = lgb.Dataset(X_trn, label=y_trn)
+        valid_dataset = lgb.Dataset(X_trn, label=y_trn)
+
+        tuning_history = []  # type: List[Dict[str, float]]
+        runner = lgb.LightGBMTuner(params,
+                                   train_dataset,
+                                   num_boost_round=3,
+                                   early_stopping_rounds=2,
+                                   valid_sets=valid_dataset,
+                                   tuning_history=tuning_history)
+        runner.tune_num_leaves()
+        assert len(tuning_history) == 20
+
     def test_tune_bagging(self):
         # type: () -> None
 

--- a/tests/integration_tests/lightgbm_tuner_tests/test_optimize.py
+++ b/tests/integration_tests/lightgbm_tuner_tests/test_optimize.py
@@ -326,7 +326,7 @@ class TestLightGBMTuner(object):
             'metric': 'binary_logloss',
             'max_depth': -1,
         }  # type: Dict[str, Any]
-        X_trn = np.random.uniform(10, size=50).reshape((10, 5))
+        X_trn = np.random.uniform(10, size=(10, 5))
         y_trn = np.random.randint(2, size=10)
         train_dataset = lgb.Dataset(X_trn, label=y_trn)
         valid_dataset = lgb.Dataset(X_trn, label=y_trn)


### PR DESCRIPTION
This PR addresses https://github.com/optuna/optuna/issues/870. Thank you @nyanp for reporting the issue!

Changes:

* Using a variable `max_depth` as an internal variable is confusing. In LightGBM Tuner, the variable is used for deciding the upper bound of `num_leaves`. This patch changes the internal variable name to `tree_depth`.
* If max_depth <= 0 is specified, the Tuner fallback to its internal default (=8).