### PR TITLE
Fix a markup in pruner page

### DIFF
--- a/optuna/pruners/hyperband.py
+++ b/optuna/pruners/hyperband.py
@@ -73,7 +73,7 @@ class HyperbandPruner(BasePruner):
         n_brackets:
 
             .. deprecated:: 1.4.0
-                This argument will be removed from :class:~optuna.pruners.HyperbandPruner. The
+                This argument will be removed from :class:`~optuna.pruners.HyperbandPruner`. The
                 number of brackets are automatically determined based on ``max_resource`` and
                 ``reduction_factor``.
 


### PR DESCRIPTION
<!-- Thank you for creating a pull request! -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

Fix a part of `parameters` in [HyperbandPruner](https://optuna.readthedocs.io/en/latest/reference/pruners.html#optuna.pruners.HyperbandPruner) section.

The latest page:

![Screenshot 2020-04-27 at 17 42 13](https://user-images.githubusercontent.com/7121753/80352228-8711d000-88ae-11ea-9b20-5c007a83cc32.png)


## Description of the changes
<!-- Describe the changes in this PR. -->

Fix it:

![Screenshot 2020-04-27 at 17 27 56](https://user-images.githubusercontent.com/7121753/80352248-8da04780-88ae-11ea-9cd6-679e73bef5ab.png)
