### PR TITLE
Fix CMA-ES boundary constraints and initial mean vector of LogUniformDistribution

### DIFF
--- a/optuna/samplers/cmaes.py
+++ b/optuna/samplers/cmaes.py
@@ -323,7 +323,7 @@ def _initialize_x0(search_space: Dict[str, BaseDistribution]) -> Dict[str, np.nd
         elif isinstance(distribution, optuna.distributions.LogUniformDistribution):
             log_high = math.log(distribution.high)
             log_low = math.log(distribution.low)
-            x0[name] = math.exp(np.mean([log_high, log_low]))
+            x0[name] = np.mean([log_high, log_low])
         else:
             raise NotImplementedError(
                 "The distribution {} is not implemented.".format(distribution)

--- a/optuna/samplers/cmaes.py
+++ b/optuna/samplers/cmaes.py
@@ -368,7 +368,7 @@ def _get_search_space_bound(
                 optuna.distributions.IntUniformDistribution,
             ),
         ):
-            bounds.append([dist.low, dist.high])
+            bounds.append([_to_cma_param(dist, dist.low), _to_cma_param(dist, dist.high)])
         else:
             raise NotImplementedError("The distribution {} is not implemented.".format(dist))
     return np.array(bounds, dtype=float)


### PR DESCRIPTION
<!-- Thank you for creating a pull request! -->

## Motivation
To fix #1241.

## Description of the changes
<!-- Describe the changes in this PR. -->
cc: @HideakiImamura.

The cause of this bug is the setting of bound constraints. Thank you for reporting.

Before:

```
(venv) $ python examples/cmaes_loguniform.py
Running 2 trials...
[I 2020-05-14 16:41:41,256] Finished trial#0 with value: 2564.887849352018 with parameters: {'w': 7.0, 'x': 50.158625626096466, 'y': 0, 'z': 0.011164816029172358}. Best is trial#0 with value: 2564.887849352018.
[W 2020-05-14 16:41:41,259] The parameter 'y' in trial#1 is sampled independently by using `RandomSampler` instead of `CmaEsSampler` (optimization performance may be degraded). You can suppress this warning by setting `warn_independent_sampling` to `False` in the constructor of `CmaEsSampler`, if this independent sampling is intended behavior.
[W 2020-05-14 16:41:41,259] The parameter 'z' in trial#1 is sampled independently by using `RandomSampler` instead of `CmaEsSampler` (optimization performance may be degraded). You can suppress this warning by setting `warn_independent_sampling` to `False` in the constructor of `CmaEsSampler`, if this independent sampling is intended behavior.
[I 2020-05-14 16:41:41,292] Finished trial#1 with value: 48.03377381412535 with parameters: {'w': 7.0, 'x': 0.18056587488656362, 'y': -1, 'z': 0.034202031398689305}. Best is trial#1 with value: 48.03377381412535.
Best value: 48.03377381412535 (params: {'w': 7.0, 'x': 0.18056587488656362, 'y': -1, 'z': 0.034202031398689305})
```


After:

```
(venv) $ python examples/cmaes_loguniform.py
Running 2 trials...
[I 2020-05-14 16:41:16,970] Finished trial#0 with value: 7728.181280557202 with parameters: {'w': 7.0, 'x': -87.63519278326524, 'y': -1, 'z': 0.50424834867147}. Best is trial#0 with value: 7728.181280557202.
[W 2020-05-14 16:41:16,973] The parameter 'y' in trial#1 is sampled independently by using `RandomSampler` instead of `CmaEsSampler` (optimization performance may be degraded). You can suppress this warning by setting `warn_independent_sampling` to `False` in the constructor of `CmaEsSampler`, if this independent sampling is intended behavior.
[I 2020-05-14 16:41:17,007] Finished trial#1 with value: 66.02744560919409 with parameters: {'w': 8.0, 'x': -0.7086091946645107, 'y': 1, 'z': 0.7247886715664064}. Best is trial#1 with value: 66.02744560919409.
Best value: 66.02744560919409 (params: {'w': 8.0, 'x': -0.7086091946645107, 'y': 1, 'z': 0.7247886715664064})
```