### PR TITLE
Define key names of `system_attrs` as variables in `LightGBMTuner`.

### DIFF
--- a/optuna/integration/lightgbm_tuner/optimize.py
+++ b/optuna/integration/lightgbm_tuner/optimize.py
@@ -33,15 +33,16 @@ if type_checking.TYPE_CHECKING:
     VALID_SET_TYPE = Union[List[lgb.Dataset], Tuple[lgb.Dataset, ...], lgb.Dataset]
 
 
-ELAPSED_SECS_KEY = "lightgbm_tuner:elapsed_secs"
-AVERAGE_ITERATION_TIME_KEY = "lightgbm_tuner:average_iteration_time"
-STEP_NAME_KEY = "lightgbm_tuner:step_name"
-LGBM_PARAMS_KEY = "lightgbm_tuner:lgbm_params"
+# Define key names of `Trial.system_attrs`.
+_ELAPSED_SECS_KEY = "lightgbm_tuner:elapsed_secs"
+_AVERAGE_ITERATION_TIME_KEY = "lightgbm_tuner:average_iteration_time"
+_STEP_NAME_KEY = "lightgbm_tuner:step_name"
+_LGBM_PARAMS_KEY = "lightgbm_tuner:lgbm_params"
 
 # EPS is used to ensure that a sampled parameter value is in pre-defined value range.
 EPS = 1e-12
 
-# Default value of tree_depth, used for upper bound of num_leaves
+# Default value of tree_depth, used for upper bound of num_leaves.
 DEFAULT_TUNER_TREE_DEPTH = 8
 
 # Default parameter values described in the official webpage.
@@ -282,10 +283,10 @@ class OptunaObjective(BaseTuner):
             )
         )
 
-        trial.set_system_attr(ELAPSED_SECS_KEY, elapsed_secs)
-        trial.set_system_attr(AVERAGE_ITERATION_TIME_KEY, average_iteration_time)
-        trial.set_system_attr(STEP_NAME_KEY, self.step_name)
-        trial.set_system_attr(LGBM_PARAMS_KEY, json.dumps(self.lgbm_params))
+        trial.set_system_attr(_ELAPSED_SECS_KEY, elapsed_secs)
+        trial.set_system_attr(_AVERAGE_ITERATION_TIME_KEY, average_iteration_time)
+        trial.set_system_attr(_STEP_NAME_KEY, self.step_name)
+        trial.set_system_attr(_LGBM_PARAMS_KEY, json.dumps(self.lgbm_params))
 
         self.trial_count += 1
 
@@ -450,7 +451,7 @@ class LightGBMTuner(BaseTuner):
     def best_params(self) -> Dict[str, Any]:
         """Return parameters of the best booster."""
         try:
-            return json.loads(self.study.best_trial.system_attrs[LGBM_PARAMS_KEY])
+            return json.loads(self.study.best_trial.system_attrs[_LGBM_PARAMS_KEY])
         except ValueError:
             # Return the default score because no trials have completed.
             params = copy.deepcopy(DEFAULT_LIGHTGBM_PARAMETERS)
@@ -733,7 +734,7 @@ class LightGBMTuner(BaseTuner):
                 # type: (bool) -> List[optuna.trial.FrozenTrial]
 
                 trials = super().get_trials(deepcopy=deepcopy)
-                return [t for t in trials if t.system_attrs.get(STEP_NAME_KEY) == self._step_name]
+                return [t for t in trials if t.system_attrs.get(_STEP_NAME_KEY) == self._step_name]
 
             @property
             def best_trial(self):

--- a/tests/integration_tests/lightgbm_tuner_tests/test_optimize.py
+++ b/tests/integration_tests/lightgbm_tuner_tests/test_optimize.py
@@ -670,7 +670,7 @@ class TestLightGBMTuner(object):
         def objective(trial: optuna.trial.Trial, value: float) -> float:
 
             trial.set_system_attr(
-                optuna.integration.lightgbm_tuner.optimize.STEP_NAME_KEY,
+                optuna.integration.lightgbm_tuner.optimize._STEP_NAME_KEY,
                 "step{:.0f}".format(value),
             )
             return trial.suggest_uniform("x", value, value)

--- a/tests/integration_tests/lightgbm_tuner_tests/test_optimize.py
+++ b/tests/integration_tests/lightgbm_tuner_tests/test_optimize.py
@@ -669,7 +669,10 @@ class TestLightGBMTuner(object):
 
         def objective(trial: optuna.trial.Trial, value: float) -> float:
 
-            trial.set_system_attr("lightgbm_tuner:step_name", "step{:.0f}".format(value))
+            trial.set_system_attr(
+                optuna.integration.lightgbm_tuner.optimize.STEP_NAME_KEY,
+                "step{:.0f}".format(value),
+            )
             return trial.suggest_uniform("x", value, value)
 
         study = optuna.create_study(direction=direction)


### PR DESCRIPTION
## Motivation
`LightGBMTuner` uses a string literals for the keys of `system_attrs`, but it may cause mistakes in future development. 

## Description of the changes
This PR defines the key names as variables, similarly to the #1163 ([here](https://github.com/optuna/optuna/pull/1163/files#diff-f8d15e6875544e214162a5701f52fd61R19)).