### PR TITLE
Add link to regression example in the header of `keras_integration.py`.

### DIFF
--- a/examples/pruning/keras_integration.py
+++ b/examples/pruning/keras_integration.py
@@ -9,6 +9,10 @@ results and stops unpromising trials.
 You can run this example as follows:
     $ python keras_integration.py
 
+For a similar Optuna example that demonstrates Keras without a pruner on a regression dataset,
+see the following link:
+    https://github.com/optuna/optuna/blob/master/examples/mlflow/keras_mlflow.py
+
 """
 
 import keras


### PR DESCRIPTION
<!-- Thank you for creating a pull request! -->

## Motivation
This PR adds a link to `keras_mlflow.py` within the header of the `keras_integration.py` example.
It saves new users some time by allowing them to easily find both a classification and a regression example using Keras within `keras_integration.py`.

## Description of the changes
Only the header documentation of `keras_integration.py` was changed.
