### PR TITLE
Hotfix to allow building the docs by avoiding latest `sphinx`.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ def get_extras_require() -> Dict[str, List[str]]:
             "mlflow",
         ],
         # TODO(hvy): Unpin `sphinx` version after https://github.com/sphinx-doc/sphinx/issues/7807.
-        "document": ["sphinx>=3.0.0,!=3.1.0", "sphinx_rtd_theme"],
+        "document": ["sphinx>=3.0.0,<3.1.0", "sphinx_rtd_theme"],
         "example": [
             "catboost",
             "chainer",


### PR DESCRIPTION
## Motivation

Temporary hotfix for https://github.com/optuna/optuna/issues/1368.

## Description of the changes

Avoids latest sphinx version.