### PR TITLE
Unify `InMemoryStorage` and `_CachedStorage`.

### DIFF
--- a/optuna/storages/_cached_storage.py
+++ b/optuna/storages/_cached_storage.py
@@ -209,6 +209,7 @@ class _CachedStorage(BaseStorage):
             with self._lock:
                 study_id, _ = self._trial_id_to_study_id_and_number[trial_id]
                 self._add_trials_to_cache(study_id, [self._backend.get_trial(trial_id)])
+                self._studies[study_id].owned_or_finished_trial_ids.add(trial_id)
         return ret
 
     def set_trial_param(

--- a/optuna/storages/_cached_storage.py
+++ b/optuna/storages/_cached_storage.py
@@ -9,7 +9,7 @@ from typing import Set
 from typing import Tuple
 
 from optuna import distributions
-from optuna.storages._rdb.storage import RDBStorage
+from optuna.storages._base import _BackEnd
 from optuna.storages import BaseStorage
 from optuna.study import StudyDirection
 from optuna.study import StudySummary
@@ -54,7 +54,7 @@ class _CachedStorage(BaseStorage):
             :class:`~optuna.storages.BaseStorage` class instance to wrap.
     """
 
-    def __init__(self, backend: RDBStorage) -> None:
+    def __init__(self, backend: _BackEnd) -> None:
         self._backend = backend
         self._studies = {}  # type: Dict[int, _StudyInfo]
         self._trial_id_to_study_id_and_number = dict()  # type: Dict[int, Tuple[int, int]]

--- a/optuna/storages/_in_memory.py
+++ b/optuna/storages/_in_memory.py
@@ -12,8 +12,8 @@ import uuid
 
 from optuna import distributions  # NOQA
 from optuna.exceptions import DuplicatedStudyError
-from optuna.storages._base import DEFAULT_STUDY_NAME_PREFIX
 from optuna.storages._base import _BackEnd
+from optuna.storages._base import DEFAULT_STUDY_NAME_PREFIX
 from optuna.storages._cached_storage import _CachedStorage
 from optuna.study import StudyDirection
 from optuna.study import StudySummary

--- a/optuna/storages/_rdb/storage.py
+++ b/optuna/storages/_rdb/storage.py
@@ -436,19 +436,6 @@ class RDBStorage(_BackEnd):
     def _create_new_trial(
         self, study_id: int, template_trial: Optional[FrozenTrial] = None
     ) -> FrozenTrial:
-        """Create a new trial and returns its trial_id and a :class:`~optuna.trial.FrozenTrial`.
-
-        Args:
-            study_id:
-                Study id.
-            template_trial:
-                A :class:`~optuna.trial.FrozenTrial` with default values for trial attributes.
-
-        Returns:
-            A :class:`~optuna.trial.FrozenTrial` instance.
-
-        """
-
         # Retry a couple of times. Deadlocks may occur in distributed environments.
         n_retries = 0
         while True:
@@ -565,34 +552,6 @@ class RDBStorage(_BackEnd):
         system_attrs: Optional[Dict[str, Any]] = None,
         datetime_complete: Optional[datetime] = None,
     ) -> bool:
-        """Sync latest trial updates to a database.
-
-        Args:
-            trial_id:
-                Trial id of the trial to update.
-            state:
-                New state. None when there are no changes.
-            value:
-                New value. None when there are no changes.
-            intermediate_values:
-                New intermediate values. None when there are no updates.
-            params:
-                New parameter dictionary. None when there are no updates.
-            distributions_:
-                New parameter distributions. None when there are no updates.
-            user_attrs:
-                New user_attr. None when there are no updates.
-            system_attrs:
-                New system_attr. None when there are no updates.
-            datetime_complete:
-                Completion time of the trial. Set if and only if this method
-                change the state of trial into one of the finished states.
-
-        Returns:
-            True when success.
-
-        """
-
         session = self.scoped_session()
 
         trial_model = (

--- a/optuna/storages/_rdb/storage.py
+++ b/optuna/storages/_rdb/storage.py
@@ -26,7 +26,7 @@ from sqlalchemy.sql import functions
 
 import optuna
 from optuna import distributions
-from optuna.storages._base import BaseStorage
+from optuna.storages._base import _BackEnd
 from optuna.storages._base import DEFAULT_STUDY_NAME_PREFIX
 from optuna.storages._rdb import models
 from optuna.study import StudyDirection
@@ -39,7 +39,7 @@ from optuna import version
 _logger = optuna.logging.get_logger(__name__)
 
 
-class RDBStorage(BaseStorage):
+class RDBStorage(_BackEnd):
     """Storage class for RDB backend.
 
     Note that library users can instantiate this class, but the attributes

--- a/tests/multi_objective/test_study.py
+++ b/tests/multi_objective/test_study.py
@@ -177,8 +177,8 @@ def test_log_completed_trial_skip_storage_access() -> None:
 
     with patch.object(storage, "get_trial", wraps=storage.get_trial) as mock_object:
         optuna.multi_objective.study._log_completed_trial(study, trial, 1.0)
-        # Trial.params and MultiObjectiveTrial._get_values access storage.
-        assert mock_object.call_count == 2
+        # Tria.number, Trial.params, and MultiObjectiveTrial._get_values access storage.
+        assert mock_object.call_count == 3
 
     optuna.logging.set_verbosity(optuna.logging.WARNING)
     with patch.object(storage, "get_trial", wraps=storage.get_trial) as mock_object:

--- a/tests/multi_objective/test_study.py
+++ b/tests/multi_objective/test_study.py
@@ -188,4 +188,4 @@ def test_log_completed_trial_skip_storage_access() -> None:
     optuna.logging.set_verbosity(optuna.logging.DEBUG)
     with patch.object(storage, "get_trial", wraps=storage.get_trial) as mock_object:
         optuna.multi_objective.study._log_completed_trial(study, trial, 1.0)
-        assert mock_object.call_count == 2
+        assert mock_object.call_count == 3

--- a/tests/storages_tests/test_cached_storage.py
+++ b/tests/storages_tests/test_cached_storage.py
@@ -2,7 +2,7 @@ from unittest.mock import patch
 
 import optuna
 from optuna.storages._cached_storage import _CachedStorage
-from optuna.storages._cached_storage import RDBStorage
+from optuna.storages import RDBStorage
 from optuna.trial import TrialState
 
 

--- a/tests/storages_tests/test_storages.py
+++ b/tests/storages_tests/test_storages.py
@@ -397,6 +397,7 @@ def test_create_new_trial_with_template_trial(storage_mode: str) -> None:
     with StorageSupplier(storage_mode) as storage:
 
         study_id = storage.create_new_study()
+        storage.set_study_direction(study_id, StudyDirection.MINIMIZE)
 
         n_trial_in_study = 3
         for i in range(n_trial_in_study):
@@ -409,6 +410,7 @@ def test_create_new_trial_with_template_trial(storage_mode: str) -> None:
             storage.create_new_trial(study_id + 1)
 
         study_id2 = storage.create_new_study()
+        storage.set_study_direction(study_id2, StudyDirection.MINIMIZE)
         for i in range(n_trial_in_study):
             storage.create_new_trial(study_id2, template_trial=template_trial)
             trials = storage.get_all_trials(study_id2)
@@ -441,6 +443,7 @@ def test_set_trial_state(storage_mode: str) -> None:
     with StorageSupplier(storage_mode) as storage:
 
         study_id = storage.create_new_study()
+        storage.set_study_direction(study_id, StudyDirection.MINIMIZE)
         trial_ids = [storage.create_new_trial(study_id) for _ in ALL_STATES]
 
         for trial_id, state in zip(trial_ids, ALL_STATES):


### PR DESCRIPTION
## Motivation
- `InMemoryStorage` and `_CachedStorage` share many functionalities. Unifying them will increase code-maintainability.
- Using `_CachedStorage` in all backends make it easy to add further caching functionalities e.g., sampler-specific caches.

## Description of the changes
Unify `InMemoryStorage` and `_CachedStorage`.

We can simplify `InMemoryStorage` more aggressively, but I didn't apply the change to make this PR smaller.

## Microbenchmark
I compared the optimization speed of the current master and this PR with the following code.

<details><summary>Code</summary>
<p>

```python
import time
import optuna


def objective(trial):
    return sum(trial.suggest_float(f"param{i}", 0.0, 1.0) for i in range(3))


if __name__ == "__main__":
    optuna.logging.set_verbosity(optuna.logging.WARNING)
    start = time.time()
    optuna.create_study().optimize(objective, n_trials=5000)
    print(time.time() - start)
```

</p>
</details>

### Result:
| Master  | This PR  | 
|---|---|
|  146.5 sec | 149.8 sec  |

## Notes
This PR depends on #1570.