### PR TITLE
User-friendly error message for fixed categorical parameter not found in choices.

### DIFF
--- a/optuna/distributions.py
+++ b/optuna/distributions.py
@@ -312,7 +312,12 @@ class CategoricalDistribution(BaseDistribution):
     def to_internal_repr(self, param_value_in_external_repr):
         # type: (CategoricalChoiceType) -> float
 
-        return self.choices.index(param_value_in_external_repr)
+        try:
+            return self.choices.index(param_value_in_external_repr)
+        except ValueError as e:
+            raise ValueError(
+                '\'{}\' not in {}.'.format(
+                    param_value_in_external_repr, self.choices)) from e
 
     def single(self):
         # type: () -> bool

--- a/tests/test_trial.py
+++ b/tests/test_trial.py
@@ -282,6 +282,10 @@ def test_fixed_trial_suggest_categorical():
     with pytest.raises(ValueError):
         trial.suggest_categorical('y', ['foo', 'bar', 'baz'])
 
+    # Not in choices.
+    with pytest.raises(ValueError):
+        trial.suggest_categorical('x', ['foo', 'bar'])
+
     # Unkown parameter and bad category type.
     with pytest.warns(UserWarning):
         with pytest.raises(ValueError):  # Must come after `pytest.warns` to catch failures.


### PR DESCRIPTION
Similar error as shown below is raised in `to_internal_repr` when suggesting a categorical using a `FixedTrial` where the fixed parameter value is not in choices. 

```python
> (1, 2, 3).index(4)

ValueError: tuple.index(x): x not in tuple
```

This PR catches this error (for `list` and `tuple`) modifying the message to be more friendly. The error type is preserved.