### PR TITLE
[RFC] Stop building Docker images in Pull Requests

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -6,6 +6,10 @@ on:
       - master
   release:
     types: [published]
+  pull_request:
+    paths:
+      - Dockerfile
+      - setup.py
 
 env:
   DOCKER_HUB_BASE_NAME: optuna/optuna
@@ -43,6 +47,7 @@ jobs:
         docker build . --build-arg PYTHON_VERSION=${{ matrix.python_version }} --build-arg BUILD_TYPE=${{ matrix.build_type }} --file Dockerfile --tag "${HUB_TAG}"
 
     - name: Login & Push to Docker Hub
+      if: ${{ github.event_name != 'pull_request' }}
       env:
         DOCKER_HUB_TOKEN: ${{ secrets.DOCKER_HUB_TOKEN }}
       run: |

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -6,12 +6,8 @@ on:
       - master
   release:
     types: [published]
-  pull_request:
-    branches:
-      - master
 
 env:
-  DOCKER_BASE_NAME: docker.pkg.github.com/${{ github.repository }}/optuna
   DOCKER_HUB_BASE_NAME: optuna/optuna
 
 jobs:
@@ -47,7 +43,6 @@ jobs:
         docker build . --build-arg PYTHON_VERSION=${{ matrix.python_version }} --build-arg BUILD_TYPE=${{ matrix.build_type }} --file Dockerfile --tag "${HUB_TAG}"
 
     - name: Login & Push to Docker Hub
-      if: ${{ github.event_name != 'pull_request' }}
       env:
         DOCKER_HUB_TOKEN: ${{ secrets.DOCKER_HUB_TOKEN }}
       run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,4 +23,4 @@ RUN if [ "${BUILD_TYPE}" = "dev" ]; then \
     else \
         pip install --no-cache-dir -e .; \
     fi \
-    && pip install jupyter notebook
+    && pip install --no-cache-dir jupyter notebook


### PR DESCRIPTION
<!-- Thank you for creating a pull request! -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
Docker build jobs on Pull Request pushes sometimes push down the CI job results which are more critical and required such as `tests-python37`.
Also, I think we can reckon that Docker build works if CI for Pull Requests pass as these two do almost exactly the same in the installation phase.

## Description of the changes
<!-- Describe the changes in this PR. -->
- Change the trigger of this job
- Remove unused environment variable
- Remove if statement