### PR TITLE
Upgrade the Version of `cmaes`.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ def get_install_requires() -> List[str]:
     return [
         "alembic",
         "cliff",
-        "cmaes>=0.3.2",
+        "cmaes>=0.5.0",
         "colorlog",
         "joblib",
         "numpy",


### PR DESCRIPTION
## Motivation
This PR aims to address the problem discussed in PR https://github.com/optuna/optuna/pull/1240#issuecomment-628385348 by upgrading the version of `cmaes` from `0.3.2` to `0.5.0`.

## Description of the changes
Upgrade `cmaes` from `0.3.2` to `0.5.0`.
