### PR TITLE
Remove experimental decorators from LightGBMTuner.

### DIFF
--- a/optuna/integration/_lightgbm_tuner/__init__.py
+++ b/optuna/integration/_lightgbm_tuner/__init__.py
@@ -1,6 +1,5 @@
 from typing import Any
 
-from optuna._experimental import experimental
 from optuna.integration._lightgbm_tuner.optimize import _imports as _imports
 from optuna.integration._lightgbm_tuner.optimize import LightGBMTuner
 from optuna.integration._lightgbm_tuner.optimize import LightGBMTunerCV  # NOQA
@@ -15,7 +14,6 @@ if type_checking.TYPE_CHECKING:
     from typing import Any  # NOQA
 
 
-@experimental("0.18.0")
 def train(*args: Any, **kwargs: Any) -> Any:
     """Wrapper of LightGBM Training API to tune hyperparameters.
 

--- a/optuna/integration/_lightgbm_tuner/optimize.py
+++ b/optuna/integration/_lightgbm_tuner/optimize.py
@@ -13,14 +13,12 @@ from typing import List
 from typing import Optional
 from typing import Tuple
 from typing import Union
-import warnings
 
 import numpy as np
 import tqdm
 
 import optuna
 from optuna._deprecated import deprecated
-from optuna._experimental import experimental
 from optuna._imports import try_import
 from optuna.integration._lightgbm_tuner.alias import _handling_alias_metrics
 from optuna.integration._lightgbm_tuner.alias import _handling_alias_parameters
@@ -470,10 +468,7 @@ class _LightGBMBaseTuner(_BaseTuner):
         param_name = "feature_fraction"
         param_values = np.linspace(0.4, 1.0, n_trials).tolist()
 
-        # TODO(toshihikoyanase): Remove catch_warnings after GridSampler becomes non-experimental.
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", category=optuna.exceptions.ExperimentalWarning)
-            sampler = optuna.samplers.GridSampler({param_name: param_values})
+        sampler = optuna.samplers.GridSampler({param_name: param_values})
         self._tune_params([param_name], len(param_values), sampler, "feature_fraction")
 
     def tune_num_leaves(self, n_trials: int = 20) -> None:
@@ -492,10 +487,7 @@ class _LightGBMBaseTuner(_BaseTuner):
         ).tolist()
         param_values = [val for val in param_values if val >= 0.4 and val <= 1.0]
 
-        # TODO(toshihikoyanase): Remove catch_warnings after GridSampler becomes non-experimental.
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", category=optuna.exceptions.ExperimentalWarning)
-            sampler = optuna.samplers.GridSampler({param_name: param_values})
+        sampler = optuna.samplers.GridSampler({param_name: param_values})
         self._tune_params([param_name], len(param_values), sampler, "feature_fraction_stage2")
 
     def tune_regularization_factors(self, n_trials: int = 20) -> None:
@@ -510,10 +502,7 @@ class _LightGBMBaseTuner(_BaseTuner):
         param_name = "min_child_samples"
         param_values = [5, 10, 25, 50, 100]
 
-        # TODO(toshihikoyanase): Remove catch_warnings after GridSampler becomes non-experimental.
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", category=optuna.exceptions.ExperimentalWarning)
-            sampler = optuna.samplers.GridSampler({param_name: param_values})
+        sampler = optuna.samplers.GridSampler({param_name: param_values})
         self._tune_params([param_name], len(param_values), sampler, "min_data_in_leaf")
 
     def _tune_params(
@@ -620,7 +609,6 @@ class _LightGBMBaseTuner(_BaseTuner):
         return _StepwiseStudy(study, step_name)
 
 
-@experimental("1.5.0")
 class LightGBMTuner(_LightGBMBaseTuner):
     """Hyperparameter tuner for LightGBM.
 
@@ -811,7 +799,6 @@ class LightGBMTuner(_LightGBMBaseTuner):
         )
 
 
-@experimental("1.5.0")
 class LightGBMTunerCV(_LightGBMBaseTuner):
     """Hyperparameter tuner for LightGBM with cross-validation.
 


### PR DESCRIPTION
## Motivation

LightGBMTuner will be considered stable in v2.0 and should not be marked experimental.

## Description of the changes

Removes the experimental decorators from LightGBMTuner.