### PR TITLE
Add a news section to `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Optuna can dynamically construct the search spaces for the hyperparameters.
 
 ## News
 
-- **2020-08-07** We are welcoming [contributions](#contribution) and are working on streamlining the experience
+- **2020-08-07** We are welcoming [contributions](#contribution) and are working on streamlining the experience. Read more about it in the [blog](https://medium.com/optuna/optuna-wants-your-pull-request-ff619572302c)
 
 ## Key Features
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ for machine learning. It features an imperative, *define-by-run* style user API.
 *define-by-run* API, the code written with Optuna enjoys high modularity, and the user of
 Optuna can dynamically construct the search spaces for the hyperparameters.
 
+## News
+
+- **2020-08-07** We are welcoming [contributions](#contribution) and are working on streamlining the experience
 
 ## Key Features
 


### PR DESCRIPTION
## Motivation

Recent changes to `README.md` about how to contribute to Optuna should be clearer. One way to do so with little intervention is to add a reference from e.g. a news section at the top.

Also, `README.md` is quite static. Adding a news sections will allows visitors to easily understand that this project is actively maintained.

## Description of the changes

Adds a news section to `README.md` with a reference to the contribution section.