### PR TITLE
Fix cma's high  for categorical dist.

### DIFF
--- a/optuna/integration/cma.py
+++ b/optuna/integration/cma.py
@@ -301,7 +301,7 @@ class _Optimizer(object):
                 # Handle categorical values by ordinal representation.
                 # TODO(Yanase): Support one-hot representation.
                 lows.append(-0.5)
-                highs.append(len(dist.choices) - 0.5)
+                highs.append(len(dist.choices) + 0.5)
             elif isinstance(dist, UniformDistribution) or isinstance(dist, LogUniformDistribution):
                 lows.append(self._to_cma_params(search_space, param_name, dist.low))
                 highs.append(self._to_cma_params(search_space, param_name, dist.high))


### PR DESCRIPTION
<!-- Thank you for creating a pull request! -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

The initialisation of `_Optimizer` for `DiscreteUniformDistribution` in `optuna/integration/cma.py` seems wrong. But I'm not sure.

## Description of the changes
<!-- Describe the changes in this PR. -->

Replace it with the correct value.