### PR TITLE
Rename `test_` to `valid_` in docs and docstring.

### DIFF
--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -152,7 +152,7 @@ For example, you can save SVM models trained in the objective function as follow
         # Save a trained model to a file.
         with open('{}.pickle'.format(trial.number), 'wb') as fout:
             pickle.dump(clf, fout)
-        return 1.0 - accuracy_score(y_test, clf.predict(X_test))
+        return 1.0 - accuracy_score(y_valid, clf.predict(X_valid))
 
 
     study = optuna.create_study()
@@ -161,7 +161,7 @@ For example, you can save SVM models trained in the objective function as follow
     # Load the best model.
     with open('{}.pickle'.format(study.best_trial.number), 'rb') as fin:
         best_clf = pickle.load(fin)
-    print(accuracy_score(y_test, best_clf.predict(X_test)))
+    print(accuracy_score(y_valid, best_clf.predict(X_valid)))
 
 
 How can I obtain reproducible optimization results?

--- a/docs/source/tutorial/pruning.rst
+++ b/docs/source/tutorial/pruning.rst
@@ -92,4 +92,4 @@ For example, :class:`~optuna.integration.XGBoostPruningCallback` introduces prun
 .. code-block:: python
 
         pruning_callback = optuna.integration.XGBoostPruningCallback(trial, 'validation-error')
-        bst = xgb.train(param, dtrain, evals=[(dtest, 'validation')], callbacks=[pruning_callback])
+        bst = xgb.train(param, dtrain, evals=[(dvalid, 'validation')], callbacks=[pruning_callback])

--- a/docs/source/tutorial/pruning.rst
+++ b/docs/source/tutorial/pruning.rst
@@ -26,7 +26,7 @@ To turn on the pruning feature, you need to call :func:`~optuna.trial.Trial.repo
     def objective(trial):
         iris = sklearn.datasets.load_iris()
         classes = list(set(iris.target))
-        train_x, test_x, train_y, test_y = \
+        train_x, valid_x, train_y, valid_y = \
             sklearn.model_selection.train_test_split(iris.data, iris.target, test_size=0.25, random_state=0)
 
         alpha = trial.suggest_loguniform('alpha', 1e-5, 1e-1)
@@ -36,14 +36,14 @@ To turn on the pruning feature, you need to call :func:`~optuna.trial.Trial.repo
             clf.partial_fit(train_x, train_y, classes=classes)
 
             # Report intermediate objective value.
-            intermediate_value = 1.0 - clf.score(test_x, test_y)
+            intermediate_value = 1.0 - clf.score(valid_x, valid_y)
             trial.report(intermediate_value, step)
 
             # Handle pruning based on the intermediate value.
             if trial.should_prune():
                 raise optuna.exceptions.TrialPruned()
 
-        return 1.0 - clf.score(test_x, test_y)
+        return 1.0 - clf.score(valid_x, valid_y)
 
     # Set up the median stopping rule as the pruning condition.
     study = optuna.create_study(pruner=optuna.pruners.MedianPruner())

--- a/optuna/exceptions.py
+++ b/optuna/exceptions.py
@@ -21,7 +21,7 @@ class TrialPruned(OptunaError):
             np.random.seed(seed=0)
             X = np.random.randn(200).reshape(-1, 1)
             y = np.where(X[:, 0] < 0.5, 0, 1)
-            X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
+            X_train, X_valid, y_train, y_valid = train_test_split(X, y, random_state=0)
             classes = np.unique(y)
 
         .. testcode::
@@ -37,13 +37,13 @@ class TrialPruned(OptunaError):
                 for step in range(n_train_iter):
                     clf.partial_fit(X_train, y_train, classes=classes)
 
-                    intermediate_value = clf.score(X_test, y_test)
+                    intermediate_value = clf.score(X_valid, y_valid)
                     trial.report(intermediate_value, step)
 
                     if trial.should_prune():
                         raise optuna.exceptions.TrialPruned()
 
-                return clf.score(X_test, y_test)
+                return clf.score(X_valid, y_valid)
 
             study = optuna.create_study(direction='maximize')
             study.optimize(objective, n_trials=20)

--- a/optuna/integration/sklearn.py
+++ b/optuna/integration/sklearn.py
@@ -193,7 +193,7 @@ class _Objective(object):
 
         groups:
             Group labels for the samples used while splitting the dataset into
-            train/test set.
+            train/validation set.
 
         max_iter:
             Maximum number of epochs. This is only used if the underlying
@@ -412,7 +412,7 @@ class OptunaSearchCV(BaseEstimator):
 
             - integer to specify the number of folds in a CV splitter,
             - a CV splitter,
-            - an iterable yielding (train, test) splits as arrays of indices.
+            - an iterable yielding (train, validation) splits as arrays of indices.
 
             For integer, if :obj:`estimator` is a classifier and :obj:`y` is
             either binary or multiclass,
@@ -466,7 +466,7 @@ class OptunaSearchCV(BaseEstimator):
             performance.
 
         scoring:
-            String or callable to evaluate the predictions on the test data.
+            String or callable to evaluate the predictions on the validation data.
             If :obj:`None`, ``score`` on the estimator is used.
 
         study:
@@ -844,7 +844,7 @@ class OptunaSearchCV(BaseEstimator):
 
             groups:
                 Group labels for the samples used while splitting the dataset
-                into train/test set.
+                into train/validation set.
 
             **fit_params:
                 Parameters passed to ``fit`` on the estimator.

--- a/optuna/pruners/hyperband.py
+++ b/optuna/pruners/hyperband.py
@@ -71,7 +71,7 @@ class HyperbandPruner(BasePruner):
             np.random.seed(seed=0)
             X = np.random.randn(200).reshape(-1, 1)
             y = np.where(X[:, 0] < 0.5, 0, 1)
-            X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
+            X_train, X_valid, y_train, y_valid = train_test_split(X, y, random_state=0)
             classes = np.unique(y)
 
         .. testcode::
@@ -88,13 +88,13 @@ class HyperbandPruner(BasePruner):
                 for step in range(n_train_iter):
                     clf.partial_fit(X_train, y_train, classes=classes)
 
-                    intermediate_value = clf.score(X_test, y_test)
+                    intermediate_value = clf.score(X_valid, y_valid)
                     trial.report(intermediate_value, step)
 
                     if trial.should_prune():
                         raise optuna.exceptions.TrialPruned()
 
-                return clf.score(X_test, y_test)
+                return clf.score(X_valid, y_valid)
 
             study = optuna.create_study(
                 direction='maximize',

--- a/optuna/pruners/median.py
+++ b/optuna/pruners/median.py
@@ -19,7 +19,7 @@ class MedianPruner(PercentilePruner):
             np.random.seed(seed=0)
             X = np.random.randn(200).reshape(-1, 1)
             y = np.where(X[:, 0] < 0.5, 0, 1)
-            X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
+            X_train, X_valid, y_train, y_valid = train_test_split(X, y, random_state=0)
             classes = np.unique(y)
 
         .. testcode::
@@ -35,13 +35,13 @@ class MedianPruner(PercentilePruner):
                 for step in range(n_train_iter):
                     clf.partial_fit(X_train, y_train, classes=classes)
 
-                    intermediate_value = clf.score(X_test, y_test)
+                    intermediate_value = clf.score(X_valid, y_valid)
                     trial.report(intermediate_value, step)
 
                     if trial.should_prune():
                         raise optuna.exceptions.TrialPruned()
 
-                return clf.score(X_test, y_test)
+                return clf.score(X_valid, y_valid)
 
             study = optuna.create_study(direction='maximize',
                                         pruner=optuna.pruners.MedianPruner(n_startup_trials=5,

--- a/optuna/pruners/nop.py
+++ b/optuna/pruners/nop.py
@@ -19,7 +19,7 @@ class NopPruner(BasePruner):
             np.random.seed(seed=0)
             X = np.random.randn(200).reshape(-1, 1)
             y = np.where(X[:, 0] < 0.5, 0, 1)
-            X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
+            X_train, X_valid, y_train, y_valid = train_test_split(X, y, random_state=0)
             classes = np.unique(y)
 
         .. testcode::
@@ -35,14 +35,14 @@ class NopPruner(BasePruner):
                 for step in range(n_train_iter):
                     clf.partial_fit(X_train, y_train, classes=classes)
 
-                    intermediate_value = clf.score(X_test, y_test)
+                    intermediate_value = clf.score(X_valid, y_valid)
                     trial.report(intermediate_value, step)
 
                     if trial.should_prune():
                         assert False, "should_prune() should always return False with this pruner."
                         raise optuna.exceptions.TrialPruned()
 
-                return clf.score(X_test, y_test)
+                return clf.score(X_valid, y_valid)
 
             study = optuna.create_study(direction='maximize',
                                         pruner=optuna.pruners.NopPruner())

--- a/optuna/pruners/percentile.py
+++ b/optuna/pruners/percentile.py
@@ -84,7 +84,7 @@ class PercentilePruner(BasePruner):
             np.random.seed(seed=0)
             X = np.random.randn(200).reshape(-1, 1)
             y = np.where(X[:, 0] < 0.5, 0, 1)
-            X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
+            X_train, X_valid, y_train, y_valid = train_test_split(X, y, random_state=0)
             classes = np.unique(y)
 
         .. testcode::
@@ -100,13 +100,13 @@ class PercentilePruner(BasePruner):
                 for step in range(n_train_iter):
                     clf.partial_fit(X_train, y_train, classes=classes)
 
-                    intermediate_value = clf.score(X_test, y_test)
+                    intermediate_value = clf.score(X_valid, y_valid)
                     trial.report(intermediate_value, step)
 
                     if trial.should_prune():
                         raise optuna.exceptions.TrialPruned()
 
-                return clf.score(X_test, y_test)
+                return clf.score(X_valid, y_valid)
 
             study = optuna.create_study(
                 direction='maximize',

--- a/optuna/pruners/successive_halving.py
+++ b/optuna/pruners/successive_halving.py
@@ -41,7 +41,7 @@ class SuccessiveHalvingPruner(BasePruner):
             np.random.seed(seed=0)
             X = np.random.randn(200).reshape(-1, 1)
             y = np.where(X[:, 0] < 0.5, 0, 1)
-            X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
+            X_train, X_valid, y_train, y_valid = train_test_split(X, y, random_state=0)
             classes = np.unique(y)
 
         .. testcode::
@@ -57,13 +57,13 @@ class SuccessiveHalvingPruner(BasePruner):
                 for step in range(n_train_iter):
                     clf.partial_fit(X_train, y_train, classes=classes)
 
-                    intermediate_value = clf.score(X_test, y_test)
+                    intermediate_value = clf.score(X_valid, y_valid)
                     trial.report(intermediate_value, step)
 
                     if trial.should_prune():
                         raise optuna.exceptions.TrialPruned()
 
-                return clf.score(X_test, y_test)
+                return clf.score(X_valid, y_valid)
 
             study = optuna.create_study(direction='maximize',
                                         pruner=optuna.pruners.SuccessiveHalvingPruner())

--- a/optuna/trial/_trial.py
+++ b/optuna/trial/_trial.py
@@ -102,7 +102,7 @@ class Trial(BaseTrial):
                 np.random.seed(seed=0)
                 X = np.random.randn(200).reshape(-1, 1)
                 y = np.random.randint(0, 2, 200)
-                X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
+                X_train, X_valid, y_train, y_valid = train_test_split(X, y, random_state=0)
 
 
             .. testcode::
@@ -117,7 +117,7 @@ class Trial(BaseTrial):
                                         solver='sgd', random_state=0, power_t=power_t)
                     clf.fit(X_train, y_train)
 
-                    return clf.score(X_test, y_test)
+                    return clf.score(X_valid, y_valid)
 
                 study = optuna.create_study(direction='maximize')
                 study.optimize(objective, n_trials=3)
@@ -175,7 +175,7 @@ class Trial(BaseTrial):
                 np.random.seed(seed=0)
                 X = np.random.randn(200).reshape(-1, 1)
                 y = np.random.randint(0, 2, 200)
-                X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
+                X_train, X_valid, y_train, y_valid = train_test_split(X, y, random_state=0)
 
             .. testcode::
 
@@ -188,7 +188,7 @@ class Trial(BaseTrial):
                                         solver='sgd', random_state=0)
                     clf.fit(X_train, y_train)
 
-                    return clf.score(X_test, y_test)
+                    return clf.score(X_valid, y_valid)
 
                 study = optuna.create_study(direction='maximize')
                 study.optimize(objective, n_trials=3)
@@ -236,7 +236,7 @@ class Trial(BaseTrial):
                 np.random.seed(seed=0)
                 X = np.random.randn(50).reshape(-1, 1)
                 y = np.random.randint(0, 2, 50)
-                X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
+                X_train, X_valid, y_train, y_valid = train_test_split(X, y, random_state=0)
 
             .. testcode::
 
@@ -247,7 +247,7 @@ class Trial(BaseTrial):
                     c = trial.suggest_loguniform('c', 1e-5, 1e2)
                     clf = SVC(C=c, gamma='scale', random_state=0)
                     clf.fit(X_train, y_train)
-                    return clf.score(X_test, y_test)
+                    return clf.score(X_valid, y_valid)
 
                 study = optuna.create_study(direction='maximize')
                 study.optimize(objective, n_trials=3)
@@ -301,7 +301,7 @@ class Trial(BaseTrial):
                 np.random.seed(seed=0)
                 X = np.random.randn(50).reshape(-1, 1)
                 y = np.random.randint(0, 2, 50)
-                X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
+                X_train, X_valid, y_train, y_valid = train_test_split(X, y, random_state=0)
 
             .. testcode::
 
@@ -312,7 +312,7 @@ class Trial(BaseTrial):
                     subsample = trial.suggest_discrete_uniform('subsample', 0.1, 1.0, 0.1)
                     clf = GradientBoostingClassifier(subsample=subsample, random_state=0)
                     clf.fit(X_train, y_train)
-                    return clf.score(X_test, y_test)
+                    return clf.score(X_valid, y_valid)
 
                 study = optuna.create_study(direction='maximize')
                 study.optimize(objective, n_trials=3)
@@ -360,7 +360,7 @@ class Trial(BaseTrial):
                 np.random.seed(seed=0)
                 X = np.random.randn(50).reshape(-1, 1)
                 y = np.random.randint(0, 2, 50)
-                X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
+                X_train, X_valid, y_train, y_valid = train_test_split(X, y, random_state=0)
 
             .. testcode::
 
@@ -371,7 +371,7 @@ class Trial(BaseTrial):
                     n_estimators = trial.suggest_int('n_estimators', 50, 400)
                     clf = RandomForestClassifier(n_estimators=n_estimators, random_state=0)
                     clf.fit(X_train, y_train)
-                    return clf.score(X_test, y_test)
+                    return clf.score(X_valid, y_valid)
 
                 study = optuna.create_study(direction='maximize')
                 study.optimize(objective, n_trials=3)
@@ -419,7 +419,7 @@ class Trial(BaseTrial):
                 np.random.seed(seed=0)
                 X = np.random.randn(50).reshape(-1, 1)
                 y = np.random.randint(0, 2, 50)
-                X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
+                X_train, X_valid, y_train, y_valid = train_test_split(X, y, random_state=0)
 
             .. testcode::
 
@@ -430,7 +430,7 @@ class Trial(BaseTrial):
                     kernel = trial.suggest_categorical('kernel', ['linear', 'poly', 'rbf'])
                     clf = SVC(kernel=kernel, gamma='scale', random_state=0)
                     clf.fit(X_train, y_train)
-                    return clf.score(X_test, y_test)
+                    return clf.score(X_valid, y_valid)
 
                 study = optuna.create_study(direction='maximize')
                 study.optimize(objective, n_trials=3)
@@ -484,7 +484,7 @@ class Trial(BaseTrial):
                 np.random.seed(seed=0)
                 X = np.random.randn(50).reshape(-1, 1)
                 y = np.random.randint(0, 2, 50)
-                X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
+                X_train, X_valid, y_train, y_valid = train_test_split(X, y, random_state=0)
 
             .. testcode::
 
@@ -495,12 +495,12 @@ class Trial(BaseTrial):
                     clf = SGDClassifier(random_state=0)
                     for step in range(100):
                         clf.partial_fit(X_train, y_train, np.unique(y))
-                        intermediate_value = clf.score(X_test, y_test)
+                        intermediate_value = clf.score(X_valid, y_valid)
                         trial.report(intermediate_value, step=step)
                         if trial.should_prune():
                             raise TrialPruned()
 
-                    return clf.score(X_test, y_test)
+                    return clf.score(X_valid, y_valid)
 
                 study = optuna.create_study(direction='maximize')
                 study.optimize(objective, n_trials=3)
@@ -581,7 +581,7 @@ class Trial(BaseTrial):
                 np.random.seed(seed=0)
                 X = np.random.randn(50).reshape(-1, 1)
                 y = np.random.randint(0, 2, 50)
-                X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
+                X_train, X_valid, y_train, y_valid = train_test_split(X, y, random_state=0)
 
             .. testcode::
 
@@ -596,7 +596,7 @@ class Trial(BaseTrial):
                                         momentum=momentum, solver='sgd', random_state=0)
                     clf.fit(X_train, y_train)
 
-                    return clf.score(X_test, y_test)
+                    return clf.score(X_valid, y_valid)
 
                 study = optuna.create_study(direction='maximize')
                 study.optimize(objective, n_trials=3)


### PR DESCRIPTION
Related to #1107 .

I noticed `test` prefix (suffix) appear in documentation.
In 67009ad, I only rename `test` appeared in docstring but they also appear in the code.
(e.g. https://github.com/himkt/optuna/blob/rename-test-in-docs/optuna/integration/sklearn.py#L339)
I left them since I think it is better to focus on documentation fix in this PR.
However, I'm not sure whether it should also rename in code.
(I also wondering mixing `test` and `validation` could be confusing for users)

I want developers to advise me.