### PR TITLE
Remove unnecessary shape-conversion and a loop from TPE sampler.

### DIFF
--- a/optuna/samplers/tpe/sampler.py
+++ b/optuna/samplers/tpe/sampler.py
@@ -371,8 +371,6 @@ class TPESampler(base.BaseSampler):
             raise ValueError(
                 "The 'sigmas' should be 2-dimension. " "But sigmas.shape = {}".format(sigmas.shape)
             )
-        _samples = samples
-        samples = _samples.flatten()
 
         p_accept = np.sum(
             weights
@@ -383,24 +381,24 @@ class TPESampler(base.BaseSampler):
         )
 
         if q is None:
-            distance = samples[:, None] - mus
+            distance = samples[..., None] - mus
             mahalanobis = (distance / np.maximum(sigmas, EPS)) ** 2
             Z = np.sqrt(2 * np.pi) * sigmas
             coefficient = weights / Z / p_accept
-            return_val = TPESampler._logsum_rows(-0.5 * mahalanobis + np.log(coefficient))
+            return TPESampler._logsum_rows(-0.5 * mahalanobis + np.log(coefficient))
         else:
-            probabilities = np.zeros(samples.shape, dtype=float)
             cdf_func = TPESampler._normal_cdf
-            for w, mu, sigma in zip(weights, mus, sigmas):
-                upper_bound = np.minimum(samples + q / 2.0, high)
-                lower_bound = np.maximum(samples - q / 2.0, low)
-                inc_amt = w * cdf_func(upper_bound, mu, sigma)
-                inc_amt -= w * cdf_func(lower_bound, mu, sigma)
-                probabilities += inc_amt
-            return_val = np.log(probabilities + EPS) - np.log(p_accept + EPS)
-
-        return_val.shape = _samples.shape
-        return return_val
+            upper_bound = np.minimum(samples + q / 2.0, high)
+            lower_bound = np.maximum(samples - q / 2.0, low)
+            probabilities = np.sum(
+                weights[..., None]
+                * (
+                    cdf_func(upper_bound[None], mus[..., None], sigmas[..., None])
+                    - cdf_func(lower_bound[None], mus[..., None], sigmas[..., None])
+                ),
+                axis=0,
+            )
+            return np.log(probabilities + EPS) - np.log(p_accept + EPS)
 
     def _sample_from_categorical_dist(self, probabilities, size):
         # type: (np.ndarray, Tuple[int]) -> np.ndarray


### PR DESCRIPTION
## Motivation
The current default sampler (TPE) involves unnecessary shape conversions (with copy) and unnecessary loops. Removing them significantly improves performance especially for discreate-uniform and int-uniform distributions.

## Description of the changes
Remove a shape-conversion (with copy) and a loop.

## Benchmark

(CPU: Intel Core i7-6700K, python: 3.5.2)

distribution: DiscreateUniformDistribution

perf:optimize-study: time taken for a single optimization

### This PR
```
{'n_study': 1, 'n_trial': 1000, 'n_param': 10}
perf:optimize-study                               0:00:34.897372
```

### Current master
```
{'n_study': 1, 'n_trial': 1000, 'n_param': 10}
perf:optimize-study                               0:02:59.235532
```

### Code
```python
import argparse
from collections import defaultdict
from datetime import datetime
import math

import optuna

profile_result = defaultdict(lambda: datetime.now() - datetime.now())


class Profile:
    def __init__(self, name):
        self.name = name

    def __enter__(self):
        self.start = datetime.now()

    def __exit__(self, exc_type, exc_val, exc_tb):
        profile_result[self.name] += datetime.now() - self.start


def print_profile():
    for key, value in sorted(profile_result.items(), key=lambda i: i[1],
                             reverse=True):
        print(key.ljust(50) + '{}'.format(value))


def build_objective_fun(n_param):
    def objective(trial):
        return sum([
            math.sin(trial.suggest_discrete_uniform('param-{}'.format(i), 0, math.pi * 2, math.pi * 0.1))
            for i in range(n_param)
        ])

    return objective


def define_flags(parser):
    parser.add_argument('n_study', type=int)
    parser.add_argument('n_trial', type=int)
    parser.add_argument('n_param', type=int)
    return parser


if __name__ == '__main__':
    parser = define_flags(argparse.ArgumentParser())
    args = parser.parse_args()
    print(vars(args))


    for i in range(args.n_study):
        study = optuna.create_study()
        with Profile('perf:optimize-study'):
            study.optimize(build_objective_fun(args.n_param), n_trials=args.n_trial, gc_after_trial=False)

    print_profile()
```
