### PR TITLE
Add examples for doctest to optuna/trial.py

### DIFF
--- a/optuna/trial.py
+++ b/optuna/trial.py
@@ -156,14 +156,19 @@ class Trial(BaseTrial):
 
         Example:
 
-            Suggest a dropout rate for neural network training.
+            .. testcode::
 
-            .. code::
+                import optuna
 
-                >>> def objective(trial):
-                >>>     ...
-                >>>     dropout_rate = trial.suggest_uniform('dropout_rate', 0, 1.0)
-                >>>     ...
+                def objective(trial):
+                    dropout_rate = trial.suggest_uniform('dropout_rate', 0, 1.0)
+                    assert 0.0 <= dropout_rate < 1.0
+
+                    return dropout_rate
+
+                study = optuna.create_study()
+                study.optimize(objective, n_trials=3)
+
 
         Args:
             name:
@@ -194,16 +199,28 @@ class Trial(BaseTrial):
 
         Example:
 
-            Suggest penalty parameter ``C`` of `SVC <https://scikit-learn.org/stable/modules/
-            generated/sklearn.svm.SVC.html>`_.
+            .. testcode::
 
-            .. code::
+                import optuna
+                import numpy as np
+                from sklearn.svm import SVC
+                from sklearn.model_selection import train_test_split
 
-                >>> def objective(trial):
-                >>>     ...
-                >>>     c = trial.suggest_loguniform('c', 1e-5, 1e2)
-                >>>     clf = sklearn.svm.SVC(C=c)
-                >>>     ...
+                def objective(trial):
+                    c = trial.suggest_loguniform('c', 1e-5, 1e2)
+                    assert 1e-5 <= c < 1e2
+
+                    np.random.seed(seed=0)
+                    X = np.random.randn(50).reshape(-1, 1)
+                    y = np.random.randint(0, 2, 50)
+                    X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
+
+                    clf = SVC(C=c, gamma='scale', random_state=0)
+                    clf.fit(X_train, y_train)
+                    return clf.score(X_test, y_test)
+
+                study = optuna.create_study()
+                study.optimize(objective, n_trials=3)
 
         Args:
             name:
@@ -239,17 +256,28 @@ class Trial(BaseTrial):
 
         Example:
 
-            Suggest a fraction of samples used for fitting the individual learners of
-            `GradientBoostingClassifier <https://scikit-learn.org/stable/modules/generated/
-            sklearn.ensemble.GradientBoostingClassifier.html>`_.
+            .. testcode::
 
-            .. code::
+                import optuna
+                import numpy as np
+                from sklearn.ensemble import GradientBoostingClassifier
+                from sklearn.model_selection import train_test_split
 
-                >>> def objective(trial):
-                >>>     ...
-                >>>     subsample = trial.suggest_discrete_uniform('subsample', 0.1, 1.0, 0.1)
-                >>>     clf = sklearn.ensemble.GradientBoostingClassifier(subsample=subsample)
-                >>>     ...
+                def objective(trial):
+                    subsample = trial.suggest_discrete_uniform('subsample', 0.1, 1.0, 0.1)
+                    assert 0.1 <= subsample <= 1.0
+
+                    np.random.seed(seed=0)
+                    X = np.random.randn(50).reshape(-1, 1)
+                    y = np.random.randint(0, 2, 50)
+                    X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
+
+                    clf = GradientBoostingClassifier(subsample=subsample, random_state=0)
+                    clf.fit(X_train, y_train)
+                    return clf.score(X_test, y_test)
+
+                study = optuna.create_study()
+                study.optimize(objective, n_trials=3)
 
         Args:
             name:
@@ -280,16 +308,29 @@ class Trial(BaseTrial):
 
         Example:
 
-            Suggest the number of trees in `RandomForestClassifier <https://scikit-learn.org/
-            stable/modules/generated/sklearn.ensemble.RandomForestClassifier.html>`_.
+            .. testcode::
 
-            .. code::
+                import optuna
+                import numpy as np
+                from sklearn.ensemble import RandomForestClassifier
+                from sklearn.model_selection import train_test_split
 
-                >>> def objective(trial):
-                >>>     ...
-                >>>     n_estimators = trial.suggest_int('n_estimators', 50, 400)
-                >>>     clf = sklearn.ensemble.RandomForestClassifier(n_estimators=n_estimators)
-                >>>     ...
+                def objective(trial):
+                    n_estimators = trial.suggest_int('n_estimators', 50, 400)
+                    assert 50 <= n_estimators <= 400
+
+                    np.random.seed(seed=0)
+                    X = np.random.randn(50).reshape(-1, 1)
+                    y = np.random.randint(0, 2, 50)
+                    X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
+
+                    clf = RandomForestClassifier(n_estimators=n_estimators, random_state=0)
+                    clf.fit(X_train, y_train)
+                    return clf.score(X_test, y_test)
+
+                study = optuna.create_study()
+                study.optimize(objective, n_trials=3)
+
 
         Args:
             name:
@@ -317,16 +358,29 @@ class Trial(BaseTrial):
 
         Example:
 
-            Suggest a kernel function of `SVC <https://scikit-learn.org/stable/modules/generated/
-            sklearn.svm.SVC.html>`_.
+            .. testcode::
 
-            .. code::
+                import optuna
+                import numpy as np
+                from sklearn.svm import SVC
+                from sklearn.model_selection import train_test_split
 
-                >>> def objective(trial):
-                >>>     ...
-                >>>     kernel = trial.suggest_categorical('kernel', ['linear', 'poly', 'rbf'])
-                >>>     clf = sklearn.svm.SVC(kernel=kernel)
-                >>>     ...
+                def objective(trial):
+                    kernel = trial.suggest_categorical('kernel', ['linear', 'poly', 'rbf'])
+                    assert kernel in ['linear', 'poly', 'rbf']
+
+                    np.random.seed(seed=0)
+                    X = np.random.randn(50).reshape(-1, 1)
+                    y = np.random.randint(0, 2, 50)
+                    X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
+
+                    clf = SVC(kernel=kernel, gamma='scale', random_state=0)
+                    clf.fit(X_train, y_train)
+                    return clf.score(X_test, y_test)
+
+                study = optuna.create_study()
+                study.optimize(objective, n_trials=3)
+
 
         Args:
             name:
@@ -357,21 +411,32 @@ class Trial(BaseTrial):
 
         Example:
 
-            Report intermediate scores of `SGDClassifier <https://scikit-learn.org/stable/modules/
-            generated/sklearn.linear_model.SGDClassifier.html>`_ training
+            .. testcode::
 
-            .. code::
+                import optuna
+                import numpy as np
+                from sklearn.linear_model import SGDClassifier
+                from sklearn.model_selection import train_test_split
 
-                >>> def objective(trial):
-                >>>     ...
-                >>>     clf = sklearn.linear_model.SGDClassifier()
-                >>>     for step in range(100):
-                >>>         clf.partial_fit(x_train , y_train , classes)
-                >>>         intermediate_value = clf.score(x_val , y_val)
-                >>>         trial.report(intermediate_value , step=step)
-                >>>         if trial.should_prune():
-                >>>             raise TrialPruned()
-                >>>     ...
+                def objective(trial):
+                    np.random.seed(seed=0)
+                    X = np.random.randn(50).reshape(-1, 1)
+                    y = np.random.randint(0, 2, 50)
+                    X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
+
+                    clf = SGDClassifier(random_state=0)
+                    for step in range(100):
+                        clf.partial_fit(X_train, y_train, np.unique(y))
+                        intermediate_value = clf.score(X_test, y_test)
+                        trial.report(intermediate_value, step=step)
+                        if trial.should_prune():
+                            raise TrialPruned()
+
+                    return clf.score(X_test, y_test)
+
+                study = optuna.create_study()
+                study.optimize(objective, n_trials=3)
+
 
         Args:
             value:
@@ -437,16 +502,20 @@ class Trial(BaseTrial):
 
         Example:
 
-            Save fixed hyperparameters of neural network training:
+            .. testcode::
 
-            .. code::
+                import optuna
 
-                >>> def objective(trial):
-                >>>     ...
-                >>>     trial.set_user_attr('BATCHSIZE', 128)
-                >>>
-                >>> study.best_trial.user_attrs
-                {'BATCHSIZE': 128}
+                def objective(trial):
+                    trial.set_user_attr('BATCHSIZE', 128)
+                    x = trial.suggest_uniform('x', 0, 1.0)
+
+                    return x
+
+                study = optuna.create_study()
+                study.optimize(objective, n_trials=3)
+                assert 'BATCHSIZE' in study.best_trial.user_attrs.keys()
+                assert study.best_trial.user_attrs['BATCHSIZE'] == 128
 
 
         Args:
@@ -634,17 +703,17 @@ class FixedTrial(BaseTrial):
 
     Example:
 
-        Evaluate an objective function with parameter values given by a user:
+        .. testcode::
 
-        .. code::
+            import optuna
 
-            >>> def objective(trial):
-            >>>     x = trial.suggest_uniform('x', -100, 100)
-            >>>     y = trial.suggest_categorical('y', [-1, 0, 1])
-            >>>     return x ** 2 + y
-            >>>
-            >>> objective(FixedTrial({'x': 1, 'y': 0}))
-            1
+            def objective(trial):
+                x = trial.suggest_uniform('x', -100, 100)
+                y = trial.suggest_categorical('y', [-1, 0, 1])
+                return x ** 2 + y
+
+            assert objective(optuna.trial.FixedTrial({'x': 1, 'y': 0})) == 1
+
 
     .. note::
         Please refer to :class:`~optuna.trial.Trial` for details of methods and properties.

--- a/optuna/trial.py
+++ b/optuna/trial.py
@@ -204,22 +204,23 @@ class Trial(BaseTrial):
             Suggest penalty parameter ``C`` of `SVC <https://scikit-learn.org/stable/modules/
             generated/sklearn.svm.SVC.html>`_.
 
+            .. testsetup::
+
+                import numpy as np
+                from sklearn.model_selection import train_test_split
+
+                np.random.seed(seed=0)
+                X = np.random.randn(50).reshape(-1, 1)
+                y = np.random.randint(0, 2, 50)
+                X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
+
             .. testcode::
 
                 import optuna
-                import numpy as np
                 from sklearn.svm import SVC
-                from sklearn.model_selection import train_test_split
 
                 def objective(trial):
                     c = trial.suggest_loguniform('c', 1e-5, 1e2)
-                    assert 1e-5 <= c < 1e2
-
-                    np.random.seed(seed=0)
-                    X = np.random.randn(50).reshape(-1, 1)
-                    y = np.random.randint(0, 2, 50)
-                    X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
-
                     clf = SVC(C=c, gamma='scale', random_state=0)
                     clf.fit(X_train, y_train)
                     return clf.score(X_test, y_test)
@@ -274,7 +275,6 @@ class Trial(BaseTrial):
 
                 def objective(trial):
                     subsample = trial.suggest_discrete_uniform('subsample', 0.1, 1.0, 0.1)
-                    assert 0.1 <= subsample <= 1.0
 
                     np.random.seed(seed=0)
                     X = np.random.randn(50).reshape(-1, 1)
@@ -320,22 +320,23 @@ class Trial(BaseTrial):
             Suggest the number of trees in `RandomForestClassifier <https://scikit-learn.org/
             stable/modules/generated/sklearn.ensemble.RandomForestClassifier.html>`_.
 
+            .. testsetup::
+
+                import numpy as np
+                from sklearn.model_selection import train_test_split
+
+                np.random.seed(seed=0)
+                X = np.random.randn(50).reshape(-1, 1)
+                y = np.random.randint(0, 2, 50)
+                X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
+
             .. testcode::
 
                 import optuna
-                import numpy as np
                 from sklearn.ensemble import RandomForestClassifier
-                from sklearn.model_selection import train_test_split
 
                 def objective(trial):
                     n_estimators = trial.suggest_int('n_estimators', 50, 400)
-                    assert 50 <= n_estimators <= 400
-
-                    np.random.seed(seed=0)
-                    X = np.random.randn(50).reshape(-1, 1)
-                    y = np.random.randint(0, 2, 50)
-                    X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
-
                     clf = RandomForestClassifier(n_estimators=n_estimators, random_state=0)
                     clf.fit(X_train, y_train)
                     return clf.score(X_test, y_test)
@@ -373,22 +374,23 @@ class Trial(BaseTrial):
             Suggest a kernel function of `SVC <https://scikit-learn.org/stable/modules/generated/
             sklearn.svm.SVC.html>`_.
 
+            .. testsetup::
+
+                import numpy as np
+                from sklearn.model_selection import train_test_split
+
+                np.random.seed(seed=0)
+                X = np.random.randn(50).reshape(-1, 1)
+                y = np.random.randint(0, 2, 50)
+                X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
+
             .. testcode::
 
                 import optuna
-                import numpy as np
                 from sklearn.svm import SVC
-                from sklearn.model_selection import train_test_split
 
                 def objective(trial):
                     kernel = trial.suggest_categorical('kernel', ['linear', 'poly', 'rbf'])
-                    assert kernel in ['linear', 'poly', 'rbf']
-
-                    np.random.seed(seed=0)
-                    X = np.random.randn(50).reshape(-1, 1)
-                    y = np.random.randint(0, 2, 50)
-                    X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
-
                     clf = SVC(kernel=kernel, gamma='scale', random_state=0)
                     clf.fit(X_train, y_train)
                     return clf.score(X_test, y_test)
@@ -431,9 +433,7 @@ class Trial(BaseTrial):
 
             .. testsetup::
 
-                import optuna
                 import numpy as np
-                from sklearn.linear_model import SGDClassifier
                 from sklearn.model_selection import train_test_split
 
                 np.random.seed(seed=0)
@@ -443,8 +443,10 @@ class Trial(BaseTrial):
 
             .. testcode::
 
-                def objective(trial):
+                import optuna
+                from sklearn.linear_model import SGDClassifier
 
+                def objective(trial):
                     clf = SGDClassifier(random_state=0)
                     for step in range(100):
                         clf.partial_fit(X_train, y_train, np.unique(y))

--- a/optuna/trial.py
+++ b/optuna/trial.py
@@ -156,6 +156,8 @@ class Trial(BaseTrial):
 
         Example:
 
+            Suggest a dropout rate for neural network training.
+
             .. testcode::
 
                 import optuna
@@ -198,6 +200,9 @@ class Trial(BaseTrial):
         :math:`\\mathsf{low}` will be returned.
 
         Example:
+
+            Suggest penalty parameter ``C`` of `SVC <https://scikit-learn.org/stable/modules/
+            generated/sklearn.svm.SVC.html>`_.
 
             .. testcode::
 
@@ -256,6 +261,10 @@ class Trial(BaseTrial):
 
         Example:
 
+            Suggest a fraction of samples used for fitting the individual learners of
+            `GradientBoostingClassifier <https://scikit-learn.org/stable/modules/generated/
+            sklearn.ensemble.GradientBoostingClassifier.html>`_.
+
             .. testcode::
 
                 import optuna
@@ -308,6 +317,9 @@ class Trial(BaseTrial):
 
         Example:
 
+            Suggest the number of trees in `RandomForestClassifier <https://scikit-learn.org/
+            stable/modules/generated/sklearn.ensemble.RandomForestClassifier.html>`_.
+
             .. testcode::
 
                 import optuna
@@ -357,6 +369,9 @@ class Trial(BaseTrial):
         The value is sampled from ``choices``.
 
         Example:
+
+            Suggest a kernel function of `SVC <https://scikit-learn.org/stable/modules/generated/
+            sklearn.svm.SVC.html>`_.
 
             .. testcode::
 
@@ -411,18 +426,24 @@ class Trial(BaseTrial):
 
         Example:
 
-            .. testcode::
+            Report intermediate scores of `SGDClassifier <https://scikit-learn.org/stable/modules/
+            generated/sklearn.linear_model.SGDClassifier.html>`_ training.
+
+            .. testsetup::
 
                 import optuna
                 import numpy as np
                 from sklearn.linear_model import SGDClassifier
                 from sklearn.model_selection import train_test_split
 
+                np.random.seed(seed=0)
+                X = np.random.randn(50).reshape(-1, 1)
+                y = np.random.randint(0, 2, 50)
+                X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
+
+            .. testcode::
+
                 def objective(trial):
-                    np.random.seed(seed=0)
-                    X = np.random.randn(50).reshape(-1, 1)
-                    y = np.random.randint(0, 2, 50)
-                    X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
 
                     clf = SGDClassifier(random_state=0)
                     for step in range(100):
@@ -501,6 +522,8 @@ class Trial(BaseTrial):
         The user attributes in the trial can be access via :func:`optuna.trial.Trial.user_attrs`.
 
         Example:
+
+            Save fixed hyperparameters of neural network training.
 
             .. testcode::
 
@@ -702,6 +725,8 @@ class FixedTrial(BaseTrial):
     useful for deploying optimization results.
 
     Example:
+
+        Evaluate an objective function with parameter values given by a user.
 
         .. testcode::
 

--- a/optuna/trial.py
+++ b/optuna/trial.py
@@ -176,7 +176,7 @@ class Trial(BaseTrial):
                 def objective(trial):
                     momentum = trial.suggest_uniform('momentum', 0.0, 1.0)
                     clf = MLPClassifier(hidden_layer_sizes=(100, 50), momentum=momentum,
-                                        tol=1e-3, random_state=0)
+                                        solver='sgd', random_state=0)
                     clf.fit(X_train, y_train)
 
                     return clf.score(X_test, y_test)
@@ -561,7 +561,7 @@ class Trial(BaseTrial):
                     momentum = trial.suggest_uniform('momentum', 0, 1.0)
                     clf = MLPClassifier(hidden_layer_sizes=(100, 50),
                                         batch_size=trial.user_attrs['BATCHSIZE'],
-                                        momentum=momentum, tol=1e-3, random_state=0)
+                                        momentum=momentum, solver='sgd', random_state=0)
                     clf.fit(X_train, y_train)
 
                     return clf.score(X_test, y_test)

--- a/optuna/trial.py
+++ b/optuna/trial.py
@@ -156,21 +156,33 @@ class Trial(BaseTrial):
 
         Example:
 
-            Suggest a dropout rate for neural network training.
+            Suggest a momentum for neural network training.
+
+            .. testsetup::
+
+                import numpy as np
+                from sklearn.model_selection import train_test_split
+
+                np.random.seed(seed=0)
+                X = np.random.randn(200).reshape(-1, 1)
+                y = np.random.randint(0, 2, 200)
+                X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
 
             .. testcode::
 
                 import optuna
+                from sklearn.neural_network import MLPClassifier
 
                 def objective(trial):
-                    dropout_rate = trial.suggest_uniform('dropout_rate', 0, 1.0)
-                    assert 0.0 <= dropout_rate < 1.0
+                    momentum = trial.suggest_uniform('momentum', 0.0, 1.0)
+                    clf = MLPClassifier(hidden_layer_sizes=(100, 50), momentum=momentum,
+                                        tol=1e-3, random_state=0)
+                    clf.fit(X_train, y_train)
 
-                    return dropout_rate
+                    return clf.score(X_test, y_test)
 
                 study = optuna.create_study()
                 study.optimize(objective, n_trials=3)
-
 
         Args:
             name:
@@ -266,21 +278,23 @@ class Trial(BaseTrial):
             `GradientBoostingClassifier <https://scikit-learn.org/stable/modules/generated/
             sklearn.ensemble.GradientBoostingClassifier.html>`_.
 
+            .. testsetup::
+
+                import numpy as np
+                from sklearn.model_selection import train_test_split
+
+                np.random.seed(seed=0)
+                X = np.random.randn(50).reshape(-1, 1)
+                y = np.random.randint(0, 2, 50)
+                X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
+
             .. testcode::
 
                 import optuna
-                import numpy as np
                 from sklearn.ensemble import GradientBoostingClassifier
-                from sklearn.model_selection import train_test_split
 
                 def objective(trial):
                     subsample = trial.suggest_discrete_uniform('subsample', 0.1, 1.0, 0.1)
-
-                    np.random.seed(seed=0)
-                    X = np.random.randn(50).reshape(-1, 1)
-                    y = np.random.randint(0, 2, 50)
-                    X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
-
                     clf = GradientBoostingClassifier(subsample=subsample, random_state=0)
                     clf.fit(X_train, y_train)
                     return clf.score(X_test, y_test)
@@ -527,15 +541,30 @@ class Trial(BaseTrial):
 
             Save fixed hyperparameters of neural network training.
 
+            .. testsetup::
+
+                import numpy as np
+                from sklearn.model_selection import train_test_split
+
+                np.random.seed(seed=0)
+                X = np.random.randn(50).reshape(-1, 1)
+                y = np.random.randint(0, 2, 50)
+                X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
+
             .. testcode::
 
                 import optuna
+                from sklearn.neural_network import MLPClassifier
 
                 def objective(trial):
                     trial.set_user_attr('BATCHSIZE', 128)
-                    x = trial.suggest_uniform('x', 0, 1.0)
+                    momentum = trial.suggest_uniform('momentum', 0, 1.0)
+                    clf = MLPClassifier(hidden_layer_sizes=(100, 50),
+                                        batch_size=trial.user_attrs['BATCHSIZE'],
+                                        momentum=momentum, tol=1e-3, random_state=0)
+                    clf.fit(X_train, y_train)
 
-                    return x
+                    return clf.score(X_test, y_test)
 
                 study = optuna.create_study()
                 study.optimize(objective, n_trials=3)


### PR DESCRIPTION
This PR add doctest example to optuna/trial.py. (Related Issue: #734)

Some simple assertions are added to each example.
Classifiers in examples are left as original.
Each classifier uses simple input array generated by `numpy.random` .

**Note**

Because of numpy issue, below warning is raised when run `make doctest` to optuna/trial.py.
Should this warning message be suppressed?

```
/opt/conda/lib/python3.6/importlib/_bootstrap.py:219: RuntimeWarning: numpy.ufunc size changed, may indicate binary incompatibility. Expected 216, got 192
  return f(*args, **kwds)
```