### PR TITLE
Avoid latest `sphinx`.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ def get_extras_require() -> Dict[str, List[str]]:
         "document": [
             # TODO(hvy): Unpin `sphinx` version after:
             # https://github.com/sphinx-doc/sphinx/issues/7807.
-            "sphinx>=3.0.0,!=3.1.0,!=3.1.1",
+            "sphinx>=3.0.0,!=3.1.0,!=3.1.1,!=3.1.2",
             # As reported in: https://github.com/readthedocs/sphinx_rtd_theme/issues/949,
             # `sphinx_rtd_theme` 0.5.0 is still not compatible with `sphinx` >= 3.0.
             "sphinx_rtd_theme<0.5.0",


### PR DESCRIPTION
## Motivation

Documentation must be successfully built. They current fail. See also the following.
- https://github.com/optuna/optuna/issues/1368
- https://github.com/optuna/optuna/pull/1393

## Description of the changes

Avoids latest `sphinx`.
