### PR TITLE
Raise `ValueError` that is not raised

### DIFF
--- a/optuna/visualization/parallel_coordinate.py
+++ b/optuna/visualization/parallel_coordinate.py
@@ -76,7 +76,7 @@ def _get_parallel_coordinate_plot(study: Study, params: Optional[List[str]] = No
     if params is not None:
         for input_p_name in params:
             if input_p_name not in all_params:
-                ValueError("Parameter {} does not exist in your study.".format(input_p_name))
+                raise ValueError("Parameter {} does not exist in your study.".format(input_p_name))
         all_params = set(params)
     sorted_params = sorted(list(all_params))
 

--- a/tests/visualization_tests/test_parallel_coordinate.py
+++ b/tests/visualization_tests/test_parallel_coordinate.py
@@ -44,7 +44,7 @@ def test_plot_parallel_coordinate():
     assert figure.data[0]["dimensions"][1]["values"] == (1.0, 2.5)
 
     # Test with wrong params that do not exist in trials
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Parameter optuna does not exist in your study."):
         plot_parallel_coordinate(study, params=["optuna", "optuna"])
 
     # Ignore failed trials.


### PR DESCRIPTION
<!-- Thank you for creating a pull request! -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

Just instantiating `ValueError` does nothing. It needs to be raised.

## Description of the changes
<!-- Describe the changes in this PR. -->

- Raise `ValueError`.
- Fix the test which currently catches a different `ValueError`.
