### PR TITLE
Add padding to contour plot

### DIFF
--- a/optuna/visualization/_contour.py
+++ b/optuna/visualization/_contour.py
@@ -175,7 +175,7 @@ def _generate_contour_subplot(
     y_range = param_values_range[y_param]
     y_indices = [y_range[0]] + y_indices + [y_range[1]]
 
-    z = [[None for _ in range(len(x_indices))] for _ in range(len(y_indices))]
+    z = [[float("nan") for _ in range(len(x_indices))] for _ in range(len(y_indices))]
 
     x_values = []
     y_values = []

--- a/tests/visualization_tests/test_contour.py
+++ b/tests/visualization_tests/test_contour.py
@@ -54,12 +54,12 @@ def test_plot_contour(params: Optional[List[str]]) -> None:
         if len(params) <= 1:
             assert not figure.data
         elif len(params) == 2:
-            assert figure.data[0]["x"] == (1.0, 2.5)
-            assert figure.data[0]["y"] == (0.0, 1.0, 2.0)
+            assert figure.data[0]["x"] == (0.925, 1.0, 2.5, 2.575)
+            assert figure.data[0]["y"] == (-0.1, 0.0, 1.0, 2.0, 2.1)
             assert figure.data[1]["x"] == (1.0, 2.5)
             assert figure.data[1]["y"] == (2.0, 1.0)
-            assert figure.layout["xaxis"]["range"] == (1.0, 2.5)
-            assert figure.layout["yaxis"]["range"] == (0.0, 2.0)
+            assert figure.layout["xaxis"]["range"] == (0.925, 2.575)
+            assert figure.layout["yaxis"]["range"] == (-0.1, 2.1)
     else:
         # TODO(crcrpar): Add more checks. Currently this only checks the number of data.
         n_params = len(params) if params is not None else 4
@@ -74,14 +74,14 @@ def test_generate_contour_plot_for_few_observations() -> None:
     # `x_axis` has one observation.
     params = ["param_a", "param_b"]
     contour, scatter = _generate_contour_subplot(
-        trials, params[0], params[1], StudyDirection.MINIMIZE
+        trials, params[0], params[1], StudyDirection.MINIMIZE, {}
     )
     assert contour.x is None and contour.y is None and scatter.x is None and scatter.y is None
 
     # `y_axis` has one observation.
     params = ["param_b", "param_a"]
     contour, scatter = _generate_contour_subplot(
-        trials, params[0], params[1], StudyDirection.MINIMIZE
+        trials, params[0], params[1], StudyDirection.MINIMIZE, {}
     )
     assert contour.x is None and contour.y is None and scatter.x is None and scatter.y is None
 
@@ -112,8 +112,8 @@ def test_plot_contour_log_scale() -> None:
     )
 
     figure = plot_contour(study)
-    assert figure.layout["xaxis"]["range"] == (-6, -5)
-    assert figure.layout["yaxis"]["range"] == (-4, -3)
+    assert figure.layout["xaxis"]["range"] == (-6.05, -4.95)
+    assert figure.layout["yaxis"]["range"] == (-4.05, -2.95)
     assert figure.layout["xaxis_type"] == "log"
     assert figure.layout["yaxis_type"] == "log"
 
@@ -143,9 +143,9 @@ def test_plot_contour_log_scale() -> None:
     )
 
     figure = plot_contour(study)
-    param_a_range = (-6, -5)
-    param_b_range = (-4, -3)
-    param_c_range = (-2, -1)
+    param_a_range = (-6.05, -4.95)
+    param_b_range = (-4.05, -2.95)
+    param_c_range = (-2.05, -0.95)
     axis_to_range = {
         "xaxis": param_a_range,
         "xaxis2": param_b_range,

--- a/tests/visualization_tests/test_contour.py
+++ b/tests/visualization_tests/test_contour.py
@@ -74,14 +74,14 @@ def test_generate_contour_plot_for_few_observations() -> None:
     # `x_axis` has one observation.
     params = ["param_a", "param_b"]
     contour, scatter = _generate_contour_subplot(
-        trials, params[0], params[1], StudyDirection.MINIMIZE, {}
+        trials, params[0], params[1], StudyDirection.MINIMIZE
     )
     assert contour.x is None and contour.y is None and scatter.x is None and scatter.y is None
 
     # `y_axis` has one observation.
     params = ["param_b", "param_a"]
     contour, scatter = _generate_contour_subplot(
-        trials, params[0], params[1], StudyDirection.MINIMIZE, {}
+        trials, params[0], params[1], StudyDirection.MINIMIZE
     )
     assert contour.x is None and contour.y is None and scatter.x is None and scatter.y is None
 


### PR DESCRIPTION
## Motivation
As mentioned in https://github.com/optuna/optuna/issues/1697, it is difficult to see when points appear at the borders.

## Description of the changes
I checked available parameters of `plotly.graph_objects.Contour` but failed to find anything useful to introduce a padding. Although `plotly.graph_objects.Figure` has a `margin` parameter, it is used for the whole figure, not the plot(s) inside it.

To this end, I choose to use an empirical padding ratio of `0.05` (not sure if it is appropriate) and manually calculate the corresponding paddings.

Plot for the following code is attached.

```python
import optuna

def objective(trial):
    x = trial.suggest_float("x", 0, 1)
    y = trial.suggest_int("y", -1, 1)
    z = trial.suggest_loguniform("z", 1e-2, 1e3)
    return (x - 0.5) ** 2 + y + z / 100

study = optuna.create_study()
study.optimize(objective, n_trials=200)

optuna.visualization.plot_contour(study).show()
```

![padding](https://user-images.githubusercontent.com/29617239/91145982-39d52c00-e6f1-11ea-8e68-121e7b66577a.png)
