### PR TITLE
Update PyTorch-Lighting minor version

### DIFF
--- a/examples/pytorch_lightning_simple.py
+++ b/examples/pytorch_lightning_simple.py
@@ -29,8 +29,8 @@ from torchvision import transforms
 import optuna
 from optuna.integration import PyTorchLightningPruningCallback
 
-if version.parse(pl.__version__) < version.parse("0.7.1"):
-    raise RuntimeError("PyTorch Lightning>=0.7.1 is required for this example.")
+if version.parse(pl.__version__) < version.parse("0.8.1"):
+    raise RuntimeError("PyTorch Lightning>=0.8.1 is required for this example.")
 
 PERCENT_VALID_EXAMPLES = 0.1
 BATCHSIZE = 128
@@ -140,7 +140,7 @@ def objective(trial):
     metrics_callback = MetricsCallback()
     trainer = pl.Trainer(
         logger=False,
-        val_percent_check=PERCENT_VALID_EXAMPLES,
+        limit_val_batches=PERCENT_VALID_EXAMPLES,
         checkpoint_callback=checkpoint_callback,
         max_epochs=EPOCHS,
         gpus=1 if torch.cuda.is_available() else None,

--- a/optuna/integration/pytorch_lightning.py
+++ b/optuna/integration/pytorch_lightning.py
@@ -26,7 +26,7 @@ class PyTorchLightningPruningCallback(EarlyStopping):
             An evaluation metric for pruning, e.g., ``val_loss`` or
             ``val_acc``. The metrics are obtained from the returned dictionaries from e.g.
             ``pytorch_lightning.LightningModule.training_step`` or
-            ``pytorch_lightning.LightningModule.validation_end`` and the names thus depend on
+            ``pytorch_lightning.LightningModule.validation_epoch_end`` and the names thus depend on
             how this dictionary is formatted.
     """
 
@@ -49,10 +49,5 @@ class PyTorchLightningPruningCallback(EarlyStopping):
             message = "Trial was pruned at epoch {}.".format(epoch)
             raise optuna.TrialPruned(message)
 
-    # NOTE (crcrpar): This method is called <0.8.0
-    def on_epoch_end(self, trainer: Trainer, pl_module: LightningModule) -> None:
-        return self._process(trainer, pl_module)
-
-    # NOTE (crcrpar): This method is called >=0.8.0
     def on_validation_end(self, trainer: Trainer, pl_module: LightningModule) -> None:
         return self._process(trainer, pl_module)

--- a/optuna/integration/pytorch_lightning.py
+++ b/optuna/integration/pytorch_lightning.py
@@ -38,7 +38,8 @@ class PyTorchLightningPruningCallback(EarlyStopping):
 
         self._trial = trial
 
-    def _process(self, trainer: Trainer, pl_module: LightningModule) -> None:
+    def on_validation_end(self, trainer: Trainer, pl_module: LightningModule) -> None:
+
         logs = trainer.callback_metrics
         epoch = pl_module.current_epoch
         current_score = logs.get(self.monitor)
@@ -48,6 +49,3 @@ class PyTorchLightningPruningCallback(EarlyStopping):
         if self._trial.should_prune():
             message = "Trial was pruned at epoch {}.".format(epoch)
             raise optuna.TrialPruned(message)
-
-    def on_validation_end(self, trainer: Trainer, pl_module: LightningModule) -> None:
-        return self._process(trainer, pl_module)

--- a/setup.py
+++ b/setup.py
@@ -94,17 +94,12 @@ def get_extras_require() -> Dict[str, List[str]]:
                 if sys.platform == "darwin"
                 else ["torch==1.6.0+cpu", "torchvision==0.7.0+cpu"]
             )
-            + ["pytorch-ignite", "thop", "skorch"]
+            + ["pytorch-ignite", "pytorch-lightning>=0.8.1", "thop", "skorch"]
             if (3, 5) < sys.version_info[:2]
             else []
         )
         + (["stable-baselines3>=0.7.0"] if (3, 5) < sys.version_info[:2] else [])
-        + (
-            ["allennlp==1.0.0", "fastai<2", "pytorch_lightning>=0.7.1"]
-            if (3, 5) < sys.version_info[:2] < (3, 8)
-            else []
-        )
-        + (["pytorch-lightning>=0.7.2"] if (3, 8) == sys.version_info[:2] else [])
+        + (["allennlp==1.0.0", "fastai<2"] if (3, 5) < sys.version_info[:2] < (3, 8) else [])
         + (
             ["llvmlite<=0.31.0", "fsspec<0.8.0"] if (3, 5) == sys.version_info[:2] else []
         )  # Newer `llvmlite` is not distributed with wheels for Python 3.5.
@@ -139,17 +134,12 @@ def get_extras_require() -> Dict[str, List[str]]:
                 if sys.platform == "darwin"
                 else ["torch==1.6.0+cpu", "torchvision==0.7.0+cpu"]
             )
-            + ["pytorch-ignite", "skorch"]
+            + ["pytorch-ignite", "pytorch-lightning>=0.8.1", "skorch"]
             if (3, 5) < sys.version_info[:2]
             else []
         )
-        + (
-            ["allennlp==1.0.0", "fastai<2", "pytorch_lightning>=0.7.1"]
-            if (3, 5) < sys.version_info[:2] < (3, 8)
-            else []
-        )
-        + (["catalyst"] if (3, 5) < sys.version_info[:2] else [])
-        + (["pytorch-lightning>=0.7.2"] if (3, 8) == sys.version_info[:2] else []),
+        + (["allennlp==1.0.0", "fastai<2"] if (3, 5) < sys.version_info[:2] < (3, 8) else [])
+        + (["catalyst"] if (3, 5) < sys.version_info[:2] else []),
         "tests": ["fakeredis", "pytest"],
         "optional": [
             "bokeh<2.0.0",  # optuna/cli.py, optuna/dashboard.py.
@@ -181,17 +171,12 @@ def get_extras_require() -> Dict[str, List[str]]:
                 if sys.platform == "darwin"
                 else ["torch==1.6.0+cpu", "torchvision==0.7.0+cpu"]
             )
-            + ["pytorch-ignite", "skorch"]
+            + ["pytorch-ignite", "pytorch-lightning>=0.8.1", "skorch"]
             if (3, 5) < sys.version_info[:2]
             else []
         )
-        + (
-            ["allennlp==1.0.0", "fastai<2", "pytorch-lightning>=0.7.1"]
-            if (3, 5) < sys.version_info[:2] < (3, 8)
-            else []
-        )
-        + (["catalyst"] if (3, 5) < sys.version_info[:2] else [])
-        + (["pytorch-lightning>=0.7.2"] if (3, 8) == sys.version_info[:2] else []),
+        + (["allennlp==1.0.0", "fastai<2"] if (3, 5) < sys.version_info[:2] < (3, 8) else [])
+        + (["catalyst"] if (3, 5) < sys.version_info[:2] else []),
     }
 
     return requirements

--- a/tests/integration_tests/test_pytorch_lightning.py
+++ b/tests/integration_tests/test_pytorch_lightning.py
@@ -37,7 +37,7 @@ class Model(pl.LightningModule):
         accuracy = pred.eq(target.view_as(pred)).double().mean()
         return {"validation_accuracy": accuracy}
 
-    def validation_end(
+    def validation_epoch_end(
         self, outputs: List[Dict[str, torch.Tensor]]
     ) -> Dict[str, Union[torch.Tensor, float]]:
 


### PR DESCRIPTION
<!-- Thank you for creating a pull request! -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

Solve #1669 and update the minor version of PyTorch-Lightning to `v0.8.1`.

## Description of the changes
<!-- Describe the changes in this PR. -->

This main change is to rename the deprecated method and arguments of PyTorch-Lightning. As a result, we need to update minor version to `pytorch_lightning>=v0.8.1` because `limit_val_batches` has been introduced since the version.
