### PR TITLE
Fix  `--cov` option for pytest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -237,7 +237,10 @@ jobs:
           name: codecov
           command: |
             . venv/bin/activate
-            pytest --cov=optuna tests
+            pytest --cov=./ --cov-report=html tests
             codecov
           environment:
             OMP_NUM_THREADS: 1
+
+      - store_artifacts:
+          path: ./htmlcov

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -237,7 +237,7 @@ jobs:
           name: codecov
           command: |
             . venv/bin/activate
-            pytest --cov=./ tests
+            pytest --cov=optuna tests
             codecov
           environment:
             OMP_NUM_THREADS: 1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -237,10 +237,7 @@ jobs:
           name: codecov
           command: |
             . venv/bin/activate
-            pytest --cov=./ --cov-report=html tests
+            pytest --cov=optuna tests
             codecov
           environment:
             OMP_NUM_THREADS: 1
-
-      - store_artifacts:
-          path: ./htmlcov


### PR DESCRIPTION
<!-- Thank you for creating a pull request! -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

We don't need to create coverage reports for files under `venv` or `tests`.

## Description of the changes
<!-- Describe the changes in this PR. -->

Fix the command that creates coverage reports as follows.

```diff
- pytest --cov=./ tests
+ pytest --cov=optuna tests
```