### PR TITLE
Apply Python3-style of type hinting to `optuna.integration.lightgbm_tuner.train`.

### DIFF
--- a/optuna/integration/lightgbm_tuner/__init__.py
+++ b/optuna/integration/lightgbm_tuner/__init__.py
@@ -1,15 +1,12 @@
+from typing import Any
+
 from optuna._experimental import experimental
 from optuna.integration.lightgbm_tuner.sklearn import LGBMClassifier, LGBMModel, LGBMRegressor  # NOQA
 from optuna.integration.lightgbm_tuner.optimize import LightGBMTuner
-from optuna import type_checking
-
-if type_checking.TYPE_CHECKING:
-    from typing import Any  # NOQA
 
 
 @experimental("0.18.0")
-def train(*args, **kwargs):
-    # type: (Any, Any) -> Any
+def train(*args: Any, **kwargs: Any) -> Any:
     """Wrapper of LightGBM Training API to tune hyperparameters.
 
     It tunes important hyperparameters (e.g., `min_child_samples` and `feature_fraction`) in a

--- a/setup.py
+++ b/setup.py
@@ -69,8 +69,7 @@ def get_extras_require():
         ],
         'document': [
             'lightgbm',
-            # TODO(yanase): Remove version constraint after sphinx works with optuna.integration.
-            'sphinx<2.4.0',
+            'sphinx',
             'sphinx_rtd_theme',
         ],
         'example': [


### PR DESCRIPTION
This PR is a followup of https://github.com/optuna/optuna/pull/942.
Sphinx 2.4.2 got a bug to access the unassigned variable `arg` when it handles type comments (see https://github.com/sphinx-doc/sphinx/pull/7152/files#diff-e03c85e3ed0c40f3caeeb4b7c5072f6cR48).

This PR applies Python3-style fo type hinging to `optuna.integration.lightgbm_tuner.train`, and removes the version constraints of `sphinx`.