### PR TITLE
Cast to `numpy.ndarray` as Python lists are no longer accepted in `xgboost==1.0`.

### DIFF
--- a/tests/integration_tests/test_xgboost.py
+++ b/tests/integration_tests/test_xgboost.py
@@ -40,8 +40,8 @@ def test_xgboost_pruning_callback():
     def objective(trial):
         # type: (optuna.trial.Trial) -> float
 
-        dtrain = xgb.DMatrix([[1.]], label=[1.])
-        dtest = xgb.DMatrix([[1.]], label=[1.])
+        dtrain = xgb.DMatrix(np.asarray([[1.]]), label=[1.])
+        dtest = xgb.DMatrix(np.asarray([[1.]]), label=[1.])
 
         pruning_callback = XGBoostPruningCallback(trial, 'validation-error')
         xgb.train({


### PR DESCRIPTION
Fixes an XGBoost integration test that started to break after the release of `xgboost==1.0`. 

The breaking change was introduced by an input validation 
https://github.com/dmlc/xgboost/pull/4850/files#diff-fd53d68e0037d3512896122d1248d969R414-R415.