### PR TITLE
Do not trigger labeler on push

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -2,6 +2,7 @@ name: Labeler
 
 on:
 - pull_request_target
+  types: [opened, reopened]
 
 jobs:
   triage:


### PR DESCRIPTION
## Motivation

To avoid automatic relabeling after manually removing labels on push events. C.f. #1610 for an actual scenario.

## Description of the changes

Limits the trigger to not fire on push events.

## See also

> By default, a workflow only runs when a pull_request_target's activity type is opened, synchronize, or reopened. 

https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request_target
