### PR TITLE
Skip entire `allennlp` example directory in CI

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -37,9 +37,9 @@ jobs:
       run: |
         # TODO(hvy): Stop ignoring allennlp_jsonnet.py when https://github.com/optuna/optuna/issues/1526 is resolved.
         if [ ${{ matrix.python-version }} = 3.5 ]; then
-          IGNORES='chainermn_.*|pytorch_lightning.*|fastai_.*|allennlp|catalyst_.*|sb3_.*|allennlp_jsonnet.py'
+          IGNORES='chainermn_.*|pytorch_lightning.*|fastai_.*|catalyst_.*|sb3_.*|allennlp'
         elif [ ${{ matrix.python-version }} = 3.8 ]; then
-          IGNORES='chainermn_.*|dask_ml_.*|keras_.*|tensorboard_.*|tensorflow_.*|tfkeras_.*|fastai_.*|allennlp|allennlp_jsonnet.py'
+          IGNORES='chainermn_.*|dask_ml_.*|keras_.*|tensorboard_.*|tensorflow_.*|tfkeras_.*|fastai_.*|allennlp'
         else
           IGNORES='chainermn_.*|allennlp_jsonnet.py'
         fi

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -37,9 +37,9 @@ jobs:
       run: |
         # TODO(hvy): Stop ignoring allennlp_jsonnet.py when https://github.com/optuna/optuna/issues/1526 is resolved.
         if [ ${{ matrix.python-version }} = 3.5 ]; then
-          IGNORES='chainermn_.*|pytorch_lightning.*|fastai_.*|allennlp_.*|catalyst_.*|sb3_.*|allennlp_jsonnet.py'
+          IGNORES='chainermn_.*|pytorch_lightning.*|fastai_.*|allennlp|catalyst_.*|sb3_.*|allennlp_jsonnet.py'
         elif [ ${{ matrix.python-version }} = 3.8 ]; then
-          IGNORES='chainermn_.*|dask_ml_.*|keras_.*|tensorboard_.*|tensorflow_.*|tfkeras_.*|fastai_.*|allennlp_.*|allennlp_jsonnet.py'
+          IGNORES='chainermn_.*|dask_ml_.*|keras_.*|tensorboard_.*|tensorflow_.*|tfkeras_.*|fastai_.*|allennlp|allennlp_jsonnet.py'
         else
           IGNORES='chainermn_.*|allennlp_jsonnet.py'
         fi


### PR DESCRIPTION
## Motivation

Fixes CI example failure caused by unintentionally executed allennlp example. C.f. https://github.com/optuna/optuna/runs/937729336?check_suite_focus=true

## Description of the changes

Skips entire `allenlp` directory, in case additional files would be added.