### PR TITLE
Add storage specification to `BaseStorage` class doc.

### DIFF
--- a/optuna/storages/base.py
+++ b/optuna/storages/base.py
@@ -31,6 +31,10 @@ class BaseStorage(object, metaclass=abc.ABCMeta):
     When users modify return values of storage classes, it might break the internal states
     of storage classes, which will result in undefined behaviors.
 
+    Storage class can assume that each RUNNING trial is modified from only one process.
+    When users modify a RUNNING trial from multiple processes, it might lead to
+    an inconsistent internal state, which will result in undefined behaviors.
+
     Storage classes must support monotonic-reads consistency model, that is, if a
     process reads a data `X`, any successive reads on data `X` does not return
     older values.

--- a/optuna/storages/base.py
+++ b/optuna/storages/base.py
@@ -58,6 +58,8 @@ class BaseStorage(object, metaclass=abc.ABCMeta):
 
     **Stronger consistency requirements for special data**
 
+    TODO(ytsmiling) Add load method to storage class implementations.
+
     Under multi-worker settings, storage classes are guaranteed to return the latest
     values of any attributes of `Study`, but not guaranteed the same thing for
     attributes of `Trial`.

--- a/optuna/storages/base.py
+++ b/optuna/storages/base.py
@@ -25,6 +25,8 @@ class BaseStorage(object, metaclass=abc.ABCMeta):
     Storage classes abstract a backend database and provide library internal interfaces to
     read/write history of studies and trials.
 
+    **Thread safety**
+
     Storage classes might be shared from multiple threads, and thus storage classes
     must be thread-safe.
     As one of the requirements of the thread-safety, storage classes must guarantee
@@ -33,6 +35,8 @@ class BaseStorage(object, metaclass=abc.ABCMeta):
     However, storage class can assume that return values are never modified by users.
     When users modify return values of storage classes, it might break the internal states
     of storage classes, which will result in undefined behaviors.
+
+    **Ownership of RUNNING trials**
 
     Trials in finished states are not allowed to be modified.
     Trials in the WAITING state are not allowed to be modified except for the `state` field.
@@ -43,12 +47,16 @@ class BaseStorage(object, metaclass=abc.ABCMeta):
     that the optuna interface is accessed from only one of the processes.
     Storage classes are not designed to provide inter-process communication functionalities.
 
+    **Consistency models**
+
     Storage classes must support monotonic-reads consistency model, that is, if a
     process reads a data `X`, any successive reads on data `X` does not return
     older values.
     They must support read-your-writes, that is, if a process writes to data `X`,
     any successive reads on data `X` from the same process must read the written
     value or one of more recent values.
+
+    **Stronger consistency requirements for special data**
 
     Under multi-worker settings, storage classes are guaranteed to return the latest
     values of any attributes of `Study`, but not guaranteed the same thing for
@@ -64,6 +72,8 @@ class BaseStorage(object, metaclass=abc.ABCMeta):
     The same applies for `user_attrs', 'system_attrs', 'intermediate_values` attributes,
     but future development may allow storage class users to explicitly skip the above
     properties for these attributes.
+
+    **Data persistence**
 
     Storage classes do not guarantee that write operations are logged into a persistent
     storage even when write methods succeed.

--- a/optuna/storages/base.py
+++ b/optuna/storages/base.py
@@ -27,42 +27,54 @@ class BaseStorage(object, metaclass=abc.ABCMeta):
 
     Storage classes might be shared from multiple threads, and thus storage classes
     must be thread-safe.
+    As one of the requirements of the thread-safety, storage classes must guarantee
+    that the returned values, such as `FrozenTrial`s will not be directly modified
+    by storage class.
     However, storage class can assume that return values are never modified by users.
     When users modify return values of storage classes, it might break the internal states
     of storage classes, which will result in undefined behaviors.
 
-    Storage class can assume that each RUNNING trial is modified from only one process.
+    Trials in finished states are not allowed to be modified.
+    Trials in the WAITING state are not allowed to be modified except for the `state` field.
+    Storage classes can assume that each RUNNING trial is modified from only one process.
     When users modify a RUNNING trial from multiple processes, it might lead to
     an inconsistent internal state, which will result in undefined behaviors.
+    To use optuna with MPI or in other multi-process programs, users must make sure
+    that the optuna interface is accessed from only one of the processes.
+    Storage classes are not designed to provide inter-process communication functionalities.
 
     Storage classes must support monotonic-reads consistency model, that is, if a
     process reads a data `X`, any successive reads on data `X` does not return
     older values.
-    They must virtually support read-your-writes, that is, if a process writes to
-    data `X`, any successive reads on data `X` from the same process must read
-    the written value or one of more recent values.
+    They must support read-your-writes, that is, if a process writes to data `X`,
+    any successive reads on data `X` from the same process must read the written
+    value or one of more recent values.
 
     Under multi-worker settings, storage classes are guaranteed to return the latest
     values of any attributes of `Study`, but not guaranteed the same thing for
     attributes of `Trial`.
-    However, if `load(study_id)` method is called, any successive reads on `state` and
-    `system_attrs` attributes of `Trial` in the study are guaranteed to return the
-    same or more recent values than the value at the time the `load` method called.
+    However, if `load(study_id)` method is called, any successive reads on the `state`
+    attribute of `Trial` in the study are guaranteed to return the same or more recent
+    values than the value at the time the `load` method called.
     Let `T` be a `Trial`.
-    Let `P` be a process that last updated the `state` or `system_attr` of `T`.
+    Let `P` be a process that last updated the `state` attribute of `T`.
     Then, any reads on any attributes of `T` are guaranteed to return the same or
     more recent values than any writes by `P` on the attribute before `P` updated
-    the `state` or `system_attr` of `T`.
+    the `state` attribute of `T`.
+    The same applies for `user_attrs', 'system_attrs', 'intermediate_values` attributes,
+    but future development may allow storage class users to explicitly skip the above
+    properties for these attributes.
 
     Storage classes do not guarantee that write operations are logged into a persistent
     storage even when write methods succeed.
     Thus, when process failure occurs, some writes might be lost.
     As exceptions, when a persistent storage is available, any writes on any attributes
-    of `Study` and writes on `state` and `system_attr` of `Trial` are guaranteed to be
-    persistent.
+    of `Study` and writes on `state` of `Trial` are guaranteed to be persistent.
     Additionally, any preceding writes on any attributes of `Trial` are guaranteed to
-    be written into a persistent storage before writes on `state` or `system_attr` of
-    `Trial` succeed.
+    be written into a persistent storage before writes on `state` of `Trial` succeed.
+    The same applies for `user_attrs', 'system_attrs', 'intermediate_values` attributes,
+    but future development may allow storage class users to explicitly skip the above
+    properties for these attributes.
     """
 
     # Basic study manipulation


### PR DESCRIPTION
## Motivation

As noted in #1170, defining consistency models let storage implementations to remove their bottlenecks.

## Description of the changes.

This PR adds a class doc to `BaseStorage` class which defines consistency models which storage classes should guarantee. Additionally, it also notes on thread-safety and data-persistence.

This PR introduces `load(study_id)` method. It is not supported by the current implementation and will be added by successive PRs. The method is not only required to reduce the sync cost with a remote database, but also necessary to alleviate the problem described in #1166 in multi-worker settings.
