### PR TITLE
Fix `plot_pareto_front` preview path

### DIFF
--- a/optuna/multi_objective/visualization/_pareto_front.py
+++ b/optuna/multi_objective/visualization/_pareto_front.py
@@ -43,7 +43,7 @@ def plot_pareto_front(
 
         .. raw:: html
 
-            <iframe src="../../_static/plot_pareto_front.html" width="100%" height="500px"
+            <iframe src="../../../_static/plot_pareto_front.html" width="100%" height="500px"
             frameborder="0"></iframe>
 
     Args:


### PR DESCRIPTION
## Motivation

See below.

## Description of the changes

Fixes a broken reference to the preview html in the Pareto front visualization function.