### PR TITLE
Always cast choices into tuple in `CategoricalDistribution`.

### DIFF
--- a/optuna/distributions.py
+++ b/optuna/distributions.py
@@ -430,7 +430,7 @@ class CategoricalDistribution(BaseDistribution):
                 )
                 warnings.warn(message)
 
-        self.choices = choices
+        self.choices = tuple(choices)
 
     def to_external_repr(self, param_value_in_internal_repr):
         # type: (float) -> CategoricalChoiceType

--- a/optuna/trial/_fixed.py
+++ b/optuna/trial/_fixed.py
@@ -124,7 +124,6 @@ class FixedTrial(BaseTrial):
     def suggest_categorical(self, name, choices):
         # type: (str, Sequence[CategoricalChoiceType]) -> CategoricalChoiceType
 
-        choices = tuple(choices)
         return self._suggest(name, CategoricalDistribution(choices=choices))
 
     def _suggest(self, name, distribution):

--- a/optuna/trial/_trial.py
+++ b/optuna/trial/_trial.py
@@ -483,9 +483,6 @@ class Trial(BaseTrial):
         Returns:
             A suggested value.
         """
-
-        choices = tuple(choices)
-
         # There is no need to call self._check_distribution because
         # CategoricalDistribution does not support dynamic value space.
 

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -19,6 +19,7 @@ EXAMPLE_DISTRIBUTIONS = {
     "iu": distributions.IntUniformDistribution(low=1, high=9, step=2),
     "c1": distributions.CategoricalDistribution(choices=(2.71, -float("inf"))),
     "c2": distributions.CategoricalDistribution(choices=("Roppongi", "Azabu")),
+    "c3": distributions.CategoricalDistribution(choices=["Roppongi", "Azabu"]),
     "ilu": distributions.IntLogUniformDistribution(low=2, high=12, step=2),
 }  # type: Dict[str, Any]
 
@@ -30,6 +31,7 @@ EXAMPLE_JSONS = {
     "iu": '{"name": "IntUniformDistribution", "attributes": {"low": 1, "high": 9, "step": 2}}',
     "c1": '{"name": "CategoricalDistribution", "attributes": {"choices": [2.71, -Infinity]}}',
     "c2": '{"name": "CategoricalDistribution", "attributes": {"choices": ["Roppongi", "Azabu"]}}',
+    "c3": '{"name": "CategoricalDistribution", "attributes": {"choices": ["Roppongi", "Azabu"]}}',
     "ilu": '{"name": "IntLogUniformDistribution", '
     '"attributes": {"low": 2, "high": 12, "step": 2}}',
 }
@@ -390,3 +392,12 @@ def test_int_log_uniform_distribution_deprecation():
     with pytest.warns(FutureWarning):
         d.step = 2
         assert d.step == 2
+
+
+def test_categorical_distribution_different_sequence_types():
+    # type: () -> None
+
+    c1 = distributions.CategoricalDistribution(choices=("Roppongi", "Azabu"))
+    c2 = distributions.CategoricalDistribution(choices=["Roppongi", "Azabu"])
+
+    assert c1 == c2


### PR DESCRIPTION
## Motivation

This PR fixes a buggy behavior of comparisons between `CategoricalDistribution`.
Additionally, fix a bug that some categorical distributions are not hashable.
Note, distributions should be hashable according to `tests/test_distributions.py`.

## Expected Behavior and master's behavior

code:
```python
from optuna.distributions import CategoricalDistribution, json_to_distribution, distribution_to_json, check_distribution_compatibility


print(CategoricalDistribution((1, 2, 3)) == CategoricalDistribution((1, 2, 3)))
print(CategoricalDistribution([1, 2, 3]) == CategoricalDistribution((1, 2, 3)))
print(json_to_distribution(distribution_to_json(CategoricalDistribution((1, 2, 3)))) == CategoricalDistribution((1, 2, 3)))
print(json_to_distribution(distribution_to_json(CategoricalDistribution([1, 2, 3]))) == CategoricalDistribution([1, 2, 3]))
print(json_to_distribution(distribution_to_json(CategoricalDistribution([1, 2, 3]))) == CategoricalDistribution((1, 2, 3)))
try:
    check_distribution_compatibility(CategoricalDistribution([1, 2, 3]), CategoricalDistribution((1, 2, 3)))
except ValueError:
    print("error")
else:
    print("no error")
try:
    hash(CategoricalDistribution([1, 2, 3]))
except TypeError:
    print("error")
else:
    print("no error")
```

Expected (and this PR's) output:
```
True
True
True
True
True
no error
no error
```

Master's output:
```
True
False
True
False
True
error
error
```

## Description of changes

There'll be two methods to address this issue. First is changing type annotation of `CategoricalDistribution` and second is always casting `choices` of `CategoricalDistribution` to tuple. This PR took the latter approach. Given that `CategoricalDistribution`s are frequently instantiated in `tests/`, I think the latter approach is more convenient.
