### PR TITLE
Re-seed RNG before each hyperparameter sampling.

### DIFF
--- a/optuna/samplers/random.py
+++ b/optuna/samplers/random.py
@@ -62,6 +62,11 @@ class RandomSampler(BaseSampler):
     def sample_independent(self, study, trial, param_name, param_distribution):
         # type: (Study, FrozenTrial, str, distributions.BaseDistribution) -> Any
 
+        # Re-seed the random generator using trial number to prevent multiple sampler instances
+        # from sampling the same parameters for different trials in parallel execution.
+        seed = (self._rng.randint(0, 2**32 - 1) + trial.number) % 2**32
+        self._rng.seed(seed)
+
         if isinstance(param_distribution, distributions.UniformDistribution):
             return self._rng.uniform(param_distribution.low, param_distribution.high)
         elif isinstance(param_distribution, distributions.LogUniformDistribution):

--- a/optuna/samplers/random.py
+++ b/optuna/samplers/random.py
@@ -36,19 +36,6 @@ class RandomSampler(BaseSampler):
 
         self._rng = numpy.random.RandomState(seed)
 
-    def __getstate__(self):
-        # type: () -> Dict[Any, Any]
-
-        state = self.__dict__.copy()
-        del state['_rng']
-        return state
-
-    def __setstate__(self, state):
-        # type: (Dict[Any, Any]) -> None
-
-        self.__dict__.update(state)
-        self._rng = numpy.random.RandomState(None)
-
     def infer_relative_search_space(self, study, trial):
         # type: (Study, FrozenTrial) -> Dict[str, BaseDistribution]
 

--- a/optuna/samplers/tpe/sampler.py
+++ b/optuna/samplers/tpe/sampler.py
@@ -133,6 +133,11 @@ class TPESampler(base.BaseSampler):
             return self._random_sampler.sample_independent(
                 study, trial, param_name, param_distribution)
 
+        # Re-seed the random generator using trial number to prevent multiple sampler instances
+        # from sampling the same parameters for different trials in parallel execution.
+        seed = (self._rng.randint(0, 2**32 - 1) + trial.number) % 2**32
+        self._rng.seed(seed)
+
         below_param_values, above_param_values = self._split_observation_pairs(values, scores)
 
         if isinstance(param_distribution, distributions.UniformDistribution):

--- a/tests/samplers_tests/test_samplers.py
+++ b/tests/samplers_tests/test_samplers.py
@@ -43,8 +43,7 @@ def test_pickle_random_sampler(seed):
 
     sampler = optuna.samplers.RandomSampler(seed)
     restored_sampler = pickle.loads(pickle.dumps(sampler))
-    assert sampler._rng != restored_sampler._rng
-    assert sampler._rng.bytes(10) != restored_sampler._rng.bytes(10)
+    assert sampler._rng.bytes(10) == restored_sampler._rng.bytes(10)
 
 
 @parametrize_sampler


### PR DESCRIPTION
This PR resolves a reproducibility problem of samplers reported by #914.

The problem was introduced by the commits https://github.com/optuna/optuna/commit/631a2a2bfab2f76b86981acf00ff5b5f4bb0330a and https://github.com/optuna/optuna/commit/3f01ca234d91dd5281e784f9c0f5f124f897f275. Those defined custom `__setstate__` and `__getstate__` methods of `RandomSampler` where the state of RNG is reset.
If we simply reverted the change, however, it would cause another problem relating to parallel optimization. That is, all the parallel workers might sample the same hyperparameters for different trials (see https://github.com/optuna/optuna/pull/692#issuecomment-555869535 for the detail).
To avoid the duplicate work, this PR re-seeds RNG by using trial number information before each hyperparameter sampling, so even if all the workers have the same initial RNG, they will sample different hyperparamers for different trials.

Note that this change would incur extra computation cost due to the additional re-seeding. I'll take a benchmark to estimate the cost.

Close #914