### PR TITLE
Implement PrunerCallback for AllenNLP.

### DIFF
--- a/.github/workflows/tests-integration.yml
+++ b/.github/workflows/tests-integration.yml
@@ -63,7 +63,8 @@ jobs:
             --ignore tests/integration_tests/test_tfkeras.py \
             --ignore tests/integration_tests/allennlp_tests/test_allennlp.py
         else
-          pytest tests/integration_tests
+          # pytest cannot collect allennlp tests with allennlp==1.0.0.
+          pytest -s tests/integration_tests
         fi
 
     - name: Tests MPI

--- a/docs/source/reference/integration.rst
+++ b/docs/source/reference/integration.rst
@@ -28,3 +28,4 @@ optuna.integration
    optuna.integration.OptunaSearchCV
    optuna.integration.AllenNLPExecutor
    optuna.integration.allennlp.dump_best_config
+   optuna.integration.AllenNLPPruningCallback

--- a/examples/allennlp/allennlp_jsonnet.py
+++ b/examples/allennlp/allennlp_jsonnet.py
@@ -21,7 +21,10 @@ We have the following two ways to execute this example:
 """
 
 import os.path
+import pkg_resources
 import shutil
+
+import allennlp
 
 import optuna
 from optuna.integration.allennlp import dump_best_config
@@ -50,6 +53,9 @@ def objective(trial):
 
 
 if __name__ == "__main__":
+    if pkg_resources.parse_version(allennlp.__version__) < pkg_resources.parse_version("1.0.0"):
+        raise RuntimeError("AllenNLP>=1.0.0 is required for this example.")
+
     study = optuna.create_study(direction="maximize")
     study.optimize(objective, n_trials=50, timeout=600)
 

--- a/examples/allennlp/allennlp_simple.py
+++ b/examples/allennlp/allennlp_simple.py
@@ -36,7 +36,7 @@ from optuna.integration import AllenNLPPruningCallback
 DEVICE = -1  # If you want to use GPU, use DEVICE = 0.
 MAX_DATA_SIZE = 3000
 MODEL_DIR = os.path.join(os.getcwd(), "result")
-TARGET_METRIC = "validation_accuracy"
+TARGET_METRIC = "accuracy"
 
 
 class SubsampledDatasetReader(allennlp.data.dataset_readers.TextClassificationJsonReader):
@@ -120,15 +120,15 @@ def objective(trial):
         optimizer=optimizer,
         data_loader=data_loader,
         validation_data_loader=validation_data_loader,
-        validation_metric="+accuracy",
+        validation_metric=f"+{TARGET_METRIC}",
         patience=None,
         num_epochs=50,
         cuda_device=DEVICE,
         serialization_dir=serialization_dir,
-        epoch_callbacks=[AllenNLPPruningCallback(trial, TARGET_METRIC)],
+        epoch_callbacks=[AllenNLPPruningCallback(trial, "validation_" + TARGET_METRIC)],
     )
     metrics = trainer.train()
-    return metrics["best_" + TARGET_METRIC]
+    return metrics["best_validation_" + TARGET_METRIC]
 
 
 if __name__ == "__main__":

--- a/examples/allennlp/allennlp_simple.py
+++ b/examples/allennlp/allennlp_simple.py
@@ -121,7 +121,7 @@ def objective(trial):
         data_loader=data_loader,
         validation_data_loader=validation_data_loader,
         validation_metric="+" + TARGET_METRIC,
-        patience=None,
+        patience=None,  # `patience=None` since it could conflict with AllenNLPPruningCallback
         num_epochs=50,
         cuda_device=DEVICE,
         serialization_dir=serialization_dir,

--- a/examples/allennlp/allennlp_simple.py
+++ b/examples/allennlp/allennlp_simple.py
@@ -140,7 +140,8 @@ if __name__ == "__main__":
     torch.manual_seed(41)
     numpy.random.seed(41)
 
-    study = optuna.create_study(direction="maximize")
+    pruner = optuna.pruners.HyperbandPruner()
+    study = optuna.create_study(direction="maximize", pruner=pruner)
     study.optimize(objective, n_trials=50, timeout=600)
 
     print("Number of finished trials: ", len(study.trials))

--- a/examples/allennlp/allennlp_simple.py
+++ b/examples/allennlp/allennlp_simple.py
@@ -108,10 +108,10 @@ def objective(trial):
     optimizer = torch.optim.SGD(model.parameters(), lr=lr)
 
     data_loader = torch.utils.data.DataLoader(
-        train_dataset, batch_size=10, collate_fn=allennlp.data.allennlp_collate
+        train_dataset, batch_size=64, collate_fn=allennlp.data.allennlp_collate
     )
     validation_data_loader = torch.utils.data.DataLoader(
-        valid_dataset, batch_size=10, collate_fn=allennlp.data.allennlp_collate
+        valid_dataset, batch_size=64, collate_fn=allennlp.data.allennlp_collate
     )
 
     serialization_dir = os.path.join(MODEL_DIR, "trial_{}".format(trial.number))
@@ -137,7 +137,7 @@ if __name__ == "__main__":
     numpy.random.seed(41)
 
     study = optuna.create_study(direction="maximize")
-    study.optimize(objective, n_trials=80, timeout=600)
+    study.optimize(objective, n_trials=50, timeout=600)
 
     print("Number of finished trials: ", len(study.trials))
     print("Best trial:")

--- a/examples/allennlp/allennlp_simple.py
+++ b/examples/allennlp/allennlp_simple.py
@@ -120,7 +120,7 @@ def objective(trial):
         optimizer=optimizer,
         data_loader=data_loader,
         validation_data_loader=validation_data_loader,
-        validation_metric=f"+{TARGET_METRIC}",
+        validation_metric="+" + TARGET_METRIC,
         patience=None,
         num_epochs=50,
         cuda_device=DEVICE,

--- a/examples/allennlp/allennlp_simple.py
+++ b/examples/allennlp/allennlp_simple.py
@@ -104,7 +104,7 @@ def objective(trial):
     if DEVICE > -1:
         model.to(torch.device("cuda:{}".format(DEVICE)))
 
-    lr = trial.suggest_float("lr", 1e-1, 1e0, log=True)
+    lr = trial.suggest_float("lr", 1e-5, 1e-1, log=True)
     optimizer = torch.optim.SGD(model.parameters(), lr=lr)
 
     data_loader = torch.utils.data.DataLoader(

--- a/examples/allennlp/allennlp_simple.py
+++ b/examples/allennlp/allennlp_simple.py
@@ -19,6 +19,7 @@ We have the following two ways to execute this example:
 """
 
 import os
+import pkg_resources
 import random
 import shutil
 
@@ -132,6 +133,9 @@ def objective(trial):
 
 
 if __name__ == "__main__":
+    if pkg_resources.parse_version(allennlp.__version__) < pkg_resources.parse_version("1.0.0"):
+        raise RuntimeError("AllenNLP>=1.0.0 is required for this example.")
+
     random.seed(41)
     torch.manual_seed(41)
     numpy.random.seed(41)

--- a/examples/allennlp/allennlp_simple.py
+++ b/examples/allennlp/allennlp_simple.py
@@ -108,14 +108,10 @@ def objective(trial):
     optimizer = torch.optim.SGD(model.parameters(), lr=lr)
 
     data_loader = torch.utils.data.DataLoader(
-        train_dataset,
-        batch_size=10,
-        collate_fn=allennlp.data.allennlp_collate
+        train_dataset, batch_size=10, collate_fn=allennlp.data.allennlp_collate
     )
     validation_data_loader = torch.utils.data.DataLoader(
-        valid_dataset,
-        batch_size=10,
-        collate_fn=allennlp.data.allennlp_collate
+        valid_dataset, batch_size=10, collate_fn=allennlp.data.allennlp_collate
     )
 
     serialization_dir = os.path.join(MODEL_DIR, "trial_{}".format(trial.number))
@@ -124,12 +120,12 @@ def objective(trial):
         optimizer=optimizer,
         data_loader=data_loader,
         validation_data_loader=validation_data_loader,
-        validation_metric='+accuracy',
+        validation_metric="+accuracy",
         patience=None,
         num_epochs=50,
         cuda_device=DEVICE,
         serialization_dir=serialization_dir,
-        epoch_callbacks=[AllenNLPPruningCallback(trial, TARGET_METRIC)]
+        epoch_callbacks=[AllenNLPPruningCallback(trial, TARGET_METRIC)],
     )
     metrics = trainer.train()
     return metrics["best_" + TARGET_METRIC]

--- a/examples/allennlp/allennlp_simple.py
+++ b/examples/allennlp/allennlp_simple.py
@@ -46,7 +46,7 @@ class SubsampledDatasetReader(allennlp.data.dataset_readers.TextClassificationJs
     def _read(self, datapath):
         data = list(super()._read(datapath))
         random.shuffle(data)
-        yield from data[:3000]
+        yield from data[:MAX_DATA_SIZE]
 
 
 def prepare_data():

--- a/examples/allennlp/allennlp_simple.py
+++ b/examples/allennlp/allennlp_simple.py
@@ -71,14 +71,7 @@ def prepare_data():
 
 
 def create_model(vocab, trial):
-    embedding = allennlp.modules.Embedding(
-        embedding_dim=50,
-        trainable=True,
-        pretrained_file="https://s3-us-west-2.amazonaws.com/allennlp/datasets/glove/glove.6B.50d.txt.gz",  # NOQA
-        vocab=vocab,
-    )
-
-    embedder = allennlp.modules.text_field_embedders.BasicTextFieldEmbedder({"tokens": embedding})
+    dropout = trial.suggest_float("dropout", 0, 0.5)
     output_dim = trial.suggest_int("output_dim", 16, 128)
     max_filter_size = trial.suggest_int("max_filter_size", 3, 6)
     num_filters = trial.suggest_int("num_filters", 16, 128)
@@ -89,7 +82,14 @@ def create_model(vocab, trial):
         output_dim=output_dim,
     )
 
-    dropout = trial.suggest_float("dropout", 0, 0.5)
+    embedding = allennlp.modules.Embedding(
+        embedding_dim=50,
+        trainable=True,
+        pretrained_file="https://s3-us-west-2.amazonaws.com/allennlp/datasets/glove/glove.6B.50d.txt.gz",  # NOQA
+        vocab=vocab,
+    )
+
+    embedder = allennlp.modules.text_field_embedders.BasicTextFieldEmbedder({"tokens": embedding})
     model = allennlp.models.BasicClassifier(
         text_field_embedder=embedder, seq2vec_encoder=encoder, dropout=dropout, vocab=vocab,
     )

--- a/examples/allennlp/classifier.jsonnet
+++ b/examples/allennlp/classifier.jsonnet
@@ -29,7 +29,7 @@ local ENCODER = CNN_FIELDS(
     lazy: false,
     type: 'text_classification_json',
     tokenizer: {
-      word_splitter: 'just_spaces',
+      type: 'spacy',
     },
     token_indexers: {
       tokens: {
@@ -53,9 +53,8 @@ local ENCODER = CNN_FIELDS(
     seq2vec_encoder: ENCODER,
     dropout: DROPOUT,
   },
-  iterator: {
-    batch_size: 10,
-    type: 'basic',
+  data_loader: {
+    batch_size: 64,
   },
 
   trainer: {
@@ -66,7 +65,6 @@ local ENCODER = CNN_FIELDS(
       type: 'adam',
     },
     patience: 2,
-    num_serialized_models_to_keep: 1,
     validation_metric: '+accuracy',
   },
 }

--- a/optuna/integration/__init__.py
+++ b/optuna/integration/__init__.py
@@ -7,7 +7,7 @@ from optuna.type_checking import TYPE_CHECKING
 
 
 _import_structure = {
-    "allennlp": ["AllenNLPExecutor"],
+    "allennlp": ["AllenNLPExecutor", "AllenNLPPruningCallback"],
     "catalyst": ["CatalystPruningCallback"],
     "chainer": ["ChainerPruningExtension"],
     "chainermn": ["ChainerMNStudy"],
@@ -33,6 +33,7 @@ __all__ = list(_import_structure.keys()) + sum(_import_structure.values(), [])
 
 if TYPE_CHECKING:
     from optuna.integration.allennlp import AllenNLPExecutor  # NOQA
+    from optuna.integration.allennlp import AllenNLPPruningCallback  # NOQA
     from optuna.integration.catalyst import CatalystPruningCallback  # NOQA
     from optuna.integration.chainer import ChainerPruningExtension  # NOQA
     from optuna.integration.chainermn import ChainerMNStudy  # NOQA

--- a/optuna/integration/allennlp.py
+++ b/optuna/integration/allennlp.py
@@ -185,7 +185,7 @@ class AllenNLPPruningCallback(EpochCallback):
         is_master: bool,
     ) -> None:
         value = metrics.get(self._monitor)
-        if not value:
+        if value is None:
             return
 
         self._trial.report(float(value), epoch)

--- a/optuna/integration/allennlp.py
+++ b/optuna/integration/allennlp.py
@@ -171,7 +171,7 @@ class AllenNLPPruningCallback(EpochCallback):
     def __init__(self, trial: optuna.trial.Trial, monitor: str):
         _imports.check()
 
-        if allennlp.__version__ < '1.0.0':
+        if allennlp.__version__ < "1.0.0":
             raise Exception("AllenNLPPruningCallback requires `allennlp`>=1.0.0.")
 
         self._trial = trial

--- a/optuna/integration/allennlp.py
+++ b/optuna/integration/allennlp.py
@@ -147,3 +147,42 @@ class AllenNLPExecutor(object):
 
         metrics = json.load(open(os.path.join(self._serialization_dir, "metrics.json")))
         return metrics[self._metrics]
+
+
+@experimental("2.0.0")
+class AllenNLPPruningCallback(allennlp.training.EpochCallback):
+    """AllenNLP callback to prune unpromising trials.
+
+    See `the example <https://github.com/optuna/optuna/blob/master/
+    examples/allennlp/allennlp_simple.py>`__
+    if you want to add a proning callback which observes a metric.
+
+    Args:
+        trial:
+            A :class:`~optuna.trial.Trial` corresponding to the current evaluation of the
+            objective function.
+        monitor:
+            An evaluation metric for pruning, e.g. ``validation_loss`` or
+            ``validation_accuracy``.
+    """
+
+    def __init__(self, trial: optuna.trial.Trial, monitor: str):
+        _imports.check()
+
+        self._trial = trial
+        self._monitor = monitor
+
+    def __call__(
+        self,
+        trainer: allennlp.training.GradientDescentTrainer,
+        metrics: Dict[str, Any],
+        epoch: int,
+        is_master: bool,
+    ) -> None:
+        value = metrics.get(self._monitor)
+        if not value:
+            return
+
+        self._trial.report(float(value), epoch)
+        if self._trial.should_prune():
+            raise optuna.TrialPruned()

--- a/setup.py
+++ b/setup.py
@@ -166,7 +166,7 @@ def get_extras_require() -> Dict[str, List[str]]:
             "xgboost",
         ]
         + (
-            ["allennlp<1", "fastai<2", "pytorch-lightning>=0.7.1"]
+            ["allennlp==1.0.0", "fastai<2", "pytorch-lightning>=0.7.1"]
             if (3, 5) < sys.version_info[:2] < (3, 8)
             else []
         )

--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,7 @@ def get_extras_require() -> Dict[str, List[str]]:
         ]
         + (["stable-baselines3>=0.7.0"] if (3, 5) < sys.version_info[:2] else [])
         + (
-            ["allennlp<1", "fastai<2", "pytorch_lightning>=0.7.1"]
+            ["allennlp==1.0.0", "fastai<2", "pytorch-lightning>=0.7.1"]
             if (3, 5) < sys.version_info[:2] < (3, 8)
             else []
         )
@@ -129,7 +129,7 @@ def get_extras_require() -> Dict[str, List[str]]:
             "xgboost",
         ]
         + (
-            ["allennlp<1", "fastai<2", "pytorch_lightning>=0.7.1"]
+            ["allennlp==1.0.0", "fastai<2", "pytorch-lightning>=0.7.1"]
             if (3, 5) < sys.version_info[:2] < (3, 8)
             else []
         )

--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,7 @@ def get_extras_require() -> Dict[str, List[str]]:
         ]
         + (["stable-baselines3>=0.7.0"] if (3, 5) < sys.version_info[:2] else [])
         + (
-            ["allennlp==1.0.0", "fastai<2", "pytorch-lightning>=0.7.1"]
+            ["allennlp==1.0.0", "fastai<2", "pytorch_lightning>=0.7.1"]
             if (3, 5) < sys.version_info[:2] < (3, 8)
             else []
         )
@@ -129,7 +129,7 @@ def get_extras_require() -> Dict[str, List[str]]:
             "xgboost",
         ]
         + (
-            ["allennlp==1.0.0", "fastai<2", "pytorch-lightning>=0.7.1"]
+            ["allennlp==1.0.0", "fastai<2", "pytorch_lightning>=0.7.1"]
             if (3, 5) < sys.version_info[:2] < (3, 8)
             else []
         )

--- a/tests/integration_tests/allennlp_tests/example.jsonnet
+++ b/tests/integration_tests/allennlp_tests/example.jsonnet
@@ -49,8 +49,7 @@ local DROPOUT = std.extVar('DROPOUT');
       bidirectional: true,
     },
   },
-  iterator: {
-    type: 'basic',
+  data_loader: {
     batch_size: 32,
   },
   trainer: {

--- a/tests/integration_tests/allennlp_tests/example_with_environment_variables.jsonnet
+++ b/tests/integration_tests/allennlp_tests/example_with_environment_variables.jsonnet
@@ -50,8 +50,7 @@ local LEARNING_RATE = std.extVar('LEARNING_RATE');
       bidirectional: true,
     },
   },
-  iterator: {
-    type: 'basic',
+  data_loader: {
     batch_size: 32,
   },
   trainer: {

--- a/tests/integration_tests/allennlp_tests/example_with_include_package.jsonnet
+++ b/tests/integration_tests/allennlp_tests/example_with_include_package.jsonnet
@@ -49,8 +49,7 @@ local DROPOUT = std.extVar('DROPOUT');
       bidirectional: true,
     },
   },
-  iterator: {
-    type: 'basic',
+  data_loader: {
     batch_size: 32,
   },
   trainer: {

--- a/tests/integration_tests/allennlp_tests/pruning_test.jsonl
+++ b/tests/integration_tests/allennlp_tests/pruning_test.jsonl
@@ -1,0 +1,7 @@
+{"id": "train_01", "text": "Chainer is a Python-based deep learning framework aiming at flexibility.", "label": 1}
+{"id": "train_02", "text": "It provides automatic differentiation APIs based on the define-by-run approach (a.k.a. dynamic computational graphs) as well as object-oriented high-level APIs to build and train neural networks.", "label": 1}
+{"id": "train_03", "text": "It also supports CUDA/cuDNN using CuPy for high performance training and inference.", "label": 1}
+{"id": "train_04", "text": "For more details about Chainer, see the documents and resources listed above and join the community in Forum, Slack, and Twitter.", "label": 1}
+{"id": "train_05", "text": "Optuna is an automatic hyperparameter optimization software framework, particularly designed for machine learning.", "label": 0}
+{"id": "train_06", "text": "It features an imperative, define-by-run style user API.", "label": 0}
+{"id": "train_07", "text": "Thanks to our define-by-run API, the code written with Optuna enjoys high modularity, and the user of Optuna can dynamically construct the search spaces for the hyperparameters.", "label": 0}

--- a/tests/integration_tests/allennlp_tests/test_allennlp.py
+++ b/tests/integration_tests/allennlp_tests/test_allennlp.py
@@ -3,11 +3,25 @@ import os
 import tempfile
 
 import _jsonnet
+import allennlp.data
+import allennlp.data.dataset_readers
+import allennlp.data.tokenizers
+import allennlp.models
+import allennlp.modules
+import allennlp.modules.seq2vec_encoders
+import allennlp.modules.text_field_embedders
+import allennlp.training
 import pytest
 import torch.optim
+<<<<<<< HEAD
 from torch.utils.data import DataLoader
+=======
+import torch.utils.data
+>>>>>>> ce15e5b4... Add fixture for pruner test
 
 import optuna
+from optuna.integration.allennlp import AllenNLPPruningCallback
+from optuna.testing.integration import DeterministicPruner
 
 
 def test_build_params() -> None:

--- a/tests/integration_tests/allennlp_tests/test_allennlp.py
+++ b/tests/integration_tests/allennlp_tests/test_allennlp.py
@@ -13,11 +13,7 @@ import allennlp.modules.text_field_embedders
 import allennlp.training
 import pytest
 import torch.optim
-<<<<<<< HEAD
 from torch.utils.data import DataLoader
-=======
-import torch.utils.data
->>>>>>> ce15e5b4... Add fixture for pruner test
 
 import optuna
 from optuna.integration.allennlp import AllenNLPPruningCallback

--- a/tests/integration_tests/allennlp_tests/tiny_single_id.py
+++ b/tests/integration_tests/allennlp_tests/tiny_single_id.py
@@ -2,11 +2,10 @@ import itertools
 from typing import Dict
 from typing import List
 
-from allennlp.common.util import pad_sequence_to_length
+from allennlp.data.token_indexers.token_indexer import IndexedTokenList
 from allennlp.data.token_indexers.token_indexer import TokenIndexer
 from allennlp.data.tokenizers.token import Token
 from allennlp.data.vocabulary import Vocabulary
-import torch
 
 
 @TokenIndexer.register("tiny_single_id")
@@ -39,7 +38,7 @@ class SingleIdTokenIndexer(TokenIndexer):
         counter["tokens"][text] += 1
 
     def tokens_to_indices(
-        self, tokens: List[Token], vocabulary: Vocabulary, index_name: str
+        self, tokens: List[Token], vocabulary: Vocabulary
     ) -> Dict[str, List[int]]:
         indices: List[int] = []
 
@@ -49,18 +48,7 @@ class SingleIdTokenIndexer(TokenIndexer):
                 text = text.lower()
             indices.append(vocabulary.get_token_index(text, "tokens"))
 
-        return {index_name: indices}
+        return {"tokens": indices}
 
-    def get_padding_lengths(self, token: int) -> Dict[str, int]:
-        return {}
-
-    def as_padded_tensor(
-        self,
-        tokens: Dict[str, List[int]],
-        desired_num_tokens: Dict[str, int],
-        padding_lengths: Dict[str, int],
-    ) -> Dict[str, torch.Tensor]:
-        return {
-            key: torch.LongTensor(pad_sequence_to_length(val, desired_num_tokens[key]))
-            for key, val in tokens.items()
-        }
+    def get_empty_token_list(self) -> IndexedTokenList:
+        return {"tokens": []}

--- a/tests/integration_tests/test_fastai.py
+++ b/tests/integration_tests/test_fastai.py
@@ -2,12 +2,14 @@ from functools import partial
 from typing import Any
 from typing import Tuple
 
+import fastai.basic_data
 from fastai.basic_data import DataBunch
 from fastai.basic_train import Learner
 from fastai.metrics import accuracy
 import numpy as np
 import pytest
 import torch.nn as nn
+import torch.utils.data
 from torch.utils.data import Dataset
 
 import optuna
@@ -74,3 +76,7 @@ def test_fastai_pruning_callback(tmpdir: Any) -> None:
     study.optimize(objective, n_trials=1)
     assert study.trials[0].state == optuna.trial.TrialState.COMPLETE
     assert study.trials[0].value == 1.0
+
+
+# https://github.com/optuna/optuna/pull/1399#issuecomment-646956305
+torch.utils.data.DataLoader.__init__ = fastai.basic_data.old_dl_init


### PR DESCRIPTION
close #1012.
revive #1333.


## Motivation
This PR introduces a pruning callback for AllenNLP.


## Description of the changes
- Introduce `AllenNLPPruningCallback`
- Bump up the version of AllenNLP in `setup.py`
  - `AllenNLPPruningCallback` uses `epoch_callbacks` in the current implementation,
      which will be available on the next major version of `AllenNLP`.


## Version requirements of AllenNLP [added in 2020/06/25]

This PR changes allennlp_simple.py, which is an example of AllenNLP+Optuna writing a model in Python script. After being merged this PR, `allennlp_simple.py` and `test_allennlp.py` will require the latest major version of AllenNLP (`allennlp>=1.0.0`). This is because an example of AllenNLP will use `AllenNLPPruningCallback`, the wrapper of Optuna's pruner implementations, which enables you to prune unpromising trials using efficient algorithms such as Hyperband. `AllenNLPPruningCallback` requires `allennlp>=1.0.0`, as it uses `EpochCallback`, which is introduced in the major version of AllenNLP. If you don't have to use `AllenNLPPruningCallback`, you can use Optuna with both the latest and earlier versions of AllenNLP.

You may want to use Optuna with AllenNLP v0.9.x or older. `AllenNLPExecutor` would work with the latest and earlier versions of AllenNLP. So if you're going to use Optuna+AllenNLP with Jsonnet, you can use Optuna without concern.


## Memo
- [RFC] how to use `AllenNLPPruningCallback` in `AllenNLPExecutor`.