### PR TITLE
Add `LightGBMTuner` reference.

### DIFF
--- a/docs/source/reference/integration.rst
+++ b/docs/source/reference/integration.rst
@@ -31,6 +31,9 @@ Integration
 .. autoclass:: optuna.integration.lightgbm_tuner.LightGBMTuner
     :members:
 
+.. autoclass:: optuna.integration.lightgbm_tuner.LightGBMTunerCV
+    :members:
+
 .. autoclass:: MLflowCallback
     :members:
 

--- a/docs/source/reference/integration.rst
+++ b/docs/source/reference/integration.rst
@@ -30,9 +30,13 @@ Integration
 
 .. autoclass:: optuna.integration.lightgbm_tuner.LightGBMTuner
     :members:
+    :inherited-members:
+    :exclude-members: sample_train_set
 
 .. autoclass:: optuna.integration.lightgbm_tuner.LightGBMTunerCV
     :members:
+    :inherited-members:
+    :exclude-members: sample_train_set
 
 .. autoclass:: MLflowCallback
     :members:

--- a/docs/source/reference/integration.rst
+++ b/docs/source/reference/integration.rst
@@ -28,6 +28,9 @@ Integration
 
 .. autofunction:: optuna.integration.lightgbm.train
 
+.. autoclass:: optuna.integration.lightgbm_tuner.LightGBMTuner
+    :members:
+
 .. autoclass:: MLflowCallback
     :members:
 

--- a/optuna/integration/lightgbm_tuner/__init__.py
+++ b/optuna/integration/lightgbm_tuner/__init__.py
@@ -32,9 +32,9 @@ def train(*args: Any, **kwargs: Any) -> Any:
     `a simple example of LightGBM Tuner <https://github.com/optuna/optuna/blob/master/examples/lig
     htgbm_tuner_simple.py>`_ which optimizes the validation log loss of cancer detection.
 
-    :func:`~optuna.integration.lightgbm.train` is a wrapper function of :class:`~optuna.integration
-    .lightgbm_tuner.LightGBMTuner`, and please use it if you want to utilize advanced features
-    such as suspending/resuming optimization and parallelization.
+    :func:`~optuna.integration.lightgbm.train` is a wrapper function of
+    :class:`~optuna.integration.lightgbm_tuner.LightGBMTuner`, and please use it if you want to
+    utilize advanced features such as suspending/resuming optimization and parallelization.
 
     Arguments and keyword arguments for `lightgbm.train()
     <https://lightgbm.readthedocs.io/en/latest/pythonapi/lightgbm.train.html>`_ can be passed.

--- a/optuna/integration/lightgbm_tuner/__init__.py
+++ b/optuna/integration/lightgbm_tuner/__init__.py
@@ -2,10 +2,11 @@ from typing import Any
 
 from optuna._experimental import experimental
 from optuna import type_checking
+from optuna.integration.lightgbm_tuner.optimize import LightGBMTuner
+from optuna.integration.lightgbm_tuner.optimize import LightGBMTunerCV  # NOQA
+from optuna.integration.lightgbm_tuner.optimize import _check_lightgbm_availability
 
 try:
-    from optuna.integration.lightgbm_tuner.optimize import LightGBMTuner
-    from optuna.integration.lightgbm_tuner.optimize import LightGBMTunerCV  # NOQA
     from optuna.integration.lightgbm_tuner.sklearn import LGBMClassifier  # NOQA
     from optuna.integration.lightgbm_tuner.sklearn import LGBMModel  # NOQA
     from optuna.integration.lightgbm_tuner.sklearn import LGBMRegressor  # NOQA
@@ -34,15 +35,3 @@ def train(*args: Any, **kwargs: Any) -> Any:
     auto_booster = LightGBMTuner(*args, **kwargs)
     auto_booster.run()
     return auto_booster.get_best_booster()
-
-
-def _check_lightgbm_availability():
-    # type: () -> None
-
-    if not _available:
-        raise ImportError(
-            "LightGBM is not available. Please install LightGBM to use this feature. "
-            "LightGBM can be installed by executing `$ pip install lightgbm`. "
-            "For further information, please refer to the installation guide of LightGBM. "
-            "(The actual import error is as follows: " + str(_import_error) + ")"
-        )

--- a/optuna/integration/lightgbm_tuner/__init__.py
+++ b/optuna/integration/lightgbm_tuner/__init__.py
@@ -32,8 +32,9 @@ def train(*args: Any, **kwargs: Any) -> Any:
     htgbm_tuner_simple.py>`_ which optimizes the validation log loss of cancer detection.
 
     :func:`~optuna.integration.lightgbm.train` is a wrapper function of
-    :class:`~optuna.integration.lightgbm_tuner.LightGBMTuner`, and please use it if you want to
-    utilize advanced features such as suspending/resuming optimization and parallelization.
+    :class:`~optuna.integration.lightgbm_tuner.LightGBMTuner`. To use feature in Optuna such as
+    suspended/resumed optimization and/or parallelization, refer to
+    :class:`~optuna.integration.lightgbm_tuner.LightGBMTuner` instead of this function.
 
     Arguments and keyword arguments for `lightgbm.train()`_ can be passed.
 

--- a/optuna/integration/lightgbm_tuner/__init__.py
+++ b/optuna/integration/lightgbm_tuner/__init__.py
@@ -1,10 +1,10 @@
 from typing import Any
 
 from optuna._experimental import experimental
-from optuna import type_checking
+from optuna.integration.lightgbm_tuner.optimize import _check_lightgbm_availability
 from optuna.integration.lightgbm_tuner.optimize import LightGBMTuner
 from optuna.integration.lightgbm_tuner.optimize import LightGBMTunerCV  # NOQA
-from optuna.integration.lightgbm_tuner.optimize import _check_lightgbm_availability
+from optuna import type_checking
 
 try:
     from optuna.integration.lightgbm_tuner.sklearn import LGBMClassifier  # NOQA

--- a/optuna/integration/lightgbm_tuner/__init__.py
+++ b/optuna/integration/lightgbm_tuner/__init__.py
@@ -26,8 +26,17 @@ if type_checking.TYPE_CHECKING:
 def train(*args: Any, **kwargs: Any) -> Any:
     """Wrapper of LightGBM Training API to tune hyperparameters.
 
-    It tunes important hyperparameters (e.g., `min_child_samples` and `feature_fraction`) in a
-    stepwise manner. Arguments and keyword arguments for `lightgbm.train()
+    It tunes important hyperparameters (e.g., ``min_child_samples`` and ``feature_fraction``) in a
+    stepwise manner. You use it by changing one import statement in your code. Just replace
+    ``import lightgbm as lgb`` with ``import optuna.integration.lightgbm as lgb``. See
+    `a simple example of LightGBM Tuner <https://github.com/optuna/optuna/blob/master/examples/lig
+    htgbm_tuner_simple.py>`_ which optimizes the validation log loss of cancer detection.
+
+    :func:`~optuna.integration.lightgbm.train` is a wrapper function of :class:`~optuna.integration
+    .lightgbm_tuner.LightGBMTuner`, and please use it if you want to utilize advanced features
+    such as suspending/resuming optimization and parallelization.
+
+    Arguments and keyword arguments for `lightgbm.train()
     <https://lightgbm.readthedocs.io/en/latest/pythonapi/lightgbm.train.html>`_ can be passed.
     """
     _check_lightgbm_availability()

--- a/optuna/integration/lightgbm_tuner/__init__.py
+++ b/optuna/integration/lightgbm_tuner/__init__.py
@@ -27,8 +27,7 @@ def train(*args: Any, **kwargs: Any) -> Any:
     """Wrapper of LightGBM Training API to tune hyperparameters.
 
     It tunes important hyperparameters (e.g., ``min_child_samples`` and ``feature_fraction``) in a
-    stepwise manner. You use it by changing one import statement in your code. Just replace
-    ``import lightgbm as lgb`` with ``import optuna.integration.lightgbm as lgb``. See
+    stepwise manner. It is a drop-in replacement for `lightgbm.train()`_. See
     `a simple example of LightGBM Tuner <https://github.com/optuna/optuna/blob/master/examples/lig
     htgbm_tuner_simple.py>`_ which optimizes the validation log loss of cancer detection.
 
@@ -36,8 +35,9 @@ def train(*args: Any, **kwargs: Any) -> Any:
     :class:`~optuna.integration.lightgbm_tuner.LightGBMTuner`, and please use it if you want to
     utilize advanced features such as suspending/resuming optimization and parallelization.
 
-    Arguments and keyword arguments for `lightgbm.train()
-    <https://lightgbm.readthedocs.io/en/latest/pythonapi/lightgbm.train.html>`_ can be passed.
+    Arguments and keyword arguments for `lightgbm.train()`_ can be passed.
+
+    .. _lightgbm.train(): https://lightgbm.readthedocs.io/en/latest/pythonapi/lightgbm.train.html
     """
     _check_lightgbm_availability()
 

--- a/optuna/integration/lightgbm_tuner/optimize.py
+++ b/optuna/integration/lightgbm_tuner/optimize.py
@@ -661,11 +661,13 @@ class LightGBMBaseTuner(BaseTuner):
 class LightGBMTuner(LightGBMBaseTuner):
     """Hyperparameter-tuning with Optuna for LightGBM.
 
-    It selects a single variable of hyperparameters to tune step by step. For example,
-    ``feature_fraction``, ``num_leaves``, and so on respectively. You can find the detailed
-    algorithm and benchmark results in `this blog article <https://medium.com/optuna/lightgbm-tune
-    r-new-optuna-integration-for-hyperparameter-optimization-8b7095e99258>`_ by `Kohei Ozaki <http
-    s://www.kaggle.com/confirm>`_, who is a Kaggle Grandmaster.
+    It optimizes the following hypeperparameters in stepwise manner:
+    ``lambda_l1``, ``lambda_l2``, ``num_leaves``, ``feature_fraction``, ``bagging_fraction``,
+    ``bagging_freq`` and ``min_child_samples``.
+
+    You can find the detailed algorithm and benchmark results in `this blog article <https://mediu
+    m.com/optuna/lightgbm-tuner-new-optuna-integration-for-hyperparameter-optimization-8b7095e9925
+    8>`_ by `Kohei Ozaki <https://www.kaggle.com/confirm>`_, who is a Kaggle Grandmaster.
 
     Arguments and keyword arguments for `lightgbm.train()
     <https://lightgbm.readthedocs.io/en/latest/pythonapi/lightgbm.train.html>`_ can be passed.

--- a/optuna/integration/lightgbm_tuner/optimize.py
+++ b/optuna/integration/lightgbm_tuner/optimize.py
@@ -664,7 +664,7 @@ class LightGBMBaseTuner(BaseTuner):
 class LightGBMTuner(LightGBMBaseTuner):
     """Hyperparameter tuner for LightGBM.
 
-    It optimizes the following hypeperparameters in stepwise manner:
+    It optimizes the following hyperparameters in a stepwise manner:
     ``lambda_l1``, ``lambda_l2``, ``num_leaves``, ``feature_fraction``, ``bagging_fraction``,
     ``bagging_freq`` and ``min_child_samples``.
 

--- a/optuna/integration/lightgbm_tuner/optimize.py
+++ b/optuna/integration/lightgbm_tuner/optimize.py
@@ -443,8 +443,7 @@ class LightGBMBaseTuner(BaseTuner):
             params.update(self.lgbm_params)
             return params
 
-    def _parse_args(self, *args, **kwargs):
-        # type: (Any, Any) -> None
+    def _parse_args(self, *args: Any, **kwargs: Any) -> None:
 
         self.auto_options = {
             option_name: kwargs.get(option_name)

--- a/optuna/integration/lightgbm_tuner/optimize.py
+++ b/optuna/integration/lightgbm_tuner/optimize.py
@@ -661,6 +661,12 @@ class LightGBMBaseTuner(BaseTuner):
 class LightGBMTuner(LightGBMBaseTuner):
     """Hyperparameter-tuning with Optuna for LightGBM.
 
+    It selects a single variable of hyperparameters to tune step by step. For example,
+    ``feature_fraction``, ``num_leaves``, and so on respectively. You can find the detailed
+    algorithm and benchmark results in `this blog article <https://medium.com/optuna/lightgbm-tune
+    r-new-optuna-integration-for-hyperparameter-optimization-8b7095e99258>`_ by `Kohei Ozaki <http
+    s://www.kaggle.com/confirm>`_, who is a Kaggle Grandmaster.
+
     Arguments and keyword arguments for `lightgbm.train()
     <https://lightgbm.readthedocs.io/en/latest/pythonapi/lightgbm.train.html>`_ can be passed.
     The arguments that only :class:`~optuna.integration.lightgbm.LightGBMTuner` has are listed

--- a/optuna/integration/lightgbm_tuner/optimize.py
+++ b/optuna/integration/lightgbm_tuner/optimize.py
@@ -424,7 +424,7 @@ class LightGBMBaseTuner(BaseTuner):
 
     @property
     def best_score(self) -> float:
-        """"Return the score of the best booster."""
+        """Return the score of the best booster."""
         try:
             return self.study.best_value
         except ValueError:
@@ -662,7 +662,7 @@ class LightGBMBaseTuner(BaseTuner):
 
 
 class LightGBMTuner(LightGBMBaseTuner):
-    """Hyperparameter-tuning with Optuna for LightGBM.
+    """Hyperparameter tuner for LightGBM.
 
     It optimizes the following hypeperparameters in stepwise manner:
     ``lambda_l1``, ``lambda_l2``, ``num_leaves``, ``feature_fraction``, ``bagging_fraction``,
@@ -674,8 +674,8 @@ class LightGBMTuner(LightGBMBaseTuner):
 
     Arguments and keyword arguments for `lightgbm.train()
     <https://lightgbm.readthedocs.io/en/latest/pythonapi/lightgbm.train.html>`_ can be passed.
-    The arguments that only :class:`~optuna.integration.lightgbm.LightGBMTuner` has are listed
-    below:
+    The arguments that only :class:`~optuna.integration.lightgbm_tuner.LightGBMTuner` has are
+    listed below:
 
     Args:
         time_budget:
@@ -891,14 +891,20 @@ class LightGBMTuner(LightGBMBaseTuner):
 
 
 class LightGBMTunerCV(LightGBMBaseTuner):
-    """Hyperparameter-tuning with Optuna for LightGBM.
+    """Hyperparameter tuner for LightGBM with cross-validation.
 
-    In each trial, it performs cross-validation with the suggested hyperparameters.
-    Arguments and keyword arguments for `lightgbm.cv()
-    <https://lightgbm.readthedocs.io/en/latest/pythonapi/lightgbm.cv.html>`_ can be passed except
+    It employs the same stepwise approach as
+    :class:`~optuna.integration.lightgbm_tuner.LightGBMTuner`.
+    :class:`~optuna.integration.lightgbm_tuner.LightGBMTunerCV` invokes `lightgbm.cv()`_ to train
+    and validate boosters while :class:`~optuna.integration.lightgbm_tuner.LightGBMTuner` invokes
+    `lightgbm.train()`_. See
+    `a simple example <https://github.com/optuna/optuna/blob/master/examples/lightgbm_tuner_cv.
+    py>`_ which optimizes the validation log loss of cancer detection.
+
+    Arguments and keyword arguments for `lightgbm.cv()`_ can be passed except
     ``metrics``, ``init_model`` and ``eval_train_metric``.
-    The arguments that only :class:`~optuna.integration.lightgbm.LightGBMTunerCV` has are listed
-    below:
+    The arguments that only :class:`~optuna.integration.lightgbm_tuner.LightGBMTunerCV` has are
+    listed below:
 
     Args:
         time_budget:
@@ -919,6 +925,7 @@ class LightGBMTunerCV(LightGBMBaseTuner):
             Please note that this is not a ``callbacks`` argument of `lightgbm.train()`_ .
 
     .. _lightgbm.train(): https://lightgbm.readthedocs.io/en/latest/pythonapi/lightgbm.train.html
+    .. _lightgbm.cv(): https://lightgbm.readthedocs.io/en/latest/pythonapi/lightgbm.cv.html
     """
 
     def __init__(

--- a/optuna/integration/lightgbm_tuner/optimize.py
+++ b/optuna/integration/lightgbm_tuner/optimize.py
@@ -670,7 +670,7 @@ class LightGBMTuner(LightGBMBaseTuner):
 
     You can find the detailed algorithm and benchmark results in `this blog article <https://mediu
     m.com/optuna/lightgbm-tuner-new-optuna-integration-for-hyperparameter-optimization-8b7095e9925
-    8>`_ by `Kohei Ozaki <https://www.kaggle.com/confirm>`_, who is a Kaggle Grandmaster.
+    8>`_ by `Kohei Ozaki <https://www.kaggle.com/confirm>`_, a Kaggle Grandmaster.
 
     Arguments and keyword arguments for `lightgbm.train()
     <https://lightgbm.readthedocs.io/en/latest/pythonapi/lightgbm.train.html>`_ can be passed.

--- a/optuna/integration/lightgbm_tuner/optimize.py
+++ b/optuna/integration/lightgbm_tuner/optimize.py
@@ -16,7 +16,6 @@ from typing import Union
 import warnings
 
 import numpy as np
-from sklearn.model_selection import BaseCrossValidator
 import tqdm
 
 import optuna
@@ -24,6 +23,10 @@ from optuna.integration.lightgbm_tuner.alias import _handling_alias_metrics
 from optuna.integration.lightgbm_tuner.alias import _handling_alias_parameters
 from optuna.study import Study
 from optuna.trial import FrozenTrial
+from optuna import type_checking
+
+if type_checking.TYPE_CHECKING:
+    from sklearn.model_selection import BaseCrossValidator  # NOQA
 
 try:
     import lightgbm as lgb
@@ -927,7 +930,7 @@ class LightGBMTunerCV(LightGBMBaseTuner):
             Union[
                 Generator[Tuple[int, int], None, None],
                 Iterator[Tuple[int, int]],
-                BaseCrossValidator,
+                "BaseCrossValidator",
             ]
         ] = None,
         nfold: int = 5,

--- a/optuna/integration/lightgbm_tuner/optimize.py
+++ b/optuna/integration/lightgbm_tuner/optimize.py
@@ -667,9 +667,9 @@ class LightGBMTuner(LightGBMBaseTuner):
     ``lambda_l1``, ``lambda_l2``, ``num_leaves``, ``feature_fraction``, ``bagging_fraction``,
     ``bagging_freq`` and ``min_child_samples``.
 
-    You can find the detailed algorithm and benchmark results in `this blog article <https://mediu
-    m.com/optuna/lightgbm-tuner-new-optuna-integration-for-hyperparameter-optimization-8b7095e9925
-    8>`_ by `Kohei Ozaki <https://www.kaggle.com/confirm>`_, a Kaggle Grandmaster.
+    You can find the details of the algorithm and benchmark results in `this blog article <https:/
+    /medium.com/optuna/lightgbm-tuner-new-optuna-integration-for-hyperparameter-optimization-8b709
+    5e99258>`_ by `Kohei Ozaki <https://www.kaggle.com/confirm>`_, a Kaggle Grandmaster.
 
     Arguments and keyword arguments for `lightgbm.train()
     <https://lightgbm.readthedocs.io/en/latest/pythonapi/lightgbm.train.html>`_ can be passed.


### PR DESCRIPTION
## Motivation

Currently, we have no reference entry for `LightGBMTuner` because it is an internal class to implement `optuna.integration.lightgbm.train`. Recently, we are extending it (e.g., #1032 and #1076) and try to make it public.


## Description of the changes

This PR adds the `LightGBMTuner` entry to the reference.
It adds availability checking of the `lightgbm` package to `optuna/integration/lightgbm_tuner/optimize.py` because it is unavailable during the build process of the document.

## TODO

- [x] Add explanation of the `LightGBMTuner` class.