### PR TITLE
Add FAQ section about OOM.

### DIFF
--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -321,3 +321,8 @@ Specify ``gc_after_trial`` to :obj:`True` when calling :func:`~optuna.study.Stud
 
 There is a performance trade-off for running the garbage collector, which could be non-negligible depending on how fast your objective function otherwise is. Therefore, ``gc_after_trial`` is :obj:`False` by default.
 Note that the above examples are similar to running the garbage collector inside the objective function, except for the fact that :func:`gc.collect` is called even when errors, including :class:`~optuna.exceptions.TrialPruned` are raised.
+
+.. note::
+
+    :class:`~optuna.integration.ChainerMNStudy` does currently not provide ``gc_after_trial`` nor callbacks for :func:`~optuna.integration.ChainerMNStudy.optimize`.
+    When using this class, you will have to call the garbage collector inside the objective function.

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -300,8 +300,8 @@ Using :class:`~optuna.trial.FixedTrial`, you can write unit tests as follows:
 
 .. _out-of-memory-gc-collect:
 
-How do I avoid running out of memory when optimizing studies?
--------------------------------------------------------------
+How do I avoid running out of memory (OOM) when optimizing studies?
+-------------------------------------------------------------------
 
 If the memory footprint increases as you run more trials, try to periodically run the garbage collector.
 Specify ``gc_after_trial`` to :obj:`True` when calling :func:`~optuna.study.Study.optimize` or call :func:`gc.collect` inside a callback.

--- a/optuna/study.py
+++ b/optuna/study.py
@@ -257,6 +257,11 @@ class Study(BaseStudy):
                 When it runs, it runs a full collection by internally calling :func:`gc.collect`.
                 If you see an increase in memory consumption over several trials, try setting this
                 flag to :obj:`True`.
+
+                .. seealso::
+
+                    :ref:`out-of-memory-gc-collect`
+
             show_progress_bar:
                 Flag to show progress bars or not. To disable progress bar, set this ``False``.
                 Currently, progress bar is experimental feature and disabled


### PR DESCRIPTION
## Motivation

Follow-up to https://github.com/optuna/optuna/pull/1380. 

Now that we don't do any GC collection sweep by default, OOM might become an issue for certain users (as described in tickets that can be tracked from the above PR). A section in the FAQ might alleviate some of the problem.

## Description of the changes

Introduces a section in the FAQ about OOM, and adds a reference to it from the API reference for `gc_after_trial`.
