### PR TITLE
Deprecate `optuna study optimize` command.

### DIFF
--- a/optuna/cli.py
+++ b/optuna/cli.py
@@ -296,8 +296,8 @@ class _StudyOptimize(_BaseCommand):
         # type: (Namespace) -> int
 
         message = (
-            "The use of the `study optimize` command is deprecated. Please execute your Python script directly "
-            "instead."
+            "The use of the `study optimize` command is deprecated. Please execute your Python "
+            "script directly instead."
         )
         warnings.warn(message, DeprecationWarning)
         self.logger.warning(message)

--- a/optuna/cli.py
+++ b/optuna/cli.py
@@ -296,7 +296,7 @@ class _StudyOptimize(_BaseCommand):
         # type: (Namespace) -> int
 
         message = (
-            "The use of `study optimize` command is deprecated. Please execute your Python script "
+            "The use of the `study optimize` command is deprecated. Please execute your Python script directly "
             "instead."
         )
         warnings.warn(message, DeprecationWarning)

--- a/optuna/cli.py
+++ b/optuna/cli.py
@@ -253,7 +253,7 @@ class _Dashboard(_BaseCommand):
 
 
 class _StudyOptimize(_BaseCommand):
-    """Start optimization of a study."""
+    """Start optimization of a study. Deprecated since version 2.0.0."""
 
     def get_parser(self, prog_name):
         # type: (str) -> ArgumentParser
@@ -294,6 +294,13 @@ class _StudyOptimize(_BaseCommand):
 
     def take_action(self, parsed_args):
         # type: (Namespace) -> int
+
+        message = (
+            "The use of `study optimize` command is deprecated. Please execute your Python script "
+            "instead."
+        )
+        warnings.warn(message, DeprecationWarning)
+        self.logger.warning(message)
 
         storage_url = _check_storage_url(self.app_args.storage)
 


### PR DESCRIPTION
## Motivation
Optuna provides the CLI to invoke optimization from the shell, but it does not support some features like the pruning and the callback. This PR proposes to remove it in the future instead of adding the new feature support because of the following reasons:

- the command-line options will be complicated to manage the pruning and callback, and
- most of the users directly execute their Python scripts.

## Description of the changes
This PR adds a deprecation warning to `optuna study optimize` command. 

We need to update the code comment in the example files, but I leave them as they are to keep the diff small.