### PR TITLE
Update layout and color of docs.

### DIFF
--- a/docs/source/_templates/footer.html
+++ b/docs/source/_templates/footer.html
@@ -27,14 +27,18 @@
             background: #F1F3F4;
         }
         .navbar {
+            background: #FFFFFF;
         }
         .navbar-nav {
+            background: #FFFFFF;
             list-style: none;
             display: flex;
             flex-direction: row;
             align-items: center;
             justify-content: flex-end;
             padding: 20px;
+            max-width: 800px;
+            margin-left: 300px;
         }
         .ml-auto {
             margin-left: auto!important;

--- a/docs/source/_templates/footer.html
+++ b/docs/source/_templates/footer.html
@@ -7,6 +7,12 @@
         .wy-side-nav-search, .wy-nav-top {
             background: #F1F3F4;
         }
+        .wy-nav-top a {
+            color: #404040;
+        }
+        .wy-nav-top i {
+            color: #404040;
+        }
         /* Sidebar */
         .wy-nav-side {
             background: #F1F3F4;

--- a/docs/source/_templates/footer.html
+++ b/docs/source/_templates/footer.html
@@ -29,6 +29,11 @@
         .navbar {
             background: #FFFFFF;
         }
+        @media only screen and (max-width: 896px) {
+            .navbar {
+                height: 0px;
+            }
+        }
         .navbar-nav {
             background: #FFFFFF;
             list-style: none;

--- a/docs/source/_templates/footer.html
+++ b/docs/source/_templates/footer.html
@@ -2,4 +2,77 @@
 {% block extrafooter %}
     {% trans path=pathto('privacy') %}<a href="{{ path }}">Privacy Policy</a>{{ privacy }}.{% endtrans %}
     {{ super() }}
+    <style>
+        /* Sidebar header (and topbar for mobile) */
+        .wy-side-nav-search, .wy-nav-top {
+            background: #F1F3F4;
+        }
+        /* Sidebar */
+        .wy-nav-side {
+            background: #F1F3F4;
+        }
+        /* A tag */
+        .wy-menu-vertical a {
+            color: #707070;
+        }
+        a {
+            color: #2BA9CD;
+        }
+        .wy-menu-vertical a:active {
+            background-color: #2BA9CD;
+            cursor: pointer;
+            color: #F1F3F4;
+        }
+        .highlight {
+            background: #F1F3F4;
+        }
+        .navbar {
+        }
+        .navbar-nav {
+            list-style: none;
+            display: flex;
+            flex-direction: row;
+            align-items: center;
+            justify-content: flex-end;
+            padding: 20px;
+        }
+        .ml-auto {
+            margin-left: auto!important;
+        }
+        .header_link {
+            margin: 15px 2px;
+            font-size: 16px;
+            font-weight: 600;
+            font-family: "Helvetica";
+            cursor: pointer;
+            padding: 0.5rem 0.8rem 0.5rem 0.5rem;
+            color: #636A73;
+        }
+        .navbar-nav a:focus, a:hover {
+           color: #2ba9cd;
+            text-decoration: none;
+        }
+        .navbar-nav a:visited {
+           color: #636A73;
+            text-decoration: none;
+        }
+        .wy-alert.wy-alert-info .wy-alert-title, .rst-content .note .wy-alert-title, .rst-content .wy-alert-info.attention .wy-alert-title, .rst-content .wy-alert-info.caution .wy-alert-title, .rst-content .wy-alert-info.danger .wy-alert-title, .rst-content .wy-alert-info.error .wy-alert-title, .rst-content .wy-alert-info.hint .wy-alert-title, .rst-content .wy-alert-info.important .wy-alert-title, .rst-content .wy-alert-info.tip .wy-alert-title, .rst-content .wy-alert-info.warning .wy-alert-title, .rst-content .seealso .wy-alert-title, .rst-content .wy-alert-info.admonition-todo .wy-alert-title, .rst-content .wy-alert-info.admonition .wy-alert-title, .wy-alert.wy-alert-info .rst-content .admonition-title, .rst-content .wy-alert.wy-alert-info .admonition-title, .rst-content .note .admonition-title, .rst-content .wy-alert-info.attention .admonition-title, .rst-content .wy-alert-info.caution .admonition-title, .rst-content .wy-alert-info.danger .admonition-title, .rst-content .wy-alert-info.error .admonition-title, .rst-content .wy-alert-info.hint .admonition-title, .rst-content .wy-alert-info.important .admonition-title, .rst-content .wy-alert-info.tip .admonition-title, .rst-content .wy-alert-info.warning .admonition-title, .rst-content .seealso .admonition-title, .rst-content .wy-alert-info.admonition-todo .admonition-title, .rst-content .wy-alert-info.admonition .admonition-title {
+            background: #2BA9CD;
+        }
+        .wy-alert, .rst-content .note, .rst-content .attention, .rst-content .caution, .rst-content .danger, .rst-content .error, .rst-content .hint, .rst-content .important, .rst-content .tip, .rst-content .warning, .rst-content .seealso, .rst-content .admonition-todo, .rst-content .admonition{
+            background: #F1F3F4;
+        }
+        .rst-content dl:not(.docutils) dt {
+            display: table;
+            margin: 6px 0;
+            font-size: 90%;
+            line-height: normal;
+            background: #F1F3F4;
+            color: #2980B9;
+            border-top: solid 3px #2BA9CD;
+            padding: 6px;
+            position: relative;
+        }
+
+    </style>
 {% endblock %}

--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -1,6 +1,6 @@
 {% extends "!layout.html" %}
 {%- block extrabody %}
-    <div class="">
+    <div class="navbar">
         <div class="navbar ml-auto">
             <ul class="navbar-nav">
                 <li>

--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -4,22 +4,22 @@
         <div class="navbar ml-auto">
             <ul class="navbar-nav">
                 <li>
-                    <a href="" class="header_link">Key Features</a>
+                    <a href="https://optuna.org/#key_features" class="header_link">Key Features</a>
                 </li>
                 <li>
-                    <a href="" class="header_link">Code Examples</a>
+                    <a href="https://optuna.org/#code_examples" class="header_link">Code Examples</a>
                 </li>
                 <li>
-                    <a href="" class="header_link">Installation</a>
+                    <a href="https://optuna.org/#installation" class="header_link">Installation</a>
                 </li>
                 <li>
-                    <a href="" class="header_link">Blog</a>
+                    <a href="https://optuna.org/#blog" class="header_link">Blog</a>
                 </li>
                 <li>
-                    <a href="" class="header_link">Videos</a>
+                    <a href="https://optuna.org/#video" class="header_link">Videos</a>
                 </li>
                 <li>
-                    <a href="" class="header_link">Paper</a>
+                    <a href="https://optuna.org/#paper" class="header_link">Paper</a>
                 </li>
             </ul>
         </div>

--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -1,0 +1,28 @@
+{% extends "!layout.html" %}
+{%- block extrabody %}
+    <div class="">
+        <div class="navbar ml-auto">
+            <ul class="navbar-nav">
+                <li>
+                    <a href="" class="header_link">Key Features</a>
+                </li>
+                <li>
+                    <a href="" class="header_link">Code Examples</a>
+                </li>
+                <li>
+                    <a href="" class="header_link">Installation</a>
+                </li>
+                <li>
+                    <a href="" class="header_link">Blog</a>
+                </li>
+                <li>
+                    <a href="" class="header_link">Videos</a>
+                </li>
+                <li>
+                    <a href="" class="header_link">Paper</a>
+                </li>
+            </ul>
+        </div>
+    </div>
+    {{ super() }}
+{% endblock %}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -92,9 +92,13 @@ if not on_rtd:
 # further.  For a list of options available for each theme, see the
 # documentation.
 #
-# html_theme_options = {}
+html_theme_options = {
+    'logo_only': True
+}
 
 html_favicon = '../image/favicon.ico'
+
+html_logo = '../image/optuna-logo.png'
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,


### PR DESCRIPTION
## Motivation
Currently, Optuna docs employ the default `sphinx_rtd_theme`. I think it is quite different from the style of https://optuna.org/.

c.f. The current docs: https://optuna.readthedocs.io/en/stable/index.html

![image](https://user-images.githubusercontent.com/3255979/84609112-8e3d7d80-aef0-11ea-9714-0b7133b68a05.png)


## Description of the changes

This PR changes the layout and color of Optuna docs.
- Add the logo at the top left of the page.
- Add the navigation bar at the top of the page.
- Use color pallet of https://optuna.org/

![image](https://user-images.githubusercontent.com/3255979/84608822-1d499600-aeef-11ea-916d-7efa7df23e5a.png)

![image](https://user-images.githubusercontent.com/3255979/84608810-11f66a80-aeef-11ea-8228-0b06f6b65e8b.png)

![image](https://user-images.githubusercontent.com/3255979/84608768-e7a4ad00-aeee-11ea-9325-14db2d01c7f5.png)

c.f. https://optuna.org

![image](https://user-images.githubusercontent.com/3255979/84609079-62ba9300-aef0-11ea-950a-4a14cf7d54de.png)

