### PR TITLE
Add cython for Python 3.5 tentatively.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -119,6 +119,12 @@ def get_extras_require():
         ] if sys.version_info[:2] < (3, 8) else []),
     }
 
+    # TODO(Yanase): Remove cython from dependencies after wheel packages of scikit-learn are
+    # released for Python 3.5.
+    if sys.version_info[:2] == (3, 5):
+        requirements['testing'].insert(0, 'cython')
+        requirements['example'].insert(0, 'cython')
+
     return requirements
 
 


### PR DESCRIPTION
This PR is a hotfix for CI failures of `tests-python35` and `examples-python35` (e.g., https://circleci.com/gh/optuna/optuna/29529).
The scikit-learn released `0.22.2.post1`, but the wheel package for Python 3.5 is not provided yet (c.f., https://pypi.org/project/scikit-learn/#files). This PR adds cython for dependencies to build scikit-learn in Python 3.5.