### PR TITLE
`FanovaImportanceEvaluator` as default importance evaluator.

### DIFF
--- a/optuna/importance/__init__.py
+++ b/optuna/importance/__init__.py
@@ -5,7 +5,7 @@ from typing import Optional
 from optuna.importance._base import BaseImportanceEvaluator
 from optuna.importance._fanova import FanovaImportanceEvaluator
 from optuna.importance._mean_decrease_impurity import (  # NOQA
-    MeanDecreaseImpurityImportanceEvaluator,
+    MeanDecreaseImpurityImportanceEvaluator,  # NOQA
 )
 from optuna.study import Study
 

--- a/optuna/importance/__init__.py
+++ b/optuna/importance/__init__.py
@@ -4,7 +4,6 @@ from typing import Optional
 
 from optuna.importance._base import BaseImportanceEvaluator
 from optuna.importance._fanova import FanovaImportanceEvaluator
-
 from optuna.importance._mean_decrease_impurity import (  # NOQA
     MeanDecreaseImpurityImportanceEvaluator,
 )

--- a/optuna/importance/__init__.py
+++ b/optuna/importance/__init__.py
@@ -5,9 +5,9 @@ from typing import Optional
 from optuna.importance._base import BaseImportanceEvaluator
 from optuna.importance._fanova import FanovaImportanceEvaluator
 
-# fmt: off
-from optuna.importance._mean_decrease_impurity import MeanDecreaseImpurityImportanceEvaluator  # NOQA
-# fmt: on
+from optuna.importance._mean_decrease_impurity import (  # NOQA
+    MeanDecreaseImpurityImportanceEvaluator,
+)
 from optuna.study import Study
 
 

--- a/optuna/importance/__init__.py
+++ b/optuna/importance/__init__.py
@@ -7,6 +7,7 @@ from optuna.importance._fanova import FanovaImportanceEvaluator
 
 # fmt: off
 from optuna.importance._mean_decrease_impurity import MeanDecreaseImpurityImportanceEvaluator  # NOQA
+# fmt: on
 from optuna.study import Study
 
 

--- a/optuna/importance/__init__.py
+++ b/optuna/importance/__init__.py
@@ -3,8 +3,10 @@ from typing import List
 from typing import Optional
 
 from optuna.importance._base import BaseImportanceEvaluator
-from optuna.importance._fanova import FanovaImportanceEvaluator  # NOQA
-from optuna.importance._mean_decrease_impurity import MeanDecreaseImpurityImportanceEvaluator
+from optuna.importance._fanova import FanovaImportanceEvaluator
+
+# fmt: off
+from optuna.importance._mean_decrease_impurity import MeanDecreaseImpurityImportanceEvaluator  # NOQA
 from optuna.study import Study
 
 
@@ -57,7 +59,7 @@ def get_param_importances(
         assessed importances.
     """
     if evaluator is None:
-        evaluator = MeanDecreaseImpurityImportanceEvaluator()
+        evaluator = FanovaImportanceEvaluator()
 
     if not isinstance(evaluator, BaseImportanceEvaluator):
         raise TypeError("Evaluator must be a subclass of BaseImportanceEvaluator.")


### PR DESCRIPTION
## Motivation

Now that both `FanovaImportanceEvaluator` and `MeanDecreaseImpurityImportanceEvaluator` both have the same dependencies, we can use the former, which is more sophisticated, as the default evaluator.

## Description of the changes

Changes the default importance evaluator.

## Note

It'd be preferable to have it included in v2.0 since it is the first major release with HPI.
