### PR TITLE
Move deep-copies for optimization speed improvement.

### DIFF
--- a/optuna/pruners/base.py
+++ b/optuna/pruners/base.py
@@ -24,6 +24,7 @@ class BasePruner(object, metaclass=abc.ABCMeta):
                 Study object of the target study.
             trial:
                 FrozenTrial object of the target trial.
+                Take a copy before modifying this object.
 
         Returns:
             A boolean value representing whether the trial should be pruned.

--- a/optuna/samplers/base.py
+++ b/optuna/samplers/base.py
@@ -58,6 +58,7 @@ class BaseSampler(object, metaclass=abc.ABCMeta):
                 Target study object.
             trial:
                 Target trial object.
+                Take a copy before modifying this object.
 
         Returns:
             A dictionary containing the parameter names and parameter's distributions.
@@ -88,6 +89,7 @@ class BaseSampler(object, metaclass=abc.ABCMeta):
                 Target study object.
             trial:
                 Target trial object.
+                Take a copy before modifying this object.
             search_space:
                 The search space returned by
                 :func:`~optuna.samplers.BaseSampler.infer_relative_search_space`.
@@ -119,6 +121,7 @@ class BaseSampler(object, metaclass=abc.ABCMeta):
                 Target study object.
             trial:
                 Target trial object.
+                Take a copy before modifying this object.
             param_name:
                 Name of the sampled parameter.
             param_distribution:

--- a/optuna/storages/base.py
+++ b/optuna/storages/base.py
@@ -1,5 +1,4 @@
 import abc
-import copy
 from typing import Any
 from typing import Dict
 from typing import List
@@ -593,7 +592,7 @@ class BaseStorage(object, metaclass=abc.ABCMeta):
         else:
             best_trial = min(all_trials, key=lambda t: t.value)
 
-        return copy.deepcopy(best_trial)
+        return best_trial
 
     def get_trial_params(self, trial_id: int) -> Dict[str, Any]:
         """Read parameter dictionary of a specified trial.

--- a/optuna/storages/cached_storage.py
+++ b/optuna/storages/cached_storage.py
@@ -280,7 +280,7 @@ class _CachedStorage(base.BaseStorage):
         with self._lock:
             trial = self._get_cached_trial(trial_id)
             if trial is not None:
-                return copy.deepcopy(trial)
+                return trial
 
         return self._backend.get_trial(trial_id)
 

--- a/optuna/storages/in_memory.py
+++ b/optuna/storages/in_memory.py
@@ -146,14 +146,14 @@ class InMemoryStorage(base.BaseStorage):
 
         with self._lock:
             self._check_study_id(study_id)
-            return copy.deepcopy(self._studies[study_id].user_attrs)
+            return self._studies[study_id].user_attrs
 
     def get_study_system_attrs(self, study_id):
         # type: (int) -> Dict[str, Any]
 
         with self._lock:
             self._check_study_id(study_id)
-            return copy.deepcopy(self._studies[study_id].system_attrs)
+            return self._studies[study_id].system_attrs
 
     def get_all_study_summaries(self):
         # type: () -> List[StudySummary]
@@ -396,7 +396,7 @@ class InMemoryStorage(base.BaseStorage):
         # type: (int) -> FrozenTrial
 
         with self._lock:
-            return copy.deepcopy(self._get_trial(trial_id))
+            return self._get_trial(trial_id)
 
     def _get_trial(self, trial_id: int) -> FrozenTrial:
 

--- a/optuna/storages/rdb/storage.py
+++ b/optuna/storages/rdb/storage.py
@@ -912,7 +912,7 @@ class RDBStorage(BaseStorage):
     def get_trial(self, trial_id):
         # type: (int) -> FrozenTrial
 
-        return self._get_and_cache_trial(trial_id)
+        return self._get_and_cache_trial(trial_id, deepcopy=False)
 
     def _get_and_cache_trial(self, trial_id, deepcopy=True):
         # type: (int, bool) -> FrozenTrial

--- a/optuna/study.py
+++ b/optuna/study.py
@@ -1,4 +1,5 @@
 import collections
+import copy
 import datetime
 import gc
 import math
@@ -93,7 +94,7 @@ class BaseStudy(object):
             A :class:`~optuna.FrozenTrial` object of the best trial.
         """
 
-        return self._storage.get_best_trial(self._study_id)
+        return copy.deepcopy(self._storage.get_best_trial(self._study_id))
 
     @property
     def direction(self):
@@ -248,7 +249,7 @@ class Study(BaseStudy):
             A dictionary containing all user attributes.
         """
 
-        return self._storage.get_study_user_attrs(self._study_id)
+        return copy.deepcopy(self._storage.get_study_user_attrs(self._study_id))
 
     @property
     def system_attrs(self):
@@ -259,7 +260,7 @@ class Study(BaseStudy):
             A dictionary containing all system attributes.
         """
 
-        return self._storage.get_study_system_attrs(self._study_id)
+        return copy.deepcopy(self._storage.get_study_system_attrs(self._study_id))
 
     def optimize(
         self,
@@ -711,7 +712,7 @@ class Study(BaseStudy):
 
         trial = self._run_trial(func, catch, gc_after_trial)
         if callbacks is not None:
-            frozen_trial = self._storage.get_trial(trial._trial_id)
+            frozen_trial = copy.deepcopy(self._storage.get_trial(trial._trial_id))
             for callback in callbacks:
                 callback(self, frozen_trial)
 

--- a/optuna/trial/_trial.py
+++ b/optuna/trial/_trial.py
@@ -635,7 +635,7 @@ class Trial(BaseTrial):
         # type: (str, BaseDistribution) -> Any
 
         if self._is_fixed_param(name, distribution):
-            param_value = self.system_attrs["fixed_params"][name]
+            param_value = self.storage.get_trial_system_attrs(self._trial_id)["fixed_params"][name]
         elif self._is_relative_param(name, distribution):
             param_value = self.relative_params[name]
         else:
@@ -663,13 +663,14 @@ class Trial(BaseTrial):
     def _is_fixed_param(self, name, distribution):
         # type: (str, BaseDistribution) -> bool
 
-        if "fixed_params" not in self.system_attrs:
+        system_attrs = self.storage.get_trial_system_attrs(self._trial_id)
+        if "fixed_params" not in system_attrs:
             return False
 
-        if name not in self.system_attrs["fixed_params"]:
+        if name not in system_attrs["fixed_params"]:
             return False
 
-        param_value = self.system_attrs["fixed_params"][name]
+        param_value = system_attrs["fixed_params"][name]
         param_value_in_internal_repr = distribution.to_internal_repr(param_value)
 
         contained = distribution._contains(param_value_in_internal_repr)
@@ -702,7 +703,9 @@ class Trial(BaseTrial):
     def _check_distribution(self, name, distribution):
         # type: (str, BaseDistribution) -> None
 
-        old_distribution = self.distributions.get(name, distribution)
+        old_distribution = self.storage.get_trial(self._trial_id).distributions.get(
+            name, distribution
+        )
         if old_distribution != distribution:
             warnings.warn(
                 'Inconsistent parameter values for distribution with name "{}"! '

--- a/optuna/trial/_trial.py
+++ b/optuna/trial/_trial.py
@@ -758,7 +758,7 @@ class Trial(BaseTrial):
             A dictionary containing all parameters.
         """
 
-        return self.storage.get_trial_params(self._trial_id)
+        return copy.deepcopy(self.storage.get_trial_params(self._trial_id))
 
     @property
     def distributions(self):
@@ -780,7 +780,7 @@ class Trial(BaseTrial):
             A dictionary containing all user attributes.
         """
 
-        return self.storage.get_trial_user_attrs(self._trial_id)
+        return copy.deepcopy(self.storage.get_trial_user_attrs(self._trial_id))
 
     @property
     def system_attrs(self):
@@ -791,7 +791,7 @@ class Trial(BaseTrial):
             A dictionary containing all system attributes.
         """
 
-        return self.storage.get_trial_system_attrs(self._trial_id)
+        return copy.deepcopy(self.storage.get_trial_system_attrs(self._trial_id))
 
     @property
     def datetime_start(self):

--- a/optuna/trial/_trial.py
+++ b/optuna/trial/_trial.py
@@ -1,3 +1,4 @@
+import copy
 import datetime
 import warnings
 
@@ -768,7 +769,7 @@ class Trial(BaseTrial):
             A dictionary containing all distributions.
         """
 
-        return self.storage.get_trial(self._trial_id).distributions
+        return copy.deepcopy(self.storage.get_trial(self._trial_id).distributions)
 
     @property
     def user_attrs(self):


### PR DESCRIPTION
## Motivation
The latest storage spec assumes that storage users won't directly modify return values of storage methods.
However, some methods did not take a copy before passing the return values to library users, which can result in undefined behavior. This PR fixes the issue.
Additionally, this PR removes unnecessary deep-copies and improves overall performance. 

## Description of the changes
- Copy `FrozenTrial`s of their attributes before passing them to users.
- Remove redundant deep-copies.

## Microbench
I used the same configuration with #1135 (1000 trials with 30 params w/ InMemoryDB).
```
This PR:
         117956150 function calls (112496390 primitive calls) in 98.936 seconds
Master:
         214822150 function calls (193042390 primitive calls) in 132.830 seconds
```

## Notes
I locally checked that any pruner method calls and sampler method calls under test/storage_test and tests/pruner_tests do not mutate `FrozenTrial` in their arguments.