### PR TITLE
Fix the Double Meanings on ``bracket_id``.

### DIFF
--- a/optuna/pruners/hyperband.py
+++ b/optuna/pruners/hyperband.py
@@ -201,10 +201,10 @@ class HyperbandPruner(BasePruner):
             if len(self._pruners) == 0:
                 return False
 
-        i = self._get_bracket_id(study, trial)
-        _logger.debug("{}th bracket is selected".format(i))
-        bracket_study = self._create_bracket_study(study, i)
-        return self._pruners[i].prune(bracket_study, trial)
+        bracket_id = self._get_bracket_id(study, trial)
+        _logger.debug("{}th bracket is selected".format(bracket_id))
+        bracket_study = self._create_bracket_study(study, bracket_id)
+        return self._pruners[bracket_id].prune(bracket_study, trial)
 
     def _try_initialization(self, study: "optuna.study.Study") -> None:
         if self._max_resource == "auto":
@@ -233,19 +233,19 @@ class HyperbandPruner(BasePruner):
 
         _logger.debug("Hyperband has {} brackets".format(self._n_brackets))
 
-        for i in range(self._n_brackets):
-            trial_allocation_budget = self._calculate_trial_allocation_budget(i)
+        for bracket_id in range(self._n_brackets):
+            trial_allocation_budget = self._calculate_trial_allocation_budget(bracket_id)
             self._total_trial_allocation_budget += trial_allocation_budget
             self._trial_allocation_budgets.append(trial_allocation_budget)
 
             if self._min_early_stopping_rate_low is None:
-                min_early_stopping_rate = i
+                min_early_stopping_rate = bracket_id
             else:
-                min_early_stopping_rate = self._min_early_stopping_rate_low + i
+                min_early_stopping_rate = self._min_early_stopping_rate_low + bracket_id
 
             _logger.debug(
                 "{}th bracket has minimum early stopping rate of {}".format(
-                    i, min_early_stopping_rate
+                    bracket_id, min_early_stopping_rate
                 )
             )
 
@@ -286,10 +286,10 @@ class HyperbandPruner(BasePruner):
             hash("{}_{}".format(study.study_name, trial.number))
             % self._total_trial_allocation_budget
         )
-        for i in range(self._n_brackets):
-            n -= self._trial_allocation_budgets[i]
+        for bracket_id in range(self._n_brackets):
+            n -= self._trial_allocation_budgets[bracket_id]
             if n < 0:
-                return i
+                return bracket_id
 
         assert False, "This line should be unreachable."
 

--- a/optuna/pruners/hyperband.py
+++ b/optuna/pruners/hyperband.py
@@ -293,15 +293,6 @@ class HyperbandPruner(BasePruner):
 
         assert False, "This line should be unreachable."
 
-    def _calculate_bracket_max_resource(self, bracket_id: int) -> int:
-        """Compute the maximum resource for a bracket of ``bracket_id``.
-        
-        The maximum resource for each bracket with a bracket id :math:`s` is calculated according 
-        to `Hyperband paper <http://www.jmlr.org/papers/volume18/16-558/16-558.pdf>`_.
-        """
-        s = self._n_brackets - 1 - bracket_id
-        return self._min_resource * (self._reduction_factor ** s)
-
     def _create_bracket_study(
         self, study: "optuna.study.Study", bracket_id: int
     ) -> "optuna.study.Study":
@@ -331,14 +322,12 @@ class HyperbandPruner(BasePruner):
                     pruner=study.pruner,
                 )
                 self._bracket_id = bracket_id
-                self._expected_maximum_resource = self.pruner._calculate_bracket_max_resource(bracket_id)
 
             def get_trials(self, deepcopy: bool = True) -> List["optuna.trial.FrozenTrial"]:
                 trials = super().get_trials(deepcopy=deepcopy)
                 pruner = self.pruner
                 assert isinstance(pruner, HyperbandPruner)
-                return [t for t in trials if pruner._get_bracket_id(self, t) == self._bracket_id
-                        or self._expected_maximum_resource <= t.last_step]
+                return [t for t in trials if pruner._get_bracket_id(self, t) == self._bracket_id]
 
             def __getattribute__(self, attr_name):  # type: ignore
                 if attr_name not in _BracketStudy._VALID_ATTRS:


### PR DESCRIPTION
##  Motivation
In the current `optuna/pruners/hyperband.py`, `bracket_id`, `bracket_index`, and `pruner_index` represent the same concept. This PR resolves those double meanings.

## Description of the changes
- Change `bracket_index` and `pruner_index` to `bracket_id`, because `bracket_id` is the most simple representative name and is directly related to the name of `_get_bracket_id` function.
