### PR TITLE
Fix direction in doctest

### DIFF
--- a/optuna/trial.py
+++ b/optuna/trial.py
@@ -183,7 +183,7 @@ class Trial(BaseTrial):
 
                     return clf.score(X_test, y_test)
 
-                study = optuna.create_study()
+                study = optuna.create_study(direction='maximize')
                 study.optimize(objective, n_trials=3)
 
         Args:
@@ -242,7 +242,7 @@ class Trial(BaseTrial):
                     clf.fit(X_train, y_train)
                     return clf.score(X_test, y_test)
 
-                study = optuna.create_study()
+                study = optuna.create_study(direction='maximize')
                 study.optimize(objective, n_trials=3)
 
         Args:
@@ -307,7 +307,7 @@ class Trial(BaseTrial):
                     clf.fit(X_train, y_train)
                     return clf.score(X_test, y_test)
 
-                study = optuna.create_study()
+                study = optuna.create_study(direction='maximize')
                 study.optimize(objective, n_trials=3)
 
         Args:
@@ -366,7 +366,7 @@ class Trial(BaseTrial):
                     clf.fit(X_train, y_train)
                     return clf.score(X_test, y_test)
 
-                study = optuna.create_study()
+                study = optuna.create_study(direction='maximize')
                 study.optimize(objective, n_trials=3)
 
 
@@ -423,7 +423,7 @@ class Trial(BaseTrial):
                     clf.fit(X_train, y_train)
                     return clf.score(X_test, y_test)
 
-                study = optuna.create_study()
+                study = optuna.create_study(direction='maximize')
                 study.optimize(objective, n_trials=3)
 
 
@@ -493,7 +493,7 @@ class Trial(BaseTrial):
 
                     return clf.score(X_test, y_test)
 
-                study = optuna.create_study()
+                study = optuna.create_study(direction='maximize')
                 study.optimize(objective, n_trials=3)
 
 
@@ -589,7 +589,7 @@ class Trial(BaseTrial):
 
                     return clf.score(X_test, y_test)
 
-                study = optuna.create_study()
+                study = optuna.create_study(direction='maximize')
                 study.optimize(objective, n_trials=3)
                 assert 'BATCHSIZE' in study.best_trial.user_attrs.keys()
                 assert study.best_trial.user_attrs['BATCHSIZE'] == 128


### PR DESCRIPTION
(related https://github.com/optuna/optuna/pull/1021#discussion_r393507789)
`clf.score` returns a mean accuracy of classification, so objective functions should be maximized.


- MLPClassifier: https://scikit-learn.org/stable/modules/generated/sklearn.neural_network.MLPClassifier.html#sklearn.neural_network.MLPClassifier.score
- SVC: https://scikit-learn.org/stable/modules/generated/sklearn.svm.SVC.html#sklearn.svm.SVC.score
- GradientBoostingClassifier: https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.GradientBoostingClassifier.html#sklearn.ensemble.GradientBoostingClassifier.score
- RandomForestClassifier: https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.RandomForestClassifier.html#sklearn.ensemble.RandomForestClassifier.score
- SGDClassifier: https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.SGDClassifier.html#sklearn.linear_model.SGDClassifier.score