### PR TITLE
Hotfix to avoid latest `keras` 2.4.0.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,13 @@ def get_extras_require() -> Dict[str, List[str]]:
             ["llvmlite<=0.31.0"] if (3, 5) == sys.version_info[:2] else []
         )  # Newer `llvmlite` is not distributed with wheels for Python 3.5.
         + (
-            ["dask[dataframe]", "dask-ml", "keras", "tensorflow>=2.0.0", "tensorflow-datasets"]
+            [
+                "dask[dataframe]",
+                "dask-ml",
+                "keras<2.4.0",
+                "tensorflow>=2.0.0",
+                "tensorflow-datasets",
+            ]
             if sys.version_info[:2] < (3, 8)
             else []
         ),
@@ -120,7 +126,9 @@ def get_extras_require() -> Dict[str, List[str]]:
             else []
         )
         + (
-            ["keras", "tensorflow", "tensorflow-datasets"] if sys.version_info[:2] < (3, 8) else []
+            ["keras<2.4.0", "tensorflow", "tensorflow-datasets"]
+            if sys.version_info[:2] < (3, 8)
+            else []
         ),
     }
 


### PR DESCRIPTION
## Motivation

Hotfix to avoid latest `keras` 2.4.0. It's breaking the master branch builds. 

## Description of the changes

Updates `setup.py` to avoid latest `keras`. 