### PR TITLE
Avoid installing `torch` with CUDA in CI.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,7 +146,7 @@ jobs:
             python -c 'import optuna'
 
             # Install all dependencies needed for testing.
-            pip install --progress-bar off $(ls dist/*.tar.gz)[testing]
+            pip install --progress-bar off $(ls dist/*.tar.gz)[testing] -f https://download.pytorch.org/whl/torch_stable.html
 
       - run: &tests
           name: tests

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -31,7 +31,7 @@ jobs:
         python -c 'import optuna'
 
         # Install all dependencies needed for examples.
-        pip install --progress-bar off $(ls dist/*.tar.gz)[example]
+        pip install --progress-bar off $(ls dist/*.tar.gz)[example] -f https://download.pytorch.org/whl/torch_stable.html
     - name: Run examples
       run: |
         if [ ${{ matrix.python-version }} = 3.5 ]; then

--- a/setup.py
+++ b/setup.py
@@ -65,8 +65,8 @@ def get_extras_require() -> Dict[str, List[str]]:
             "pytorch-ignite",
             "scikit-image",
             "scikit-learn",
-            "torch",
-            "torchvision>=0.5.0",
+            "torch>=1.4.0+cpu",
+            "torchvision>=0.5.0+cpu",
             "xgboost",
         ]
         + (["allennlp", "fastai<2"] if (3, 5) < sys.version_info[:2] < (3, 8) else [])
@@ -103,8 +103,8 @@ def get_extras_require() -> Dict[str, List[str]]:
             "pytorch-ignite",
             "scikit-learn>=0.19.0",
             "scikit-optimize",
-            "torch",
-            "torchvision>=0.5.0",
+            "torch>=1.4.0+cpu",
+            "torchvision>=0.5.0+cpu",
             "xgboost",
         ]
         + (["fastai<2"] if (3, 5) < sys.version_info[:2] < (3, 8) else [])


### PR DESCRIPTION
Install PyTorch without CUDA to save space as GPU environments are not tested anyway. Changes are based on the officially recommended configurations in https://pytorch.org/. Currently, the daily examples fail due to lack of space, which is hopefully or at least partially fixed by this change.

#### Before

```
Collecting torch
   Downloading torch-1.4.0-cp37-cp37m-manylinux1_x86_64.whl (753.4 MB)
Collecting torchvision>=0.5.0
   Downloading torchvision-0.5.0-cp37-cp37m-manylinux1_x86_64.whl (4.0 MB)
```

#### After

```
Collecting torch==1.4.0+cpu
  Downloading https://download.pytorch.org/whl/cpu/torch-1.4.0%2Bcpu-cp37-cp37m-linux_x86_64.whl (127.2 MB)
Collecting torchvision>=0.5.0+cpu
  Downloading https://download.pytorch.org/whl/cu92/torchvision-0.5.0%2Bcu92-cp37-cp37m-linux_x86_64.whl (3.9 MB)
```