### PR TITLE
Update pytorch_lightning_simple.py

### DIFF
--- a/examples/pytorch_lightning_simple.py
+++ b/examples/pytorch_lightning_simple.py
@@ -150,7 +150,7 @@ def objective(trial):
         val_percent_check=PERCENT_VALID_EXAMPLES,
         checkpoint_callback=checkpoint_callback,
         max_epochs=EPOCHS,
-        gpus=0 if torch.cuda.is_available() else None,
+        gpus='0' if torch.cuda.is_available() else None,
         callbacks=[metrics_callback],
         early_stop_callback=PyTorchLightningPruningCallback(trial, monitor="val_acc"),
     )


### PR DESCRIPTION
Wrong parameter for 'gpu': should be '0', a string, rather than 0, an integer

<!-- Thank you for creating a pull request! -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
Bug Fixed. The former edition could not start a GPU training job because of the wrong parameter 'gpu'.
## Description of the changes
<!-- Describe the changes in this PR. -->
For the trainer, the value for parameter 'gpu' has been changed from an integer 0 to  a string '0'