### PR TITLE
Temporarily constraint to `xgboost<1.0.0`.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,9 @@ def get_extras_require():
             'scikit-learn',
             'torch',
             'torchvision>=0.5.0',
-            'xgboost',
+            # TODO(hvy): Remove version constraint when
+            # https://github.com/dmlc/xgboost/issues/5328 is fixed.
+            'xgboost<1.0.0',
         ] + (['fastai<2'] if (3, 5) < sys.version_info[:2] < (3, 8) else [])
         + ([
             'dask[dataframe]',
@@ -108,7 +110,9 @@ def get_extras_require():
             'scikit-optimize',
             'torch',
             'torchvision>=0.5.0',
-            'xgboost',
+            # TODO(hvy): Remove version constraint when
+            # https://github.com/dmlc/xgboost/issues/5328 is fixed.
+            'xgboost<1.0.0',
         ] + (['fastai<2'] if (3, 5) < sys.version_info[:2] < (3, 8) else [])
         + ([
             'keras',


### PR DESCRIPTION
Temporarily constraint to `xgboost<1.0.0` since `1.0.0` seems to contain accidental f-strings which cause our Python 3.5 CI builds to fail.

Should be reverted after https://github.com/dmlc/xgboost/issues/5328 is addressed.