### PR TITLE
Use `.. warning::` instead of `.. note::` for the deprecation decorator.

### DIFF
--- a/optuna/_deprecated.py
+++ b/optuna/_deprecated.py
@@ -13,7 +13,7 @@ from optuna._experimental import _validate_version
 
 _DEPRECATION_NOTE_TEMPLATE = """
 
-.. note::
+.. warning::
     Deprecated in v{d_ver}. This feature will be removed in the future. The removal of this
     feature is currently scheduled for v{r_ver}, but this schedule is subject to change.
     See https://github.com/optuna/optuna/releases/tag/v{d_ver}.

--- a/tests/test_deprecated.py
+++ b/tests/test_deprecated.py
@@ -22,7 +22,7 @@ class _Sample(object):
 
         detail
 
-        .. note::
+        .. warning::
             Deprecated in v1.1.0. This feature will be removed in the future. The removal of this
             feature is currently scheduled for v3.0.0, but this schedule is subject to change.
             See https://github.com/optuna/optuna/releases/tag/v1.1.0.


### PR DESCRIPTION
## Motivation
This is the follow-up PR of #1382.

## Description of the changes
- Use `.. warning::` instead of `.. note::` as suggested in https://github.com/optuna/optuna/pull/1382#issuecomment-647465798.