### PR TITLE
Use argument of `pytorch_lightning.Trainer` to disable `checkpoint_callback`.

### DIFF
--- a/tests/integration_tests/test_pytorch_lightning.py
+++ b/tests/integration_tests/test_pytorch_lightning.py
@@ -85,8 +85,8 @@ def test_pytorch_lightning_pruning_callback():
             early_stop_callback=PyTorchLightningPruningCallback(trial, monitor="accuracy"),
             min_epochs=0,  # Required to fire the callback after the first epoch.
             max_epochs=2,
+            checkpoint_callback=False,
         )
-        trainer.checkpoint_callback = None  # Disable unrelated checkpoint callbacks.
 
         model = Model()
         trainer.fit(model)


### PR DESCRIPTION
## Motivation
This PR addresses CI errors of the PyTorch Lightning integration (e.g., https://app.circleci.com/pipelines/github/optuna/optuna/1364/workflows/89f8e402-baff-4cb0-8527-bb8198c71b2e/jobs/47343/steps).

PyTorch Lightning 0.8.2 assumes that the `Trainer.checkpoint_callback is not None` as can be seen in this PR (https://github.com/PyTorchLightning/pytorch-lightning/pull/2391/files#diff-83daa7ca33fd6ab1387ae6e8c88d2f55L331). I think it is reasonable because the type hinting of the `checkpoint_callback` is `Union[ModelCheckpoint, bool]`.

## Description of the changes
This PR set `False` to `checkpoint_callback` argument to disable `checkpoint_callback`. It accepts `bool` since (at least) 0.7.2 (https://github.com/PyTorchLightning/pytorch-lightning/blob/0.7.2/pytorch_lightning/trainer/trainer.py#L80).