### PR TITLE
Relax `sphinx` version.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ def get_extras_require() -> Dict[str, List[str]]:
             "mlflow",
         ],
         # TODO(hvy): Unpin `sphinx` version after https://github.com/sphinx-doc/sphinx/issues/7807.
-        "document": ["sphinx>=3.0.0,<3.1.0", "sphinx_rtd_theme"],
+        "document": ["sphinx>=3.0.0,!=3.1.0,!=3.1.1", "sphinx_rtd_theme"],
         "example": [
             "catboost",
             "chainer",


### PR DESCRIPTION
## Motivation

It's better to try keep supporting the newest version of `sphinx`.

## Description of the changes

Changes `setup.py` to not ignore future `sphinx` release. I believe we can close https://github.com/optuna/optuna/issues/1368 when this PR is merged.