### PR TITLE
Add test for deprecation error of `HyperbandPruner`

### DIFF
--- a/tests/pruners_tests/test_hyperband.py
+++ b/tests/pruners_tests/test_hyperband.py
@@ -24,13 +24,23 @@ def test_hyperband_experimental_warning() -> None:
         )
 
 
-def test_hyperband_deprecation_warning() -> None:
+def test_hyperband_deprecation_warning_n_brackets() -> None:
     with pytest.deprecated_call():
         optuna.pruners.HyperbandPruner(
             min_resource=MIN_RESOURCE,
             max_resource=MAX_RESOURCE,
             reduction_factor=REDUCTION_FACTOR,
             n_brackets=N_BRACKETS,
+        )
+
+
+def test_hyperband_deprecation_warning_min_early_stopping_rate_low() -> None:
+    with pytest.deprecated_call():
+        optuna.pruners.HyperbandPruner(
+            min_resource=MIN_RESOURCE,
+            max_resource=MAX_RESOURCE,
+            reduction_factor=REDUCTION_FACTOR,
+            min_early_stopping_rate_low=EARLY_STOPPING_RATE_LOW,
         )
 
 


### PR DESCRIPTION
## Motivation
In the current `HyperbandPruner`, the arguments of ``n_brackets`` and ``min_early_stopping_rate_low`` are deprecated, but there is no test for that deprecation errors. This PR provides the test for deprecation errors.

## Description of the changes
- Add test for deprecation error for the argument ``min_early_stopping_rate_low``.
- Rename `test_hyperband_deprecation_warning` to `test_hyperband_deprecation_warning_n_brackets`.
