### PR TITLE
Update FAQ about trials raising exceptions and returning NaN.

### DIFF
--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -162,13 +162,13 @@ To deal with this problem, please set an option (e.g., random seed) to make the 
 How are exceptions from trials handled?
 ---------------------------------------
 
-Trials that raise, without catching, exceptions will be treated as failures, i.e. with the :obj:`~optuna.structs.TrialState.FAIL` status.
+Trials that raise exceptions without catching them will be treated as failures, i.e. with the :obj:`~optuna.structs.TrialState.FAIL` status.
 
-By default, all exceptions raised in objective functions are propagated to user code.
-In other words, studies are aborted when exceptions are raised.
+By default, all exceptions except :class:`~optuna.exceptions.TrialPruned` raised in objective functions are propagated to the caller of :func:`~optuna.study.Study.optimize`.
+In other words, studies are aborted when such exceptions are raised.
 It might be desirable to continue a study with the remaining trials.
-To do so, you can specify in :func:`~optuna.study.Study.optimize` which exceptions types to catch using the ``catch`` argument.
-Exceptions of these types are caught inside the study and will not be propagated to user code.
+To do so, you can specify in :func:`~optuna.study.Study.optimize` which exception types to catch using the ``catch`` argument.
+Exceptions of these types are caught inside the study and will not propagate further.
 
 You can find the failed trials in log messages.
 

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -159,26 +159,23 @@ Second, if your objective function behaves in a non-deterministic way (i.e., it 
 To deal with this problem, please set an option (e.g., random seed) to make the behavior deterministic if your optimization target (e.g., an ML library) provides it.
 
 
-How does Optuna handle NaNs and exceptions reported by the objective function?
-------------------------------------------------------------------------------
+How are exceptions from trials handled?
+---------------------------------------
 
-Optuna treats such trials as failures (i.e., :obj:`~optuna.structs.TrialState.FAIL`) and continues the study.
-The Optuna's system process will not be crashed by any objective values or exceptions raised in objective functions.
+Trials that raise, without catching, exceptions will be treated as failures, i.e. with the :obj:`~optuna.structs.TrialState.FAIL` status.
+
+By default, all exceptions raised in objective functions are propagated to user code.
+In other words, studies are aborted when exceptions are raised.
+It might be desirable to continue a study with the remaining trials.
+To do so, you can specify in :func:`~optuna.study.Study.optimize` which exceptions types to catch using the ``catch`` argument.
+Exceptions of these types are caught inside the study and will not be propagated to user code.
 
 You can find the failed trials in log messages.
-Errors raised in objective functions are shown as follows:
 
 .. code-block:: sh
 
     [W 2018-12-07 16:38:36,889] Setting status of trial#0 as TrialState.FAIL because of \
     the following error: ValueError('A sample error in objective.')
-
-And trials which returned :obj:`NaN` are shown as follows:
-
-.. code-block:: sh
-
-    [W 2018-12-07 16:41:59,000] Setting status of trial#2 as TrialState.FAIL because the \
-    objective function returned nan.
 
 You can also find the failed trials by checking the trial states as follows:
 
@@ -191,6 +188,23 @@ You can also find the failed trials by checking the trial states as follows:
     number,state,value,...,params,system_attrs
     0,TrialState.FAIL,,...,0,Setting status of trial#0 as TrialState.FAIL because of the following error: ValueError('A test error in objective.')
     1,TrialState.COMPLETE,1269,...,1,
+
+.. seealso::
+
+    The ``catch`` arcument in :func:`~optuna.study.Study.optimize`.
+
+
+How are NaNs returned by trials handled?
+----------------------------------------
+
+Trials that return :obj:`NaN` (``float('nan')``) are treated as failures, but they will not abort studies.
+
+Trials which return :obj:`NaN` are shown as follows:
+
+.. code-block:: sh
+
+    [W 2018-12-07 16:41:59,000] Setting status of trial#2 as TrialState.FAIL because the \
+    objective function returned nan.
 
 
 What happens when I dynamically alter a search space?


### PR DESCRIPTION
Updates documentation that have become obsolete due to https://github.com/optuna/optuna/pull/638.