### PR TITLE
Remove deprecated features in `optuna/study.py`.

### DIFF
--- a/optuna/_study_summary.py
+++ b/optuna/_study_summary.py
@@ -2,7 +2,6 @@ import datetime
 from typing import Any
 from typing import Dict
 from typing import Optional
-import warnings
 
 from optuna._study_direction import StudyDirection
 from optuna import logging
@@ -78,25 +77,3 @@ class StudySummary(object):
             return NotImplemented
 
         return self._study_id <= other._study_id
-
-    @property
-    def study_id(self) -> int:
-        """Return the study ID.
-
-        .. deprecated:: 0.20.0
-            The direct use of this attribute is deprecated and it is recommended that you use
-            :attr:`~optuna.study.StudySummary.study_name` instead.
-
-        Returns:
-            The study ID.
-
-        """
-        message = (
-            "The use of `StudySummary.study_id` is deprecated. "
-            "Please use `StudySummary.study_name` instead."
-        )
-        warnings.warn(message, DeprecationWarning)
-
-        _logger.warning(message)
-
-        return self._study_id

--- a/optuna/study.py
+++ b/optuna/study.py
@@ -139,35 +139,6 @@ class BaseStudy(object):
         self._storage.read_trials_from_remote_storage(self._study_id)
         return self._storage.get_all_trials(self._study_id, deepcopy=deepcopy)
 
-    @property
-    def storage(self):
-        # type: () -> storages.BaseStorage
-        """Return the storage object used by the study.
-
-        .. deprecated:: 0.15.0
-            The direct use of storage is deprecated.
-            Please access to storage via study's public methods
-            (e.g., :meth:`~optuna.study.Study.set_user_attr`).
-
-        Returns:
-            A storage object.
-        """
-
-        warnings.warn(
-            "The direct use of storage is deprecated. "
-            "Please access to storage via study's public methods "
-            "(e.g., `Study.set_user_attr`)",
-            DeprecationWarning,
-        )
-
-        _logger.warning(
-            "The direct use of storage is deprecated. "
-            "Please access to storage via study's public methods "
-            "(e.g., `Study.set_user_attr`)"
-        )
-
-        return self._storage
-
 
 class Study(BaseStudy):
     """A study corresponds to an optimization task, i.e., a set of trials.
@@ -213,27 +184,6 @@ class Study(BaseStudy):
 
         self.__dict__.update(state)
         self._optimize_lock = threading.Lock()
-
-    @property
-    def study_id(self):
-        # type: () -> int
-        """Return the study ID.
-
-        .. deprecated:: 0.20.0
-            The direct use of this attribute is deprecated and it is recommended that you use
-            :attr:`~optuna.study.Study.study_name` instead.
-
-        Returns:
-            The study ID.
-        """
-
-        message = (
-            "The use of `Study.study_id` is deprecated. Please use `Study.study_name` instead."
-        )
-        warnings.warn(message, DeprecationWarning)
-        _logger.warning(message)
-
-        return self._study_id
 
     @property
     def user_attrs(self):

--- a/tests/test_study.py
+++ b/tests/test_study.py
@@ -7,7 +7,6 @@ import time
 from unittest.mock import Mock  # NOQA
 from unittest.mock import patch
 import uuid
-import warnings
 
 import joblib
 import pandas as pd
@@ -853,13 +852,6 @@ def test_enqueue_trial_with_out_of_range_parameters(storage_mode):
         assert t.params["x"] == 1
 
 
-def test_storage_property():
-    # type: () -> None
-
-    study = optuna.create_study()
-    assert study.storage == study._storage
-
-
 @patch("optuna.study.gc.collect")
 def test_optimize_with_gc(collect_mock):
     # type: (Mock) -> None
@@ -970,36 +962,6 @@ def test_get_trials(storage_mode):
             trials2 = study.trials
             assert mock_object.call_count > old_count
             assert trials0 == trials2
-
-
-def test_study_id():
-    # type: () -> None
-
-    study = optuna.create_study()
-
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", category=DeprecationWarning)
-        assert study.study_id == study._study_id
-
-    with pytest.warns(DeprecationWarning):
-        study.study_id
-
-
-def test_study_summary_study_id():
-    # type: () -> None
-
-    study = optuna.create_study()
-    summaries = study._storage.get_all_study_summaries()
-    assert len(summaries) == 1
-
-    summary = summaries[0]
-
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", category=DeprecationWarning)
-        assert summary.study_id == summary._study_id
-
-    with pytest.warns(DeprecationWarning):
-        summary.study_id
 
 
 def test_study_summary_eq_ne():


### PR DESCRIPTION
## Motivation
This PR is one of the follow-ups PRs for #1346.

## Description of the changes
- Remove `study.StudySummary.study_id`.
- Remove `study.Study.study_id`.
- Remove `study.BaseStudy.storage`.
