### PR TITLE
Skip GitHub Actions builds on forked repositories.

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -12,6 +12,7 @@ jobs:
       matrix:
         python-version: [3.5, 3.6, 3.7, 3.8]
 
+    if: github.repository == 'optuna/optuna'
     steps:
     - uses: actions/checkout@v2
     - name: setup-python${{ matrix.python-version }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -9,6 +9,7 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    if: github.repository == 'optuna/optuna'
     steps:
     - uses: actions/stale@v2.0.0
       with:


### PR DESCRIPTION
Close #1151 

This PR make GitHub Actions check if a job runs on `optuna/optuna`.
Builds will be skipped on forked repos.

ref. https://github.com/optuna/optuna/issues/1151#issuecomment-618112469