### PR TITLE
Overwrite parameters correctly.

### DIFF
--- a/optuna/storages/_rdb/storage.py
+++ b/optuna/storages/_rdb/storage.py
@@ -691,7 +691,14 @@ class RDBStorage(BaseStorage):
                 .filter(models.TrialParamModel.trial_id == trial_id)
                 .all()
             )
-            param_keys = set(param.param_name for param in trial_param)
+            trial_param_dict = {attr.param_name: attr for attr in trial_param}
+            for name, v in params.items():
+                if name in trial_param_dict:
+                    trial_param_dict[name].distribution_json = distributions.distribution_to_json(
+                        distributions_[name]
+                    )
+                    trial_param_dict[name].param_value = v
+                    session.add(trial_param_dict[name])
             trial_model.params.extend(
                 models.TrialParamModel(
                     param_name=param_name,
@@ -701,7 +708,7 @@ class RDBStorage(BaseStorage):
                     ),
                 )
                 for param_name, param_value in params.items()
-                if param_name not in param_keys
+                if param_name not in trial_param_dict
             )
         session.add(trial_model)
         self._commit(session)

--- a/tests/storages_tests/rdb_tests/test_storage.py
+++ b/tests/storages_tests/rdb_tests/test_storage.py
@@ -266,7 +266,7 @@ def test_update_trial_second_write() -> None:
         "number": trial_before_update.number,
         "state": TrialState.RUNNING,
         "value": 1.1,
-        "params": {"paramA": 0.1, "paramB": 1.1, "paramC": 2.3},
+        "params": {"paramA": 0.2, "paramB": 1.1, "paramC": 2.3},
         "_distributions": {
             "paramA": UniformDistribution(0, 1),
             "paramB": UniformDistribution(0, 2),


### PR DESCRIPTION
## Motivation
This PR fixes the storage spec violation that `_CachedStorage` + `RDBStorage` does not overwrite parameters. Background of the spec: #1308.

## Additional context
This functionality is (currently) never used by users since `trial.suggest` immediately returns when already-suggested keys are passed to the method.
