### PR TITLE
Constraint `llvmlite` version for Python 3.5.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -78,6 +78,9 @@ def get_extras_require() -> Dict[str, List[str]]:
         ]
         + (["allennlp<1", "fastai<2"] if (3, 5) < sys.version_info[:2] < (3, 8) else [])
         + (
+            ["llvmlite<=0.31.0"] if (3, 5) == sys.version_info[:2] else []
+        )  # Newer `llvmlite` is not distributed with wheels for Python 3.5.
+        + (
             [
                 "dask[dataframe]",
                 "dask-ml",


### PR DESCRIPTION
## Motivation

The latest `llvmlite` does not come with a wheel for Python 3.5. The GitHub Actions daily example build with Python 3.5 is failing trying to build it (`llvmlite` is used by `numba` which is used by `dask-ml`). 

## Description of the changes

A quick fix, restricting the version of `llvmlite`.
