### PR TITLE
Fix sphinx version to avoid build error.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,8 @@ def get_extras_require():
         ],
         'document': [
             'lightgbm',
-            'sphinx',
+            # TODO(yanase): Remove version constraint after sphinx works with optuna.integration.
+            'sphinx<2.4.0',
             'sphinx_rtd_theme',
         ],
         'example': [


### PR DESCRIPTION
This PR is a tentative fix for the `document` and `doctest` in CI jobs. Sphinx 2.4.x was released yesterday, but it cannot build `optuna.integration` properly, and this PR revert the Sphinx version to 2.3.x.

build log using 2.4.2:
```
WARNING: error while formatting arguments for optuna.integration.lightgbm.train: local variable 'arg' referenced before assignment
```

build log using 2.4.1:
```
WARNING: error while formatting arguments for optuna.integration.ChainerMNStudy: list index out of range
WARNING: error while formatting arguments for optuna.integration.ChainerMNStudy.optimize: list index out of range
WARNING: error while formatting arguments for optuna.integration.CmaEsSampler: list index out of range
WARNING: error while formatting arguments for optuna.integration.OptunaSearchCV: list index out of range
WARNING: error while formatting arguments for optuna.integration.OptunaSearchCV.fit: list index out of range
WARNING: error while formatting arguments for optuna.integration.OptunaSearchCV.score: list index out of range
WARNING: error while formatting arguments for optuna.samplers.TPESampler: list index out of range
WARNING: error while formatting arguments for optuna.structs.FrozenTrial: list index out of range
WARNING: error while formatting arguments for optuna.structs.StudySummary: list index out of range
WARNING: error while formatting arguments for optuna.study.Study: list index out of range
WARNING: error while formatting arguments for optuna.study.Study.optimize: list index out of range
WARNING: error while formatting arguments for optuna.study.Study.trials_dataframe: list index out of range
WARNING: error while formatting arguments for optuna.study.create_study: list index out of range
WARNING: error while formatting arguments for optuna.study.load_study: list index out of range
WARNING: error while formatting arguments for optuna.study.delete_study: list index out of range
WARNING: error while formatting arguments for optuna.trial.Trial: list index out of range
```
https://circleci.com/gh/optuna/optuna/28210