### PR TITLE
Fix the metric name in `KerasPruningCallback` example.

### DIFF
--- a/examples/pruning/keras_integration.py
+++ b/examples/pruning/keras_integration.py
@@ -74,7 +74,7 @@ def objective(trial):
         x_train,
         y_train,
         batch_size=BATCHSIZE,
-        callbacks=[KerasPruningCallback(trial, "val_acc")],
+        callbacks=[KerasPruningCallback(trial, "val_accuracy")],
         epochs=EPOCHS,
         validation_data=(x_valid, y_valid),
         verbose=1,

--- a/optuna/integration/keras.py
+++ b/optuna/integration/keras.py
@@ -29,7 +29,7 @@ class KerasPruningCallback(Callback):
             objective function.
         monitor:
             An evaluation metric for pruning, e.g., ``val_loss`` and
-            ``val_acc``. Please refer to `keras.Callback reference
+            ``val_accuracy``. Please refer to `keras.Callback reference
             <https://keras.io/callbacks/#callback>`_ for further details.
         interval:
             Check if trial should be pruned every n-th epoch. By default ``interval=1`` and


### PR DESCRIPTION
## Motivation

`examples/pruning/keras_integration.py` does not prune any trials. This is because the metric name has been changed from `val_acc` to `val_accuracy`.

## Changes

This PR simply updates the metric name, but it may be better to show warning messages if the metric cannot be found in the callback. If you have any comments, please let me know.