### PR TITLE
Add duration into FrozenTrial and DataFrame.

### DIFF
--- a/optuna/structs.py
+++ b/optuna/structs.py
@@ -271,14 +271,17 @@ class FrozenTrial(object):
 
     @property
     def duration(self):
-        # type: () -> timedelta
+        # type: () -> Optional[timedelta]
         """Return the elapsed time taken to complete the trial.
 
         Returns:
             The duration.
         """
 
-        return self.datetime_complete - self.datetime_start
+        if self.datetime_start and self.datetime_complete:
+            return self.datetime_complete - self.datetime_start
+        else:
+            return None
 
 
 class StudySummary(object):
@@ -289,7 +292,7 @@ class StudySummary(object):
     Attributes:
         study_name:
             Name of the :class:`~optuna.study.Study`.
-        direction:
+        # direction:
             :class:`StudyDirection` of the :class:`~optuna.study.Study`.
         best_trial:
             :class:`FrozenTrial` with best objective value in the :class:`~optuna.study.Study`.

--- a/optuna/structs.py
+++ b/optuna/structs.py
@@ -7,6 +7,7 @@ from optuna import type_checking
 
 if type_checking.TYPE_CHECKING:
     from datetime import datetime  # NOQA
+    from datetime import timedelta  # NOQA
     from typing import Any  # NOQA
     from typing import Dict  # NOQA
     from typing import Optional  # NOQA
@@ -267,6 +268,17 @@ class FrozenTrial(object):
             return None
         else:
             return max(self.intermediate_values.keys())
+
+    @property
+    def duration(self):
+        # type: () -> timedelta
+        """Return the elapsed time taken to complete the trial.
+
+        Returns:
+            The duration.
+        """
+
+        return self.datetime_complete - self.datetime_start
 
 
 class StudySummary(object):

--- a/optuna/structs.py
+++ b/optuna/structs.py
@@ -292,7 +292,7 @@ class StudySummary(object):
     Attributes:
         study_name:
             Name of the :class:`~optuna.study.Study`.
-        # direction:
+        direction:
             :class:`StudyDirection` of the :class:`~optuna.study.Study`.
         best_trial:
             :class:`FrozenTrial` with best objective value in the :class:`~optuna.study.Study`.

--- a/optuna/study.py
+++ b/optuna/study.py
@@ -410,6 +410,7 @@ class Study(BaseStudy):
             "value",
             "datetime_start",
             "datetime_complete",
+            "duration",
             "params",
             "user_attrs",
             "system_attrs",

--- a/tests/test_study.py
+++ b/tests/test_study.py
@@ -495,6 +495,7 @@ def test_study_trials_dataframe_with_no_trials():
             "value",
             "datetime_start",
             "datetime_complete",
+            "duration",
             "params",
             "user_attrs",
             "system_attrs",
@@ -535,8 +536,8 @@ def test_trials_dataframe(storage_mode, attrs, multi_index):
             df.set_index("number", inplace=True, drop=False)
         assert len(df) == 3
 
-        # Number columns are as follows (total of 12):
-        #   non-nested: 5 (number, value, state, datetime_start, datetime_complete)
+        # Number columns are as follows (total of 13):
+        #   non-nested: 6 (number, value, state, datetime_start, datetime_complete, duration)
         #   params: 2
         #   distributions: 2
         #   user_attrs: 1
@@ -562,6 +563,8 @@ def test_trials_dataframe(storage_mode, attrs, multi_index):
                     assert ("distributions", "y") in df.columns
                 if "_trial_id" in attrs:
                     assert ("trial_id", "") in df.columns  # trial_id depends on other tests.
+                if "duration" in attrs:
+                    assert ("duration", "") in df.columns
 
                 assert df.params.x[i] == 1
                 assert df.params.y[i] == 2.5
@@ -573,6 +576,8 @@ def test_trials_dataframe(storage_mode, attrs, multi_index):
                     assert "distributions_y" in df.columns
                 if "_trial_id" in attrs:
                     assert "trial_id" in df.columns  # trial_id depends on other tests.
+                if "duration" in attrs:
+                    assert "duration" in df.columns
 
                 assert df.params_x[i] == 1
                 assert df.params_y[i] == 2.5
@@ -600,14 +605,15 @@ def test_trials_dataframe_with_failure(storage_mode):
         # Change index to access rows via trial number.
         df.set_index("number", inplace=True, drop=False)
         assert len(df) == 3
-        # non-nested: 5, params: 2, user_attrs: 1 system_attrs: 1
-        assert len(df.columns) == 9
+        # non-nested: 6, params: 2, user_attrs: 1 system_attrs: 1
+        assert len(df.columns) == 10
         for i in range(3):
             assert df.number[i] == i
             assert df.state[i] == "FAIL"
             assert df.value[i] is None
             assert isinstance(df.datetime_start[i], pd.Timestamp)
             assert isinstance(df.datetime_complete[i], pd.Timestamp)
+            assert isinstance(df.duration[i], pd.Timedelta)
             assert df.params_x[i] == 1
             assert df.params_y[i] == 2.5
             assert df.user_attrs_train_loss[i] == 3


### PR DESCRIPTION
This PR adds duration (of each trial) to FrozenTrial and DataFrame generated by trials.

Related issue: #1058 