### PR TITLE
Set the version constraint of cmaes library

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ def get_install_requires() -> List[str]:
     return [
         "alembic",
         "cliff",
-        "cmaes",
+        "cmaes>=0.3.2",
         "colorlog",
         "joblib",
         "numpy",


### PR DESCRIPTION
`dim` property method which returns the dimension of multivariate gaussian distribution is added at v0.3.2. So v0.3.1 or lower is unsupported