### PR TITLE
Simplify usage of `deprecated` by omitting removed version.

### DIFF
--- a/optuna/integration/_lightgbm_tuner/optimize.py
+++ b/optuna/integration/_lightgbm_tuner/optimize.py
@@ -732,7 +732,6 @@ class LightGBMTuner(_LightGBMBaseTuner):
     @property  # type: ignore
     @deprecated(
         "1.4.0",
-        "3.0.0",
         text=(
             "Please get the best booster via "
             ":class:`~optuna.integration.lightgbm.LightGBMTuner.get_best_booster` instead."

--- a/optuna/integration/cma.py
+++ b/optuna/integration/cma.py
@@ -454,9 +454,7 @@ class _Optimizer(object):
         return cma_param_value
 
 
-@deprecated(
-    "2.0.0", "4.0.0", text="This class is renamed to :class:`~optuna.integration.PyCmaSampler`."
-)
+@deprecated("2.0.0", text="This class is renamed to :class:`~optuna.integration.PyCmaSampler`.")
 class CmaEsSampler(PyCmaSampler):
     """Wrapper class of PyCmaSampler for backward compatibility."""
 

--- a/optuna/structs.py
+++ b/optuna/structs.py
@@ -41,7 +41,6 @@ TrialState = trial.TrialState
 
 @deprecated(
     "1.4.0",
-    "3.0.0",
     text=(
         "This class was moved to :mod:`~optuna.trial`. Please use "
         ":class:`~optuna.trial.FrozenTrial` instead."
@@ -230,7 +229,6 @@ class FrozenTrial(object):
 
 @deprecated(
     "1.4.0",
-    "3.0.0",
     text=(
         "This class was moved to :mod:`~optuna.study`. Please use "
         ":class:`~optuna.study.StudySummary` instead."
@@ -316,7 +314,6 @@ class StudySummary(object):
 
 @deprecated(
     "0.19.0",
-    "3.0.0",
     text=(
         "This class was moved to :mod:`~optuna.exceptions`. Please use "
         ":class:`~optuna.exceptions.TrialPruned` instead."


### PR DESCRIPTION
## Motivation

Follow-up to https://github.com/optuna/optuna/pull/1418.

## Description of the changes

Simplifies code by relying on default arguments.