### PR TITLE
Avoid installing `torch` with CUDA in CI by locking version.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ def get_extras_require() -> Dict[str, List[str]]:
             "scikit-image",
             "scikit-learn",
             "torch==1.4.0+cpu",
-            "torchvision>=0.5.0+cpu",
+            "torchvision==0.5.0+cpu",
             "xgboost",
         ]
         + (["allennlp", "fastai<2"] if (3, 5) < sys.version_info[:2] < (3, 8) else [])
@@ -112,7 +112,7 @@ def get_extras_require() -> Dict[str, List[str]]:
             "scikit-learn>=0.19.0",
             "scikit-optimize",
             "torch==1.4.0+cpu",
-            "torchvision>=0.5.0+cpu",
+            "torchvision==0.5.0+cpu",
             "xgboost",
         ]
         + (["fastai<2"] if (3, 5) < sys.version_info[:2] < (3, 8) else [])

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ def get_extras_require() -> Dict[str, List[str]]:
             "pytorch-ignite",
             "scikit-image",
             "scikit-learn",
-            "torch>=1.4.0+cpu",
+            "torch==1.4.0+cpu",
             "torchvision>=0.5.0+cpu",
             "xgboost",
         ]
@@ -111,7 +111,7 @@ def get_extras_require() -> Dict[str, List[str]]:
             "pytorch-ignite",
             "scikit-learn>=0.19.0",
             "scikit-optimize",
-            "torch>=1.4.0+cpu",
+            "torch==1.4.0+cpu",
             "torchvision>=0.5.0+cpu",
             "xgboost",
         ]


### PR DESCRIPTION
~_This PR is marked WIP since I'd like to verify the behavior on CircleCI before merging._~ _(done)_

Follow-up to https://github.com/optuna/optuna/pull/1118.

`>=` will install the CUDA version, while `==` won't.

**Installation logs from my fork**

- [Log from `>=`](https://github.com/hvy/optuna/pull/5/checks?sha=306b2e89defadc4685ae860ae64c05e99b4a0ead)
- [Log from `==`](https://github.com/hvy/optuna/pull/5/checks?sha=c7e3683d76370d5d823460566101c5f0b527876d)