### PR TITLE
Do not label `contribution-welcome` and `bug` issues as stale.

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -20,3 +20,4 @@ jobs:
         days-before-close: -1
         stale-issue-label: 'stale'
         stale-pr-label: 'stale'
+        exempt-issue-labels: 'contribution-welcome'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -20,4 +20,4 @@ jobs:
         days-before-close: -1
         stale-issue-label: 'stale'
         stale-pr-label: 'stale'
-        exempt-issue-labels: 'contribution-welcome'
+        exempt-issue-labels: 'bug,contribution-welcome'


### PR DESCRIPTION
## Motivation

Issues labeled with `contribution-welcome`, as with any other issue or PR, are currently labeled stale if no updates occur for a certain period of time. Usually, these issues are still valid after this period.

## Description of the changes

Let the stale bot exclude issues labeled with `contribution-welcome`. See https://github.com/actions/stale/blob/v2.0.0/action.yml.
