### PR TITLE
Add PyPI release to workflow.

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -37,4 +37,10 @@ jobs:
         password: ${{ secrets.test_pypi_password }}
         repository_url: https://test.pypi.org/legacy/
 
-    # TODO(toshihikoyanase): Add tasks to upload packages to PyPI.
+    - name: Publish distribution to PyPI
+      # The following upload action cannot be executed in the forked repository.
+      if: github.repository == 'optuna/optuna'
+      uses: pypa/gh-action-pypi-publish@v1.1.0
+      with:
+        user: __token__
+        password: ${{ secrets.pypi_password }}


### PR DESCRIPTION
## Motivation
This PR depends on #1291. 

## Description of the changes
This PR adds a step to upload distribution packages to PyPI.

TODO
- [x] Add an access token to Github Secret.