### PR TITLE
Move `colorlog` after `threading`.

### DIFF
--- a/optuna/logging.py
+++ b/optuna/logging.py
@@ -1,4 +1,3 @@
-import colorlog
 import logging
 from logging import CRITICAL  # NOQA
 from logging import DEBUG  # NOQA
@@ -8,6 +7,8 @@ from logging import INFO  # NOQA
 from logging import WARN  # NOQA
 from logging import WARNING  # NOQA
 import threading
+
+import colorlog
 
 from optuna import type_checking
 


### PR DESCRIPTION
Related to #514.

## Motivation
This is a tweak PR but `colorlog` is not a standard library.
(ref. https://pypi.org/project/colorlog/)

## Description of the changes
- edited `logging.py` to import `colorlog` after importing standard libraries