### PR TITLE
Replace `DeprecationWarning` with `FutureWarning` in `@deprecated`.

### DIFF
--- a/optuna/_deprecated.py
+++ b/optuna/_deprecated.py
@@ -107,7 +107,7 @@ def deprecated(
                         deprecated_version,
                         removed_version,
                     ),
-                    DeprecationWarning,
+                    FutureWarning,
                     stacklevel=2,
                 )
 
@@ -131,7 +131,7 @@ def deprecated(
                         deprecated_version,
                         removed_version,
                     ),
-                    DeprecationWarning,
+                    FutureWarning,
                     stacklevel=2,
                 )
 

--- a/optuna/structs.py
+++ b/optuna/structs.py
@@ -271,13 +271,6 @@ class StudySummary(object):
     ):
         # type: (...) -> None
 
-        message = (
-            "The use of `structs.StudySummary` is deprecated. "
-            "Please use `study.StudySummary` instead."
-        )
-        warnings.warn(message, DeprecationWarning)
-        _logger.warning(message)
-
         self.study_name = study_name
         self.direction = direction
         self.best_trial = best_trial

--- a/tests/integration_tests/lightgbm_tuner_tests/test_optimize.py
+++ b/tests/integration_tests/lightgbm_tuner_tests/test_optimize.py
@@ -584,7 +584,7 @@ class TestLightGBMTuner(object):
         assert best_booster.params["lambda_l1"] != unexpected_value
 
         # TODO(toshihikoyanase): Remove this check when LightGBMTuner.best_booster is removed.
-        with pytest.warns(DeprecationWarning):
+        with pytest.warns(FutureWarning):
             tuner.best_booster
 
         tuner2 = LightGBMTuner(params, dataset, valid_sets=dataset, study=study)

--- a/tests/integration_tests/test_cma.py
+++ b/tests/integration_tests/test_cma.py
@@ -23,7 +23,7 @@ from optuna.trial import TrialState
 
 
 def test_cmaes_deprecation_warning() -> None:
-    with pytest.deprecated_call():
+    with pytest.warns(FutureWarning):
         optuna.integration.CmaEsSampler()
 
 

--- a/tests/test_deprecated.py
+++ b/tests/test_deprecated.py
@@ -55,7 +55,7 @@ def test_deprecation_decorator() -> None:
         d_ver=deprecated_version, r_ver=removed_version
     )
 
-    with pytest.warns(DeprecationWarning):
+    with pytest.warns(FutureWarning):
         decorated_func()
 
 
@@ -69,7 +69,7 @@ def test_deprecation_method_decorator() -> None:
     assert decorated_method.__name__ == _Sample._method.__name__
     assert decorated_method.__doc__ == _Sample._method_expected.__doc__
 
-    with pytest.warns(DeprecationWarning):
+    with pytest.warns(FutureWarning):
         decorated_method(None)
 
 
@@ -86,7 +86,7 @@ def test_deprecation_class_decorator() -> None:
         d_ver=deprecated_version, r_ver=removed_version
     )
 
-    with pytest.warns(DeprecationWarning):
+    with pytest.warns(FutureWarning):
         decorated_class("a", "b", "c")
 
 
@@ -96,7 +96,7 @@ def test_deprecation_class_decorator_name() -> None:
     decorator_deprecation = _deprecated.deprecated("1.1.0", "3.0.0", name=name)
     decorated_sample = decorator_deprecation(_Sample)
 
-    with pytest.warns(DeprecationWarning) as record:
+    with pytest.warns(FutureWarning) as record:
         decorated_sample("a", "b", "c")
 
     assert name in record.list[0].message.args[0]
@@ -111,7 +111,7 @@ def test_deprecation_decorator_name() -> None:
     decorator_deprecation = _deprecated.deprecated("1.1.0", "3.0.0", name=name)
     decorated_sample_func = decorator_deprecation(_func)
 
-    with pytest.warns(DeprecationWarning) as record:
+    with pytest.warns(FutureWarning) as record:
         decorated_sample_func()
 
     assert name in record.list[0].message.args[0]
@@ -172,7 +172,7 @@ def test_deprecation_decorator_default_removed_version() -> None:
         d_ver=deprecated_version, r_ver="3.0.0"
     )
 
-    with pytest.warns(DeprecationWarning):
+    with pytest.warns(FutureWarning):
         decorated_func()
 
 

--- a/tests/test_structs.py
+++ b/tests/test_structs.py
@@ -12,7 +12,7 @@ from optuna.structs import TrialState
 
 def test_frozen_trial_deprecated() -> None:
 
-    with pytest.deprecated_call():
+    with pytest.warns(FutureWarning):
         FrozenTrial(
             number=0,
             trial_id=0,
@@ -30,7 +30,7 @@ def test_frozen_trial_deprecated() -> None:
 
 def test_study_summary_deprecated() -> None:
 
-    with pytest.deprecated_call():
+    with pytest.warns(FutureWarning):
         StudySummary(
             study_name="test",
             direction=StudyDirection.NOT_SET,
@@ -45,5 +45,5 @@ def test_study_summary_deprecated() -> None:
 
 def test_trial_pruned_deprecated() -> None:
 
-    with pytest.deprecated_call():
+    with pytest.warns(FutureWarning):
         TrialPruned()


### PR DESCRIPTION
## Motivation

By default, the message of `DeprecationWarning` is suppressed and it may be difficult for users to find the deprecated features. Since Python 3.7, the definition of `FutureWarning` was changed, and I think we can utilize it to notify the deprecated feature to users.

Since Python 3.7
- `DeprecationWarning`: warnings about deprecated features when those warnings are intended for other Python developers
- `FeatureWarning`: warnings about deprecated features when those warnings are intended for end users of applications that are written in Python.

Notes
- `FutureWarning` is also used by `scikit-learn` for this purpose ([See](https://github.com/scikit-learn/scikit-learn/blob/95d4f0841/sklearn/utils/deprecation.py#L102)). 
- Do Python 3.5, 3.6 users have any troubles with this change?

## Description of the changes
This PR uses `FutureWarning` instead of `DeprecationWarning` in `@deprecated`.