### PR TITLE
Implement some methods almost compatible with Scikit-learn private methods

### DIFF
--- a/optuna/integration/sklearn.py
+++ b/optuna/integration/sklearn.py
@@ -119,7 +119,7 @@ def _is_arraylike(x):
 # https://github.com/scikit-learn/scikit-learn/blob/ \
 # 8caa93889f85254fc3ca84caa0a24a1640eebdd1/sklearn/utils/validation.py#L217-L234
 def _make_indexable(iterable):
-    # type: (IndexableType) -> (IterableType)
+    # type: (IterableType) -> (IndexableType)
 
     tocsr_func = getattr(iterable, "tocsr", None)
     if tocsr_func is not None and sp.sparse.issparse(iterable):

--- a/optuna/integration/sklearn.py
+++ b/optuna/integration/sklearn.py
@@ -66,6 +66,13 @@ def _check_fit_params(
 
     fit_params_validated = {}
     for key, value in fit_params.items():
+
+        # NOTE Original implementation:
+        # https://github.com/scikit-learn/scikit-learn/blob/ \
+        # 2467e1b84aeb493a22533fa15ff92e0d7c05ed1c/sklearn/utils/validation.py#L1324-L1328
+        # Scikit-learn does not accept non-iterable inputs.
+        # This line is for keeping backward compatibility.
+        # (See: https://github.com/scikit-learn/scikit-learn/issues/15805)
         if (
             not _is_arraylike(value) or
             _num_samples(value) != _num_samples(X)

--- a/optuna/integration/sklearn.py
+++ b/optuna/integration/sklearn.py
@@ -136,7 +136,7 @@ def _num_samples(x):
 
     # NOTE For dask dataframes
     # https://github.com/scikit-learn/scikit-learn/blob/ \
-    # 8caa93889f85254fc3ca84caa0a24a1640eebdd1/sklearn/utils/validation.py#L155-L
+    # 8caa93889f85254fc3ca84caa0a24a1640eebdd1/sklearn/utils/validation.py#L155-L158
     x_shape = getattr(x, 'shape', None)
     if x_shape is not None:
         if isinstance(x_shape[0], Integral):

--- a/optuna/integration/sklearn.py
+++ b/optuna/integration/sklearn.py
@@ -118,7 +118,6 @@ def _is_arraylike(x):
 # NOTE Original implementation:
 # https://github.com/scikit-learn/scikit-learn/blob/ \
 # 8caa93889f85254fc3ca84caa0a24a1640eebdd1/sklearn/utils/validation.py#L217-L234
-# It removed the check if an input is scipy sparse matrix
 def _make_indexable(iterable):
     # type: (IndexableType) -> (IterableType)
 

--- a/optuna/integration/sklearn.py
+++ b/optuna/integration/sklearn.py
@@ -81,7 +81,7 @@ def _check_fit_params(
 ):
     # type: (...) -> Dict
 
-    fit_params_validated: Dict = {}
+    fit_params_validated = {}
     for key, value in fit_params.items():
         if (
             not _is_arraylike(value) or

--- a/optuna/integration/sklearn.py
+++ b/optuna/integration/sklearn.py
@@ -130,10 +130,11 @@ def _num_samples(x):
 
     # NOTE For dask dataframes
     # https://github.com/scikit-learn/scikit-learn/blob/ \
-    # 8caa93889f85254fc3ca84caa0a24a1640eebdd1/sklearn/utils/validation.py#L155-L158
-    if hasattr(x, 'shape') and x.shape is not None:
-        if isinstance(x.shape[0], Integral):
-            return x.shape[0]
+    # 8caa93889f85254fc3ca84caa0a24a1640eebdd1/sklearn/utils/validation.py#L155-L
+    x_shape = getattr(x, 'shape', None)
+    if x_shape is not None:
+        if isinstance(x_shape[0], Integral):
+            return int(x_shape[0])
 
     try:
         return len(x)

--- a/optuna/integration/sklearn.py
+++ b/optuna/integration/sklearn.py
@@ -145,7 +145,7 @@ def _num_samples(x):
     try:
         return len(x)
     except TypeError:
-        raise TypeError('Expected sequence or array-like, got %s' % type(x))
+        raise TypeError('Expected sequence or array-like, got %s.' % type(x))
 
 
 def _safe_indexing(

--- a/optuna/integration/sklearn.py
+++ b/optuna/integration/sklearn.py
@@ -2,6 +2,7 @@ from logging import DEBUG
 from logging import INFO
 from logging import WARNING
 from numbers import Number
+from numbers import Integral
 from time import time
 
 import numpy as np
@@ -55,6 +56,9 @@ if type_checking.TYPE_CHECKING:
 _logger = logging.get_logger(__name__)
 
 
+# NOTE Original implementation:
+# https://github.com/scikit-learn/scikit-learn/blob/ \
+# 8caa93889f85254fc3ca84caa0a24a1640eebdd1/sklearn/utils/validation.py#L131-L135
 def _is_arraylike(x):
     # type: (Any) -> bool
 
@@ -67,6 +71,13 @@ def _is_arraylike(x):
 
 def _num_samples(x):
     # type: (ArrayLikeType) -> int
+
+    # NOTE For dask dataframes
+    # https://github.com/scikit-learn/scikit-learn/blob/ \
+    # 8caa93889f85254fc3ca84caa0a24a1640eebdd1/sklearn/utils/validation.py#L155-L158
+    if hasattr(x, 'shape') and x.shape is not None:
+        if isinstance(x.shape[0], Integral):
+            return x.shape[0]
 
     try:
         return len(x)

--- a/optuna/integration/sklearn.py
+++ b/optuna/integration/sklearn.py
@@ -122,7 +122,7 @@ def _make_indexable(iterable):
     # type: (IndexableType) -> (IterableType)
 
     tocsr_func = getattr(iterable, "tocsr", None)
-    if tocsr_func is not None and sp.issparse(iterable):
+    if tocsr_func is not None and sp.sparse.issparse(iterable):
         return tocsr_func(iterable)
     elif hasattr(iterable, "__getitem__") or hasattr(iterable, "iloc"):
         return iterable

--- a/tests/integration_tests/test_sklearn.py
+++ b/tests/integration_tests/test_sklearn.py
@@ -16,7 +16,8 @@ def test_is_arraylike() -> None:
     assert not integration.sklearn._is_arraylike(1)
 
 
-def test__num_samples():
+def test_num_samples() -> None:
+
     x1 = np.random.random((10, 10))
     x2 = [1, 2, 3]
     assert integration.sklearn._num_samples(x1) == 10

--- a/tests/integration_tests/test_sklearn.py
+++ b/tests/integration_tests/test_sklearn.py
@@ -11,6 +11,7 @@ import numpy as np
 
 def test__is_arraylike():
     assert integration.sklearn._is_arraylike([])
+    assert integration.sklearn._is_arraylike(np.zeros(5))
     assert not integration.sklearn._is_arraylike(1)
 
 

--- a/tests/integration_tests/test_sklearn.py
+++ b/tests/integration_tests/test_sklearn.py
@@ -7,6 +7,7 @@ from optuna import distributions
 from optuna import integration
 
 import numpy as np
+import scipy as sp
 
 
 def test_is_arraylike() -> None:
@@ -22,6 +23,18 @@ def test_num_samples() -> None:
     x2 = [1, 2, 3]
     assert integration.sklearn._num_samples(x1) == 10
     assert integration.sklearn._num_samples(x2) == 3
+
+
+def test_make_indexable() -> None:
+
+    x1 = np.random.random((10, 10))
+    x2 = sp.sparse.coo_matrix(x1)
+    x3 = [1, 2, 3]
+
+    assert hasattr(integration.sklearn._make_indexable(x1), '__getitem__')
+    assert hasattr(integration.sklearn._make_indexable(x2), '__getitem__')
+    assert hasattr(integration.sklearn._make_indexable(x3), '__getitem__')
+    assert integration.sklearn._make_indexable(None) is None
 
 
 @pytest.mark.parametrize('enable_pruning', [True, False])

--- a/tests/integration_tests/test_sklearn.py
+++ b/tests/integration_tests/test_sklearn.py
@@ -9,7 +9,8 @@ from optuna import integration
 import numpy as np
 
 
-def test__is_arraylike():
+def test_is_arraylike() -> None:
+
     assert integration.sklearn._is_arraylike([])
     assert integration.sklearn._is_arraylike(np.zeros(5))
     assert not integration.sklearn._is_arraylike(1)

--- a/tests/integration_tests/test_sklearn.py
+++ b/tests/integration_tests/test_sklearn.py
@@ -9,6 +9,18 @@ from optuna import integration
 import numpy as np
 
 
+def test__is_arraylike():
+    assert integration.sklearn._is_arraylike([])
+    assert not integration.sklearn._is_arraylike(1)
+
+
+def test__num_samples():
+    x1 = np.random.random((10, 10))
+    x2 = [1, 2, 3]
+    assert integration.sklearn._num_samples(x1) == 10
+    assert integration.sklearn._num_samples(x2) == 3
+
+
 @pytest.mark.parametrize('enable_pruning', [True, False])
 @pytest.mark.parametrize('fit_params', ['', 'coef_init'])
 @pytest.mark.filterwarnings('ignore::UserWarning')


### PR DESCRIPTION
This PR is follow-up for #881.

I implement some methods to reduce dependencies on scikit-learn private methods.
I basically define methods to be compatible with scikit-learn's, but some points are different.


(The name of this branch should be `sklearn-privates`...:innocent:)