### PR TITLE
Remove generated directories with `make clean`

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -22,4 +22,7 @@ help:
 # Copy from https://sphinx-gallery.github.io/stable/advanced.html#cleaning-the-gallery-files
 clean:
 	rm -rf $(BUILDDIR)/*
+	rm -rf source/reference/alias_generated/
+	rm -rf source/reference/generated/
+	rm -rf source/reference/multi_objective/generated/
 	rm -rf source/tutorial/


### PR DESCRIPTION
## Motivation

Auto-generated directories when building the docs can be removed with `make clean` by adding them to `Makefile`. C.f. https://github.com/optuna/optuna/pull/1650.

## Description of the changes

Adds auto-generated directories among the files to be removed with `make clean`.
