### PR TITLE
Remove duplicate description of `FrozenTrial.distributions`.

### DIFF
--- a/optuna/structs.py
+++ b/optuna/structs.py
@@ -81,8 +81,6 @@ class FrozenTrial(object):
             Datetime where the :class:`~optuna.trial.Trial` finished.
         params:
             Dictionary that contains suggested parameters.
-        distributions:
-            Dictionary that contains the distributions of :attr:`params`.
         user_attrs:
             Dictionary that contains the attributes of the :class:`~optuna.trial.Trial` set with
             :func:`optuna.trial.Trial.set_user_attr`.
@@ -214,10 +212,7 @@ class FrozenTrial(object):
     @property
     def distributions(self):
         # type: () -> Dict[str, BaseDistribution]
-        """Return the distributions for this trial.
-
-        Returns:
-            The distributions.
+        """Dictionary that contains the distributions of :attr:`params`.
         """
 
         return self._distributions
@@ -225,12 +220,6 @@ class FrozenTrial(object):
     @distributions.setter
     def distributions(self, value):
         # type: (Dict[str, BaseDistribution]) -> None
-        """Set the distributions for this trial.
-
-        Args:
-            value: The distributions.
-        """
-
         self._distributions = value
 
     @property

--- a/optuna/structs.py
+++ b/optuna/structs.py
@@ -212,8 +212,7 @@ class FrozenTrial(object):
     @property
     def distributions(self):
         # type: () -> Dict[str, BaseDistribution]
-        """Dictionary that contains the distributions of :attr:`params`.
-        """
+        """Dictionary that contains the distributions of :attr:`params`."""
 
         return self._distributions
 


### PR DESCRIPTION
Remove duplicate description of `FrozenTrial.distributions` to get rid off sphinx warning, fixing `document` and `doctest` CI job failures.

I followed https://github.com/optuna/optuna/wiki/Coding-Style-Conventions#example-1.