### PR TITLE
Use OrderedDict to keep the order of intermediate values.

### DIFF
--- a/optuna/storages/in_memory.py
+++ b/optuna/storages/in_memory.py
@@ -1,3 +1,4 @@
+from collections import OrderedDict
 import copy
 from datetime import datetime
 import threading
@@ -182,7 +183,7 @@ class InMemoryStorage(base.BaseStorage):
             user_attrs={},
             system_attrs={},
             value=None,
-            intermediate_values={},
+            intermediate_values=OrderedDict(),
             datetime_start=datetime.now(),
             datetime_complete=None)
 

--- a/optuna/storages/rdb/models.py
+++ b/optuna/storages/rdb/models.py
@@ -447,7 +447,8 @@ class TrialValueModel(BaseModel):
         # type: (StudyModel, orm.Session) -> List[TrialValueModel]
 
         trial_values = session.query(cls).join(TrialModel). \
-            filter(TrialModel.study_id == study.study_id).all()
+            filter(TrialModel.study_id == study.study_id). \
+            order_by(cls.trial_value_id).all()
 
         return trial_values
 
@@ -455,7 +456,8 @@ class TrialValueModel(BaseModel):
     def where_trial(cls, trial, session):
         # type: (TrialModel, orm.Session) -> List[TrialValueModel]
 
-        trial_values = session.query(cls).filter(cls.trial_id == trial.trial_id).all()
+        trial_values = session.query(cls).filter(cls.trial_id == trial.trial_id). \
+            order_by(cls.trial_value_id).all()
 
         return trial_values
 
@@ -463,7 +465,7 @@ class TrialValueModel(BaseModel):
     def all(cls, session):
         # type: (orm.Session) -> List[TrialValueModel]
 
-        return session.query(cls).all()
+        return session.query(cls).order_by(cls.trial_value_id).all()
 
 
 class VersionInfoModel(BaseModel):

--- a/optuna/storages/rdb/storage.py
+++ b/optuna/storages/rdb/storage.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+from collections import OrderedDict
 import copy
 from datetime import datetime
 import json
@@ -812,7 +813,7 @@ class RDBStorage(BaseStorage):
                 params[param.param_name] = distribution.to_external_repr(param.param_value)
                 param_distributions[param.param_name] = distribution
 
-            intermediate_values = {}
+            intermediate_values = OrderedDict()
             for value in id_to_values[trial_id]:
                 intermediate_values[value.step] = value.value
 


### PR DESCRIPTION
This PR addresses #886. 

I think it has two issues.

1. `dict` does not keep the order of keys

The current implementation of `FrozenTrial.intermediate_values` employs `dict`. The order of keys is not ensured if the users use Python 3.6 or older. This PR uses `OrderedDict` for `FrozenTrial.intermediate_values`.

2. RDBs do not ensure the order of results if a query has no `order by` clause.

This PR arranges the intermediate values when they are retrieved from databases.
Please note that the results are not necessarily ordered by primary keys when queries do not contain `order by`. (c.f., ['When no 'Order by' is specified, what order does a query choose for your record set?'](https://stackoverflow.com/questions/20050341/when-no-order-by-is-specified-what-order-does-a-query-choose-for-your-record))