### PR TITLE
Add border to markers in contour plot

### DIFF
--- a/optuna/visualization/_contour.py
+++ b/optuna/visualization/_contour.py
@@ -198,10 +198,7 @@ def _generate_contour_subplot(
     scatter = go.Scatter(
         x=x_values,
         y=y_values,
-        marker={
-            "line": {"width": 0.5, "color": "Grey"},
-            "color": "black",
-        },
+        marker={"line": {"width": 0.5, "color": "Grey"}, "color": "black"},
         mode="markers",
         showlegend=False,
     )


### PR DESCRIPTION
<!-- Thank you for creating a pull request! -->

## Motivation
As mentioned in https://github.com/optuna/optuna/issues/670, markers in contour plots are sometimes big. They are difficult to recognize when they overlapped with each other.

## Description of the changes
I added border in the same way as slide plot (https://github.com/optuna/optuna/blob/master/optuna/visualization/_slice.py#L121).

The result is shown as follows.
<img width="977" alt="improvement" src="https://user-images.githubusercontent.com/29617239/90968827-0d23e780-e52c-11ea-8bd6-8556693643a8.png">

It successfully passed `pytest tests/visualization_tests/test_contour.py`.

