### PR TITLE
GitHub Action labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,26 @@
+optuna.importance:
+  - optuna/importance/**/*
+
+optuna.integration:
+  - optuna/integration/**/*
+
+optuna.pruners:
+  - optuna/pruners/**/*
+
+optuna.samplers:
+  - optuna/samplers/**/*
+
+optuna.storages:
+  - optuna/storages/**/*
+
+optuna.testing:
+  - optuna/testing/**/*
+
+optuna.visualization:
+  - optuna/visualization/**/*
+
+optuna.study:
+  - optuna/study.py
+
+optuna.trial:
+  - optuna/trial/**/*

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,12 @@
+name: Labeler
+
+on:
+- pull_request_target
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v2
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
## Motivation

Reintroduced #1068, which was once reverted in https://github.com/optuna/optuna/pull/1094, using the [recently introduced `pull_request_target` event](https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/).

## Description of the changes

Introduces automatic labeling depending on modified files. I'm not sure how to test this locally but please let me know if there's a good way to do so.