### PR TITLE
Simplify documentation of `BaseDistribution.single`

### DIFF
--- a/optuna/distributions.py
+++ b/optuna/distributions.py
@@ -48,9 +48,6 @@ class BaseDistribution(object, metaclass=abc.ABCMeta):
     def single(self) -> bool:
         """Test whether the range of this distribution contains just a single value.
 
-        When this method returns :obj:`True`, :mod:`~optuna.samplers` always sample
-        the same value from the distribution.
-
         Returns:
             :obj:`True` if the range of this distribution contains just a single value,
             otherwise :obj:`False`.


### PR DESCRIPTION
## Motivation

Simplify documentation of `BaseDistribution.single` by removing unnecessary some possibly question-raising description. 

An alternative would be to elaborate and describe more precisely how this affects `Trial._suggest` but it seems a bit like stretching the scope of the documentation for this method.

## Description of the changes

See above.