### PR TITLE
Reduce HPI variance with default args.

### DIFF
--- a/optuna/importance/_fanova/_evaluator.py
+++ b/optuna/importance/_fanova/_evaluator.py
@@ -62,7 +62,7 @@ class FanovaImportanceEvaluator(BaseImportanceEvaluator):
     """
 
     def __init__(
-        self, *, n_trees: int = 16, max_depth: int = 64, seed: Optional[int] = None
+        self, *, n_trees: int = 64, max_depth: int = 64, seed: Optional[int] = None
     ) -> None:
         self._evaluator = _Fanova(
             n_trees=n_trees,

--- a/optuna/importance/_mean_decrease_impurity.py
+++ b/optuna/importance/_mean_decrease_impurity.py
@@ -43,7 +43,7 @@ class MeanDecreaseImpurityImportanceEvaluator(BaseImportanceEvaluator):
     """
 
     def __init__(
-        self, *, n_trees: int = 16, max_depth: int = 64, seed: Optional[int] = None
+        self, *, n_trees: int = 64, max_depth: int = 64, seed: Optional[int] = None
     ) -> None:
         _imports.check()
 


### PR DESCRIPTION
## Motivation

Configuring the forest parameters for HPI isn't necessarily trivial. This PR aims to give the user a better experience by reducing the variance between each importance assessment by preferring larger forests by default.

## Description of the changes

Changes the number of trees.

## Bench

LightGBM example with 100 trials.

<details><summary>Code</summary>
<p>

```python
from collections import defaultdict
import time

import numpy as np
import optuna
from optuna import importance


if __name__ == "__main__":
    # Or, some other already-optimized study.
    study = optuna.load_study(
        storage="sqlite:///lightgbm.db", study_name="lightgbm-compare-forests"
    )

    print(f"Trials {len(study.trials)}")

    n = 100
    n_trees_list = [
        "default",
        32,
        64,
    ]

    for evaluator_cls in [
        importance.FanovaImportanceEvaluator,
        importance.MeanDecreaseImpurityImportanceEvaluator,
    ]:
        print(evaluator_cls.__name__)

        importance_history_all_n_trees_stds = defaultdict(list)

        for n_trees in n_trees_list:
            importances_history = defaultdict(list)

            if n_trees == "default":
                kwargs = {}
            else:
                kwargs = {"n_trees": n_trees}

            start = time.time()
            for _ in range(n):

                evaluator = evaluator_cls(**kwargs)
                importances = importance.get_param_importances(study, evaluator=evaluator)
                for param, imp in importances.items():
                    importances_history[param].append(imp)

            end = time.time()
            print(f"Trees: {n_trees}\tAvg. time (n={n}): {(end - start) / n:.2f}")
            for param, imps in sorted(importances_history.items()):
                importance_history_all_n_trees_stds[param].append(np.std(imps))

        print(f"| Param | {' | '.join(map(str, n_trees_list))} |")
        print(f"| ----- | {' | '.join('-' * len(n_trees_list))} |")
        for param, stds in sorted(importance_history_all_n_trees_stds.items()):
            print("|", param, "|", " | ".join(f"{p:.5f}" for p in stds), "|")
```

</p>
</details>


**`FanovaImportanceEvaluator`**

Trees: default  Avg. time (n=100): 0.33
Trees: 32       Avg. time (n=100): 0.63
Trees: 64       Avg. time (n=100): 1.30

Std table

| Param | 16 (`master` default) | 32 | 64 |
| ----- | - | - | - |
| bagging_fraction | 0.04835 | 0.03608 | 0.02274 |
| bagging_freq | 0.01769 | 0.01094 | 0.00861 |
| feature_fraction | 0.03810 | 0.02382 | 0.01854 |
| lambda_l1 | 0.04853 | 0.03662 | 0.02813 |
| lambda_l2 | 0.01539 | 0.01375 | 0.00747 |
| min_child_samples | 0.03114 | 0.02216 | 0.01486 |
| num_leaves | 0.05811 | 0.04181 | 0.03243 |

**`MeanDecreaseImpurityImportanceEvaluator`**

Trees: default  Avg. time (n=100): 0.04
Trees: 32       Avg. time (n=100): 0.05
Trees: 64       Avg. time (n=100): 0.09

Std table

| Param | 16 (`master` default) | 32 | 64 |
| ----- | - | - | - |
| bagging_fraction | 0.02292 | 0.01876 | 0.01445 |
| bagging_freq | 0.01351 | 0.00907 | 0.00650 |
| feature_fraction | 0.01713 | 0.01220 | 0.01002 |
| lambda_l1 | 0.01753 | 0.01367 | 0.00857 |
| lambda_l2 | 0.02018 | 0.01369 | 0.01002 |
| min_child_samples | 0.01958 | 0.01567 | 0.01047 |
| num_leaves | 0.02531 | 0.01846 | 0.01324 |