### PR TITLE
Remove checking and alerting installation `pfnopt`.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -155,16 +155,6 @@ def find_any_distribution(pkgs: List[str]) -> Optional[pkg_resources.Distributio
     return None
 
 
-pfnopt_pkg = find_any_distribution(["pfnopt"])
-if pfnopt_pkg is not None:
-    msg = (
-        "We detected that PFNOpt is installed in your environment.\n"
-        "PFNOpt has been renamed Optuna. Please uninstall the old\n"
-        "PFNOpt in advance (e.g. by executing `$ pip uninstall pfnopt`)."
-    )
-    print(msg)
-    exit(1)
-
 setup(
     name="optuna",
     version=get_version(),


### PR DESCRIPTION
#175

I'm not confident but we can remove a message for users to let them uninstall `pfnopt`.
This PR drops checking and alerting `pfnopt` installation.