### PR TITLE
Remove license section from `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,11 +125,6 @@ Any contributions to Optuna are welcome! When you send a pull request, please fo
 [contribution guide](./CONTRIBUTING.md).
 
 
-## License
-
-MIT License (see [LICENSE](./LICENSE)).
-
-
 ## Reference
 
 Takuya Akiba, Shotaro Sano, Toshihiko Yanase, Takeru Ohta, and Masanori Koyama. 2019.


### PR DESCRIPTION
## Motivation

Simplify `README.md`.

## Description of the changes

Removes the license section from `README.md` since it's well "integrated" with the GitHub UI, more precisely, it's already shown under `About` in https://github.com/optuna/optuna (at the top right).