### PR TITLE
More verbose warning message in Trial._check_distribution

### DIFF
--- a/optuna/trial.py
+++ b/optuna/trial.py
@@ -570,9 +570,17 @@ class Trial(BaseTrial):
         if old_distribution_in_trial is None:
             self._distributions_in_trial[name] = dist_dict
         elif old_distribution_in_trial != dist_dict:
-            warnings.warn('Inconsistent parameter values for distribution {}! '
-                          'This might be a configuration mistake.'
-                          .format(name), RuntimeWarning)
+            old_distribution_in_trial_values = 'low = {}, high = {}'.format(old_distribution_in_trial['low'], old_distribution_in_trial['high'])
+            if 'q' in old_distribution_in_trial:
+                old_distribution_in_trial_values += ', q = {}'.format(old_distribution_in_trial['q'])
+            warnings.warn('Inconsistent parameter values for distribution with name "{}"! '
+                          'This might be a configuration mistake. '
+                          'Optuna allows to call the same distribution with the same '
+                          'name more then once in a trial. '
+                          'When the parameter values are inconsistent optuna only '
+                          'uses the values of the first call and ignores all following. '
+                          'Using these values: {}'
+                          .format(name, old_distribution_in_trial_values), RuntimeWarning)
 
     @property
     def number(self):

--- a/optuna/trial.py
+++ b/optuna/trial.py
@@ -570,9 +570,11 @@ class Trial(BaseTrial):
         if old_distribution_in_trial is None:
             self._distributions_in_trial[name] = dist_dict
         elif old_distribution_in_trial != dist_dict:
-            old_distribution_in_trial_values = 'low = {}, high = {}'.format(old_distribution_in_trial['low'], old_distribution_in_trial['high'])
+            old_distribution_in_trial_values = 'low = {}, high = {}'.format(
+                old_distribution_in_trial['low'], old_distribution_in_trial['high'])
             if 'q' in old_distribution_in_trial:
-                old_distribution_in_trial_values += ', q = {}'.format(old_distribution_in_trial['q'])
+                old_distribution_in_trial_values += ', q = {}'.format(
+                    old_distribution_in_trial['q'])
             warnings.warn('Inconsistent parameter values for distribution with name "{}"! '
                           'This might be a configuration mistake. '
                           'Optuna allows to call the same distribution with the same '


### PR DESCRIPTION
More verbose warning message of `Trial._check_distribution` as suggested here: https://github.com/optuna/optuna/pull/908#pullrequestreview-357181201