### PR TITLE
GitHub Actions to automatically label stale issues and PRs.

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,21 @@
+name: stale
+
+on:
+  schedule:
+    - cron: '0 15 * * *'
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/stale@v1.1.0
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: 'This issue has not seen any recent activity.'
+        stale-pr-message: 'This pull request has not seen any recent activity.'
+        days-before-stale: 14
+        days-before-close: -1
+        stale-issue-label: 'stale'
+        stale-pr-label: 'stale'


### PR DESCRIPTION
Introduces a GitHub Action to automatically label stale issues and PRs. 

- 14 days of inactivity is considered stale.
- Issues and PRs are only labeled and never closed.

This would for instance render most of our issues stale. Open for discussion.

See https://github.com/actions/stale for details.