### PR TITLE
Fix split_observations for conditional parameters

### DIFF
--- a/optuna/samplers/tpe/parzen_estimator.py
+++ b/optuna/samplers/tpe/parzen_estimator.py
@@ -63,6 +63,11 @@ class _ParzenEstimator(object):
         weights_func,  # type: Callable[[int], ndarray]
     ):
         # type: (...) -> Tuple[ndarray, ndarray, ndarray]
+        """Calculates the weights, mus and sigma for the Parzen estimator.
+
+           Note: When the number of observations is zero, the Parzen estimator ignores the
+           `consider_prior` flag and utilizes a prior. Validation of this approach is future work.
+        """
 
         mus = numpy.asarray(mus)
         sigma = numpy.asarray([], dtype=float)

--- a/optuna/samplers/tpe/parzen_estimator.py
+++ b/optuna/samplers/tpe/parzen_estimator.py
@@ -67,6 +67,11 @@ class _ParzenEstimator(object):
         mus = numpy.asarray(mus)
         sigma = numpy.asarray([], dtype=float)
         prior_pos = 0
+
+        # Parzen estimator construction requires at least one observation or a priror.
+        if mus.size == 0:
+            consider_prior = True
+
         if consider_prior:
             prior_mu = 0.5 * (low + high)
             prior_sigma = 1.0 * (high - low)

--- a/optuna/samplers/tpe/sampler.py
+++ b/optuna/samplers/tpe/sampler.py
@@ -137,14 +137,6 @@ class TPESampler(base.BaseSampler):
             )
         below_param_values, above_param_values = self._split_observation_pairs(values, scores)
 
-        # Parzen estimator construction requires at least one observation or a priror.
-        n_below = len(below_param_values)
-        n_above = len(above_param_values)
-        if not self._parzen_estimator_parameters.consider_prior and (n_below == 0 or n_above == 0):
-            return self._random_sampler.sample_independent(
-                study, trial, param_name, param_distribution
-            )
-
         if isinstance(param_distribution, distributions.UniformDistribution):
             return self._sample_uniform(param_distribution, below_param_values, above_param_values)
         elif isinstance(param_distribution, distributions.LogUniformDistribution):

--- a/optuna/samplers/tpe/sampler.py
+++ b/optuna/samplers/tpe/sampler.py
@@ -190,9 +190,9 @@ class TPESampler(base.BaseSampler):
         n_below = self._gamma(len(config_vals))
         loss_ascending = np.argsort(loss_vals)
         below = config_vals[np.sort(loss_ascending[:n_below])]
-        below = below[below != None].astype(float)
+        below = np.asarray([v for v in below if v is not None], dtype=float)
         above = config_vals[np.sort(loss_ascending[n_below:])]
-        above = above[above != None].astype(float)
+        above = np.asarray([v for v in above if v is not None], dtype=float)
         return below, above
 
     def _sample_uniform(self, distribution, below, above):

--- a/optuna/samplers/tpe/sampler.py
+++ b/optuna/samplers/tpe/sampler.py
@@ -135,8 +135,15 @@ class TPESampler(base.BaseSampler):
             return self._random_sampler.sample_independent(
                 study, trial, param_name, param_distribution
             )
-
         below_param_values, above_param_values = self._split_observation_pairs(values, scores)
+
+        # Parzen estimator construction requires at least one observation or a priror.
+        n_below = len(below_param_values)
+        n_above = len(above_param_values)
+        if not self._parzen_estimator_parameters.consider_prior and (n_below == 0 or n_above == 0):
+            return self._random_sampler.sample_independent(
+                study, trial, param_name, param_distribution
+            )
 
         if isinstance(param_distribution, distributions.UniformDistribution):
             return self._sample_uniform(param_distribution, below_param_values, above_param_values)
@@ -245,6 +252,7 @@ class TPESampler(base.BaseSampler):
 
         size = (self._n_ei_candidates,)
 
+        self._parzen_estimator_parameters
         parzen_estimator_below = _ParzenEstimator(
             mus=below, low=low, high=high, parameters=self._parzen_estimator_parameters
         )

--- a/optuna/samplers/tpe/sampler.py
+++ b/optuna/samplers/tpe/sampler.py
@@ -252,7 +252,6 @@ class TPESampler(base.BaseSampler):
 
         size = (self._n_ei_candidates,)
 
-        self._parzen_estimator_parameters
         parzen_estimator_below = _ParzenEstimator(
             mus=below, low=low, high=high, parameters=self._parzen_estimator_parameters
         )

--- a/optuna/samplers/tpe/sampler.py
+++ b/optuna/samplers/tpe/sampler.py
@@ -179,7 +179,7 @@ class TPESampler(base.BaseSampler):
 
     def _split_observation_pairs(
         self,
-        config_vals,  # type: List[float]
+        config_vals,  # type: List[Optional[float]]
         loss_vals,  # type: List[Tuple[float, float]]
     ):
         # type: (...) -> Tuple[np.ndarray, np.ndarray]
@@ -538,7 +538,7 @@ class TPESampler(base.BaseSampler):
 
 
 def _get_observation_pairs(study, param_name, trial):
-    # type: (Study, str, FrozenTrial) -> Tuple[List[float], List[Tuple[float, float]]]
+    # type: (Study, str, FrozenTrial) -> Tuple[List[Optional[float]], List[Tuple[float, float]]]
     """Get observation pairs from the study.
 
        This function collects observation pairs from the complete or pruned trials of the study.
@@ -565,7 +565,7 @@ def _get_observation_pairs(study, param_name, trial):
         pruner = study.pruner  # type: HyperbandPruner
         study = pruner._create_bracket_study(study, pruner._get_bracket_id(study, trial))
 
-    values = []
+    values = []  # type: List[Optional[float]]
     scores = []
     for trial in study.get_trials(deepcopy=False):
         if trial.state is TrialState.COMPLETE and trial.value is not None:
@@ -582,11 +582,11 @@ def _get_observation_pairs(study, param_name, trial):
         else:
             continue
 
+        param_value = None  # type: Optional[float]
         if param_name in trial.params:
             distribution = trial.distributions[param_name]
             param_value = distribution.to_internal_repr(trial.params[param_name])
-        else:
-            param_value = None  # the parameter is not active for this trial
+
         values.append(param_value)
         scores.append(score)
 

--- a/tests/samplers_tests/tpe_tests/test_parzen_estimator.py
+++ b/tests/samplers_tests/tpe_tests/test_parzen_estimator.py
@@ -37,10 +37,11 @@ class TestParzenEstimator(object):
             weights_func=default_weights,
         )
 
-        # Result contains an additional value for a prior distribution if prior is True.
-        assert len(s_weights) == len(mus) + int(prior)
-        assert len(s_mus) == len(mus) + int(prior)
-        assert len(s_sigmas) == len(mus) + int(prior)
+        # Result contains an additional value for a prior distribution if prior is True or
+        # len(mus) == 0 (in this case, prior is always used).
+        assert len(s_weights) == len(mus) + int(prior) if len(mus) > 0 else len(mus) + 1
+        assert len(s_mus) == len(mus) + int(prior) if len(mus) > 0 else len(mus) + 1
+        assert len(s_sigmas) == len(mus) + int(prior) if len(mus) > 0 else len(mus) + 1
 
     # TODO(ytsmiling): Improve test coverage for weights_func.
     @staticmethod
@@ -50,7 +51,7 @@ class TestParzenEstimator(object):
             [
                 [],
                 {"prior": False, "magic_clip": False, "endpoints": True},
-                {"weights": [], "mus": [], "sigmas": []},
+                {"weights": [1.0], "mus": [0.0], "sigmas": [2.0]},
             ],
             [
                 [],

--- a/tests/samplers_tests/tpe_tests/test_sampler.py
+++ b/tests/samplers_tests/tpe_tests/test_sampler.py
@@ -340,7 +340,15 @@ def test_get_observation_pairs():
             (float("inf"), 0.0),  # PRUNED (without intermediate values)
         ],
     )
-    assert tpe.sampler._get_observation_pairs(study, "y", trial) == ([], [])
+    assert tpe.sampler._get_observation_pairs(study, "y", trial) == (
+        [None, None, None, None],
+        [
+            (-float("inf"), 5.0),  # COMPLETE
+            (-7, 2),  # PRUNED (with intermediate values)
+            (-3, float("inf")),  # PRUNED (with a NaN intermediate value; it's treated as infinity)
+            (float("inf"), 0.0),  # PRUNED (without intermediate values)
+        ],
+    )
 
     # Test direction=maximize.
     study = optuna.create_study(direction="maximize")
@@ -356,7 +364,15 @@ def test_get_observation_pairs():
             (float("inf"), 0.0),  # PRUNED (without intermediate values)
         ],
     )
-    assert tpe.sampler._get_observation_pairs(study, "y", trial) == ([], [])
+    assert tpe.sampler._get_observation_pairs(study, "y", trial) == (
+        [None, None, None, None],
+        [
+            (-float("inf"), -5.0),  # COMPLETE
+            (-7, -2),  # PRUNED (with intermediate values)
+            (-3, float("inf")),  # PRUNED (with a NaN intermediate value; it's treated as infinity)
+            (float("inf"), 0.0),  # PRUNED (without intermediate values)
+        ],
+    )
 
 
 def frozen_trial_factory(


### PR DESCRIPTION
This PR fixes split_observations for conditional parameters to calculate EI values.

## Motivation
The current implementation of the split_observations in the TPESampler is as follows:
1. The sampler discards the trials that do not contain the parameter named ``param_name`` when it gets observation pairs. This causes different len(config_vals) for conditional parameters.
  https://github.com/optuna/optuna/blob/f614d69875cbbd24f989fc8c75f9b18f3bb7c541/optuna/samplers/tpe/sampler.py#L562
2. Then, the sampler calculates the y* value based on the gamma = min(int(np.ceil(0.1 * len(config_vals))), 25)
  https://github.com/optuna/optuna/blob/f614d69875cbbd24f989fc8c75f9b18f3bb7c541/optuna/samplers/tpe/sampler.py#L183
3. Finally, the sampler splits config_vals into the ones with loss_vals < y* (i.e., the observations for l(x)) and the remaining ones (i.e., the observations for g(x)).

Based on my understanding, y* which determines the integration interval for the EI calculation should be the same value for all parameters (ref. [the TPE paper](https://papers.nips.cc/paper/4443-algorithms-for-hyper-parameter-optimization.pdf)).
However, the current strategy may set different y* values for conditional parameters.
[Here](https://gist.github.com/y0z/d85e5b1c1cb0d608bc93a02f89e1f8d4) is an example of this situation (note: this example is maximization).
In this example, y* for params_classifier is 0.9466666666666667, whereas y* for params_svc_c 0.32.
This seems to cause a curious EI calculation, i.e., a different integration interval is set for each parameter.

## Description of the changes
This PR changes the split_observation procedure as follows:
1. The sampler does not discard the trials that do not contain the parameter named ``param_name`` when it gets observation.
2. Then, the sampler calculates the y* value based on the gamma = min(int(np.ceil(0.1 * len(config_vals))), 25). This y* is consistent among all hyperparameters.
3. After that, the sampler splits config_vals into the observations for l(x) and the observations for g(x).
4. Finally, the sampler discards the config_vals with the observations that do not contain the parameter named ``param_name`` from the observations for l(x) and g(x).

I have also confirmed that the split_observation procedure in the original TPE implementation in HyperOpt is like this.
https://github.com/hyperopt/hyperopt/blob/master/hyperopt/tpe.py#L625
In this implementation, ``o_vals`` is the set of config_vals that contain the parameter named ``param_name`` only, whereas ``l_vals`` is the set of all of the observed losses so far.

My apologies if I am misunderstanding the algorithm and please close this PR.