### PR TITLE
Prevent `doc-link` from running on unrelated status update events

### DIFF
--- a/.github/workflows/doc-link.yml
+++ b/.github/workflows/doc-link.yml
@@ -5,6 +5,7 @@ on: status
 jobs:
   doc-link:
     runs-on: ubuntu-latest
+    if: contains(github.context.target_url, 'circle-artifacts.com')
     steps:
     - uses: larsoner/circleci-artifacts-redirector-action@master
       with:

--- a/.github/workflows/doc-link.yml
+++ b/.github/workflows/doc-link.yml
@@ -5,7 +5,7 @@ on: status
 jobs:
   doc-link:
     runs-on: ubuntu-latest
-    if: contains(github.context.target_url, 'circle-artifacts.com')
+    if: "github.event.context == 'ci/circleci: document'"
     steps:
     - uses: larsoner/circleci-artifacts-redirector-action@master
       with:


### PR DESCRIPTION
<!-- Thank you for creating a pull request! -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

Prevnet [`doc-link`](https://github.com/optuna/optuna/blob/master/.github/workflows/doc-link.yml) from running on unrelated status update events to save [GitHub Actions usage](https://help.github.com/en/actions/getting-started-with-github-actions/about-github-actions#usage-limits).

## Description of the changes
<!-- Describe the changes in this PR. -->

Add an `if` condition to prevent `doc-link` from running on unrelated events.