### PR TITLE
Continue to allow using `IntLogUnioformDistribution.step` during deprecation.

### DIFF
--- a/optuna/distributions.py
+++ b/optuna/distributions.py
@@ -326,8 +326,7 @@ class IntLogUniformDistribution(BaseDistribution):
                 but this schedule is subject to change.
 
                 Samplers and other components in Optuna relying on this distribution will ignore
-                this value and assume that
-                :attr:`~optuna.distributions.IntLogUniformDistribution.step` is always 1.
+                this value and assume that ``step`` is always 1.
                 User-defined samplers may continue to use other values besides 1 during the
                 deprecation.
     """

--- a/optuna/distributions.py
+++ b/optuna/distributions.py
@@ -2,13 +2,13 @@ import abc
 import copy
 import decimal
 import json
+from typing import Dict
 import warnings
 
 from optuna import type_checking
 
 if type_checking.TYPE_CHECKING:
     from typing import Any  # NOQA
-    from typing import Dict  # NOQA
     from typing import Sequence  # NOQA
     from typing import Union  # NOQA
 
@@ -351,17 +351,13 @@ class IntLogUniformDistribution(BaseDistribution):
         self.high = high
         self._step = step
 
-    def __repr__(self):
-        # type: () -> str
-
+    def __repr__(self) -> str:
         # TODO(hvy): `BaseDistribution.__repr__` could rely on `_asdict` instead of `__dict__`.
         # `IntLogUniformDistribution` would not have to override `__repr__`.
         kwargs = ", ".join("{}={}".format(k, v) for k, v in sorted(self._asdict().items()))
         return "{}({})".format(self.__class__.__name__, kwargs)
 
-    def _asdict(self):
-        # type: () -> Dict
-
+    def _asdict(self) -> Dict:
         d = copy.copy(self.__dict__)
         d["step"] = d.pop("_step")
         return d
@@ -375,24 +371,16 @@ class IntLogUniformDistribution(BaseDistribution):
             FutureWarning,
         )
 
-    def to_external_repr(self, param_value_in_internal_repr):
-        # type: (float) -> int
-
+    def to_external_repr(self, param_value_in_internal_repr: float) -> int:
         return int(param_value_in_internal_repr)
 
-    def to_internal_repr(self, param_value_in_external_repr):
-        # type: (int) -> float
-
+    def to_internal_repr(self, param_value_in_external_repr: int) -> float:
         return float(param_value_in_external_repr)
 
-    def single(self):
-        # type: () -> bool
-
+    def single(self) -> bool:
         return self.low == self.high
 
-    def _contains(self, param_value_in_internal_repr):
-        # type: (float) -> bool
-
+    def _contains(self, param_value_in_internal_repr: float) -> bool:
         value = param_value_in_internal_repr
         return self.low <= value <= self.high
 

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -19,7 +19,7 @@ EXAMPLE_DISTRIBUTIONS = {
     "iu": distributions.IntUniformDistribution(low=1, high=9, step=2),
     "c1": distributions.CategoricalDistribution(choices=(2.71, -float("inf"))),
     "c2": distributions.CategoricalDistribution(choices=("Roppongi", "Azabu")),
-    "ilu": distributions.IntLogUniformDistribution(low=2, high=12),
+    "ilu": distributions.IntLogUniformDistribution(low=2, high=12, step=2),
 }  # type: Dict[str, Any]
 
 EXAMPLE_JSONS = {
@@ -30,7 +30,8 @@ EXAMPLE_JSONS = {
     "iu": '{"name": "IntUniformDistribution", "attributes": {"low": 1, "high": 9, "step": 2}}',
     "c1": '{"name": "CategoricalDistribution", "attributes": {"choices": [2.71, -Infinity]}}',
     "c2": '{"name": "CategoricalDistribution", "attributes": {"choices": ["Roppongi", "Azabu"]}}',
-    "ilu": '{"name": "IntLogUniformDistribution", "attributes": {"low": 2, "high": 12}}',
+    "ilu": '{"name": "IntLogUniformDistribution", '
+    '"attributes": {"low": 2, "high": 12, "step": 2}}',
 }
 
 
@@ -358,12 +359,34 @@ def test_int_uniform_distribution_asdict():
 def test_int_log_uniform_distribution_asdict():
     # type: () -> None
 
-    assert EXAMPLE_DISTRIBUTIONS["ilu"]._asdict() == {"low": 2, "high": 12}
+    assert EXAMPLE_DISTRIBUTIONS["ilu"]._asdict() == {"low": 2, "high": 12, "step": 2}
 
 
 def test_int_log_uniform_distribution_deprecation():
     # type: () -> None
 
     # step != 1 is deprecated
+
+    d = distributions.IntLogUniformDistribution(low=1, high=100)
+
     with pytest.warns(FutureWarning):
-        distributions.IntLogUniformDistribution(low=1, high=100, step=2)
+        # `step` should always be assumed to be 1 and samplers and other components should never
+        # have to get/set the attribute.
+        assert d.step == 1
+
+    with pytest.warns(FutureWarning):
+        d.step = 2
+
+    with pytest.warns(FutureWarning):
+        d = distributions.IntLogUniformDistribution(low=1, high=100, step=2)
+
+    with pytest.warns(FutureWarning):
+        assert d.step == 2
+
+    with pytest.warns(FutureWarning):
+        d.step = 1
+        assert d.step == 1
+
+    with pytest.warns(FutureWarning):
+        d.step = 2
+        assert d.step == 2


### PR DESCRIPTION
## Motivation

A minor follow-up to https://github.com/optuna/optuna/pull/1387 and specifically https://github.com/optuna/optuna/pull/1387#issuecomment-649981524.

## Description of the changes

Allow users to continue using the `step` attribute of `IntLogUniformDistribution` during deprecation.
