### PR TITLE
Remove stale labels from Issues or PRs when they are updated or commented on.

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -11,7 +11,7 @@ jobs:
 
     if: github.repository == 'optuna/optuna'
     steps:
-    - uses: actions/stale@v2
+    - uses: actions/stale@v3
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'This issue has not seen any recent activity.'
@@ -21,4 +21,3 @@ jobs:
         stale-issue-label: 'stale'
         stale-pr-label: 'stale'
         exempt-issue-labels: 'no-stale'
-        remove-stale-when-updated: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -21,3 +21,4 @@ jobs:
         stale-issue-label: 'stale'
         stale-pr-label: 'stale'
         exempt-issue-labels: 'no-stale'
+        remove-stale-when-updated: true


### PR DESCRIPTION
## Motivation
In the current workflow of Optuna's GitHub actions, the stale labels have been processed by the developers. This PR introduces a workflow to automate the removal of stale labels.

## Description of the changes
- Add workflow to remove stale labels automatically
