### PR TITLE
Fix fANOVA for `IntLogUniformDistribution`

### DIFF
--- a/optuna/importance/_fanova/_evaluator.py
+++ b/optuna/importance/_fanova/_evaluator.py
@@ -7,6 +7,7 @@ import numpy
 
 from optuna.distributions import CategoricalDistribution
 from optuna.distributions import DiscreteUniformDistribution
+from optuna.distributions import IntLogUniformDistribution
 from optuna.distributions import IntUniformDistribution
 from optuna.distributions import LogUniformDistribution
 from optuna.distributions import UniformDistribution
@@ -96,6 +97,7 @@ class FanovaImportanceEvaluator(BaseImportanceEvaluator):
                 distribution,
                 (
                     DiscreteUniformDistribution,
+                    IntLogUniformDistribution,
                     IntUniformDistribution,
                     LogUniformDistribution,
                     UniformDistribution,

--- a/tests/importance_tests/test_init.py
+++ b/tests/importance_tests/test_init.py
@@ -36,15 +36,16 @@ def test_get_param_importances(
         x2 = trial.suggest_loguniform("x2", 0.1, 3)
         x3 = trial.suggest_discrete_uniform("x3", 0, 3, 1)
         x4 = trial.suggest_int("x4", -3, 3)
-        x5 = trial.suggest_categorical("x5", [1.0, 1.1, 1.2])
+        x5 = trial.suggest_int("x5", 1, 5, log=True)
+        x6 = trial.suggest_categorical("x6", [1.0, 1.1, 1.2])
         if trial.number % 2 == 0:
             # Conditional parameters are ignored unless `params` is specified and is not `None`.
-            x6 = trial.suggest_uniform("x6", 0.1, 3)
+            x7 = trial.suggest_uniform("x7", 0.1, 3)
 
-        assert isinstance(x5, float)
-        value = x1 ** 4 + x2 + x3 - x4 ** 2 - x5
+        assert isinstance(x6, float)
+        value = x1 ** 4 + x2 + x3 - x4 ** 2 - x5 + x6
         if trial.number % 2 == 0:
-            value += x6
+            value += x7
         return value
 
     study = create_study(storage_init_func(), sampler=samplers.RandomSampler())
@@ -53,8 +54,10 @@ def test_get_param_importances(
     param_importance = get_param_importances(study, evaluator=evaluator_init_func())
 
     assert isinstance(param_importance, OrderedDict)
-    assert len(param_importance) == 5
-    assert all(param_name in param_importance for param_name in ["x1", "x2", "x3", "x4", "x5"])
+    assert len(param_importance) == 6
+    assert all(
+        param_name in param_importance for param_name in ["x1", "x2", "x3", "x4", "x5", "x6"]
+    )
     prev_importance = float("inf")
     for param_name, importance in param_importance.items():
         assert isinstance(param_name, str)


### PR DESCRIPTION
## Motivation

See below.

## Description of the changes

Fixes a bug in fANOVA where `IntLogUniformDistribution` parameters used to raise an assertion error.
