### PR TITLE
Use `Colab` to demonstrate a notebook instead of `nbviewer`.

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -59,7 +59,7 @@ In addition, integration modules are available for the following libraries, prov
 
 ### Examples of Visualization
 
-* [Visualizing study](https://nbviewer.jupyter.org/github/optuna/optuna/blob/master/examples/visualization/plot_study.ipynb)
+* [Visualizing study](https://colab.research.google.com/github/optuna/optuna/blob/master/examples/visualization/plot_study.ipynb)
 
 ### Examples of MLflow
 


### PR DESCRIPTION
## Motivation

Currently, the [README.md](https://github.com/optuna/optuna/blob/master/examples/README.md) in `optuna/exmaples` links to the [nbviewer](https://nbviewer.jupyter.org/github/optuna/optuna/blob/master/examples/visualization/plot_study.ipynb) to demonstrate the visualization feature. It has some problems:
- It sometimes shows 503 as reported in #617.
- It does not show figures and users need to click the link to Colab at the top of the file.

## Description of the changes

Instead of linking to the `nbviewer`, this PR directly links the README to [Colab](https://colab.research.google.com/github/optuna/optuna/blob/master/examples/visualization/plot_study.ipynb).