### PR TITLE
`BaseStorage.set_trial_param` to return `None` instead of `bool`.

### DIFF
--- a/optuna/distributions.py
+++ b/optuna/distributions.py
@@ -1,17 +1,13 @@
 import abc
 import decimal
 import json
+from typing import Any  # NOQA
+from typing import Dict  # NOQA
+from typing import Sequence  # NOQA
+from typing import Union
 import warnings
 
-from optuna import type_checking
-
-if type_checking.TYPE_CHECKING:
-    from typing import Any  # NOQA
-    from typing import Dict  # NOQA
-    from typing import Sequence  # NOQA
-    from typing import Union  # NOQA
-
-    CategoricalChoiceType = Union[None, bool, int, float, str]
+CategoricalChoiceType = Union[None, bool, int, float, str]
 
 
 class BaseDistribution(object, metaclass=abc.ABCMeta):
@@ -545,3 +541,22 @@ def _adjust_int_uniform_high(low: int, high: int, step: int) -> int:
             )
         )
     return high
+
+
+def _get_single_value(distribution: BaseDistribution) -> Union[int, float, CategoricalChoiceType]:
+    assert distribution.single()
+
+    if isinstance(
+        distribution,
+        (
+            UniformDistribution,
+            LogUniformDistribution,
+            DiscreteUniformDistribution,
+            IntUniformDistribution,
+            IntLogUniformDistribution,
+        ),
+    ):
+        return distribution.low
+    elif isinstance(distribution, CategoricalDistribution):
+        return distribution.choices[0]
+    assert False

--- a/optuna/distributions.py
+++ b/optuna/distributions.py
@@ -1,13 +1,17 @@
 import abc
 import decimal
 import json
-from typing import Any  # NOQA
-from typing import Dict  # NOQA
-from typing import Sequence  # NOQA
-from typing import Union
 import warnings
 
-CategoricalChoiceType = Union[None, bool, int, float, str]
+from optuna import type_checking
+
+if type_checking.TYPE_CHECKING:
+    from typing import Any  # NOQA
+    from typing import Dict  # NOQA
+    from typing import Sequence  # NOQA
+    from typing import Union  # NOQA
+
+    CategoricalChoiceType = Union[None, bool, int, float, str]
 
 
 class BaseDistribution(object, metaclass=abc.ABCMeta):
@@ -543,7 +547,9 @@ def _adjust_int_uniform_high(low: int, high: int, step: int) -> int:
     return high
 
 
-def _get_single_value(distribution: BaseDistribution) -> Union[int, float, CategoricalChoiceType]:
+def _get_single_value(distribution):
+    # type: (BaseDistribution) -> Union[int, float, CategoricalChoiceType]
+
     assert distribution.single()
 
     if isinstance(

--- a/optuna/storages/base.py
+++ b/optuna/storages/base.py
@@ -354,8 +354,8 @@ class BaseStorage(object, metaclass=abc.ABCMeta):
         param_name: str,
         param_value_internal: float,
         distribution: "distributions.BaseDistribution",
-    ) -> bool:
-        """Add a parameter to a trial.
+    ) -> None:
+        """Set a parameter to a trial.
 
         Args:
             trial_id:
@@ -367,16 +367,11 @@ class BaseStorage(object, metaclass=abc.ABCMeta):
             distribution:
                 Sampled distribution of the parameter.
 
-        Returns:
-            :obj:`False` when the parameter is already set to the trial, :obj:`True` otherwise.
-
         Raises:
             :exc:`KeyError`:
                 If no trial with the matching ``trial_id`` exists.
             :exc:`RuntimeError`:
                 If the trial is already finished.
-            :exc:`ValueError`:
-                If the parameter is already set and the distribution is different.
         """
         raise NotImplementedError
 

--- a/optuna/storages/cached_storage.py
+++ b/optuna/storages/cached_storage.py
@@ -37,6 +37,8 @@ class _StudyInfo:
         self.owned_or_finished_trial_ids = set()  # type: Set[int]
         # Cache any writes which are not reflected to the actual storage yet in updates.
         self.updates = dict()  # type: Dict[int, _TrialUpdate]
+        # Cache distributions to avoid storage access on distribution consistency check.
+        self.param_distribution = {}  # type: Dict[str, distributions.BaseDistribution]
         self.direction = StudyDirection.NOT_SET  # type: StudyDirection
         self.name = None  # type: Optional[str]
 
@@ -221,15 +223,29 @@ class _CachedStorage(base.BaseStorage):
             cached_trial = self._get_cached_trial(trial_id)
             if cached_trial is not None:
                 self._check_trial_is_updatable(cached_trial)
-                updates = self._get_updates(trial_id)
+
+                study_id, _ = self._trial_id_to_study_id_and_number[trial_id]
+                cached_dist = self._studies[study_id].param_distribution.get(param_name, None)
+                if cached_dist:
+                    distributions.check_distribution_compatibility(cached_dist, distribution)
+                else:
+                    self._backend._check_or_set_param_distribution(
+                        trial_id, param_name, param_value_internal, distribution
+                    )
+                    self._studies[study_id].param_distribution[param_name] = distribution
+
                 params = copy.copy(cached_trial.params)
                 params[param_name] = distribution.to_external_repr(param_value_internal)
                 cached_trial.params = params
+
                 dists = copy.copy(cached_trial.distributions)
                 dists[param_name] = distribution
                 cached_trial.distributions = dists
-                updates.params[param_name] = param_value_internal
-                updates.distributions[param_name] = distribution
+
+                if cached_dist:
+                    updates = self._get_updates(trial_id)
+                    updates.params[param_name] = param_value_internal
+                    updates.distributions[param_name] = distribution
                 return
 
         self._backend.set_trial_param(trial_id, param_name, param_value_internal, distribution)

--- a/optuna/storages/in_memory.py
+++ b/optuna/storages/in_memory.py
@@ -243,7 +243,7 @@ class InMemoryStorage(base.BaseStorage):
             return True
 
     def set_trial_param(self, trial_id, param_name, param_value_internal, distribution):
-        # type: (int, str, float, distributions.BaseDistribution) -> bool
+        # type: (int, str, float, distributions.BaseDistribution) -> None
 
         with self._lock:
             trial = self._get_trial(trial_id)
@@ -251,15 +251,6 @@ class InMemoryStorage(base.BaseStorage):
             self.check_trial_is_updatable(trial_id, trial.state)
 
             study_id = self._trial_id_to_study_id_and_number[trial_id][0]
-            # Check param distribution compatibility with previous trial(s).
-            if param_name in self._studies[study_id].param_distribution:
-                distributions.check_distribution_compatibility(
-                    self._studies[study_id].param_distribution[param_name], distribution
-                )
-
-            # Check param has not been set; otherwise, return False.
-            if param_name in trial.params:
-                return False
 
             # Set param distribution.
             self._studies[study_id].param_distribution[param_name] = distribution
@@ -271,8 +262,6 @@ class InMemoryStorage(base.BaseStorage):
             trial.distributions = copy.copy(trial.distributions)
             trial.distributions[param_name] = distribution
             self._set_trial(trial_id, trial)
-
-            return True
 
     def get_trial_number_from_id(self, trial_id):
         # type: (int) -> int

--- a/optuna/storages/in_memory.py
+++ b/optuna/storages/in_memory.py
@@ -251,6 +251,11 @@ class InMemoryStorage(base.BaseStorage):
             self.check_trial_is_updatable(trial_id, trial.state)
 
             study_id = self._trial_id_to_study_id_and_number[trial_id][0]
+            # Check param distribution compatibility with previous trial(s).
+            if param_name in self._studies[study_id].param_distribution:
+                distributions.check_distribution_compatibility(
+                    self._studies[study_id].param_distribution[param_name], distribution
+                )
 
             # Set param distribution.
             self._studies[study_id].param_distribution[param_name] = distribution

--- a/optuna/storages/rdb/storage.py
+++ b/optuna/storages/rdb/storage.py
@@ -709,23 +709,20 @@ class RDBStorage(BaseStorage):
         return self._commit_with_integrity_check(session)
 
     def set_trial_param(self, trial_id, param_name, param_value_internal, distribution):
-        # type: (int, str, float, distributions.BaseDistribution) -> bool
+        # type: (int, str, float, distributions.BaseDistribution) -> None
 
         session = self.scoped_session()
 
-        if not self._set_trial_param_without_commit(
+        self._set_trial_param_without_commit(
             session, trial_id, param_name, param_value_internal, distribution
-        ):
-            return False
+        )
 
-        commit_success = self._commit_with_integrity_check(session)
-
-        return commit_success
+        self._commit_with_integrity_check(session)
 
     def _set_trial_param_without_commit(
         self, session, trial_id, param_name, param_value_internal, distribution
     ):
-        # type: (orm.Session, int, str, float, distributions.BaseDistribution) -> bool
+        # type: (orm.Session, int, str, float, distributions.BaseDistribution) -> None
 
         trial = models.TrialModel.find_or_raise_by_id(trial_id, session)
         self.check_trial_is_updatable(trial_id, trial.state)
@@ -735,66 +732,17 @@ class RDBStorage(BaseStorage):
         )
 
         if trial_param is not None:
-            # Raise error in case distribution is incompatible.
-            distributions.check_distribution_compatibility(
-                distributions.json_to_distribution(trial_param.distribution_json), distribution
-            )
-
-            # Terminate transaction explicitly to avoid connection timeout during transaction.
-            self._commit(session)
-            # Return False when distribution is compatible but parameter has already been set.
-            return False
-
-        param = models.TrialParamModel(
-            trial_id=trial_id,
-            param_name=param_name,
-            param_value=param_value_internal,
-            distribution_json=distributions.distribution_to_json(distribution),
-        )
-
-        param.check_and_add(session)
-
-        return True
-
-    def _check_or_set_param_distribution(
-        self,
-        trial_id: int,
-        param_name: str,
-        param_value_internal: float,
-        distribution: distributions.BaseDistribution,
-    ) -> None:
-
-        session = self.scoped_session()
-
-        # Acquire a lock of this trial.
-        trial = models.TrialModel.find_by_id(trial_id, session, for_update=True)
-        if trial is None:
-            raise KeyError(models.NOT_FOUND_MSG)
-
-        previous_record = (
-            session.query(models.TrialParamModel)
-            .join(models.TrialModel)
-            .filter(models.TrialModel.study_id == trial.study_id)
-            .filter(models.TrialParamModel.param_name == param_name)
-            .first()
-        )
-        if previous_record is not None:
-            distributions.check_distribution_compatibility(
-                distributions.json_to_distribution(previous_record.distribution_json),
-                distribution,
-            )
+            trial_param.param_value = param_value_internal
+            trial_param.distribution_json = distributions.distribution_to_json(distribution)
         else:
-            session.add(
-                models.TrialParamModel(
-                    trial_id=trial_id,
-                    param_name=param_name,
-                    param_value=param_value_internal,
-                    distribution_json=distributions.distribution_to_json(distribution),
-                )
+            trial_param = models.TrialParamModel(
+                trial_id=trial_id,
+                param_name=param_name,
+                param_value=param_value_internal,
+                distribution_json=distributions.distribution_to_json(distribution),
             )
 
-        # Release lock.
-        session.commit()
+            trial_param.check_and_add(session)
 
     def get_trial_param(self, trial_id, param_name):
         # type: (int, str) -> float

--- a/optuna/storages/redis.py
+++ b/optuna/storages/redis.py
@@ -387,9 +387,15 @@ class RedisStorage(base.BaseStorage):
         self._check_trial_id(trial_id)
         self.check_trial_is_updatable(trial_id, self.get_trial(trial_id).state)
 
-        trial = self.get_trial(trial_id)
+        # Check param distribution compatibility with previous trial(s).
         study_id = self.get_study_id_from_trial_id(trial_id)
         param_distribution = self._get_study_param_distribution(study_id)
+        if param_name in param_distribution:
+            distributions.check_distribution_compatibility(
+                param_distribution[param_name], distribution
+            )
+
+        trial = self.get_trial(trial_id)
 
         with self._redis.pipeline() as pipe:
             pipe.multi()

--- a/optuna/trial/_trial.py
+++ b/optuna/trial/_trial.py
@@ -215,9 +215,6 @@ class Trial(BaseTrial):
 
         self._check_distribution(name, distribution)
 
-        if distribution.low == distribution.high:
-            return self._set_new_param_or_get_existing(name, distribution.low, distribution)
-
         return self._suggest(name, distribution)
 
     def suggest_loguniform(self, name, low, high):
@@ -270,9 +267,6 @@ class Trial(BaseTrial):
         distribution = LogUniformDistribution(low=low, high=high)
 
         self._check_distribution(name, distribution)
-
-        if distribution.low == distribution.high:
-            return self._set_new_param_or_get_existing(name, distribution.low, distribution)
 
         return self._suggest(name, distribution)
 
@@ -333,9 +327,6 @@ class Trial(BaseTrial):
         distribution = DiscreteUniformDistribution(low=low, high=high, q=q)
 
         self._check_distribution(name, distribution)
-
-        if distribution.low == distribution.high:
-            return self._set_new_param_or_get_existing(name, distribution.low, distribution)
 
         return self._suggest(name, distribution)
 
@@ -408,9 +399,6 @@ class Trial(BaseTrial):
             distribution = IntUniformDistribution(low=low, high=high, step=step)
 
         self._check_distribution(name, distribution)
-
-        if distribution.low == distribution.high:
-            return self._set_new_param_or_get_existing(name, distribution.low, distribution)
 
         return int(self._suggest(name, distribution))
 
@@ -638,29 +626,31 @@ class Trial(BaseTrial):
     def _suggest(self, name, distribution):
         # type: (str, BaseDistribution) -> Any
 
+        storage = self.storage
+        trial_id = self._trial_id
+
+        # Do an early return if parameter with `name` is already suggested.
+        prev_distributions = storage.get_trial(trial_id).distributions
+        if name in prev_distributions:
+            distributions.check_distribution_compatibility(prev_distributions[name], distribution)
+            return distribution.to_external_repr(storage.get_trial_param(trial_id, name))
+
+        # Parameter has not yet been suggested and must be written to the storage.
         if self._is_fixed_param(name, distribution):
-            param_value = self.storage.get_trial_system_attrs(self._trial_id)["fixed_params"][name]
+            param_value = storage.get_trial_system_attrs(trial_id)["fixed_params"][name]
+        elif distribution.single():
+            param_value = distributions._get_single_value(distribution)
         elif self._is_relative_param(name, distribution):
             param_value = self.relative_params[name]
         else:
-            trial = self.storage.get_trial(self._trial_id)
-
+            trial = storage.get_trial(trial_id)
             study = pruners._filter_study(self.study, trial)
-
             param_value = self.study.sampler.sample_independent(study, trial, name, distribution)
 
-        return self._set_new_param_or_get_existing(name, param_value, distribution)
-
-    def _set_new_param_or_get_existing(self, name, param_value, distribution):
-        # type: (str, Any, BaseDistribution) -> Any
-
         param_value_in_internal_repr = distribution.to_internal_repr(param_value)
-        set_success = self.storage.set_trial_param(
-            self._trial_id, name, param_value_in_internal_repr, distribution
+        set_success = storage.set_trial_param(
+            trial_id, name, param_value_in_internal_repr, distribution
         )
-        if not set_success:
-            param_value_in_internal_repr = self.storage.get_trial_param(self._trial_id, name)
-            param_value = distribution.to_external_repr(param_value_in_internal_repr)
 
         return param_value
 

--- a/optuna/trial/_trial.py
+++ b/optuna/trial/_trial.py
@@ -630,11 +630,10 @@ class Trial(BaseTrial):
         trial_id = self._trial_id
 
         trial = storage.get_trial(trial_id)
-        trial_distributions = trial.distributions
 
-        if name in trial_distributions:
+        if name in trial.distributions:
             # No need to sample if already suggested.
-            distributions.check_distribution_compatibility(trial_distributions[name], distribution)
+            distributions.check_distribution_compatibility(trial.distributions[name], distribution)
             param_value = distribution.to_external_repr(storage.get_trial_param(trial_id, name))
         else:
             if self._is_fixed_param(name, distribution):

--- a/optuna/trial/_trial.py
+++ b/optuna/trial/_trial.py
@@ -629,10 +629,12 @@ class Trial(BaseTrial):
         storage = self.storage
         trial_id = self._trial_id
 
-        prev_distributions = storage.get_trial(trial_id).distributions
-        if name in prev_distributions:
+        trial = storage.get_trial(trial_id)
+        trial_distributions = trial.distributions
+
+        if name in trial_distributions:
             # No need to sample if already suggested.
-            distributions.check_distribution_compatibility(prev_distributions[name], distribution)
+            distributions.check_distribution_compatibility(trial_distributions[name], distribution)
             param_value = distribution.to_external_repr(storage.get_trial_param(trial_id, name))
         else:
             if self._is_fixed_param(name, distribution):
@@ -642,7 +644,6 @@ class Trial(BaseTrial):
             elif self._is_relative_param(name, distribution):
                 param_value = self.relative_params[name]
             else:
-                trial = storage.get_trial(trial_id)
                 study = pruners._filter_study(self.study, trial)
                 param_value = self.study.sampler.sample_independent(
                     study, trial, name, distribution

--- a/tests/storages_tests/test_storages.py
+++ b/tests/storages_tests/test_storages.py
@@ -533,6 +533,17 @@ def test_set_trial_param(storage_mode: str) -> None:
         assert storage.get_trial(trial_id_2).params == {"x": 0.3, "z": 0.1}
         assert storage.get_trial_params(trial_id_2) == {"x": 0.3, "z": 0.1}
 
+        # Set params with distributions that do not match previous ones.
+        with pytest.raises(ValueError):
+            storage.set_trial_param(trial_id_2, "x", 0.5, distribution_z)
+        with pytest.raises(ValueError):
+            storage.set_trial_param(trial_id_2, "y", 0.5, distribution_z)
+        # Choices in CategoricalDistribution should match including its order.
+        with pytest.raises(ValueError):
+            storage.set_trial_param(
+                trial_id_2, "y", 2, CategoricalDistribution(choices=("Meguro", "Shibuya", "Ebisu"))
+            )
+
         storage.set_trial_state(trial_id_2, TrialState.COMPLETE)
         # Cannot assign params to finished trial.
         with pytest.raises(RuntimeError):

--- a/tests/storages_tests/test_storages.py
+++ b/tests/storages_tests/test_storages.py
@@ -512,36 +512,26 @@ def test_set_trial_param(storage_mode: str) -> None:
         distribution_z = LogUniformDistribution(low=1.0, high=100.0)
 
         # Set new params.
-        assert storage.set_trial_param(trial_id_1, "x", 0.5, distribution_x)
-        assert storage.set_trial_param(trial_id_1, "y", 2, distribution_y_1)
+        storage.set_trial_param(trial_id_1, "x", 0.5, distribution_x)
+        storage.set_trial_param(trial_id_1, "y", 2, distribution_y_1)
         assert storage.get_trial_param(trial_id_1, "x") == 0.5
         assert storage.get_trial_param(trial_id_1, "y") == 2
         # Check set_param breaks neither get_trial nor get_trial_params.
         assert storage.get_trial(trial_id_1).params == {"x": 0.5, "y": "Meguro"}
         assert storage.get_trial_params(trial_id_1) == {"x": 0.5, "y": "Meguro"}
-        # Duplicated registration should return False.
-        assert not storage.set_trial_param(trial_id_1, "x", 0.6, distribution_x)
-        # Duplicated registration should not change the existing value.
-        assert storage.get_trial_param(trial_id_1, "x") == 0.5
+        # Duplicated registration should overwrite.
+        storage.set_trial_param(trial_id_1, "x", 0.6, distribution_x)
+        assert storage.get_trial_param(trial_id_1, "x") == 0.6
+        assert storage.get_trial(trial_id_1).params == {"x": 0.6, "y": "Meguro"}
+        assert storage.get_trial_params(trial_id_1) == {"x": 0.6, "y": "Meguro"}
 
         # Set params to another trial.
-        assert storage.set_trial_param(trial_id_2, "x", 0.3, distribution_x)
-        assert storage.set_trial_param(trial_id_2, "z", 0.1, distribution_z)
+        storage.set_trial_param(trial_id_2, "x", 0.3, distribution_x)
+        storage.set_trial_param(trial_id_2, "z", 0.1, distribution_z)
         assert storage.get_trial_param(trial_id_2, "x") == 0.3
         assert storage.get_trial_param(trial_id_2, "z") == 0.1
         assert storage.get_trial(trial_id_2).params == {"x": 0.3, "z": 0.1}
         assert storage.get_trial_params(trial_id_2) == {"x": 0.3, "z": 0.1}
-
-        # Set params with distributions that do not match previous ones.
-        with pytest.raises(ValueError):
-            storage.set_trial_param(trial_id_2, "x", 0.5, distribution_z)
-        with pytest.raises(ValueError):
-            storage.set_trial_param(trial_id_2, "y", 0.5, distribution_z)
-        # Choices in CategoricalDistribution should match including its order.
-        with pytest.raises(ValueError):
-            storage.set_trial_param(
-                trial_id_2, "y", 2, CategoricalDistribution(choices=("Meguro", "Shibuya", "Ebisu"))
-            )
 
         storage.set_trial_state(trial_id_2, TrialState.COMPLETE)
         # Cannot assign params to finished trial.
@@ -555,7 +545,7 @@ def test_set_trial_param(storage_mode: str) -> None:
             storage.set_trial_param(trial_id_2, "y", 0.4, distribution_z)
 
         # Set params of trials in a different study.
-        assert storage.set_trial_param(trial_id_3, "y", 1, distribution_y_2)
+        storage.set_trial_param(trial_id_3, "y", 1, distribution_y_2)
         assert storage.get_trial_param(trial_id_3, "y") == 1
         assert storage.get_trial(trial_id_3).params == {"y": "Shinsen"}
         assert storage.get_trial_params(trial_id_3) == {"y": "Shinsen"}

--- a/tests/test_trial.py
+++ b/tests/test_trial.py
@@ -142,7 +142,7 @@ def test_suggest_uniform(storage_init_func):
     # type: (Callable[[], storages.BaseStorage]) -> None
 
     mock = Mock()
-    mock.side_effect = [1.0, 2.0, 3.0]
+    mock.side_effect = [1.0, 2.0]
     sampler = samplers.RandomSampler()
 
     with patch.object(sampler, "sample_independent", mock) as mock_object:
@@ -152,9 +152,9 @@ def test_suggest_uniform(storage_init_func):
 
         assert trial._suggest("x", distribution) == 1.0  # Test suggesting a param.
         assert trial._suggest("x", distribution) == 1.0  # Test suggesting the same param.
-        assert trial._suggest("y", distribution) == 3.0  # Test suggesting a different param.
-        assert trial.params == {"x": 1.0, "y": 3.0}
-        assert mock_object.call_count == 3
+        assert trial._suggest("y", distribution) == 2.0  # Test suggesting a different param.
+        assert trial.params == {"x": 1.0, "y": 2.0}
+        assert mock_object.call_count == 2
 
 
 @parametrize_storage
@@ -168,7 +168,7 @@ def test_suggest_loguniform(storage_init_func):
         LogUniformDistribution(low=0.0, high=0.9)
 
     mock = Mock()
-    mock.side_effect = [1.0, 2.0, 3.0]
+    mock.side_effect = [1.0, 2.0]
     sampler = samplers.RandomSampler()
 
     with patch.object(sampler, "sample_independent", mock) as mock_object:
@@ -178,9 +178,9 @@ def test_suggest_loguniform(storage_init_func):
 
         assert trial._suggest("x", distribution) == 1.0  # Test suggesting a param.
         assert trial._suggest("x", distribution) == 1.0  # Test suggesting the same param.
-        assert trial._suggest("y", distribution) == 3.0  # Test suggesting a different param.
-        assert trial.params == {"x": 1.0, "y": 3.0}
-        assert mock_object.call_count == 3
+        assert trial._suggest("y", distribution) == 2.0  # Test suggesting a different param.
+        assert trial.params == {"x": 1.0, "y": 2.0}
+        assert mock_object.call_count == 2
 
 
 @parametrize_storage
@@ -188,7 +188,7 @@ def test_suggest_discrete_uniform(storage_init_func):
     # type: (Callable[[], storages.BaseStorage]) -> None
 
     mock = Mock()
-    mock.side_effect = [1.0, 2.0, 3.0]
+    mock.side_effect = [1.0, 2.0]
     sampler = samplers.RandomSampler()
 
     with patch.object(sampler, "sample_independent", mock) as mock_object:
@@ -198,9 +198,9 @@ def test_suggest_discrete_uniform(storage_init_func):
 
         assert trial._suggest("x", distribution) == 1.0  # Test suggesting a param.
         assert trial._suggest("x", distribution) == 1.0  # Test suggesting the same param.
-        assert trial._suggest("y", distribution) == 3.0  # Test suggesting a different param.
-        assert trial.params == {"x": 1.0, "y": 3.0}
-        assert mock_object.call_count == 3
+        assert trial._suggest("y", distribution) == 2.0  # Test suggesting a different param.
+        assert trial.params == {"x": 1.0, "y": 2.0}
+        assert mock_object.call_count == 2
 
 
 @parametrize_storage
@@ -210,37 +210,26 @@ def test_suggest_low_equals_high(storage_init_func):
     study = create_study(storage_init_func(), sampler=samplers.TPESampler(n_startup_trials=0))
     trial = Trial(study, study._storage.create_new_trial(study._study_id))
 
-    # Parameter values are determined without suggestion when low == high.
-    with patch.object(trial, "_suggest", wraps=trial._suggest) as mock_object:
-        assert trial.suggest_uniform("a", 1.0, 1.0) == 1.0  # Suggesting a param.
-        assert trial.suggest_uniform("a", 1.0, 1.0) == 1.0  # Suggesting the same param.
-        assert mock_object.call_count == 0
-        assert trial.suggest_loguniform("b", 1.0, 1.0) == 1.0  # Suggesting a param.
-        assert trial.suggest_loguniform("b", 1.0, 1.0) == 1.0  # Suggesting the same param.
-        assert mock_object.call_count == 0
-        assert trial.suggest_discrete_uniform("c", 1.0, 1.0, 1.0) == 1.0  # Suggesting a param.
-        assert (
-            trial.suggest_discrete_uniform("c", 1.0, 1.0, 1.0) == 1.0
-        )  # Suggesting the same param.
-        assert mock_object.call_count == 0
-        assert trial.suggest_int("d", 1, 1) == 1  # Suggesting a param.
-        assert trial.suggest_int("d", 1, 1) == 1  # Suggesting the same param.
-        assert mock_object.call_count == 0
-        assert trial.suggest_float("e", 1.0, 1.0) == 1.0  # Suggesting a param.
-        assert trial.suggest_float("e", 1.0, 1.0) == 1.0  # Suggesting the same param.
-        assert mock_object.call_count == 0
-        assert trial.suggest_float("f", 0.5, 0.5, log=True) == 0.5  # Suggesting a param.
-        assert trial.suggest_float("f", 0.5, 0.5, log=True) == 0.5  # Suggesting the same param.
-        assert mock_object.call_count == 0
-        assert trial.suggest_float("g", 0.5, 0.5, log=False) == 0.5  # Suggesting a param.
-        assert trial.suggest_float("g", 0.5, 0.5, log=False) == 0.5  # Suggesting the same param.
-        assert mock_object.call_count == 0
-        assert trial.suggest_float("h", 0.5, 0.5, step=1.0) == 0.5  # Suggesting a param.
-        assert trial.suggest_float("h", 0.5, 0.5, step=1.0) == 0.5  # Suggesting the same param.
-        assert mock_object.call_count == 0
-        assert trial.suggest_int("i", 1, 1, log=True) == 1  # Suggesting a param.
-        assert trial.suggest_int("i", 1, 1, log=True) == 1  # Suggesting the same param.
-        assert mock_object.call_count == 0
+    assert trial.suggest_uniform("a", 1.0, 1.0) == 1.0  # Suggesting a param.
+    assert trial.suggest_uniform("a", 1.0, 1.0) == 1.0  # Suggesting the same param.
+    assert trial.suggest_loguniform("b", 1.0, 1.0) == 1.0  # Suggesting a param.
+    assert trial.suggest_loguniform("b", 1.0, 1.0) == 1.0  # Suggesting the same param.
+    assert trial.suggest_discrete_uniform("c", 1.0, 1.0, 1.0) == 1.0  # Suggesting a param.
+    assert (
+        trial.suggest_discrete_uniform("c", 1.0, 1.0, 1.0) == 1.0
+    )  # Suggesting the same param.
+    assert trial.suggest_int("d", 1, 1) == 1  # Suggesting a param.
+    assert trial.suggest_int("d", 1, 1) == 1  # Suggesting the same param.
+    assert trial.suggest_float("e", 1.0, 1.0) == 1.0  # Suggesting a param.
+    assert trial.suggest_float("e", 1.0, 1.0) == 1.0  # Suggesting the same param.
+    assert trial.suggest_float("f", 0.5, 0.5, log=True) == 0.5  # Suggesting a param.
+    assert trial.suggest_float("f", 0.5, 0.5, log=True) == 0.5  # Suggesting the same param.
+    assert trial.suggest_float("g", 0.5, 0.5, log=False) == 0.5  # Suggesting a param.
+    assert trial.suggest_float("g", 0.5, 0.5, log=False) == 0.5  # Suggesting the same param.
+    assert trial.suggest_float("h", 0.5, 0.5, step=1.0) == 0.5  # Suggesting a param.
+    assert trial.suggest_float("h", 0.5, 0.5, step=1.0) == 0.5  # Suggesting the same param.
+    assert trial.suggest_int("i", 1, 1, log=True) == 1  # Suggesting a param.
+    assert trial.suggest_int("i", 1, 1, log=True) == 1  # Suggesting the same param.
 
 
 @parametrize_storage
@@ -293,7 +282,7 @@ def test_suggest_int(storage_init_func):
     # type: (Callable[[], storages.BaseStorage]) -> None
 
     mock = Mock()
-    mock.side_effect = [1, 2, 3]
+    mock.side_effect = [1, 2]
     sampler = samplers.RandomSampler()
 
     with patch.object(sampler, "sample_independent", mock) as mock_object:
@@ -303,9 +292,9 @@ def test_suggest_int(storage_init_func):
 
         assert trial._suggest("x", distribution) == 1  # Test suggesting a param.
         assert trial._suggest("x", distribution) == 1  # Test suggesting the same param.
-        assert trial._suggest("y", distribution) == 3  # Test suggesting a different param.
-        assert trial.params == {"x": 1, "y": 3}
-        assert mock_object.call_count == 3
+        assert trial._suggest("y", distribution) == 2  # Test suggesting a different param.
+        assert trial.params == {"x": 1, "y": 2}
+        assert mock_object.call_count == 2
 
 
 @parametrize_storage
@@ -357,7 +346,7 @@ def test_suggest_int_log(storage_init_func):
     # type: (Callable[[], storages.BaseStorage]) -> None
 
     mock = Mock()
-    mock.side_effect = [1, 2, 3]
+    mock.side_effect = [1, 2]
     sampler = samplers.RandomSampler()
 
     with patch.object(sampler, "sample_independent", mock) as mock_object:
@@ -367,9 +356,9 @@ def test_suggest_int_log(storage_init_func):
 
         assert trial._suggest("x", distribution) == 1  # Test suggesting a param.
         assert trial._suggest("x", distribution) == 1  # Test suggesting the same param.
-        assert trial._suggest("y", distribution) == 3  # Test suggesting a different param.
-        assert trial.params == {"x": 1, "y": 3}
-        assert mock_object.call_count == 3
+        assert trial._suggest("y", distribution) == 2  # Test suggesting a different param.
+        assert trial.params == {"x": 1, "y": 2}
+        assert mock_object.call_count == 2
 
     with pytest.raises(ValueError):
         study = create_study(storage_init_func(), sampler=sampler)

--- a/tests/test_trial.py
+++ b/tests/test_trial.py
@@ -215,9 +215,7 @@ def test_suggest_low_equals_high(storage_init_func):
     assert trial.suggest_loguniform("b", 1.0, 1.0) == 1.0  # Suggesting a param.
     assert trial.suggest_loguniform("b", 1.0, 1.0) == 1.0  # Suggesting the same param.
     assert trial.suggest_discrete_uniform("c", 1.0, 1.0, 1.0) == 1.0  # Suggesting a param.
-    assert (
-        trial.suggest_discrete_uniform("c", 1.0, 1.0, 1.0) == 1.0
-    )  # Suggesting the same param.
+    assert trial.suggest_discrete_uniform("c", 1.0, 1.0, 1.0) == 1.0  # Suggesting the same param.
     assert trial.suggest_int("d", 1, 1) == 1  # Suggesting a param.
     assert trial.suggest_int("d", 1, 1) == 1  # Suggesting the same param.
     assert trial.suggest_float("e", 1.0, 1.0) == 1.0  # Suggesting a param.

--- a/tests/test_trial.py
+++ b/tests/test_trial.py
@@ -10,6 +10,7 @@ import warnings
 import numpy as np
 import pytest
 
+import optuna
 from optuna.distributions import CategoricalDistribution
 from optuna.distributions import DiscreteUniformDistribution
 from optuna.distributions import IntLogUniformDistribution
@@ -267,24 +268,55 @@ def test_suggest_low_equals_high(storage_init_func):
     study = create_study(storage_init_func(), sampler=samplers.TPESampler(n_startup_trials=0))
     trial = Trial(study, study._storage.create_new_trial(study._study_id))
 
-    assert trial.suggest_uniform("a", 1.0, 1.0) == 1.0  # Suggesting a param.
-    assert trial.suggest_uniform("a", 1.0, 1.0) == 1.0  # Suggesting the same param.
-    assert trial.suggest_loguniform("b", 1.0, 1.0) == 1.0  # Suggesting a param.
-    assert trial.suggest_loguniform("b", 1.0, 1.0) == 1.0  # Suggesting the same param.
-    assert trial.suggest_discrete_uniform("c", 1.0, 1.0, 1.0) == 1.0  # Suggesting a param.
-    assert trial.suggest_discrete_uniform("c", 1.0, 1.0, 1.0) == 1.0  # Suggesting the same param.
-    assert trial.suggest_int("d", 1, 1) == 1  # Suggesting a param.
-    assert trial.suggest_int("d", 1, 1) == 1  # Suggesting the same param.
-    assert trial.suggest_float("e", 1.0, 1.0) == 1.0  # Suggesting a param.
-    assert trial.suggest_float("e", 1.0, 1.0) == 1.0  # Suggesting the same param.
-    assert trial.suggest_float("f", 0.5, 0.5, log=True) == 0.5  # Suggesting a param.
-    assert trial.suggest_float("f", 0.5, 0.5, log=True) == 0.5  # Suggesting the same param.
-    assert trial.suggest_float("g", 0.5, 0.5, log=False) == 0.5  # Suggesting a param.
-    assert trial.suggest_float("g", 0.5, 0.5, log=False) == 0.5  # Suggesting the same param.
-    assert trial.suggest_float("h", 0.5, 0.5, step=1.0) == 0.5  # Suggesting a param.
-    assert trial.suggest_float("h", 0.5, 0.5, step=1.0) == 0.5  # Suggesting the same param.
-    assert trial.suggest_int("i", 1, 1, log=True) == 1  # Suggesting a param.
-    assert trial.suggest_int("i", 1, 1, log=True) == 1  # Suggesting the same param.
+    with patch.object(
+        optuna.distributions, "_get_single_value", wraps=optuna.distributions._get_single_value
+    ) as mock_object:
+        assert trial.suggest_uniform("a", 1.0, 1.0) == 1.0  # Suggesting a param.
+        assert mock_object.call_count == 1
+        assert trial.suggest_uniform("a", 1.0, 1.0) == 1.0  # Suggesting the same param.
+        assert mock_object.call_count == 1
+
+        assert trial.suggest_loguniform("b", 1.0, 1.0) == 1.0  # Suggesting a param.
+        assert mock_object.call_count == 2
+        assert trial.suggest_loguniform("b", 1.0, 1.0) == 1.0  # Suggesting the same param.
+        assert mock_object.call_count == 2
+
+        assert trial.suggest_discrete_uniform("c", 1.0, 1.0, 1.0) == 1.0  # Suggesting a param.
+        assert mock_object.call_count == 3
+        assert (
+            trial.suggest_discrete_uniform("c", 1.0, 1.0, 1.0) == 1.0
+        )  # Suggesting the same param.
+        assert mock_object.call_count == 3
+
+        assert trial.suggest_int("d", 1, 1) == 1  # Suggesting a param.
+        assert mock_object.call_count == 4
+        assert trial.suggest_int("d", 1, 1) == 1  # Suggesting the same param.
+        assert mock_object.call_count == 4
+
+        assert trial.suggest_float("e", 1.0, 1.0) == 1.0  # Suggesting a param.
+        assert mock_object.call_count == 5
+        assert trial.suggest_float("e", 1.0, 1.0) == 1.0  # Suggesting the same param.
+        assert mock_object.call_count == 5
+
+        assert trial.suggest_float("f", 0.5, 0.5, log=True) == 0.5  # Suggesting a param.
+        assert mock_object.call_count == 6
+        assert trial.suggest_float("f", 0.5, 0.5, log=True) == 0.5  # Suggesting the same param.
+        assert mock_object.call_count == 6
+
+        assert trial.suggest_float("g", 0.5, 0.5, log=False) == 0.5  # Suggesting a param.
+        assert mock_object.call_count == 7
+        assert trial.suggest_float("g", 0.5, 0.5, log=False) == 0.5  # Suggesting the same param.
+        assert mock_object.call_count == 7
+
+        assert trial.suggest_float("h", 0.5, 0.5, step=1.0) == 0.5  # Suggesting a param.
+        assert mock_object.call_count == 8
+        assert trial.suggest_float("h", 0.5, 0.5, step=1.0) == 0.5  # Suggesting the same param.
+        assert mock_object.call_count == 8
+
+        assert trial.suggest_int("i", 1, 1, log=True) == 1  # Suggesting a param.
+        assert mock_object.call_count == 9
+        assert trial.suggest_int("i", 1, 1, log=True) == 1  # Suggesting the same param.
+        assert mock_object.call_count == 9
 
 
 @parametrize_storage

--- a/tests/test_trial.py
+++ b/tests/test_trial.py
@@ -63,8 +63,16 @@ def test_check_distribution_suggest_float(storage_init_func):
     x6 = trial.suggest_discrete_uniform("x3", 10, 20, 1.0)
 
     assert x5 == x6
+
     with pytest.raises(NotImplementedError):
         trial.suggest_float("x4", 1e-5, 1e-2, step=1e-5, log=True)
+
+    with pytest.raises(ValueError):
+        trial.suggest_int("x1", 10, 20)
+
+    trial = Trial(study, study._storage.create_new_trial(study._study_id))
+    with pytest.raises(ValueError):
+        trial.suggest_int("x1", 10, 20)
 
 
 @parametrize_storage
@@ -83,6 +91,13 @@ def test_check_distribution_suggest_uniform(storage_init_func):
     # we expect exactly one warning
     assert len(record) == 1
 
+    with pytest.raises(ValueError):
+        trial.suggest_int("x", 10, 20)
+
+    trial = Trial(study, study._storage.create_new_trial(study._study_id))
+    with pytest.raises(ValueError):
+        trial.suggest_int("x", 10, 20)
+
 
 @parametrize_storage
 def test_check_distribution_suggest_loguniform(storage_init_func):
@@ -100,6 +115,13 @@ def test_check_distribution_suggest_loguniform(storage_init_func):
     # we expect exactly one warning
     assert len(record) == 1
 
+    with pytest.raises(ValueError):
+        trial.suggest_int("x", 10, 20)
+
+    trial = Trial(study, study._storage.create_new_trial(study._study_id))
+    with pytest.raises(ValueError):
+        trial.suggest_int("x", 10, 20)
+
 
 @parametrize_storage
 def test_check_distribution_suggest_discrete_uniform(storage_init_func):
@@ -116,6 +138,13 @@ def test_check_distribution_suggest_discrete_uniform(storage_init_func):
 
     # we expect exactly one warning
     assert len(record) == 1
+
+    with pytest.raises(ValueError):
+        trial.suggest_int("x", 10, 20, 2)
+
+    trial = Trial(study, study._storage.create_new_trial(study._study_id))
+    with pytest.raises(ValueError):
+        trial.suggest_int("x", 10, 20, 2)
 
 
 @parametrize_storage
@@ -135,6 +164,34 @@ def test_check_distribution_suggest_int(
 
     # We expect exactly one warning.
     assert len(record) == 1
+
+    with pytest.raises(ValueError):
+        trial.suggest_float("x", 10, 20, log=enable_log)
+
+    trial = Trial(study, study._storage.create_new_trial(study._study_id))
+    with pytest.raises(ValueError):
+        trial.suggest_float("x", 10, 20, log=enable_log)
+
+
+@parametrize_storage
+def test_check_distribution_suggest_categorical(storage_init_func):
+    # type: (Callable[[], storages.BaseStorage]) -> None
+
+    sampler = samplers.RandomSampler()
+    study = create_study(storage_init_func(), sampler=sampler)
+    trial = Trial(study, study._storage.create_new_trial(study._study_id))
+
+    trial.suggest_categorical("x", [10, 20, 30])
+
+    with pytest.raises(ValueError):
+        trial.suggest_categorical("x", [10, 20])
+
+    with pytest.raises(ValueError):
+        trial.suggest_int("x", 10, 20)
+
+    trial = Trial(study, study._storage.create_new_trial(study._study_id))
+    with pytest.raises(ValueError):
+        trial.suggest_int("x", 10, 20)
 
 
 @parametrize_storage


### PR DESCRIPTION
## Motivation

See https://github.com/optuna/optuna/issues/1308.

## Description of the changes

Fixes https://github.com/optuna/optuna/issues/1308 and the following.
- The storage always sets, i.e the distribution compatibility check is removed. The check is performed by the trial.
- Simplified `Trial` by removing `_set_new_param_or_get_existing`.
