### PR TITLE
Add `TensorBoardCallback` to docs.

### DIFF
--- a/docs/source/reference/integration.rst
+++ b/docs/source/reference/integration.rst
@@ -6,7 +6,7 @@ optuna.integration
    :nosignatures:
 
    optuna.integration.ChainerPruningExtension
-   optuna.integration.ChainerMNStudy 
+   optuna.integration.ChainerMNStudy
    optuna.integration.CatalystPruningCallback
    optuna.integration.PyCmaSampler
    optuna.integration.CmaEsSampler
@@ -21,6 +21,7 @@ optuna.integration
    optuna.integration.PyTorchIgnitePruningHandler
    optuna.integration.PyTorchLightningPruningCallback
    optuna.integration.SkoptSampler
+   optuna.integration.TensorBoardCallback
    optuna.integration.TensorFlowPruningHook
    optuna.integration.TFKerasPruningCallback
    optuna.integration.XGBoostPruningCallback

--- a/optuna/integration/__init__.py
+++ b/optuna/integration/__init__.py
@@ -20,6 +20,7 @@ _import_structure = {
     "sklearn": ["OptunaSearchCV"],
     "mxnet": ["MXNetPruningCallback"],
     "skopt": ["SkoptSampler"],
+    "tensorboard": ["TensorBoardCallback"],
     "tensorflow": ["TensorFlowPruningHook"],
     "tfkeras": ["TFKerasPruningCallback"],
     "xgboost": ["XGBoostPruningCallback"],
@@ -48,6 +49,7 @@ if TYPE_CHECKING:
     from optuna.integration.pytorch_lightning import PyTorchLightningPruningCallback  # NOQA
     from optuna.integration.sklearn import OptunaSearchCV  # NOQA
     from optuna.integration.skopt import SkoptSampler  # NOQA
+    from optuna.integration.tensorboard import TensorBoardCallback  # NOQA
     from optuna.integration.tensorflow import TensorFlowPruningHook  # NOQA
     from optuna.integration.tfkeras import TFKerasPruningCallback  # NOQA
     from optuna.integration.xgboost import XGBoostPruningCallback  # NOQA

--- a/optuna/integration/tensorboard.py
+++ b/optuna/integration/tensorboard.py
@@ -15,6 +15,7 @@ class TensorBoardCallback(object):
     """Callback to track Optuna trials with TensorBoard.
 
     This callback adds relevant information that is tracked by Optuna to TensorBoard.
+
     Args:
         dirname:
             Directory to store TensorBoard logs.
@@ -22,6 +23,7 @@ class TensorBoardCallback(object):
             Name of the metric. Since the metric itself is just a number,
             `metric_name` can be used to give it a name. So you know later
             if it was roc-auc or accuracy.
+
     """
 
     def __init__(self, dirname: str, metric_name: str) -> None:


### PR DESCRIPTION
## Motivation

`TensorBoardCallback` which is a public API should be documented.

## Description of the changes

Adds `TensorBoardCallback` to the documentation.
