### PR TITLE
Overwrite intermediate values correctly.

### DIFF
--- a/optuna/storages/_rdb/storage.py
+++ b/optuna/storages/_rdb/storage.py
@@ -676,9 +676,9 @@ class RDBStorage(BaseStorage):
                 .all()
             )
             value_dict = {value_model.step: value_model for value_model in value_models}
-            for s, v in value_dict.items():
+            for s, v in intermediate_values.items():
                 if s in value_dict:
-                    value_dict[s] = v
+                    value_dict[s].value = v
                     session.add(value_dict[s])
             trial_model.values.extend(
                 models.TrialValueModel(step=s, value=v)

--- a/tests/storages_tests/rdb_tests/test_storage.py
+++ b/tests/storages_tests/rdb_tests/test_storage.py
@@ -266,6 +266,7 @@ def test_update_trial_second_write() -> None:
         "number": trial_before_update.number,
         "state": TrialState.RUNNING,
         "value": 1.1,
+        "intermediate_values": {3: 2.3, 5: 9.2, 7: 3.3},
         "params": {"paramA": 0.1, "paramB": 1.1, "paramC": 2.3},
         "_distributions": {
             "paramA": UniformDistribution(0, 1),


### PR DESCRIPTION
## Motivation
This PR fixes a bug that intermediate values are not overwritten when RDB backend + CachedStorage.
This violates the storage specification.

## Additional context
This functionality is (currently) never used by users because `trial.report` immediately returns when users try to assign values for with duplicated `step`s.