### PR TITLE
[DO NOT MERGE] Support pruning/resume/parallelization for `LightGBMTuner`.

### DIFF
--- a/optuna/integration/lightgbm_tuner/optimize.py
+++ b/optuna/integration/lightgbm_tuner/optimize.py
@@ -1,5 +1,6 @@
 import contextlib
 import copy
+from optuna.structs import StudyDirection
 import time
 
 import lightgbm as lgb
@@ -364,6 +365,20 @@ class LightGBMTuner(BaseTuner):
                 direction='maximize' if self.higher_is_better() else 'minimize')
         else:
             self.study = study
+
+        if self.higher_is_better():
+            if self.study.direction != StudyDirection.MAXIMIZE:
+                metric_name = self.lgbm_params.get('metric', 'binary_logloss')
+                raise ValueError(
+                    "Study direction is inconsistent with the metric {}. "
+                    "Please set 'maximize' to the direction.".format(metric_name))
+        else:
+            if self.study.direction != StudyDirection.MINIMIZE:
+                print(self.study.direction)
+                metric_name = self.lgbm_params.get('metric', 'binary_logloss')
+                raise ValueError(
+                    "Study direction is inconsistent with the metric {}. "
+                    "Please set 'minimize' to the direction.".format(metric_name))
 
         if valid_sets is None:
             raise ValueError("`valid_sets` is required.")

--- a/tests/integration_tests/lightgbm_tuner_tests/test_optimize.py
+++ b/tests/integration_tests/lightgbm_tuner_tests/test_optimize.py
@@ -464,63 +464,61 @@ class TestLightGBMTuner(object):
         params = {}  # type: Dict
         valid_data = np.zeros((10, 10))
         valid_sets = lgb.Dataset(valid_data)
-        tuner = LightGBMTuner(params, None, valid_sets=valid_sets)
-        assert not tuner.higher_is_better()
 
         objective_class_name = 'optuna.integration.lightgbm_tuner.optimize.OptunaObjective'
 
-        with mock.patch(objective_class_name) as objective_mock,\
-                mock.patch('optuna.study.Study') as study_mock,\
-                mock.patch('optuna.trial.Trial') as trial_mock:
-
-            fake_objective = mock.MagicMock(spec=OptunaObjective)
-            fake_objective.report = []
-            fake_objective.best_booster = None
-            objective_mock.return_value = fake_objective
-
+        with mock.patch('optuna.study.Study') as study_mock:
             fake_study = mock.MagicMock(spec=Study)
             fake_study._storage = mock.MagicMock()
             fake_study.best_value = 0.9
             study_mock.return_value = fake_study
 
-            fake_trial = mock.MagicMock(spec=Trial)
-            fake_trial.best_params = {
-                'feature_fraction': 0.2,
-            }
-            trial_mock.return_value = fake_trial
+            tuner = LightGBMTuner(params, None, valid_sets=valid_sets)
+            assert not tuner.higher_is_better()
 
-            tuner.tune_feature_fraction()
+            with mock.patch(objective_class_name) as objective_mock,\
+                    mock.patch('optuna.trial.Trial') as trial_mock:
 
-            fake_study.optimize.assert_called()
+                fake_objective = mock.MagicMock(spec=OptunaObjective)
+                fake_objective.report = []
+                fake_objective.best_booster = None
+                objective_mock.return_value = fake_objective
 
-        assert 'feature_fraction' in tuner.best_params
-        assert tuner.best_score == 0.9
+                fake_trial = mock.MagicMock(spec=Trial)
+                fake_trial.best_params = {
+                    'feature_fraction': 0.2,
+                }
+                trial_mock.return_value = fake_trial
 
-        with mock.patch(objective_class_name) as objective_mock,\
-                mock.patch('optuna.study.Study') as study_mock,\
-                mock.patch('optuna.trial.Trial') as trial_mock:
+                tuner.tune_feature_fraction()
 
-            fake_objective = mock.MagicMock(spec=OptunaObjective)
-            fake_objective.report = []
-            fake_objective.best_booster = None
-            objective_mock.return_value = fake_objective
+                fake_study.optimize.assert_called()
+
+            assert 'feature_fraction' in tuner.best_params
+            assert tuner.best_score == 0.9
 
             # Assume that tuning `num_leaves` doesn't improve the `best_score`.
-            fake_study = mock.MagicMock(spec=Study)
-            fake_study._storage = mock.MagicMock()
             fake_study.best_value = 1.1
-            study_mock.return_value = fake_study
 
-            fake_trial = mock.MagicMock(spec=Trial)
-            fake_trial.best_params = {
-                'num_leaves': 128,
-            }
-            trial_mock.return_value = fake_trial
+            with mock.patch(objective_class_name) as objective_mock,\
+                    mock.patch('optuna.study.Study') as study_mock,\
+                    mock.patch('optuna.trial.Trial') as trial_mock:
 
-            tuner.tune_num_leaves()
+                fake_objective = mock.MagicMock(spec=OptunaObjective)
+                fake_objective.report = []
+                fake_objective.best_booster = None
+                objective_mock.return_value = fake_objective
 
-            fake_study.optimize.assert_called()
+                fake_trial = mock.MagicMock(spec=Trial)
+                fake_trial.best_params = {
+                    'num_leaves': 128,
+                }
+                trial_mock.return_value = fake_trial
 
-        # `num_leaves` should not be same as default.
-        assert tuner.best_params['num_leaves'] == 31
-        assert tuner.best_score == 0.9
+                tuner.tune_num_leaves()
+
+                fake_study.optimize.assert_called()
+
+            # `num_leaves` should not be same as default.
+            assert tuner.best_params['num_leaves'] == 31
+            assert tuner.best_score == 0.9


### PR DESCRIPTION
This PR provides a prototypical implementation of a new version of LightGBMTuner. It extends https://github.com/optuna/optuna/pull/1032 to support some features such as pruning, resume of studies, and distributed optimization. I'd like to share this implementation to discuss the design of https://github.com/optuna/optuna/pull/1032. So, intensive review regarding tests or type hinting is out of the scope of this PR.

Examples
- [pruning example](https://gist.github.com/toshihikoyanase/6253fe69f055e69d299ea5d4042331bd#file-lightgbm_tuner_pruning-py)
- [parallelization example](https://gist.github.com/toshihikoyanase/6253fe69f055e69d299ea5d4042331bd#file-lightgbm_tuner_parallel-py)
