### PR TITLE
Fix contour plot error for categorical distributions

### DIFF
--- a/optuna/visualization/_contour.py
+++ b/optuna/visualization/_contour.py
@@ -104,6 +104,7 @@ def _get_contour_plot(study: Study, params: Optional[List[str]] = None) -> "go.F
             max_value = math.pow(10, math.log10(max_value) + padding)
 
         elif _is_categorical(trials, p_name):
+            # For numeric values, plotly does not automatically plot as "category" type.
             update_category_axes[p_name] = any([str(v).isnumeric() for v in set(values)])
 
         else:
@@ -122,9 +123,9 @@ def _get_contour_plot(study: Study, params: Optional[List[str]] = None) -> "go.F
         figure.update_xaxes(title_text=x_param, range=param_values_range[x_param])
         figure.update_yaxes(title_text=y_param, range=param_values_range[y_param])
 
-        if _is_categorical(trials, x_param) and update_category_axes[x_param]:
+        if update_category_axes.get(x_param, False):
             figure.update_xaxes(type="category")
-        if _is_categorical(trials, y_param) and update_category_axes[y_param]:
+        if update_category_axes.get(y_param, False):
             figure.update_yaxes(type="category")
 
         if _is_log_scale(trials, x_param):
@@ -158,9 +159,9 @@ def _get_contour_plot(study: Study, params: Optional[List[str]] = None) -> "go.F
                 figure.update_xaxes(range=param_values_range[x_param], row=y_i + 1, col=x_i + 1)
                 figure.update_yaxes(range=param_values_range[y_param], row=y_i + 1, col=x_i + 1)
 
-                if _is_categorical(trials, x_param) and update_category_axes[x_param]:
+                if update_category_axes.get(x_param, False):
                     figure.update_xaxes(type="category", row=y_i + 1, col=x_i + 1)
-                if _is_categorical(trials, y_param) and update_category_axes[y_param]:
+                if update_category_axes.get(y_param, False):
                     figure.update_yaxes(type="category", row=y_i + 1, col=x_i + 1)
 
                 if _is_log_scale(trials, x_param):

--- a/optuna/visualization/_utils.py
+++ b/optuna/visualization/_utils.py
@@ -1,5 +1,6 @@
 from typing import List
 
+from optuna.distributions import CategoricalDistribution
 from optuna.distributions import LogUniformDistribution
 from optuna.trial import FrozenTrial
 from optuna.visualization import _plotly_imports
@@ -28,6 +29,15 @@ def _is_log_scale(trials: List[FrozenTrial], param: str) -> bool:
 
     return any(
         isinstance(t.distributions[param], LogUniformDistribution)
+        for t in trials
+        if param in t.params
+    )
+
+
+def _is_categorical(trials: List[FrozenTrial], param: str) -> bool:
+
+    return any(
+        isinstance(t.distributions[param], CategoricalDistribution)
         for t in trials
         if param in t.params
     )

--- a/tests/visualization_tests/test_contour.py
+++ b/tests/visualization_tests/test_contour.py
@@ -3,6 +3,7 @@ from typing import Optional
 
 import pytest
 
+from optuna.distributions import CategoricalDistribution
 from optuna.distributions import LogUniformDistribution
 from optuna.study import create_study
 from optuna.study import StudyDirection
@@ -86,87 +87,90 @@ def test_generate_contour_plot_for_few_observations() -> None:
     assert contour.x is None and contour.y is None and scatter.x is None and scatter.y is None
 
 
-def test_plot_contour_log_scale() -> None:
+def test_plot_contour_log_scale_and_str_category() -> None:
 
     # If the search space has two parameters, plot_contour generates a single plot.
     study = create_study()
     study.add_trial(
         create_trial(
             value=0.0,
-            params={"param_a": 1e-6, "param_b": 1e-4},
+            params={"param_a": 1e-6, "param_b": "100"},
             distributions={
                 "param_a": LogUniformDistribution(1e-7, 1e-2),
-                "param_b": LogUniformDistribution(1e-5, 1e-1),
+                "param_b": CategoricalDistribution(["100", "101"]),
             },
         )
     )
     study.add_trial(
         create_trial(
             value=1.0,
-            params={"param_a": 1e-5, "param_b": 1e-3},
+            params={"param_a": 1e-5, "param_b": "101"},
             distributions={
                 "param_a": LogUniformDistribution(1e-7, 1e-2),
-                "param_b": LogUniformDistribution(1e-5, 1e-1),
+                "param_b": CategoricalDistribution(["100", "101"]),
             },
         )
     )
 
     figure = plot_contour(study)
     assert figure.layout["xaxis"]["range"] == (-6.05, -4.95)
-    assert figure.layout["yaxis"]["range"] == (-4.05, -2.95)
+    assert figure.layout["yaxis"]["range"] == ("100", "101")
     assert figure.layout["xaxis_type"] == "log"
-    assert figure.layout["yaxis_type"] == "log"
+    assert figure.layout["yaxis_type"] == "category"
 
     # If the search space has three parameters, plot_contour generates nine plots.
     study = create_study()
     study.add_trial(
         create_trial(
             value=0.0,
-            params={"param_a": 1e-6, "param_b": 1e-4, "param_c": 1e-2},
+            params={"param_a": 1e-6, "param_b": "100", "param_c": "one"},
             distributions={
                 "param_a": LogUniformDistribution(1e-7, 1e-2),
-                "param_b": LogUniformDistribution(1e-5, 1e-1),
-                "param_c": LogUniformDistribution(1e-3, 10),
+                "param_b": CategoricalDistribution(["100", "101"]),
+                "param_c": CategoricalDistribution(["one", "two"]),
             },
         )
     )
     study.add_trial(
         create_trial(
             value=1.0,
-            params={"param_a": 1e-5, "param_b": 1e-3, "param_c": 1e-1},
+            params={"param_a": 1e-5, "param_b": "101", "param_c": "two"},
             distributions={
                 "param_a": LogUniformDistribution(1e-7, 1e-2),
-                "param_b": LogUniformDistribution(1e-5, 1e-1),
-                "param_c": LogUniformDistribution(1e-3, 10),
+                "param_b": CategoricalDistribution(["100", "101"]),
+                "param_c": CategoricalDistribution(["one", "two"]),
             },
         )
     )
 
     figure = plot_contour(study)
     param_a_range = (-6.05, -4.95)
-    param_b_range = (-4.05, -2.95)
-    param_c_range = (-2.05, -0.95)
-    axis_to_range = {
-        "xaxis": param_a_range,
-        "xaxis2": param_b_range,
-        "xaxis3": param_c_range,
-        "xaxis4": param_a_range,
-        "xaxis5": param_b_range,
-        "xaxis6": param_c_range,
-        "xaxis7": param_a_range,
-        "xaxis8": param_b_range,
-        "xaxis9": param_c_range,
-        "yaxis": param_a_range,
-        "yaxis2": param_a_range,
-        "yaxis3": param_a_range,
-        "yaxis4": param_b_range,
-        "yaxis5": param_b_range,
-        "yaxis6": param_b_range,
-        "yaxis7": param_c_range,
-        "yaxis8": param_c_range,
-        "yaxis9": param_c_range,
+    param_b_range = ("100", "101")
+    param_c_range = ("one", "two")
+    param_a_type = "log"
+    param_b_type = "category"
+    param_c_type = None
+    axis_to_range_and_type = {
+        "xaxis": (param_a_range, param_a_type),
+        "xaxis2": (param_b_range, param_b_type),
+        "xaxis3": (param_c_range, param_c_type),
+        "xaxis4": (param_a_range, param_a_type),
+        "xaxis5": (param_b_range, param_b_type),
+        "xaxis6": (param_c_range, param_c_type),
+        "xaxis7": (param_a_range, param_a_type),
+        "xaxis8": (param_b_range, param_b_type),
+        "xaxis9": (param_c_range, param_c_type),
+        "yaxis": (param_a_range, param_a_type),
+        "yaxis2": (param_a_range, param_a_type),
+        "yaxis3": (param_a_range, param_a_type),
+        "yaxis4": (param_b_range, param_b_type),
+        "yaxis5": (param_b_range, param_b_type),
+        "yaxis6": (param_b_range, param_b_type),
+        "yaxis7": (param_c_range, param_c_type),
+        "yaxis8": (param_c_range, param_c_type),
+        "yaxis9": (param_c_range, param_c_type),
     }
 
-    for axis, param_range in axis_to_range.items():
+    for axis, (param_range, param_type) in axis_to_range_and_type.items():
         assert figure.layout[axis]["range"] == param_range
-        assert figure.layout[axis]["type"] == "log"
+        assert figure.layout[axis]["type"] == param_type


### PR DESCRIPTION
## Motivation
As mentioned in https://github.com/optuna/optuna/issues/1803, error occurs when a categorical distribution of non-numerical values are used.

## Description of the changes
This pull request fixed the above error. 

For a categorical distribution, plotly behaves differently depending on the values.

- For values such as `[""sigmoid", "relu", "leakyrelu""]` which cannot be converted to numbers, plotly will automatically plot it as the category type. In this case, updating the axes type will cause undesirable plots (shown below).
- For values such as `["10", "11", "100"]` which can be converted to numbers, plotly will plot it as normal numbers. In this case, we need to update the axes type.

Therefore, I introduce a dictinary `update_category_axes` to store the above information.

Sample code and output:
```python
def objective(trial):
    x = trial.suggest_categorical("x", ["10", "11", "100"])
    y = trial.suggest_categorical("y", ["sigmoid", "relu", "leakyrelu"])
    z = trial.suggest_loguniform("z", 1e-1, 1e2)
    return int("0" in x) + abs(len(y) - 5) + (z/50) ** 2

study = optuna.create_study()
study.optimize(objective, n_trials=30)

optuna.visualization.plot_contour(study).show()
```

<img width="1286" alt="good" src="https://user-images.githubusercontent.com/29617239/92988691-cf9df300-f508-11ea-9b40-8d95745ca218.png">

For parameter `"y"`, if the axes type is manually updated, the plot becomes as follows.

<img width="1291" alt="bad" src="https://user-images.githubusercontent.com/29617239/92988713-fbb97400-f508-11ea-8f3f-0c5593105786.png">
