### PR TITLE
Relax PyTorch Lightning version constraint to fix daily CI build.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,7 @@ def get_extras_require() -> Dict[str, List[str]]:
             'keras',
             # TODO(toshihikoyanase): Remove the version constraint after resolving the issue
             # https://github.com/optuna/optuna/issues/997.
-            'pytorch-lightning<0.6.0',
+            'pytorch-lightning<0.7.0',
             'tensorflow>=2.0.0',
         ] if sys.version_info[:2] < (3, 8) else []),
         'testing': [
@@ -114,7 +114,7 @@ def get_extras_require() -> Dict[str, List[str]]:
             'keras',
             # TODO(toshihikoyanase): Remove the version constraint after resolving the issue
             # https://github.com/optuna/optuna/issues/997.
-            'pytorch-lightning<0.6.0',
+            'pytorch-lightning<0.7.0',
             'tensorflow',
             'tensorflow-datasets',
         ] if sys.version_info[:2] < (3, 8) else []),


### PR DESCRIPTION
Relaxing PyTorch Lightning version constraint to fix broken CircleCI daily builds (`examples-python36`, `examples-python37`). The following error https://github.com/optuna/optuna/blob/master/examples/pytorch_lightning_simple.py#L38-L39 is raised. It is probably caused by https://github.com/optuna/optuna/pull/998, sorry we should've noticed sooner.