### PR TITLE
Always use Sphinx RTD theme.

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -16,11 +16,9 @@
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
 
-import os
 import pkg_resources
 
 __version__ = pkg_resources.get_distribution('optuna').version
-on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 
 # -- Project information -----------------------------------------------------
 
@@ -85,8 +83,7 @@ pygments_style = 'sphinx'
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-if not on_rtd:
-    html_theme = 'sphinx_rtd_theme'
+html_theme = 'sphinx_rtd_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the


### PR DESCRIPTION
## Motivation

Follow-up to https://github.com/optuna/optuna/pull/1370. The `logo_only` should take effect but it isn't.

## Description of the changes

Changes to always, incl. building on RTD, apply the RTD Sphinx Theme. This makes sure that `logo_only` takes effect on the deployed RTD environment.

### Note
- The removed condition was initially introduced in https://github.com/optuna/optuna/pull/191 when changing the theme and I'm not aware of the underlying reason but it seems like we can remove it now.
- Preview https://hvy-optuna.readthedocs.io/en/rtd-sphinx-test/index.html