### PR TITLE
Add TestPyPI release to workflow.

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -1,10 +1,10 @@
 name: Publish distributions to TestPyPI and PyPI
 
-# Only activate if the v* tag is pushed.
+# Only activate if the release is published.
 on:
-  push:
-    tags:
-      - v*
+  release:
+    types:
+      - published
 
 jobs:
   build-n-publish:
@@ -30,7 +30,7 @@ jobs:
 
     - name: Publish distribution to Test PyPI
       # The following upload action cannot be executed in the forked repository.
-      if: startsWith(github.event.ref, 'refs/tags') && github.repository == 'optuna/optuna'
+      if: github.repository == 'optuna/optuna'
       uses: pypa/gh-action-pypi-publish@v1.1.0
       with:
         user: __token__

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -5,10 +5,6 @@ on:
   push:
     tags:
       - v*
-  # TODO(toshihikoyanase): Remove pull_request when you enable PyPI upload.
-  pull_request:
-    branches:
-      - master
 
 jobs:
   build-n-publish:
@@ -32,11 +28,13 @@ jobs:
     - name: Verify the distributions
       run: twine check dist/*
 
-    # Save the package to the GitHub Actions' artifact. It will be deleted after 90 days.
-    - name: Save dist directory
-      uses: actions/upload-artifact@v1
+    - name: Publish distribution to Test PyPI
+      # The following upload action cannot be executed in the forked repository.
+      if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags') && github.repository == 'optuna/optuna'
+      uses: pypa/gh-action-pypi-publish@v1.1.0
       with:
-        name: optuna-dist
-        path: dist
+        user: __token__
+        password: ${{ secrets.test_pypi_password }}
+        repository_url: https://test.pypi.org/legacy/
 
-    # TODO(toshihikoyanase): Add tasks to upload packages to TestPyPI and PyPI.
+    # TODO(toshihikoyanase): Add tasks to upload packages to PyPI.

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -30,7 +30,7 @@ jobs:
 
     - name: Publish distribution to Test PyPI
       # The following upload action cannot be executed in the forked repository.
-      if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags') && github.repository == 'optuna/optuna'
+      if: startsWith(github.event.ref, 'refs/tags') && github.repository == 'optuna/optuna'
       uses: pypa/gh-action-pypi-publish@v1.1.0
       with:
         user: __token__


### PR DESCRIPTION
## Motivation
This PR depends on #1283. An additional PR to add the PyPI release will follow this PR.

## Description of the changes

This PR adds a step to upload distribution packages to TestPyPI. Please review #1283 in advance.

## Reference

- [pypi-publish](https://github.com/marketplace/actions/pypi-publish)
- [Publishing package distribution releases using GitHub Actions CI/CD workflows](https://packaging.python.org/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/)