### PR TITLE
Hide the interface so that all samplers can use `HyperbandPruner`

### DIFF
--- a/optuna/pruners/hyperband.py
+++ b/optuna/pruners/hyperband.py
@@ -1,12 +1,13 @@
 import math
+from typing import Any
+from typing import Dict
 from typing import List
 from typing import Optional
 import warnings
 
-import numpy
-
+import optuna
 from optuna._experimental import experimental
-from optuna import distributions
+from optuna.distributions import BaseDistribution
 from optuna import logging
 from optuna.pruners.base import BasePruner
 from optuna.pruners.successive_halving import SuccessiveHalvingPruner
@@ -219,23 +220,38 @@ class HyperbandPruner(BasePruner):
 
 
 class _HyperbandSampler(BaseSampler):
-    def __init__(self, sampler, hyperband_pruner):
+    def __init__(self, sampler: BaseSampler, hyperband_pruner: HyperbandPruner) -> None:
         self._sampler = sampler
         self._pruner = hyperband_pruner
 
-    def infer_relative_search_space(self, study, trial):
+    def infer_relative_search_space(
+            self,
+            study: "optuna.study.Study",
+            trial: FrozenTrial
+    ) -> Dict[str, BaseDistribution]:
         study = self._pruner._create_bracket_study(
             study, self._pruner._get_bracket_id(study, trial)
         )
         return self._sampler.infer_relative_search_space(study, trial)
 
-    def sample_relative(self, study, trial, search_space):
+    def sample_relative(
+            self,
+            study: "optuna.study.Study",
+            trial: FrozenTrial,
+            search_space: Dict[str, BaseDistribution]
+    ) -> Dict[str, Any]:
         study = self._pruner._create_bracket_study(
             study, self._pruner._get_bracket_id(study, trial)
         )
         return self._sampler.sample_relative(study, trial, search_space)
 
-    def sample_independent(self, study, trial, param_name, param_distribution):
+    def sample_independent(
+            self,
+            study: "optuna.study.Study",
+            trial: FrozenTrial,
+            param_name: str,
+            param_distribution: BaseDistribution
+    ) -> Any:
         study = self._pruner._create_bracket_study(
             study, self._pruner._get_bracket_id(study, trial)
         )

--- a/optuna/pruners/hyperband.py
+++ b/optuna/pruners/hyperband.py
@@ -224,10 +224,16 @@ class _HyperbandSampler(BaseSampler):
         self._sampler = sampler
         self._pruner = hyperband_pruner
 
+    @property
+    def sampler(self) -> BaseSampler:
+        return self._sampler
+
+    @sampler.setter
+    def sampler(self, new_sampler: BaseSampler) -> None:
+        self._sampler = new_sampler
+
     def infer_relative_search_space(
-            self,
-            study: "optuna.study.Study",
-            trial: FrozenTrial
+        self, study: "optuna.study.Study", trial: FrozenTrial
     ) -> Dict[str, BaseDistribution]:
         study = self._pruner._create_bracket_study(
             study, self._pruner._get_bracket_id(study, trial)
@@ -235,10 +241,10 @@ class _HyperbandSampler(BaseSampler):
         return self._sampler.infer_relative_search_space(study, trial)
 
     def sample_relative(
-            self,
-            study: "optuna.study.Study",
-            trial: FrozenTrial,
-            search_space: Dict[str, BaseDistribution]
+        self,
+        study: "optuna.study.Study",
+        trial: FrozenTrial,
+        search_space: Dict[str, BaseDistribution],
     ) -> Dict[str, Any]:
         study = self._pruner._create_bracket_study(
             study, self._pruner._get_bracket_id(study, trial)
@@ -246,11 +252,11 @@ class _HyperbandSampler(BaseSampler):
         return self._sampler.sample_relative(study, trial, search_space)
 
     def sample_independent(
-            self,
-            study: "optuna.study.Study",
-            trial: FrozenTrial,
-            param_name: str,
-            param_distribution: BaseDistribution
+        self,
+        study: "optuna.study.Study",
+        trial: FrozenTrial,
+        param_name: str,
+        param_distribution: BaseDistribution,
     ) -> Any:
         study = self._pruner._create_bracket_study(
             study, self._pruner._get_bracket_id(study, trial)

--- a/optuna/pruners/hyperband.py
+++ b/optuna/pruners/hyperband.py
@@ -3,10 +3,14 @@ from typing import List
 from typing import Optional
 import warnings
 
+import numpy
+
 from optuna._experimental import experimental
+from optuna import distributions
 from optuna import logging
 from optuna.pruners.base import BasePruner
 from optuna.pruners.successive_halving import SuccessiveHalvingPruner
+from optuna.samplers.base import BaseSampler
 from optuna.study import Study
 from optuna.trial import FrozenTrial
 
@@ -212,3 +216,27 @@ class HyperbandPruner(BasePruner):
                     return object.__getattribute__(self, attr_name)
 
         return _BracketStudy(study, bracket_index)
+
+
+class _HyperbandSampler(BaseSampler):
+    def __init__(self, sampler, hyperband_pruner):
+        self._sampler = sampler
+        self._pruner = hyperband_pruner
+
+    def infer_relative_search_space(self, study, trial):
+        study = self._pruner._create_bracket_study(
+            study, self._pruner._get_bracket_id(study, trial)
+        )
+        return self._sampler.infer_relative_search_space(study, trial)
+
+    def sample_relative(self, study, trial, search_space):
+        study = self._pruner._create_bracket_study(
+            study, self._pruner._get_bracket_id(study, trial)
+        )
+        return self._sampler.sample_relative(study, trial, search_space)
+
+    def sample_independent(self, study, trial, param_name, param_distribution):
+        study = self._pruner._create_bracket_study(
+            study, self._pruner._get_bracket_id(study, trial)
+        )
+        return self._sampler.sample_independent(study, trial, param_name, param_distribution)

--- a/optuna/pruners/hyperband.py
+++ b/optuna/pruners/hyperband.py
@@ -235,6 +235,9 @@ class _HyperbandSampler(BaseSampler):
         self._sampler = sampler
         self._pruner = hyperband_pruner
 
+    def reseed_rng(self) -> None:
+        self._sampler.reseed_rng()
+
     @property
     def sampler(self) -> BaseSampler:
         return self._sampler

--- a/optuna/pruners/hyperband.py
+++ b/optuna/pruners/hyperband.py
@@ -214,7 +214,7 @@ class HyperbandPruner(BasePruner):
                 "pruner",
                 "study_name",
                 "_bracket_id",
-                "sampler",
+                "_sampler",
             )
 
             def __init__(self, study: "optuna.study.Study", bracket_id: int) -> None:
@@ -250,14 +250,6 @@ class _HyperbandSampler(BaseSampler):
 
     def reseed_rng(self) -> None:
         self._sampler.reseed_rng()
-
-    @property
-    def sampler(self) -> BaseSampler:
-        return self._sampler
-
-    @sampler.setter
-    def sampler(self, new_sampler: BaseSampler) -> None:
-        self._sampler = new_sampler
 
     def infer_relative_search_space(
         self, study: "optuna.study.Study", trial: FrozenTrial

--- a/optuna/samplers/tpe/sampler.py
+++ b/optuna/samplers/tpe/sampler.py
@@ -5,7 +5,6 @@ import scipy.special
 from scipy.stats import truncnorm
 
 from optuna import distributions
-from optuna.pruners import HyperbandPruner
 from optuna.samplers import base
 from optuna.samplers import random
 from optuna.samplers.tpe.parzen_estimator import _ParzenEstimator

--- a/optuna/samplers/tpe/sampler.py
+++ b/optuna/samplers/tpe/sampler.py
@@ -550,11 +550,6 @@ def _get_observation_pairs(study, param_name, trial):
     if study.direction == StudyDirection.MAXIMIZE:
         sign = -1
 
-    if isinstance(study.pruner, HyperbandPruner):
-        # Create `_BracketStudy` to use trials that have the same bracket id.
-        pruner = study.pruner  # type: HyperbandPruner
-        study = pruner._create_bracket_study(study, pruner._get_bracket_id(study, trial))
-
     values = []
     scores = []
     for trial in study.get_trials(deepcopy=False):

--- a/optuna/study.py
+++ b/optuna/study.py
@@ -45,6 +45,7 @@ if type_checking.TYPE_CHECKING:
     from typing import Union  # NOQA
 
     from optuna.distributions import BaseDistribution  # NOQA
+    from optuna.samplers import BaseSampler  # NOQA
 
     ObjectiveFuncType = Callable[[trial_module.Trial], float]
 
@@ -201,6 +202,8 @@ class Study(BaseStudy):
 
         self.sampler = sampler or samplers.TPESampler()
         self.pruner = pruner or pruners.MedianPruner()
+        if isinstance(self.pruner, pruners.HyperbandPruner):
+            self.sampler = pruners.hyperband._HyperbandSampler(self.sampler, self.pruner)
 
         self._optimize_lock = threading.Lock()
 


### PR DESCRIPTION
## Motivation
The current Hyperband implementation in Optuna imposes users who want to implement a new sampler to implement the specific logic. This annoys us because it is exactly the same logic for all samplers. This PR aims to hide the interface so that all samplers can use HyperbandPruner without any additional efforts.

## Description of the changes
- Remove the specific logic for Hyperband in `samplers/tpe/sampler.py`.
- Add sampler selection logic to `study.py` when the pruner is `HyperbandPruner`.
- Add special sampler `_HyperbandSampler` to `pruners/hyperband.py`.

## Note
This PR opposite PR #1196. If PR #1196 is merged, this PR should not be merged, and vice versa.

## TODO
- [x] Implementation
- [x] Benchmark experiments to verify the no performance difference for `RandomSampler` and `TPESampler`.

## Benchmark results
(CPU: Intel Core i7-7820HQ, python: 3.6.5)
- Using `kurobako`
- Compare the previous Hyperband and the new Hyperband
- 2 types of samplers: `RandomSampler` and `TPESampler`
- 5 types of benchmark dataset: `HPO-bench-Naval`, `HPO-bench-Parkinson`, `HPO-bench-Protein`, `HPO-bench-Slice`, and `NASBench (A)`.

### `RandomSampler`
![hpo-bench-naval-ee2999bfd9f1fc303e0c5bdf4a76d7237e1884aafdf1d535316bbc1927817235](https://user-images.githubusercontent.com/38826298/80304755-12c62680-87f3-11ea-9995-7201e6801543.png)
![hpo-bench-parkinson-7f71d7f6c0b01f3bdcaa8ee5e8e6b9cea2667628dd9623a90fdb5af14754467f](https://user-images.githubusercontent.com/38826298/80304756-148fea00-87f3-11ea-9405-443bf767652d.png)
![hpo-bench-protein-8832ffb88f2ff6f835eadbd07398b19fce3042047382d8479c80eea0e02c8886](https://user-images.githubusercontent.com/38826298/80304757-15c11700-87f3-11ea-94f4-a1213a178f20.png)
![hpo-bench-slice-f512579d4e11ff63a39870d249d3e7aff31b11ef5a1805dc50b4b40b0f30571a](https://user-images.githubusercontent.com/38826298/80304759-15c11700-87f3-11ea-9069-fba0a8efa383.png)
![nasbench-a-9779307a379c2e5cf46d8fca53726d8b88d3c0d7752d16589401a6a20ca60850](https://user-images.githubusercontent.com/38826298/80304760-1659ad80-87f3-11ea-9adb-ca1e123f682c.png)

### `TPESampler`
![hpo-bench-naval-ee2999bfd9f1fc303e0c5bdf4a76d7237e1884aafdf1d535316bbc1927817235](https://user-images.githubusercontent.com/38826298/80304886-20c87700-87f4-11ea-9683-aa981138305b.png)
![hpo-bench-parkinson-7f71d7f6c0b01f3bdcaa8ee5e8e6b9cea2667628dd9623a90fdb5af14754467f](https://user-images.githubusercontent.com/38826298/80304766-1eb1e880-87f3-11ea-90c3-027077b07e90.png)
![hpo-bench-protein-8832ffb88f2ff6f835eadbd07398b19fce3042047382d8479c80eea0e02c8886](https://user-images.githubusercontent.com/38826298/80304769-1fe31580-87f3-11ea-8013-d23ea5008272.png)
![hpo-bench-slice-f512579d4e11ff63a39870d249d3e7aff31b11ef5a1805dc50b4b40b0f30571a](https://user-images.githubusercontent.com/38826298/80304771-207bac00-87f3-11ea-9e31-a66b66ceada2.png)
![nasbench-a-9779307a379c2e5cf46d8fca53726d8b88d3c0d7752d16589401a6a20ca60850](https://user-images.githubusercontent.com/38826298/80304773-21144280-87f3-11ea-8bd9-c784bc2537cb.png)

