### PR TITLE
Add type hints to `optuna/integration/tensorflow.py`

### DIFF
--- a/optuna/integration/tensorflow.py
+++ b/optuna/integration/tensorflow.py
@@ -52,7 +52,7 @@ class TensorFlowPruningHook(SessionRunHook):
 
     def before_run(
         self, run_context: "tf.estimator.SessionRunContext"
-    ) -> tf.estimator.SessionRunArgs:
+    ) -> "tf.estimator.SessionRunArgs":
 
         del run_context
         return tf.estimator.SessionRunArgs(self._global_step_tensor)


### PR DESCRIPTION
## Motivation
Please refer to the Issue #711
## Description of the changes
I added the type annotations of files under integration/tensorflow.py

