### PR TITLE
Exempt PRs with `no-stale` label from stale bot.

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -21,3 +21,4 @@ jobs:
         stale-issue-label: 'stale'
         stale-pr-label: 'stale'
         exempt-issue-labels: 'no-stale'
+        exempt-pr-labels: 'no-stale'


### PR DESCRIPTION
## Motivation
`no-stale` issues are excluded from the target of stale bot by #1321 , but the PR with `no-stale` can be labeled as 'stale'. See https://github.com/optuna/optuna/pull/1106#issuecomment-648474136.

## Description of the changes
It simply adds `exempt-pr-labels` (c.f., https://github.com/actions/stale/blob/master/action.yml#L27-L29).