### PR TITLE
Feat tensorboard

### DIFF
--- a/optuna/integration/tensorboard.py
+++ b/optuna/integration/tensorboard.py
@@ -51,7 +51,7 @@ class TensorBoardCallback(object):
         with tf.summary.create_file_writer(run_dir).as_default():
             hp.hparams_config(
                 hparams=list(hparams.keys()),
-                # Control metric valued displayed on HPARAMS tab of TensorBoard.
+                # Control metric values displayed on HPARAMS tab of TensorBoard.
                 metrics=[
                     hp.Metric(
                         tag=self._metric_name,

--- a/optuna/integration/tensorboard.py
+++ b/optuna/integration/tensorboard.py
@@ -49,7 +49,7 @@ class TensorBoardCallback(object):
         run_name = "trial-%d" % trial.number
         run_dir = os.path.join(self._dirname, run_name)
         with tf.summary.create_file_writer(run_dir).as_default():
-            hp.hparams(hparams)  # record the values used in this trial
+            hp.hparams(hparams, trial_id=run_name)  # record the values used in this trial
             tf.summary.scalar(self._metric_name, trial_value, step=1)
 
     def _add_distributions(

--- a/optuna/integration/tensorboard.py
+++ b/optuna/integration/tensorboard.py
@@ -50,7 +50,7 @@ class TensorBoardCallback(object):
         run_dir = os.path.join(self._dirname, run_name)
         with tf.summary.create_file_writer(run_dir).as_default():
             hp.hparams(hparams, trial_id=run_name)  # record the values used in this trial
-            tf.summary.scalar(self._metric_name, trial_value, step=1)
+            tf.summary.scalar(self._metric_name, trial_value, step=trial.number)
 
     def _add_distributions(
         self, distributions: Dict[str, optuna.distributions.BaseDistribution]

--- a/optuna/integration/tensorboard.py
+++ b/optuna/integration/tensorboard.py
@@ -49,17 +49,6 @@ class TensorBoardCallback(object):
         run_name = "trial-%d" % trial.number
         run_dir = os.path.join(self._dirname, run_name)
         with tf.summary.create_file_writer(run_dir).as_default():
-            hp.hparams_config(
-                hparams=list(hparams.keys()),
-                # Control metric values displayed on HPARAMS tab of TensorBoard.
-                metrics=[
-                    hp.Metric(
-                        tag=self._metric_name,
-                        display_name=self._metric_name,
-                        description="Trial value optimized with Optuna.",
-                    )
-                ],
-            )
             hp.hparams(hparams, trial_id=run_name)  # record the values used in this trial
             tf.summary.scalar(self._metric_name, trial_value, step=trial.number)
 

--- a/optuna/integration/tensorboard.py
+++ b/optuna/integration/tensorboard.py
@@ -56,9 +56,9 @@ class TensorBoardCallback(object):
                     hp.Metric(
                         tag=self._metric_name,
                         display_name=self._metric_name,
-                        description="Trial value optimized with Optuna."
+                        description="Trial value optimized with Optuna.",
                     )
-                ]
+                ],
             )
             hp.hparams(hparams, trial_id=run_name)  # record the values used in this trial
             tf.summary.scalar(self._metric_name, trial_value, step=trial.number)

--- a/optuna/integration/tensorboard.py
+++ b/optuna/integration/tensorboard.py
@@ -49,6 +49,17 @@ class TensorBoardCallback(object):
         run_name = "trial-%d" % trial.number
         run_dir = os.path.join(self._dirname, run_name)
         with tf.summary.create_file_writer(run_dir).as_default():
+            hp.hparams_config(
+                hparams=list(hparams.keys()),
+                # Control metric valued displayed on HPARAMS tab of TensorBoard.
+                metrics=[
+                    hp.Metric(
+                        tag=self._metric_name,
+                        display_name=self._metric_name,
+                        description="Trial value optimized with Optuna."
+                    )
+                ]
+            )
             hp.hparams(hparams, trial_id=run_name)  # record the values used in this trial
             tf.summary.scalar(self._metric_name, trial_value, step=trial.number)
 


### PR DESCRIPTION
# Motivation

This PR close #1811.

## Description of the changes

### Major changes

- Use `trial-{trial number}` as IDs displayed on TensorBoard
- Use trial number as horizontal axis on scalar tab

### Minor changes

Add description of metric:
![image](https://user-images.githubusercontent.com/2109535/92987169-01a85880-f4fb-11ea-99c8-2f3116192437.png)

Add hparams config as below.
We can control metrics displayed on HPARAMS tab and it might be useful in future.

```python
hp.hparams_config(
    hparams=list(hparams.keys()),
    # Control metric values displayed on HPARAMS tab of TensorBoard.
    metrics=[
        hp.Metric(
            tag=self._metric_name,
            display_name=self._metric_name,
            description="Trial value optimized with Optuna."
        )
    ]
)
```

### Examples

You can see the result of sample code here:

**The result of [Current example (Optuna v2.1.0)](https://github.com/optuna/optuna/blob/release-v2.1.0/examples/tensorboard_simple.py):**
https://tensorboard.dev/experiment/fN5hPkJlSKiXcxePCDUosw/

**The proposed change:**
https://tensorboard.dev/experiment/GaKU5NcjT1CweWO6BzXDqg/