### PR TITLE
Apply experimental decorator.

### DIFF
--- a/optuna/dashboard.py
+++ b/optuna/dashboard.py
@@ -2,9 +2,11 @@ import collections
 from distutils.version import StrictVersion
 import threading
 import time
+import warnings
 
 import numpy as np
 
+from optuna._experimental import experimental
 from optuna._imports import try_import
 import optuna.logging
 import optuna.study
@@ -255,11 +257,11 @@ if _imports.is_successful():
             self.all_trials_widget.update(current_trials, new_trials)
 
 
+@experimental("0.1.0")
 def _show_experimental_warning():
     # type: () -> None
 
-    logger = optuna.logging.get_logger(__name__)
-    logger.warning("Optuna dashboard is still highly experimental. Please use with caution!")
+    warnings.warn("Optuna dashboard is still highly experimental. Please use with caution!")
 
 
 def _get_this_source_path():

--- a/optuna/dashboard.py
+++ b/optuna/dashboard.py
@@ -2,7 +2,6 @@ import collections
 from distutils.version import StrictVersion
 import threading
 import time
-import warnings
 
 import numpy as np
 
@@ -257,11 +256,11 @@ if _imports.is_successful():
             self.all_trials_widget.update(current_trials, new_trials)
 
 
-@experimental("0.1.0")
+@experimental("0.1.0", name="Optuna dashboard")
 def _show_experimental_warning():
     # type: () -> None
 
-    warnings.warn("Optuna dashboard is still highly experimental. Please use with caution!")
+    pass
 
 
 def _get_this_source_path():

--- a/optuna/integration/sklearn.py
+++ b/optuna/integration/sklearn.py
@@ -8,6 +8,7 @@ from time import time
 import numpy as np
 import scipy as sp
 
+from optuna._experimental import experimental
 from optuna._imports import try_import
 from optuna import distributions  # NOQA
 from optuna import TrialPruned  # NOQA
@@ -373,12 +374,9 @@ class _Objective(object):
             trial.set_user_attr("std_{}".format(name), np.nanstd(array))
 
 
+@experimental("0.17.0")
 class OptunaSearchCV(BaseEstimator):
     """Hyperparameter search with cross-validation.
-
-    .. warning::
-
-        This feature is experimental. The interface may be changed in the future.
 
     Args:
         estimator:


### PR DESCRIPTION
## Motivation
Apply the experimental decorator to classes which are experimental without the experimental decorator.

## Description of the changes
This PR applies the experimental decorator to the following classes:
- `optuna.dashboard`
- `optuna.integration.sklearn.OptunaSearchCV`