### PR TITLE
Fix path of `lightgbm.train` function in the reference doc.

### DIFF
--- a/docs/source/reference/integration.rst
+++ b/docs/source/reference/integration.rst
@@ -26,7 +26,7 @@ Integration
 .. autoclass:: LightGBMPruningCallback
     :members:
 
-.. autofunction:: optuna.integration.lightgbm.train
+.. autofunction:: lightgbm.train
 
 .. autoclass:: MXNetPruningCallback
     :members:


### PR DESCRIPTION
[The current reference doc](https://optuna.readthedocs.io/en/latest/reference/integration.html) doesn't contain the entry of `optuna.integration.lightgbm.train` function. This PR fix that.

# Before (current)

![image](https://user-images.githubusercontent.com/181413/73997824-02946d00-49a3-11ea-8a58-abffaafebd95.png)

# After

![image](https://user-images.githubusercontent.com/181413/73997833-0b853e80-49a3-11ea-9fda-9f0b2bcc8643.png)

