### PR TITLE
`log` argument for `suggest_int` of skopt integration

### DIFF
--- a/optuna/integration/skopt.py
+++ b/optuna/integration/skopt.py
@@ -237,7 +237,7 @@ class _Optimizer(object):
                     np.round((value - distribution.low) / distribution.step) * distribution.step
                     + distribution.low
                 )
-                value = int(min(max(value, distribution.low), distribution.high))
+                value = min(max(value, distribution.low), distribution.high)
 
             params[name] = value
 

--- a/optuna/integration/skopt.py
+++ b/optuna/integration/skopt.py
@@ -237,6 +237,7 @@ class _Optimizer(object):
                     np.round((value - distribution.low) / distribution.step) * distribution.step
                     + distribution.low
                 )
+                value = int(min(max(value, distribution.low), distribution.high))
 
             params[name] = value
 

--- a/optuna/integration/skopt.py
+++ b/optuna/integration/skopt.py
@@ -274,8 +274,6 @@ class _Optimizer(object):
                 param_value = (param_value - distribution.low) // distribution.q
             if isinstance(distribution, distributions.IntUniformDistribution):
                 param_value = (param_value - distribution.low) // distribution.step
-            if isinstance(distribution, distributions.IntLogUniformDistribution):
-                param_value = np.log(param_value)
 
             param_values.append(param_value)
 

--- a/tests/integration_tests/test_skopt.py
+++ b/tests/integration_tests/test_skopt.py
@@ -28,10 +28,10 @@ def test_conversion_from_distribution_to_dimension():
             space.Real(-3.3, 5.2),
             # Original: trial.suggest_uniform('p1', 2.0, 2.0)
             # => Skipped because `skopt.Optimizer` cannot handle an empty `Real` dimension.
-            # Original: trial.suggest_int('p10', 1, 8, log=True)
-            space.Real(0.5, 8.5, prior="log-uniform"),
-            # Original: trial.suggest_int('p11', 3, 9, step=2, log=True)
-            space.Real(2.5, 9.5, prior="log-uniform"),
+            # Original: trial.suggest_discrete_uniform('p10', 2.2, 2.2, 0.5)
+            # => Skipped because `skopt.Optimizer` cannot handle an empty `Real` dimension.
+            # Original: trial.suggest_categorical('p11', ['9', '3', '0', '8'])
+            space.Categorical(("9", "3", "0", "8")),
             # Original: trial.suggest_loguniform('p2', 0.0001, 0.3)
             space.Real(0.0001, 0.3, prior="log-uniform"),
             # Original: trial.suggest_loguniform('p3', 1.1, 1.1)
@@ -40,15 +40,16 @@ def test_conversion_from_distribution_to_dimension():
             space.Integer(0, 108),
             # Original: trial.suggest_int('p5', -20, -20)
             # => Skipped because `skopt.Optimizer` cannot handle an empty `Real` dimension.
-            # Original: trial.suggest_discrete_uniform('p6', 10, 20, 2)
+            # Original: trial.suggest_int('p6', 1, 8, log=True)
+            space.Real(0.5, 8.5, prior="log-uniform"),
+            # Original: trial.suggest_int('p7', 3, 9, step=2, log=True)
+            space.Real(2.5, 9.5, prior="log-uniform"),
+            # Original: trial.suggest_discrete_uniform('p8', 10, 20, 2)
             space.Integer(0, 5),
-            # Original: trial.suggest_discrete_uniform('p7', 0.1, 1.0, 0.1)
+            # Original: trial.suggest_discrete_uniform('p9', 0.1, 1.0, 0.1)
             space.Integer(0, 8),
-            # Original: trial.suggest_discrete_uniform('p8', 2.2, 2.2, 0.5)
-            # => Skipped because `skopt.Optimizer` cannot handle an empty `Real` dimension.
-            # Original: trial.suggest_categorical('p9', ['9', '3', '0', '8'])
-            space.Categorical(("9", "3", "0", "8")),
         ]
+
         assert mock_object.mock_calls[0] == call(dimensions)
 
 
@@ -153,15 +154,15 @@ def _objective(trial):
     p3 = trial.suggest_loguniform("p3", 1.1, 1.1)
     p4 = trial.suggest_int("p4", -100, 8)
     p5 = trial.suggest_int("p5", -20, -20)
-    p6 = trial.suggest_discrete_uniform("p6", 10, 20, 2)
-    p7 = trial.suggest_discrete_uniform("p7", 0.1, 1.0, 0.1)
-    p8 = trial.suggest_discrete_uniform("p8", 2.2, 2.2, 0.5)
-    p9 = trial.suggest_categorical("p9", ["9", "3", "0", "8"])
-    assert isinstance(p9, str)
-    p10 = trial.suggest_int("p10", 1, 8, log=True)
-    p11 = trial.suggest_int("p11", 3, 9, step=2, log=True)
+    p6 = trial.suggest_int("p6", 1, 8, log=True)
+    p7 = trial.suggest_int("p7", 3, 9, step=2, log=True)
+    p8 = trial.suggest_discrete_uniform("p8", 10, 20, 2)
+    p9 = trial.suggest_discrete_uniform("p9", 0.1, 1.0, 0.1)
+    p10 = trial.suggest_discrete_uniform("p10", 2.2, 2.2, 0.5)
+    p11 = trial.suggest_categorical("p11", ["9", "3", "0", "8"])
+    assert isinstance(p11, str)
 
-    return p0 + p1 + p2 + p3 + p4 + p5 + p6 + p7 + p8 + int(p9) + p10 + p11
+    return p0 + p1 + p2 + p3 + p4 + p5 + p6 + p7 + p8 + p9 + p10 + int(p11)
 
 
 def test_sample_relative_n_startup_trials():

--- a/tests/integration_tests/test_skopt.py
+++ b/tests/integration_tests/test_skopt.py
@@ -28,6 +28,10 @@ def test_conversion_from_distribution_to_dimension():
             space.Real(-3.3, 5.2),
             # Original: trial.suggest_uniform('p1', 2.0, 2.0)
             # => Skipped because `skopt.Optimizer` cannot handle an empty `Real` dimension.
+            # Original: trial.suggest_int('p10', 1, 8, log=True)
+            space.Real(0.5, 8.5, prior="log-uniform"),
+            # Original: trial.suggest_int('p11', 3, 9, step=2, log=True)
+            space.Real(2.5, 9.5, prior="log-uniform"),
             # Original: trial.suggest_loguniform('p2', 0.0001, 0.3)
             space.Real(0.0001, 0.3, prior="log-uniform"),
             # Original: trial.suggest_loguniform('p3', 1.1, 1.1)
@@ -154,8 +158,10 @@ def _objective(trial):
     p8 = trial.suggest_discrete_uniform("p8", 2.2, 2.2, 0.5)
     p9 = trial.suggest_categorical("p9", ["9", "3", "0", "8"])
     assert isinstance(p9, str)
+    p10 = trial.suggest_int("p10", 1, 8, log=True)
+    p11 = trial.suggest_int("p11", 3, 9, step=2, log=True)
 
-    return p0 + p1 + p2 + p3 + p4 + p5 + p6 + p7 + p8 + int(p9)
+    return p0 + p1 + p2 + p3 + p4 + p5 + p6 + p7 + p8 + int(p9) + p10 + p11
 
 
 def test_sample_relative_n_startup_trials():


### PR DESCRIPTION
<!-- Thank you for creating a pull request! -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

One of the follow-up PRs related to #1201

## Description of the changes
<!-- Describe the changes in this PR. -->

Introduce`log` argument for `skopt` integration and add a test for it.

I'm not sure my implementation is correct: we can consider using `Integer(low, high, prior="log-uniform")` and then a sample is converted instead of using `Real`.

Ref: [Skopt's `Space.Integer`](https://scikit-optimize.github.io/stable/modules/generated/skopt.space.space.Integer.html#skopt.space.space.Integer)
