### PR TITLE
Set `python_requires` in setup.py to clarify supported Python version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -164,6 +164,7 @@ setup(
             "storages/rdb/alembic/versions/*.*",
         ]
     },
+    python_requires=">=3.5",
     install_requires=get_install_requires(),
     tests_require=get_tests_require(),
     extras_require=get_extras_require(),


### PR DESCRIPTION
<!-- Thank you for creating a pull request! -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

To clarify Optuna only supports certain Python versions (3.5 or newer currently).

## Description of the changes
<!-- Describe the changes in this PR. -->

- Add `python_requires=">=3.5"` in `setup.py`.

## References
- https://packaging.python.org/guides/distributing-packages-using-setuptools/#python-requires
- https://packaging.python.org/guides/dropping-older-python-versions/