### PR TITLE
Add `read_trials_from_remote_storage` method to Storage implementations.

### DIFF
--- a/optuna/samplers/_search_space.py
+++ b/optuna/samplers/_search_space.py
@@ -54,7 +54,7 @@ class IntersectionSearchSpace(object):
                 raise ValueError("`IntersectionSearchSpace` cannot handle multiple studies.")
 
         next_cursor = self._cursor
-        for trial in reversed(study.get_trials(deepcopy=False)):
+        for trial in reversed(study._storage.get_all_trials(study._study_id, deepcopy=False)):
             if self._cursor > trial.number:
                 break
 

--- a/optuna/samplers/cmaes.py
+++ b/optuna/samplers/cmaes.py
@@ -153,7 +153,9 @@ class CmaEsSampler(BaseSampler):
             return {}
 
         completed_trials = [
-            t for t in study.get_trials(deepcopy=False) if t.state == TrialState.COMPLETE
+            t
+            for t in study._storage.get_all_trials(study._study_id, deepcopy=False)
+            if t.state == TrialState.COMPLETE
         ]
         if len(completed_trials) < self._n_startup_trials:
             return {}

--- a/optuna/samplers/tpe/sampler.py
+++ b/optuna/samplers/tpe/sampler.py
@@ -615,7 +615,7 @@ def _get_observation_pairs(study, param_name, trial):
 
     values = []
     scores = []
-    for trial in study.get_trials(deepcopy=False):
+    for trial in study._storage.get_all_trials(study._study_id, deepcopy=False):
         if trial.state is TrialState.COMPLETE and trial.value is not None:
             score = (-float("inf"), sign * trial.value)
         elif trial.state is TrialState.PRUNED:

--- a/optuna/storages/base.py
+++ b/optuna/storages/base.py
@@ -56,7 +56,7 @@ class BaseStorage(object, metaclass=abc.ABCMeta):
     of a study, not necessarily for the attributes of a `Trial`.
     However, if the `read_from_remote_storage(study_id)` method is called, any successive reads on
     the `state` attribute of a `Trial` are guaranteed to return the same or more recent values than
-    the value at the time of call to the `load` method.
+    the value at the time of the call to the `read_from_remote_storage(study_id)` method.
     Let `T` be a `Trial`.
     Let `P` be the process that last updated the `state` attribute of `T`.
     Then, any reads on any attributes of `T` are guaranteed to return the same or

--- a/optuna/storages/base.py
+++ b/optuna/storages/base.py
@@ -52,13 +52,11 @@ class BaseStorage(object, metaclass=abc.ABCMeta):
 
     **Stronger consistency requirements for special data**
 
-    TODO(ytsmiling) Add load method to storage class implementations.
-
     Under a multi-worker setting, a storage class must return the latest values of any attributes
     of a study, not necessarily for the attributes of a `Trial`.
-    However, if the `load(study_id)` method is called, any successive reads on the `state`
-    attribute of a `Trial` are guaranteed to return the same or more recent values than the value
-    at the time of call to the `load` method.
+    However, if the `read_from_remote_storage(study_id)` method is called, any successive reads on
+    the `state` attribute of a `Trial` are guaranteed to return the same or more recent values than
+    the value at the time of call to the `load` method.
     Let `T` be a `Trial`.
     Let `P` be the process that last updated the `state` attribute of `T`.
     Then, any reads on any attributes of `T` are guaranteed to return the same or
@@ -644,6 +642,19 @@ class BaseStorage(object, metaclass=abc.ABCMeta):
                 If no trial with the matching ``trial_id`` exists.
         """
         return self.get_trial(trial_id).system_attrs
+
+    def read_from_remote_storage(self, study_id: int) -> None:
+        """Make an internal cache of trials up-to-date.
+
+        Args:
+            study_id:
+                ID of the study.
+
+        Raises:
+            :exc:`KeyError`:
+                If no study with the matching ``study_id`` exists.
+        """
+        raise NotImplementedError
 
     def remove_session(self) -> None:
         """Clean up all connections to a database."""

--- a/optuna/storages/base.py
+++ b/optuna/storages/base.py
@@ -54,9 +54,10 @@ class BaseStorage(object, metaclass=abc.ABCMeta):
 
     Under a multi-worker setting, a storage class must return the latest values of any attributes
     of a study, not necessarily for the attributes of a `Trial`.
-    However, if the `read_from_remote_storage(study_id)` method is called, any successive reads on
-    the `state` attribute of a `Trial` are guaranteed to return the same or more recent values than
-    the value at the time of the call to the `read_from_remote_storage(study_id)` method.
+    However, if the `read_trials_from_remote_storage(study_id)` method is called, any successive
+    reads on the `state` attribute of a `Trial` are guaranteed to return the same or more recent
+    values than the value at the time of the call to the
+    `read_trials_from_remote_storage(study_id)` method.
     Let `T` be a `Trial`.
     Let `P` be the process that last updated the `state` attribute of `T`.
     Then, any reads on any attributes of `T` are guaranteed to return the same or
@@ -643,7 +644,7 @@ class BaseStorage(object, metaclass=abc.ABCMeta):
         """
         return self.get_trial(trial_id).system_attrs
 
-    def read_from_remote_storage(self, study_id: int) -> None:
+    def read_trials_from_remote_storage(self, study_id: int) -> None:
         """Make an internal cache of trials up-to-date.
 
         Args:

--- a/optuna/storages/cached_storage.py
+++ b/optuna/storages/cached_storage.py
@@ -354,7 +354,7 @@ class _CachedStorage(base.BaseStorage):
 
     def get_all_trials(self, study_id: int, deepcopy: bool = True) -> List[FrozenTrial]:
         if study_id not in self._studies:
-            self.read_from_remote_storage(study_id)
+            self.read_trials_from_remote_storage(study_id)
 
         with self._lock:
             study = self._studies[study_id]
@@ -367,7 +367,7 @@ class _CachedStorage(base.BaseStorage):
 
         return self._backend.get_n_trials(study_id, state)
 
-    def read_from_remote_storage(self, study_id: int) -> None:
+    def read_trials_from_remote_storage(self, study_id: int) -> None:
         with self._lock:
             if study_id not in self._studies:
                 self._studies[study_id] = _StudyInfo()

--- a/optuna/storages/cached_storage.py
+++ b/optuna/storages/cached_storage.py
@@ -353,9 +353,10 @@ class _CachedStorage(base.BaseStorage):
         return self._backend.get_trial(trial_id)
 
     def get_all_trials(self, study_id: int, deepcopy: bool = True) -> List[FrozenTrial]:
+        if study_id not in self._studies:
+            self.read_from_remote_storage(study_id)
+
         with self._lock:
-            if study_id not in self._studies:
-                self.read_from_remote_storage(study_id)
             study = self._studies[study_id]
             # We need to sort trials by their number because some samplers assume this behavior.
             # The following two lines are latency-sensitive.

--- a/optuna/storages/in_memory.py
+++ b/optuna/storages/in_memory.py
@@ -430,6 +430,9 @@ class InMemoryStorage(base.BaseStorage):
                 trial.state == state for trial in self.get_all_trials(study_id, deepcopy=False)
             )
 
+    def read_from_remote_storage(self, study_id: int) -> None:
+        self._check_study_id(study_id)
+
     def _check_study_id(self, study_id):
         # type: (int) -> None
 

--- a/optuna/storages/in_memory.py
+++ b/optuna/storages/in_memory.py
@@ -430,7 +430,7 @@ class InMemoryStorage(base.BaseStorage):
                 trial.state == state for trial in self.get_all_trials(study_id, deepcopy=False)
             )
 
-    def read_from_remote_storage(self, study_id: int) -> None:
+    def read_trials_from_remote_storage(self, study_id: int) -> None:
         self._check_study_id(study_id)
 
     def _check_study_id(self, study_id):

--- a/optuna/storages/rdb/storage.py
+++ b/optuna/storages/rdb/storage.py
@@ -1009,6 +1009,12 @@ class RDBStorage(BaseStorage):
         self._commit(session)
         return n_trials
 
+    def read_from_remote_storage(self, study_id: int) -> None:
+        # Check that that study exists.
+        session = self.scoped_session()
+        models.StudyModel.find_or_raise_by_id(study_id, session)
+        self._commit(session)
+
     @staticmethod
     def _set_default_engine_kwargs_for_mysql(url, engine_kwargs):
         # type: (str, Dict[str, Any]) -> None

--- a/optuna/storages/rdb/storage.py
+++ b/optuna/storages/rdb/storage.py
@@ -1009,7 +1009,7 @@ class RDBStorage(BaseStorage):
         self._commit(session)
         return n_trials
 
-    def read_from_remote_storage(self, study_id: int) -> None:
+    def read_trials_from_remote_storage(self, study_id: int) -> None:
         # Make sure that the given study exists.
         session = self.scoped_session()
         models.StudyModel.find_or_raise_by_id(study_id, session)

--- a/optuna/storages/rdb/storage.py
+++ b/optuna/storages/rdb/storage.py
@@ -1010,7 +1010,7 @@ class RDBStorage(BaseStorage):
         return n_trials
 
     def read_from_remote_storage(self, study_id: int) -> None:
-        # Check that that study exists.
+        # Make sure that the given study exists.
         session = self.scoped_session()
         models.StudyModel.find_or_raise_by_id(study_id, session)
         self._commit(session)

--- a/optuna/storages/redis.py
+++ b/optuna/storages/redis.py
@@ -603,6 +603,9 @@ class RedisStorage(base.BaseStorage):
 
         return len([t for t in self.get_all_trials(study_id) if t.state == state])
 
+    def read_from_remote_storage(self, study_id: int) -> None:
+        self._check_study_id(study_id)
+
     def _check_study_id(self, study_id):
         # type: (int) -> None
 

--- a/optuna/storages/redis.py
+++ b/optuna/storages/redis.py
@@ -603,7 +603,7 @@ class RedisStorage(base.BaseStorage):
 
         return len([t for t in self.get_all_trials(study_id) if t.state == state])
 
-    def read_from_remote_storage(self, study_id: int) -> None:
+    def read_trials_from_remote_storage(self, study_id: int) -> None:
         self._check_study_id(study_id)
 
     def _check_study_id(self, study_id):

--- a/optuna/study.py
+++ b/optuna/study.py
@@ -725,6 +725,9 @@ class Study(BaseStudy):
     ):
         # type: (...) -> trial_module.Trial
 
+        # Sync storage once at the beginning of the objective evaluation.
+        self._storage.read_from_remote_storage(self._study_id)
+
         trial_id = self._pop_waiting_trial_id()
         if trial_id is None:
             trial_id = self._storage.create_new_trial(self._study_id)

--- a/optuna/study.py
+++ b/optuna/study.py
@@ -142,6 +142,7 @@ class BaseStudy(object):
             A list of :class:`~optuna.FrozenTrial` objects.
         """
 
+        self._storage.read_from_remote_storage(self._study_id)
         return self._storage.get_all_trials(self._study_id, deepcopy=deepcopy)
 
     @property

--- a/optuna/study.py
+++ b/optuna/study.py
@@ -690,7 +690,7 @@ class Study(BaseStudy):
         # type: () -> Optional[int]
 
         # TODO(c-bata): Reduce database query counts for extracting waiting trials.
-        for trial in self.get_trials(deepcopy=False):
+        for trial in self._storage.get_all_trials(self._study_id, deepcopy=False):
             if trial.state != TrialState.WAITING:
                 continue
 

--- a/optuna/study.py
+++ b/optuna/study.py
@@ -142,7 +142,7 @@ class BaseStudy(object):
             A list of :class:`~optuna.FrozenTrial` objects.
         """
 
-        self._storage.read_from_remote_storage(self._study_id)
+        self._storage.read_trials_from_remote_storage(self._study_id)
         return self._storage.get_all_trials(self._study_id, deepcopy=deepcopy)
 
     @property
@@ -726,7 +726,7 @@ class Study(BaseStudy):
         # type: (...) -> trial_module.Trial
 
         # Sync storage once at the beginning of the objective evaluation.
-        self._storage.read_from_remote_storage(self._study_id)
+        self._storage.read_trials_from_remote_storage(self._study_id)
 
         trial_id = self._pop_waiting_trial_id()
         if trial_id is None:

--- a/tests/samplers_tests/tpe_tests/test_sampler.py
+++ b/tests/samplers_tests/tpe_tests/test_sampler.py
@@ -53,15 +53,15 @@ def test_sample_independent_seed_fix() -> None:
     # Prepare a trial and a sample for later checks.
     trial = frozen_trial_factory(8)
     sampler = TPESampler(n_startup_trials=5, seed=0)
-    with patch("optuna.Study.get_trials", return_value=past_trials):
+    with patch.object(study._storage, "get_all_trials", return_value=past_trials):
         suggestion = sampler.sample_independent(study, trial, "param-a", dist)
 
     sampler = TPESampler(n_startup_trials=5, seed=0)
-    with patch("optuna.Study.get_trials", return_value=past_trials):
+    with patch.object(study._storage, "get_all_trials", return_value=past_trials):
         assert sampler.sample_independent(study, trial, "param-a", dist) == suggestion
 
     sampler = TPESampler(n_startup_trials=5, seed=1)
-    with patch("optuna.Study.get_trials", return_value=past_trials):
+    with patch.object(study._storage, "get_all_trials", return_value=past_trials):
         assert sampler.sample_independent(study, trial, "param-a", dist) != suggestion
 
 
@@ -73,15 +73,15 @@ def test_sample_independent_prior() -> None:
     # Prepare a trial and a sample for later checks.
     trial = frozen_trial_factory(8)
     sampler = TPESampler(n_startup_trials=5, seed=0)
-    with patch("optuna.Study.get_trials", return_value=past_trials):
+    with patch.object(study._storage, "get_all_trials", return_value=past_trials):
         suggestion = sampler.sample_independent(study, trial, "param-a", dist)
 
     sampler = TPESampler(consider_prior=False, n_startup_trials=5, seed=0)
-    with patch("optuna.Study.get_trials", return_value=past_trials):
+    with patch.object(study._storage, "get_all_trials", return_value=past_trials):
         assert sampler.sample_independent(study, trial, "param-a", dist) != suggestion
 
     sampler = TPESampler(prior_weight=0.5, n_startup_trials=5, seed=0)
-    with patch("optuna.Study.get_trials", return_value=past_trials):
+    with patch.object(study._storage, "get_all_trials", return_value=past_trials):
         assert sampler.sample_independent(study, trial, "param-a", dist) != suggestion
 
 
@@ -92,14 +92,14 @@ def test_sample_independent_n_startup_trial() -> None:
 
     trial = frozen_trial_factory(8)
     sampler = TPESampler(n_startup_trials=5, seed=0)
-    with patch("optuna.Study.get_trials", return_value=past_trials[:4]):
+    with patch.object(study._storage, "get_all_trials", return_value=past_trials[:4]):
         with patch.object(
             optuna.samplers.random.RandomSampler, "sample_independent", return_value=1.0
         ) as sample_method:
             sampler.sample_independent(study, trial, "param-a", dist)
     assert sample_method.call_count == 1
     sampler = TPESampler(n_startup_trials=5, seed=0)
-    with patch("optuna.Study.get_trials", return_value=past_trials[:5]):
+    with patch.object(study._storage, "get_all_trials", return_value=past_trials):
         with patch.object(
             optuna.samplers.random.RandomSampler, "sample_independent", return_value=1.0
         ) as sample_method:
@@ -115,16 +115,16 @@ def test_sample_independent_misc_arguments() -> None:
     # Prepare a trial and a sample for later checks.
     trial = frozen_trial_factory(8)
     sampler = TPESampler(n_startup_trials=5, seed=0)
-    with patch("optuna.Study.get_trials", return_value=past_trials):
+    with patch.object(study._storage, "get_all_trials", return_value=past_trials):
         suggestion = sampler.sample_independent(study, trial, "param-a", dist)
 
     # Test misc. parameters.
     sampler = TPESampler(n_ei_candidates=13, n_startup_trials=5, seed=0)
-    with patch("optuna.Study.get_trials", return_value=past_trials):
+    with patch.object(study._storage, "get_all_trials", return_value=past_trials):
         assert sampler.sample_independent(study, trial, "param-a", dist) != suggestion
 
     sampler = TPESampler(gamma=lambda _: 5, n_startup_trials=5, seed=0)
-    with patch("optuna.Study.get_trials", return_value=past_trials):
+    with patch.object(study._storage, "get_all_trials", return_value=past_trials):
         assert sampler.sample_independent(study, trial, "param-a", dist) != suggestion
 
     sampler = TPESampler(
@@ -142,7 +142,7 @@ def test_sample_independent_uniform_distributions() -> None:
     past_trials = [frozen_trial_factory(i, dist=uni_dist) for i in range(1, 8)]
     trial = frozen_trial_factory(8)
     sampler = TPESampler(n_startup_trials=5, seed=0)
-    with patch("optuna.Study.get_trials", return_value=past_trials):
+    with patch.object(study._storage, "get_all_trials", return_value=past_trials):
         uniform_suggestion = sampler.sample_independent(study, trial, "param-a", uni_dist)
     assert 1.0 <= uniform_suggestion < 100.0
 
@@ -155,7 +155,7 @@ def test_sample_independent_log_uniform_distributions() -> None:
     past_trials = [frozen_trial_factory(i, dist=uni_dist) for i in range(1, 8)]
     trial = frozen_trial_factory(8)
     sampler = TPESampler(n_startup_trials=5, seed=0)
-    with patch("optuna.Study.get_trials", return_value=past_trials):
+    with patch.object(study._storage, "get_all_trials", return_value=past_trials):
         uniform_suggestion = sampler.sample_independent(study, trial, "param-a", uni_dist)
 
     # Test sample from log-uniform is different from uniform.
@@ -163,7 +163,7 @@ def test_sample_independent_log_uniform_distributions() -> None:
     past_trials = [frozen_trial_factory(i, dist=log_dist) for i in range(1, 8)]
     trial = frozen_trial_factory(8)
     sampler = TPESampler(n_startup_trials=5, seed=0)
-    with patch("optuna.Study.get_trials", return_value=past_trials):
+    with patch.object(study._storage, "get_all_trials", return_value=past_trials):
         loguniform_suggestion = sampler.sample_independent(study, trial, "param-a", log_dist)
     assert 1.0 <= loguniform_suggestion < 100.0
     assert uniform_suggestion != loguniform_suggestion
@@ -206,7 +206,7 @@ def test_sample_independent_categorical_distributions() -> None:
     ]
     trial = frozen_trial_factory(8)
     sampler = TPESampler(n_startup_trials=5, seed=0)
-    with patch("optuna.Study.get_trials", return_value=past_trials):
+    with patch.object(study._storage, "get_all_trials", return_value=past_trials):
         categorical_suggestion = sampler.sample_independent(study, trial, "param-a", cat_dist)
     assert categorical_suggestion in categories
 
@@ -226,7 +226,7 @@ def test_sample_int_uniform_distributions() -> None:
     ]
     trial = frozen_trial_factory(8)
     sampler = TPESampler(n_startup_trials=5, seed=0)
-    with patch("optuna.Study.get_trials", return_value=past_trials):
+    with patch.object(study._storage, "get_all_trials", return_value=past_trials):
         int_suggestion = sampler.sample_independent(study, trial, "param-a", int_dist)
     assert 1 <= int_suggestion <= 100
     assert isinstance(int_suggestion, int)
@@ -249,7 +249,7 @@ def test_sample_independent_handle_unsuccessful_states(state: optuna.trial.Trial
     past_trials = [frozen_trial_factory(i, dist=dist) for i in range(1, 30)]
     trial = frozen_trial_factory(30)
     sampler = TPESampler(n_startup_trials=5, seed=0)
-    with patch("optuna.Study.get_trials", return_value=past_trials):
+    with patch.object(study._storage, "get_all_trials", return_value=past_trials):
         all_success_suggestion = sampler.sample_independent(study, trial, "param-a", dist)
 
     # Test unsuccessful trials are handled differently.
@@ -257,7 +257,7 @@ def test_sample_independent_handle_unsuccessful_states(state: optuna.trial.Trial
     past_trials = [frozen_trial_factory(i, dist=dist, state_fn=state_fn) for i in range(1, 30)]
     trial = frozen_trial_factory(30)
     sampler = TPESampler(n_startup_trials=5, seed=0)
-    with patch("optuna.Study.get_trials", return_value=past_trials):
+    with patch.object(study._storage, "get_all_trials", return_value=past_trials):
         partial_unsuccessful_suggestion = sampler.sample_independent(study, trial, "param-a", dist)
     assert partial_unsuccessful_suggestion != all_success_suggestion
 
@@ -277,7 +277,7 @@ def test_sample_independent_ignored_states() -> None:
         past_trials = [frozen_trial_factory(i, dist=dist, state_fn=state_fn) for i in range(1, 30)]
         trial = frozen_trial_factory(30)
         sampler = TPESampler(n_startup_trials=5, seed=0)
-        with patch("optuna.Study.get_trials", return_value=past_trials):
+        with patch.object(study._storage, "get_all_trials", return_value=past_trials):
             suggestions.append(sampler.sample_independent(study, trial, "param-a", dist))
 
     assert len(set(suggestions)) == 1
@@ -298,7 +298,7 @@ def test_sample_independent_pruned_state() -> None:
         past_trials = [frozen_trial_factory(i, dist=dist, state_fn=state_fn) for i in range(1, 30)]
         trial = frozen_trial_factory(30)
         sampler = TPESampler(n_startup_trials=5, seed=0)
-        with patch("optuna.Study.get_trials", return_value=past_trials):
+        with patch.object(study._storage, "get_all_trials", return_value=past_trials):
             suggestions.append(sampler.sample_independent(study, trial, "param-a", dist))
 
     assert len(set(suggestions)) == 3


### PR DESCRIPTION
## Motivation
This PR implements `read_from_remote_storage`, which has been a TODO comment in the `BaseStorage` class doc (the method has been referred to be `load` method, and the name is subject for discussion).

This PR
1. improves optimization speed with RDB backend, and
2. fix trial-inconsistency bug between parameter sampling.

## Bugfix
Optuna's samplers have synced storage immediately, and thus, "past trials" might differ between `trial.suggest_*` method calls in a single trial. This can introduce unintentional behavior similar to #1166 in multi-worker settings. This PR mitigates the problem by loading remote storage's content only at the very beginning of each trial (and each prune call). Note, however, this PR cannot fix the behavior w/ multi-thread or w/ `RedisStorage`. The problem with `RedisStorage` will be resolved when we extend `_CachedStorage` and wrap `RedisStorage` as well.

## Description of the changes
This PR add implementations of `read_from_remote_storage` method.
Additionally, this PR modifies samplers' and study's implementation so that they avoid unintentional storage accesses.

## Microbenchmark
This PR added almost no overhead on optimization with `InMemoryStorage`.
I used the same setting with #1140 to measure performance improvement for optimization w/ RDB backend.

### Master
```
{'n_study': 1, 'n_trial': 500, 'n_param': 30}
perf:optimize-study                               0:03:29.107132
```
### This PR
```
{'n_study': 1, 'n_trial': 500, 'n_param': 30}
perf:optimize-study                               0:01:11.178871
```


