### PR TITLE
Clean running trials after keyboard interruption

### DIFF
--- a/optuna/storages/base.py
+++ b/optuna/storages/base.py
@@ -109,6 +109,12 @@ class BaseStorage(object, metaclass=abc.ABCMeta):
         raise NotImplementedError
 
     @abc.abstractmethod
+    def clean_running_trials(self):
+        # type: () -> bool
+
+        raise NotImplementedError
+
+    @abc.abstractmethod
     def set_trial_state(self, trial_id, state):
         # type: (int, structs.TrialState) -> bool
 

--- a/optuna/storages/in_memory.py
+++ b/optuna/storages/in_memory.py
@@ -189,6 +189,14 @@ class InMemoryStorage(base.BaseStorage):
             datetime_complete=None,
         )
 
+    def clean_running_trials(self):
+        # type: () -> bool
+
+        for trial_id in range(len(self.trials)):
+            if self.trials[trial_id].state == structs.TrialState.RUNNING:
+                self.set_trial_state(trial_id, structs.TrialState.FAIL)
+        return True
+
     def set_trial_state(self, trial_id, state):
         # type: (int, structs.TrialState) -> bool
 

--- a/optuna/storages/rdb/models.py
+++ b/optuna/storages/rdb/models.py
@@ -177,6 +177,13 @@ class TrialModel(BaseModel):
         return trial
 
     @classmethod
+    def delete_running_trials(cls, session):
+        # type: (orm.Session) -> int
+
+        n_trials_deleted = session.query(cls).filter(cls.state == TrialState.RUNNING).delete()
+        return n_trials_deleted
+
+    @classmethod
     def find_max_value_trial(cls, study_id, session):
         # type: (int, orm.Session) -> TrialModel
 

--- a/optuna/storages/rdb/storage.py
+++ b/optuna/storages/rdb/storage.py
@@ -480,6 +480,14 @@ class RDBStorage(BaseStorage):
 
         return trial.trial_id
 
+    def clean_running_trials(self):
+        # type: () -> bool
+
+        session = self.scoped_session()
+        models.TrialModel.delete_running_trials(session)
+
+        return self._commit_with_integrity_check(session)
+
     def set_trial_state(self, trial_id, state):
         # type: (int, structs.TrialState) -> bool
 

--- a/optuna/study.py
+++ b/optuna/study.py
@@ -371,6 +371,8 @@ class Study(BaseStudy):
                         )
                         for _ in _iter
                     )
+        except KeyboardInterrupt:
+            self._storage.clean_running_trials()
         finally:
             self._optimize_lock.release()
             self._progress_bar.close()

--- a/tests/test_study.py
+++ b/tests/test_study.py
@@ -170,9 +170,7 @@ def test_optimize_with_direction():
 
 @pytest.mark.parametrize(
     "n_trials, n_jobs, storage_mode",
-    itertools.product(
-        (0, 1, 20), (1, 2, -1), STORAGE_MODES,  # n_trials  # n_jobs  # storage_mode
-    ),
+    itertools.product((0, 1, 20), (1, 2, -1), STORAGE_MODES),  # n_trials  # n_jobs  # storage_mode
 )
 def test_optimize_parallel(n_trials, n_jobs, storage_mode):
     # type: (int, int, str)-> None
@@ -189,7 +187,7 @@ def test_optimize_parallel(n_trials, n_jobs, storage_mode):
 @pytest.mark.parametrize(
     "n_trials, n_jobs, storage_mode",
     itertools.product(
-        (0, 1, 20, None), (1, 2, -1), STORAGE_MODES,  # n_trials  # n_jobs  # storage_mode
+        (0, 1, 20, None), (1, 2, -1), STORAGE_MODES  # n_trials  # n_jobs  # storage_mode
     ),
 )
 def test_optimize_parallel_timeout(n_trials, n_jobs, storage_mode):
@@ -897,11 +895,8 @@ def test_study_id():
 
 
 @pytest.mark.parametrize(
-    'n_jobs, storage_mode',
-    itertools.product(
-        (1, 2),  # n_jobs
-        STORAGE_MODES,  # storage_mode
-    ))
+    "n_jobs, storage_mode", itertools.product((1, 2), STORAGE_MODES)  # n_jobs  # storage_mode
+)
 def test_interrupt_study(n_jobs, storage_mode):
     # type: (int, str)-> None
 


### PR DESCRIPTION
related: #913 .

Add `KeyboardInterrupt` handler for `optimize`.  Once `KeyboardInterrupt ` is triggered, running trials will be removed from the database (`storage`) or set to FAIL(`in_memory`).