### PR TITLE
Fix `CachedStorage` skipping trial param row insertion on cache miss.

### DIFF
--- a/optuna/storages/_cached_storage.py
+++ b/optuna/storages/_cached_storage.py
@@ -229,9 +229,7 @@ class _CachedStorage(BaseStorage):
                 if cached_dist:
                     distributions.check_distribution_compatibility(cached_dist, distribution)
                 else:
-                    self._backend._check_or_set_param_distribution(
-                        trial_id, param_name, param_value_internal, distribution
-                    )
+                    self._backend._check_param_distribution(trial_id, param_name, distribution)
                     self._studies[study_id].param_distribution[param_name] = distribution
 
                 params = copy.copy(cached_trial.params)
@@ -242,10 +240,9 @@ class _CachedStorage(BaseStorage):
                 dists[param_name] = distribution
                 cached_trial.distributions = dists
 
-                if cached_dist:
-                    updates = self._get_updates(trial_id)
-                    updates.params[param_name] = param_value_internal
-                    updates.distributions[param_name] = distribution
+                updates = self._get_updates(trial_id)
+                updates.params[param_name] = param_value_internal
+                updates.distributions[param_name] = distribution
                 return
 
         self._backend.set_trial_param(trial_id, param_name, param_value_internal, distribution)

--- a/optuna/storages/_cached_storage.py
+++ b/optuna/storages/_cached_storage.py
@@ -229,7 +229,13 @@ class _CachedStorage(BaseStorage):
                 if cached_dist:
                     distributions.check_distribution_compatibility(cached_dist, distribution)
                 else:
-                    self._backend._check_param_distribution(trial_id, param_name, distribution)
+                    # On cache miss, check compatibility against previous trials in the database
+                    # and INSERT immediately to prevent other processes from creating incompatible
+                    # ones. By INSERT, it is assumed that no previous entry has been persisted
+                    # already.
+                    self._backend._check_and_set_param_distribution(
+                        trial_id, param_name, param_value_internal, distribution
+                    )
                     self._studies[study_id].param_distribution[param_name] = distribution
 
                 params = copy.copy(cached_trial.params)
@@ -240,9 +246,10 @@ class _CachedStorage(BaseStorage):
                 dists[param_name] = distribution
                 cached_trial.distributions = dists
 
-                updates = self._get_updates(trial_id)
-                updates.params[param_name] = param_value_internal
-                updates.distributions[param_name] = distribution
+                if cached_dist:  # Already persisted in case of cache miss so no need to update.
+                    updates = self._get_updates(trial_id)
+                    updates.params[param_name] = param_value_internal
+                    updates.distributions[param_name] = distribution
                 return
 
         self._backend.set_trial_param(trial_id, param_name, param_value_internal, distribution)

--- a/optuna/storages/_rdb/storage.py
+++ b/optuna/storages/_rdb/storage.py
@@ -750,13 +750,19 @@ class RDBStorage(BaseStorage):
 
             trial_param.check_and_add(session)
 
-    def _check_param_distribution(
-        self, trial_id: int, param_name: str, distribution: distributions.BaseDistribution,
+    def _check_and_set_param_distribution(
+        self,
+        trial_id: int,
+        param_name: str,
+        param_value_internal: float,
+        distribution: distributions.BaseDistribution,
     ) -> None:
 
         session = self.scoped_session()
 
-        trial = models.TrialModel.find_by_id(trial_id, session)
+        # Acquire a lock of this trial.
+        trial = models.TrialModel.find_by_id(trial_id, session, for_update=True)
+
         if trial is None:
             raise KeyError(models.NOT_FOUND_MSG)
 
@@ -767,12 +773,23 @@ class RDBStorage(BaseStorage):
             .filter(models.TrialParamModel.param_name == param_name)
             .first()
         )
-
         if previous_record is not None:
             distributions.check_distribution_compatibility(
                 distributions.json_to_distribution(previous_record.distribution_json),
                 distribution,
             )
+
+        session.add(
+            models.TrialParamModel(
+                trial_id=trial_id,
+                param_name=param_name,
+                param_value=param_value_internal,
+                distribution_json=distributions.distribution_to_json(distribution),
+            )
+        )
+
+        # Release lock.
+        session.commit()
 
     def get_trial_param(self, trial_id, param_name):
         # type: (int, str) -> float

--- a/optuna/storages/_rdb/storage.py
+++ b/optuna/storages/_rdb/storage.py
@@ -750,18 +750,13 @@ class RDBStorage(BaseStorage):
 
             trial_param.check_and_add(session)
 
-    def _check_or_set_param_distribution(
-        self,
-        trial_id: int,
-        param_name: str,
-        param_value_internal: float,
-        distribution: distributions.BaseDistribution,
+    def _check_param_distribution(
+        self, trial_id: int, param_name: str, distribution: distributions.BaseDistribution,
     ) -> None:
 
         session = self.scoped_session()
 
-        # Acquire a lock of this trial.
-        trial = models.TrialModel.find_by_id(trial_id, session, for_update=True)
+        trial = models.TrialModel.find_by_id(trial_id, session)
         if trial is None:
             raise KeyError(models.NOT_FOUND_MSG)
 
@@ -772,23 +767,12 @@ class RDBStorage(BaseStorage):
             .filter(models.TrialParamModel.param_name == param_name)
             .first()
         )
+
         if previous_record is not None:
             distributions.check_distribution_compatibility(
                 distributions.json_to_distribution(previous_record.distribution_json),
                 distribution,
             )
-        else:
-            session.add(
-                models.TrialParamModel(
-                    trial_id=trial_id,
-                    param_name=param_name,
-                    param_value=param_value_internal,
-                    distribution_json=distributions.distribution_to_json(distribution),
-                )
-            )
-
-        # Release lock.
-        session.commit()
 
     def get_trial_param(self, trial_id, param_name):
         # type: (int, str) -> float


### PR DESCRIPTION
## Motivation

Fixes https://github.com/optuna/optuna/issues/1488#issuecomment-655428975.

## Description of the changes

Makes sure parameters are flushed/committed even for the first trial that is a "cache miss". 

## Note

This is only an issue for the first trial in a distributed environment/continuing optimization on an already started/finished study.