### PR TITLE
Wider main content container in the documentation.

### DIFF
--- a/docs/source/_static/css/custom.css
+++ b/docs/source/_static/css/custom.css
@@ -41,6 +41,11 @@ em.sig-param > span:not(:nth-child(1)):not(:nth-child(2)) {
   border-left: solid 3px #6ab0de;
 }
 
+/* Main content */
+.wy-nav-content {
+    max-width: 1200px;
+}
+
 /* Sidebar header (and topbar for mobile) */
 .wy-side-nav-search,
 .wy-nav-top {

--- a/docs/source/_static/css/custom.css
+++ b/docs/source/_static/css/custom.css
@@ -105,7 +105,7 @@ a {
   align-items: center;
   justify-content: flex-end;
   padding: 20px;
-  max-width: 800px;
+  max-width: 1200px;
   margin-left: 300px;
 }
 

--- a/docs/source/_static/css/custom.css
+++ b/docs/source/_static/css/custom.css
@@ -43,7 +43,7 @@ em.sig-param > span:not(:nth-child(1)):not(:nth-child(2)) {
 
 /* Main content */
 .wy-nav-content {
-    max-width: 1200px;
+  max-width: 1200px;
 }
 
 /* Sidebar header (and topbar for mobile) */


### PR DESCRIPTION
## Motivation

Rightmost space in the documentation is unused (for desktop). Content container can be wider aiding readability and reducing content height.

## Description of the changes

Increases the width of container of the main content in the docs. Tables for instance are more compact.
