### PR TITLE
Use major version instead of semver for stale

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -11,7 +11,7 @@ jobs:
 
     if: github.repository == 'optuna/optuna'
     steps:
-    - uses: actions/stale@v2.0.0
+    - uses: actions/stale@v2
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'This issue has not seen any recent activity.'


### PR DESCRIPTION
Non-breaking changes and fixes will automatically get consumed if minor version isn't pinned.