### PR TITLE
Make Optuna PEP 561 Compliant

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -222,6 +222,7 @@ setup(
             "storages/_rdb/alembic.ini",
             "storages/_rdb/alembic/*.*",
             "storages/_rdb/alembic/versions/*.*",
+            "py.typed",
         ]
     },
     python_requires=">=3.5",


### PR DESCRIPTION
Fixes [#1719](https://github.com/optuna/optuna/issues/1719) by adding a `py.typed` under package `optuna` and distributing it as part of package data in `setup.py`.