### PR TITLE
Fix incorrect type annotations for `catch`.

### DIFF
--- a/optuna/integration/chainermn.py
+++ b/optuna/integration/chainermn.py
@@ -106,7 +106,7 @@ class ChainerMNStudy(object):
         func,  # type: Callable[[ChainerMNTrial, CommunicatorBase], float]
         n_trials=None,  # type: Optional[int]
         timeout=None,  # type: Optional[float]
-        catch=(),  # type: Union[Tuple[()], Tuple[Type[Exception]]]
+        catch=(),  # type: Tuple[Type[Exception], ...]
     ):
         # type: (...) -> None
         """Optimize an objective function.

--- a/optuna/multi_objective/study.py
+++ b/optuna/multi_objective/study.py
@@ -215,7 +215,7 @@ class MultiObjectiveStudy(object):
         timeout: Optional[int] = None,
         n_trials: Optional[int] = None,
         n_jobs: int = 1,
-        catch: Union[Tuple[()], Tuple[Type[Exception]]] = (),
+        catch: Tuple[Type[Exception], ...] = (),
         callbacks: Optional[List[CallbackFuncType]] = None,
         gc_after_trial: bool = True,
         show_progress_bar: bool = False,

--- a/optuna/study.py
+++ b/optuna/study.py
@@ -214,7 +214,7 @@ class Study(BaseStudy):
         n_trials=None,  # type: Optional[int]
         timeout=None,  # type: Optional[float]
         n_jobs=1,  # type: int
-        catch=(),  # type: Union[Tuple[()], Tuple[Type[Exception]]]
+        catch=(),  # type: Tuple[Type[Exception], ...]
         callbacks=None,  # type: Optional[List[Callable[[Study, FrozenTrial], None]]]
         gc_after_trial=False,  # type: bool
         show_progress_bar=False,  # type: bool
@@ -608,7 +608,7 @@ class Study(BaseStudy):
         func,  # type: ObjectiveFuncType
         n_trials,  # type: Optional[int]
         timeout,  # type: Optional[float]
-        catch,  # type: Union[Tuple[()], Tuple[Type[Exception]]]
+        catch,  # type: Tuple[Type[Exception], ...]
         callbacks,  # type: Optional[List[Callable[[Study, FrozenTrial], None]]]
         gc_after_trial,  # type: bool
         time_start,  # type: Optional[datetime.datetime]
@@ -625,7 +625,7 @@ class Study(BaseStudy):
         func,  # type: ObjectiveFuncType
         n_trials,  # type: Optional[int]
         timeout,  # type: Optional[float]
-        catch,  # type: Union[Tuple[()], Tuple[Type[Exception]]]
+        catch,  # type: Tuple[Type[Exception], ...]
         callbacks,  # type: Optional[List[Callable[[Study, FrozenTrial], None]]]
         gc_after_trial,  # type: bool
         time_start,  # type: Optional[datetime.datetime]
@@ -676,7 +676,7 @@ class Study(BaseStudy):
     def _run_trial_and_callbacks(
         self,
         func,  # type: ObjectiveFuncType
-        catch,  # type: Union[Tuple[()], Tuple[Type[Exception]]]
+        catch,  # type: Tuple[Type[Exception], ...]
         callbacks,  # type: Optional[List[Callable[[Study, FrozenTrial], None]]]
         gc_after_trial,  # type: bool
     ):
@@ -691,7 +691,7 @@ class Study(BaseStudy):
     def _run_trial(
         self,
         func,  # type: ObjectiveFuncType
-        catch,  # type: Union[Tuple[()], Tuple[Type[Exception]]]
+        catch,  # type: Tuple[Type[Exception], ...]
         gc_after_trial,  # type: bool
     ):
         # type: (...) -> trial_module.Trial


### PR DESCRIPTION
<!-- Thank you for creating a pull request! -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

`catch` is annotated as `Union[Tuple[()], Tuple[Type[Exception]]]` which stands for an empty tuple or a one-element tuple of `Exception`. That's incorrect. It should be annotated as `Tuple[Type[Exception], ...]` which stands for a **variable-length** tuple of `Exception`.

## Description of the changes
<!-- Describe the changes in this PR. -->

Fix incorrect type annotations for `catch`.