### PR TITLE
Fix incorrect test names in `test_experimental.py`

### DIFF
--- a/tests/test_experimental.py
+++ b/tests/test_experimental.py
@@ -80,7 +80,7 @@ def test_experimental_class_decorator() -> None:
         decorated_class("a", "b", "c")
 
 
-def test_experimental_decorator_name() -> None:
+def test_experimental_class_decorator_name() -> None:
 
     name = "foo"
     decorator_experimental = _experimental.experimental("1.1.0", name=name)
@@ -92,7 +92,7 @@ def test_experimental_decorator_name() -> None:
     assert name in record.list[0].message.args[0]
 
 
-def test_experimental_class_decorator_name() -> None:
+def test_experimental_decorator_name() -> None:
 
     name = "bar"
     decorator_experimental = _experimental.experimental("1.1.0", name=name)


### PR DESCRIPTION
<!-- Thank you for creating a pull request! -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

The test names `test_experimental_class_decorator_name` and `test_experimental_decorator_name` should be swapped because they currently don't do what their names indicate.

## Description of the changes
<!-- Describe the changes in this PR. -->

- Swap the test names.
