### PR TITLE
Add type hints to optuna/testing

### DIFF
--- a/optuna/testing/distribution.py
+++ b/optuna/testing/distribution.py
@@ -1,22 +1,17 @@
-from optuna.distributions import BaseDistribution
-from optuna import type_checking
+from typing import Dict
 
-if type_checking.TYPE_CHECKING:
-    from typing import Dict  # NOQA
+from optuna.distributions import BaseDistribution
 
 
 class UnsupportedDistribution(BaseDistribution):
-    def single(self):
-        # type: () -> bool
+    def single(self) -> bool:
 
         return False
 
-    def _contains(self, param_value_in_internal_repr):
-        # type: (float) -> bool
+    def _contains(self, param_value_in_internal_repr: float) -> bool:
 
         return True
 
-    def _asdict(self):
-        # type: () -> Dict
+    def _asdict(self) -> Dict:
 
         return {}

--- a/optuna/testing/integration.py
+++ b/optuna/testing/integration.py
@@ -2,19 +2,16 @@ import optuna
 
 
 class DeterministicPruner(optuna.pruners.BasePruner):
-    def __init__(self, is_pruning):
-        # type: (bool) -> None
+    def __init__(self, is_pruning: bool) -> None:
 
         self.is_pruning = is_pruning
 
-    def prune(self, study, trial):
-        # type: (optuna.study.Study, optuna.trial.FrozenTrial) -> bool
+    def prune(self, study: "optuna.study.Study", trial: "optuna.trial.FrozenTrial") -> bool:
 
         return self.is_pruning
 
 
-def create_running_trial(study, value):
-    # type: (optuna.study.Study, float) -> optuna.trial.Trial
+def create_running_trial(study: "optuna.study.Study", value: float) -> optuna.trial.Trial:
 
     trial_id = study._storage.create_new_trial(study._study_id)
     study._storage.set_trial_value(trial_id, value)

--- a/optuna/testing/sampler.py
+++ b/optuna/testing/sampler.py
@@ -1,34 +1,41 @@
+from typing import Any
+from typing import Dict
+
 import optuna
 from optuna import distributions
-
-if optuna.type_checking.TYPE_CHECKING:
-    from typing import Any  # NOQA
-    from typing import Dict  # NOQA
-
-    from optuna.distributions import BaseDistribution  # NOQA
-    from optuna.study import Study  # NOQA
-    from optuna.trial import FrozenTrial  # NOQA
+from optuna.distributions import BaseDistribution
 
 
 class DeterministicRelativeSampler(optuna.samplers.BaseSampler):
-    def __init__(self, relative_search_space, relative_params):
-        # type: (Dict[str, BaseDistribution], Dict[str, Any]) -> None
+    def __init__(
+        self, relative_search_space: Dict[str, BaseDistribution], relative_params: Dict[str, Any]
+    ) -> None:
 
         self.relative_search_space = relative_search_space
         self.relative_params = relative_params
 
-    def infer_relative_search_space(self, study, trial):
-        # type: (Study, FrozenTrial) -> Dict[str, BaseDistribution]
+    def infer_relative_search_space(
+        self, study: "optuna.study.Study", trial: "optuna.trial.FrozenTrial"
+    ) -> Dict[str, BaseDistribution]:
 
         return self.relative_search_space
 
-    def sample_relative(self, study, trial, search_space):
-        # type: (Study, FrozenTrial, Dict[str, BaseDistribution]) -> Dict[str, Any]
+    def sample_relative(
+        self,
+        study: "optuna.study.Study",
+        trial: "optuna.trial.FrozenTrial",
+        search_space: Dict[str, BaseDistribution],
+    ) -> Dict[str, Any]:
 
         return self.relative_params
 
-    def sample_independent(self, study, trial, param_name, param_distribution):
-        # type: (Study, FrozenTrial, str, BaseDistribution) -> Any
+    def sample_independent(
+        self,
+        study: "optuna.study.Study",
+        trial: "optuna.trial.FrozenTrial",
+        param_name: str,
+        param_distribution: BaseDistribution,
+    ) -> Any:
 
         if isinstance(param_distribution, distributions.UniformDistribution):
             param_value = param_distribution.low  # type: Any
@@ -47,16 +54,25 @@ class DeterministicRelativeSampler(optuna.samplers.BaseSampler):
 
 
 class FirstTrialOnlyRandomSampler(optuna.samplers.RandomSampler):
-    def sample_relative(self, study, trial, search_space):
-        # type: (Study, FrozenTrial, Dict[str, BaseDistribution]) -> Dict[str, float]
+    def sample_relative(
+        self,
+        study: "optuna.study.Study",
+        trial: "optuna.trial.FrozenTrial",
+        search_space: Dict[str, BaseDistribution],
+    ) -> Dict[str, float]:
 
         if len(study.trials) > 1:
             raise RuntimeError("`FirstTrialOnlyRandomSampler` only works on the first trial.")
 
         return super(FirstTrialOnlyRandomSampler, self).sample_relative(study, trial, search_space)
 
-    def sample_independent(self, study, trial, param_name, param_distribution):
-        # type: (Study, FrozenTrial, str, BaseDistribution) -> float
+    def sample_independent(
+        self,
+        study: "optuna.study.Study",
+        trial: "optuna.trial.FrozenTrial",
+        param_name: str,
+        param_distribution: BaseDistribution,
+    ) -> float:
 
         if len(study.trials) > 1:
             raise RuntimeError("`FirstTrialOnlyRandomSampler` only works on the first trial.")

--- a/optuna/testing/storage.py
+++ b/optuna/testing/storage.py
@@ -1,29 +1,24 @@
 import tempfile
+from types import TracebackType
+from typing import Any
+from typing import IO
+from typing import Optional
+from typing import Type
 
 import fakeredis
 
 import optuna
-from optuna import type_checking
-
-if type_checking.TYPE_CHECKING:
-    from types import TracebackType  # NOQA
-    from typing import Any  # NOQA
-    from typing import IO  # NOQA
-    from typing import Optional  # NOQA
-    from typing import Type  # NOQA
 
 SQLITE3_TIMEOUT = 300
 
 
 class StorageSupplier(object):
-    def __init__(self, storage_specifier):
-        # type: (str) -> None
+    def __init__(self, storage_specifier: str) -> None:
 
         self.storage_specifier = storage_specifier
         self.tempfile = None  # type: Optional[IO[Any]]
 
-    def __enter__(self):
-        # type: () -> optuna.storages.BaseStorage
+    def __enter__(self) -> optuna.storages.BaseStorage:
 
         if self.storage_specifier == "inmemory":
             return optuna.storages.InMemoryStorage()
@@ -48,8 +43,9 @@ class StorageSupplier(object):
         else:
             assert False
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        # type: (Type[BaseException], BaseException, TracebackType) -> None
+    def __exit__(
+        self, exc_type: Type[BaseException], exc_val: BaseException, exc_tb: TracebackType
+    ) -> None:
 
         if self.tempfile:
             self.tempfile.close()

--- a/optuna/testing/visualization.py
+++ b/optuna/testing/visualization.py
@@ -1,14 +1,13 @@
 from optuna.distributions import UniformDistribution
+from optuna import Study
 from optuna.study import create_study
 from optuna.trial import create_trial
-from optuna import type_checking
-
-if type_checking.TYPE_CHECKING:
-    from optuna import Study  # NOQA
 
 
-def prepare_study_with_trials(no_trials=False, less_than_two=False, with_c_d=True):
-    # type: (bool, bool, bool) -> Study
+def prepare_study_with_trials(
+    no_trials: bool = False, less_than_two: bool = False, with_c_d: bool = True
+) -> Study:
+
     """Prepare a study for tests.
 
     Args:


### PR DESCRIPTION
## Motivation
Please refer to the Issue #711 .

## Description of the changes
I added type hints into `optuna/testing/distribution.py`, `optuna/testing/integration.py`, `optuna/testing/sampler.py`, `optuna/testing/storage.py`, and `optuna/testing/visualization.py`.

I use forward reference suggested [here](https://github.com/optuna/optuna/issues/711#issuecomment-597088465) in order to avoid the importing problem of `optuna.study.Study` and `optuna.trial.FrozenTrial`.