### PR TITLE
Do not use deprecated `pytorch_lightning.data_loader` decorator 

### DIFF
--- a/tests/integration_tests/test_pytorch_lightning.py
+++ b/tests/integration_tests/test_pytorch_lightning.py
@@ -54,13 +54,11 @@ class Model(pl.LightningModule):
 
         return torch.optim.SGD(self._model.parameters(), lr=1e-2)
 
-    @pl.data_loader
     def train_dataloader(self):
         # type: () -> torch.utils.data.DataLoader
 
         return self._generate_dummy_dataset()
 
-    @pl.data_loader
     def val_dataloader(self):
         # type: () -> torch.utils.data.DataLoader
 


### PR DESCRIPTION
## Motivation

See below.

## Description of the changes

Fixes a test failure due to the recent release of `pytorch-lightning=0.9.0` where the deprecated `data_loader` decorator was removed. This decorator seems more or less to have been a NOOP operations for the last couple of releases. C.f. [`0.8.0`](https://github.com/PyTorchLightning/pytorch-lightning/blob/0.8.0/pytorch_lightning/core/decorators.py), [`0.6.0`](https://github.com/PyTorchLightning/pytorch-lightning/blob/0.6.0/pytorch_lightning/core/decorators.py).
