### PR TITLE
Use `step` to calculate range of `IntUniformDistribution` in PyCmaSampler.

### DIFF
--- a/optuna/integration/cma.py
+++ b/optuna/integration/cma.py
@@ -316,8 +316,8 @@ class _Optimizer(object):
                 lows.append(0 - 0.5 * dist.q)
                 highs.append(r + 0.5 * dist.q)
             elif isinstance(dist, IntUniformDistribution):
-                lows.append(dist.low - 0.5)
-                highs.append(dist.high + 0.5)
+                lows.append(dist.low - 0.5 * dist.step)
+                highs.append(dist.high + 0.5 * dist.step)
             elif isinstance(dist, IntLogUniformDistribution):
                 lows.append(self._to_cma_params(search_space, param_name, dist.low - 0.5))
                 highs.append(self._to_cma_params(search_space, param_name, dist.high + 0.5))

--- a/tests/integration_tests/test_cma.py
+++ b/tests/integration_tests/test_cma.py
@@ -184,8 +184,8 @@ class TestOptimizer(object):
                 {
                     "BoundaryHandler": cma.BoundTransform,
                     "bounds": [
-                        [-0.5, -1.0, -1.5, -1.5, math.log(1.5), math.log(0.001), -2,],
-                        [1.5, 11.0, 1.5, 3.5, math.log(16.5), math.log(0.1), 2],
+                        [-0.5, -1.0, -1.5, -2.0, math.log(1.5), math.log(0.001), -2,],
+                        [1.5, 11.0, 1.5, 4.0, math.log(16.5), math.log(0.1), 2],
                     ],
                     "popsize": 5,
                     "seed": 1,


### PR DESCRIPTION
## Motivation
This PR derived from https://github.com/optuna/optuna/pull/1302#discussion_r447462314.

## Description of the changes
`PyCmaSampler` does not consider the `IntUniformDistribution.step` to calculate the range (i.e., `low`, `high`). I think it is inconsistent with the range calculation for `DiscreteUniformDistribution`. This PR fixes the range of `IntUniformDistribution`.