### PR TITLE
Add RDBStorage argument to set session wait_timeout for MySQL.

### DIFF
--- a/optuna/storages/rdb/storage.py
+++ b/optuna/storages/rdb/storage.py
@@ -69,9 +69,14 @@ class RDBStorage(BaseStorage):
         engine_kwargs:
             A dictionary of keyword arguments that is passed to
             `sqlalchemy.engine.create_engine`_ function.
+        mysql_wait_timeout:
+            `wait_timeout`_ value of the MySQL session. If the value is set to :obj:`None`,
+            the global `wait_timeout` value will be used.
 
     .. _sqlalchemy.engine.create_engine:
         https://docs.sqlalchemy.org/en/latest/core/engines.html#sqlalchemy.create_engine
+    .. _wait_timeout:
+        https://dev.mysql.com/doc/refman/5.6/en/server-system-variables.html#sysvar_wait_timeout
 
     .. note::
         If you use MySQL, `pool_pre_ping`_ will be set to :obj:`True` by default to prevent

--- a/setup.py
+++ b/setup.py
@@ -108,6 +108,7 @@ def get_extras_require():
             'mxnet',
             'pandas',
             'plotly>=4.0.0',
+            'PyMySQL',
             'pytest',
             # TODO(Yanase): Update sklearn integration to support v0.22.1 or newer.
             # See https://github.com/optuna/optuna/issues/825 for further details.

--- a/tests/storages_tests/rdb_tests/test_storage.py
+++ b/tests/storages_tests/rdb_tests/test_storage.py
@@ -431,17 +431,16 @@ def test_check_python_version():
             RDBStorage._check_python_version()
 
 
-def test_set_mysql_wait_timeout():
-    # type: () -> None
+@pytest.mark.parametrize('url,mysql_wait_timeout,expected', [
+    ('mysql+pymysql://localhost', None, False),
+    ('mysql+pymysql://localhost', 3600, True),
+    ('sqlite:///tmp.db', 1, False),
+])
+def test_set_mysql_wait_timeout(url, mysql_wait_timeout, expected):
+    # type: (str, Optional[int], bool) -> None
 
-    engine = sqlalchemy.create_engine('mysql+pymysql://localhost')
+    engine = sqlalchemy.create_engine(url)
 
     with patch('sqlalchemy.event.listens_for') as my_mock:
-        RDBStorage._set_mysql_wait_timeout(engine, None)
-    assert not my_mock.called
-
-    engine = sqlalchemy.create_engine('mysql+pymysql://localhost')
-
-    with patch('sqlalchemy.event.listens_for') as my_mock:
-        RDBStorage._set_mysql_wait_timeout(engine, 3600)
-    assert my_mock.called
+        RDBStorage._set_mysql_wait_timeout(engine, mysql_wait_timeout)
+    assert my_mock.called is expected

--- a/tests/storages_tests/rdb_tests/test_storage.py
+++ b/tests/storages_tests/rdb_tests/test_storage.py
@@ -4,6 +4,7 @@ import tempfile
 
 from mock import patch
 import pytest
+import sqlalchemy
 
 from optuna.distributions import CategoricalDistribution
 from optuna.distributions import json_to_distribution
@@ -403,3 +404,19 @@ def test_check_python_version():
             v_info.minor = ver["minor"]
             v_info.micro = ver["micro"]
             RDBStorage._check_python_version()
+
+
+def test_set_mysql_wait_timeout():
+    # type: () -> None
+
+    engine = sqlalchemy.create_engine('mysql+pymysql://localhost')
+
+    with patch('sqlalchemy.event.listens_for') as my_mock:
+        RDBStorage._set_mysql_wait_timeout(engine, None)
+    assert not my_mock.called
+
+    engine = sqlalchemy.create_engine('mysql+pymysql://localhost')
+
+    with patch('sqlalchemy.event.listens_for') as my_mock:
+        RDBStorage._set_mysql_wait_timeout(engine, 3600)
+    assert my_mock.called


### PR DESCRIPTION
This PR enables users to set the `wait_timeout` variable to each connection of MySQL.

Although #806 has been merged to handle timeout connections, some users still encounter connection timeout. They finally resolved the errors when they extend the `wait_timeout` variable of MySQL server.

The feature in this PR enables users to set `wait_timeout`  by themselves.

Please note that it will decrease the test coverage because `_set_session_wait_timeout` is not executed in the unit test. I think a MySQL server is required for the test. If you have any comments, please let me know.

## Example code

MySQL config: `./mysql.conf.d/wait_timeout.cnf`

```config
[mysqld]
wait_timeout = 10
```

Launching MySQL server:

```
$ docker run -v $(pwd)/mysql.conf.d:/etc/mysql/conf.d --name some-mysql -e MYSQL_ROOT_PASSWORD=test -p 3306:3306 -p 33060:33060 -d mysql:5.7
$ docker run --network host -it --rm mysql:5.7  mysql -h 127.0.0.1 -uroot -p -e "create database optunatest;"
```

```python
import optuna
import time
from sqlalchemy import create_engine, exc

url = 'mysql+pymysql://root:test@localhost/optunatest'

def objective(trial):
    return trial.suggest_int('x', -10, 10)

def get_wait_timeout(engine):
    return [r for r in engine.execute("show variables like 'wait_timeout';")][0][1]

storage = optuna.storages.RDBStorage(url)
print('Global wait_timeout: {}'.format(get_wait_timeout(storage.engine)))
# Global wait_timeout: 10

storage = optuna.storages.RDBStorage(url, mysql_wait_timeout=5)
print('Optuna\'s session wait_timeout: {}'.format(get_wait_timeout(storage.engine)))
# Optuna's session wait_timeout: 5

study = optuna.create_study(storage=storage)

study.optimize(objective, n_trials=1)

time.sleep(11)  # All connections will be timeout.

study.optimize(objective, n_trials=1)

print('Reconnected session\'s wait_timeout: {}'.format(get_wait_timeout(storage.engine)))
# Reconnected session's wait_timeout: 5

engine = create_engine(url)
print('wait_timeout outside Optuna: {}'.format(get_wait_timeout(engine)))
# wait_timeout outside Optuna: 10
```

