### PR TITLE
Match the order of definition in `trial`

### DIFF
--- a/optuna/trial/_fixed.py
+++ b/optuna/trial/_fixed.py
@@ -126,6 +126,25 @@ class FixedTrial(BaseTrial):
 
         return self._suggest(name, CategoricalDistribution(choices=choices))
 
+    def report(self, value, step):
+        # type: (float, int) -> None
+
+        pass
+
+    def should_prune(self) -> bool:
+
+        return False
+
+    def set_user_attr(self, key, value):
+        # type: (str, Any) -> None
+
+        self._user_attrs[key] = value
+
+    def set_system_attr(self, key, value):
+        # type: (str, Any) -> None
+
+        self._system_attrs[key] = value
+
     def _suggest(self, name, distribution):
         # type: (str, BaseDistribution) -> Any
 
@@ -150,25 +169,6 @@ class FixedTrial(BaseTrial):
         self._distributions[name] = distribution
 
         return value
-
-    def report(self, value, step):
-        # type: (float, int) -> None
-
-        pass
-
-    def should_prune(self) -> bool:
-
-        return False
-
-    def set_user_attr(self, key, value):
-        # type: (str, Any) -> None
-
-        self._user_attrs[key] = value
-
-    def set_system_attr(self, key, value):
-        # type: (str, Any) -> None
-
-        self._system_attrs[key] = value
 
     @property
     def params(self):

--- a/optuna/trial/_trial.py
+++ b/optuna/trial/_trial.py
@@ -743,17 +743,6 @@ class Trial(BaseTrial):
             )
 
     @property
-    def number(self):
-        # type: () -> int
-        """Return trial's number which is consecutive and unique in a study.
-
-        Returns:
-            A trial number.
-        """
-
-        return self.storage.get_trial_number_from_id(self._trial_id)
-
-    @property
     def params(self):
         # type: () -> Dict[str, Any]
         """Return parameters to be optimized.
@@ -806,3 +795,14 @@ class Trial(BaseTrial):
             Datetime where the :class:`~optuna.trial.Trial` started.
         """
         return self.storage.get_trial(self._trial_id).datetime_start
+
+    @property
+    def number(self):
+        # type: () -> int
+        """Return trial's number which is consecutive and unique in a study.
+
+        Returns:
+            A trial number.
+        """
+
+        return self.storage.get_trial_number_from_id(self._trial_id)


### PR DESCRIPTION
<!-- Thank you for creating a pull request! -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

The order of definition of functions is slightly different between `_fixed.py` and `_trial.py` as pointed by https://github.com/optuna/optuna/pull/1503#discussion_r454770915. The order consistency is supposed to be important for contributors.

## Description of the changes
<!-- Describe the changes in this PR. -->

Put the definition of `_suggest` in `_fixed.py` after the definitions of public function.
