### PR TITLE
Remove `allennlp.common.params.infer_and_cast` from AllenNLP integrations.

### DIFF
--- a/examples/allennlp/classifier.jsonnet
+++ b/examples/allennlp/classifier.jsonnet
@@ -2,7 +2,7 @@
 local TRAIN_PATH = 'https://s3-us-west-2.amazonaws.com/allennlp/datasets/imdb/dev.jsonl';
 local VALIDATION_PATH = 'https://s3-us-west-2.amazonaws.com/allennlp/datasets/imdb/test.jsonl';
 
-// std.parseJson for floating point
+// std.parseJson for floating point.
 local DROPOUT = std.parseJson(std.extVar('DROPOUT'));
 local EMBEDDING_DIM = std.parseInt(std.extVar('EMBEDDING_DIM'));
 local CNN_FIELDS(max_filter_size, embedding_dim, hidden_size, num_filters) = {

--- a/examples/allennlp/classifier.jsonnet
+++ b/examples/allennlp/classifier.jsonnet
@@ -1,8 +1,10 @@
 // Use dev.jsonl for training to reduce computation time.
 local TRAIN_PATH = 'https://s3-us-west-2.amazonaws.com/allennlp/datasets/imdb/dev.jsonl';
 local VALIDATION_PATH = 'https://s3-us-west-2.amazonaws.com/allennlp/datasets/imdb/test.jsonl';
-local DROPOUT = std.extVar('DROPOUT');
-local EMBEDDING_DIM = std.extVar('EMBEDDING_DIM');
+
+// std.parseJson for floating point
+local DROPOUT = std.parseJson(std.extVar('DROPOUT'));
+local EMBEDDING_DIM = std.parseInt(std.extVar('EMBEDDING_DIM'));
 local CNN_FIELDS(max_filter_size, embedding_dim, hidden_size, num_filters) = {
   type: 'cnn',
   ngram_filter_sizes: std.range(1, max_filter_size),
@@ -16,8 +18,8 @@ local CNN_FIELDS(max_filter_size, embedding_dim, hidden_size, num_filters) = {
 local ENCODER = CNN_FIELDS(
   std.parseInt(std.extVar('MAX_FILTER_SIZE')),
   EMBEDDING_DIM,
-  std.extVar('HIDDEN_SIZE'),
-  std.extVar('NUM_FILTERS')
+  std.parseInt(std.extVar('HIDDEN_SIZE')),
+  std.parseInt(std.extVar('NUM_FILTERS'))
 );
 
 

--- a/optuna/integration/allennlp.py
+++ b/optuna/integration/allennlp.py
@@ -42,7 +42,6 @@ def dump_best_config(input_config_file: str, output_config_file: str, study: opt
     for key, value in best_params.items():
         best_params[key] = str(value)
     best_config = json.loads(_jsonnet.evaluate_file(input_config_file, ext_vars=best_params))
-    best_config = allennlp.common.params.infer_and_cast(best_config)
 
     with open(output_config_file, "w") as f:
         json.dump(best_config, f, indent=4)
@@ -56,8 +55,11 @@ class AllenNLPExecutor(object):
     The interface may change without prior notice to correspond to the update.
 
     See the examples of `objective function <https://github.com/optuna/optuna/blob/
-    master/examples/allennlp/allennlp_jsonnet.py>`_ and
-    `config file <https://github.com/optuna/optuna/blob/master/
+    master/examples/allennlp/allennlp_jsonnet.py>`_.
+
+    From Optuna v2.1.0, user has to cast their parameters by using methods in Jsonnet.
+    Call ``std.parseInt`` for integer, or ``std.parseJson`` for floating point.
+    Please see the example of `config file <https://github.com/optuna/optuna/blob/master/
     examples/allennlp/classifier.jsonnet>`_.
 
     .. note::
@@ -112,19 +114,14 @@ class AllenNLPExecutor(object):
     def _build_params(self) -> Dict[str, Any]:
         """Create a dict of params for AllenNLP.
 
-        _build_params is based on allentune's train_func.
+        _build_params is based on allentune's ``train_func``.
         For more detail, please refer to
         https://github.com/allenai/allentune/blob/master/allentune/modules/allennlp_runner.py#L34-L65
 
         """
         params = self._environment_variables()
         params.update({key: str(value) for key, value in self._params.items()})
-
-        allennlp_params = json.loads(_jsonnet.evaluate_file(self._config_file, ext_vars=params))
-        # allennlp_params contains a list of string or string as value values.
-        # Some params couldn't be casted correctly and
-        # infer_and_cast converts them into desired values.
-        return allennlp.common.params.infer_and_cast(allennlp_params)
+        return json.loads(_jsonnet.evaluate_file(self._config_file, ext_vars=params))
 
     @staticmethod
     def _is_encodable(value: str) -> bool:

--- a/optuna/integration/allennlp.py
+++ b/optuna/integration/allennlp.py
@@ -57,9 +57,9 @@ class AllenNLPExecutor(object):
     See the examples of `objective function <https://github.com/optuna/optuna/blob/
     master/examples/allennlp/allennlp_jsonnet.py>`_.
 
-    From Optuna v2.1.0, user has to cast their parameters by using methods in Jsonnet.
+    From Optuna v2.1.0, users have to cast their parameters by using methods in Jsonnet.
     Call ``std.parseInt`` for integer, or ``std.parseJson`` for floating point.
-    Please see the example of `config file <https://github.com/optuna/optuna/blob/master/
+    Please see the `example configuration <https://github.com/optuna/optuna/blob/master/
     examples/allennlp/classifier.jsonnet>`_.
 
     .. note::

--- a/tests/integration_tests/allennlp_tests/example.jsonnet
+++ b/tests/integration_tests/allennlp_tests/example.jsonnet
@@ -1,4 +1,4 @@
-local DROPOUT = std.extVar('DROPOUT');
+local DROPOUT = std.parseJson(std.extVar('DROPOUT'));
 
 
 {

--- a/tests/integration_tests/allennlp_tests/example_with_environment_variables.jsonnet
+++ b/tests/integration_tests/allennlp_tests/example_with_environment_variables.jsonnet
@@ -1,5 +1,5 @@
-local DROPOUT = std.extVar('DROPOUT');
-local LEARNING_RATE = std.extVar('LEARNING_RATE');
+local DROPOUT = std.parseJson(std.extVar('DROPOUT'));
+local LEARNING_RATE = std.parseJson(std.extVar('LEARNING_RATE'));
 
 
 {

--- a/tests/integration_tests/allennlp_tests/example_with_include_package.jsonnet
+++ b/tests/integration_tests/allennlp_tests/example_with_include_package.jsonnet
@@ -1,4 +1,4 @@
-local DROPOUT = std.extVar('DROPOUT');
+local DROPOUT = std.parseJson(std.extVar('DROPOUT'));
 
 
 {

--- a/tests/integration_tests/allennlp_tests/test.jsonnet
+++ b/tests/integration_tests/allennlp_tests/test.jsonnet
@@ -1,7 +1,7 @@
 {
   model: {
-    dropout: '0.1',
+    dropout: 0.1,
     input_size: 100,
-    hidden_size: ['100', '200', '300'],
+    hidden_size: [100, 200, 300],
   },
 }


### PR DESCRIPTION
Related issue: #1535

## Motivation

Current `AllenNLPExecutor` and `dump_best_config` call `allennlp.common.params.infer_and_cast` to cast string literals from environment variables into desired types (in almost case, int or float). By calling `infer_and_cast`, user can define search space in Jsonnet simply by writing `some_parameter: std.extVar('some_parameter')`.

However, it has a drawback; an executor doesn't work with `null` in jsonnet. It would be better to let users cast their parameters in Jsonnet (by using `std.parseInt` for integer and `std.parseJson` for floating-point). See #1535 for details.

## Description of changes

In this PR, I remove `infer_and_cast` from `AllenNLPExecutor` and `dump_best_config` and update a docstring to instruct users to use Jsonnet functionalities for casting parameters.

I also update an example and tests as well.