### PR TITLE
Fix link to the definition of `StudySummary`

### DIFF
--- a/docs/source/tutorial/attributes.rst
+++ b/docs/source/tutorial/attributes.rst
@@ -27,7 +27,7 @@ We can access annotated attributes with :attr:`~optuna.study.Study.user_attr` pr
 
     study.user_attrs  # {'contributors': ['Akiba', 'Sano'], 'dataset': 'MNIST'}
 
-:class:`~optuna.struct.StudySummary` object, which can be retrieved by
+:class:`~optuna.study.StudySummary` object, which can be retrieved by
 :func:`~optuna.study.get_all_study_summaries`, also contains user-defined attributes.
 
 .. code-block:: python


### PR DESCRIPTION
<!-- Thank you for creating a pull request! -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

The current link is broken due to the typo (`struct.StudySummary` instead `structs.StudySummary`) and `structs.StudySummary` is deprecated now.

## Description of the changes
<!-- Describe the changes in this PR. -->

This PR replaces it with ``study.StudySummary``.