### PR TITLE
Disable `--cache-from` if trigger of docker image build is `release`

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -46,6 +46,7 @@ jobs:
 
     - name: Build the Docker image
       run: |
+        # If the event is release, cache is not available because the image tag includes the Optuna version.
         if [ "${{ github.event_name }}" != 'release' ]; then
           docker pull "${HUB_TAG}"
           CACHE_FROM="--cache-from=${HUB_TAG}"

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -47,12 +47,11 @@ jobs:
     - name: Build the Docker image
       run: |
         if [ "${{ github.event_name }}" = 'release' ]; then
-          export CACHE_FROM=""
+          docker build . --build-arg PYTHON_VERSION=${{ matrix.python_version }} --build-arg BUILD_TYPE=${{ matrix.build_type }} --file Dockerfile --tag "${HUB_TAG}"
         else
           docker pull "${HUB_TAG}"
-          export CACHE_FROM="--cache-from ${HUB_TAG}"
+          docker build --cache-from "${HUB_TAG}" . --build-arg PYTHON_VERSION=${{ matrix.python_version }} --build-arg BUILD_TYPE=${{ matrix.build_type }} --file Dockerfile --tag "${HUB_TAG}"
         fi
-        docker build "${CACHE_FROM}" . --build-arg PYTHON_VERSION=${{ matrix.python_version }} --build-arg BUILD_TYPE=${{ matrix.build_type }} --file Dockerfile --tag "${HUB_TAG}"
 
     - name: Verify the built image
       run: |

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -46,12 +46,11 @@ jobs:
 
     - name: Build the Docker image
       run: |
-        if [ "${{ github.event_name }}" = 'release' ]; then
-          docker build . --build-arg PYTHON_VERSION=${{ matrix.python_version }} --build-arg BUILD_TYPE=${{ matrix.build_type }} --file Dockerfile --tag "${HUB_TAG}"
-        else
+        if [ "${{ github.event_name }}" != 'release' ]; then
           docker pull "${HUB_TAG}"
-          docker build --cache-from "${HUB_TAG}" . --build-arg PYTHON_VERSION=${{ matrix.python_version }} --build-arg BUILD_TYPE=${{ matrix.build_type }} --file Dockerfile --tag "${HUB_TAG}"
+          CACHE_FROM="--cache-from=${HUB_TAG}"
         fi
+        docker build ${CACHE_FROM} . --build-arg PYTHON_VERSION=${{ matrix.python_version }} --build-arg BUILD_TYPE=${{ matrix.build_type }} --file Dockerfile --tag "${HUB_TAG}"
 
     - name: Verify the built image
       run: |

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -46,8 +46,10 @@ jobs:
 
     - name: Build the Docker image
       run: |
-        # If the event is release, cache is not available because the image tag includes the Optuna version.
-        if [ "${{ github.event_name }}" != 'release' ]; then
+        if [ "${{ github.event_name }}" = 'release' ]; then
+          # Cache is not available because the image tag includes the Optuna version.
+          CACHE_FROM=""
+        else
           docker pull "${HUB_TAG}"
           CACHE_FROM="--cache-from=${HUB_TAG}"
         fi

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -47,10 +47,10 @@ jobs:
     - name: Build the Docker image
       run: |
         if [ "${{ github.event_name }}" = 'release' ]; then
-          CACHE_FROM=""
+          export CACHE_FROM=""
         else
           docker pull "${HUB_TAG}"
-          CACHE_FROM="--cache-from ${HUB_TAG}"
+          export CACHE_FROM="--cache-from ${HUB_TAG}"
         fi
         docker build "${CACHE_FROM}" . --build-arg PYTHON_VERSION=${{ matrix.python_version }} --build-arg BUILD_TYPE=${{ matrix.build_type }} --file Dockerfile --tag "${HUB_TAG}"
 

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -44,13 +44,15 @@ jobs:
         fi
         echo "::set-env name=HUB_TAG::${DOCKER_HUB_BASE_NAME}:${TAG_NAME}"
 
-    - name: Pull the Docker image
-      run: |
-        docker pull "${HUB_TAG}"
-
     - name: Build the Docker image
       run: |
-        docker build --cache-from "${HUB_TAG}" . --build-arg PYTHON_VERSION=${{ matrix.python_version }} --build-arg BUILD_TYPE=${{ matrix.build_type }} --file Dockerfile --tag "${HUB_TAG}"
+        if [ "${{ github.event_name }}" = 'release' ]; then
+          CACHE_FROM=""
+        else
+          docker pull "${HUB_TAG}"
+          CACHE_FROM="--cache-from ${HUB_TAG}"
+        fi
+        docker build "${CACHE_FROM}" . --build-arg PYTHON_VERSION=${{ matrix.python_version }} --build-arg BUILD_TYPE=${{ matrix.build_type }} --file Dockerfile --tag "${HUB_TAG}"
 
     - name: Verify the built image
       run: |


### PR DESCRIPTION
## Motivation

The docker image build for `v2.1.0` was failed due to the missing image cache as follows:

```console
Run docker pull "${HUB_TAG}"
  docker pull "${HUB_TAG}"
  shell: /bin/bash -e {0}
  env:
    DOCKER_HUB_BASE_NAME: optuna/optuna
    HUB_TAG: optuna/optuna:v2.1.0-py3.7
Error response from daemon: manifest for optuna/optuna:v2.1.0-py3.7 not found: manifest unknown: manifest unknown
```

See https://github.com/optuna/optuna/actions/runs/242435515 for details.

## Description of the changes
This PR disables `--cache-from` option of the `docker build` and build the images from scratch if the trigger is `release`.