### PR TITLE
Remove experimental decorator from `HyperbandPruner`.

### DIFF
--- a/optuna/pruners/_hyperband.py
+++ b/optuna/pruners/_hyperband.py
@@ -4,7 +4,6 @@ from typing import Optional
 from typing import Union
 
 import optuna
-from optuna._experimental import experimental
 from optuna import logging
 from optuna.pruners._base import BasePruner
 from optuna.pruners._successive_halving import SuccessiveHalvingPruner
@@ -13,7 +12,6 @@ from optuna.trial._state import TrialState
 _logger = logging.get_logger(__name__)
 
 
-@experimental("1.1.0")
 class HyperbandPruner(BasePruner):
     """Pruner using Hyperband.
 

--- a/tests/pruners_tests/test_hyperband.py
+++ b/tests/pruners_tests/test_hyperband.py
@@ -16,14 +16,6 @@ N_REPORTS = 10
 EXPECTED_N_TRIALS_PER_BRACKET = 10
 
 
-def test_hyperband_experimental_warning() -> None:
-
-    with pytest.warns(optuna.exceptions.ExperimentalWarning):
-        optuna.pruners.HyperbandPruner(
-            min_resource=MIN_RESOURCE, max_resource=MAX_RESOURCE, reduction_factor=REDUCTION_FACTOR
-        )
-
-
 def test_hyperband_pruner_intermediate_values() -> None:
     pruner = optuna.pruners.HyperbandPruner(
         min_resource=MIN_RESOURCE, max_resource=MAX_RESOURCE, reduction_factor=REDUCTION_FACTOR


### PR DESCRIPTION
## Motivation

Related to #1246, This PR makes `HyperbandPruner` non-experimental.

## Description of the changes

This PR simply remove `@experimental` from `HyperbandPruner`.