### PR TITLE
Use `Trial.system_attrs` to store `LightGBMTuner`'s results.

### DIFF
--- a/optuna/integration/lightgbm_tuner/optimize.py
+++ b/optuna/integration/lightgbm_tuner/optimize.py
@@ -277,10 +277,10 @@ class OptunaObjective(BaseTuner):
             )
         )
 
-        trial.set_user_attr("lightgbm_tuner:elapsed_secs", elapsed_secs)
-        trial.set_user_attr("lightgbm_tuner:average_iteration_time", average_iteration_time)
-        trial.set_user_attr("lightgbm_tuner:step_name", self.step_name)
-        trial.set_user_attr("lightgbm_tuner:lgbm_params", json.dumps(self.lgbm_params))
+        trial.set_system_attr("lightgbm_tuner:elapsed_secs", elapsed_secs)
+        trial.set_system_attr("lightgbm_tuner:average_iteration_time", average_iteration_time)
+        trial.set_system_attr("lightgbm_tuner:step_name", self.step_name)
+        trial.set_system_attr("lightgbm_tuner:lgbm_params", json.dumps(self.lgbm_params))
 
         self.trial_count += 1
 
@@ -314,7 +314,7 @@ class LightGBMTuner(BaseTuner):
 
         study:
             A :class:`~optuna.study.Study` instance to store optimization results. The
-            :class:`~optuna.trial.Trial` instances in it has the following user attributes:
+            :class:`~optuna.trial.Trial` instances in it has the following system attributes:
             ``elapsed_secs`` is the elapsed time since the optimization starts.
             ``average_iteration_time`` is the average time of iteration to train the booster
             model in the trial. ``lgbm_params`` is a JSON-serialized dictionary of LightGBM
@@ -445,7 +445,7 @@ class LightGBMTuner(BaseTuner):
     def best_params(self) -> Dict[str, Any]:
         """Return parameters of the best booster."""
         try:
-            return json.loads(self.study.best_trial.user_attrs["lightgbm_tuner:lgbm_params"])
+            return json.loads(self.study.best_trial.system_attrs["lightgbm_tuner:lgbm_params"])
         except ValueError:
             # Return the default score because no trials have completed.
             params = copy.deepcopy(DEFAULT_LIGHTGBM_PARAMETERS)
@@ -731,7 +731,7 @@ class LightGBMTuner(BaseTuner):
                 return [
                     t
                     for t in trials
-                    if t.user_attrs.get("lightgbm_tuner:step_name") == self._step_name
+                    if t.system_attrs.get("lightgbm_tuner:step_name") == self._step_name
                 ]
 
             @property

--- a/tests/integration_tests/lightgbm_tuner_tests/test_optimize.py
+++ b/tests/integration_tests/lightgbm_tuner_tests/test_optimize.py
@@ -669,7 +669,7 @@ class TestLightGBMTuner(object):
 
         def objective(trial: optuna.trial.Trial, value: float) -> float:
 
-            trial.set_user_attr("lightgbm_tuner:step_name", "step{:.0f}".format(value))
+            trial.set_system_attr("lightgbm_tuner:step_name", "step{:.0f}".format(value))
             return trial.suggest_uniform("x", value, value)
 
         study = optuna.create_study(direction=direction)


### PR DESCRIPTION
## Motivation

Currently, `LightGBMTuner` uses `user_attrs` to store some results such as `lightgbm_tuner:elapsed_secs` and `lightgbm_tuner:lgbm_params`. I think the `LightGBMTuner` is a part of Optuna system and I think `system_attrs` is preferable to store them.

`optuna.samplers.CmaEsSampler` also use `system_attrs` to save the information (c.f., https://github.com/optuna/optuna/blob/master/optuna/samplers/cmaes.py#L204).

## Description of the changes

This PR simply replace `user_attrs` with `system_attrs` in `LightGBMTuner`.