### PR TITLE
Remove experimental decorator from `GridSampler`.

### DIFF
--- a/optuna/samplers/_grid.py
+++ b/optuna/samplers/_grid.py
@@ -2,7 +2,6 @@ import collections
 import itertools
 import random
 
-from optuna._experimental import experimental
 from optuna.logging import get_logger
 from optuna.samplers import BaseSampler
 from optuna import type_checking
@@ -25,7 +24,6 @@ if type_checking.TYPE_CHECKING:
 _logger = get_logger(__name__)
 
 
-@experimental("1.2.0")
 class GridSampler(BaseSampler):
     """Sampler using grid search.
 

--- a/tests/samplers_tests/test_grid.py
+++ b/tests/samplers_tests/test_grid.py
@@ -25,13 +25,6 @@ def _n_grids(search_space):
     return int(np.prod([len(v) for v in search_space.values()]))
 
 
-def test_grid_sampler_experimental_warning():
-    # type: () -> None
-
-    with pytest.warns(optuna.exceptions.ExperimentalWarning):
-        optuna.samplers.GridSampler({"some_param": [0, 1]})
-
-
 def test_study_optimize_with_single_search_space():
     # type: () -> None
 


### PR DESCRIPTION
## Motivation

`GridSampler` will be considered stable in v2.0 and should not be marked experimental.

## Description of the changes

Removes the experimental decorator from `GridSampler`.