### PR TITLE
Import `optuna.exceptions.TrialPruned` in `__init__.py`.

### DIFF
--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -190,7 +190,7 @@ How are exceptions from trials handled?
 
 Trials that raise exceptions without catching them will be treated as failures, i.e. with the :obj:`~optuna.trial.TrialState.FAIL` status.
 
-By default, all exceptions except :class:`~optuna.exceptions.TrialPruned` raised in objective functions are propagated to the caller of :func:`~optuna.study.Study.optimize`.
+By default, all exceptions except :class:`~optuna.TrialPruned` raised in objective functions are propagated to the caller of :func:`~optuna.study.Study.optimize`.
 In other words, studies are aborted when such exceptions are raised.
 It might be desirable to continue a study with the remaining trials.
 To do so, you can specify in :func:`~optuna.study.Study.optimize` which exception types to catch using the ``catch`` argument.

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -190,7 +190,7 @@ How are exceptions from trials handled?
 
 Trials that raise exceptions without catching them will be treated as failures, i.e. with the :obj:`~optuna.trial.TrialState.FAIL` status.
 
-By default, all exceptions except :class:`~optuna.TrialPruned` raised in objective functions are propagated to the caller of :func:`~optuna.study.Study.optimize`.
+By default, all exceptions except :class:`~optuna.exceptions.TrialPruned` raised in objective functions are propagated to the caller of :func:`~optuna.study.Study.optimize`.
 In other words, studies are aborted when such exceptions are raised.
 It might be desirable to continue a study with the remaining trials.
 To do so, you can specify in :func:`~optuna.study.Study.optimize` which exception types to catch using the ``catch`` argument.

--- a/docs/source/scripts/plot_intermediate_values.py
+++ b/docs/source/scripts/plot_intermediate_values.py
@@ -22,7 +22,7 @@ def objective(trial):
 
         trial.report(y, step=step)
         if trial.should_prune():
-            raise optuna.exceptions.TrialPruned()
+            raise optuna.TrialPruned()
 
         gy = df(x)
         x -= gy * lr

--- a/docs/source/tutorial/pruning.rst
+++ b/docs/source/tutorial/pruning.rst
@@ -41,7 +41,7 @@ To turn on the pruning feature, you need to call :func:`~optuna.trial.Trial.repo
 
             # Handle pruning based on the intermediate value.
             if trial.should_prune():
-                raise optuna.exceptions.TrialPruned()
+                raise optuna.TrialPruned()
 
         return 1.0 - clf.score(valid_x, valid_y)
 

--- a/examples/pruning/simple.py
+++ b/examples/pruning/simple.py
@@ -40,7 +40,7 @@ def objective(trial):
 
         # Handle pruning based on the intermediate value.
         if trial.should_prune():
-            raise optuna.exceptions.TrialPruned()
+            raise optuna.TrialPruned()
 
     return clf.score(valid_x, valid_y)
 

--- a/examples/visualization/plot_study.ipynb
+++ b/examples/visualization/plot_study.ipynb
@@ -149,7 +149,7 @@
         "\n",
         "        # Handle pruning based on the intermediate value.\n",
         "        if trial.should_prune(step):\n",
-        "            raise optuna.exceptions.TrialPruned()  \n",
+        "            raise optuna.TrialPruned()  \n",
         "\n",
         "    return value"
       ],

--- a/examples/visualization/plot_study.py
+++ b/examples/visualization/plot_study.py
@@ -53,7 +53,7 @@ def objective(trial):
 
         # Handle pruning based on the intermediate value.
         if trial.should_prune(step):
-            raise optuna.exceptions.TrialPruned()
+            raise optuna.TrialPruned()
 
     return value
 

--- a/optuna/__init__.py
+++ b/optuna/__init__.py
@@ -16,6 +16,7 @@ from optuna import trial  # NOQA
 from optuna import version  # NOQA
 from optuna import visualization  # NOQA
 
+from optuna.exceptions import TrialPruned  # NOQA
 from optuna.study import create_study  # NOQA
 from optuna.study import delete_study  # NOQA
 from optuna.study import get_all_study_summaries  # NOQA

--- a/optuna/exceptions.py
+++ b/optuna/exceptions.py
@@ -41,7 +41,7 @@ class TrialPruned(OptunaError):
                     trial.report(intermediate_value, step)
 
                     if trial.should_prune():
-                        raise optuna.exceptions.TrialPruned()
+                        raise optuna.TrialPruned()
 
                 return clf.score(X_valid, y_valid)
 

--- a/optuna/integration/chainer.py
+++ b/optuna/integration/chainer.py
@@ -106,7 +106,7 @@ class ChainerPruningExtension(Extension):
         self._trial.report(current_score, step=current_step)
         if self._trial.should_prune():
             message = "Trial was pruned at {} {}.".format(self._pruner_trigger.unit, current_step)
-            raise optuna.exceptions.TrialPruned(message)
+            raise optuna.TrialPruned(message)
 
 
 def _check_chainer_availability():

--- a/optuna/integration/chainermn.py
+++ b/optuna/integration/chainermn.py
@@ -1,12 +1,12 @@
 import gc
 import warnings
 
-from optuna.exceptions import TrialPruned
 from optuna.logging import get_logger
 from optuna.storages import InMemoryStorage
 from optuna.storages import RDBStorage
 from optuna.trial import BaseTrial
 from optuna import type_checking
+from optuna import TrialPruned
 
 if type_checking.TYPE_CHECKING:
     from datetime import datetime  # NOQA

--- a/optuna/integration/chainermn.py
+++ b/optuna/integration/chainermn.py
@@ -5,8 +5,8 @@ from optuna.logging import get_logger
 from optuna.storages import InMemoryStorage
 from optuna.storages import RDBStorage
 from optuna.trial import BaseTrial
-from optuna import type_checking
 from optuna import TrialPruned
+from optuna import type_checking
 
 if type_checking.TYPE_CHECKING:
     from datetime import datetime  # NOQA

--- a/optuna/integration/fastai.py
+++ b/optuna/integration/fastai.py
@@ -72,7 +72,7 @@ class FastAIPruningCallback(TrackerCallback):
         self._trial.report(float(value), step=epoch)
         if self._trial.should_prune():
             message = "Trial was pruned at epoch {}.".format(epoch)
-            raise optuna.exceptions.TrialPruned(message)
+            raise optuna.TrialPruned(message)
 
 
 def _check_fastai_availability():

--- a/optuna/integration/keras.py
+++ b/optuna/integration/keras.py
@@ -61,7 +61,7 @@ class KerasPruningCallback(Callback):
         self._trial.report(float(current_score), step=epoch)
         if self._trial.should_prune():
             message = "Trial was pruned at epoch {}.".format(epoch)
-            raise optuna.exceptions.TrialPruned(message)
+            raise optuna.TrialPruned(message)
 
 
 def _check_keras_availability():

--- a/optuna/integration/lightgbm.py
+++ b/optuna/integration/lightgbm.py
@@ -117,7 +117,7 @@ class LightGBMPruningCallback(object):
             self._trial.report(current_score, step=env.iteration)
             if self._trial.should_prune():
                 message = "Trial was pruned at iteration {}.".format(env.iteration)
-                raise optuna.exceptions.TrialPruned(message)
+                raise optuna.TrialPruned(message)
 
             return None
 

--- a/optuna/integration/mxnet.py
+++ b/optuna/integration/mxnet.py
@@ -55,7 +55,7 @@ class MXNetPruningCallback(object):
             self._trial.report(current_score, step=param.epoch)
             if self._trial.should_prune():
                 message = "Trial was pruned at epoch {}.".format(param.epoch)
-                raise optuna.exceptions.TrialPruned(message)
+                raise optuna.TrialPruned(message)
 
 
 def _check_mxnet_availability():

--- a/optuna/integration/pytorch_ignite.py
+++ b/optuna/integration/pytorch_ignite.py
@@ -46,7 +46,7 @@ class PyTorchIgnitePruningHandler(object):
         self._trial.report(score, self._trainer.state.epoch)
         if self._trial.should_prune():
             message = "Trial was pruned at {} epoch.".format(self._trainer.state.epoch)
-            raise optuna.exceptions.TrialPruned(message)
+            raise optuna.TrialPruned(message)
 
 
 def _check_pytorch_ignite_availability():

--- a/optuna/integration/pytorch_lightning.py
+++ b/optuna/integration/pytorch_lightning.py
@@ -58,7 +58,7 @@ class PyTorchLightningPruningCallback(EarlyStopping):
         self._trial.report(current_score, step=epoch)
         if self._trial.should_prune():
             message = "Trial was pruned at epoch {}.".format(epoch)
-            raise optuna.exceptions.TrialPruned(message)
+            raise optuna.TrialPruned(message)
 
 
 def _check_pytorch_lightning_availability():

--- a/optuna/integration/sklearn.py
+++ b/optuna/integration/sklearn.py
@@ -35,7 +35,7 @@ except ImportError as e:
     _available = False
 
 from optuna import distributions  # NOQA
-from optuna import exceptions  # NOQA
+from optuna.exceptions import TrialPruned  # NOQA
 from optuna import logging  # NOQA
 from optuna import samplers  # NOQA
 from optuna import study as study_module  # NOQA
@@ -314,7 +314,7 @@ class _Objective(object):
             if trial.should_prune():
                 self._store_scores(trial, scores)
 
-                raise exceptions.TrialPruned("trial was pruned at iteration {}.".format(step))
+                raise TrialPruned("trial was pruned at iteration {}.".format(step))
 
         return scores
 

--- a/optuna/integration/sklearn.py
+++ b/optuna/integration/sklearn.py
@@ -35,7 +35,7 @@ except ImportError as e:
     _available = False
 
 from optuna import distributions  # NOQA
-from optuna.exceptions import TrialPruned  # NOQA
+from optuna import TrialPruned  # NOQA
 from optuna import logging  # NOQA
 from optuna import samplers  # NOQA
 from optuna import study as study_module  # NOQA

--- a/optuna/integration/tensorflow.py
+++ b/optuna/integration/tensorflow.py
@@ -80,7 +80,7 @@ class TensorFlowPruningHook(SessionRunHook):
                 self._current_summary_step = summary_step
             if self._trial.should_prune():
                 message = "Trial was pruned at iteration {}.".format(self._current_summary_step)
-                raise optuna.exceptions.TrialPruned(message)
+                raise optuna.TrialPruned(message)
 
 
 def _check_tensorflow_availability():

--- a/optuna/integration/tfkeras.py
+++ b/optuna/integration/tfkeras.py
@@ -59,7 +59,7 @@ class TFKerasPruningCallback(Callback):
         # Prune trial if needed
         if self._trial.should_prune():
             message = "Trial was pruned at epoch {}.".format(epoch)
-            raise optuna.exceptions.TrialPruned(message)
+            raise optuna.TrialPruned(message)
 
 
 def _check_tensorflow_availability():

--- a/optuna/integration/xgboost.py
+++ b/optuna/integration/xgboost.py
@@ -65,7 +65,7 @@ class XGBoostPruningCallback(object):
         self._trial.report(current_score, step=env.iteration)
         if self._trial.should_prune():
             message = "Trial was pruned at iteration {}.".format(env.iteration)
-            raise optuna.exceptions.TrialPruned(message)
+            raise optuna.TrialPruned(message)
 
 
 def _check_xgboost_availability():

--- a/optuna/pruners/hyperband.py
+++ b/optuna/pruners/hyperband.py
@@ -92,7 +92,7 @@ class HyperbandPruner(BasePruner):
                     trial.report(intermediate_value, step)
 
                     if trial.should_prune():
-                        raise optuna.exceptions.TrialPruned()
+                        raise optuna.TrialPruned()
 
                 return clf.score(X_valid, y_valid)
 

--- a/optuna/pruners/median.py
+++ b/optuna/pruners/median.py
@@ -39,7 +39,7 @@ class MedianPruner(PercentilePruner):
                     trial.report(intermediate_value, step)
 
                     if trial.should_prune():
-                        raise optuna.exceptions.TrialPruned()
+                        raise optuna.TrialPruned()
 
                 return clf.score(X_valid, y_valid)
 

--- a/optuna/pruners/nop.py
+++ b/optuna/pruners/nop.py
@@ -40,7 +40,7 @@ class NopPruner(BasePruner):
 
                     if trial.should_prune():
                         assert False, "should_prune() should always return False with this pruner."
-                        raise optuna.exceptions.TrialPruned()
+                        raise optuna.TrialPruned()
 
                 return clf.score(X_valid, y_valid)
 

--- a/optuna/pruners/percentile.py
+++ b/optuna/pruners/percentile.py
@@ -104,7 +104,7 @@ class PercentilePruner(BasePruner):
                     trial.report(intermediate_value, step)
 
                     if trial.should_prune():
-                        raise optuna.exceptions.TrialPruned()
+                        raise optuna.TrialPruned()
 
                 return clf.score(X_valid, y_valid)
 

--- a/optuna/pruners/successive_halving.py
+++ b/optuna/pruners/successive_halving.py
@@ -61,7 +61,7 @@ class SuccessiveHalvingPruner(BasePruner):
                     trial.report(intermediate_value, step)
 
                     if trial.should_prune():
-                        raise optuna.exceptions.TrialPruned()
+                        raise optuna.TrialPruned()
 
                 return clf.score(X_valid, y_valid)
 

--- a/optuna/pruners/threshold.py
+++ b/optuna/pruners/threshold.py
@@ -30,8 +30,8 @@ class ThresholdPruner(BasePruner):
         .. testcode::
 
             from optuna import create_study
-            from optuna.exceptions import TrialPruned
             from optuna.pruners import ThresholdPruner
+            from optuna import TrialPruned
 
             def objective_for_upper(trial):
                 for step, y in enumerate(ys_for_upper):

--- a/optuna/structs.py
+++ b/optuna/structs.py
@@ -24,7 +24,7 @@ _message = (
     "`structs.StudySummary`->`study.StudySummary`, "
     "`structs.FrozenTrial`->`trial.FrozenTrial`, "
     "`structs.TrialState`->`trial.TrialState`, "
-    "`structs.TrialPruned`->`exceptions.TrialPruned`."
+    "`structs.TrialPruned`->`TrialPruned`."
 )
 warnings.warn(_message, DeprecationWarning)
 _logger.warning(_message)
@@ -369,7 +369,7 @@ class TrialPruned(exceptions.TrialPruned):
     .. deprecated:: 0.19.0
 
         This class was moved to :mod:`~optuna.exceptions`. Please use
-        :class:`~optuna.exceptions.TrialPruned` instead.
+        :class:`~optuna.TrialPruned` instead.
     """
 
     def __init__(self, *args, **kwargs):
@@ -377,7 +377,7 @@ class TrialPruned(exceptions.TrialPruned):
 
         message = (
             "The use of `optuna.structs.TrialPruned` is deprecated. "
-            "Please use `optuna.exceptions.TrialPruned` instead."
+            "Please use `optuna.TrialPruned` instead."
         )
         warnings.warn(message, DeprecationWarning)
         _logger.warning(message)

--- a/optuna/structs.py
+++ b/optuna/structs.py
@@ -24,7 +24,7 @@ _message = (
     "`structs.StudySummary`->`study.StudySummary`, "
     "`structs.FrozenTrial`->`trial.FrozenTrial`, "
     "`structs.TrialState`->`trial.TrialState`, "
-    "`structs.TrialPruned`->`TrialPruned`."
+    "`structs.TrialPruned`->`exceptions.TrialPruned`."
 )
 warnings.warn(_message, DeprecationWarning)
 _logger.warning(_message)
@@ -369,7 +369,7 @@ class TrialPruned(exceptions.TrialPruned):
     .. deprecated:: 0.19.0
 
         This class was moved to :mod:`~optuna.exceptions`. Please use
-        :class:`~optuna.TrialPruned` instead.
+        :class:`~optuna.exceptions.TrialPruned` instead.
     """
 
     def __init__(self, *args, **kwargs):

--- a/optuna/study.py
+++ b/optuna/study.py
@@ -731,7 +731,7 @@ class Study(BaseStudy):
 
         try:
             result = func(trial)
-        except optuna.TrialPruned as e:
+        except exceptions.TrialPruned as e:
             message = "Setting status of trial#{} as {}. {}".format(
                 trial_number, TrialState.PRUNED, str(e)
             )

--- a/optuna/study.py
+++ b/optuna/study.py
@@ -300,7 +300,7 @@ class Study(BaseStudy):
             catch:
                 A study continues to run even when a trial raises one of the exceptions specified
                 in this argument. Default is an empty tuple, i.e. the study will stop for any
-                exception except for :class:`~optuna.TrialPruned`.
+                exception except for :class:`~optuna.exceptions.TrialPruned`.
             callbacks:
                 List of callback functions that are invoked at the end of each trial. Each function
                 must accept two parameters with the following types in this order:
@@ -731,7 +731,7 @@ class Study(BaseStudy):
 
         try:
             result = func(trial)
-        except exceptions.TrialPruned as e:
+        except optuna.TrialPruned as e:
             message = "Setting status of trial#{} as {}. {}".format(
                 trial_number, TrialState.PRUNED, str(e)
             )

--- a/optuna/study.py
+++ b/optuna/study.py
@@ -300,7 +300,7 @@ class Study(BaseStudy):
             catch:
                 A study continues to run even when a trial raises one of the exceptions specified
                 in this argument. Default is an empty tuple, i.e. the study will stop for any
-                exception except for :class:`~optuna.exceptions.TrialPruned`.
+                exception except for :class:`~optuna.TrialPruned`.
             callbacks:
                 List of callback functions that are invoked at the end of each trial. Each function
                 must accept two parameters with the following types in this order:

--- a/optuna/trial/_trial.py
+++ b/optuna/trial/_trial.py
@@ -19,9 +19,9 @@ if type_checking.TYPE_CHECKING:
     from optuna.distributions import CategoricalChoiceType  # NOQA
     from optuna.study import Study  # NOQA
 
-        FloatingPointDistributionType = Union[
-            distributions.UniformDistribution, distributions.LogUniformDistribution
-        ]
+    FloatingPointDistributionType = Union[
+        distributions.UniformDistribution, distributions.LogUniformDistribution
+    ]
 
 
 class Trial(BaseTrial):

--- a/optuna/trial/_trial.py
+++ b/optuna/trial/_trial.py
@@ -19,9 +19,9 @@ if type_checking.TYPE_CHECKING:
     from optuna.distributions import CategoricalChoiceType  # NOQA
     from optuna.study import Study  # NOQA
 
-    FloatingPointDistributionType = Union[
-        distributions.UniformDistribution, distributions.LogUniformDistribution
-    ]
+        FloatingPointDistributionType = Union[
+            distributions.UniformDistribution, distributions.LogUniformDistribution
+        ]
 
 
 class Trial(BaseTrial):

--- a/optuna/trial/_trial.py
+++ b/optuna/trial/_trial.py
@@ -498,7 +498,7 @@ class Trial(BaseTrial):
                         intermediate_value = clf.score(X_valid, y_valid)
                         trial.report(intermediate_value, step=step)
                         if trial.should_prune():
-                            raise TrialPruned()
+                            raise optuna.TrialPruned()
 
                     return clf.score(X_valid, y_valid)
 

--- a/optuna/visualization/intermediate_values.py
+++ b/optuna/visualization/intermediate_values.py
@@ -40,7 +40,7 @@ def plot_intermediate_values(study):
 
                     trial.report(y, step=step)
                     if trial.should_prune():
-                        raise optuna.exceptions.TrialPruned()
+                        raise optuna.TrialPruned()
 
                     gy = df(x)
                     x -= gy * lr

--- a/tests/integration_tests/test_chainer.py
+++ b/tests/integration_tests/test_chainer.py
@@ -10,7 +10,6 @@ import numpy as np
 import pytest
 
 import optuna
-from optuna.exceptions import TrialPruned
 from optuna.integration.chainer import ChainerPruningExtension
 from optuna.testing.integration import create_running_trial
 from optuna.testing.integration import DeterministicPruner
@@ -96,7 +95,7 @@ def test_chainer_pruning_extension_observation_nan():
     trainer = MockTrainer(observation={"main/loss": float("nan")}, updater=MockUpdater(1))
 
     with patch.object(extension, "_observation_exists", Mock(return_value=True)) as mock:
-        with pytest.raises(TrialPruned):
+        with pytest.raises(optuna.TrialPruned):
             extension(trainer)
         assert mock.call_count == 1
 

--- a/tests/integration_tests/test_chainermn.py
+++ b/tests/integration_tests/test_chainermn.py
@@ -4,12 +4,12 @@ import pytest
 
 from optuna import create_study
 from optuna import distributions
-from optuna.exceptions import TrialPruned
 from optuna import integration
 from optuna.integration import ChainerMNStudy
 from optuna import pruners
 from optuna.storages import RDBStorage
 from optuna import Study
+from optuna import TrialPruned
 from optuna.testing.integration import DeterministicPruner
 from optuna.testing.sampler import DeterministicRelativeSampler
 from optuna.testing.storage import StorageSupplier

--- a/tests/integration_tests/test_chainermn.py
+++ b/tests/integration_tests/test_chainermn.py
@@ -9,12 +9,12 @@ from optuna.integration import ChainerMNStudy
 from optuna import pruners
 from optuna.storages import RDBStorage
 from optuna import Study
-from optuna import TrialPruned
 from optuna.testing.integration import DeterministicPruner
 from optuna.testing.sampler import DeterministicRelativeSampler
 from optuna.testing.storage import StorageSupplier
 from optuna.trial import Trial
 from optuna.trial import TrialState
+from optuna import TrialPruned
 from optuna import type_checking
 
 if type_checking.TYPE_CHECKING:

--- a/tests/integration_tests/test_keras.py
+++ b/tests/integration_tests/test_keras.py
@@ -50,8 +50,8 @@ def test_keras_pruning_callback_observation_isnan():
     trial = create_running_trial(study, 1.0)
     callback = KerasPruningCallback(trial, "loss")
 
-    with pytest.raises(optuna.exceptions.TrialPruned):
+    with pytest.raises(optuna.TrialPruned):
         callback.on_epoch_end(0, {"loss": 1.0})
 
-    with pytest.raises(optuna.exceptions.TrialPruned):
+    with pytest.raises(optuna.TrialPruned):
         callback.on_epoch_end(0, {"loss": float("nan")})

--- a/tests/integration_tests/test_lightgbm.py
+++ b/tests/integration_tests/test_lightgbm.py
@@ -40,7 +40,7 @@ def test_lightgbm_pruning_callback_call(cv):
     study = optuna.create_study(pruner=DeterministicPruner(True))
     trial = create_running_trial(study, 1.0)
     pruning_callback = LightGBMPruningCallback(trial, "binary_error", valid_name="validation")
-    with pytest.raises(optuna.exceptions.TrialPruned):
+    with pytest.raises(optuna.TrialPruned):
         pruning_callback(env)
 
 

--- a/tests/integration_tests/test_pytorch_ignite.py
+++ b/tests/integration_tests/test_pytorch_ignite.py
@@ -30,7 +30,7 @@ def test_pytorch_ignite_pruning_handler():
     handler = optuna.integration.PyTorchIgnitePruningHandler(trial, "accuracy", trainer)
     with patch.object(trainer, "state", epoch=3):
         with patch.object(evaluator, "state", metrics={"accuracy": 1}):
-            with pytest.raises(optuna.exceptions.TrialPruned):
+            with pytest.raises(optuna.TrialPruned):
                 handler(evaluator)
             assert study.trials[0].intermediate_values == {3: 1}
 

--- a/tests/integration_tests/test_tfkeras.py
+++ b/tests/integration_tests/test_tfkeras.py
@@ -52,8 +52,8 @@ def test_tfkeras_pruning_callback_observation_isnan():
     trial = create_running_trial(study, 1.0)
     callback = TFKerasPruningCallback(trial, "loss")
 
-    with pytest.raises(optuna.exceptions.TrialPruned):
+    with pytest.raises(optuna.TrialPruned):
         callback.on_epoch_end(0, {"loss": 1.0})
 
-    with pytest.raises(optuna.exceptions.TrialPruned):
+    with pytest.raises(optuna.TrialPruned):
         callback.on_epoch_end(0, {"loss": float("nan")})

--- a/tests/integration_tests/test_xgboost.py
+++ b/tests/integration_tests/test_xgboost.py
@@ -31,7 +31,7 @@ def test_xgboost_pruning_callback_call():
     study = optuna.create_study(pruner=DeterministicPruner(True))
     trial = create_running_trial(study, 1.0)
     pruning_callback = XGBoostPruningCallback(trial, "validation-error")
-    with pytest.raises(optuna.exceptions.TrialPruned):
+    with pytest.raises(optuna.TrialPruned):
         pruning_callback(env)
 
 

--- a/tests/pruners_tests/test_hyperband.py
+++ b/tests/pruners_tests/test_hyperband.py
@@ -106,7 +106,7 @@ def test_hyperband_max_resource_is_auto() -> None:
         for i in range(N_REPORTS):
             trial.report(1.0, i)
             if trial.should_prune():
-                raise optuna.exceptions.TrialPruned()
+                raise optuna.TrialPruned()
 
         return 1.0
 
@@ -226,7 +226,7 @@ def test_hyperband_no_call_of_filter_study_in_should_prune(
                 trial.report(i, step=i)
                 if trial.should_prune():
                     method_mock.assert_not_called()
-                    raise optuna.exceptions.TrialPruned()
+                    raise optuna.TrialPruned()
                 else:
                     method_mock.assert_not_called()
 

--- a/tests/pruners_tests/test_successive_halving.py
+++ b/tests/pruners_tests/test_successive_halving.py
@@ -127,7 +127,7 @@ def test_successive_halving_pruner_with_auto_min_resource(n_reports, n_trials):
         for i in range(n_reports):
             trial.report(1.0 / (i + 1), i)
             if trial.should_prune():
-                raise optuna.exceptions.TrialPruned()
+                raise optuna.TrialPruned()
         return 1.0
 
     study.optimize(objective, n_trials=n_trials)

--- a/tests/samplers_tests/test_samplers.py
+++ b/tests/samplers_tests/test_samplers.py
@@ -296,7 +296,7 @@ def test_intersection_search_space() -> None:
         raise exception
 
     study.optimize(lambda t: objective(t, RuntimeError()), n_trials=1, catch=(RuntimeError,))
-    study.optimize(lambda t: objective(t, optuna.exceptions.TrialPruned()), n_trials=1)
+    study.optimize(lambda t: objective(t, optuna.TrialPruned()), n_trials=1)
     assert search_space.calculate(study) == {"y": UniformDistribution(low=-3, high=3)}
     assert search_space.calculate(study) == optuna.samplers.intersection_search_space(study)
 

--- a/tests/samplers_tests/tpe_tests/test_sampler.py
+++ b/tests/samplers_tests/tpe_tests/test_sampler.py
@@ -10,9 +10,9 @@ import numpy as np
 import pytest
 
 import optuna
-from optuna.exceptions import TrialPruned
 from optuna.samplers import tpe
 from optuna.samplers import TPESampler
+from optuna import TrialPruned
 
 if optuna.type_checking.TYPE_CHECKING:
     from optuna.trial import Trial  # NOQA

--- a/tests/test_importance.py
+++ b/tests/test_importance.py
@@ -93,7 +93,7 @@ def test_get_param_importances_invalid_empty_study() -> None:
         get_param_importances(study, evaluator=FanovaImportanceEvaluator())
 
     def objective(trial: Trial) -> float:
-        raise optuna.exceptions.TrialPruned
+        raise optuna.TrialPruned
 
     study.optimize(objective, n_trials=3)
 
@@ -130,7 +130,7 @@ def test_get_param_importances_invalid_no_completed_trials_params() -> None:
         x1 = trial.suggest_uniform("x1", 0.1, 3)
         if trial.number % 2 == 0:
             _ = trial.suggest_loguniform("x2", 0.1, 3)
-            raise optuna.exceptions.TrialPruned
+            raise optuna.TrialPruned
         return x1 ** 2
 
     study = create_study()

--- a/tests/test_study.py
+++ b/tests/test_study.py
@@ -444,11 +444,11 @@ def test_run_trial(storage_mode):
 
 # TODO(Yanase): Remove this test function after removing `optuna.structs.TrialPruned`.
 @pytest.mark.parametrize(
-    "trial_pruned_class", [optuna.exceptions.TrialPruned, optuna.structs.TrialPruned]
+    "trial_pruned_class",
+    [optuna.TrialPruned, optuna.exceptions.TrialPruned, optuna.structs.TrialPruned],
 )
 @pytest.mark.parametrize("report_value", [None, 1.2])
 def test_run_trial_with_trial_pruned(trial_pruned_class, report_value):
-    # type: (Callable[[], optuna.exceptions.TrialPruned], Optional[float]) -> None
 
     study = optuna.create_study()
 

--- a/tests/test_study.py
+++ b/tests/test_study.py
@@ -449,6 +449,7 @@ def test_run_trial(storage_mode):
 )
 @pytest.mark.parametrize("report_value", [None, 1.2])
 def test_run_trial_with_trial_pruned(trial_pruned_class, report_value):
+    # type: (Callable[[], optuna.exceptions.TrialPruned], Optional[float]) -> None
 
     study = optuna.create_study()
 


### PR DESCRIPTION
<!-- Thank you for creating a pull request! -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
Although `optuna.exceptions.TrialPruned` is exception, but it is used by users to prune trials. So, it is better that users can use it by `optuna.TrialPruned`.

## Description of the changes
<!-- Describe the changes in this PR. -->

- Import TrialPruned in `__init__`.
- Use `optuna.TrialPruned` in unittests and integration.

## Discussion topics
1. Do we have any ideas to implement it in a better way?
2. Is it okay to use `exception` as normal control flow?
