### PR TITLE
Load environment variables in AllenNLPExecutor

### DIFF
--- a/optuna/integration/allennlp.py
+++ b/optuna/integration/allennlp.py
@@ -59,8 +59,8 @@ class AllenNLPExecutor(object):
 
     .. note::
         In :class:`~optuna.integration.AllenNLPExecutor`,
-        you can pass parameter to AllenNLP by either defining a search space using
-        Optuna suggest methods or setting a environment variable just like AllenNLP cli.
+        you can pass parameters to AllenNLP by either defining a search space using
+        Optuna suggest methods or setting environment variables just like AllenNLP CLI.
         If a value is set in both a search space in Optuna and the environment variables,
         the executor will use the value specified in the search space in Optuna.
 

--- a/optuna/integration/allennlp.py
+++ b/optuna/integration/allennlp.py
@@ -58,7 +58,9 @@ class AllenNLPExecutor(object):
     examples/allennlp/classifier.jsonnet>`_.
 
     .. note::
-        :class:`~optuna.integration.AllenNLPExecutor` also reads environment variables.
+        In :class:`~optuna.integration.AllenNLPExecutor`,
+        you can pass parameter to AllenNLP by either defining a search space using
+        Optuna suggest methods or setting a environment variable just like AllenNLP cli.
         If a value is set in both a search space in Optuna and the environment variables,
         the executor will use the value specified in the search space in Optuna.
 

--- a/optuna/integration/allennlp.py
+++ b/optuna/integration/allennlp.py
@@ -57,6 +57,11 @@ class AllenNLPExecutor(object):
     `config file <https://github.com/optuna/optuna/blob/master/
     examples/allennlp/classifier.jsonnet>`_.
 
+    .. note::
+        :class:`~optuna.integration.AllenNLPExecutor` also reads environment variables.
+        If a value is set in both a search space in Optuna and the environment variables,
+        the executor will use the value specified in the search space in Optuna.
+
     Args:
         trial:
             A :class:`~optuna.trial.Trial` corresponding to the current evaluation
@@ -105,10 +110,6 @@ class AllenNLPExecutor(object):
         _build_params is based on allentune's train_func.
         For more detail, please refer to
         https://github.com/allenai/allentune/blob/master/allentune/modules/allennlp_runner.py#L34-L65
-
-        :class:`~optuna.integration.AllenNLPExecutor` also reads environment variables.
-        If a value is set in both a search space in Optuna and the environment variables,
-        the executor will use the value specified in the search space in Optuna.
 
         """
         params = self._environment_variables()

--- a/optuna/integration/allennlp.py
+++ b/optuna/integration/allennlp.py
@@ -100,9 +100,17 @@ class AllenNLPExecutor(object):
             self._include_package = include_package
 
     def _build_params(self) -> Dict[str, Any]:
-        """Create a dict of params for AllenNLP."""
-        # _build_params is based on allentune's train_func.
-        # https://github.com/allenai/allentune/blob/master/allentune/modules/allennlp_runner.py#L34-L65
+        """Create a dict of params for AllenNLP.
+
+        _build_params is based on allentune's train_func.
+        For more detail, please refer to
+        https://github.com/allenai/allentune/blob/master/allentune/modules/allennlp_runner.py#L34-L65
+
+        :class:`~optuna.integration.AllenNLPExecutor` also reads environment variables.
+        If a value is set in both search space in Optuna and the environment variables,
+        the executor will use a value specified in a search space in Optuna.
+
+        """
         params = self._environment_variables()
         params.update({key: str(value) for key, value in self._params.items()})
 

--- a/optuna/integration/allennlp.py
+++ b/optuna/integration/allennlp.py
@@ -107,8 +107,8 @@ class AllenNLPExecutor(object):
         https://github.com/allenai/allentune/blob/master/allentune/modules/allennlp_runner.py#L34-L65
 
         :class:`~optuna.integration.AllenNLPExecutor` also reads environment variables.
-        If a value is set in both search space in Optuna and the environment variables,
-        the executor will use a value specified in a search space in Optuna.
+        If a value is set in both a search space in Optuna and the environment variables,
+        the executor will use the value specified in the search space in Optuna.
 
         """
         params = self._environment_variables()

--- a/tests/integration_tests/allennlp_tests/example_with_environment_variables.jsonnet
+++ b/tests/integration_tests/allennlp_tests/example_with_environment_variables.jsonnet
@@ -1,0 +1,64 @@
+local DROPOUT = std.extVar('DROPOUT');
+local LEARNING_RATE = std.extVar('LEARNING_RATE');
+
+
+{
+  dataset_reader: {
+    type: 'sequence_tagging',
+    word_tag_delimiter: '/',
+    token_indexers: {
+      tokens: {
+        type: 'tiny_single_id',
+        lowercase_tokens: true,
+      },
+      token_characters: {
+        type: 'characters',
+      },
+    },
+  },
+  train_data_path: std.extVar('TRAIN_PATH'),
+  validation_data_path: std.extVar('VALID_PATH'),
+  model: {
+    type: 'simple_tagger',
+    text_field_embedder: {
+      token_embedders: {
+        tokens: {
+          type: 'embedding',
+          embedding_dim: 5,
+        },
+        token_characters: {
+          type: 'character_encoding',
+          embedding: {
+            embedding_dim: 4,
+          },
+          encoder: {
+            type: 'cnn',
+            embedding_dim: 4,
+            num_filters: 5,
+            ngram_filter_sizes: [3],
+          },
+          dropout: DROPOUT,
+        },
+      },
+    },
+    encoder: {
+      type: 'lstm',
+      input_size: 10,
+      hidden_size: 10,
+      num_layers: 2,
+      dropout: 0,
+      bidirectional: true,
+    },
+  },
+  iterator: {
+    type: 'basic',
+    batch_size: 32,
+  },
+  trainer: {
+    optimizer: 'adam',
+    lr: LEARNING_RATE,
+    num_epochs: 1,
+    patience: 10,
+    cuda_device: -1,
+  },
+}

--- a/tests/integration_tests/allennlp_tests/test_allennlp.py
+++ b/tests/integration_tests/allennlp_tests/test_allennlp.py
@@ -23,7 +23,7 @@ def test__build_params() -> None:
     assert params["model"]["hidden_size"] == [100, 200, 300]
 
 
-def test__build_params_with_environment_variables() -> None:
+def test__build_params_overwiting_environment_variable() -> None:
     study = optuna.create_study(direction="maximize")
     trial = optuna.trial.Trial(study, study._storage.create_new_trial(study._study_id))
     trial.suggest_uniform("LEARNING_RATE", 1e-2, 1e-1)

--- a/tests/integration_tests/allennlp_tests/test_allennlp.py
+++ b/tests/integration_tests/allennlp_tests/test_allennlp.py
@@ -23,7 +23,7 @@ def test_build_params() -> None:
     assert params["model"]["hidden_size"] == [100, 200, 300]
 
 
-def test__build_params_overwriting_environment_variable() -> None:
+def test_build_params_overwriting_environment_variable() -> None:
     study = optuna.create_study(direction="maximize")
     trial = optuna.trial.Trial(study, study._storage.create_new_trial(study._study_id))
     trial.suggest_uniform("LEARNING_RATE", 1e-2, 1e-1)

--- a/tests/integration_tests/allennlp_tests/test_allennlp.py
+++ b/tests/integration_tests/allennlp_tests/test_allennlp.py
@@ -44,7 +44,7 @@ def test__build_params_overwriting_environment_variable() -> None:
     )
 
 
-def test__build_params_when_optuna_and_environment_variable_both_exist() -> None:
+def test_build_params_when_optuna_and_environment_variable_both_exist() -> None:
     study = optuna.create_study(direction="maximize")
     trial = optuna.trial.Trial(study, study._storage.create_new_trial(study._study_id))
     trial.suggest_uniform("LEARNING_RATE", 1e-2, 1e-2)

--- a/tests/integration_tests/allennlp_tests/test_allennlp.py
+++ b/tests/integration_tests/allennlp_tests/test_allennlp.py
@@ -8,7 +8,7 @@ import pytest
 import optuna
 
 
-def test__build_params() -> None:
+def test_build_params() -> None:
     study = optuna.create_study(direction="maximize")
     trial = optuna.trial.Trial(study, study._storage.create_new_trial(study._study_id))
     trial.suggest_uniform("LEARNING_RATE", 1e-2, 1e-1)

--- a/tests/integration_tests/allennlp_tests/test_allennlp.py
+++ b/tests/integration_tests/allennlp_tests/test_allennlp.py
@@ -23,7 +23,7 @@ def test__build_params() -> None:
     assert params["model"]["hidden_size"] == [100, 200, 300]
 
 
-def test__build_params_overwiting_environment_variable() -> None:
+def test__build_params_overwriting_environment_variable() -> None:
     study = optuna.create_study(direction="maximize")
     trial = optuna.trial.Trial(study, study._storage.create_new_trial(study._study_id))
     trial.suggest_uniform("LEARNING_RATE", 1e-2, 1e-1)

--- a/tests/integration_tests/allennlp_tests/test_allennlp.py
+++ b/tests/integration_tests/allennlp_tests/test_allennlp.py
@@ -1,5 +1,5 @@
 import json
-import os.path
+import os
 import tempfile
 
 import _jsonnet
@@ -8,7 +8,7 @@ import pytest
 import optuna
 
 
-def test__set_param() -> None:
+def test__build_params() -> None:
     study = optuna.create_study(direction="maximize")
     trial = optuna.trial.Trial(study, study._storage.create_new_trial(study._study_id))
     trial.suggest_uniform("LEARNING_RATE", 1e-2, 1e-1)
@@ -21,6 +21,52 @@ def test__set_param() -> None:
     assert params["model"]["dropout"] == 0.1
     assert params["model"]["input_size"] == 100
     assert params["model"]["hidden_size"] == [100, 200, 300]
+
+
+def test__build_params_with_environment_variables() -> None:
+    study = optuna.create_study(direction="maximize")
+    trial = optuna.trial.Trial(study, study._storage.create_new_trial(study._study_id))
+    trial.suggest_uniform("LEARNING_RATE", 1e-2, 1e-1)
+    trial.suggest_uniform("DROPOUT", 0.0, 0.5)
+    os.environ["TRAIN_PATH"] = "tests/integration_tests/allennlp_tests/sentences.train"
+    os.environ["VALID_PATH"] = "tests/integration_tests/allennlp_tests/sentences.valid"
+    executor = optuna.integration.AllenNLPExecutor(
+        trial,
+        "tests/integration_tests/allennlp_tests/example_with_environment_variables.jsonnet",
+        "test",
+    )
+    params = executor._build_params()
+    os.environ.pop("TRAIN_PATH")
+    os.environ.pop("VALID_PATH")
+    assert params["train_data_path"] == "tests/integration_tests/allennlp_tests/sentences.train"
+    assert (
+        params["validation_data_path"] == "tests/integration_tests/allennlp_tests/sentences.valid"
+    )
+
+
+def test__build_params_when_optuna_and_environment_variable_both_exist() -> None:
+    study = optuna.create_study(direction="maximize")
+    trial = optuna.trial.Trial(study, study._storage.create_new_trial(study._study_id))
+    trial.suggest_uniform("LEARNING_RATE", 1e-2, 1e-2)
+    os.environ["TRAIN_PATH"] = "tests/integration_tests/allennlp_tests/sentences.train"
+    os.environ["VALID_PATH"] = "tests/integration_tests/allennlp_tests/sentences.valid"
+    os.environ["LEARNING_RATE"] = "1e-3"
+    os.environ["DROPOUT"] = "0.0"
+    executor = optuna.integration.AllenNLPExecutor(
+        trial,
+        "tests/integration_tests/allennlp_tests/example_with_environment_variables.jsonnet",
+        "test",
+    )
+    params = executor._build_params()
+    os.environ.pop("TRAIN_PATH")
+    os.environ.pop("VALID_PATH")
+    os.environ.pop("LEARNING_RATE")
+    os.environ.pop("DROPOUT")
+
+    # Optuna trial overwrites a parameter specified by environment variable
+    assert params["trainer"]["lr"] == 1e-2
+    path = params["model"]["text_field_embedder"]["token_embedders"]["token_characters"]["dropout"]
+    assert path == 0.0
 
 
 def test_missing_config_file() -> None:


### PR DESCRIPTION
## Motivation
This PR resolves #1446.

## Description of the changes
The current implementation of `AllenNLPExecutor` doesn't pass environment variables to `AllenNLP`.
It means users couldn't use environment variables for specifying some configs such as file path.
This PR changes `AllenNLPExecutor._build_params` to load environment variables and pass them to `AllenNLP`.

(I confirmed it works in https://gist.github.com/himkt/ecf2c1a0fb0bc3bec4eb59eed03a5561)