### PR TITLE
ignore `alias_generated`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,5 +112,6 @@ ENV/
 tutorial/example.db
 docs/_build/
 docs/source/reference/generated/
+docs/source/reference/alias_generated/
 docs/source/reference/multi_objective/generated/
 docs/source/tutorial/

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -26,6 +26,7 @@ doctest:
 # Copy from https://sphinx-gallery.github.io/stable/advanced.html#cleaning-the-gallery-files
 clean:
 	rm -rf $(BUILDDIR)/*
+	rm -rf source/reference/alias_generated/
 	rm -rf source/reference/generated/
 	rm -rf source/reference/multi_objective/generated/
 	rm -rf source/tutorial/


### PR DESCRIPTION
<!-- Thank you for creating a pull request! -->

I think `alias_generated` is still generated.

```bash
➜ git st
On branch tutorial-reorganization
Untracked files:
  (use "git add <file>..." to include in what will be committed)
        docs/source/reference/alias_generated/
nothing added to commit but untracked files present (use "git add" to track)
```