### PR TITLE
Remove deprecated features in `optuna.trial`.

### DIFF
--- a/examples/visualization/plot_study.ipynb
+++ b/examples/visualization/plot_study.ipynb
@@ -148,7 +148,7 @@
         "        trial.report(value, step)\n",
         "\n",
         "        # Handle pruning based on the intermediate value.\n",
-        "        if trial.should_prune(step):\n",
+        "        if trial.should_prune():\n",
         "            raise optuna.TrialPruned()  \n",
         "\n",
         "    return value"

--- a/examples/visualization/plot_study.py
+++ b/examples/visualization/plot_study.py
@@ -52,7 +52,7 @@ def objective(trial):
         trial.report(value, step)
 
         # Handle pruning based on the intermediate value.
-        if trial.should_prune(step):
+        if trial.should_prune():
             raise optuna.TrialPruned()
 
     return value

--- a/optuna/integration/chainermn.py
+++ b/optuna/integration/chainermn.py
@@ -1,5 +1,6 @@
 import gc
 from typing import Optional
+import warnings
 
 from optuna._imports import try_import
 from optuna.logging import get_logger
@@ -293,6 +294,17 @@ class ChainerMNTrial(BaseTrial):
             return self.delegate.number
 
         return self._call_with_mpi(func)
+
+    @property
+    def trial_id(self):
+        # type: () -> int
+
+        warnings.warn(
+            "The use of `ChainerMNTrial.trial_id` is deprecated. "
+            "Please use `ChainerMNTrial.number` instead.",
+            DeprecationWarning,
+        )
+        return self._trial_id
 
     @property
     def _trial_id(self):

--- a/optuna/integration/chainermn.py
+++ b/optuna/integration/chainermn.py
@@ -1,6 +1,5 @@
 import gc
 from typing import Optional
-import warnings
 
 from optuna._imports import try_import
 from optuna.logging import get_logger
@@ -294,17 +293,6 @@ class ChainerMNTrial(BaseTrial):
             return self.delegate.number
 
         return self._call_with_mpi(func)
-
-    @property
-    def trial_id(self):
-        # type: () -> int
-
-        warnings.warn(
-            "The use of `ChainerMNTrial.trial_id` is deprecated. "
-            "Please use `ChainerMNTrial.number` instead.",
-            DeprecationWarning,
-        )
-        return self._trial_id
 
     @property
     def _trial_id(self):

--- a/optuna/integration/chainermn.py
+++ b/optuna/integration/chainermn.py
@@ -258,14 +258,12 @@ class ChainerMNTrial(BaseTrial):
             self.delegate.report(value, step)
         self.comm.mpi_comm.barrier()
 
-    def should_prune(self, step=None):
-        # type: (Optional[int]) -> bool
-
+    def should_prune(self) -> bool:
         def func():
             # type: () -> bool
 
             assert self.delegate is not None
-            return self.delegate.should_prune(step)
+            return self.delegate.should_prune()
 
         return self._call_with_mpi(func)
 

--- a/optuna/trial/_base.py
+++ b/optuna/trial/_base.py
@@ -14,7 +14,6 @@ if type_checking.TYPE_CHECKING:
 
     from optuna.distributions import BaseDistribution  # NOQA
     from optuna.distributions import CategoricalChoiceType  # NOQA
-    from optuna.study import Study  # NOQA
 
     FloatingPointDistributionType = Union[
         distributions.UniformDistribution, distributions.LogUniformDistribution
@@ -79,8 +78,7 @@ class BaseTrial(object, metaclass=abc.ABCMeta):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def should_prune(self, step=None):
-        # type: (Optional[int]) -> bool
+    def should_prune(self) -> bool:
 
         raise NotImplementedError
 

--- a/optuna/trial/_fixed.py
+++ b/optuna/trial/_fixed.py
@@ -19,7 +19,6 @@ if type_checking.TYPE_CHECKING:
 
     from optuna.distributions import BaseDistribution  # NOQA
     from optuna.distributions import CategoricalChoiceType  # NOQA
-    from optuna.study import Study  # NOQA
 
     FloatingPointDistributionType = Union[UniformDistribution, LogUniformDistribution]
 
@@ -160,8 +159,7 @@ class FixedTrial(BaseTrial):
 
         pass
 
-    def should_prune(self, step=None):
-        # type: (Optional[int]) -> bool
+    def should_prune(self) -> bool:
 
         return False
 

--- a/optuna/trial/_frozen.py
+++ b/optuna/trial/_frozen.py
@@ -1,5 +1,4 @@
 import datetime
-import warnings
 
 from optuna import distributions
 from optuna import logging
@@ -10,12 +9,9 @@ if type_checking.TYPE_CHECKING:
     from typing import Any  # NOQA
     from typing import Dict  # NOQA
     from typing import Optional  # NOQA
-    from typing import Sequence  # NOQA
     from typing import Union  # NOQA
 
     from optuna.distributions import BaseDistribution  # NOQA
-    from optuna.distributions import CategoricalChoiceType  # NOQA
-    from optuna.study import Study  # NOQA
 
     FloatingPointDistributionType = Union[
         distributions.UniformDistribution, distributions.LogUniformDistribution
@@ -180,32 +176,6 @@ class FrozenTrial(object):
     def distributions(self, value):
         # type: (Dict[str, BaseDistribution]) -> None
         self._distributions = value
-
-    @property
-    def trial_id(self):
-        # type: () -> int
-        """Return the trial ID.
-
-        .. deprecated:: 0.19.0
-            The direct use of this attribute is deprecated and it is recommended that you use
-            :attr:`~optuna.trial.FrozenTrial.number` instead.
-
-        Returns:
-            The trial ID.
-        """
-
-        warnings.warn(
-            "The use of `FrozenTrial.trial_id` is deprecated. "
-            "Please use `FrozenTrial.number` instead.",
-            DeprecationWarning,
-        )
-
-        _logger.warning(
-            "The use of `FrozenTrial.trial_id` is deprecated. "
-            "Please use `FrozenTrial.number` instead."
-        )
-
-        return self._trial_id
 
     @property
     def last_step(self):

--- a/optuna/trial/_trial.py
+++ b/optuna/trial/_trial.py
@@ -584,8 +584,6 @@ class Trial(BaseTrial):
         .. seealso::
             Please refer to the example code in :func:`optuna.trial.Trial.report`.
 
-        Args:
-
         Returns:
             A boolean value. If :obj:`True`, the trial should be pruned according to the
             configured pruning algorithm. Otherwise, the trial should continue.

--- a/optuna/trial/_trial.py
+++ b/optuna/trial/_trial.py
@@ -567,8 +567,7 @@ class Trial(BaseTrial):
 
         self.storage.set_trial_intermediate_value(self._trial_id, step, value)
 
-    def should_prune(self, step=None):
-        # type: (Optional[int]) -> bool
+    def should_prune(self) -> bool:
         """Suggest whether the trial should be pruned or not.
 
         The suggestion is made by a pruning algorithm associated with the trial and is based on
@@ -584,21 +583,11 @@ class Trial(BaseTrial):
             Please refer to the example code in :func:`optuna.trial.Trial.report`.
 
         Args:
-            step:
-                Deprecated since 0.12.0: Step of the trial (e.g., epoch of neural network
-                training). Deprecated in favor of always considering the most recent step.
 
         Returns:
             A boolean value. If :obj:`True`, the trial should be pruned according to the
             configured pruning algorithm. Otherwise, the trial should continue.
         """
-        if step is not None:
-            warnings.warn(
-                "The use of `step` argument is deprecated. "
-                "The last reported step is used instead of "
-                "the step given by the argument.",
-                DeprecationWarning,
-            )
 
         trial = self.study._storage.get_trial(self._trial_id)
         return self.study.pruner.prune(self.study, trial)
@@ -767,29 +756,6 @@ class Trial(BaseTrial):
         return self.storage.get_trial_number_from_id(self._trial_id)
 
     @property
-    def trial_id(self):
-        # type: () -> int
-        """Return trial ID.
-
-        Note that the use of this is deprecated.
-        Please use :attr:`~optuna.trial.Trial.number` instead.
-
-        Returns:
-            A trial ID.
-        """
-
-        warnings.warn(
-            "The use of `Trial.trial_id` is deprecated. Please use `Trial.number` instead.",
-            DeprecationWarning,
-        )
-
-        self.logger.warning(
-            "The use of `Trial.trial_id` is deprecated. Please use `Trial.number` instead."
-        )
-
-        return self._trial_id
-
-    @property
     def params(self):
         # type: () -> Dict[str, Any]
         """Return parameters to be optimized.
@@ -842,22 +808,3 @@ class Trial(BaseTrial):
             Datetime where the :class:`~optuna.trial.Trial` started.
         """
         return self.storage.get_trial(self._trial_id).datetime_start
-
-    @property
-    def study_id(self):
-        # type: () -> int
-        """Return the study ID.
-
-        .. deprecated:: 0.20.0
-            The direct use of this attribute is deprecated and it is recommended that you use
-            :attr:`~optuna.trial.Trial.study` instead.
-
-        Returns:
-            The study ID.
-        """
-
-        message = "The use of `Trial.study_id` is deprecated. Please use `Trial.study` instead."
-        warnings.warn(message, DeprecationWarning)
-        self.logger.warning(message)
-
-        return self.study._study_id

--- a/tests/test_trial.py
+++ b/tests/test_trial.py
@@ -633,7 +633,6 @@ def test_fixed_trial_should_prune():
 
     # FixedTrial never prunes trials.
     assert FixedTrial({}).should_prune() is False
-    assert FixedTrial({}).should_prune(1) is False
 
 
 def test_fixed_trial_datetime_start():
@@ -761,12 +760,7 @@ def test_study_id():
     study = create_study()
     trial = Trial(study, study._storage.create_new_trial(study._study_id))
 
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", category=DeprecationWarning)
-        assert trial.study_id == trial.study._study_id
-
-    with pytest.warns(DeprecationWarning):
-        trial.study_id
+    assert trial._study_id == trial.study._study_id
 
 
 def test_frozen_trial_validate():


### PR DESCRIPTION
## Motivation
This PR is one of the follow-ups PRs for #1346.

## Description of the changes
- Remove the `optuna.trial.FrozenTrial.trial_id`.
- Remove the `step` argument in `optuna.trial.{BaseTrial, Trial, FizedTrial, ChainerMNTrial}.should_prune`.
- Remove the `optuna.trial.Trial.trial_id`.
- Remove the `optuna.trial.Trial.study_id`.
