### PR TITLE
Remove version restriction of `allennlp`.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,7 @@ def get_extras_require() -> Dict[str, List[str]]:
         ]
         + (["stable-baselines3>=0.7.0"] if (3, 5) < sys.version_info[:2] else [])
         + (
-            ["allennlp<1", "fastai<2", "pytorch_lightning>=0.7.1"]
+            ["allennlp", "fastai<2", "pytorch_lightning>=0.7.1"]
             if (3, 5) < sys.version_info[:2] < (3, 8)
             else []
         )
@@ -129,7 +129,7 @@ def get_extras_require() -> Dict[str, List[str]]:
             "xgboost",
         ]
         + (
-            ["allennlp<1", "fastai<2", "pytorch_lightning>=0.7.1"]
+            ["allennlp", "fastai<2", "pytorch_lightning>=0.7.1"]
             if (3, 5) < sys.version_info[:2] < (3, 8)
             else []
         )
@@ -166,7 +166,7 @@ def get_extras_require() -> Dict[str, List[str]]:
             "xgboost",
         ]
         + (
-            ["allennlp<1", "fastai<2", "pytorch-lightning>=0.7.1"]
+            ["allennlp", "fastai<2", "pytorch-lightning>=0.7.1"]
             if (3, 5) < sys.version_info[:2] < (3, 8)
             else []
         )

--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,7 @@ def get_extras_require() -> Dict[str, List[str]]:
         ]
         + (["stable-baselines3>=0.7.0"] if (3, 5) < sys.version_info[:2] else [])
         + (
-            ["allennlp", "fastai<2", "pytorch_lightning>=0.7.1"]
+            ["allennlp<1", "fastai<2", "pytorch_lightning>=0.7.1"]
             if (3, 5) < sys.version_info[:2] < (3, 8)
             else []
         )


### PR DESCRIPTION
## Motivation
Currently, `setup.py` does not allow AllenNLP 1.0.0, but `AllenNLPExecutor` works with 1.0.0 (see CI of https://github.com/optuna/optuna/pull/1399).

## Description of the changes
This PR simply removes the version restriction of `allennlp`.

@himkt I'm sorry for delayed review of https://github.com/optuna/optuna/pull/1399, but I'd like to pick-up the change about AllenNLP version for v2.0.0. If you have comments about it, please let me know.