### PR TITLE
Install `fsspec<0.8.0` for Python 3.5.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -100,8 +100,9 @@ def get_extras_require() -> Dict[str, List[str]]:
         )
         + (["pytorch-lightning>=0.7.2"] if (3, 8) == sys.version_info[:2] else [])
         + (
-            ["llvmlite<=0.31.0"] if (3, 5) == sys.version_info[:2] else []
+            ["llvmlite<=0.31.0", "fsspec<0.8.0"] if (3, 5) == sys.version_info[:2] else []
         )  # Newer `llvmlite` is not distributed with wheels for Python 3.5.
+        # Newer `fsspec` uses f-strings, which is not compatible with Python 3.5.
         + (["dask[dataframe]", "dask-ml",] if sys.version_info[:2] < (3, 8) else [])
         + (["catalyst"] if (3, 5) < sys.version_info[:2] else []),
         "experimental": ["redis"],


### PR DESCRIPTION
## Motivation

The example jobs of the daily CI failed due to the update of the `fsspec` library, which is a dependency of `dask-ml`. It employes `f-string` from 0.8.0 ([here](https://github.com/intake/filesystem_spec/blob/0.8.0/fsspec/core.py#L314)), and it raises syntax errors in Python 3.5 environment.

https://github.com/optuna/optuna/runs/945419687?check_suite_focus=true

## Description of the changes
This PR downgrades the `fsspec` to 0.7.x. It does not contain `f-strings` at least in the same file.
https://github.com/intake/filesystem_spec/blob/0.7.4/fsspec/core.py