### PR TITLE
Add `packaging` in install_requires.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ def get_install_requires() -> List[str]:
         "colorlog",
         "joblib",
         "numpy",
+        "packaging",
         "scipy!=1.4.0",
         "sqlalchemy>=1.1.0",
         "tqdm",


### PR DESCRIPTION
<!-- Thank you for creating a pull request! -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

In #1382, [packaging](https://github.com/pypa/packaging) is introduced but it's not listed in `install_requires`.

```console
$ python3.8 -m venv venv
$ source venv/bin/activate
$ pip install -U pip setuptools
...
Successfully installed pip-20.1.1 setuptools-49.2.0
$ pip install git+https://github.com/optuna/optuna.git
...
Successfully installed Mako-1.1.3 MarkupSafe-1.1.1 PrettyTable-0.7.2 PyYAML-5.3.1 alembic-1.4.2 attrs-19.3.0 cliff-3.3.0 cmaes-0.5.1 cmd2-1.2.1 colorama-0.4.3 colorlog-4.2.1 joblib-0.16.0 numpy-1.19.1 optuna-2.0.0 pbr-5.4.5 pyparsing-2.4.7 pyperclip-1.8.0 python-dateutil-2.8.1 python-editor-1.0.4 scipy-1.5.2 six-1.15.0 sqlalchemy-1.3.18 stevedore-3.2.0 tqdm-4.48.0 wcwidth-0.2.5
$ python -c 'from packaging import version'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
ModuleNotFoundError: No module named 'packaging'
```

```python
>>> from optuna.structs import FrozenTrial
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/a14737/sandbox/optuna-istallation/venv/lib/python3.8/site-packages/optuna/structs.py", line 3, in <module>
    from optuna._deprecated import deprecated
  File "/Users/a14737/sandbox/optuna-istallation/venv/lib/python3.8/site-packages/optuna/_deprecated.py", line 3, in <module>
    from packaging import version
ModuleNotFoundError: No module named 'packaging'
```

## Description of the changes
<!-- Describe the changes in this PR. -->
