### PR TITLE
Remove unnecessary `removed_version`.

### DIFF
--- a/optuna/integration/_lightgbm_tuner/optimize.py
+++ b/optuna/integration/_lightgbm_tuner/optimize.py
@@ -727,7 +727,6 @@ class LightGBMTuner(_LightGBMBaseTuner):
     @property  # type: ignore
     @deprecated(
         "1.4.0",
-        "3.0.0",
         text=(
             "Please get the best booster via "
             ":class:`~optuna.integration.lightgbm.LightGBMTuner.get_best_booster` instead."

--- a/optuna/integration/cma.py
+++ b/optuna/integration/cma.py
@@ -455,7 +455,7 @@ class _Optimizer(object):
 
 
 @deprecated(
-    "2.0.0", "4.0.0", text="This class is renamed to :class:`~optuna.integration.PyCmaSampler`."
+    "2.0.0", text="This class is renamed to :class:`~optuna.integration.PyCmaSampler`."
 )
 class CmaEsSampler(PyCmaSampler):
     """Wrapper class of PyCmaSampler for backward compatibility."""

--- a/optuna/structs.py
+++ b/optuna/structs.py
@@ -41,7 +41,6 @@ TrialState = trial.TrialState
 
 @deprecated(
     "1.4.0",
-    "3.0.0",
     text=(
         "This class was moved to :mod:`~optuna.trial`. Please use "
         ":class:`~optuna.trial.FrozenTrial` instead."
@@ -230,7 +229,6 @@ class FrozenTrial(object):
 
 @deprecated(
     "1.4.0",
-    "3.0.0",
     text=(
         "This class was moved to :mod:`~optuna.study`. Please use "
         ":class:`~optuna.study.StudySummary` instead."


### PR DESCRIPTION
## Motivation
This is a followup PR for #1413 .

## Description of the changes

#1418 provides the default `removed_version` for `@deprecated`. This PR removes unnecessary `removed_version` to simply the code.