### PR TITLE
Refactoring of `TrialState` and `FrozenTrial`.

### DIFF
--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -188,7 +188,7 @@ To deal with this problem, please set an option (e.g., random seed) to make the 
 How are exceptions from trials handled?
 ---------------------------------------
 
-Trials that raise exceptions without catching them will be treated as failures, i.e. with the :obj:`~optuna.structs.TrialState.FAIL` status.
+Trials that raise exceptions without catching them will be treated as failures, i.e. with the :obj:`~optuna.trial.TrialState.FAIL` status.
 
 By default, all exceptions except :class:`~optuna.exceptions.TrialPruned` raised in objective functions are propagated to the caller of :func:`~optuna.study.Study.optimize`.
 In other words, studies are aborted when such exceptions are raised.

--- a/docs/source/reference/structs.rst
+++ b/docs/source/reference/structs.rst
@@ -6,6 +6,10 @@ Structs
 .. autoclass:: TrialState
     :members:
 
+    .. deprecated:: 1.4.0
+            The use of this class is deprecated and it is recommended that you use :class:`~optuna.trial.TrialState` instead.
+
+
 .. autoclass:: StudyDirection
     :members:
 

--- a/docs/source/reference/structs.rst
+++ b/docs/source/reference/structs.rst
@@ -7,8 +7,7 @@ Structs
     :members:
 
     .. deprecated:: 1.4.0
-            The use of this class is deprecated and it is recommended that you use :class:`~optuna.trial.TrialState` instead.
-
+            This class is deprecated. Please use :class:`~optuna.trial.TrialState` instead.
 
 .. autoclass:: StudyDirection
     :members:

--- a/docs/source/reference/trial.rst
+++ b/docs/source/reference/trial.rst
@@ -12,6 +12,7 @@ Trial
 
 .. autoclass:: FrozenTrial
     :members:
+    :exclude-members: system_attrs, trial_id
 
 .. autoclass:: TrialState
     :members:

--- a/docs/source/reference/trial.rst
+++ b/docs/source/reference/trial.rst
@@ -9,3 +9,9 @@ Trial
     :exclude-members: system_attrs, set_system_attr, trial_id
 
 .. autoclass:: FixedTrial
+
+.. autoclass:: TrialState
+    :members:
+
+.. autoclass:: FrozenTrial
+    :members:

--- a/docs/source/reference/trial.rst
+++ b/docs/source/reference/trial.rst
@@ -10,8 +10,8 @@ Trial
 
 .. autoclass:: FixedTrial
 
-.. autoclass:: TrialState
+.. autoclass:: FrozenTrial
     :members:
 
-.. autoclass:: FrozenTrial
+.. autoclass:: TrialState
     :members:

--- a/examples/pruning/chainer_integration.py
+++ b/examples/pruning/chainer_integration.py
@@ -102,8 +102,8 @@ def objective(trial):
 if __name__ == "__main__":
     study = optuna.create_study(direction="maximize", pruner=optuna.pruners.MedianPruner())
     study.optimize(objective, n_trials=100)
-    pruned_trials = [t for t in study.trials if t.state == optuna.structs.TrialState.PRUNED]
-    complete_trials = [t for t in study.trials if t.state == optuna.structs.TrialState.COMPLETE]
+    pruned_trials = [t for t in study.trials if t.state == optuna.trial.TrialState.PRUNED]
+    complete_trials = [t for t in study.trials if t.state == optuna.trial.TrialState.COMPLETE]
     print("Study statistics: ")
     print("  Number of finished trials: ", len(study.trials))
     print("  Number of pruned trials: ", len(pruned_trials))

--- a/examples/pruning/chainermn_integration.py
+++ b/examples/pruning/chainermn_integration.py
@@ -122,10 +122,8 @@ if __name__ == "__main__":
     chainermn_study.optimize(objective, n_trials=25)
 
     if comm.rank == 0:
-        pruned_trials = [t for t in study.trials if t.state == optuna.structs.TrialState.PRUNED]
-        complete_trials = [
-            t for t in study.trials if t.state == optuna.structs.TrialState.COMPLETE
-        ]
+        pruned_trials = [t for t in study.trials if t.state == optuna.trial.TrialState.PRUNED]
+        complete_trials = [t for t in study.trials if t.state == optuna.trial.TrialState.COMPLETE]
         print("Study statistics: ")
         print("  Number of finished trials: ", len(study.trials))
         print("  Number of pruned trials: ", len(pruned_trials))

--- a/examples/pruning/keras_integration.py
+++ b/examples/pruning/keras_integration.py
@@ -88,8 +88,8 @@ def objective(trial):
 if __name__ == "__main__":
     study = optuna.create_study(direction="maximize", pruner=optuna.pruners.MedianPruner())
     study.optimize(objective, n_trials=100)
-    pruned_trials = [t for t in study.trials if t.state == optuna.structs.TrialState.PRUNED]
-    complete_trials = [t for t in study.trials if t.state == optuna.structs.TrialState.COMPLETE]
+    pruned_trials = [t for t in study.trials if t.state == optuna.trial.TrialState.PRUNED]
+    complete_trials = [t for t in study.trials if t.state == optuna.trial.TrialState.COMPLETE]
     print("Study statistics: ")
     print("  Number of finished trials: ", len(study.trials))
     print("  Number of pruned trials: ", len(pruned_trials))

--- a/examples/pruning/mxnet_integration.py
+++ b/examples/pruning/mxnet_integration.py
@@ -108,8 +108,8 @@ def objective(trial):
 if __name__ == "__main__":
     study = optuna.create_study(direction="maximize", pruner=optuna.pruners.MedianPruner())
     study.optimize(objective, n_trials=100, timeout=600)
-    pruned_trials = [t for t in study.trials if t.state == optuna.structs.TrialState.PRUNED]
-    complete_trials = [t for t in study.trials if t.state == optuna.structs.TrialState.COMPLETE]
+    pruned_trials = [t for t in study.trials if t.state == optuna.trial.TrialState.PRUNED]
+    complete_trials = [t for t in study.trials if t.state == optuna.trial.TrialState.COMPLETE]
 
     print("Study statistics: ")
     print("  Number of finished trials: ", len(study.trials))

--- a/examples/pruning/simple.py
+++ b/examples/pruning/simple.py
@@ -49,8 +49,8 @@ if __name__ == "__main__":
     study = optuna.create_study(direction="maximize")
     study.optimize(objective, n_trials=100)
 
-    pruned_trials = [t for t in study.trials if t.state == optuna.structs.TrialState.PRUNED]
-    complete_trials = [t for t in study.trials if t.state == optuna.structs.TrialState.COMPLETE]
+    pruned_trials = [t for t in study.trials if t.state == optuna.trial.TrialState.PRUNED]
+    complete_trials = [t for t in study.trials if t.state == optuna.trial.TrialState.COMPLETE]
 
     print("Study statistics: ")
     print("  Number of finished trials: ", len(study.trials))

--- a/examples/pruning/tensorflow_estimator_integration.py
+++ b/examples/pruning/tensorflow_estimator_integration.py
@@ -99,8 +99,8 @@ def objective(trial):
 def main():
     study = optuna.create_study(direction="maximize")
     study.optimize(objective, n_trials=25)
-    pruned_trials = [t for t in study.trials if t.state == optuna.structs.TrialState.PRUNED]
-    complete_trials = [t for t in study.trials if t.state == optuna.structs.TrialState.COMPLETE]
+    pruned_trials = [t for t in study.trials if t.state == optuna.trial.TrialState.PRUNED]
+    complete_trials = [t for t in study.trials if t.state == optuna.trial.TrialState.COMPLETE]
     print("Study statistics: ")
     print("  Number of finished trials: ", len(study.trials))
     print("  Number of pruned trials: ", len(pruned_trials))

--- a/examples/pruning/tfkeras_integration.py
+++ b/examples/pruning/tfkeras_integration.py
@@ -112,8 +112,8 @@ def objective(trial):
 
 def show_result(study):
 
-    pruned_trials = [t for t in study.trials if t.state == optuna.structs.TrialState.PRUNED]
-    complete_trials = [t for t in study.trials if t.state == optuna.structs.TrialState.COMPLETE]
+    pruned_trials = [t for t in study.trials if t.state == optuna.trial.TrialState.PRUNED]
+    complete_trials = [t for t in study.trials if t.state == optuna.trial.TrialState.COMPLETE]
 
     print("Study statistics: ")
     print("  Number of finished trials: ", len(study.trials))

--- a/examples/samplers/simulated_annealing_sampler.py
+++ b/examples/samplers/simulated_annealing_sampler.py
@@ -18,8 +18,8 @@ import numpy as np
 import optuna
 from optuna import distributions
 from optuna.samplers import BaseSampler
-from optuna import structs
 from optuna.study import StudyDirection
+from optuna.trial import TrialState
 
 
 class SimulatedAnnealingSampler(BaseSampler):
@@ -97,7 +97,7 @@ class SimulatedAnnealingSampler(BaseSampler):
 
     @staticmethod
     def _get_last_complete_trial(study):
-        complete_trials = [t for t in study.trials if t.state == structs.TrialState.COMPLETE]
+        complete_trials = [t for t in study.trials if t.state == TrialState.COMPLETE]
         return complete_trials[-1]
 
     def sample_independent(self, study, trial, param_name, param_distribution):

--- a/optuna/_study_summary.py
+++ b/optuna/_study_summary.py
@@ -7,7 +7,7 @@ import warnings
 from optuna._study_direction import StudyDirection
 
 from optuna import logging
-from optuna import structs
+from optuna import trial
 
 
 _logger = logging.get_logger(__name__)
@@ -41,7 +41,7 @@ class StudySummary(object):
         self,
         study_name: str,
         direction: StudyDirection,
-        best_trial: Optional[structs.FrozenTrial],
+        best_trial: Optional[trial.FrozenTrial],
         user_attrs: Dict[str, Any],
         system_attrs: Dict[str, Any],
         n_trials: int,

--- a/optuna/dashboard.py
+++ b/optuna/dashboard.py
@@ -20,9 +20,9 @@ import time
 import numpy as np
 
 import optuna.logging
-import optuna.structs
 import optuna.study
 from optuna.study import StudyDirection
+import optuna.trial
 from optuna import type_checking
 
 if type_checking.TYPE_CHECKING:
@@ -56,10 +56,10 @@ if _available:
 
     class _CompleteTrialsWidget(object):
         def __init__(self, trials, direction):
-            # type: (List[optuna.structs.FrozenTrial], StudyDirection) -> None
+            # type: (List[optuna.trial.FrozenTrial], StudyDirection) -> None
 
             complete_trials = [
-                trial for trial in trials if trial.state == optuna.structs.TrialState.COMPLETE
+                trial for trial in trials if trial.state == optuna.trial.TrialState.COMPLETE
             ]
             self.trial_ids = set([trial._trial_id for trial in complete_trials])
 
@@ -91,12 +91,12 @@ if _available:
             return figure
 
         def update(self, new_trials):
-            # type: (List[optuna.structs.FrozenTrial]) -> None
+            # type: (List[optuna.trial.FrozenTrial]) -> None
 
             stream_dict = collections.defaultdict(list)  # type: Dict[str, List[Any]]
 
             for trial in new_trials:
-                if trial.state != optuna.structs.TrialState.COMPLETE:
+                if trial.state != optuna.trial.TrialState.COMPLETE:
                     continue
                 if trial._trial_id in self.trial_ids:
                     continue
@@ -114,7 +114,7 @@ if _available:
 
     class _AllTrialsWidget(object):
         def __init__(self, trials):
-            # type: (List[optuna.structs.FrozenTrial]) -> None
+            # type: (List[optuna.trial.FrozenTrial]) -> None
 
             self.cds = bokeh.models.ColumnDataSource(self.trials_to_dict(trials))
 
@@ -138,8 +138,8 @@ if _available:
 
         def update(
             self,
-            old_trials,  # type: List[optuna.structs.FrozenTrial]
-            new_trials,  # type: List[optuna.structs.FrozenTrial]
+            old_trials,  # type: List[optuna.trial.FrozenTrial]
+            new_trials,  # type: List[optuna.trial.FrozenTrial]
         ):
             # type: (...) -> None
 
@@ -159,7 +159,7 @@ if _available:
 
         @staticmethod
         def trials_to_dict(trials):
-            # type: (List[optuna.structs.FrozenTrial]) -> Dict[str, List[Any]]
+            # type: (List[optuna.trial.FrozenTrial]) -> Dict[str, List[Any]]
 
             return {
                 "number": [trial.number for trial in trials],
@@ -194,8 +194,8 @@ if _available:
             self.doc = doc
             self.current_trials = (
                 self.study.trials
-            )  # type: Optional[List[optuna.structs.FrozenTrial]]
-            self.new_trials = None  # type: Optional[List[optuna.structs.FrozenTrial]]
+            )  # type: Optional[List[optuna.trial.FrozenTrial]]
+            self.new_trials = None  # type: Optional[List[optuna.trial.FrozenTrial]]
             self.complete_trials_widget = _CompleteTrialsWidget(
                 self.current_trials, self.study.direction
             )

--- a/optuna/importance/_base.py
+++ b/optuna/importance/_base.py
@@ -11,7 +11,7 @@ from optuna._experimental import experimental
 from optuna.distributions import BaseDistribution
 from optuna.distributions import CategoricalDistribution
 from optuna.samplers import intersection_search_space
-from optuna.structs import TrialState
+from optuna.trial import TrialState
 from optuna.study import Study
 
 

--- a/optuna/importance/_base.py
+++ b/optuna/importance/_base.py
@@ -11,8 +11,8 @@ from optuna._experimental import experimental
 from optuna.distributions import BaseDistribution
 from optuna.distributions import CategoricalDistribution
 from optuna.samplers import intersection_search_space
-from optuna.trial import TrialState
 from optuna.study import Study
+from optuna.trial import TrialState
 
 
 @experimental("1.3.0")

--- a/optuna/integration/cma.py
+++ b/optuna/integration/cma.py
@@ -11,8 +11,8 @@ from optuna.distributions import IntUniformDistribution
 from optuna.distributions import LogUniformDistribution
 from optuna.distributions import UniformDistribution
 from optuna.samplers import BaseSampler
-from optuna.trial import TrialState
 from optuna.study import StudyDirection
+from optuna.trial import TrialState
 from optuna import type_checking
 
 try:

--- a/optuna/integration/cma.py
+++ b/optuna/integration/cma.py
@@ -11,7 +11,7 @@ from optuna.distributions import IntUniformDistribution
 from optuna.distributions import LogUniformDistribution
 from optuna.distributions import UniformDistribution
 from optuna.samplers import BaseSampler
-from optuna.structs import TrialState
+from optuna.trial import TrialState
 from optuna.study import StudyDirection
 from optuna import type_checking
 
@@ -32,7 +32,7 @@ if type_checking.TYPE_CHECKING:
     from typing import Set  # NOQA
 
     from optuna.distributions import BaseDistribution  # NOQA
-    from optuna.structs import FrozenTrial  # NOQA
+    from optuna.trial import FrozenTrial  # NOQA
     from optuna.study import Study  # NOQA
 
 # Minimum value of sigma0 to avoid ZeroDivisionError in cma.CMAEvolutionStrategy.

--- a/optuna/integration/lightgbm_tuner/optimize.py
+++ b/optuna/integration/lightgbm_tuner/optimize.py
@@ -419,14 +419,14 @@ class LightGBMTuner(BaseTuner):
             self.study = study
 
         if self.higher_is_better():
-            if self.study.direction != optuna.structs.StudyDirection.MAXIMIZE:
+            if self.study.direction != optuna.study.StudyDirection.MAXIMIZE:
                 metric_name = self.lgbm_params.get("metric", "binary_logloss")
                 raise ValueError(
                     "Study direction is inconsistent with the metric {}. "
                     "Please set 'maximize' as the direction.".format(metric_name)
                 )
         else:
-            if self.study.direction != optuna.structs.StudyDirection.MINIMIZE:
+            if self.study.direction != optuna.study.StudyDirection.MINIMIZE:
                 metric_name = self.lgbm_params.get("metric", "binary_logloss")
                 raise ValueError(
                     "Study direction is inconsistent with the metric {}. "
@@ -660,7 +660,7 @@ class LightGBMTuner(BaseTuner):
                 self._step_name = step_name
 
             def get_trials(self, deepcopy=True):
-                # type: (bool) -> List[optuna.structs.FrozenTrial]
+                # type: (bool) -> List[optuna.trial.FrozenTrial]
 
                 trials = super().get_trials(deepcopy=deepcopy)
                 return [
@@ -671,20 +671,20 @@ class LightGBMTuner(BaseTuner):
 
             @property
             def best_trial(self):
-                # type: () -> optuna.structs.FrozenTrial
+                # type: () -> optuna.trial.FrozenTrial
                 """Return the best trial in the study.
 
                 Returns:
-                    A :class:`~optuna.structs.FrozenTrial` object of the best trial.
+                    A :class:`~optuna.trial.FrozenTrial` object of the best trial.
                 """
 
                 trials = self.get_trials(deepcopy=False)
-                trials = [t for t in trials if t.state is optuna.structs.TrialState.COMPLETE]
+                trials = [t for t in trials if t.state is optuna.trial.TrialState.COMPLETE]
 
                 if len(trials) == 0:
                     raise ValueError("No trials are completed yet.")
 
-                if self.direction == optuna.structs.StudyDirection.MINIMIZE:
+                if self.direction == optuna.study.StudyDirection.MINIMIZE:
                     best_trial = min(trials, key=lambda t: t.value)
                 else:
                     best_trial = max(trials, key=lambda t: t.value)

--- a/optuna/integration/lightgbm_tuner/optimize.py
+++ b/optuna/integration/lightgbm_tuner/optimize.py
@@ -22,7 +22,7 @@ if type_checking.TYPE_CHECKING:
     from typing import Union  # NOQA
 
     from optuna.distributions import BaseDistribution  # NOQA
-    from optuna.structs import FrozenTrial  # NOQA
+    from optuna.trial import FrozenTrial  # NOQA
     from optuna.study import Study  # NOQA
     from optuna.trial import Trial  # NOQA
 

--- a/optuna/integration/sklearn.py
+++ b/optuna/integration/sklearn.py
@@ -38,10 +38,10 @@ from optuna import distributions  # NOQA
 from optuna import exceptions  # NOQA
 from optuna import logging  # NOQA
 from optuna import samplers  # NOQA
-from optuna import structs  # NOQA
 from optuna import study as study_module  # NOQA
 from optuna.study import StudyDirection  # NOQA
 from optuna import trial as trial_module  # NOQA
+from optuna.trial import FrozenTrial  # NOQA
 from optuna import type_checking  # NOQA
 
 if type_checking.TYPE_CHECKING:
@@ -566,7 +566,7 @@ class OptunaSearchCV(BaseEstimator):
 
     @property
     def best_trial_(self):
-        # type: () -> structs.FrozenTrial
+        # type: () -> FrozenTrial
         """Best trial in the :class:`~optuna.study.Study`."""
 
         self._check_is_fitted()
@@ -591,7 +591,7 @@ class OptunaSearchCV(BaseEstimator):
 
     @property
     def trials_(self):
-        # type: () -> List[structs.FrozenTrial]
+        # type: () -> List[FrozenTrial]
         """All trials in the :class:`~optuna.study.Study`."""
 
         self._check_is_fitted()

--- a/optuna/integration/skopt.py
+++ b/optuna/integration/skopt.py
@@ -4,8 +4,8 @@ import optuna
 from optuna import distributions
 from optuna import samplers
 from optuna.samplers import BaseSampler
-from optuna import structs
 from optuna.study import StudyDirection
+from optuna.trial import TrialState
 from optuna import type_checking
 
 try:
@@ -26,7 +26,7 @@ if type_checking.TYPE_CHECKING:
     from typing import Tuple  # NOQA
 
     from optuna.distributions import BaseDistribution  # NOQA
-    from optuna.structs import FrozenTrial  # NOQA
+    from optuna.trial import FrozenTrial  # NOQA
     from optuna.study import Study  # NOQA
 
 
@@ -128,7 +128,7 @@ class SkoptSampler(BaseSampler):
         if len(search_space) == 0:
             return {}
 
-        complete_trials = [t for t in study.trials if t.state == structs.TrialState.COMPLETE]
+        complete_trials = [t for t in study.trials if t.state == TrialState.COMPLETE]
         if len(complete_trials) < self._n_startup_trials:
             return {}
 
@@ -140,7 +140,7 @@ class SkoptSampler(BaseSampler):
         # type: (Study, FrozenTrial, str, BaseDistribution) -> Any
 
         if self._warn_independent_sampling:
-            complete_trials = [t for t in study.trials if t.state == structs.TrialState.COMPLETE]
+            complete_trials = [t for t in study.trials if t.state == TrialState.COMPLETE]
             if len(complete_trials) >= self._n_startup_trials:
                 self._log_independent_sampling(trial, param_name)
 

--- a/optuna/integration/skopt.py
+++ b/optuna/integration/skopt.py
@@ -26,8 +26,8 @@ if type_checking.TYPE_CHECKING:
     from typing import Tuple  # NOQA
 
     from optuna.distributions import BaseDistribution  # NOQA
-    from optuna.trial import FrozenTrial  # NOQA
     from optuna.study import Study  # NOQA
+    from optuna.trial import FrozenTrial  # NOQA
 
 
 class SkoptSampler(BaseSampler):

--- a/optuna/pruners/base.py
+++ b/optuna/pruners/base.py
@@ -3,8 +3,8 @@ import abc
 from optuna.type_checking import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from optuna.trial import FrozenTrial  # NOQA
     from optuna.study import Study  # NOQA
+    from optuna.trial import FrozenTrial  # NOQA
 
 
 class BasePruner(object, metaclass=abc.ABCMeta):

--- a/optuna/pruners/base.py
+++ b/optuna/pruners/base.py
@@ -3,7 +3,7 @@ import abc
 from optuna.type_checking import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from optuna.structs import FrozenTrial  # NOQA
+    from optuna.trial import FrozenTrial  # NOQA
     from optuna.study import Study  # NOQA
 
 

--- a/optuna/pruners/hyperband.py
+++ b/optuna/pruners/hyperband.py
@@ -8,7 +8,7 @@ from optuna import type_checking
 if type_checking.TYPE_CHECKING:
     from typing import List  # NOQA
 
-    from optuna import structs  # NOQA
+    from optuna.trial import FrozenTrial  # NOQA
 
 _logger = logging.get_logger(__name__)
 
@@ -104,7 +104,7 @@ class HyperbandPruner(BasePruner):
             self._pruners.append(pruner)
 
     def prune(self, study, trial):
-        # type: (optuna.study.Study, structs.FrozenTrial) -> bool
+        # type: (optuna.study.Study, FrozenTrial) -> bool
 
         i = self._get_bracket_id(study, trial)
         _logger.debug("{}th bracket is selected".format(i))
@@ -119,7 +119,7 @@ class HyperbandPruner(BasePruner):
         return n + (n / 2) * (n_brackets - 1 - pruner_index)
 
     def _get_bracket_id(self, study, trial):
-        # type: (optuna.study.Study, structs.FrozenTrial) -> int
+        # type: (optuna.study.Study, FrozenTrial) -> int
         """Computes the index of bracket for a trial of ``trial_number``.
 
         The index of a bracket is noted as :math:`s` in
@@ -166,7 +166,7 @@ class HyperbandPruner(BasePruner):
                 self._bracket_id = bracket_id
 
             def get_trials(self, deepcopy=True):
-                # type: (bool) -> List[structs.FrozenTrial]
+                # type: (bool) -> List[FrozenTrial]
 
                 trials = super().get_trials(deepcopy=deepcopy)
                 pruner = self.pruner

--- a/optuna/pruners/nop.py
+++ b/optuna/pruners/nop.py
@@ -2,8 +2,8 @@ from optuna.pruners import BasePruner
 from optuna import type_checking
 
 if type_checking.TYPE_CHECKING:
-    from optuna import structs  # NOQA
     from optuna.study import Study  # NOQA
+    from optuna.trial import FrozenTrial  # NOQA
 
 
 class NopPruner(BasePruner):
@@ -50,6 +50,6 @@ class NopPruner(BasePruner):
     """
 
     def prune(self, study, trial):
-        # type: (Study, structs.FrozenTrial) -> bool
+        # type: (Study, FrozenTrial) -> bool
 
         return False

--- a/optuna/pruners/percentile.py
+++ b/optuna/pruners/percentile.py
@@ -4,8 +4,8 @@ import math
 import numpy as np
 
 from optuna.pruners import BasePruner
-from optuna import structs
 from optuna.study import StudyDirection
+from optuna.trial import TrialState
 from optuna import type_checking
 
 if type_checking.TYPE_CHECKING:
@@ -13,10 +13,11 @@ if type_checking.TYPE_CHECKING:
     from typing import List  # NOQA
 
     from optuna.study import Study  # NOQA
+    from optuna.trial import FrozenTrial  # NOQA
 
 
 def _get_best_intermediate_result_over_steps(trial, direction):
-    # type: (structs.FrozenTrial, StudyDirection) -> float
+    # type: (FrozenTrial, StudyDirection) -> float
 
     values = np.array(list(trial.intermediate_values.values()), np.float)
     if direction == StudyDirection.MAXIMIZE:
@@ -25,9 +26,9 @@ def _get_best_intermediate_result_over_steps(trial, direction):
 
 
 def _get_percentile_intermediate_result_over_trials(all_trials, direction, step, percentile):
-    # type: (List[structs.FrozenTrial], StudyDirection, int, float) -> float
+    # type: (List[FrozenTrial], StudyDirection, int, float) -> float
 
-    completed_trials = [t for t in all_trials if t.state == structs.TrialState.COMPLETE]
+    completed_trials = [t for t in all_trials if t.state == TrialState.COMPLETE]
 
     if len(completed_trials) == 0:
         raise ValueError("No trials have been completed.")
@@ -153,10 +154,10 @@ class PercentilePruner(BasePruner):
         self._interval_steps = interval_steps
 
     def prune(self, study, trial):
-        # type: (Study, structs.FrozenTrial) -> bool
+        # type: (Study, FrozenTrial) -> bool
 
         all_trials = study.get_trials(deepcopy=False)
-        n_trials = len([t for t in all_trials if t.state == structs.TrialState.COMPLETE])
+        n_trials = len([t for t in all_trials if t.state == TrialState.COMPLETE])
 
         if n_trials == 0:
             return False

--- a/optuna/pruners/successive_halving.py
+++ b/optuna/pruners/successive_halving.py
@@ -1,8 +1,8 @@
 import math
 
 from optuna.pruners.base import BasePruner
-from optuna.trial import TrialState
 from optuna.study import StudyDirection
+from optuna.trial import TrialState
 from optuna import type_checking
 
 if type_checking.TYPE_CHECKING:

--- a/optuna/pruners/successive_halving.py
+++ b/optuna/pruners/successive_halving.py
@@ -1,7 +1,7 @@
 import math
 
 from optuna.pruners.base import BasePruner
-from optuna.structs import TrialState
+from optuna.trial import TrialState
 from optuna.study import StudyDirection
 from optuna import type_checking
 
@@ -10,7 +10,7 @@ if type_checking.TYPE_CHECKING:
     from typing import Optional  # NOQA
     from typing import Union  # NOQA
 
-    from optuna.structs import FrozenTrial  # NOQA
+    from optuna.trial import FrozenTrial  # NOQA
     from optuna.study import Study  # NOQA
 
 

--- a/optuna/pruners/successive_halving.py
+++ b/optuna/pruners/successive_halving.py
@@ -10,8 +10,8 @@ if type_checking.TYPE_CHECKING:
     from typing import Optional  # NOQA
     from typing import Union  # NOQA
 
-    from optuna.trial import FrozenTrial  # NOQA
     from optuna.study import Study  # NOQA
+    from optuna.trial import FrozenTrial  # NOQA
 
 
 class SuccessiveHalvingPruner(BasePruner):

--- a/optuna/pruners/threshold.py
+++ b/optuna/pruners/threshold.py
@@ -111,7 +111,7 @@ class ThresholdPruner(BasePruner):
         self._n_warmup_steps = n_warmup_steps
         self._interval_steps = interval_steps
 
-    def prune(self, study: "optuna.study.Study", trial: optuna.structs.FrozenTrial) -> bool:
+    def prune(self, study: "optuna.study.Study", trial: optuna.trial.FrozenTrial) -> bool:
 
         step = trial.last_step
         if step is None:

--- a/optuna/samplers/__init__.py
+++ b/optuna/samplers/__init__.py
@@ -39,7 +39,7 @@ def intersection_search_space(study, ordered_dict=False):
 
     search_space = None
     for trial in study.trials:
-        if trial.state != optuna.structs.TrialState.COMPLETE:
+        if trial.state != optuna.trial.TrialState.COMPLETE:
             continue
 
         if search_space is None:

--- a/optuna/samplers/base.py
+++ b/optuna/samplers/base.py
@@ -7,7 +7,7 @@ if type_checking.TYPE_CHECKING:
     from typing import Dict  # NOQA
 
     from optuna.distributions import BaseDistribution  # NOQA
-    from optuna.structs import FrozenTrial  # NOQA
+    from optuna.trial import FrozenTrial  # NOQA
     from optuna.study import Study  # NOQA
 
 

--- a/optuna/samplers/base.py
+++ b/optuna/samplers/base.py
@@ -7,8 +7,8 @@ if type_checking.TYPE_CHECKING:
     from typing import Dict  # NOQA
 
     from optuna.distributions import BaseDistribution  # NOQA
-    from optuna.trial import FrozenTrial  # NOQA
     from optuna.study import Study  # NOQA
+    from optuna.trial import FrozenTrial  # NOQA
 
 
 class BaseSampler(object, metaclass=abc.ABCMeta):

--- a/optuna/samplers/cmaes.py
+++ b/optuna/samplers/cmaes.py
@@ -110,7 +110,7 @@ class CmaEsSampler(BaseSampler):
         self._cma_rng = np.random.RandomState(seed)
 
     def infer_relative_search_space(
-        self, study: "optuna.Study", trial: "optuna.structs.FrozenTrial",
+        self, study: "optuna.Study", trial: "optuna.trial.FrozenTrial",
     ) -> Dict[str, BaseDistribution]:
 
         search_space = {}  # type: Dict[str, BaseDistribution]
@@ -139,7 +139,7 @@ class CmaEsSampler(BaseSampler):
     def sample_relative(
         self,
         study: "optuna.Study",
-        trial: "optuna.structs.FrozenTrial",
+        trial: "optuna.trial.FrozenTrial",
         search_space: Dict[str, BaseDistribution],
     ) -> Dict[str, Any]:
 
@@ -213,7 +213,7 @@ class CmaEsSampler(BaseSampler):
 
     def _restore_or_init_optimizer(
         self,
-        completed_trials: "List[optuna.structs.FrozenTrial]",
+        completed_trials: "List[optuna.trial.FrozenTrial]",
         search_space: Dict[str, BaseDistribution],
         ordered_keys: List[str],
     ) -> CMA:
@@ -250,7 +250,7 @@ class CmaEsSampler(BaseSampler):
     def sample_independent(
         self,
         study: "optuna.Study",
-        trial: "optuna.structs.FrozenTrial",
+        trial: "optuna.trial.FrozenTrial",
         param_name: str,
         param_distribution: BaseDistribution,
     ) -> Any:

--- a/optuna/samplers/cmaes.py
+++ b/optuna/samplers/cmaes.py
@@ -12,8 +12,8 @@ import numpy as np
 import optuna
 from optuna.distributions import BaseDistribution
 from optuna.samplers import BaseSampler
-from optuna.structs import FrozenTrial
-from optuna.structs import TrialState
+from optuna.trial import FrozenTrial
+from optuna.trial import TrialState
 
 # Minimum value of sigma0 to avoid ZeroDivisionError.
 _MIN_SIGMA0 = 1e-10

--- a/optuna/samplers/grid.py
+++ b/optuna/samplers/grid.py
@@ -15,8 +15,8 @@ if type_checking.TYPE_CHECKING:
     from typing import Union
 
     from optuna.distributions import BaseDistribution  # NOQA
-    from optuna.trial import FrozenTrial  # NOQA
     from optuna.study import Study  # NOQA
+    from optuna.trial import FrozenTrial  # NOQA
 
     GridValueType = Union[str, float, int, bool, None]
 

--- a/optuna/samplers/grid.py
+++ b/optuna/samplers/grid.py
@@ -13,7 +13,7 @@ if type_checking.TYPE_CHECKING:
     from typing import Union
 
     from optuna.distributions import BaseDistribution  # NOQA
-    from optuna.structs import FrozenTrial  # NOQA
+    from optuna.trial import FrozenTrial  # NOQA
     from optuna.study import Study  # NOQA
 
     GridValueType = Union[str, float, int, bool, None]

--- a/optuna/samplers/random.py
+++ b/optuna/samplers/random.py
@@ -10,7 +10,7 @@ if type_checking.TYPE_CHECKING:
     from typing import Optional  # NOQA
 
     from optuna.distributions import BaseDistribution  # NOQA
-    from optuna.structs import FrozenTrial  # NOQA
+    from optuna.trial import FrozenTrial  # NOQA
     from optuna.study import Study  # NOQA
 
 

--- a/optuna/samplers/random.py
+++ b/optuna/samplers/random.py
@@ -10,8 +10,8 @@ if type_checking.TYPE_CHECKING:
     from typing import Optional  # NOQA
 
     from optuna.distributions import BaseDistribution  # NOQA
-    from optuna.trial import FrozenTrial  # NOQA
     from optuna.study import Study  # NOQA
+    from optuna.trial import FrozenTrial  # NOQA
 
 
 class RandomSampler(BaseSampler):

--- a/optuna/samplers/tpe/sampler.py
+++ b/optuna/samplers/tpe/sampler.py
@@ -22,7 +22,7 @@ if type_checking.TYPE_CHECKING:
     from typing import Tuple  # NOQA
 
     from optuna.distributions import BaseDistribution  # NOQA
-    from optuna.structs import FrozenTrial  # NOQA
+    from optuna.trial import FrozenTrial  # NOQA
     from optuna.study import Study  # NOQA
 
 EPS = 1e-12

--- a/optuna/samplers/tpe/sampler.py
+++ b/optuna/samplers/tpe/sampler.py
@@ -9,8 +9,8 @@ from optuna.samplers import base
 from optuna.samplers import random
 from optuna.samplers.tpe.parzen_estimator import _ParzenEstimator
 from optuna.samplers.tpe.parzen_estimator import _ParzenEstimatorParameters
-from optuna import structs
 from optuna.study import StudyDirection
+from optuna.trial import TrialState
 from optuna import type_checking
 
 if type_checking.TYPE_CHECKING:
@@ -577,9 +577,9 @@ def _get_observation_pairs(study, param_name, trial):
         if param_name not in trial.params:
             continue
 
-        if trial.state is structs.TrialState.COMPLETE and trial.value is not None:
+        if trial.state is TrialState.COMPLETE and trial.value is not None:
             score = (-float("inf"), sign * trial.value)
-        elif trial.state is structs.TrialState.PRUNED:
+        elif trial.state is TrialState.PRUNED:
             if len(trial.intermediate_values) > 0:
                 step, intermediate_value = max(trial.intermediate_values.items())
                 if math.isnan(intermediate_value):

--- a/optuna/samplers/tpe/sampler.py
+++ b/optuna/samplers/tpe/sampler.py
@@ -22,8 +22,8 @@ if type_checking.TYPE_CHECKING:
     from typing import Tuple  # NOQA
 
     from optuna.distributions import BaseDistribution  # NOQA
-    from optuna.trial import FrozenTrial  # NOQA
     from optuna.study import Study  # NOQA
+    from optuna.trial import FrozenTrial  # NOQA
 
 EPS = 1e-12
 

--- a/optuna/storages/base.py
+++ b/optuna/storages/base.py
@@ -1,8 +1,8 @@
 import abc
 import copy
 
-from optuna import structs
 from optuna import study
+from optuna.trial import TrialState
 from optuna import type_checking
 
 if type_checking.TYPE_CHECKING:
@@ -12,6 +12,7 @@ if type_checking.TYPE_CHECKING:
     from typing import Optional  # NOQA
 
     from optuna import distributions  # NOQA
+    from optuna.trial import FrozenTrial  # NOQA
 
 DEFAULT_STUDY_NAME_PREFIX = "no-name-"
 
@@ -105,13 +106,13 @@ class BaseStorage(object, metaclass=abc.ABCMeta):
 
     @abc.abstractmethod
     def create_new_trial(self, study_id, template_trial=None):
-        # type: (int, Optional[structs.FrozenTrial]) -> int
+        # type: (int, Optional[FrozenTrial]) -> int
 
         raise NotImplementedError
 
     @abc.abstractmethod
     def set_trial_state(self, trial_id, state):
-        # type: (int, structs.TrialState) -> bool
+        # type: (int, TrialState) -> bool
 
         raise NotImplementedError
 
@@ -161,27 +162,27 @@ class BaseStorage(object, metaclass=abc.ABCMeta):
 
     @abc.abstractmethod
     def get_trial(self, trial_id):
-        # type: (int) -> structs.FrozenTrial
+        # type: (int) -> FrozenTrial
 
         raise NotImplementedError
 
     @abc.abstractmethod
     def get_all_trials(self, study_id, deepcopy=True):
-        # type: (int, bool) -> List[structs.FrozenTrial]
+        # type: (int, bool) -> List[FrozenTrial]
 
         raise NotImplementedError
 
     @abc.abstractmethod
     def get_n_trials(self, study_id, state=None):
-        # type: (int, Optional[structs.TrialState]) -> int
+        # type: (int, Optional[TrialState]) -> int
 
         raise NotImplementedError
 
     def get_best_trial(self, study_id):
-        # type: (int) -> structs.FrozenTrial
+        # type: (int) -> FrozenTrial
 
         all_trials = self.get_all_trials(study_id, deepcopy=False)
-        all_trials = [t for t in all_trials if t.state is structs.TrialState.COMPLETE]
+        all_trials = [t for t in all_trials if t.state is TrialState.COMPLETE]
 
         if len(all_trials) == 0:
             raise ValueError("No trials are completed yet.")
@@ -214,7 +215,7 @@ class BaseStorage(object, metaclass=abc.ABCMeta):
         pass
 
     def check_trial_is_updatable(self, trial_id, trial_state):
-        # type: (int, structs.TrialState) -> None
+        # type: (int, TrialState) -> None
 
         if trial_state.is_finished():
             trial = self.get_trial(trial_id)

--- a/optuna/storages/rdb/models.py
+++ b/optuna/storages/rdb/models.py
@@ -16,7 +16,7 @@ from sqlalchemy import String
 from sqlalchemy import UniqueConstraint
 
 from optuna import distributions
-from optuna.structs import TrialState
+from optuna.trial import TrialState
 from optuna.study import StudyDirection
 from optuna import type_checking
 

--- a/optuna/storages/rdb/models.py
+++ b/optuna/storages/rdb/models.py
@@ -16,8 +16,8 @@ from sqlalchemy import String
 from sqlalchemy import UniqueConstraint
 
 from optuna import distributions
-from optuna.trial import TrialState
 from optuna.study import StudyDirection
+from optuna.trial import TrialState
 from optuna import type_checking
 
 if type_checking.TYPE_CHECKING:

--- a/optuna/storages/rdb/storage.py
+++ b/optuna/storages/rdb/storage.py
@@ -24,9 +24,10 @@ from optuna import distributions
 from optuna.storages.base import BaseStorage
 from optuna.storages.base import DEFAULT_STUDY_NAME_PREFIX
 from optuna.storages.rdb import models
-from optuna import structs
 from optuna.study import StudyDirection
 from optuna.study import StudySummary
+from optuna.trial import FrozenTrial
+from optuna.trial import TrialState
 from optuna import type_checking
 from optuna import version
 
@@ -356,7 +357,7 @@ class RDBStorage(BaseStorage):
 
             # Get best trial.
             completed_trial_models = [
-                t for t in study_trial_models if t.state is structs.TrialState.COMPLETE
+                t for t in study_trial_models if t.state is TrialState.COMPLETE
             ]
             best_trial = None
             if len(completed_trial_models) > 0:
@@ -421,20 +422,18 @@ class RDBStorage(BaseStorage):
         return study_summaries
 
     def create_new_trial(self, study_id, template_trial=None):
-        # type: (int, Optional[structs.FrozenTrial]) -> int
+        # type: (int, Optional[FrozenTrial]) -> int
 
         session = self.scoped_session()
 
         if template_trial is None:
-            trial = models.TrialModel(
-                study_id=study_id, number=None, state=structs.TrialState.RUNNING,
-            )
+            trial = models.TrialModel(study_id=study_id, number=None, state=TrialState.RUNNING,)
         else:
             # Because only `RUNNING` trials can be updated,
             # we temporarily set the state of the new trial to `RUNNING`.
             # After all fields of the trial have been updated,
             # the state is set to `template_trial.state`.
-            temp_state = structs.TrialState.RUNNING
+            temp_state = TrialState.RUNNING
 
             trial = models.TrialModel(
                 study_id=study_id,
@@ -483,7 +482,7 @@ class RDBStorage(BaseStorage):
         return trial.trial_id
 
     def set_trial_state(self, trial_id, state):
-        # type: (int, structs.TrialState) -> bool
+        # type: (int, TrialState) -> bool
 
         session = self.scoped_session()
 
@@ -494,7 +493,7 @@ class RDBStorage(BaseStorage):
 
         self.check_trial_is_updatable(trial_id, trial.state)
 
-        if state == structs.TrialState.RUNNING and trial.state != structs.TrialState.WAITING:
+        if state == TrialState.RUNNING and trial.state != TrialState.WAITING:
             session.rollback()
             return False
 
@@ -667,12 +666,12 @@ class RDBStorage(BaseStorage):
         return trial_number
 
     def get_trial(self, trial_id):
-        # type: (int) -> structs.FrozenTrial
+        # type: (int) -> FrozenTrial
 
         return self._get_and_cache_trial(trial_id)
 
     def _get_and_cache_trial(self, trial_id, deepcopy=True):
-        # type: (int, bool) -> structs.FrozenTrial
+        # type: (int, bool) -> FrozenTrial
 
         cached_trial = self._finished_trials_cache.get_cached_trial(trial_id)
         if cached_trial is not None:
@@ -701,7 +700,7 @@ class RDBStorage(BaseStorage):
         return frozen_trial
 
     def get_all_trials(self, study_id, deepcopy=True):
-        # type: (int, bool) -> List[structs.FrozenTrial]
+        # type: (int, bool) -> List[FrozenTrial]
 
         if self._finished_trials_cache.is_empty():
             trials = self._get_all_trials_without_cache(study_id)
@@ -715,7 +714,7 @@ class RDBStorage(BaseStorage):
         return trials
 
     def get_best_trial(self, study_id):
-        # type: (int) -> structs.FrozenTrial
+        # type: (int) -> FrozenTrial
 
         session = self.scoped_session()
         if self.get_study_direction(study_id) == StudyDirection.MAXIMIZE:
@@ -741,7 +740,7 @@ class RDBStorage(BaseStorage):
         return trial_ids
 
     def _get_all_trials_without_cache(self, study_id):
-        # type: (int) -> List[structs.FrozenTrial]
+        # type: (int) -> List[FrozenTrial]
 
         session = self.scoped_session()
 
@@ -761,7 +760,7 @@ class RDBStorage(BaseStorage):
         return all_trials
 
     def get_n_trials(self, study_id, state=None):
-        # type: (int, Optional[structs.TrialState]) -> int
+        # type: (int, Optional[TrialState]) -> int
 
         session = self.scoped_session()
         study = models.StudyModel.find_or_raise_by_id(study_id, session)
@@ -779,7 +778,7 @@ class RDBStorage(BaseStorage):
         trial_user_attrs,  # type: List[models.TrialUserAttributeModel]
         trial_system_attrs,  # type: List[models.TrialSystemAttributeModel]
     ):
-        # type: (...) -> List[structs.FrozenTrial]
+        # type: (...) -> List[FrozenTrial]
 
         id_to_trial = {}
         for trial in trials:
@@ -827,7 +826,7 @@ class RDBStorage(BaseStorage):
                 system_attrs[system_attr.key] = json.loads(system_attr.value_json)
 
             result.append(
-                structs.FrozenTrial(
+                FrozenTrial(
                     number=trial.number,
                     state=trial.state,
                     params=params,
@@ -1114,7 +1113,7 @@ class _FinishedTrialsCache(object):
     def __init__(self):
         # type: () -> None
 
-        self._finished_trials = {}  # type: Dict[int, structs.FrozenTrial]
+        self._finished_trials = {}  # type: Dict[int, FrozenTrial]
         self._lock = threading.Lock()
 
     def is_empty(self):
@@ -1124,14 +1123,14 @@ class _FinishedTrialsCache(object):
             return len(self._finished_trials) == 0
 
     def cache_trial_if_finished(self, trial):
-        # type: (structs.FrozenTrial) -> None
+        # type: (FrozenTrial) -> None
 
         if trial.state.is_finished():
             with self._lock:
                 self._finished_trials[trial._trial_id] = trial
 
     def get_cached_trial(self, trial_id):
-        # type: (int) -> Optional[structs.FrozenTrial]
+        # type: (int) -> Optional[FrozenTrial]
 
         with self._lock:
             return self._finished_trials.get(trial_id)

--- a/optuna/structs.py
+++ b/optuna/structs.py
@@ -22,7 +22,7 @@ _logger = logging.get_logger(__name__)
 # study.StudyDirection instead. See the API reference for more details.
 StudyDirection = _study_direction.StudyDirection
 
-# The use of the structs.TrialState is deprecated and it is recommended that you use
+# The use of the trial.TrialState is deprecated and it is recommended that you use
 # trial.TrialState instead. See the API reference for more details.
 TrialState = trial.TrialState
 

--- a/optuna/structs.py
+++ b/optuna/structs.py
@@ -22,7 +22,7 @@ _logger = logging.get_logger(__name__)
 # study.StudyDirection instead. See the API reference for more details.
 StudyDirection = _study_direction.StudyDirection
 
-# The use of the trial.TrialState is deprecated and it is recommended that you use
+# The use of the structs.TrialState is deprecated and it is recommended that you use
 # trial.TrialState instead. See the API reference for more details.
 TrialState = trial.TrialState
 

--- a/optuna/structs.py
+++ b/optuna/structs.py
@@ -1,9 +1,9 @@
-import enum
 import warnings
 
 from optuna import _study_direction
 from optuna import exceptions
 from optuna import logging
+from optuna import trial
 from optuna import type_checking
 
 if type_checking.TYPE_CHECKING:
@@ -22,41 +22,18 @@ _logger = logging.get_logger(__name__)
 # study.StudyDirection instead. See the API reference for more details.
 StudyDirection = _study_direction.StudyDirection
 
-
-class TrialState(enum.Enum):
-    """State of a :class:`~optuna.trial.Trial`.
-
-    Attributes:
-        RUNNING:
-            The :class:`~optuna.trial.Trial` is running.
-        COMPLETE:
-            The :class:`~optuna.trial.Trial` has been finished without any error.
-        PRUNED:
-            The :class:`~optuna.trial.Trial` has been pruned with
-            :class:`~optuna.exceptions.TrialPruned`.
-        FAIL:
-            The :class:`~optuna.trial.Trial` has failed due to an uncaught error.
-    """
-
-    RUNNING = 0
-    COMPLETE = 1
-    PRUNED = 2
-    FAIL = 3
-    WAITING = 4
-
-    def __repr__(self):
-        # type: () -> str
-
-        return str(self)
-
-    def is_finished(self):
-        # type: () -> bool
-
-        return self != TrialState.RUNNING and self != TrialState.WAITING
+# The use of the structs.TrialState is deprecated and it is recommended that you use
+# trial.TrialState instead. See the API reference for more details.
+TrialState = trial.TrialState
 
 
 class FrozenTrial(object):
     """Status and results of a :class:`~optuna.trial.Trial`.
+
+    .. deprecated:: 1.4.0
+
+        This class was moved to :mod:`~optuna.trial`. Please use
+        :class:`~optuna.trial.FrozenTrial` instead.
 
     Attributes:
         number:
@@ -94,6 +71,13 @@ class FrozenTrial(object):
         trial_id,  # type: int
     ):
         # type: (...) -> None
+
+        message = (
+            "The use of `structs.FrozenTrial` is deprecated. "
+            "Please use `trial.FrozenTrial` instead."
+        )
+        warnings.warn(message, DeprecationWarning)
+        _logger.warning(message)
 
         self.number = number
         self.state = state
@@ -305,7 +289,7 @@ class StudySummary(object):
         # type: (...) -> None
 
         message = (
-            "The use of `study.StudySummary` is deprecated. "
+            "The use of `structs.StudySummary` is deprecated. "
             "Please use `study.StudySummary` instead."
         )
         warnings.warn(message, DeprecationWarning)

--- a/optuna/testing/integration.py
+++ b/optuna/testing/integration.py
@@ -8,7 +8,7 @@ class DeterministicPruner(optuna.pruners.BasePruner):
         self.is_pruning = is_pruning
 
     def prune(self, study, trial):
-        # type: (optuna.study.Study, optuna.structs.FrozenTrial) -> bool
+        # type: (optuna.study.Study, optuna.trial.FrozenTrial) -> bool
 
         return self.is_pruning
 

--- a/optuna/testing/sampler.py
+++ b/optuna/testing/sampler.py
@@ -6,8 +6,8 @@ if optuna.type_checking.TYPE_CHECKING:
     from typing import Dict  # NOQA
 
     from optuna.distributions import BaseDistribution  # NOQA
-    from optuna.trial import FrozenTrial  # NOQA
     from optuna.study import Study  # NOQA
+    from optuna.trial import FrozenTrial  # NOQA
 
 
 class DeterministicRelativeSampler(optuna.samplers.BaseSampler):

--- a/optuna/testing/sampler.py
+++ b/optuna/testing/sampler.py
@@ -6,7 +6,7 @@ if optuna.type_checking.TYPE_CHECKING:
     from typing import Dict  # NOQA
 
     from optuna.distributions import BaseDistribution  # NOQA
-    from optuna.structs import FrozenTrial  # NOQA
+    from optuna.trial import FrozenTrial  # NOQA
     from optuna.study import Study  # NOQA
 
 

--- a/optuna/trial.py
+++ b/optuna/trial.py
@@ -1,6 +1,8 @@
 import abc
 from datetime import datetime
+from datetime import timedelta
 import decimal
+import enum
 import warnings
 
 from optuna import distributions
@@ -21,6 +23,247 @@ if type_checking.TYPE_CHECKING:
     FloatingPointDistributionType = Union[
         distributions.UniformDistribution, distributions.LogUniformDistribution
     ]
+
+_logger = logging.get_logger(__name__)
+
+
+class TrialState(enum.Enum):
+    """State of a :class:`~optuna.trial.Trial`.
+
+    Attributes:
+        RUNNING:
+            The :class:`~optuna.trial.Trial` is running.
+        COMPLETE:
+            The :class:`~optuna.trial.Trial` has been finished without any error.
+        PRUNED:
+            The :class:`~optuna.trial.Trial` has been pruned with
+            :class:`~optuna.exceptions.TrialPruned`.
+        FAIL:
+            The :class:`~optuna.trial.Trial` has failed due to an uncaught error.
+    """
+
+    RUNNING = 0
+    COMPLETE = 1
+    PRUNED = 2
+    FAIL = 3
+    WAITING = 4
+
+    def __repr__(self):
+        # type: () -> str
+
+        return str(self)
+
+    def is_finished(self):
+        # type: () -> bool
+
+        return self != TrialState.RUNNING and self != TrialState.WAITING
+
+
+class FrozenTrial(object):
+    """Status and results of a :class:`~optuna.trial.Trial`.
+
+    Attributes:
+        number:
+            Unique and consecutive number of :class:`~optuna.trial.Trial` for each
+            :class:`~optuna.study.Study`. Note that this field uses zero-based numbering.
+        state:
+            :class:`TrialState` of the :class:`~optuna.trial.Trial`.
+        value:
+            Objective value of the :class:`~optuna.trial.Trial`.
+        datetime_start:
+            Datetime where the :class:`~optuna.trial.Trial` started.
+        datetime_complete:
+            Datetime where the :class:`~optuna.trial.Trial` finished.
+        params:
+            Dictionary that contains suggested parameters.
+        user_attrs:
+            Dictionary that contains the attributes of the :class:`~optuna.trial.Trial` set with
+            :func:`optuna.trial.Trial.set_user_attr`.
+        intermediate_values:
+            Intermediate objective values set with :func:`optuna.trial.Trial.report`.
+    """
+
+    def __init__(
+        self,
+        number,  # type: int
+        state,  # type: TrialState
+        value,  # type: Optional[float]
+        datetime_start,  # type: Optional[datetime]
+        datetime_complete,  # type: Optional[datetime]
+        params,  # type: Dict[str, Any]
+        distributions,  # type: Dict[str, BaseDistribution]
+        user_attrs,  # type: Dict[str, Any]
+        system_attrs,  # type: Dict[str, Any]
+        intermediate_values,  # type: Dict[int, float]
+        trial_id,  # type: int
+    ):
+        # type: (...) -> None
+
+        self.number = number
+        self.state = state
+        self.value = value
+        self.datetime_start = datetime_start
+        self.datetime_complete = datetime_complete
+        self.params = params
+        self.user_attrs = user_attrs
+        self.system_attrs = system_attrs
+        self.intermediate_values = intermediate_values
+        self._distributions = distributions
+        self._trial_id = trial_id
+
+    # Ordered list of fields required for `__repr__`, `__hash__` and dataframe creation.
+    # TODO(hvy): Remove this list in Python 3.6 as the order of `self.__dict__` is preserved.
+    _ordered_fields = [
+        "number",
+        "value",
+        "datetime_start",
+        "datetime_complete",
+        "params",
+        "_distributions",
+        "user_attrs",
+        "system_attrs",
+        "intermediate_values",
+        "_trial_id",
+        "state",
+    ]
+
+    def __eq__(self, other):
+        # type: (Any) -> bool
+
+        if not isinstance(other, FrozenTrial):
+            return NotImplemented
+        return other.__dict__ == self.__dict__
+
+    def __lt__(self, other):
+        # type: (Any) -> bool
+
+        if not isinstance(other, FrozenTrial):
+            return NotImplemented
+
+        return self.number < other.number
+
+    def __le__(self, other):
+        # type: (Any) -> bool
+
+        if not isinstance(other, FrozenTrial):
+            return NotImplemented
+
+        return self.number <= other.number
+
+    def __hash__(self):
+        # type: () -> int
+
+        return hash(tuple(getattr(self, field) for field in self._ordered_fields))
+
+    def __repr__(self):
+        # type: () -> str
+
+        return "{cls}({kwargs})".format(
+            cls=self.__class__.__name__,
+            kwargs=", ".join(
+                "{field}={value}".format(
+                    field=field if not field.startswith("_") else field[1:],
+                    value=repr(getattr(self, field)),
+                )
+                for field in self._ordered_fields
+            ),
+        )
+
+    def _validate(self):
+        # type: () -> None
+
+        if self.datetime_start is None:
+            raise ValueError("`datetime_start` is supposed to be set.")
+
+        if self.state.is_finished():
+            if self.datetime_complete is None:
+                raise ValueError("`datetime_complete` is supposed to be set for a finished trial.")
+        else:
+            if self.datetime_complete is not None:
+                raise ValueError(
+                    "`datetime_complete` is supposed to be None for an unfinished trial."
+                )
+
+        if self.state == TrialState.COMPLETE and self.value is None:
+            raise ValueError("`value` is supposed to be set for a complete trial.")
+
+        if set(self.params.keys()) != set(self.distributions.keys()):
+            raise ValueError(
+                "Inconsistent parameters {} and distributions {}.".format(
+                    set(self.params.keys()), set(self.distributions.keys())
+                )
+            )
+
+        for param_name, param_value in self.params.items():
+            distribution = self.distributions[param_name]
+
+            param_value_in_internal_repr = distribution.to_internal_repr(param_value)
+            if not distribution._contains(param_value_in_internal_repr):
+                raise ValueError(
+                    "The value {} of parameter '{}' isn't contained in the distribution "
+                    "{}.".format(param_value, param_name, distribution)
+                )
+
+    @property
+    def distributions(self):
+        # type: () -> Dict[str, BaseDistribution]
+        """Dictionary that contains the distributions of :attr:`params`."""
+
+        return self._distributions
+
+    @distributions.setter
+    def distributions(self, value):
+        # type: (Dict[str, BaseDistribution]) -> None
+        self._distributions = value
+
+    @property
+    def trial_id(self):
+        # type: () -> int
+        """Return the trial ID.
+
+        .. deprecated:: 0.19.0
+            The direct use of this attribute is deprecated and it is recommended that you use
+            :attr:`~optuna.trial.FrozenTrial.number` instead.
+
+        Returns:
+            The trial ID.
+        """
+
+        warnings.warn(
+            "The use of `FrozenTrial.trial_id` is deprecated. "
+            "Please use `FrozenTrial.number` instead.",
+            DeprecationWarning,
+        )
+
+        _logger.warning(
+            "The use of `FrozenTrial.trial_id` is deprecated. "
+            "Please use `FrozenTrial.number` instead."
+        )
+
+        return self._trial_id
+
+    @property
+    def last_step(self):
+        # type: () -> Optional[int]
+
+        if len(self.intermediate_values) == 0:
+            return None
+        else:
+            return max(self.intermediate_values.keys())
+
+    @property
+    def duration(self):
+        # type: () -> Optional[timedelta]
+        """Return the elapsed time taken to complete the trial.
+
+        Returns:
+            The duration.
+        """
+
+        if self.datetime_start and self.datetime_complete:
+            return self.datetime_complete - self.datetime_start
+        else:
+            return None
 
 
 class BaseTrial(object, metaclass=abc.ABCMeta):
@@ -1062,8 +1305,7 @@ def _adjust_discrete_uniform_high(name, low, high, q):
 
     if d_r % d_q != decimal.Decimal("0"):
         high = float((d_r // d_q) * d_q + d_low)
-        logger = logging.get_logger(__name__)
-        logger.warning(
+        _logger.warning(
             "The range of parameter `{}` is not divisible by `q`, and is "
             "replaced by [{}, {}].".format(name, low, high)
         )

--- a/optuna/trial.py
+++ b/optuna/trial.py
@@ -1,6 +1,5 @@
 import abc
-from datetime import datetime
-from datetime import timedelta
+import datetime
 import decimal
 import enum
 import warnings
@@ -88,8 +87,8 @@ class FrozenTrial(object):
         number,  # type: int
         state,  # type: TrialState
         value,  # type: Optional[float]
-        datetime_start,  # type: Optional[datetime]
-        datetime_complete,  # type: Optional[datetime]
+        datetime_start,  # type: Optional[datetime.datetime]
+        datetime_complete,  # type: Optional[datetime.datetime]
         params,  # type: Dict[str, Any]
         distributions,  # type: Dict[str, BaseDistribution]
         user_attrs,  # type: Dict[str, Any]
@@ -253,7 +252,7 @@ class FrozenTrial(object):
 
     @property
     def duration(self):
-        # type: () -> Optional[timedelta]
+        # type: () -> Optional[datetime.timedelta]
         """Return the elapsed time taken to complete the trial.
 
         Returns:
@@ -348,7 +347,7 @@ class BaseTrial(object, metaclass=abc.ABCMeta):
 
     @property
     def datetime_start(self):
-        # type: () -> Optional[datetime]
+        # type: () -> Optional[datetime.datetime]
 
         raise NotImplementedError
 
@@ -1113,7 +1112,7 @@ class Trial(BaseTrial):
 
     @property
     def datetime_start(self):
-        # type: () -> Optional[datetime]
+        # type: () -> Optional[datetime.datetime]
         """Return start datetime.
 
         Returns:
@@ -1185,7 +1184,7 @@ class FixedTrial(BaseTrial):
         self._distributions = {}  # type: Dict[str, BaseDistribution]
         self._user_attrs = {}  # type: Dict[str, Any]
         self._system_attrs = {}  # type: Dict[str, Any]
-        self._datetime_start = datetime.now()
+        self._datetime_start = datetime.datetime.now()
         self._number = number
 
     def suggest_float(self, name, low, high, *, log=False):
@@ -1297,7 +1296,7 @@ class FixedTrial(BaseTrial):
 
     @property
     def datetime_start(self):
-        # type: () -> Optional[datetime]
+        # type: () -> Optional[datetime.datetime]
 
         return self._datetime_start
 

--- a/optuna/visualization/contour.py
+++ b/optuna/visualization/contour.py
@@ -1,7 +1,7 @@
 import math
 
 from optuna.logging import get_logger
-from optuna.structs import TrialState
+from optuna.trial import TrialState
 from optuna.study import StudyDirection
 from optuna import type_checking
 from optuna.visualization.utils import _check_plotly_availability
@@ -13,7 +13,7 @@ if type_checking.TYPE_CHECKING:
     from typing import Optional  # NOQA
     from typing import Tuple  # NOQA
 
-    from optuna.structs import FrozenTrial  # NOQA
+    from optuna.trial import FrozenTrial  # NOQA
     from optuna.study import Study  # NOQA
     from optuna.visualization.plotly_imports import Contour  # NOQA
     from optuna.visualization.plotly_imports import Scatter  # NOQA

--- a/optuna/visualization/contour.py
+++ b/optuna/visualization/contour.py
@@ -13,8 +13,8 @@ if type_checking.TYPE_CHECKING:
     from typing import Optional  # NOQA
     from typing import Tuple  # NOQA
 
-    from optuna.trial import FrozenTrial  # NOQA
     from optuna.study import Study  # NOQA
+    from optuna.trial import FrozenTrial  # NOQA
     from optuna.visualization.plotly_imports import Contour  # NOQA
     from optuna.visualization.plotly_imports import Scatter  # NOQA
 

--- a/optuna/visualization/contour.py
+++ b/optuna/visualization/contour.py
@@ -1,8 +1,8 @@
 import math
 
 from optuna.logging import get_logger
-from optuna.trial import TrialState
 from optuna.study import StudyDirection
+from optuna.trial import TrialState
 from optuna import type_checking
 from optuna.visualization.utils import _check_plotly_availability
 from optuna.visualization.utils import _is_log_scale

--- a/optuna/visualization/intermediate_values.py
+++ b/optuna/visualization/intermediate_values.py
@@ -1,5 +1,5 @@
 from optuna.logging import get_logger
-from optuna.structs import TrialState
+from optuna.trial import TrialState
 from optuna import type_checking
 from optuna.visualization.utils import _check_plotly_availability
 from optuna.visualization.utils import is_available

--- a/optuna/visualization/optimization_history.py
+++ b/optuna/visualization/optimization_history.py
@@ -1,6 +1,6 @@
 from optuna.logging import get_logger
-from optuna.trial import TrialState
 from optuna.study import StudyDirection
+from optuna.trial import TrialState
 from optuna import type_checking
 from optuna.visualization.utils import _check_plotly_availability
 from optuna.visualization.utils import is_available

--- a/optuna/visualization/optimization_history.py
+++ b/optuna/visualization/optimization_history.py
@@ -1,5 +1,5 @@
 from optuna.logging import get_logger
-from optuna.structs import TrialState
+from optuna.trial import TrialState
 from optuna.study import StudyDirection
 from optuna import type_checking
 from optuna.visualization.utils import _check_plotly_availability

--- a/optuna/visualization/parallel_coordinate.py
+++ b/optuna/visualization/parallel_coordinate.py
@@ -6,9 +6,9 @@ from typing import List
 from typing import Optional
 
 from optuna.logging import get_logger
-from optuna.trial import TrialState
 from optuna.study import Study
 from optuna.study import StudyDirection
+from optuna.trial import TrialState
 from optuna.visualization.utils import _check_plotly_availability
 from optuna.visualization.utils import is_available
 

--- a/optuna/visualization/parallel_coordinate.py
+++ b/optuna/visualization/parallel_coordinate.py
@@ -6,7 +6,7 @@ from typing import List
 from typing import Optional
 
 from optuna.logging import get_logger
-from optuna.structs import TrialState
+from optuna.trial import TrialState
 from optuna.study import Study
 from optuna.study import StudyDirection
 from optuna.visualization.utils import _check_plotly_availability

--- a/optuna/visualization/slice.py
+++ b/optuna/visualization/slice.py
@@ -9,8 +9,8 @@ if type_checking.TYPE_CHECKING:
     from typing import List  # NOQA
     from typing import Optional  # NOQA
 
-    from optuna.trial import FrozenTrial  # NOQA
     from optuna.study import Study  # NOQA
+    from optuna.trial import FrozenTrial  # NOQA
     from optuna.visualization.plotly_imports import Scatter  # NOQA
 
 if is_available():

--- a/optuna/visualization/slice.py
+++ b/optuna/visualization/slice.py
@@ -1,5 +1,5 @@
 from optuna.logging import get_logger
-from optuna.structs import TrialState
+from optuna.trial import TrialState
 from optuna import type_checking
 from optuna.visualization.utils import _check_plotly_availability
 from optuna.visualization.utils import _is_log_scale
@@ -9,7 +9,7 @@ if type_checking.TYPE_CHECKING:
     from typing import List  # NOQA
     from typing import Optional  # NOQA
 
-    from optuna.structs import FrozenTrial  # NOQA
+    from optuna.trial import FrozenTrial  # NOQA
     from optuna.study import Study  # NOQA
     from optuna.visualization.plotly_imports import Scatter  # NOQA
 

--- a/optuna/visualization/utils.py
+++ b/optuna/visualization/utils.py
@@ -5,7 +5,7 @@ from optuna.visualization import plotly_imports
 if type_checking.TYPE_CHECKING:
     from typing import List  # NOQA
 
-    from optuna.structs import FrozenTrial  # NOQA
+    from optuna.trial import FrozenTrial  # NOQA
 
 
 __all__ = ["is_available"]

--- a/tests/integration_tests/test_chainer.py
+++ b/tests/integration_tests/test_chainer.py
@@ -76,11 +76,11 @@ def test_chainer_pruning_extension():
 
     study = optuna.create_study(pruner=DeterministicPruner(True))
     study.optimize(objective, n_trials=1)
-    assert study.trials[0].state == optuna.structs.TrialState.PRUNED
+    assert study.trials[0].state == optuna.trial.TrialState.PRUNED
 
     study = optuna.create_study(pruner=DeterministicPruner(False))
     study.optimize(objective, n_trials=1)
-    assert study.trials[0].state == optuna.structs.TrialState.COMPLETE
+    assert study.trials[0].state == optuna.trial.TrialState.COMPLETE
     assert study.trials[0].value == 1.0
 
 

--- a/tests/integration_tests/test_chainermn.py
+++ b/tests/integration_tests/test_chainermn.py
@@ -10,7 +10,7 @@ from optuna.integration import ChainerMNStudy
 from optuna import pruners
 from optuna.storages import InMemoryStorage
 from optuna.storages import RDBStorage
-from optuna.structs import TrialState
+from optuna.trial import TrialState
 from optuna import Study
 from optuna.testing.integration import DeterministicPruner
 from optuna.testing.sampler import DeterministicRelativeSampler

--- a/tests/integration_tests/test_chainermn.py
+++ b/tests/integration_tests/test_chainermn.py
@@ -10,12 +10,12 @@ from optuna.integration import ChainerMNStudy
 from optuna import pruners
 from optuna.storages import InMemoryStorage
 from optuna.storages import RDBStorage
-from optuna.trial import TrialState
 from optuna import Study
 from optuna.testing.integration import DeterministicPruner
 from optuna.testing.sampler import DeterministicRelativeSampler
 from optuna.testing.storage import StorageSupplier
 from optuna.trial import Trial
+from optuna.trial import TrialState
 from optuna import type_checking
 
 if type_checking.TYPE_CHECKING:

--- a/tests/integration_tests/test_cma.py
+++ b/tests/integration_tests/test_cma.py
@@ -12,11 +12,11 @@ from optuna.distributions import IntUniformDistribution
 from optuna.distributions import LogUniformDistribution
 from optuna.distributions import UniformDistribution
 from optuna.integration.cma import _Optimizer
-from optuna.trial import FrozenTrial
-from optuna.trial import TrialState
 from optuna.study import StudyDirection
 from optuna.testing.distribution import UnsupportedDistribution
 from optuna.testing.sampler import DeterministicRelativeSampler
+from optuna.trial import FrozenTrial
+from optuna.trial import TrialState
 
 if optuna.type_checking.TYPE_CHECKING:
     from typing import Any  # NOQA

--- a/tests/integration_tests/test_cma.py
+++ b/tests/integration_tests/test_cma.py
@@ -12,8 +12,8 @@ from optuna.distributions import IntUniformDistribution
 from optuna.distributions import LogUniformDistribution
 from optuna.distributions import UniformDistribution
 from optuna.integration.cma import _Optimizer
-from optuna.structs import FrozenTrial
-from optuna.structs import TrialState
+from optuna.trial import FrozenTrial
+from optuna.trial import TrialState
 from optuna.study import StudyDirection
 from optuna.testing.distribution import UnsupportedDistribution
 from optuna.testing.sampler import DeterministicRelativeSampler

--- a/tests/integration_tests/test_fastai.py
+++ b/tests/integration_tests/test_fastai.py
@@ -73,9 +73,9 @@ def test_fastai_pruning_callback(tmpdir):
 
     study = optuna.create_study(pruner=DeterministicPruner(True))
     study.optimize(objective, n_trials=1)
-    assert study.trials[0].state == optuna.structs.TrialState.PRUNED
+    assert study.trials[0].state == optuna.trial.TrialState.PRUNED
 
     study = optuna.create_study(pruner=DeterministicPruner(False))
     study.optimize(objective, n_trials=1)
-    assert study.trials[0].state == optuna.structs.TrialState.COMPLETE
+    assert study.trials[0].state == optuna.trial.TrialState.COMPLETE
     assert study.trials[0].value == 1.0

--- a/tests/integration_tests/test_keras.py
+++ b/tests/integration_tests/test_keras.py
@@ -31,11 +31,11 @@ def test_keras_pruning_callback():
 
     study = optuna.create_study(pruner=DeterministicPruner(True))
     study.optimize(objective, n_trials=1)
-    assert study.trials[0].state == optuna.structs.TrialState.PRUNED
+    assert study.trials[0].state == optuna.trial.TrialState.PRUNED
 
     study = optuna.create_study(pruner=DeterministicPruner(False))
     study.optimize(objective, n_trials=1)
-    assert study.trials[0].state == optuna.structs.TrialState.COMPLETE
+    assert study.trials[0].state == optuna.trial.TrialState.COMPLETE
     assert study.trials[0].value == 1.0
 
 

--- a/tests/integration_tests/test_lightgbm.py
+++ b/tests/integration_tests/test_lightgbm.py
@@ -50,28 +50,28 @@ def test_lightgbm_pruning_callback(cv):
 
     study = optuna.create_study(pruner=DeterministicPruner(True))
     study.optimize(partial(objective, cv=cv), n_trials=1)
-    assert study.trials[0].state == optuna.structs.TrialState.PRUNED
+    assert study.trials[0].state == optuna.trial.TrialState.PRUNED
 
     study = optuna.create_study(pruner=DeterministicPruner(False))
     study.optimize(partial(objective, cv=cv), n_trials=1)
-    assert study.trials[0].state == optuna.structs.TrialState.COMPLETE
+    assert study.trials[0].state == optuna.trial.TrialState.COMPLETE
     assert study.trials[0].value == 1.0
 
     # Use non default validation name.
     custom_valid_name = "my_validation"
     study = optuna.create_study(pruner=DeterministicPruner(False))
     study.optimize(lambda trial: objective(trial, valid_name=custom_valid_name, cv=cv), n_trials=1)
-    assert study.trials[0].state == optuna.structs.TrialState.COMPLETE
+    assert study.trials[0].state == optuna.trial.TrialState.COMPLETE
     assert study.trials[0].value == 1.0
 
     # Check "maximize" direction.
     study = optuna.create_study(pruner=DeterministicPruner(True), direction="maximize")
     study.optimize(lambda trial: objective(trial, metric="auc", cv=cv), n_trials=1, catch=())
-    assert study.trials[0].state == optuna.structs.TrialState.PRUNED
+    assert study.trials[0].state == optuna.trial.TrialState.PRUNED
 
     study = optuna.create_study(pruner=DeterministicPruner(False), direction="maximize")
     study.optimize(lambda trial: objective(trial, metric="auc", cv=cv), n_trials=1, catch=())
-    assert study.trials[0].state == optuna.structs.TrialState.COMPLETE
+    assert study.trials[0].state == optuna.trial.TrialState.COMPLETE
     assert study.trials[0].value == 1.0
 
 

--- a/tests/integration_tests/test_mxnet.py
+++ b/tests/integration_tests/test_mxnet.py
@@ -54,11 +54,11 @@ def test_mxnet_pruning_callback():
 
     study = optuna.create_study(pruner=DeterministicPruner(True))
     study.optimize(lambda trial: objective(trial, "accuracy"), n_trials=1)
-    assert study.trials[0].state == optuna.structs.TrialState.PRUNED
+    assert study.trials[0].state == optuna.trial.TrialState.PRUNED
 
     study = optuna.create_study(pruner=DeterministicPruner(False))
     study.optimize(lambda trial: objective(trial, "accuracy"), n_trials=1)
-    assert study.trials[0].state == optuna.structs.TrialState.COMPLETE
+    assert study.trials[0].state == optuna.trial.TrialState.COMPLETE
     assert study.trials[0].value == 1.0
 
     with pytest.raises(ValueError):

--- a/tests/integration_tests/test_pytorch_lightning.py
+++ b/tests/integration_tests/test_pytorch_lightning.py
@@ -96,9 +96,9 @@ def test_pytorch_lightning_pruning_callback():
 
     study = optuna.create_study(pruner=DeterministicPruner(True))
     study.optimize(objective, n_trials=1)
-    assert study.trials[0].state == optuna.structs.TrialState.PRUNED
+    assert study.trials[0].state == optuna.trial.TrialState.PRUNED
 
     study = optuna.create_study(pruner=DeterministicPruner(False))
     study.optimize(objective, n_trials=1)
-    assert study.trials[0].state == optuna.structs.TrialState.COMPLETE
+    assert study.trials[0].state == optuna.trial.TrialState.COMPLETE
     assert study.trials[0].value == 1.0

--- a/tests/integration_tests/test_skopt.py
+++ b/tests/integration_tests/test_skopt.py
@@ -5,8 +5,9 @@ from skopt.space import space
 
 import optuna
 from optuna import distributions
-from optuna.trial import FrozenTrial
 from optuna.testing.sampler import DeterministicRelativeSampler
+from optuna.trial import FrozenTrial
+
 
 if optuna.type_checking.TYPE_CHECKING:
     from typing import Any  # NOQA
@@ -172,7 +173,7 @@ def _create_frozen_trial(params, param_distributions):
     return FrozenTrial(
         number=0,
         value=1.0,
-        state=optuna.structs.TrialState.COMPLETE,
+        state=optuna.trial.TrialState.COMPLETE,
         user_attrs={},
         system_attrs={},
         params=params,

--- a/tests/integration_tests/test_skopt.py
+++ b/tests/integration_tests/test_skopt.py
@@ -5,7 +5,7 @@ from skopt.space import space
 
 import optuna
 from optuna import distributions
-from optuna.structs import FrozenTrial
+from optuna.trial import FrozenTrial
 from optuna.testing.sampler import DeterministicRelativeSampler
 
 if optuna.type_checking.TYPE_CHECKING:

--- a/tests/integration_tests/test_tensorflow.py
+++ b/tests/integration_tests/test_tensorflow.py
@@ -51,11 +51,11 @@ def test_tensorflow_pruning_hook():
 
     study = optuna.create_study(pruner=DeterministicPruner(True), direction="maximize")
     study.optimize(objective, n_trials=1)
-    assert study.trials[0].state == optuna.structs.TrialState.PRUNED
+    assert study.trials[0].state == optuna.trial.TrialState.PRUNED
 
     study = optuna.create_study(pruner=DeterministicPruner(False), direction="maximize")
     study.optimize(objective, n_trials=1)
-    assert study.trials[0].state == optuna.structs.TrialState.COMPLETE
+    assert study.trials[0].state == optuna.trial.TrialState.COMPLETE
     assert study.trials[0].value == 1.0
 
     # Check if eval_metrics returns the None value.
@@ -65,4 +65,4 @@ def test_tensorflow_pruning_hook():
         study.optimize(objective, n_trials=1)
         assert mock_obj.call_count == 1
         assert math.isnan(study.trials[0].intermediate_values[10])
-        assert study.trials[0].state == optuna.structs.TrialState.PRUNED
+        assert study.trials[0].state == optuna.trial.TrialState.PRUNED

--- a/tests/integration_tests/test_tfkeras.py
+++ b/tests/integration_tests/test_tfkeras.py
@@ -37,11 +37,11 @@ def test_tfkeras_pruning_callback():
 
     study = optuna.create_study(pruner=DeterministicPruner(True))
     study.optimize(objective, n_trials=1)
-    assert study.trials[0].state == optuna.structs.TrialState.PRUNED
+    assert study.trials[0].state == optuna.trial.TrialState.PRUNED
 
     study = optuna.create_study(pruner=DeterministicPruner(False))
     study.optimize(objective, n_trials=1)
-    assert study.trials[0].state == optuna.structs.TrialState.COMPLETE
+    assert study.trials[0].state == optuna.trial.TrialState.COMPLETE
     assert study.trials[0].value == 1.0
 
 

--- a/tests/integration_tests/test_xgboost.py
+++ b/tests/integration_tests/test_xgboost.py
@@ -57,11 +57,11 @@ def test_xgboost_pruning_callback():
 
     study = optuna.create_study(pruner=DeterministicPruner(True))
     study.optimize(objective, n_trials=1)
-    assert study.trials[0].state == optuna.structs.TrialState.PRUNED
+    assert study.trials[0].state == optuna.trial.TrialState.PRUNED
 
     study = optuna.create_study(pruner=DeterministicPruner(False))
     study.optimize(objective, n_trials=1)
-    assert study.trials[0].state == optuna.structs.TrialState.COMPLETE
+    assert study.trials[0].state == optuna.trial.TrialState.COMPLETE
     assert study.trials[0].value == 1.0
 
 
@@ -83,9 +83,9 @@ def test_xgboost_pruning_callback_cv():
 
     study = optuna.create_study(pruner=DeterministicPruner(True))
     study.optimize(objective, n_trials=1)
-    assert study.trials[0].state == optuna.structs.TrialState.PRUNED
+    assert study.trials[0].state == optuna.trial.TrialState.PRUNED
 
     study = optuna.create_study(pruner=DeterministicPruner(False))
     study.optimize(objective, n_trials=1)
-    assert study.trials[0].state == optuna.structs.TrialState.COMPLETE
+    assert study.trials[0].state == optuna.trial.TrialState.COMPLETE
     assert study.trials[0].value == 1.0

--- a/tests/pruners_tests/test_median.py
+++ b/tests/pruners_tests/test_median.py
@@ -1,7 +1,7 @@
 import pytest
 
 import optuna
-from optuna.structs import TrialState
+from optuna.trial import TrialState
 from optuna import type_checking
 
 if type_checking.TYPE_CHECKING:

--- a/tests/pruners_tests/test_percentile.py
+++ b/tests/pruners_tests/test_percentile.py
@@ -4,7 +4,7 @@ import pytest
 
 import optuna
 from optuna.pruners import percentile
-from optuna.structs import TrialState
+from optuna.trial import TrialState
 from optuna.study import StudyDirection
 from optuna import type_checking
 

--- a/tests/pruners_tests/test_percentile.py
+++ b/tests/pruners_tests/test_percentile.py
@@ -4,8 +4,8 @@ import pytest
 
 import optuna
 from optuna.pruners import percentile
-from optuna.trial import TrialState
 from optuna.study import StudyDirection
+from optuna.trial import TrialState
 from optuna import type_checking
 
 if type_checking.TYPE_CHECKING:

--- a/tests/samplers_tests/test_samplers.py
+++ b/tests/samplers_tests/test_samplers.py
@@ -21,7 +21,7 @@ if optuna.type_checking.TYPE_CHECKING:
 
     from optuna.distributions import BaseDistribution  # NOQA
     from optuna.distributions import CategoricalChoiceType  # NOQA
-    from optuna.structs import FrozenTrial  # NOQA
+    from optuna.trial import FrozenTrial  # NOQA
     from optuna.study import Study  # NOQA
     from optuna.trial import Trial  # NOQA
 

--- a/tests/storages_tests/rdb_tests/test_models.py
+++ b/tests/storages_tests/rdb_tests/test_models.py
@@ -12,7 +12,7 @@ from optuna.storages.rdb.models import TrialModel
 from optuna.storages.rdb.models import TrialSystemAttributeModel
 from optuna.storages.rdb.models import TrialUserAttributeModel
 from optuna.storages.rdb.models import VersionInfoModel
-from optuna.structs import TrialState
+from optuna.trial import TrialState
 from optuna.study import StudyDirection
 
 

--- a/tests/storages_tests/rdb_tests/test_models.py
+++ b/tests/storages_tests/rdb_tests/test_models.py
@@ -12,8 +12,8 @@ from optuna.storages.rdb.models import TrialModel
 from optuna.storages.rdb.models import TrialSystemAttributeModel
 from optuna.storages.rdb.models import TrialUserAttributeModel
 from optuna.storages.rdb.models import VersionInfoModel
-from optuna.trial import TrialState
 from optuna.study import StudyDirection
+from optuna.trial import TrialState
 
 
 @pytest.fixture

--- a/tests/storages_tests/rdb_tests/test_storage.py
+++ b/tests/storages_tests/rdb_tests/test_storage.py
@@ -16,7 +16,7 @@ from optuna.storages.rdb.models import TrialModel
 from optuna.storages.rdb.models import TrialParamModel
 from optuna.storages.rdb.models import VersionInfoModel
 from optuna.storages import RDBStorage
-from optuna.structs import TrialState
+from optuna.trial import TrialState
 from optuna.study import StudyDirection
 from optuna.study import StudySummary
 from optuna import type_checking
@@ -29,7 +29,7 @@ if type_checking.TYPE_CHECKING:
     from typing import Optional  # NOQA
 
     from optuna.distributions import BaseDistribution  # NOQA
-    from optuna.structs import FrozenTrial  # NOQA
+    from optuna.trial import FrozenTrial  # NOQA
 
 
 def test_init():

--- a/tests/storages_tests/rdb_tests/test_storage.py
+++ b/tests/storages_tests/rdb_tests/test_storage.py
@@ -16,9 +16,9 @@ from optuna.storages.rdb.models import TrialModel
 from optuna.storages.rdb.models import TrialParamModel
 from optuna.storages.rdb.models import VersionInfoModel
 from optuna.storages import RDBStorage
-from optuna.trial import TrialState
 from optuna.study import StudyDirection
 from optuna.study import StudySummary
+from optuna.trial import TrialState
 from optuna import type_checking
 from optuna import version
 

--- a/tests/storages_tests/test_storages.py
+++ b/tests/storages_tests/test_storages.py
@@ -15,8 +15,8 @@ from optuna.storages import BaseStorage  # NOQA
 from optuna.storages import InMemoryStorage
 from optuna.storages import RDBStorage
 from optuna.storages import RedisStorage
-from optuna.structs import FrozenTrial
-from optuna.structs import TrialState
+from optuna.trial import FrozenTrial
+from optuna.trial import TrialState
 from optuna.study import StudyDirection
 from optuna.testing.storage import StorageSupplier
 from optuna import type_checking

--- a/tests/storages_tests/test_storages.py
+++ b/tests/storages_tests/test_storages.py
@@ -15,10 +15,10 @@ from optuna.storages import BaseStorage  # NOQA
 from optuna.storages import InMemoryStorage
 from optuna.storages import RDBStorage
 from optuna.storages import RedisStorage
-from optuna.trial import FrozenTrial
-from optuna.trial import TrialState
 from optuna.study import StudyDirection
 from optuna.testing.storage import StorageSupplier
+from optuna.trial import FrozenTrial
+from optuna.trial import TrialState
 from optuna import type_checking
 
 if type_checking.TYPE_CHECKING:

--- a/tests/test_structs.py
+++ b/tests/test_structs.py
@@ -6,9 +6,9 @@ import pytest
 import optuna
 from optuna.distributions import LogUniformDistribution
 from optuna.distributions import UniformDistribution
-from optuna.structs import FrozenTrial
+from optuna.trial import FrozenTrial
 from optuna.structs import StudySummary
-from optuna.structs import TrialState
+from optuna.trial import TrialState
 from optuna.study import StudyDirection
 
 if optuna.type_checking.TYPE_CHECKING:

--- a/tests/test_structs.py
+++ b/tests/test_structs.py
@@ -1,152 +1,31 @@
-import copy
 import datetime
 
 import pytest
 
-import optuna
-from optuna.distributions import LogUniformDistribution
 from optuna.distributions import UniformDistribution
-from optuna.trial import FrozenTrial
+from optuna.structs import FrozenTrial
+from optuna.structs import StudyDirection
 from optuna.structs import StudySummary
-from optuna.trial import TrialState
-from optuna.study import StudyDirection
-
-if optuna.type_checking.TYPE_CHECKING:
-    from typing import Any  # NOQA
-    from typing import Dict  # NOQA
-    from typing import List  # NOQA
-    from typing import Tuple  # NOQA
-
-    from optuna.distributions import BaseDistribution  # NOQA
+from optuna.structs import TrialState
 
 
-def test_frozen_trial_validate():
+def test_frozen_trial_deprecated():
     # type: () -> None
 
-    # Valid.
-    valid_trial = _create_frozen_trial()
-    valid_trial._validate()
-
-    # Invalid: `datetime_start` is not set.
-    invalid_trial = copy.copy(valid_trial)
-    invalid_trial.datetime_start = None
-    with pytest.raises(ValueError):
-        invalid_trial._validate()
-
-    # Invalid: `state` is `RUNNING` and `datetime_complete` is set.
-    invalid_trial = copy.copy(valid_trial)
-    invalid_trial.state = TrialState.RUNNING
-    with pytest.raises(ValueError):
-        invalid_trial._validate()
-
-    # Invalid: `state` is not `RUNNING` and `datetime_complete` is not set.
-    for state in [TrialState.COMPLETE, TrialState.PRUNED, TrialState.FAIL]:
-        invalid_trial = copy.copy(valid_trial)
-        invalid_trial.state = state
-        invalid_trial.datetime_complete = None
-        with pytest.raises(ValueError):
-            invalid_trial._validate()
-
-    # Invalid: `state` is `COMPLETE` and `value` is not set.
-    invalid_trial = copy.copy(valid_trial)
-    invalid_trial.value = None
-    with pytest.raises(ValueError):
-        invalid_trial._validate()
-
-    # Invalid: Inconsistent `params` and `distributions`
-    inconsistent_pairs = [
-        # `params` has an extra element.
-        ({"x": 0.1, "y": 0.5}, {"x": UniformDistribution(0, 1)}),
-        # `distributions` has an extra element.
-        ({"x": 0.1}, {"x": UniformDistribution(0, 1), "y": LogUniformDistribution(0, 1)}),
-        # The value of `x` isn't contained in the distribution.
-        ({"x": -0.5}, {"x": UniformDistribution(0, 1)}),
-    ]  # type: List[Tuple[Dict[str, Any], Dict[str, BaseDistribution]]]
-
-    for params, distributions in inconsistent_pairs:
-        invalid_trial = copy.copy(valid_trial)
-        invalid_trial.params = params
-        invalid_trial.distributions = distributions
-        with pytest.raises(ValueError):
-            invalid_trial._validate()
-
-
-def test_frozen_trial_eq_ne():
-    # type: () -> None
-
-    trial = _create_frozen_trial()
-
-    trial_other = copy.copy(trial)
-    assert trial == trial_other
-
-    trial_other.value = 0.3
-    assert trial != trial_other
-
-
-def test_frozen_trial_lt():
-    # type: () -> None
-
-    trial = _create_frozen_trial()
-
-    trial_other = copy.copy(trial)
-    assert not trial < trial_other
-
-    trial_other.number = trial.number + 1
-    assert trial < trial_other
-    assert not trial_other < trial
-
-    with pytest.raises(TypeError):
-        trial < 1
-
-    assert trial <= trial_other
-    assert not trial_other <= trial
-
-    with pytest.raises(TypeError):
-        trial <= 1
-
-    # A list of FrozenTrials is sortable.
-    trials = [trial_other, trial]
-    trials.sort()
-    assert trials[0] is trial
-    assert trials[1] is trial_other
-
-
-def _create_frozen_trial():
-    # type: () -> FrozenTrial
-
-    return FrozenTrial(
-        number=0,
-        trial_id=0,
-        state=TrialState.COMPLETE,
-        value=0.2,
-        datetime_start=datetime.datetime.now(),
-        datetime_complete=datetime.datetime.now(),
-        params={"x": 10},
-        distributions={"x": UniformDistribution(5, 12)},
-        user_attrs={},
-        system_attrs={},
-        intermediate_values={},
-    )
-
-
-def test_frozen_trial_repr():
-    # type: () -> None
-
-    trial = FrozenTrial(
-        number=0,
-        trial_id=0,
-        state=TrialState.COMPLETE,
-        value=0.2,
-        datetime_start=datetime.datetime.now(),
-        datetime_complete=datetime.datetime.now(),
-        params={"x": 10},
-        distributions={"x": UniformDistribution(5, 12)},
-        user_attrs={},
-        system_attrs={},
-        intermediate_values={},
-    )
-
-    assert trial == eval(repr(trial))
+    with pytest.deprecated_call():
+        FrozenTrial(
+            number=0,
+            trial_id=0,
+            state=TrialState.COMPLETE,
+            value=0.2,
+            datetime_start=datetime.datetime.now(),
+            datetime_complete=datetime.datetime.now(),
+            params={"x": 10},
+            distributions={"x": UniformDistribution(5, 12)},
+            user_attrs={},
+            system_attrs={},
+            intermediate_values={},
+        )
 
 
 def test_study_summary_deprecated():

--- a/tests/test_study.py
+++ b/tests/test_study.py
@@ -26,7 +26,7 @@ if type_checking.TYPE_CHECKING:
 
     from _pytest.recwarn import WarningsRecorder  # NOQA
 
-    CallbackFuncType = Callable[[optuna.study.Study, optuna.structs.FrozenTrial], None]
+    CallbackFuncType = Callable[[optuna.study.Study, optuna.trial.FrozenTrial], None]
 
 STORAGE_MODES = [
     "none",  # We give `None` to storage argument, so InMemoryStorage is used.
@@ -97,9 +97,9 @@ def check_value(value):
 
 
 def check_frozen_trial(frozen_trial):
-    # type: (optuna.structs.FrozenTrial) -> None
+    # type: (optuna.trial.FrozenTrial) -> None
 
-    if frozen_trial.state == optuna.structs.TrialState.COMPLETE:
+    if frozen_trial.state == optuna.trial.TrialState.COMPLETE:
         check_params(frozen_trial.params)
         check_value(frozen_trial.value)
 
@@ -110,7 +110,7 @@ def check_study(study):
     for trial in study.trials:
         check_frozen_trial(trial)
 
-    complete_trials = [t for t in study.trials if t.state == optuna.structs.TrialState.COMPLETE]
+    complete_trials = [t for t in study.trials if t.state == optuna.trial.TrialState.COMPLETE]
     if len(complete_trials) == 0:
         with pytest.raises(ValueError):
             study.best_params
@@ -230,18 +230,18 @@ def test_optimize_with_catch(storage_mode):
         with pytest.raises(ValueError):
             study.optimize(func_value_error, n_trials=20)
         assert len(study.trials) == 1
-        assert all(trial.state == optuna.structs.TrialState.FAIL for trial in study.trials)
+        assert all(trial.state == optuna.trial.TrialState.FAIL for trial in study.trials)
 
         # Test acceptable exception.
         study.optimize(func_value_error, n_trials=20, catch=(ValueError,))
         assert len(study.trials) == 21
-        assert all(trial.state == optuna.structs.TrialState.FAIL for trial in study.trials)
+        assert all(trial.state == optuna.trial.TrialState.FAIL for trial in study.trials)
 
         # Test trial with unacceptable exception.
         with pytest.raises(ValueError):
             study.optimize(func_value_error, n_trials=20, catch=(ArithmeticError,))
         assert len(study.trials) == 22
-        assert all(trial.state == optuna.structs.TrialState.FAIL for trial in study.trials)
+        assert all(trial.state == optuna.trial.TrialState.FAIL for trial in study.trials)
 
 
 @pytest.mark.parametrize("catch", [[], [Exception], None, 1])
@@ -385,7 +385,7 @@ def test_run_trial(storage_mode):
             "Setting status of trial#1 as TrialState.FAIL because of the "
             "following error: ValueError()"
         )
-        assert frozen_trial.state == optuna.structs.TrialState.FAIL
+        assert frozen_trial.state == optuna.trial.TrialState.FAIL
         assert frozen_trial.system_attrs["fail_reason"] == expected_message
 
         # Test trial with unacceptable exception.
@@ -406,7 +406,7 @@ def test_run_trial(storage_mode):
             "value from the objective function cannot be casted to float. "
             "Returned value is: None"
         )
-        assert frozen_trial.state == optuna.structs.TrialState.FAIL
+        assert frozen_trial.state == optuna.trial.TrialState.FAIL
         assert frozen_trial.system_attrs["fail_reason"] == expected_message
 
         # Test trial with invalid objective value: nan
@@ -422,7 +422,7 @@ def test_run_trial(storage_mode):
             "Setting status of trial#4 as TrialState.FAIL because the objective "
             "function returned nan."
         )
-        assert frozen_trial.state == optuna.structs.TrialState.FAIL
+        assert frozen_trial.state == optuna.trial.TrialState.FAIL
         assert frozen_trial.system_attrs["fail_reason"] == expected_message
 
 
@@ -447,7 +447,7 @@ def test_run_trial_with_trial_pruned(trial_pruned_class, report_value):
     trial = study._run_trial(func_with_trial_pruned, catch=(), gc_after_trial=True)
     frozen_trial = study._storage.get_trial(trial._trial_id)
     assert frozen_trial.value == report_value
-    assert frozen_trial.state == optuna.structs.TrialState.PRUNED
+    assert frozen_trial.state == optuna.trial.TrialState.PRUNED
 
 
 def test_study_pickle():
@@ -805,7 +805,7 @@ def test_callbacks(n_jobs):
         # type: (CallbackFuncType) -> CallbackFuncType
 
         def callback(study, trial):
-            # type: (optuna.study.Study, optuna.structs.FrozenTrial) -> None
+            # type: (optuna.study.Study, optuna.trial.FrozenTrial) -> None
 
             with lock:
                 f(study, trial)
@@ -850,7 +850,7 @@ def test_callbacks(n_jobs):
         n_jobs=n_jobs,
         catch=(ZeroDivisionError,),
     )
-    assert states == [optuna.structs.TrialState.FAIL] * 10
+    assert states == [optuna.trial.TrialState.FAIL] * 10
 
     # If a trial is failed with an exception and the exception isn't caught by the study,
     # callbacks aren't invoked.

--- a/tests/test_trial.py
+++ b/tests/test_trial.py
@@ -1,3 +1,5 @@
+import copy
+import datetime
 import math
 import warnings
 
@@ -6,19 +8,31 @@ from mock import patch
 import numpy as np
 import pytest
 
-from optuna import distributions
+from optuna.distributions import CategoricalDistribution
+from optuna.distributions import DiscreteUniformDistribution
+from optuna.distributions import IntUniformDistribution
+from optuna.distributions import LogUniformDistribution
+from optuna.distributions import UniformDistribution
 from optuna import samplers
 from optuna import storages
 from optuna.study import create_study
 from optuna.testing.integration import DeterministicPruner
 from optuna.testing.sampler import DeterministicRelativeSampler
 from optuna.trial import FixedTrial
+from optuna.trial import FrozenTrial
 from optuna.trial import Trial
+from optuna.trial import TrialState
 from optuna import type_checking
 
 if type_checking.TYPE_CHECKING:
-    from datetime import datetime  # NOQA
-    import typing  # NOQA
+    from typing import Any  # NOQA
+    from typing import Callable  # NOQA
+    from typing import Dict  # NOQA
+    from typing import List  # NOQA
+    from typing import Optional  # NOQA
+    from typing import Tuple  # NOQA
+
+    from optuna.distributions import BaseDistribution  # NOQA
 
 parametrize_storage = pytest.mark.parametrize(
     "storage_init_func",
@@ -28,7 +42,7 @@ parametrize_storage = pytest.mark.parametrize(
 
 @parametrize_storage
 def test_check_distribution_suggest_float(storage_init_func):
-    # type: (typing.Callable[[], storages.BaseStorage]) -> None
+    # type: (Callable[[], storages.BaseStorage]) -> None
 
     sampler = samplers.RandomSampler()
     study = create_study(storage_init_func(), sampler=sampler)
@@ -47,7 +61,7 @@ def test_check_distribution_suggest_float(storage_init_func):
 
 @parametrize_storage
 def test_check_distribution_suggest_uniform(storage_init_func):
-    # type: (typing.Callable[[], storages.BaseStorage]) -> None
+    # type: (Callable[[], storages.BaseStorage]) -> None
 
     sampler = samplers.RandomSampler()
     study = create_study(storage_init_func(), sampler=sampler)
@@ -64,7 +78,7 @@ def test_check_distribution_suggest_uniform(storage_init_func):
 
 @parametrize_storage
 def test_check_distribution_suggest_loguniform(storage_init_func):
-    # type: (typing.Callable[[], storages.BaseStorage]) -> None
+    # type: (Callable[[], storages.BaseStorage]) -> None
 
     sampler = samplers.RandomSampler()
     study = create_study(storage_init_func(), sampler=sampler)
@@ -81,7 +95,7 @@ def test_check_distribution_suggest_loguniform(storage_init_func):
 
 @parametrize_storage
 def test_check_distribution_suggest_discrete_uniform(storage_init_func):
-    # type: (typing.Callable[[], storages.BaseStorage]) -> None
+    # type: (Callable[[], storages.BaseStorage]) -> None
 
     sampler = samplers.RandomSampler()
     study = create_study(storage_init_func(), sampler=sampler)
@@ -98,7 +112,7 @@ def test_check_distribution_suggest_discrete_uniform(storage_init_func):
 
 @parametrize_storage
 def test_check_distribution_suggest_int(storage_init_func):
-    # type: (typing.Callable[[], storages.BaseStorage]) -> None
+    # type: (Callable[[], storages.BaseStorage]) -> None
 
     sampler = samplers.RandomSampler()
     study = create_study(storage_init_func(), sampler=sampler)
@@ -115,7 +129,7 @@ def test_check_distribution_suggest_int(storage_init_func):
 
 @parametrize_storage
 def test_suggest_uniform(storage_init_func):
-    # type: (typing.Callable[[], storages.BaseStorage]) -> None
+    # type: (Callable[[], storages.BaseStorage]) -> None
 
     mock = Mock()
     mock.side_effect = [1.0, 2.0, 3.0]
@@ -124,7 +138,7 @@ def test_suggest_uniform(storage_init_func):
     with patch.object(sampler, "sample_independent", mock) as mock_object:
         study = create_study(storage_init_func(), sampler=sampler)
         trial = Trial(study, study._storage.create_new_trial(study._study_id))
-        distribution = distributions.UniformDistribution(low=0.0, high=3.0)
+        distribution = UniformDistribution(low=0.0, high=3.0)
 
         assert trial._suggest("x", distribution) == 1.0  # Test suggesting a param.
         assert trial._suggest("x", distribution) == 1.0  # Test suggesting the same param.
@@ -135,7 +149,7 @@ def test_suggest_uniform(storage_init_func):
 
 @parametrize_storage
 def test_suggest_discrete_uniform(storage_init_func):
-    # type: (typing.Callable[[], storages.BaseStorage]) -> None
+    # type: (Callable[[], storages.BaseStorage]) -> None
 
     mock = Mock()
     mock.side_effect = [1.0, 2.0, 3.0]
@@ -144,7 +158,7 @@ def test_suggest_discrete_uniform(storage_init_func):
     with patch.object(sampler, "sample_independent", mock) as mock_object:
         study = create_study(storage_init_func(), sampler=sampler)
         trial = Trial(study, study._storage.create_new_trial(study._study_id))
-        distribution = distributions.DiscreteUniformDistribution(low=0.0, high=3.0, q=1.0)
+        distribution = DiscreteUniformDistribution(low=0.0, high=3.0, q=1.0)
 
         assert trial._suggest("x", distribution) == 1.0  # Test suggesting a param.
         assert trial._suggest("x", distribution) == 1.0  # Test suggesting the same param.
@@ -155,7 +169,7 @@ def test_suggest_discrete_uniform(storage_init_func):
 
 @parametrize_storage
 def test_suggest_low_equals_high(storage_init_func):
-    # type: (typing.Callable[[], storages.BaseStorage]) -> None
+    # type: (Callable[[], storages.BaseStorage]) -> None
 
     study = create_study(storage_init_func(), sampler=samplers.TPESampler(n_startup_trials=0))
     trial = Trial(study, study._storage.create_new_trial(study._study_id))
@@ -203,7 +217,7 @@ def test_suggest_low_equals_high(storage_init_func):
     ],
 )
 def test_suggest_discrete_uniform_range(storage_init_func, range_config):
-    # type: (typing.Callable[[], storages.BaseStorage], typing.Dict[str, float]) -> None
+    # type: (Callable[[], storages.BaseStorage], Dict[str, float]) -> None
 
     sampler = samplers.RandomSampler()
 
@@ -236,7 +250,7 @@ def test_suggest_discrete_uniform_range(storage_init_func, range_config):
 
 @parametrize_storage
 def test_suggest_int(storage_init_func):
-    # type: (typing.Callable[[], storages.BaseStorage]) -> None
+    # type: (Callable[[], storages.BaseStorage]) -> None
 
     mock = Mock()
     mock.side_effect = [1, 2, 3]
@@ -245,7 +259,7 @@ def test_suggest_int(storage_init_func):
     with patch.object(sampler, "sample_independent", mock) as mock_object:
         study = create_study(storage_init_func(), sampler=sampler)
         trial = Trial(study, study._storage.create_new_trial(study._study_id))
-        distribution = distributions.IntUniformDistribution(low=0, high=3)
+        distribution = IntUniformDistribution(low=0, high=3)
 
         assert trial._suggest("x", distribution) == 1  # Test suggesting a param.
         assert trial._suggest("x", distribution) == 1  # Test suggesting the same param.
@@ -256,7 +270,7 @@ def test_suggest_int(storage_init_func):
 
 @parametrize_storage
 def test_distributions(storage_init_func):
-    # type: (typing.Callable[[], storages.BaseStorage]) -> None
+    # type: (Callable[[], storages.BaseStorage]) -> None
 
     def objective(trial):
         # type: (Trial) -> float
@@ -273,11 +287,11 @@ def test_distributions(storage_init_func):
     study.optimize(objective, n_trials=1)
 
     assert study.best_trial.distributions == {
-        "a": distributions.UniformDistribution(low=0, high=10),
-        "b": distributions.LogUniformDistribution(low=0.1, high=10),
-        "c": distributions.DiscreteUniformDistribution(low=0, high=10, q=1),
-        "d": distributions.IntUniformDistribution(low=0, high=10),
-        "e": distributions.CategoricalDistribution(choices=("foo", "bar", "baz")),
+        "a": UniformDistribution(low=0, high=10),
+        "b": LogUniformDistribution(low=0.1, high=10),
+        "c": DiscreteUniformDistribution(low=0, high=10, q=1),
+        "d": IntUniformDistribution(low=0, high=10),
+        "e": CategoricalDistribution(choices=("foo", "bar", "baz")),
     }
 
 
@@ -423,11 +437,11 @@ def test_fixed_trial_datetime_start():
 
 @parametrize_storage
 def test_relative_parameters(storage_init_func):
-    # type: (typing.Callable[[], storages.BaseStorage]) -> None
+    # type: (Callable[[], storages.BaseStorage]) -> None
 
     relative_search_space = {
-        "x": distributions.UniformDistribution(low=5, high=6),
-        "y": distributions.UniformDistribution(low=5, high=6),
+        "x": UniformDistribution(low=5, high=6),
+        "y": UniformDistribution(low=5, high=6),
     }
     relative_params = {"x": 5.5, "y": 5.5, "z": 5.5}
 
@@ -441,7 +455,7 @@ def test_relative_parameters(storage_init_func):
 
     # Suggested from `relative_params`.
     trial0 = create_trial()
-    distribution0 = distributions.UniformDistribution(low=0, high=100)
+    distribution0 = UniformDistribution(low=0, high=100)
     assert trial0._suggest("x", distribution0) == 5.5
 
     # Not suggested from `relative_params` (due to unknown parameter name).
@@ -451,27 +465,27 @@ def test_relative_parameters(storage_init_func):
 
     # Not suggested from `relative_params` (due to incompatible value range).
     trial2 = create_trial()
-    distribution2 = distributions.UniformDistribution(low=0, high=5)
+    distribution2 = UniformDistribution(low=0, high=5)
     assert trial2._suggest("x", distribution2) != 5.5
 
     # Error (due to incompatible distribution class).
     trial3 = create_trial()
-    distribution3 = distributions.IntUniformDistribution(low=1, high=100)
+    distribution3 = IntUniformDistribution(low=1, high=100)
     with pytest.raises(ValueError):
         trial3._suggest("y", distribution3)
 
     # Error ('z' is included in `relative_params` but not in `relative_search_space`).
     trial4 = create_trial()
-    distribution4 = distributions.UniformDistribution(low=0, high=10)
+    distribution4 = UniformDistribution(low=0, high=10)
     with pytest.raises(ValueError):
         trial4._suggest("z", distribution4)
 
 
 @parametrize_storage
 def test_datetime_start(storage_init_func):
-    # type: (typing.Callable[[], storages.BaseStorage]) -> None
+    # type: (Callable[[], storages.BaseStorage]) -> None
 
-    trial_datetime_start = [None]  # type: typing.List[typing.Optional[datetime]]
+    trial_datetime_start = [None]  # type: List[Optional[datetime.datetime]]
 
     def objective(trial):
         # type: (Trial) -> float
@@ -528,3 +542,132 @@ def test_study_id():
 
     with pytest.warns(DeprecationWarning):
         trial.study_id
+
+
+def test_frozen_trial_validate():
+    # type: () -> None
+
+    # Valid.
+    valid_trial = _create_frozen_trial()
+    valid_trial._validate()
+
+    # Invalid: `datetime_start` is not set.
+    invalid_trial = copy.copy(valid_trial)
+    invalid_trial.datetime_start = None
+    with pytest.raises(ValueError):
+        invalid_trial._validate()
+
+    # Invalid: `state` is `RUNNING` and `datetime_complete` is set.
+    invalid_trial = copy.copy(valid_trial)
+    invalid_trial.state = TrialState.RUNNING
+    with pytest.raises(ValueError):
+        invalid_trial._validate()
+
+    # Invalid: `state` is not `RUNNING` and `datetime_complete` is not set.
+    for state in [TrialState.COMPLETE, TrialState.PRUNED, TrialState.FAIL]:
+        invalid_trial = copy.copy(valid_trial)
+        invalid_trial.state = state
+        invalid_trial.datetime_complete = None
+        with pytest.raises(ValueError):
+            invalid_trial._validate()
+
+    # Invalid: `state` is `COMPLETE` and `value` is not set.
+    invalid_trial = copy.copy(valid_trial)
+    invalid_trial.value = None
+    with pytest.raises(ValueError):
+        invalid_trial._validate()
+
+    # Invalid: Inconsistent `params` and `distributions`
+    inconsistent_pairs = [
+        # `params` has an extra element.
+        ({"x": 0.1, "y": 0.5}, {"x": UniformDistribution(0, 1)}),
+        # `distributions` has an extra element.
+        ({"x": 0.1}, {"x": UniformDistribution(0, 1), "y": LogUniformDistribution(0, 1)}),
+        # The value of `x` isn't contained in the distribution.
+        ({"x": -0.5}, {"x": UniformDistribution(0, 1)}),
+    ]  # type: List[Tuple[Dict[str, Any], Dict[str, BaseDistribution]]]
+
+    for params, distributions in inconsistent_pairs:
+        invalid_trial = copy.copy(valid_trial)
+        invalid_trial.params = params
+        invalid_trial.distributions = distributions
+        with pytest.raises(ValueError):
+            invalid_trial._validate()
+
+
+def test_frozen_trial_eq_ne():
+    # type: () -> None
+
+    trial = _create_frozen_trial()
+
+    trial_other = copy.copy(trial)
+    assert trial == trial_other
+
+    trial_other.value = 0.3
+    assert trial != trial_other
+
+
+def test_frozen_trial_lt():
+    # type: () -> None
+
+    trial = _create_frozen_trial()
+
+    trial_other = copy.copy(trial)
+    assert not trial < trial_other
+
+    trial_other.number = trial.number + 1
+    assert trial < trial_other
+    assert not trial_other < trial
+
+    with pytest.raises(TypeError):
+        trial < 1
+
+    assert trial <= trial_other
+    assert not trial_other <= trial
+
+    with pytest.raises(TypeError):
+        trial <= 1
+
+    # A list of FrozenTrials is sortable.
+    trials = [trial_other, trial]
+    trials.sort()
+    assert trials[0] is trial
+    assert trials[1] is trial_other
+
+
+def _create_frozen_trial():
+    # type: () -> FrozenTrial
+
+    return FrozenTrial(
+        number=0,
+        trial_id=0,
+        state=TrialState.COMPLETE,
+        value=0.2,
+        datetime_start=datetime.datetime.now(),
+        datetime_complete=datetime.datetime.now(),
+        params={"x": 10},
+        distributions={"x": UniformDistribution(5, 12)},
+        user_attrs={},
+        system_attrs={},
+        intermediate_values={},
+    )
+
+
+def test_frozen_trial_repr():
+    # type: () -> None
+
+    trial = FrozenTrial(
+        number=0,
+        trial_id=0,
+        state=TrialState.COMPLETE,
+        value=0.2,
+        datetime_start=datetime.datetime.now(),
+        datetime_complete=datetime.datetime.now(),
+        params={"x": 10},
+        distributions={"x": UniformDistribution(5, 12)},
+        user_attrs={},
+        system_attrs={},
+        intermediate_values={},
+    )
+
+    assert trial == eval(repr(trial))


### PR DESCRIPTION
Depends on #1095 

A minor refactoring of the `TrialState` class and the `FrozenTrial` class to increase affinity with the `Trial` class similar to #1090 .
By making these class independent with `structs.py`, it is easy to understand that they are related to `Trial` class.
Note that the change of this PR depends on the history of #1095 , so we have to review and merge #1095  first.

I moved all codes about `TrialState` and `FrozenTrial` from `structs.py` to `trial.py`.

Additionally, I moved the unit test cases about `TrialState` and `FrozenTrial` from `test_structs.py` to `test_trial.py`.