### PR TITLE
Run daily unit tests.

### DIFF
--- a/.github/workflows/tests-integration.yml
+++ b/.github/workflows/tests-integration.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - master
   pull_request: {}
+  schedule:
+    - cron: '0 23 * * SUN-THU'
 
 jobs:
   build:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - master
   pull_request: {}
+  schedule:
+    - cron: '0 23 * * SUN-THU'
 
 jobs:
   build:


### PR DESCRIPTION
## Motivation

It's possible to detect unit test failures due to external factors, such as new releases of depending libraries, faster. Currently, we cannot really detect such failures until for instance a PR is updated to trigger CircleCI/GitHub Actions unit tets.

_Follow-up to https://github.com/optuna/optuna/pull/1352._

## Description of the changes

Adds daily cron triggers to unit tests. The interval is the same as in the stale bot https://github.com/optuna/optuna/blob/master/.github/workflows/stale.yml.