### PR TITLE
Create a documentation for the root namespace `optuna`.

### DIFF
--- a/docs/source/reference/core.rst
+++ b/docs/source/reference/core.rst
@@ -10,3 +10,6 @@ Core
 .. autofunction:: get_all_study_summaries
 
 .. autofunction:: load_study
+
+.. autoclass:: TrialPruned
+    :members:

--- a/docs/source/reference/core.rst
+++ b/docs/source/reference/core.rst
@@ -6,25 +6,25 @@ Core
 .. autofunction:: create_study
 
 .. seealso::
-    :func:`optuna.study.create_study`.
+    This is an alias for :func:`optuna.study.create_study`.
 
 .. autofunction:: load_study
 
 .. seealso::
-    :func:`optuna.study.load_study`.
+    This is an alias for :func:`optuna.study.load_study`.
 
 .. autofunction:: delete_study
 
 .. seealso::
-    :func:`optuna.study.delete_study`.
+    This is an alias for :func:`optuna.study.delete_study`.
 
 .. autofunction:: get_all_study_summaries
 
 .. seealso::
-    :func:`optuna.study.get_all_study_summaries`.
+    This is an alias for :func:`optuna.study.get_all_study_summaries`.
 
 .. autoclass:: TrialPruned
     :members:
 
 .. seealso::
-    :class:`optuna.exceptions.TrialPruned`.
+    This is an alias for :class:`optuna.exceptions.TrialPruned`.

--- a/docs/source/reference/core.rst
+++ b/docs/source/reference/core.rst
@@ -5,11 +5,26 @@ Core
 
 .. autofunction:: create_study
 
-.. autofunction:: delete_study
-
-.. autofunction:: get_all_study_summaries
+.. seealso::
+    :func:`optuna.study.create_study`.
 
 .. autofunction:: load_study
 
+.. seealso::
+    :func:`optuna.study.load_study`.
+
+.. autofunction:: delete_study
+
+.. seealso::
+    :func:`optuna.study.delete_study`.
+
+.. autofunction:: get_all_study_summaries
+
+.. seealso::
+    :func:`optuna.study.get_all_study_summaries`.
+
 .. autoclass:: TrialPruned
     :members:
+
+.. seealso::
+    :class:`optuna.exceptions.TrialPruned`.

--- a/docs/source/reference/core.rst
+++ b/docs/source/reference/core.rst
@@ -1,0 +1,12 @@
+.. module:: optuna
+
+Core
+====
+
+.. autofunction:: create_study
+
+.. autofunction:: delete_study
+
+.. autofunction:: get_all_study_summaries
+
+.. autofunction:: load_study

--- a/docs/source/reference/exceptions.rst
+++ b/docs/source/reference/exceptions.rst
@@ -9,6 +9,9 @@ Exceptions
 .. autoclass:: TrialPruned
     :members:
 
+.. seealso::
+    :class:`optuna.TrialPruned`.
+
 .. autoclass:: CLIUsageError
     :members:
 

--- a/docs/source/reference/exceptions.rst
+++ b/docs/source/reference/exceptions.rst
@@ -10,7 +10,7 @@ Exceptions
     :members:
 
 .. seealso::
-    :class:`optuna.TrialPruned`.
+    The alias also exists as :class:`optuna.TrialPruned`.
 
 .. autoclass:: CLIUsageError
     :members:

--- a/docs/source/reference/index.rst
+++ b/docs/source/reference/index.rst
@@ -4,7 +4,7 @@ API Reference
 .. toctree::
     :maxdepth: 2
 
-    public
+    core
     cli
     distributions
     exceptions

--- a/docs/source/reference/index.rst
+++ b/docs/source/reference/index.rst
@@ -4,6 +4,7 @@ API Reference
 .. toctree::
     :maxdepth: 2
 
+    public
     cli
     distributions
     exceptions

--- a/docs/source/reference/public.rst
+++ b/docs/source/reference/public.rst
@@ -1,0 +1,6 @@
+.. module:: optuna
+
+Public API
+==========
+
+.. autofunction:: create_study

--- a/docs/source/reference/public.rst
+++ b/docs/source/reference/public.rst
@@ -1,6 +1,0 @@
-.. module:: optuna
-
-Public API
-==========
-
-.. autofunction:: create_study

--- a/docs/source/reference/study.rst
+++ b/docs/source/reference/study.rst
@@ -9,9 +9,24 @@ Study
     :exclude-members: system_attrs, set_system_attr, storage
 
 .. autofunction:: create_study
+
+.. seealso::
+    :func:`optuna.create_study`.
+
 .. autofunction:: load_study
+
+.. seealso::
+    :func:`optuna.load_study`.
+
 .. autofunction:: delete_study
+
+.. seealso::
+    :func:`optuna.delete_study`.
+
 .. autofunction:: get_all_study_summaries
+
+.. seealso::
+    :func:`optuna.get_all_study_summaries`.
 
 .. autoclass:: StudyDirection
     :members:

--- a/docs/source/reference/study.rst
+++ b/docs/source/reference/study.rst
@@ -11,22 +11,22 @@ Study
 .. autofunction:: create_study
 
 .. seealso::
-    :func:`optuna.create_study`.
+    The alias also exists as :func:`optuna.create_study`.
 
 .. autofunction:: load_study
 
 .. seealso::
-    :func:`optuna.load_study`.
+    The alias also exists as :func:`optuna.load_study`.
 
 .. autofunction:: delete_study
 
 .. seealso::
-    :func:`optuna.delete_study`.
+    The alias also exists as :func:`optuna.delete_study`.
 
 .. autofunction:: get_all_study_summaries
 
 .. seealso::
-    :func:`optuna.get_all_study_summaries`.
+    The alias also exists as :func:`optuna.get_all_study_summaries`.
 
 .. autoclass:: StudyDirection
     :members:


### PR DESCRIPTION
<!-- Thank you for creating a pull request! -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

### Background
Currently, several classes and functions are imported in `optuna/__init__.py`, but we do not have the documentation for `optuna/__init__.py`.

e.g. `create_study`
- `create_study` is defined in `optuna/study.py`.
- `create_study` is imported in `optuna/__init__.py`.
- `create_study` description is written in `API Reference / Study` doc.
- No documentation for `optuna/__init__.py`

### Purpose
I think that we should create the documentation for the root namespace, and describe the classes and functions imported in `optuna/__init__.py` there.

## Description of the changes
<!-- Describe the changes in this PR. -->
To show what I want to do, I just modified the documentation for `create_study`.

## Discussion points
I checked the way of current branch implementation.

### What classes and functions should be imported in `optuna/__init__.py`?

From [this reddit discussion](https://www.reddit.com/r/Python/comments/1bbbwk/whats_your_opinion_on_what_to_include_in_init_py/), there are three type of policies, and optuna follows third one. 

- [ ] 1. Leave the __init__.py blank. This enforces explicit imports and thus clear namespaces. I've read Alex Martelli post in favor of this option on various questions at Stack Overflow. The cons are, the user of the package has to import seperate modules and call them with the dot notation.
- [ ] 2. Import all modules in __init__.py. The user doesn't have to do multiple imports. The cons are explicit vs implicit, and also as Martelli puts it (paraphrased), "if that's how your package works, maybe it should all go in a single module anyway".
- [x] 3. Import key functions from various modules directly into the package namespace. If you restructure modules, you still have the option to keep the same API for end users. Cons, it dirties the namespace, and very implicit / hacky.

### What is a good title for the documentation of API?
- [x] 1. `Public API`, or `Key API`. (Currently, in oputuna, documentation titles are named from functionality.)
- [ ] 2. `optuna` (Other libraries s.t. pytorch use module names for titles of API documentation. If we choose it, we need to change all titles to their module names.)

### Where to write the documentation?

e.g. `create_study`
- [ ] 1. It should be documented only in `optuna/__init__.py`. (numpy and pytorch follow this one.)
- [ ] 2. It should be documented only in `optuna/study/__init__.py`.
- [x] 3. It should be documented  in both `optuna/study/__init__.py` and `optuna/__init__.py`.