### PR TITLE
[DO NOT MERGE] Add darglint check in circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,6 +59,12 @@ jobs:
             . venv/bin/activate
             mypy .
 
+      - run:
+          name: darglint
+          command: |
+            . venv/bin/activate
+            darglint optuna
+
   document:
     docker:
       - image: readthedocs/build:latest

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,3 +14,9 @@ column_limit = 99
 [mypy]
 disallow_untyped_defs = True
 ignore_missing_imports = True
+
+# This section is for darglint.
+[darglint]
+strictness = long
+docstring_style = google
+ignore = DAR301,DAR302,DAR401,DAR402

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ def get_tests_require() -> List[str]:
 def get_extras_require() -> Dict[str, List[str]]:
 
     requirements = {
-        "checking": ["black", "hacking", "mypy",],
+        "checking": ["black", "hacking", "mypy", "darglint",],
         "codecov": ["codecov", "pytest-cov",],
         "doctest": ["cma", "pandas", "plotly>=4.0.0", "scikit-learn>=0.19.0", "scikit-optimize",],
         "document": ["sphinx", "sphinx_rtd_theme",],


### PR DESCRIPTION
<!-- Thank you for creating a pull request!

Please go through [our contribution guide][CONTRIBUTING.md] to hopefully get your changes merged quicker.

[CONTRIBUTING.md]: https://github.com/optuna/optuna/blob/master/CONTRIBUTING.md -->

This PR for introcuding [darglint](https://github.com/terrencepreilly/darglint) to check that docstrings are compatible with function definitions.

In the current configuration, it will check as follows:

> - 000: Syntax, formatting, and style
> - 100: Args section
> - 200: Returns section
> - 500: Variables section

Also, we can choose strictness, and current strictness is the most mild.

> long: One-line descriptions and descriptions without arguments/returns/yields/etc. sections will be allowed. Anything more, and the docstring will be fully checked.