### PR TITLE
Install RDB servers and their bindings for storage tests.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,9 +11,9 @@ workflows:
       - tests-python37
       - tests-python36
       - tests-python35
+      - tests-rdbstorage
 
 jobs:
-
   # Lint and static type checking
 
   checks:
@@ -123,8 +123,6 @@ jobs:
           command: |
             sudo apt-get update
             sudo apt-get -y install openmpi-bin libopenmpi-dev
-            sudo apt-get -y install default-mysql-server default-mysql-client
-            sudo apt-get -y install postgresql postgresql-client
 
             python -m venv venv || virtualenv venv
             . venv/bin/activate
@@ -138,9 +136,6 @@ jobs:
 
             # Install all dependencies needed for testing.
             pip install --progress-bar off $(ls dist/*.tar.gz)[testing] -f https://download.pytorch.org/whl/torch_stable.html
-
-            # Install RDB bindings for storage tests.
-            pip install --progress-bar off PyMySQL cryptography psycopg2-binary
 
       - run:
           name: install-codecov
@@ -236,3 +231,39 @@ jobs:
                 --ignore tests/integration_tests/test_catalyst.py
 
       - run: *tests-mn
+
+  tests-rdbstorage:
+    docker:
+      - image: circleci/python:3.7
+      - image: circleci/redis:5.0.7
+      - image: circleci/mysql:5.7
+        environment:
+          MYSQL_DATABASE: optunatest
+          MYSQL_USER: user
+          MYSQL_PASSWORD: test
+      - image: circleci/postgres:10.1-alpine
+        environment:
+          POSTGRES_USER: user
+          POSTGRES_DB: optunatest
+          POSTGRES_PASSWORD: test
+    steps:
+      - checkout
+
+      - run: *checkout-merge-master
+
+      - run: *install
+
+      - run: &tests-rdb
+          name: tests-rdb
+          command: |
+            . venv/bin/activate
+            # Install RDB bindings for storage tests.
+            pip install --progress-bar off PyMySQL cryptography psycopg2-binary
+
+            export TEST_DB_URL=mysql+pymysql://user:test@127.0.0.1/optunatest
+            pytest tests/storages_tests/rdb_tests/test_with_server.py
+
+            export TEST_DB_URL=postgres+psycopg2://user:test@127.0.0.1/optunatest
+            pytest tests/storages_tests/rdb_tests/test_with_server.py
+          environment:
+            OMP_NUM_THREADS: 1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -253,7 +253,7 @@ jobs:
       - run: *install
 
       - run: &install-rdb-bindings
-          name: tests-mysql
+          name: install-rdb-bindings
           command: |
             . venv/bin/activate
             pip install --progress-bar off PyMySQL cryptography psycopg2-binary

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -274,4 +274,4 @@ jobs:
             pytest tests/storages_tests/rdb_tests/test_with_server.py
           environment:
             OMP_NUM_THREADS: 1
-            TEST_DB_URL: postgres+psycopg2://user:test@127.0.0.1/optunatest
+            TEST_DB_URL: postgresql+psycopg2://user:test@127.0.0.1/optunatest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -252,17 +252,26 @@ jobs:
 
       - run: *install
 
-      - run: &tests-rdb
-          name: tests-rdb
+      - run: &install-rdb-bindings
+          name: tests-mysql
           command: |
             . venv/bin/activate
-            # Install RDB bindings for storage tests.
             pip install --progress-bar off PyMySQL cryptography psycopg2-binary
 
-            export TEST_DB_URL=mysql+pymysql://user:test@127.0.0.1/optunatest
-            pytest tests/storages_tests/rdb_tests/test_with_server.py
-
-            export TEST_DB_URL=postgres+psycopg2://user:test@127.0.0.1/optunatest
+      - run: &tests-mysql
+          name: tests-mysql
+          command: |
+            . venv/bin/activate
             pytest tests/storages_tests/rdb_tests/test_with_server.py
           environment:
             OMP_NUM_THREADS: 1
+            TEST_DB_URL: mysql+pymysql://user:test@127.0.0.1/optunatest
+
+      - run: &tests-postgresql
+          name: tests-postgresql
+          command: |
+            . venv/bin/activate
+            pytest tests/storages_tests/rdb_tests/test_with_server.py
+          environment:
+            OMP_NUM_THREADS: 1
+            TEST_DB_URL: postgres+psycopg2://user:test@127.0.0.1/optunatest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -235,7 +235,6 @@ jobs:
   tests-rdbstorage:
     docker:
       - image: circleci/python:3.7
-      - image: circleci/redis:5.0.7
       - image: circleci/mysql:5.7
         environment:
           MYSQL_DATABASE: optunatest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,6 +123,8 @@ jobs:
           command: |
             sudo apt-get update
             sudo apt-get -y install openmpi-bin libopenmpi-dev
+            sudo apt-get -y install default-mysql-server default-mysql-client
+            sudo apt-get -y install postgresql postgresql-client
 
             python -m venv venv || virtualenv venv
             . venv/bin/activate
@@ -136,6 +138,9 @@ jobs:
 
             # Install all dependencies needed for testing.
             pip install --progress-bar off $(ls dist/*.tar.gz)[testing] -f https://download.pytorch.org/whl/torch_stable.html
+
+            # Install RDB bindings for storage tests.
+            pip install --progress-bar off PyMySQL cryptography psycopg2-binary
 
       - run:
           name: install-codecov

--- a/tests/storages_tests/rdb_tests/test_with_server.py
+++ b/tests/storages_tests/rdb_tests/test_with_server.py
@@ -95,7 +95,7 @@ def test_loaded_trials(storage_url: str) -> None:
     _check_trials(trials)
 
     # Create a new study to confirm the study can load trial properly.
-    loaded_study = optuna.create_study(study_name=_STUDY_NAME, storage=storage_url,)
+    loaded_study = optuna.load_study(study_name=_STUDY_NAME, storage=storage_url,)
     _check_trials(loaded_study.trials)
 
 

--- a/tests/storages_tests/rdb_tests/test_with_server.py
+++ b/tests/storages_tests/rdb_tests/test_with_server.py
@@ -84,6 +84,8 @@ def _check_trials(trials: Sequence[optuna.trial.FrozenTrial]) -> None:
 
 
 def test_loaded_trials(storage_url: str) -> None:
+    # Please create the tables by placing this function before the multi-process tests.
+
     N_TRIALS = 20
     study = optuna.create_study(study_name=_STUDY_NAME, storage=storage_url,)
     # Run optimization

--- a/tests/storages_tests/rdb_tests/test_with_server.py
+++ b/tests/storages_tests/rdb_tests/test_with_server.py
@@ -35,7 +35,7 @@ def run_optimize(args: Tuple[str, str]) -> None:
 
 
 @pytest.fixture
-def storage() -> str:
+def storage_url() -> str:
     if "TEST_DB_URL" not in os.environ:
         pytest.skip("This test requires TEST_DB_URL.")
     storage_url = os.environ["TEST_DB_URL"]

--- a/tests/storages_tests/rdb_tests/test_with_server.py
+++ b/tests/storages_tests/rdb_tests/test_with_server.py
@@ -71,14 +71,14 @@ def _check_trials(trials: Sequence[optuna.trial.FrozenTrial]) -> None:
         np.isclose(
             [trial.user_attrs["x"] for trial in trials],
             [trial.params["x"] for trial in trials],
-            atol=1e-4
+            atol=1e-4,
         )
     )
     assert all(
         np.isclose(
             [trial.system_attrs["y"] for trial in trials],
             [trial.params["y"] for trial in trials],
-            atol=1e-4
+            atol=1e-4,
         )
     )
 
@@ -93,6 +93,10 @@ def test_many_trials(storage: str) -> None:
     assert len(trials) == N_TRIALS
 
     _check_trials(trials)
+
+    # Create a new study to confirm the study can load trial properly.
+    loaded_study = optuna.create_study(study_name=_STUDY_NAME, storage=storage,)
+    _check_trials(loaded_study.trials)
 
 
 def test_multiprocess(storage: str) -> None:

--- a/tests/storages_tests/rdb_tests/test_with_server.py
+++ b/tests/storages_tests/rdb_tests/test_with_server.py
@@ -67,8 +67,20 @@ def _check_trials(trials: Sequence[optuna.trial.FrozenTrial]) -> None:
     assert all((trial.params["y"] == trial.intermediate_values[1] for trial in trials))
 
     # Check attrs.
-    assert all((trial.user_attrs["x"] == trial.params["x"] for trial in trials))
-    assert all((trial.system_attrs["y"] == trial.params["y"] for trial in trials))
+    assert all(
+        np.isclose(
+            [trial.user_attrs["x"] for trial in trials],
+            [trial.params["x"] for trial in trials],
+            atol=1e-4
+        )
+    )
+    assert all(
+        np.isclose(
+            [trial.system_attrs["y"] for trial in trials],
+            [trial.params["y"] for trial in trials],
+            atol=1e-4
+        )
+    )
 
 
 def test_many_trials(storage: str) -> None:

--- a/tests/storages_tests/rdb_tests/test_with_server.py
+++ b/tests/storages_tests/rdb_tests/test_with_server.py
@@ -1,0 +1,98 @@
+from multiprocessing import Pool
+import os
+from typing import Sequence
+from typing import Tuple
+
+import numpy as np
+import pytest
+
+import optuna
+
+_STUDY_NAME = "_test_multiprocess"
+
+
+def f(x: float, y: float) -> float:
+    return (x - 3) ** 2 + y
+
+
+def objective(trial: optuna.Trial) -> float:
+    x = trial.suggest_float("x", -10, 10)
+    y = trial.suggest_float("y", -10, 10)
+    trial.report(x, 0)
+    trial.report(y, 1)
+    trial.set_user_attr("x", x)
+    trial.set_system_attr("y", y)
+    return f(x, y)
+
+
+def run_optimize(args: Tuple[str, str]) -> None:
+    study_name = args[0]
+    storage = args[1]
+    # Create a study
+    study = optuna.create_study(study_name=study_name, storage=storage, load_if_exists=True,)
+    # Run optimization
+    study.optimize(objective, n_trials=20)
+
+
+@pytest.fixture
+def storage() -> str:
+    if "TEST_DB_URL" not in os.environ:
+        pytest.skip("This test requires TEST_DB_URL.")
+    storage_url = os.environ["TEST_DB_URL"]
+    try:
+        optuna.study.delete_study(_STUDY_NAME, storage_url)
+    except KeyError:
+        pass
+    return storage_url
+
+
+def _check_trials(trials: Sequence[optuna.trial.FrozenTrial]) -> None:
+    # Check trial states.
+    assert all((trial.state == optuna.trial.TrialState.COMPLETE for trial in trials))
+
+    # Check trial values and params.
+    assert all(("x" in trial.params for trial in trials))
+    assert all(("y" in trial.params for trial in trials))
+    assert all(
+        np.isclose(
+            [trial.value for trial in trials],
+            [f(trial.params["x"], trial.params["y"]) for trial in trials],
+            atol=1e-4,
+        )
+    )
+
+    # Check intermediate values.
+    assert all((len(trial.intermediate_values) == 2 for trial in trials))
+    assert all((trial.params["x"] == trial.intermediate_values[0] for trial in trials))
+    assert all((trial.params["y"] == trial.intermediate_values[1] for trial in trials))
+
+    # Check attrs.
+    assert all((trial.user_attrs["x"] == trial.params["x"] for trial in trials))
+    assert all((trial.system_attrs["y"] == trial.params["y"] for trial in trials))
+
+
+def test_many_trials(storage: str) -> None:
+    N_TRIALS = 1000
+    study = optuna.create_study(study_name=_STUDY_NAME, storage=storage,)
+    # Run optimization
+    study.optimize(objective, n_trials=N_TRIALS)
+
+    trials = study.trials
+    assert len(trials) == N_TRIALS
+
+    _check_trials(trials)
+
+
+def test_multiprocess(storage: str) -> None:
+    n_workers = 8
+    study_name = _STUDY_NAME
+    storage = storage
+    with Pool(n_workers) as pool:
+        pool.map(run_optimize, [(study_name, storage)] * n_workers)
+
+    study = optuna.load_study(study_name=study_name, storage=storage)
+
+    trials = study.trials
+    assert len(trials) == n_workers * 20
+
+    _check_trials(trials)

--- a/tests/storages_tests/rdb_tests/test_with_server.py
+++ b/tests/storages_tests/rdb_tests/test_with_server.py
@@ -52,7 +52,7 @@ def _check_trials(trials: Sequence[optuna.trial.FrozenTrial]) -> None:
 
     # Check trial values and params.
     assert all(("x" in trial.params for trial in trials))
-    assert all(("y" in trial.params for trial in trials))
+    assert all("y" in trial.params for trial in trials)
     assert all(
         np.isclose(
             [trial.value for trial in trials],

--- a/tests/storages_tests/rdb_tests/test_with_server.py
+++ b/tests/storages_tests/rdb_tests/test_with_server.py
@@ -27,9 +27,9 @@ def objective(trial: optuna.Trial) -> float:
 
 def run_optimize(args: Tuple[str, str]) -> None:
     study_name = args[0]
-    storage = args[1]
+    storage_url = args[1]
     # Create a study
-    study = optuna.create_study(study_name=study_name, storage=storage, load_if_exists=True,)
+    study = optuna.create_study(study_name=study_name, storage=storage_url, load_if_exists=True,)
     # Run optimization
     study.optimize(objective, n_trials=20)
 
@@ -83,9 +83,9 @@ def _check_trials(trials: Sequence[optuna.trial.FrozenTrial]) -> None:
     )
 
 
-def test_many_trials(storage: str) -> None:
+def test_many_trials(storage_url: str) -> None:
     N_TRIALS = 1000
-    study = optuna.create_study(study_name=_STUDY_NAME, storage=storage,)
+    study = optuna.create_study(study_name=_STUDY_NAME, storage=storage_url,)
     # Run optimization
     study.optimize(objective, n_trials=N_TRIALS)
 
@@ -95,18 +95,17 @@ def test_many_trials(storage: str) -> None:
     _check_trials(trials)
 
     # Create a new study to confirm the study can load trial properly.
-    loaded_study = optuna.create_study(study_name=_STUDY_NAME, storage=storage,)
+    loaded_study = optuna.create_study(study_name=_STUDY_NAME, storage=storage_url,)
     _check_trials(loaded_study.trials)
 
 
-def test_multiprocess(storage: str) -> None:
+def test_multiprocess(storage_url: str) -> None:
     n_workers = 8
     study_name = _STUDY_NAME
-    storage = storage
     with Pool(n_workers) as pool:
-        pool.map(run_optimize, [(study_name, storage)] * n_workers)
+        pool.map(run_optimize, [(study_name, storage_url)] * n_workers)
 
-    study = optuna.load_study(study_name=study_name, storage=storage)
+    study = optuna.load_study(study_name=study_name, storage=storage_url)
 
     trials = study.trials
     assert len(trials) == n_workers * 20

--- a/tests/storages_tests/rdb_tests/test_with_server.py
+++ b/tests/storages_tests/rdb_tests/test_with_server.py
@@ -48,10 +48,10 @@ def storage_url() -> str:
 
 def _check_trials(trials: Sequence[optuna.trial.FrozenTrial]) -> None:
     # Check trial states.
-    assert all((trial.state == optuna.trial.TrialState.COMPLETE for trial in trials))
+    assert all(trial.state == optuna.trial.TrialState.COMPLETE for trial in trials)
 
     # Check trial values and params.
-    assert all(("x" in trial.params for trial in trials))
+    assert all("x" in trial.params for trial in trials)
     assert all("y" in trial.params for trial in trials)
     assert all(
         np.isclose(
@@ -62,9 +62,9 @@ def _check_trials(trials: Sequence[optuna.trial.FrozenTrial]) -> None:
     )
 
     # Check intermediate values.
-    assert all((len(trial.intermediate_values) == 2 for trial in trials))
-    assert all((trial.params["x"] == trial.intermediate_values[0] for trial in trials))
-    assert all((trial.params["y"] == trial.intermediate_values[1] for trial in trials))
+    assert all(len(trial.intermediate_values) == 2 for trial in trials)
+    assert all(trial.params["x"] == trial.intermediate_values[0] for trial in trials)
+    assert all(trial.params["y"] == trial.intermediate_values[1] for trial in trials)
 
     # Check attrs.
     assert all(

--- a/tests/storages_tests/rdb_tests/test_with_server.py
+++ b/tests/storages_tests/rdb_tests/test_with_server.py
@@ -83,8 +83,8 @@ def _check_trials(trials: Sequence[optuna.trial.FrozenTrial]) -> None:
     )
 
 
-def test_many_trials(storage_url: str) -> None:
-    N_TRIALS = 1000
+def test_loaded_trials(storage_url: str) -> None:
+    N_TRIALS = 20
     study = optuna.create_study(study_name=_STUDY_NAME, storage=storage_url,)
     # Run optimization
     study.optimize(objective, n_trials=N_TRIALS)


### PR DESCRIPTION
## Motivation
This PR is related to the changes in #1495. Recently, we received some issues on concurrent access to the `RDBStorage` such as #1488 and #1496. However, we do not use DB servers in any test case. To detect such issues, we need to run tests of storages using various storage backends.

## Description of the changes
This PR introduces MySQL and PostgreSQL to cover a wider variety of user environments.

## Update on June 14

- Replace apt packages with docker images.
  - The RDB servers failed on startup.
  - The [official document](https://circleci.com/docs/2.0/postgres-config/) recommends docker containers to launch RDB servers.
- Add test cases
  - A test case to reproduce the issue #1488.
  - Another test case to run many trials.
  - Currently, they fail due to the issue on #1496, but it will be resolved by #1509 
  - They may fail due to another issue reported in #1508 after merging #1509
- The test cases can be run as follows: `circleci build --job tests-rdbstorage`