### PR TITLE
Add missing `CatalystPruningCallback` in the documentation.

### DIFF
--- a/docs/source/reference/integration.rst
+++ b/docs/source/reference/integration.rst
@@ -7,6 +7,7 @@ optuna.integration
 
    optuna.integration.ChainerPruningExtension
    optuna.integration.ChainerMNStudy 
+   optuna.integration.CatalystPruningCallback
    optuna.integration.PyCmaSampler
    optuna.integration.CmaEsSampler
    optuna.integration.FastAIPruningCallback


### PR DESCRIPTION
<!-- Thank you for creating a pull request! -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

`CatalystPruningCallback` is missing in the documentation.

## Description of the changes
<!-- Describe the changes in this PR. -->

Add `optuna.integration.CatalystPruningCallback` in `docs/source/reference/integration.rst`