### PR TITLE
Add examples for doctest to optuna/samplers/*.py and optuna/integrati…

### DIFF
--- a/optuna/integration/skopt.py
+++ b/optuna/integration/skopt.py
@@ -37,7 +37,9 @@ class SkoptSampler(BaseSampler):
 
         Optimize a simple quadratic function by using :class:`~optuna.integration.SkoptSampler`.
 
-        .. code::
+        .. testcode::
+
+                import optuna
 
                 def objective(trial):
                     x = trial.suggest_uniform('x', -10, 10)
@@ -46,7 +48,7 @@ class SkoptSampler(BaseSampler):
 
                 sampler = optuna.integration.SkoptSampler()
                 study = optuna.create_study(sampler=sampler)
-                study.optimize(objective, n_trials=100)
+                study.optimize(objective, n_trials=10)
 
     Args:
         independent_sampler:

--- a/optuna/samplers/random.py
+++ b/optuna/samplers/random.py
@@ -22,10 +22,17 @@ class RandomSampler(BaseSampler):
 
     Example:
 
-        .. code::
+        .. testcode::
 
-            >>> study = optuna.create_study(sampler=RandomSampler())
-            >>> study.optimize(objective, direction='minimize')
+            import optuna
+            from optuna.samplers import RandomSampler
+
+            def objective(trial):
+                x = trial.suggest_uniform('x', -5, 5)
+                return x ** 2
+
+            study = optuna.create_study(sampler=RandomSampler(), direction='minimize')
+            study.optimize(objective, n_trials=10)
 
         Args:
             seed: Seed for random number generator.

--- a/optuna/samplers/random.py
+++ b/optuna/samplers/random.py
@@ -29,9 +29,9 @@ class RandomSampler(BaseSampler):
 
             def objective(trial):
                 x = trial.suggest_uniform('x', -5, 5)
-                return x ** 2
+                return x**2
 
-            study = optuna.create_study(sampler=RandomSampler(), direction='minimize')
+            study = optuna.create_study(sampler=RandomSampler())
             study.optimize(objective, n_trials=10)
 
         Args:

--- a/optuna/samplers/tpe/sampler.py
+++ b/optuna/samplers/tpe/sampler.py
@@ -73,7 +73,7 @@ class TPESampler(base.BaseSampler):
 
     Example:
 
-        .. code::
+        .. testcode::
 
             import optuna
             from optuna.samplers import TPESampler
@@ -83,7 +83,7 @@ class TPESampler(base.BaseSampler):
                 return x**2
 
             study = optuna.create_study(sampler=TPESampler())
-            study.optimize(objective, n_trials=100)
+            study.optimize(objective, n_trials=10)
 
     """
 
@@ -486,7 +486,7 @@ class TPESampler(base.BaseSampler):
             Create a :class:`~optuna.samplers.TPESampler` instance with the default
             parameters of `hyperopt <https://github.com/hyperopt/hyperopt/tree/0.1.2>`_.
 
-            .. code::
+            .. testcode::
 
                     import optuna
                     from optuna.samplers import TPESampler
@@ -497,7 +497,7 @@ class TPESampler(base.BaseSampler):
 
                     sampler = TPESampler(**TPESampler.hyperopt_parameters())
                     study = optuna.create_study(sampler=sampler)
-                    study.optimize(objective, n_trials=100)
+                    study.optimize(objective, n_trials=10)
 
         Returns:
             A dictionary containing the default parameters of hyperopt.

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,7 @@ def get_extras_require() -> Dict[str, List[str]]:
             'cma',
             'scikit-learn>=0.19.0',
             'plotly>=4.0.0',
+            'scikit-optimize',
         ],
         'document': [
             'sphinx',


### PR DESCRIPTION
This PR add doctest example to below files.

* optuna/samplers/random.py
* optuna/samplers/tpe/sampler.py
* optuna/integration/skopt.py

I changed `n_trials` to `10` in some tests, because `n_trials=100` is too much for testing.  
Also, I fixed an incorrect argument of `study.optimize` about `RandomSampler` doctest.

Related Issue: #734 