### PR TITLE
Fix docstring on `optuna/distributions.py`

### DIFF
--- a/optuna/distributions.py
+++ b/optuna/distributions.py
@@ -293,7 +293,7 @@ class CategoricalDistribution(BaseDistribution):
     .. note::
 
         Not all types are guaranteed to be compatible with all storages. It is recommended to
-        restrict the types of the choices to :obj:`None`, :class:`bool`, :class"`int`,
+        restrict the types of the choices to :obj:`None`, :class:`bool`, :class:`int`,
         :class:`float` and :class:`str`.
 
     Attributes:


### PR DESCRIPTION
This PR fixes docstring on optuna/distributions.py. The docstring for `optuna.distributions.CategoricalDistribution` includes a typo.

* Ref: https://optuna.readthedocs.io/en/stable/reference/distributions.html#optuna.distributions.CategoricalDistribution

**Before**:
![before](https://user-images.githubusercontent.com/19337/78420906-7f378500-768e-11ea-81e0-dc4d68bcca4e.png)

**After**:
![after](https://user-images.githubusercontent.com/19337/78420945-db020e00-768e-11ea-806f-46e9839f2c9e.png):