### PR TITLE
Avoid latest `ConfigSpace` where Python 3.5 is dropped.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -110,6 +110,7 @@ def get_extras_require() -> Dict[str, List[str]]:
             # TODO(toshihikoyanase): Remove the version constraint after resolving the issue
             # https://github.com/optuna/optuna/issues/1000.
             "bokeh<2.0.0",
+            "ConfigSpace<0.4.13",  # Required for `fanova` with Python 3.5.
             "chainer>=5.0.0",
             "cma",
             "fakeredis",


### PR DESCRIPTION
## Motivation

CI builds are breaking since the latest release of `ConfigSpace` dropped support for Python 3.5. I am not sure why this started occurring now since the release took place in May.

## Description of the changes

Changes CI install configurations to stick to previous `ConfigSpace` where Python 3.5 is supported.

