### PR TITLE
Remove Swig installation from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,16 +7,6 @@ ENV PIP_OPTIONS "--no-cache-dir --progress-bar off"
 RUN apt-get update \
     && apt-get -y install openmpi-bin libopenmpi-dev \
     && rm -rf /var/lib/apt/lists/* \
-    && wget -q http://prdownloads.sourceforge.net/swig/swig-3.0.12.tar.gz \
-    && tar -zxvf swig-3.0.12.tar.gz \
-    && cd swig-3.0.12 \
-    && ./configure \
-    && make --silent -j \
-    && make install --silent \
-    && cd .. \
-    && rm -rf swig-3.0.12 \
-    && rm swig-3.0.12.tar.gz \
-    && swig -version \
     && pip install --no-cache-dir -U pip \
     && pip install ${PIP_OPTIONS} -U setuptools \
     && pip install ${PIP_OPTIONS} Cython  # for automl/ConfigSpace

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@ ARG PYTHON_VERSION=3.7
 
 FROM python:${PYTHON_VERSION}
 
+ENV PIP_OPTIONS "--no-cache-dir --progress-bar off"
+
 RUN apt-get update \
     && apt-get -y install openmpi-bin libopenmpi-dev \
     && rm -rf /var/lib/apt/lists/* \
@@ -16,8 +18,8 @@ RUN apt-get update \
     && rm swig-3.0.12.tar.gz \
     && swig -version \
     && pip install --no-cache-dir -U pip \
-    && pip install --no-cache-dir --progress-bar off -U setuptools \
-    && pip install --no-cache-dir --progress-bar off Cython  # for automl/ConfigSpace
+    && pip install ${PIP_OPTIONS} -U setuptools \
+    && pip install ${PIP_OPTIONS} Cython  # for automl/ConfigSpace
 
 WORKDIR /workspaces
 COPY . .
@@ -26,11 +28,13 @@ ARG BUILD_TYPE='dev'
 
 RUN if [ "${BUILD_TYPE}" = "dev" ]; then \
         if [ "${PYTHON_VERSION}" \< "3.6" ]; then \
-            pip install --no-cache-dir --progress-bar off -e '.[doctest, document, example, testing]' -f https://download.pytorch.org/whl/torch_stable.html; \
+            pip install ${PIP_OPTIONS} -e '.[doctest, document, example, testing]' -f https://download.pytorch.org/whl/torch_stable.html; \
         else \
-            pip install --no-cache-dir --progress-bar off -e '.[checking, doctest, document, example, testing]' -f https://download.pytorch.org/whl/torch_stable.html; \
+            pip install ${PIP_OPTIONS} -e '.[checking, doctest, document, example, testing]' -f https://download.pytorch.org/whl/torch_stable.html; \
         fi \
     else \
-        pip install --no-cache-dir --progress-bar off -e .; \
+        pip install ${PIP_OPTIONS} -e .; \
     fi \
-    && pip install --no-cache-dir --progress-bar off jupyter notebook
+    && pip install ${PIP_OPTIONS} jupyter notebook
+
+ENV PIP_OPTIONS ""

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,20 @@ FROM python:${PYTHON_VERSION}
 
 RUN apt-get update \
     && apt-get -y install openmpi-bin libopenmpi-dev \
-    && apt-get -y install swig  \
     && rm -rf /var/lib/apt/lists/* \
+    && wget -q http://prdownloads.sourceforge.net/swig/swig-3.0.12.tar.gz \
+    && tar -zxvf swig-3.0.12.tar.gz \
+    && cd swig-3.0.12 \
+    && ./configure \
+    && make --silent -j \
+    && make install --silent \
+    && cd .. \
+    && rm -rf swig-3.0.12 \
+    && rm swig-3.0.12.tar.gz \
+    && swig -version \
     && pip install --no-cache-dir -U pip \
-    && pip install --no-cache-dir --progress-bar off -U setuptools
+    && pip install --no-cache-dir --progress-bar off -U setuptools \
+    && pip install --no-cache-dir --progress-bar off Cython  # for automl/ConfigSpace
 
 WORKDIR /workspaces
 COPY . .
@@ -16,11 +26,11 @@ ARG BUILD_TYPE='dev'
 
 RUN if [ "${BUILD_TYPE}" = "dev" ]; then \
         if [ "${PYTHON_VERSION}" \< "3.6" ]; then \
-            pip install --no-cache-dir -e '.[doctest, document, example, testing]' -f https://download.pytorch.org/whl/torch_stable.html; \
+            pip install --no-cache-dir --progress-bar off -e '.[doctest, document, example, testing]' -f https://download.pytorch.org/whl/torch_stable.html; \
         else \
-            pip install --no-cache-dir -e '.[checking, doctest, document, example, testing]' -f https://download.pytorch.org/whl/torch_stable.html; \
+            pip install --no-cache-dir --progress-bar off -e '.[checking, doctest, document, example, testing]' -f https://download.pytorch.org/whl/torch_stable.html; \
         fi \
     else \
-        pip install --no-cache-dir -e .; \
+        pip install --no-cache-dir --progress-bar off -e .; \
     fi \
-    && pip install --no-cache-dir jupyter notebook
+    && pip install --no-cache-dir --progress-bar off jupyter notebook

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,7 @@ RUN apt-get update \
     && apt-get -y install openmpi-bin libopenmpi-dev \
     && rm -rf /var/lib/apt/lists/* \
     && pip install --no-cache-dir -U pip \
-    && pip install ${PIP_OPTIONS} -U setuptools \
-    && pip install ${PIP_OPTIONS} Cython  # for automl/ConfigSpace
+    && pip install ${PIP_OPTIONS} -U setuptools
 
 WORKDIR /workspaces
 COPY . .


### PR DESCRIPTION
Now swig installation of Dockerfile is the same as that of CI.

I'm not pretty sure whether this completely fixes the issue that some Docker images on DockerHub fail to install Keras :sweat: 