### PR TITLE
Remove description and example of `optuna.structs.TrialPruned` (followup of #958).

### DIFF
--- a/optuna/structs.py
+++ b/optuna/structs.py
@@ -346,21 +346,6 @@ class TrialPruned(exceptions.TrialPruned):
 
         This class was moved to :mod:`~optuna.exceptions`. Please use
         :class:`~optuna.exceptions.TrialPruned` instead.
-
-    This error tells a trainer that the current :class:`~optuna.trial.Trial` was pruned. It is
-    supposed to be raised after :func:`optuna.trial.Trial.should_prune` as shown in the following
-    example.
-
-    Example:
-
-        .. code::
-
-            >>> def objective(trial):
-            >>>     ...
-            >>>     for step in range(n_train_iter):
-            >>>         ...
-            >>>         if trial.should_prune():
-            >>>             raise TrailPruned()
     """
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
This is a follow-up PR of https://github.com/optuna/optuna/pull/958.
It will remove the description and the example of `optuna.structs.TrialPruned` and leave the message about deprecation as it is. https://github.com/optuna/optuna/pull/958 updates the example (including typo fix), but I don't think it is reasonable to update the example of `optuna.structs.TrialPruned` because it has been deprecated since 0.19.0.
