### PR TITLE
Use cache-from to build docker image faster

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -8,6 +8,7 @@ on:
     types: [published]
   pull_request:
     paths:
+      - .github/workflows/dockerimage.yml
       - Dockerfile
       - .dockerignore
       - setup.py
@@ -42,10 +43,13 @@ jobs:
         fi
         echo "::set-env name=HUB_TAG::${DOCKER_HUB_BASE_NAME}:${TAG_NAME}"
 
+    - name: Pull the Docker image
+      run: |
+        docker pull "${HUB_TAG}"
 
     - name: Build the Docker image
       run: |
-        docker build . --build-arg PYTHON_VERSION=${{ matrix.python_version }} --build-arg BUILD_TYPE=${{ matrix.build_type }} --file Dockerfile --tag "${HUB_TAG}"
+        docker build --cache-from "${HUB_TAG}" . --build-arg PYTHON_VERSION=${{ matrix.python_version }} --build-arg BUILD_TYPE=${{ matrix.build_type }} --file Dockerfile --tag "${HUB_TAG}"
 
     - name: Login & Push to Docker Hub
       if: ${{ github.event_name != 'pull_request' }}


### PR DESCRIPTION
<!-- Thank you for creating a pull request! -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

- Build docker images faster.
- We don't have to rebuild images from scratch on unrelated changes.

## Description of the changes
<!-- Describe the changes in this PR. -->

Pull docker images before build and use `cache-from`.