### PR TITLE
Add cross-validation support for `LightGBMTuner`.

### DIFF
--- a/examples/lightgbm_tuner_cv.py
+++ b/examples/lightgbm_tuner_cv.py
@@ -1,0 +1,38 @@
+"""
+Optuna example that optimizes a classifier configuration for cancer dataset using LightGBM tuner.
+
+In this example, we optimize the cross-validated log loss of cancer detection.
+
+You can execute this code directly.
+    $ python lightgbm_tuner_cv.py
+
+"""
+import sklearn.datasets
+from sklearn.model_selection import KFold
+
+import optuna.integration.lightgbm as lgb
+
+
+if __name__ == "__main__":
+    data, target = sklearn.datasets.load_breast_cancer(return_X_y=True)
+    dtrain = lgb.Dataset(data, label=target)
+
+    params = {
+        "objective": "binary",
+        "metric": "binary_logloss",
+        "verbosity": -1,
+        "boosting_type": "gbdt",
+    }
+
+    tuner = lgb.LightGBMTunerCV(
+        params, dtrain, verbose_eval=100, early_stopping_rounds=100, folds=KFold(n_splits=3)
+    )
+
+    tuner.run()
+
+    print("Best score:", tuner.best_score)
+    best_params = tuner.best_params
+    print("Best params:", best_params)
+    print("  Params: ")
+    for key, value in best_params.items():
+        print("    {}: {}".format(key, value))

--- a/optuna/integration/lightgbm.py
+++ b/optuna/integration/lightgbm.py
@@ -19,6 +19,7 @@ if _available:
     # To pass tests/integration_tests/lightgbm_tuner_tests/test_optimize.py.
     from lightgbm import Dataset  # NOQA
     from optuna.integration.lightgbm_tuner import LightGBMTuner  # NOQA
+    from optuna.integration.lightgbm_tuner import LightGBMTunerCV  # NOQA
 
     _names_from_tuners = ["train", "LGBMModel", "LGBMClassifier", "LGBMRegressor"]
 

--- a/optuna/integration/lightgbm_tuner/__init__.py
+++ b/optuna/integration/lightgbm_tuner/__init__.py
@@ -5,6 +5,7 @@ from optuna import type_checking
 
 try:
     from optuna.integration.lightgbm_tuner.optimize import LightGBMTuner
+    from optuna.integration.lightgbm_tuner.optimize import LightGBMTunerCV  # NOQA
     from optuna.integration.lightgbm_tuner.sklearn import LGBMClassifier  # NOQA
     from optuna.integration.lightgbm_tuner.sklearn import LGBMModel  # NOQA
     from optuna.integration.lightgbm_tuner.sklearn import LGBMRegressor  # NOQA

--- a/optuna/integration/lightgbm_tuner/optimize.py
+++ b/optuna/integration/lightgbm_tuner/optimize.py
@@ -363,7 +363,7 @@ class LightGBMBaseTuner(BaseTuner):
         time_budget: Optional[int] = None,
         sample_size: Optional[int] = None,
         study: Optional[optuna.study.Study] = None,
-        optuna_callbacks: Optional[List[Callable[[Study, FrozenTrial], None]]]=None,
+        optuna_callbacks: Optional[List[Callable[[Study, FrozenTrial], None]]] = None,
         verbosity: Optional[int] = 1,
     ) -> None:
         params = copy.deepcopy(params)
@@ -725,7 +725,7 @@ class LightGBMTuner(LightGBMBaseTuner):
         best_params: Optional[Dict[str, Any]] = None,
         tuning_history: Optional[List[Dict[str, Any]]] = None,
         study: Optional[optuna.study.Study] = None,
-        optuna_callbacks: Optional[List[Callable[[Study, FrozenTrial], None]]]=None,
+        optuna_callbacks: Optional[List[Callable[[Study, FrozenTrial], None]]] = None,
         model_dir: Optional[str] = None,
         verbosity: Optional[int] = 1,
     ) -> None:
@@ -933,7 +933,7 @@ class LightGBMTunerCV(LightGBMBaseTuner):
         time_budget: Optional[int] = None,
         sample_size: Optional[int] = None,
         study: Optional[optuna.study.Study] = None,
-        optuna_callbacks: Optional[List[Callable[[Study, FrozenTrial], None]]]=None,
+        optuna_callbacks: Optional[List[Callable[[Study, FrozenTrial], None]]] = None,
         verbosity: int = 1,
     ) -> None:
 

--- a/optuna/integration/lightgbm_tuner/optimize.py
+++ b/optuna/integration/lightgbm_tuner/optimize.py
@@ -1,36 +1,31 @@
+import abc
 import copy
 import json
 import os
 import pickle
 import time
 from typing import Any
+from typing import Callable
 from typing import Dict
+from typing import Generator
+from typing import Iterator
+from typing import List
+from typing import Optional
+from typing import Tuple
+from typing import Union
 import warnings
 
 import lightgbm as lgb
 import numpy as np
+from sklearn.model_selection import BaseCrossValidator
 import tqdm
 
 import optuna
 from optuna.integration.lightgbm_tuner.alias import _handling_alias_metrics
 from optuna.integration.lightgbm_tuner.alias import _handling_alias_parameters
-from optuna import type_checking
 
-if type_checking.TYPE_CHECKING:
-    from typing import Callable  # NOQA
-    from typing import Generator  # NOQA
-    from typing import List  # NOQA
-    from typing import Optional  # NOQA
-    from typing import Tuple  # NOQA
-    from typing import Union  # NOQA
 
-    from optuna.distributions import BaseDistribution  # NOQA
-    from optuna.trial import FrozenTrial  # NOQA
-    from optuna.study import Study  # NOQA
-    from optuna.trial import Trial  # NOQA
-
-    VALID_SET_TYPE = Union[List[lgb.Dataset], Tuple[lgb.Dataset, ...], lgb.Dataset]
-
+VALID_SET_TYPE = Union[List[lgb.Dataset], Tuple[lgb.Dataset, ...], lgb.Dataset]
 
 # Define key names of `Trial.system_attrs`.
 _ELAPSED_SECS_KEY = "lightgbm_tuner:elapsed_secs"
@@ -177,6 +172,7 @@ class OptunaObjective(BaseTuner):
         self.model_dir = model_dir
 
         self._check_target_names_supported()
+        self.pbar_fmt = "{}, val_score: {:.6f}"
 
     def _check_target_names_supported(self):
         # type: () -> None
@@ -194,13 +190,9 @@ class OptunaObjective(BaseTuner):
             if target_param_name not in supported_param_names:
                 raise NotImplementedError("Parameter `{}` is not supported for tunning.")
 
-    def __call__(self, trial):
-        # type: (Trial) -> float
-
-        pbar_fmt = "{}, val_score: {:.6f}"
-
+    def _preprocess(self, trial: optuna.trial.Trial) -> None:
         if self.pbar is not None:
-            self.pbar.set_description(pbar_fmt.format(self.step_name, self.best_score))
+            self.pbar.set_description(self.pbar_fmt.format(self.step_name, self.best_score))
 
         if "lambda_l1" in self.target_param_names:
             self.lgbm_params["lambda_l1"] = trial.suggest_loguniform("lambda_l1", 1e-8, 10.0)
@@ -228,6 +220,10 @@ class OptunaObjective(BaseTuner):
             param_value = int(trial.suggest_uniform("min_child_samples", 5, 100 + EPS))
             self.lgbm_params["min_child_samples"] = param_value
 
+    def __call__(self, trial: optuna.trial.Trial) -> float:
+
+        self._preprocess(trial)
+
         start_time = time.time()
         booster = lgb.train(self.lgbm_params, self.train_set, **self.lgbm_kwargs)
 
@@ -245,8 +241,19 @@ class OptunaObjective(BaseTuner):
             self.best_score = val_score
             self.best_booster_with_trial_number = (booster, trial.number)
 
+        self._postprocess(trial, val_score, elapsed_secs, average_iteration_time)
+
+        return val_score
+
+    def _postprocess(
+        self,
+        trial: optuna.trial.Trial,
+        val_score: float,
+        elapsed_secs: float,
+        average_iteration_time: float,
+    ) -> None:
         if self.pbar is not None:
-            self.pbar.set_description(pbar_fmt.format(self.step_name, self.best_score))
+            self.pbar.set_description(self.pbar_fmt.format(self.step_name, self.best_score))
             self.pbar.update(1)
 
         self.report.append(
@@ -269,78 +276,93 @@ class OptunaObjective(BaseTuner):
 
         self.trial_count += 1
 
+
+class OptunaCVObjective(OptunaObjective):
+    def __init__(
+        self,
+        target_param_names: List[str],
+        lgbm_params: Dict[str, Any],
+        train_set: lgb.Dataset,
+        lgbm_kwargs: Dict[str, Any],
+        best_score: float,
+        step_name: str,
+        pbar: Optional[tqdm.tqdm] = None,
+    ):
+
+        super(OptunaCVObjective, self).__init__(
+            target_param_names,
+            lgbm_params,
+            train_set,
+            lgbm_kwargs,
+            best_score,
+            step_name,
+            model_dir=None,
+            pbar=pbar,
+        )
+
+    def _get_cv_scores(self, cv_results: Dict[str, List[float]]) -> List[float]:
+
+        metric = self.lgbm_params.get("metric", "binary_logloss")
+
+        # todo (smly): This implementation is different logic from the LightGBM's python bindings.
+        if type(metric) is str:
+            pass
+        elif type(metric) is list:
+            metric = metric[-1]
+        elif type(metric) is set:
+            metric = list(metric)[-1]
+        else:
+            raise NotImplementedError
+
+        metric = self._metric_with_eval_at(metric)
+        val_scores = cv_results["{}-mean".format(metric)]
+        return val_scores
+
+    def __call__(self, trial: optuna.trial.Trial) -> float:
+
+        self._preprocess(trial)
+
+        start_time = time.time()
+        cv_results = lgb.cv(self.lgbm_params, self.train_set, **self.lgbm_kwargs)
+
+        val_scores = self._get_cv_scores(cv_results)
+        val_score = val_scores[-1]
+        elapsed_secs = time.time() - start_time
+        average_iteration_time = elapsed_secs / len(val_scores)
+
+        if self.compare_validation_metrics(val_score, self.best_score):
+            self.best_score = val_score
+
+        self._postprocess(trial, val_score, elapsed_secs, average_iteration_time)
+
         return val_score
 
 
-class LightGBMTuner(BaseTuner):
-    """Hyperparameter-tuning with Optuna for LightGBM.
+class LightGBMBaseTuner(BaseTuner):
+    """Base class of LightGBM Tuners.
 
-    Arguments and keyword arguments for `lightgbm.train()
-    <https://lightgbm.readthedocs.io/en/latest/pythonapi/lightgbm.train.html>`_ can be passed.
-    The arguments that only :class:`~optuna.integration.lightgbm.LightGBMTuner` has are listed
-    below:
-
-    Args:
-        time_budget:
-            A time budget for parameter tuning in seconds.
-
-        best_params:
-            A dictionary to store the best parameters.
-
-            .. deprecated:: 1.4.0
-                Please use the ``params`` attribute of the best booster, which is obtained by
-                :meth:`~optuna.integration.lightgbm.LightGBMTuner.get_best_booster`.
-
-        tuning_history:
-            A List to store the history of parameter tuning.
-
-            .. deprecated:: 1.4.0
-                Please use the ``study`` argument to access optimization history.
-
-        study:
-            A :class:`~optuna.study.Study` instance to store optimization results. The
-            :class:`~optuna.trial.Trial` instances in it has the following system attributes:
-            ``elapsed_secs`` is the elapsed time since the optimization starts.
-            ``average_iteration_time`` is the average time of iteration to train the booster
-            model in the trial. ``lgbm_params`` is a JSON-serialized dictionary of LightGBM
-            parameters used in the trial.
-
-        model_dir:
-            A directory to save boosters. By default, it is set to :obj:`None` and no boosters are
-            saved. Please set shared directory (e.g., directories on NFS) if you want to access
-            :meth:`~optuna.integration.LightGBMTuner.get_best_booster` in distributed environments.
-            Otherwise, it may raise :obj:`ValueError`. If the directory does not exist, it will be
-            created. The filenames of the boosters will be ``{model_dir}/{trial_number}.pkl``
-            (e.g., ``./boosters/0.pkl``).
+    This class has common attributes and method of
+    :class:`~optuna.integration.lightgbm_tuner.LightGBMTuner` and
+    :class:`~optuna.integration.lightgbm_tuner.LightGBMTunerCV`.
     """
 
     def __init__(
         self,
-        params,  # type: Dict[str, Any]
-        train_set,  # type: lgb.Dataset
-        num_boost_round=1000,  # type: int
-        valid_sets=None,  # type: Optional[VALID_SET_TYPE]
-        valid_names=None,  # type: Optional[Any]
-        fobj=None,  # type: Optional[Callable[..., Any]]
-        feval=None,  # type: Optional[Callable[..., Any]]
-        feature_name="auto",  # type: str
-        categorical_feature="auto",  # type: str
-        early_stopping_rounds=None,  # type: Optional[int]
-        evals_result=None,  # type: Optional[Dict[Any, Any]]
-        verbose_eval=True,  # type: Optional[bool]
-        learning_rates=None,  # type: Optional[List[float]]
-        keep_training_booster=False,  # type: Optional[bool]
-        callbacks=None,  # type: Optional[List[Callable[..., Any]]]
-        time_budget=None,  # type: Optional[int]
-        sample_size=None,  # type: Optional[int]
-        best_params=None,  # type: Optional[Dict[str, Any]]
-        tuning_history=None,  # type: Optional[List[Dict[str, Any]]]
-        study=None,  # type: Optional[Study]
-        model_dir=None,  # type: Optional[str]
-        verbosity=1,  # type: Optional[int]
-    ):
-        # type: (...) -> None
-
+        params: Dict[str, Any],
+        train_set: lgb.Dataset,
+        num_boost_round: int = 1000,
+        fobj: Optional[Callable[..., Any]] = None,
+        feval: Optional[Callable[..., Any]] = None,
+        feature_name: str = "auto",
+        categorical_feature: str = "auto",
+        early_stopping_rounds: Optional[int] = None,
+        verbose_eval: Optional[Union[bool, int]] = True,
+        callbacks: Optional[List[Callable[..., Any]]] = None,
+        time_budget: Optional[int] = None,
+        sample_size: Optional[int] = None,
+        study: Optional[optuna.study.Study] = None,
+        verbosity: Optional[int] = 1,
+    ) -> None:
         params = copy.deepcopy(params)
 
         # Handling alias metrics.
@@ -349,46 +371,20 @@ class LightGBMTuner(BaseTuner):
         args = [params, train_set]
         kwargs = dict(
             num_boost_round=num_boost_round,
-            valid_sets=valid_sets,
-            valid_names=valid_names,
             fobj=fobj,
             feval=feval,
             feature_name=feature_name,
             categorical_feature=categorical_feature,
             early_stopping_rounds=early_stopping_rounds,
-            evals_result=evals_result,
             verbose_eval=verbose_eval,
-            learning_rates=learning_rates,
-            keep_training_booster=keep_training_booster,
             callbacks=callbacks,
             time_budget=time_budget,
-            verbosity=verbosity,
             sample_size=sample_size,
+            verbosity=verbosity,
         )  # type: Dict[str, Any]
         self._parse_args(*args, **kwargs)
-        self._best_booster_with_trial_number = None  # type: Optional[Tuple[lgb.Booster, int]]
-        self._start_time = None  # type: Optional[float]
-        self._model_dir = model_dir
-
-        if self._model_dir is not None and not os.path.exists(self._model_dir):
-            os.mkdir(self._model_dir)
-
-        if best_params is not None:
-            warnings.warn(
-                "The `best_params` argument is deprecated. "
-                "Please get the parameter values via `lightgbm.basic.Booster.params`.",
-                DeprecationWarning,
-            )
-
-        if tuning_history is not None:
-            warnings.warn(
-                "The `tuning_history` argument is deprecated. "
-                "Please use the `study` argument to access optimization history.",
-                DeprecationWarning,
-            )
-
-        self._best_params = {} if best_params is None else best_params
-        self.tuning_history = [] if tuning_history is None else tuning_history
+        self._start_time = None
+        self._best_params = {}
 
         # Set default parameters as best.
         self._best_params.update(DEFAULT_LIGHTGBM_PARAMETERS)
@@ -415,9 +411,6 @@ class LightGBMTuner(BaseTuner):
                     "Please set 'minimize' as the direction.".format(metric_name)
                 )
 
-        if valid_sets is None:
-            raise ValueError("`valid_sets` is required.")
-
     @property
     def best_score(self) -> float:
         """"Return the score of the best booster."""
@@ -438,6 +431,341 @@ class LightGBMTuner(BaseTuner):
             # self.lgbm_params may contain parameters given by users.
             params.update(self.lgbm_params)
             return params
+
+    def _parse_args(self, *args: Any, **kwargs: Any) -> None:
+
+        self.auto_options = {
+            option_name: kwargs.get(option_name)
+            for option_name in [
+                "time_budget",
+                "sample_size",
+                "best_params",
+                "tuning_history",
+                "verbosity",
+            ]
+        }
+
+        # Split options.
+        for option_name in self.auto_options.keys():
+            if option_name in kwargs:
+                del kwargs[option_name]
+
+        self.lgbm_params = args[0]
+        self.train_set = args[1]
+        self.train_subset = None  # Use for sampling.
+        self.lgbm_kwargs = kwargs
+
+    def run(self) -> None:
+        """Perform the hyperparameter-tuning with given parameters."""
+        # Surpress log messages.
+        if self.auto_options["verbosity"] == 0:
+            optuna.logging.disable_default_handler()
+            self.lgbm_params["verbose"] = -1
+            self.lgbm_params["seed"] = 111
+            self.lgbm_kwargs["verbose_eval"] = False
+
+        # Handling aliases.
+        _handling_alias_parameters(self.lgbm_params)
+
+        # Sampling.
+        self.sample_train_set()
+
+        self.tune_feature_fraction()
+        self.tune_num_leaves()
+        self.tune_bagging()
+        self.tune_feature_fraction_stage2()
+        self.tune_regularization_factors()
+        self.tune_min_data_in_leaf()
+
+    def sample_train_set(self) -> None:
+        """Make subset of `self.train_set` Dataset object."""
+
+        if self.auto_options["sample_size"] is None:
+            return
+
+        self.train_set.construct()
+        n_train_instance = self.train_set.get_label().shape[0]
+        if n_train_instance > self.auto_options["sample_size"]:
+            offset = n_train_instance - self.auto_options["sample_size"]
+            idx_list = offset + np.arange(self.auto_options["sample_size"])
+            self.train_subset = self.train_set.subset(idx_list)
+
+    def tune_feature_fraction(self, n_trials: int = 7) -> None:
+        param_name = "feature_fraction"
+        param_values = np.linspace(0.4, 1.0, n_trials).tolist()
+
+        # TODO(toshihikoyanase): Remove catch_warnings after GridSampler becomes non-experimental.
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=optuna.exceptions.ExperimentalWarning)
+            sampler = optuna.samplers.GridSampler({param_name: param_values})
+        self.tune_params([param_name], len(param_values), sampler, "feature_fraction")
+
+    def tune_num_leaves(self, n_trials: int = 20) -> None:
+        self.tune_params(["num_leaves"], n_trials, optuna.samplers.TPESampler(), "num_leaves")
+
+    def tune_bagging(self, n_trials: int = 10) -> None:
+        self.tune_params(
+            ["bagging_fraction", "bagging_freq"], n_trials, optuna.samplers.TPESampler(), "bagging"
+        )
+
+    def tune_feature_fraction_stage2(self, n_trials: int = 6) -> None:
+        param_name = "feature_fraction"
+        best_feature_fraction = self.best_params[param_name]
+        param_values = np.linspace(
+            best_feature_fraction - 0.08, best_feature_fraction + 0.08, n_trials
+        ).tolist()
+        param_values = [val for val in param_values if val >= 0.4 and val <= 1.0]
+
+        # TODO(toshihikoyanase): Remove catch_warnings after GridSampler becomes non-experimental.
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=optuna.exceptions.ExperimentalWarning)
+            sampler = optuna.samplers.GridSampler({param_name: param_values})
+        self.tune_params([param_name], len(param_values), sampler, "feature_fraction_stage2")
+
+    def tune_regularization_factors(self, n_trials: int = 20) -> None:
+        self.tune_params(
+            ["lambda_l1", "lambda_l2"],
+            n_trials,
+            optuna.samplers.TPESampler(),
+            "regularization_factors",
+        )
+
+    def tune_min_data_in_leaf(self) -> None:
+        param_name = "min_child_samples"
+        param_values = [5, 10, 25, 50, 100]
+
+        # TODO(toshihikoyanase): Remove catch_warnings after GridSampler becomes non-experimental.
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=optuna.exceptions.ExperimentalWarning)
+            sampler = optuna.samplers.GridSampler({param_name: param_values})
+        self.tune_params([param_name], len(param_values), sampler, "min_data_in_leaf")
+
+    def tune_params(
+        self,
+        target_param_names: List[str],
+        n_trials: int,
+        sampler: optuna.samplers.BaseSampler,
+        step_name: str,
+    ) -> OptunaObjective:
+        pbar = tqdm.tqdm(total=n_trials, ascii=True)
+
+        # Set current best parameters.
+        self.lgbm_params.update(self.best_params)
+
+        train_set = self.train_set
+        if self.train_subset is not None:
+            train_set = self.train_subset
+
+        objective = self._create_objective(target_param_names, train_set, step_name, pbar)
+
+        study = self._create_stepwise_study(self.study, step_name)
+        study.sampler = sampler
+
+        complete_trials = [
+            t
+            for t in study.trials
+            if t.state in (optuna.trial.TrialState.COMPLETE, optuna.trial.TrialState.PRUNED)
+        ]
+        _n_trials = n_trials - len(complete_trials)
+
+        if self._start_time is None:
+            self._start_time = time.time()
+
+        if self.auto_options["time_budget"] is not None:
+            _timeout = self.auto_options["time_budget"] - (time.time() - self._start_time)
+        else:
+            _timeout = None
+        if _n_trials > 0:
+            try:
+                study.optimize(objective, n_trials=_n_trials, timeout=_timeout, catch=())
+            except ValueError:
+                # ValueError is raised by GridSampler when all combinations were examined.
+                # TODO(toshihikoyanase): Remove this try-except after Study.stop is implemented.
+                pass
+
+        pbar.close()
+        del pbar
+
+        return objective
+
+    @abc.abstractmethod
+    def _create_objective(
+        self,
+        target_param_names: List[str],
+        train_set: lgb.Dataset,
+        step_name: str,
+        pbar: tqdm.tqdm,
+    ) -> OptunaObjective:
+
+        raise NotImplementedError
+
+    def _create_stepwise_study(
+        self, study: "optuna.study.Study", step_name: str
+    ) -> "optuna.study.Study":
+
+        # This class is assumed to be passed to a sampler and a pruner corresponding to the step.
+        class _StepwiseStudy(optuna.study.Study):
+            def __init__(self, study: optuna.study.Study, step_name: str) -> None:
+
+                super().__init__(
+                    study_name=study.study_name,
+                    storage=study._storage,
+                    sampler=study.sampler,
+                    pruner=study.pruner,
+                )
+                self._step_name = step_name
+
+            def get_trials(self, deepcopy: bool = True) -> List[optuna.trial.FrozenTrial]:
+
+                trials = super().get_trials(deepcopy=deepcopy)
+                return [t for t in trials if t.system_attrs.get(_STEP_NAME_KEY) == self._step_name]
+
+            @property
+            def best_trial(self) -> optuna.trial.FrozenTrial:
+                """Return the best trial in the study.
+
+                Returns:
+                    A :class:`~optuna.trial.FrozenTrial` object of the best trial.
+                """
+
+                trials = self.get_trials(deepcopy=False)
+                trials = [t for t in trials if t.state is optuna.trial.TrialState.COMPLETE]
+
+                if len(trials) == 0:
+                    raise ValueError("No trials are completed yet.")
+
+                if self.direction == optuna.study.StudyDirection.MINIMIZE:
+                    best_trial = min(trials, key=lambda t: t.value)
+                else:
+                    best_trial = max(trials, key=lambda t: t.value)
+                return copy.deepcopy(best_trial)
+
+        return _StepwiseStudy(study, step_name)
+
+
+class LightGBMTuner(LightGBMBaseTuner):
+    """Hyperparameter-tuning with Optuna for LightGBM.
+
+    Arguments and keyword arguments for `lightgbm.train()
+    <https://lightgbm.readthedocs.io/en/latest/pythonapi/lightgbm.train.html>`_ can be passed.
+    The arguments that only :class:`~optuna.integration.lightgbm.LightGBMTuner` has are listed
+    below:
+
+    Args:
+        time_budget:
+            A time budget for parameter tuning in seconds.
+
+        best_params:
+            A dictionary to store the best parameters.
+
+            .. deprecated:: 1.4.0
+                Please use the ``params`` attribute of the best booster, which is obtained by
+                :meth:`~optuna.integration.lightgbm.LightGBMTuner.get_best_booster`.
+
+        tuning_history:
+            A List to store the history of parameter tuning.
+
+            .. deprecated:: 1.4.0
+                Please use the ``study`` argument to access optimization history.
+
+        study:
+            A :class:`~optuna.study.Study` instance to store optimization results. The
+            :class:`~optuna.trial.Trial` instances in it has the following user attributes:
+            ``elapsed_secs`` is the elapsed time since the optimization starts.
+            ``average_iteration_time`` is the average time of iteration to train the booster
+            model in the trial. ``lgbm_params`` is a JSON-serialized dictionary of LightGBM
+            parameters used in the trial.
+
+        model_dir:
+            A directory to save boosters. By default, it is set to :obj:`None` and no boosters are
+            saved. Please set shared directory (e.g., directories on NFS) if you want to access
+            :meth:`~optuna.integration.LightGBMTuner.get_best_booster` in distributed environments.
+            Otherwise, it may raise :obj:`ValueError`. If the directory does not exist, it will be
+            created. The filenames of the boosters will be ``{model_dir}/{trial_number}.pkl``
+            (e.g., ``./boosters/0.pkl``).
+    """
+
+    def __init__(
+        self,
+        params: Dict[str, Any],
+        train_set: lgb.Dataset,
+        num_boost_round: int = 1000,
+        valid_sets: Optional[VALID_SET_TYPE] = None,
+        valid_names: Optional[Any] = None,
+        fobj: Optional[Callable[..., Any]] = None,
+        feval: Optional[Callable[..., Any]] = None,
+        feature_name: str = "auto",
+        categorical_feature: str = "auto",
+        early_stopping_rounds: Optional[int] = None,
+        evals_result: Optional[Dict[Any, Any]] = None,
+        verbose_eval: Optional[Union[bool, int]] = True,
+        learning_rates: Optional[List[float]] = None,
+        keep_training_booster: Optional[bool] = False,
+        callbacks: Optional[List[Callable[..., Any]]] = None,
+        time_budget: Optional[int] = None,
+        sample_size: Optional[int] = None,
+        best_params: Optional[Dict[str, Any]] = None,
+        tuning_history: Optional[List[Dict[str, Any]]] = None,
+        study: Optional[optuna.study.Study] = None,
+        model_dir: Optional[str] = None,
+        verbosity: Optional[int] = 1,
+    ) -> None:
+
+        super(LightGBMTuner, self).__init__(
+            params,
+            train_set,
+            num_boost_round=num_boost_round,
+            fobj=fobj,
+            feval=feval,
+            feature_name=feature_name,
+            categorical_feature=categorical_feature,
+            early_stopping_rounds=early_stopping_rounds,
+            verbose_eval=verbose_eval,
+            callbacks=callbacks,
+            time_budget=time_budget,
+            sample_size=sample_size,
+            study=study,
+            verbosity=verbosity,
+        )
+
+        self.lgbm_kwargs["valid_sets"] = valid_sets
+        self.lgbm_kwargs["valid_names"] = valid_names
+        self.lgbm_kwargs["evals_result"] = evals_result
+        self.lgbm_kwargs["learning_rates"] = learning_rates
+        self.lgbm_kwargs["keep_training_booster"] = keep_training_booster
+
+        self.auto_options["best_params"] = best_params
+        self.auto_options["tuning_history"] = tuning_history
+
+        # TODO(toshihikoyanase): Remove _best_params updates after removing best_params argument.
+        self._best_params = {} if best_params is None else best_params
+        # Set default parameters as best.
+        self._best_params.update(DEFAULT_LIGHTGBM_PARAMETERS)
+
+        self._best_booster_with_trial_number = None  # type: Optional[Tuple[lgb.Booster, int]]
+        self._model_dir = model_dir
+
+        if self._model_dir is not None and not os.path.exists(self._model_dir):
+            os.mkdir(self._model_dir)
+
+        if best_params is not None:
+            warnings.warn(
+                "The `best_params` argument is deprecated. "
+                "Please get the parameter values via `lightgbm.basic.Booster.params`.",
+                DeprecationWarning,
+            )
+
+        if tuning_history is not None:
+            warnings.warn(
+                "The `tuning_history` argument is deprecated. "
+                "Please use the `study` argument to access optimization history.",
+                DeprecationWarning,
+            )
+
+        self.tuning_history = [] if tuning_history is None else tuning_history
+
+        if valid_sets is None:
+            raise ValueError("`valid_sets` is required.")
 
     @property
     def best_booster(self) -> lgb.Booster:
@@ -492,148 +820,29 @@ class LightGBMTuner(BaseTuner):
 
         return booster
 
-    def _get_params(self):
-        # type: () -> Dict[str, Any]
-
-        params = copy.deepcopy(self.lgbm_params)
-        params.update(self.best_params)
-        return params
-
-    def _parse_args(self, *args, **kwargs):
-        # type: (Any, Any) -> None
-
-        self.auto_options = {
-            option_name: kwargs.get(option_name)
-            for option_name in [
-                "time_budget",
-                "sample_size",
-                "best_params",
-                "tuning_history",
-                "verbosity",
-            ]
-        }
-
-        # Split options.
-        for option_name in self.auto_options.keys():
-            if option_name in kwargs:
-                del kwargs[option_name]
-
-        self.lgbm_params = args[0]
-        self.train_set = args[1]
-        self.train_subset = None  # Use for sampling.
-        self.lgbm_kwargs = kwargs
-
-    def run(self) -> None:
-        """Perform the hyperparameter-tuning with given parameters."""
-        # Surpress log messages.
-        if self.auto_options["verbosity"] == 0:
-            optuna.logging.disable_default_handler()
-            self.lgbm_params["verbose"] = -1
-            self.lgbm_params["seed"] = 111
-            self.lgbm_kwargs["verbose_eval"] = False
-
-        # Handling aliases.
-        _handling_alias_parameters(self.lgbm_params)
-
-        # Sampling.
-        self.sample_train_set()
-
-        self.tune_feature_fraction()
-        self.tune_num_leaves()
-        self.tune_bagging()
-        self.tune_feature_fraction_stage2()
-        self.tune_regularization_factors()
-        self.tune_min_data_in_leaf()
-
-    def sample_train_set(self):
-        # type: () -> None
-        """Make subset of `self.train_set` Dataset object."""
-
-        if self.auto_options["sample_size"] is None:
-            return
-
-        self.train_set.construct()
-        n_train_instance = self.train_set.get_label().shape[0]
-        if n_train_instance > self.auto_options["sample_size"]:
-            offset = n_train_instance - self.auto_options["sample_size"]
-            idx_list = offset + np.arange(self.auto_options["sample_size"])
-            self.train_subset = self.train_set.subset(idx_list)
-
-    def tune_feature_fraction(self, n_trials=7):
-        # type: (int) -> None
-
-        param_name = "feature_fraction"
-        param_values = np.linspace(0.4, 1.0, n_trials).tolist()
-
-        # TODO(toshihikoyanase): Remove catch_warnings after GridSampler becomes non-experimental.
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", category=optuna.exceptions.ExperimentalWarning)
-            sampler = optuna.samplers.GridSampler({param_name: param_values})
-        self.tune_params([param_name], len(param_values), sampler, "feature_fraction")
-
-    def tune_num_leaves(self, n_trials=20):
-        # type: (int) -> None
-
-        self.tune_params(["num_leaves"], n_trials, optuna.samplers.TPESampler(), "num_leaves")
-
-    def tune_bagging(self, n_trials=10):
-        # type: (int) -> None
-
-        self.tune_params(
-            ["bagging_fraction", "bagging_freq"], n_trials, optuna.samplers.TPESampler(), "bagging"
-        )
-
-    def tune_feature_fraction_stage2(self, n_trials=6):
-        # type: (int) -> None
-
-        param_name = "feature_fraction"
-        best_feature_fraction = self.best_params[param_name]
-        param_values = np.linspace(
-            best_feature_fraction - 0.08, best_feature_fraction + 0.08, n_trials
-        ).tolist()
-        param_values = [val for val in param_values if val >= 0.4 and val <= 1.0]
-
-        # TODO(toshihikoyanase): Remove catch_warnings after GridSampler becomes non-experimental.
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", category=optuna.exceptions.ExperimentalWarning)
-            sampler = optuna.samplers.GridSampler({param_name: param_values})
-        self.tune_params([param_name], len(param_values), sampler, "feature_fraction_stage2")
-
-    def tune_regularization_factors(self, n_trials=20):
-        # type: (int) -> None
-
-        self.tune_params(
-            ["lambda_l1", "lambda_l2"],
-            n_trials,
-            optuna.samplers.TPESampler(),
-            "regularization_factors",
-        )
-
-    def tune_min_data_in_leaf(self):
-        # type: () -> None
-
-        param_name = "min_child_samples"
-        param_values = [5, 10, 25, 50, 100]
-
-        # TODO(toshihikoyanase): Remove catch_warnings after GridSampler becomes non-experimental.
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", category=optuna.exceptions.ExperimentalWarning)
-            sampler = optuna.samplers.GridSampler({param_name: param_values})
-        self.tune_params([param_name], len(param_values), sampler, "min_data_in_leaf")
-
     def tune_params(self, target_param_names, n_trials, sampler, step_name):
-        # type: (List[str], int, optuna.samplers.BaseSampler, str) -> None
+        # type: (List[str], int, optuna.samplers.BaseSampler, str) -> OptunaObjective
 
-        pbar = tqdm.tqdm(total=n_trials, ascii=True)
+        objective = super(LightGBMTuner, self).tune_params(
+            target_param_names, n_trials, sampler, step_name
+        )
 
-        # Set current best parameters.
-        self.lgbm_params.update(self.best_params)
+        # Add tuning history.
+        self.tuning_history += objective.report
 
-        train_set = self.train_set
-        if self.train_subset is not None:
-            train_set = self.train_subset
+        if objective.best_booster_with_trial_number is not None:
+            self._best_booster_with_trial_number = objective.best_booster_with_trial_number
+            self._best_params.update(self.best_params)
+        return objective
 
-        objective = OptunaObjective(
+    def _create_objective(
+        self,
+        target_param_names: List[str],
+        train_set: lgb.Dataset,
+        step_name: str,
+        pbar: tqdm.tqdm,
+    ) -> OptunaObjective:
+        return OptunaObjective(
             target_param_names,
             self.lgbm_params,
             train_set,
@@ -644,83 +853,99 @@ class LightGBMTuner(BaseTuner):
             pbar=pbar,
         )
 
-        study = self._create_stepwise_study(self.study, step_name)
-        study.sampler = sampler
 
-        complete_trials = [
-            t
-            for t in study.trials
-            if t.state in (optuna.trial.TrialState.COMPLETE, optuna.trial.TrialState.PRUNED)
-        ]
-        _n_trials = n_trials - len(complete_trials)
+class LightGBMTunerCV(LightGBMBaseTuner):
+    """Hyperparameter-tuning with Optuna for LightGBM.
 
-        if self._start_time is None:
-            self._start_time = time.time()
+    In each trial, it performs cross-validation with the suggested hyperparameters.
+    Arguments and keyword arguments for `lightgbm.cv()
+    <https://lightgbm.readthedocs.io/en/latest/pythonapi/lightgbm.cv.html>`_ can be passed except
+    ``metrics`` and ``init_model``.
+    The arguments that only :class:`~optuna.integration.lightgbm.LightGBMTunerCV` has are listed
+    below:
 
-        if self.auto_options["time_budget"] is not None:
-            _timeout = self.auto_options["time_budget"] - (time.time() - self._start_time)
-        else:
-            _timeout = None
-        if _n_trials > 0:
-            try:
-                study.optimize(objective, n_trials=_n_trials, timeout=_timeout, catch=())
-            except ValueError:
-                # ValueError is raised by GridSampler when all combinations were examined.
-                # TODO(toshihikoyanase): Remove this try-except after Study.stop is implemented.
-                pass
+    Args:
+        time_budget:
+            A time budget for parameter tuning in seconds.
 
-        pbar.close()
-        del pbar
+        study:
+            A :class:`~optuna.study.Study` instance to store optimization results. The
+            :class:`~optuna.trial.Trial` instances in it has the following user attributes:
+            ``elapsed_secs`` is the elapsed time since the optimization starts.
+            ``average_iteration_time`` is the average time of iteration to train the booster
+            model in the trial. ``lgbm_params`` is a JSON-serialized dictionary of LightGBM
+            parameters used in the trial.
+    """
 
-        # Add tuning history.
-        self.tuning_history += objective.report
+    def __init__(
+        self,
+        params: Dict[str, Any],
+        train_set: lgb.Dataset,
+        num_boost_round: int = 1000,
+        folds: Optional[
+            Union[
+                Generator[Tuple[int, int], None, None],
+                Iterator[Tuple[int, int]],
+                BaseCrossValidator,
+            ]
+        ] = None,
+        nfold: int = 5,
+        stratified: bool = True,
+        shuffle: bool = True,
+        fobj: Optional[Callable[..., Any]] = None,
+        feval: Optional[Callable[..., Any]] = None,
+        feature_name: str = "auto",
+        categorical_feature: str = "auto",
+        early_stopping_rounds: Optional[int] = None,
+        fpreproc: Optional[Callable[..., Any]] = None,
+        verbose_eval: Optional[Union[bool, int]] = True,
+        show_stdv: bool = True,
+        seed: int = 0,
+        callbacks: Optional[List[Callable[..., Any]]] = None,
+        time_budget: Optional[int] = None,
+        sample_size: Optional[int] = None,
+        study: Optional[optuna.study.Study] = None,
+        verbosity: int = 1,
+    ) -> None:
 
-        if objective.best_booster_with_trial_number is not None:
-            self._best_booster_with_trial_number = objective.best_booster_with_trial_number
-            self._best_params.update(self.best_params)
+        super(LightGBMTunerCV, self).__init__(
+            params,
+            train_set,
+            num_boost_round,
+            fobj=fobj,
+            feval=feval,
+            feature_name=feature_name,
+            categorical_feature=categorical_feature,
+            early_stopping_rounds=early_stopping_rounds,
+            verbose_eval=verbose_eval,
+            callbacks=callbacks,
+            time_budget=time_budget,
+            sample_size=sample_size,
+            study=study,
+            verbosity=verbosity,
+        )
 
-    def _create_stepwise_study(
-        self, study: "optuna.study.Study", step_name: str
-    ) -> "optuna.study.Study":
+        self.lgbm_kwargs["folds"] = folds
+        self.lgbm_kwargs["nfold"] = nfold
+        self.lgbm_kwargs["stratified"] = stratified
+        self.lgbm_kwargs["shuffle"] = shuffle
+        self.lgbm_kwargs["show_stdv"] = show_stdv
+        self.lgbm_kwargs["seed"] = seed
+        self.lgbm_kwargs["fpreproc"] = fpreproc
 
-        # This class is assumed to be passed to a sampler and a pruner corresponding to the step.
-        class _StepwiseStudy(optuna.study.Study):
-            def __init__(self, study, step_name):
-                # type: (optuna.study.Study, str) -> None
-
-                super().__init__(
-                    study_name=study.study_name,
-                    storage=study._storage,
-                    sampler=study.sampler,
-                    pruner=study.pruner,
-                )
-                self._step_name = step_name
-
-            def get_trials(self, deepcopy=True):
-                # type: (bool) -> List[optuna.trial.FrozenTrial]
-
-                trials = super().get_trials(deepcopy=deepcopy)
-                return [t for t in trials if t.system_attrs.get(_STEP_NAME_KEY) == self._step_name]
-
-            @property
-            def best_trial(self):
-                # type: () -> optuna.trial.FrozenTrial
-                """Return the best trial in the study.
-
-                Returns:
-                    A :class:`~optuna.trial.FrozenTrial` object of the best trial.
-                """
-
-                trials = self.get_trials(deepcopy=False)
-                trials = [t for t in trials if t.state is optuna.trial.TrialState.COMPLETE]
-
-                if len(trials) == 0:
-                    raise ValueError("No trials are completed yet.")
-
-                if self.direction == optuna.study.StudyDirection.MINIMIZE:
-                    best_trial = min(trials, key=lambda t: t.value)
-                else:
-                    best_trial = max(trials, key=lambda t: t.value)
-                return copy.deepcopy(best_trial)
-
-        return _StepwiseStudy(study, step_name)
+    def _create_objective(
+        self,
+        target_param_names: List[str],
+        train_set: lgb.Dataset,
+        step_name: str,
+        pbar: tqdm.tqdm,
+    ) -> OptunaObjective:
+        return OptunaCVObjective(
+            target_param_names,
+            self.lgbm_params,
+            train_set,
+            self.lgbm_kwargs,
+            self.best_score,
+            step_name=step_name,
+            pbar=pbar,
+        )

--- a/optuna/integration/lightgbm_tuner/optimize.py
+++ b/optuna/integration/lightgbm_tuner/optimize.py
@@ -277,7 +277,7 @@ class OptunaObjective(BaseTuner):
         self.trial_count += 1
 
 
-class OptunaCVObjective(OptunaObjective):
+class OptunaObjectiveCV(OptunaObjective):
     def __init__(
         self,
         target_param_names: List[str],
@@ -289,7 +289,7 @@ class OptunaCVObjective(OptunaObjective):
         pbar: Optional[tqdm.tqdm] = None,
     ):
 
-        super(OptunaCVObjective, self).__init__(
+        super(OptunaObjectiveCV, self).__init__(
             target_param_names,
             lgbm_params,
             train_set,
@@ -940,7 +940,7 @@ class LightGBMTunerCV(LightGBMBaseTuner):
         step_name: str,
         pbar: tqdm.tqdm,
     ) -> OptunaObjective:
-        return OptunaCVObjective(
+        return OptunaObjectiveCV(
             target_param_names,
             self.lgbm_params,
             train_set,

--- a/optuna/integration/lightgbm_tuner/optimize.py
+++ b/optuna/integration/lightgbm_tuner/optimize.py
@@ -383,7 +383,7 @@ class LightGBMBaseTuner(BaseTuner):
             verbosity=verbosity,
         )  # type: Dict[str, Any]
         self._parse_args(*args, **kwargs)
-        self._start_time = None
+        self._start_time = None  # type: Optional[float]
         self._best_params = {}
 
         # Set default parameters as best.

--- a/tests/integration_tests/lightgbm_tuner_tests/test_optimize.py
+++ b/tests/integration_tests/lightgbm_tuner_tests/test_optimize.py
@@ -907,9 +907,7 @@ class TestLightGBMTunerCV(object):
         callback_mock = mock.MagicMock()
 
         study = optuna.create_study()
-        tuner = LightGBMTunerCV(
-            params, dataset, study=study, optuna_callbacks=[callback_mock],
-        )
+        tuner = LightGBMTunerCV(params, dataset, study=study, optuna_callbacks=[callback_mock],)
 
         with mock.patch.object(OptunaObjectiveCV, "_get_cv_scores", return_value=[1.0]):
             tuner.tune_params(["num_leaves"], 10, optuna.samplers.TPESampler(), "num_leaves")

--- a/tests/integration_tests/lightgbm_tuner_tests/test_optimize.py
+++ b/tests/integration_tests/lightgbm_tuner_tests/test_optimize.py
@@ -15,7 +15,9 @@ import optuna
 import optuna.integration.lightgbm as lgb
 from optuna.integration.lightgbm_tuner.optimize import BaseTuner
 from optuna.integration.lightgbm_tuner.optimize import LightGBMTuner
+from optuna.integration.lightgbm_tuner.optimize import LightGBMTunerCV
 from optuna.integration.lightgbm_tuner.optimize import OptunaObjective
+from optuna.integration.lightgbm_tuner.optimize import OptunaObjectiveCV
 from optuna import type_checking
 
 if type_checking.TYPE_CHECKING:
@@ -49,6 +51,16 @@ def turnoff_train(metric: Optional[str] = "binary_logloss") -> Generator[None, N
         yield
 
 
+@contextlib.contextmanager
+def turnoff_cv(metric: Optional[str] = "binary_logloss") -> Generator[None, None, None]:
+
+    unexpected_value = 0.5
+    dummy_results = {"{}-mean".format(metric): [unexpected_value]}
+
+    with mock.patch("lightgbm.cv", return_value=dummy_results):
+        yield
+
+
 class TestOptunaObjective(object):
     def test_init_(self):
         # type: () -> None
@@ -73,6 +85,30 @@ class TestOptunaObjective(object):
 
         with turnoff_train():
             objective = OptunaObjective(
+                target_param_names,
+                lgbm_params,
+                train_set,
+                lgbm_kwargs,
+                best_score,
+                "tune_lambda_l1",
+                None,
+            )
+            study = optuna.create_study(direction="minimize")
+            study.optimize(objective, n_trials=10)
+
+            assert study.best_value == 0.5
+
+
+class TestOptunaObjectiveCV(object):
+    def test_call(self) -> None:
+        target_param_names = ["lambda_l1"]
+        lgbm_params = {}  # type: Dict[str, Any]
+        train_set = lgb.Dataset(None)
+        lgbm_kwargs = {}  # type: Dict[str, Any]
+        best_score = -np.inf
+
+        with turnoff_cv():
+            objective = OptunaObjectiveCV(
                 target_param_names,
                 lgbm_params,
                 train_set,
@@ -693,3 +729,157 @@ class TestLightGBMTuner(object):
         assert study_step1.best_trial.value == 1
         assert study_step2.best_trial.value == 2
         assert study.best_trial.value == overall_best
+
+
+class TestLightGBMTunerCV(object):
+    def _get_tunercv_object(
+        self,
+        params: Dict[str, Any] = {},
+        train_set: lgb.Dataset = None,
+        kwargs_options: Dict[str, Any] = {},
+        study: Optional[optuna.study.Study] = None,
+    ) -> LightGBMTunerCV:
+
+        # Required keyword arguments.
+        kwargs = dict(
+            num_boost_round=5, early_stopping_rounds=2, study=study
+        )  # type: Dict[str, Any]
+        kwargs.update(kwargs_options)
+
+        runner = LightGBMTunerCV(params, train_set, **kwargs)
+        return runner
+
+    @pytest.mark.parametrize(
+        "metric, study_direction",
+        [
+            ("auc", "minimize"),
+            ("mse", "maximize"),
+            (None, "maximize"),  # The default metric is binary_logloss.
+        ],
+    )
+    def test_inconsistent_study_direction(self, metric: str, study_direction: str) -> None:
+
+        params = {}  # type: Dict[str, Any]
+        if metric is not None:
+            params["metric"] = metric
+        train_set = lgb.Dataset(None)
+        study = optuna.create_study(direction=study_direction)
+        with pytest.raises(ValueError) as excinfo:
+            LightGBMTunerCV(
+                params, train_set, num_boost_round=5, early_stopping_rounds=2, study=study,
+            )
+
+        assert excinfo.type == ValueError
+        assert str(excinfo.value).startswith("Study direction is inconsistent with the metric")
+
+    def test_with_minimum_required_args(self) -> None:
+
+        runner = self._get_tunercv_object()
+        assert "num_boost_round" in runner.lgbm_kwargs
+        assert "num_boost_round" not in runner.auto_options
+        assert runner.lgbm_kwargs["num_boost_round"] == 5
+
+    def test_tune_feature_fraction(self) -> None:
+        unexpected_value = 1.1  # out of scope.
+
+        with turnoff_cv():
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", category=DeprecationWarning)
+                runner = self._get_tunercv_object(
+                    params=dict(
+                        feature_fraction=unexpected_value,  # set default as unexpected value.
+                    ),
+                )
+            runner.tune_feature_fraction()
+
+            assert runner.lgbm_params["feature_fraction"] != unexpected_value
+            assert len(runner.study.trials) == 7
+
+    def test_tune_num_leaves(self) -> None:
+        unexpected_value = 1  # out of scope.
+
+        with turnoff_cv():
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", category=DeprecationWarning)
+                runner = self._get_tunercv_object(params=dict(num_leaves=unexpected_value,),)
+            assert len(runner.study.trials) == 0
+            runner.tune_num_leaves()
+
+            assert runner.lgbm_params["num_leaves"] != unexpected_value
+            assert len(runner.study.trials) == 20
+
+    def test_tune_bagging(self) -> None:
+        unexpected_value = 1  # out of scope.
+
+        with turnoff_cv():
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", category=DeprecationWarning)
+                runner = self._get_tunercv_object(params=dict(bagging_fraction=unexpected_value,),)
+            assert len(runner.study.trials) == 0
+            runner.tune_bagging()
+
+            assert runner.lgbm_params["bagging_fraction"] != unexpected_value
+            assert len(runner.study.trials) == 10
+
+    def test_tune_feature_fraction_stage2(self) -> None:
+        unexpected_value = 0.5
+
+        with turnoff_cv():
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", category=DeprecationWarning)
+                runner = self._get_tunercv_object(params=dict(feature_fraction=unexpected_value,),)
+            assert len(runner.study.trials) == 0
+            runner.tune_feature_fraction_stage2()
+
+            assert runner.lgbm_params["feature_fraction"] != unexpected_value
+            assert len(runner.study.trials) == 6
+
+    def test_tune_regularization_factors(self) -> None:
+        unexpected_value = 20  # out of scope.
+
+        with turnoff_cv():
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", category=DeprecationWarning)
+                runner = self._get_tunercv_object(
+                    params=dict(lambda_l1=unexpected_value,),  # set default as unexpected value.
+                )
+            assert len(runner.study.trials) == 0
+            runner.tune_regularization_factors()
+
+            assert runner.lgbm_params["lambda_l1"] != unexpected_value
+            assert len(runner.study.trials) == 20
+
+    def test_tune_min_data_in_leaf(self) -> None:
+        unexpected_value = 1  # out of scope.
+
+        with turnoff_cv():
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", category=DeprecationWarning)
+                runner = self._get_tunercv_object(
+                    params=dict(
+                        min_child_samples=unexpected_value,  # set default as unexpected value.
+                    ),
+                )
+            assert len(runner.study.trials) == 0
+            runner.tune_min_data_in_leaf()
+
+            assert runner.lgbm_params["min_child_samples"] != unexpected_value
+            assert len(runner.study.trials) == 5
+
+    def test_resume_run(self) -> None:
+        params = {"verbose": -1}  # type: Dict
+        dataset = lgb.Dataset(np.zeros((10, 10)))
+
+        study = optuna.create_study()
+        tuner = LightGBMTunerCV(params, dataset, study=study)
+
+        with mock.patch.object(OptunaObjectiveCV, "_get_cv_scores", return_value=[1.0]):
+            tuner.tune_regularization_factors()
+
+        n_trials = len(study.trials)
+        assert n_trials == len(study.trials)
+
+        tuner2 = LightGBMTuner(params, dataset, valid_sets=dataset, study=study)
+        with mock.patch.object(OptunaObjectiveCV, "_get_cv_scores", return_value=[1.0]):
+            tuner2.tune_regularization_factors()
+        assert n_trials == len(study.trials)


### PR DESCRIPTION
## Motivation

This PR adds support of cross-validation for `LightGBMTuner`. It evaluates the hyperparameter using cross-validation (i.e., [`LightGBM.cv()` function](https://lightgbm.readthedocs.io/en/latest/pythonapi/lightgbm.cv.html)).

## Description of the changes

1. Add `LightGBMTunerCV`
1. Extract common properties and methods in `LightGBMTuner` and `LightGBMTunerCV` to `LightGBMBaseTuner`.
1. Extend `OptunaObjective` and add `OptunaObjectiveCV` for `LightGBMTunerCV`
1. Add an example to demonstrate the usage of `LightGBMTunerCV`.

### `LightGBMTunerCV`

At first, I added some argument to `LightGBMTuner` for cross-validation, but it seems to be complicated. This is because some arguments (e.g., `learning_rate`) only work with [`LightGBM.train`](https://lightgbm.readthedocs.io/en/latest/pythonapi/lightgbm.train.html) and some of the others work with [`LightGBM.cv()`](https://lightgbm.readthedocs.io/en/latest/pythonapi/lightgbm.cv.html). These arguments will confuse users, and also may cause bugs. I decided to separate the classes in this PR.

### `LightGBMBaseTuner`

I extracted the common properties and methods to `LightGBMBaseTuner`. This design may be controversial because we have already had the `BaseTuner`. I think we can simplify the class hierarchy if we also refactor `OptunaObjective`. Do we work on it in this PR or separate PRs?

### `OptunaObjectiveCV`

Most of the functionalities of `OptunaObjective` can be used for cross-validation. So, I simply extend it to create an objective function for cross-validation.

### `lightgbm_tuner_cv.py` example

I add an example to discuss the user interface of the cross-validation feature. The arguments of [`LightGBM.cv`](https://lightgbm.readthedocs.io/en/latest/pythonapi/lightgbm.cv.html) except `metrics` and `init_model` can be used. Please use it to check the usability.

## TODO

- [x] Add tests for `LightGBMTunerCV`
- [x] Add tests for `OptunaObjectiveCV`
