### PR TITLE
Sort intermediate values in plot_intermediate_values.

### DIFF
--- a/optuna/visualization/intermediate_values.py
+++ b/optuna/visualization/intermediate_values.py
@@ -67,9 +67,10 @@ def _get_intermediate_plot(study):
     traces = []
     for trial in trials:
         if trial.intermediate_values:
+            sorted_intermediate_values = sorted(trial.intermediate_values.items())
             trace = go.Scatter(
-                x=tuple(trial.intermediate_values.keys()),
-                y=tuple(trial.intermediate_values.values()),
+                x=tuple((x for x, _ in sorted_intermediate_values)),
+                y=tuple((y for _, y in sorted_intermediate_values)),
                 mode='lines+markers',
                 marker={
                     'maxdisplayed': 10


### PR DESCRIPTION
This PR addresses #886. 

It simply sorts the intermediate steps before plotting them. #887 also addresses this issue, but I found out that its approach is not appropriate in some cases. So, I'd like to employ this approach and close #887.