### PR TITLE
Align `LightGBMTuner` verbosity level to the original LightGBM.

### DIFF
--- a/optuna/integration/_lightgbm_tuner/optimize.py
+++ b/optuna/integration/_lightgbm_tuner/optimize.py
@@ -13,6 +13,7 @@ from typing import List
 from typing import Optional
 from typing import Tuple
 from typing import Union
+import warnings
 
 import numpy as np
 import tqdm
@@ -337,7 +338,8 @@ class _LightGBMBaseTuner(_BaseTuner):
         sample_size: Optional[int] = None,
         study: Optional[optuna.study.Study] = None,
         optuna_callbacks: Optional[List[Callable[[Study, FrozenTrial], None]]] = None,
-        verbosity: int = 1,
+        verbosity: Optional[int] = None,
+        show_progress_bar: bool = True,
     ) -> None:
 
         _imports.check()
@@ -360,10 +362,10 @@ class _LightGBMBaseTuner(_BaseTuner):
             time_budget=time_budget,
             sample_size=sample_size,
             verbosity=verbosity,
+            show_progress_bar=show_progress_bar,
         )  # type: Dict[str, Any]
         self._parse_args(*args, **kwargs)
         self._start_time = None  # type: Optional[float]
-        self._use_pbar = True
         self._optuna_callbacks = optuna_callbacks
         self._best_params = {}
 
@@ -392,6 +394,15 @@ class _LightGBMBaseTuner(_BaseTuner):
                     "Please set 'minimize' as the direction.".format(metric_name)
                 )
 
+        if verbosity is not None:
+            warnings.warn(
+                "`verbosity` argument is deprecated and will be removed in the future. "
+                "The removal of this feature is currently scheduled for v4.0.0, "
+                "but this schedule is subject to change. Please use optuna.logging.set_verbosity()"
+                " instead.",
+                FutureWarning,
+            )
+
     @property
     def best_score(self) -> float:
         """Return the score of the best booster."""
@@ -417,7 +428,7 @@ class _LightGBMBaseTuner(_BaseTuner):
 
         self.auto_options = {
             option_name: kwargs.get(option_name)
-            for option_name in ["time_budget", "sample_size", "verbosity"]
+            for option_name in ["time_budget", "sample_size", "verbosity", "show_progress_bar"]
         }
 
         # Split options.
@@ -433,21 +444,15 @@ class _LightGBMBaseTuner(_BaseTuner):
     def run(self) -> None:
         """Perform the hyperparameter-tuning with given parameters."""
         verbosity = self.auto_options["verbosity"]
-        assert verbosity is not None
-        if verbosity > 1:
-            optuna.logging.set_verbosity(optuna.logging.DEBUG)
-            self._use_pbar = True
-        elif verbosity == 1:
-            optuna.logging.set_verbosity(optuna.logging.INFO)
-            self._use_pbar = True
-        elif verbosity == 0:
-            optuna.logging.set_verbosity(optuna.logging.WARNING)
-            self.lgbm_kwargs["verbose_eval"] = False
-            self._use_pbar = False
-        else:
-            optuna.logging.set_verbosity(optuna.logging.FATAL)
-            self.lgbm_kwargs["verbose_eval"] = False
-            self._use_pbar = False
+        if verbosity is not None:
+            if verbosity > 1:
+                optuna.logging.set_verbosity(optuna.logging.DEBUG)
+            elif verbosity == 1:
+                optuna.logging.set_verbosity(optuna.logging.INFO)
+            elif verbosity == 0:
+                optuna.logging.set_verbosity(optuna.logging.WARNING)
+            else:
+                optuna.logging.set_verbosity(optuna.logging.CRITICAL)
 
         # Handling aliases.
         _handling_alias_parameters(self.lgbm_params)
@@ -523,7 +528,11 @@ class _LightGBMBaseTuner(_BaseTuner):
         sampler: optuna.samplers.BaseSampler,
         step_name: str,
     ) -> _OptunaObjective:
-        pbar = tqdm.tqdm(total=n_trials, ascii=True) if self._use_pbar else None
+        pbar = (
+            tqdm.tqdm(total=n_trials, ascii=True)
+            if self.auto_options["show_progress_bar"]
+            else None
+        )
 
         # Set current best parameters.
         self.lgbm_params.update(self.best_params)
@@ -663,7 +672,26 @@ class LightGBMTuner(_LightGBMBaseTuner):
             created. The filenames of the boosters will be ``{model_dir}/{trial_number}.pkl``
             (e.g., ``./boosters/0.pkl``).
 
+        verbosity:
+            A verbosity level to change Optuna's logging level. The level is aligned to
+            `LightGBM's verbosity`_ .
+
+            .. warning::
+                Deprecated in v2.0.0. ``verbosity`` argument will be removed in the future.
+                The removal of this feature is currently scheduled for v4.0.0,
+                but this schedule is subject to change.
+
+                Please use :func:`~optuna.logging.set_verbosity` instead.
+
+        show_progress_bar:
+            Flag to show progress bars or not. To disable progress bar, set this ``False``.
+
+            .. note::
+                Progress bars will be fragmented by logging messages of LightGBM and Optuna.
+                Please suppress such messages to show the progress bars properly.
+
     .. _lightgbm.train(): https://lightgbm.readthedocs.io/en/latest/pythonapi/lightgbm.train.html
+    .. _LightGBM's verbosity: https://lightgbm.readthedocs.io/en/latest/Parameters.html#verbosity
     """
 
     def __init__(
@@ -688,7 +716,8 @@ class LightGBMTuner(_LightGBMBaseTuner):
         study: Optional[optuna.study.Study] = None,
         optuna_callbacks: Optional[List[Callable[[Study, FrozenTrial], None]]] = None,
         model_dir: Optional[str] = None,
-        verbosity: int = 1,
+        verbosity: Optional[int] = None,
+        show_progress_bar: bool = True,
     ) -> None:
 
         super(LightGBMTuner, self).__init__(
@@ -707,6 +736,7 @@ class LightGBMTuner(_LightGBMBaseTuner):
             study=study,
             optuna_callbacks=optuna_callbacks,
             verbosity=verbosity,
+            show_progress_bar=show_progress_bar,
         )
 
         self.lgbm_kwargs["valid_sets"] = valid_sets
@@ -845,8 +875,27 @@ class LightGBMTunerCV(_LightGBMBaseTuner):
             :class:`~optuna.study.Study` and :class:`~optuna.FrozenTrial`.
             Please note that this is not a ``callbacks`` argument of `lightgbm.train()`_ .
 
+        verbosity:
+            A verbosity level to change Optuna's logging level. The level is aligned to
+            `LightGBM's verbosity`_ .
+
+            .. warning::
+                Deprecated in v2.0.0. ``verbosity`` argument will be removed in the future.
+                The removal of this feature is currently scheduled for v4.0.0,
+                but this schedule is subject to change.
+
+                Please use :func:`~optuna.logging.set_verbosity` instead.
+
+        show_progress_bar:
+            Flag to show progress bars or not. To disable progress bar, set this ``False``.
+
+            .. note::
+                Progress bars will be fragmented by logging messages of LightGBM and Optuna.
+                Please suppress such messages to show the progress bars properly.
+
     .. _lightgbm.train(): https://lightgbm.readthedocs.io/en/latest/pythonapi/lightgbm.train.html
     .. _lightgbm.cv(): https://lightgbm.readthedocs.io/en/latest/pythonapi/lightgbm.cv.html
+    .. _LightGBM's verbosity: https://lightgbm.readthedocs.io/en/latest/Parameters.html#verbosity
     """
 
     def __init__(
@@ -878,7 +927,8 @@ class LightGBMTunerCV(_LightGBMBaseTuner):
         sample_size: Optional[int] = None,
         study: Optional[optuna.study.Study] = None,
         optuna_callbacks: Optional[List[Callable[[Study, FrozenTrial], None]]] = None,
-        verbosity: int = 1,
+        verbosity: Optional[int] = None,
+        show_progress_bar: bool = True,
     ) -> None:
 
         super(LightGBMTunerCV, self).__init__(
@@ -897,6 +947,7 @@ class LightGBMTunerCV(_LightGBMBaseTuner):
             study=study,
             optuna_callbacks=optuna_callbacks,
             verbosity=verbosity,
+            show_progress_bar=show_progress_bar,
         )
 
         self.lgbm_kwargs["folds"] = folds

--- a/optuna/integration/_lightgbm_tuner/optimize.py
+++ b/optuna/integration/_lightgbm_tuner/optimize.py
@@ -433,6 +433,7 @@ class _LightGBMBaseTuner(_BaseTuner):
     def run(self) -> None:
         """Perform the hyperparameter-tuning with given parameters."""
         verbosity = self.auto_options["verbosity"]
+        assert verbosity is not None
         if verbosity > 1:
             optuna.logging.set_verbosity(optuna.logging.DEBUG)
             self._use_pbar = True

--- a/optuna/integration/_lightgbm_tuner/optimize.py
+++ b/optuna/integration/_lightgbm_tuner/optimize.py
@@ -684,7 +684,7 @@ class LightGBMTuner(_LightGBMBaseTuner):
                 Please use :func:`~optuna.logging.set_verbosity` instead.
 
         show_progress_bar:
-            Flag to show progress bars or not. To disable progress bar, set this ``False``.
+            Flag to show progress bars or not. To disable progress bar, set this :obj:`False`.
 
             .. note::
                 Progress bars will be fragmented by logging messages of LightGBM and Optuna.
@@ -887,7 +887,7 @@ class LightGBMTunerCV(_LightGBMBaseTuner):
                 Please use :func:`~optuna.logging.set_verbosity` instead.
 
         show_progress_bar:
-            Flag to show progress bars or not. To disable progress bar, set this ``False``.
+            Flag to show progress bars or not. To disable progress bar, set this :obj:`False`.
 
             .. note::
                 Progress bars will be fragmented by logging messages of LightGBM and Optuna.

--- a/optuna/integration/_lightgbm_tuner/optimize.py
+++ b/optuna/integration/_lightgbm_tuner/optimize.py
@@ -337,7 +337,7 @@ class _LightGBMBaseTuner(_BaseTuner):
         sample_size: Optional[int] = None,
         study: Optional[optuna.study.Study] = None,
         optuna_callbacks: Optional[List[Callable[[Study, FrozenTrial], None]]] = None,
-        verbosity: Optional[int] = 1,
+        verbosity: int = 1,
     ) -> None:
 
         _imports.check()
@@ -432,10 +432,19 @@ class _LightGBMBaseTuner(_BaseTuner):
 
     def run(self) -> None:
         """Perform the hyperparameter-tuning with given parameters."""
-        # Suppress log messages.
-        if self.auto_options["verbosity"] == 0:
-            optuna.logging.disable_default_handler()
-            self.lgbm_params["verbose"] = -1
+        verbosity = self.auto_options["verbosity"]
+        if verbosity > 1:
+            optuna.logging.set_verbosity(optuna.logging.DEBUG)
+            self._use_pbar = True
+        elif verbosity == 1:
+            optuna.logging.set_verbosity(optuna.logging.INFO)
+            self._use_pbar = True
+        elif verbosity == 0:
+            optuna.logging.set_verbosity(optuna.logging.WARNING)
+            self.lgbm_kwargs["verbose_eval"] = False
+            self._use_pbar = False
+        else:
+            optuna.logging.set_verbosity(optuna.logging.FATAL)
             self.lgbm_kwargs["verbose_eval"] = False
             self._use_pbar = False
 
@@ -678,7 +687,7 @@ class LightGBMTuner(_LightGBMBaseTuner):
         study: Optional[optuna.study.Study] = None,
         optuna_callbacks: Optional[List[Callable[[Study, FrozenTrial], None]]] = None,
         model_dir: Optional[str] = None,
-        verbosity: Optional[int] = 1,
+        verbosity: int = 1,
     ) -> None:
 
         super(LightGBMTuner, self).__init__(

--- a/tests/integration_tests/lightgbm_tuner_tests/test_optimize.py
+++ b/tests/integration_tests/lightgbm_tuner_tests/test_optimize.py
@@ -13,7 +13,6 @@ import pytest
 
 import optuna
 from optuna.integration._lightgbm_tuner.optimize import _BaseTuner
-from optuna.integration._lightgbm_tuner.optimize import _LightGBMBaseTuner
 from optuna.integration._lightgbm_tuner.optimize import _OptunaObjective
 from optuna.integration._lightgbm_tuner.optimize import _OptunaObjectiveCV
 from optuna.integration._lightgbm_tuner.optimize import LightGBMTuner


### PR DESCRIPTION
## Motivation
The current `LightGBMTuner` has only two levels of verbosity (i.e., `0` or `1`) while the original LightGBM has four levels (i.e., `<0`, `=0`, `=1`, `>1`. See this [link](https://lightgbm.readthedocs.io/en/latest/Parameters.html#verbosity)).

## Description of the changes
This PR aligns the verbosity level to LightGBM. I follow [this implementation](https://github.com/microsoft/LightGBM/blob/bca2da97284403b1b724a0e2966a76ecbb733fc9/src/io/config.cpp#L234-L242) to determine the logging level.

Changes
- Instead of disabling Optuna's handler, this PR changes the logging level of Optuna.
- The current implementation also changes the value of `verbose` option of LightGBM, this PR keeps the user-given value.
- The current implementation allows `None` in addition to `int` for `verbosity`, this PR only accept `int`.
- The progress bar is enabled if `verbosity >= 1`.