### PR TITLE
Remove settings for yapf

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,11 +5,6 @@ max-line-length = 99
 statistics = True
 exclude = venv,build
 
-# This section is for yapf.
-[yapf]
-based_on_style = pep8
-column_limit = 99
-
 # This section is for mypy.
 [mypy]
 disallow_untyped_defs = True


### PR DESCRIPTION
In #1030, Optuna changed a code formatter from `autopep8` to `black`.
I think we don't need a configuration for`yapf` anymore since `yapf` have a different formatting rule from `black`.

BTW, `black` seems to support only `pyproject.toml`. (https://github.com/psf/black/issues/683)