### PR TITLE
Mark `CatalystPruningCallback` integration as experimental.

### DIFF
--- a/optuna/integration/catalyst.py
+++ b/optuna/integration/catalyst.py
@@ -2,6 +2,7 @@ from typing import Any  # NOQA
 
 import optuna
 
+from optuna._experimental import experimental
 from optuna._imports import try_import
 
 with try_import() as _imports:
@@ -11,6 +12,7 @@ if not _imports.is_successful():
     Callback = object  # NOQA
 
 
+@experimental("2.0.0")
 class CatalystPruningCallback(Callback):
     """Catalyst callback to prune unpromising trials.
 

--- a/tests/integration_tests/test_catalyst.py
+++ b/tests/integration_tests/test_catalyst.py
@@ -1,7 +1,7 @@
 import shutil
-import sys
 import tempfile
 
+import catalyst
 import pytest
 import torch
 
@@ -9,13 +9,13 @@ import optuna
 from optuna.integration import CatalystPruningCallback
 from optuna.testing.integration import DeterministicPruner
 
-catalyst = pytest.importorskip("catalyst")
+
+def test_catalyst_pruning_callback_experimental_warning() -> None:
+    with pytest.warns(optuna.exceptions.ExperimentalWarning):
+        CatalystPruningCallback(None)  # type: ignore
 
 
-@pytest.mark.skipif(sys.version_info < (3, 6), reason="catalyst requires python3.6 or higher")
-def test_catalyst_pruning_callback():
-    # type: () -> None
-
+def test_catalyst_pruning_callback() -> None:
     data = torch.zeros(3, 4, dtype=torch.float32)
     target = torch.zeros(3, dtype=torch.float32)
     dataset = torch.utils.data.TensorDataset(data, target)


### PR DESCRIPTION
## Motivation

Follow up to https://github.com/optuna/optuna/pull/1056.

## Description of the changes

Marks `CatalystPruningCallback` as experimental as the Catalyst ecosystem is quite big and we might want to reserve ourselves for fast changes to the design. Also includes some minor cosmetics.
