### PR TITLE
Do not run the GC after every trial by default.

### DIFF
--- a/optuna/integration/chainermn.py
+++ b/optuna/integration/chainermn.py
@@ -1,4 +1,3 @@
-import gc
 from typing import Optional
 
 from optuna._imports import try_import
@@ -138,12 +137,6 @@ class ChainerMNStudy(object):
                     pass
                 except catch:
                     pass
-                finally:
-                    # The following line mitigates memory problems that can be occurred in some
-                    # environments (e.g., services that use computing containers such as CircleCI).
-                    # Please refer to the following PR for further details:
-                    # https://github.com/optuna/optuna/pull/325.
-                    gc.collect()
 
     def __getattr__(self, attr_name):
         # type: (str) -> Any

--- a/optuna/study.py
+++ b/optuna/study.py
@@ -265,7 +265,7 @@ class Study(BaseStudy):
         n_jobs=1,  # type: int
         catch=(),  # type: Union[Tuple[()], Tuple[Type[Exception]]]
         callbacks=None,  # type: Optional[List[Callable[[Study, FrozenTrial], None]]]
-        gc_after_trial=True,  # type: bool
+        gc_after_trial=False,  # type: bool
         show_progress_bar=False,  # type: bool
     ):
         # type: (...) -> None
@@ -302,9 +302,11 @@ class Study(BaseStudy):
                 must accept two parameters with the following types in this order:
                 :class:`~optuna.study.Study` and :class:`~optuna.FrozenTrial`.
             gc_after_trial:
-                Flag to execute garbage collection at the end of each trial. By default, garbage
-                collection is enabled, just in case. You can turn it off with this argument if
-                memory is safely managed in your objective function.
+                Flag to determine whether to automatically run garbage collection after each trial.
+                Set to :obj:`True` to run the garbage collection, :obj:`False` otherwise.
+                When it runs, it runs a full collection by internally calling :func:`gc.collect`.
+                If you see an increase in memory consumption over several trials, try setting this
+                flag to :obj:`True`.
             show_progress_bar:
                 Flag to show progress bars or not. To disable progress bar, set this ``False``.
                 Currently, progress bar is experimental feature and disabled


### PR DESCRIPTION
## Motivation

Fixes https://github.com/optuna/optuna/issues/1307. See this issue for discussions.

## Description of the changes

Changes the default GC collection behavior of `Study.optimize` to not run a collection.