### PR TITLE
Remove either `warnings.warn()` or `optuna.logging.Logger.warning()` from codes which have both of them.

### DIFF
--- a/optuna/cli.py
+++ b/optuna/cli.py
@@ -147,7 +147,6 @@ class _StudySetUserAttribute(_BaseCommand):
         elif parsed_args.study:
             message = "The use of `--study` is deprecated. Please use `--study-name` instead."
             warnings.warn(message, DeprecationWarning)
-            self.logger.warning(message)
             study = optuna.load_study(storage=storage_url, study_name=parsed_args.study)
         elif parsed_args.study_name:
             study = optuna.load_study(storage=storage_url, study_name=parsed_args.study_name)
@@ -238,7 +237,6 @@ class _Dashboard(_BaseCommand):
         elif parsed_args.study:
             message = "The use of `--study` is deprecated. Please use `--study-name` instead."
             warnings.warn(message, DeprecationWarning)
-            self.logger.warning(message)
             study = optuna.load_study(storage=storage_url, study_name=parsed_args.study)
         elif parsed_args.study_name:
             study = optuna.load_study(storage=storage_url, study_name=parsed_args.study_name)
@@ -300,7 +298,6 @@ class _StudyOptimize(_BaseCommand):
             "script directly instead."
         )
         warnings.warn(message, DeprecationWarning)
-        self.logger.warning(message)
 
         storage_url = _check_storage_url(self.app_args.storage)
 
@@ -312,7 +309,6 @@ class _StudyOptimize(_BaseCommand):
         elif parsed_args.study:
             message = "The use of `--study` is deprecated. Please use `--study-name` instead."
             warnings.warn(message, DeprecationWarning)
-            self.logger.warning(message)
             study = optuna.load_study(storage=storage_url, study_name=parsed_args.study)
         elif parsed_args.study_name:
             study = optuna.load_study(storage=storage_url, study_name=parsed_args.study_name)
@@ -372,7 +368,7 @@ class _StorageUpgrade(_BaseCommand):
             storage.upgrade()
             self.logger.info("Completed to upgrade the storage.")
         else:
-            self.logger.warning(
+            warnings.warn(
                 "Your optuna version seems outdated against the storage version. "
                 "Please try updating optuna to the latest version by "
                 "`$ pip install -U optuna`."

--- a/optuna/cli.py
+++ b/optuna/cli.py
@@ -146,7 +146,7 @@ class _StudySetUserAttribute(_BaseCommand):
             )
         elif parsed_args.study:
             message = "The use of `--study` is deprecated. Please use `--study-name` instead."
-            warnings.warn(message, DeprecationWarning)
+            warnings.warn(message, FutureWarning)
             study = optuna.load_study(storage=storage_url, study_name=parsed_args.study)
         elif parsed_args.study_name:
             study = optuna.load_study(storage=storage_url, study_name=parsed_args.study_name)
@@ -236,7 +236,7 @@ class _Dashboard(_BaseCommand):
             )
         elif parsed_args.study:
             message = "The use of `--study` is deprecated. Please use `--study-name` instead."
-            warnings.warn(message, DeprecationWarning)
+            warnings.warn(message, FutureWarning)
             study = optuna.load_study(storage=storage_url, study_name=parsed_args.study)
         elif parsed_args.study_name:
             study = optuna.load_study(storage=storage_url, study_name=parsed_args.study_name)
@@ -297,7 +297,7 @@ class _StudyOptimize(_BaseCommand):
             "The use of the `study optimize` command is deprecated. Please execute your Python "
             "script directly instead."
         )
-        warnings.warn(message, DeprecationWarning)
+        warnings.warn(message, FutureWarning)
 
         storage_url = _check_storage_url(self.app_args.storage)
 
@@ -308,7 +308,7 @@ class _StudyOptimize(_BaseCommand):
             )
         elif parsed_args.study:
             message = "The use of `--study` is deprecated. Please use `--study-name` instead."
-            warnings.warn(message, DeprecationWarning)
+            warnings.warn(message, FutureWarning)
             study = optuna.load_study(storage=storage_url, study_name=parsed_args.study)
         elif parsed_args.study_name:
             study = optuna.load_study(storage=storage_url, study_name=parsed_args.study_name)

--- a/optuna/integration/chainermn.py
+++ b/optuna/integration/chainermn.py
@@ -1,6 +1,5 @@
-import warnings
-
 from typing import Optional
+import warnings
 
 from optuna._imports import try_import
 from optuna.storages import InMemoryStorage

--- a/optuna/integration/chainermn.py
+++ b/optuna/integration/chainermn.py
@@ -1,7 +1,8 @@
+import warnings
+
 from typing import Optional
 
 from optuna._imports import try_import
-from optuna.logging import get_logger
 from optuna.storages import InMemoryStorage
 from optuna.storages import RDBStorage
 from optuna.trial import BaseTrial
@@ -89,8 +90,7 @@ class ChainerMNStudy(object):
 
         if isinstance(study._storage, RDBStorage):
             if study._storage.engine.dialect.name == "sqlite":
-                logger = get_logger(__name__)
-                logger.warning(
+                warnings.warn(
                     "SQLite may cause synchronization problems when used with "
                     "ChainerMN integration. Please use other DBs like PostgreSQL."
                 )

--- a/optuna/structs.py
+++ b/optuna/structs.py
@@ -24,7 +24,7 @@ _message = (
     "`structs.TrialState`->`trial.TrialState`, "
     "`structs.TrialPruned`->`exceptions.TrialPruned`."
 )
-warnings.warn(_message, DeprecationWarning)
+warnings.warn(_message, FutureWarning)
 
 # The use of the structs.StudyDirection is deprecated and it is recommended that you use
 # study.StudyDirection instead. See the API reference for more details.

--- a/optuna/structs.py
+++ b/optuna/structs.py
@@ -2,7 +2,6 @@ import warnings
 
 from optuna import _study_direction
 from optuna import exceptions
-from optuna import logging
 from optuna import trial
 from optuna import type_checking
 
@@ -16,8 +15,6 @@ if type_checking.TYPE_CHECKING:
     from optuna.distributions import BaseDistribution  # NOQA
 
 
-_logger = logging.get_logger(__name__)
-
 _message = (
     "`structs` is deprecated. Classes have moved to the following modules. "
     "`structs.StudyDirection`->`study.StudyDirection`, "
@@ -27,7 +24,6 @@ _message = (
     "`structs.TrialPruned`->`exceptions.TrialPruned`."
 )
 warnings.warn(_message, DeprecationWarning)
-_logger.warning(_message)
 
 # The use of the structs.StudyDirection is deprecated and it is recommended that you use
 # study.StudyDirection instead. See the API reference for more details.
@@ -88,7 +84,6 @@ class FrozenTrial(object):
             "Please use `trial.FrozenTrial` instead."
         )
         warnings.warn(message, DeprecationWarning)
-        _logger.warning(message)
 
         self.number = number
         self.state = state
@@ -278,7 +273,6 @@ class StudySummary(object):
             "Please use `study.StudySummary` instead."
         )
         warnings.warn(message, DeprecationWarning)
-        _logger.warning(message)
 
         self.study_name = study_name
         self.direction = direction
@@ -331,4 +325,3 @@ class TrialPruned(exceptions.TrialPruned):
             "Please use `optuna.TrialPruned` instead."
         )
         warnings.warn(message, DeprecationWarning)
-        _logger.warning(message)

--- a/optuna/study.py
+++ b/optuna/study.py
@@ -294,7 +294,6 @@ class Study(BaseStudy):
                 if show_progress_bar:
                     msg = "Progress bar only supports serial execution (`n_jobs=1`)."
                     warnings.warn(msg)
-                    _logger.warning(msg)
 
                 time_start = datetime.datetime.now()
 
@@ -325,7 +324,6 @@ class Study(BaseStudy):
                             "https://optuna.readthedocs.io/en/stable/tutorial/rdb.html."
                         )
                         warnings.warn(msg, UserWarning)
-                        _logger.warning(msg)
 
                     parallel(
                         delayed(self._reseed_and_optimize_sequential)(


### PR DESCRIPTION
## Motivation
From the current Optuna [coding style convention](https://github.com/optuna/optuna/wiki/Coding-Style-Conventions), we should not use both `warnings.warn()` and `optuna.logging.Logger.warning()` at the same place. This PR applies that convention to the optuna code base.

## Description of the changes
- Remove `optuna.logging.Logger.warning()` from `optuna/cli.py`, because they are deprecation warnings.
- Remove `optuna.logging.Logger.warning()` from `optuna/structs.py`, because they are deprecation warnings.
- Remove `optuna.logging.Logger.warning()` and add `warnings.warn()` from `optuna/integration/chainermn.py`, because they are fixed by user codes.
- Remove `optuna.logging.Logger.warning()` from `optuna/study.py`, because they can be fixed by user codes.
