### PR TITLE
Implement `log` argument for `suggest_int` of pycma integration.

### DIFF
--- a/optuna/integration/cma.py
+++ b/optuna/integration/cma.py
@@ -234,7 +234,7 @@ class PyCmaSampler(BaseSampler):
             elif isinstance(distribution, IntUniformDistribution):
                 x0[name] = int(numpy.mean([distribution.high, distribution.low]))
             elif isinstance(distribution, LogUniformDistribution) or isinstance(
-                dist, IntLogUniformDistribution
+                distribution, IntLogUniformDistribution
             ):
                 log_high = math.log(distribution.high)
                 log_low = math.log(distribution.low)
@@ -261,7 +261,7 @@ class PyCmaSampler(BaseSampler):
             elif isinstance(distribution, IntUniformDistribution):
                 sigma0s.append((distribution.high - distribution.low) / 6)
             elif isinstance(distribution, LogUniformDistribution) or isinstance(
-                dist, IntLogUniformDistribution
+                distribution, IntLogUniformDistribution
             ):
                 log_high = math.log(distribution.high)
                 log_low = math.log(distribution.low)

--- a/optuna/integration/cma.py
+++ b/optuna/integration/cma.py
@@ -456,8 +456,7 @@ class _Optimizer(object):
             return int(v)
         if isinstance(dist, IntLogUniformDistribution):
             exp_value = math.exp(cma_param_value)
-            r = numpy.round((exp_value - dist.low) / dist.step)
-            v = r * dist.step + dist.low
+            v = numpy.round(exp_value)
             return int(min(max(v, dist.low), dist.high))
 
         if isinstance(dist, CategoricalDistribution):

--- a/optuna/integration/cma.py
+++ b/optuna/integration/cma.py
@@ -431,7 +431,7 @@ class _Optimizer(object):
         # type: (Dict[str, BaseDistribution], str, Any) -> float
 
         dist = search_space[param_name]
-        if isinstance(dist, LogUniformDistribution) or isinstance(dist, IntLogUniformDistribution):
+        if isinstance(dist, (LogUniformDistribution, IntLogUniformDistribution)):
             return math.log(optuna_param_value)
         elif isinstance(dist, DiscreteUniformDistribution):
             return optuna_param_value - dist.low

--- a/optuna/integration/cma.py
+++ b/optuna/integration/cma.py
@@ -233,11 +233,7 @@ class PyCmaSampler(BaseSampler):
                 x0[name] = numpy.mean([distribution.high, distribution.low])
             elif isinstance(distribution, IntUniformDistribution):
                 x0[name] = int(numpy.mean([distribution.high, distribution.low]))
-            elif isinstance(distribution, IntLogUniformDistribution):
-                log_high = math.log(distribution.high)
-                log_low = math.log(distribution.low)
-                x0[name] = math.exp(numpy.mean([log_high, log_low]))
-            elif isinstance(distribution, LogUniformDistribution):
+            elif isinstance(distribution, LogUniformDistribution) or isinstance(dist, IntLogUniformDistribution):
                 log_high = math.log(distribution.high)
                 log_low = math.log(distribution.low)
                 x0[name] = math.exp(numpy.mean([log_high, log_low]))
@@ -262,11 +258,7 @@ class PyCmaSampler(BaseSampler):
                 sigma0s.append((distribution.high - distribution.low) / 6)
             elif isinstance(distribution, IntUniformDistribution):
                 sigma0s.append((distribution.high - distribution.low) / 6)
-            elif isinstance(distribution, IntLogUniformDistribution):
-                log_high = math.log(distribution.high)
-                log_low = math.log(distribution.low)
-                sigma0s.append((log_high - log_low) / 6)
-            elif isinstance(distribution, LogUniformDistribution):
+            elif isinstance(distribution, LogUniformDistribution) or isinstance(dist, IntLogUniformDistribution):
                 log_high = math.log(distribution.high)
                 log_low = math.log(distribution.low)
                 sigma0s.append((log_high - log_low) / 6)

--- a/optuna/integration/cma.py
+++ b/optuna/integration/cma.py
@@ -233,9 +233,7 @@ class PyCmaSampler(BaseSampler):
                 x0[name] = numpy.mean([distribution.high, distribution.low])
             elif isinstance(distribution, IntUniformDistribution):
                 x0[name] = int(numpy.mean([distribution.high, distribution.low]))
-            elif isinstance(distribution, LogUniformDistribution) or isinstance(
-                distribution, IntLogUniformDistribution
-            ):
+            elif isinstance(distribution, (LogUniformDistribution, IntLogUniformDistribution)):
                 log_high = math.log(distribution.high)
                 log_low = math.log(distribution.low)
                 x0[name] = math.exp(numpy.mean([log_high, log_low]))

--- a/optuna/integration/cma.py
+++ b/optuna/integration/cma.py
@@ -327,7 +327,6 @@ class _Optimizer(object):
                 lows.append(dist.low - 0.5 * dist.step)
                 highs.append(dist.high + 0.5 * dist.step)
             elif isinstance(dist, IntLogUniformDistribution):
-                # TODO(toshihikoyanase): Shifting 0.5 is not sufficient if step > 1.
                 lows.append(self._to_cma_params(search_space, param_name, dist.low - 0.5))
                 highs.append(self._to_cma_params(search_space, param_name, dist.high + 0.5))
             else:

--- a/optuna/integration/cma.py
+++ b/optuna/integration/cma.py
@@ -463,7 +463,7 @@ class _Optimizer(object):
             exp_value = math.exp(cma_param_value)
             r = numpy.round((exp_value - dist.low) / dist.step)
             v = r * dist.step + dist.low
-            return int(v)
+            return int(min(max(v, dist.low), dist.high))
 
         if isinstance(dist, CategoricalDistribution):
             v = int(numpy.round(cma_param_value))

--- a/optuna/integration/cma.py
+++ b/optuna/integration/cma.py
@@ -258,9 +258,7 @@ class PyCmaSampler(BaseSampler):
                 sigma0s.append((distribution.high - distribution.low) / 6)
             elif isinstance(distribution, IntUniformDistribution):
                 sigma0s.append((distribution.high - distribution.low) / 6)
-            elif isinstance(distribution, LogUniformDistribution) or isinstance(
-                distribution, IntLogUniformDistribution
-            ):
+            elif isinstance(distribution, (LogUniformDistribution, IntLogUniformDistribution)):
                 log_high = math.log(distribution.high)
                 log_low = math.log(distribution.low)
                 sigma0s.append((log_high - log_low) / 6)

--- a/optuna/integration/cma.py
+++ b/optuna/integration/cma.py
@@ -327,7 +327,7 @@ class _Optimizer(object):
                 lows.append(dist.low - 0.5 * dist.step)
                 highs.append(dist.high + 0.5 * dist.step)
             elif isinstance(dist, IntLogUniformDistribution):
-                # TODO(toshihikoyanase): Shiting 0.5 is not sufficient if step > 1.
+                # TODO(toshihikoyanase): Shifting 0.5 is not sufficient if step > 1.
                 lows.append(self._to_cma_params(search_space, param_name, dist.low - 0.5))
                 highs.append(self._to_cma_params(search_space, param_name, dist.high + 0.5))
             else:

--- a/optuna/integration/cma.py
+++ b/optuna/integration/cma.py
@@ -316,8 +316,8 @@ class _Optimizer(object):
                 lows.append(0 - 0.5 * dist.q)
                 highs.append(r + 0.5 * dist.q)
             elif isinstance(dist, IntUniformDistribution):
-                lows.append(dist.low - 0.5 * dist.step)
-                highs.append(dist.high + 0.5 * dist.step)
+                lows.append(dist.low - 0.5)
+                highs.append(dist.high + 0.5)
             elif isinstance(dist, IntLogUniformDistribution):
                 lows.append(self._to_cma_params(search_space, param_name, dist.low - 0.5))
                 highs.append(self._to_cma_params(search_space, param_name, dist.high + 0.5))

--- a/optuna/integration/cma.py
+++ b/optuna/integration/cma.py
@@ -233,7 +233,9 @@ class PyCmaSampler(BaseSampler):
                 x0[name] = numpy.mean([distribution.high, distribution.low])
             elif isinstance(distribution, IntUniformDistribution):
                 x0[name] = int(numpy.mean([distribution.high, distribution.low]))
-            elif isinstance(distribution, LogUniformDistribution) or isinstance(dist, IntLogUniformDistribution):
+            elif isinstance(distribution, LogUniformDistribution) or isinstance(
+                dist, IntLogUniformDistribution
+            ):
                 log_high = math.log(distribution.high)
                 log_low = math.log(distribution.low)
                 x0[name] = math.exp(numpy.mean([log_high, log_low]))
@@ -258,7 +260,9 @@ class PyCmaSampler(BaseSampler):
                 sigma0s.append((distribution.high - distribution.low) / 6)
             elif isinstance(distribution, IntUniformDistribution):
                 sigma0s.append((distribution.high - distribution.low) / 6)
-            elif isinstance(distribution, LogUniformDistribution) or isinstance(dist, IntLogUniformDistribution):
+            elif isinstance(distribution, LogUniformDistribution) or isinstance(
+                dist, IntLogUniformDistribution
+            ):
                 log_high = math.log(distribution.high)
                 log_low = math.log(distribution.low)
                 sigma0s.append((log_high - log_low) / 6)

--- a/tests/integration_tests/test_cma.py
+++ b/tests/integration_tests/test_cma.py
@@ -184,8 +184,8 @@ class TestOptimizer(object):
                 {
                     "BoundaryHandler": cma.BoundTransform,
                     "bounds": [
-                        [-0.5, -1.0, -1.5, -2.0, math.log(1.5), math.log(0.001), -2,],
-                        [1.5, 11.0, 1.5, 4.0, math.log(16.5), math.log(0.1), 2],
+                        [-0.5, -1.0, -1.5, -1.5, math.log(1.5), math.log(0.001), -2,],
+                        [1.5, 11.0, 1.5, 3.5, math.log(16.5), math.log(0.1), 2],
                     ],
                     "popsize": 5,
                     "seed": 1,

--- a/tests/integration_tests/test_cma.py
+++ b/tests/integration_tests/test_cma.py
@@ -11,6 +11,7 @@ import optuna
 from optuna.distributions import BaseDistribution
 from optuna.distributions import CategoricalDistribution
 from optuna.distributions import DiscreteUniformDistribution
+from optuna.distributions import IntLogUniformDistribution
 from optuna.distributions import IntUniformDistribution
 from optuna.distributions import LogUniformDistribution
 from optuna.distributions import UniformDistribution
@@ -151,6 +152,8 @@ class TestOptimizer(object):
             "d": DiscreteUniformDistribution(-1, 9, 2),
             "i": IntUniformDistribution(-1, 1),
             "ii": IntUniformDistribution(-1, 3, 2),
+            "il": IntLogUniformDistribution(2, 16),
+            "ili": IntLogUniformDistribution(2, 16, 2),
             "l": LogUniformDistribution(0.001, 0.1),
             "u": UniformDistribution(-2, 2),
         }
@@ -164,6 +167,8 @@ class TestOptimizer(object):
             "d": -1,
             "i": -1,
             "ii": -1,
+            "il": 2,
+            "ili": 2,
             "l": 0.001,
             "u": -2,
         }
@@ -176,13 +181,22 @@ class TestOptimizer(object):
                 search_space, x0, 0.2, None, {"popsize": 5, "seed": 1}
             )
             assert mock_obj.mock_calls[0] == call(
-                [0, 0, -1, -1, math.log(0.001), -2],
+                [0, 0, -1, -1, math.log(2), math.log(2), math.log(0.001), -2],
                 0.2,
                 {
                     "BoundaryHandler": cma.BoundTransform,
                     "bounds": [
-                        [-0.5, -1.0, -1.5, -1.5, math.log(0.001), -2],
-                        [1.5, 11.0, 1.5, 3.5, math.log(0.1), 2],
+                        [
+                            -0.5,
+                            -1.0,
+                            -1.5,
+                            -2.0,
+                            math.log(1.5),
+                            math.log(1.5),
+                            math.log(0.001),
+                            -2,
+                        ],
+                        [1.5, 11.0, 1.5, 4.0, math.log(16.5), math.log(16.5), math.log(0.1), 2],
                     ],
                     "popsize": 5,
                     "seed": 1,

--- a/tests/integration_tests/test_cma.py
+++ b/tests/integration_tests/test_cma.py
@@ -153,7 +153,6 @@ class TestOptimizer(object):
             "i": IntUniformDistribution(-1, 1),
             "ii": IntUniformDistribution(-1, 3, 2),
             "il": IntLogUniformDistribution(2, 16),
-            "ili": IntLogUniformDistribution(2, 16, 2),
             "l": LogUniformDistribution(0.001, 0.1),
             "u": UniformDistribution(-2, 2),
         }
@@ -168,7 +167,6 @@ class TestOptimizer(object):
             "i": -1,
             "ii": -1,
             "il": 2,
-            "ili": 2,
             "l": 0.001,
             "u": -2,
         }
@@ -181,22 +179,13 @@ class TestOptimizer(object):
                 search_space, x0, 0.2, None, {"popsize": 5, "seed": 1}
             )
             assert mock_obj.mock_calls[0] == call(
-                [0, 0, -1, -1, math.log(2), math.log(2), math.log(0.001), -2],
+                [0, 0, -1, -1, math.log(2), math.log(0.001), -2],
                 0.2,
                 {
                     "BoundaryHandler": cma.BoundTransform,
                     "bounds": [
-                        [
-                            -0.5,
-                            -1.0,
-                            -1.5,
-                            -2.0,
-                            math.log(1.5),
-                            math.log(1.5),
-                            math.log(0.001),
-                            -2,
-                        ],
-                        [1.5, 11.0, 1.5, 4.0, math.log(16.5), math.log(16.5), math.log(0.1), 2],
+                        [-0.5, -1.0, -1.5, -2.0, math.log(1.5), math.log(0.001), -2,],
+                        [1.5, 11.0, 1.5, 4.0, math.log(16.5), math.log(0.1), 2],
                     ],
                     "popsize": 5,
                     "seed": 1,


### PR DESCRIPTION
## Motivation
This one of the follow-up PRs of #1201.

## Description of the changes
This PR adds support for `IntLogUniformDistribution` to `optuna.integration.CmaEsSampler`.

I have two concerns about this implementation:
- Although `optuna.samplers.CmaEsSampler` quantizes the suggested values by `step` in the log domain, this implementation quantizes them in the linear domain similarly to the `optuna.samplers.RandomSampler`. If this change is acceptable, I think I also update the `optuna.samplers.CmaEsSampler`.
- When `optuna.samplers.RandomSampler` suggests values from `DiscreteUniformDistribution`, it expands `low` and `high` by `0.5 * q` to make the bins of quantization equivalent to others. On the other hand, it expands `0.5` when it uses `IntLogUniformDistribution`. I think this is because the `low` can be negative depending on `step`. In the most cases, users will use `step=1`  and the calculation will be correct. So, I follow this definition in `optuna.integration.CmaEsSampler`, but I'm a bit concerned about performance degradation when users specify `step>1`.