### PR TITLE
Add examples for `doctest` to `optuna/prunes/*.py`

### DIFF
--- a/optuna/pruners/median.py
+++ b/optuna/pruners/median.py
@@ -11,16 +11,43 @@ class MedianPruner(PercentilePruner):
 
         We minimize an objective function with the median stopping rule.
 
-        .. code::
+        .. testsetup::
 
-            >>> from optuna import create_study
-            >>> from optuna.pruners import MedianPruner
-            >>>
-            >>> def objective(trial):
-            >>>     ...
-            >>>
-            >>> study = create_study(pruner=MedianPruner())
-            >>> study.optimize(objective)
+            import numpy as np
+            from sklearn.model_selection import train_test_split
+
+            np.random.seed(seed=0)
+            X = np.random.randn(200).reshape(-1, 1)
+            y = np.where(X[:, 0] < 0.5, 0, 1)
+            X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
+            classes = np.unique(y)
+
+        .. testcode::
+
+            import optuna
+            from sklearn.linear_model import SGDClassifier
+
+            def objective(trial):
+                alpha = trial.suggest_uniform('alpha', 0.0, 1.0)
+                clf = SGDClassifier(alpha=alpha)
+                n_train_iter = 100
+
+                for step in range(n_train_iter):
+                    clf.partial_fit(X_train, y_train, classes=classes)
+
+                    intermediate_value = clf.score(X_test, y_test)
+                    trial.report(intermediate_value, step)
+
+                    if trial.should_prune():
+                        raise optuna.exceptions.TrialPruned()
+
+                return clf.score(X_test, y_test)
+
+            study = optuna.create_study(direction='maximize',
+                                        pruner=optuna.pruners.MedianPruner(n_startup_trials=5,
+                                                                           n_warmup_steps=30,
+                                                                           interval_steps=10))
+            study.optimize(objective, n_trials=20)
 
     Args:
         n_startup_trials:

--- a/optuna/pruners/nop.py
+++ b/optuna/pruners/nop.py
@@ -11,16 +11,42 @@ class NopPruner(BasePruner):
 
     Example:
 
-        .. code::
+        .. testsetup::
 
-            >>> from optuna import create_study
-            >>> from optuna.pruners import NopPruner
-            >>>
-            >>> def objective(trial):
-            >>>     ...
-            >>>
-            >>> study = create_study(pruner=NopPruner())
-            >>> study.optimize(objective)
+            import numpy as np
+            from sklearn.model_selection import train_test_split
+
+            np.random.seed(seed=0)
+            X = np.random.randn(200).reshape(-1, 1)
+            y = np.where(X[:, 0] < 0.5, 0, 1)
+            X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
+            classes = np.unique(y)
+
+        .. testcode::
+
+            import optuna
+            from sklearn.linear_model import SGDClassifier
+
+            def objective(trial):
+                alpha = trial.suggest_uniform('alpha', 0.0, 1.0)
+                clf = SGDClassifier(alpha=alpha)
+                n_train_iter = 100
+
+                for step in range(n_train_iter):
+                    clf.partial_fit(X_train, y_train, classes=classes)
+
+                    intermediate_value = clf.score(X_test, y_test)
+                    trial.report(intermediate_value, step)
+
+                    if trial.should_prune():
+                        print("Never reach here")
+                        raise optuna.exceptions.TrialPruned()
+
+                return clf.score(X_test, y_test)
+
+            study = optuna.create_study(direction='maximize',
+                                        pruner=optuna.pruners.NopPruner())
+            study.optimize(objective, n_trials=20)
     """
 
     def prune(self, study, trial):

--- a/optuna/pruners/nop.py
+++ b/optuna/pruners/nop.py
@@ -39,7 +39,7 @@ class NopPruner(BasePruner):
                     trial.report(intermediate_value, step)
 
                     if trial.should_prune():
-                        print("Never reach here")
+                        assert False, "should_prune() should always return False with this pruner."
                         raise optuna.exceptions.TrialPruned()
 
                 return clf.score(X_test, y_test)

--- a/optuna/pruners/percentile.py
+++ b/optuna/pruners/percentile.py
@@ -65,16 +65,43 @@ class PercentilePruner(BasePruner):
 
     Example:
 
-        .. code::
+        .. testsetup::
 
-            >>> from optuna import create_study
-            >>> from optuna.pruners import PercentilePruner
-            >>>
-            >>> def objective(trial):
-            >>>     ...
-            >>>
-            >>> study = create_study(pruner=PercentilePruner(25.0))
-            >>> study.optimize(objective)
+            import numpy as np
+            from sklearn.model_selection import train_test_split
+
+            np.random.seed(seed=0)
+            X = np.random.randn(200).reshape(-1, 1)
+            y = np.where(X[:, 0] < 0.5, 0, 1)
+            X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
+            classes = np.unique(y)
+
+        .. testcode::
+
+            import optuna
+            from sklearn.linear_model import SGDClassifier
+
+            def objective(trial):
+                alpha = trial.suggest_uniform('alpha', 0.0, 1.0)
+                clf = SGDClassifier(alpha=alpha)
+                n_train_iter = 100
+
+                for step in range(n_train_iter):
+                    clf.partial_fit(X_train, y_train, classes=classes)
+
+                    intermediate_value = clf.score(X_test, y_test)
+                    trial.report(intermediate_value, step)
+
+                    if trial.should_prune():
+                        raise optuna.exceptions.TrialPruned()
+
+                return clf.score(X_test, y_test)
+
+            study = optuna.create_study(
+                direction='maximize',
+                pruner=optuna.pruners.PercentilePruner(25.0, n_startup_trials=5,
+                                                       n_warmup_steps=30, interval_steps=10))
+            study.optimize(objective, n_trials=20)
 
     Args:
         percentile:

--- a/optuna/pruners/successive_halving.py
+++ b/optuna/pruners/successive_halving.py
@@ -33,16 +33,41 @@ class SuccessiveHalvingPruner(BasePruner):
 
         We minimize an objective function with ``SuccessiveHalvingPruner``.
 
-        .. code::
+        .. testsetup::
 
-            >>> from optuna import create_study
-            >>> from optuna.pruners import SuccessiveHalvingPruner
-            >>>
-            >>> def objective(trial):
-            >>>     ...
-            >>>
-            >>> study = create_study(pruner=SuccessiveHalvingPruner())
-            >>> study.optimize(objective)
+            import numpy as np
+            from sklearn.model_selection import train_test_split
+
+            np.random.seed(seed=0)
+            X = np.random.randn(200).reshape(-1, 1)
+            y = np.where(X[:, 0] < 0.5, 0, 1)
+            X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
+            classes = np.unique(y)
+
+        .. testcode::
+
+            import optuna
+            from sklearn.linear_model import SGDClassifier
+
+            def objective(trial):
+                alpha = trial.suggest_uniform('alpha', 0.0, 1.0)
+                clf = SGDClassifier(alpha=alpha)
+                n_train_iter = 100
+
+                for step in range(n_train_iter):
+                    clf.partial_fit(X_train, y_train, classes=classes)
+
+                    intermediate_value = clf.score(X_test, y_test)
+                    trial.report(intermediate_value, step)
+
+                    if trial.should_prune():
+                        raise optuna.exceptions.TrialPruned()
+
+                return clf.score(X_test, y_test)
+
+            study = optuna.create_study(direction='maximize',
+                                        pruner=optuna.pruners.SuccessiveHalvingPruner())
+            study.optimize(objective, n_trials=20)
 
     Args:
         min_resource:


### PR DESCRIPTION
This PR add doctest example to below files.

* optuna/pruners/successive_halving
* optuna/pruners/nop
* optuna/pruners/median
* optuna/pruners/percentile

Related Issue: #734
