### PR TITLE
GitHub Actions to automatically label PRs.

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,17 @@
+optuna.integration:
+  - optuna/integration/**/*
+
+optuna.pruners:
+  - optuna/pruners/**/*
+
+optuna.samplers:
+  - optuna/samplers/**/*
+
+optuna.storages:
+  - optuna/storages/**/*
+
+optuna.testing:
+  - optuna/testing/**/*
+
+optuna.visualization:
+  - optuna/visualization/**/*

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -15,3 +15,9 @@ optuna.testing:
 
 optuna.visualization:
   - optuna/visualization/**/*
+
+optuna.study:
+  - optuna/study.py
+
+optuna.trial:
+  - optuna/trial.py

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,3 +1,6 @@
+optuna.importance:
+  - optuna/importance/**/*
+
 optuna.integration:
   - optuna/integration/**/*
 

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,3 +1,6 @@
+# Label pull requests using https://github.com/actions/labeler.
+# Note that once added to a pull request, a label will not removed, even when changes are reverted.
+
 name: labeler
 
 on:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,12 @@
+name: labeler
+
+on:
+- pull_request
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v2
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Introduces GitHub Actions to automatically label PRs. This hopefully makes the list of PRs somewhat more comprehensible. Note that new GitHub labels are suggested in this PR which are also open for comments.