### PR TITLE
Add description of `observation_key` in `XGBoostPruningCallback`

### DIFF
--- a/optuna/integration/xgboost.py
+++ b/optuna/integration/xgboost.py
@@ -43,6 +43,9 @@ class XGBoostPruningCallback(object):
             ``validation-merror``. Please refer to ``eval_metric`` in
             `XGBoost reference <https://xgboost.readthedocs.io/en/latest/parameter.html>`_
             for further details.
+            Note that when using the sklearn API callback, the index number of `eval_set`
+            must be included in the `observation_key`, e.g., ``validation_0-error`` and
+            ``validation_0-merror``.
     """
 
     def __init__(self, trial, observation_key):

--- a/optuna/integration/xgboost.py
+++ b/optuna/integration/xgboost.py
@@ -44,7 +44,7 @@ class XGBoostPruningCallback(object):
             `XGBoost reference <https://xgboost.readthedocs.io/en/latest/parameter.html>`_
             for further details.
             Note that when using the sklearn API callback, the index number of `eval_set`
-            must be included in the `observation_key`, e.g., ``validation_0-error`` and
+            must be included in the ``observation_key``, e.g., ``validation_0-error`` and
             ``validation_0-merror``.
     """
 

--- a/optuna/integration/xgboost.py
+++ b/optuna/integration/xgboost.py
@@ -40,12 +40,11 @@ class XGBoostPruningCallback(object):
             objective function.
         observation_key:
             An evaluation metric for pruning, e.g., ``validation-error`` and
-            ``validation-merror``. Please refer to ``eval_metric`` in
+            ``validation-merror``. When using the Scikit-Learn API, the index number of
+            ``eval_set`` must be included in the ``observation_key``, e.g., ``validation_0-error``
+            and ``validation_0-merror``. Please refer to ``eval_metric`` in
             `XGBoost reference <https://xgboost.readthedocs.io/en/latest/parameter.html>`_
             for further details.
-            Note that when using the sklearn API callback, the index number of `eval_set`
-            must be included in the ``observation_key``, e.g., ``validation_0-error`` and
-            ``validation_0-merror``.
     """
 
     def __init__(self, trial, observation_key):


### PR DESCRIPTION
<!-- Thank you for creating a pull request! -->

## Motivation

<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

This PR adds a description of `observation_key` in `XGBoostPruningCallback`.
Related issue: https://github.com/optuna/optuna/issues/1237.

XGBRegressor and XGBClassifier always uses a metric name like `validation_(index)-(metric)`, not `validation-(metric)`. This PR adds the description to notice this point.

## Description of the changes

<!-- Describe the changes in this PR. -->

This change adds the following description:

```
Note that when using the sklearn API callback,
the index number of `eval_set` must be included in the `observation_key`.
e.g., ``validation_0-error`` and ``validation_0-merror``.
```