### PR TITLE
Fix indents of the example of `multi_objective.visualization.plot_pareto_front`

### DIFF
--- a/optuna/multi_objective/visualization/_pareto_front.py
+++ b/optuna/multi_objective/visualization/_pareto_front.py
@@ -29,12 +29,12 @@ def plot_pareto_front(
             import optuna
 
             def objective(trial):
-               x = trial.suggest_float("x", 0, 5)
-               y = trial.suggest_float("y", 0, 3)
+                x = trial.suggest_float("x", 0, 5)
+                y = trial.suggest_float("y", 0, 3)
 
-               v0 = 4 * x ** 2 + 4 * y ** 2
-               v1 = (x - 5) ** 2 + (y - 5) ** 2
-               return v0, v1
+                v0 = 4 * x ** 2 + 4 * y ** 2
+                v1 = (x - 5) ** 2 + (y - 5) ** 2
+                return v0, v1
 
             study = optuna.multi_objective.create_study(["minimize", "minimize"])
             study.optimize(objective, n_trials=50)


### PR DESCRIPTION
<!-- Thank you for creating a pull request! -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

The indents of `objective` in the example code of `multi_objective.visualization.plot_pareto_front` are three. This is not consistent with the indent rule in the codebase.

Ref: [the document page](https://optuna.readthedocs.io/en/latest/reference/multi_objective/generated/optuna.multi_objective.visualization.plot_pareto_front.html)

## Description of the changes
<!-- Describe the changes in this PR. -->

Change the indents with 4 spaces.
