### PR TITLE
Add GitHub action that posts link to documentation

### DIFF
--- a/.github/workflows/doc-link.yml
+++ b/.github/workflows/doc-link.yml
@@ -1,0 +1,13 @@
+name: Add Documentation Link
+
+on: status
+
+jobs:
+  doc-link:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: larsoner/circleci-artifacts-redirector-action@master
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          artifact-path: 0/docs/build/html/index.html
+          circleci-jobs: document

--- a/.github/workflows/doc-link.yml
+++ b/.github/workflows/doc-link.yml
@@ -6,8 +6,8 @@ jobs:
   doc-link:
     runs-on: ubuntu-latest
     steps:
-      - uses: larsoner/circleci-artifacts-redirector-action@master
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          artifact-path: 0/docs/build/html/index.html
-          circleci-jobs: document
+    - uses: larsoner/circleci-artifacts-redirector-action@master
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        artifact-path: 0/docs/build/html/index.html
+        circleci-jobs: document


### PR DESCRIPTION
<!-- Thank you for creating a pull request! -->

## Motivation

Fixes #1097

## Description of the changes

Add a GitHub action that posts the link to the documentation stored in CircleCI.


(I captured this on my repo.)
![image](https://user-images.githubusercontent.com/17039389/82049208-e8c89b80-96f0-11ea-91ae-b49d3e7990ad.png)
