### PR TITLE
Fix broken link to example and add README for AllenNLP examples.

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -26,7 +26,8 @@ This page contains a list of example codes written with Optuna.
 * [Tensorflow(eager)](./tensorflow_eager_simple.py)
 * [Keras](./keras_simple.py)
 * [FastAI](./fastai_simple.py)
-* [AllenNLP](./allennlp_simple.py)
+* [AllenNLP](./allennlp/allennlp_simple.py)
+* [AllenNLP (Jsonnet)](./allennlp/allennlp_jsonnet.py)
 
 ### An example where an objective function uses additional arguments
 

--- a/examples/allennlp/README.md
+++ b/examples/allennlp/README.md
@@ -1,6 +1,6 @@
 # Hyperparameter optimization using Optuna
 
-This examples show two ways using Optuna for tuning AllenNLP models.
+These examples show two ways of using Optuna for tuning AllenNLP models.
 
 1. [Write Python script](./allennlp_simple.py)
 2. [Use `AllenNLPExecutor` to reuse your Jsonnet config](./allennlp_jsonnet.py)

--- a/examples/allennlp/README.md
+++ b/examples/allennlp/README.md
@@ -1,0 +1,6 @@
+# Hyperparameter optimization using Optuna
+
+This examples show two ways using Optuna for tuning AllenNLP models.
+
+1. [Write Python script](./allennlp_simple.py)
+2. [Use `AllenNLPExecutor` to reuse your Jsonnet config](./allennlp_jsonnet.py)


### PR DESCRIPTION
This PR fixes the broken reference and adds an index page for AllenNLP examples.

- ef449ad Fix broken link and add a link to `allennlp_jsonnet.py`.
- 9f2178e7 Add README