### PR TITLE
Temporarily skip `allennlp_jsonnet.py` example in CI.

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -35,12 +35,13 @@ jobs:
         pip install --progress-bar off $(ls dist/*.tar.gz)[example] -f https://download.pytorch.org/whl/torch_stable.html
     - name: Run examples
       run: |
+        # TODO(hvy): Stop ignoring allennlp_jsonnet.py when https://github.com/optuna/optuna/issues/1526 is resolved.
         if [ ${{ matrix.python-version }} = 3.5 ]; then
-          IGNORES='chainermn_.*|pytorch_lightning.*|fastai_.*|allennlp_.*|catalyst_.*|sb3_.*'
+          IGNORES='chainermn_.*|pytorch_lightning.*|fastai_.*|allennlp_.*|catalyst_.*|sb3_.*|allennlp_jsonnet.py'
         elif [ ${{ matrix.python-version }} = 3.8 ]; then
-          IGNORES='chainermn_.*|dask_ml_.*|keras_.*|tensorboard_.*|tensorflow_.*|tfkeras_.*|fastai_.*|allennlp_.*'
+          IGNORES='chainermn_.*|dask_ml_.*|keras_.*|tensorboard_.*|tensorflow_.*|tfkeras_.*|fastai_.*|allennlp_.*|allennlp_jsonnet.py'
         else
-          IGNORES='chainermn_.*'
+          IGNORES='chainermn_.*|allennlp_jsonnet.py'
         fi
 
         for file in `find examples -name '*.py' -not -name '*_distributed.py' | grep -vE "$IGNORES"`


### PR DESCRIPTION
## Motivation

See https://github.com/optuna/optuna/issues/1526.

## Description of the changes

Temporarily skips the failing AllenNLP example in our CI. Note that this example runs fine locally.