### PR TITLE
Deprecate step argument in IntLogUniformDistribution

### DIFF
--- a/optuna/distributions.py
+++ b/optuna/distributions.py
@@ -320,7 +320,8 @@ class IntLogUniformDistribution(BaseDistribution):
             A step for spacing between values.
 
             .. deprecated:: 2.0.0
-                ``step`` argument will be removed in the future. The removal of this feature is currently scheduled for v3.0.0, but this schedule is subject to change.
+                ``step`` argument will be removed in the future. The removal of this feature is
+                currently scheduled for v4.0.0, but this schedule is subject to change.
     """
 
     def __init__(self, low: int, high: int, step: int = 1) -> None:
@@ -334,6 +335,12 @@ class IntLogUniformDistribution(BaseDistribution):
             raise ValueError(
                 "The `low` value must be equal to or greater than 1 for a log distribution "
                 "(low={}, high={}).".format(low, high)
+            )
+
+        if step != 1:
+            warnings.warn(
+                "`step` accepts only `1`, so `step` is replaced with `1`. "
+                "`step` argument is deprecated and will be removed in the future."
             )
 
         self.low = low

--- a/optuna/distributions.py
+++ b/optuna/distributions.py
@@ -3,6 +3,7 @@ import decimal
 import json
 import warnings
 
+from optuna import logging
 from optuna import type_checking
 
 if type_checking.TYPE_CHECKING:
@@ -12,6 +13,9 @@ if type_checking.TYPE_CHECKING:
     from typing import Union  # NOQA
 
     CategoricalChoiceType = Union[None, bool, int, float, str]
+
+
+_logger = logging.get_logger(__name__)
 
 
 class BaseDistribution(object, metaclass=abc.ABCMeta):
@@ -341,7 +345,7 @@ class IntLogUniformDistribution(BaseDistribution):
             )
 
         if step != 1:
-            warnings.warn(
+            _logger.warning(
                 "`step` accepts only `1`, so `step` is replaced with `1`. "
                 "`step` argument is deprecated and will be removed in the future. "
                 "The removal of this feature is currently scheduled for v4.0.0, "

--- a/optuna/distributions.py
+++ b/optuna/distributions.py
@@ -347,7 +347,7 @@ class IntLogUniformDistribution(BaseDistribution):
                 "`step` argument is deprecated and will be removed in the future. "
                 "The removal of this feature is currently scheduled for v4.0.0, "
                 "but this schedule is subject to change.",
-                DeprecationWarning,
+                FutureWarning,
             )
 
         self.low = low

--- a/optuna/distributions.py
+++ b/optuna/distributions.py
@@ -3,7 +3,6 @@ import decimal
 import json
 import warnings
 
-from optuna import logging
 from optuna import type_checking
 
 if type_checking.TYPE_CHECKING:
@@ -13,9 +12,6 @@ if type_checking.TYPE_CHECKING:
     from typing import Union  # NOQA
 
     CategoricalChoiceType = Union[None, bool, int, float, str]
-
-
-_logger = logging.get_logger(__name__)
 
 
 class BaseDistribution(object, metaclass=abc.ABCMeta):
@@ -326,9 +322,10 @@ class IntLogUniformDistribution(BaseDistribution):
             .. note::
                 This value is valid for only 1. Otherwise, the value is replaced with 1.
 
-            .. deprecated:: 2.0.0
-                ``step`` argument will be removed in the future. The removal of this feature is
-                currently scheduled for v4.0.0, but this schedule is subject to change.
+            .. warning::
+                Deprecated in v2.0.0. ``step`` argument will be removed in the future.
+                The removal of this feature is currently scheduled for v4.0.0,
+                but this schedule is subject to change.
     """
 
     def __init__(self, low: int, high: int, step: int = 1) -> None:
@@ -345,11 +342,12 @@ class IntLogUniformDistribution(BaseDistribution):
             )
 
         if step != 1:
-            _logger.warning(
+            warnings.warn(
                 "`step` accepts only `1`, so `step` is replaced with `1`. "
                 "`step` argument is deprecated and will be removed in the future. "
                 "The removal of this feature is currently scheduled for v4.0.0, "
-                "but this schedule is subject to change."
+                "but this schedule is subject to change.",
+                DeprecationWarning,
             )
 
         self.low = low

--- a/optuna/distributions.py
+++ b/optuna/distributions.py
@@ -316,9 +316,14 @@ class IntLogUniformDistribution(BaseDistribution):
             Lower endpoint of the range of the distribution. ``low`` is included in the range.
         high:
             Upper endpoint of the range of the distribution. ``high`` is included in the range.
+        step:
+            A step for spacing between values.
+
+            .. deprecated:: 2.0.0
+                ``step`` argument will be removed in the future. The removal of this feature is currently scheduled for v3.0.0, but this schedule is subject to change.
     """
 
-    def __init__(self, low: int, high: int) -> None:
+    def __init__(self, low: int, high: int, step: int = 1) -> None:
         if low > high:
             raise ValueError(
                 "The `low` value must be smaller than or equal to the `high` value "

--- a/optuna/distributions.py
+++ b/optuna/distributions.py
@@ -311,31 +311,18 @@ class IntLogUniformDistribution(BaseDistribution):
     This object is instantiated by :func:`~optuna.trial.Trial.suggest_int`, and passed to
     :mod:`~optuna.samplers` in general.
 
-    .. note::
-        If the range :math:`[\\mathsf{low}, \\mathsf{high}]` is not divisible by
-        :math:`\\mathsf{step}`, :math:`\\mathsf{high}` will be replaced with the maximum of
-        :math:`k \\times \\mathsf{step} + \\mathsf{low} \\lt \\mathsf{high}`, where :math:`k` is
-        an integer.
-
     Attributes:
         low:
             Lower endpoint of the range of the distribution. ``low`` is included in the range.
         high:
             Upper endpoint of the range of the distribution. ``high`` is included in the range.
-        step:
-            A step for spacing between values.
     """
 
-    def __init__(self, low: int, high: int, step: int = 1) -> None:
+    def __init__(self, low: int, high: int) -> None:
         if low > high:
             raise ValueError(
                 "The `low` value must be smaller than or equal to the `high` value "
                 "(low={}, high={}).".format(low, high)
-            )
-
-        if step <= 0:
-            raise ValueError(
-                "The `step` value must be non-zero positive value, but step={}.".format(step)
             )
 
         if low < 1.0:
@@ -344,11 +331,8 @@ class IntLogUniformDistribution(BaseDistribution):
                 "(low={}, high={}).".format(low, high)
             )
 
-        high = _adjust_int_uniform_high(low, high, step)
-
         self.low = low
         self.high = high
-        self.step = step
 
     def to_external_repr(self, param_value_in_internal_repr):
         # type: (float) -> int
@@ -363,9 +347,7 @@ class IntLogUniformDistribution(BaseDistribution):
     def single(self):
         # type: () -> bool
 
-        if self.low == self.high:
-            return True
-        return (self.high - self.low) < self.step
+        return self.low == self.high
 
     def _contains(self, param_value_in_internal_repr):
         # type: (float) -> bool

--- a/optuna/distributions.py
+++ b/optuna/distributions.py
@@ -319,6 +319,9 @@ class IntLogUniformDistribution(BaseDistribution):
         step:
             A step for spacing between values.
 
+            .. note::
+                This value is valid for only 1. Otherwise, the value is replaced with 1.
+
             .. deprecated:: 2.0.0
                 ``step`` argument will be removed in the future. The removal of this feature is
                 currently scheduled for v4.0.0, but this schedule is subject to change.
@@ -340,7 +343,9 @@ class IntLogUniformDistribution(BaseDistribution):
         if step != 1:
             warnings.warn(
                 "`step` accepts only `1`, so `step` is replaced with `1`. "
-                "`step` argument is deprecated and will be removed in the future."
+                "`step` argument is deprecated and will be removed in the future. "
+                "The removal of this feature is currently scheduled for v4.0.0, "
+                "but this schedule is subject to change."
             )
 
         self.low = low

--- a/optuna/importance/_fanova.py
+++ b/optuna/importance/_fanova.py
@@ -100,7 +100,7 @@ def _distribution_to_hyperparameter(name: str, distribution: BaseDistribution) -
     elif isinstance(d, IntUniformDistribution):
         hp = UniformIntegerHyperparameter(name, lower=d.low, upper=d.high, q=d.step)
     elif isinstance(d, IntLogUniformDistribution):
-        hp = UniformIntegerHyperparameter(name, lower=d.low, upper=d.high, q=d.step, log=True)
+        hp = UniformIntegerHyperparameter(name, lower=d.low, upper=d.high, log=True)
     elif isinstance(d, CategoricalDistribution):
         hp = CategoricalHyperparameter(name, choices=[d.to_internal_repr(c) for c in d.choices])
     else:

--- a/optuna/integration/skopt.py
+++ b/optuna/integration/skopt.py
@@ -227,10 +227,7 @@ class _Optimizer(object):
             if isinstance(distribution, distributions.IntUniformDistribution):
                 value = value * distribution.step + distribution.low
             if isinstance(distribution, distributions.IntLogUniformDistribution):
-                value = int(
-                    np.round((value - distribution.low) / distribution.step) * distribution.step
-                    + distribution.low
-                )
+                value = int(np.round(value))
                 value = min(max(value, distribution.low), distribution.high)
 
             params[name] = value

--- a/optuna/samplers/_cmaes.py
+++ b/optuna/samplers/_cmaes.py
@@ -358,8 +358,8 @@ def _to_optuna_param(distribution: BaseDistribution, cma_param: float) -> Any:
         v = r * distribution.step + distribution.low
         return int(v)
     if isinstance(distribution, optuna.distributions.IntLogUniformDistribution):
-        r = np.round((cma_param - math.log(distribution.low)) / math.log(distribution.step))
-        v = r * math.log(distribution.step) + math.log(distribution.low)
+        r = np.round(cma_param - math.log(distribution.low))
+        v = r + math.log(distribution.low)
         return int(math.exp(v))
     return cma_param
 

--- a/optuna/samplers/_random.py
+++ b/optuna/samplers/_random.py
@@ -87,11 +87,7 @@ class RandomSampler(BaseSampler):
             log_low = numpy.log(param_distribution.low - 0.5)
             log_high = numpy.log(param_distribution.high + 0.5)
             s = numpy.exp(self._rng.uniform(log_low, log_high))
-            v = (
-                numpy.round((s - param_distribution.low) / param_distribution.step)
-                * param_distribution.step
-                + param_distribution.low
-            )
+            v = numpy.round(s)
             return int(min(max(v, param_distribution.low), param_distribution.high))
         elif isinstance(param_distribution, distributions.CategoricalDistribution):
             choices = param_distribution.choices

--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -281,10 +281,8 @@ class TPESampler(BaseSampler):
         high = distribution.high + 0.5
 
         sample = self._sample_numerical(low, high, below, above, is_log=True)
-        best_sample = (
-            np.round((sample - distribution.low) / distribution.step) * distribution.step
-            + distribution.low
-        )
+        best_sample = np.round(sample)
+
         return int(min(max(best_sample, distribution.low), distribution.high))
 
     def _sample_numerical(

--- a/optuna/trial/_fixed.py
+++ b/optuna/trial/_fixed.py
@@ -118,7 +118,7 @@ class FixedTrial(BaseTrial):
                 )  # type: Union[IntUniformDistribution, IntLogUniformDistribution]
         else:
             if log:
-                distribution = IntLogUniformDistribution(low=low, high=high, step=step)
+                distribution = IntLogUniformDistribution(low=low, high=high)
             else:
                 distribution = IntUniformDistribution(low=low, high=high, step=step)
         return int(self._suggest(name, distribution))

--- a/optuna/trial/_trial.py
+++ b/optuna/trial/_trial.py
@@ -432,7 +432,7 @@ class Trial(BaseTrial):
                 )  # type: Union[IntUniformDistribution, IntLogUniformDistribution]
         else:
             if log:
-                distribution = IntLogUniformDistribution(low=low, high=high, step=step)
+                distribution = IntLogUniformDistribution(low=low, high=high)
             else:
                 distribution = IntUniformDistribution(low=low, high=high, step=step)
 

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -359,3 +359,11 @@ def test_int_log_uniform_distribution_asdict():
     # type: () -> None
 
     assert EXAMPLE_DISTRIBUTIONS["ilu"]._asdict() == {"low": 2, "high": 12}
+
+
+def test_int_log_uniform_distribution_deprecation():
+    # type: () -> None
+
+    # step != 1 is deprecated
+    with pytest.warns(FutureWarning):
+        distributions.IntLogUniformDistribution(low=1, high=100, step=2)

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -19,7 +19,7 @@ EXAMPLE_DISTRIBUTIONS = {
     "iu": distributions.IntUniformDistribution(low=1, high=9, step=2),
     "c1": distributions.CategoricalDistribution(choices=(2.71, -float("inf"))),
     "c2": distributions.CategoricalDistribution(choices=("Roppongi", "Azabu")),
-    "ilu": distributions.IntLogUniformDistribution(low=2, high=12, step=2),
+    "ilu": distributions.IntLogUniformDistribution(low=2, high=12),
 }  # type: Dict[str, Any]
 
 EXAMPLE_JSONS = {
@@ -30,8 +30,7 @@ EXAMPLE_JSONS = {
     "iu": '{"name": "IntUniformDistribution", "attributes": {"low": 1, "high": 9, "step": 2}}',
     "c1": '{"name": "CategoricalDistribution", "attributes": {"choices": [2.71, -Infinity]}}',
     "c2": '{"name": "CategoricalDistribution", "attributes": {"choices": ["Roppongi", "Azabu"]}}',
-    "ilu": '{"name": "IntLogUniformDistribution",'
-    '"attributes": {"low": 2, "high": 12, "step": 2}}',
+    "ilu": '{"name": "IntLogUniformDistribution", "attributes": {"low": 2, "high": 12}}',
 }
 
 
@@ -104,8 +103,7 @@ def test_check_distribution_compatibility():
         EXAMPLE_DISTRIBUTIONS["iu"], distributions.IntUniformDistribution(low=-1, high=1)
     )
     distributions.check_distribution_compatibility(
-        EXAMPLE_DISTRIBUTIONS["ilu"],
-        distributions.IntLogUniformDistribution(low=1, high=13, step=1),
+        EXAMPLE_DISTRIBUTIONS["ilu"], distributions.IntLogUniformDistribution(low=1, high=13),
     )
 
 
@@ -174,19 +172,14 @@ def test_contains() -> None:
     assert not ilu._contains(12.1)
     assert not ilu._contains(13)
 
-    # IntLogUniformDistribution with a 'step' parameter.
-    with warnings.catch_warnings():
-        # UserWarning will be raised since the range is not divisible by 2.
-        # The range will be replaced with [2, 6].
-        warnings.simplefilter("ignore", category=UserWarning)
-        iluq = distributions.IntLogUniformDistribution(low=2, high=7, step=2)
+    iluq = distributions.IntLogUniformDistribution(low=2, high=7)
     assert not iluq._contains(0.9)
     assert iluq._contains(2)
     assert iluq._contains(4)
     assert iluq._contains(5)
     assert iluq._contains(6)
-    assert not iluq._contains(6.1)
-    assert not iluq._contains(7)
+    assert not iluq._contains(7.1)
+    assert not iluq._contains(8)
 
 
 def test_empty_range_contains():
@@ -243,7 +236,6 @@ def test_single():
             distributions.IntUniformDistribution(low=-123, high=-120, step=4),
             distributions.CategoricalDistribution(choices=("foo",)),
             distributions.IntLogUniformDistribution(low=2, high=2),
-            distributions.IntLogUniformDistribution(low=2, high=2, step=2),
         ]  # type: List[distributions.BaseDistribution]
     for distribution in single_distributions:
         assert distribution.single()
@@ -260,7 +252,6 @@ def test_single():
         distributions.IntUniformDistribution(low=-123, high=0, step=123),
         distributions.CategoricalDistribution(choices=("foo", "bar")),
         distributions.IntLogUniformDistribution(low=2, high=4),
-        distributions.IntLogUniformDistribution(low=2, high=4, step=2),
     ]  # type: List[distributions.BaseDistribution]
     for distribution in nonsingle_distributions:
         assert not distribution.single()
@@ -290,9 +281,6 @@ def test_empty_distribution():
 
     with pytest.raises(ValueError):
         distributions.IntLogUniformDistribution(low=123, high=100)
-
-    with pytest.raises(ValueError):
-        distributions.IntLogUniformDistribution(low=123, high=100, step=2)
 
 
 def test_invalid_distribution():
@@ -370,4 +358,4 @@ def test_int_uniform_distribution_asdict():
 def test_int_log_uniform_distribution_asdict():
     # type: () -> None
 
-    assert EXAMPLE_DISTRIBUTIONS["ilu"]._asdict() == {"low": 2, "high": 12, "step": 2}
+    assert EXAMPLE_DISTRIBUTIONS["ilu"]._asdict() == {"low": 2, "high": 12}


### PR DESCRIPTION
<!-- Thank you for creating a pull request! -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
Since https://github.com/optuna/optuna/pull/1329 disables `suggest_int` to use `step > 1` with `log=True`, we do not need to have `step` argument in `IntLogUniformDistribution`. 

## Description of the changes
<!-- Describe the changes in this PR. -->

This PR removes the `step` argument and refactors the sampling and tests codes.