### PR TITLE
Add the pruning feature to `LightGBMTuner`.

### DIFF
--- a/optuna/integration/lightgbm_tuner/optimize.py
+++ b/optuna/integration/lightgbm_tuner/optimize.py
@@ -250,15 +250,15 @@ class OptunaObjective(BaseTuner):
 
         lgbm_kwargs = copy.copy(self.lgbm_kwargs)
         if not isinstance(trial.study.pruner, optuna.pruners.NopPruner):
-            if lgbm_kwargs["callbacks"] is None:
-                lgbm_kwargs["callbacks"] = []
-            lgbm_kwargs["callbacks"].append(
+            callbacks = [] if lgbm_kwargs["callbacks"] is None else lgbm_kwargs["callbacks"]
+            callbacks.append(
                 optuna.integration.LightGBMPruningCallback(
                     trial,
                     self.lgbm_params.get("metric", "binary_logloss"),
                     valid_name=self._get_valid_name_for_objective(),
                 )
             )
+            lgbm_kwargs["callbacks"] = callbacks
 
         with _timer() as t:
             booster = lgb.train(self.lgbm_params, self.train_set, **lgbm_kwargs)

--- a/tests/integration_tests/lightgbm_tuner_tests/test_optimize.py
+++ b/tests/integration_tests/lightgbm_tuner_tests/test_optimize.py
@@ -84,7 +84,7 @@ class TestOptunaObjective(object):
                 "tune_lambda_l1",
                 None,
             )
-            study = optuna.create_study(direction="minimize")
+            study = optuna.create_study(direction="minimize", pruner=optuna.pruners.NopPruner())
             study.optimize(objective, n_trials=10)
 
             assert study.best_value == 0.5
@@ -317,7 +317,7 @@ class TestLightGBMTuner(object):
             params["metric"] = metric
         train_set = lgb.Dataset(None)
         valid_set = lgb.Dataset(None)
-        study = optuna.create_study(direction=study_direction)
+        study = optuna.create_study(direction=study_direction, pruner=optuna.pruners.NopPruner())
         with pytest.raises(ValueError) as excinfo:
             lgb.LightGBMTuner(
                 params,
@@ -367,7 +367,9 @@ class TestLightGBMTuner(object):
     )
     def test_best_score(self, metric: str, study_direction: str, expected: float) -> None:
         with turnoff_train(metric=metric):
-            study = optuna.create_study(direction=study_direction)
+            study = optuna.create_study(
+                direction=study_direction, pruner=optuna.pruners.NopPruner()
+            )
             runner = self._get_tuner_object(
                 params=dict(lambda_l1=0.0, metric=metric), kwargs_options={}, study=study,
             )
@@ -414,7 +416,7 @@ class TestLightGBMTuner(object):
     )
     def test_pruning(
         self,
-        pruner: Optional[optuna.pruners.BasePruner],
+        pruner: optuna.pruners.BasePruner,
         trial_state: optuna.trial.TrialState,
         prune_count: int,
     ) -> None:
@@ -629,7 +631,7 @@ class TestLightGBMTuner(object):
         params = {"verbose": -1}  # type: Dict
         dataset = lgb.Dataset(np.zeros((10, 10)))
 
-        study = optuna.create_study()
+        study = optuna.create_study(pruner=optuna.pruners.NopPruner())
         tuner = LightGBMTuner(params, dataset, valid_sets=dataset, study=study)
 
         with mock.patch.object(BaseTuner, "_get_booster_best_score", return_value=1.0):
@@ -649,7 +651,7 @@ class TestLightGBMTuner(object):
         params = {"verbose": -1, "lambda_l1": unexpected_value}  # type: Dict
         dataset = lgb.Dataset(np.zeros((10, 10)))
 
-        study = optuna.create_study()
+        study = optuna.create_study(pruner=optuna.pruners.NopPruner())
         tuner = LightGBMTuner(params, dataset, valid_sets=dataset, study=study)
 
         with pytest.raises(ValueError):
@@ -675,7 +677,7 @@ class TestLightGBMTuner(object):
         params = {"verbose": -1}  # type: Dict
         dataset = lgb.Dataset(np.zeros((10, 10)))
 
-        study = optuna.create_study()
+        study = optuna.create_study(pruner=optuna.pruners.NopPruner())
         with TemporaryDirectory() as tmpdir:
             tuner = LightGBMTuner(
                 params, dataset, valid_sets=dataset, study=study, model_dir=tmpdir


### PR DESCRIPTION
This PR enables `LightGBMTuner` to prune unpromising trials using `optuna.pruners`.
Currently, pruning is activated if `LightGBMTuner.study.pruner` is not `NopPruner`. The default pruner created in the `LightGBMTuner.__init__` is `NopPruner`, and the pruning is disabled by default.

I have a concern about user-given studies. If users create LightGBMTuner with `LightGBMTuner(study=optuna.create_study())`, the `MedianPruner` will be used. I feel a bit tricky because the pruning feature is disabled by default in other usages. If you have any comments or suggestions, please let me know.

Please merge this branch after #1076.