### PR TITLE
Fix OptunaSearchCV by adding the method that was implemented in sklearn

### DIFF
--- a/optuna/integration/sklearn.py
+++ b/optuna/integration/sklearn.py
@@ -62,6 +62,8 @@ def _check_fit_params(
     fit_params,  # type: Dict
     indices  # type: OneDimArrayLikeType
 ):
+    # type: (...) -> Dict
+
     if _sklearn_version >= '0.22.1':
         return validation._check_fit_params(X, fit_params, indices)
     else:  # '_sklearn_version < 0.22.1'

--- a/optuna/integration/sklearn.py
+++ b/optuna/integration/sklearn.py
@@ -1,10 +1,3 @@
-from optuna import distributions
-from optuna import exceptions
-from optuna import logging
-from optuna import structs
-from optuna import study as study_module
-from optuna import type_checking
-
 from logging import DEBUG
 from logging import INFO
 from logging import WARNING
@@ -42,8 +35,14 @@ if _available:
     else:
         from sklearn.utils.validation import _index_param_value as _sklearn_index_param_value  # NOQA
 
+from optuna import distributions  # NOQA
+from optuna import exceptions  # NOQA
+from optuna import logging  # NOQA
 from optuna import samplers  # NOQA
+from optuna import structs  # NOQA
+from optuna import study as study_module  # NOQA
 from optuna import trial as trial_module  # NOQA
+from optuna import type_checking  # NOQA
 
 if type_checking.TYPE_CHECKING:
     import pandas as pd  # NOQA

--- a/optuna/integration/sklearn.py
+++ b/optuna/integration/sklearn.py
@@ -18,6 +18,7 @@ try:
     from sklearn.utils.metaestimators import _safe_split
     from sklearn.utils import safe_indexing as sklearn_safe_indexing
     from sklearn.utils.validation import _num_samples
+    from sklearn.utils.validation import _check_fit_params
     from sklearn.utils.validation import check_is_fitted
 
     _available = True
@@ -66,22 +67,6 @@ def _check_sklearn_availability():
             'please refer to the installation guide of scikit-learn. (The '
             'actual import error is as follows: ' + str(_import_error) + ')'
         )
-
-
-def _is_arraylike(x):
-    # type: (Any) -> bool
-    return hasattr(x, '__len__')
-
-
-def _index_param_value(
-    X,  # type: TwoDimArrayLikeType
-    v,  # type: Any
-    indices  # type: OneDimArrayLikeType
-):
-    # type: (...) -> Union[OneDimArrayLikeType, TwoDimArrayLikeType]
-    if not _is_arraylike(v) or _num_samples(v) != _num_samples(X):
-        return v
-    return _safe_indexing(v, indices)
 
 
 def _safe_indexing(
@@ -856,13 +841,7 @@ class OptunaSearchCV(BaseEstimator):
         fit_params_res = fit_params
 
         if fit_params_res is not None:
-            fit_params_res = {
-                key: _index_param_value(
-                    X,
-                    value,
-                    self.sample_indices_
-                ) for key, value in fit_params.items()
-            }
+            fit_params_res = _check_fit_params(X, fit_params, self.sample_indices_)
 
         classifier = is_classifier(self.estimator)
         cv = check_cv(self.cv, y_res, classifier)

--- a/optuna/integration/sklearn.py
+++ b/optuna/integration/sklearn.py
@@ -18,7 +18,6 @@ try:
     from sklearn.utils import check_random_state
     from sklearn.utils.metaestimators import _safe_split
     from sklearn.utils import safe_indexing as sklearn_safe_indexing
-    from sklearn.utils import validation
     from sklearn.utils.validation import _num_samples
     from sklearn.utils.validation import check_is_fitted
 
@@ -29,6 +28,12 @@ except ImportError as e:
 
     _import_error = e
     _available = False
+
+if _available:
+    if _sklearn_version >= '0.22.1':
+        from sklearn.utils.validation import _check_fit_params as _sklearn_check_fit_params  # NOQA
+    else:
+        from sklearn.utils.validation import _index_param_value as _sklearn_index_param_value  # NOQA
 
 from optuna import distributions
 from optuna import exceptions
@@ -65,10 +70,10 @@ def _check_fit_params(
     # type: (...) -> Dict
 
     if _sklearn_version >= '0.22.1':
-        return validation._check_fit_params(X, fit_params, indices)
+        return _sklearn_check_fit_params(X, fit_params, indices)
     else:  # '_sklearn_version < 0.22.1'
         return {
-            key: validation._index_param_value(
+            key: _sklearn_index_param_value(
                 X,
                 value,
                 indices

--- a/optuna/integration/sklearn.py
+++ b/optuna/integration/sklearn.py
@@ -11,7 +11,6 @@ try:
     from sklearn.base import clone
     from sklearn.base import is_classifier
     from sklearn.metrics.scorer import check_scoring
-    from sklearn.model_selection._validation import _index_param_value
     from sklearn.model_selection import BaseCrossValidator  # NOQA
     from sklearn.model_selection import check_cv
     from sklearn.model_selection import cross_validate
@@ -67,6 +66,22 @@ def _check_sklearn_availability():
             'please refer to the installation guide of scikit-learn. (The '
             'actual import error is as follows: ' + str(_import_error) + ')'
         )
+
+
+def _is_arraylike(x):
+    # type: (Any) -> bool
+    return hasattr(x, '__len__')
+
+
+def _index_param_value(
+    X,  # type: TwoDimArrayLikeType
+    v,  # type: Any
+    indices  # type: OneDimArrayLikeType
+):
+    # type: (...) -> Union[OneDimArrayLikeType, TwoDimArrayLikeType]
+    if not _is_arraylike(v) or _num_samples(v) != _num_samples(X):
+        return v
+    return _safe_indexing(v, indices)
 
 
 def _safe_indexing(

--- a/optuna/integration/sklearn.py
+++ b/optuna/integration/sklearn.py
@@ -31,9 +31,9 @@ except ImportError as e:
 
 if _available:
     if _sklearn_version >= '0.22.1':
-        from sklearn.utils.validation import _check_fit_params as _sklearn_check_fit_params  # NOQA
+        from sklearn.utils.validation import _check_fit_params as _sklearn_check_fit_params
     else:
-        from sklearn.utils.validation import _index_param_value as _sklearn_index_param_value  # NOQA
+        from sklearn.utils.validation import _index_param_value as _sklearn_index_param_value
 
 from optuna import distributions  # NOQA
 from optuna import exceptions  # NOQA

--- a/optuna/integration/sklearn.py
+++ b/optuna/integration/sklearn.py
@@ -57,7 +57,7 @@ if type_checking.TYPE_CHECKING:
 _logger = logging.get_logger(__name__)
 
 
-def check_fit_params(
+def _check_fit_params(
     X,  # type: TwoDimArrayLikeType
     fit_params,  # type: Dict
     indices  # type: OneDimArrayLikeType
@@ -860,7 +860,7 @@ class OptunaSearchCV(BaseEstimator):
         fit_params_res = fit_params
 
         if fit_params_res is not None:
-            fit_params_res = check_fit_params(X, fit_params, self.sample_indices_)
+            fit_params_res = _check_fit_params(X, fit_params, self.sample_indices_)
 
         classifier = is_classifier(self.estimator)
         cv = check_cv(self.cv, y_res, classifier)

--- a/optuna/integration/sklearn.py
+++ b/optuna/integration/sklearn.py
@@ -18,8 +18,9 @@ try:
     from sklearn.utils.metaestimators import _safe_split
     from sklearn.utils import safe_indexing as sklearn_safe_indexing
     from sklearn.utils.validation import _num_samples
-    from sklearn.utils.validation import _check_fit_params
     from sklearn.utils.validation import check_is_fitted
+    from sklearn.utils import validation
+    from sklearn import __version__ as _sklearn_version
 
     _available = True
 
@@ -54,6 +55,24 @@ if type_checking.TYPE_CHECKING:
         Union[List[List[float]], np.ndarray, pd.DataFrame, spmatrix]
 
 _logger = logging.get_logger(__name__)
+
+
+def check_fit_params(
+    X,  # type: TwoDimArrayLikeType
+    fit_params,  # type: Dict
+    indices  # type: OneDimArrayLikeType
+):
+    assert _available
+    if _sklearn_version >= '0.22.1':
+        return validation._check_fit_params(X, fit_params, indices)
+    else:  # '_sklearn_version < 0.22.1'
+        return {
+            key: validation._index_param_value(
+                X,
+                value,
+                indices
+            ) for key, value in fit_params.items()
+        }
 
 
 def _check_sklearn_availability():
@@ -841,7 +860,7 @@ class OptunaSearchCV(BaseEstimator):
         fit_params_res = fit_params
 
         if fit_params_res is not None:
-            fit_params_res = _check_fit_params(X, fit_params, self.sample_indices_)
+            fit_params_res = check_fit_params(X, fit_params, self.sample_indices_)
 
         classifier = is_classifier(self.estimator)
         cv = check_cv(self.cv, y_res, classifier)

--- a/optuna/integration/sklearn.py
+++ b/optuna/integration/sklearn.py
@@ -7,6 +7,7 @@ from time import time
 import numpy as np
 
 try:
+    from sklearn import __version__ as _sklearn_version
     from sklearn.base import BaseEstimator
     from sklearn.base import clone
     from sklearn.base import is_classifier
@@ -17,10 +18,9 @@ try:
     from sklearn.utils import check_random_state
     from sklearn.utils.metaestimators import _safe_split
     from sklearn.utils import safe_indexing as sklearn_safe_indexing
+    from sklearn.utils import validation
     from sklearn.utils.validation import _num_samples
     from sklearn.utils.validation import check_is_fitted
-    from sklearn.utils import validation
-    from sklearn import __version__ as _sklearn_version
 
     _available = True
 

--- a/optuna/integration/sklearn.py
+++ b/optuna/integration/sklearn.py
@@ -1,3 +1,10 @@
+from optuna import distributions
+from optuna import exceptions
+from optuna import logging
+from optuna import structs
+from optuna import study as study_module
+from optuna import type_checking
+
 from logging import DEBUG
 from logging import INFO
 from logging import WARNING
@@ -35,14 +42,8 @@ if _available:
     else:
         from sklearn.utils.validation import _index_param_value as _sklearn_index_param_value  # NOQA
 
-from optuna import distributions
-from optuna import exceptions
-from optuna import logging
 from optuna import samplers  # NOQA
-from optuna import structs
-from optuna import study as study_module
 from optuna import trial as trial_module  # NOQA
-from optuna import type_checking
 
 if type_checking.TYPE_CHECKING:
     import pandas as pd  # NOQA

--- a/setup.py
+++ b/setup.py
@@ -65,9 +65,7 @@ def get_extras_require():
         ],
         'doctest': [
             'pandas',
-            # TODO(Yanase): Update sklearn integration to support v0.22.1 or newer.
-            # See https://github.com/optuna/optuna/issues/825 for further details.
-            'scikit-learn>=0.19.0,<=0.22.0',
+            'scikit-learn>=0.19.0',
         ],
         'document': [
             'lightgbm',
@@ -81,9 +79,7 @@ def get_extras_require():
             'mlflow',
             'mxnet',
             'scikit-image',
-            # TODO(Yanase): Update sklearn integration to support v0.22.1 or newer.
-            # See https://github.com/optuna/optuna/issues/825 for further details.
-            'scikit-learn<=0.22.0',
+            'scikit-learn',
             'xgboost',
         ] + (['fastai<2'] if (3, 5) < sys.version_info[:2] < (3, 8) else [])
         + ([
@@ -107,9 +103,7 @@ def get_extras_require():
             'pandas',
             'plotly>=4.0.0',
             'pytest',
-            # TODO(Yanase): Update sklearn integration to support v0.22.1 or newer.
-            # See https://github.com/optuna/optuna/issues/825 for further details.
-            'scikit-learn>=0.19.0,<=0.22.0',
+            'scikit-learn>=0.19.0',
             'scikit-optimize',
             'xgboost',
         ] + (['fastai<2'] if (3, 5) < sys.version_info[:2] < (3, 8) else [])

--- a/tests/integration_tests/test_sklearn.py
+++ b/tests/integration_tests/test_sklearn.py
@@ -2,15 +2,20 @@ import pytest
 from sklearn.datasets import make_blobs
 from sklearn.exceptions import NotFittedError
 from sklearn.linear_model import SGDClassifier
+from typing import Dict
+from typing import Optional
 
 from optuna import distributions
 from optuna import integration
 
+import numpy as np
+
 
 @pytest.mark.parametrize('enable_pruning', [True, False])
+@pytest.mark.parametrize('fit_params', [None, 'sample_weight'])
 @pytest.mark.filterwarnings('ignore::UserWarning')
-def test_optuna_search(enable_pruning):
-    # type: (bool) -> None
+def test_optuna_search(enable_pruning, fit_params):
+    # type: (bool, Optional[Dict]) -> None
 
     X, y = make_blobs(n_samples=10)
     est = SGDClassifier(max_iter=5, tol=1e-03)
@@ -29,7 +34,12 @@ def test_optuna_search(enable_pruning):
     with pytest.raises(NotFittedError):
         optuna_search._check_is_fitted()
 
-    optuna_search.fit(X, y)
+    if fit_params == 'sample_weight':
+        sample_weight = np.ones_like(y)
+        optuna_search.fit(X, y, sample_weight=sample_weight)
+    else:
+        optuna_search.fit(X, y)
+
     optuna_search.trials_dataframe()
     optuna_search.decision_function(X)
     optuna_search.predict(X)

--- a/tests/integration_tests/test_sklearn.py
+++ b/tests/integration_tests/test_sklearn.py
@@ -2,7 +2,6 @@ import pytest
 from sklearn.datasets import make_blobs
 from sklearn.exceptions import NotFittedError
 from sklearn.linear_model import SGDClassifier
-from typing import Dict
 from typing import Optional
 
 from optuna import distributions

--- a/tests/integration_tests/test_sklearn.py
+++ b/tests/integration_tests/test_sklearn.py
@@ -2,7 +2,6 @@ import pytest
 from sklearn.datasets import make_blobs
 from sklearn.exceptions import NotFittedError
 from sklearn.linear_model import SGDClassifier
-from typing import Optional
 
 from optuna import distributions
 from optuna import integration
@@ -11,10 +10,10 @@ import numpy as np
 
 
 @pytest.mark.parametrize('enable_pruning', [True, False])
-@pytest.mark.parametrize('fit_params', [None, 'sample_weight'])
+@pytest.mark.parametrize('fit_params', ['', 'sample_weight'])
 @pytest.mark.filterwarnings('ignore::UserWarning')
 def test_optuna_search(enable_pruning, fit_params):
-    # type: (bool, Optional[str]) -> None
+    # type: (bool, str) -> None
 
     X, y = make_blobs(n_samples=10)
     est = SGDClassifier(max_iter=5, tol=1e-03)

--- a/tests/integration_tests/test_sklearn.py
+++ b/tests/integration_tests/test_sklearn.py
@@ -15,7 +15,7 @@ import numpy as np
 @pytest.mark.parametrize('fit_params', [None, 'sample_weight'])
 @pytest.mark.filterwarnings('ignore::UserWarning')
 def test_optuna_search(enable_pruning, fit_params):
-    # type: (bool, Optional[Dict]) -> None
+    # type: (bool, Optional[str]) -> None
 
     X, y = make_blobs(n_samples=10)
     est = SGDClassifier(max_iter=5, tol=1e-03)

--- a/tests/integration_tests/test_sklearn.py
+++ b/tests/integration_tests/test_sklearn.py
@@ -10,7 +10,7 @@ import numpy as np
 
 
 @pytest.mark.parametrize('enable_pruning', [True, False])
-@pytest.mark.parametrize('fit_params', ['', 'sample_weight'])
+@pytest.mark.parametrize('fit_params', ['', 'coef_init'])
 @pytest.mark.filterwarnings('ignore::UserWarning')
 def test_optuna_search(enable_pruning, fit_params):
     # type: (bool, str) -> None
@@ -32,9 +32,8 @@ def test_optuna_search(enable_pruning, fit_params):
     with pytest.raises(NotFittedError):
         optuna_search._check_is_fitted()
 
-    if fit_params == 'sample_weight':
-        sample_weight = np.ones_like(y)
-        optuna_search.fit(X, y, sample_weight=sample_weight)
+    if fit_params == 'coef_init' and not enable_pruning:
+        optuna_search.fit(X, y, coef_init=np.ones((3, 2), dtype=np.float64))
     else:
         optuna_search.fit(X, y)
 


### PR DESCRIPTION
This PR aims to resolve #825.

Optuna doesn't work with `scikit-learn>=0.22.1` since
it removed the private method `_index_param_value`, which was used in Optuna.
This PR adds `_index_param_value` and makes optuna work with the latest scikit-learn.