### PR TITLE
Install PyTorch without CPU option on macOS.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -73,8 +73,8 @@ def get_extras_require() -> Dict[str, List[str]]:
             "scikit-image",
             "scikit-learn",
             "thop",
-            "torch==1.4.0+cpu",
-            "torchvision==0.5.0+cpu",
+            "torch==1.4.0" if sys.platform == "darwin" else "torch==1.4.0+cpu",
+            "torchvision==0.5.0" if sys.platform == "darwin" else "torchvision==0.5.0+cpu",
             "xgboost",
         ]
         + (
@@ -109,8 +109,8 @@ def get_extras_require() -> Dict[str, List[str]]:
             "pytorch-ignite",
             "scikit-learn>=0.19.0",
             "scikit-optimize",
-            "torch==1.4.0+cpu",
-            "torchvision==0.5.0+cpu",
+            "torch==1.4.0" if sys.platform == "darwin" else "torch==1.4.0+cpu",
+            "torchvision==0.5.0" if sys.platform == "darwin" else "torchvision==0.5.0+cpu",
             "xgboost",
         ]
         + (


### PR DESCRIPTION
## Motivation
This PR fixes the problem of the installing failure of Optuna with the extra `testing` on macOS.

## Description of the changes
```
$ pip install 'torch==1.4.0+cpu'
Collecting torch==1.4.0+cpu
  ERROR: Could not find a version that satisfies the requirement torch==1.4.0+cpu (from versions: 0.1.2, 0.1.2.post1, 0.1.2.post2, 0.4.1, 1.0.0, 1.0.1, 1.0.1.post2, 1.1.0, 1.1.0.post2, 1.2.0, 1.3.0, 1.3.0.post2, 1.3.1, 1.4.0, 1.5.0)
ERROR: No matching distribution found for torch==1.4.0+cpu
```

I've noticed `torch==1.4.0+cpu` is not available for macOS and I modified `setup.py` to install PyTorch by running `pip install torch==1.4.0` on macOS.
(I'm wondering the same problem could happen on Windows but I couldn't test it.)

```python
"torch==1.4.0" if sys.platform == "darwin" else "torch==1.4.0+cpu",
"torchvision==0.5.0" if sys.platform == "darwin" else "torchvision==0.5.0+cpu",
```