### PR TITLE
Use packaging to check the library version

### DIFF
--- a/examples/allennlp/allennlp_jsonnet.py
+++ b/examples/allennlp/allennlp_jsonnet.py
@@ -10,10 +10,10 @@ we here use the validation dataset instead.
 """
 
 import os.path
-from packaging import version
 import shutil
 
 import allennlp
+from packaging import version
 
 import optuna
 from optuna.integration.allennlp import dump_best_config

--- a/examples/allennlp/allennlp_jsonnet.py
+++ b/examples/allennlp/allennlp_jsonnet.py
@@ -10,7 +10,7 @@ we here use the validation dataset instead.
 """
 
 import os.path
-import pkg_resources
+from packaging import version
 import shutil
 
 import allennlp
@@ -42,7 +42,7 @@ def objective(trial):
 
 
 if __name__ == "__main__":
-    if pkg_resources.parse_version(allennlp.__version__) < pkg_resources.parse_version("1.0.0"):
+    if version.parse(allennlp.__version__) < version.parse("1.0.0"):
         raise RuntimeError("AllenNLP>=1.0.0 is required for this example.")
 
     study = optuna.create_study(direction="maximize")

--- a/examples/allennlp/allennlp_simple.py
+++ b/examples/allennlp/allennlp_simple.py
@@ -8,7 +8,7 @@ Since it is too time-consuming to use the entire dataset, we here use a small su
 """
 
 import os
-import pkg_resources
+from packaging import version
 import random
 import shutil
 import sys
@@ -117,7 +117,7 @@ def objective(trial):
 
 
 if __name__ == "__main__":
-    if pkg_resources.parse_version(allennlp.__version__) < pkg_resources.parse_version("1.0.0"):
+    if version.parse(allennlp.__version__) < version.parse("1.0.0"):
         raise RuntimeError("AllenNLP>=1.0.0 is required for this example.")
 
     random.seed(41)

--- a/examples/allennlp/allennlp_simple.py
+++ b/examples/allennlp/allennlp_simple.py
@@ -8,7 +8,6 @@ Since it is too time-consuming to use the entire dataset, we here use a small su
 """
 
 import os
-from packaging import version
 import random
 import shutil
 import sys
@@ -18,6 +17,7 @@ import allennlp.data
 import allennlp.models
 import allennlp.modules
 import numpy
+from packaging import version
 import torch
 
 import optuna

--- a/examples/chainer_simple.py
+++ b/examples/chainer_simple.py
@@ -12,12 +12,12 @@ import chainer
 import chainer.functions as F
 import chainer.links as L
 import numpy as np
-import pkg_resources
+from packaging import version
 
 import optuna
 from optuna.integration import ChainerPruningExtension
 
-if pkg_resources.parse_version(chainer.__version__) < pkg_resources.parse_version("4.0.0"):
+if version.parse(chainer.__version__) < version.parse("4.0.0"):
     raise RuntimeError("Chainer>=4.0.0 is required for this example.")
 
 N_TRAIN_EXAMPLES = 3000

--- a/examples/pruning/chainer_integration.py
+++ b/examples/pruning/chainer_integration.py
@@ -15,11 +15,11 @@ import chainer
 import chainer.functions as F
 import chainer.links as L
 import numpy as np
-import pkg_resources
+from packaging import version
 
 import optuna
 
-if pkg_resources.parse_version(chainer.__version__) < pkg_resources.parse_version("4.0.0"):
+if version.parse(chainer.__version__) < version.parse("4.0.0"):
     raise RuntimeError("Chainer>=4.0.0 is required for this example.")
 
 N_TRAIN_EXAMPLES = 3000

--- a/examples/pytorch_lightning_simple.py
+++ b/examples/pytorch_lightning_simple.py
@@ -13,7 +13,7 @@ argument.
 
 import argparse
 import os
-import pkg_resources
+from packaging import version
 import shutil
 
 import pytorch_lightning as pl
@@ -29,7 +29,7 @@ from torchvision import transforms
 import optuna
 from optuna.integration import PyTorchLightningPruningCallback
 
-if pkg_resources.parse_version(pl.__version__) < pkg_resources.parse_version("0.7.1"):
+if version.parse(pl.__version__) < version.parse("0.7.1"):
     raise RuntimeError("PyTorch Lightning>=0.7.1 is required for this example.")
 
 PERCENT_VALID_EXAMPLES = 0.1

--- a/examples/pytorch_lightning_simple.py
+++ b/examples/pytorch_lightning_simple.py
@@ -13,9 +13,9 @@ argument.
 
 import argparse
 import os
-from packaging import version
 import shutil
 
+from packaging import version
 import pytorch_lightning as pl
 from pytorch_lightning import Callback
 import torch

--- a/examples/tensorflow_eager_simple.py
+++ b/examples/tensorflow_eager_simple.py
@@ -7,13 +7,13 @@ configuration.
 
 """
 
-import pkg_resources
+from packaging import version
 import tensorflow as tf
 from tensorflow.keras.datasets import mnist
 
 import optuna
 
-if pkg_resources.parse_version(tf.__version__) < pkg_resources.parse_version("2.0.0"):
+if version.parse(tf.__version__) < version.parse("2.0.0"):
     raise RuntimeError("tensorflow>=2.0.0 is required for this example.")
 
 N_TRAIN_EXAMPLES = 3000

--- a/optuna/dashboard.py
+++ b/optuna/dashboard.py
@@ -1,5 +1,5 @@
 import collections
-from distutils.version import StrictVersion
+from packaging import version
 import threading
 import time
 
@@ -30,7 +30,7 @@ with try_import() as _imports:
     import bokeh.themes
     import tornado.gen
 
-    if StrictVersion(bokeh_version) >= StrictVersion("2.0.0"):
+    if version.parse(bokeh_version) >= version.parse("2.0.0"):
         raise ImportError(
             "Your version of bokeh is " + bokeh_version + " . "
             "Please install bokeh version earlier than 2.0.0. "

--- a/optuna/dashboard.py
+++ b/optuna/dashboard.py
@@ -1,9 +1,9 @@
 import collections
-from packaging import version
 import threading
 import time
 
 import numpy as np
+from packaging import version
 
 from optuna._experimental import experimental
 from optuna._imports import try_import

--- a/optuna/visualization/_plotly_imports.py
+++ b/optuna/visualization/_plotly_imports.py
@@ -1,4 +1,4 @@
-from distutils.version import StrictVersion
+from packaging import version
 
 from optuna._imports import try_import
 
@@ -11,7 +11,7 @@ with try_import() as _imports:  # NOQA
 
     from plotly import __version__ as plotly_version
 
-    if StrictVersion(plotly_version) < StrictVersion("4.0.0"):
+    if version.parse(plotly_version) < version.parse("4.0.0"):
         raise ImportError(
             "Your version of Plotly is " + plotly_version + " . "
             "Please install plotly version 4.0.0 or higher. "

--- a/tests/integration_tests/test_tfkeras.py
+++ b/tests/integration_tests/test_tfkeras.py
@@ -1,5 +1,5 @@
 import numpy as np
-import pkg_resources
+from packaging import version
 import pytest
 import tensorflow as tf
 
@@ -21,7 +21,7 @@ def test_tfkeras_pruning_callback():
 
         # TODO(Yanase): Unify the metric with 'accuracy' after stopping TensorFlow 1.x support.
         callback_metric_name = "accuracy"
-        if pkg_resources.parse_version(tf.__version__) < pkg_resources.parse_version("2.0.0"):
+        if version.parse(tf.__version__) < version.parse("2.0.0"):
             callback_metric_name = "acc"
 
         model.fit(


### PR DESCRIPTION
<!-- Thank you for creating a pull request! -->

## Motivation
Use `packaging` to check the library version
Related #1589 

## Description of the changes
Update the version checking in the following files to use `packaging`:

 Files which use distutils:

- [x] optuna/dashboard.py
- [x] optuna/visualization/_plotly_imports.py

Files which use pkg_resources:

- [x] examples/allennlp/allennlp_jsonnet.py
- [x] examples/allennlp/allennlp_simple.py
- [x] examples/chainer_simple.py
- [x] examples/pruning/chainer_integration.py
- [x] examples/pytorch_lightning_simple.py
- [x] examples/tensorflow_eager_simple.py
- [x] tests/integration_tests/test_tfkeras.py
