### PR TITLE
Reorder arguments of `Trial.suggest_float`.

### DIFF
--- a/optuna/integration/chainermn.py
+++ b/optuna/integration/chainermn.py
@@ -1,4 +1,5 @@
 import gc
+from typing import Optional
 import warnings
 
 from optuna.logging import get_logger
@@ -13,7 +14,6 @@ if type_checking.TYPE_CHECKING:
     from typing import Any  # NOQA
     from typing import Callable  # NOQA
     from typing import Dict  # NOQA
-    from typing import Optional  # NOQA
     from typing import Sequence  # NOQA
     from typing import Tuple  # NOQA
     from typing import Type  # NOQA
@@ -183,12 +183,16 @@ class ChainerMNTrial(BaseTrial):
         self.delegate = trial
         self.comm = comm
 
-    def suggest_float(self, name, low, high, *, log=False, step=None):
-        # type: (str, float, float, bool, Optional[float]) -> float
-
-        def func():
-            # type: () -> float
-
+    def suggest_float(
+        self,
+        name: str,
+        low: float,
+        high: float,
+        *,
+        step: Optional[float] = None,
+        log: bool = False
+    ) -> float:
+        def func() -> float:
             assert self.delegate is not None
             return self.delegate.suggest_float(name, low, high, log=log, step=step)
 

--- a/optuna/multi_objective/trial.py
+++ b/optuna/multi_objective/trial.py
@@ -48,8 +48,8 @@ class MultiObjectiveTrial(object):
         low: float,
         high: float,
         *,
-        log: bool = False,
-        step: Optional[float] = None
+        step: Optional[float] = None,
+        log: bool = False
     ) -> float:
         """Suggest a value for the floating point parameter.
 
@@ -57,7 +57,7 @@ class MultiObjectiveTrial(object):
         for further details.
         """
 
-        return self._trial.suggest_float(name, low, high, log=log, step=step)
+        return self._trial.suggest_float(name, low, high, step=step, log=log)
 
     def suggest_uniform(self, name: str, low: float, high: float) -> float:
         """Suggest a value for the continuous parameter.

--- a/optuna/trial/_base.py
+++ b/optuna/trial/_base.py
@@ -1,5 +1,6 @@
 import abc
 import datetime
+from typing import Optional
 
 from optuna import distributions
 from optuna import logging
@@ -8,7 +9,6 @@ from optuna import type_checking
 if type_checking.TYPE_CHECKING:
     from typing import Any  # NOQA
     from typing import Dict  # NOQA
-    from typing import Optional  # NOQA
     from typing import Sequence  # NOQA
     from typing import Union  # NOQA
 
@@ -30,10 +30,15 @@ class BaseTrial(object, metaclass=abc.ABCMeta):
     """
 
     @abc.abstractmethod
-    def suggest_float(self, name, low, high, *, log=False, step=None):
-        # type: (str, float, float, bool, Optional[float])-> float
-
-        # TODO(nzw0301) swap log's position for step's one to match suggest_int for consistency.
+    def suggest_float(
+        self,
+        name: str,
+        low: float,
+        high: float,
+        *,
+        step: Optional[float] = None,
+        log: bool = False
+    ) -> float:
 
         raise NotImplementedError
 

--- a/optuna/trial/_fixed.py
+++ b/optuna/trial/_fixed.py
@@ -1,4 +1,5 @@
 import datetime
+from typing import Optional
 
 from optuna import distributions
 from optuna.trial._base import BaseTrial
@@ -8,7 +9,6 @@ from optuna import type_checking
 if type_checking.TYPE_CHECKING:
     from typing import Any  # NOQA
     from typing import Dict  # NOQA
-    from typing import Optional  # NOQA
     from typing import Sequence  # NOQA
     from typing import Union  # NOQA
 
@@ -68,8 +68,15 @@ class FixedTrial(BaseTrial):
         self._datetime_start = datetime.datetime.now()
         self._number = number
 
-    def suggest_float(self, name, low, high, *, log=False, step=None):
-        # type: (str, float, float, bool, Optional[float]) -> float
+    def suggest_float(
+        self,
+        name: str,
+        low: float,
+        high: float,
+        *,
+        step: Optional[float] = None,
+        log: bool = False
+    ) -> float:
 
         if step is not None:
             if log:

--- a/optuna/trial/_trial.py
+++ b/optuna/trial/_trial.py
@@ -1,5 +1,6 @@
 import copy
 import datetime
+from typing import Optional
 import warnings
 
 from optuna import distributions
@@ -18,7 +19,6 @@ from optuna import type_checking
 if type_checking.TYPE_CHECKING:
     from typing import Any  # NOQA
     from typing import Dict  # NOQA
-    from typing import Optional  # NOQA
     from typing import Sequence  # NOQA
     from typing import Union  # NOQA
 
@@ -77,8 +77,15 @@ class Trial(BaseTrial):
             study, trial, self.relative_search_space
         )
 
-    def suggest_float(self, name, low, high, *, log=False, step=None):
-        # type: (str, float, float, bool, Optional[float]) -> float
+    def suggest_float(
+        self,
+        name: str,
+        low: float,
+        high: float,
+        *,
+        step: Optional[float] = None,
+        log: bool = False
+    ) -> float:
         """Suggest a value for the floating point parameter.
 
         Note that this is a wrapper method for :func:`~optuna.trial.Trial.suggest_uniform`,

--- a/optuna/trial/_trial.py
+++ b/optuna/trial/_trial.py
@@ -139,13 +139,13 @@ class Trial(BaseTrial):
             high:
                 Upper endpoint of the range of suggested values. ``high`` is excluded from the
                 range.
+            step:
+                A step of discretization.
             log:
                 A flag to sample the value from the log domain or not.
                 If ``log`` is true, the value is sampled from the range in the log domain.
                 Otherwise, the value is sampled from the range in the linear domain.
                 See also :func:`suggest_uniform` and :func:`suggest_loguniform`.
-            step:
-                A step of discretization.
 
         Returns:
             A suggested float value.

--- a/tests/test_trial.py
+++ b/tests/test_trial.py
@@ -64,7 +64,7 @@ def test_check_distribution_suggest_float(storage_init_func):
 
     assert x5 == x6
     with pytest.raises(NotImplementedError):
-        trial.suggest_float("x4", 1e-5, 1e-2, log=True, step=1e-5)
+        trial.suggest_float("x4", 1e-5, 1e-2, step=1e-5, log=True)
 
 
 @parametrize_storage


### PR DESCRIPTION
## Motivation
This is a followup PR for #1201. It addresses [this comment](https://github.com/optuna/optuna/pull/1201#discussion_r427863114), and makes the order of the `Trial.suggest_float` arguments consistent with the `Trial.suggest_int` arguments. I think it is helpful for users if we include this change into v1.5.0.

## Description of the changes

It reorders the argument of `Trial.suggest_float`. More concretely, it swaps `log` for `step`. This change does not affect user code because both of them are keyword-only arguments.