### PR TITLE
`lightgbm<3.0.0` to circumvent error with `feature_pre_filter`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ def get_extras_require() -> Dict[str, List[str]]:
         "example": [
             "catboost",
             "chainer",
-            "lightgbm",
+            "lightgbm<3.0.0",
             "mlflow",
             "mpi4py",
             "mxnet",
@@ -119,7 +119,7 @@ def get_extras_require() -> Dict[str, List[str]]:
             "chainer>=5.0.0",
             "cma",
             "fakeredis",
-            "lightgbm",
+            "lightgbm<3.0.0",
             "mlflow",
             "mpi4py",
             "mxnet",
@@ -163,7 +163,7 @@ def get_extras_require() -> Dict[str, List[str]]:
             # https://github.com/optuna/optuna/issues/1000.
             "chainer>=5.0.0",
             "cma",
-            "lightgbm",
+            "lightgbm<3.0.0",
             "mlflow",
             "mpi4py",
             "mxnet",


### PR DESCRIPTION
## Motivation

Temporary hotfix for broken `master` caused by the release of `lightgbm==3.0.0`.

## Description of the changes

Constrains the version of `lightgbm` in `setup.py`.

## Note

This issue is addressed by https://github.com/optuna/optuna/issues/1718.