### PR TITLE
Fix `mypy` in an environment where some dependencies are installed

### DIFF
--- a/optuna/dashboard.py
+++ b/optuna/dashboard.py
@@ -233,7 +233,7 @@ if _imports.is_successful():
                         self.doc.add_next_tick_callback(self.update_callback)
 
         @tornado.gen.coroutine
-        def update_callback(self) -> None:
+        def update_callback(self) -> Any:
 
             with self.lock:
                 current_trials = self.current_trials

--- a/optuna/integration/chainer.py
+++ b/optuna/integration/chainer.py
@@ -10,7 +10,7 @@ with optuna._imports.try_import() as _imports:
     from chainer.training.triggers import ManualScheduleTrigger
 
 if not _imports.is_successful():
-    Extension = object  # NOQA
+    Extension = object  # type: ignore # NOQA
 
 
 class ChainerPruningExtension(Extension):
@@ -71,10 +71,10 @@ class ChainerPruningExtension(Extension):
         _imports.check()
 
         if isinstance(observation_value, chainer.Variable):
-            observation_value = observation_value.data
+            observation_value = observation_value.data  # type: ignore
 
         try:
-            observation_value = float(observation_value)
+            observation_value = float(observation_value)  # type: ignore
         except TypeError:
             raise TypeError(
                 "Type of observation value is not supported by ChainerPruningExtension.\n"

--- a/tests/integration_tests/test_chainer.py
+++ b/tests/integration_tests/test_chainer.py
@@ -44,7 +44,7 @@ def test_chainer_pruning_extension_trigger() -> None:
     assert isinstance(extension._pruner_trigger, triggers.ManualScheduleTrigger)
 
     with pytest.raises(TypeError):
-        ChainerPruningExtension(trial, "main/loss", triggers.TimeTrigger(1.0))
+        ChainerPruningExtension(trial, "main/loss", triggers.TimeTrigger(1.0))  # type: ignore
 
 
 def test_chainer_pruning_extension() -> None:
@@ -86,7 +86,7 @@ def test_chainer_pruning_extension_observation_nan() -> None:
 
     with patch.object(extension, "_observation_exists", Mock(return_value=True)) as mock:
         with pytest.raises(optuna.TrialPruned):
-            extension(trainer)
+            extension(trainer)  # type: ignore
         assert mock.call_count == 1
 
 
@@ -100,17 +100,17 @@ def test_observation_exists() -> None:
     # Trigger is deactivated. Return False whether trainer has observation or not.
     with patch.object(triggers.IntervalTrigger, "__call__", Mock(return_value=False)) as mock:
         extension = ChainerPruningExtension(trial, "NG", (1, "epoch"))
-        assert extension._observation_exists(trainer) is False
+        assert extension._observation_exists(trainer) is False  # type: ignore
         extension = ChainerPruningExtension(trial, "OK", (1, "epoch"))
-        assert extension._observation_exists(trainer) is False
+        assert extension._observation_exists(trainer) is False  # type: ignore
         assert mock.call_count == 2
 
     # Trigger is activated. Return True if trainer has observation.
     with patch.object(triggers.IntervalTrigger, "__call__", Mock(return_value=True)) as mock:
         extension = ChainerPruningExtension(trial, "NG", (1, "epoch"))
-        assert extension._observation_exists(trainer) is False
+        assert extension._observation_exists(trainer) is False  # type: ignore
         extension = ChainerPruningExtension(trial, "OK", (1, "epoch"))
-        assert extension._observation_exists(trainer) is True
+        assert extension._observation_exists(trainer) is True  # type: ignore
         assert mock.call_count == 2
 
 
@@ -120,4 +120,4 @@ def test_get_float_value() -> None:
     assert 1.0 == ChainerPruningExtension._get_float_value(chainer.Variable(np.array([1.0])))
     assert math.isnan(ChainerPruningExtension._get_float_value(float("nan")))
     with pytest.raises(TypeError):
-        ChainerPruningExtension._get_float_value([])
+        ChainerPruningExtension._get_float_value([])  # type: ignore

--- a/tests/integration_tests/test_fastai.py
+++ b/tests/integration_tests/test_fastai.py
@@ -79,4 +79,4 @@ def test_fastai_pruning_callback(tmpdir: Any) -> None:
 
 
 # https://github.com/optuna/optuna/pull/1399#issuecomment-646956305
-torch.utils.data.DataLoader.__init__ = fastai.basic_data.old_dl_init
+torch.utils.data.DataLoader.__init__ = fastai.basic_data.old_dl_init  # type: ignore

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -73,7 +73,7 @@ def test_verbosity(capsys: _pytest.capture.CaptureFixture) -> None:
     assert "bye-debug" not in err
 
 
-def test_propagation(caplog: _pytest.capture.CaptureFixture) -> None:
+def test_propagation(caplog: _pytest.logging.LogCaptureFixture) -> None:
 
     optuna.logging._reset_library_root_logger()
     logger = optuna.logging.get_logger("optuna.foo")


### PR DESCRIPTION
## Motivation
Address the issue #1801. I have observed the same issue reported in #1801 after installing all dependencies by `pip install -e ".[testing]"`.

Related issue: #1801 

## Description of the changes
Change some typing annotations and set `# type: ignore`.

## Before
```
(venv) HideakinoMacBook-puro:optuna mamu$ mypy .
optuna/dashboard.py:235: error: Argument 1 to "coroutine" has incompatible type "Callable[[_DashboardApp], None]"; expected "Callable[..., Generator[Any, Any, <nothing>]]"
optuna/integration/chainer.py:13: error: Cannot assign to a type
optuna/integration/chainer.py:13: error: Incompatible types in assignment (expression has type "Type[object]", variable has type "Type[Extension]")
optuna/integration/chainer.py:74: error: Incompatible types in assignment (expression has type "Optional[Any]", variable has type "Union[float, Variable]")
optuna/integration/chainer.py:77: error: Argument 1 to "float" has incompatible type "Union[float, Variable]"; expected "Union[SupportsFloat, _SupportsIndex, str, bytes, bytearray]"
tests/test_logging.py:82: error: "CaptureFixture" has no attribute "at_level"
tests/test_logging.py:84: error: "CaptureFixture" has no attribute "text"
tests/test_logging.py:88: error: "CaptureFixture" has no attribute "at_level"
tests/test_logging.py:90: error: "CaptureFixture" has no attribute "text"
tests/test_logging.py:94: error: "CaptureFixture" has no attribute "at_level"
tests/test_logging.py:96: error: "CaptureFixture" has no attribute "text"
tests/integration_tests/test_fastai.py:82: error: Cannot assign to a method
tests/integration_tests/test_chainer.py:47: error: Argument 3 to "ChainerPruningExtension" has incompatible type "TimeTrigger"; expected "Union[Tuple[int, str], IntervalTrigger, ManualScheduleTrigger]"
tests/integration_tests/test_chainer.py:89: error: Argument 1 to "__call__" of "ChainerPruningExtension" has incompatible type "_MockTrainer@83"; expected "Trainer"
tests/integration_tests/test_chainer.py:103: error: Argument 1 to "_observation_exists" of "ChainerPruningExtension" has incompatible type "_MockTrainer@97"; expected "Trainer"
tests/integration_tests/test_chainer.py:105: error: Argument 1 to "_observation_exists" of "ChainerPruningExtension" has incompatible type "_MockTrainer@97"; expected "Trainer"
tests/integration_tests/test_chainer.py:111: error: Argument 1 to "_observation_exists" of "ChainerPruningExtension" has incompatible type "_MockTrainer@97"; expected "Trainer"
tests/integration_tests/test_chainer.py:113: error: Argument 1 to "_observation_exists" of "ChainerPruningExtension" has incompatible type "_MockTrainer@97"; expected "Trainer"
tests/integration_tests/test_chainer.py:123: error: Argument 1 to "_get_float_value" of "ChainerPruningExtension" has incompatible type "List[<nothing>]"; expected "Union[float, Variable]"
Found 19 errors in 5 files (checked 192 source files)
```

## After
```
(venv) HideakinoMacBook-puro:optuna mamu$ mypy .
Success: no issues found in 192 source files
```
