### PR TITLE
Add interval to PercentilePruner.

### DIFF
--- a/optuna/integration/keras.py
+++ b/optuna/integration/keras.py
@@ -31,14 +31,10 @@ class KerasPruningCallback(Callback):
             An evaluation metric for pruning, e.g., ``val_loss`` and
             ``val_accuracy``. Please refer to `keras.Callback reference
             <https://keras.io/callbacks/#callback>`_ for further details.
-        interval:
-            Check if trial should be pruned every n-th epoch. By default ``interval=1`` and
-            pruning is performed after every epoch. Increase ``interval`` to run several
-            epochs faster before applying pruning.
-     """
+    """
 
-    def __init__(self, trial, monitor, interval=1):
-        # type: (optuna.trial.Trial, str, int) -> None
+    def __init__(self, trial, monitor):
+        # type: (optuna.trial.Trial, str) -> None
 
         super(KerasPruningCallback, self).__init__()
 
@@ -46,12 +42,11 @@ class KerasPruningCallback(Callback):
 
         self._trial = trial
         self._monitor = monitor
-        self._interval = interval
 
     def on_epoch_end(self, epoch, logs=None):
         # type: (int, Dict[str, float]) -> None
 
-        if (epoch + 1) % self._interval != 0:
+        if not self._trial.study.pruner.is_target_step(epoch):
             return
 
         logs = logs or {}

--- a/optuna/pruners/base.py
+++ b/optuna/pruners/base.py
@@ -30,3 +30,10 @@ class BasePruner(object, metaclass=abc.ABCMeta):
         """
 
         raise NotImplementedError
+
+    def is_target_step(self, step):
+        # type: (int) -> bool
+        """Judge whether :func:`optuna.pruners.base.prune` should be called.
+        """
+
+        raise NotImplementedError

--- a/optuna/pruners/base.py
+++ b/optuna/pruners/base.py
@@ -33,7 +33,6 @@ class BasePruner(object, metaclass=abc.ABCMeta):
 
     def is_target_step(self, step):
         # type: (int) -> bool
-        """Judge whether :func:`optuna.pruners.base.prune` should be called.
-        """
+        """Judge whether :func:`optuna.pruners.base.prune` should be called."""
 
         raise NotImplementedError

--- a/optuna/pruners/percentile.py
+++ b/optuna/pruners/percentile.py
@@ -192,3 +192,10 @@ class PercentilePruner(BasePruner):
         if direction == StudyDirection.MAXIMIZE:
             return best_intermediate_result < p
         return best_intermediate_result > p
+
+    def is_target_step(self, step):
+        # type: (int) -> bool
+        if step < self._n_warmup_steps:
+            return False
+
+        return (step - self._n_warmup_steps) % self._interval_steps == 0

--- a/optuna/testing/integration.py
+++ b/optuna/testing/integration.py
@@ -2,15 +2,21 @@ import optuna
 
 
 class DeterministicPruner(optuna.pruners.BasePruner):
-    def __init__(self, is_pruning):
-        # type: (bool) -> None
+    def __init__(self, is_pruning, interval=1):
+        # type: (bool, int) -> None
 
         self.is_pruning = is_pruning
+        self._interval = interval
 
     def prune(self, study, trial):
         # type: (optuna.study.Study, optuna.trial.FrozenTrial) -> bool
 
         return self.is_pruning
+
+    def is_target_step(self, step):
+        # type: (int) -> bool
+
+        return step % self._interval == 0
 
 
 def create_running_trial(study, value):

--- a/tests/integration_tests/test_keras.py
+++ b/tests/integration_tests/test_keras.py
@@ -1,3 +1,4 @@
+import itertools
 from keras.layers import Dense
 from keras import Sequential
 import numpy as np
@@ -9,8 +10,38 @@ from optuna.testing.integration import create_running_trial
 from optuna.testing.integration import DeterministicPruner
 
 
-@pytest.mark.parametrize("interval, epochs", [(1, 1), (2, 1), (2, 2)])
-def test_keras_pruning_callback(interval, epochs):
+def test_keras_pruning_callback():
+    # type: (int, int) -> None
+
+    def objective(trial):
+        # type: (optuna.trial.Trial) -> float
+
+        model = Sequential()
+        model.add(Dense(1, activation="sigmoid", input_dim=20))
+        model.compile(optimizer="rmsprop", loss="binary_crossentropy", metrics=["accuracy"])
+        model.fit(
+            np.zeros((16, 20), np.float32),
+            np.zeros((16,), np.int32),
+            batch_size=1,
+            epochs=2,
+            callbacks=[KerasPruningCallback(trial, "accuracy")],
+            verbose=0,
+        )
+
+        return 1.0
+
+    study = optuna.create_study(pruner=DeterministicPruner(True))
+    study.optimize(objective, n_trials=1)
+    assert study.trials[0].state == optuna.trial.TrialState.PRUNED
+
+    study = optuna.create_study(pruner=DeterministicPruner(False))
+    study.optimize(objective, n_trials=1)
+    assert study.trials[0].state == optuna.trial.TrialState.COMPLETE
+    assert study.trials[0].value == 1.0
+
+
+@pytest.mark.parametrize("interval, epochs", itertools.product([1, 2], [1, 2]))
+def test_keras_pruning_callback_interval(interval, epochs):
     # type: (int, int) -> None
 
     def objective(trial):
@@ -24,20 +55,17 @@ def test_keras_pruning_callback(interval, epochs):
             np.zeros((16,), np.int32),
             batch_size=1,
             epochs=epochs,
-            callbacks=[KerasPruningCallback(trial, "accuracy", interval=interval)],
+            callbacks=[KerasPruningCallback(trial, "accuracy")],
             verbose=0,
         )
 
         return 1.0
 
-    study = optuna.create_study(pruner=DeterministicPruner(True))
+    study = optuna.create_study(pruner=DeterministicPruner(True, interval=interval))
     study.optimize(objective, n_trials=1)
-    if interval <= epochs:
-        assert study.trials[0].state == optuna.trial.TrialState.PRUNED
-    else:
-        assert study.trials[0].state == optuna.trial.TrialState.COMPLETE
+    assert study.trials[0].state == optuna.trial.TrialState.PRUNED
 
-    study = optuna.create_study(pruner=DeterministicPruner(False))
+    study = optuna.create_study(pruner=DeterministicPruner(False, interval=interval))
     study.optimize(objective, n_trials=1)
     assert study.trials[0].state == optuna.trial.TrialState.COMPLETE
     assert study.trials[0].value == 1.0

--- a/tests/integration_tests/test_keras.py
+++ b/tests/integration_tests/test_keras.py
@@ -11,7 +11,7 @@ from optuna.testing.integration import DeterministicPruner
 
 
 def test_keras_pruning_callback():
-    # type: (int, int) -> None
+    # type: () -> None
 
     def objective(trial):
         # type: (optuna.trial.Trial) -> float

--- a/tests/pruners_tests/test_percentile.py
+++ b/tests/pruners_tests/test_percentile.py
@@ -241,3 +241,23 @@ def test_get_percentile_intermediate_result_over_trials():
     assert math.isnan(
         percentile._get_percentile_intermediate_result_over_trials(all_trials, direction, 2, 75)
     )
+
+
+def test_percentile_pruner_interval_is_target_step():
+    # type: () -> None
+
+    pruner = optuna.pruners.PercentilePruner(25.0, interval_steps=1)
+    assert pruner.is_target_step(0)
+    assert pruner.is_target_step(1)
+    assert pruner.is_target_step(2)
+
+    pruner = optuna.pruners.PercentilePruner(25.0, interval_steps=5)
+    assert pruner.is_target_step(0)
+    assert not pruner.is_target_step(1)
+    assert pruner.is_target_step(5)
+
+    pruner = optuna.pruners.PercentilePruner(25.0, n_warmup_steps=3, interval_steps=1)
+    assert not pruner.is_target_step(0)
+    assert not pruner.is_target_step(1)
+    assert not pruner.is_target_step(2)
+    assert pruner.is_target_step(3)


### PR DESCRIPTION
<!-- Thank you for creating a pull request! -->
Address #1136 .


## Description of the changes
<!-- Describe the changes in this PR. -->
1. Add `is_target_step` to `BasePruner` and implement `is_target_step` in `PercentilePruner`.
2. Use `pruner.is_target_step(epoch)` in `KerasPruningCallback` to skip pruning by interval.
