### PR TITLE
Remove redundancy from `HyperbandPruner` by deprecating `min_early_stopping_rate_low`

### DIFF
--- a/optuna/pruners/hyperband.py
+++ b/optuna/pruners/hyperband.py
@@ -82,7 +82,7 @@ class HyperbandPruner(BasePruner):
         min_early_stopping_rate_low:
 
             .. deprecated:: 1.4.0
-                This argument will be removed from :class:~optuna.pruners.HyperbandPruner.
+                This argument will be removed from :class:`~optuna.pruners.HyperbandPruner`.
 
             A parameter for specifying the minimum early-stopping rate.
             This parameter is related to a parameter that is referred to as :math:`s` and used in

--- a/optuna/pruners/hyperband.py
+++ b/optuna/pruners/hyperband.py
@@ -87,7 +87,7 @@ class HyperbandPruner(BasePruner):
                  based on ``min_resource`` and ``reduction_factor``.
 
             A parameter for specifying the minimum early-stopping rate.
-            This parameter is related to a parameter that is referred to as :math:`r` and used in
+            This parameter is related to a parameter that is referred to as :math:`s` and used in
             `Asynchronous SuccessiveHalving paper <http://arxiv.org/abs/1810.05934>`_.
             The minimum early stopping rate for :math:`i` th bracket is :math:`i + s`.
     """
@@ -177,7 +177,8 @@ class HyperbandPruner(BasePruner):
         The minimum early-stopping rate is not appeared in
         `Hyperband paper <http://www.jmlr.org/papers/volume18/16-558/16-558.pdf>`_.
         See the details for :class:`~optuna.pruners.SuccessiveHalvingPruner`.
-        The minimum early stopping rate for :math:`i` th bracket is :math:`i + s`.
+        The minimum early stopping rate for :math:`i` th bracket is
+        :math:`i + \\lfloor \\log_\\eta \\mathrm{min ersource}`.
         """
         return (
             math.floor(math.log2(min_resource) / math.log2(self._reduction_factor)) + pruner_index

--- a/optuna/pruners/hyperband.py
+++ b/optuna/pruners/hyperband.py
@@ -136,7 +136,7 @@ class HyperbandPruner(BasePruner):
 
             # N.B. (crcrpar): `min_early_stopping_rate` has the information of `bracket_index`.
             if min_early_stopping_rate_low is None:
-                min_early_stopping_rate = self._calc_min_early_stopping_rate(i, min_resource)
+                min_early_stopping_rate = i
             else:
                 message = (
                     "The argument of `min_early_stopping_rate_low` is deprecated. "
@@ -147,10 +147,7 @@ class HyperbandPruner(BasePruner):
                 )
                 warnings.warn(message, DeprecationWarning)
                 _logger.warning(message)
-                min_early_stopping_rate = (
-                    min_early_stopping_rate_low
-                    + self._calc_min_early_stopping_rate(i, min_resource)
-                )
+                min_early_stopping_rate = min_early_stopping_rate_low + i
 
             _logger.debug(
                 "{}th bracket has minimum early stopping rate of {}".format(
@@ -159,7 +156,7 @@ class HyperbandPruner(BasePruner):
             )
 
             pruner = SuccessiveHalvingPruner(
-                min_resource=1,
+                min_resource=min_resource,
                 reduction_factor=reduction_factor,
                 min_early_stopping_rate=min_early_stopping_rate,
             )
@@ -170,19 +167,6 @@ class HyperbandPruner(BasePruner):
         _logger.debug("{}th bracket is selected".format(i))
         bracket_study = self._create_bracket_study(study, i)
         return self._pruners[i].prune(bracket_study, trial)
-
-    def _calc_min_early_stopping_rate(self, pruner_index: int, min_resource: int) -> int:
-        """Computes the minimum early-stopping rate
-
-        The minimum early-stopping rate is not appeared in
-        `Hyperband paper <http://www.jmlr.org/papers/volume18/16-558/16-558.pdf>`_.
-        See the details for :class:`~optuna.pruners.SuccessiveHalvingPruner`.
-        The minimum early stopping rate for :math:`i` th bracket is
-        :math:`i + \\lfloor \\log_\\eta \\mathrm{min ersource}`.
-        """
-        return (
-            math.floor(math.log2(min_resource) / math.log2(self._reduction_factor)) + pruner_index
-        )
 
     # TODO(crcrpar): Improve resource computation/allocation algorithm.
     def _calc_bracket_resource_budget(self, pruner_index: int, n_brackets: int) -> int:

--- a/optuna/pruners/hyperband.py
+++ b/optuna/pruners/hyperband.py
@@ -147,8 +147,10 @@ class HyperbandPruner(BasePruner):
                 )
                 warnings.warn(message, DeprecationWarning)
                 _logger.warning(message)
-                min_early_stopping_rate = min_early_stopping_rate_low + \
-                                          self._calc_min_early_stopping_rate(i, min_resource)
+                min_early_stopping_rate = (
+                    min_early_stopping_rate_low
+                    + self._calc_min_early_stopping_rate(i, min_resource)
+                )
 
             _logger.debug(
                 "{}th bracket has minimum early stopping rate of {}".format(
@@ -177,7 +179,9 @@ class HyperbandPruner(BasePruner):
         See the details for :class:`~optuna.pruners.SuccessiveHalvingPruner`.
         The minimum early stopping rate for :math:`i` th bracket is :math:`i + s`.
         """
-        return math.floor(math.log2(min_resource) / math.log2(self._reduction_factor)) + pruner_index
+        return (
+            math.floor(math.log2(min_resource) / math.log2(self._reduction_factor)) + pruner_index
+        )
 
     # TODO(crcrpar): Improve resource computation/allocation algorithm.
     def _calc_bracket_resource_budget(self, pruner_index: int, n_brackets: int) -> int:

--- a/optuna/pruners/hyperband.py
+++ b/optuna/pruners/hyperband.py
@@ -82,9 +82,7 @@ class HyperbandPruner(BasePruner):
         min_early_stopping_rate_low:
 
             .. deprecated:: 1.4.0
-                This argument will be removed from :class:~optuna.pruners.HyperbandPruner. The
-                 minimum value of the minimum early-stopping rate are automatically determined
-                 based on ``min_resource`` and ``reduction_factor``.
+                This argument will be removed from :class:~optuna.pruners.HyperbandPruner.
 
             A parameter for specifying the minimum early-stopping rate.
             This parameter is related to a parameter that is referred to as :math:`s` and used in
@@ -140,10 +138,7 @@ class HyperbandPruner(BasePruner):
             else:
                 message = (
                     "The argument of `min_early_stopping_rate_low` is deprecated. "
-                    "The minimum value of the minimum early-stopping rate is automatically "
-                    "determined by `min_resource` and `reduction_factor` as "
-                    "`min_early_stopping_rate_low = floor(log(min_resource) / "
-                    "log(reduction_factor))`. Please specify `min_resource` appropriately."
+                    "Please specify `min_resource` appropriately."
                 )
                 warnings.warn(message, DeprecationWarning)
                 _logger.warning(message)


### PR DESCRIPTION
## Motivation
In the current `HyperbandPruner` implementation, roles of two arguments: `min_resource` and `min_early_stopping_rate_low` are redundant. This PR aims to remove its redundancy.

## Description of the changes
- Remove redundancy by deprecating `min_early_stopping_rate_low`.
- The method how we calculate the minimum early-stopping rate for each bracket is based on the following equation: `min_resource = (reduction_factor) ** (min_early_stopping_rate)`