### PR TITLE
[WIP] Improve the Aggregation Algorithm of the Observations in `HyperbandPruner`.

### DIFF
--- a/optuna/pruners/__init__.py
+++ b/optuna/pruners/__init__.py
@@ -14,6 +14,6 @@ def _filter_study(
     if isinstance(study.pruner, HyperbandPruner):
         # Create `_BracketStudy` to use trials that have the same bracket id.
         pruner = study.pruner  # type: HyperbandPruner
-        return pruner._create_bracket_study(study, pruner._get_bracket_id(study, trial))
+        return pruner._create_study_for_sampler(study, pruner._get_bracket_id(study, trial))
     else:
         return study

--- a/tests/pruners_tests/test_hyperband.py
+++ b/tests/pruners_tests/test_hyperband.py
@@ -68,7 +68,7 @@ def test_bracket_study() -> None:
         min_resource=MIN_RESOURCE, max_resource=MAX_RESOURCE, reduction_factor=REDUCTION_FACTOR
     )
     study = optuna.study.create_study(sampler=optuna.samplers.RandomSampler(), pruner=pruner)
-    bracket_study = pruner._create_bracket_study(study, 0)
+    bracket_study = pruner._create_study_for_sampler(study, 0)
 
     with pytest.raises(AttributeError):
         bracket_study.optimize(lambda *args: 1.0)


### PR DESCRIPTION
## Motivation
In the current implementation of `HyperbandPruner`, observations (trials) to sample new points are filtered using only information of ``bracket_id`` and aggregated into `_BracketStudy`. However, the resources allocated to the observations can be used to increase the number of observations aggregated. This PR provides improved filtering and aggregation of observations.

## Description of the changes
- Add the `_calculate_bracket_max_resource` method to calculate the maximum resource for each bracket to be allocated.
- Add trials to the aggregated trials that have already allocated more resources than the maximum resources allocated to the current trial.

## TODO
- [ ] Performace improvement in all cases
- [x] Benchmark experiments

## Benchmark experiments
(CPU: Intel Core i7-7820HQ, python: 3.6.5)
- Using `kurobako`
- 2 types of samplers: `RandomSampler` and `TPESampler`
- 5 types of benchmark dataset: `HPO-bench-Naval`, `HPO-bench-Parkinson`, `HPO-bench-Protein`, `HPO-bench-Slice`, and `NASBench (A)`.

### Results of `RandomSampler`
There is no difference between previous and new algorithms as we expected. 
![hpo-bench-naval-77d6558d0ea51787e1ad60be3e50c393a3e370ad812d5e1fdb2f5ca5c69a644d](https://user-images.githubusercontent.com/38826298/82803969-68f2bc00-9ebc-11ea-812c-2394aa5e1365.png)
![hpo-bench-parkinson-b25702872d95f2a0d9b2d38f9f90e5950cdc0efa2da7c2954294ee7b23efc278](https://user-images.githubusercontent.com/38826298/82803980-6abc7f80-9ebc-11ea-91f7-6115e4b39104.png)
![hpo-bench-protein-bba52364e4b4ec03003330070d0755e637eabb669ee5864ed4eec521bee215c6](https://user-images.githubusercontent.com/38826298/82803984-6bedac80-9ebc-11ea-882d-ca4ede82ba84.png)
![hpo-bench-slice-88a2191f9b676e7878d93c8905ffde539488937a81829a0297ff7ef833fa76ae](https://user-images.githubusercontent.com/38826298/82803985-6c864300-9ebc-11ea-9f60-f94947667a47.png)
![nasbench-a-9c7ea8bffeac222495d24726b4db8f790031db67987031175788d150893e53bb](https://user-images.githubusercontent.com/38826298/82803988-6c864300-9ebc-11ea-9322-ca7f377660ef.png)

### Results of `TPESampler`
The performance slightly improves in some cases, but decrades in other cases. We need to improve the new algorithm.
![hpo-bench-naval-77d6558d0ea51787e1ad60be3e50c393a3e370ad812d5e1fdb2f5ca5c69a644d](https://user-images.githubusercontent.com/38826298/82804066-8b84d500-9ebc-11ea-9f6d-3c5a0a6cd3a8.png)
![hpo-bench-parkinson-b25702872d95f2a0d9b2d38f9f90e5950cdc0efa2da7c2954294ee7b23efc278](https://user-images.githubusercontent.com/38826298/82804067-8d4e9880-9ebc-11ea-8758-6f90b3bc0454.png)
![hpo-bench-protein-bba52364e4b4ec03003330070d0755e637eabb669ee5864ed4eec521bee215c6](https://user-images.githubusercontent.com/38826298/82804069-8de72f00-9ebc-11ea-90cd-584d1b37be0c.png)
![hpo-bench-slice-88a2191f9b676e7878d93c8905ffde539488937a81829a0297ff7ef833fa76ae](https://user-images.githubusercontent.com/38826298/82804070-8e7fc580-9ebc-11ea-8159-752400925c41.png)
![nasbench-a-9c7ea8bffeac222495d24726b4db8f790031db67987031175788d150893e53bb](https://user-images.githubusercontent.com/38826298/82804071-8f185c00-9ebc-11ea-953b-a261e073a632.png)
