### PR TITLE
Add test for hypervolume computation for solution sets with duplicate points

### DIFF
--- a/tests/multi_objective_tests/hypervolume_tests/test_wfg.py
+++ b/tests/multi_objective_tests/hypervolume_tests/test_wfg.py
@@ -39,6 +39,23 @@ def test_wfg_nd() -> None:
         assert v == 10 ** n - 1
 
 
+def test_wfg_duplicate_points() -> None:
+    n = 3
+    r = 10 * np.ones(n)
+    s = [np.hstack((np.zeros(i), [1], np.zeros(n - i - 1))) for i in range(n)]
+    for _ in range(10):
+        s.append(np.random.randint(1, 10, size=(n,)))
+    s = np.asarray(s)
+    v = optuna.multi_objective._hypervolume.WFG().compute(s, r)
+
+    # Add an already existing point.
+    s = np.vstack([s, s[-1]])
+
+    np.random.shuffle(s)
+    v_with_duplicate_point = optuna.multi_objective._hypervolume.WFG().compute(s, r)
+    assert v == v_with_duplicate_point
+
+
 def test_invalid_input() -> None:
     r = np.ones(3)
     s = np.atleast_2d(2 * np.ones(3))


### PR DESCRIPTION
## Motivation

A solution set with duplicated points can be considered a rare edge case for hypervolume computation. It should be covered by unit tests.

## Description of the changes

Adds a test for hypervolume computation for solution sets with duplicate points.