### PR TITLE
Fix `plot_param_importances` test.

### DIFF
--- a/tests/visualization_tests/test_param_importances.py
+++ b/tests/visualization_tests/test_param_importances.py
@@ -21,13 +21,17 @@ def test_plot_param_importances() -> None:
     # Test with a trial.
     figure = plot_param_importances(study)
     assert len(figure.data) == 1
-    assert figure.data[0].x == ("param_b", "param_d")  # "param_a", "param_c" are conditional.
+    assert set(figure.data[0].x) == set(
+        ("param_b", "param_d")
+    )  # "param_a", "param_c" are conditional.
     assert math.isclose(1.0, sum(i for i in figure.data[0].y), abs_tol=1e-5)
 
     # Test with an evaluator.
     plot_param_importances(study, evaluator=MeanDecreaseImpurityImportanceEvaluator())
     assert len(figure.data) == 1
-    assert figure.data[0].x == ("param_b", "param_d")  # "param_a", "param_c" are conditional.
+    assert set(figure.data[0].x) == set(
+        ("param_b", "param_d")
+    )  # "param_a", "param_c" are conditional.
     assert math.isclose(1.0, sum(i for i in figure.data[0].y), abs_tol=1e-5)
 
     # Test with a trial to select parameter.


### PR DESCRIPTION
## Motivation

Unit test for `plot_param_importances` was fragile as it could fail depending on the evaluated importance (order).

## Description of the changes

Fix the test to not consider the order.