### PR TITLE
Add a step to push images to Docker Hub.

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -46,7 +46,7 @@ jobs:
 
     - name: Login & Push to Docker Hub
       # The following push action cannot be executed in the forked repository.
-      if: github.repository == 'optuna/optuna'
+      if: github.repository == 'optuna/optuna' && env.DOCKER_HUB_USER != ''
       env:
         DOCKER_HUB_USER: ${{ secrets.DOCKER_HUB_USER }}
         DOCKER_HUB_TOKEN: ${{ secrets.DOCKER_HUB_TOKEN }}

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -25,6 +25,7 @@ jobs:
         python_version: ['3.5', '3.6', '3.7', '3.8']
         build_type: ['', 'dev']  # "dev" installs all the dependencies including pytest.
 
+    if: github.repository == 'optuna/optuna'
     steps:
     - uses: actions/checkout@v2
 
@@ -46,10 +47,8 @@ jobs:
 
     - name: Login & Push to Docker Hub
       # The following push action cannot be executed in the forked repository.
-      if: github.repository == 'optuna/optuna' && env.DOCKER_HUB_USER != ''
       env:
-        DOCKER_HUB_USER: ${{ secrets.DOCKER_HUB_USER }}
         DOCKER_HUB_TOKEN: ${{ secrets.DOCKER_HUB_TOKEN }}
       run: |
-        echo "${DOCKER_HUB_TOKEN}" | docker login -u ${DOCKER_HUB_USER} --password-stdin
+        echo "${DOCKER_HUB_TOKEN}" | docker login -u optunabot --password-stdin
         docker push "${HUB_TAG}"

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -25,6 +25,7 @@ jobs:
         python_version: ['3.5', '3.6', '3.7', '3.8']
         build_type: ['', 'dev']  # "dev" installs all the dependencies including pytest.
 
+    # This action cannot be executed in the forked repository.
     if: github.repository == 'optuna/optuna'
     steps:
     - uses: actions/checkout@v2
@@ -46,7 +47,7 @@ jobs:
         docker build . --build-arg PYTHON_VERSION=${{ matrix.python_version }} --build-arg BUILD_TYPE=${{ matrix.build_type }} --file Dockerfile --tag "${HUB_TAG}"
 
     - name: Login & Push to Docker Hub
-      # The following push action cannot be executed in the forked repository.
+      if: ${{ github.event_name != 'pull_request' }}
       env:
         DOCKER_HUB_TOKEN: ${{ secrets.DOCKER_HUB_TOKEN }}
       run: |

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -43,3 +43,13 @@ jobs:
     - name: Build the Docker image
       run: |
         docker build . --build-arg PYTHON_VERSION=${{ matrix.python_version }} --build-arg BUILD_TYPE=${{ matrix.build_type }} --file Dockerfile --tag "${HUB_TAG}"
+
+    - name: Login & Push to Docker Hub
+      # The following push action cannot be executed in the forked repository.
+      if: github.repository == 'optuna/optuna'
+      env:
+        DOCKER_HUB_USER: ${{ secrets.DOCKER_HUB_USER }}
+        DOCKER_HUB_TOKEN: ${{ secrets.DOCKER_HUB_TOKEN }}
+      run: |
+        echo "${DOCKER_HUB_TOKEN}" | docker login -u ${DOCKER_HUB_USER} --password-stdin
+        docker push "${HUB_TAG}"


### PR DESCRIPTION
## Motivation
This PR addresses a TODO item in #901. #901 creates docker images and this PR uploads them to Docker Hub.

## Description of the changes

- Add a step to upload images to Docker Hub. I extracted the code in #874 by @crcrpar.
- [Opinion Wanted] I wanted to use the access token of the `optuna` organization, but DockerHub does not allow such tokens. Instead, it provides a personal token. So, I parameterized the user name in addition to the access token and read them from GitHub Secret. If you have any concerns, please let me know.

Currently, the upload step will be skipped because I didn't set docker hub token to the GitHub Secret.