### PR TITLE
Use `circleci/python` for dev image and install RDB servers.

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -35,16 +35,19 @@ jobs:
         export TAG_NAME="py${{ matrix.python_version }}"
         if [ "${{ github.event_name }}" = 'release' ]; then
           export TAG_NAME="${{ github.event.release.tag_name }}-${TAG_NAME}"
+          export BASE_IMAGE="python"
         fi
         if [ "${{matrix.build_type}}" = 'dev' ]; then
           export TAG_NAME="${TAG_NAME}-dev"
+          export BASE_IMAGE="circleci/python"
         fi
         echo "::set-env name=HUB_TAG::${DOCKER_HUB_BASE_NAME}:${TAG_NAME}"
 
 
     - name: Build the Docker image
       run: |
-        docker build . --build-arg PYTHON_VERSION=${{ matrix.python_version }} --build-arg BUILD_TYPE=${{ matrix.build_type }} --file Dockerfile --tag "${HUB_TAG}"
+        docker build . --build-arg PYTHON_VERSION=${{ matrix.python_version }} --build-arg BUILD_TYPE=${{ matrix.build_type }} --build-arg BASE_IMAG
+E="${BASE_IMAGE}" --file Dockerfile --tag "${HUB_TAG}"
 
     - name: Login & Push to Docker Hub
       if: ${{ github.event_name != 'pull_request' }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,16 @@
 ARG PYTHON_VERSION=3.7
+ARG BASE_IMAGE=python
 
-FROM python:${PYTHON_VERSION}
+FROM ${BASE_IMAGE}:${PYTHON_VERSION}
 
 RUN apt-get update \
     && apt-get -y install openmpi-bin libopenmpi-dev \
     && apt-get -y install swig  \
     && rm -rf /var/lib/apt/lists/* \
     && pip install --no-cache-dir -U pip \
-    && pip install --no-cache-dir --progress-bar off -U setuptools
+    && pip install --no-cache-dir --progress-bar off -U setuptools \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /workspaces
 COPY . .
@@ -15,10 +18,18 @@ COPY . .
 ARG BUILD_TYPE='dev'
 
 RUN if [ "${BUILD_TYPE}" = "dev" ]; then \
+        apt-get update \
+        && apt-get -y install default-mysql-server default-mysql-client \
+        && apt-get -y install postgresql postgresql-client \
+        && apt-get clean \
+        && rm -rf /var/lib/apt/lists/*; \
+    fi
+
+RUN if [ "${BUILD_TYPE}" = "dev" ]; then \
         if [ "${PYTHON_VERSION}" \< "3.6" ]; then \
-            pip install --no-cache-dir -e '.[doctest, document, example, testing]' -f https://download.pytorch.org/whl/torch_stable.html; \
+            pip install --no-cache-dir -e '.[doctest, document, example, testing]' PyMySQL cryptography psycopg2-binary -f https://download.pytorch.org/whl/torch_stable.html; \
         else \
-            pip install --no-cache-dir -e '.[checking, doctest, document, example, testing]' -f https://download.pytorch.org/whl/torch_stable.html; \
+            pip install --no-cache-dir -e '.[checking, doctest, document, example, testing]' PyMySQL cryptography psycopg2-binary -f https://download.pytorch.org/whl/torch_stable.html; \
         fi \
     else \
         pip install --no-cache-dir -e .; \


### PR DESCRIPTION
## Motivation
The current docker images do not contain CircleCI related files, so we cannot use it to execute CI jobs locally.
In addition, it lacks DB servers and we need to install them to test with such servers.

## Description of the changes
This PR will apply the following changes:
- Change base image from `python` to `circleci/python`.
- Add DBs, i.e., `default-mysql-server`, `default-mysql-client`, `postgresql`, and `postgresql-client`
- Python DB bindings