### PR TITLE
Add logger to show deprecated warning

### DIFF
--- a/optuna/_deprecated.py
+++ b/optuna/_deprecated.py
@@ -9,7 +9,9 @@ import warnings
 
 from optuna._experimental import _get_docstring_indent
 from optuna._experimental import _validate_version
+from optuna import logging
 
+_logger = logging.get_logger(__name__)
 
 _DEPRECATION_NOTE_TEMPLATE = """
 
@@ -86,15 +88,18 @@ def deprecated(
             # TODO(mamu): Annotate this correctly.
             @functools.wraps(func)
             def new_func(*args: Any, **kwargs: Any) -> Any:
-                warnings.warn(
+                message = (
                     "{} has been deprecated in v{}. "
                     "This feature will be removed in v{}.".format(
                         name if name is not None else func.__name__,
                         deprecated_version,
                         removed_version,
-                    ),
-                    DeprecationWarning,
+                    )
                 )
+                warnings.warn(
+                    message, DeprecationWarning,
+                )
+                _logger.warning(message)
 
                 return func(*args, **kwargs)  # type: ignore
 
@@ -109,15 +114,18 @@ def deprecated(
 
             @functools.wraps(_original_init)
             def wrapped_init(self, *args, **kwargs) -> None:  # type: ignore
-                warnings.warn(
+                message = (
                     "{} has been deprecated in v{}. "
                     "This feature will be removed in v{}.".format(
                         name if name is not None else cls.__name__,
                         deprecated_version,
                         removed_version,
-                    ),
-                    DeprecationWarning,
+                    )
                 )
+                warnings.warn(
+                    message, DeprecationWarning,
+                )
+                _logger.warning(message)
 
                 _original_init(self, *args, **kwargs)
 

--- a/optuna/_deprecated.py
+++ b/optuna/_deprecated.py
@@ -96,9 +96,7 @@ def deprecated(
                         removed_version,
                     )
                 )
-                warnings.warn(
-                    message, DeprecationWarning,
-                )
+                warnings.warn(message, DeprecationWarning)
                 _logger.warning(message)
 
                 return func(*args, **kwargs)  # type: ignore
@@ -122,9 +120,7 @@ def deprecated(
                         removed_version,
                     )
                 )
-                warnings.warn(
-                    message, DeprecationWarning,
-                )
+                warnings.warn(message, DeprecationWarning)
                 _logger.warning(message)
 
                 _original_init(self, *args, **kwargs)


### PR DESCRIPTION
<!-- Thank you for creating a pull request! -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

Solve #1411

## Description of the changes
<!-- Describe the changes in this PR. -->

After applying this PR, the example in #1411 shows the following messages:

```python
from optuna.distributions import IntLogUniformDistribution

dist = IntLogUniformDistribution(1, 10)
dist.single()
```

```bash
[W 2020-06-24 01:39:05,302] IntLogUniformDistribution has been deprecated in v2.0.0. This feature will be removed in v2.0.1.
[W 2020-06-24 01:39:05,303] single has been deprecated in v2.0.0. This feature will be removed in v2.0.1.
```