### PR TITLE
Stop installing PyTorch Lightning if Python version is 3.5.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,7 @@ def get_extras_require() -> Dict[str, List[str]]:
             ["llvmlite<=0.31.0"] if (3, 5) == sys.version_info[:2] else []
         )  # Newer `llvmlite` is not distributed with wheels for Python 3.5.
         + (
-            ["dask[dataframe]", "dask-ml", "keras", "tensorflow>=2.0.0", "tensorflow-datasets",]
+            ["dask[dataframe]", "dask-ml", "keras", "tensorflow>=2.0.0", "tensorflow-datasets"]
             if sys.version_info[:2] < (3, 8)
             else []
         ),

--- a/setup.py
+++ b/setup.py
@@ -77,19 +77,16 @@ def get_extras_require() -> Dict[str, List[str]]:
             "torchvision==0.5.0+cpu",
             "xgboost",
         ]
-        + (["allennlp<1", "fastai<2"] if (3, 5) < sys.version_info[:2] < (3, 8) else [])
+        + (
+            ["allennlp<1", "fastai<2", "pytorch-lightning>=0.7.1"]
+            if (3, 5) < sys.version_info[:2] < (3, 8)
+            else []
+        )
         + (
             ["llvmlite<=0.31.0"] if (3, 5) == sys.version_info[:2] else []
         )  # Newer `llvmlite` is not distributed with wheels for Python 3.5.
         + (
-            [
-                "dask[dataframe]",
-                "dask-ml",
-                "keras",
-                "pytorch-lightning>=0.7.1",
-                "tensorflow>=2.0.0",
-                "tensorflow-datasets",
-            ]
+            ["dask[dataframe]", "dask-ml", "keras", "tensorflow>=2.0.0", "tensorflow-datasets",]
             if sys.version_info[:2] < (3, 8)
             else []
         ),


### PR DESCRIPTION
## Motivation

This is a follow-up PR for #1013 . PyTorch Lightning does not support Python 3.5 but is installed via `get_extras_require()` in `setup.py`.

## Description of the changes

This PR stops installing PyTorch Lightning if Python version is 3.5.x. CI jobs skip PyTorch Lightning, so we do not update the [`.github/workflows/examples.yml`](https://github.com/optuna/optuna/blob/master/.github/workflows/examples.yml#L39).