### PR TITLE
Fix for PyTorch Lightning v0.8.0.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -181,7 +181,6 @@ jobs:
             . venv/bin/activate
             pytest tests --ignore tests/integration_tests/test_fastai.py \
                 --ignore tests/integration_tests/test_keras.py \
-                --ignore tests/integration_tests/test_pytorch_lightning.py \
                 --ignore tests/integration_tests/test_tensorflow.py \
                 --ignore tests/integration_tests/test_tfkeras.py \
                 --ignore tests/integration_tests/allennlp_tests/test_allennlp.py

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -38,7 +38,7 @@ jobs:
         if [ ${{ matrix.python-version }} = 3.5 ]; then
           IGNORES='chainermn_.*|pytorch_lightning.*|fastai_.*|allennlp_.*'
         elif [ ${{ matrix.python-version }} = 3.8 ]; then
-          IGNORES='chainermn_.*|dask_ml_.*|keras_.*|pytorch_lightning_.*|tensorflow_.*|tfkeras_.*|fastai_.*|allennlp_.*'
+          IGNORES='chainermn_.*|dask_ml_.*|keras_.*|tensorflow_.*|tfkeras_.*|fastai_.*|allennlp_.*'
         else
           IGNORES='chainermn_.*'
         fi

--- a/examples/pytorch_lightning_simple.py
+++ b/examples/pytorch_lightning_simple.py
@@ -108,8 +108,7 @@ class LightningNet(pl.LightningModule):
         data, target = batch
         output = self.forward(data)
         pred = output.argmax(dim=1, keepdim=True)
-        correct = pred.eq(target.view_as(pred)).sum().item()
-        accuracy = correct / data.size(0)
+        accuracy = pred.eq(target.view_as(pred)).float().mean()
         return {"batch_val_acc": accuracy}
 
     def validation_epoch_end(self, outputs):
@@ -158,7 +157,7 @@ def objective(trial):
     model = LightningNet(trial)
     trainer.fit(model)
 
-    return metrics_callback.metrics[-1]["val_acc"]
+    return metrics_callback.metrics[-1]["val_acc"].item()
 
 
 if __name__ == "__main__":

--- a/optuna/integration/pytorch_lightning.py
+++ b/optuna/integration/pytorch_lightning.py
@@ -28,18 +28,15 @@ class PyTorchLightningPruningCallback(EarlyStopping):
             how this dictionary is formatted.
     """
 
-    def __init__(self, trial, monitor):
-        # type: (optuna.trial.Trial, str) -> None
+    def __init__(self, trial: optuna.trial.Trial, monitor: str) -> None:
 
         _imports.check()
 
         super(PyTorchLightningPruningCallback, self).__init__(monitor=monitor)
 
         self._trial = trial
-        self._monitor = monitor
 
-    def _process(self, trainer, pl_module):
-        # type: (Trainer, LightningModule) -> None
+    def _process(self, trainer: Trainer, pl_module: LightningModule) -> None:
         logs = trainer.callback_metrics
         epoch = pl_module.current_epoch
         current_score = logs.get(self.monitor)
@@ -51,11 +48,9 @@ class PyTorchLightningPruningCallback(EarlyStopping):
             raise optuna.TrialPruned(message)
 
     # NOTE (crcrpar): This method is called <0.8.0
-    def on_epoch_end(self, trainer, pl_module):
-        # type: (Trainer, LightningModule) -> None
+    def on_epoch_end(self, trainer: Trainer, pl_module: LightningModule) -> None:
         return self._process(trainer, pl_module)
 
     # NOTE (crcrpar): This method is called >=0.8.0
-    def on_validation_end(self, trainer, pl_module):
-        # type: (Trainer, LightningModule) -> None
+    def on_validation_end(self, trainer: Trainer, pl_module: LightningModule) -> None:
         return self._process(trainer, pl_module)

--- a/optuna/integration/pytorch_lightning.py
+++ b/optuna/integration/pytorch_lightning.py
@@ -7,6 +7,8 @@ with optuna._imports.try_import() as _imports:
 
 if not _imports.is_successful():
     EarlyStopping = object  # NOQA
+    LightningModule = object  # NOQA
+    Trainer = object  # NOQA
 
 
 class PyTorchLightningPruningCallback(EarlyStopping):

--- a/optuna/integration/pytorch_lightning.py
+++ b/optuna/integration/pytorch_lightning.py
@@ -1,9 +1,5 @@
 import optuna
 
-if optuna.type_checking.TYPE_CHECKING:
-    from typing import Dict  # NOQA
-    from typing import Optional  # NOQA
-
 with optuna._imports.try_import() as _imports:
     from pytorch_lightning.callbacks import EarlyStopping
     from pytorch_lightning import LightningModule

--- a/setup.py
+++ b/setup.py
@@ -79,9 +79,12 @@ def get_extras_require() -> Dict[str, List[str]]:
             "xgboost",
         ]
         + (
-            ["allennlp<1", "fastai<2", "pytorch-lightning>=0.7.1,!=0.8.0"]
+            ["allennlp<1", "fastai<2", "pytorch_lightning>=0.7.1"]
             if (3, 5) < sys.version_info[:2] < (3, 8)
             else []
+        )
+        + (
+            ["pytorch-lightning>=0.7.2"] if (3, 8) == sys.version_info[:2] else []
         )
         + (
             ["llvmlite<=0.31.0"] if (3, 5) == sys.version_info[:2] else []
@@ -121,9 +124,11 @@ def get_extras_require() -> Dict[str, List[str]]:
             "xgboost",
         ]
         + (
-            ["allennlp<1", "fastai<2", "pytorch-lightning>=0.7.1,!=0.8.0"]
+            ["allennlp<1", "fastai<2", "pytorch_lightning>=0.7.1"]
             if (3, 5) < sys.version_info[:2] < (3, 8)
             else []
+        ) + (
+            ["pytorch-lightning>=0.7.2"] if (3, 8) == sys.version_info[:2] else []
         )
         + (
             ["keras<2.4.0", "tensorflow", "tensorflow-datasets"]

--- a/setup.py
+++ b/setup.py
@@ -83,9 +83,7 @@ def get_extras_require() -> Dict[str, List[str]]:
             if (3, 5) < sys.version_info[:2] < (3, 8)
             else []
         )
-        + (
-            ["pytorch-lightning>=0.7.2"] if (3, 8) == sys.version_info[:2] else []
-        )
+        + (["pytorch-lightning>=0.7.2"] if (3, 8) == sys.version_info[:2] else [])
         + (
             ["llvmlite<=0.31.0"] if (3, 5) == sys.version_info[:2] else []
         )  # Newer `llvmlite` is not distributed with wheels for Python 3.5.
@@ -127,9 +125,8 @@ def get_extras_require() -> Dict[str, List[str]]:
             ["allennlp<1", "fastai<2", "pytorch_lightning>=0.7.1"]
             if (3, 5) < sys.version_info[:2] < (3, 8)
             else []
-        ) + (
-            ["pytorch-lightning>=0.7.2"] if (3, 8) == sys.version_info[:2] else []
         )
+        + (["pytorch-lightning>=0.7.2"] if (3, 8) == sys.version_info[:2] else [])
         + (
             ["keras<2.4.0", "tensorflow", "tensorflow-datasets"]
             if sys.version_info[:2] < (3, 8)

--- a/tests/integration_tests/test_pytorch_lightning.py
+++ b/tests/integration_tests/test_pytorch_lightning.py
@@ -40,8 +40,7 @@ class Model(pl.LightningModule):
         data, target = batch
         output = self.forward(data)
         pred = output.argmax(dim=1, keepdim=True)
-        correct = pred.eq(target.view_as(pred)).sum()
-        accuracy = correct.double() / data.size(0)
+        accuracy = pred.eq(target.view_as(pred)).double().mean()
         return {"validation_accuracy": accuracy}
 
     def validation_end(self, outputs):
@@ -84,8 +83,8 @@ def test_pytorch_lightning_pruning_callback():
 
         trainer = pl.Trainer(
             early_stop_callback=PyTorchLightningPruningCallback(trial, monitor="accuracy"),
-            min_nb_epochs=0,  # Required to fire the callback after the first epoch.
-            max_nb_epochs=2,
+            min_epochs=0,  # Required to fire the callback after the first epoch.
+            max_epochs=2,
         )
         trainer.checkpoint_callback = None  # Disable unrelated checkpoint callbacks.
 


### PR DESCRIPTION
<!-- Thank you for creating a pull request! -->

PyTorch Lightning v0.8.0 has some breaking changes:
1. `Trainer` module and the changes of `(min|max)_nb_epochs` to `(min|max)_epochss` affect our integration tests for it.
2. `EarlyStoppingCallback` is now triggered by `on_validation_end` instead of `epoch_end`.

## Description of the changes
<!-- Describe the changes in this PR. -->
- Fixes for the above two changes
- Support Python 3.8


__TODO__

- [x] enable test & example on Python 3.8