### PR TITLE
Fix SkoptSampler's n_initial_points problem

### DIFF
--- a/optuna/integration/skopt.py
+++ b/optuna/integration/skopt.py
@@ -105,8 +105,9 @@ class SkoptSampler(BaseSampler):
             n_initial_points = self._skopt_kwargs["n_initial_points"]
             if n_initial_points > n_startup_trials:
                 raise ValueError(
-                    "The n_initial_points should smaller or equal to n_startup_trials to get expect"
-                    "behavior, but the value is {}.".format(self._skopt_kwargs["n_initial_points"])
+                    "The n_initial_points should smaller or equal to n_startup_trials "
+                    "to get expect behavior, but the value "
+                    "is {}.".format(self._skopt_kwargs["n_initial_points"])
                 )
         else:
             logger = optuna.logging.get_logger(__name__)

--- a/optuna/integration/skopt.py
+++ b/optuna/integration/skopt.py
@@ -101,6 +101,18 @@ class SkoptSampler(BaseSampler):
         if "dimensions" in self._skopt_kwargs:
             del self._skopt_kwargs["dimensions"]
 
+        if "n_initial_points" in self._skopt_kwargs:
+            n_initial_points = self._skopt_kwargs["n_initial_points"]
+            if n_initial_points > n_startup_trials:
+                raise ValueError(
+                    "The n_initial_points should smaller or equal to n_startup_trials to get expect"
+                    "behavior, but the value is {}.".format(self._skopt_kwargs["n_initial_points"])
+                )
+        else:
+            logger = optuna.logging.get_logger(__name__)
+            logger.warning("The n_initial_points in skopt_kwargs would be set to zero.")
+            self._skopt_kwargs["n_initial_points"] = 0
+
         self._independent_sampler = independent_sampler or samplers.RandomSampler()
         self._warn_independent_sampling = warn_independent_sampling
         self._n_startup_trials = n_startup_trials

--- a/tests/integration_tests/test_sampler.py
+++ b/tests/integration_tests/test_sampler.py
@@ -20,7 +20,7 @@ parametrize_sampler = pytest.mark.parametrize(
     "sampler_class",
     [
         lambda: SkoptSampler(
-            independent_sampler=FirstTrialOnlyRandomSampler(), skopt_kwargs={"n_initial_points": 5}
+            independent_sampler=FirstTrialOnlyRandomSampler(), skopt_kwargs={"n_initial_points": 1}
         ),
         lambda: CmaEsSampler(independent_sampler=FirstTrialOnlyRandomSampler()),
     ],


### PR DESCRIPTION
The n_initial_points in SkoptSampler's skopt_kwargs could cause trouble when n_starup_trials is smaller than n_initial_points  default value. So I enforce the n_initial_points be set to zero and fix some tests. The issue is mentioned at https://github.com/optuna/optuna/pull/951#issuecomment-601832976.