### PR TITLE
Implement ThresholdPruner

### DIFF
--- a/docs/source/reference/pruners.rst
+++ b/docs/source/reference/pruners.rst
@@ -25,3 +25,7 @@ Pruners
 .. autoclass:: HyperbandPruner
     :members:
     :exclude-members: prune
+
+.. autoclass:: ThresholdPruner
+    :members:
+    :exclude-members: prune

--- a/optuna/pruners/__init__.py
+++ b/optuna/pruners/__init__.py
@@ -4,3 +4,4 @@ from optuna.pruners.median import MedianPruner  # NOQA
 from optuna.pruners.nop import NopPruner  # NOQA
 from optuna.pruners.percentile import PercentilePruner  # NOQA
 from optuna.pruners.successive_halving import SuccessiveHalvingPruner  # NOQA
+from optuna.pruners.threshold import ThresholdPruner  # NOQA

--- a/optuna/pruners/threshold.py
+++ b/optuna/pruners/threshold.py
@@ -73,11 +73,11 @@ class ThresholdPruner(BasePruner):
     ) -> None:
 
         if isinstance(lower, bool) or isinstance(upper, bool):
-            raise ValueError("lower and upper should be either None, integers or floating points")
-        if (lower is not None) and (not isinstance(lower, int)) and (not isinstance(lower, float)):
-            raise ValueError("lower should be either None, integer or floating point.")
-        if (upper is not None) and (not isinstance(upper, int)) and (not isinstance(upper, float)):
-            raise ValueError("upper should be either None, integer or floating point.")
+            raise TypeError("lower and upper should be either None, integers or floating points")
+        if lower is not None and not isinstance(lower, (int, float)):
+            raise TypeError("lower should be either None, integer or floating point.")
+        if upper is not None and not isinstance(upper, (int, float)):
+            raise TypeError("upper should be either None, integer or floating point.")
         if lower is None and upper is None:
             raise ValueError("Either lower or upper must be specified.")
         if lower is not None and upper is not None and lower > upper:

--- a/optuna/pruners/threshold.py
+++ b/optuna/pruners/threshold.py
@@ -15,14 +15,39 @@ class ThresholdPruner(BasePruner):
     falls behind lower bound threshold.
 
     Example:
+        .. testcode::
 
-        .. code::
+            from optuna import create_study
+            from optuna.exceptions import TrialPruned
+            from optuna.pruners import ThresholdPruner
 
-            >>> from optuna import create_study
-            >>> from optuna.pruners import ThresholdPruner
-            >>>
-            >>> study = create_study(pruner=ThresholdPruner(upper=500))
-            >>> study.optimize(objective)
+
+            def objective_1(trial):
+                for step in range(n_trial_step):
+                    trial.report(ys_for_upper[step], step)
+
+                    if trial.should_prune():
+                        raise TrialPruned()
+
+
+            def objective_2(trial):
+                for step in range(n_trial_step):
+                    trial.report(ys_for_lower[step], step)
+
+                    if trial.should_prune():
+                        raise TrialPruned()
+
+
+            ys_for_upper = [0.0, 0.1, 0.2, 0.5, 1.2]
+            ys_for_lower = [100.0, 90.0, 0.1, 0.0, -1]
+            n_trial_step = 5
+
+            study = create_study(pruner=ThresholdPruner(upper=1.0))
+            study.optimize(objective_1, n_trials=10)
+
+            study = create_study(pruner=ThresholdPruner(lower=0.0))
+            study.optimize(objective_2, n_trials=10)
+
 
     Args
         lower:

--- a/optuna/pruners/threshold.py
+++ b/optuna/pruners/threshold.py
@@ -9,8 +9,8 @@ from optuna.pruners.percentile import _is_first_in_interval_step
 class ThresholdPruner(BasePruner):
     """Pruner to detect outlying metrics of the trials.
 
-    Prune if a metric exceeds upper bound threshold or
-    falls behind lower bound threshold.
+    Prune if a metric exceeds upper threshold,
+    falls behind lower threshold or reaches ``nan``.
 
     Example:
         .. testcode::

--- a/optuna/pruners/threshold.py
+++ b/optuna/pruners/threshold.py
@@ -1,6 +1,5 @@
 import math
 from typing import Optional
-import warnings
 
 import optuna
 from optuna.pruners import BasePruner

--- a/optuna/pruners/threshold.py
+++ b/optuna/pruners/threshold.py
@@ -3,8 +3,6 @@ from typing import Optional
 
 from optuna.pruners import BasePruner
 from optuna.pruners.percentile import _is_first_in_interval_step
-from optuna import structs
-from optuna.structs import FrozenTrial
 
 import optuna
 
@@ -72,16 +70,12 @@ class ThresholdPruner(BasePruner):
             self,
             lower: Optional[float] = None,
             upper: Optional[float] = None,
-            n_startup_trials: int = 5,
             n_warmup_steps: int = 0,
             interval_steps: int = 1
     ) -> None:
 
         if isinstance(lower, float) and isinstance(upper, float) and lower > upper:
             raise ValueError('lower should be smaller than upper')
-        if n_startup_trials < 0:
-            raise ValueError(
-                'Number of startup trials cannot be negative but got {}.'.format(n_startup_trials))
         if n_warmup_steps < 0:
             raise ValueError(
                 'Number of warmup steps cannot be negative but got {}.'.format(n_warmup_steps))
@@ -91,17 +85,10 @@ class ThresholdPruner(BasePruner):
 
         self.lower = lower
         self.upper = upper
-        self._n_startup_trials = n_startup_trials
         self._n_warmup_steps = n_warmup_steps
         self._interval_steps = interval_steps
 
-    def prune(self, study: 'optuna.study.Study', trial: FrozenTrial) -> bool:
-
-        all_trials = study.get_trials(deepcopy=False)
-        n_trials = len([t for t in all_trials if t.state == structs.TrialState.COMPLETE])
-
-        if n_trials < self._n_startup_trials:
-            return False
+    def prune(self, study: 'optuna.study.Study', trial: optuna.structs.FrozenTrial) -> bool:
 
         step = trial.last_step
         if step is None:

--- a/optuna/pruners/threshold.py
+++ b/optuna/pruners/threshold.py
@@ -124,17 +124,3 @@ class ThresholdPruner(BasePruner):
             return True
 
         return False
-
-    @property
-    def lower(self) -> Optional[float]:
-
-        if self._lower == -float("inf"):
-            return None
-        return self._lower
-
-    @property
-    def upper(self) -> Optional[float]:
-
-        if self._upper == float("inf"):
-            return None
-        return self._upper

--- a/optuna/pruners/threshold.py
+++ b/optuna/pruners/threshold.py
@@ -26,20 +26,20 @@ class ThresholdPruner(BasePruner):
             >>> study.optimize(objective)
 
     Args
-        lower_bound:
+        lower:
             minimum value which determines whether pruner prunes or not
-            (If value is smaller than lower_bound, it prunes)
-        upper_bound:
+            (If value is smaller than lower, it prunes)
+        upper:
             maximum value which determines whether pruner prunes or not
-            (If value is larger than upper_bound, it prunes)
+            (If value is larger than upper, it prunes)
 
     """
 
-    def __init__(self, lower_bound=None, upper_bound=None):
+    def __init__(self, lower=None, upper=None):
         # type: (Optional[float], Optional[float]) -> None
 
-        self.lower_bound = lower_bound
-        self.upper_bound = upper_bound
+        self.lower = lower
+        self.upper = upper
 
     def prune(self, study, trial):
         # type: (Study, FrozenTrial) -> bool
@@ -50,10 +50,10 @@ class ThresholdPruner(BasePruner):
 
         latest_value = trial.intermediate_values[last_step]
 
-        if self.lower_bound is not None and latest_value < self.lower_bound:
+        if self.lower is not None and latest_value < self.lower:
             return True
 
-        if self.upper_bound is not None and latest_value > self.upper_bound:
+        if self.upper is not None and latest_value > self.upper:
             return True
 
         return False

--- a/optuna/pruners/threshold.py
+++ b/optuna/pruners/threshold.py
@@ -21,16 +21,16 @@ class ThresholdPruner(BasePruner):
 
 
             def objective_1(trial):
-                for step in range(n_trial_step):
-                    trial.report(ys_for_upper[step], step)
+                for step, y in enumerate(ys_for_upper):
+                    trial.report(y, step)
 
                     if trial.should_prune():
                         raise TrialPruned()
 
 
             def objective_2(trial):
-                for step in range(n_trial_step):
-                    trial.report(ys_for_lower[step], step)
+                for step, y in enumerate(ys_for_lower):
+                    trial.report(y, step)
 
                     if trial.should_prune():
                         raise TrialPruned()

--- a/optuna/pruners/threshold.py
+++ b/optuna/pruners/threshold.py
@@ -51,8 +51,8 @@ class ThresholdPruner(BasePruner):
 
     Args
         lower:
-            minimum value which determines whether pruner prunes or not
-            (If value is smaller than lower, it prunes)
+            A minimum value which determines whether pruner prunes or not.
+            If an intermediate value is smaller than lower, it prunes.
         upper:
             maximum value which determines whether pruner prunes or not
             (If value is larger than upper, it prunes)

--- a/optuna/pruners/threshold.py
+++ b/optuna/pruners/threshold.py
@@ -81,7 +81,7 @@ class ThresholdPruner(BasePruner):
         if (upper is not None) and (not isinstance(upper, int)) and (not isinstance(upper, float)):
             raise ValueError('upper should be either None, integer or floating point.')
         if lower is None and upper is None:
-            warnings.warn('Both lower and upper are not specified.')
+            raise ValueError('Either lower or upper must be specified.')
         if lower is not None and upper is not None and lower > upper:
             raise ValueError('lower should be smaller than upper.')
         if n_warmup_steps < 0:

--- a/optuna/pruners/threshold.py
+++ b/optuna/pruners/threshold.py
@@ -67,36 +67,38 @@ class ThresholdPruner(BasePruner):
     """
 
     def __init__(
-            self,
-            lower: Optional[float] = None,
-            upper: Optional[float] = None,
-            n_warmup_steps: int = 0,
-            interval_steps: int = 1
+        self,
+        lower: Optional[float] = None,
+        upper: Optional[float] = None,
+        n_warmup_steps: int = 0,
+        interval_steps: int = 1,
     ) -> None:
 
         if isinstance(lower, bool) or isinstance(upper, bool):
-            raise ValueError('lower and upper should be either None, integers or floating points')
+            raise ValueError("lower and upper should be either None, integers or floating points")
         if (lower is not None) and (not isinstance(lower, int)) and (not isinstance(lower, float)):
-            raise ValueError('lower should be either None, integer or floating point.')
+            raise ValueError("lower should be either None, integer or floating point.")
         if (upper is not None) and (not isinstance(upper, int)) and (not isinstance(upper, float)):
-            raise ValueError('upper should be either None, integer or floating point.')
+            raise ValueError("upper should be either None, integer or floating point.")
         if lower is None and upper is None:
-            raise ValueError('Either lower or upper must be specified.')
+            raise ValueError("Either lower or upper must be specified.")
         if lower is not None and upper is not None and lower > upper:
-            raise ValueError('lower should be smaller than upper.')
+            raise ValueError("lower should be smaller than upper.")
         if n_warmup_steps < 0:
             raise ValueError(
-                'Number of warmup steps cannot be negative but got {}.'.format(n_warmup_steps))
+                "Number of warmup steps cannot be negative but got {}.".format(n_warmup_steps)
+            )
         if interval_steps < 1:
             raise ValueError(
-                'Pruning interval steps must be at least 1 but got {}.'.format(interval_steps))
+                "Pruning interval steps must be at least 1 but got {}.".format(interval_steps)
+            )
 
         self.lower = lower
         self.upper = upper
         self._n_warmup_steps = n_warmup_steps
         self._interval_steps = interval_steps
 
-    def prune(self, study: 'optuna.study.Study', trial: optuna.structs.FrozenTrial) -> bool:
+    def prune(self, study: "optuna.study.Study", trial: optuna.structs.FrozenTrial) -> bool:
 
         step = trial.last_step
         if step is None:
@@ -107,8 +109,8 @@ class ThresholdPruner(BasePruner):
             return False
 
         if not _is_first_in_interval_step(
-            step, trial.intermediate_values.keys(), n_warmup_steps,
-                self._interval_steps):
+            step, trial.intermediate_values.keys(), n_warmup_steps, self._interval_steps
+        ):
             return False
 
         latest_value = trial.intermediate_values[step]

--- a/optuna/pruners/threshold.py
+++ b/optuna/pruners/threshold.py
@@ -77,7 +77,7 @@ class ThresholdPruner(BasePruner):
         if lower is None and upper is None:
             warnings.warn('Both lower and upper are not specified.')
         if lower is not None and upper is not None and lower > upper:
-            raise ValueError('lower should be smaller than upper')
+            raise ValueError('lower should be smaller than upper.')
         if n_warmup_steps < 0:
             raise ValueError(
                 'Number of warmup steps cannot be negative but got {}.'.format(n_warmup_steps))

--- a/optuna/pruners/threshold.py
+++ b/optuna/pruners/threshold.py
@@ -7,7 +7,7 @@ from optuna.pruners import BasePruner
 from optuna.pruners.percentile import _is_first_in_interval_step
 
 
-def _check_value(value: Any) -> None:
+def _check_value(value: Any) -> float:
     try:
         # For convenience, we allow users to report a value that can be cast to `float`.
         value = float(value)
@@ -16,6 +16,8 @@ def _check_value(value: Any) -> None:
             type(value).__name__
         )
         raise TypeError(message)
+
+    return value
 
 
 class ThresholdPruner(BasePruner):
@@ -86,9 +88,9 @@ class ThresholdPruner(BasePruner):
         if lower is None and upper is None:
             raise TypeError("Either lower or upper must be specified.")
         if lower is not None:
-            _check_value(lower)
+            lower = _check_value(lower)
         if upper is not None:
-            _check_value(upper)
+            upper = _check_value(upper)
 
         lower = lower if lower is not None else -float("inf")
         upper = upper if upper is not None else float("inf")

--- a/optuna/pruners/threshold.py
+++ b/optuna/pruners/threshold.py
@@ -12,15 +12,25 @@ if TYPE_CHECKING:
 class ThresholdPruner(BasePruner):
     """Pruner to detect abnormal metrics of the trials.
 
-    Prune if the metric exceed a threshold.
+    Prune if the metric exceeds user-specified upper/lower bounds.
 
     Example:
 
         .. code::
 
             >>> from optuna import create_study
+            >>> from optuna.pruners import ThresholdPruner
+            >>>
+            >>> study = create_study(pruner=ThresholdPruner(upper=500))
+            >>> study.optimize(objective)
 
     Args
+        lower_bound:
+            minimum value which determines whether pruner prunes or not
+            (If value is smaller than lower_bound, it prunes)
+        upper_bound:
+            maximum value which determines whether pruner prunes or not
+            (If value is larger than upper_bound, it prunes)
 
     """
 

--- a/optuna/pruners/threshold.py
+++ b/optuna/pruners/threshold.py
@@ -54,8 +54,6 @@ class ThresholdPruner(BasePruner):
         upper:
             maximum value which determines whether pruner prunes or not
             (If value is larger than upper, it prunes)
-        n_startup_trials:
-            Pruning is disabled until the given number of trials finish in the same study.
         n_warmup_steps:
             Pruning is disabled until the trial exceeds the given number of step.
         interval_steps:

--- a/optuna/pruners/threshold.py
+++ b/optuna/pruners/threshold.py
@@ -1,9 +1,21 @@
 import math
+from typing import Any
 from typing import Optional
 
 import optuna
 from optuna.pruners import BasePruner
 from optuna.pruners.percentile import _is_first_in_interval_step
+
+
+def _check_value(value: Any) -> None:
+    try:
+        # For convenience, we allow users to report a value that can be cast to `float`.
+        value = float(value)
+    except (TypeError, ValueError):
+        message = "The `value` argument is of type '{}' but supposed to be a float.".format(
+            type(value).__name__
+        )
+        raise TypeError(message)
 
 
 class ThresholdPruner(BasePruner):
@@ -71,12 +83,12 @@ class ThresholdPruner(BasePruner):
         interval_steps: int = 1,
     ) -> None:
 
-        if lower is not None and not isinstance(lower, float):
-            raise TypeError("lower should be either None or a floating point.")
-        if upper is not None and not isinstance(upper, float):
-            raise TypeError("upper should be either None or a floating point.")
         if lower is None and upper is None:
-            raise ValueError("Either lower or upper must be specified.")
+            raise TypeError("Either lower or upper must be specified.")
+        if lower is not None:
+            _check_value(lower)
+        if upper is not None:
+            _check_value(upper)
 
         lower = lower if lower is not None else -float("inf")
         upper = upper if upper is not None else float("inf")

--- a/optuna/pruners/threshold.py
+++ b/optuna/pruners/threshold.py
@@ -1,15 +1,11 @@
 import math
+from typing import Optional
 
 from optuna.pruners import BasePruner
 from optuna.pruners.percentile import _is_first_in_interval_step
 from optuna import structs
-from optuna.type_checking import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from typing import Optional
-
-    from optuna.structs import FrozenTrial
-    from optuna.study import Study
+from optuna.structs import FrozenTrial
+from optuna import Study
 
 
 class ThresholdPruner(BasePruner):
@@ -73,13 +69,12 @@ class ThresholdPruner(BasePruner):
 
     def __init__(
             self,
-            lower=None,
-            upper=None,
-            n_startup_trials=5,
-            n_warmup_steps=0,
-            interval_steps=1
-    ):
-        # type: (Optional[float], Optional[float], int, int, int) -> None
+            lower: Optional[float] = None,
+            upper: Optional[float] = None,
+            n_startup_trials: int = 5,
+            n_warmup_steps: int = 0,
+            interval_steps: int = 1
+    ) -> None:
 
         if isinstance(lower, float) and isinstance(upper, float) and lower > upper:
             raise ValueError('lower should be smaller than upper')
@@ -99,8 +94,7 @@ class ThresholdPruner(BasePruner):
         self._n_warmup_steps = n_warmup_steps
         self._interval_steps = interval_steps
 
-    def prune(self, study, trial):
-        # type: (Study, FrozenTrial) -> bool
+    def prune(self, study: Study, trial: FrozenTrial) -> bool:
 
         all_trials = study.get_trials(deepcopy=False)
         n_trials = len([t for t in all_trials if t.state == structs.TrialState.COMPLETE])

--- a/optuna/pruners/threshold.py
+++ b/optuna/pruners/threshold.py
@@ -74,6 +74,12 @@ class ThresholdPruner(BasePruner):
             interval_steps: int = 1
     ) -> None:
 
+        if isinstance(lower, bool) or isinstance(upper, bool):
+            raise ValueError('lower and upper should be either None, integers or floating points')
+        if (lower is not None) and (not isinstance(lower, int)) and (not isinstance(lower, float)):
+            raise ValueError('lower should be either None, integer or floating point.')
+        if (upper is not None) and (not isinstance(upper, int)) and (not isinstance(upper, float)):
+            raise ValueError('upper should be either None, integer or floating point.')
         if lower is None and upper is None:
             warnings.warn('Both lower and upper are not specified.')
         if lower is not None and upper is not None and lower > upper:

--- a/optuna/pruners/threshold.py
+++ b/optuna/pruners/threshold.py
@@ -59,11 +59,31 @@ class ThresholdPruner(BasePruner):
 
     """
 
-    def __init__(self, lower=None, upper=None):
-        # type: (Optional[float], Optional[float]) -> None
+    def __init__(
+            self,
+            lower=None,
+            upper=None,
+            n_startup_trials=5,
+            n_warmup_steps=0,
+            interval_steps=1
+    ):
+        # type: (Optional[float], Optional[float], int, int, int) -> None
+
+        if n_startup_trials < 0:
+            raise ValueError(
+                'Number of startup trials cannot be negative but got {}.'.format(n_startup_trials))
+        if n_warmup_steps < 0:
+            raise ValueError(
+                'Number of warmup steps cannot be negative but got {}.'.format(n_warmup_steps))
+        if interval_steps < 1:
+            raise ValueError(
+                'Pruning interval steps must be at least 1 but got {}.'.format(interval_steps))
 
         self.lower = lower
         self.upper = upper
+        self._n_startup_trials = n_startup_trials
+        self._n_warmup_steps = n_warmup_steps
+        self._interval_steps = interval_steps
 
     def prune(self, study, trial):
         # type: (Study, FrozenTrial) -> bool

--- a/optuna/pruners/threshold.py
+++ b/optuna/pruners/threshold.py
@@ -9,10 +9,10 @@ if TYPE_CHECKING:
 
 
 class ThresholdPruner(BasePruner):
-    """Pruner to detect abnormal metrics of the trials.
+    """Pruner to detect outlying metrics of the trials.
 
     Prune if a metric exceeds upper bound threshold or
-    falls behind lower bound threshold which users specify.
+    falls behind lower bound threshold.
 
     Example:
 

--- a/optuna/pruners/threshold.py
+++ b/optuna/pruners/threshold.py
@@ -44,10 +44,10 @@ class ThresholdPruner(BasePruner):
             n_trial_step = 5
 
             study = create_study(pruner=ThresholdPruner(upper=1.0))
-            study.optimize(objective_1, n_trials=10)
+            study.optimize(objective_for_upper, n_trials=10)
 
             study = create_study(pruner=ThresholdPruner(lower=0.0))
-            study.optimize(objective_2, n_trials=10)
+            study.optimize(objective_for_lower, n_trials=10)
 
 
     Args

--- a/optuna/pruners/threshold.py
+++ b/optuna/pruners/threshold.py
@@ -1,5 +1,6 @@
 import math
 from typing import Optional
+import warnings
 
 import optuna
 from optuna.pruners import BasePruner
@@ -73,6 +74,8 @@ class ThresholdPruner(BasePruner):
             interval_steps: int = 1
     ) -> None:
 
+        if lower is None and upper is None:
+            warnings.warn('Both lower and upper are not specified.')
         if lower is not None and upper is not None and lower > upper:
             raise ValueError('lower should be smaller than upper')
         if n_warmup_steps < 0:

--- a/optuna/pruners/threshold.py
+++ b/optuna/pruners/threshold.py
@@ -1,5 +1,4 @@
 from optuna.pruners import BasePruner
-
 from optuna.type_checking import TYPE_CHECKING
 
 if TYPE_CHECKING:

--- a/optuna/pruners/threshold.py
+++ b/optuna/pruners/threshold.py
@@ -20,7 +20,7 @@ class ThresholdPruner(BasePruner):
             from optuna.pruners import ThresholdPruner
 
 
-            def objective_1(trial):
+            def objective_for_upper(trial):
                 for step, y in enumerate(ys_for_upper):
                     trial.report(y, step)
 
@@ -28,7 +28,7 @@ class ThresholdPruner(BasePruner):
                         raise TrialPruned()
 
 
-            def objective_2(trial):
+            def objective_for_lower(trial):
                 for step, y in enumerate(ys_for_lower):
                     trial.report(y, step)
 

--- a/optuna/pruners/threshold.py
+++ b/optuna/pruners/threshold.py
@@ -73,7 +73,7 @@ class ThresholdPruner(BasePruner):
             interval_steps: int = 1
     ) -> None:
 
-        if isinstance(lower, float) and isinstance(upper, float) and lower > upper:
+        if lower is not None and upper is not None and lower > upper:
             raise ValueError('lower should be smaller than upper')
         if n_warmup_steps < 0:
             raise ValueError(

--- a/optuna/pruners/threshold.py
+++ b/optuna/pruners/threshold.py
@@ -5,7 +5,8 @@ from optuna.pruners import BasePruner
 from optuna.pruners.percentile import _is_first_in_interval_step
 from optuna import structs
 from optuna.structs import FrozenTrial
-from optuna import Study
+
+import optuna
 
 
 class ThresholdPruner(BasePruner):
@@ -94,7 +95,7 @@ class ThresholdPruner(BasePruner):
         self._n_warmup_steps = n_warmup_steps
         self._interval_steps = interval_steps
 
-    def prune(self, study: Study, trial: FrozenTrial) -> bool:
+    def prune(self, study: 'optuna.study.Study', trial: FrozenTrial) -> bool:
 
         all_trials = study.get_trials(deepcopy=False)
         n_trials = len([t for t in all_trials if t.state == structs.TrialState.COMPLETE])

--- a/optuna/pruners/threshold.py
+++ b/optuna/pruners/threshold.py
@@ -60,6 +60,14 @@ class ThresholdPruner(BasePruner):
         upper:
             maximum value which determines whether pruner prunes or not
             (If value is larger than upper, it prunes)
+        n_startup_trials:
+            Pruning is disabled until the given number of trials finish in the same study.
+        n_warmup_steps:
+            Pruning is disabled until the trial exceeds the given number of step.
+        interval_steps:
+            Interval in number of steps between the pruning checks, offset by the warmup steps.
+            If no value has been reported at the time of a pruning check, that particular check
+            will be postponed until a value is reported. Value must be at least 1.
 
     """
 

--- a/optuna/pruners/threshold.py
+++ b/optuna/pruners/threshold.py
@@ -89,8 +89,8 @@ class ThresholdPruner(BasePruner):
                 "Pruning interval steps must be at least 1 but got {}.".format(interval_steps)
             )
 
-        self.lower = lower
-        self.upper = upper
+        self._lower = lower if lower is not None else -float("inf")
+        self._upper = upper if upper is not None else float("inf")
         self._n_warmup_steps = n_warmup_steps
         self._interval_steps = interval_steps
 
@@ -113,10 +113,24 @@ class ThresholdPruner(BasePruner):
         if math.isnan(latest_value):
             return True
 
-        if self.lower is not None and latest_value < self.lower:
+        if latest_value < self._lower:
             return True
 
-        if self.upper is not None and latest_value > self.upper:
+        if latest_value > self._upper:
             return True
 
         return False
+
+    @property
+    def lower(self) -> Optional[float]:
+
+        if self._lower == -float("inf"):
+            return None
+        return self._lower
+
+    @property
+    def upper(self) -> Optional[float]:
+
+        if self._upper == float("inf"):
+            return None
+        return self._upper

--- a/optuna/pruners/threshold.py
+++ b/optuna/pruners/threshold.py
@@ -1,10 +1,9 @@
 import math
 from typing import Optional
 
+import optuna
 from optuna.pruners import BasePruner
 from optuna.pruners.percentile import _is_first_in_interval_step
-
-import optuna
 
 
 class ThresholdPruner(BasePruner):

--- a/optuna/pruners/threshold.py
+++ b/optuna/pruners/threshold.py
@@ -81,6 +81,8 @@ class ThresholdPruner(BasePruner):
     ):
         # type: (Optional[float], Optional[float], int, int, int) -> None
 
+        if isinstance(lower, float) and isinstance(upper, float) and lower > upper:
+            raise ValueError('lower should be smaller than upper')
         if n_startup_trials < 0:
             raise ValueError(
                 'Number of startup trials cannot be negative but got {}.'.format(n_startup_trials))

--- a/optuna/pruners/threshold.py
+++ b/optuna/pruners/threshold.py
@@ -54,8 +54,8 @@ class ThresholdPruner(BasePruner):
             A minimum value which determines whether pruner prunes or not.
             If an intermediate value is smaller than lower, it prunes.
         upper:
-            maximum value which determines whether pruner prunes or not
-            (If value is larger than upper, it prunes)
+            A maximum value which determines whether pruner prunes or not.
+            If an intermediate value is larger than upper, it prunes.
         n_warmup_steps:
             Pruning is disabled until the trial exceeds the given number of step.
         interval_steps:

--- a/optuna/pruners/threshold.py
+++ b/optuna/pruners/threshold.py
@@ -19,7 +19,6 @@ class ThresholdPruner(BasePruner):
             from optuna.exceptions import TrialPruned
             from optuna.pruners import ThresholdPruner
 
-
             def objective_for_upper(trial):
                 for step, y in enumerate(ys_for_upper):
                     trial.report(y, step)

--- a/optuna/pruners/threshold.py
+++ b/optuna/pruners/threshold.py
@@ -12,7 +12,8 @@ if TYPE_CHECKING:
 class ThresholdPruner(BasePruner):
     """Pruner to detect abnormal metrics of the trials.
 
-    Prune if the metric exceeds user-specified upper/lower bounds.
+    Prune if a metric exceeds upper bound threshold or
+    falls behind lower bound threshold which users specify.
 
     Example:
 

--- a/optuna/pruners/threshold.py
+++ b/optuna/pruners/threshold.py
@@ -72,13 +72,17 @@ class ThresholdPruner(BasePruner):
         interval_steps: int = 1,
     ) -> None:
 
-        if lower is not None and not isinstance(lower, (float)):
+        if lower is not None and not isinstance(lower, float):
             raise TypeError("lower should be either None or a floating point.")
-        if upper is not None and not isinstance(upper, (float)):
+        if upper is not None and not isinstance(upper, float):
             raise TypeError("upper should be either None or a floating point.")
         if lower is None and upper is None:
             raise ValueError("Either lower or upper must be specified.")
-        if lower is not None and upper is not None and lower > upper:
+
+        lower = lower if lower is not None else -float("inf")
+        upper = upper if upper is not None else float("inf")
+
+        if lower > upper:
             raise ValueError("lower should be smaller than upper.")
         if n_warmup_steps < 0:
             raise ValueError(
@@ -89,8 +93,8 @@ class ThresholdPruner(BasePruner):
                 "Pruning interval steps must be at least 1 but got {}.".format(interval_steps)
             )
 
-        self._lower = lower if lower is not None else -float("inf")
-        self._upper = upper if upper is not None else float("inf")
+        self._lower = lower
+        self._upper = upper
         self._n_warmup_steps = n_warmup_steps
         self._interval_steps = interval_steps
 

--- a/optuna/pruners/threshold.py
+++ b/optuna/pruners/threshold.py
@@ -1,0 +1,66 @@
+import operator
+
+from optuna.pruners import BasePruner
+
+from optuna.type_checking import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Callable
+
+    from optuna.structs import FrozenTrial
+    from optuna.study import Study
+
+
+class ThresholdPruner(BasePruner):
+    """Pruner to detect abnormal metrics of the trials.
+
+    Prune if the metric exceed a threshold.
+
+    Example:
+
+        .. code::
+
+            >>> from optuna import create_study
+
+    Args
+
+    """
+
+    def __init__(self, threshold, op):
+        # type: (float, str) -> None
+
+        self.threshold = threshold
+        self.operator = self.get_operator_func(op)
+
+    @staticmethod
+    def get_operator_func(op):
+        # type: (str) -> Callable
+
+        # When minimize some metric (e.g. loss),
+        # it prunes if the metric be extremely large.
+        if op == 'gt':
+            return operator.gt
+
+        # When maximize some metric (e.g. accuracy),
+        # it prunes if the metric be extremely small.
+        if op == 'lt':
+            return operator.lt
+
+        # It prunes if the metric go out from a given range
+        if op == 'range':
+            return lambda x, y: not (-y < x < y)
+
+        raise ValueError('Unexpected operator given')
+
+    def prune(self, study, trial):
+        # type: (Study, FrozenTrial) -> bool
+
+        last_step = trial.last_step
+        if last_step is None:
+            return False
+
+        latest_value = trial.intermediate_values[last_step]
+        if self.operator(latest_value, self.threshold):
+            return True
+
+        return False

--- a/optuna/pruners/threshold.py
+++ b/optuna/pruners/threshold.py
@@ -72,12 +72,10 @@ class ThresholdPruner(BasePruner):
         interval_steps: int = 1,
     ) -> None:
 
-        if isinstance(lower, bool) or isinstance(upper, bool):
-            raise TypeError("lower and upper should be either None, integers or floating points")
-        if lower is not None and not isinstance(lower, (int, float)):
-            raise TypeError("lower should be either None, integer or floating point.")
-        if upper is not None and not isinstance(upper, (int, float)):
-            raise TypeError("upper should be either None, integer or floating point.")
+        if lower is not None and not isinstance(lower, (float)):
+            raise TypeError("lower should be either None or a floating point.")
+        if upper is not None and not isinstance(upper, (float)):
+            raise TypeError("upper should be either None or a floating point.")
         if lower is None and upper is None:
             raise ValueError("Either lower or upper must be specified.")
         if lower is not None and upper is not None and lower > upper:

--- a/optuna/pruners/threshold.py
+++ b/optuna/pruners/threshold.py
@@ -26,6 +26,7 @@ class ThresholdPruner(BasePruner):
 
                     if trial.should_prune():
                         raise TrialPruned()
+                return ys_for_upper[-1]
 
 
             def objective_for_lower(trial):
@@ -34,6 +35,7 @@ class ThresholdPruner(BasePruner):
 
                     if trial.should_prune():
                         raise TrialPruned()
+                return ys_for_lower[-1]
 
 
             ys_for_upper = [0.0, 0.1, 0.2, 0.5, 1.2]

--- a/tests/pruners_tests/test_threshold.py
+++ b/tests/pruners_tests/test_threshold.py
@@ -77,6 +77,18 @@ def test_threshold_pruner_with_invalid_inputs() -> None:
         optuna.pruners.ThresholdPruner(lower=None, upper=None)
 
 
+def test_threshold_pruner_with_nan() -> None:
+
+    study = optuna.study.create_study()
+    trial = optuna.trial.Trial(study, study._storage.create_new_trial(study._study_id))
+    pruner = optuna.pruners.ThresholdPruner(
+        lower=0.0, upper=1.0, n_warmup_steps=0, interval_steps=1
+    )
+
+    trial.report(float("nan"), 1)
+    assert pruner.prune(study=study, trial=study._storage.get_trial(trial._trial_id))
+
+
 def test_threshold_pruner_n_warmup_steps() -> None:
     study = optuna.study.create_study()
     trial = optuna.trial.Trial(study, study._storage.create_new_trial(study._study_id))

--- a/tests/pruners_tests/test_threshold.py
+++ b/tests/pruners_tests/test_threshold.py
@@ -36,3 +36,31 @@ def test_threshold_pruner_with_lt():
     trial.report(1, 2)
     assert pruner.prune(
         study=study, trial=study._storage.get_trial(trial._trial_id))
+
+
+def test_threshold_pruner_with_two_side():
+    # type: () -> None
+
+    study = optuna.study.create_study()
+    trial = optuna.trial.Trial(study, study._storage.create_new_trial(study._study_id))
+    pruner = optuna.pruners.ThresholdPruner(lower_bound=0, upper_bound=1)
+
+    trial.report(-0.1, 1)
+    assert pruner.prune(
+        study=study, trial=study._storage.get_trial(trial._trial_id))
+
+    trial.report(0, 2)
+    assert not pruner.prune(
+        study=study, trial=study._storage.get_trial(trial._trial_id))
+
+    trial.report(0.4, 3)
+    assert not pruner.prune(
+        study=study, trial=study._storage.get_trial(trial._trial_id))
+
+    trial.report(1, 4)
+    assert not pruner.prune(
+        study=study, trial=study._storage.get_trial(trial._trial_id))
+
+    trial.report(1.1, 5)
+    assert pruner.prune(
+        study=study, trial=study._storage.get_trial(trial._trial_id))

--- a/tests/pruners_tests/test_threshold.py
+++ b/tests/pruners_tests/test_threshold.py
@@ -10,12 +10,10 @@ def test_threshold_pruner_with_ub() -> None:
     pruner = optuna.pruners.ThresholdPruner(upper=2, n_warmup_steps=0, interval_steps=1)
 
     trial.report(1, 1)
-    assert not pruner.prune(
-        study=study, trial=study._storage.get_trial(trial._trial_id))
+    assert not pruner.prune(study=study, trial=study._storage.get_trial(trial._trial_id))
 
     trial.report(3, 2)
-    assert pruner.prune(
-        study=study, trial=study._storage.get_trial(trial._trial_id))
+    assert pruner.prune(study=study, trial=study._storage.get_trial(trial._trial_id))
 
 
 def test_threshold_pruner_with_lt() -> None:
@@ -25,12 +23,10 @@ def test_threshold_pruner_with_lt() -> None:
     pruner = optuna.pruners.ThresholdPruner(lower=2, n_warmup_steps=0, interval_steps=1)
 
     trial.report(3, 1)
-    assert not pruner.prune(
-        study=study, trial=study._storage.get_trial(trial._trial_id))
+    assert not pruner.prune(study=study, trial=study._storage.get_trial(trial._trial_id))
 
     trial.report(1, 2)
-    assert pruner.prune(
-        study=study, trial=study._storage.get_trial(trial._trial_id))
+    assert pruner.prune(study=study, trial=study._storage.get_trial(trial._trial_id))
 
 
 def test_threshold_pruner_with_two_side() -> None:
@@ -40,24 +36,19 @@ def test_threshold_pruner_with_two_side() -> None:
     pruner = optuna.pruners.ThresholdPruner(lower=0, upper=1, n_warmup_steps=0, interval_steps=1)
 
     trial.report(-0.1, 1)
-    assert pruner.prune(
-        study=study, trial=study._storage.get_trial(trial._trial_id))
+    assert pruner.prune(study=study, trial=study._storage.get_trial(trial._trial_id))
 
     trial.report(0, 2)
-    assert not pruner.prune(
-        study=study, trial=study._storage.get_trial(trial._trial_id))
+    assert not pruner.prune(study=study, trial=study._storage.get_trial(trial._trial_id))
 
     trial.report(0.4, 3)
-    assert not pruner.prune(
-        study=study, trial=study._storage.get_trial(trial._trial_id))
+    assert not pruner.prune(study=study, trial=study._storage.get_trial(trial._trial_id))
 
     trial.report(1, 4)
-    assert not pruner.prune(
-        study=study, trial=study._storage.get_trial(trial._trial_id))
+    assert not pruner.prune(study=study, trial=study._storage.get_trial(trial._trial_id))
 
     trial.report(1.1, 5)
-    assert pruner.prune(
-        study=study, trial=study._storage.get_trial(trial._trial_id))
+    assert pruner.prune(study=study, trial=study._storage.get_trial(trial._trial_id))
 
 
 def test_threshold_pruner_with_invalid_inputs() -> None:
@@ -66,13 +57,55 @@ def test_threshold_pruner_with_invalid_inputs() -> None:
         optuna.pruners.ThresholdPruner(lower=False, upper=1)  # type: ignore
 
     with pytest.raises(ValueError):
-        optuna.pruners.ThresholdPruner(lower='0', upper=1)  # type: ignore
+        optuna.pruners.ThresholdPruner(lower="0", upper=1)  # type: ignore
 
     with pytest.raises(ValueError):
         optuna.pruners.ThresholdPruner(lower=0, upper=False)
 
     with pytest.raises(ValueError):
-        optuna.pruners.ThresholdPruner(lower=0, upper='1')  # type: ignore
+        optuna.pruners.ThresholdPruner(lower=0, upper="1")  # type: ignore
 
     with pytest.raises(ValueError):
         optuna.pruners.ThresholdPruner(lower=None, upper=None)
+
+
+def test_threshold_pruner_n_warmup_steps() -> None:
+    study = optuna.study.create_study()
+    trial = optuna.trial.Trial(study, study._storage.create_new_trial(study._study_id))
+    pruner = optuna.pruners.ThresholdPruner(lower=0, upper=1, n_warmup_steps=2)
+
+    trial.report(-10, 1)
+    assert not pruner.prune(study=study, trial=study._storage.get_trial(trial._trial_id))
+
+    trial.report(100, 2)
+    assert not pruner.prune(study=study, trial=study._storage.get_trial(trial._trial_id))
+
+    trial.report(-100, 3)
+    assert pruner.prune(study=study, trial=study._storage.get_trial(trial._trial_id))
+
+    trial.report(1, 4)
+    assert not pruner.prune(study=study, trial=study._storage.get_trial(trial._trial_id))
+
+    trial.report(1000, 5)
+    assert pruner.prune(study=study, trial=study._storage.get_trial(trial._trial_id))
+
+
+def test_threshold_pruner_interval_steps() -> None:
+    study = optuna.study.create_study()
+    trial = optuna.trial.Trial(study, study._storage.create_new_trial(study._study_id))
+    pruner = optuna.pruners.ThresholdPruner(lower=0, upper=1, interval_steps=2)
+
+    trial.report(-10, 1)
+    assert pruner.prune(study=study, trial=study._storage.get_trial(trial._trial_id))
+
+    trial.report(100, 2)
+    assert not pruner.prune(study=study, trial=study._storage.get_trial(trial._trial_id))
+
+    trial.report(-100, 3)
+    assert pruner.prune(study=study, trial=study._storage.get_trial(trial._trial_id))
+
+    trial.report(10, 4)
+    assert not pruner.prune(study=study, trial=study._storage.get_trial(trial._trial_id))
+
+    trial.report(1000, 5)
+    assert pruner.prune(study=study, trial=study._storage.get_trial(trial._trial_id))

--- a/tests/pruners_tests/test_threshold.py
+++ b/tests/pruners_tests/test_threshold.py
@@ -56,10 +56,10 @@ def test_threshold_pruner_with_two_side() -> None:
 def test_threshold_pruner_with_invalid_inputs() -> None:
 
     with pytest.raises(TypeError):
-        optuna.pruners.ThresholdPruner(lower="0", upper=1.0)  # type: ignore
+        optuna.pruners.ThresholdPruner(lower="val", upper=1.0)  # type: ignore
 
     with pytest.raises(TypeError):
-        optuna.pruners.ThresholdPruner(lower=0.0, upper="1")  # type: ignore
+        optuna.pruners.ThresholdPruner(lower=0.0, upper="val")  # type: ignore
 
     with pytest.raises(TypeError):
         optuna.pruners.ThresholdPruner(lower=None, upper=None)

--- a/tests/pruners_tests/test_threshold.py
+++ b/tests/pruners_tests/test_threshold.py
@@ -11,7 +11,8 @@ def test_threshold_pruner_with_ub():
 
     study = optuna.study.create_study()
     trial = optuna.trial.Trial(study, study._storage.create_new_trial(study._study_id))
-    pruner = optuna.pruners.ThresholdPruner(upper=2)
+    pruner = optuna.pruners.ThresholdPruner(
+        upper=2, n_startup_trials=0, n_warmup_steps=0, interval_steps=1)
 
     trial.report(1, 1)
     assert not pruner.prune(
@@ -27,7 +28,8 @@ def test_threshold_pruner_with_lt():
 
     study = optuna.study.create_study()
     trial = optuna.trial.Trial(study, study._storage.create_new_trial(study._study_id))
-    pruner = optuna.pruners.ThresholdPruner(lower=2)
+    pruner = optuna.pruners.ThresholdPruner(
+        lower=2, n_startup_trials=0, n_warmup_steps=0, interval_steps=1)
 
     trial.report(3, 1)
     assert not pruner.prune(
@@ -43,7 +45,8 @@ def test_threshold_pruner_with_two_side():
 
     study = optuna.study.create_study()
     trial = optuna.trial.Trial(study, study._storage.create_new_trial(study._study_id))
-    pruner = optuna.pruners.ThresholdPruner(lower=0, upper=1)
+    pruner = optuna.pruners.ThresholdPruner(
+        lower=0, upper=1, n_startup_trials=0, n_warmup_steps=0, interval_steps=1)
 
     trial.report(-0.1, 1)
     assert pruner.prune(

--- a/tests/pruners_tests/test_threshold.py
+++ b/tests/pruners_tests/test_threshold.py
@@ -5,8 +5,7 @@ def test_threshold_pruner_with_ub() -> None:
 
     study = optuna.study.create_study()
     trial = optuna.trial.Trial(study, study._storage.create_new_trial(study._study_id))
-    pruner = optuna.pruners.ThresholdPruner(
-        upper=2, n_startup_trials=0, n_warmup_steps=0, interval_steps=1)
+    pruner = optuna.pruners.ThresholdPruner(upper=2, n_warmup_steps=0, interval_steps=1)
 
     trial.report(1, 1)
     assert not pruner.prune(
@@ -21,8 +20,7 @@ def test_threshold_pruner_with_lt() -> None:
 
     study = optuna.study.create_study()
     trial = optuna.trial.Trial(study, study._storage.create_new_trial(study._study_id))
-    pruner = optuna.pruners.ThresholdPruner(
-        lower=2, n_startup_trials=0, n_warmup_steps=0, interval_steps=1)
+    pruner = optuna.pruners.ThresholdPruner(lower=2, n_warmup_steps=0, interval_steps=1)
 
     trial.report(3, 1)
     assert not pruner.prune(
@@ -37,8 +35,7 @@ def test_threshold_pruner_with_two_side() -> None:
 
     study = optuna.study.create_study()
     trial = optuna.trial.Trial(study, study._storage.create_new_trial(study._study_id))
-    pruner = optuna.pruners.ThresholdPruner(
-        lower=0, upper=1, n_startup_trials=0, n_warmup_steps=0, interval_steps=1)
+    pruner = optuna.pruners.ThresholdPruner(lower=0, upper=1, n_warmup_steps=0, interval_steps=1)
 
     trial.report(-0.1, 1)
     assert pruner.prune(

--- a/tests/pruners_tests/test_threshold.py
+++ b/tests/pruners_tests/test_threshold.py
@@ -1,0 +1,38 @@
+import optuna
+from optuna import type_checking
+
+if type_checking.TYPE_CHECKING:
+    from typing import List  # NOQA
+    from typing import Tuple  # NOQA
+
+
+def test_threshold_pruner_with_gt():
+    # type: () -> None
+
+    study = optuna.study.create_study()
+    trial = optuna.trial.Trial(study, study._storage.create_new_trial(study._study_id))
+    pruner = optuna.pruners.ThresholdPruner(2, 'gt')
+
+    trial.report(1, 1)
+    assert not pruner.prune(
+        study=study, trial=study._storage.get_trial(trial._trial_id))
+
+    trial.report(3, 2)
+    assert pruner.prune(
+        study=study, trial=study._storage.get_trial(trial._trial_id))
+
+
+def test_threshold_pruner_with_lt():
+    # type: () -> None
+
+    study = optuna.study.create_study()
+    trial = optuna.trial.Trial(study, study._storage.create_new_trial(study._study_id))
+    pruner = optuna.pruners.ThresholdPruner(2, 'lt')
+
+    trial.report(3, 1)
+    assert not pruner.prune(
+        study=study, trial=study._storage.get_trial(trial._trial_id))
+
+    trial.report(1, 2)
+    assert pruner.prune(
+        study=study, trial=study._storage.get_trial(trial._trial_id))

--- a/tests/pruners_tests/test_threshold.py
+++ b/tests/pruners_tests/test_threshold.py
@@ -6,12 +6,12 @@ if type_checking.TYPE_CHECKING:
     from typing import Tuple  # NOQA
 
 
-def test_threshold_pruner_with_gt():
+def test_threshold_pruner_with_ub():
     # type: () -> None
 
     study = optuna.study.create_study()
     trial = optuna.trial.Trial(study, study._storage.create_new_trial(study._study_id))
-    pruner = optuna.pruners.ThresholdPruner(2, 'gt')
+    pruner = optuna.pruners.ThresholdPruner(upper_bound=2)
 
     trial.report(1, 1)
     assert not pruner.prune(
@@ -27,7 +27,7 @@ def test_threshold_pruner_with_lt():
 
     study = optuna.study.create_study()
     trial = optuna.trial.Trial(study, study._storage.create_new_trial(study._study_id))
-    pruner = optuna.pruners.ThresholdPruner(2, 'lt')
+    pruner = optuna.pruners.ThresholdPruner(lower_bound=2)
 
     trial.report(3, 1)
     assert not pruner.prune(

--- a/tests/pruners_tests/test_threshold.py
+++ b/tests/pruners_tests/test_threshold.py
@@ -7,12 +7,12 @@ def test_threshold_pruner_with_ub() -> None:
 
     study = optuna.study.create_study()
     trial = optuna.trial.Trial(study, study._storage.create_new_trial(study._study_id))
-    pruner = optuna.pruners.ThresholdPruner(upper=2, n_warmup_steps=0, interval_steps=1)
+    pruner = optuna.pruners.ThresholdPruner(upper=2.0, n_warmup_steps=0, interval_steps=1)
 
-    trial.report(1, 1)
+    trial.report(1.0, 1)
     assert not pruner.prune(study=study, trial=study._storage.get_trial(trial._trial_id))
 
-    trial.report(3, 2)
+    trial.report(3.0, 2)
     assert pruner.prune(study=study, trial=study._storage.get_trial(trial._trial_id))
 
 
@@ -20,12 +20,12 @@ def test_threshold_pruner_with_lt() -> None:
 
     study = optuna.study.create_study()
     trial = optuna.trial.Trial(study, study._storage.create_new_trial(study._study_id))
-    pruner = optuna.pruners.ThresholdPruner(lower=2, n_warmup_steps=0, interval_steps=1)
+    pruner = optuna.pruners.ThresholdPruner(lower=2.0, n_warmup_steps=0, interval_steps=1)
 
-    trial.report(3, 1)
+    trial.report(3.0, 1)
     assert not pruner.prune(study=study, trial=study._storage.get_trial(trial._trial_id))
 
-    trial.report(1, 2)
+    trial.report(1.0, 2)
     assert pruner.prune(study=study, trial=study._storage.get_trial(trial._trial_id))
 
 
@@ -33,18 +33,20 @@ def test_threshold_pruner_with_two_side() -> None:
 
     study = optuna.study.create_study()
     trial = optuna.trial.Trial(study, study._storage.create_new_trial(study._study_id))
-    pruner = optuna.pruners.ThresholdPruner(lower=0, upper=1, n_warmup_steps=0, interval_steps=1)
+    pruner = optuna.pruners.ThresholdPruner(
+        lower=0.0, upper=1.0, n_warmup_steps=0, interval_steps=1
+    )
 
     trial.report(-0.1, 1)
     assert pruner.prune(study=study, trial=study._storage.get_trial(trial._trial_id))
 
-    trial.report(0, 2)
+    trial.report(0.0, 2)
     assert not pruner.prune(study=study, trial=study._storage.get_trial(trial._trial_id))
 
     trial.report(0.4, 3)
     assert not pruner.prune(study=study, trial=study._storage.get_trial(trial._trial_id))
 
-    trial.report(1, 4)
+    trial.report(1.0, 4)
     assert not pruner.prune(study=study, trial=study._storage.get_trial(trial._trial_id))
 
     trial.report(1.1, 5)
@@ -53,17 +55,23 @@ def test_threshold_pruner_with_two_side() -> None:
 
 def test_threshold_pruner_with_invalid_inputs() -> None:
 
-    with pytest.raises(ValueError):
-        optuna.pruners.ThresholdPruner(lower=False, upper=1)  # type: ignore
+    with pytest.raises(TypeError):
+        optuna.pruners.ThresholdPruner(lower=False, upper=1.0)  # type: ignore
 
-    with pytest.raises(ValueError):
-        optuna.pruners.ThresholdPruner(lower="0", upper=1)  # type: ignore
+    with pytest.raises(TypeError):
+        optuna.pruners.ThresholdPruner(lower="0", upper=1.0)  # type: ignore
 
-    with pytest.raises(ValueError):
-        optuna.pruners.ThresholdPruner(lower=0, upper=False)
+    with pytest.raises(TypeError):
+        optuna.pruners.ThresholdPruner(lower=0, upper=1.0)  # type: ignore
 
-    with pytest.raises(ValueError):
-        optuna.pruners.ThresholdPruner(lower=0, upper="1")  # type: ignore
+    with pytest.raises(TypeError):
+        optuna.pruners.ThresholdPruner(lower=0.0, upper=False)
+
+    with pytest.raises(TypeError):
+        optuna.pruners.ThresholdPruner(lower=0.0, upper="1")  # type: ignore
+
+    with pytest.raises(TypeError):
+        optuna.pruners.ThresholdPruner(lower=0.0, upper=1)  # type: ignore
 
     with pytest.raises(ValueError):
         optuna.pruners.ThresholdPruner(lower=None, upper=None)
@@ -72,40 +80,40 @@ def test_threshold_pruner_with_invalid_inputs() -> None:
 def test_threshold_pruner_n_warmup_steps() -> None:
     study = optuna.study.create_study()
     trial = optuna.trial.Trial(study, study._storage.create_new_trial(study._study_id))
-    pruner = optuna.pruners.ThresholdPruner(lower=0, upper=1, n_warmup_steps=2)
+    pruner = optuna.pruners.ThresholdPruner(lower=0.0, upper=1.0, n_warmup_steps=2)
 
-    trial.report(-10, 1)
+    trial.report(-10.0, 1)
     assert not pruner.prune(study=study, trial=study._storage.get_trial(trial._trial_id))
 
-    trial.report(100, 2)
+    trial.report(100.0, 2)
     assert not pruner.prune(study=study, trial=study._storage.get_trial(trial._trial_id))
 
-    trial.report(-100, 3)
+    trial.report(-100.0, 3)
     assert pruner.prune(study=study, trial=study._storage.get_trial(trial._trial_id))
 
-    trial.report(1, 4)
+    trial.report(1.0, 4)
     assert not pruner.prune(study=study, trial=study._storage.get_trial(trial._trial_id))
 
-    trial.report(1000, 5)
+    trial.report(1000.0, 5)
     assert pruner.prune(study=study, trial=study._storage.get_trial(trial._trial_id))
 
 
 def test_threshold_pruner_interval_steps() -> None:
     study = optuna.study.create_study()
     trial = optuna.trial.Trial(study, study._storage.create_new_trial(study._study_id))
-    pruner = optuna.pruners.ThresholdPruner(lower=0, upper=1, interval_steps=2)
+    pruner = optuna.pruners.ThresholdPruner(lower=0.0, upper=1.0, interval_steps=2)
 
-    trial.report(-10, 1)
+    trial.report(-10.0, 1)
     assert pruner.prune(study=study, trial=study._storage.get_trial(trial._trial_id))
 
-    trial.report(100, 2)
+    trial.report(100.0, 2)
     assert not pruner.prune(study=study, trial=study._storage.get_trial(trial._trial_id))
 
-    trial.report(-100, 3)
+    trial.report(-100.0, 3)
     assert pruner.prune(study=study, trial=study._storage.get_trial(trial._trial_id))
 
-    trial.report(10, 4)
+    trial.report(10.0, 4)
     assert not pruner.prune(study=study, trial=study._storage.get_trial(trial._trial_id))
 
-    trial.report(1000, 5)
+    trial.report(1000.0, 5)
     assert pruner.prune(study=study, trial=study._storage.get_trial(trial._trial_id))

--- a/tests/pruners_tests/test_threshold.py
+++ b/tests/pruners_tests/test_threshold.py
@@ -1,3 +1,5 @@
+import pytest
+
 import optuna
 
 
@@ -56,3 +58,12 @@ def test_threshold_pruner_with_two_side() -> None:
     trial.report(1.1, 5)
     assert pruner.prune(
         study=study, trial=study._storage.get_trial(trial._trial_id))
+
+
+def test_threshold_pruner_with_invalid_inputs() -> None:
+
+    with pytest.raises(Exception):
+        pruner = optuna.pruners.ThresholdPruner(lower='0', upper=1)  # NOQA
+
+    with pytest.raises(Exception):
+        pruner = optuna.pruners.ThresholdPruner(lower=0, upper=False)  # NOQA

--- a/tests/pruners_tests/test_threshold.py
+++ b/tests/pruners_tests/test_threshold.py
@@ -11,7 +11,7 @@ def test_threshold_pruner_with_ub():
 
     study = optuna.study.create_study()
     trial = optuna.trial.Trial(study, study._storage.create_new_trial(study._study_id))
-    pruner = optuna.pruners.ThresholdPruner(upper_bound=2)
+    pruner = optuna.pruners.ThresholdPruner(upper=2)
 
     trial.report(1, 1)
     assert not pruner.prune(
@@ -27,7 +27,7 @@ def test_threshold_pruner_with_lt():
 
     study = optuna.study.create_study()
     trial = optuna.trial.Trial(study, study._storage.create_new_trial(study._study_id))
-    pruner = optuna.pruners.ThresholdPruner(lower_bound=2)
+    pruner = optuna.pruners.ThresholdPruner(lower=2)
 
     trial.report(3, 1)
     assert not pruner.prune(
@@ -43,7 +43,7 @@ def test_threshold_pruner_with_two_side():
 
     study = optuna.study.create_study()
     trial = optuna.trial.Trial(study, study._storage.create_new_trial(study._study_id))
-    pruner = optuna.pruners.ThresholdPruner(lower_bound=0, upper_bound=1)
+    pruner = optuna.pruners.ThresholdPruner(lower=0, upper=1)
 
     trial.report(-0.1, 1)
     assert pruner.prune(

--- a/tests/pruners_tests/test_threshold.py
+++ b/tests/pruners_tests/test_threshold.py
@@ -62,8 +62,17 @@ def test_threshold_pruner_with_two_side() -> None:
 
 def test_threshold_pruner_with_invalid_inputs() -> None:
 
-    with pytest.raises(Exception):
-        pruner = optuna.pruners.ThresholdPruner(lower='0', upper=1)  # type: ignore
+    with pytest.raises(ValueError):
+        optuna.pruners.ThresholdPruner(lower=False, upper=1)  # type: ignore
 
-    with pytest.raises(Exception):
-        pruner = optuna.pruners.ThresholdPruner(lower=0, upper=False)  # NOQA
+    with pytest.raises(ValueError):
+        optuna.pruners.ThresholdPruner(lower='0', upper=1)  # type: ignore
+
+    with pytest.raises(ValueError):
+        optuna.pruners.ThresholdPruner(lower=0, upper=False)
+
+    with pytest.raises(ValueError):
+        optuna.pruners.ThresholdPruner(lower=0, upper='1')  # type: ignore
+
+    with pytest.raises(ValueError):
+        optuna.pruners.ThresholdPruner(lower=None, upper=None)

--- a/tests/pruners_tests/test_threshold.py
+++ b/tests/pruners_tests/test_threshold.py
@@ -117,3 +117,13 @@ def test_threshold_pruner_interval_steps() -> None:
 
     trial.report(1000.0, 5)
     assert pruner.prune(study=study, trial=study._storage.get_trial(trial._trial_id))
+
+
+def test_accessors() -> None:
+    pruner = optuna.pruners.ThresholdPruner(lower=None, upper=1.0)
+    assert pruner.lower is None
+    assert pruner.upper == 1.0
+
+    pruner = optuna.pruners.ThresholdPruner(lower=-1.0, upper=None)
+    assert pruner.lower == -1.0
+    assert pruner.upper is None

--- a/tests/pruners_tests/test_threshold.py
+++ b/tests/pruners_tests/test_threshold.py
@@ -56,24 +56,12 @@ def test_threshold_pruner_with_two_side() -> None:
 def test_threshold_pruner_with_invalid_inputs() -> None:
 
     with pytest.raises(TypeError):
-        optuna.pruners.ThresholdPruner(lower=False, upper=1.0)  # type: ignore
-
-    with pytest.raises(TypeError):
         optuna.pruners.ThresholdPruner(lower="0", upper=1.0)  # type: ignore
-
-    with pytest.raises(TypeError):
-        optuna.pruners.ThresholdPruner(lower=0, upper=1.0)  # type: ignore
-
-    with pytest.raises(TypeError):
-        optuna.pruners.ThresholdPruner(lower=0.0, upper=False)
 
     with pytest.raises(TypeError):
         optuna.pruners.ThresholdPruner(lower=0.0, upper="1")  # type: ignore
 
     with pytest.raises(TypeError):
-        optuna.pruners.ThresholdPruner(lower=0.0, upper=1)  # type: ignore
-
-    with pytest.raises(ValueError):
         optuna.pruners.ThresholdPruner(lower=None, upper=None)
 
 

--- a/tests/pruners_tests/test_threshold.py
+++ b/tests/pruners_tests/test_threshold.py
@@ -1,13 +1,7 @@
 import optuna
-from optuna import type_checking
-
-if type_checking.TYPE_CHECKING:
-    from typing import List  # NOQA
-    from typing import Tuple  # NOQA
 
 
-def test_threshold_pruner_with_ub():
-    # type: () -> None
+def test_threshold_pruner_with_ub() -> None:
 
     study = optuna.study.create_study()
     trial = optuna.trial.Trial(study, study._storage.create_new_trial(study._study_id))
@@ -23,8 +17,7 @@ def test_threshold_pruner_with_ub():
         study=study, trial=study._storage.get_trial(trial._trial_id))
 
 
-def test_threshold_pruner_with_lt():
-    # type: () -> None
+def test_threshold_pruner_with_lt() -> None:
 
     study = optuna.study.create_study()
     trial = optuna.trial.Trial(study, study._storage.create_new_trial(study._study_id))
@@ -40,8 +33,7 @@ def test_threshold_pruner_with_lt():
         study=study, trial=study._storage.get_trial(trial._trial_id))
 
 
-def test_threshold_pruner_with_two_side():
-    # type: () -> None
+def test_threshold_pruner_with_two_side() -> None:
 
     study = optuna.study.create_study()
     trial = optuna.trial.Trial(study, study._storage.create_new_trial(study._study_id))

--- a/tests/pruners_tests/test_threshold.py
+++ b/tests/pruners_tests/test_threshold.py
@@ -129,13 +129,3 @@ def test_threshold_pruner_interval_steps() -> None:
 
     trial.report(1000.0, 5)
     assert pruner.prune(study=study, trial=study._storage.get_trial(trial._trial_id))
-
-
-def test_accessors() -> None:
-    pruner = optuna.pruners.ThresholdPruner(lower=None, upper=1.0)
-    assert pruner.lower is None
-    assert pruner.upper == 1.0
-
-    pruner = optuna.pruners.ThresholdPruner(lower=-1.0, upper=None)
-    assert pruner.lower == -1.0
-    assert pruner.upper is None

--- a/tests/pruners_tests/test_threshold.py
+++ b/tests/pruners_tests/test_threshold.py
@@ -63,7 +63,7 @@ def test_threshold_pruner_with_two_side() -> None:
 def test_threshold_pruner_with_invalid_inputs() -> None:
 
     with pytest.raises(Exception):
-        pruner = optuna.pruners.ThresholdPruner(lower='0', upper=1)  # NOQA
+        pruner = optuna.pruners.ThresholdPruner(lower='0', upper=1)  # type: ignore
 
     with pytest.raises(Exception):
         pruner = optuna.pruners.ThresholdPruner(lower=0, upper=False)  # NOQA


### PR DESCRIPTION
This PR introduces a simple threshold base pruner.
A threshold-based pruner is useful for people who want to
prune a trial whose metric is extremely bad.

```python
from optuna import create_study
from optuna.pruners import ThresholdPruner


def objective(trial):
    # something

pruner = optuna.pruners.ThresholdPruner(lower=0, upper=1)
# A trial will be pruned if a metric exceeds 1 or falls behind 0.
study = create_study(pruner=pruner)
study.optimize(objective)
```

- [x] warm_up
- [x] doctest
- [x] nan checking