### PR TITLE
Add Neptune to the list of external libraries which use Optuna.

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -66,3 +66,7 @@ In addition, integration modules are available for the following libraries, prov
 ### Examples of Distributed Optimization
 
 * [Optimizing on Kubernetes](./distributed/kubernetes/README.md)
+
+### External libraries using Optuna
+
+* [Analyzing optimization results using Neptune](https://neptune-contrib.readthedocs.io/user_guide/monitoring/optuna.html)


### PR DESCRIPTION
This PR updates `examples/README.md` to introduce external libraries using Optuna. It adds [`Neptune`](https://neptune.ai/) to the list as a first entry, and it will be followed by other libraries such as [OptGBM](https://github.com/optuna/optuna/issues/534).

Please note that neptune.ml was recently moved to neptune.ai and is called Neptune in the official site.

Screenshot
![image](https://user-images.githubusercontent.com/3255979/73718426-d0df9400-475f-11ea-982a-f3410e201c57.png)
