### PR TITLE
Fix docstring on optuna/integration/tensorflow.py

### DIFF
--- a/optuna/integration/tensorflow.py
+++ b/optuna/integration/tensorflow.py
@@ -21,8 +21,9 @@ class TensorFlowPruningHook(SessionRunHook):
 
     Example:
 
-        See example on GitHub for adding a pruning SessionRunHook for a TensorFlow's Estimator.
-        https://github.com/optuna/optuna/blob/master/examples/tensorflow_estimator_simple.py
+        See `the example <https://github.com/optuna/optuna/blob/30dba8814d332ff4
+        0d9c7465ee660a8ecf499547/examples/tensorflow_estimator_simple.py>`_
+        if you want to add a pruning SessionRunHook for TensorFlow's Estimator.
 
     Args:
         trial:

--- a/optuna/integration/tensorflow.py
+++ b/optuna/integration/tensorflow.py
@@ -21,23 +21,9 @@ class TensorFlowPruningHook(SessionRunHook):
 
     Example:
 
-        Add a pruning SessionRunHook for a TensorFlow's Estimator.
+        See example on GitHub for adding a pruning SessionRunHook for a TensorFlow's Estimator.
+        https://github.com/optuna/optuna/blob/master/examples/tensorflow_estimator_simple.py
 
-        .. code::
-
-                pruning_hook = TensorFlowPruningHook(
-                    trial=trial,
-                    estimator=clf,
-                    metric="accuracy",
-                    is_higher_better=True,
-                    run_every_steps=10,
-                )
-                hooks = [pruning_hook]
-                tf.estimator.train_and_evaluate(
-                    clf,
-                    tf.estimator.TrainSpec(input_fn=train_input_fn, max_steps=500, hooks=hooks),
-                    eval_spec
-                )
     Args:
         trial:
             A :class:`~optuna.trial.Trial` corresponding to the current evaluation of


### PR DESCRIPTION
This PR fixes docstring on optuna/integration/tensorflow.py.

From https://github.com/optuna/optuna/issues/734#issuecomment-597459320 , I removed original docstring and put a reference to examples/pruning/tensorflow_estimator_integration.py.
I think examples/pruning/tensorflow_estimator_integration.py is simple enough to understand a usage.

Related Issue: #734 