### PR TITLE
Fix the experimental warning message for `CmaEsSampler`.

### DIFF
--- a/optuna/samplers/_cmaes.py
+++ b/optuna/samplers/_cmaes.py
@@ -136,7 +136,7 @@ class CmaEsSampler(BaseSampler):
         if self._consider_pruned_trials:
             self._raise_experimental_warning_for_consider_pruned_trials()
 
-    @experimental("2.0.0")
+    @experimental("2.0.0", name="`consider_pruned_trials = True` in CmaEsSampler")
     def _raise_experimental_warning_for_consider_pruned_trials(self) -> None:
         pass
 


### PR DESCRIPTION
## Motivation
This PR aims to fix the experimental warning message for `CmaEsSampler`.

## Description of the changes
- Add `name = "consider_pruned_trials = True" in CmaEsSampler` to the experimental decorator in `CmaEsSampler`.

### Before merging
<img width="1583" alt="スクリーンショット 2020-06-25 20 52 07" src="https://user-images.githubusercontent.com/38826298/85714816-c2e9da00-b725-11ea-857f-1eeeb2cc92ef.png">

### After merging
<img width="1536" alt="スクリーンショット 2020-06-25 20 50 40" src="https://user-images.githubusercontent.com/38826298/85714845-c9785180-b725-11ea-8748-5a233ab642c7.png">

