### PR TITLE
Add missing documentation for `BaseStorage.set_trial_param`.

### DIFF
--- a/optuna/storages/base.py
+++ b/optuna/storages/base.py
@@ -375,6 +375,8 @@ class BaseStorage(object, metaclass=abc.ABCMeta):
                 If no trial with the matching ``trial_id`` exists.
             :exc:`RuntimeError`:
                 If the trial is already finished.
+            :exc:`ValueError`:
+                If the parameter is already set and the distribution is different.
         """
         raise NotImplementedError
 


### PR DESCRIPTION
## Motivation

Documentation should reflect the logic. Some explanation about raised exceptions in `BaseStorage.set_trial_param` were missing.

## Description of the changes

Document how `ValueError`s are raised from `BaseStorage.set_trial_param`. Note that this behavior is already tested in https://github.com/optuna/optuna/blob/master/tests/storages_tests/test_storages.py#L535-L544.