### PR TITLE
`BaseStorage.set_trial_intermediate_valute` to return `None` instead of `bool`.

### DIFF
--- a/optuna/storages/base.py
+++ b/optuna/storages/base.py
@@ -444,8 +444,10 @@ class BaseStorage(object, metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def set_trial_intermediate_value(
         self, trial_id: int, step: int, intermediate_value: float
-    ) -> bool:
+    ) -> None:
         """Report an intermediate value of an objective function.
+
+        This method overwrites any existing intermediate value associated with the given step.
 
         Args:
             trial_id:
@@ -454,9 +456,6 @@ class BaseStorage(object, metaclass=abc.ABCMeta):
                 Step of the trial (e.g., the epoch when training a neural network).
             intermediate_value:
                 Intermediate value corresponding to the step.
-
-        Returns:
-            :obj:`False` when the step is already set, :obj:`True` otherwise.
 
         Raises:
             :exc:`KeyError`:

--- a/optuna/storages/cached_storage.py
+++ b/optuna/storages/cached_storage.py
@@ -277,23 +277,21 @@ class _CachedStorage(base.BaseStorage):
 
     def set_trial_intermediate_value(
         self, trial_id: int, step: int, intermediate_value: float
-    ) -> bool:
+    ) -> None:
 
         with self._lock:
             cached_trial = self._get_cached_trial(trial_id)
             if cached_trial is not None:
                 self._check_trial_is_updatable(cached_trial)
                 updates = self._get_updates(trial_id)
-                if step in cached_trial.intermediate_values:
-                    return False
                 intermediate_values = copy.copy(cached_trial.intermediate_values)
                 intermediate_values[step] = intermediate_value
                 cached_trial.intermediate_values = intermediate_values
                 updates.intermediate_values[step] = intermediate_value
                 self._flush_trial(trial_id)
-                return True
+                return
 
-        return self._backend.set_trial_intermediate_value(trial_id, step, intermediate_value)
+        self._backend.set_trial_intermediate_value(trial_id, step, intermediate_value)
 
     def set_trial_user_attr(self, trial_id: int, key: str, value: Any) -> None:
 

--- a/optuna/storages/in_memory.py
+++ b/optuna/storages/in_memory.py
@@ -344,24 +344,16 @@ class InMemoryStorage(base.BaseStorage):
                 self._studies[study_id].best_trial_id = trial_id
 
     def set_trial_intermediate_value(self, trial_id, step, intermediate_value):
-        # type: (int, int, float) -> bool
+        # type: (int, int, float) -> None
 
         with self._lock:
             trial = self._get_trial(trial_id)
             self.check_trial_is_updatable(trial_id, trial.state)
 
-            self.check_trial_is_updatable(trial_id, trial.state)
-
             trial = copy.copy(trial)
-            values = copy.copy(trial.intermediate_values)
-            if step in values:
-                return False
-
-            values[step] = intermediate_value
-            trial.intermediate_values = values
+            trial.intermediate_values = copy.copy(trial.intermediate_values)
+            trial.intermediate_values[step] = intermediate_value
             self._set_trial(trial_id, trial)
-
-            return True
 
     def set_trial_user_attr(self, trial_id, key, value):
         # type: (int, str, Any) -> None

--- a/optuna/storages/rdb/storage.py
+++ b/optuna/storages/rdb/storage.py
@@ -823,38 +823,32 @@ class RDBStorage(BaseStorage):
         self._commit(session)
 
     def set_trial_intermediate_value(self, trial_id, step, intermediate_value):
-        # type: (int, int, float) -> bool
+        # type: (int, int, float) -> None
 
         session = self.scoped_session()
 
-        if not self._set_trial_intermediate_value_without_commit(
+        self._set_trial_intermediate_value_without_commit(
             session, trial_id, step, intermediate_value
-        ):
-            return False
+        )
 
-        commit_success = self._commit_with_integrity_check(session)
-
-        return commit_success
+        self._commit_with_integrity_check(session)
 
     def _set_trial_intermediate_value_without_commit(
         self, session, trial_id, step, intermediate_value
     ):
-        # type: (orm.Session, int, int, float) -> bool
+        # type: (orm.Session, int, int, float) -> None
 
         trial = models.TrialModel.find_or_raise_by_id(trial_id, session)
         self.check_trial_is_updatable(trial_id, trial.state)
 
         trial_value = models.TrialValueModel.find_by_trial_and_step(trial, step, session)
-        if trial_value is not None:
-            return False
-
-        trial_value = models.TrialValueModel(
-            trial_id=trial_id, step=step, value=intermediate_value
-        )
-
-        session.add(trial_value)
-
-        return True
+        if trial_value is None:
+            trial_value = models.TrialValueModel(
+                trial_id=trial_id, step=step, value=intermediate_value
+            )
+            session.add(trial_value)
+        else:
+            trial_value.value = intermediate_value
 
     def set_trial_user_attr(self, trial_id, key, value):
         # type: (int, str, Any) -> None

--- a/optuna/storages/redis.py
+++ b/optuna/storages/redis.py
@@ -501,19 +501,13 @@ class RedisStorage(base.BaseStorage):
         return
 
     def set_trial_intermediate_value(self, trial_id, step, intermediate_value):
-        # type: (int, int, float) -> bool
+        # type: (int, int, float) -> None
 
         self._check_trial_id(trial_id)
-        self.check_trial_is_updatable(trial_id, self.get_trial(trial_id).state)
-
         frozen_trial = self.get_trial(trial_id)
-        if step in frozen_trial.intermediate_values:
-            return False
-
+        self.check_trial_is_updatable(trial_id, frozen_trial.state)
         frozen_trial.intermediate_values[step] = intermediate_value
         self._set_trial(trial_id, frozen_trial)
-
-        return True
 
     def set_trial_user_attr(self, trial_id, key, value):
         # type: (int, str, Any) -> None

--- a/optuna/trial/_trial.py
+++ b/optuna/trial/_trial.py
@@ -537,7 +537,8 @@ class Trial(BaseTrial):
 
         if step in intermediate_values:
             # Do nothing if already reported.
-            # TODO(hvy): Consider raising an error.
+            # TODO(hvy): Consider raising a warning or an error.
+            # See https://github.com/optuna/optuna/issues/852.
             return
 
         self.storage.set_trial_intermediate_value(self._trial_id, step, value)

--- a/optuna/trial/_trial.py
+++ b/optuna/trial/_trial.py
@@ -533,6 +533,13 @@ class Trial(BaseTrial):
         if step < 0:
             raise ValueError("The `step` argument is {} but cannot be negative.".format(step))
 
+        intermediate_values = self.storage.get_trial(self._trial_id).intermediate_values
+
+        if step in intermediate_values:
+            # Do nothing if already reported.
+            # TODO(hvy): Consider raising an error.
+            return
+
         self.storage.set_trial_intermediate_value(self._trial_id, step, value)
 
     def should_prune(self, step=None):

--- a/tests/storages_tests/test_storages.py
+++ b/tests/storages_tests/test_storages.py
@@ -611,18 +611,19 @@ def test_set_trial_intermediate_value(storage_mode: str) -> None:
         trial_id_3 = storage.create_new_trial(storage.create_new_study())
 
         # Test setting new values.
-        assert storage.set_trial_intermediate_value(trial_id_1, 0, 0.3)
-        assert storage.set_trial_intermediate_value(trial_id_1, 2, 0.4)
-        assert storage.set_trial_intermediate_value(trial_id_3, 0, 0.1)
-        assert storage.set_trial_intermediate_value(trial_id_3, 1, 0.4)
-        assert storage.set_trial_intermediate_value(trial_id_3, 2, 0.5)
+        storage.set_trial_intermediate_value(trial_id_1, 0, 0.3)
+        storage.set_trial_intermediate_value(trial_id_1, 2, 0.4)
+        storage.set_trial_intermediate_value(trial_id_3, 0, 0.1)
+        storage.set_trial_intermediate_value(trial_id_3, 1, 0.4)
+        storage.set_trial_intermediate_value(trial_id_3, 2, 0.5)
 
         assert storage.get_trial(trial_id_1).intermediate_values == {0: 0.3, 2: 0.4}
         assert storage.get_trial(trial_id_2).intermediate_values == {}
         assert storage.get_trial(trial_id_3).intermediate_values == {0: 0.1, 1: 0.4, 2: 0.5}
 
         # Test setting existing step.
-        assert not storage.set_trial_intermediate_value(trial_id_1, 0, 0.3)
+        storage.set_trial_intermediate_value(trial_id_1, 0, 0.2)
+        assert storage.get_trial(trial_id_1).intermediate_values == {0: 0.2, 2: 0.4}
 
         non_existent_trial_id = max(trial_id_1, trial_id_2, trial_id_3) + 1
         with pytest.raises(KeyError):


### PR DESCRIPTION
## Motivation

See #1309.

## Description of the changes

Fixes #1309, in particular the following.
- The storage always sets. The check for "NOOP" is performed by the trial.