### PR TITLE
Apply #1291 and #1306 to the `release-v1.5.0`.

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -1,14 +1,10 @@
 name: Publish distributions to TestPyPI and PyPI
 
-# Only activate if the v* tag is pushed.
+# Only activate if the release is published.
 on:
-  push:
-    tags:
-      - v*
-  # TODO(toshihikoyanase): Remove pull_request when you enable PyPI upload.
-  pull_request:
-    branches:
-      - master
+  release:
+    types:
+      - published
 
 jobs:
   build-n-publish:
@@ -32,11 +28,13 @@ jobs:
     - name: Verify the distributions
       run: twine check dist/*
 
-    # Save the package to the GitHub Actions' artifact. It will be deleted after 90 days.
-    - name: Save dist directory
-      uses: actions/upload-artifact@v1
+    - name: Publish distribution to Test PyPI
+      # The following upload action cannot be executed in the forked repository.
+      if: github.repository == 'optuna/optuna'
+      uses: pypa/gh-action-pypi-publish@v1.1.0
       with:
-        name: optuna-dist
-        path: dist
+        user: __token__
+        password: ${{ secrets.test_pypi_password }}
+        repository_url: https://test.pypi.org/legacy/
 
-    # TODO(toshihikoyanase): Add tasks to upload packages to TestPyPI and PyPI.
+    # TODO(toshihikoyanase): Add tasks to upload packages to PyPI.

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -37,4 +37,10 @@ jobs:
         password: ${{ secrets.test_pypi_password }}
         repository_url: https://test.pypi.org/legacy/
 
-    # TODO(toshihikoyanase): Add tasks to upload packages to PyPI.
+    - name: Publish distribution to PyPI
+      # The following upload action cannot be executed in the forked repository.
+      if: github.repository == 'optuna/optuna'
+      uses: pypa/gh-action-pypi-publish@v1.1.0
+      with:
+        user: __token__
+        password: ${{ secrets.pypi_password }}


### PR DESCRIPTION
This PR backports #1291 and #1306 to the `release-v1.5.0`.