### PR TITLE
Run `actions/stale` on weekday mornings Tokyo time.

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -2,7 +2,7 @@ name: stale
 
 on:
   schedule:
-    - cron: '0 23 * * 7,1,2,3,4'
+    - cron: '0 23 * * SUN-THU'
 
 jobs:
   stale:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -2,7 +2,7 @@ name: stale
 
 on:
   schedule:
-    - cron: '0 15 * * *'
+    - cron: '0 23 * * 7,1,2,3,4'
 
 jobs:
   stale:


### PR DESCRIPTION
Limited the bot to run on weekdays only. Also, changed the time from midnight to morning (8:00, Tokyo). We might not want to have issues and PR "states" being changed by a bot during weekends when there's less work. 