### PR TITLE
Implement hypervolume calculator for two-dimensional space

### DIFF
--- a/optuna/multi_objective/_hypervolume/__init__.py
+++ b/optuna/multi_objective/_hypervolume/__init__.py
@@ -1,3 +1,4 @@
+from optuna.multi_objective._hypervolume.utils import _compute_2d  # NOQA
 from optuna.multi_objective._hypervolume.utils import _compute_2points_volume  # NOQA
 from optuna.multi_objective._hypervolume.base import BaseHypervolume  # NOQA
 from optuna.multi_objective._hypervolume.wfg import WFG  # NOQA

--- a/optuna/multi_objective/_hypervolume/utils.py
+++ b/optuna/multi_objective/_hypervolume/utils.py
@@ -17,8 +17,8 @@ def _compute_2points_volume(point1: np.ndarray, point2: np.ndarray) -> float:
 def _compute_2d(solution_set: np.ndarray, reference_point: np.ndarray) -> float:
     """Compute the hypervolume for the two-dimensional space.
 
-    This algorithm divides a hypervolume area into smaller rectangles
-    and sum these areas.
+    This algorithm divides a hypervolume into
+    smaller rectangles and sum these areas.
 
     Args:
         solution_set:
@@ -30,16 +30,16 @@ def _compute_2d(solution_set: np.ndarray, reference_point: np.ndarray) -> float:
     sorted_solution_set = solution_set[np.lexsort((-solution_set[:, 1], solution_set[:, 0]))]
 
     hypervolume = 0.0
-    for point1 in sorted_solution_set:
-        if reference_point[1] < point1[1]:
+    for solution in sorted_solution_set:
+        if reference_point[1] < solution[1]:
             continue
 
         # Compute an area of a rectangle with reference_point
         # and one point in solution_sets as diagonals.
-        hypervolume += _compute_2points_volume(reference_point, point1)
+        hypervolume += _compute_2points_volume(reference_point, solution)
 
-        # Update ry such that the above rectangle and
-        # a next rectangle don't overlap
-        reference_point[1] = point1[1]
+        # Update a reference_point to create a new hypervolume that
+        # exclude a rectangle from the current hypervolume
+        reference_point[1] = solution[1]
 
     return hypervolume

--- a/optuna/multi_objective/_hypervolume/utils.py
+++ b/optuna/multi_objective/_hypervolume/utils.py
@@ -12,3 +12,27 @@ def _compute_2points_volume(point1: np.ndarray, point2: np.ndarray) -> float:
     """
 
     return float(np.abs(np.prod(point1 - point2)))
+
+
+def _compute_2d(solution_set: np.ndarray, reference_point: np.ndarray) -> float:
+    """Compute the hypervolume for the two-dimensional space.
+
+    Args:
+        solution_set:
+            The solution set which we want to compute the hypervolume.
+        reference_point:
+            The reference point to compute the hypervolume.
+    """
+
+    rx, ry = reference_point
+    _solution_set = solution_set[np.lexsort((-solution_set[:,1], solution_set[:,0]))]
+
+    hypervolume = 0.0
+    for (xi, yi) in _solution_set:
+        if ry - yi < 0:
+            continue
+
+        hypervolume += (rx - xi) * (ry - yi)
+        ry = yi
+
+    return hypervolume

--- a/optuna/multi_objective/_hypervolume/utils.py
+++ b/optuna/multi_objective/_hypervolume/utils.py
@@ -25,7 +25,7 @@ def _compute_2d(solution_set: np.ndarray, reference_point: np.ndarray) -> float:
     """
 
     rx, ry = reference_point
-    _solution_set = solution_set[np.lexsort((-solution_set[:,1], solution_set[:,0]))]
+    _solution_set = solution_set[np.lexsort((-solution_set[:, 1], solution_set[:, 0]))]
 
     hypervolume = 0.0
     for (xi, yi) in _solution_set:

--- a/optuna/multi_objective/_hypervolume/utils.py
+++ b/optuna/multi_objective/_hypervolume/utils.py
@@ -17,6 +17,9 @@ def _compute_2points_volume(point1: np.ndarray, point2: np.ndarray) -> float:
 def _compute_2d(solution_set: np.ndarray, reference_point: np.ndarray) -> float:
     """Compute the hypervolume for the two-dimensional space.
 
+    This algorithm divides a hypervolume area into smaller rectangles
+    and sum these areas.
+
     Args:
         solution_set:
             The solution set which we want to compute the hypervolume.
@@ -24,15 +27,19 @@ def _compute_2d(solution_set: np.ndarray, reference_point: np.ndarray) -> float:
             The reference point to compute the hypervolume.
     """
 
-    rx, ry = reference_point
     sorted_solution_set = solution_set[np.lexsort((-solution_set[:, 1], solution_set[:, 0]))]
 
     hypervolume = 0.0
-    for (xi, yi) in sorted_solution_set:
-        if ry < yi:
+    for point1 in sorted_solution_set:
+        if reference_point[1] < point1[1]:
             continue
 
-        hypervolume += (rx - xi) * (ry - yi)
-        ry = yi
+        # Compute an area of a rectangle with reference_point
+        # and one point in solution_sets as diagonals.
+        hypervolume += _compute_2points_volume(reference_point, point1)
+
+        # Update ry such that the above rectangle and
+        # a next rectangle don't overlap
+        reference_point[1] = point1[1]
 
     return hypervolume

--- a/optuna/multi_objective/_hypervolume/utils.py
+++ b/optuna/multi_objective/_hypervolume/utils.py
@@ -25,10 +25,10 @@ def _compute_2d(solution_set: np.ndarray, reference_point: np.ndarray) -> float:
     """
 
     rx, ry = reference_point
-    _solution_set = solution_set[np.lexsort((-solution_set[:, 1], solution_set[:, 0]))]
+    sorted_solution_set = solution_set[np.lexsort((-solution_set[:, 1], solution_set[:, 0]))]
 
     hypervolume = 0.0
-    for (xi, yi) in _solution_set:
+    for (xi, yi) in sorted_solution_set:
         if ry - yi < 0:
             continue
 

--- a/optuna/multi_objective/_hypervolume/wfg.py
+++ b/optuna/multi_objective/_hypervolume/wfg.py
@@ -1,5 +1,6 @@
 import numpy as np
 
+from optuna.multi_objective._hypervolume import _compute_2d
 from optuna.multi_objective._hypervolume import _compute_2points_volume
 from optuna.multi_objective._hypervolume import BaseHypervolume
 
@@ -23,6 +24,14 @@ class WFG(BaseHypervolume):
     def _compute_rec(self, solution_set: np.ndarray) -> float:
         assert self._reference_point is not None
         n_points = solution_set.shape[0]
+        _shape = self._reference_point.shape
+
+        if len(_shape) == 1 and _shape[0] == 2:
+            return _compute_2d(solution_set, self._reference_point)
+
+        if len(_shape) == 2:
+            if (_shape[0] == 2 and _shape[1] == 1) or (_shape[0] == 1 and _shape[1] == 2):
+                return _compute_2d(solution_set, self._reference_point)
 
         if n_points == 1:
             return _compute_2points_volume(solution_set[0], self._reference_point)

--- a/optuna/multi_objective/_hypervolume/wfg.py
+++ b/optuna/multi_objective/_hypervolume/wfg.py
@@ -24,13 +24,13 @@ class WFG(BaseHypervolume):
     def _compute_rec(self, solution_set: np.ndarray) -> float:
         assert self._reference_point is not None
         n_points = solution_set.shape[0]
-        _shape = self._reference_point.shape
+        shape = self._reference_point.shape
 
-        if len(_shape) == 1 and _shape[0] == 2:
+        if len(shape) == 1 and shape[0] == 2:
             return _compute_2d(solution_set, self._reference_point)
 
-        if len(_shape) == 2:
-            if (_shape[0] == 2 and _shape[1] == 1) or (_shape[0] == 1 and _shape[1] == 2):
+        if len(shape) == 2:
+            if (shape[0] == 2 and shape[1] == 1) or (shape[0] == 1 and shape[1] == 2):
                 return _compute_2d(solution_set, self._reference_point)
 
         if n_points == 1:

--- a/optuna/multi_objective/_hypervolume/wfg.py
+++ b/optuna/multi_objective/_hypervolume/wfg.py
@@ -24,14 +24,9 @@ class WFG(BaseHypervolume):
     def _compute_rec(self, solution_set: np.ndarray) -> float:
         assert self._reference_point is not None
         n_points = solution_set.shape[0]
-        shape = self._reference_point.shape
 
-        if len(shape) == 1 and shape[0] == 2:
+        if self._reference_point.shape[0] == 2:
             return _compute_2d(solution_set, self._reference_point)
-
-        if len(shape) == 2:
-            if (shape[0] == 2 and shape[1] == 1) or (shape[0] == 1 and shape[1] == 2):
-                return _compute_2d(solution_set, self._reference_point)
 
         if n_points == 1:
             return _compute_2points_volume(solution_set[0], self._reference_point)

--- a/tests/multi_objective_tests/hypervolume_tests/test_utils.py
+++ b/tests/multi_objective_tests/hypervolume_tests/test_utils.py
@@ -12,3 +12,14 @@ def test_compute_2points_volume() -> None:
     p1 = np.ones(10) * 2
     p2 = np.ones(10)
     assert 1 == optuna.multi_objective._hypervolume._compute_2points_volume(p1, p2)
+
+
+def test_wfg_2d() -> None:
+    for n in range(2, 30):
+        r = n * np.ones(2)
+        s = np.asarray([[n - 1 - i, i] for i in range(n)])
+        for i in range(n + 1):
+            s = np.vstack((s, np.asarray([i, n - i])))
+        np.random.shuffle(s)
+        v = optuna.multi_objective._hypervolume._compute_2d(s, r)
+        assert v == n * n - n * (n - 1) // 2


### PR DESCRIPTION
## Motivation
This PR introduces a faster implementation for hypervolume calculation when input data are two-dimensional.

## Description of the changes
For a two-dimensional space, naive volume calculation is faster than WFG algorithm.
This PR implement 2d naive hypervolume calculation and use it in WFG for the 2d input.

## Simple benchmark

I've conducted the tiny benchmark test.
In this benchmark, I commented out using [2d specific calculation](https://github.com/optuna/optuna/pull/1771/files#diff-b206833eab1f890feb67db6e1d82d874R27-R34).

```
> python benchmark.py
Current WFG: 0.043965911865234374 (std: 0.0018644321275790372)
_compute_2d: 0.0003278970718383789 (std: 7.801164113928833e-05)
```

```python
import numpy as np

import optuna
import time


def benchmark():
    n = 100
    r = n * np.ones(2)
    s = np.asarray([[n - 1 - i, i] for i in range(n)])
    for i in range(n + 1):
        s = np.vstack((s, np.asarray([i, n - i])))

    wfg = optuna.multi_objective._hypervolume.WFG()
    tm1s = []
    tm2s = []

    for _ in range(10):
        st1 = time.time()
        v = wfg.compute(s, r)
        fn1 = time.time()

        st2 = time.time()
        v = optuna.multi_objective._hypervolume._compute_2d(s, r)
        fn2 = time.time()

        tm1s.append(fn1 - st1)
        tm2s.append(fn2 - st2)

    mean1 = np.mean(tm1s)
    mean2 = np.mean(tm2s)

    std1 = np.std(tm1s)
    std2 = np.std(tm2s)

    print(f"Current WFG: {mean1} (std: {std1})")
    print(f"_compute_2d: {mean2} (std: {std2})")


benchmark()
```