### PR TITLE
Applied `@abc.abstractmethod` decorator to the abstract methods of `BaseTrial`

### DIFF
--- a/optuna/integration/chainermn.py
+++ b/optuna/integration/chainermn.py
@@ -196,7 +196,7 @@ class ChainerMNTrial(BaseTrial):
             # type: () -> float
 
             assert self.delegate is not None
-            return self.delegate.suggest_float(name, low, high)
+            return self.delegate.suggest_float(name, low, high, log)
 
         return self._call_with_mpi(func)
 

--- a/optuna/integration/chainermn.py
+++ b/optuna/integration/chainermn.py
@@ -196,7 +196,7 @@ class ChainerMNTrial(BaseTrial):
             # type: () -> float
 
             assert self.delegate is not None
-            return self.delegate.suggest_float(name, low, high, log)
+            return self.delegate.suggest_float(name, low, high, log=log)
 
         return self._call_with_mpi(func)
 

--- a/optuna/integration/chainermn.py
+++ b/optuna/integration/chainermn.py
@@ -189,6 +189,17 @@ class ChainerMNTrial(BaseTrial):
         self.delegate = trial
         self.comm = comm
 
+    def suggest_float(self, name, low, high, *, log=False):
+        # type: (str, float, float, bool) -> float
+
+        def func():
+            # type: () -> float
+
+            assert self.delegate is not None
+            return self.delegate.suggest_float(name, low, high)
+
+        return self._call_with_mpi(func)
+
     def suggest_uniform(self, name, low, high):
         # type: (str, float, float) -> float
 

--- a/optuna/trial.py
+++ b/optuna/trial.py
@@ -28,82 +28,96 @@ class BaseTrial(object, metaclass=abc.ABCMeta):
 
     Note that this class is not supposed to be directly accessed by library users.
     """
-
+    @abc.abstractmethod
     def suggest_float(self, name, low, high, *, log=False):
         # type: (str, float, float, bool) -> float
 
         raise NotImplementedError
 
+    @abc.abstractmethod
     def suggest_uniform(self, name, low, high):
         # type: (str, float, float) -> float
 
         raise NotImplementedError
 
+    @abc.abstractmethod
     def suggest_loguniform(self, name, low, high):
         # type: (str, float, float) -> float
 
         raise NotImplementedError
 
+    @abc.abstractmethod
     def suggest_discrete_uniform(self, name, low, high, q):
         # type: (str, float, float, float) -> float
 
         raise NotImplementedError
 
+    @abc.abstractmethod
     def suggest_int(self, name, low, high, step=1):
         # type: (str, int, int, int) -> int
 
         raise NotImplementedError
 
+    @abc.abstractmethod
     def suggest_categorical(self, name, choices):
         # type: (str, Sequence[CategoricalChoiceType]) -> CategoricalChoiceType
 
         raise NotImplementedError
 
+    @abc.abstractmethod
     def report(self, value, step):
         # type: (float, int) -> None
 
         raise NotImplementedError
 
+    @abc.abstractmethod
     def should_prune(self, step=None):
         # type: (Optional[int]) -> bool
 
         raise NotImplementedError
 
+    @abc.abstractmethod
     def set_user_attr(self, key, value):
         # type: (str, Any) -> None
 
         raise NotImplementedError
 
+    @abc.abstractmethod
     def set_system_attr(self, key, value):
         # type: (str, Any) -> None
 
         raise NotImplementedError
 
     @property
+    @abc.abstractmethod
     def params(self):
         # type: () -> Dict[str, Any]
 
         raise NotImplementedError
 
     @property
+    @abc.abstractmethod
     def distributions(self):
         # type: () -> Dict[str, BaseDistribution]
 
         raise NotImplementedError
 
     @property
+    @abc.abstractmethod
     def user_attrs(self):
         # type: () -> Dict[str, Any]
 
         raise NotImplementedError
 
     @property
+    @abc.abstractmethod
     def system_attrs(self):
         # type: () -> Dict[str, Any]
 
         raise NotImplementedError
 
     @property
+    @abc.abstractmethod
     def datetime_start(self):
         # type: () -> Optional[datetime]
 

--- a/optuna/trial.py
+++ b/optuna/trial.py
@@ -28,6 +28,7 @@ class BaseTrial(object, metaclass=abc.ABCMeta):
 
     Note that this class is not supposed to be directly accessed by library users.
     """
+
     @abc.abstractmethod
     def suggest_float(self, name, low, high, *, log=False):
         # type: (str, float, float, bool) -> float

--- a/tests/integration_tests/test_chainermn.py
+++ b/tests/integration_tests/test_chainermn.py
@@ -311,17 +311,33 @@ class TestChainerMNTrial(object):
 
         with MultiNodeStorageSupplier(storage_mode, comm) as storage:
             study = TestChainerMNStudy._create_shared_study(storage, comm)
-            mn_trial = _create_new_chainermn_trial(study, comm)
+            low=0.5
+            high=10
+            for _ in range(10):
+                mn_trial = _create_new_chainermn_trial(study, comm)
 
-            x1 = mn_trial.suggest_float("x1", 10, 20)
-            x2 = mn_trial.suggest_uniform("x1", 10, 20)
+                x1 = mn_trial.suggest_float("x1", low, high)
+                x2 = mn_trial.suggest_uniform("x1", low, high)
 
-            assert x1 == x2
+                assert x1 == x2
 
-            x3 = mn_trial.suggest_float("x2", 1e-5, 1e-3, log=True)
-            x4 = mn_trial.suggest_loguniform("x2", 1e-5, 1e-3)
+                with pytest.raises(ValueError):
+                    mn_trial.suggest_loguniform("x", low, high)
 
-            assert x3 == x4
+        with MultiNodeStorageSupplier(storage_mode, comm) as storage:
+            study = TestChainerMNStudy._create_shared_study(storage, comm)
+            low = 1e-5
+            high = 1e-3
+            for _ in range(10):
+                mn_trial = _create_new_chainermn_trial(study, comm)
+
+                x3 = mn_trial.suggest_float("x2", low, high, log=True)
+                x4 = mn_trial.suggest_loguniform("x2", low, high)
+
+                assert x3 == x4
+
+                with pytest.raises(ValueError):
+                    mn_trial.suggest_uniform("x", low, high)
 
     @staticmethod
     @pytest.mark.parametrize("storage_mode", STORAGE_MODES)

--- a/tests/integration_tests/test_chainermn.py
+++ b/tests/integration_tests/test_chainermn.py
@@ -326,7 +326,6 @@ class TestChainerMNTrial(object):
                 with pytest.raises(ValueError):
                     mn_trial.suggest_loguniform("x1", low1, high1)
 
-
             low2 = 1e-7
             high2 = 1e-2
             for _ in range(10):
@@ -338,7 +337,7 @@ class TestChainerMNTrial(object):
                 x4 = mn_trial.suggest_loguniform("x2", low2, high2)
 
                 assert x3 == x4
-                
+
                 with pytest.raises(ValueError):
                     mn_trial.suggest_uniform("x2", low2, high2)
 

--- a/tests/integration_tests/test_chainermn.py
+++ b/tests/integration_tests/test_chainermn.py
@@ -311,8 +311,8 @@ class TestChainerMNTrial(object):
 
         with MultiNodeStorageSupplier(storage_mode, comm) as storage:
             study = TestChainerMNStudy._create_shared_study(storage, comm)
-            low=0.5
-            high=10
+            low = 0.5
+            high = 10
             for _ in range(10):
                 mn_trial = _create_new_chainermn_trial(study, comm)
 

--- a/tests/integration_tests/test_chainermn.py
+++ b/tests/integration_tests/test_chainermn.py
@@ -311,33 +311,27 @@ class TestChainerMNTrial(object):
 
         with MultiNodeStorageSupplier(storage_mode, comm) as storage:
             study = TestChainerMNStudy._create_shared_study(storage, comm)
-            low = 0.5
-            high = 10
             for _ in range(10):
                 mn_trial = _create_new_chainermn_trial(study, comm)
 
-                x1 = mn_trial.suggest_float("x1", low, high)
-                x2 = mn_trial.suggest_uniform("x1", low, high)
+                x1 = mn_trial.suggest_float("x1", 0.5, 10)
+                x2 = mn_trial.suggest_uniform("x1", 0.5, 10)
 
                 assert x1 == x2
 
                 with pytest.raises(ValueError):
-                    mn_trial.suggest_loguniform("x", low, high)
+                    mn_trial.suggest_loguniform("x", 0.5, 10)
 
-        with MultiNodeStorageSupplier(storage_mode, comm) as storage:
-            study = TestChainerMNStudy._create_shared_study(storage, comm)
-            low = 1e-5
-            high = 1e-3
             for _ in range(10):
                 mn_trial = _create_new_chainermn_trial(study, comm)
 
-                x3 = mn_trial.suggest_float("x2", low, high, log=True)
-                x4 = mn_trial.suggest_loguniform("x2", low, high)
+                x3 = mn_trial.suggest_float("x2", 1e-3, 1e-5, log=True)
+                x4 = mn_trial.suggest_loguniform("x2", 1e-3, 1e-5)
 
                 assert x3 == x4
 
                 with pytest.raises(ValueError):
-                    mn_trial.suggest_uniform("x", low, high)
+                    mn_trial.suggest_uniform("x", 1e-3, 1e-5)
 
     @staticmethod
     @pytest.mark.parametrize("storage_mode", STORAGE_MODES)

--- a/tests/integration_tests/test_chainermn.py
+++ b/tests/integration_tests/test_chainermn.py
@@ -323,9 +323,6 @@ class TestChainerMNTrial(object):
 
                 assert x1 == x2
 
-                with pytest.raises(ValueError):
-                    mn_trial.suggest_loguniform("x", low1, high1)
-
             low2 = 1e-7
             high2 = 1e-2
             for _ in range(10):
@@ -337,9 +334,6 @@ class TestChainerMNTrial(object):
                 x4 = mn_trial.suggest_loguniform("x2", low2, high2)
 
                 assert x3 == x4
-
-                with pytest.raises(ValueError):
-                    mn_trial.suggest_uniform("x", low2, high2)
 
     @staticmethod
     @pytest.mark.parametrize("storage_mode", STORAGE_MODES)

--- a/tests/integration_tests/test_chainermn.py
+++ b/tests/integration_tests/test_chainermn.py
@@ -323,6 +323,10 @@ class TestChainerMNTrial(object):
 
                 assert x1 == x2
 
+                with pytest.raises(ValueError):
+                    mn_trial.suggest_loguniform("x1", low1, high1)
+
+
             low2 = 1e-7
             high2 = 1e-2
             for _ in range(10):
@@ -334,6 +338,9 @@ class TestChainerMNTrial(object):
                 x4 = mn_trial.suggest_loguniform("x2", low2, high2)
 
                 assert x3 == x4
+                
+                with pytest.raises(ValueError):
+                    mn_trial.suggest_uniform("x2", low2, high2)
 
     @staticmethod
     @pytest.mark.parametrize("storage_mode", STORAGE_MODES)

--- a/tests/integration_tests/test_chainermn.py
+++ b/tests/integration_tests/test_chainermn.py
@@ -306,6 +306,25 @@ class TestChainerMNTrial(object):
 
     @staticmethod
     @pytest.mark.parametrize("storage_mode", STORAGE_MODES)
+    def test_suggest_float(storage_mode, comm):
+        # type: (str, CommunicatorBase) -> None
+
+        with MultiNodeStorageSupplier(storage_mode, comm) as storage:
+            study = TestChainerMNStudy._create_shared_study(storage, comm)
+            mn_trial = _create_new_chainermn_trial(study, comm)
+
+            x1 = mn_trial.suggest_float("x1", 10, 20)
+            x2 = mn_trial.suggest_uniform("x1", 10, 20)
+
+            assert x1 == x2
+
+            x3 = mn_trial.suggest_float("x2", 1e-5, 1e-3, log=True)
+            x4 = mn_trial.suggest_loguniform("x2", 1e-5, 1e-3)
+
+            assert x3 == x4
+
+    @staticmethod
+    @pytest.mark.parametrize("storage_mode", STORAGE_MODES)
     def test_suggest_uniform(storage_mode, comm):
         # type: (str, CommunicatorBase) -> None
 

--- a/tests/integration_tests/test_chainermn.py
+++ b/tests/integration_tests/test_chainermn.py
@@ -311,27 +311,35 @@ class TestChainerMNTrial(object):
 
         with MultiNodeStorageSupplier(storage_mode, comm) as storage:
             study = TestChainerMNStudy._create_shared_study(storage, comm)
+            low = 10
+            high = 20
             for _ in range(10):
                 mn_trial = _create_new_chainermn_trial(study, comm)
 
-                x1 = mn_trial.suggest_float("x1", 0.5, 1.0)
-                x2 = mn_trial.suggest_uniform("x1", 0.5, 1.0)
+                x1 = mn_trial.suggest_float("x1", low, high)
+                assert low <= x1 <= high
+
+                x2 = mn_trial.suggest_uniform("x1", low, high)
 
                 assert x1 == x2
 
                 with pytest.raises(ValueError):
-                    mn_trial.suggest_loguniform("x", 0.5, 1.0)
+                    mn_trial.suggest_loguniform("x", low, high)
 
+            low = 1e-5
+            high = 1e-3
             for _ in range(10):
                 mn_trial = _create_new_chainermn_trial(study, comm)
 
-                x3 = mn_trial.suggest_float("x2", 1e-3, 1e-5, log=True)
-                x4 = mn_trial.suggest_loguniform("x2", 1e-3, 1e-5)
+                x3 = mn_trial.suggest_float("x2", low, high, log=True)
+                assert low <= x3 <= high
+
+                x4 = mn_trial.suggest_loguniform("x2", low, high)
 
                 assert x3 == x4
 
                 with pytest.raises(ValueError):
-                    mn_trial.suggest_uniform("x", 1e-3, 1e-5)
+                    mn_trial.suggest_uniform("x", low, high)
 
     @staticmethod
     @pytest.mark.parametrize("storage_mode", STORAGE_MODES)

--- a/tests/integration_tests/test_chainermn.py
+++ b/tests/integration_tests/test_chainermn.py
@@ -311,8 +311,8 @@ class TestChainerMNTrial(object):
 
         with MultiNodeStorageSupplier(storage_mode, comm) as storage:
             study = TestChainerMNStudy._create_shared_study(storage, comm)
-            low1 = 10
-            high1 = 20
+            low1 = 0.5
+            high1 = 1.0
             for _ in range(10):
                 mn_trial = _create_new_chainermn_trial(study, comm)
 
@@ -326,8 +326,8 @@ class TestChainerMNTrial(object):
                 with pytest.raises(ValueError):
                     mn_trial.suggest_loguniform("x", low1, high1)
 
-            low2 = 1e-5
-            high2 = 1e-3
+            low2 = 1e-7
+            high2 = 1e-2
             for _ in range(10):
                 mn_trial = _create_new_chainermn_trial(study, comm)
 

--- a/tests/integration_tests/test_chainermn.py
+++ b/tests/integration_tests/test_chainermn.py
@@ -314,13 +314,13 @@ class TestChainerMNTrial(object):
             for _ in range(10):
                 mn_trial = _create_new_chainermn_trial(study, comm)
 
-                x1 = mn_trial.suggest_float("x1", 0.5, 10)
-                x2 = mn_trial.suggest_uniform("x1", 0.5, 10)
+                x1 = mn_trial.suggest_float("x1", 0.5, 1.0)
+                x2 = mn_trial.suggest_uniform("x1", 0.5, 1.0)
 
                 assert x1 == x2
 
                 with pytest.raises(ValueError):
-                    mn_trial.suggest_loguniform("x", 0.5, 10)
+                    mn_trial.suggest_loguniform("x", 0.5, 1.0)
 
             for _ in range(10):
                 mn_trial = _create_new_chainermn_trial(study, comm)

--- a/tests/integration_tests/test_chainermn.py
+++ b/tests/integration_tests/test_chainermn.py
@@ -311,35 +311,35 @@ class TestChainerMNTrial(object):
 
         with MultiNodeStorageSupplier(storage_mode, comm) as storage:
             study = TestChainerMNStudy._create_shared_study(storage, comm)
-            low = 10
-            high = 20
+            low1 = 10
+            high1 = 20
             for _ in range(10):
                 mn_trial = _create_new_chainermn_trial(study, comm)
 
-                x1 = mn_trial.suggest_float("x1", low, high)
-                assert low <= x1 <= high
+                x1 = mn_trial.suggest_float("x1", low1, high1)
+                assert low1 <= x1 <= high1
 
-                x2 = mn_trial.suggest_uniform("x1", low, high)
+                x2 = mn_trial.suggest_uniform("x1", low1, high1)
 
                 assert x1 == x2
 
                 with pytest.raises(ValueError):
-                    mn_trial.suggest_loguniform("x", low, high)
+                    mn_trial.suggest_loguniform("x", low1, high1)
 
-            low = 1e-5
-            high = 1e-3
+            low2 = 1e-5
+            high2 = 1e-3
             for _ in range(10):
                 mn_trial = _create_new_chainermn_trial(study, comm)
 
-                x3 = mn_trial.suggest_float("x2", low, high, log=True)
-                assert low <= x3 <= high
+                x3 = mn_trial.suggest_float("x2", low2, high2, log=True)
+                assert low2 <= x3 <= high2
 
-                x4 = mn_trial.suggest_loguniform("x2", low, high)
+                x4 = mn_trial.suggest_loguniform("x2", low2, high2)
 
                 assert x3 == x4
 
                 with pytest.raises(ValueError):
-                    mn_trial.suggest_uniform("x", low, high)
+                    mn_trial.suggest_uniform("x", low2, high2)
 
     @staticmethod
     @pytest.mark.parametrize("storage_mode", STORAGE_MODES)


### PR DESCRIPTION
issue #1084

This PR applied `@abc.abstractmethod` decorator to the abstract methods of `BaseTrial`
