### PR TITLE
Avoid to sample the value which equals to upper bound

### DIFF
--- a/optuna/integration/cma.py
+++ b/optuna/integration/cma.py
@@ -314,13 +314,13 @@ class _Optimizer(object):
             elif isinstance(dist, DiscreteUniformDistribution):
                 r = dist.high - dist.low
                 lows.append(0 - 0.5 * dist.q)
-                highs.append(r + 0.5 * dist.q - _EPS)
+                highs.append(r + 0.5 * dist.q)
             elif isinstance(dist, IntUniformDistribution):
                 lows.append(dist.low - 0.5 * dist.step)
-                highs.append(dist.high + 0.5 * dist.step - _EPS)
+                highs.append(dist.high + 0.5 * dist.step)
             elif isinstance(dist, IntLogUniformDistribution):
                 lows.append(self._to_cma_params(search_space, param_name, dist.low - 0.5))
-                highs.append(self._to_cma_params(search_space, param_name, dist.high + 0.5) - _EPS)
+                highs.append(self._to_cma_params(search_space, param_name, dist.high + 0.5))
             else:
                 raise NotImplementedError("The distribution {} is not implemented.".format(dist))
 

--- a/optuna/integration/cma.py
+++ b/optuna/integration/cma.py
@@ -38,6 +38,9 @@ _logger = logging.get_logger(__name__)
 # Minimum value of sigma0 to avoid ZeroDivisionError in cma.CMAEvolutionStrategy.
 _MIN_SIGMA0 = 1e-10
 
+# Tiny value that avoids to sample upper bound of the search space.
+_UPPER_BOUND_CAP = 1e-10
+
 
 class PyCmaSampler(BaseSampler):
     """A Sampler using cma library as the backend.
@@ -310,17 +313,17 @@ class _Optimizer(object):
                 highs.append(len(dist.choices) - 0.5)
             elif isinstance(dist, UniformDistribution) or isinstance(dist, LogUniformDistribution):
                 lows.append(self._to_cma_params(search_space, param_name, dist.low))
-                highs.append(self._to_cma_params(search_space, param_name, dist.high))
+                highs.append(self._to_cma_params(search_space, param_name, dist.high) - _UPPER_BOUND_CAP)
             elif isinstance(dist, DiscreteUniformDistribution):
                 r = dist.high - dist.low
                 lows.append(0 - 0.5 * dist.q)
-                highs.append(r + 0.5 * dist.q)
+                highs.append(r + 0.5 * dist.q - _UPPER_BOUND_CAP)
             elif isinstance(dist, IntUniformDistribution):
                 lows.append(dist.low - 0.5 * dist.step)
-                highs.append(dist.high + 0.5 * dist.step)
+                highs.append(dist.high + 0.5 * dist.step - _UPPER_BOUND_CAP)
             elif isinstance(dist, IntLogUniformDistribution):
                 lows.append(self._to_cma_params(search_space, param_name, dist.low - 0.5))
-                highs.append(self._to_cma_params(search_space, param_name, dist.high + 0.5))
+                highs.append(self._to_cma_params(search_space, param_name, dist.high + 0.5 - _UPPER_BOUND_CAP))
             else:
                 raise NotImplementedError("The distribution {} is not implemented.".format(dist))
 

--- a/optuna/samplers/_cmaes.py
+++ b/optuna/samplers/_cmaes.py
@@ -426,13 +426,19 @@ def _get_search_space_bound(
             (
                 optuna.distributions.UniformDistribution,
                 optuna.distributions.LogUniformDistribution,
+            ),
+        ):
+            # These distributions cannot accept the value which equals to the upper bound.
+            bounds.append([_to_cma_param(dist, dist.low), _to_cma_param(dist, dist.high) - _EPS])
+        elif isinstance(
+            dist,
+            (
                 optuna.distributions.DiscreteUniformDistribution,
                 optuna.distributions.IntUniformDistribution,
                 optuna.distributions.IntLogUniformDistribution,
             ),
         ):
-            # Optuna cannot accept the value which equals to upper bound.
-            bounds.append([_to_cma_param(dist, dist.low), _to_cma_param(dist, dist.high) - _EPS])
+            bounds.append([_to_cma_param(dist, dist.low), _to_cma_param(dist, dist.high)])
         else:
             raise NotImplementedError("The distribution {} is not implemented.".format(dist))
     return np.array(bounds, dtype=float)

--- a/optuna/samplers/_cmaes.py
+++ b/optuna/samplers/_cmaes.py
@@ -20,11 +20,7 @@ from optuna.trial import TrialState
 
 _logger = logging.get_logger(__name__)
 
-# Minimum value of sigma0 to avoid ZeroDivisionError.
-_MIN_SIGMA0 = 1e-10
-
-# Tiny value that avoids to sample upper bound of the search space.
-_UPPER_BOUND_CAP = 1e-10
+_EPS = 1e-10
 
 
 class CmaEsSampler(BaseSampler):
@@ -275,7 +271,9 @@ class CmaEsSampler(BaseSampler):
             sigma0 = _initialize_sigma0(search_space)
         else:
             sigma0 = self._sigma0
-        sigma0 = max(sigma0, _MIN_SIGMA0)
+
+        # Avoid ZeroDivisionError in cmaes.
+        sigma0 = max(sigma0, _EPS)
         mean = np.array([self._x0[k] for k in ordered_keys], dtype=float)
         bounds = _get_search_space_bound(ordered_keys, search_space)
         n_dimension = len(ordered_keys)
@@ -434,9 +432,7 @@ def _get_search_space_bound(
             ),
         ):
             # Optuna cannot accept the value which equals to upper bound.
-            bounds.append(
-                [_to_cma_param(dist, dist.low), _to_cma_param(dist, dist.high) - _UPPER_BOUND_CAP]
-            )
+            bounds.append([_to_cma_param(dist, dist.low), _to_cma_param(dist, dist.high) - _EPS])
         else:
             raise NotImplementedError("The distribution {} is not implemented.".format(dist))
     return np.array(bounds, dtype=float)

--- a/optuna/samplers/_cmaes.py
+++ b/optuna/samplers/_cmaes.py
@@ -23,6 +23,9 @@ _logger = logging.get_logger(__name__)
 # Minimum value of sigma0 to avoid ZeroDivisionError.
 _MIN_SIGMA0 = 1e-10
 
+# Tiny value that avoids to sample upper bound of the search space.
+_UPPER_BOUND_CAP = 1e-10
+
 
 class CmaEsSampler(BaseSampler):
     """A Sampler using CMA-ES algorithm.
@@ -430,7 +433,10 @@ def _get_search_space_bound(
                 optuna.distributions.IntLogUniformDistribution,
             ),
         ):
-            bounds.append([_to_cma_param(dist, dist.low), _to_cma_param(dist, dist.high)])
+            # Optuna cannot accept the value which equals to upper bound.
+            bounds.append(
+                [_to_cma_param(dist, dist.low), _to_cma_param(dist, dist.high) - _UPPER_BOUND_CAP]
+            )
         else:
             raise NotImplementedError("The distribution {} is not implemented.".format(dist))
     return np.array(bounds, dtype=float)

--- a/tests/integration_tests/test_cma.py
+++ b/tests/integration_tests/test_cma.py
@@ -174,6 +174,9 @@ class TestOptimizer(object):
     @staticmethod
     def test_init(search_space: Dict[str, BaseDistribution], x0: Dict[str, Any]) -> None:
 
+        # TODO(c-bata): Avoid exact assertion checks
+        eps = 1e-10
+
         with patch("cma.CMAEvolutionStrategy") as mock_obj:
             optuna.integration.cma._Optimizer(
                 search_space, x0, 0.2, None, {"popsize": 5, "seed": 1}
@@ -184,8 +187,16 @@ class TestOptimizer(object):
                 {
                     "BoundaryHandler": cma.BoundTransform,
                     "bounds": [
-                        [-0.5, -1.0, -1.5, -2.0, math.log(1.5), math.log(0.001), -2,],
-                        [1.5, 11.0, 1.5, 4.0, math.log(16.5), math.log(0.1), 2],
+                        [-0.5, -1.0, -1.5, -2.0, math.log(1.5), math.log(0.001), -2],
+                        [
+                            1.5,
+                            11.0 - eps,
+                            1.5 - eps,
+                            4.0 - eps,
+                            math.log(16.5) - eps,
+                            math.log(0.1) - eps,
+                            2 - eps,
+                        ],
                     ],
                     "popsize": 5,
                     "seed": 1,

--- a/tests/integration_tests/test_cma.py
+++ b/tests/integration_tests/test_cma.py
@@ -188,15 +188,7 @@ class TestOptimizer(object):
                     "BoundaryHandler": cma.BoundTransform,
                     "bounds": [
                         [-0.5, -1.0, -1.5, -2.0, math.log(1.5), math.log(0.001), -2],
-                        [
-                            1.5,
-                            11.0 - eps,
-                            1.5 - eps,
-                            4.0 - eps,
-                            math.log(16.5) - eps,
-                            math.log(0.1) - eps,
-                            2 - eps,
-                        ],
+                        [1.5, 11.0, 1.5, 4.0, math.log(16.5), math.log(0.1) - eps, 2 - eps],
                     ],
                     "popsize": 5,
                     "seed": 1,

--- a/tests/samplers_tests/test_cmaes.py
+++ b/tests/samplers_tests/test_cmaes.py
@@ -45,7 +45,7 @@ def test_init_cmaes_opts() -> None:
         _, actual_kwargs = cma_class.call_args
         assert np.array_equal(actual_kwargs["mean"], np.array([0, 0]))
         assert actual_kwargs["sigma"] == 0.1
-        assert np.array_equal(actual_kwargs["bounds"], np.array([(-1, 1), (-1, 1),]))
+        assert np.allclose(actual_kwargs["bounds"], np.array([(-1, 1), (-1, 1)]))
         assert actual_kwargs["seed"] == np.random.RandomState(1).randint(1, 2 ** 32)
         assert actual_kwargs["n_max_resampling"] == 10 * 2
 


### PR DESCRIPTION
<!-- Thank you for creating a pull request! -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

To fix #1557.

## Description of the changes
<!-- Describe the changes in this PR. -->

It is not prohibited to sample the value which equals to upper bound in CyberAgent/cmaes (and pycma). But Optuna's continuous distribution only accepts `[low, high)`. So I cap the upper bound with tiny value to fix the problem which I reported to #1557.