### PR TITLE
Allow omitting the removal version in `deprecated`.

### DIFF
--- a/optuna/_deprecated.py
+++ b/optuna/_deprecated.py
@@ -33,18 +33,30 @@ def _format_text(text: str) -> str:
     return "\n\n" + textwrap.indent(text.strip(), "    ") + "\n"
 
 
+def _get_removed_version_from_deprecated_version(deprecated_version: str) -> str:
+    parsed_deprecated_version = version.parse(deprecated_version)
+    assert isinstance(parsed_deprecated_version, version.Version)  # Required for mypy.
+    return "{}.0.0".format(parsed_deprecated_version.major + 2)
+
+
 def deprecated(
     deprecated_version: str,
-    removed_version: str,
+    removed_version: Optional[str] = None,
     name: Optional[str] = None,
     text: Optional[str] = None,
 ) -> Any:
     """Decorate class or function as deprecated.
 
     Args:
-        deprecated_version: The version in which the target feature is deprecated.
-        removed_version: The version in which the target feature will be removed.
-        name: The name of the feature. Defaults to the function or class name. Optional.
+        deprecated_version:
+            The version in which the target feature is deprecated.
+        removed_version:
+            The version in which the target feature will be removed. If :obj:`None`, determined
+            based on the deprecated version. In this case, it will become the next next major
+            version after the deprecated version. E.g. if ``deprecated_version`` is ``1.5.0``,
+            this version becomes ``3.0.0``.
+        name:
+            The name of the feature. Defaults to the function or class name. Optional.
         text:
             The additional text for the deprecation note. The default note is build using specified
             ``deprecated_version`` and ``removed_version``. If you want to provide additional
@@ -61,6 +73,8 @@ def deprecated(
     """
 
     _validate_version(deprecated_version)
+    if removed_version is None:
+        removed_version = _get_removed_version_from_deprecated_version(deprecated_version)
     _validate_version(removed_version)
     _validate_two_version(deprecated_version, removed_version)
 

--- a/tests/test_deprecated.py
+++ b/tests/test_deprecated.py
@@ -31,7 +31,7 @@ class _Sample(object):
 
 
 @pytest.mark.parametrize("deprecated_version", ["1.1", 100, None, "2.0.0"])
-@pytest.mark.parametrize("removed_version", ["1.1", 10, None, "1.0.0"])
+@pytest.mark.parametrize("removed_version", ["1.1", 10, "1.0.0"])
 def test_deprecation_raises_error_for_invalid_version(
     deprecated_version: Any, removed_version: Any
 ) -> None:
@@ -155,3 +155,27 @@ def test_deprecation_class_text_specified(text: Optional[str]) -> None:
         expected_class_doc += "\n\n\n"
     assert decorated_class.__name__ == _Class.__name__
     assert decorated_class.__doc__ == expected_class_doc
+
+
+def test_deprecation_decorator_default_removed_version() -> None:
+    deprecated_version = "1.1.0"
+    decorator_deprecation = _deprecated.deprecated(deprecated_version)
+    assert callable(decorator_deprecation)
+
+    def _func(_: Any) -> int:
+
+        return 10
+
+    decorated_func = decorator_deprecation(_func)
+    assert decorated_func.__name__ == _func.__name__
+    assert decorated_func.__doc__ == _deprecated._DEPRECATION_NOTE_TEMPLATE.format(
+        d_ver=deprecated_version, r_ver="3.0.0"
+    )
+
+    with pytest.warns(DeprecationWarning):
+        decorated_func(None)
+
+
+def test_get_removed_version_from_deprecated_version() -> None:
+    assert _deprecated._get_removed_version_from_deprecated_version("1.0.0") == "3.0.0"
+    assert _deprecated._get_removed_version_from_deprecated_version("1.5.0") == "3.0.0"


### PR DESCRIPTION
## Motivation

Better to avoid unnecessary verbosity and redundancy. Noticed while reviewing https://github.com/optuna/optuna/pull/1413 that the deprecation decorator could be improved.

## Description of the changes

Allows omitting the removal version when applying the deprecation decorator.

