### PR TITLE
Make sampling from trunc-norm efficient in TPE sampler.

### DIFF
--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -389,7 +389,7 @@ class TPESampler(BaseSampler):
         active = np.argmax(self._rng.multinomial(1, weights, size=size), axis=-1)
         trunc_low = (low - mus[active]) / sigmas[active]
         trunc_high = (high - mus[active]) / sigmas[active]
-        samples = np.full(size, fill_value=high + 1.0, dtype=np.float64)
+        samples = np.full((), fill_value=high + 1.0, dtype=np.float64)
         while (samples >= high).any():
             samples = np.where(
                 samples < high,

--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -389,17 +389,20 @@ class TPESampler(BaseSampler):
         active = np.argmax(self._rng.multinomial(1, weights, size=size), axis=-1)
         trunc_low = (low - mus[active]) / sigmas[active]
         trunc_high = (high - mus[active]) / sigmas[active]
-        while True:
-            samples = truncnorm.rvs(
-                trunc_low,
-                trunc_high,
-                size=size,
-                loc=mus[active],
-                scale=sigmas[active],
-                random_state=self._rng,
+        samples = np.ones(size) * (high + 1.0)
+        while (samples >= high).any():
+            samples = np.where(
+                samples < high,
+                samples,
+                truncnorm.rvs(
+                    trunc_low,
+                    trunc_high,
+                    size=size,
+                    loc=mus[active],
+                    scale=sigmas[active],
+                    random_state=self._rng,
+                ),
             )
-            if (samples < high).all():
-                break
 
         if q is None:
             return samples

--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -389,7 +389,7 @@ class TPESampler(BaseSampler):
         active = np.argmax(self._rng.multinomial(1, weights, size=size), axis=-1)
         trunc_low = (low - mus[active]) / sigmas[active]
         trunc_high = (high - mus[active]) / sigmas[active]
-        samples = np.ones(size) * (high + 1.0)
+        samples = np.full(size, fill_value=high + 1.0, dtype=np.float64)
         while (samples >= high).any():
             samples = np.where(
                 samples < high,


### PR DESCRIPTION
## Motivation
This PR makes sampling from truncated normal distribution in TPE sampler efficient.

## Description of the changes
Samples from trunc-norm are resampled only when they violate the range condition.
