### PR TITLE
Friendlier error message for unsupported `plotly` versions.

### DIFF
--- a/optuna/visualization/plotly_imports.py
+++ b/optuna/visualization/plotly_imports.py
@@ -16,5 +16,6 @@ with try_import() as _imports:  # NOQA
             "Your version of Plotly is " + plotly_version + " . "
             "Please install plotly version 4.0.0 or higher. "
             "Plotly can be installed by executing `$ pip install -U plotly>=4.0.0`. "
-            "For further information, please refer to the installation guide of plotly. "
+            "For further information, please refer to the installation guide of plotly. ",
+            name="plotly",
         )


### PR DESCRIPTION
## Motivation

See https://github.com/optuna/optuna/pull/1326#discussion_r436528869.

## Description of the changes

Makes the error message for unsupported `plotly` versions friendlier to the users. See the discussion above in #1326 for details.