### PR TITLE
Cosmetic fixes to documentation in `BaseStorage`.

### DIFF
--- a/optuna/storages/base.py
+++ b/optuna/storages/base.py
@@ -21,7 +21,7 @@ class BaseStorage(object, metaclass=abc.ABCMeta):
 
     This class is not supposed to be directly accessed by library users.
 
-    A storage class abstract a backend database and provide library internal interfaces to
+    A storage class abstracts a backend database and provide library internal interfaces to
     read/write histories of studies and trials.
 
     **Thread safety**

--- a/optuna/storages/base.py
+++ b/optuna/storages/base.py
@@ -21,7 +21,7 @@ class BaseStorage(object, metaclass=abc.ABCMeta):
 
     This class is not supposed to be directly accessed by library users.
 
-    A storage class abstracts a backend database and provide library internal interfaces to
+    A storage class abstracts a backend database and provides library internal interfaces to
     read/write histories of studies and trials.
 
     **Thread safety**


### PR DESCRIPTION
Updates the documentation of the `BaseStorage`. Changes target English grammar and simplification, style and formatting, and some consistencies. In short, they're mostly cosmetic. 

Refer to https://github.com/optuna/optuna/pull/1175#pullrequestreview-412446405 for more context.