### PR TITLE
Ignore allennlp in Python3.5 and Python3.8.

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -37,7 +37,7 @@ jobs:
         if [ ${{ matrix.python-version }} = 3.5 ]; then
           IGNORES='chainermn_.*|pytorch_lightning.*|fastai_.*'
         elif [ ${{ matrix.python-version }} = 3.8 ]; then
-          IGNORES='chainermn_.*|dask_ml_.*|keras_.*|pytorch_lightning_.*|tensorflow_.*|tfkeras_.*|fastai_.*'
+          IGNORES='chainermn_.*|dask_ml_.*|keras_.*|pytorch_lightning_.*|tensorflow_.*|tfkeras_.*|fastai_.*|allennlp_*'
         else
           IGNORES='chainermn_.*'
         fi

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -35,9 +35,9 @@ jobs:
     - name: Run examples
       run: |
         if [ ${{ matrix.python-version }} = 3.5 ]; then
-          IGNORES='chainermn_.*|pytorch_lightning.*|fastai_.*'
+          IGNORES='chainermn_.*|pytorch_lightning.*|fastai_.*|allennlp_.*'
         elif [ ${{ matrix.python-version }} = 3.8 ]; then
-          IGNORES='chainermn_.*|dask_ml_.*|keras_.*|pytorch_lightning_.*|tensorflow_.*|tfkeras_.*|fastai_.*|allennlp_*'
+          IGNORES='chainermn_.*|dask_ml_.*|keras_.*|pytorch_lightning_.*|tensorflow_.*|tfkeras_.*|fastai_.*|allennlp_.*'
         else
           IGNORES='chainermn_.*'
         fi


### PR DESCRIPTION
Fix https://github.com/optuna/optuna/actions/runs/58270527.
This PR skips an example test using allennlp in `Python3.8`.