### PR TITLE
Test `_CachedStorage` in `test_study.py`.

### DIFF
--- a/tests/test_study.py
+++ b/tests/test_study.py
@@ -33,6 +33,7 @@ if type_checking.TYPE_CHECKING:
 STORAGE_MODES = [
     "inmemory",
     "sqlite",
+    "cache",
     "redis",
 ]
 

--- a/tests/test_study.py
+++ b/tests/test_study.py
@@ -29,7 +29,6 @@ if type_checking.TYPE_CHECKING:
 
     CallbackFuncType = Callable[[optuna.study.Study, optuna.trial.FrozenTrial], None]
 
-# TODO(ytsmiling) Add tests for multi-worker settings.
 STORAGE_MODES = [
     "inmemory",
     "sqlite",


### PR DESCRIPTION
## Motivation
`_CachedStorage` class was not used in the `test_study.py`. Since the `test_study.py` serves as a kind of integration test, adding the storage into the `test_study.py` will increase the ability to catch bugs in the test.

## Description of the changes
Test `_CachedStorage` in `test_study.py`.