### PR TITLE
Support metric aliases for LightGBM Tuner #960

### DIFF
--- a/optuna/integration/lightgbm_tuner/alias.py
+++ b/optuna/integration/lightgbm_tuner/alias.py
@@ -59,3 +59,34 @@ def _handling_alias_parameters(lgbm_params):
             if alias_name in lgbm_params:
                 lgbm_params[param_name] = lgbm_params[alias_name]
                 del lgbm_params[alias_name]
+
+
+ALIAS_METRIC_LIST = [
+    {
+        'metric_name': 'ndcg',
+        'alias_names': ['lambdarank', 'rank_xendcg', 'xendcg', 'xe_ndcg',
+                        'xe_ndcg_mart', 'xendcg_mart'],
+    },
+    {
+        'metric_name': 'map',
+        'alias_names': ['mean_average_precision'],
+    },
+]  # type: List[Dict[str, Any]]
+
+
+def _handling_alias_metrics(lgbm_params):
+    # type: (Dict[str, Any]) -> None
+    """Handling alias metrics."""
+
+    if 'metric' not in lgbm_params.keys():
+        return
+
+    for metric in ALIAS_METRIC_LIST:
+        metric_name = metric['metric_name']
+        alias_names = metric['alias_names']
+
+        for alias_name in alias_names:
+            if lgbm_params['metric'].startswith(alias_name):
+                lgbm_params['metric'] = \
+                    lgbm_params['metric'].replace(alias_name, metric_name)
+                break

--- a/optuna/integration/lightgbm_tuner/alias.py
+++ b/optuna/integration/lightgbm_tuner/alias.py
@@ -86,7 +86,6 @@ def _handling_alias_metrics(lgbm_params):
         alias_names = metric['alias_names']
 
         for alias_name in alias_names:
-            if lgbm_params['metric'].startswith(alias_name):
-                lgbm_params['metric'] = \
-                    lgbm_params['metric'].replace(alias_name, metric_name)
+            if lgbm_params['metric'] == alias_name:
+                lgbm_params['metric'] = metric_name
                 break

--- a/optuna/integration/lightgbm_tuner/optimize.py
+++ b/optuna/integration/lightgbm_tuner/optimize.py
@@ -7,6 +7,7 @@ import numpy as np
 import tqdm
 
 import optuna
+from optuna.integration.lightgbm_tuner.alias import _handling_alias_metrics
 from optuna.integration.lightgbm_tuner.alias import _handling_alias_parameters
 from optuna import type_checking
 
@@ -105,6 +106,10 @@ class BaseTuner(object):
     ):
         # type: (Dict[str, Any], Dict[str,Any]) -> None
 
+        # Handling alias metrics.
+        if lgbm_params is not None:
+            _handling_alias_metrics(lgbm_params)
+
         self.lgbm_params = lgbm_params or {}
         self.lgbm_kwargs = lgbm_kwargs or {}
 
@@ -174,7 +179,7 @@ class BaseTuner(object):
         # type: () -> bool
 
         metric_name = self.lgbm_params.get('metric', 'binary_logloss')
-        return metric_name.startswith(('auc', 'ndcg', 'map', 'accuracy'))
+        return metric_name.startswith(('auc', 'ndcg', 'map'))
 
     def compare_validation_metrics(self, val_score, best_score):
         # type: (float, float) -> bool
@@ -317,6 +322,10 @@ class LightGBMTuner(BaseTuner):
             verbosity=1,  # type: Optional[int]
     ):
         params = copy.deepcopy(params)
+
+        # Handling alias metrics.
+        _handling_alias_metrics(params)
+
         args = [params, train_set]
         kwargs = dict(num_boost_round=num_boost_round,
                       valid_sets=valid_sets,

--- a/tests/integration_tests/lightgbm_tuner_tests/test_alias.py
+++ b/tests/integration_tests/lightgbm_tuner_tests/test_alias.py
@@ -1,3 +1,4 @@
+from optuna.integration.lightgbm_tuner.alias import _handling_alias_metrics
 from optuna.integration.lightgbm_tuner.alias import _handling_alias_parameters
 
 
@@ -37,3 +38,22 @@ def test_handling_alias_parameter():
     assert 'min_data' not in params
     assert 'min_data_in_leaf' in params
     assert params['min_data_in_leaf'] == 0.2
+
+
+def test_handling_alias_metrics():
+    # type: () -> None
+
+    for alias in ['lambdarank', 'rank_xendcg', 'xendcg', 'xe_ndcg',
+                  'xe_ndcg_mart', 'xendcg_mart', 'ndcg']:
+        lgbm_params = {'metric': alias}
+        _handling_alias_metrics(lgbm_params)
+        assert lgbm_params['metric'] == 'ndcg'
+
+    for alias in ['mean_average_precision', 'map']:
+        lgbm_params = {'metric': alias}
+        _handling_alias_metrics(lgbm_params)
+        assert lgbm_params['metric'] == 'map'
+
+    lgbm_params = {}
+    _handling_alias_metrics(lgbm_params)
+    assert lgbm_params == {}

--- a/tests/integration_tests/lightgbm_tuner_tests/test_alias.py
+++ b/tests/integration_tests/lightgbm_tuner_tests/test_alias.py
@@ -57,3 +57,11 @@ def test_handling_alias_metrics():
     lgbm_params = {}
     _handling_alias_metrics(lgbm_params)
     assert lgbm_params == {}
+
+    lgbm_params = {'metric': 'auc'}
+    _handling_alias_metrics(lgbm_params)
+    assert lgbm_params['metric'] == 'auc'
+
+    lgbm_params = {'metric': 'rmse'}
+    _handling_alias_metrics(lgbm_params)
+    assert lgbm_params['metric'] == 'rmse'

--- a/tests/integration_tests/lightgbm_tuner_tests/test_optimize.py
+++ b/tests/integration_tests/lightgbm_tuner_tests/test_optimize.py
@@ -129,7 +129,9 @@ class TestBaseTuner(object):
     def test_higher_is_better(self):
         # type: () -> None
 
-        for metric in ['auc', 'ndcg', 'map', 'accuracy']:
+        for metric in ['auc', 'ndcg', 'lambdarank', 'rank_xendcg', 'xendcg',
+                       'xe_ndcg', 'xe_ndcg_mart', 'xendcg_mart', 'map',
+                       'mean_average_precision']:
             tuner = BaseTuner(lgbm_params={'metric': metric})
             assert tuner.higher_is_better()
 
@@ -189,7 +191,9 @@ class TestBaseTuner(object):
     def test_compare_validation_metrics(self):
         # type: () -> None
 
-        for metric in ['auc', 'ndcg', 'map', 'accuracy']:
+        for metric in ['auc', 'ndcg', 'lambdarank', 'rank_xendcg', 'xendcg',
+                       'xe_ndcg', 'xe_ndcg_mart', 'xendcg_mart', 'map',
+                       'mean_average_precision']:
             tuner = BaseTuner(lgbm_params={'metric': metric})
             assert tuner.compare_validation_metrics(0.5, 0.1)
             assert not tuner.compare_validation_metrics(0.5, 0.5)


### PR DESCRIPTION
Support aliases for learning-to-rank metrics in LightGBM Tuner and
remove accuracy metric (fix #960)

<!-- Thank you for creating a pull request!

Please go through [our contribution guide][CONTRIBUTING.md] to hopefully get your changes merged quicker.

[CONTRIBUTING.md]: https://github.com/optuna/optuna/blob/master/CONTRIBUTING.md -->
