### PR TITLE
Exit thread after session is destroyed

### DIFF
--- a/optuna/dashboard.py
+++ b/optuna/dashboard.py
@@ -219,7 +219,7 @@ if _imports.is_successful():
                 self.stop_event = threading.Event()
                 thread.daemon = True
                 thread.start()
-                self.doc.on_session_destroyed(lambda session_context: self.stop_event.set())
+                self.doc.on_session_destroyed(lambda _: self.stop_event.set())
 
         def thread_loop(self) -> None:
 


### PR DESCRIPTION
<!-- Thank you for creating a pull request! -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

Fix https://github.com/optuna/optuna/issues/278

## Description of the changes
<!-- Describe the changes in this PR. -->

When bokeh's session is destroyed, set flag(stop_event) to true, and thread exits.

