### PR TITLE
Fix a type casting error when using `CmaEsSampler`.

### DIFF
--- a/optuna/samplers/cmaes.py
+++ b/optuna/samplers/cmaes.py
@@ -195,7 +195,10 @@ class CmaEsSampler(BaseSampler):
             solutions = []  # type: List[Tuple[np.ndarray, float]]
             for t in solution_trials[: optimizer.population_size]:
                 assert t.value is not None, "completed trials must have a value"
-                x = np.array([_to_cma_param(search_space[k], t.params[k]) for k in ordered_keys])
+                x = np.array(
+                    [_to_cma_param(search_space[k], t.params[k]) for k in ordered_keys],
+                    dtype=float,
+                )
                 solutions.append((x, t.value))
 
             optimizer.tell(solutions)
@@ -368,4 +371,4 @@ def _get_search_space_bound(
             bounds.append([dist.low, dist.high])
         else:
             raise NotImplementedError("The distribution {} is not implemented.".format(dist))
-    return np.array(bounds)
+    return np.array(bounds, dtype=float)

--- a/optuna/samplers/cmaes.py
+++ b/optuna/samplers/cmaes.py
@@ -241,7 +241,7 @@ class CmaEsSampler(BaseSampler):
         else:
             sigma0 = self._sigma0
         sigma0 = max(sigma0, _MIN_SIGMA0)
-        mean = np.array([self._x0[k] for k in ordered_keys])
+        mean = np.array([self._x0[k] for k in ordered_keys], dtype=float)
         bounds = _get_search_space_bound(ordered_keys, search_space)
         n_dimension = len(ordered_keys)
         return CMA(


### PR DESCRIPTION
This PR fixes the following error that was occurred when I run a `CmaEsSampler` benchmark:
```console
$ kurobako --version
kurobako 0.1.14

$ wget $(kurobako dataset hpobench URL) && tar zxvf fcnet_tabular_benchmarks.tar.gz
$ kurobako problem-suite hpobench fcnet fcnet_tabular_benchmarks/ > problems.json
$ kurobako solver optuna --sampler cma-es > solvers.json

$ kurobako studies --problems (cat problems.json) --solvers (cat solvers.json) | kurobako run -q > result.json
  File "/home/ohta/.local/lib/python3.7/site-packages/kurobako/solver/__init__.py", line 172, in run
    while self._run_once():
  File "/home/ohta/.local/lib/python3.7/site-packages/kurobako/solver/__init__.py", line 186, in _run_once
    self._handle_ask_call(message)
  File "/home/ohta/.local/lib/python3.7/site-packages/kurobako/solver/__init__.py", line 214, in _handle_ask_call
    trial = solver.ask(idg)
  File "/home/ohta/.local/lib/python3.7/site-packages/kurobako/solver/optuna.py", line 86, in ask
    trial = self._create_new_trial()
  File "/home/ohta/.local/lib/python3.7/site-packages/kurobako/solver/optuna.py", line 172, in _create_new_trial
    return optuna.trial.Trial(self._study, trial_id)
  File "/home/ohta/dev/python/optuna/optuna/trial.py", line 409, in __init__
    self._init_relative_params()
  File "/home/ohta/dev/python/optuna/optuna/trial.py", line 420, in _init_relative_params
    self.study, trial, self.relative_search_space
  File "/home/ohta/dev/python/optuna/optuna/samplers/cmaes.py", line 201, in sample_relative
    optimizer.tell(solutions)
  File "/home/ohta/.local/lib/python3.7/site-packages/cmaes/cma.py", line 265, in tell
    self._mean += self._cm * self._sigma * y_w
numpy.core._exceptions.UFuncTypeError: Cannot cast ufunc 'add' output from dtype('float64') to dtype('int64') with casting rule 'same_kind'
```