### PR TITLE
Exempt issues with `no-stale` labelel from stale bot.

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -20,4 +20,4 @@ jobs:
         days-before-close: -1
         stale-issue-label: 'stale'
         stale-pr-label: 'stale'
-        exempt-issue-labels: 'bug,no-stale'
+        exempt-issue-labels: 'no-stale'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -20,4 +20,4 @@ jobs:
         days-before-close: -1
         stale-issue-label: 'stale'
         stale-pr-label: 'stale'
-        exempt-issue-labels: 'bug,contribution-welcome'
+        exempt-issue-labels: 'bug,no-stale'


### PR DESCRIPTION
**Before**

Exempt: bug,contribution-welcome

**After**

Exempt: bug, no-stale

<!-- Thank you for creating a pull request! -->

<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
Currently stale bot marks release tracker issues that theoretically not marked because we don't have an appropriate label which is exempt from the bot. So I've created a new label of "no-stale" and this PR updates the workflow and removes `bug` and `contribution-welcome`.

 Upon this PR gets merged, I'd love developers with write access to handle `bug`/`contribution-welcome` issues as follows
1. Attach both `bug`/`contribution-welcome` and `no-stale`.
2. Once someone (or you) is decided to tackle it, remove `no-stale`. This is because `stale` bot would help you and contributor stay tuned.