### PR TITLE
Stop overwriting seed in `LightGBMTuner`.

### DIFF
--- a/optuna/integration/_lightgbm_tuner/optimize.py
+++ b/optuna/integration/_lightgbm_tuner/optimize.py
@@ -435,7 +435,6 @@ class _LightGBMBaseTuner(_BaseTuner):
         if self.auto_options["verbosity"] == 0:
             optuna.logging.disable_default_handler()
             self.lgbm_params["verbose"] = -1
-            self.lgbm_params["seed"] = 111
             self.lgbm_kwargs["verbose_eval"] = False
 
         # Handling aliases.


### PR DESCRIPTION
## Motivation
Related to #1460. 

> During the modification, I found that LightGBM's seed is set to 111 in the run method. I think usual users do not expect such configuration change. Do we remove the line?

## Description of the changes

This PR removes the line to overwrite the seed when `verbosity == 1`, and always uses the seeds given by users.