### PR TITLE
Fix import order of `packaging.version`

### DIFF
--- a/optuna/_deprecated.py
+++ b/optuna/_deprecated.py
@@ -1,11 +1,12 @@
 import functools
 import inspect
-from packaging import version
 import textwrap
 from typing import Any
 from typing import Callable
 from typing import Optional
 import warnings
+
+from packaging import version
 
 from optuna._experimental import _get_docstring_indent
 from optuna._experimental import _validate_version


### PR DESCRIPTION
## Motivation

See https://github.com/optuna/optuna/pull/1610#pullrequestreview-464993315.

## Description of the changes

Places the `packaging.version` third party library import where it should be, separated from the standard library imports.