### PR TITLE
Add initial implementation of `suggest_float`.

### DIFF
--- a/optuna/trial.py
+++ b/optuna/trial.py
@@ -165,7 +165,7 @@ class Trial(BaseTrial):
         # type: (str, float, float, bool) -> float
         """Wrapper method for ``suggest_uniform`` and ``suggest_loguniform``.
 
-        .. versionadded:: 1.2.0
+        .. versionadded:: 1.3.0
 
         .. seealso::
             Please see also :func:`~optuna.trial.Trial.suggest_uniform` and

--- a/optuna/trial.py
+++ b/optuna/trial.py
@@ -160,7 +160,10 @@ class Trial(BaseTrial):
 
     def suggest_float(self, name, low, high, *, log=False):
         # type: (str, float, float, bool) -> float
-        """Wrapper method for ``suggest_uniform`` and ``suggest_loguniform``.
+        """Suggest a value for the floating point parameter.
+
+        Note that this is a wrapper method for :func:`~optuna.trial.Trial.suggest_uniform`
+        and :func:`~optuna.trial.Trial.suggest_loguniform`.
 
         .. versionadded:: 1.3.0
 

--- a/optuna/trial.py
+++ b/optuna/trial.py
@@ -30,7 +30,8 @@ class BaseTrial(object, metaclass=abc.ABCMeta):
     Note that this class is not supposed to be directly accessed by library users.
     """
 
-    def suggest_float(self, name, low, high, log):
+    @experimental("1.2.0")
+    def suggest_float(self, name, low, high, *, log=False):
         # type: (str, float, float, bool) -> float
 
         raise NotImplementedError
@@ -160,7 +161,7 @@ class Trial(BaseTrial):
         )
 
     @experimental("1.2.0")
-    def suggest_float(self, name, low, high, log=False):
+    def suggest_float(self, name, low, high, *, log=False):
         # type: (str, float, float, bool) -> float
         """Wrapper method for ``suggest_uniform`` and ``suggest_loguniform``.
 
@@ -943,7 +944,8 @@ class FixedTrial(BaseTrial):
         self._system_attrs = {}  # type: Dict[str, Any]
         self._datetime_start = datetime.now()
 
-    def suggest_float(self, name, low, high, log=False):
+    @experimental("1.2.0")
+    def suggest_float(self, name, low, high, *, log=False):
         # type: (str, float, float, bool) -> float
 
         if log:

--- a/optuna/trial.py
+++ b/optuna/trial.py
@@ -208,6 +208,11 @@ class Trial(BaseTrial):
             high:
                 Upper endpoint of the range of suggested values. ``high`` is excluded from the
                 range.
+            log:
+                A flag to sample the value from the log domain or not.
+                If ``log`` is true, the value is sampled from the range in the log domain.
+                Otherwise, the value is sampled from the range in the linear domain.
+                See also :func:`suggest_uniform` and :func:`suggest_loguniform`.
 
         Returns:
             A suggested float value.

--- a/optuna/trial.py
+++ b/optuna/trial.py
@@ -12,10 +12,16 @@ if type_checking.TYPE_CHECKING:
     from typing import Dict  # NOQA
     from typing import Optional  # NOQA
     from typing import Sequence  # NOQA
+    from typing import Union  # NOQA
 
     from optuna.distributions import BaseDistribution  # NOQA
     from optuna.distributions import CategoricalChoiceType  # NOQA
     from optuna.study import Study  # NOQA
+
+    FloatingPointDistributionType = Union[
+        distributions.UniformDistribution,
+        distributions.LogUniformDistribution
+    ]
 
 
 class BaseTrial(object, metaclass=abc.ABCMeta):
@@ -183,7 +189,7 @@ class Trial(BaseTrial):
         """
 
         if log:
-            distribution = distributions.LogUniformDistribution(low=low, high=high)
+            distribution = distributions.LogUniformDistribution(low=low, high=high)  # type: FloatingPointDistributionType  # NOQA
         else:
             distribution = distributions.UniformDistribution(low=low, high=high)
 

--- a/optuna/trial.py
+++ b/optuna/trial.py
@@ -24,6 +24,11 @@ class BaseTrial(object, metaclass=abc.ABCMeta):
     Note that this class is not supposed to be directly accessed by library users.
     """
 
+    def suggest_float(self, name, low, high, log):
+        # type: (str, float, float, bool) -> float
+
+        raise NotImplementedError
+
     def suggest_uniform(self, name, low, high):
         # type: (str, float, float) -> float
 
@@ -147,6 +152,40 @@ class Trial(BaseTrial):
         self.relative_params = self.study.sampler.sample_relative(
             self.study, trial, self.relative_search_space
         )
+
+    def suggest_float(self, name, low, high, log=False):
+        # type: (str, float, float, bool) -> float
+        """
+        Wrapper method for suggest_uniform and suggest_loguniform.
+
+        Example:
+
+            Suggest a xxxx.
+
+        Args:
+            name:
+                A parameter name.
+            low:
+                Lower endpoint of the range of suggested values. ``low`` is included in the range.
+            high:
+                Upper endpoint of the range of suggested values. ``high`` is excluded from the
+                range.
+
+        Returns:
+            A suggested float value.
+        """
+
+        if log:
+            distribution = distributions.LogUniformDistribution(low=low, high=high)
+        else:
+            distribution = distributions.UniformDistribution(low=low, high=high)
+
+        self._check_distribution(name, distribution)
+
+        if low == high:
+            return self._set_new_param_or_get_existing(name, low, distribution)
+
+        return self._suggest(name, distribution)
 
     def suggest_uniform(self, name, low, high):
         # type: (str, float, float) -> float

--- a/optuna/trial.py
+++ b/optuna/trial.py
@@ -162,11 +162,13 @@ class Trial(BaseTrial):
     @experimental("1.2.0")
     def suggest_float(self, name, low, high, log=False):
         # type: (str, float, float, bool) -> float
-        """Wrapper method for suggest_uniform and suggest_loguniform.
+        """Wrapper method for ``suggest_uniform`` and ``suggest_loguniform``.
+
+        .. versionadded:: 1.2.0
 
         .. seealso::
-            Please refer to :class:`~optuna.trial.Trial.suggest_uniform` and
-            `~optuna.trial.Trial.suggest_loguniform`.
+            Please see also :func:`~optuna.trial.Trial.suggest_uniform` and
+            :func:`~optuna.trial.Trial.suggest_loguniform`.
 
         Example:
 

--- a/optuna/trial.py
+++ b/optuna/trial.py
@@ -223,18 +223,9 @@ class Trial(BaseTrial):
         """
 
         if log:
-            distribution = distributions.LogUniformDistribution(
-                low=low, high=high
-            )  # type: FloatingPointDistributionType
+            return self.suggest_loguniform(name, low, high)
         else:
-            distribution = distributions.UniformDistribution(low=low, high=high)
-
-        self._check_distribution(name, distribution)
-
-        if low == high:
-            return self._set_new_param_or_get_existing(name, low, distribution)
-
-        return self._suggest(name, distribution)
+            return self.suggest_uniform(name, low, high)
 
     def suggest_uniform(self, name, low, high):
         # type: (str, float, float) -> float

--- a/optuna/trial.py
+++ b/optuna/trial.py
@@ -943,6 +943,14 @@ class FixedTrial(BaseTrial):
         self._system_attrs = {}  # type: Dict[str, Any]
         self._datetime_start = datetime.now()
 
+    def suggest_float(self, name, low, high, log=False):
+        # type: (str, float, float, bool) -> float
+
+        if log:
+            return self._suggest(name, distributions.LogUniformDistribution(low=low, high=high))
+        else:
+            return self._suggest(name, distributions.UniformDistribution(low=low, high=high))
+
     def suggest_uniform(self, name, low, high):
         # type: (str, float, float) -> float
 

--- a/optuna/trial.py
+++ b/optuna/trial.py
@@ -155,12 +155,19 @@ class Trial(BaseTrial):
 
     def suggest_float(self, name, low, high, log=False):
         # type: (str, float, float, bool) -> float
-        """
-        Wrapper method for suggest_uniform and suggest_loguniform.
+        """Wrapper method for suggest_uniform and suggest_loguniform.
 
         Example:
 
             Suggest a xxxx.
+
+            .. testsetup::
+
+                import numpy
+
+            ..testcode::
+
+                import optuna
 
         Args:
             name:

--- a/optuna/trial.py
+++ b/optuna/trial.py
@@ -163,17 +163,42 @@ class Trial(BaseTrial):
         # type: (str, float, float, bool) -> float
         """Wrapper method for suggest_uniform and suggest_loguniform.
 
+        .. seealso::
+            Please refer to :class:`~optuna.trial.Trial.suggest_uniform` and
+            `~optuna.trial.Trial.suggest_loguniform`.
+
         Example:
 
-            Suggest a xxxx.
+            Suggest a momentum and learning rate for neural network training.
 
             .. testsetup::
 
-                import numpy
+                import numpy as np
+                import optuna
+                from sklearn.model_selection import train_test_split
+                from sklearn.neural_network import MLPClassifier
+
+                np.random.seed(seed=0)
+                X = np.random.randn(200).reshape(-1, 1)
+                y = np.random.randint(0, 2, 200)
+                X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
+
 
             ..testcode::
 
-                import optuna
+                def objective(trial):
+                    momentum = trial.suggest_float('momentum', 0.0, 1.0)
+                    learning_rate_init = trial.suggest_float('learning_rate_init',
+                                                             1e-5, 1e-3, log=True)
+                    clf = MLPClassifier(hidden_layer_sizes=(100, 50), momentum=momentum,
+                                        learning_rate_init=learning_rate_init,
+                                        solver='sgd', random_state=0)
+                    clf.fit(X_train, y_train)
+
+                    return clf.score(X_test, y_test)
+
+                study = optuna.create_study()
+                study.optimize(objective, n_trials=3)
 
         Args:
             name:

--- a/optuna/trial.py
+++ b/optuna/trial.py
@@ -197,7 +197,7 @@ class Trial(BaseTrial):
 
                     return clf.score(X_test, y_test)
 
-                study = optuna.create_study()
+                study = optuna.create_study(direction='maximize')
                 study.optimize(objective, n_trials=3)
 
         Args:

--- a/optuna/trial.py
+++ b/optuna/trial.py
@@ -3,7 +3,6 @@ from datetime import datetime
 import decimal
 import warnings
 
-from optuna._experimental import experimental
 from optuna import distributions
 from optuna import logging
 from optuna import type_checking
@@ -30,7 +29,6 @@ class BaseTrial(object, metaclass=abc.ABCMeta):
     Note that this class is not supposed to be directly accessed by library users.
     """
 
-    @experimental("1.2.0")
     def suggest_float(self, name, low, high, *, log=False):
         # type: (str, float, float, bool) -> float
 
@@ -160,7 +158,6 @@ class Trial(BaseTrial):
             self.study, trial, self.relative_search_space
         )
 
-    @experimental("1.2.0")
     def suggest_float(self, name, low, high, *, log=False):
         # type: (str, float, float, bool) -> float
         """Wrapper method for ``suggest_uniform`` and ``suggest_loguniform``.
@@ -944,7 +941,6 @@ class FixedTrial(BaseTrial):
         self._system_attrs = {}  # type: Dict[str, Any]
         self._datetime_start = datetime.now()
 
-    @experimental("1.2.0")
     def suggest_float(self, name, low, high, *, log=False):
         # type: (str, float, float, bool) -> float
 

--- a/optuna/trial.py
+++ b/optuna/trial.py
@@ -3,6 +3,7 @@ from datetime import datetime
 import decimal
 import warnings
 
+from optuna._experimental import experimental
 from optuna import distributions
 from optuna import logging
 from optuna import type_checking
@@ -158,6 +159,7 @@ class Trial(BaseTrial):
             self.study, trial, self.relative_search_space
         )
 
+    @experimental("1.2.0")
     def suggest_float(self, name, low, high, log=False):
         # type: (str, float, float, bool) -> float
         """Wrapper method for suggest_uniform and suggest_loguniform.

--- a/optuna/trial.py
+++ b/optuna/trial.py
@@ -19,8 +19,7 @@ if type_checking.TYPE_CHECKING:
     from optuna.study import Study  # NOQA
 
     FloatingPointDistributionType = Union[
-        distributions.UniformDistribution,
-        distributions.LogUniformDistribution
+        distributions.UniformDistribution, distributions.LogUniformDistribution
     ]
 
 
@@ -219,7 +218,9 @@ class Trial(BaseTrial):
         """
 
         if log:
-            distribution = distributions.LogUniformDistribution(low=low, high=high)  # type: FloatingPointDistributionType  # NOQA
+            distribution = distributions.LogUniformDistribution(
+                low=low, high=high
+            )  # type: FloatingPointDistributionType
         else:
             distribution = distributions.UniformDistribution(low=low, high=high)
 

--- a/tests/test_trial.py
+++ b/tests/test_trial.py
@@ -27,6 +27,25 @@ parametrize_storage = pytest.mark.parametrize(
 
 
 @parametrize_storage
+def test_check_distribution_suggest_float(storage_init_func):
+    # type: (typing.Callable[[], storages.BaseStorage]) -> None
+
+    sampler = samplers.RandomSampler()
+    study = create_study(storage_init_func(), sampler=sampler)
+    trial = Trial(study, study._storage.create_new_trial(study._study_id))
+
+    x1 = trial.suggest_float('x1', 10, 20)
+    x2 = trial.suggest_uniform('x1', 10, 20)
+
+    assert x1 == x2
+
+    x3 = trial.suggest_float('x2', 1e-5, 1e-3, log=True)
+    x4 = trial.suggest_loguniform('x2', 1e-5, 1e-3)
+
+    assert x3 == x4
+
+
+@parametrize_storage
 def test_check_distribution_suggest_uniform(storage_init_func):
     # type: (typing.Callable[[], storages.BaseStorage]) -> None
 

--- a/tests/test_trial.py
+++ b/tests/test_trial.py
@@ -288,6 +288,16 @@ def test_trial_should_prune():
     assert trial.should_prune()
 
 
+def test_fixed_trial_suggest_float():
+    # type: () -> None
+
+    trial = FixedTrial({"x": 1.0})
+    assert trial.suggest_float("x", -100.0, 100.0) == 1.0
+
+    with pytest.raises(ValueError):
+        trial.suggest_uniform("y", -100.0, 100.0)
+
+
 def test_fixed_trial_suggest_uniform():
     # type: () -> None
 

--- a/tests/test_trial.py
+++ b/tests/test_trial.py
@@ -34,13 +34,13 @@ def test_check_distribution_suggest_float(storage_init_func):
     study = create_study(storage_init_func(), sampler=sampler)
     trial = Trial(study, study._storage.create_new_trial(study._study_id))
 
-    x1 = trial.suggest_float('x1', 10, 20)
-    x2 = trial.suggest_uniform('x1', 10, 20)
+    x1 = trial.suggest_float("x1", 10, 20)
+    x2 = trial.suggest_uniform("x1", 10, 20)
 
     assert x1 == x2
 
-    x3 = trial.suggest_float('x2', 1e-5, 1e-3, log=True)
-    x4 = trial.suggest_loguniform('x2', 1e-5, 1e-3)
+    x3 = trial.suggest_float("x2", 1e-5, 1e-3, log=True)
+    x4 = trial.suggest_loguniform("x2", 1e-5, 1e-3)
 
     assert x3 == x4
 
@@ -176,11 +176,11 @@ def test_suggest_low_equals_high(storage_init_func):
         assert trial.suggest_int("d", 1, 1) == 1  # Suggesting a param.
         assert trial.suggest_int("d", 1, 1) == 1  # Suggesting the same param.
         assert mock_object.call_count == 0
-        assert trial.suggest_float('e', 1.0, 1.0) == 1.0  # Suggesting a param.
-        assert trial.suggest_float('e', 1.0, 1.0) == 1.0  # Suggesting the same param.
+        assert trial.suggest_float("e", 1.0, 1.0) == 1.0  # Suggesting a param.
+        assert trial.suggest_float("e", 1.0, 1.0) == 1.0  # Suggesting the same param.
         assert mock_object.call_count == 0
-        assert trial.suggest_float('f', 0.5, 0.5, log=True) == 0.5  # Suggesting a param.
-        assert trial.suggest_float('f', 0.5, 0.5, log=True) == 0.5  # Suggesting the same param.
+        assert trial.suggest_float("f", 0.5, 0.5, log=True) == 0.5  # Suggesting a param.
+        assert trial.suggest_float("f", 0.5, 0.5, log=True) == 0.5  # Suggesting the same param.
         assert mock_object.call_count == 0
 
 

--- a/tests/test_trial.py
+++ b/tests/test_trial.py
@@ -176,6 +176,12 @@ def test_suggest_low_equals_high(storage_init_func):
         assert trial.suggest_int("d", 1, 1) == 1  # Suggesting a param.
         assert trial.suggest_int("d", 1, 1) == 1  # Suggesting the same param.
         assert mock_object.call_count == 0
+        assert trial.suggest_float('e', 1.0, 1.0) == 1.0  # Suggesting a param.
+        assert trial.suggest_float('e', 1.0, 1.0) == 1.0  # Suggesting the same param.
+        assert mock_object.call_count == 0
+        assert trial.suggest_float('f', 0.5, 0.5, log=True) == 0.5  # Suggesting a param.
+        assert trial.suggest_float('f', 0.5, 0.5, log=True) == 0.5  # Suggesting the same param.
+        assert mock_object.call_count == 0
 
 
 @parametrize_storage

--- a/tests/test_trial.py
+++ b/tests/test_trial.py
@@ -182,6 +182,9 @@ def test_suggest_low_equals_high(storage_init_func):
         assert trial.suggest_float("f", 0.5, 0.5, log=True) == 0.5  # Suggesting a param.
         assert trial.suggest_float("f", 0.5, 0.5, log=True) == 0.5  # Suggesting the same param.
         assert mock_object.call_count == 0
+        assert trial.suggest_float("g", 0.5, 0.5, log=False) == 0.5  # Suggesting a param.
+        assert trial.suggest_float("g", 0.5, 0.5, log=False) == 0.5  # Suggesting the same param.
+        assert mock_object.call_count == 0
 
 
 @parametrize_storage


### PR DESCRIPTION
related #510 

This PR adds a new method `suggest_float`, which is a wrapper of `suggest_uniform` and `suggest_loguniform`.