### PR TITLE
Make TPE categorical sampling faster

### DIFF
--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -344,13 +344,16 @@ class TPESampler(BaseSampler):
         below = list(map(int, below))
         above = list(map(int, above))
         upper = len(choices)
-        size = (self._n_ei_candidates,)
 
         weights_below = self._weights(len(below))
         counts_below = np.bincount(below, minlength=upper, weights=weights_below)
         weighted_below = counts_below + self._prior_weight
         weighted_below /= weighted_below.sum()
-        samples_below = self._sample_from_categorical_dist(weighted_below, size)
+        if self._n_ei_candidates >= upper:
+            samples_below = np.arange(upper)
+        else:
+            size = (self._n_ei_candidates,)
+            samples_below = self._sample_from_categorical_dist(weighted_below, size)
         log_likelihoods_below = TPESampler._categorical_log_pdf(samples_below, weighted_below)
 
         weights_above = self._weights(len(above))


### PR DESCRIPTION
<!-- Thank you for creating a pull request! -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

The cardinality of categorical parameters tends to be lower than `n_ei_candidates` (default: 24).


## Description of the changes
<!-- Describe the changes in this PR. -->

Use `np.arange(len(choices))` instead of sampling from `l(x)` distribution.
