### PR TITLE
`experimental` decorator to accept optional `name` and apply to progress bar.

### DIFF
--- a/optuna/_experimental.py
+++ b/optuna/_experimental.py
@@ -55,11 +55,12 @@ def _validate_version(version: str) -> None:
                 version))
 
 
-def experimental(version: str) -> Any:
+def experimental(version: str, name: str = None) -> Any:
     """Decorate class or function as experimental.
 
     Args:
         version: The first version that supports the target feature.
+        name: The name of the feature. Defaults to the function or class name. Optional.
     """
 
     _validate_version(version)
@@ -81,7 +82,8 @@ def experimental(version: str) -> Any:
 
                 warnings.warn(
                     "{} is experimental (supported from v{}). "
-                    "The interface can change in the future.".format(func.__name__, version),
+                    "The interface can change in the future.".format(
+                        name if name is not None else func.__name__, version),
                     ExperimentalWarning
                 )
 
@@ -100,7 +102,8 @@ def experimental(version: str) -> Any:
             def wrapped_init(self, *args, **kwargs) -> None:  # type: ignore
                 warnings.warn(
                     "{} is experimental (supported from v{}). "
-                    "The interface can change in the future.".format(cls.__name__, version),
+                    "The interface can change in the future.".format(
+                        name if name is not None else cls.__name__, version),
                     ExperimentalWarning
                 )
 

--- a/optuna/progress_bar.py
+++ b/optuna/progress_bar.py
@@ -24,7 +24,6 @@ class _TqdmLoggingHandler(logging.StreamHandler):
             self.handleError(record)
 
 
-@experimental('1.2.0', name='Progress bar')
 class _ProgressBar(object):
     """Progress Bar implementation for `Study.optimize` on the top of `tqdm`.
 
@@ -48,14 +47,20 @@ class _ProgressBar(object):
         self._timeout = timeout
 
         if self._is_valid:
-            self._progress_bar = tqdm(range(n_trials) if n_trials is not None else None)
-            global _tqdm_handler
+            self._init_valid()
 
-            _tqdm_handler = _TqdmLoggingHandler()
-            _tqdm_handler.setLevel(logging.INFO)
-            _tqdm_handler.setFormatter(optuna_logging.create_default_formatter())
-            optuna_logging.disable_default_handler()
-            optuna_logging._get_library_root_logger().addHandler(_tqdm_handler)
+    # TODO(hvy): Remove initialization indirection via this method when the progress bar is no
+    # longer experimental.
+    @experimental('1.2.0', name='Progress bar')
+    def _init_valid(self) -> None:
+        self._progress_bar = tqdm(range(self._n_trials) if self._n_trials is not None else None)
+        global _tqdm_handler
+
+        _tqdm_handler = _TqdmLoggingHandler()
+        _tqdm_handler.setLevel(logging.INFO)
+        _tqdm_handler.setFormatter(optuna_logging.create_default_formatter())
+        optuna_logging.disable_default_handler()
+        optuna_logging._get_library_root_logger().addHandler(_tqdm_handler)
 
     def update(self, elapsed_seconds: Optional[float]) -> None:
         """Update the progress bars if ``is_valid`` is ``True``.

--- a/optuna/progress_bar.py
+++ b/optuna/progress_bar.py
@@ -4,6 +4,7 @@ from typing import Optional
 
 from tqdm.auto import tqdm
 
+from optuna._experimental import experimental
 from optuna import logging as optuna_logging
 
 _tqdm_handler = None  # type: Optional[_TqdmLoggingHandler]
@@ -23,6 +24,7 @@ class _TqdmLoggingHandler(logging.StreamHandler):
             self.handleError(record)
 
 
+@experimental('1.2.0', name='Progress bar')
 class _ProgressBar(object):
     """Progress Bar implementation for `Study.optimize` on the top of `tqdm`.
 

--- a/tests/test_experimental.py
+++ b/tests/test_experimental.py
@@ -83,3 +83,27 @@ def test_experimental_class_decorator(version: str) -> None:
 
         with pytest.warns(ExperimentalWarning):
             decorated_sample('a', 'b', 'c')
+
+
+def test_experimental_decorator_name() -> None:
+
+    name = 'foo'
+    decorator_experimental = _experimental.experimental('1.1.0', name=name)
+    decorated_sample = decorator_experimental(_Sample)
+
+    with pytest.warns(ExperimentalWarning) as record:
+        decorated_sample('a', 'b', 'c')
+
+    assert name in record.list[0].message.args[0]
+
+
+def test_experimental_class_decorator_name() -> None:
+
+    name = 'bar'
+    decorator_experimental = _experimental.experimental('1.1.0', name=name)
+    decorated_sample_func = decorator_experimental(_sample_func)
+
+    with pytest.warns(ExperimentalWarning) as record:
+        decorated_sample_func(None)
+
+    assert name in record.list[0].message.args[0]


### PR DESCRIPTION
`experimental` decorator to accept optional `name` and apply to progress bar. The parameter introduced can be used when marking private functions or classes (whose names should not be directly visible to the user).

This PR is a follow up to the progress bar PR. C.f. https://github.com/optuna/optuna/pull/844#pullrequestreview-357195776.