### PR TITLE
Use `weakref.finalize` instead of __del__ for `RDBStorage`.

### DIFF
--- a/optuna/storages/rdb/storage.py
+++ b/optuna/storages/rdb/storage.py
@@ -7,6 +7,7 @@ import os
 import sys
 import threading
 import uuid
+import weakref
 
 import alembic.command
 import alembic.config
@@ -111,6 +112,7 @@ class RDBStorage(BaseStorage):
             self._version_manager.check_table_schema_compatibility()
 
         self._finished_trials_cache = _FinishedTrialsCache()
+        weakref.finalize(self, self._finalize)
 
     def __getstate__(self):
         # type: () -> Dict[Any, Any]
@@ -931,7 +933,7 @@ class RDBStorage(BaseStorage):
 
         self.scoped_session.remove()
 
-    def __del__(self):
+    def _finalize(self):
         # type: () -> None
 
         # This destructor calls remove_session to explicitly close the DB connection. We need this


### PR DESCRIPTION
This PR addresses https://github.com/optuna/optuna/issues/938.

Currently, `RDBStorage` uses `__del__` to remove sessions when the program ends. But, the execution of `__del__` is not guaranteed according to the reference of [`__del__`](https://docs.python.org/3/reference/datamodel.html#object.__del__).

> It is not guaranteed that __del__() methods are called for objects that still exist when the interpreter exits.

In the case of https://github.com/optuna/optuna/issues/938, the Python 3.8 with `ipython` or `jupyter` affects the timing of the call of `RDBStorage.__del__()`, and it causes the errors.

Please take a look at a log of `python -v 938.py`. (`938.py` can be found in https://github.com/optuna/optuna/issues/938#issuecomment-587322175.)
```
...
# destroy sqlalchemy.orm.state
...
# cleanup[3] wiping __mp_main__
Exception ignored in: <function RDBStorage.__del__ at 0x7f352b1c6310>
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/optuna/storages/rdb/storage.py", line 943, in __del__
  File "/usr/local/lib/python3.8/site-packages/optuna/storages/rdb/storage.py", line 932, in remove_session
...
  File "/usr/local/lib/python3.8/site-packages/sqlalchemy/orm/session.py", line 1352, in expunge_all
AttributeError: 'NoneType' object has no attribute 'InstanceState'
```

`RDBStorage.__del__` tried to access `state.InstanceState` ([here](https://github.com/sqlalchemy/sqlalchemy/blob/master/lib/sqlalchemy/orm/session.py#L1360)), but `sqlalchemy.orm.state` was destroyed at that time. I don't think this is expected behavior, but it would be safe if we explicitly remove the sessions.

This PR uses `weakref.finalize` instead of `__del__` as shown in [the reference of weakref](https://docs.python.org/3/library/weakref.html#comparing-finalizers-with-del-methods).
