### PR TITLE
Specify the version of packaging to >= 20.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ def get_install_requires() -> List[str]:
         "colorlog",
         "joblib",
         "numpy",
-        "packaging",
+        "packaging>=20.0",
         "scipy!=1.4.0",
         "sqlalchemy>=1.1.0",
         "tqdm",


### PR DESCRIPTION
## Motivation
This PR is to address #1598. 
Current setup.py does not specify the version of packaging.
However, ```packaging.version.Version.major``` which is used in [_deprecated.py](https://github.com/optuna/optuna/blob/master/optuna/_deprecated.py#L39) was introduced in version 20.0.

## Description of the changes
With this change, we specify the version of ```packaging``` package to be installed as ```>=20.0``` to make sure the ```major``` attribute exists. 