### PR TITLE
Fix exception chaining all over the codebase

### DIFF
--- a/optuna/integration/chainer.py
+++ b/optuna/integration/chainer.py
@@ -79,7 +79,7 @@ class ChainerPruningExtension(Extension):
             raise TypeError(
                 "Type of observation value is not supported by ChainerPruningExtension.\n"
                 "{} cannot be cast to float.".format(type(observation_value))
-            )
+            ) from None
 
         return observation_value
 

--- a/optuna/integration/sklearn.py
+++ b/optuna/integration/sklearn.py
@@ -116,7 +116,7 @@ def _num_samples(x: ArrayLikeType) -> int:
     try:
         return len(x)
     except TypeError:
-        raise TypeError("Expected sequence or array-like, got %s." % type(x))
+        raise TypeError("Expected sequence or array-like, got %s." % type(x)) from None
 
 
 def _safe_indexing(
@@ -323,7 +323,7 @@ class _Objective(object):
                     train_score = self.error_score
 
             else:
-                raise ValueError("error_score must be 'raise' or numeric.")
+                raise ValueError("error_score must be 'raise' or numeric.") from e
 
         else:
             fit_time = time() - start_time

--- a/optuna/pruners/_threshold.py
+++ b/optuna/pruners/_threshold.py
@@ -15,7 +15,7 @@ def _check_value(value: Any) -> float:
         message = "The `value` argument is of type '{}' but supposed to be a float.".format(
             type(value).__name__
         )
-        raise TypeError(message)
+        raise TypeError(message) from None
 
     return value
 

--- a/optuna/storages/_rdb/storage.py
+++ b/optuna/storages/_rdb/storage.py
@@ -111,8 +111,8 @@ class RDBStorage(BaseStorage):
         except ImportError as e:
             raise ImportError(
                 "Failed to import DB access module for the specified storage URL. "
-                "Please install appropriate one. (The actual import error is: " + str(e) + ".)"
-            )
+                "Please install appropriate one."
+            ) from e
 
         self.scoped_session = orm.scoped_session(orm.sessionmaker(bind=self.engine))
         models.BaseModel.metadata.create_all(self.engine)
@@ -139,8 +139,8 @@ class RDBStorage(BaseStorage):
         except ImportError as e:
             raise ImportError(
                 "Failed to import DB access module for the specified storage URL. "
-                "Please install appropriate one. (The actual import error is: " + str(e) + ".)"
-            )
+                "Please install appropriate one."
+            ) from e
 
         self.scoped_session = orm.scoped_session(orm.sessionmaker(bind=self.engine))
         models.BaseModel.metadata.create_all(self.engine)
@@ -1107,10 +1107,9 @@ class RDBStorage(BaseStorage):
             message = (
                 "An exception is raised during the commit. "
                 "This typically happens due to invalid data in the commit, "
-                "e.g. exceeding max length. "
-                "(The actual exception is as follows: {})".format(repr(e))
+                "e.g. exceeding max length."
             )
-            raise optuna.exceptions.StorageInternalError(message).with_traceback(sys.exc_info()[2])
+            raise optuna.exceptions.StorageInternalError(message).with_traceback(sys.exc_info()[2]) from e
 
     def remove_session(self) -> None:
         """Removes the current session.

--- a/optuna/storages/_rdb/storage.py
+++ b/optuna/storages/_rdb/storage.py
@@ -1109,7 +1109,9 @@ class RDBStorage(BaseStorage):
                 "This typically happens due to invalid data in the commit, "
                 "e.g. exceeding max length."
             )
-            raise optuna.exceptions.StorageInternalError(message).with_traceback(sys.exc_info()[2]) from e
+            raise optuna.exceptions.StorageInternalError(message).with_traceback(
+                sys.exc_info()[2]
+            ) from e
 
     def remove_session(self) -> None:
         """Removes the current session.

--- a/optuna/trial/_trial.py
+++ b/optuna/trial/_trial.py
@@ -539,7 +539,7 @@ class Trial(BaseTrial):
             message = "The `value` argument is of type '{}' but supposed to be a float.".format(
                 type(value).__name__
             )
-            raise TypeError(message)
+            raise TypeError(message) from None
 
         if step < 0:
             raise ValueError("The `step` argument is {} but cannot be negative.".format(step))


### PR DESCRIPTION
## Motivation
Fixes #1779.

## Description of the changes
I used either:
- `raise .. from e` to chain exceptions where the first exception `e` has valuable information and seems useful for users.
- `raise .. from None` to unchain exceptions where the first exception has no valuable information and seems noisy and redundant.

## List of lines to check
I wrote [a simple script](https://gist.github.com/akihironitta/4223c1b32404b36c1b349d70c4c93b4d) using ast, a Python standard library, to list all the lines containing `raise` in `except` clause. (It doesn't necessarily mean that all these lines have to be changed.)

- [x] https://github.com/optuna/optuna/blob/fe1e3e54f961897b871daa7fe23d92c4e1eaa408/optuna/progress_bar.py#L21
- [x] https://github.com/optuna/optuna/blob/fe1e3e54f961897b871daa7fe23d92c4e1eaa408/optuna/integration/sklearn.py#L119
- [x] https://github.com/optuna/optuna/blob/fe1e3e54f961897b871daa7fe23d92c4e1eaa408/optuna/integration/sklearn.py#L315
- [x] https://github.com/optuna/optuna/blob/fe1e3e54f961897b871daa7fe23d92c4e1eaa408/optuna/integration/sklearn.py#L326
- [x] https://github.com/optuna/optuna/blob/fe1e3e54f961897b871daa7fe23d92c4e1eaa408/optuna/integration/chainer.py#L79
- [x] https://github.com/optuna/optuna/blob/fe1e3e54f961897b871daa7fe23d92c4e1eaa408/optuna/integration/chainermn.py#L321
- [x] https://github.com/optuna/optuna/blob/fe1e3e54f961897b871daa7fe23d92c4e1eaa408/optuna/storages/_rdb/storage.py#L112
- [x] https://github.com/optuna/optuna/blob/fe1e3e54f961897b871daa7fe23d92c4e1eaa408/optuna/storages/_rdb/storage.py#L140
- [x] https://github.com/optuna/optuna/blob/fe1e3e54f961897b871daa7fe23d92c4e1eaa408/optuna/storages/_rdb/storage.py#L474
- [x] https://github.com/optuna/optuna/blob/fe1e3e54f961897b871daa7fe23d92c4e1eaa408/optuna/storages/_rdb/storage.py#L1113
- [x] https://github.com/optuna/optuna/blob/fe1e3e54f961897b871daa7fe23d92c4e1eaa408/optuna/storages/_rdb/alembic/versions/v1.3.0.a.py#L65
- [x] https://github.com/optuna/optuna/blob/fe1e3e54f961897b871daa7fe23d92c4e1eaa408/optuna/storages/_rdb/alembic/versions/v1.3.0.a.py#L87
- [x] https://github.com/optuna/optuna/blob/fe1e3e54f961897b871daa7fe23d92c4e1eaa408/optuna/pruners/_threshold.py#L18
- [x] https://github.com/optuna/optuna/blob/fe1e3e54f961897b871daa7fe23d92c4e1eaa408/optuna/distributions.py#L416
- [x] https://github.com/optuna/optuna/blob/fe1e3e54f961897b871daa7fe23d92c4e1eaa408/optuna/trial/_trial.py#L542
- [x] https://github.com/optuna/optuna/blob/fe1e3e54f961897b871daa7fe23d92c4e1eaa408/optuna/study.py#L749
- [x] https://github.com/optuna/optuna/blob/fe1e3e54f961897b871daa7fe23d92c4e1eaa408/optuna/study.py#L884
- [x] https://github.com/optuna/optuna/blob/fe1e3e54f961897b871daa7fe23d92c4e1eaa408/tests/integration_tests/test_tensorboard.py#L36
