### PR TITLE
Fix race condition for trial number computation.

### DIFF
--- a/optuna/storages/_rdb/models.py
+++ b/optuna/storages/_rdb/models.py
@@ -45,18 +45,21 @@ class StudyModel(BaseModel):
     direction = Column(Enum(StudyDirection), nullable=False)
 
     @classmethod
-    def find_by_id(cls, study_id, session):
-        # type: (int, orm.Session) -> Optional[StudyModel]
+    def find_by_id(cls, study_id, session, for_update=False):
+        # type: (int, orm.Session, bool) -> Optional[StudyModel]
 
-        study = session.query(cls).filter(cls.study_id == study_id).one_or_none()
+        query = session.query(cls).filter(cls.study_id == study_id)
 
-        return study
+        if for_update:
+            query = query.with_for_update()
+
+        return query.one_or_none()
 
     @classmethod
-    def find_or_raise_by_id(cls, study_id, session):
-        # type: (int, orm.Session) -> StudyModel
+    def find_or_raise_by_id(cls, study_id, session, for_update=False):
+        # type: (int, orm.Session, bool) -> StudyModel
 
-        study = cls.find_by_id(study_id, session)
+        study = cls.find_by_id(study_id, session, for_update)
         if study is None:
             raise KeyError(NOT_FOUND_MSG)
 

--- a/optuna/storages/_rdb/storage.py
+++ b/optuna/storages/_rdb/storage.py
@@ -470,7 +470,7 @@ class RDBStorage(BaseStorage):
         try:
             # Locking within a study is necessary since the creation of a trial is not an atomic
             # operation. More precisely, the trial number computed in `_get_prepared_new_trial` is
-            # prone to race conditions within this lock.
+            # prone to race conditions without this lock.
             session.query(models.StudyModel).filter(
                 models.StudyModel.study_id == study_id
             ).with_for_update().one()

--- a/optuna/storages/_rdb/storage.py
+++ b/optuna/storages/_rdb/storage.py
@@ -462,22 +462,31 @@ class RDBStorage(BaseStorage):
 
         """
 
-        session = self.scoped_session()
+        # Retry a couple of times. Deadlocks may occur in distributed environments.
+        n_retries = 0
+        while True:
+            session = self.scoped_session()
 
-        try:
-            # Ensure that that study exists.
-            #
-            # Locking within a study is necessary since the creation of a trial is not an atomic
-            # operation. More precisely, the trial number computed in `_get_prepared_new_trial` is
-            # prone to race conditions without this lock.
-            models.StudyModel.find_or_raise_by_id(study_id, session, for_update=True)
+            try:
+                # Ensure that that study exists.
+                #
+                # Locking within a study is necessary since the creation of a trial is not an
+                # atomic operation. More precisely, the trial number computed in
+                # `_get_prepared_new_trial` is prone to race conditions without this lock.
+                models.StudyModel.find_or_raise_by_id(study_id, session, for_update=True)
 
-            trial = self._get_prepared_new_trial(study_id, template_trial, session)
-            self._commit(session)
-        except OperationalError:
-            # Retry after deadlock. This may happen in distributed environments.
-            session.rollback()
-            return self._create_new_trial(study_id, template_trial)
+                trial = self._get_prepared_new_trial(study_id, template_trial, session)
+
+                self._commit(session)
+
+                break  # Successfully created trial.
+            except OperationalError:
+                session.rollback()
+
+                if n_retries > 2:
+                    raise
+
+            n_retries += 1
 
         if template_trial:
             frozen = copy.deepcopy(template_trial)

--- a/optuna/storages/_rdb/storage.py
+++ b/optuna/storages/_rdb/storage.py
@@ -464,16 +464,13 @@ class RDBStorage(BaseStorage):
 
         session = self.scoped_session()
 
-        # Ensure that that study exists.
-        models.StudyModel.find_or_raise_by_id(study_id, session)
-
         try:
+            # Ensure that that study exists.
+            #
             # Locking within a study is necessary since the creation of a trial is not an atomic
             # operation. More precisely, the trial number computed in `_get_prepared_new_trial` is
             # prone to race conditions without this lock.
-            session.query(models.StudyModel).filter(
-                models.StudyModel.study_id == study_id
-            ).with_for_update().one()
+            models.StudyModel.find_or_raise_by_id(study_id, session, for_update=True)
 
             trial = self._get_prepared_new_trial(study_id, template_trial, session)
             self._commit(session)

--- a/optuna/storages/_rdb/storage.py
+++ b/optuna/storages/_rdb/storage.py
@@ -463,6 +463,10 @@ class RDBStorage(BaseStorage):
         """
 
         session = self.scoped_session()
+
+        # Ensure that that study exists.
+        models.StudyModel.find_or_raise_by_id(study_id, session)
+
         try:
             # Locking within a study is necessary since the creation of a trial is not an atomic
             # operation. More precisely, the trial number computed in `_get_prepared_new_trial` is
@@ -503,9 +507,6 @@ class RDBStorage(BaseStorage):
     def _get_prepared_new_trial(
         self, study_id: int, template_trial: Optional[FrozenTrial], session: orm.Session
     ) -> models.TrialModel:
-        # Ensure that that study exists.
-        models.StudyModel.find_or_raise_by_id(study_id, session)
-
         if template_trial is None:
             trial = models.TrialModel(study_id=study_id, number=None, state=TrialState.RUNNING)
         else:


### PR DESCRIPTION
## Motivation

Fixes https://github.com/optuna/optuna/issues/1488.

## Description of the changes

Allows `count_past_trials` to circumvent repeatable read isolation level. See the comments in the code for details.

## Note

Verified the changes with MySQL, by inspection, by checking for unique trial numbers after running a distributed optimization. The bug is otherwise reproducible, simply running a lot of trials with.

```sql
SELECT COUNT(DISTINCT(number)) FROM trials;
```

```python
import optuna
from optuna.samplers import TPESampler

def objective(trial, n_params):
    return sum(trial.suggest_float(f"x{i}", 0.0, 1.0) for i in range(n_params))

if __name__ == "__main__":
    n_params = 10
    n_trials = 200

    database = "duplicatenumber1488"
    storage = "mysql://root@localhost/duplicatenumber1488"
    study = optuna.create_study(sampler=TPESampler(), study_name=database, storage=storage, load_if_exists=True)

    study.optimize(lambda trial: objective(trial, n_params), n_trials=n_trials)
```

**About isolation levels in sqlalchemy for different dialect** 
https://docs.sqlalchemy.org/en/13/core/connections.html#sqlalchemy.engine.Connection.execution_options.params.isolation_level.