### PR TITLE
Replace `mock` with `unittest.mock`.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -102,7 +102,6 @@ def get_extras_require() -> Dict[str, List[str]]:
             "fanova",
             "lightgbm",
             "mlflow",
-            "mock",
             "mpi4py",
             "mxnet",
             "pandas",

--- a/tests/integration_tests/lightgbm_tuner_tests/test_optimize.py
+++ b/tests/integration_tests/lightgbm_tuner_tests/test_optimize.py
@@ -4,9 +4,9 @@ from typing import Dict
 from typing import Generator
 from typing import List
 from typing import Optional
+from unittest import mock
 import warnings
 
-import mock
 import numpy as np
 import pytest
 

--- a/tests/integration_tests/test_chainer.py
+++ b/tests/integration_tests/test_chainer.py
@@ -1,11 +1,11 @@
 from collections import namedtuple
 import math
+from unittest.mock import Mock
+from unittest.mock import patch
 
 import chainer
 import chainer.links as L
 from chainer.training import triggers
-from mock import Mock
-from mock import patch
 import numpy as np
 import pytest
 

--- a/tests/integration_tests/test_cma.py
+++ b/tests/integration_tests/test_cma.py
@@ -1,8 +1,8 @@
 import math
+from unittest.mock import call
+from unittest.mock import patch
 
 import cma
-from mock import call
-from mock import patch
 import pytest
 
 import optuna

--- a/tests/integration_tests/test_pytorch_ignite.py
+++ b/tests/integration_tests/test_pytorch_ignite.py
@@ -1,5 +1,6 @@
+from unittest.mock import patch
+
 from ignite.engine import Engine
-from mock import patch
 import pytest
 
 import optuna

--- a/tests/integration_tests/test_sampler.py
+++ b/tests/integration_tests/test_sampler.py
@@ -1,4 +1,5 @@
-from mock import patch
+from unittest.mock import patch
+
 import pytest
 
 import optuna

--- a/tests/integration_tests/test_skopt.py
+++ b/tests/integration_tests/test_skopt.py
@@ -1,5 +1,6 @@
-from mock import call
-from mock import patch
+from unittest.mock import call
+from unittest.mock import patch
+
 import pytest
 from skopt.space import space
 

--- a/tests/integration_tests/test_tensorflow.py
+++ b/tests/integration_tests/test_tensorflow.py
@@ -1,7 +1,7 @@
 from collections import OrderedDict
 import math
+from unittest.mock import patch
 
-from mock import patch
 import numpy as np
 import tensorflow as tf
 

--- a/tests/samplers_tests/test_cmaes.py
+++ b/tests/samplers_tests/test_cmaes.py
@@ -32,9 +32,9 @@ def test_init_cmaes_opts() -> None:
             lambda t: t.suggest_uniform("x", -1, 1) + t.suggest_uniform("y", -1, 1), n_trials=2
         )
 
-        cma_class.assert_called_once()
+        assert cma_class.call_count == 1
 
-        actual_kwargs = cma_class.mock_calls[0].kwargs
+        _, actual_kwargs = cma_class.call_args
         assert np.array_equal(actual_kwargs["mean"], np.array([0, 0]))
         assert actual_kwargs["sigma"] == 0.1
         assert np.array_equal(actual_kwargs["bounds"], np.array([(-1, 1), (-1, 1),]))

--- a/tests/samplers_tests/test_cmaes.py
+++ b/tests/samplers_tests/test_cmaes.py
@@ -1,5 +1,5 @@
-from mock import MagicMock
-from mock import patch
+from unittest.mock import MagicMock
+from unittest.mock import patch
 
 import numpy as np
 import pytest

--- a/tests/storages_tests/rdb_tests/test_storage.py
+++ b/tests/storages_tests/rdb_tests/test_storage.py
@@ -1,8 +1,8 @@
 import pickle
 import sys
 import tempfile
+from unittest.mock import patch
 
-from mock import patch
 import pytest
 
 from optuna.distributions import CategoricalDistribution

--- a/tests/storages_tests/test_storages.py
+++ b/tests/storages_tests/test_storages.py
@@ -1,8 +1,8 @@
 import copy
 from datetime import datetime
+from unittest.mock import patch
 
 import fakeredis
-from mock import patch
 import pytest
 
 import optuna

--- a/tests/test_study.py
+++ b/tests/test_study.py
@@ -4,12 +4,12 @@ import multiprocessing
 import pickle
 import threading
 import time
+from unittest.mock import Mock  # NOQA
+from unittest.mock import patch
 import uuid
 import warnings
 
 import joblib
-from mock import Mock  # NOQA
-from mock import patch
 import pandas as pd
 import pytest
 

--- a/tests/test_trial.py
+++ b/tests/test_trial.py
@@ -1,10 +1,10 @@
 import copy
 import datetime
 import math
+from unittest.mock import Mock
+from unittest.mock import patch
 import warnings
 
-from mock import Mock
-from mock import patch
 import numpy as np
 import pytest
 


### PR DESCRIPTION
`mock` is in the standard library starting from Python 3.3 meaning we should prefer that `mock` over the third-party `mock`. C.f. https://mock.readthedocs.io/en/latest/.