### PR TITLE
Remove experimental decorator from `Study.stop`.

### DIFF
--- a/optuna/study.py
+++ b/optuna/study.py
@@ -480,7 +480,6 @@ class Study(BaseStudy):
 
         return df
 
-    @experimental("1.4.0")
     def stop(self) -> None:
 
         """Exit from the current optimization loop after the running trials finish.


### PR DESCRIPTION
## Motivation

`Study.stop` will be considered stable in v2.0 and should not be marked experimental.

## Description of the changes

Removes the experimental decorator from `Study.stop`.

## Note

We should probably add a doctest example in the documentation of `Study.stop` about how it should be used.