### PR TITLE
Add type hints to tests/storages_tests/rdb_tests

### DIFF
--- a/tests/storages_tests/rdb_tests/test_models.py
+++ b/tests/storages_tests/rdb_tests/test_models.py
@@ -17,8 +17,7 @@ from optuna.trial import TrialState
 
 
 @pytest.fixture
-def session():
-    # type: () -> Session
+def session() -> Session:
 
     engine = create_engine("sqlite:///:memory:")
     BaseModel.metadata.create_all(engine)
@@ -27,8 +26,7 @@ def session():
 
 class TestStudySystemAttributeModel(object):
     @staticmethod
-    def test_find_by_study_and_key(session):
-        # type: (Session) -> None
+    def test_find_by_study_and_key(session: Session) -> None:
 
         study = StudyModel(study_id=1, study_name="test-study")
         session.add(
@@ -42,8 +40,7 @@ class TestStudySystemAttributeModel(object):
         assert StudySystemAttributeModel.find_by_study_and_key(study, "not-found", session) is None
 
     @staticmethod
-    def test_where_study_id(session):
-        # type: (Session) -> None
+    def test_where_study_id(session: Session) -> None:
 
         sample_study = StudyModel(study_id=1, study_name="test-study")
         empty_study = StudyModel(study_id=2, study_name="test-study")
@@ -60,8 +57,7 @@ class TestStudySystemAttributeModel(object):
         assert 0 == len(StudySystemAttributeModel.where_study_id(-1, session))
 
     @staticmethod
-    def test_cascade_delete_on_study(session):
-        # type: (Session) -> None
+    def test_cascade_delete_on_study(session: Session) -> None:
 
         study_id = 1
         study = StudyModel(
@@ -86,8 +82,7 @@ class TestStudySystemAttributeModel(object):
 
 class TestTrialModel(object):
     @staticmethod
-    def test_default_datetime(session):
-        # type: (Session) -> None
+    def test_default_datetime(session: Session) -> None:
 
         datetime_1 = datetime.now()
 
@@ -101,8 +96,7 @@ class TestTrialModel(object):
         assert trial_model.datetime_complete is None
 
     @staticmethod
-    def test_count(session):
-        # type: (Session) -> None
+    def test_count(session: Session) -> None:
 
         study_1 = StudyModel(study_id=1, study_name="test-study-1")
         study_2 = StudyModel(study_id=2, study_name="test-study-2")
@@ -117,8 +111,7 @@ class TestTrialModel(object):
         assert 1 == TrialModel.count(session, state=TrialState.COMPLETE)
 
     @staticmethod
-    def test_count_past_trials(session):
-        # type: (Session) -> None
+    def test_count_past_trials(session: Session) -> None:
 
         study_1 = StudyModel(study_id=1, study_name="test-study-1")
         study_2 = StudyModel(study_id=2, study_name="test-study-2")
@@ -139,8 +132,7 @@ class TestTrialModel(object):
         assert 0 == trial_2_1.count_past_trials(session)
 
     @staticmethod
-    def test_cascade_delete_on_study(session):
-        # type: (Session) -> None
+    def test_cascade_delete_on_study(session: Session) -> None:
 
         study_id = 1
         study = StudyModel(
@@ -161,8 +153,7 @@ class TestTrialModel(object):
 
 class TestTrialUserAttributeModel(object):
     @staticmethod
-    def test_find_by_trial_and_key(session):
-        # type: (Session) -> None
+    def test_find_by_trial_and_key(session: Session) -> None:
 
         study = StudyModel(study_id=1, study_name="test-study")
         trial = TrialModel(study_id=study.study_id)
@@ -178,8 +169,7 @@ class TestTrialUserAttributeModel(object):
         assert TrialUserAttributeModel.find_by_trial_and_key(trial, "not-found", session) is None
 
     @staticmethod
-    def test_where_study(session):
-        # type: (Session) -> None
+    def test_where_study(session: Session) -> None:
 
         study = StudyModel(study_id=1, study_name="test-study", direction=StudyDirection.MINIMIZE)
         trial = TrialModel(trial_id=1, study_id=study.study_id, state=TrialState.COMPLETE)
@@ -197,8 +187,7 @@ class TestTrialUserAttributeModel(object):
         assert "1" == user_attributes[0].value_json
 
     @staticmethod
-    def test_where_trial(session):
-        # type: (Session) -> None
+    def test_where_trial(session: Session) -> None:
 
         study = StudyModel(study_id=1, study_name="test-study", direction=StudyDirection.MINIMIZE)
         trial = TrialModel(trial_id=1, study_id=study.study_id, state=TrialState.COMPLETE)
@@ -214,8 +203,7 @@ class TestTrialUserAttributeModel(object):
         assert "1" == user_attributes[0].value_json
 
     @staticmethod
-    def test_all(session):
-        # type: (Session) -> None
+    def test_all(session: Session) -> None:
 
         study = StudyModel(study_id=1, study_name="test-study", direction=StudyDirection.MINIMIZE)
         trial = TrialModel(trial_id=1, study_id=study.study_id, state=TrialState.COMPLETE)
@@ -231,8 +219,7 @@ class TestTrialUserAttributeModel(object):
         assert "1" == user_attributes[0].value_json
 
     @staticmethod
-    def test_cascade_delete_on_trial(session):
-        # type: (Session) -> None
+    def test_cascade_delete_on_trial(session: Session) -> None:
 
         trial_id = 1
         study = StudyModel(study_id=1, study_name="test-study", direction=StudyDirection.MINIMIZE)
@@ -257,8 +244,7 @@ class TestTrialUserAttributeModel(object):
 
 class TestTrialSystemAttributeModel(object):
     @staticmethod
-    def test_find_by_trial_and_key(session):
-        # type: (Session) -> None
+    def test_find_by_trial_and_key(session: Session) -> None:
 
         study = StudyModel(study_id=1, study_name="test-study")
         trial = TrialModel(study_id=study.study_id)
@@ -274,8 +260,7 @@ class TestTrialSystemAttributeModel(object):
         assert TrialSystemAttributeModel.find_by_trial_and_key(trial, "not-found", session) is None
 
     @staticmethod
-    def test_where_study(session):
-        # type: (Session) -> None
+    def test_where_study(session: Session) -> None:
 
         study = StudyModel(study_id=1, study_name="test-study", direction=StudyDirection.MINIMIZE)
         trial = TrialModel(trial_id=1, study_id=study.study_id, state=TrialState.COMPLETE)
@@ -293,8 +278,7 @@ class TestTrialSystemAttributeModel(object):
         assert "1" == system_attributes[0].value_json
 
     @staticmethod
-    def test_where_trial(session):
-        # type: (Session) -> None
+    def test_where_trial(session: Session) -> None:
 
         study = StudyModel(study_id=1, study_name="test-study", direction=StudyDirection.MINIMIZE)
         trial = TrialModel(trial_id=1, study_id=study.study_id, state=TrialState.COMPLETE)
@@ -310,8 +294,7 @@ class TestTrialSystemAttributeModel(object):
         assert "1" == system_attributes[0].value_json
 
     @staticmethod
-    def test_all(session):
-        # type: (Session) -> None
+    def test_all(session: Session) -> None:
 
         study = StudyModel(study_id=1, study_name="test-study", direction=StudyDirection.MINIMIZE)
         trial = TrialModel(trial_id=1, study_id=study.study_id, state=TrialState.COMPLETE)
@@ -327,8 +310,7 @@ class TestTrialSystemAttributeModel(object):
         assert "1" == system_attributes[0].value_json
 
     @staticmethod
-    def test_cascade_delete_on_trial(session):
-        # type: (Session) -> None
+    def test_cascade_delete_on_trial(session: Session) -> None:
 
         trial_id = 1
         study = StudyModel(study_id=1, study_name="test-study", direction=StudyDirection.MINIMIZE)
@@ -353,8 +335,7 @@ class TestTrialSystemAttributeModel(object):
 
 class TestVersionInfoModel(object):
     @staticmethod
-    def test_version_info_id_constraint(session):
-        # type: (Session) -> None
+    def test_version_info_id_constraint(session: Session) -> None:
 
         session.add(VersionInfoModel(schema_version=1, library_version="0.0.1"))
         session.commit()

--- a/tests/storages_tests/rdb_tests/test_storage.py
+++ b/tests/storages_tests/rdb_tests/test_storage.py
@@ -19,7 +19,6 @@ from optuna.trial import TrialState
 from optuna import version
 
 
-
 def test_init() -> None:
 
     storage = create_test_storage()
@@ -84,7 +83,9 @@ def test_engine_kwargs() -> None:
         ("mysql://localhost", {"pool_size": 5}, True),
     ],
 )
-def test_set_default_engine_kwargs_for_mysql(url: str, engine_kwargs: Dict[str, Any], expected: bool) -> None:
+def test_set_default_engine_kwargs_for_mysql(
+    url: str, engine_kwargs: Dict[str, Any], expected: bool
+) -> None:
 
     RDBStorage._set_default_engine_kwargs_for_mysql(url, engine_kwargs)
     assert engine_kwargs["pool_pre_ping"] is expected

--- a/tests/storages_tests/rdb_tests/test_storage.py
+++ b/tests/storages_tests/rdb_tests/test_storage.py
@@ -3,6 +3,8 @@ import sys
 import tempfile
 from typing import Any
 from typing import Dict
+from typing import List
+from typing import Optional
 from unittest.mock import patch
 
 import pytest
@@ -15,16 +17,11 @@ from optuna.storages._rdb.models import VersionInfoModel
 from optuna.storages import RDBStorage
 from optuna.trial import FrozenTrial
 from optuna.trial import TrialState
-from optuna import type_checking
 from optuna import version
 
-if type_checking.TYPE_CHECKING:
-    from typing import List  # NOQA
-    from typing import Optional  # NOQA
 
 
-def test_init():
-    # type: () -> None
+def test_init() -> None:
 
     storage = create_test_storage()
     session = storage.scoped_session()
@@ -37,16 +34,14 @@ def test_init():
     assert storage.get_all_versions() == ["v1.3.0.a", "v1.2.0.a", "v0.9.0.a"]
 
 
-def test_init_url_template():
-    # type: ()-> None
+def test_init_url_template() -> None:
 
     with tempfile.NamedTemporaryFile(suffix="{SCHEMA_VERSION}") as tf:
         storage = RDBStorage("sqlite:///" + tf.name)
         assert storage.engine.url.database.endswith(str(SCHEMA_VERSION))
 
 
-def test_init_url_that_contains_percent_character():
-    # type: ()-> None
+def test_init_url_that_contains_percent_character() -> None:
 
     # Alembic's ini file regards '%' as the special character for variable expansion.
     # We checks `RDBStorage` does not raise an error even if a storage url contains the character.
@@ -60,8 +55,7 @@ def test_init_url_that_contains_percent_character():
         RDBStorage("sqlite:///" + tf.name)
 
 
-def test_init_db_module_import_error():
-    # type: () -> None
+def test_init_db_module_import_error() -> None:
 
     expected_msg = (
         "Failed to import DB access module for the specified storage URL. "
@@ -73,8 +67,7 @@ def test_init_db_module_import_error():
             RDBStorage("postgresql://user:password@host/database")
 
 
-def test_engine_kwargs():
-    # type: () -> None
+def test_engine_kwargs() -> None:
 
     create_test_storage(engine_kwargs={"pool_size": 5})
 
@@ -92,15 +85,13 @@ def test_engine_kwargs():
         ("mysql://localhost", {"pool_size": 5}, True),
     ],
 )
-def test_set_default_engine_kwargs_for_mysql(url, engine_kwargs, expected):
-    # type: (str, Dict[str, Any], bool)-> None
+def test_set_default_engine_kwargs_for_mysql(url: str, engine_kwargs: Dict[str, Any], expected: bool) -> None:
 
     RDBStorage._set_default_engine_kwargs_for_mysql(url, engine_kwargs)
     assert engine_kwargs["pool_pre_ping"] is expected
 
 
-def test_set_default_engine_kwargs_for_mysql_with_other_rdb():
-    # type: ()-> None
+def test_set_default_engine_kwargs_for_mysql_with_other_rdb() -> None:
 
     # Do not change engine_kwargs if database is not MySQL.
     engine_kwargs = {}  # type: Dict[str, Any]
@@ -110,8 +101,7 @@ def test_set_default_engine_kwargs_for_mysql_with_other_rdb():
     assert "pool_pre_ping" not in engine_kwargs
 
 
-def test_check_table_schema_compatibility():
-    # type: () -> None
+def test_check_table_schema_compatibility() -> None:
 
     storage = create_test_storage()
     session = storage.scoped_session()
@@ -132,15 +122,13 @@ def test_check_table_schema_compatibility():
     #     storage._check_table_schema_compatibility()
 
 
-def create_test_storage(engine_kwargs=None):
-    # type: (Optional[Dict[str, Any]]) -> RDBStorage
+def create_test_storage(engine_kwargs: Optional[Dict[str, Any]] = None) -> RDBStorage:
 
     storage = RDBStorage("sqlite:///:memory:", engine_kwargs=engine_kwargs)
     return storage
 
 
-def test_pickle_storage():
-    # type: () -> None
+def test_pickle_storage() -> None:
 
     storage = create_test_storage()
     restored_storage = pickle.loads(pickle.dumps(storage))
@@ -152,8 +140,7 @@ def test_pickle_storage():
     assert storage._version_manager != restored_storage._version_manager
 
 
-def test_commit():
-    # type: () -> None
+def test_commit() -> None:
 
     storage = create_test_storage()
     session = storage.scoped_session()
@@ -165,8 +152,7 @@ def test_commit():
         storage._commit(session)
 
 
-def test_upgrade():
-    # type: () -> None
+def test_upgrade() -> None:
 
     storage = create_test_storage()
 

--- a/tests/storages_tests/rdb_tests/test_storage.py
+++ b/tests/storages_tests/rdb_tests/test_storage.py
@@ -203,6 +203,7 @@ def test_upgrade() -> None:
     ],
 )
 def test_update_trial(fields_to_modify: Dict[str, Any], kwargs: Dict[str, Any]) -> None:
+
     storage = create_test_storage()
     study_id = storage.create_new_study()
 
@@ -219,6 +220,7 @@ def test_update_trial(fields_to_modify: Dict[str, Any], kwargs: Dict[str, Any]) 
 
 
 def test_update_trial_second_write() -> None:
+
     storage = create_test_storage()
     study_id = storage.create_new_study()
     template = FrozenTrial(
@@ -267,6 +269,7 @@ def test_update_trial_second_write() -> None:
 
 
 def test_get_trials_excluded_trial_ids() -> None:
+
     storage = create_test_storage()
     study_id = storage.create_new_study()
 

--- a/tests/storages_tests/rdb_tests/test_storage.py
+++ b/tests/storages_tests/rdb_tests/test_storage.py
@@ -3,7 +3,6 @@ import sys
 import tempfile
 from typing import Any
 from typing import Dict
-from typing import List
 from typing import Optional
 from unittest.mock import patch
 


### PR DESCRIPTION
## Motivation  
Please refer to the issue #711 .  

## Description of the changes  
I added type hints to `tests/storages_tests/rdb_tests/test_storage.py` and `tests/storages_tests/rdb_tests/test_models.py`.  
