### PR TITLE
Input validation for `IntLogUniformDistribution`.

### DIFF
--- a/optuna/distributions.py
+++ b/optuna/distributions.py
@@ -323,9 +323,9 @@ class IntLogUniformDistribution(BaseDistribution):
                 "The `step` value must be non-zero positive value, but step={}.".format(step)
             )
 
-        if low <= 0.0:
+        if low < 1.0:
             raise ValueError(
-                "The `low` value must be larger than 0 for a log distribution "
+                "The `low` value must be equal to or greater than 1 for a log distribution "
                 "(low={}, high={}).".format(low, high)
             )
 

--- a/tests/test_trial.py
+++ b/tests/test_trial.py
@@ -332,7 +332,7 @@ def test_suggest_int_log(storage_init_func):
     with pytest.raises(ValueError):
         study = create_study(storage_init_func(), sampler=sampler)
         trial = Trial(study, study._storage.create_new_trial(study._study_id))
-        trial.suggest_int("z", 0.5, 10, log=True)
+        trial.suggest_int("z", 0.5, 10, log=True)  # type: ignore
 
 
 @parametrize_storage

--- a/tests/test_trial.py
+++ b/tests/test_trial.py
@@ -329,6 +329,11 @@ def test_suggest_int_log(storage_init_func):
         assert trial.params == {"x": 1, "y": 3}
         assert mock_object.call_count == 3
 
+    with pytest.raises(ValueError):
+        study = create_study(storage_init_func(), sampler=sampler)
+        trial = Trial(study, study._storage.create_new_trial(study._study_id))
+        trial.suggest_int("z", 0.5, 10, log=True)
+
 
 @parametrize_storage
 def test_distributions(storage_init_func):


### PR DESCRIPTION
`IntLogUniformDistribution` raises `OverflowError` for `0.0 < low <=0.5`. This behavior occurs since `log_low` would be equal or less than zero in [here](https://github.com/optuna/optuna/blob/master/optuna/samplers/random.py#L87). It may not be a problem since `low` is annotated with `int` but I think we shouldn't export an internal error and it's kind for users to validate `low` explicitly.

This PR introduces a validation that it check if `low` is equal or larger than `1`. Currently, `suggest_float(..., log=True)` works with `0.5<low<1.0` but I don't think it is not expected behavior for an integer distribution.


Reproduction

```python
from optuna.study import create_study
from optuna import Trial

def objective(trial):
    trial.suggest_int('x', 0.4, 10, log=True)

study = create_study()
study.optimize(objective, n_trials=10)
```

```python
Traceback (most recent call last):
	...
    trial.suggest_int('x', 0.4, 10, log=True)
  File "/Users/xxx/work/github.com/himkt/optuna/optuna/trial/_trial.py", line 419, in suggest_int
    return int(self._suggest(name, distribution))
  File "/Users/xxx/work/github.com/himkt/optuna/optuna/trial/_trial.py", line 663, in _suggest
    param_value = self.study.sampler.sample_independent(study, trial, name, distribution)
  File "/Users/xxx/work/github.com/himkt/optuna/optuna/samplers/tpe/sampler.py", line 180, in sample_independent
    study, trial, param_name, param_distribution
  File "/Users/xxx/work/github.com/himkt/optuna/optuna/samplers/random.py", line 89, in sample_independent
    s = numpy.exp(self._rng.uniform(log_low, log_high))
  File "mtrand.pyx", line 1091, in numpy.r
OverflowError: Range exceeds valid bounds
```