### PR TITLE
Add an explanation of failed trials from samplers' perspective.

### DIFF
--- a/optuna/samplers/base.py
+++ b/optuna/samplers/base.py
@@ -78,7 +78,7 @@ class BaseSampler(object, metaclass=abc.ABCMeta):
         evaluation of the objective function. This method is suitable for sampling algorithms
         that use relationship between parameters such as Gaussian Process and CMA-ES.
 
-        ... note::
+        .. note::
                 The failed trials are ignored by any build-in samplers when they sample new
                 parameters. Thus, failed trials are regarded as deleted in the samplers'
                 perspective.
@@ -109,7 +109,7 @@ class BaseSampler(object, metaclass=abc.ABCMeta):
         for sampling algorithms that do not use relationship between parameters such as random
         sampling and TPE.
 
-        ... note::
+        .. note::
                 The failed trials are ignored by any build-in samplers when they sample new
                 parameters. Thus, failed trials are regarded as deleted in the samplers'
                 perspective.

--- a/optuna/samplers/base.py
+++ b/optuna/samplers/base.py
@@ -78,6 +78,11 @@ class BaseSampler(object, metaclass=abc.ABCMeta):
         evaluation of the objective function. This method is suitable for sampling algorithms
         that use relationship between parameters such as Gaussian Process and CMA-ES.
 
+        ... note::
+                The failed trials are ignored by any build-in samplers when they sample new
+                parameters. Thus, failed trials are regarded as deleted in the samplers'
+                perspective.
+
         Args:
             study:
                 Target study object.
@@ -103,6 +108,11 @@ class BaseSampler(object, metaclass=abc.ABCMeta):
         by :func:`~optuna.samplers.BaseSampler.sample_relative` method. This method is suitable
         for sampling algorithms that do not use relationship between parameters such as random
         sampling and TPE.
+
+        ... note::
+                The failed trials are ignored by any build-in samplers when they sample new
+                parameters. Thus, failed trials are regarded as deleted in the samplers'
+                perspective.
 
         Args:
             study:

--- a/optuna/trial.py
+++ b/optuna/trial.py
@@ -40,7 +40,7 @@ class TrialState(enum.Enum):
         FAIL:
             The :class:`~optuna.trial.Trial` has failed due to an uncaught error.
 
-            ... note::
+            .. note::
                 The failed trials are ignored by any build-in samplers when they sample new
                 parameters. Thus, failed trials are regarded as deleted in the samplers'
                 perspective.

--- a/optuna/trial.py
+++ b/optuna/trial.py
@@ -39,6 +39,11 @@ class TrialState(enum.Enum):
             :class:`~optuna.exceptions.TrialPruned`.
         FAIL:
             The :class:`~optuna.trial.Trial` has failed due to an uncaught error.
+
+            ... note::
+                The failed trials are ignored by any build-in samplers when they sample new
+                parameters. Thus, failed trials are regarded as deleted in the samplers'
+                perspective.
     """
 
     RUNNING = 0


### PR DESCRIPTION
## Motivation
As noted in Issue #685, all built-in samplers ignore FAIL-ed trials. This PR gives the explanation in `optuna.trial.TrialState`.

## Description of the changes
Add an explanation of failed trials in `optuna.trial.py`.
