### PR TITLE
Simplify log messages

### DIFF
--- a/docs/source/tutorial/first.rst
+++ b/docs/source/tutorial/first.rst
@@ -39,15 +39,15 @@ Out:
 
 .. code-block:: console
 
-    [I 2020-04-08 10:42:09,028] Finished trial#0 with value: 25.77382032395108 with parameters: {'x': 7.076792326257898}. Best is trial#0 with value: 25.77382032395108.
-    [I 2020-04-08 10:42:09,064] Finished trial#1 with value: 1.5189812248635903 with parameters: {'x': 0.7675304365366298}. Best is trial#1 with value: 1.5189812248635903.
-    [I 2020-04-08 10:42:09,106] Finished trial#2 with value: 34.4074691838153 with parameters: {'x': -3.865788027521562}. Best is trial#1 with value: 1.5189812248635903.
-    [I 2020-04-08 10:42:09,145] Finished trial#3 with value: 3.3601305753722657 with parameters: {'x': 3.8330658949891205}. Best is trial#1 with value: 1.5189812248635903.
-    [I 2020-04-08 10:42:09,185] Finished trial#4 with value: 61.16797535698886 with parameters: {'x': -5.820995803412048}. Best is trial#1 with value: 1.5189812248635903.
-    [I 2020-04-08 10:42:09,228] Finished trial#5 with value: 90.08665552769618 with parameters: {'x': -7.491399028999686}. Best is trial#1 with value: 1.5189812248635903.
-    [I 2020-04-08 10:42:09,274] Finished trial#6 with value: 25.254236332163032 with parameters: {'x': 7.025359323686519}. Best is trial#1 with value: 1.5189812248635903.
+    [I 2020-04-08 10:42:09,028] Trial 0 finished with value: 25.77382032395108 with parameters: {'x': 7.076792326257898}. Best is trial 0 with value: 25.77382032395108.
+    [I 2020-04-08 10:42:09,064] Trial 1 finished with value: 1.5189812248635903 with parameters: {'x': 0.7675304365366298}. Best is trial 1 with value: 1.5189812248635903.
+    [I 2020-04-08 10:42:09,106] Trial 2 finished with value: 34.4074691838153 with parameters: {'x': -3.865788027521562}. Best is trial 1 with value: 1.5189812248635903.
+    [I 2020-04-08 10:42:09,145] Trial 3 finished with value: 3.3601305753722657 with parameters: {'x': 3.8330658949891205}. Best is trial 1 with value: 1.5189812248635903.
+    [I 2020-04-08 10:42:09,185] Trial 4 finished with value: 61.16797535698886 with parameters: {'x': -5.820995803412048}. Best is trial 1 with value: 1.5189812248635903.
+    [I 2020-04-08 10:42:09,228] Trial 5 finished with value: 90.08665552769618 with parameters: {'x': -7.491399028999686}. Best is trial 1 with value: 1.5189812248635903.
+    [I 2020-04-08 10:42:09,274] Trial 6 finished with value: 25.254236332163032 with parameters: {'x': 7.025359323686519}. Best is trial 1 with value: 1.5189812248635903.
     ...
-    [I 2020-04-08 10:42:14,237] Finished trial#99 with value: 0.5227007740782738 with parameters: {'x': 2.7229804797352926}. Best is trial#67 with value: 2.916284393762304e-06.
+    [I 2020-04-08 10:42:14,237] Trial 99 finished with value: 0.5227007740782738 with parameters: {'x': 2.7229804797352926}. Best is trial 67 with value: 2.916284393762304e-06.
 
 You can get the best parameter as follows.
 

--- a/docs/source/tutorial/pruning.rst
+++ b/docs/source/tutorial/pruning.rst
@@ -55,19 +55,19 @@ Executing the script above:
 .. code-block:: bash
 
     $ python prune.py
-    [I 2018-11-21 17:27:57,836] Finished trial#0 resulted in value: 0.052631578947368474. Current best value is 0.052631578947368474 with parameters: {'alpha': 0.011428158279113485}.
-    [I 2018-11-21 17:27:57,963] Finished trial#1 resulted in value: 0.02631578947368418. Current best value is 0.02631578947368418 with parameters: {'alpha': 0.01862693201743629}.
-    [I 2018-11-21 17:27:58,164] Finished trial#2 resulted in value: 0.21052631578947367. Current best value is 0.02631578947368418 with parameters: {'alpha': 0.01862693201743629}.
-    [I 2018-11-21 17:27:58,333] Finished trial#3 resulted in value: 0.02631578947368418. Current best value is 0.02631578947368418 with parameters: {'alpha': 0.01862693201743629}.
-    [I 2018-11-21 17:27:58,617] Finished trial#4 resulted in value: 0.23684210526315785. Current best value is 0.02631578947368418 with parameters: {'alpha': 0.01862693201743629}.
-    [I 2018-11-21 17:27:58,642] Setting status of trial#5 as TrialState.PRUNED.
-    [I 2018-11-21 17:27:58,666] Setting status of trial#6 as TrialState.PRUNED.
-    [I 2018-11-21 17:27:58,675] Setting status of trial#7 as TrialState.PRUNED.
-    [I 2018-11-21 17:27:59,183] Finished trial#8 resulted in value: 0.39473684210526316. Current best value is 0.02631578947368418 with parameters: {'alpha': 0.01862693201743629}.
-    [I 2018-11-21 17:27:59,202] Setting status of trial#9 as TrialState.PRUNED.
+    [I 2020-06-12 16:54:23,876] Trial 0 finished with value: 0.3157894736842105 and parameters: {'alpha': 0.00181467547181131}. Best is trial 0 with value: 0.3157894736842105.
+    [I 2020-06-12 16:54:23,981] Trial 1 finished with value: 0.07894736842105265 and parameters: {'alpha': 0.015378744419287613}. Best is trial 1 with value: 0.07894736842105265.
+    [I 2020-06-12 16:54:24,083] Trial 2 finished with value: 0.21052631578947367 and parameters: {'alpha': 0.04089428832878595}. Best is trial 1 with value: 0.07894736842105265.
+    [I 2020-06-12 16:54:24,185] Trial 3 finished with value: 0.052631578947368474 and parameters: {'alpha': 0.004018735937374473}. Best is trial 3 with value: 0.052631578947368474.
+    [I 2020-06-12 16:54:24,303] Trial 4 finished with value: 0.07894736842105265 and parameters: {'alpha': 2.805688697062864e-05}. Best is trial 3 with value: 0.052631578947368474.
+    [I 2020-06-12 16:54:24,315] Trial 5 pruned. 
+    [I 2020-06-12 16:54:24,355] Trial 6 pruned. 
+    [I 2020-06-12 16:54:24,511] Trial 7 finished with value: 0.052631578947368474 and parameters: {'alpha': 2.243775785299103e-05}. Best is trial 3 with value: 0.052631578947368474.
+    [I 2020-06-12 16:54:24,625] Trial 8 finished with value: 0.1842105263157895 and parameters: {'alpha': 0.007021209286214553}. Best is trial 3 with value: 0.052631578947368474.
+    [I 2020-06-12 16:54:24,629] Trial 9 pruned. 
     ...
 
-We can see ``Setting status of trial#{} as TrialState.PRUNED`` in the log messages.
+We can see ``Trial 5 pruned.`` in the log messages.
 This means several trials are stopped before they finish all iterations.
 
 

--- a/docs/source/tutorial/pruning.rst
+++ b/docs/source/tutorial/pruning.rst
@@ -67,8 +67,7 @@ Executing the script above:
     [I 2020-06-12 16:54:24,629] Trial 9 pruned. 
     ...
 
-We can see ``Trial 5 pruned.`` in the log messages.
-This means several trials are stopped before they finish all iterations.
+``Trial 5 pruned.``, etc. in the log messages means several trials were stopped before they finished all of the iterations.
 
 
 Integration Modules for Pruning

--- a/optuna/integration/chainer.py
+++ b/optuna/integration/chainer.py
@@ -85,7 +85,7 @@ class ChainerPruningExtension(Extension):
         except TypeError:
             raise TypeError(
                 "Type of observation value is not supported by ChainerPruningExtension.\n"
-                "{} cannot be casted to float.".format(type(observation_value))
+                "{} cannot be cast to float.".format(type(observation_value))
             )
 
         return observation_value

--- a/optuna/logging.py
+++ b/optuna/logging.py
@@ -141,8 +141,8 @@ def disable_default_handler() -> None:
             # There are logs in sys.stderr.
             optuna.logging.enable_default_handler()
             study.optimize(objective, n_trials=10)
-            # [I 2020-02-23 17:00:54,314] Finished trial#10 with value: ...
-            # [I 2020-02-23 17:00:54,356] Finished trial#11 with value: ...
+            # [I 2020-02-23 17:00:54,314] Trial 10 finished with value: ...
+            # [I 2020-02-23 17:00:54,356] Trial 11 finished with value: ...
             # ...
 
     """
@@ -212,7 +212,7 @@ def enable_propagation() -> None:
 
             with open('foo.log') as f:
                 assert f.readline() == "Start optimization.\\n"
-                assert f.readline().startswith("Finished trial#0 with value:")
+                assert f.readline().startswith("Trial 0 finished with value:")
 
     """
 

--- a/optuna/multi_objective/study.py
+++ b/optuna/multi_objective/study.py
@@ -395,7 +395,7 @@ class MultiObjectiveStudy(object):
 def _log_completed_trial(self: Study, trial: Trial, result: float) -> None:
     values = multi_objective.trial.MultiObjectiveTrial(trial)._get_values()
     _logger.info(
-        "Finished trial#{} with values: {} with parameters: {}.".format(
+        "Trial {} finished with values: {} with parameters: {}.".format(
             trial.number, values, trial.params,
         )
     )

--- a/optuna/study.py
+++ b/optuna/study.py
@@ -378,7 +378,7 @@ class Study(BaseStudy):
 
                     parallel(
                         delayed(self._reseed_and_optimize_sequential)(
-                            func, 1, timeout, catch, callbacks, gc_after_trial, time_start
+                            func, 1, timeout, catch, callbacks, gc_after_trial, time_start,
                         )
                         for _ in _iter
                     )
@@ -697,7 +697,7 @@ class Study(BaseStudy):
             if not self._storage.set_trial_state(trial._trial_id, TrialState.RUNNING):
                 continue
 
-            _logger.debug("Trial#{} is popped from the trial queue.".format(trial.number))
+            _logger.debug("Trial {} popped from the trial queue.".format(trial.number))
             return trial._trial_id
 
         return None
@@ -737,9 +737,7 @@ class Study(BaseStudy):
         try:
             result = func(trial)
         except exceptions.TrialPruned as e:
-            message = "Setting status of trial#{} as {}. {}".format(
-                trial_number, TrialState.PRUNED, str(e)
-            )
+            message = "Trial {} pruned. {}".format(trial_number, str(e))
             _logger.info(message)
 
             # Register the last intermediate value if present as the value of the trial.
@@ -753,8 +751,8 @@ class Study(BaseStudy):
             self._storage.set_trial_state(trial_id, TrialState.PRUNED)
             return trial
         except Exception as e:
-            message = "Setting status of trial#{} as {} because of the following error: {}".format(
-                trial_number, TrialState.FAIL, repr(e)
+            message = "Trial {} failed because of the following error: {}".format(
+                trial_number, repr(e)
             )
             _logger.warning(message, exc_info=True)
             self._storage.set_trial_system_attr(trial_id, "fail_reason", message)
@@ -778,9 +776,9 @@ class Study(BaseStudy):
             TypeError,
         ):
             message = (
-                "Setting status of trial#{} as {} because the returned value from the "
-                "objective function cannot be casted to float. Returned value is: "
-                "{}".format(trial_number, TrialState.FAIL, repr(result))
+                "Trial {} failed, because the returned value from the "
+                "objective function cannot be cast to float. Returned value is: "
+                "{}".format(trial_number, repr(result))
             )
             _logger.warning(message)
             self._storage.set_trial_system_attr(trial_id, "fail_reason", message)
@@ -788,9 +786,8 @@ class Study(BaseStudy):
             return trial
 
         if math.isnan(result):
-            message = (
-                "Setting status of trial#{} as {} because the objective function "
-                "returned {}.".format(trial_number, TrialState.FAIL, result)
+            message = "Trial {} failed, because the objective function " "returned {}.".format(
+                trial_number, result
             )
             _logger.warning(message)
             self._storage.set_trial_system_attr(trial_id, "fail_reason", message)
@@ -807,9 +804,9 @@ class Study(BaseStudy):
         # type: (trial_module.Trial, float) -> None
 
         _logger.info(
-            "Finished trial#{} with value: {} with parameters: {}. "
-            "Best is trial#{} with value: {}.".format(
-                trial.number, result, trial.params, self.best_trial.number, self.best_value
+            "Trial {} finished with value: {} and parameters: {}. "
+            "Best is trial {} with value: {}.".format(
+                trial.number, result, trial.params, self.best_trial.number, self.best_value,
             )
         )
 

--- a/tests/test_study.py
+++ b/tests/test_study.py
@@ -405,7 +405,7 @@ def test_run_trial(storage_mode):
 
         expected_message = (
             "Trial 3 failed, because the returned "
-            "value from the objective function cannot be casted to float. "
+            "value from the objective function cannot be cast to float. "
             "Returned value is: None"
         )
         assert frozen_trial.state == optuna.trial.TrialState.FAIL

--- a/tests/test_study.py
+++ b/tests/test_study.py
@@ -386,7 +386,7 @@ def test_run_trial(storage_mode):
         trial = study._run_trial(func_value_error, catch=(ValueError,), gc_after_trial=True)
         frozen_trial = study._storage.get_trial(trial._trial_id)
 
-        expected_message = "Trial 1 failed because of the " "following error: ValueError()"
+        expected_message = "Trial 1 failed because of the following error: ValueError()"
         assert frozen_trial.state == optuna.trial.TrialState.FAIL
         assert frozen_trial.system_attrs["fail_reason"] == expected_message
 
@@ -420,7 +420,7 @@ def test_run_trial(storage_mode):
         trial = study._run_trial(func_nan, catch=(Exception,), gc_after_trial=True)
         frozen_trial = study._storage.get_trial(trial._trial_id)
 
-        expected_message = "Trial 4 failed, because the objective " "function returned nan."
+        expected_message = "Trial 4 failed, because the objective function returned nan."
         assert frozen_trial.state == optuna.trial.TrialState.FAIL
         assert frozen_trial.system_attrs["fail_reason"] == expected_message
 

--- a/tests/test_study.py
+++ b/tests/test_study.py
@@ -386,10 +386,7 @@ def test_run_trial(storage_mode):
         trial = study._run_trial(func_value_error, catch=(ValueError,), gc_after_trial=True)
         frozen_trial = study._storage.get_trial(trial._trial_id)
 
-        expected_message = (
-            "Setting status of trial#1 as TrialState.FAIL because of the "
-            "following error: ValueError()"
-        )
+        expected_message = "Trial 1 failed because of the " "following error: ValueError()"
         assert frozen_trial.state == optuna.trial.TrialState.FAIL
         assert frozen_trial.system_attrs["fail_reason"] == expected_message
 
@@ -407,7 +404,7 @@ def test_run_trial(storage_mode):
         frozen_trial = study._storage.get_trial(trial._trial_id)
 
         expected_message = (
-            "Setting status of trial#3 as TrialState.FAIL because the returned "
+            "Trial 3 failed, because the returned "
             "value from the objective function cannot be casted to float. "
             "Returned value is: None"
         )
@@ -423,10 +420,7 @@ def test_run_trial(storage_mode):
         trial = study._run_trial(func_nan, catch=(Exception,), gc_after_trial=True)
         frozen_trial = study._storage.get_trial(trial._trial_id)
 
-        expected_message = (
-            "Setting status of trial#4 as TrialState.FAIL because the objective "
-            "function returned nan."
-        )
+        expected_message = "Trial 4 failed, because the objective " "function returned nan."
         assert frozen_trial.state == optuna.trial.TrialState.FAIL
         assert frozen_trial.system_attrs["fail_reason"] == expected_message
 


### PR DESCRIPTION
<!-- Thank you for creating a pull request! -->

## Motivation
Log messages for Optuna are long and use `#` which is superfluous.

## Description of the changes
Shorten the log messages for pruned, successful, and failed trials.