### PR TITLE
Fix for O(N) queries being produced if even a single trial is cached

### DIFF
--- a/optuna/storages/rdb/storage.py
+++ b/optuna/storages/rdb/storage.py
@@ -845,7 +845,7 @@ class RDBStorage(BaseStorage):
             id_to_system_attrs[system_attr.trial_id].append(system_attr)
 
         result = []
-        for trial_id, trial in id_to_trial.items():
+        for trial_id, trial in sorted(id_to_trial.items(), key=lambda x: x[0]):
             params = {}
             param_distributions = {}
             for param in id_to_params[trial_id]:

--- a/optuna/storages/rdb/storage.py
+++ b/optuna/storages/rdb/storage.py
@@ -456,7 +456,7 @@ class RDBStorage(BaseStorage):
         models.StudyModel.find_or_raise_by_id(study_id, session)
 
         if template_trial is None:
-            trial = models.TrialModel(study_id=study_id, number=None, state=TrialState.RUNNING,)
+            trial = models.TrialModel(study_id=study_id, number=None, state=TrialState.RUNNING)
         else:
             # Because only `RUNNING` trials can be updated,
             # we temporarily set the state of the new trial to `RUNNING`.
@@ -736,7 +736,13 @@ class RDBStorage(BaseStorage):
             # Check if no more than 5 trials are missing from the cache.
             # This prevents a single item in the cache from resulting in O(N) database lookups when
             # the bulk fetch below would be significantly faster.
-            if sum(not self._finished_trials_cache.get_cached_trial(trial_id) for trial_id in trial_ids) < 5:
+            if (
+                sum(
+                    not self._finished_trials_cache.get_cached_trial(trial_id)
+                    for trial_id in trial_ids
+                )
+                < 5
+            ):
                 trials = [self._get_and_cache_trial(trial_id, deepcopy) for trial_id in trial_ids]
                 return trials
 


### PR DESCRIPTION
## Motivation
While debugging some performance issues when running with a remote database, we noticed that calling the following two methods in a different order produced WILDY different runtime behavior.
```python
study.best_params
study.trials_dataframe()
```

If `best_params` is called first, the call to `trials_dataframe` would take 5 minutes. If we inverted the calls, both methods would complete in a matter of seconds.

Digging in it turned out that `best_params` causes a single 'trial' to be cached in the system, which causes `trials_dataframe` to go from making a single bulk-database query to making N individual queries for each trial in the study (in our case, 700). This was probably especially noticeable in our case because the database was remote, but I expect even a local database would see improved performance from batch fetches.

## Description of the changes
This change modifies the cache code to prefer the bulk database fetch, which will almost always result in lower latency than making sequential queries. The cache is only used if less than 5 elements are missing (or not finished).