### PR TITLE
Fix LightGBMTuner to handle metrics with evaluation positions.

### DIFF
--- a/optuna/integration/lightgbm_tuner/optimize.py
+++ b/optuna/integration/lightgbm_tuner/optimize.py
@@ -142,14 +142,39 @@ class BaseTuner(object):
         else:
             raise NotImplementedError
 
+        metric = self._metric_with_eval_at(metric)
         val_score = booster.best_score[valid_name][metric]
         return val_score
+
+    def _metric_with_eval_at(self, metric):
+        # type: (str) -> str
+
+        if metric != 'ndcg' and metric != 'map':
+            return metric
+
+        eval_at = self.lgbm_params.get('eval_at')
+        if eval_at is None:
+            eval_at = self.lgbm_params.get('{}_at'.format(metric))
+        if eval_at is None:
+            eval_at = self.lgbm_params.get('{}_eval_at'.format(metric))
+        if eval_at is None:
+            # Set default value of LightGBM.
+            # See https://lightgbm.readthedocs.io/en/latest/Parameters.html#eval_at.
+            eval_at = [1, 2, 3, 4, 5]
+
+        # Optuna can handle only a single metric. Choose first one.
+        if type(eval_at) in [list, tuple]:
+            return '{}@{}'.format(metric, eval_at[0])
+        if type(eval_at) is int:
+            return '{}@{}'.format(metric, eval_at)
+        raise ValueError('The value of eval_at is expected to be int or a list/tuple of int.'
+                         '\'{}\' is specified.'.format(eval_at))
 
     def higher_is_better(self):
         # type: () -> bool
 
         metric_name = self.lgbm_params.get('metric', 'binary_logloss')
-        return metric_name.startswith(('auc', 'ndcg@', 'map@', 'accuracy'))
+        return metric_name.startswith(('auc', 'ndcg', 'map', 'accuracy'))
 
     def compare_validation_metrics(self, val_score, best_score):
         # type: (float, float) -> bool

--- a/tests/integration_tests/lightgbm_tuner_tests/test_optimize.py
+++ b/tests/integration_tests/lightgbm_tuner_tests/test_optimize.py
@@ -20,6 +20,7 @@ if type_checking.TYPE_CHECKING:
     from typing import Dict  # NOQA
     from typing import Generator  # NOQA
     from typing import List  # NOQA
+    from typing import Union  # NOQA
 
 
 @contextlib.contextmanager
@@ -128,7 +129,7 @@ class TestBaseTuner(object):
     def test_higher_is_better(self):
         # type: () -> None
 
-        for metric in ['auc', 'accuracy']:
+        for metric in ['auc', 'ndcg', 'map', 'accuracy']:
             tuner = BaseTuner(lgbm_params={'metric': metric})
             assert tuner.higher_is_better()
 
@@ -188,7 +189,7 @@ class TestBaseTuner(object):
     def test_compare_validation_metrics(self):
         # type: () -> None
 
-        for metric in ['auc', 'accuracy']:
+        for metric in ['auc', 'ndcg', 'map', 'accuracy']:
             tuner = BaseTuner(lgbm_params={'metric': metric})
             assert tuner.compare_validation_metrics(0.5, 0.1)
             assert not tuner.compare_validation_metrics(0.5, 0.5)
@@ -199,6 +200,38 @@ class TestBaseTuner(object):
             assert not tuner.compare_validation_metrics(0.5, 0.1)
             assert not tuner.compare_validation_metrics(0.5, 0.5)
             assert tuner.compare_validation_metrics(0.1, 0.5)
+
+    @pytest.mark.parametrize('metric, eval_at_param, expected', [
+        ('auc', {'eval_at': 5}, 'auc'),
+        ('accuracy', {'eval_at': 5}, 'accuracy'),
+        ('rmsle', {'eval_at': 5}, 'rmsle'),
+        ('rmse', {'eval_at': 5}, 'rmse'),
+        ('binary_logloss', {'eval_at': 5}, 'binary_logloss'),
+        ('ndcg', {'eval_at': 5}, 'ndcg@5'),
+        ('ndcg', {'ndcg_at': 5}, 'ndcg@5'),
+        ('ndcg', {'ndcg_eval_at': 5}, 'ndcg@5'),
+        ('ndcg', {'eval_at': [20]}, 'ndcg@20'),
+        ('ndcg', {'eval_at': [10, 20]}, 'ndcg@10'),
+        ('ndcg', {}, 'ndcg@1'),
+        ('map', {'eval_at': 5}, 'map@5'),
+        ('map', {'eval_at': [20]}, 'map@20'),
+        ('map', {'eval_at': [10, 20]}, 'map@10'),
+        ('map', {}, 'map@1'),
+    ])
+    def test_metric_with_eval_at(self, metric, eval_at_param, expected):
+        # type: (str, Dict[str, Union[int, List[int]]], str) -> None
+
+        params = {'metric': metric}  # type: Dict[str, Union[str, int, List[int]]]
+        params.update(eval_at_param)
+        tuner = BaseTuner(lgbm_params=params)
+        assert tuner._metric_with_eval_at(metric) == expected
+
+    def test_metric_with_eval_at_error(self):
+        # type: () -> None
+
+        tuner = BaseTuner(lgbm_params={'metric': 'ndcg', 'eval_at': '1'})
+        with pytest.raises(ValueError):
+            tuner._metric_with_eval_at('ndcg')
 
 
 class TestLightGBMTuner(object):


### PR DESCRIPTION
This PR addresses #909. 
It also fixes the output of `BaseTuner.higher_is_better`. If the metric is `'ndcg'` or `'map'`, the study direction seems to be reverted. I think `BaseTuner.higher_is_better` fails to handle the metric value, because it does not contain `'@'`. 