### PR TITLE
[AllenNLP] Implement config exporter to save training config with best_params in study.

### DIFF
--- a/docs/source/reference/integration.rst
+++ b/docs/source/reference/integration.rst
@@ -56,4 +56,4 @@ Integration
 .. autoclass:: AllenNLPExecutor
     :members:
 
-.. autofunction:: optuna.integration.allennlp.save_best_config
+.. autofunction:: optuna.integration.allennlp.dump_best_config

--- a/docs/source/reference/integration.rst
+++ b/docs/source/reference/integration.rst
@@ -55,3 +55,5 @@ Integration
 
 .. autoclass:: AllenNLPExecutor
     :members:
+
+.. autofunction:: optuna.integration.allennlp.save_best_config

--- a/optuna/integration/allennlp.py
+++ b/optuna/integration/allennlp.py
@@ -29,7 +29,7 @@ def _dump_best_config(config_file: str, study: optuna.Study) -> Dict:
     return allennlp.common.params.infer_and_cast(config)
 
 
-def save_best_config(input_config_file: str, output_config_file: str, study: optuna.Study) -> None:
+def dump_best_config(input_config_file: str, output_config_file: str, study: optuna.Study) -> None:
     """Save resulting jsonnet replacing masks with best params in the experiment.
 
     Args:

--- a/optuna/integration/allennlp.py
+++ b/optuna/integration/allennlp.py
@@ -36,8 +36,8 @@ def dump_best_config(input_config_file: str, output_config_file: str, study: opt
     best_params = study.best_params
     for key, value in best_params.items():
         best_params[key] = str(value)
-    config = json.loads(_jsonnet.evaluate_file(config_file, ext_vars=best_params))
-    best_config = allennlp.common.params.infer_and_cast(config)
+    best_config = json.loads(_jsonnet.evaluate_file(input_config_file, ext_vars=best_params))
+    best_config = allennlp.common.params.infer_and_cast(best_config)
 
     with open(output_config_file, "w") as f:
         json.dump(best_config, f, indent=4)

--- a/optuna/integration/allennlp.py
+++ b/optuna/integration/allennlp.py
@@ -21,7 +21,7 @@ except ImportError as e:
     TrackerCallback = object
 
 
-def _save_best_config(config_file: str, study: optuna.Study) -> Dict:
+def _dump_best_config(config_file: str, study: optuna.Study) -> Dict:
     best_params = study.best_params
     for key, value in best_params.items():
         best_params[key] = str(value)
@@ -42,7 +42,7 @@ def save_best_config(input_config_file: str, output_config_file: str, study: opt
             ``optimized`` means it requires ``study.best_trial_id`` is not empty.
 
     """
-    best_config = _save_best_config(input_config_file, study)
+    best_config = _dump_best_config(input_config_file, study)
     with open(output_config_file, "w") as f:
         json.dump(best_config, f, indent=4)
 

--- a/optuna/integration/allennlp.py
+++ b/optuna/integration/allennlp.py
@@ -29,21 +29,21 @@ def _save_best_config(config_file: str, study: optuna.Study) -> Dict:
     return allennlp.common.params.infer_and_cast(config)
 
 
-def save_best_config(config_file: str, dest_file: str, study: optuna.Study) -> None:
+def save_best_config(input_config_file: str, output_config_file: str, study: optuna.Study) -> None:
     """Save resulting jsonnet replacing masks with best params in the experiment.
 
     Args:
-        config_file:
+        input_config_file:
             Config file used in AllenNLPExecutor.
-        dest_file:
+        output_config_file:
             Path to output a optimized jsonnet config file.
         study:
             A optimized study instance.
             ``optimized`` means it requires ``study.best_trial_id`` is not empty.
 
     """
-    best_config = _save_best_config(config_file, study)
-    with open(dest_file, "w") as f:
+    best_config = _save_best_config(input_config_file, study)
+    with open(output_config_file, "w") as f:
         json.dump(best_config, f, indent=4)
 
 

--- a/optuna/integration/allennlp.py
+++ b/optuna/integration/allennlp.py
@@ -21,14 +21,6 @@ except ImportError as e:
     TrackerCallback = object
 
 
-def _dump_best_config(config_file: str, study: optuna.Study) -> Dict:
-    best_params = study.best_params
-    for key, value in best_params.items():
-        best_params[key] = str(value)
-    config = json.loads(_jsonnet.evaluate_file(config_file, ext_vars=best_params))
-    return allennlp.common.params.infer_and_cast(config)
-
-
 def dump_best_config(input_config_file: str, output_config_file: str, study: optuna.Study) -> None:
     """Save resulting jsonnet replacing masks with best params in the experiment.
 
@@ -42,7 +34,12 @@ def dump_best_config(input_config_file: str, output_config_file: str, study: opt
             ``optimized`` means it requires ``study.best_trial_id`` is not empty.
 
     """
-    best_config = _dump_best_config(input_config_file, study)
+    best_params = study.best_params
+    for key, value in best_params.items():
+        best_params[key] = str(value)
+    config = json.loads(_jsonnet.evaluate_file(config_file, ext_vars=best_params))
+    best_config = allennlp.common.params.infer_and_cast(config)
+
     with open(output_config_file, "w") as f:
         json.dump(best_config, f, indent=4)
 

--- a/tests/integration_tests/allennlp_tests/test_allennlp.py
+++ b/tests/integration_tests/allennlp_tests/test_allennlp.py
@@ -112,7 +112,7 @@ def test_allennlp_executor_with_include_package_arr() -> None:
         assert isinstance(result, float)
 
 
-def test_save_best_config() -> None:
+def test_dump_best_config() -> None:
     with tempfile.TemporaryDirectory() as tmp_dir:
 
         def objective(trial: optuna.Trial) -> float:
@@ -127,7 +127,7 @@ def test_save_best_config() -> None:
         study = optuna.create_study(direction="maximize")
         study.optimize(objective, n_trials=1)
 
-        optuna.integration.allennlp.save_best_config(input_config_file, output_config_file, study)
+        optuna.integration.allennlp.dump_best_config(input_config_file, output_config_file, study)
         best_config = json.loads(_jsonnet.evaluate_file(output_config_file))
         model_config = best_config["model"]
         target_config = model_config["text_field_embedder"]["token_embedders"]["token_characters"]


### PR DESCRIPTION
Depends on #1149.

This PR introduces `optuna.integration.allennlp.save_best_config`, which enables users to generate a jsonnet config file filled masked values with optimized ones in the `study.optimize()`.

A generated jsonnet file is executable on `allennlp train`.
I put a typical use case below:

```bash
# optimize hyperparameters using optuna
python optimize_hyperparams.py --input config.jsonnet --output optimized.config.jsonnet

# train a model using hyperparameters optimized in optimized_hyperparameters.py
allennlp train -s xxx optimized.config.jsonnet
```