### PR TITLE
Implement `AllenNLPPruningCallback`.

### DIFF
--- a/docs/source/reference/integration.rst
+++ b/docs/source/reference/integration.rst
@@ -66,4 +66,7 @@ Integration
 .. autoclass:: AllenNLPExecutor
     :members:
 
+.. autoclass:: AllenNLPPruningCallback
+    :members:
+
 .. autofunction:: optuna.integration.allennlp.dump_best_config

--- a/examples/allennlp/allennlp_simple.py
+++ b/examples/allennlp/allennlp_simple.py
@@ -108,14 +108,10 @@ def objective(trial):
     optimizer = torch.optim.SGD(model.parameters(), lr=lr)
 
     data_loader = torch.utils.data.DataLoader(
-        train_dataset,
-        batch_size=10,
-        collate_fn=allennlp.data.allennlp_collate
+        train_dataset, batch_size=10, collate_fn=allennlp.data.allennlp_collate
     )
     validation_data_loader = torch.utils.data.DataLoader(
-        valid_dataset,
-        batch_size=10,
-        collate_fn=allennlp.data.allennlp_collate
+        valid_dataset, batch_size=10, collate_fn=allennlp.data.allennlp_collate
     )
 
     serialization_dir = os.path.join(MODEL_DIR, "trial_{}".format(trial.number))
@@ -124,12 +120,12 @@ def objective(trial):
         optimizer=optimizer,
         data_loader=data_loader,
         validation_data_loader=validation_data_loader,
-        validation_metric='+accuracy',
+        validation_metric="+accuracy",
         patience=None,
         num_epochs=50,
         cuda_device=DEVICE,
         serialization_dir=serialization_dir,
-        epoch_callbacks=[AllenNLPPruningCallback(trial, TARGET_METRIC)]
+        epoch_callbacks=[AllenNLPPruningCallback(trial, TARGET_METRIC)],
     )
     metrics = trainer.train()
     return metrics["best_" + TARGET_METRIC]

--- a/examples/allennlp/allennlp_simple.py
+++ b/examples/allennlp/allennlp_simple.py
@@ -19,46 +19,54 @@ We have the following two ways to execute this example:
 """
 
 import os
+import random
 import shutil
 
 import allennlp
 import allennlp.data
 import allennlp.models
 import allennlp.modules
+import numpy
 import torch
 
 import optuna
+from optuna.integration import AllenNLPPruningCallback
 
 
 DEVICE = -1  # If you want to use GPU, use DEVICE = 0.
 MAX_DATA_SIZE = 3000
+MODEL_DIR = os.path.join(os.getcwd(), "result")
+TARGET_METRIC = "validation_accuracy"
 
-DIR = os.getcwd()
-MODEL_DIR = os.path.join(DIR, "result")
 
-GLOVE_FILE_PATH = "https://s3-us-west-2.amazonaws.com/allennlp/datasets/glove/glove.6B.50d.txt.gz"
+class SubsampledDatasetReader(allennlp.data.dataset_readers.TextClassificationJsonReader):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+    def _read(self, datapath):
+        data = list(super()._read(datapath))
+        random.shuffle(data)
+        yield from data[:3000]
 
 
 def prepare_data():
     glove_indexer = allennlp.data.token_indexers.SingleIdTokenIndexer(lowercase_tokens=True)
-    tokenizer = allennlp.data.tokenizers.WordTokenizer(
-        word_splitter=allennlp.data.tokenizers.word_splitter.JustSpacesWordSplitter(),
-    )
+    tokenizer = allennlp.data.tokenizers.whitespace_tokenizer.WhitespaceTokenizer()
 
-    reader = allennlp.data.dataset_readers.TextClassificationJsonReader(
+    reader = SubsampledDatasetReader(
         token_indexers={"tokens": glove_indexer}, tokenizer=tokenizer,
     )
     train_dataset = reader.read(
         "https://s3-us-west-2.amazonaws.com/allennlp/datasets/imdb/train.jsonl"
     )
-    train_dataset = train_dataset[:MAX_DATA_SIZE]
 
     valid_dataset = reader.read(
         "https://s3-us-west-2.amazonaws.com/allennlp/datasets/imdb/dev.jsonl"
     )
-    valid_dataset = valid_dataset[:MAX_DATA_SIZE]
 
     vocab = allennlp.data.Vocabulary.from_instances(train_dataset)
+    train_dataset.index_with(vocab)
+    valid_dataset.index_with(vocab)
     return train_dataset, valid_dataset, vocab
 
 
@@ -66,12 +74,11 @@ def create_model(vocab, trial):
     embedding = allennlp.modules.Embedding(
         embedding_dim=50,
         trainable=True,
-        pretrained_file=GLOVE_FILE_PATH,
-        num_embeddings=vocab.get_vocab_size("tokens"),
+        pretrained_file="https://s3-us-west-2.amazonaws.com/allennlp/datasets/glove/glove.6B.50d.txt.gz",  # NOQA
+        vocab=vocab,
     )
 
     embedder = allennlp.modules.text_field_embedders.BasicTextFieldEmbedder({"tokens": embedding})
-
     output_dim = trial.suggest_int("output_dim", 16, 128)
     max_filter_size = trial.suggest_int("max_filter_size", 3, 6)
     num_filters = trial.suggest_int("num_filters", 16, 128)
@@ -97,29 +104,42 @@ def objective(trial):
     if DEVICE > -1:
         model.to(torch.device("cuda:{}".format(DEVICE)))
 
-    lr = trial.suggest_loguniform("lr", 1e-1, 1e0)
+    lr = trial.suggest_loguniform("lr", 1e-2, 1e-1)
     optimizer = torch.optim.SGD(model.parameters(), lr=lr)
 
-    iterator = allennlp.data.iterators.BasicIterator(batch_size=10,)
-    iterator.index_with(vocab)
+    data_loader = torch.utils.data.DataLoader(
+        train_dataset,
+        batch_size=10,
+        collate_fn=allennlp.data.allennlp_collate
+    )
+    validation_data_loader = torch.utils.data.DataLoader(
+        valid_dataset,
+        batch_size=10,
+        collate_fn=allennlp.data.allennlp_collate
+    )
 
     serialization_dir = os.path.join(MODEL_DIR, "trial_{}".format(trial.number))
-    trainer = allennlp.training.Trainer(
+    trainer = allennlp.training.GradientDescentTrainer(
         model=model,
         optimizer=optimizer,
-        iterator=iterator,
-        train_dataset=train_dataset,
-        validation_dataset=valid_dataset,
-        patience=3,
-        num_epochs=6,
+        data_loader=data_loader,
+        validation_data_loader=validation_data_loader,
+        validation_metric='+accuracy',
+        patience=None,
+        num_epochs=50,
         cuda_device=DEVICE,
         serialization_dir=serialization_dir,
+        epoch_callbacks=[AllenNLPPruningCallback(trial, TARGET_METRIC)]
     )
     metrics = trainer.train()
-    return metrics["best_validation_accuracy"]
+    return metrics["best_" + TARGET_METRIC]
 
 
 if __name__ == "__main__":
+    random.seed(41)
+    torch.manual_seed(41)
+    numpy.random.seed(41)
+
     study = optuna.create_study(direction="maximize")
     study.optimize(objective, n_trials=80, timeout=600)
 

--- a/optuna/integration/__init__.py
+++ b/optuna/integration/__init__.py
@@ -7,7 +7,7 @@ from optuna.type_checking import TYPE_CHECKING
 
 
 _import_structure = {
-    "allennlp": ["AllenNLPExecutor"],
+    "allennlp": ["AllenNLPExecutor", "AllenNLPPruningCallback"],
     "chainer": ["ChainerPruningExtension"],
     "chainermn": ["ChainerMNStudy"],
     "cma": ["CmaEsSampler"],
@@ -31,6 +31,7 @@ __all__ = list(_import_structure.keys()) + sum(_import_structure.values(), [])
 
 if TYPE_CHECKING:
     from optuna.integration.allennlp import AllenNLPExecutor  # NOQA
+    from optuna.integration.allennlp import AllenNLPPruningCallback  # NOQA
     from optuna.integration.chainer import ChainerPruningExtension  # NOQA
     from optuna.integration.chainermn import ChainerMNStudy  # NOQA
     from optuna.integration.cma import CmaEsSampler  # NOQA

--- a/optuna/integration/allennlp.py
+++ b/optuna/integration/allennlp.py
@@ -18,6 +18,7 @@ with try_import() as _imports:
 
 if _imports.is_successful():
     import _jsonnet
+else:
     EpochCallback = object  # NOQA
 
 

--- a/optuna/integration/allennlp.py
+++ b/optuna/integration/allennlp.py
@@ -163,6 +163,7 @@ class AllenNLPPruningCallback(EpochCallback):
         trainer: "allennlp.training.GradientDescentTrainer",
         metrics: Dict[str, Any],
         epoch: int,
+        is_master: bool,
     ) -> None:
         value = metrics.get(self._monitor)
         if not value:

--- a/optuna/integration/allennlp.py
+++ b/optuna/integration/allennlp.py
@@ -151,7 +151,7 @@ class AllenNLPPruningCallback(EpochCallback):
     def __init__(self, trial: optuna.trial.Trial, monitor: str):
         _imports.check()
 
-        if allennlp.__version__ < '1.0.0':
+        if allennlp.__version__ < "1.0.0":
             raise Exception("AllenNLPPruningCallback requires `allennlp`>=1.0.0.")
 
         self._trial = trial

--- a/optuna/integration/allennlp.py
+++ b/optuna/integration/allennlp.py
@@ -160,7 +160,7 @@ class AllenNLPPruningCallback(EpochCallback):
 
     def __call__(
         self,
-        trainer: allennlp.training.GradientDescentTrainer,
+        trainer: "allennlp.training.GradientDescentTrainer",
         metrics: Dict[str, Any],
         epoch: int,
     ) -> None:

--- a/setup.py
+++ b/setup.py
@@ -73,12 +73,12 @@ def get_extras_require() -> Dict[str, List[str]]:
             "scikit-image",
             "scikit-learn",
             "thop",
-            "torch==1.4.0" if sys.platform == "darwin" else "torch==1.4.0+cpu",
+            "torch==1.5.0" if sys.platform == "darwin" else "torch==1.5.0+cpu",
             "torchvision==0.5.0" if sys.platform == "darwin" else "torchvision==0.5.0+cpu",
             "xgboost",
         ]
         + (
-            ["allennlp<1", "fastai<2", "pytorch-lightning>=0.7.1"]
+            ["allennlp==1.0.0", "fastai<2", "pytorch-lightning>=0.7.1"]
             if (3, 5) < sys.version_info[:2] < (3, 8)
             else []
         )
@@ -109,12 +109,12 @@ def get_extras_require() -> Dict[str, List[str]]:
             "pytorch-ignite",
             "scikit-learn>=0.19.0,<0.23.0",
             "scikit-optimize",
-            "torch==1.4.0" if sys.platform == "darwin" else "torch==1.4.0+cpu",
+            "torch==1.5.0" if sys.platform == "darwin" else "torch==1.5.0+cpu",
             "torchvision==0.5.0" if sys.platform == "darwin" else "torchvision==0.5.0+cpu",
             "xgboost",
         ]
         + (
-            ["allennlp<1", "fastai<2", "pytorch-lightning>=0.7.1"]
+            ["allennlp==1.0.0", "fastai<2", "pytorch-lightning>=0.7.1"]
             if (3, 5) < sys.version_info[:2] < (3, 8)
             else []
         )

--- a/setup.py
+++ b/setup.py
@@ -73,8 +73,8 @@ def get_extras_require() -> Dict[str, List[str]]:
             "scikit-image",
             "scikit-learn",
             "thop",
-            "torch==1.5.0" if sys.platform == "darwin" else "torch==1.5.0+cpu",
-            "torchvision==0.5.0" if sys.platform == "darwin" else "torchvision==0.5.0+cpu",
+            "torch==1.5.1" if sys.platform == "darwin" else "torch==1.5.1+cpu",
+            "torchvision==0.6.1" if sys.platform == "darwin" else "torchvision==0.6.1+cpu",
             "xgboost",
         ]
         + (
@@ -109,8 +109,8 @@ def get_extras_require() -> Dict[str, List[str]]:
             "pytorch-ignite",
             "scikit-learn>=0.19.0,<0.23.0",
             "scikit-optimize",
-            "torch==1.5.0" if sys.platform == "darwin" else "torch==1.5.0+cpu",
-            "torchvision==0.5.0" if sys.platform == "darwin" else "torchvision==0.5.0+cpu",
+            "torch==1.5.1" if sys.platform == "darwin" else "torch==1.5.1+cpu",
+            "torchvision==0.6.1" if sys.platform == "darwin" else "torchvision==0.6.1+cpu",
             "xgboost",
         ]
         + (

--- a/tests/integration_tests/allennlp_tests/example.jsonnet
+++ b/tests/integration_tests/allennlp_tests/example.jsonnet
@@ -49,8 +49,7 @@ local DROPOUT = std.extVar('DROPOUT');
       bidirectional: true,
     },
   },
-  iterator: {
-    type: 'basic',
+  data_loader: {
     batch_size: 32,
   },
   trainer: {

--- a/tests/integration_tests/allennlp_tests/example_with_include_package.jsonnet
+++ b/tests/integration_tests/allennlp_tests/example_with_include_package.jsonnet
@@ -49,8 +49,7 @@ local DROPOUT = std.extVar('DROPOUT');
       bidirectional: true,
     },
   },
-  iterator: {
-    type: 'basic',
+  data_loader: {
     batch_size: 32,
   },
   trainer: {

--- a/tests/integration_tests/allennlp_tests/pruning_test.jsonl
+++ b/tests/integration_tests/allennlp_tests/pruning_test.jsonl
@@ -1,0 +1,7 @@
+{"id": "train_01", "text": "Chainer is a Python-based deep learning framework aiming at flexibility.", "label": 1}
+{"id": "train_02", "text": "It provides automatic differentiation APIs based on the define-by-run approach (a.k.a. dynamic computational graphs) as well as object-oriented high-level APIs to build and train neural networks.", "label": 1}
+{"id": "train_03", "text": "It also supports CUDA/cuDNN using CuPy for high performance training and inference.", "label": 1}
+{"id": "train_04", "text": "For more details about Chainer, see the documents and resources listed above and join the community in Forum, Slack, and Twitter.", "label": 1}
+{"id": "train_05", "text": "Optuna is an automatic hyperparameter optimization software framework, particularly designed for machine learning.", "label": 0}
+{"id": "train_06", "text": "It features an imperative, define-by-run style user API.", "label": 0}
+{"id": "train_07", "text": "Thanks to our define-by-run API, the code written with Optuna enjoys high modularity, and the user of Optuna can dynamically construct the search spaces for the hyperparameters.", "label": 0}

--- a/tests/integration_tests/allennlp_tests/test_allennlp.py
+++ b/tests/integration_tests/allennlp_tests/test_allennlp.py
@@ -13,7 +13,7 @@ import allennlp.modules.text_field_embedders
 import allennlp.training
 import pytest
 import torch.optim
-import torch.utils.data
+from torch.utils.data import DataLoader
 
 import optuna
 from optuna.integration.allennlp import AllenNLPPruningCallback
@@ -168,7 +168,7 @@ def test_allennlp_pruning_callback() -> None:
                 text_field_embedder=embedder, seq2vec_encoder=encoder, vocab=vocab
             )
             optimizer = torch.optim.SGD(model.parameters(), lr=0.1)
-            data_loader = allennlp.data.DataLoader(
+            data_loader = DataLoader(
                 dataset, batch_size=10, collate_fn=allennlp.data.allennlp_collate
             )
             serialization_dir = os.path.join(tmp_dir, "trial_{}".format(trial.number))

--- a/tests/integration_tests/allennlp_tests/test_allennlp.py
+++ b/tests/integration_tests/allennlp_tests/test_allennlp.py
@@ -162,19 +162,14 @@ def test_allennlp_pruning_callback() -> None:
                 {"tokens": allennlp.modules.Embedding(50, vocab=vocab)}
             )
             encoder = allennlp.modules.seq2vec_encoders.GruSeq2VecEncoder(
-                input_size=50,
-                hidden_size=50
+                input_size=50, hidden_size=50
             )
             model = allennlp.models.BasicClassifier(
-                text_field_embedder=embedder,
-                seq2vec_encoder=encoder,
-                vocab=vocab
+                text_field_embedder=embedder, seq2vec_encoder=encoder, vocab=vocab
             )
             optimizer = torch.optim.SGD(model.parameters(), lr=0.1)
             data_loader = torch.utils.data.DataLoader(
-                dataset,
-                batch_size=10,
-                collate_fn=allennlp.data.allennlp_collate
+                dataset, batch_size=10, collate_fn=allennlp.data.allennlp_collate
             )
             serialization_dir = os.path.join(tmp_dir, "trial_{}".format(trial.number))
             trainer = allennlp.training.GradientDescentTrainer(
@@ -184,7 +179,7 @@ def test_allennlp_pruning_callback() -> None:
                 patience=None,
                 num_epochs=1,
                 serialization_dir=serialization_dir,
-                epoch_callbacks=[AllenNLPPruningCallback(trial, "training_loss")]
+                epoch_callbacks=[AllenNLPPruningCallback(trial, "training_loss")],
             )
             trainer.train()
             return 1.0

--- a/tests/integration_tests/allennlp_tests/test_allennlp.py
+++ b/tests/integration_tests/allennlp_tests/test_allennlp.py
@@ -3,9 +3,21 @@ import os.path
 import tempfile
 
 import _jsonnet
+import allennlp.data
+import allennlp.data.dataset_readers
+import allennlp.data.tokenizers
+import allennlp.models
+import allennlp.modules
+import allennlp.modules.seq2vec_encoders
+import allennlp.modules.text_field_embedders
+import allennlp.training
 import pytest
+import torch.optim
+import torch.utils.data
 
 import optuna
+from optuna.integration.allennlp import AllenNLPPruningCallback
+from optuna.testing.integration import DeterministicPruner
 
 
 def test__set_param() -> None:
@@ -134,3 +146,54 @@ def test_dump_best_config() -> None:
         model_config = best_config["model"]
         target_config = model_config["text_field_embedder"]["token_embedders"]["token_characters"]
         assert target_config["dropout"] == dropout
+
+
+def test_allennlp_pruning_callback() -> None:
+    with tempfile.TemporaryDirectory() as tmp_dir:
+
+        def objective(trial: optuna.Trial) -> float:
+            reader = allennlp.data.dataset_readers.TextClassificationJsonReader(
+                tokenizer=allennlp.data.tokenizers.SpacyTokenizer()
+            )
+            dataset = reader.read("tests/integration_tests/allennlp_tests/pruning_test.jsonl")
+            vocab = allennlp.data.Vocabulary.from_instances(dataset)
+            dataset.index_with(vocab)
+            embedder = allennlp.modules.text_field_embedders.BasicTextFieldEmbedder(
+                {"tokens": allennlp.modules.Embedding(50, vocab=vocab)}
+            )
+            encoder = allennlp.modules.seq2vec_encoders.GruSeq2VecEncoder(
+                input_size=50,
+                hidden_size=50
+            )
+            model = allennlp.models.BasicClassifier(
+                text_field_embedder=embedder,
+                seq2vec_encoder=encoder,
+                vocab=vocab
+            )
+            optimizer = torch.optim.SGD(model.parameters(), lr=0.1)
+            data_loader = torch.utils.data.DataLoader(
+                dataset,
+                batch_size=10,
+                collate_fn=allennlp.data.allennlp_collate
+            )
+            serialization_dir = os.path.join(tmp_dir, "trial_{}".format(trial.number))
+            trainer = allennlp.training.GradientDescentTrainer(
+                model=model,
+                optimizer=optimizer,
+                data_loader=data_loader,
+                patience=None,
+                num_epochs=1,
+                serialization_dir=serialization_dir,
+                epoch_callbacks=[AllenNLPPruningCallback(trial, "training_loss")]
+            )
+            trainer.train()
+            return 1.0
+
+        study = optuna.create_study(pruner=DeterministicPruner(True))
+        study.optimize(objective, n_trials=1)
+        assert study.trials[0].state == optuna.trial.TrialState.PRUNED
+
+        study = optuna.create_study(pruner=DeterministicPruner(False))
+        study.optimize(objective, n_trials=1)
+        assert study.trials[0].state == optuna.trial.TrialState.COMPLETE
+        assert study.trials[0].value == 1.0

--- a/tests/integration_tests/allennlp_tests/test_allennlp.py
+++ b/tests/integration_tests/allennlp_tests/test_allennlp.py
@@ -168,7 +168,7 @@ def test_allennlp_pruning_callback() -> None:
                 text_field_embedder=embedder, seq2vec_encoder=encoder, vocab=vocab
             )
             optimizer = torch.optim.SGD(model.parameters(), lr=0.1)
-            data_loader = torch.utils.data.DataLoader(
+            data_loader = allennlp.data.DataLoader(
                 dataset, batch_size=10, collate_fn=allennlp.data.allennlp_collate
             )
             serialization_dir = os.path.join(tmp_dir, "trial_{}".format(trial.number))

--- a/tests/integration_tests/allennlp_tests/tiny_single_id.py
+++ b/tests/integration_tests/allennlp_tests/tiny_single_id.py
@@ -2,11 +2,10 @@ import itertools
 from typing import Dict
 from typing import List
 
-from allennlp.common.util import pad_sequence_to_length
+from allennlp.data.token_indexers.token_indexer import IndexedTokenList
 from allennlp.data.token_indexers.token_indexer import TokenIndexer
 from allennlp.data.tokenizers.token import Token
 from allennlp.data.vocabulary import Vocabulary
-import torch
 
 
 @TokenIndexer.register("tiny_single_id")
@@ -39,7 +38,7 @@ class SingleIdTokenIndexer(TokenIndexer):
         counter["tokens"][text] += 1
 
     def tokens_to_indices(
-        self, tokens: List[Token], vocabulary: Vocabulary, index_name: str
+        self, tokens: List[Token], vocabulary: Vocabulary
     ) -> Dict[str, List[int]]:
         indices: List[int] = []
 
@@ -49,18 +48,7 @@ class SingleIdTokenIndexer(TokenIndexer):
                 text = text.lower()
             indices.append(vocabulary.get_token_index(text, "tokens"))
 
-        return {index_name: indices}
+        return {"tokens": indices}
 
-    def get_padding_lengths(self, token: int) -> Dict[str, int]:
-        return {}
-
-    def as_padded_tensor(
-        self,
-        tokens: Dict[str, List[int]],
-        desired_num_tokens: Dict[str, int],
-        padding_lengths: Dict[str, int],
-    ) -> Dict[str, torch.Tensor]:
-        return {
-            key: torch.LongTensor(pad_sequence_to_length(val, desired_num_tokens[key]))
-            for key, val in tokens.items()
-        }
+    def get_empty_token_list(self) -> IndexedTokenList:
+        return {"tokens": []}


### PR DESCRIPTION
close #1012.

## Motivation
This PR introduces a pruning callback for AllenNLP.

## Description of the changes
- add `AllenNLPPruningCallback`
- [WIP] bump up the version of AllenNLP
  - `AllenNLPPruningCallback` uses `epoch_callbacks` in the current implementation, which will be available on the next major version of `AllenNLP`.

## Memo
- [RFC] how to use `AllenNLPPruningCallback` in `AllenNLPExecutor`.
