### PR TITLE
Add missing commas in FAQ.

### DIFF
--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -238,7 +238,7 @@ What happens when I dynamically alter a search space?
 
 Since parameters search spaces are specified in each call to the suggestion API, e.g.
 :func:`~optuna.trial.Trial.suggest_uniform` and :func:`~optuna.trial.Trial.suggest_int`,
-it is possible to in a single study alter the range by sampling parameters from different search
+it is possible to, in a single study, alter the range by sampling parameters from different search
 spaces in different trials.
 The behavior when altered is defined by each sampler individually.
 


### PR DESCRIPTION
## Motivation
This fix is originally suggested by @ belldandyxtq.

## Description of the changes
It simply adds missing commas.