### PR TITLE
Set `timeout` for relatively long-running examples.

### DIFF
--- a/examples/mxnet_simple.py
+++ b/examples/mxnet_simple.py
@@ -114,7 +114,7 @@ def objective(trial):
 
 if __name__ == "__main__":
     study = optuna.create_study(direction="maximize")
-    study.optimize(objective, n_trials=100)
+    study.optimize(objective, n_trials=100, timeout=600)
 
     print("Number of finished trials: ", len(study.trials))
 

--- a/examples/pytorch_simple.py
+++ b/examples/pytorch_simple.py
@@ -133,7 +133,7 @@ def objective(trial):
 
 if __name__ == "__main__":
     study = optuna.create_study(direction="maximize")
-    study.optimize(objective, n_trials=100)
+    study.optimize(objective, n_trials=100, timeout=600)
 
     pruned_trials = [t for t in study.trials if t.state == optuna.trial.TrialState.PRUNED]
     complete_trials = [t for t in study.trials if t.state == optuna.trial.TrialState.COMPLETE]

--- a/examples/tensorflow_estimator_simple.py
+++ b/examples/tensorflow_estimator_simple.py
@@ -104,7 +104,7 @@ def objective(trial):
 
 def main():
     study = optuna.create_study(direction="maximize")
-    study.optimize(objective, n_trials=25)
+    study.optimize(objective, n_trials=25, timeout=600)
 
     print("Number of finished trials: ", len(study.trials))
 


### PR DESCRIPTION
## Motivation

See https://github.com/optuna/optuna/pull/1344. Additionally, most examples already utilize this `timeout` argument, while some are not.

## Description of the changes

Use the `timeout` argument for relatively long-running examples that don't already.