### PR TITLE
Add navigation links for contributors to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Any contributions to Optuna are more than welcome!
 
 If you are new to Optuna, please check the [good first issues](https://github.com/optuna/optuna/labels/good%20first%20issue). They are relatively simple, well-defined and are often good starting points for you to get familiar with the contribution workflow and other developers.
 
-If you have already contributed to Optuna, we recommend the other [contribution-welcome issues](https://github.com/optuna/optuna/labels/contribution-welcome).
+If you already have contributed to Optuna, we recommend the other [contribution-welcome issues](https://github.com/optuna/optuna/labels/contribution-welcome).
 
 For general guidelines how to contribute to the project, take a look at [CONTRIBUTING.md](./CONTRIBUTING.md).
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Also, we also provide Optuna docker images on [DockerHub](https://hub.docker.com
 
 Any contributions to Optuna are more than welcome!
 
-If you are new to Optuna, please check the [good first issues](https://github.com/optuna/optuna/labels/good%20first%20issue). They are simple and well-defined so that they can be good starting points for you to get familiar with the contribution workflow and other developers.
+If you are new to Optuna, please check the [good first issues](https://github.com/optuna/optuna/labels/good%20first%20issue). They are relatively simple, well-defined and are often good starting points for you to get familiar with the contribution workflow and other developers.
 
 If you have already contributed to Optuna, we recommend the other [contribution-welcome issues](https://github.com/optuna/optuna/labels/contribution-welcome).
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Also, we also provide Optuna docker images on [DockerHub](https://hub.docker.com
 
 Any contributions to Optuna are more than welcome!
 
-If you are new to Optuna, please check [good first issues](https://github.com/optuna/optuna/labels/good%20first%20issue). These are simple and well-defined so that they can be good starting points for you to get familiar with the contribution workflow and other developers.
+If you are new to Optuna, please check the [good first issues](https://github.com/optuna/optuna/labels/good%20first%20issue). These are simple and well-defined so that they can be good starting points for you to get familiar with the contribution workflow and other developers.
 
 If you have already contributed to Optuna, we recommend the other [contribution-welcome issues](https://github.com/optuna/optuna/labels/contribution-welcome).
 

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Any contributions to Optuna are welcome!
 
 If you are a new contributor, please check [good first issues](https://github.com/optuna/optuna/labels/good%20first%20issue). These are simple and well-defined so that they can be good starting points for you to get familiar with the contribution workflow and other developers.
 
-If you have already contributed to Optuna, please search for the other [contribution-welcome issues](https://github.com/optuna/optuna/labels/contribution-welcome).
+If you have already contributed to Optuna, I would highly recommend the other [contribution-welcome issues](https://github.com/optuna/optuna/labels/contribution-welcome).
 
 When you send a pull request, please follow the
 [contribution guide](./CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Also, we also provide Optuna docker images on [DockerHub](https://hub.docker.com
 
 ## Contribution
 
-Any contributions to Optuna are welcome!
+Any contributions to Optuna are more than welcome!
 
 If you are a new contributor, please check [good first issues](https://github.com/optuna/optuna/labels/good%20first%20issue). These are simple and well-defined so that they can be good starting points for you to get familiar with the contribution workflow and other developers.
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,13 @@ Also, we also provide Optuna docker images on [DockerHub](https://hub.docker.com
 
 ## Contribution
 
-Any contributions to Optuna are welcome! When you send a pull request, please follow the
+Any contributions to Optuna are welcome!
+
+If you are a new contributor, please check [good first issues](https://github.com/optuna/optuna/labels/good%20first%20issue). These are simple and well-defined so that they can be good starting points for you to get familiar with the contribution workflow and other developers.
+
+If you have already contributed to Optuna, please search for the other [contribution-welcome issues](https://github.com/optuna/optuna/labels/contribution-welcome).
+
+When you send a pull request, please follow the
 [contribution guide](./CONTRIBUTING.md).
 
 

--- a/README.md
+++ b/README.md
@@ -128,8 +128,7 @@ If you are new to Optuna, please check [good first issues](https://github.com/op
 
 If you have already contributed to Optuna, I would highly recommend the other [contribution-welcome issues](https://github.com/optuna/optuna/labels/contribution-welcome).
 
-When you send a pull request, please follow the
-[contribution guide](./CONTRIBUTING.md).
+For general guidelines how to contribute to the project, take a look at [CONTRIBUTING.md](./CONTRIBUTING.md).
 
 
 ## Reference

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Any contributions to Optuna are more than welcome!
 
 If you are new to Optuna, please check [good first issues](https://github.com/optuna/optuna/labels/good%20first%20issue). These are simple and well-defined so that they can be good starting points for you to get familiar with the contribution workflow and other developers.
 
-If you have already contributed to Optuna, I would highly recommend the other [contribution-welcome issues](https://github.com/optuna/optuna/labels/contribution-welcome).
+If you have already contributed to Optuna, we recommend the other [contribution-welcome issues](https://github.com/optuna/optuna/labels/contribution-welcome).
 
 For general guidelines how to contribute to the project, take a look at [CONTRIBUTING.md](./CONTRIBUTING.md).
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Also, we also provide Optuna docker images on [DockerHub](https://hub.docker.com
 
 Any contributions to Optuna are more than welcome!
 
-If you are a new contributor, please check [good first issues](https://github.com/optuna/optuna/labels/good%20first%20issue). These are simple and well-defined so that they can be good starting points for you to get familiar with the contribution workflow and other developers.
+If you are new to Optuna, please check [good first issues](https://github.com/optuna/optuna/labels/good%20first%20issue). These are simple and well-defined so that they can be good starting points for you to get familiar with the contribution workflow and other developers.
 
 If you have already contributed to Optuna, I would highly recommend the other [contribution-welcome issues](https://github.com/optuna/optuna/labels/contribution-welcome).
 


### PR DESCRIPTION
## Motivation
`REAME.md` has the `Contribution` section, but it simply guides possible contributors to `CONTRIBUTING.md`. I guess we can encourage the contributors if we show the actual issue items.

## Description of the changes
This PR adds links to issue lists.
- `good first issue` for new contributors
- `contribution-welcome` for experienced contributors