### PR TITLE
Add Notes for `auto` argument values in `HyperbandPruner` and `SuccessiveHalvingPruner`.

### DIFF
--- a/optuna/pruners/hyperband.py
+++ b/optuna/pruners/hyperband.py
@@ -127,7 +127,7 @@ class HyperbandPruner(BasePruner):
 
             .. note::
                 If the step of the last intermediate value may change with each trial, please
-                manually specify the maximum possible step to `max_resource`.
+                manually specify the maximum possible step to ``max_resource``.
         reduction_factor:
             A parameter for specifying reduction factor of promotable trials noted as
             :math:`\\eta` in the paper.

--- a/optuna/pruners/hyperband.py
+++ b/optuna/pruners/hyperband.py
@@ -124,6 +124,10 @@ class HyperbandPruner(BasePruner):
                 :meth:`~optuna.trial.Trial.report` in the first, or one of the first if trained in
                 parallel, completed trial. No trials will be pruned until the maximum resource is
                 determined.
+
+            .. note::
+                If the step of the last intermediate value may change with each trial, please
+                manually specify the maximum possible step to `max_resource`.
         reduction_factor:
             A parameter for specifying reduction factor of promotable trials noted as
             :math:`\\eta` in the paper.

--- a/optuna/pruners/successive_halving.py
+++ b/optuna/pruners/successive_halving.py
@@ -92,6 +92,10 @@ class SuccessiveHalvingPruner(BasePruner):
             (\\mathsf{min}\\_\\mathsf{early}\\_\\mathsf{stopping}\\_\\mathsf{rate}
             + \\mathsf{rung})}` steps)
             and repeats the same procedure.
+
+            .. note::
+                If the step of the last intermediate value may change with each trial, please
+                manually specify the minimum possible step to `min_resource`.
         reduction_factor:
             A parameter for specifying reduction factor of promotable trials
             (in the `paper <http://arxiv.org/abs/1810.05934>`_ this parameter is

--- a/optuna/pruners/successive_halving.py
+++ b/optuna/pruners/successive_halving.py
@@ -95,7 +95,7 @@ class SuccessiveHalvingPruner(BasePruner):
 
             .. note::
                 If the step of the last intermediate value may change with each trial, please
-                manually specify the minimum possible step to `min_resource`.
+                manually specify the minimum possible step to ``min_resource``.
         reduction_factor:
             A parameter for specifying reduction factor of promotable trials
             (in the `paper <http://arxiv.org/abs/1810.05934>`_ this parameter is


### PR DESCRIPTION
## Motivation
If the value of `max_resource` (`min_resource`) in `HyperbandPruner` (`SuccessiveHalvingPruner`) is set to `auto`, the `max_resource` (`min_resource`) is automatically determined by first completed trials. As discussed in Issue #1220, this heuristics causes inconsistent values of `max_resource` (`min_resource`). This PR gives a note in the document for setting `auto` values.

## Description of the changes
- Add Notes in `HyperbandPruner` and `SuccessiveHalvingPruner`.
