### PR TITLE
Stop suggesting using deprecated option in AllenNLP example.

### DIFF
--- a/examples/allennlp/allennlp_jsonnet.py
+++ b/examples/allennlp/allennlp_jsonnet.py
@@ -15,7 +15,7 @@ We have the following two ways to execute this example:
 
 (2) Execute through CLI.
     $ STUDY_NAME=`optuna create-study --direction maximize --storage sqlite:///example.db`
-    $ optuna study optimize allennlp_jsonnet.py objective --n-trials=100 --study $STUDY_NAME \
+    $ optuna study optimize allennlp_jsonnet.py objective --n-trials=100 --study-name $STUDY_NAME \
       --storage sqlite:///example.db
 
 """


### PR DESCRIPTION
## Motivation

We should not suggest the user to use a deprecated option. This is a follow up to https://github.com/optuna/optuna/pull/1079.

## Description of the changes

Updates the documentation to suggest using the new option.
