### PR TITLE
Temporary hotfix for `sphinx` update breaking existing type annotations.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,8 @@ def get_extras_require() -> Dict[str, List[str]]:
             "scikit-optimize",
             "mlflow",
         ],
-        "document": ["sphinx", "sphinx_rtd_theme"],
+        # TODO(hvy): Unpin `sphinx` version after https://github.com/sphinx-doc/sphinx/issues/7807.
+        "document": ["sphinx<3.1.0", "sphinx_rtd_theme"],
         "example": [
             "catboost",
             "chainer",


### PR DESCRIPTION
## Motivation

The latest `sphinx` update 3.1.0 broke the `master` branch and is blocking other PRs from being merged.

## Description of the changes

Pins the version of `sphinx` to older versions.