### PR TITLE
Apply minor code fix to #1201.

### DIFF
--- a/optuna/samplers/tpe/sampler.py
+++ b/optuna/samplers/tpe/sampler.py
@@ -280,9 +280,9 @@ class TPESampler(base.BaseSampler):
         low = distribution.low - 0.5
         high = distribution.high + 0.5
 
-        log_sample = self._sample_numerical(low, high, below, above, is_log=True)
+        sample = self._sample_numerical(low, high, below, above, is_log=True)
         best_sample = (
-            np.round((log_sample - distribution.low) / distribution.step) * distribution.step
+            np.round((sample - distribution.low) / distribution.step) * distribution.step
             + distribution.low
         )
         return int(min(max(best_sample, distribution.low), distribution.high))

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -278,7 +278,7 @@ def test_empty_distribution():
         distributions.IntLogUniformDistribution(low=123, high=100)
 
     with pytest.raises(ValueError):
-        distributions.IntLogUniformDistribution(low=123, high=100)
+        distributions.IntLogUniformDistribution(low=123, high=100, step=2)
 
 
 def test_invalid_distribution():

--- a/tests/test_trial.py
+++ b/tests/test_trial.py
@@ -1,6 +1,7 @@
 import copy
 import datetime
 import math
+from typing import Callable
 from unittest.mock import Mock
 from unittest.mock import patch
 import warnings
@@ -27,7 +28,6 @@ from optuna import type_checking
 
 if type_checking.TYPE_CHECKING:
     from typing import Any  # NOQA
-    from typing import Callable  # NOQA
     from typing import Dict  # NOQA
     from typing import List  # NOQA
     from typing import Optional  # NOQA
@@ -119,32 +119,21 @@ def test_check_distribution_suggest_discrete_uniform(storage_init_func):
 
 
 @parametrize_storage
-def test_check_distribution_suggest_int(storage_init_func):
-    # type: (Callable[[], storages.BaseStorage]) -> None
+@pytest.mark.parametrize("enable_log", [False, True])
+def test_check_distribution_suggest_int(
+    storage_init_func: Callable[[], storages.BaseStorage], enable_log: bool
+) -> None:
 
     sampler = samplers.RandomSampler()
     study = create_study(storage_init_func(), sampler=sampler)
     trial = Trial(study, study._storage.create_new_trial(study._study_id))
 
     with pytest.warns(None) as record:
-        trial.suggest_int("x", 10, 20)
-        trial.suggest_int("x", 10, 20)
-        trial.suggest_int("x", 10, 22)
+        trial.suggest_int("x", 10, 20, log=enable_log)
+        trial.suggest_int("x", 10, 20, log=enable_log)
+        trial.suggest_int("x", 10, 22, log=enable_log)
 
-    # we expect exactly one warning
-    assert len(record) == 1
-
-    # log test
-    sampler = samplers.RandomSampler()
-    study = create_study(storage_init_func(), sampler=sampler)
-    trial = Trial(study, study._storage.create_new_trial(study._study_id))
-
-    with pytest.warns(None) as record:
-        trial.suggest_int("x", 10, 20, log=True)
-        trial.suggest_int("x", 10, 20, log=True)
-        trial.suggest_int("x", 10, 22, log=True)
-
-    # we expect exactly one warning
+    # We expect exactly one warning.
     assert len(record) == 1
 
 


### PR DESCRIPTION
## Motivation

This PR is a minor code fix for #1201.

## Description of the changes

- https://github.com/optuna/optuna/commit/965c2f9a9ad8a388cc9ab54655e997386e674e9c : IMO, `log_sample` is a bit confusing because the value returned by `self._sample_numerical(low, high, below, above, is_log=True)` is in a linear domain.
- https://github.com/optuna/optuna/commit/8b6e233306ed0184f45aa1ef72ccc3d18e4a0772 : The test cases are duplicated. I think an argument is missing.
- https://github.com/optuna/optuna/commit/148be96909ecfb985c151bca35189412d941b56f : I applied `pytest.mark.parametrize` to make the test case simple.
