### PR TITLE
Align `sphinx-rtd-theme` and Python versions used on Read the Docs to CircleCI.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,7 +69,7 @@ jobs:
       - run:
           name: install
           command: |
-            python -m venv venv || virtualenv venv --python=python3
+            python -m venv venv || virtualenv venv --python=python3.8
             . venv/bin/activate
             pip install -U pip
             pip install --progress-bar off .[document]

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -13,7 +13,7 @@ formats: all
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.7
+  version: 3.8
   install:
     - method: pip
       path: .

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -13,6 +13,8 @@ formats: all
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
+  # Sphinx requires either Python >= 3.8 or `typed-ast` to reflect type comments 
+  # in the documentation. See: https://github.com/sphinx-doc/sphinx/pull/6984
   version: 3.8
   install:
     - method: pip

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -13,7 +13,7 @@ formats: all
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  # Sphinx requires either Python >= 3.8 or `typed-ast` to reflect type comments 
+  # `sphinx` requires either Python >= 3.8 or `typed-ast` to reflect type comments 
   # in the documentation. See: https://github.com/sphinx-doc/sphinx/pull/6984
   version: 3.8
   install:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -97,6 +97,8 @@ html_favicon = '../image/favicon.ico'
 
 html_logo = '../image/optuna-logo.png'
 
+html4_writer = True
+
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -97,8 +97,6 @@ html_favicon = '../image/favicon.ico'
 
 html_logo = '../image/optuna-logo.png'
 
-html4_writer = True
-
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ def get_extras_require() -> Dict[str, List[str]]:
             "mlflow",
         ],
         # TODO(hvy): Unpin `sphinx` version after https://github.com/sphinx-doc/sphinx/issues/7807.
-        "document": ["sphinx>=3.0.0,!=3.1.0,!=3.1.1", "sphinx_rtd_theme"],
+        "document": ["sphinx>=3.0.0,!=3.1.0,!=3.1.1", "sphinx_rtd_theme>=0.5.0"],
         "example": [
             "catboost",
             "chainer",

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ def get_extras_require() -> Dict[str, List[str]]:
             "mlflow",
         ],
         # TODO(hvy): Unpin `sphinx` version after https://github.com/sphinx-doc/sphinx/issues/7807.
-        "document": ["sphinx>=3.0.0,!=3.1.0,!=3.1.1", "sphinx_rtd_theme>=0.5.0"],
+        "document": ["sphinx>=3.0.0,!=3.1.0,!=3.1.1", "sphinx_rtd_theme<0.5.0"],
         "example": [
             "catboost",
             "chainer",

--- a/setup.py
+++ b/setup.py
@@ -60,8 +60,14 @@ def get_extras_require() -> Dict[str, List[str]]:
             "scikit-optimize",
             "mlflow",
         ],
-        # TODO(hvy): Unpin `sphinx` version after https://github.com/sphinx-doc/sphinx/issues/7807.
-        "document": ["sphinx>=3.0.0,!=3.1.0,!=3.1.1", "sphinx_rtd_theme<0.5.0"],
+        "document": [
+            # TODO(hvy): Unpin `sphinx` version after:
+            # https://github.com/sphinx-doc/sphinx/issues/7807.
+            "sphinx>=3.0.0,!=3.1.0,!=3.1.1",
+            # As reported in: https://github.com/readthedocs/sphinx_rtd_theme/issues/949,
+            # `sphinx_rtd_theme` 0.5.0 is still not compatible with `sphinx` >= 3.0.
+            "sphinx_rtd_theme<0.5.0",
+        ],
         "example": [
             "catboost",
             "chainer",


### PR DESCRIPTION
<!-- Thank you for creating a pull request! -->

## Motivation

<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

Currently, the version of `sphinx_rtd_theme` is not specified. This causes Read-the-docs (RTD) to use the pre-installed `sphinx_rtd_theme<0.5`.

https://readthedocs.org/projects/optuna/builds/11327552/

<img width="573" alt="Screen Shot 2020-06-25 at 21 36 45" src="https://user-images.githubusercontent.com/17039389/85721163-14956300-b72c-11ea-93bb-360b0f64dd83.png">

This PR adds a version specifier for `sphinx-rtd-theme` that enforces the update on RTD and aligns the version used on RTD and CircleCI.

## Difference

The screenshots below compare how the doc looks like on RTD and CricleCI. On RTD, the type hints are not rendered.

###  Read-the-Docs

<img width="1006" alt="Screen Shot 2020-06-25 at 21 28 46" src="https://user-images.githubusercontent.com/17039389/85720192-2a565880-b72b-11ea-836a-5dc28fec7318.png">

https://optuna.readthedocs.io/en/stable/reference/study.html

### CircleCI

<img width="1006" alt="Screen Shot 2020-06-25 at 21 28 51" src="https://user-images.githubusercontent.com/17039389/85720176-2591a480-b72b-11ea-8998-9d91735ed4eb.png">

https://46950-122299416-gh.circle-artifacts.com/0/docs/build/html/reference/study.html

## Description of the changes
<!-- Describe the changes in this PR. -->
