### PR TITLE
Add storage cache

### DIFF
--- a/optuna/storages/__init__.py
+++ b/optuna/storages/__init__.py
@@ -3,8 +3,8 @@ from typing import Union  # NOQA
 from optuna.storages.base import BaseStorage  # NOQA
 from optuna.storages.cached_storage import _CachedStorage
 from optuna.storages.in_memory import InMemoryStorage
-from optuna.storages.redis import RedisStorage
 from optuna.storages.rdb.storage import RDBStorage
+from optuna.storages.redis import RedisStorage
 
 
 def get_storage(storage):

--- a/optuna/storages/__init__.py
+++ b/optuna/storages/__init__.py
@@ -1,9 +1,10 @@
-from optuna.storages.base import BaseStorage  # NOQA
-from optuna.storages.in_memory import InMemoryStorage  # NOQA
-from optuna.storages.redis import RedisStorage  # NOQA
-from optuna.storages.rdb.storage import RDBStorage  # NOQA
-
 from typing import Union  # NOQA
+
+from optuna.storages.base import BaseStorage  # NOQA
+from optuna.storages.cached_storage import _CachedStorage
+from optuna.storages.in_memory import InMemoryStorage
+from optuna.storages.redis import RedisStorage
+from optuna.storages.rdb.storage import RDBStorage
 
 
 def get_storage(storage):
@@ -15,6 +16,8 @@ def get_storage(storage):
         if storage.startswith("redis"):
             return RedisStorage(storage)
         else:
-            return RDBStorage(storage)
+            return _CachedStorage(RDBStorage(storage))
+    elif isinstance(storage, RDBStorage):
+        return _CachedStorage(storage)
     else:
         return storage

--- a/optuna/storages/cached_storage.py
+++ b/optuna/storages/cached_storage.py
@@ -15,7 +15,7 @@ from optuna.trial import FrozenTrial
 from optuna.trial import TrialState
 
 
-class _TrialUpdates:
+class _TrialUpdate:
     def __init__(self) -> None:
         self.state = None  # type: Optional[TrialState]
         self.value = None  # type: Optional[float]
@@ -29,7 +29,7 @@ class _TrialUpdates:
 class _StudyInfo:
     def __init__(self) -> None:
         self.trials = dict()  # type: Dict[int, FrozenTrial]
-        self.updates = dict()  # type: Dict[int, _TrialUpdates]
+        self.updates = dict()  # type: Dict[int, _TrialUpdate]
         self.param_distribution = {}  # type: Dict[str, distributions.BaseDistribution]
 
 
@@ -267,12 +267,12 @@ class _CachedStorage(base.BaseStorage):
         study_id, number = self._trial_id_to_study_id_and_number[trial_id]
         return self._studies[study_id].trials.get(number, None)
 
-    def _get_updates(self, trial_id: int) -> _TrialUpdates:
+    def _get_updates(self, trial_id: int) -> _TrialUpdate:
         study_id, number = self._trial_id_to_study_id_and_number[trial_id]
         updates = self._studies[study_id].updates.get(number, None)
         if updates is not None:
             return updates
-        updates = _TrialUpdates()
+        updates = _TrialUpdate()
         self._studies[study_id].updates[number] = updates
         return updates
 

--- a/optuna/storages/cached_storage.py
+++ b/optuna/storages/cached_storage.py
@@ -174,10 +174,14 @@ class _CachedStorage(base.BaseStorage):
                     self._studies[study_id].param_distribution[param_name] = distribution
                 if param_name in cached_trial.params:
                     return False
-                cached_trial.params[param_name] = distribution.to_external_repr(
+                params = copy.copy(cached_trial.params)
+                params[param_name] = distribution.to_external_repr(
                     param_value_internal
                 )
-                cached_trial.distributions[param_name] = distribution
+                cached_trial.params = params
+                dists = copy.copy(cached_trial.distributions)
+                dists[param_name] = distribution
+                cached_trial.distributions[param_name] = dists
                 updates.params[param_name] = param_value_internal
                 updates.distributions[param_name] = distribution
                 return True
@@ -222,7 +226,9 @@ class _CachedStorage(base.BaseStorage):
                 updates = self._get_updates(trial_id)
                 if step in cached_trial.intermediate_values:
                     return False
-                cached_trial.intermediate_values[step] = intermediate_value
+                values = copy.copy(cached_trial.intermediate_values)
+                values[step] = intermediate_value
+                cached_trial.intermediate_values = values
                 updates.values[step] = intermediate_value
                 self._flush_trial(trial_id)
                 return True
@@ -235,7 +241,9 @@ class _CachedStorage(base.BaseStorage):
             cached_trial = self._get_cached_trial(trial_id)
             if cached_trial is not None:
                 updates = self._get_updates(trial_id)
-                cached_trial.user_attrs[key] = value
+                attrs = copy.copy(cached_trial.user_attrs)
+                attrs[key] = value
+                cached_trial.user_attrs = attrs
                 updates.user_attrs[key] = value
                 self._flush_trial(trial_id)
                 return
@@ -248,7 +256,9 @@ class _CachedStorage(base.BaseStorage):
             cached_trial = self._get_cached_trial(trial_id)
             if cached_trial is not None:
                 updates = self._get_updates(trial_id)
-                cached_trial.system_attrs[key] = value
+                attrs = copy.copy(cached_trial.system_attrs)
+                attrs[key] = value
+                cached_trial.system_attrs = attrs
                 updates.system_attrs[key] = value
                 self._flush_trial(trial_id)
                 return

--- a/optuna/storages/cached_storage.py
+++ b/optuna/storages/cached_storage.py
@@ -50,14 +50,12 @@ class _CachedStorage(base.BaseStorage):
         self._trial_id_to_study_id_and_number = dict()  # type: Dict[int, Tuple[int, int]]
         self._lock = threading.RLock()
 
-    def __getstate__(self):
-        # type: () -> Dict[Any, Any]
+    def __getstate__(self) -> Dict[Any, Any]:
         state = self.__dict__.copy()
         del state["_lock"]
         return state
 
-    def __setstate__(self, state):
-        # type: (Dict[Any, Any]) -> None
+    def __setstate__(self, state: Dict[Any, Any]) -> None:
         self.__dict__.update(state)
         self._lock = threading.RLock()
 

--- a/optuna/storages/cached_storage.py
+++ b/optuna/storages/cached_storage.py
@@ -298,11 +298,6 @@ class _CachedStorage(base.BaseStorage):
 
         return self._backend.get_n_trials(study_id, state)
 
-    def flush(self) -> None:
-        for study in self._studies.values():
-            for trial_id in study.updates:
-                self._flush_trial(trial_id)
-
     def _flush_trial(self, trial_id: int) -> bool:
         if trial_id not in self._trial_id_to_study_id_and_number:
             # The trial has not been managed by this class.

--- a/optuna/storages/cached_storage.py
+++ b/optuna/storages/cached_storage.py
@@ -1,0 +1,318 @@
+import copy
+import threading
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import Optional
+from typing import Tuple
+
+from optuna import distributions
+from optuna.storages import base
+from optuna.storages.rdb.storage import RDBStorage
+from optuna.study import StudyDirection
+from optuna.study import StudySummary
+from optuna.trial import FrozenTrial
+from optuna.trial import TrialState
+
+
+class _TrialUpdates:
+    def __init__(self) -> None:
+        self.state = None  # type: Optional[TrialState]
+        self.value = None  # type: Optional[float]
+        self.values = dict()  # type: Dict[int, float]
+        self.user_attrs = dict()  # type: Dict[str, Any]
+        self.system_attrs = dict()  # type: Dict[str, Any]
+        self.params = dict()  # type: Dict[str, Any]
+        self.distributions = dict()  # type: Dict[str, distributions.BaseDistribution]
+
+
+class _StudyInfo:
+    def __init__(self) -> None:
+        self.trials = dict()  # type: Dict[int, FrozenTrial]
+        self.updates = dict()  # type: Dict[int, _TrialUpdates]
+        self.param_distribution = {}  # type: Dict[str, distributions.BaseDistribution]
+
+
+class _CachedStorage(base.BaseStorage):
+    """A wrapper class of storage backends.
+
+    This class is used in :func:`~optuna.get_storage` function and automatically
+    wraps :class:`~optuna.storages.RDBStorage` class.
+
+    Args:
+        storage:
+            BaseStorage class instance to wrap.
+    """
+
+    def __init__(self, backend: RDBStorage) -> None:
+        self._backend = backend
+        self._studies = {}  # type: Dict[int, _StudyInfo]
+        self._trial_id_to_study_id_and_number = dict()  # type: Dict[int, Tuple[int, int]]
+        self._lock = threading.RLock()
+
+    def __getstate__(self):
+        # type: () -> Dict[Any, Any]
+        state = self.__dict__.copy()
+        del state["_lock"]
+        return state
+
+    def __setstate__(self, state):
+        # type: (Dict[Any, Any]) -> None
+        self.__dict__.update(state)
+        self._lock = threading.RLock()
+
+    def create_new_study(self, study_name: Optional[str] = None) -> int:
+
+        study_id = self._backend.create_new_study(study_name)
+        self._studies[study_id] = _StudyInfo()
+        return study_id
+
+    def delete_study(self, study_id: int) -> None:
+
+        with self._lock:
+            if study_id in self._studies:
+                for trial_id in self._studies[study_id].trials:
+                    trial_ids_to_delete = []
+                    if trial_id in self._trial_id_to_study_id_and_number:
+                        trial_ids_to_delete.append(trial_id)
+                    for trial_id in trial_ids_to_delete:
+                        del self._trial_id_to_study_id_and_number[trial_id]
+                del self._studies[study_id]
+
+        self._backend.delete_study(study_id)
+
+    def set_study_direction(self, study_id: int, direction: StudyDirection) -> None:
+
+        self._backend.set_study_direction(study_id, direction)
+
+    def set_study_user_attr(self, study_id: int, key: str, value: Any) -> None:
+
+        self._backend.set_study_user_attr(study_id, key, value)
+
+    def set_study_system_attr(self, study_id: int, key: str, value: Any) -> None:
+
+        self._backend.set_study_system_attr(study_id, key, value)
+
+    def get_study_id_from_name(self, study_name: str) -> int:
+
+        return self._backend.get_study_id_from_name(study_name)
+
+    def get_study_id_from_trial_id(self, trial_id: int) -> int:
+
+        return self._backend.get_study_id_from_trial_id(trial_id)
+
+    def get_study_name_from_id(self, study_id: int) -> str:
+
+        return self._backend.get_study_name_from_id(study_id)
+
+    def get_study_direction(self, study_id: int) -> StudyDirection:
+
+        return self._backend.get_study_direction(study_id)
+
+    def get_study_user_attrs(self, study_id: int) -> Dict[str, Any]:
+
+        return self._backend.get_study_user_attrs(study_id)
+
+    def get_study_system_attrs(self, study_id: int) -> Dict[str, Any]:
+
+        return self._backend.get_study_system_attrs(study_id)
+
+    def get_all_study_summaries(self) -> List[StudySummary]:
+
+        return self._backend.get_all_study_summaries()
+
+    def create_new_trial(self, study_id: int, template_trial: Optional[FrozenTrial] = None) -> int:
+
+        trial_id, frozen_trial = self._backend._create_new_trial_with_trial(
+            study_id, template_trial
+        )
+        with self._lock:
+            if study_id not in self._studies:
+                self._studies[study_id] = _StudyInfo()
+            self._trial_id_to_study_id_and_number[trial_id] = study_id, frozen_trial.number
+            if frozen_trial.state == TrialState.RUNNING:
+                self._studies[study_id].trials[frozen_trial.number] = frozen_trial
+            return trial_id
+
+    def set_trial_state(self, trial_id: int, state: TrialState) -> bool:
+
+        with self._lock:
+            cached_trial = self._get_cached_trial(trial_id)
+            if cached_trial is not None:
+                updates = self._get_updates(trial_id)
+                cached_trial.state = state
+                updates.state = state
+                ret = self._flush_trial(trial_id)
+                if cached_trial.state != TrialState.RUNNING:
+                    study_id, number = self._trial_id_to_study_id_and_number[trial_id]
+                    del self._studies[study_id].trials[number]
+                return ret
+
+        return self._backend.set_trial_state(trial_id, state)
+
+    def set_trial_param(
+        self,
+        trial_id: int,
+        param_name: str,
+        param_value_internal: float,
+        distribution: distributions.BaseDistribution,
+    ) -> bool:
+
+        with self._lock:
+            cached_trial = self._get_cached_trial(trial_id)
+            if cached_trial is not None:
+                updates = self._get_updates(trial_id)
+                study_id, _ = self._trial_id_to_study_id_and_number[trial_id]
+                cached_dist = self._studies[study_id].param_distribution.get(param_name, None)
+                if cached_dist:
+                    distributions.check_distribution_compatibility(cached_dist, distribution)
+                else:
+                    self._backend._check_or_set_param_distribution(
+                        trial_id, param_name, param_value_internal, distribution
+                    )
+                    self._studies[study_id].param_distribution[param_name] = distribution
+                if param_name in cached_trial.params:
+                    return False
+                cached_trial.params[param_name] = distribution.to_external_repr(
+                    param_value_internal
+                )
+                cached_trial.distributions[param_name] = distribution
+                updates.params[param_name] = param_value_internal
+                updates.distributions[param_name] = distribution
+                return True
+
+        return self._backend.set_trial_param(
+            trial_id, param_name, param_value_internal, distribution
+        )
+
+    def get_trial_number_from_id(self, trial_id: int) -> int:
+
+        return self.get_trial(trial_id).number
+
+    def get_best_trial(self, study_id: int) -> FrozenTrial:
+
+        return self._backend.get_best_trial(study_id)
+
+    def get_trial_param(self, trial_id: int, param_name: str) -> float:
+
+        trial = self.get_trial(trial_id)
+        return trial.distributions[param_name].to_internal_repr(trial.params[param_name])
+
+    def set_trial_value(self, trial_id: int, value: float) -> None:
+
+        with self._lock:
+            cached_trial = self._get_cached_trial(trial_id)
+            if cached_trial is not None:
+                updates = self._get_updates(trial_id)
+                cached_trial.value = value
+                updates.value = value
+                self._flush_trial(trial_id)
+                return
+
+        self._backend._update_trial(trial_id, value=value)
+
+    def set_trial_intermediate_value(
+        self, trial_id: int, step: int, intermediate_value: float
+    ) -> bool:
+
+        with self._lock:
+            cached_trial = self._get_cached_trial(trial_id)
+            if cached_trial is not None:
+                updates = self._get_updates(trial_id)
+                if step in cached_trial.intermediate_values:
+                    return False
+                cached_trial.intermediate_values[step] = intermediate_value
+                updates.values[step] = intermediate_value
+                self._flush_trial(trial_id)
+                return True
+
+        return self._backend.set_trial_intermediate_value(trial_id, step, intermediate_value)
+
+    def set_trial_user_attr(self, trial_id: int, key: str, value: Any) -> None:
+
+        with self._lock:
+            cached_trial = self._get_cached_trial(trial_id)
+            if cached_trial is not None:
+                updates = self._get_updates(trial_id)
+                cached_trial.user_attrs[key] = value
+                updates.user_attrs[key] = value
+                self._flush_trial(trial_id)
+                return
+
+        self._backend._update_trial(trial_id, user_attrs={key: value})
+
+    def set_trial_system_attr(self, trial_id: int, key: str, value: Any) -> None:
+
+        with self._lock:
+            cached_trial = self._get_cached_trial(trial_id)
+            if cached_trial is not None:
+                updates = self._get_updates(trial_id)
+                cached_trial.system_attrs[key] = value
+                updates.system_attrs[key] = value
+                self._flush_trial(trial_id)
+                return
+
+        self._backend._update_trial(trial_id, system_attrs={key: value})
+
+    def _get_cached_trial(self, trial_id: int) -> Optional[FrozenTrial]:
+        if trial_id not in self._trial_id_to_study_id_and_number:
+            return None
+        study_id, number = self._trial_id_to_study_id_and_number[trial_id]
+        return self._studies[study_id].trials.get(number, None)
+
+    def _get_updates(self, trial_id: int) -> _TrialUpdates:
+        study_id, number = self._trial_id_to_study_id_and_number[trial_id]
+        updates = self._studies[study_id].updates.get(number, None)
+        if updates is not None:
+            return updates
+        updates = _TrialUpdates()
+        self._studies[study_id].updates[number] = updates
+        return updates
+
+    def get_trial(self, trial_id: int) -> FrozenTrial:
+
+        with self._lock:
+            trial = self._get_cached_trial(trial_id)
+            if trial is not None:
+                return copy.deepcopy(trial)
+
+        return self._backend.get_trial(trial_id)
+
+    def get_all_trials(self, study_id: int, deepcopy: bool = True) -> List[FrozenTrial]:
+
+        trials = self._backend.get_all_trials(study_id, deepcopy=False)
+        if study_id in self._studies:
+            for trial in self._studies[study_id].trials.values():
+                trials[trial.number] = trial
+        return copy.deepcopy(trials) if deepcopy else trials
+
+    def get_n_trials(self, study_id: int, state: Optional[TrialState] = None) -> int:
+
+        return self._backend.get_n_trials(study_id, state)
+
+    def flush(self) -> None:
+        for study in self._studies.values():
+            for trial_id in study.updates:
+                self._flush_trial(trial_id)
+
+    def _flush_trial(self, trial_id: int) -> bool:
+        if trial_id not in self._trial_id_to_study_id_and_number:
+            # The trial has not been managed by this class.
+            return True
+        study_id, number = self._trial_id_to_study_id_and_number[trial_id]
+        study = self._studies[study_id]
+        updates = study.updates.get(number, None)
+        if updates is None:
+            # The trial is up-to-date.
+            return True
+        del study.updates[number]
+        return self._backend._update_trial(
+            trial_id=trial_id,
+            value=updates.value,
+            values=updates.values,
+            state=updates.state,
+            params=updates.params,
+            dists=updates.distributions,
+            user_attrs=updates.user_attrs,
+            system_attrs=updates.system_attrs,
+        )

--- a/optuna/storages/cached_storage.py
+++ b/optuna/storages/cached_storage.py
@@ -179,7 +179,7 @@ class _CachedStorage(base.BaseStorage):
                 cached_trial.params = params
                 dists = copy.copy(cached_trial.distributions)
                 dists[param_name] = distribution
-                cached_trial.distributions[param_name] = dists
+                cached_trial.distributions = dists
                 updates.params[param_name] = param_value_internal
                 updates.distributions[param_name] = distribution
                 return True

--- a/optuna/storages/cached_storage.py
+++ b/optuna/storages/cached_storage.py
@@ -122,7 +122,8 @@ class _CachedStorage(base.BaseStorage):
 
     def create_new_trial(self, study_id: int, template_trial: Optional[FrozenTrial] = None) -> int:
 
-        trial_id, frozen_trial = self._backend._create_new_trial(study_id, template_trial)
+        frozen_trial = self._backend._create_new_trial(study_id, template_trial)
+        trial_id = frozen_trial._trial_id
         with self._lock:
             if study_id not in self._studies:
                 self._studies[study_id] = _StudyInfo()

--- a/optuna/storages/cached_storage.py
+++ b/optuna/storages/cached_storage.py
@@ -41,7 +41,7 @@ class _CachedStorage(base.BaseStorage):
 
     Args:
         storage:
-            BaseStorage class instance to wrap.
+            :class:`~optuna.storages.BaseStorage` class instance to wrap.
     """
 
     def __init__(self, backend: RDBStorage) -> None:

--- a/optuna/storages/cached_storage.py
+++ b/optuna/storages/cached_storage.py
@@ -175,9 +175,7 @@ class _CachedStorage(base.BaseStorage):
                 if param_name in cached_trial.params:
                     return False
                 params = copy.copy(cached_trial.params)
-                params[param_name] = distribution.to_external_repr(
-                    param_value_internal
-                )
+                params[param_name] = distribution.to_external_repr(param_value_internal)
                 cached_trial.params = params
                 dists = copy.copy(cached_trial.distributions)
                 dists[param_name] = distribution

--- a/optuna/storages/rdb/storage.py
+++ b/optuna/storages/rdb/storage.py
@@ -448,11 +448,11 @@ class RDBStorage(BaseStorage):
     def create_new_trial(self, study_id, template_trial=None):
         # type: (int, Optional[FrozenTrial]) -> int
 
-        return self._create_new_trial(study_id, template_trial)[0]
+        return self._create_new_trial(study_id, template_trial)._trial_id
 
     def _create_new_trial(
         self, study_id: int, template_trial: Optional[FrozenTrial] = None
-    ) -> Tuple[int, FrozenTrial]:
+    ) -> FrozenTrial:
         """Create a new trial and returns its trial_id and a :class:`~optuna.trial.FrozenTrial`.
 
         Args:
@@ -462,8 +462,7 @@ class RDBStorage(BaseStorage):
                 A :class:`~optuna.trial.FrozenTrial` with default values for trial attributes.
 
         Returns:
-            A tuple of the trial_id of the created trial and the trial converted
-            into a :class:`~optuna.trial.FrozenTrial` instance.
+            A :class:`~optuna.trial.FrozenTrial` instance.
 
         """
 
@@ -545,7 +544,7 @@ class RDBStorage(BaseStorage):
                 trial_id=trial.trial_id,
             )
 
-        return trial.trial_id, frozen
+        return frozen
 
     def _update_trial(
         self,

--- a/optuna/storages/rdb/storage.py
+++ b/optuna/storages/rdb/storage.py
@@ -453,7 +453,7 @@ class RDBStorage(BaseStorage):
     def _create_new_trial_with_trial(
         self, study_id: int, template_trial: Optional[FrozenTrial] = None
     ) -> Tuple[int, FrozenTrial]:
-        """Create a new trial and returns trial_id and the trial converted into a FrozenTrial.
+        """Create a new trial and returns its trial_id and a :class:`~optuna.trial.FrozenTrial`.
 
         Args:
             study_id:

--- a/optuna/storages/rdb/storage.py
+++ b/optuna/storages/rdb/storage.py
@@ -10,7 +10,6 @@ from typing import Any
 from typing import Dict
 from typing import List
 from typing import Optional
-from typing import Tuple
 import uuid
 import weakref
 

--- a/optuna/storages/rdb/storage.py
+++ b/optuna/storages/rdb/storage.py
@@ -459,7 +459,7 @@ class RDBStorage(BaseStorage):
             study_id:
                 Study id.
             template_trial:
-                A FrozenTrial with default trial attributes.
+                A :class:`~optuna.trial.FrozenTrial` with default values for trial attributes.
 
         Returns:
             A tuple of the trial_id of the created trial and the trial converted

--- a/optuna/storages/rdb/storage.py
+++ b/optuna/storages/rdb/storage.py
@@ -463,7 +463,7 @@ class RDBStorage(BaseStorage):
 
         Returns:
             A tuple of the trial_id of the created trial and the trial converted
-            into a FrozenTrial instance.
+            into a :class:`~optuna.trial.FrozenTrial` instance.
 
         """
 

--- a/optuna/testing/storage.py
+++ b/optuna/testing/storage.py
@@ -33,6 +33,14 @@ class StorageSupplier(object):
             return optuna.storages.RDBStorage(
                 url, engine_kwargs={"connect_args": {"timeout": SQLITE3_TIMEOUT}},
             )
+        elif self.storage_specifier == "cache":
+            self.tempfile = tempfile.NamedTemporaryFile()
+            url = "sqlite:///{}".format(self.tempfile.name)
+            return optuna.storages.cached_storage._CachedStorage(
+                optuna.storages.RDBStorage(
+                    url, engine_kwargs={"connect_args": {"timeout": SQLITE3_TIMEOUT}},
+                )
+            )
         elif self.storage_specifier == "redis":
             storage = optuna.storages.RedisStorage("redis://localhost")
             storage._redis = fakeredis.FakeStrictRedis()

--- a/tests/storages_tests/rdb_tests/test_storage.py
+++ b/tests/storages_tests/rdb_tests/test_storage.py
@@ -5,11 +5,14 @@ from unittest.mock import patch
 
 import pytest
 
+from optuna.distributions import CategoricalDistribution
+from optuna.distributions import UniformDistribution
 from optuna.exceptions import StorageInternalError
 from optuna.storages.rdb.models import SCHEMA_VERSION
 from optuna.storages.rdb.models import TrialModel
 from optuna.storages.rdb.models import VersionInfoModel
 from optuna.storages import RDBStorage
+from optuna.trial import FrozenTrial
 from optuna.trial import TrialState
 from optuna import type_checking
 from optuna import version
@@ -19,8 +22,7 @@ if type_checking.TYPE_CHECKING:
     from typing import Dict  # NOQA
     from typing import List  # NOQA
     from typing import Optional  # NOQA
-
-    from optuna.trial import FrozenTrial  # NOQA
+    from typing import Tuple  # NOQA
 
 
 def test_init():
@@ -215,3 +217,103 @@ def test_storage_cache():
     ) as mock_object:
         assert storage.get_all_trials(study_id) == trials
         assert mock_object.call_count == 1
+
+
+def test_update_trial() -> None:
+    storage = create_test_storage()
+    study_id = storage.create_new_study()
+
+    test_sets = [
+        (
+            {"state": TrialState.COMPLETE, "datetime_complete": None},
+            {"state": TrialState.COMPLETE},
+        ),
+        ({"value": 1.1}, {"value": 1.1}),
+        ({"intermediate_values": {1: 2.3, 3: 2.5}}, {"values": {1: 2.3, 3: 2.5}}),
+        (
+            {
+                "params": {"paramA": 3, "paramB": "bar",},
+                "_distributions": {
+                    "paramA": UniformDistribution(0, 3),
+                    "paramB": CategoricalDistribution(("foo", "bar")),
+                },
+            },
+            {
+                "params": {
+                    "paramA": UniformDistribution(0, 3).to_internal_repr(3),
+                    "paramB": CategoricalDistribution(["foo", "bar"]).to_internal_repr("bar"),
+                },
+                "dists": {
+                    "paramA": UniformDistribution(0, 3),
+                    "paramB": CategoricalDistribution(["foo", "bar"]),
+                },
+            },
+        ),
+        (
+            {"user_attrs": {"attrA": 2.3, "attrB": "foo"}},
+            {"user_attrs": {"attrA": 2.3, "attrB": "foo"}},
+        ),
+        (
+            {"system_attrs": {"attrC": 2.3, "attrB": "bar"}},
+            {"system_attrs": {"attrC": 2.3, "attrB": "bar"}},
+        ),
+    ]  # type: List[Tuple[Dict[str, Any], Dict[str, Any]]]
+
+    for fields_to_modify, kwargs in test_sets:
+        trial_id = storage.create_new_trial(study_id)
+        trial_before_update = storage.get_trial(trial_id)
+        storage._update_trial(trial_id, **kwargs)
+        trial_after_update = storage.get_trial(trial_id)
+        for field in FrozenTrial._ordered_fields:
+            if field not in fields_to_modify:
+                assert getattr(trial_before_update, field) == getattr(trial_after_update, field)
+            for key, value in fields_to_modify.items():
+                if value is not None:
+                    assert getattr(trial_after_update, key) == value
+
+
+def test_update_trial_second_write() -> None:
+    storage = create_test_storage()
+    study_id = storage.create_new_study()
+    template = FrozenTrial(
+        number=1,
+        state=TrialState.RUNNING,
+        value=0.1,
+        datetime_start=None,
+        datetime_complete=None,
+        params={"paramA": 0.1, "paramB": 1.1},
+        distributions={"paramA": UniformDistribution(0, 1), "paramB": UniformDistribution(0, 2)},
+        user_attrs={"userA": 2, "userB": 3},
+        system_attrs={"sysA": 4, "sysB": 5},
+        intermediate_values={3: 1.2, 5: 9.2},
+        trial_id=1,
+    )
+    trial_id = storage.create_new_trial(study_id, template)
+    trial_before_update = storage.get_trial(trial_id)
+    storage._update_trial(
+        trial_id,
+        state=None,
+        value=1.1,
+        values={3: 2.3, 7: 3.3},
+        params={"paramA": 0.2, "paramC": 2.3},
+        dists={"paramA": UniformDistribution(0, 1), "paramC": UniformDistribution(0, 4)},
+        user_attrs={"userA": 1, "userC": "attr"},
+        system_attrs={"sysA": 6, "sysC": 8},
+    )
+    trial_after_update = storage.get_trial(trial_id)
+    expected_attrs = {
+        "_trial_id": trial_before_update._trial_id,
+        "number": trial_before_update.number,
+        "state": TrialState.RUNNING,
+        "value": 1.1,
+        "params": {"paramA": 0.1, "paramB": 1.1, "paramC": 2.3},
+        "_distributions": {
+            "paramA": UniformDistribution(0, 1),
+            "paramB": UniformDistribution(0, 2),
+            "paramC": UniformDistribution(0, 4),
+        },
+        "user_attrs": {"userA": 1, "userB": 3, "userC": "attr"},
+        "system_attrs": {"sysA": 6, "sysB": 5, "sysC": 8},
+    }
+    for key, value in expected_attrs.items():
+        assert getattr(trial_after_update, key) == value

--- a/tests/storages_tests/test_cached_storage.py
+++ b/tests/storages_tests/test_cached_storage.py
@@ -1,0 +1,152 @@
+from unittest.mock import patch
+
+import optuna
+from optuna.storages.cached_storage import _CachedStorage
+from optuna.storages.cached_storage import RDBStorage
+from optuna.trial import TrialState
+
+
+def test_create_trial() -> None:
+    base_storage = RDBStorage("sqlite:///:memory:")
+    storage = _CachedStorage(base_storage)
+    study_id = storage.create_new_study("test-study")
+    frozen_trial = optuna.trial.FrozenTrial(
+        number=1,
+        state=TrialState.RUNNING,
+        value=None,
+        datetime_start=None,
+        datetime_complete=None,
+        params={},
+        distributions={},
+        user_attrs={},
+        system_attrs={},
+        intermediate_values={},
+        trial_id=1,
+    )
+    with patch.object(
+        base_storage, "_create_new_trial_with_trial", return_value=(1, frozen_trial)
+    ):
+        storage.create_new_trial(study_id)
+    storage.create_new_trial(study_id)
+
+
+def test_cached_set() -> None:
+
+    """Test CachedStorage does not flush to persistent storages.
+
+     The CachedStorage does not flush when it modifies trial updates of params.
+
+    """
+
+    base_storage = RDBStorage("sqlite:///:memory:")
+    storage = _CachedStorage(base_storage)
+    study_id = storage.create_new_study("test-study")
+
+    trial_id = storage.create_new_trial(study_id)
+    with patch.object(base_storage, "_update_trial", return_value=True) as update_mock:
+        with patch.object(base_storage, "set_trial_param", return_value=True) as set_mock:
+            storage.set_trial_param(
+                trial_id, "paramA", 1.2, optuna.distributions.UniformDistribution(-0.2, 2.3)
+            )
+            assert update_mock.call_count == 0
+            assert set_mock.call_count == 0
+
+
+def test_uncached_set() -> None:
+
+    """Test CachedStorage does flush to persistent storages.
+
+     The CachedStorage flushes modifications of trials to a persistent storage when
+     it modifies either value, intermediate_values, state, user_attrs, or system_attrs.
+
+    """
+
+    base_storage = RDBStorage("sqlite:///:memory:")
+    storage = _CachedStorage(base_storage)
+    study_id = storage.create_new_study("test-study")
+
+    for state in [TrialState.COMPLETE, TrialState.PRUNED, TrialState.FAIL, TrialState.WAITING]:
+        trial_id = storage.create_new_trial(study_id)
+        with patch.object(base_storage, "_update_trial", return_value=True) as update_mock:
+            with patch.object(base_storage, "set_trial_state", return_value=True) as set_mock:
+                storage.set_trial_state(trial_id, state)
+                assert update_mock.call_count == 1
+                assert set_mock.call_count == 0
+
+    trial_id = storage.create_new_trial(study_id)
+    with patch.object(base_storage, "_update_trial", return_value=True) as update_mock:
+        with patch.object(base_storage, "set_trial_value", return_value=None) as set_mock:
+            storage.set_trial_value(trial_id, 0.3)
+            assert update_mock.call_count == 1
+            assert set_mock.call_count == 0
+
+    trial_id = storage.create_new_trial(study_id)
+    with patch.object(base_storage, "_update_trial", return_value=True) as update_mock:
+        with patch.object(
+            base_storage, "set_trial_intermediate_value", return_value=None
+        ) as set_mock:
+            storage.set_trial_intermediate_value(trial_id, 3, 0.3)
+            assert update_mock.call_count == 1
+            assert set_mock.call_count == 0
+
+    trial_id = storage.create_new_trial(study_id)
+    with patch.object(base_storage, "_update_trial", return_value=True) as update_mock:
+        with patch.object(base_storage, "set_trial_system_attr", return_value=None) as set_mock:
+            storage.set_trial_system_attr(trial_id, "attrA", "foo")
+            assert update_mock.call_count == 1
+            assert set_mock.call_count == 0
+
+    trial_id = storage.create_new_trial(study_id)
+    with patch.object(base_storage, "_update_trial", return_value=True) as update_mock:
+        with patch.object(base_storage, "set_trial_user_attr", return_value=None) as set_mock:
+            storage.set_trial_user_attr(trial_id, "attrB", "bar")
+            assert update_mock.call_count == 1
+            assert set_mock.call_count == 0
+
+
+def test_cache_deletion() -> None:
+
+    """Test CachedStorage deletes a cache when trial finishes."""
+
+    base_storage = RDBStorage("sqlite:///:memory:")
+    storage = _CachedStorage(base_storage)
+    study_id = storage.create_new_study("test-study")
+
+    for state in [TrialState.COMPLETE, TrialState.PRUNED, TrialState.FAIL, TrialState.WAITING]:
+        trial_id = storage.create_new_trial(study_id)
+        with patch.object(base_storage, "_update_trial", return_value=True) as update_mock:
+            with patch.object(base_storage, "set_trial_state", return_value=True) as set_mock:
+                with patch.object(base_storage, "get_trial", return_value=True) as get_mock:
+                    storage.get_trial(trial_id)
+                    assert update_mock.call_count == 0
+                    assert set_mock.call_count == 0
+                    assert get_mock.call_count == 0
+
+                    storage.set_trial_state(trial_id, state)
+                    assert update_mock.call_count == 1
+                    assert set_mock.call_count == 0
+                    assert get_mock.call_count == 0
+
+                    storage.get_trial(trial_id)
+                    assert update_mock.call_count == 1
+                    assert set_mock.call_count == 0
+                    assert get_mock.call_count == 1
+
+    trial_id = storage.create_new_trial(study_id)
+    with patch.object(base_storage, "_update_trial", return_value=True) as update_mock:
+        with patch.object(base_storage, "set_trial_state", return_value=True) as set_mock:
+            with patch.object(base_storage, "get_trial", return_value=True) as get_mock:
+                storage.get_trial(trial_id)
+                assert update_mock.call_count == 0
+                assert set_mock.call_count == 0
+                assert get_mock.call_count == 0
+
+                storage.set_trial_state(trial_id, TrialState.RUNNING)
+                assert update_mock.call_count == 1
+                assert set_mock.call_count == 0
+                assert get_mock.call_count == 0
+
+                storage.get_trial(trial_id)
+                assert update_mock.call_count == 1
+                assert set_mock.call_count == 0
+                assert get_mock.call_count == 0

--- a/tests/storages_tests/test_cached_storage.py
+++ b/tests/storages_tests/test_cached_storage.py
@@ -43,13 +43,14 @@ def test_cached_set() -> None:
     study_id = storage.create_new_study("test-study")
 
     trial_id = storage.create_new_trial(study_id)
-    with patch.object(base_storage, "_update_trial", return_value=True) as update_mock:
-        with patch.object(base_storage, "set_trial_param", return_value=True) as set_mock:
-            storage.set_trial_param(
-                trial_id, "paramA", 1.2, optuna.distributions.UniformDistribution(-0.2, 2.3)
-            )
-            assert update_mock.call_count == 0
-            assert set_mock.call_count == 0
+    with patch.object(
+        base_storage, "_update_trial", return_value=True
+    ) as update_mock, patch.object(base_storage, "set_trial_param", return_value=True) as set_mock:
+        storage.set_trial_param(
+            trial_id, "paramA", 1.2, optuna.distributions.UniformDistribution(-0.2, 2.3)
+        )
+        assert update_mock.call_count == 0
+        assert set_mock.call_count == 0
 
 
 def test_uncached_set() -> None:
@@ -67,41 +68,52 @@ def test_uncached_set() -> None:
 
     for state in [TrialState.COMPLETE, TrialState.PRUNED, TrialState.FAIL, TrialState.WAITING]:
         trial_id = storage.create_new_trial(study_id)
-        with patch.object(base_storage, "_update_trial", return_value=True) as update_mock:
-            with patch.object(base_storage, "set_trial_state", return_value=True) as set_mock:
-                storage.set_trial_state(trial_id, state)
-                assert update_mock.call_count == 1
-                assert set_mock.call_count == 0
-
-    trial_id = storage.create_new_trial(study_id)
-    with patch.object(base_storage, "_update_trial", return_value=True) as update_mock:
-        with patch.object(base_storage, "set_trial_value", return_value=None) as set_mock:
-            storage.set_trial_value(trial_id, 0.3)
-            assert update_mock.call_count == 1
-            assert set_mock.call_count == 0
-
-    trial_id = storage.create_new_trial(study_id)
-    with patch.object(base_storage, "_update_trial", return_value=True) as update_mock:
         with patch.object(
-            base_storage, "set_trial_intermediate_value", return_value=None
+            base_storage, "_update_trial", return_value=True
+        ) as update_mock, patch.object(
+            base_storage, "set_trial_state", return_value=True
         ) as set_mock:
-            storage.set_trial_intermediate_value(trial_id, 3, 0.3)
+            storage.set_trial_state(trial_id, state)
             assert update_mock.call_count == 1
             assert set_mock.call_count == 0
 
     trial_id = storage.create_new_trial(study_id)
-    with patch.object(base_storage, "_update_trial", return_value=True) as update_mock:
-        with patch.object(base_storage, "set_trial_system_attr", return_value=None) as set_mock:
-            storage.set_trial_system_attr(trial_id, "attrA", "foo")
-            assert update_mock.call_count == 1
-            assert set_mock.call_count == 0
+    with patch.object(
+        base_storage, "_update_trial", return_value=True
+    ) as update_mock, patch.object(base_storage, "set_trial_value", return_value=None) as set_mock:
+        storage.set_trial_value(trial_id, 0.3)
+        assert update_mock.call_count == 1
+        assert set_mock.call_count == 0
 
     trial_id = storage.create_new_trial(study_id)
-    with patch.object(base_storage, "_update_trial", return_value=True) as update_mock:
-        with patch.object(base_storage, "set_trial_user_attr", return_value=None) as set_mock:
-            storage.set_trial_user_attr(trial_id, "attrB", "bar")
-            assert update_mock.call_count == 1
-            assert set_mock.call_count == 0
+    with patch.object(
+        base_storage, "_update_trial", return_value=True
+    ) as update_mock, patch.object(
+        base_storage, "set_trial_intermediate_value", return_value=None
+    ) as set_mock:
+        storage.set_trial_intermediate_value(trial_id, 3, 0.3)
+        assert update_mock.call_count == 1
+        assert set_mock.call_count == 0
+
+    trial_id = storage.create_new_trial(study_id)
+    with patch.object(
+        base_storage, "_update_trial", return_value=True
+    ) as update_mock, patch.object(
+        base_storage, "set_trial_system_attr", return_value=None
+    ) as set_mock:
+        storage.set_trial_system_attr(trial_id, "attrA", "foo")
+        assert update_mock.call_count == 1
+        assert set_mock.call_count == 0
+
+    trial_id = storage.create_new_trial(study_id)
+    with patch.object(
+        base_storage, "_update_trial", return_value=True
+    ) as update_mock, patch.object(
+        base_storage, "set_trial_user_attr", return_value=None
+    ) as set_mock:
+        storage.set_trial_user_attr(trial_id, "attrB", "bar")
+        assert update_mock.call_count == 1
+        assert set_mock.call_count == 0
 
 
 def test_cache_deletion() -> None:
@@ -114,39 +126,47 @@ def test_cache_deletion() -> None:
 
     for state in [TrialState.COMPLETE, TrialState.PRUNED, TrialState.FAIL, TrialState.WAITING]:
         trial_id = storage.create_new_trial(study_id)
-        with patch.object(base_storage, "_update_trial", return_value=True) as update_mock:
-            with patch.object(base_storage, "set_trial_state", return_value=True) as set_mock:
-                with patch.object(base_storage, "get_trial", return_value=True) as get_mock:
-                    storage.get_trial(trial_id)
-                    assert update_mock.call_count == 0
-                    assert set_mock.call_count == 0
-                    assert get_mock.call_count == 0
+        with patch.object(
+            base_storage, "_update_trial", return_value=True
+        ) as update_mock, patch.object(
+            base_storage, "set_trial_state", return_value=True
+        ) as set_mock, patch.object(
+            base_storage, "get_trial", return_value=True
+        ) as get_mock:
+            storage.get_trial(trial_id)
+            assert update_mock.call_count == 0
+            assert set_mock.call_count == 0
+            assert get_mock.call_count == 0
 
-                    storage.set_trial_state(trial_id, state)
-                    assert update_mock.call_count == 1
-                    assert set_mock.call_count == 0
-                    assert get_mock.call_count == 0
+            storage.set_trial_state(trial_id, state)
+            assert update_mock.call_count == 1
+            assert set_mock.call_count == 0
+            assert get_mock.call_count == 0
 
-                    storage.get_trial(trial_id)
-                    assert update_mock.call_count == 1
-                    assert set_mock.call_count == 0
-                    assert get_mock.call_count == 1
+            storage.get_trial(trial_id)
+            assert update_mock.call_count == 1
+            assert set_mock.call_count == 0
+            assert get_mock.call_count == 1
 
     trial_id = storage.create_new_trial(study_id)
-    with patch.object(base_storage, "_update_trial", return_value=True) as update_mock:
-        with patch.object(base_storage, "set_trial_state", return_value=True) as set_mock:
-            with patch.object(base_storage, "get_trial", return_value=True) as get_mock:
-                storage.get_trial(trial_id)
-                assert update_mock.call_count == 0
-                assert set_mock.call_count == 0
-                assert get_mock.call_count == 0
+    with patch.object(
+        base_storage, "_update_trial", return_value=True
+    ) as update_mock, patch.object(
+        base_storage, "set_trial_state", return_value=True
+    ) as set_mock, patch.object(
+        base_storage, "get_trial", return_value=True
+    ) as get_mock:
+        storage.get_trial(trial_id)
+        assert update_mock.call_count == 0
+        assert set_mock.call_count == 0
+        assert get_mock.call_count == 0
 
-                storage.set_trial_state(trial_id, TrialState.RUNNING)
-                assert update_mock.call_count == 1
-                assert set_mock.call_count == 0
-                assert get_mock.call_count == 0
+        storage.set_trial_state(trial_id, TrialState.RUNNING)
+        assert update_mock.call_count == 1
+        assert set_mock.call_count == 0
+        assert get_mock.call_count == 0
 
-                storage.get_trial(trial_id)
-                assert update_mock.call_count == 1
-                assert set_mock.call_count == 0
-                assert get_mock.call_count == 0
+        storage.get_trial(trial_id)
+        assert update_mock.call_count == 1
+        assert set_mock.call_count == 0
+        assert get_mock.call_count == 0

--- a/tests/storages_tests/test_cached_storage.py
+++ b/tests/storages_tests/test_cached_storage.py
@@ -23,7 +23,7 @@ def test_create_trial() -> None:
         intermediate_values={},
         trial_id=1,
     )
-    with patch.object(base_storage, "_create_new_trial", return_value=(1, frozen_trial)):
+    with patch.object(base_storage, "_create_new_trial", return_value=frozen_trial):
         storage.create_new_trial(study_id)
     storage.create_new_trial(study_id)
 

--- a/tests/storages_tests/test_cached_storage.py
+++ b/tests/storages_tests/test_cached_storage.py
@@ -23,9 +23,7 @@ def test_create_trial() -> None:
         intermediate_values={},
         trial_id=1,
     )
-    with patch.object(
-        base_storage, "_create_new_trial_with_trial", return_value=(1, frozen_trial)
-    ):
+    with patch.object(base_storage, "_create_new_trial", return_value=(1, frozen_trial)):
         storage.create_new_trial(study_id)
     storage.create_new_trial(study_id)
 

--- a/tests/storages_tests/test_storages.py
+++ b/tests/storages_tests/test_storages.py
@@ -16,6 +16,7 @@ from optuna.distributions import LogUniformDistribution
 from optuna.distributions import UniformDistribution
 from optuna.storages.base import DEFAULT_STUDY_NAME_PREFIX
 from optuna.storages import BaseStorage
+from optuna.storages.cached_storage import _CachedStorage
 from optuna.storages import InMemoryStorage
 from optuna.storages import RDBStorage
 from optuna.storages import RedisStorage
@@ -38,13 +39,14 @@ STORAGE_MODES = [
     "inmemory",
     "sqlite",
     "redis",
+    "cache",
 ]
 
 
 def test_get_storage() -> None:
 
     assert isinstance(optuna.storages.get_storage(None), InMemoryStorage)
-    assert isinstance(optuna.storages.get_storage("sqlite:///:memory:"), RDBStorage)
+    assert isinstance(optuna.storages.get_storage("sqlite:///:memory:"), _CachedStorage)
     assert isinstance(
         optuna.storages.get_storage("redis://test_user:passwd@localhost:6379/0"), RedisStorage
     )
@@ -82,7 +84,7 @@ def test_create_new_study_unique_id(storage_mode: str) -> None:
         study_id3 = storage.create_new_study()
 
         # Study id must not be reused after deletion.
-        if not isinstance(storage, RDBStorage):
+        if not (isinstance(storage, RDBStorage) or isinstance(storage, _CachedStorage)):
             # TODO(ytsmiling) Fix RDBStorage so that it does not reuse study_id.
             assert len({study_id, study_id2, study_id3}) == 3
         summaries = storage.get_all_study_summaries()


### PR DESCRIPTION
## Motivation
Flushing updates of trials to persistent storages on every update (including parameter suggests) can be a significant bottleneck. This PR mitigates the bottleneck by introducing a wrapper class that wraps the `RDBStorage/ class and providing the lazy-sync capability.

## Description of the changes
- Add `CachedStorage`, which is a wrapper of `RDBStorage` and provide the lazy-sync capability.
    - While `CachedStorage` only supports `RDBStorage`, it is straightforward to support other classes such as `RedisStorage`. Thus, `CachedStorage` file is placed directly under the `optuna/storages` class.
- Introduce two additional public methods to `RDBStorage`.
    - One returns `FrozenTrial` when creating a new trial. Note, `create_new_trial` in `BaseStorage` only returns the trial-id.
    - The other receives a `FrozenTrial` and flush the updates to persistent storages.

## Current Status
- [x] Implement `CachedStorage` class.
- [x] Add tests.
- [x] Add docs where necessary.

## Microbench
(DB: official mysql docker image (tag:8.0.19), storage: SSD, CPU: Intel Core i7-6700K, python: 3.5.2)
- perf:optimize-study: time taken for a single optimization

### This PR
```
{'n_study': 1, 'n_trial': 100, 'n_param': 3}
perf:optimize-study                               0:00:10.169289
{'n_study': 1, 'n_trial': 100, 'n_param': 30}
perf:optimize-study                               0:00:47.566834
```

### Current master
```
{'n_study': 1, 'n_trial': 100, 'n_param': 3}
perf:optimize-study                               0:00:22.499407
{'n_study': 1, 'n_trial': 100, 'n_param': 30}
perf:optimize-study                               0:02:33.151298
```

Benchmark code:
```python
import argparse
from collections import defaultdict
from datetime import datetime
import math

import sqlalchemy
import optuna

profile_result = defaultdict(lambda: datetime.now() - datetime.now())


class Profile:
    def __init__(self, name):
        self.name = name

    def __enter__(self):
        self.start = datetime.now()

    def __exit__(self, exc_type, exc_val, exc_tb):
        profile_result[self.name] += datetime.now() - self.start


def print_profile():
    for key, value in sorted(profile_result.items(), key=lambda i: i[1],
                             reverse=True):
        print(key.ljust(50) + '{}'.format(value))


def build_objective_fun(n_param):
    def objective(trial):
        return sum([
            math.sin(trial.suggest_float('param-{}'.format(i), 0, math.pi * 2))
            for i in range(n_param)
        ])

    return objective


def define_flags(parser):
    parser.add_argument('mysql_user', type=str)
    parser.add_argument('mysql_password', type=str)
    parser.add_argument('mysql_host', type=str)
    parser.add_argument('n_study', type=int)
    parser.add_argument('n_trial', type=int)
    parser.add_argument('n_param', type=int)
    return parser


if __name__ == '__main__':
    parser = define_flags(argparse.ArgumentParser())
    args = parser.parse_args()
    print(vars(args))

    storage_str = 'mysql+pymysql://{}:{}@{}/'.format(
        args.mysql_user,
        args.mysql_password,
        args.mysql_host,
    )
    engine = sqlalchemy.create_engine(storage_str)
    sampler = optuna.samplers.TPESampler()
    conn = engine.connect()
    conn.execute("commit")
    database_str = 'profile_storage_s{}_t{}_p{}'.format(
        args.n_study, args.n_trial, args.n_param)

    try:
        conn.execute(
            "drop database {}".format(database_str))
    except:
        pass
    conn.execute("create database {}".format(
        database_str
    ))
    conn.close()

    for i in range(args.n_study):
        storage = optuna.storages.get_storage(storage_str + database_str)
        study = optuna.create_study(sampler=sampler, storage=storage)
        study_id = study.study_id
        with Profile('perf:optimize-study'):
            study.optimize(build_objective_fun(args.n_param), n_trials=args.n_trial, gc_after_trial=False)

    print_profile()

```