### PR TITLE
Reduce search space for AllenNLP example.

### DIFF
--- a/examples/allennlp/allennlp_simple.py
+++ b/examples/allennlp/allennlp_simple.py
@@ -40,7 +40,7 @@ from subsample_dataset_reader import SubsampleDatasetReader  # NOQA
 
 DEVICE = -1  # If you want to use GPU, use DEVICE = 0.
 N_TRAIN_DATA_SIZE = 2000
-N_VALID_DATA_SIZE = 1000
+N_VALIDATION_DATA_SIZE = 1000
 MODEL_DIR = os.path.join(os.getcwd(), "result")
 TARGET_METRIC = "accuracy"
 
@@ -53,7 +53,7 @@ def prepare_data():
         token_indexers={"tokens": indexer},
         tokenizer=tokenizer,
         train_data_size=N_TRAIN_DATA_SIZE,
-        valid_data_size=N_VALID_DATA_SIZE,
+        validation_data_size=N_VALIDATION_DATA_SIZE,
     )
     train_dataset = reader.read(
         "https://s3-us-west-2.amazonaws.com/allennlp/datasets/imdb/train.jsonl"

--- a/examples/allennlp/allennlp_simple.py
+++ b/examples/allennlp/allennlp_simple.py
@@ -5,17 +5,6 @@ This script is based on the example of allentune (https://github.com/allenai/all
 In this example, we optimize the validation accuracy of sentiment classification using AllenNLP.
 Since it is too time-consuming to use the entire dataset, we here use a small subset of it.
 
-We have the following two ways to execute this example:
-
-(1) Execute this code directly.
-    $ python allennlp_simple.py
-
-
-(2) Execute through CLI.
-    $ STUDY_NAME=`optuna create-study --direction maximize --storage sqlite:///example.db`
-    $ optuna study optimize allennlp_simple.py objective --n-trials=100 --study-name $STUDY_NAME \
-      --storage sqlite:///example.db
-
 """
 
 import os

--- a/examples/allennlp/allennlp_simple.py
+++ b/examples/allennlp/allennlp_simple.py
@@ -1,6 +1,6 @@
 """
 Optuna example that optimizes a classifier configuration for IMDB movie review dataset.
-This script is based on the example of allentune (https://github.com/allenai/allentune).
+This script is based on the example of AllenTune (https://github.com/allenai/allentune).
 
 In this example, we optimize the validation accuracy of sentiment classification using AllenNLP.
 Since it is too time-consuming to use the entire dataset, we here use a small subset of it.

--- a/examples/allennlp/allennlp_simple.py
+++ b/examples/allennlp/allennlp_simple.py
@@ -22,6 +22,7 @@ import os
 import pkg_resources
 import random
 import shutil
+import sys
 
 import allennlp
 import allennlp.data
@@ -33,38 +34,33 @@ import torch
 import optuna
 from optuna.integration import AllenNLPPruningCallback
 
+sys.path.append(os.path.dirname(os.path.abspath(__file__)))
+from subsample_dataset_reader import SubsampledDatasetReader  # NOQA
+
 
 DEVICE = -1  # If you want to use GPU, use DEVICE = 0.
-MAX_DATA_SIZE = 3000
+N_TRAIN_DATA_SIZE = 2000
+N_VALID_DATA_SIZE = 1000
 MODEL_DIR = os.path.join(os.getcwd(), "result")
 TARGET_METRIC = "accuracy"
 
 
-class SubsampledDatasetReader(allennlp.data.dataset_readers.TextClassificationJsonReader):
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-
-    def _read(self, datapath):
-        data = list(super()._read(datapath))
-        random.shuffle(data)
-        yield from data[:MAX_DATA_SIZE]
-
-
 def prepare_data():
-    glove_indexer = allennlp.data.token_indexers.SingleIdTokenIndexer(lowercase_tokens=True)
+    indexer = allennlp.data.token_indexers.SingleIdTokenIndexer(lowercase_tokens=True)
     tokenizer = allennlp.data.tokenizers.whitespace_tokenizer.WhitespaceTokenizer()
 
     reader = SubsampledDatasetReader(
-        token_indexers={"tokens": glove_indexer}, tokenizer=tokenizer,
+        token_indexers={"tokens": indexer},
+        tokenizer=tokenizer,
+        train_data_size=N_TRAIN_DATA_SIZE,
+        valid_data_size=N_VALID_DATA_SIZE,
     )
     train_dataset = reader.read(
         "https://s3-us-west-2.amazonaws.com/allennlp/datasets/imdb/train.jsonl"
     )
-
     valid_dataset = reader.read(
         "https://s3-us-west-2.amazonaws.com/allennlp/datasets/imdb/dev.jsonl"
     )
-
     vocab = allennlp.data.Vocabulary.from_instances(train_dataset)
     train_dataset.index_with(vocab)
     valid_dataset.index_with(vocab)
@@ -73,21 +69,22 @@ def prepare_data():
 
 def create_model(vocab, trial):
     dropout = trial.suggest_float("dropout", 0, 0.5)
-    output_dim = trial.suggest_int("output_dim", 16, 128)
-    max_filter_size = trial.suggest_int("max_filter_size", 3, 6)
-    num_filters = trial.suggest_int("num_filters", 16, 128)
-    encoder = allennlp.modules.seq2vec_encoders.CnnEncoder(
-        ngram_filter_sizes=range(1, max_filter_size),
-        num_filters=num_filters,
-        embedding_dim=50,
-        output_dim=output_dim,
-    )
+    embedding_dim = trial.suggest_int("embedding_dim", 16, 128)
+    output_dim = trial.suggest_int("output_dim", 32, 128)
+    max_filter_size = trial.suggest_int("max_filter_size", 3, 4)
+    num_filters = trial.suggest_int("num_filters", 32, 128)
 
     embedding = allennlp.modules.Embedding(
-        embedding_dim=50,
+        embedding_dim=embedding_dim,
         trainable=True,
-        pretrained_file="https://s3-us-west-2.amazonaws.com/allennlp/datasets/glove/glove.6B.50d.txt.gz",  # NOQA
         vocab=vocab,
+    )
+
+    encoder = allennlp.modules.seq2vec_encoders.CnnEncoder(
+        ngram_filter_sizes=range(2, max_filter_size),
+        num_filters=num_filters,
+        embedding_dim=embedding_dim,
+        output_dim=output_dim,
     )
 
     embedder = allennlp.modules.text_field_embedders.BasicTextFieldEmbedder({"tokens": embedding})
@@ -105,11 +102,11 @@ def objective(trial):
     if DEVICE > -1:
         model.to(torch.device("cuda:{}".format(DEVICE)))
 
-    lr = trial.suggest_float("lr", 1e-5, 1e-1, log=True)
+    lr = trial.suggest_float("lr", 1e-2, 1e-1, log=True)
     optimizer = torch.optim.SGD(model.parameters(), lr=lr)
 
     data_loader = torch.utils.data.DataLoader(
-        train_dataset, batch_size=64, collate_fn=allennlp.data.allennlp_collate
+        train_dataset, batch_size=16, collate_fn=allennlp.data.allennlp_collate
     )
     validation_data_loader = torch.utils.data.DataLoader(
         valid_dataset, batch_size=64, collate_fn=allennlp.data.allennlp_collate
@@ -123,7 +120,7 @@ def objective(trial):
         validation_data_loader=validation_data_loader,
         validation_metric="+" + TARGET_METRIC,
         patience=None,  # `patience=None` since it could conflict with AllenNLPPruningCallback
-        num_epochs=50,
+        num_epochs=30,
         cuda_device=DEVICE,
         serialization_dir=serialization_dir,
         epoch_callbacks=[AllenNLPPruningCallback(trial, "validation_" + TARGET_METRIC)],

--- a/examples/allennlp/allennlp_simple.py
+++ b/examples/allennlp/allennlp_simple.py
@@ -35,7 +35,7 @@ import optuna
 from optuna.integration import AllenNLPPruningCallback
 
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
-from subsample_dataset_reader import SubsampledDatasetReader  # NOQA
+from subsample_dataset_reader import SubsampleDatasetReader  # NOQA
 
 
 DEVICE = -1  # If you want to use GPU, use DEVICE = 0.
@@ -49,7 +49,7 @@ def prepare_data():
     indexer = allennlp.data.token_indexers.SingleIdTokenIndexer(lowercase_tokens=True)
     tokenizer = allennlp.data.tokenizers.whitespace_tokenizer.WhitespaceTokenizer()
 
-    reader = SubsampledDatasetReader(
+    reader = SubsampleDatasetReader(
         token_indexers={"tokens": indexer},
         tokenizer=tokenizer,
         train_data_size=N_TRAIN_DATA_SIZE,
@@ -75,9 +75,7 @@ def create_model(vocab, trial):
     num_filters = trial.suggest_int("num_filters", 32, 128)
 
     embedding = allennlp.modules.Embedding(
-        embedding_dim=embedding_dim,
-        trainable=True,
-        vocab=vocab,
+        embedding_dim=embedding_dim, trainable=True, vocab=vocab,
     )
 
     encoder = allennlp.modules.seq2vec_encoders.CnnEncoder(

--- a/examples/allennlp/allennlp_simple.py
+++ b/examples/allennlp/allennlp_simple.py
@@ -89,7 +89,7 @@ def objective(trial):
     if DEVICE > -1:
         model.to(torch.device("cuda:{}".format(DEVICE)))
 
-    lr = trial.suggest_float("lr", 1e-2, 1e-1, log=True)
+    lr = trial.suggest_float("lr", 1e-3, 1e-1, log=True)
     optimizer = torch.optim.SGD(model.parameters(), lr=lr)
 
     data_loader = torch.utils.data.DataLoader(

--- a/examples/allennlp/subsample_dataset_reader.py
+++ b/examples/allennlp/subsample_dataset_reader.py
@@ -6,7 +6,7 @@ from sklearn.model_selection import train_test_split
 
 
 @DatasetReader.register("subsample")
-class SubsampledDatasetReader(allennlp.data.dataset_readers.TextClassificationJsonReader):
+class SubsampleDatasetReader(allennlp.data.dataset_readers.TextClassificationJsonReader):
     def __init__(self, train_data_size, validation_data_size, **kwargs):
         super().__init__(**kwargs)
         self.train_data_size = train_data_size

--- a/examples/allennlp/subsample_dataset_reader.py
+++ b/examples/allennlp/subsample_dataset_reader.py
@@ -1,3 +1,4 @@
+import itertools
 import random
 
 import allennlp
@@ -13,14 +14,9 @@ class SubsampleDatasetReader(allennlp.data.dataset_readers.TextClassificationJso
         self.validation_data_size = validation_data_size
 
     def _read(self, datapath):
-        data = list(super()._read(datapath))
-        labels = list(map(lambda instance: instance.get("label").label, data))
-
         if datapath.endswith("train.jsonl"):
-            train_size = self.train_data_size
+            data_size = self.train_data_size
         else:
-            train_size = self.validation_data_size
+            data_size = self.validation_data_size
 
-        _data, _ = train_test_split(data, stratify=labels, train_size=train_size)
-        random.shuffle(_data)
-        yield from _data
+        yield from itertools.islice(super()._read(datapath), data_size)

--- a/examples/allennlp/subsample_dataset_reader.py
+++ b/examples/allennlp/subsample_dataset_reader.py
@@ -1,9 +1,7 @@
 import itertools
-import random
 
 import allennlp
 from allennlp.data.dataset_readers.dataset_reader import DatasetReader
-from sklearn.model_selection import train_test_split
 
 
 @DatasetReader.register("subsample")

--- a/examples/allennlp/subsample_dataset_reader.py
+++ b/examples/allennlp/subsample_dataset_reader.py
@@ -6,22 +6,20 @@ from sklearn.model_selection import train_test_split
 
 
 @DatasetReader.register("subsample")
-class SubsampleDatasetReader(allennlp.data.dataset_readers.TextClassificationJsonReader):
+class SubsampledDatasetReader(allennlp.data.dataset_readers.TextClassificationJsonReader):
     def __init__(self, train_data_size, validation_data_size, **kwargs):
         super().__init__(**kwargs)
         self.train_data_size = train_data_size
-        self.valid_data_size = valid_data_size
+        self.validation_data_size = validation_data_size
 
     def _read(self, datapath):
         data = list(super()._read(datapath))
         labels = list(map(lambda instance: instance.get("label").label, data))
 
         if datapath.endswith("train.jsonl"):
-            print("train file")
             train_size = self.train_data_size
         else:
-            print("valid file")
-            train_size = self.valid_data_size
+            train_size = self.validation_data_size
 
         _data, _ = train_test_split(data, stratify=labels, train_size=train_size)
         random.shuffle(_data)

--- a/examples/allennlp/subsample_dataset_reader.py
+++ b/examples/allennlp/subsample_dataset_reader.py
@@ -1,0 +1,28 @@
+import random
+
+import allennlp
+from allennlp.data.dataset_readers.dataset_reader import DatasetReader
+from sklearn.model_selection import train_test_split
+
+
+@DatasetReader.register("subsample")
+class SubsampleDatasetReader(allennlp.data.dataset_readers.TextClassificationJsonReader):
+    def __init__(self, train_data_size, validation_data_size, **kwargs):
+        super().__init__(**kwargs)
+        self.train_data_size = train_data_size
+        self.valid_data_size = valid_data_size
+
+    def _read(self, datapath):
+        data = list(super()._read(datapath))
+        labels = list(map(lambda instance: instance.get("label").label, data))
+
+        if datapath.endswith("train.jsonl"):
+            print("train file")
+            train_size = self.train_data_size
+        else:
+            print("valid file")
+            train_size = self.valid_data_size
+
+        _data, _ = train_test_split(data, stratify=labels, train_size=train_size)
+        random.shuffle(_data)
+        yield from _data


### PR DESCRIPTION
## Motivation
Current `allennlp_simple.py` may be computationally extensive and it sometimes causes a timeout.
https://github.com/optuna/optuna/actions/runs/175854473

## Description of the changes
In this PR, I reduce the hyperparameter search space for the model.
Additionally, I extracted the dataset reader from the script and created the module because I'll also use it in `allennlp_jsonnet.py`.

I tested this new example on GitHub Actions to confirm that it reduced the execution time for each trial.
https://github.com/himkt/optuna/runs/894041267