### PR TITLE
Copy datasets before objective evaluation.

### DIFF
--- a/optuna/integration/_lightgbm_tuner/optimize.py
+++ b/optuna/integration/_lightgbm_tuner/optimize.py
@@ -228,6 +228,13 @@ class _OptunaObjective(_BaseTuner):
             param_value = int(trial.suggest_uniform("min_child_samples", 5, 100 + _EPS))
             self.lgbm_params["min_child_samples"] = param_value
 
+    def _copy_valid_sets(self, valid_sets: "VALID_SET_TYPE") -> "VALID_SET_TYPE":
+        if isinstance(valid_sets, list):
+            return [copy.copy(d) for d in valid_sets]
+        if isinstance(valid_sets, tuple):
+            return tuple([copy.copy(d) for d in valid_sets])
+        return copy.copy(valid_sets)
+
     def __call__(self, trial: optuna.trial.Trial) -> float:
 
         self._preprocess(trial)
@@ -235,7 +242,7 @@ class _OptunaObjective(_BaseTuner):
         start_time = time.time()
         train_set = copy.copy(self.train_set)
         kwargs = copy.copy(self.lgbm_kwargs)
-        kwargs["valid_sets"] = [copy.copy(d) for d in kwargs["valid_sets"]]
+        kwargs["valid_sets"] = self._copy_valid_sets(kwargs["valid_sets"])
         booster = lgb.train(self.lgbm_params, train_set, **kwargs)
 
         val_score = self._get_booster_best_score(booster)

--- a/optuna/integration/_lightgbm_tuner/optimize.py
+++ b/optuna/integration/_lightgbm_tuner/optimize.py
@@ -233,7 +233,10 @@ class _OptunaObjective(_BaseTuner):
         self._preprocess(trial)
 
         start_time = time.time()
-        booster = lgb.train(self.lgbm_params, self.train_set, **self.lgbm_kwargs)
+        train_set = copy.copy(self.train_set)
+        kwargs = copy.copy(self.lgbm_kwargs)
+        kwargs["valid_sets"] = [copy.copy(d) for d in kwargs["valid_sets"]]
+        booster = lgb.train(self.lgbm_params, train_set, **kwargs)
 
         val_score = self._get_booster_best_score(booster)
         elapsed_secs = time.time() - start_time
@@ -302,7 +305,8 @@ class _OptunaObjectiveCV(_OptunaObjective):
         self._preprocess(trial)
 
         start_time = time.time()
-        cv_results = lgb.cv(self.lgbm_params, self.train_set, **self.lgbm_kwargs)
+        train_set = copy.copy(self.train_set)
+        cv_results = lgb.cv(self.lgbm_params, train_set, **self.lgbm_kwargs)
 
         val_scores = self._get_cv_scores(cv_results)
         val_score = val_scores[-1]


### PR DESCRIPTION
## Motivation

As discussed in #1718, LightGBM datasets have parameters and they will be tuned during the model training. I guess the dataset parameters can be the cause of #1500.

## Description of the changes

This PR simply copied the dataset before training the booster models. Currently, I used the shallow copy, and I confirmed that I could enable `feature_pre_filter` when I ran the  `examples/lightgbm_tuner_cv.py`.