### PR TITLE
Add description about zero-based numbering of `step`.

### DIFF
--- a/optuna/pruners/_hyperband.py
+++ b/optuna/pruners/_hyperband.py
@@ -56,10 +56,8 @@ class HyperbandPruner(BasePruner):
         6 in most use cases).　Please see Section 3.6 of the `original paper
         <http://www.jmlr.org/papers/volume18/16-558/16-558.pdf>`_ for the detail.
 
-    .. note::
-        ``HyperbandPruner`` assumes that ``step`` starts at zero when it calculates the resource
-        for each trial. Please ensure that ``step`` is zero-based numbering when you report the
-        intermediate values using :meth:`~optuna.trial.Trial.report`.
+    .. seealso::
+        Please refer to :meth:`~optuna.trial.Trial.report`.
 
     Example:
 

--- a/optuna/pruners/_hyperband.py
+++ b/optuna/pruners/_hyperband.py
@@ -56,6 +56,11 @@ class HyperbandPruner(BasePruner):
         6 in most use cases).　Please see Section 3.6 of the `original paper
         <http://www.jmlr.org/papers/volume18/16-558/16-558.pdf>`_ for the detail.
 
+    .. note::
+        ``HyperbandPruner`` assumes that ``step`` starts at zero when it calculates the resource
+        for each trial. Please ensure that ``step`` is zero-based numbering when you report the
+        intermediate values using :meth:`~optuna.trial.Trial.report`.
+
     Example:
 
         We minimize an objective function with Hyperband pruning algorithm.

--- a/optuna/pruners/_median.py
+++ b/optuna/pruners/_median.py
@@ -50,7 +50,8 @@ class MedianPruner(PercentilePruner):
         n_startup_trials:
             Pruning is disabled until the given number of trials finish in the same study.
         n_warmup_steps:
-            Pruning is disabled until the trial exceeds the given number of step.
+            Pruning is disabled until the trial exceeds the given number of step. Note that
+            this feature assumes that ``step`` starts at zero.
         interval_steps:
             Interval in number of steps between the pruning checks, offset by the warmup steps.
             If no value has been reported at the time of a pruning check, that particular check

--- a/optuna/pruners/_percentile.py
+++ b/optuna/pruners/_percentile.py
@@ -118,7 +118,8 @@ class PercentilePruner(BasePruner):
         n_startup_trials:
             Pruning is disabled until the given number of trials finish in the same study.
         n_warmup_steps:
-            Pruning is disabled until the trial exceeds the given number of step.
+            Pruning is disabled until the trial exceeds the given number of step. Note that
+            this feature assumes that ``step`` starts at zero.
         interval_steps:
             Interval in number of steps between the pruning checks, offset by the warmup steps.
             If no value has been reported at the time of a pruning check, that particular check

--- a/optuna/pruners/_successive_halving.py
+++ b/optuna/pruners/_successive_halving.py
@@ -29,10 +29,8 @@ class SuccessiveHalvingPruner(BasePruner):
     ``EPOCH`` number in `chainer_integration.py
     <https://github.com/optuna/optuna/tree/c5777b3e/examples/pruning/chainer_integration.py#L65>`_).
 
-    .. note::
-        ``SuccessiveHalvingPruner`` assumes that ``step`` starts at zero when it calculates the
-        resource for each trial. Please ensure that ``step`` is zero-based numbering when you
-        report the intermediate values using :meth:`~optuna.trial.Trial.report`.
+    .. seealso::
+        Please refer to :meth:`~optuna.trial.Trial.report`.
 
     Example:
 

--- a/optuna/pruners/_successive_halving.py
+++ b/optuna/pruners/_successive_halving.py
@@ -29,6 +29,11 @@ class SuccessiveHalvingPruner(BasePruner):
     ``EPOCH`` number in `chainer_integration.py
     <https://github.com/optuna/optuna/tree/c5777b3e/examples/pruning/chainer_integration.py#L65>`_).
 
+    .. note::
+        ``SuccessiveHalvingPruner`` assumes that ``step`` starts at zero when it calculates the
+        resource for each trial. Please ensure that ``step`` is zero-based numbering when you
+        report the intermediate values using :meth:`~optuna.trial.Trial.report`.
+
     Example:
 
         We minimize an objective function with ``SuccessiveHalvingPruner``.

--- a/optuna/trial/_trial.py
+++ b/optuna/trial/_trial.py
@@ -544,7 +544,10 @@ class Trial(BaseTrial):
             value:
                 A value returned from the objective function.
             step:
-                Step of the trial (e.g., Epoch of neural network training).
+                Step of the trial (e.g., Epoch of neural network training). Note that pruners
+                assume that ``step`` starts at zero. For example,
+                :class:`~optuna.pruners.MedianPruner` simply checks if ``step`` is less than
+                ``n_warmup_steps`` as the warmup mechanism.
         """
 
         try:


### PR DESCRIPTION
## Motivation
This PR is a followup for #1430.

## Description of the changes
It provides notes for zero-based numbering of `step` for the following classes and methods:
- `Trial.report`: the `step` argument
- `MedianPruner`: the `n_warmup_steps` argument
- `PercentilePruner`: the `n_warmup_steps` argument
- `SuccessiveHalvingPruner`: resource calculation.
- `HyperbandPruner`: resource calculation.