### PR TITLE
Return trial_id at `study._append_trial()`.

### DIFF
--- a/optuna/study.py
+++ b/optuna/study.py
@@ -569,7 +569,7 @@ class Study(BaseStudy):
         datetime_start=None,  # type: Optional[datetime.datetime]
         datetime_complete=None,  # type: Optional[datetime.datetime]
     ):
-        # type: (...) -> None
+        # type: (...) -> int
 
         params = params or {}
         distributions = distributions or {}
@@ -597,7 +597,8 @@ class Study(BaseStudy):
 
         trial._validate()
 
-        self._storage.create_new_trial(self._study_id, template_trial=trial)
+        trial_id = self._storage.create_new_trial(self._study_id, template_trial=trial)
+        return trial_id
 
     def _optimize_sequential(
         self,

--- a/tests/test_study.py
+++ b/tests/test_study.py
@@ -713,8 +713,7 @@ def test_append_trial(storage_mode):
         assert len(study.trials) == 0
 
         trial_id = study._append_trial(value=0.8)
-        if isinstance(study._storage, optuna.storages.InMemoryStorage):
-            assert trial_id == 0
+        assert study.trials[0]._trial_id == trial_id
         assert len(study.trials) == 1
         assert study.best_value == 0.8
 

--- a/tests/test_study.py
+++ b/tests/test_study.py
@@ -712,7 +712,7 @@ def test_append_trial(storage_mode):
         study = optuna.create_study(storage=storage)
         assert len(study.trials) == 0
 
-        trial_id = study._append_trial(value=0.8) == 0
+        trial_id = study._append_trial(value=0.8)
         if isinstance(study._storage, optuna.storages.InMemoryStorage):
             assert trial_id == 0
         assert len(study.trials) == 1

--- a/tests/test_study.py
+++ b/tests/test_study.py
@@ -712,7 +712,9 @@ def test_append_trial(storage_mode):
         study = optuna.create_study(storage=storage)
         assert len(study.trials) == 0
 
-        study._append_trial(value=0.8)
+        trial_id = study._append_trial(value=0.8) == 0
+        if isinstance(study._storage, optuna.storages.InMemoryStorage):
+            assert trial_id == 0
         assert len(study.trials) == 1
         assert study.best_value == 0.8
 


### PR DESCRIPTION
It is sometimes useful if `_append_trial()` returns `trial_id` (e.g. https://github.com/c-bata/optuna-memorydump).