### PR TITLE
Add a workflow to create distribution packages.

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -4,7 +4,7 @@ name: Publish distributions to TestPyPI and PyPI
 on:
   push:
     tags:
-    - v*
+      - v*
   # TODO(toshihikoyanase): Remove pull_request when you enable PyPI upload.
   pull_request:
     branches:

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -5,6 +5,10 @@ on:
   push:
     tags:
     - v*
+  # TODO(toshihikoyanase): Remove pull_request when you enable PyPI upload.
+  pull_request:
+    branches:
+      - master
 
 jobs:
   build-n-publish:
@@ -28,19 +32,11 @@ jobs:
     - name: Verify the distributions
       run: twine check dist/*
 
-    - name: Publish distribution to Test PyPI
-      # The following upload action cannot be executed in the forked repository.
-      if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')  && github.repository == 'optuna/optuna'
-      uses: pypa/gh-action-pypi-publish@v1.1.0
+    # Save the package to the GitHub Actions' artifact. It will be deleted after 90 days.
+    - name: Save dist directory
+      uses: actions/upload-artifact@v1
       with:
-        user: __token__
-        password: ${{ secrets.test_pypi_password }}
-        repository_url: https://test.pypi.org/legacy/
+        name: optuna-dist
+        path: dist
 
-    - name: Publish distribution to PyPI
-      # The following upload action cannot be executed in the forked repository.
-      if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')  && github.repository == 'optuna/optuna'
-      uses: pypa/gh-action-pypi-publish@v1.1.0
-      with:
-        user: __token__
-        password: ${{ secrets.pypi_password }}
+    # TODO(toshihikoyanase): Add tasks to upload packages to TestPyPI and PyPI.

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -1,0 +1,46 @@
+name: Publish distributions to TestPyPI and PyPI
+
+# Only activate if the v* tag is pushed.
+on:
+  push:
+    tags:
+    - v*
+
+jobs:
+  build-n-publish:
+    name: Build and publish Python distributions to TestPyPI and PyPI
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.7
+
+    - name: Install twine
+      run: >-
+        python -m pip install -U twine
+
+    - name: Build a tar ball
+      run: >-
+        python setup.py sdist
+
+    - name: Verify the distributions
+      run: twine check dist/*
+
+    - name: Publish distribution to Test PyPI
+      # Do not upload the package from forked repository.
+      if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')  && github.repository == 'optuna/optuna'
+      uses: pypa/gh-action-pypi-publish@v1.1.0
+      with:
+        user: __token__
+        password: ${{ secrets.test_pypi_password }}
+        repository_url: https://test.pypi.org/legacy/
+
+    - name: Publish distribution to PyPI
+      # Do not upload the package from forked repository.
+      if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')  && github.repository == 'optuna/optuna'
+      uses: pypa/gh-action-pypi-publish@v1.1.0
+      with:
+        user: __token__
+        password: ${{ secrets.pypi_password }}

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -38,7 +38,7 @@ jobs:
         repository_url: https://test.pypi.org/legacy/
 
     - name: Publish distribution to PyPI
-      # Do not upload the package from forked repository.
+      # The following upload action cannot be executed in the forked repository.
       if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')  && github.repository == 'optuna/optuna'
       uses: pypa/gh-action-pypi-publish@v1.1.0
       with:

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -29,7 +29,7 @@ jobs:
       run: twine check dist/*
 
     - name: Publish distribution to Test PyPI
-      # Do not upload the package from forked repository.
+      # The following upload action cannot be executed in the forked repository.
       if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')  && github.repository == 'optuna/optuna'
       uses: pypa/gh-action-pypi-publish@v1.1.0
       with:


### PR DESCRIPTION
## Motivation

This PR will automate tasks to release Python packages at TestPyPI and PyPI using [`pypi-publish`](https://github.com/marketplace/actions/pypi-publish).

## Description of the changes

It creates a source tarball, checks it with `twine`, and uploads it to TestPyPI and PyPI.
It will be triggered when the `v*` tags (e.g., `v1.5.0`) are pushed. Note that we need to push tags manually if we want to release the package prior to release notes.

## References

- [pypi-publish config in AllenNLP](https://github.com/allenai/allennlp/blob/master/.github/workflows/master.yml)
- [pypi-publish](https://github.com/marketplace/actions/pypi-publish)
- [Publishing package distribution releases using GitHub Actions CI/CD workflows](https://packaging.python.org/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/)