### PR TITLE
Remove deprecated features in `integration/chainermn.py`.

### DIFF
--- a/optuna/integration/chainermn.py
+++ b/optuna/integration/chainermn.py
@@ -1,6 +1,5 @@
 import gc
 from typing import Optional
-import warnings
 
 from optuna._imports import try_import
 from optuna.logging import get_logger
@@ -296,17 +295,6 @@ class ChainerMNTrial(BaseTrial):
             return self.delegate.number
 
         return self._call_with_mpi(func)
-
-    @property
-    def trial_id(self):
-        # type: () -> int
-
-        warnings.warn(
-            "The use of `ChainerMNTrial.trial_id` is deprecated. "
-            "Please use `ChainerMNTrial.number` instead.",
-            DeprecationWarning,
-        )
-        return self._trial_id
 
     @property
     def _trial_id(self):


### PR DESCRIPTION
## Motivation

See https://github.com/optuna/optuna/issues/1346 and https://github.com/optuna/optuna/pull/1371#discussion_r439938138.

## Description of the changes

Removes the deprecated `trial_id` property from the ChainerMN integration.