### PR TITLE
Reduce GitHub Actions `examples` durations.

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -1,8 +1,6 @@
 name: examples
 
-on:
-  schedule:
-    - cron: '0 15 * * *'
+on: [push, pull_request]
 
 jobs:
   build:
@@ -46,10 +44,10 @@ jobs:
         for file in `find examples -name '*.py' -not -name '*_distributed.py' | grep -vE "$IGNORES"`
         do
           echo $file
-          python $file > /dev/null
+          time python $file > /dev/null 2>&1
           if grep -e '\-\-pruning' $file > /dev/null; then
             echo $file --pruning
-            python $file --pruning > /dev/null
+            time python $file --pruning > /dev/null 2>&1
           fi
         done
       env:


### PR DESCRIPTION
## Motivation

Examples executed in our daily GitHub Actions are resource intensive and could maybe be shortened. For instance, it's likely that they run many or heavy trials. This PR aims to profile existing examples in order to find out if certain examples cannot be shortened, and shorten them if possible.

## Description of the changes

- [x] Prints example durations in the GitHub Actions log.
- [ ] ...

## Note

- We might want to specify the number of trials as command line arguments?
- See also https://github.com/optuna/optuna/pull/1343