### PR TITLE
Introduce a new argument to plot all evaluation points by `multi_objective.visualization.plot_pareto_front`

### DIFF
--- a/optuna/multi_objective/visualization/_pareto_front.py
+++ b/optuna/multi_objective/visualization/_pareto_front.py
@@ -16,7 +16,9 @@ _logger = optuna.logging.get_logger(__name__)
 
 @experimental("2.0.0")
 def plot_pareto_front(
-    study: MultiObjectiveStudy, names: Optional[List[str]] = None
+    study: MultiObjectiveStudy,
+    names: Optional[List[str]] = None,
+    plot_all: bool = False,
 ) -> "go.Figure":
     """Plot the pareto front of a study.
 
@@ -53,6 +55,9 @@ def plot_pareto_front(
         names:
             Objective name list used as the axis titles. If :obj:`None` is specified,
             "Objective {objective_index}" is used instead.
+        plot_all:
+            A flag to include all trial's objective values.
+
 
     Returns:
         A :class:`plotly.graph_objs.Figure` object.
@@ -65,14 +70,28 @@ def plot_pareto_front(
     _imports.check()
 
     if study.n_objectives == 2:
-        return _get_pareto_front_2d(study, names)
+        return _get_pareto_front_2d(study, names, plot_all)
     elif study.n_objectives == 3:
-        return _get_pareto_front_3d(study, names)
+        return _get_pareto_front_3d(study, names, plot_all)
     else:
         raise ValueError("`plot_pareto_front` function only supports 2 or 3 objective studies.")
 
 
-def _get_pareto_front_2d(study: MultiObjectiveStudy, names: Optional[List[str]]) -> "go.Figure":
+def _get_non_pareto_front_trials(
+    study: MultiObjectiveStudy,
+    pareto_trials: List["multi_objective.trial.FrozenMultiObjectiveTrial"],
+) -> List["multi_objective.trial.FrozenMultiObjectiveTrial"]:
+
+    non_pareto_trials = []
+    for trial in study.get_trials():
+        if trial not in pareto_trials:
+            non_pareto_trials.append(trial)
+    return non_pareto_trials
+
+
+def _get_pareto_front_2d(
+    study: MultiObjectiveStudy, names: Optional[List[str]], plot_all: bool = False
+) -> "go.Figure":
     if names is None:
         names = ["Objective 0", "Objective 1"]
     elif len(names) != 2:
@@ -82,18 +101,27 @@ def _get_pareto_front_2d(study: MultiObjectiveStudy, names: Optional[List[str]])
     if len(trials) == 0:
         _logger.warning("Your study does not have any completed trials.")
 
+    point_colors = ["blue"] * len(trials)
+    if plot_all:
+        non_pareto_trials = _get_non_pareto_front_trials(study, trials)
+        point_colors += ["red"] * len(non_pareto_trials)
+        trials += non_pareto_trials
+
     data = go.Scatter(
         x=[t.values[0] for t in trials],
         y=[t.values[1] for t in trials],
         text=[_make_hovertext(t) for t in trials],
         mode="markers",
         hovertemplate="%{text}<extra></extra>",
+        marker={"color": point_colors},
     )
     layout = go.Layout(title="Pareto-front Plot", xaxis_title=names[0], yaxis_title=names[1])
     return go.Figure(data=data, layout=layout)
 
 
-def _get_pareto_front_3d(study: MultiObjectiveStudy, names: Optional[List[str]]) -> "go.Figure":
+def _get_pareto_front_3d(
+    study: MultiObjectiveStudy, names: Optional[List[str]], plot_all: bool = False
+) -> "go.Figure":
     if names is None:
         names = ["Objective 0", "Objective 1", "Objective 2"]
     elif len(names) != 3:
@@ -103,6 +131,12 @@ def _get_pareto_front_3d(study: MultiObjectiveStudy, names: Optional[List[str]])
     if len(trials) == 0:
         _logger.warning("Your study does not have any completed trials.")
 
+    point_colors = ["blue"] * len(trials)
+    if plot_all:
+        non_pareto_trials = _get_non_pareto_front_trials(study, trials)
+        point_colors += ["red"] * len(non_pareto_trials)
+        trials += non_pareto_trials
+
     data = go.Scatter3d(
         x=[t.values[0] for t in trials],
         y=[t.values[1] for t in trials],
@@ -110,6 +144,7 @@ def _get_pareto_front_3d(study: MultiObjectiveStudy, names: Optional[List[str]])
         text=[_make_hovertext(t) for t in trials],
         mode="markers",
         hovertemplate="%{text}<extra></extra>",
+        marker={"color": point_colors},
     )
     layout = go.Layout(
         title="Pareto-front Plot",

--- a/tests/multi_objective_tests/visualization_tests/test_pareto_front.py
+++ b/tests/multi_objective_tests/visualization_tests/test_pareto_front.py
@@ -4,11 +4,11 @@ import optuna
 from optuna.multi_objective.visualization import plot_pareto_front
 
 
-@pytest.mark.parametrize("enable_include_dominated_trials", [False, True])
-def test_plot_pareto_front_2d(enable_include_dominated_trials: bool) -> None:
+@pytest.mark.parametrize("include_dominated_trials", [False, True])
+def test_plot_pareto_front_2d(include_dominated_trials: bool) -> None:
     # Test with no trial.
     study = optuna.multi_objective.create_study(["minimize", "minimize"])
-    figure = plot_pareto_front(study, include_dominated_trials=enable_include_dominated_trials)
+    figure = plot_pareto_front(study, include_dominated_trials=include_dominated_trials)
     assert len(figure.data) == 1
     assert figure.data[0]["x"] == ()
     assert figure.data[0]["y"] == ()
@@ -19,9 +19,9 @@ def test_plot_pareto_front_2d(enable_include_dominated_trials: bool) -> None:
     study.enqueue_trial({"x": 0, "y": 1})
     study.optimize(lambda t: [t.suggest_int("x", 0, 1), t.suggest_int("y", 0, 1)], n_trials=3)
 
-    figure = plot_pareto_front(study, include_dominated_trials=enable_include_dominated_trials)
+    figure = plot_pareto_front(study, include_dominated_trials=include_dominated_trials)
     assert len(figure.data) == 1
-    if enable_include_dominated_trials:
+    if include_dominated_trials:
         # The last elements come from dominated trial that is enqueued firstly.
         assert figure.data[0]["x"] == (1, 0, 1)
         assert figure.data[0]["y"] == (0, 1, 1)
@@ -34,36 +34,32 @@ def test_plot_pareto_front_2d(enable_include_dominated_trials: bool) -> None:
 
     # Test with `names` argument.
     with pytest.raises(ValueError):
-        plot_pareto_front(
-            study, names=[], include_dominated_trials=enable_include_dominated_trials
-        )
+        plot_pareto_front(study, names=[], include_dominated_trials=include_dominated_trials)
 
     with pytest.raises(ValueError):
-        plot_pareto_front(
-            study, names=["Foo"], include_dominated_trials=enable_include_dominated_trials
-        )
+        plot_pareto_front(study, names=["Foo"], include_dominated_trials=include_dominated_trials)
 
     with pytest.raises(ValueError):
         plot_pareto_front(
             study,
             names=["Foo", "Bar", "Baz"],
-            include_dominated_trials=enable_include_dominated_trials,
+            include_dominated_trials=include_dominated_trials,
         )
 
     figure = plot_pareto_front(
         study,
         names=["Foo", "Bar"],
-        include_dominated_trials=enable_include_dominated_trials,
+        include_dominated_trials=include_dominated_trials,
     )
     assert figure.layout.xaxis.title.text == "Foo"
     assert figure.layout.yaxis.title.text == "Bar"
 
 
-@pytest.mark.parametrize("enable_include_dominated_trials", [False, True])
-def test_plot_pareto_front_3d(enable_include_dominated_trials: bool) -> None:
+@pytest.mark.parametrize("include_dominated_trials", [False, True])
+def test_plot_pareto_front_3d(include_dominated_trials: bool) -> None:
     # Test with no trial.
     study = optuna.multi_objective.create_study(["minimize", "minimize", "minimize"])
-    figure = plot_pareto_front(study, include_dominated_trials=enable_include_dominated_trials)
+    figure = plot_pareto_front(study, include_dominated_trials=include_dominated_trials)
     assert len(figure.data) == 1
     assert figure.data[0]["x"] == ()
     assert figure.data[0]["y"] == ()
@@ -78,9 +74,9 @@ def test_plot_pareto_front_3d(enable_include_dominated_trials: bool) -> None:
         n_trials=3,
     )
 
-    figure = plot_pareto_front(study, include_dominated_trials=enable_include_dominated_trials)
+    figure = plot_pareto_front(study, include_dominated_trials=include_dominated_trials)
     assert len(figure.data) == 1
-    if enable_include_dominated_trials:
+    if include_dominated_trials:
         # The last elements come from dominated trial that is enqueued firstly.
         assert figure.data[0]["x"] == (1, 1, 1)
         assert figure.data[0]["y"] == (0, 1, 1)
@@ -96,27 +92,23 @@ def test_plot_pareto_front_3d(enable_include_dominated_trials: bool) -> None:
 
     # Test with `names` argument.
     with pytest.raises(ValueError):
-        plot_pareto_front(
-            study, names=[], include_dominated_trials=enable_include_dominated_trials
-        )
+        plot_pareto_front(study, names=[], include_dominated_trials=include_dominated_trials)
 
     with pytest.raises(ValueError):
-        plot_pareto_front(
-            study, names=["Foo"], include_dominated_trials=enable_include_dominated_trials
-        )
+        plot_pareto_front(study, names=["Foo"], include_dominated_trials=include_dominated_trials)
 
     with pytest.raises(ValueError):
         plot_pareto_front(
             study,
             names=["Foo", "Bar"],
-            include_dominated_trials=enable_include_dominated_trials,
+            include_dominated_trials=include_dominated_trials,
         )
 
     with pytest.raises(ValueError):
         plot_pareto_front(
             study,
             names=["Foo", "Bar", "Baz", "Qux"],
-            include_dominated_trials=enable_include_dominated_trials,
+            include_dominated_trials=include_dominated_trials,
         )
 
     figure = plot_pareto_front(study, names=["Foo", "Bar", "Baz"])
@@ -125,23 +117,23 @@ def test_plot_pareto_front_3d(enable_include_dominated_trials: bool) -> None:
     assert figure.layout.scene.zaxis.title.text == "Baz"
 
 
-@pytest.mark.parametrize("enable_include_dominated_trials", [False, True])
-def test_plot_pareto_front_unsupported_dimensions(enable_include_dominated_trials: bool) -> None:
+@pytest.mark.parametrize("include_dominated_trials", [False, True])
+def test_plot_pareto_front_unsupported_dimensions(include_dominated_trials: bool) -> None:
     # Unsupported: n_objectives == 1.
     with pytest.raises(ValueError):
         study = optuna.multi_objective.create_study(["minimize"])
         study.optimize(lambda t: [0], n_trials=1)
-        plot_pareto_front(study, include_dominated_trials=enable_include_dominated_trials)
+        plot_pareto_front(study, include_dominated_trials=include_dominated_trials)
 
     # Supported: n_objectives == 2.
     study = optuna.multi_objective.create_study(["minimize", "minimize"])
     study.optimize(lambda t: [0, 0], n_trials=1)
-    plot_pareto_front(study, include_dominated_trials=enable_include_dominated_trials)
+    plot_pareto_front(study, include_dominated_trials=include_dominated_trials)
 
     # Supported: n_objectives == 3.
     study = optuna.multi_objective.create_study(["minimize", "minimize", "minimize"])
     study.optimize(lambda t: [0, 0, 0], n_trials=1)
-    plot_pareto_front(study, include_dominated_trials=enable_include_dominated_trials)
+    plot_pareto_front(study, include_dominated_trials=include_dominated_trials)
 
     # Unsupported: n_objectives == 4.
     with pytest.raises(ValueError):
@@ -149,4 +141,4 @@ def test_plot_pareto_front_unsupported_dimensions(enable_include_dominated_trial
             ["minimize", "minimize", "minimize", "minimize"]
         )
         study.optimize(lambda t: [0, 0, 0, 0], n_trials=1)
-        plot_pareto_front(study, include_dominated_trials=enable_include_dominated_trials)
+        plot_pareto_front(study, include_dominated_trials=include_dominated_trials)

--- a/tests/multi_objective_tests/visualization_tests/test_pareto_front.py
+++ b/tests/multi_objective_tests/visualization_tests/test_pareto_front.py
@@ -4,10 +4,11 @@ import optuna
 from optuna.multi_objective.visualization import plot_pareto_front
 
 
-def test_plot_pareto_front_2d() -> None:
+@pytest.mark.parametrize("enable_include_dominated_trials", [False, True])
+def test_plot_pareto_front_2d(enable_include_dominated_trials: bool) -> None:
     # Test with no trial.
     study = optuna.multi_objective.create_study(["minimize", "minimize"])
-    figure = plot_pareto_front(study)
+    figure = plot_pareto_front(study, include_dominated_trials=enable_include_dominated_trials)
     assert len(figure.data) == 1
     assert figure.data[0]["x"] == ()
     assert figure.data[0]["y"] == ()
@@ -18,33 +19,51 @@ def test_plot_pareto_front_2d() -> None:
     study.enqueue_trial({"x": 0, "y": 1})
     study.optimize(lambda t: [t.suggest_int("x", 0, 1), t.suggest_int("y", 0, 1)], n_trials=3)
 
-    figure = plot_pareto_front(study)
+    figure = plot_pareto_front(study, include_dominated_trials=enable_include_dominated_trials)
     assert len(figure.data) == 1
-    assert figure.data[0]["x"] == (1, 0)
-    assert figure.data[0]["y"] == (0, 1)
+    if enable_include_dominated_trials:
+        # The last elements come from dominated trial that is enqueued firstly.
+        assert figure.data[0]["x"] == (1, 0, 1)
+        assert figure.data[0]["y"] == (0, 1, 1)
+    else:
+        assert figure.data[0]["x"] == (1, 0)
+        assert figure.data[0]["y"] == (0, 1)
 
     assert figure.layout.xaxis.title.text == "Objective 0"
     assert figure.layout.yaxis.title.text == "Objective 1"
 
     # Test with `names` argument.
     with pytest.raises(ValueError):
-        plot_pareto_front(study, names=[])
+        plot_pareto_front(
+            study, names=[], include_dominated_trials=enable_include_dominated_trials
+        )
 
     with pytest.raises(ValueError):
-        plot_pareto_front(study, names=["Foo"])
+        plot_pareto_front(
+            study, names=["Foo"], include_dominated_trials=enable_include_dominated_trials
+        )
 
     with pytest.raises(ValueError):
-        plot_pareto_front(study, names=["Foo", "Bar", "Baz"])
+        plot_pareto_front(
+            study,
+            names=["Foo", "Bar", "Baz"],
+            include_dominated_trials=enable_include_dominated_trials,
+        )
 
-    figure = plot_pareto_front(study, names=["Foo", "Bar"])
+    figure = plot_pareto_front(
+        study,
+        names=["Foo", "Bar"],
+        include_dominated_trials=enable_include_dominated_trials,
+    )
     assert figure.layout.xaxis.title.text == "Foo"
     assert figure.layout.yaxis.title.text == "Bar"
 
 
-def test_plot_pareto_front_3d() -> None:
+@pytest.mark.parametrize("enable_include_dominated_trials", [False, True])
+def test_plot_pareto_front_3d(enable_include_dominated_trials: bool) -> None:
     # Test with no trial.
     study = optuna.multi_objective.create_study(["minimize", "minimize", "minimize"])
-    figure = plot_pareto_front(study)
+    figure = plot_pareto_front(study, include_dominated_trials=enable_include_dominated_trials)
     assert len(figure.data) == 1
     assert figure.data[0]["x"] == ()
     assert figure.data[0]["y"] == ()
@@ -59,11 +78,17 @@ def test_plot_pareto_front_3d() -> None:
         n_trials=3,
     )
 
-    figure = plot_pareto_front(study)
+    figure = plot_pareto_front(study, include_dominated_trials=enable_include_dominated_trials)
     assert len(figure.data) == 1
-    assert figure.data[0]["x"] == (1, 1)
-    assert figure.data[0]["y"] == (0, 1)
-    assert figure.data[0]["z"] == (1, 0)
+    if enable_include_dominated_trials:
+        # The last elements come from dominated trial that is enqueued firstly.
+        assert figure.data[0]["x"] == (1, 1, 1)
+        assert figure.data[0]["y"] == (0, 1, 1)
+        assert figure.data[0]["z"] == (1, 0, 1)
+    else:
+        assert figure.data[0]["x"] == (1, 1)
+        assert figure.data[0]["y"] == (0, 1)
+        assert figure.data[0]["z"] == (1, 0)
 
     assert figure.layout.scene.xaxis.title.text == "Objective 0"
     assert figure.layout.scene.yaxis.title.text == "Objective 1"
@@ -71,16 +96,28 @@ def test_plot_pareto_front_3d() -> None:
 
     # Test with `names` argument.
     with pytest.raises(ValueError):
-        plot_pareto_front(study, names=[])
+        plot_pareto_front(
+            study, names=[], include_dominated_trials=enable_include_dominated_trials
+        )
 
     with pytest.raises(ValueError):
-        plot_pareto_front(study, names=["Foo"])
+        plot_pareto_front(
+            study, names=["Foo"], include_dominated_trials=enable_include_dominated_trials
+        )
 
     with pytest.raises(ValueError):
-        plot_pareto_front(study, names=["Foo", "Bar"])
+        plot_pareto_front(
+            study,
+            names=["Foo", "Bar"],
+            include_dominated_trials=enable_include_dominated_trials,
+        )
 
     with pytest.raises(ValueError):
-        plot_pareto_front(study, names=["Foo", "Bar", "Baz", "Qux"])
+        plot_pareto_front(
+            study,
+            names=["Foo", "Bar", "Baz", "Qux"],
+            include_dominated_trials=enable_include_dominated_trials,
+        )
 
     figure = plot_pareto_front(study, names=["Foo", "Bar", "Baz"])
     assert figure.layout.scene.xaxis.title.text == "Foo"
@@ -88,22 +125,23 @@ def test_plot_pareto_front_3d() -> None:
     assert figure.layout.scene.zaxis.title.text == "Baz"
 
 
-def test_plot_pareto_front_unsupported_dimensions() -> None:
+@pytest.mark.parametrize("enable_include_dominated_trials", [False, True])
+def test_plot_pareto_front_unsupported_dimensions(enable_include_dominated_trials: bool) -> None:
     # Unsupported: n_objectives == 1.
     with pytest.raises(ValueError):
         study = optuna.multi_objective.create_study(["minimize"])
         study.optimize(lambda t: [0], n_trials=1)
-        plot_pareto_front(study)
+        plot_pareto_front(study, include_dominated_trials=enable_include_dominated_trials)
 
     # Supported: n_objectives == 2.
     study = optuna.multi_objective.create_study(["minimize", "minimize"])
     study.optimize(lambda t: [0, 0], n_trials=1)
-    plot_pareto_front(study)
+    plot_pareto_front(study, include_dominated_trials=enable_include_dominated_trials)
 
     # Supported: n_objectives == 3.
     study = optuna.multi_objective.create_study(["minimize", "minimize", "minimize"])
     study.optimize(lambda t: [0, 0, 0], n_trials=1)
-    plot_pareto_front(study)
+    plot_pareto_front(study, include_dominated_trials=enable_include_dominated_trials)
 
     # Unsupported: n_objectives == 4.
     with pytest.raises(ValueError):
@@ -111,4 +149,4 @@ def test_plot_pareto_front_unsupported_dimensions() -> None:
             ["minimize", "minimize", "minimize", "minimize"]
         )
         study.optimize(lambda t: [0, 0, 0, 0], n_trials=1)
-        plot_pareto_front(study)
+        plot_pareto_front(study, include_dominated_trials=enable_include_dominated_trials)


### PR DESCRIPTION
<!-- Thank you for creating a pull request! -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

`multi_objective.visualization.plot_pareto_front` plots only Pareto points in the current optuna. It is nice for optuna users to show all trial's objectives and hyper-parameters.

## Description of the changes
<!-- Describe the changes in this PR. -->

This PR introduces a new argument about whether plots all points or not.


```python
import optuna

def objective(trial):
    x = trial.suggest_float("x", 0, 5)
    y = trial.suggest_float("y", 0, 3)

    v0 = 4 * x ** 2 + 4 * y ** 2
    v1 = (x - 5) ** 2 + (y - 5) ** 2
    return v0, v1

study = optuna.multi_objective.create_study(["minimize", "minimize"])
study.optimize(objective, n_trials=50)
optuna.multi_objective.visualization.plot_pareto_front(study, include_dominated_trials =True)
```

![newplot (1)](https://user-images.githubusercontent.com/7121753/92990004-64a5e980-f513-11ea-9599-de174c33ff97.png)


The example code is based on the example code in the page of [`multi_objective.visualization.plot_pareto_front`](https://optuna.readthedocs.io/en/latest/reference/multi_objective/generated/optuna.multi_objective.visualization.plot_pareto_front.html#optuna.multi_objective.visualization.plot_pareto_front).

---

3D plot example:

```python
def objective(trial):
    x = trial.suggest_float("x", 0, 5)
    y = trial.suggest_float("y", 0, 3)
    z = trial.suggest_float("z", 0, 3)

    v0 = 4 * x ** 2 + 4 * y ** 2
    v1 = (x - 5) ** 2 + (y - 5) ** 2
    v2 = (x + 3) ** 4 + (z + 5) ** 2
    return v0, v1, v2


study = optuna.multi_objective.create_study(["minimize", "minimize", "minimize"])
study.optimize(objective, n_trials=50)

optuna.multi_objective.visualization.plot_pareto_front(study, include_dominated_trials=True)
```
![newplot (2)](https://user-images.githubusercontent.com/7121753/92990852-97071500-f51a-11ea-898f-c9c20ea34966.png)

