### PR TITLE
Remove experimental decorator from HPI visualization.

### DIFF
--- a/optuna/visualization/_param_importances.py
+++ b/optuna/visualization/_param_importances.py
@@ -3,7 +3,6 @@ from typing import List
 from typing import Optional
 
 import optuna
-from optuna._experimental import experimental
 from optuna.distributions import BaseDistribution
 from optuna.distributions import CategoricalDistribution
 from optuna.distributions import DiscreteUniformDistribution
@@ -36,7 +35,6 @@ if _imports.is_successful():
 logger = get_logger(__name__)
 
 
-@experimental("1.5.0")
 def plot_param_importances(
     study: Study, evaluator: BaseImportanceEvaluator = None, params: Optional[List[str]] = None
 ) -> "go.Figure":


### PR DESCRIPTION
## Motivation

HPI visualization is no longer experimental since the HPI features are stable https://github.com/optuna/optuna/pull/1440.

## Description of the changes

Removes the experimental decorator from HPI visualization.