### PR TITLE
Support parallel execution of `LightGBMTuner`.

### DIFF
--- a/optuna/integration/lightgbm_tuner/__init__.py
+++ b/optuna/integration/lightgbm_tuner/__init__.py
@@ -32,7 +32,7 @@ def train(*args: Any, **kwargs: Any) -> Any:
 
     auto_booster = LightGBMTuner(*args, **kwargs)
     auto_booster.run()
-    return auto_booster.best_booster
+    return auto_booster.get_best_booster()
 
 
 def _check_lightgbm_availability():

--- a/optuna/integration/lightgbm_tuner/__init__.py
+++ b/optuna/integration/lightgbm_tuner/__init__.py
@@ -31,8 +31,8 @@ def train(*args: Any, **kwargs: Any) -> Any:
     _check_lightgbm_availability()
 
     auto_booster = LightGBMTuner(*args, **kwargs)
-    booster = auto_booster.run()
-    return booster
+    auto_booster.run()
+    return auto_booster.best_booster
 
 
 def _check_lightgbm_availability():

--- a/optuna/integration/lightgbm_tuner/optimize.py
+++ b/optuna/integration/lightgbm_tuner/optimize.py
@@ -573,7 +573,9 @@ class LightGBMTuner(BaseTuner):
 
         param_name = "feature_fraction"
         param_values = list(np.linspace(0.4, 1.0, n_trials))
-        sampler = optuna.samplers.GridSampler({param_name: param_values})
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=optuna.exceptions.ExperimentalWarning)
+            sampler = optuna.samplers.GridSampler({param_name: param_values})
         self.tune_params([param_name], len(param_values), sampler, "feature_fraction")
 
     def tune_num_leaves(self, n_trials=20):
@@ -597,7 +599,9 @@ class LightGBMTuner(BaseTuner):
             np.linspace(best_feature_fraction - 0.08, best_feature_fraction + 0.08, n_trials)
         )
         param_values = [val for val in param_values if val >= 0.4 and val <= 1.0]
-        sampler = optuna.samplers.GridSampler({param_name: param_values})
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=optuna.exceptions.ExperimentalWarning)
+            sampler = optuna.samplers.GridSampler({param_name: param_values})
         self.tune_params([param_name], len(param_values), sampler, "feature_fraction_stage2")
 
     def tune_regularization_factors(self, n_trials=20):
@@ -615,7 +619,9 @@ class LightGBMTuner(BaseTuner):
 
         param_name = "min_child_samples"
         param_values = [5, 10, 25, 50, 100]
-        sampler = optuna.samplers.GridSampler({param_name: param_values})
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=optuna.exceptions.ExperimentalWarning)
+            sampler = optuna.samplers.GridSampler({param_name: param_values})
         self.tune_params([param_name], len(param_values), sampler, "min_data_in_leaf")
 
     def tune_params(self, target_param_names, n_trials, sampler, step_name):
@@ -647,7 +653,7 @@ class LightGBMTuner(BaseTuner):
         complete_trials = [
             t
             for t in study.trials
-            if t.state in (optuna.structs.TrialState.COMPLETE, optuna.structs.TrialState.PRUNED)
+            if t.state in (optuna.trial.TrialState.COMPLETE, optuna.trial.TrialState.PRUNED)
         ]
         _n_trials = n_trials - len(complete_trials)
         if _n_trials > 0:

--- a/optuna/integration/lightgbm_tuner/optimize.py
+++ b/optuna/integration/lightgbm_tuner/optimize.py
@@ -324,7 +324,8 @@ class LightGBMTuner(BaseTuner):
             saved. Please set shared directory (e.g., directories on NFS) if you want to access
             :meth:`~optuna.integration.LightGBMTuner.best_booster` in distributed environments.
             Otherwise, it may raise :obj:`ValueError`. If the directory does not exist, it will be
-            created. The filenames of the boosters will be ``model_dir/{trial_number}.pkl``.
+            created. The filenames of the boosters will be ``{model_dir}/{trial_number}.pkl``
+            (e.g., ``./boosters/0.pkl``).
     """
 
     def __init__(

--- a/optuna/integration/lightgbm_tuner/optimize.py
+++ b/optuna/integration/lightgbm_tuner/optimize.py
@@ -598,7 +598,7 @@ class LightGBMTuner(BaseTuner):
         # type: () -> None
 
         param_name = "min_child_samples"
-        param_values = [5, 10, 25, 50, 100]  # type: List[Union[str, float, int, bool, None]]
+        param_values = [5, 10, 25, 50, 100]
         sampler = optuna.samplers.GridSampler({param_name: param_values})
         self.tune_params([param_name], len(param_values), sampler, "min_data_in_leaf")
 

--- a/optuna/integration/lightgbm_tuner/optimize.py
+++ b/optuna/integration/lightgbm_tuner/optimize.py
@@ -50,6 +50,8 @@ DEFAULT_LIGHTGBM_PARAMETERS = {
     "min_child_samples": 20,
 }
 
+_logger = optuna.logging.get_logger(__name__)
+
 
 class _TimeKeeper(object):
     def __init__(self):
@@ -252,6 +254,7 @@ class OptunaObjective(BaseTuner):
             path = os.path.join(self.model_dir, "{}.pkl".format(trial.number))
             with open(path, "wb") as fout:
                 pickle.dump(booster, fout)
+            _logger.info("The booster of trial#{} was saved as {}.".format(trial.number, path))
 
         if self.compare_validation_metrics(val_score, self.best_score):
             self.best_score = val_score
@@ -321,7 +324,7 @@ class LightGBMTuner(BaseTuner):
             saved. Please set shared directory (e.g., directories on NFS) if you want to access
             :meth:`~optuna.integration.LightGBMTuner.best_booster` in distributed environments.
             Otherwise, it may raise :obj:`ValueError`. If the directory does not exist, it will be
-            created.
+            created. The filenames of the boosters will be ``model_dir/{trial_number}.pkl``.
     """
 
     def __init__(
@@ -581,6 +584,8 @@ class LightGBMTuner(BaseTuner):
 
         param_name = "feature_fraction"
         param_values = np.linspace(0.4, 1.0, n_trials).tolist()
+
+        # TODO(toshihikoyanase): Remove catch_warnings after GridSampler becomes non-experimental.
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", category=optuna.exceptions.ExperimentalWarning)
             sampler = optuna.samplers.GridSampler({param_name: param_values})
@@ -607,6 +612,8 @@ class LightGBMTuner(BaseTuner):
             best_feature_fraction - 0.08, best_feature_fraction + 0.08, n_trials
         ).tolist()
         param_values = [val for val in param_values if val >= 0.4 and val <= 1.0]
+
+        # TODO(toshihikoyanase): Remove catch_warnings after GridSampler becomes non-experimental.
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", category=optuna.exceptions.ExperimentalWarning)
             sampler = optuna.samplers.GridSampler({param_name: param_values})
@@ -627,6 +634,8 @@ class LightGBMTuner(BaseTuner):
 
         param_name = "min_child_samples"
         param_values = [5, 10, 25, 50, 100]
+
+        # TODO(toshihikoyanase): Remove catch_warnings after GridSampler becomes non-experimental.
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", category=optuna.exceptions.ExperimentalWarning)
             sampler = optuna.samplers.GridSampler({param_name: param_values})

--- a/optuna/integration/lightgbm_tuner/optimize.py
+++ b/optuna/integration/lightgbm_tuner/optimize.py
@@ -598,7 +598,7 @@ class LightGBMTuner(BaseTuner):
         # type: () -> None
 
         param_name = "min_child_samples"
-        param_values = [5, 10, 25, 50, 100]
+        param_values = [5, 10, 25, 50, 100]  # type: List[Union[str, float, int, bool, None]]
         sampler = optuna.samplers.GridSampler({param_name: param_values})
         self.tune_params([param_name], len(param_values), sampler, "min_data_in_leaf")
 

--- a/optuna/integration/lightgbm_tuner/optimize.py
+++ b/optuna/integration/lightgbm_tuner/optimize.py
@@ -580,7 +580,7 @@ class LightGBMTuner(BaseTuner):
         # type: (int) -> None
 
         param_name = "feature_fraction"
-        param_values = list(np.linspace(0.4, 1.0, n_trials))
+        param_values = np.linspace(0.4, 1.0, n_trials).tolist()
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", category=optuna.exceptions.ExperimentalWarning)
             sampler = optuna.samplers.GridSampler({param_name: param_values})
@@ -603,9 +603,9 @@ class LightGBMTuner(BaseTuner):
 
         param_name = "feature_fraction"
         best_feature_fraction = self.best_params[param_name]
-        param_values = list(
-            np.linspace(best_feature_fraction - 0.08, best_feature_fraction + 0.08, n_trials)
-        )
+        param_values = np.linspace(
+            best_feature_fraction - 0.08, best_feature_fraction + 0.08, n_trials
+        ).tolist()
         param_values = [val for val in param_values if val >= 0.4 and val <= 1.0]
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", category=optuna.exceptions.ExperimentalWarning)

--- a/optuna/integration/lightgbm_tuner/optimize.py
+++ b/optuna/integration/lightgbm_tuner/optimize.py
@@ -320,7 +320,8 @@ class LightGBMTuner(BaseTuner):
             A directory to save boosters. By default, it is set to :obj:`None` and no boosters are
             saved. Please set shared directory (e.g., directories on NFS) if you want to access
             :meth:`~optuna.integration.LightGBMTuner.best_booster` in distributed environments.
-            Otherwise, it may raise :obj:`ValueError`.
+            Otherwise, it may raise :obj:`ValueError`. If the directory does not exist, it will be
+            created.
     """
 
     def __init__(

--- a/optuna/integration/lightgbm_tuner/optimize.py
+++ b/optuna/integration/lightgbm_tuner/optimize.py
@@ -453,7 +453,7 @@ class LightGBMTuner(BaseTuner):
         """Return the best booster.
 
         If the best booster cannot be found, :class:`ValueError` will be raised. To prevent the
-        errors, please save boosters by specifying the `model_dir` arguments of
+        errors, please save boosters by specifying the ``model_dir`` arguments of
         :meth:`~optuna.integration.lightgbm.LightGBMTuner.__init__` when you resume tuning
         or you run tuning in parallel.
         """

--- a/optuna/integration/lightgbm_tuner/optimize.py
+++ b/optuna/integration/lightgbm_tuner/optimize.py
@@ -298,12 +298,13 @@ class LightGBMTuner(BaseTuner):
     Args:
         time_budget:
             A time budget for parameter tuning in seconds.
+
         best_params:
             A dictionary to store the best parameters.
 
             .. deprecated:: 1.4.0
-                Please get the parameter values via the ``params`` property of the
-                :class:`~optuna.integration.lightgbm.LightGBMTuner.best_booster`.
+                Please use the ``params`` attribute of the best booster, which is obtained by
+                :meth:`~optuna.integration.lightgbm.LightGBMTuner.get_best_booster`.
 
         tuning_history:
             A List to store the history of parameter tuning.
@@ -322,7 +323,7 @@ class LightGBMTuner(BaseTuner):
         model_dir:
             A directory to save boosters. By default, it is set to :obj:`None` and no boosters are
             saved. Please set shared directory (e.g., directories on NFS) if you want to access
-            :meth:`~optuna.integration.LightGBMTuner.best_booster` in distributed environments.
+            :meth:`~optuna.integration.LightGBMTuner.get_best_booster` in distributed environments.
             Otherwise, it may raise :obj:`ValueError`. If the directory does not exist, it will be
             created. The filenames of the boosters will be ``{model_dir}/{trial_number}.pkl``
             (e.g., ``./boosters/0.pkl``).
@@ -454,6 +455,20 @@ class LightGBMTuner(BaseTuner):
 
     @property
     def best_booster(self) -> lgb.Booster:
+        """Return the best booster.
+
+        .. deprecated:: 1.4.0
+            Please get the best booster via
+            :class:`~optuna.integration.lightgbm.LightGBMTuner.get_best_booster` instead.
+        """
+        warnings.warn(
+            "The `best_booster` attribute is deprecated. Please use `get_best_booster` instead.",
+            DeprecationWarning,
+        )
+
+        return self.get_best_booster()
+
+    def get_best_booster(self) -> lgb.Booster:
         """Return the best booster.
 
         If the best booster cannot be found, :class:`ValueError` will be raised. To prevent the

--- a/optuna/integration/lightgbm_tuner/optimize.py
+++ b/optuna/integration/lightgbm_tuner/optimize.py
@@ -220,7 +220,7 @@ class OptunaObjective(BaseTuner):
             max_num_leaves = 2 ** tree_depth if tree_depth > 0 else 2 ** DEFAULT_TUNER_TREE_DEPTH
             self.lgbm_params["num_leaves"] = trial.suggest_int("num_leaves", 2, max_num_leaves)
         if "feature_fraction" in self.target_param_names:
-            # `_GridSamplerUniform1D` is used for sampling feature_fraction value.
+            # `GridSampler` is used for sampling feature_fraction value.
             # The value 1.0 for the hyperparameter is always sampled.
             param_value = min(trial.suggest_uniform("feature_fraction", 0.4, 1.0 + EPS), 1.0)
             self.lgbm_params["feature_fraction"] = param_value
@@ -232,7 +232,7 @@ class OptunaObjective(BaseTuner):
         if "bagging_freq" in self.target_param_names:
             self.lgbm_params["bagging_freq"] = trial.suggest_int("bagging_freq", 1, 7)
         if "min_child_samples" in self.target_param_names:
-            # `_GridSamplerUniform1D` is used for sampling min_child_samples value.
+            # `GridSampler` is used for sampling min_child_samples value.
             # The value 1.0 for the hyperparameter is always sampled.
             param_value = int(trial.suggest_uniform("min_child_samples", 5, 100 + EPS))
             self.lgbm_params["min_child_samples"] = param_value

--- a/tests/integration_tests/lightgbm_tuner_tests/test_optimize.py
+++ b/tests/integration_tests/lightgbm_tuner_tests/test_optimize.py
@@ -595,30 +595,28 @@ class TestLightGBMTuner(object):
 
     def test_resume_run(self) -> None:
         params = {"verbose": -1}  # type: Dict
-        valid_data = np.zeros((10, 10))
-        valid_sets = lgb.Dataset(valid_data)
+        dataset = lgb.Dataset(np.zeros((10, 10)))
 
         study = optuna.create_study()
-        tuner = LightGBMTuner(params, valid_sets, valid_sets=valid_sets, study=study)
+        tuner = LightGBMTuner(params, dataset, valid_sets=dataset, study=study)
 
         with mock.patch.object(BaseTuner, "_get_booster_best_score", return_value=1.0):
-            tuner.run()
+            tuner.tune_regularization_factors()
 
         n_trials = len(study.trials)
         assert n_trials == len(study.trials)
 
-        tuner2 = LightGBMTuner(params, valid_sets, valid_sets=valid_sets, study=study)
+        tuner2 = LightGBMTuner(params, dataset, valid_sets=dataset, study=study)
         with mock.patch.object(BaseTuner, "_get_booster_best_score", return_value=1.0):
-            tuner2.run()
+            tuner2.tune_regularization_factors()
         assert n_trials == len(study.trials)
 
     def test_best_booster(self) -> None:
         params = {"verbose": -1}  # type: Dict
-        valid_data = np.zeros((10, 10))
-        valid_sets = lgb.Dataset(valid_data)
+        dataset = lgb.Dataset(np.zeros((10, 10)))
 
         study = optuna.create_study()
-        tuner = LightGBMTuner(params, valid_sets, valid_sets=valid_sets, study=study)
+        tuner = LightGBMTuner(params, dataset, valid_sets=dataset, study=study)
 
         with mock.patch.object(BaseTuner, "_get_booster_best_score", return_value=1.0):
             initial_best_booster = tuner.best_booster
@@ -628,12 +626,12 @@ class TestLightGBMTuner(object):
             initial_best_booster.params[key] == value
 
         with mock.patch.object(BaseTuner, "_get_booster_best_score", return_value=0.0):
-            tuner.run()
+            tuner.tune_regularization_factors()
 
         best_booster = tuner.best_booster
-        assert best_booster.params == initial_best_booster.params
+        assert best_booster.params != initial_best_booster.params
 
-        tuner2 = LightGBMTuner(params, valid_sets, valid_sets=valid_sets, study=study)
+        tuner2 = LightGBMTuner(params, dataset, valid_sets=dataset, study=study)
 
         # If the best booster is None and study has trials, the tuner retrain the booster with
         # the best parameters.


### PR DESCRIPTION
This is a draft PR of the parallelization of LightGBMTuner. In this PR, I also work on the resume feature of LightGBMTuner.

Here's [an example code](https://gist.github.com/toshihikoyanase/83f47966bef0f5d9d147d013742a3e85) to execute LightGBMTuner in parallel.
Please download it and execute `lightgbm_tuner_parallel.py` in two command prompts.

```
python lightgbm_tuner_parallel.py &
python lightgbm_tuner_parallel.py 
```

The result can be dumped as a CSV file using `lightgbm_tuner_dump_result.py` at the same directory.

```
python lightgbm_tuner_dump_result.py
```

## Design choice of `LightGBMTuner.best_booster`.

Currently, a booster corresponding to each trial is not shared with workers. This is because booster can be too large to store in Optuna's storage. I think we have several choices when users call `LightGBMTuner.best_booster` in a worker which does not have the best booster instance.

1. Raise `ValueError` with a message (e.g., In a parallel environment, best_booster is not always available. Please retrain it using the best parameters).
2. Retrain the best booster using the best parameters. This branch employs this approach.
3. Share booster instances using shared file system.

Which one do you prefer?

## Known issue

- `GridSampler` may sample the same parameter values at the same time. If so, it samples all combinations.
- `GridSampler` may leave running trials if it does not have any candidates.
- The parallel execution of LightGBMTuner is not tested.  Do you have any ideas to test it in a parallel environment?

[Done] ~~Please merge after https://github.com/optuna/optuna/pull/1032.~~