### PR TITLE
Add type hints to optuna/trial

### DIFF
--- a/optuna/trial/_base.py
+++ b/optuna/trial/_base.py
@@ -1,16 +1,12 @@
 import abc
+import datetime
+from typing import Any
+from typing import Dict
 from typing import Optional
+from typing import Sequence
 
-from optuna import type_checking
-
-if type_checking.TYPE_CHECKING:
-    import datetime  # NOQA
-    from typing import Any  # NOQA
-    from typing import Dict  # NOQA
-    from typing import Sequence  # NOQA
-
-    from optuna.distributions import BaseDistribution  # NOQA
-    from optuna.distributions import CategoricalChoiceType  # NOQA
+from optuna.distributions import BaseDistribution
+from optuna.distributions import CategoricalChoiceType
 
 
 class BaseTrial(object, metaclass=abc.ABCMeta):
@@ -33,38 +29,34 @@ class BaseTrial(object, metaclass=abc.ABCMeta):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def suggest_uniform(self, name, low, high):
-        # type: (str, float, float) -> float
+    def suggest_uniform(self, name: str, low: float, high: float) -> float:
 
         raise NotImplementedError
 
     @abc.abstractmethod
-    def suggest_loguniform(self, name, low, high):
-        # type: (str, float, float) -> float
+    def suggest_loguniform(self, name: str, low: float, high: float) -> float:
 
         raise NotImplementedError
 
     @abc.abstractmethod
-    def suggest_discrete_uniform(self, name, low, high, q):
-        # type: (str, float, float, float) -> float
+    def suggest_discrete_uniform(self, name: str, low: float, high: float, q: float) -> float:
 
         raise NotImplementedError
 
     @abc.abstractmethod
-    def suggest_int(self, name, low, high, step=1, log=False):
-        # type: (str, int, int, int, bool) -> int
+    def suggest_int(self, name: str, low: int, high: int, step: int = 1, log: bool = False) -> int:
 
         raise NotImplementedError
 
     @abc.abstractmethod
-    def suggest_categorical(self, name, choices):
-        # type: (str, Sequence[CategoricalChoiceType]) -> CategoricalChoiceType
+    def suggest_categorical(
+        self, name: str, choices: Sequence[CategoricalChoiceType]
+    ) -> CategoricalChoiceType:
 
         raise NotImplementedError
 
     @abc.abstractmethod
-    def report(self, value, step):
-        # type: (float, int) -> None
+    def report(self, value: float, step: int) -> None:
 
         raise NotImplementedError
 
@@ -74,49 +66,42 @@ class BaseTrial(object, metaclass=abc.ABCMeta):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def set_user_attr(self, key, value):
-        # type: (str, Any) -> None
+    def set_user_attr(self, key: str, value: Any) -> None:
 
         raise NotImplementedError
 
     @abc.abstractmethod
-    def set_system_attr(self, key, value):
-        # type: (str, Any) -> None
-
-        raise NotImplementedError
-
-    @property
-    @abc.abstractmethod
-    def params(self):
-        # type: () -> Dict[str, Any]
+    def set_system_attr(self, key: str, value: Any) -> None:
 
         raise NotImplementedError
 
     @property
     @abc.abstractmethod
-    def distributions(self):
-        # type: () -> Dict[str, BaseDistribution]
+    def params(self) -> Dict[str, Any]:
 
         raise NotImplementedError
 
     @property
     @abc.abstractmethod
-    def user_attrs(self):
-        # type: () -> Dict[str, Any]
+    def distributions(self) -> Dict[str, BaseDistribution]:
 
         raise NotImplementedError
 
     @property
     @abc.abstractmethod
-    def system_attrs(self):
-        # type: () -> Dict[str, Any]
+    def user_attrs(self) -> Dict[str, Any]:
 
         raise NotImplementedError
 
     @property
     @abc.abstractmethod
-    def datetime_start(self):
-        # type: () -> Optional[datetime.datetime]
+    def system_attrs(self) -> Dict[str, Any]:
+
+        raise NotImplementedError
+
+    @property
+    @abc.abstractmethod
+    def datetime_start(self) -> Optional[datetime.datetime]:
 
         raise NotImplementedError
 

--- a/optuna/trial/_fixed.py
+++ b/optuna/trial/_fixed.py
@@ -1,7 +1,13 @@
 import datetime
+from typing import Any
+from typing import Dict
 from typing import Optional
+from typing import Sequence
+from typing import Union
 
 from optuna import distributions
+from optuna.distributions import BaseDistribution
+from optuna.distributions import CategoricalChoiceType
 from optuna.distributions import CategoricalDistribution
 from optuna.distributions import DiscreteUniformDistribution
 from optuna.distributions import IntLogUniformDistribution
@@ -9,16 +15,6 @@ from optuna.distributions import IntUniformDistribution
 from optuna.distributions import LogUniformDistribution
 from optuna.distributions import UniformDistribution
 from optuna.trial._base import BaseTrial
-from optuna import type_checking
-
-if type_checking.TYPE_CHECKING:
-    from typing import Any  # NOQA
-    from typing import Dict  # NOQA
-    from typing import Sequence  # NOQA
-    from typing import Union  # NOQA
-
-    from optuna.distributions import BaseDistribution  # NOQA
-    from optuna.distributions import CategoricalChoiceType  # NOQA
 
 
 class FixedTrial(BaseTrial):
@@ -57,8 +53,7 @@ class FixedTrial(BaseTrial):
 
     """
 
-    def __init__(self, params, number=0):
-        # type: (Dict[str, Any], int) -> None
+    def __init__(self, params: Dict[str, Any], number: int = 0) -> None:
 
         self._params = params
         self._suggested_params = {}  # type: Dict[str, Any]
@@ -89,13 +84,11 @@ class FixedTrial(BaseTrial):
             else:
                 return self._suggest(name, UniformDistribution(low=low, high=high))
 
-    def suggest_uniform(self, name, low, high):
-        # type: (str, float, float) -> float
+    def suggest_uniform(self, name: str, low: float, high: float) -> float:
 
         return self._suggest(name, UniformDistribution(low=low, high=high))
 
-    def suggest_loguniform(self, name, low, high):
-        # type: (str, float, float) -> float
+    def suggest_loguniform(self, name: str, low: float, high: float) -> float:
 
         return self._suggest(name, LogUniformDistribution(low=low, high=high))
 
@@ -121,13 +114,13 @@ class FixedTrial(BaseTrial):
                 distribution = IntUniformDistribution(low=low, high=high, step=step)
         return int(self._suggest(name, distribution))
 
-    def suggest_categorical(self, name, choices):
-        # type: (str, Sequence[CategoricalChoiceType]) -> CategoricalChoiceType
+    def suggest_categorical(
+        self, name: str, choices: Sequence[CategoricalChoiceType]
+    ) -> CategoricalChoiceType:
 
         return self._suggest(name, CategoricalDistribution(choices=choices))
 
-    def report(self, value, step):
-        # type: (float, int) -> None
+    def report(self, value: float, step: int) -> None:
 
         pass
 
@@ -135,18 +128,15 @@ class FixedTrial(BaseTrial):
 
         return False
 
-    def set_user_attr(self, key, value):
-        # type: (str, Any) -> None
+    def set_user_attr(self, key: str, value: Any) -> None:
 
         self._user_attrs[key] = value
 
-    def set_system_attr(self, key, value):
-        # type: (str, Any) -> None
+    def set_system_attr(self, key: str, value: Any) -> None:
 
         self._system_attrs[key] = value
 
-    def _suggest(self, name, distribution):
-        # type: (str, BaseDistribution) -> Any
+    def _suggest(self, name: str, distribution: BaseDistribution) -> Any:
 
         if name not in self._params:
             raise ValueError(
@@ -171,32 +161,27 @@ class FixedTrial(BaseTrial):
         return value
 
     @property
-    def params(self):
-        # type: () -> Dict[str, Any]
+    def params(self) -> Dict[str, Any]:
 
         return self._suggested_params
 
     @property
-    def distributions(self):
-        # type: () -> Dict[str, BaseDistribution]
+    def distributions(self) -> Dict[str, BaseDistribution]:
 
         return self._distributions
 
     @property
-    def user_attrs(self):
-        # type: () -> Dict[str, Any]
+    def user_attrs(self) -> Dict[str, Any]:
 
         return self._user_attrs
 
     @property
-    def system_attrs(self):
-        # type: () -> Dict[str, Any]
+    def system_attrs(self) -> Dict[str, Any]:
 
         return self._system_attrs
 
     @property
-    def datetime_start(self):
-        # type: () -> Optional[datetime.datetime]
+    def datetime_start(self) -> Optional[datetime.datetime]:
 
         return self._datetime_start
 

--- a/optuna/trial/_state.py
+++ b/optuna/trial/_state.py
@@ -22,12 +22,10 @@ class TrialState(enum.Enum):
     FAIL = 3
     WAITING = 4
 
-    def __repr__(self):
-        # type: () -> str
+    def __repr__(self) -> str:
 
         return str(self)
 
-    def is_finished(self):
-        # type: () -> bool
+    def is_finished(self) -> bool:
 
         return self != TrialState.RUNNING and self != TrialState.WAITING

--- a/optuna/trial/_trial.py
+++ b/optuna/trial/_trial.py
@@ -1,8 +1,16 @@
 import copy
+import datetime
+from typing import Any
+from typing import Dict
 from typing import Optional
+from typing import Sequence
+from typing import Union
 import warnings
 
+import optuna
 from optuna import distributions
+from optuna.distributions import BaseDistribution
+from optuna.distributions import CategoricalChoiceType
 from optuna.distributions import CategoricalDistribution
 from optuna.distributions import DiscreteUniformDistribution
 from optuna.distributions import IntLogUniformDistribution
@@ -12,18 +20,6 @@ from optuna.distributions import UniformDistribution
 from optuna import logging
 from optuna import pruners
 from optuna.trial._base import BaseTrial
-from optuna import type_checking
-
-if type_checking.TYPE_CHECKING:
-    import datetime  # NOQA
-    from typing import Any  # NOQA
-    from typing import Dict  # NOQA
-    from typing import Sequence  # NOQA
-    from typing import Union  # NOQA
-
-    from optuna.distributions import BaseDistribution  # NOQA
-    from optuna.distributions import CategoricalChoiceType  # NOQA
-    from optuna.study import Study  # NOQA
 
 
 _logger = logging.get_logger(__name__)
@@ -48,12 +44,7 @@ class Trial(BaseTrial):
 
     """
 
-    def __init__(
-        self,
-        study,  # type: Study
-        trial_id,  # type: int
-    ):
-        # type: (...) -> None
+    def __init__(self, study: "optuna.study.Study", trial_id: int,) -> None:
 
         self.study = study
         self._trial_id = trial_id
@@ -64,8 +55,7 @@ class Trial(BaseTrial):
 
         self._init_relative_params()
 
-    def _init_relative_params(self):
-        # type: () -> None
+    def _init_relative_params(self) -> None:
 
         trial = self.storage.get_trial(self._trial_id)
 
@@ -173,8 +163,7 @@ class Trial(BaseTrial):
             else:
                 return self.suggest_uniform(name, low, high)
 
-    def suggest_uniform(self, name, low, high):
-        # type: (str, float, float) -> float
+    def suggest_uniform(self, name: str, low: float, high: float) -> float:
         """Suggest a value for the continuous parameter.
 
         The value is sampled from the range :math:`[\\mathsf{low}, \\mathsf{high})`
@@ -227,8 +216,7 @@ class Trial(BaseTrial):
 
         return self._suggest(name, distribution)
 
-    def suggest_loguniform(self, name, low, high):
-        # type: (str, float, float) -> float
+    def suggest_loguniform(self, name: str, low: float, high: float) -> float:
         """Suggest a value for the continuous parameter.
 
         The value is sampled from the range :math:`[\\mathsf{low}, \\mathsf{high})`
@@ -280,8 +268,7 @@ class Trial(BaseTrial):
 
         return self._suggest(name, distribution)
 
-    def suggest_discrete_uniform(self, name, low, high, q):
-        # type: (str, float, float, float) -> float
+    def suggest_discrete_uniform(self, name: str, low: float, high: float, q: float) -> float:
         """Suggest a value for the discrete parameter.
 
         The value is sampled from the range :math:`[\\mathsf{low}, \\mathsf{high}]`,
@@ -438,8 +425,9 @@ class Trial(BaseTrial):
 
         return int(self._suggest(name, distribution))
 
-    def suggest_categorical(self, name, choices):
-        # type: (str, Sequence[CategoricalChoiceType]) -> CategoricalChoiceType
+    def suggest_categorical(
+        self, name: str, choices: Sequence[CategoricalChoiceType]
+    ) -> CategoricalChoiceType:
         """Suggest a value for the categorical parameter.
 
         The value is sampled from ``choices``.
@@ -488,8 +476,7 @@ class Trial(BaseTrial):
 
         return self._suggest(name, CategoricalDistribution(choices=choices))
 
-    def report(self, value, step):
-        # type: (float, int) -> None
+    def report(self, value: float, step: int) -> None:
         """Report an objective function value for a given step.
 
         The reported values are used by the pruners to determine whether this trial should be
@@ -590,8 +577,7 @@ class Trial(BaseTrial):
         trial = self.study._storage.get_trial(self._trial_id)
         return self.study.pruner.prune(self.study, trial)
 
-    def set_user_attr(self, key, value):
-        # type: (str, Any) -> None
+    def set_user_attr(self, key: str, value: Any) -> None:
         """Set user attributes to the trial.
 
         The user attributes in the trial can be access via :func:`optuna.trial.Trial.user_attrs`.
@@ -637,8 +623,7 @@ class Trial(BaseTrial):
 
         self.storage.set_trial_user_attr(self._trial_id, key, value)
 
-    def set_system_attr(self, key, value):
-        # type: (str, Any) -> None
+    def set_system_attr(self, key: str, value: Any) -> None:
         """Set system attributes to the trial.
 
         Note that Optuna internally uses this method to save system messages such as failure
@@ -654,8 +639,7 @@ class Trial(BaseTrial):
 
         self.storage.set_trial_system_attr(self._trial_id, key, value)
 
-    def _suggest(self, name, distribution):
-        # type: (str, BaseDistribution) -> Any
+    def _suggest(self, name: str, distribution: BaseDistribution) -> Any:
 
         storage = self.storage
         trial_id = self._trial_id
@@ -684,8 +668,7 @@ class Trial(BaseTrial):
 
         return param_value
 
-    def _is_fixed_param(self, name, distribution):
-        # type: (str, BaseDistribution) -> bool
+    def _is_fixed_param(self, name: str, distribution: BaseDistribution) -> bool:
 
         system_attrs = self.storage.get_trial_system_attrs(self._trial_id)
         if "fixed_params" not in system_attrs:
@@ -705,8 +688,7 @@ class Trial(BaseTrial):
             )
         return contained
 
-    def _is_relative_param(self, name, distribution):
-        # type: (str, BaseDistribution) -> bool
+    def _is_relative_param(self, name: str, distribution: BaseDistribution) -> bool:
 
         if name not in self.relative_params:
             return False
@@ -724,8 +706,7 @@ class Trial(BaseTrial):
         param_value_in_internal_repr = distribution.to_internal_repr(param_value)
         return distribution._contains(param_value_in_internal_repr)
 
-    def _check_distribution(self, name, distribution):
-        # type: (str, BaseDistribution) -> None
+    def _check_distribution(self, name: str, distribution: BaseDistribution) -> None:
 
         old_distribution = self.storage.get_trial(self._trial_id).distributions.get(
             name, distribution
@@ -743,8 +724,7 @@ class Trial(BaseTrial):
             )
 
     @property
-    def params(self):
-        # type: () -> Dict[str, Any]
+    def params(self) -> Dict[str, Any]:
         """Return parameters to be optimized.
 
         Returns:
@@ -754,8 +734,7 @@ class Trial(BaseTrial):
         return copy.deepcopy(self.storage.get_trial_params(self._trial_id))
 
     @property
-    def distributions(self):
-        # type: () -> Dict[str, BaseDistribution]
+    def distributions(self) -> Dict[str, BaseDistribution]:
         """Return distributions of parameters to be optimized.
 
         Returns:
@@ -765,8 +744,7 @@ class Trial(BaseTrial):
         return copy.deepcopy(self.storage.get_trial(self._trial_id).distributions)
 
     @property
-    def user_attrs(self):
-        # type: () -> Dict[str, Any]
+    def user_attrs(self) -> Dict[str, Any]:
         """Return user attributes.
 
         Returns:
@@ -776,8 +754,7 @@ class Trial(BaseTrial):
         return copy.deepcopy(self.storage.get_trial_user_attrs(self._trial_id))
 
     @property
-    def system_attrs(self):
-        # type: () -> Dict[str, Any]
+    def system_attrs(self) -> Dict[str, Any]:
         """Return system attributes.
 
         Returns:
@@ -787,8 +764,7 @@ class Trial(BaseTrial):
         return copy.deepcopy(self.storage.get_trial_system_attrs(self._trial_id))
 
     @property
-    def datetime_start(self):
-        # type: () -> Optional[datetime.datetime]
+    def datetime_start(self) -> Optional[datetime.datetime]:
         """Return start datetime.
 
         Returns:
@@ -797,8 +773,7 @@ class Trial(BaseTrial):
         return self.storage.get_trial(self._trial_id).datetime_start
 
     @property
-    def number(self):
-        # type: () -> int
+    def number(self) -> int:
         """Return trial's number which is consecutive and unique in a study.
 
         Returns:

--- a/optuna/trial/_trial.py
+++ b/optuna/trial/_trial.py
@@ -44,7 +44,7 @@ class Trial(BaseTrial):
 
     """
 
-    def __init__(self, study: "optuna.study.Study", trial_id: int,) -> None:
+    def __init__(self, study: "optuna.study.Study", trial_id: int) -> None:
 
         self.study = study
         self._trial_id = trial_id


### PR DESCRIPTION
## Motivation
Please refer to the Issue #711 .

## Description of the changes
I added type hints into `optuna/trial/_base.py`, `optuna/trial/_fixed.py`, `optuna/trial/_state.py`, and `optuna/trial/_trial.py`.

https://github.com/optuna/optuna/issues/711#issuecomment-597088465

I encountered the importing problem of `optuna.study.Study` in updating `optuna/trial/_trial.py`, and I avoid this error by forward reference as suggested [here](https://github.com/optuna/optuna/issues/711#issuecomment-597088465).

## Local test
I ran two tests according to the [article](https://tech.preferred.jp/ja/blog/optuna-wants-your-pull-requests/).
```
$ pytest tests
$ circleci build --job checks
```