### PR TITLE
Introduce GitHub Action to execute CI for examples.

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -1,6 +1,8 @@
 name: examples
 
-on: [push, pull_request]
+on:
+  schedule:
+    - cron: '0 15 * * *'
 
 jobs:
   build:

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -1,0 +1,64 @@
+name: examples
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.5, 3.6, 3.7, 3.8]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: setup-python${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install
+      run: |
+        sudo apt-get update
+        sudo apt-get -y install openmpi-bin libopenmpi-dev
+        python -m pip install --upgrade pip
+        pip install --progress-bar off -U setuptools
+        python setup.py sdist
+
+        # Install minimal dependencies and confirm that `import optuna` is successful.
+        pip install --progress-bar off $(ls dist/*.tar.gz)
+        python -c 'import optuna'
+
+        # Install all dependencies needed for examples.
+        pip install --progress-bar off $(ls dist/*.tar.gz)[example]
+    - name: Run examples
+      run: |
+        if [ ${{ matrix.python-version }} = 3.5 ]; then
+          IGNORES='chainermn_.*|pytorch_lightning.*|fastai_.*'
+        elif [ ${{ matrix.python-version }} = 3.8 ]; then
+          IGNORES='chainermn_.*|dask_ml_.*|keras_.*|pytorch_lightning_.*|tensorflow_.*|tfkeras_.*|fastai_.*'
+        else
+          IGNORES='chainermn_.*'
+        fi
+
+        for file in `find examples -name '*.py' -not -name '*_distributed.py' | grep -vE "$IGNORES"`
+        do
+          echo $file
+          python $file > /dev/null
+          if grep -e '\-\-pruning' $file > /dev/null; then
+            echo $file --pruning
+            python $file --pruning > /dev/null
+          fi
+        done
+      env:
+        OMP_NUM_THREADS: 1
+    - name: Run multi-node examples
+      run: |
+        STORAGE_URL=sqlite:///example.db
+        for file in `find examples -name 'chainermn_*.py'`
+        do
+          echo $file
+          STUDY_NAME=`optuna create-study --storage $STORAGE_URL`
+          mpirun -n 2 -- python $file $STUDY_NAME $STORAGE_URL > /dev/null
+        done
+      env:
+        OMP_NUM_THREADS: 1

--- a/setup.py
+++ b/setup.py
@@ -74,6 +74,7 @@ def get_extras_require() -> Dict[str, List[str]]:
             'chainer',
             'lightgbm',
             'mlflow',
+            'mpi4py',
             'mxnet',
             'pytorch-ignite',
             'scikit-image',
@@ -90,6 +91,7 @@ def get_extras_require() -> Dict[str, List[str]]:
             # https://github.com/optuna/optuna/issues/997.
             'pytorch-lightning<0.7.0',
             'tensorflow>=2.0.0',
+            'tensorflow-datasets',
         ] if sys.version_info[:2] < (3, 8) else []),
         'testing': [
             # TODO(toshihikoyanase): Remove the version constraint after resolving the issue


### PR DESCRIPTION
This PR introduces GitHub Actions to execute CI for `optuna/examples`. I'll change the trigger from `push` and `pull_request` to `cron` as follows after I confirm the jobs can be executed successfully.

```yaml
on:
  schedule:
    - cron: '0 15 * * *'
```

I'll update the trigger since all jobs successfully finished (see https://github.com/optuna/optuna/actions/runs/53509621).