### PR TITLE
Fix `experimental` decorator to decorate a class properly

### DIFF
--- a/optuna/_experimental.py
+++ b/optuna/_experimental.py
@@ -70,7 +70,10 @@ def experimental(version: str, name: str = None) -> Any:
 
             This decorator is supposed to be applied to the experimental class.
             """
-            @functools.wraps(cls.__init__)
+
+            _original_init = cls.__init__
+
+            @functools.wraps(_original_init)
             def wrapped_init(self, *args, **kwargs) -> None:  # type: ignore
                 warnings.warn(
                     "{} is experimental (supported from v{}). "
@@ -80,7 +83,7 @@ def experimental(version: str, name: str = None) -> Any:
                     ExperimentalWarning,
                 )
 
-                cls.__init__(self, *args, **kwargs)
+                _original_init(self, *args, **kwargs)
 
             cls.__init__ = wrapped_init
 

--- a/optuna/_experimental.py
+++ b/optuna/_experimental.py
@@ -89,7 +89,7 @@ def experimental(version: str, name: str = None) -> Any:
 
             if cls.__doc__ is None:
                 cls.__doc__ = ""
-            cls.__doc__ = cls.__doc__ + _EXPERIMENTAL_DOCSTRING_TEMPLATE.format(ver=version)
+            cls.__doc__ += _EXPERIMENTAL_DOCSTRING_TEMPLATE.format(ver=version)
             return cls
 
         return _experimental_class(f) if inspect.isclass(f) else _experimental_func(f)

--- a/optuna/_experimental.py
+++ b/optuna/_experimental.py
@@ -89,9 +89,7 @@ def experimental(version: str, name: str = None) -> Any:
 
             if cls.__doc__ is None:
                 cls.__doc__ = ""
-            cls.__doc__ = cls.__doc__ + _EXPERIMENTAL_DOCSTRING_TEMPLATE.format(
-                ver=version
-            )
+            cls.__doc__ = cls.__doc__ + _EXPERIMENTAL_DOCSTRING_TEMPLATE.format(ver=version)
             return cls
 
         return _experimental_class(f) if inspect.isclass(f) else _experimental_func(f)

--- a/optuna/_experimental.py
+++ b/optuna/_experimental.py
@@ -18,35 +18,6 @@ _EXPERIMENTAL_DOCSTRING_TEMPLATE = """
 """
 
 
-def _make_func_spec_str(func: Callable[..., Any]) -> str:
-
-    name = func.__name__
-    argspec = inspect.getfullargspec(func)
-
-    n_defaults = len(argspec.defaults) if argspec.defaults is not None else 0
-    offset = int(len(argspec.args) > 0 and argspec.args[0] == "self")
-
-    if n_defaults > 0:
-        args = ", ".join(argspec.args[offset:-n_defaults])
-        with_default_values = ", ".join(
-            [
-                "{}={}".format(a, d)
-                for a, d in zip(argspec.args[-n_defaults:], argspec.defaults)  # type: ignore
-            ]
-        )
-    else:
-        args = ", ".join(argspec.args[offset:])
-        with_default_values = ""
-
-    if len(args) > 0 and len(with_default_values) > 0:
-        args += ", "
-
-    # NOTE(crcrpar): The four spaces are necessary to correctly render documentation.
-    # Different classes or methods require more spaces.
-    str_args_description = "(" + args + with_default_values + ")\n\n    "
-    return name + str_args_description
-
-
 def _validate_version(version: str) -> None:
 
     if not isinstance(version, str) or len(version.split(".")) != 3:

--- a/optuna/_experimental.py
+++ b/optuna/_experimental.py
@@ -70,10 +70,7 @@ def experimental(version: str, name: str = None) -> Any:
 
             This decorator is supposed to be applied to the experimental class.
             """
-
-            _original_init = cls.__init__
-
-            @functools.wraps(_original_init)
+            @functools.wraps(cls.__init__)
             def wrapped_init(self, *args, **kwargs) -> None:  # type: ignore
                 warnings.warn(
                     "{} is experimental (supported from v{}). "
@@ -83,7 +80,7 @@ def experimental(version: str, name: str = None) -> Any:
                     ExperimentalWarning,
                 )
 
-                _original_init(self, *args, **kwargs)
+                cls.__init__(self, *args, **kwargs)
 
             cls.__init__ = wrapped_init
 

--- a/optuna/_experimental.py
+++ b/optuna/_experimental.py
@@ -102,6 +102,7 @@ def experimental(version: str, name: str = None) -> Any:
 
             _original_init = cls.__init__
 
+            @functools.wraps(_original_init)
             def wrapped_init(self, *args, **kwargs) -> None:  # type: ignore
                 warnings.warn(
                     "{} is experimental (supported from v{}). "
@@ -117,10 +118,8 @@ def experimental(version: str, name: str = None) -> Any:
 
             if cls.__doc__ is None:
                 cls.__doc__ = ""
-            cls.__doc__ = (
-                _make_func_spec_str(_original_init)
-                + cls.__doc__
-                + _EXPERIMENTAL_DOCSTRING_TEMPLATE.format(ver=version)
+            cls.__doc__ = cls.__doc__ + _EXPERIMENTAL_DOCSTRING_TEMPLATE.format(
+                ver=version
             )
             return cls
 

--- a/tests/test_experimental.py
+++ b/tests/test_experimental.py
@@ -11,28 +11,9 @@ def _sample_func(_: Any) -> int:
     return 10
 
 
-def _f() -> None:
-    pass
-
-
-def _g(a: Any, b: Any = None) -> None:
-    pass
-
-
-def _h(a: Any = None, b: int = 10) -> None:
-    pass
-
-
 class _Sample(object):
     def __init__(self, a: Any, b: Any, c: Any) -> None:
         pass
-
-
-def test_str() -> None:
-
-    assert _experimental._make_func_spec_str(_f) == "_f()\n\n    "
-    assert _experimental._make_func_spec_str(_g) == "_g(a, b=None)\n\n    "
-    assert _experimental._make_func_spec_str(_h) == "_h(a=None, b=10)\n\n    "
 
 
 @pytest.mark.parametrize("version", ["1.1.0", "1.1", 100, None])
@@ -74,10 +55,10 @@ def test_experimental_class_decorator(version: str) -> None:
 
         decorated_sample = decorator_experimental(_Sample)
         assert decorated_sample.__name__ == "_Sample"
+        assert decorated_sample.__init__.__name__ == "__init__"
         assert (
             decorated_sample.__doc__
-            == "__init__(a, b, c)\n\n    "
-            + _experimental._EXPERIMENTAL_DOCSTRING_TEMPLATE.format(ver=version)
+            == _experimental._EXPERIMENTAL_DOCSTRING_TEMPLATE.format(ver=version)
         )
 
         with pytest.warns(ExperimentalWarning):

--- a/tests/test_experimental.py
+++ b/tests/test_experimental.py
@@ -56,9 +56,8 @@ def test_experimental_class_decorator(version: str) -> None:
         decorated_sample = decorator_experimental(_Sample)
         assert decorated_sample.__name__ == "_Sample"
         assert decorated_sample.__init__.__name__ == "__init__"
-        assert (
-            decorated_sample.__doc__
-            == _experimental._EXPERIMENTAL_DOCSTRING_TEMPLATE.format(ver=version)
+        assert decorated_sample.__doc__ == _experimental._EXPERIMENTAL_DOCSTRING_TEMPLATE.format(
+            ver=version
         )
 
         with pytest.warns(ExperimentalWarning):


### PR DESCRIPTION
<!-- Thank you for creating a pull request! -->

## Motivation

Fix #1281

`experimental` decorator has two issues when decorating a class:
1. It drops type annotations.
2. It drops keyword-only arguments.

This PR aims to fix them.

## Description of the changes

- Decorate `wrapped_init` by `functools.wraps` to preserve an original class signature.
- Remove `_make_func_spec_str` because it's no longer used.
- Fix the tests.