### PR TITLE
Update type hinting of `GridSampler.__init__`.

### DIFF
--- a/optuna/samplers/grid.py
+++ b/optuna/samplers/grid.py
@@ -10,6 +10,8 @@ if type_checking.TYPE_CHECKING:
     from typing import Any  # NOQA
     from typing import Dict  # NOQA
     from typing import List  # NOQA
+    from typing import Mapping  # NOQA
+    from typing import Sequence  # NOQA
     from typing import Union
 
     from optuna.distributions import BaseDistribution  # NOQA
@@ -79,7 +81,7 @@ class GridSampler(BaseSampler):
     """
 
     def __init__(self, search_space):
-        # type: (Dict[str, List[GridValueType]]) -> None
+        # type: (Mapping[str, Sequence[GridValueType]]) -> None
 
         for param_name, param_values in search_space.items():
             for value in param_values:
@@ -180,7 +182,7 @@ class GridSampler(BaseSampler):
         return list(unvisited_grids)
 
     def _same_search_space(self, search_space):
-        # type: (Dict[str, List[GridValueType]]) -> bool
+        # type: (Mapping[str, Sequence[GridValueType]]) -> bool
 
         if set(search_space.keys()) != set(self._search_space.keys()):
             return False

--- a/tests/samplers_tests/test_grid.py
+++ b/tests/samplers_tests/test_grid.py
@@ -9,8 +9,8 @@ from optuna import samplers
 
 if optuna.type_checking.TYPE_CHECKING:
     from collections import ValuesView  # NOQA
-    from typing import Dict  # NOQA
-    from typing import List  # NOQA
+    from typing import Mapping  # NOQA
+    from typing import Sequence  # NOQA
     from typing import Union  # NOQA
 
     from optuna.samplers.grid import GridValueType  # NOQA
@@ -18,7 +18,7 @@ if optuna.type_checking.TYPE_CHECKING:
 
 
 def _n_grids(search_space):
-    # type: (Dict[str, List[Union[str, float, None]]]) -> int
+    # type: (Mapping[str, Sequence[Union[str, float, None]]]) -> int
 
     return int(np.prod([len(v) for v in search_space.values()]))
 
@@ -60,7 +60,7 @@ def test_study_optimize_with_single_search_space():
     study.optimize(objective, n_trials=n_grids)
 
     def sorted_values(d):
-        # type: (Dict[str, List[GridValueType]]) -> ValuesView[List[GridValueType]]
+        # type: (Mapping[str, Sequence[GridValueType]]) -> ValuesView[Sequence[GridValueType]]
 
         return OrderedDict(sorted(d.items())).values()
 
@@ -106,7 +106,7 @@ def test_study_optimize_with_multiple_search_spaces():
         return a * b
 
     # Run 3 trials with a search space.
-    search_space_0 = {"a": [0, 50], "b": [-50, 0, 50]}  # type: Dict[str, List[GridValueType]]
+    search_space_0 = {"a": [0, 50], "b": [-50, 0, 50]}
     sampler_0 = samplers.GridSampler(search_space_0)
     study = optuna.create_study(sampler=sampler_0)
     study.optimize(objective, n_trials=3)
@@ -116,7 +116,7 @@ def test_study_optimize_with_multiple_search_spaces():
         assert sampler_0._same_search_space(t.system_attrs["search_space"])
 
     # Run 2 trials with another space.
-    search_space_1 = {"a": [0, 25], "b": [-50]}  # type: Dict[str, List[GridValueType]]
+    search_space_1 = {"a": [0, 25], "b": [-50]}
     sampler_1 = samplers.GridSampler(search_space_1)
     study.sampler = sampler_1
     study.optimize(objective, n_trials=2)
@@ -160,7 +160,7 @@ def test_cast_value():
 def test_has_same_search_space():
     # type: () -> None
 
-    search_space = {"x": [3, 2, 1], "y": ["a", "b", "c"]}  # type: Dict[str, List[GridValueType]]
+    search_space = {"x": [3, 2, 1], "y": ["a", "b", "c"]}
     sampler = samplers.GridSampler(search_space)
     assert sampler._same_search_space(search_space)
     assert sampler._same_search_space({"x": np.array([3, 2, 1]), "y": ["a", "b", "c"]})

--- a/tests/samplers_tests/test_grid.py
+++ b/tests/samplers_tests/test_grid.py
@@ -9,6 +9,8 @@ from optuna import samplers
 
 if optuna.type_checking.TYPE_CHECKING:
     from collections import ValuesView  # NOQA
+    from typing import Dict  # NOQA
+    from typing import List  # NOQA
     from typing import Mapping  # NOQA
     from typing import Sequence  # NOQA
     from typing import Union  # NOQA
@@ -160,7 +162,7 @@ def test_cast_value():
 def test_has_same_search_space():
     # type: () -> None
 
-    search_space = {"x": [3, 2, 1], "y": ["a", "b", "c"]}
+    search_space = {"x": [3, 2, 1], "y": ["a", "b", "c"]}  # type: Dict[str, List[Union[int, str]]]
     sampler = samplers.GridSampler(search_space)
     assert sampler._same_search_space(search_space)
     assert sampler._same_search_space({"x": np.array([3, 2, 1]), "y": ["a", "b", "c"]})


### PR DESCRIPTION
The current type hinting of `GridSampler.__init__` is `Dict[str, List[Union[str, float, int, bool, None]
]`. As mentioned in https://github.com/optuna/optuna/pull/1076#discussion_r405252822, I found that `List[int]` was not compatible with `List[Union[str, float, int, bool, None]`. 

In this PR, `List` is replaced with `Sequence` for mypy to infer the type properly. The [typing reference](https://docs.python.org/3/library/typing.html#typing.List) recommend `Sequence` or `Iterable` instead of `List`.

> Generic version of list. Useful for annotating return types. To annotate arguments it is preferred to use an abstract collection type such as Sequence or Iterable.

`Dict` is also replaced with `Mapping` for the same reason.