### PR TITLE
Add metric alias for LightGBMTuner

### DIFF
--- a/optuna/integration/_lightgbm_tuner/alias.py
+++ b/optuna/integration/_lightgbm_tuner/alias.py
@@ -41,6 +41,7 @@ def _handling_alias_parameters(lgbm_params: Dict[str, Any]) -> None:
 
 
 _ALIAS_METRIC_LIST = [
+    # The list `alias_names` do not include the `metric_name` itself.
     {
         "metric_name": "ndcg",
         "alias_names": [
@@ -55,20 +56,19 @@ _ALIAS_METRIC_LIST = [
     {"metric_name": "map", "alias_names": ["mean_average_precision"]},
     {
         "metric_name": "l2",
-        "alias_names": ["regression", "regression_l2", "l2", "mean_squared_error", "mse"],
+        "alias_names": ["regression", "regression_l2", "mean_squared_error", "mse"],
     },
     {
         "metric_name": "l1",
-        "alias_names": ["regression_l1", "l1", "mean_absolute_error", "mae"],
+        "alias_names": ["regression_l1", "mean_absolute_error", "mae"],
     },
     {
         "metric_name": "binary_logloss",
-        "alias_names": ["binary_logloss", "binary"],
+        "alias_names": ["binary"],
     },
     {
         "metric_name": "multi_logloss",
         "alias_names": [
-            "multi_logloss",
             "multiclass",
             "softmax",
             "multiclassova",
@@ -79,27 +79,23 @@ _ALIAS_METRIC_LIST = [
     },
     {
         "metric_name": "cross_entropy",
-        "alias_names": ["cross_entropy", "xentropy"],
+        "alias_names": ["xentropy"],
     },
     {
         "metric_name": "cross_entropy_lambda",
-        "alias_names": ["cross_entropy_lambda", "xentlambda"],
+        "alias_names": ["xentlambda"],
     },
     {
         "metric_name": "kullback_leibler",
-        "alias_names": ["kullback_leibler", "kldiv"],
+        "alias_names": ["kldiv"],
     },
     {
         "metric_name": "mape",
-        "alias_names": ["mape", "mean_absolute_percentage_error"],
-    },
-    {
-        "metric_name": "auc_mu",
-        "alias_names": ["auc_mu"],
+        "alias_names": ["mean_absolute_percentage_error"],
     },
     {
         "metric_name": "custom",
-        "alias_names": ["none", "null", "custom", "na"],
+        "alias_names": ["none", "null", "na"],
     },
     {
         "metric_name": "rmse",

--- a/optuna/integration/_lightgbm_tuner/alias.py
+++ b/optuna/integration/_lightgbm_tuner/alias.py
@@ -57,6 +57,50 @@ _ALIAS_METRIC_LIST = [
         "metric_name": "l2",
         "alias_names": ["regression", "regression_l2", "l2", "mean_squared_error", "mse"],
     },
+    {
+        "metric_name": "l1",
+        "alias_names": ["regression_l1", "l1", "mean_absolute_error", "mae"],
+    },
+    {
+        "metric_name": "binary_logloss",
+        "alias_names": ["binary_logloss", "binary"],
+    },
+    {
+        "metric_name": "multi_logloss",
+        "alias_names": [
+            "multi_logloss",
+            "multiclass",
+            "softmax",
+            "multiclassova",
+            "multiclass_ova",
+            "ova",
+            "ovr",
+        ],
+    },
+    {
+        "metric_name": "cross_entropy",
+        "alias_names": ["cross_entropy", "xentropy"],
+    },
+    {
+        "metric_name": "cross_entropy_lambda",
+        "alias_names": ["cross_entropy_lambda", "xentlambda"],
+    },
+    {
+        "metric_name": "kullback_leibler",
+        "alias_names": ["kullback_leibler", "kldiv"],
+    },
+    {
+        "metric_name": "mape",
+        "alias_names": ["mape", "mean_absolute_percentage_error"],
+    },
+    {
+        "metric_name": "auc_mu",
+        "alias_names": ["auc_mu"],
+    },
+    {
+        "metric_name": "custom",
+        "alias_names": ["none", "null", "custom", "na"],
+    },
 ]  # type: List[Dict[str, Any]]
 
 

--- a/tests/integration_tests/lightgbm_tuner_tests/test_alias.py
+++ b/tests/integration_tests/lightgbm_tuner_tests/test_alias.py
@@ -73,3 +73,56 @@ def test_handling_alias_metrics() -> None:
     lgbm_params = {"metric": "rmse"}
     _handling_alias_metrics(lgbm_params)
     assert lgbm_params["metric"] == "rmse"
+
+    for alias in ["regression_l1", "l1", "mean_absolute_error", "mae"]:
+        lgbm_params = {"metric": alias}
+        _handling_alias_metrics(lgbm_params)
+        assert lgbm_params["metric"] == "l1"
+
+    for alias in ["binary_logloss", "binary"]:
+        lgbm_params = {"metric": alias}
+        _handling_alias_metrics(lgbm_params)
+        assert lgbm_params["metric"] == "binary_logloss"
+
+    for alias in [
+        "multi_logloss",
+        "multiclass",
+        "softmax",
+        "multiclassova",
+        "multiclass_ova",
+        "ova",
+        "ovr",
+    ]:
+        lgbm_params = {"metric": alias}
+        _handling_alias_metrics(lgbm_params)
+        assert lgbm_params["metric"] == "multi_logloss"
+
+    for alias in ["cross_entropy", "xentropy"]:
+        lgbm_params = {"metric": alias}
+        _handling_alias_metrics(lgbm_params)
+        assert lgbm_params["metric"] == "cross_entropy"
+
+    for alias in ["cross_entropy_lambda", "xentlambda"]:
+        lgbm_params = {"metric": alias}
+        _handling_alias_metrics(lgbm_params)
+        assert lgbm_params["metric"] == "cross_entropy_lambda"
+
+    for alias in ["kullback_leibler", "kldiv"]:
+        lgbm_params = {"metric": alias}
+        _handling_alias_metrics(lgbm_params)
+        assert lgbm_params["metric"] == "kullback_leibler"
+
+    for alias in ["mape", "mean_absolute_percentage_error"]:
+        lgbm_params = {"metric": alias}
+        _handling_alias_metrics(lgbm_params)
+        assert lgbm_params["metric"] == "mape"
+
+    for alias in ["auc_mu"]:
+        lgbm_params = {"metric": alias}
+        _handling_alias_metrics(lgbm_params)
+        assert lgbm_params["metric"] == "auc_mu"
+
+    for alias in ["none", "null", "custom", "na"]:
+        lgbm_params = {"metric": alias}
+        _handling_alias_metrics(lgbm_params)
+        assert lgbm_params["metric"] == "custom"

--- a/tests/integration_tests/lightgbm_tuner_tests/test_alias.py
+++ b/tests/integration_tests/lightgbm_tuner_tests/test_alias.py
@@ -1,3 +1,5 @@
+from typing import List
+
 import pytest
 
 from optuna.integration._lightgbm_tuner.alias import _handling_alias_metrics
@@ -78,10 +80,10 @@ def test_handling_alias_parameter() -> None:
         (["mape", "mean_absolute_percentage_error"], "mape"),
         (["auc_mu"], "auc_mu"),
         (["custom", "none", "null", "na"], "custom"),
-        ([], None),  # if "metric" not in lgbm_params.keys(): return None
+        ([], None),  # If "metric" not in lgbm_params.keys(): return None.
     ],
 )
-def test_handling_alias_metrics(aliases, expect) -> None:
+def test_handling_alias_metrics(aliases: List[str], expect: str) -> None:
     if len(aliases) > 0:
         for alias in aliases:
             lgbm_params = {"metric": alias}

--- a/tests/integration_tests/lightgbm_tuner_tests/test_alias.py
+++ b/tests/integration_tests/lightgbm_tuner_tests/test_alias.py
@@ -92,5 +92,4 @@ def test_handling_alias_metrics(aliases: List[str], expect: str) -> None:
     else:
         lgbm_params = {}
         _handling_alias_metrics(lgbm_params)
-        print("null case")
         assert lgbm_params == {}


### PR DESCRIPTION
## Motivation
To address #1806 

## Description of the changes
Added the aliases of the remaining metrics to [_ALIAS_METRIC_LIST](https://github.com/optuna/optuna/blob/master/optuna/integration/_lightgbm_tuner/alias.py#L43)
