### PR TITLE
Fix a TPE implementation on DiscreteUniformDistribution

### DIFF
--- a/optuna/samplers/tpe/sampler.py
+++ b/optuna/samplers/tpe/sampler.py
@@ -199,6 +199,11 @@ class TPESampler(base.BaseSampler):
         # [low, high] is shifted to [0, r] to align sampled values at regular intervals.
         low = 0 - 0.5 * q
         high = r + 0.5 * q
+
+        # Shift below and above to [0, r]
+        above -= distribution.low
+        below -= distribution.low
+
         best_sample = self._sample_numerical(low, high, below, above, q=q) + distribution.low
         return min(max(best_sample, distribution.low), distribution.high)
 


### PR DESCRIPTION
I executed an example which is used at #916.

```python
import optuna
import pprint


def objective(trial):
    x = trial.suggest_discrete_uniform('x', -10, 10, q=2.0)
    y = trial.suggest_discrete_uniform('y', -10, 10, q=2.0)
    return (x-8)**2 + (y+8)**2


if __name__ == '__main__':
    study = optuna.create_study(sampler=optuna.samplers.TPESampler(seed=0))
    study.optimize(objective, n_trials=40)
    pprint.pprint([t.params for t in study.trials])
    print('Best value: {} (params: {})\n'.format(study.best_value, study.best_params))
```

The best trials is `Best value: 0.0 (params: {'x': 8.0, 'y': -8.0})`.

<details>

<summary>execution log</summary>

```console
$ python examples/quadratic_simple.py 
[I 2020-02-12 12:51:39,173] Finished trial#0 resulted in value: 180.0. Current best value is 180.0 with parameters: {'x': 2.0, 'y': 4.0}.
[I 2020-02-12 12:51:39,196] Finished trial#1 resulted in value: 100.0. Current best value is 100.0 with parameters: {'x': 2.0, 'y': 0.0}.
[I 2020-02-12 12:51:39,219] Finished trial#2 resulted in value: 244.0. Current best value is 100.0 with parameters: {'x': 2.0, 'y': 0.0}.
[I 2020-02-12 12:51:39,241] Finished trial#3 resulted in value: 356.0. Current best value is 100.0 with parameters: {'x': 2.0, 'y': 0.0}.
[I 2020-02-12 12:51:39,264] Finished trial#4 resulted in value: 40.0. Current best value is 40.0 with parameters: {'x': 10.0, 'y': -2.0}.
[I 2020-02-12 12:51:39,288] Finished trial#5 resulted in value: 68.0. Current best value is 40.0 with parameters: {'x': 10.0, 'y': -2.0}.
[I 2020-02-12 12:51:39,312] Finished trial#6 resulted in value: 360.0. Current best value is 40.0 with parameters: {'x': 10.0, 'y': -2.0}.
[I 2020-02-12 12:51:39,335] Finished trial#7 resulted in value: 328.0. Current best value is 40.0 with parameters: {'x': 10.0, 'y': -2.0}.
[I 2020-02-12 12:51:39,358] Finished trial#8 resulted in value: 580.0. Current best value is 40.0 with parameters: {'x': 10.0, 'y': -2.0}.
[I 2020-02-12 12:51:39,381] Finished trial#9 resulted in value: 260.0. Current best value is 40.0 with parameters: {'x': 10.0, 'y': -2.0}.
[I 2020-02-12 12:51:39,408] Finished trial#10 resulted in value: 4.0. Current best value is 4.0 with parameters: {'x': 10.0, 'y': -8.0}.
[I 2020-02-12 12:51:39,435] Finished trial#11 resulted in value: 8.0. Current best value is 4.0 with parameters: {'x': 10.0, 'y': -8.0}.
[I 2020-02-12 12:51:39,462] Finished trial#12 resulted in value: 8.0. Current best value is 4.0 with parameters: {'x': 10.0, 'y': -8.0}.
[I 2020-02-12 12:51:39,491] Finished trial#13 resulted in value: 4.0. Current best value is 4.0 with parameters: {'x': 10.0, 'y': -8.0}.
[I 2020-02-12 12:51:39,518] Finished trial#14 resulted in value: 8.0. Current best value is 4.0 with parameters: {'x': 10.0, 'y': -8.0}.
[I 2020-02-12 12:51:39,548] Finished trial#15 resulted in value: 4.0. Current best value is 4.0 with parameters: {'x': 10.0, 'y': -8.0}.
[I 2020-02-12 12:51:39,575] Finished trial#16 resulted in value: 200.0. Current best value is 4.0 with parameters: {'x': 10.0, 'y': -8.0}.
[I 2020-02-12 12:51:39,603] Finished trial#17 resulted in value: 20.0. Current best value is 4.0 with parameters: {'x': 10.0, 'y': -8.0}.
[I 2020-02-12 12:51:39,630] Finished trial#18 resulted in value: 16.0. Current best value is 4.0 with parameters: {'x': 10.0, 'y': -8.0}.
[I 2020-02-12 12:51:39,658] Finished trial#19 resulted in value: 20.0. Current best value is 4.0 with parameters: {'x': 10.0, 'y': -8.0}.
[I 2020-02-12 12:51:39,686] Finished trial#20 resulted in value: 36.0. Current best value is 4.0 with parameters: {'x': 10.0, 'y': -8.0}.
[I 2020-02-12 12:51:39,713] Finished trial#21 resulted in value: 0.0. Current best value is 0.0 with parameters: {'x': 8.0, 'y': -8.0}.
[I 2020-02-12 12:51:39,740] Finished trial#22 resulted in value: 0.0. Current best value is 0.0 with parameters: {'x': 8.0, 'y': -8.0}.
[I 2020-02-12 12:51:39,767] Finished trial#23 resulted in value: 16.0. Current best value is 0.0 with parameters: {'x': 8.0, 'y': -8.0}.
[I 2020-02-12 12:51:39,795] Finished trial#24 resulted in value: 0.0. Current best value is 0.0 with parameters: {'x': 8.0, 'y': -8.0}.
[I 2020-02-12 12:51:39,822] Finished trial#25 resulted in value: 16.0. Current best value is 0.0 with parameters: {'x': 8.0, 'y': -8.0}.
[I 2020-02-12 12:51:39,852] Finished trial#26 resulted in value: 68.0. Current best value is 0.0 with parameters: {'x': 8.0, 'y': -8.0}.
[I 2020-02-12 12:51:39,881] Finished trial#27 resulted in value: 0.0. Current best value is 0.0 with parameters: {'x': 8.0, 'y': -8.0}.
[I 2020-02-12 12:51:39,909] Finished trial#28 resulted in value: 20.0. Current best value is 0.0 with parameters: {'x': 8.0, 'y': -8.0}.
[I 2020-02-12 12:51:39,938] Finished trial#29 resulted in value: 160.0. Current best value is 0.0 with parameters: {'x': 8.0, 'y': -8.0}.
[I 2020-02-12 12:51:39,967] Finished trial#30 resulted in value: 100.0. Current best value is 0.0 with parameters: {'x': 8.0, 'y': -8.0}.
[I 2020-02-12 12:51:39,995] Finished trial#31 resulted in value: 0.0. Current best value is 0.0 with parameters: {'x': 8.0, 'y': -8.0}.
[I 2020-02-12 12:51:40,024] Finished trial#32 resulted in value: 4.0. Current best value is 0.0 with parameters: {'x': 8.0, 'y': -8.0}.
[I 2020-02-12 12:51:40,054] Finished trial#33 resulted in value: 4.0. Current best value is 0.0 with parameters: {'x': 8.0, 'y': -8.0}.
[I 2020-02-12 12:51:40,082] Finished trial#34 resulted in value: 36.0. Current best value is 0.0 with parameters: {'x': 8.0, 'y': -8.0}.
[I 2020-02-12 12:51:40,111] Finished trial#35 resulted in value: 104.0. Current best value is 0.0 with parameters: {'x': 8.0, 'y': -8.0}.
[I 2020-02-12 12:51:40,139] Finished trial#36 resulted in value: 20.0. Current best value is 0.0 with parameters: {'x': 8.0, 'y': -8.0}.
[I 2020-02-12 12:51:40,168] Finished trial#37 resulted in value: 148.0. Current best value is 0.0 with parameters: {'x': 8.0, 'y': -8.0}.
[I 2020-02-12 12:51:40,196] Finished trial#38 resulted in value: 40.0. Current best value is 0.0 with parameters: {'x': 8.0, 'y': -8.0}.
[I 2020-02-12 12:51:40,224] Finished trial#39 resulted in value: 36.0. Current best value is 0.0 with parameters: {'x': 8.0, 'y': -8.0}.
[{'x': 2.0, 'y': 4.0},
 {'x': 2.0, 'y': 0.0},
 {'x': -2.0, 'y': 4.0},
 {'x': -2.0, 'y': 8.0},
 {'x': 10.0, 'y': -2.0},
 {'x': 6.0, 'y': 0.0},
 {'x': 2.0, 'y': 10.0},
 {'x': -10.0, 'y': -10.0},
 {'x': -10.0, 'y': 8.0},
 {'x': 6.0, 'y': 8.0},
 {'x': 10.0, 'y': -8.0},
 {'x': 10.0, 'y': -10.0},
 {'x': 10.0, 'y': -10.0},
 {'x': 8.0, 'y': -6.0},
 {'x': 6.0, 'y': -6.0},
 {'x': 8.0, 'y': -6.0},
 {'x': -6.0, 'y': -6.0},
 {'x': 6.0, 'y': -4.0},
 {'x': 8.0, 'y': -4.0},
 {'x': 4.0, 'y': -6.0},
 {'x': 8.0, 'y': -2.0},
 {'x': 8.0, 'y': -8.0},
 {'x': 8.0, 'y': -8.0},
 {'x': 4.0, 'y': -8.0},
 {'x': 8.0, 'y': -8.0},
 {'x': 4.0, 'y': -8.0},
 {'x': 0.0, 'y': -10.0},
 {'x': 8.0, 'y': -8.0},
 {'x': 10.0, 'y': -4.0},
 {'x': 4.0, 'y': 4.0},
 {'x': 0.0, 'y': -2.0},
 {'x': 8.0, 'y': -8.0},
 {'x': 6.0, 'y': -8.0},
 {'x': 8.0, 'y': -10.0},
 {'x': 2.0, 'y': -8.0},
 {'x': 10.0, 'y': 2.0},
 {'x': 6.0, 'y': -4.0},
 {'x': -4.0, 'y': -10.0},
 {'x': 2.0, 'y': -6.0},
 {'x': 8.0, 'y': -2.0}]
Best value: 0.0 (params: {'x': 8.0, 'y': -8.0})
```

</details>

