### PR TITLE
Raise `ImportError` if `bokeh` version is 2.0.0 or newer.

### DIFF
--- a/optuna/dashboard.py
+++ b/optuna/dashboard.py
@@ -27,6 +27,20 @@ with try_import() as _imports:
     import bokeh.themes
     import tornado.gen
 
+if _imports.is_successful():
+    from distutils.version import StrictVersion
+
+    from bokeh import __version__ as bokeh_version
+
+    if StrictVersion(bokeh_version) >= StrictVersion("2.0.0"):
+        raise ImportError(
+            "Your version of bokeh is " + bokeh_version + " . "
+            "Please install bokeh version earlier than 2.0.0. "
+            "Bokeh can be installed by executing `$ pip install 'bokeh<2.0.0'`. "
+            "For further information, please refer to the installation guide of bokeh. "
+        )
+
+
 _mode = None  # type: Optional[str]
 _study = None  # type: Optional[optuna.study.Study]
 

--- a/optuna/dashboard.py
+++ b/optuna/dashboard.py
@@ -1,4 +1,5 @@
 import collections
+from distutils.version import StrictVersion
 import threading
 import time
 
@@ -18,8 +19,6 @@ if type_checking.TYPE_CHECKING:
     from typing import Optional  # NOQA
 
 with try_import() as _imports:
-    from distutils.version import StrictVersion
-
     from bokeh import __version__ as bokeh_version
     import bokeh.command.bootstrap
     import bokeh.document  # NOQA

--- a/optuna/dashboard.py
+++ b/optuna/dashboard.py
@@ -18,6 +18,9 @@ if type_checking.TYPE_CHECKING:
     from typing import Optional  # NOQA
 
 with try_import() as _imports:
+    from distutils.version import StrictVersion
+
+    from bokeh import __version__ as bokeh_version
     import bokeh.command.bootstrap
     import bokeh.document  # NOQA
     import bokeh.layouts
@@ -27,17 +30,13 @@ with try_import() as _imports:
     import bokeh.themes
     import tornado.gen
 
-if _imports.is_successful():
-    from distutils.version import StrictVersion
-
-    from bokeh import __version__ as bokeh_version
-
     if StrictVersion(bokeh_version) >= StrictVersion("2.0.0"):
         raise ImportError(
             "Your version of bokeh is " + bokeh_version + " . "
             "Please install bokeh version earlier than 2.0.0. "
             "Bokeh can be installed by executing `$ pip install 'bokeh<2.0.0'`. "
-            "For further information, please refer to the installation guide of bokeh. "
+            "For further information, please refer to the installation guide of bokeh. ",
+            name="bokeh",
         )
 
 


### PR DESCRIPTION
## Motivation
This PR addresses #1319 and #1320 

The current dashboard is not compatible with `bokeh>=2.0.0`, and it may not work correctly without showing any error messages.

## Description of the changes

This PR adds version checking of `bokeh`. Note that this modification will conflict with #1315 , please merge it in advance.