### PR TITLE
RDB storage to do eager backref "join"s when fetching all trials.

### DIFF
--- a/optuna/storages/_rdb/storage.py
+++ b/optuna/storages/_rdb/storage.py
@@ -969,6 +969,10 @@ class RDBStorage(BaseStorage):
         try:
             trial_models = (
                 session.query(models.TrialModel)
+                .options(orm.selectinload(models.TrialModel.params))
+                .options(orm.selectinload(models.TrialModel.values))
+                .options(orm.selectinload(models.TrialModel.user_attributes))
+                .options(orm.selectinload(models.TrialModel.system_attributes))
                 .filter(
                     models.TrialModel.trial_id.in_(trial_ids),
                     models.TrialModel.study_id == study_id,
@@ -988,6 +992,10 @@ class RDBStorage(BaseStorage):
 
             trial_models = (
                 session.query(models.TrialModel)
+                .options(orm.selectinload(models.TrialModel.params))
+                .options(orm.selectinload(models.TrialModel.values))
+                .options(orm.selectinload(models.TrialModel.user_attributes))
+                .options(orm.selectinload(models.TrialModel.system_attributes))
                 .filter(models.TrialModel.study_id == study_id)
                 .all()
             )


### PR DESCRIPTION
## Motivation

_Not high prio for the most basic optimization scenarios._

When with the RDB storage fetching all trials, `RDBStorage._get_trials`, in favor of performance, we can issue queries with eager "joins" (or `SELECT IN`) for backref tables (params, intermediate values, system and user attributes). Currently it's done lazily. Since backrefs are later referenced anyway, they lazily issue an unnecessary amount of queries hurting performance.

This will also improve for the `_CachedStorage`

- The first fetch of all trials from an already optimized study
- Parallel optimization with a decent number of workers, since the cached storage has to query a O(worker) trials on each trial

It shouldn't have any negative consequences, from the current logic of loading lazily.

**Simple benchmarks from loading trials from already optimized studies (MySQL, `_CachedStorage`, time in seconds).**

| Study | `master` | `PR` |
| - | - | - |
| 1k trials, 4 params | 1.4286811351776123 | 0.36625194549560547 |
| 1k trials, 4 param, 10 intermediate values, 3 user attrs | 2.0547759532928467 | 0.6724259853363037 |

## Description of the changes

In `RDBStorage._get_trials` chains `selectinload` to eagerly load trials and backref table rows.

## Note

See 
- https://docs.sqlalchemy.org/en/13/orm/tutorial.html#eager-loading
- https://docs.sqlalchemy.org/en/13/orm/relationship_api.html#sqlalchemy.orm.relationship.params.lazy