### PR TITLE
Revert "Temporarily constraint to `xgboost<1.0.0`".

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -83,9 +83,7 @@ def get_extras_require():
             'scikit-learn',
             'torch',
             'torchvision>=0.5.0',
-            # TODO(hvy): Remove version constraint when
-            # https://github.com/dmlc/xgboost/issues/5328 is fixed.
-            'xgboost<1.0.0',
+            'xgboost',
         ] + (['fastai<2'] if (3, 5) < sys.version_info[:2] < (3, 8) else [])
         + ([
             'dask[dataframe]',
@@ -110,9 +108,7 @@ def get_extras_require():
             'scikit-optimize',
             'torch',
             'torchvision>=0.5.0',
-            # TODO(hvy): Remove version constraint when
-            # https://github.com/dmlc/xgboost/issues/5328 is fixed.
-            'xgboost<1.0.0',
+            'xgboost',
         ] + (['fastai<2'] if (3, 5) < sys.version_info[:2] < (3, 8) else [])
         + ([
             'keras',


### PR DESCRIPTION
This reverts commit bb48c474756ce42796fe79aed45cffedbfc8db27 (https://github.com/optuna/optuna/pull/948) as xgboost has been fixed.