### PR TITLE
Refactoring of `StudySummary`.

### DIFF
--- a/docs/source/reference/study.rst
+++ b/docs/source/reference/study.rst
@@ -14,3 +14,7 @@ Study
 .. autofunction:: get_all_study_summaries
 
 .. autoclass:: StudyDirection
+    :members:
+
+.. autoclass:: StudySummary
+    :members:

--- a/optuna/_study_summary.py
+++ b/optuna/_study_summary.py
@@ -1,16 +1,16 @@
 import datetime
+from typing import Any
+from typing import Dict
+from typing import Optional
 import warnings
 
 from optuna._study_direction import StudyDirection
 
 from optuna import logging
 from optuna import structs
-from optuna import type_checking
 
-if type_checking.TYPE_CHECKING:
-    from typing import Any  # NOQA
-    from typing import Dict  # NOQA
-    from typing import Optional  # NOQA
+
+_logger = logging.get_logger(__name__)
 
 
 class StudySummary(object):
@@ -39,16 +39,15 @@ class StudySummary(object):
 
     def __init__(
         self,
-        study_name,  # type: str
-        direction,  # type: StudyDirection
-        best_trial,  # type: Optional[structs.FrozenTrial]
-        user_attrs,  # type: Dict[str, Any]
-        system_attrs,  # type: Dict[str, Any]
-        n_trials,  # type: int
-        datetime_start,  # type: Optional[datetime.datetime]
-        study_id,  # type: int
+        study_name: str,
+        direction: StudyDirection,
+        best_trial: Optional[structs.FrozenTrial],
+        user_attrs: Dict[str, Any],
+        system_attrs: Dict[str, Any],
+        n_trials: int,
+        datetime_start: Optional[datetime.datetime],
+        study_id: int,
     ):
-        # type: (...) -> None
 
         self.study_name = study_name
         self.direction = direction
@@ -59,24 +58,21 @@ class StudySummary(object):
         self.datetime_start = datetime_start
         self._study_id = study_id
 
-    def __eq__(self, other):
-        # type: (Any) -> bool
+    def __eq__(self, other: Any) -> bool:
 
         if not isinstance(other, StudySummary):
             return NotImplemented
 
         return other.__dict__ == self.__dict__
 
-    def __lt__(self, other):
-        # type: (Any) -> bool
+    def __lt__(self, other: Any) -> bool:
 
         if not isinstance(other, StudySummary):
             return NotImplemented
 
         return self._study_id < other._study_id
 
-    def __le__(self, other):
-        # type: (Any) -> bool
+    def __le__(self, other: Any) -> bool:
 
         if not isinstance(other, StudySummary):
             return NotImplemented
@@ -84,8 +80,7 @@ class StudySummary(object):
         return self._study_id <= other._study_id
 
     @property
-    def study_id(self):
-        # type: () -> int
+    def study_id(self) -> int:
         """Return the study ID.
 
         .. deprecated:: 0.20.0
@@ -102,7 +97,6 @@ class StudySummary(object):
         )
         warnings.warn(message, DeprecationWarning)
 
-        logger = logging.get_logger(__name__)
-        logger.warning(message)
+        _logger.warning(message)
 
         return self._study_id

--- a/optuna/_study_summary.py
+++ b/optuna/_study_summary.py
@@ -1,0 +1,108 @@
+import datetime
+import warnings
+
+from optuna._study_direction import StudyDirection
+
+from optuna import logging
+from optuna import structs
+from optuna import type_checking
+
+if type_checking.TYPE_CHECKING:
+    from typing import Any  # NOQA
+    from typing import Dict  # NOQA
+    from typing import Optional  # NOQA
+
+
+class StudySummary(object):
+    """Basic attributes and aggregated results of a :class:`~optuna.study.Study`.
+
+    See also :func:`optuna.study.get_all_study_summaries`.
+
+    Attributes:
+        study_name:
+            Name of the :class:`~optuna.study.Study`.
+        direction:
+            :class:`~optuna.study.StudyDirection` of the :class:`~optuna.study.Study`.
+        best_trial:
+            :class:`FrozenTrial` with best objective value in the :class:`~optuna.study.Study`.
+        user_attrs:
+            Dictionary that contains the attributes of the :class:`~optuna.study.Study` set with
+            :func:`optuna.study.Study.set_user_attr`.
+        system_attrs:
+            Dictionary that contains the attributes of the :class:`~optuna.study.Study` internally
+            set by Optuna.
+        n_trials:
+            The number of trials ran in the :class:`~optuna.study.Study`.
+        datetime_start:
+            Datetime where the :class:`~optuna.study.Study` started.
+    """
+
+    def __init__(
+        self,
+        study_name,  # type: str
+        direction,  # type: StudyDirection
+        best_trial,  # type: Optional[structs.FrozenTrial]
+        user_attrs,  # type: Dict[str, Any]
+        system_attrs,  # type: Dict[str, Any]
+        n_trials,  # type: int
+        datetime_start,  # type: Optional[datetime.datetime]
+        study_id,  # type: int
+    ):
+        # type: (...) -> None
+
+        self.study_name = study_name
+        self.direction = direction
+        self.best_trial = best_trial
+        self.user_attrs = user_attrs
+        self.system_attrs = system_attrs
+        self.n_trials = n_trials
+        self.datetime_start = datetime_start
+        self._study_id = study_id
+
+    def __eq__(self, other):
+        # type: (Any) -> bool
+
+        if not isinstance(other, StudySummary):
+            return NotImplemented
+
+        return other.__dict__ == self.__dict__
+
+    def __lt__(self, other):
+        # type: (Any) -> bool
+
+        if not isinstance(other, StudySummary):
+            return NotImplemented
+
+        return self._study_id < other._study_id
+
+    def __le__(self, other):
+        # type: (Any) -> bool
+
+        if not isinstance(other, StudySummary):
+            return NotImplemented
+
+        return self._study_id <= other._study_id
+
+    @property
+    def study_id(self):
+        # type: () -> int
+        """Return the study ID.
+
+        .. deprecated:: 0.20.0
+            The direct use of this attribute is deprecated and it is recommended that you use
+            :attr:`~optuna.study.StudySummary.study_name` instead.
+
+        Returns:
+            The study ID.
+        """
+
+        message = (
+            "The use of `StudySummary.study_id` is deprecated. "
+            "Please use `StudySummary.study_name` instead."
+        )
+        warnings.warn(message, DeprecationWarning)
+
+        logger = logging.get_logger(__name__)
+        logger.warning(message)
+
+        return self._study_id

--- a/optuna/_study_summary.py
+++ b/optuna/_study_summary.py
@@ -5,7 +5,6 @@ from typing import Optional
 import warnings
 
 from optuna._study_direction import StudyDirection
-
 from optuna import logging
 from optuna import structs
 

--- a/optuna/_study_summary.py
+++ b/optuna/_study_summary.py
@@ -91,7 +91,6 @@ class StudySummary(object):
             The study ID.
 
         """
-
         message = (
             "The use of `StudySummary.study_id` is deprecated. "
             "Please use `StudySummary.study_name` instead."

--- a/optuna/_study_summary.py
+++ b/optuna/_study_summary.py
@@ -35,6 +35,7 @@ class StudySummary(object):
             The number of trials ran in the :class:`~optuna.study.Study`.
         datetime_start:
             Datetime where the :class:`~optuna.study.Study` started.
+
     """
 
     def __init__(
@@ -89,6 +90,7 @@ class StudySummary(object):
 
         Returns:
             The study ID.
+
         """
 
         message = (

--- a/optuna/storages/base.py
+++ b/optuna/storages/base.py
@@ -97,7 +97,7 @@ class BaseStorage(object, metaclass=abc.ABCMeta):
 
     @abc.abstractmethod
     def get_all_study_summaries(self):
-        # type: () -> List[structs.StudySummary]
+        # type: () -> List[study.StudySummary]
 
         raise NotImplementedError
 

--- a/optuna/storages/in_memory.py
+++ b/optuna/storages/in_memory.py
@@ -7,6 +7,7 @@ from optuna.storages import base
 from optuna.storages.base import DEFAULT_STUDY_NAME_PREFIX
 from optuna import structs
 from optuna.study import StudyDirection
+from optuna.study import StudySummary
 from optuna import type_checking
 
 if type_checking.TYPE_CHECKING:
@@ -131,7 +132,7 @@ class InMemoryStorage(base.BaseStorage):
             return copy.deepcopy(self.study_system_attrs)
 
     def get_all_study_summaries(self):
-        # type: () -> List[structs.StudySummary]
+        # type: () -> List[StudySummary]
 
         best_trial = None
         if any(t for t in self.trials if t.state == structs.TrialState.COMPLETE):
@@ -142,7 +143,7 @@ class InMemoryStorage(base.BaseStorage):
             datetime_start = min([t.datetime_start for t in self.trials])
 
         return [
-            structs.StudySummary(
+            StudySummary(
                 study_name=self.study_name,
                 direction=self.direction,
                 best_trial=best_trial,

--- a/optuna/storages/rdb/storage.py
+++ b/optuna/storages/rdb/storage.py
@@ -26,6 +26,7 @@ from optuna.storages.base import DEFAULT_STUDY_NAME_PREFIX
 from optuna.storages.rdb import models
 from optuna import structs
 from optuna.study import StudyDirection
+from optuna.study import StudySummary
 from optuna import type_checking
 from optuna import version
 
@@ -337,7 +338,7 @@ class RDBStorage(BaseStorage):
 
     # TODO(sano): Optimize this method to reduce the number of queries.
     def get_all_study_summaries(self):
-        # type: () -> List[structs.StudySummary]
+        # type: () -> List[StudySummary]
 
         session = self.scoped_session()
 
@@ -402,7 +403,7 @@ class RDBStorage(BaseStorage):
 
             # Consolidate StudySummary.
             study_summaries.append(
-                structs.StudySummary(
+                StudySummary(
                     study_name=study_model.study_name,
                     direction=self.get_study_direction(study_model.study_id),
                     best_trial=best_trial,

--- a/optuna/storages/redis.py
+++ b/optuna/storages/redis.py
@@ -184,10 +184,7 @@ class RedisStorage(base.BaseStorage):
             direction_pkl = self._redis.get(self._key_study_direction(study_id))
             assert direction_pkl is not None
             current_direction = pickle.loads(direction_pkl)
-            if (
-                current_direction != StudyDirection.NOT_SET
-                and current_direction != direction
-            ):
+            if current_direction != StudyDirection.NOT_SET and current_direction != direction:
                 raise ValueError(
                     "Cannot overwrite study direction from {} to {}.".format(
                         current_direction, direction

--- a/optuna/structs.py
+++ b/optuna/structs.py
@@ -289,6 +289,11 @@ class FrozenTrial(object):
 class StudySummary(object):
     """Basic attributes and aggregated results of a :class:`~optuna.study.Study`.
 
+    .. deprecated:: 1.3.0
+
+        This class was moved to :mod:`~optuna.study`. Please use
+        :class:`~optuna.study.StudySummary` instead.
+
     See also :func:`optuna.study.get_all_study_summaries`.
 
     Attributes:
@@ -322,6 +327,14 @@ class StudySummary(object):
         study_id,  # type: int
     ):
         # type: (...) -> None
+
+        message = (
+            "The use of `structs.StudySummary` is deprecated. "
+            "Please use `study.StudySummary` instead."
+        )
+        warnings.warn(message, DeprecationWarning)
+        logger = logging.get_logger(__name__)
+        logger.warning(message)
 
         self.study_name = study_name
         self.direction = direction

--- a/optuna/structs.py
+++ b/optuna/structs.py
@@ -329,7 +329,7 @@ class StudySummary(object):
         # type: (...) -> None
 
         message = (
-            "The use of `structs.StudySummary` is deprecated. "
+            "The use of `study.StudySummary` is deprecated. "
             "Please use `study.StudySummary` instead."
         )
         warnings.warn(message, DeprecationWarning)

--- a/optuna/structs.py
+++ b/optuna/structs.py
@@ -376,7 +376,7 @@ class StudySummary(object):
 
         .. deprecated:: 0.20.0
             The direct use of this attribute is deprecated and it is recommended that you use
-            :attr:`~optuna.structs.StudySummary.study_name` instead.
+            :attr:`~optuna.study.StudySummary.study_name` instead.
 
         Returns:
             The study ID.

--- a/optuna/structs.py
+++ b/optuna/structs.py
@@ -18,7 +18,7 @@ if type_checking.TYPE_CHECKING:
 
 _logger = logging.get_logger(__name__)
 
-# The use of the structs.StudyDirectino is deprecated and it is recommended that you use
+# The use of the structs.StudyDirection is deprecated and it is recommended that you use
 # study.StudyDirection instead. See the API reference for more details.
 StudyDirection = _study_direction.StudyDirection
 

--- a/optuna/structs.py
+++ b/optuna/structs.py
@@ -305,7 +305,7 @@ class StudySummary(object):
         # type: (...) -> None
 
         message = (
-            "The use of `study.StudySummary` is deprecated. "
+            "The use of `structs.StudySummary` is deprecated. "
             "Please use `study.StudySummary` instead."
         )
         warnings.warn(message, DeprecationWarning)

--- a/optuna/structs.py
+++ b/optuna/structs.py
@@ -18,9 +18,8 @@ if type_checking.TYPE_CHECKING:
 
 _logger = logging.get_logger(__name__)
 
-# The use of the structs.StudyDirectino is deprecated and
-# it is recommended that you use study.StudyDirection instead.
-# See the API reference for more details.
+# The use of the structs.StudyDirectino is deprecated and it is recommended that you use
+# study.StudyDirection instead. See the API reference for more details.
 StudyDirection = _study_direction.StudyDirection
 
 

--- a/optuna/structs.py
+++ b/optuna/structs.py
@@ -16,6 +16,8 @@ if type_checking.TYPE_CHECKING:
     from optuna.distributions import BaseDistribution  # NOQA
 
 
+_logger = logging.get_logger(__name__)
+
 StudyDirection = _study_direction.StudyDirection
 
 
@@ -227,8 +229,7 @@ class FrozenTrial(object):
             DeprecationWarning,
         )
 
-        logger = logging.get_logger(__name__)
-        logger.warning(
+        _logger.warning(
             "The use of `FrozenTrial.trial_id` is deprecated. "
             "Please use `FrozenTrial.number` instead."
         )
@@ -306,8 +307,7 @@ class StudySummary(object):
             "Please use `study.StudySummary` instead."
         )
         warnings.warn(message, DeprecationWarning)
-        logger = logging.get_logger(__name__)
-        logger.warning(message)
+        _logger.warning(message)
 
         self.study_name = study_name
         self.direction = direction
@@ -361,8 +361,7 @@ class StudySummary(object):
         )
         warnings.warn(message, DeprecationWarning)
 
-        logger = logging.get_logger(__name__)
-        logger.warning(message)
+        _logger.warning(message)
 
         return self._study_id
 
@@ -384,5 +383,4 @@ class TrialPruned(exceptions.TrialPruned):
             "Please use `optuna.exceptions.TrialPruned` instead."
         )
         warnings.warn(message, DeprecationWarning)
-        logger = logging.get_logger(__name__)
-        logger.warning(message)
+        _logger.warning(message)

--- a/optuna/study.py
+++ b/optuna/study.py
@@ -11,7 +11,6 @@ from joblib import Parallel
 
 from optuna._experimental import experimental
 from optuna._study_direction import StudyDirection
-from optuna._study_summary import StudySummary
 
 try:
     import pandas as pd  # NOQA
@@ -44,6 +43,7 @@ if type_checking.TYPE_CHECKING:
     from typing import Union  # NOQA
 
     from optuna.distributions import BaseDistribution  # NOQA
+    from optuna._study_summary import StudySummary  # NOQA
 
     ObjectiveFuncType = Callable[[trial_module.Trial], float]
 

--- a/optuna/study.py
+++ b/optuna/study.py
@@ -50,6 +50,101 @@ if type_checking.TYPE_CHECKING:
 _logger = logging.get_logger(__name__)
 
 
+class StudySummary(object):
+    """Basic attributes and aggregated results of a :class:`~optuna.study.Study`.
+
+    See also :func:`optuna.study.get_all_study_summaries`.
+
+    Attributes:
+        study_name:
+            Name of the :class:`~optuna.study.Study`.
+        direction:
+            :class:`~optuna.study.StudyDirection` of the :class:`~optuna.study.Study`.
+        best_trial:
+            :class:`FrozenTrial` with best objective value in the :class:`~optuna.study.Study`.
+        user_attrs:
+            Dictionary that contains the attributes of the :class:`~optuna.study.Study` set with
+            :func:`optuna.study.Study.set_user_attr`.
+        system_attrs:
+            Dictionary that contains the attributes of the :class:`~optuna.study.Study` internally
+            set by Optuna.
+        n_trials:
+            The number of trials ran in the :class:`~optuna.study.Study`.
+        datetime_start:
+            Datetime where the :class:`~optuna.study.Study` started.
+    """
+
+    def __init__(
+        self,
+        study_name,  # type: str
+        direction,  # type: StudyDirection
+        best_trial,  # type: Optional[structs.FrozenTrial]
+        user_attrs,  # type: Dict[str, Any]
+        system_attrs,  # type: Dict[str, Any]
+        n_trials,  # type: int
+        datetime_start,  # type: Optional[datetime]
+        study_id,  # type: int
+    ):
+        # type: (...) -> None
+
+        self.study_name = study_name
+        self.direction = direction
+        self.best_trial = best_trial
+        self.user_attrs = user_attrs
+        self.system_attrs = system_attrs
+        self.n_trials = n_trials
+        self.datetime_start = datetime_start
+        self._study_id = study_id
+
+    def __eq__(self, other):
+        # type: (Any) -> bool
+
+        if not isinstance(other, StudySummary):
+            return NotImplemented
+
+        return other.__dict__ == self.__dict__
+
+    def __lt__(self, other):
+        # type: (Any) -> bool
+
+        if not isinstance(other, StudySummary):
+            return NotImplemented
+
+        return self._study_id < other._study_id
+
+    def __le__(self, other):
+        # type: (Any) -> bool
+
+        if not isinstance(other, StudySummary):
+            return NotImplemented
+
+        return self._study_id <= other._study_id
+
+    @property
+    def study_id(self):
+        # type: () -> int
+        """Return the study ID.
+
+        .. deprecated:: 0.20.0
+            The direct use of this attribute is deprecated and it is recommended that you use
+            :attr:`~optuna.study.StudySummary.study_name` instead.
+
+        Returns:
+            The study ID.
+        """
+
+        message = (
+            "The use of `StudySummary.study_id` is deprecated. "
+            "Please use `StudySummary.study_name` instead."
+        )
+        warnings.warn(message, DeprecationWarning)
+
+        logger = logging.get_logger(__name__)
+        logger.warning(message)
+
+        return self._study_id
+
+
 class BaseStudy(object):
     def __init__(self, study_id, storage):
         # type: (int, storages.BaseStorage) -> None

--- a/optuna/study.py
+++ b/optuna/study.py
@@ -11,6 +11,7 @@ from joblib import Parallel
 
 from optuna._experimental import experimental
 from optuna._study_direction import StudyDirection
+from optuna._study_summary import StudySummary  # NOQA
 
 try:
     import pandas as pd  # NOQA
@@ -43,7 +44,6 @@ if type_checking.TYPE_CHECKING:
     from typing import Union  # NOQA
 
     from optuna.distributions import BaseDistribution  # NOQA
-    from optuna._study_summary import StudySummary  # NOQA
 
     ObjectiveFuncType = Callable[[trial_module.Trial], float]
 

--- a/optuna/study.py
+++ b/optuna/study.py
@@ -11,6 +11,7 @@ from joblib import Parallel
 
 from optuna._experimental import experimental
 from optuna._study_direction import StudyDirection
+from optuna._study_summary import StudySummary
 
 try:
     import pandas as pd  # NOQA
@@ -48,101 +49,6 @@ if type_checking.TYPE_CHECKING:
 
 
 _logger = logging.get_logger(__name__)
-
-
-class StudySummary(object):
-    """Basic attributes and aggregated results of a :class:`~optuna.study.Study`.
-
-    See also :func:`optuna.study.get_all_study_summaries`.
-
-    Attributes:
-        study_name:
-            Name of the :class:`~optuna.study.Study`.
-        direction:
-            :class:`~optuna.study.StudyDirection` of the :class:`~optuna.study.Study`.
-        best_trial:
-            :class:`FrozenTrial` with best objective value in the :class:`~optuna.study.Study`.
-        user_attrs:
-            Dictionary that contains the attributes of the :class:`~optuna.study.Study` set with
-            :func:`optuna.study.Study.set_user_attr`.
-        system_attrs:
-            Dictionary that contains the attributes of the :class:`~optuna.study.Study` internally
-            set by Optuna.
-        n_trials:
-            The number of trials ran in the :class:`~optuna.study.Study`.
-        datetime_start:
-            Datetime where the :class:`~optuna.study.Study` started.
-    """
-
-    def __init__(
-        self,
-        study_name,  # type: str
-        direction,  # type: StudyDirection
-        best_trial,  # type: Optional[structs.FrozenTrial]
-        user_attrs,  # type: Dict[str, Any]
-        system_attrs,  # type: Dict[str, Any]
-        n_trials,  # type: int
-        datetime_start,  # type: Optional[datetime]
-        study_id,  # type: int
-    ):
-        # type: (...) -> None
-
-        self.study_name = study_name
-        self.direction = direction
-        self.best_trial = best_trial
-        self.user_attrs = user_attrs
-        self.system_attrs = system_attrs
-        self.n_trials = n_trials
-        self.datetime_start = datetime_start
-        self._study_id = study_id
-
-    def __eq__(self, other):
-        # type: (Any) -> bool
-
-        if not isinstance(other, StudySummary):
-            return NotImplemented
-
-        return other.__dict__ == self.__dict__
-
-    def __lt__(self, other):
-        # type: (Any) -> bool
-
-        if not isinstance(other, StudySummary):
-            return NotImplemented
-
-        return self._study_id < other._study_id
-
-    def __le__(self, other):
-        # type: (Any) -> bool
-
-        if not isinstance(other, StudySummary):
-            return NotImplemented
-
-        return self._study_id <= other._study_id
-
-    @property
-    def study_id(self):
-        # type: () -> int
-        """Return the study ID.
-
-        .. deprecated:: 0.20.0
-            The direct use of this attribute is deprecated and it is recommended that you use
-            :attr:`~optuna.study.StudySummary.study_name` instead.
-
-        Returns:
-            The study ID.
-        """
-
-        message = (
-            "The use of `StudySummary.study_id` is deprecated. "
-            "Please use `StudySummary.study_name` instead."
-        )
-        warnings.warn(message, DeprecationWarning)
-
-        logger = logging.get_logger(__name__)
-        logger.warning(message)
-
-        return self._study_id
 
 
 class BaseStudy(object):
@@ -984,7 +890,7 @@ def delete_study(
 
 
 def get_all_study_summaries(storage):
-    # type: (Union[str, storages.BaseStorage]) -> List[structs.StudySummary]
+    # type: (Union[str, storages.BaseStorage]) -> List[StudySummary]
     """Get all history of studies stored in a specified storage.
 
     Args:
@@ -993,7 +899,7 @@ def get_all_study_summaries(storage):
             :func:`~optuna.study.create_study` for further details.
 
     Returns:
-        List of study history summarized as :class:`~optuna.structs.StudySummary` objects.
+        List of study history summarized as :class:`~optuna.study.StudySummary` objects.
 
     """
 

--- a/tests/storages_tests/rdb_tests/test_storage.py
+++ b/tests/storages_tests/rdb_tests/test_storage.py
@@ -16,9 +16,9 @@ from optuna.storages.rdb.models import TrialModel
 from optuna.storages.rdb.models import TrialParamModel
 from optuna.storages.rdb.models import VersionInfoModel
 from optuna.storages import RDBStorage
-from optuna.structs import StudySummary
 from optuna.structs import TrialState
 from optuna.study import StudyDirection
+from optuna.study import StudySummary
 from optuna import type_checking
 from optuna import version
 

--- a/tests/test_structs.py
+++ b/tests/test_structs.py
@@ -1,6 +1,5 @@
 import copy
 import datetime
-import warnings
 
 import pytest
 
@@ -148,77 +147,6 @@ def test_frozen_trial_repr():
     )
 
     assert trial == eval(repr(trial))
-
-
-def test_study_summary_study_id():
-    # type: () -> None
-
-    study = optuna.create_study()
-    summaries = study._storage.get_all_study_summaries()
-    assert len(summaries) == 1
-
-    summary = summaries[0]
-
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", category=DeprecationWarning)
-        assert summary.study_id == summary._study_id
-
-    with pytest.warns(DeprecationWarning):
-        summary.study_id
-
-
-def test_study_summary_eq_ne():
-    # type: () -> None
-
-    storage = optuna.storages.RDBStorage("sqlite:///:memory:")
-
-    optuna.create_study(storage=storage)
-    study = optuna.create_study(storage=storage)
-
-    summaries = study._storage.get_all_study_summaries()
-    assert len(summaries) == 2
-
-    assert summaries[0] == copy.deepcopy(summaries[0])
-    assert not summaries[0] != copy.deepcopy(summaries[0])
-
-    assert not summaries[0] == summaries[1]
-    assert summaries[0] != summaries[1]
-
-    assert not summaries[0] == 1
-    assert summaries[0] != 1
-
-
-def test_study_summary_lt_le():
-    # type: () -> None
-
-    storage = optuna.storages.RDBStorage("sqlite:///:memory:")
-
-    optuna.create_study(storage=storage)
-    study = optuna.create_study(storage=storage)
-
-    summaries = study._storage.get_all_study_summaries()
-    assert len(summaries) == 2
-
-    summary_0 = summaries[0]
-    summary_1 = summaries[1]
-
-    assert summary_0 < summary_1
-    assert not summary_1 < summary_0
-
-    with pytest.raises(TypeError):
-        summary_0 < 1
-
-    assert summary_0 <= summary_0
-    assert not summary_1 <= summary_0
-
-    with pytest.raises(TypeError):
-        summary_0 <= 1
-
-    # A list of StudySummaries is sortable.
-    summaries.reverse()
-    summaries.sort()
-    assert summaries[0] == summary_0
-    assert summaries[1] == summary_1
 
 
 def test_study_summary_deprecated():

--- a/tests/test_structs.py
+++ b/tests/test_structs.py
@@ -8,7 +8,9 @@ import optuna
 from optuna.distributions import LogUniformDistribution
 from optuna.distributions import UniformDistribution
 from optuna.structs import FrozenTrial
+from optuna.structs import StudySummary
 from optuna.structs import TrialState
+from optuna.study import StudyDirection
 
 if optuna.type_checking.TYPE_CHECKING:
     from typing import Any  # NOQA
@@ -217,3 +219,19 @@ def test_study_summary_lt_le():
     summaries.sort()
     assert summaries[0] == summary_0
     assert summaries[1] == summary_1
+
+
+def test_study_summary_deprecated():
+    # type: () -> None
+
+    with pytest.deprecated_call():
+        StudySummary(
+            study_name="test",
+            direction=StudyDirection.NOT_SET,
+            best_trial=None,
+            user_attrs={},
+            system_attrs={},
+            n_trials=0,
+            datetime_start=datetime.datetime.now(),
+            study_id=0,
+        )

--- a/tests/test_study.py
+++ b/tests/test_study.py
@@ -898,3 +898,74 @@ def test_study_id():
 
     with pytest.warns(DeprecationWarning):
         study.study_id
+
+
+def test_study_summary_study_id():
+    # type: () -> None
+
+    study = optuna.create_study()
+    summaries = study._storage.get_all_study_summaries()
+    assert len(summaries) == 1
+
+    summary = summaries[0]
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", category=DeprecationWarning)
+        assert summary.study_id == summary._study_id
+
+    with pytest.warns(DeprecationWarning):
+        summary.study_id
+
+
+def test_study_summary_eq_ne():
+    # type: () -> None
+
+    storage = optuna.storages.RDBStorage("sqlite:///:memory:")
+
+    optuna.create_study(storage=storage)
+    study = optuna.create_study(storage=storage)
+
+    summaries = study._storage.get_all_study_summaries()
+    assert len(summaries) == 2
+
+    assert summaries[0] == copy.deepcopy(summaries[0])
+    assert not summaries[0] != copy.deepcopy(summaries[0])
+
+    assert not summaries[0] == summaries[1]
+    assert summaries[0] != summaries[1]
+
+    assert not summaries[0] == 1
+    assert summaries[0] != 1
+
+
+def test_study_summary_lt_le():
+    # type: () -> None
+
+    storage = optuna.storages.RDBStorage("sqlite:///:memory:")
+
+    optuna.create_study(storage=storage)
+    study = optuna.create_study(storage=storage)
+
+    summaries = study._storage.get_all_study_summaries()
+    assert len(summaries) == 2
+
+    summary_0 = summaries[0]
+    summary_1 = summaries[1]
+
+    assert summary_0 < summary_1
+    assert not summary_1 < summary_0
+
+    with pytest.raises(TypeError):
+        summary_0 < 1
+
+    assert summary_0 <= summary_0
+    assert not summary_1 <= summary_0
+
+    with pytest.raises(TypeError):
+        summary_0 <= 1
+
+    # A list of StudySummaries is sortable.
+    summaries.reverse()
+    summaries.sort()
+    assert summaries[0] == summary_0
+    assert summaries[1] == summary_1


### PR DESCRIPTION
Depends on #1090 

A minor refactoring of the StudySummary class to increase affinity with the Study class similar to #1090 .
By making the StudySummary class independent with structs.py, it is easy to understand that the StudySummary class is related to Study class.
Note that the change of this PR depends on the history of #1090, so we have to review and merge #1090 first.

I made `_study_summary.py` which includes the same implementation of `StudySummary` with `structs.py`. I also added the warning of using structs.StudySummary.
To promote the user experience, while the `StudySummary` class is contained in `_study_summary.py`, the class can be referenced as `study.StudySummary`.

Additionally, I moved the unit test cases about `StudySummary` from `test_structs.py` to `test_study.py`. 