### PR TITLE
Add metric alias of rmse for LightGBMTuner

### DIFF
--- a/optuna/integration/_lightgbm_tuner/alias.py
+++ b/optuna/integration/_lightgbm_tuner/alias.py
@@ -57,6 +57,10 @@ _ALIAS_METRIC_LIST = [
         "metric_name": "l2",
         "alias_names": ["regression", "regression_l2", "l2", "mean_squared_error", "mse"],
     },
+    {
+        "metric_name": "rmse",
+        "alias_names": ["l2_root", "root_mean_squared_error"],
+    },
 ]  # type: List[Dict[str, Any]]
 
 

--- a/tests/integration_tests/lightgbm_tuner_tests/test_alias.py
+++ b/tests/integration_tests/lightgbm_tuner_tests/test_alias.py
@@ -70,6 +70,7 @@ def test_handling_alias_metrics() -> None:
     _handling_alias_metrics(lgbm_params)
     assert lgbm_params["metric"] == "auc"
 
-    lgbm_params = {"metric": "rmse"}
-    _handling_alias_metrics(lgbm_params)
-    assert lgbm_params["metric"] == "rmse"
+    for alias in ["l2_root", "root_mean_squared_error", "rmse"]:
+        lgbm_params = {"metric": alias}
+        _handling_alias_metrics(lgbm_params)
+        assert lgbm_params["metric"] == "rmse"


### PR DESCRIPTION
<!-- Thank you for creating a pull request! -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
Please refer to the Issue #1806.

## Description of the changes
<!-- Describe the changes in this PR. -->
I added metric alias of rmse for LightGBMTuner. We can see metric aliases [here](https://github.com/microsoft/LightGBM/blob/master/include/LightGBM/config.h#L1119-L1120). 