### PR TITLE
Add Matplotlib to `setup.py`.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ def get_extras_require() -> Dict[str, List[str]]:
         "codecov": ["codecov", "pytest-cov"],
         "doctest": [
             "cma",
+            "matplotlib>=3.0.0",
             "pandas",
             "plotly>=4.0.0",
             "scikit-learn>=0.19.0,<0.23.0",
@@ -115,6 +116,7 @@ def get_extras_require() -> Dict[str, List[str]]:
             "cma",
             "fakeredis",
             "lightgbm",
+            "matplotlib>=3.0.0",
             "mlflow",
             "mpi4py",
             "mxnet",
@@ -143,6 +145,7 @@ def get_extras_require() -> Dict[str, List[str]]:
         "tests": ["fakeredis", "pytest"],
         "optional": [
             "bokeh<2.0.0",  # optuna/cli.py, optuna/dashboard.py.
+            "matplotlib>=3.0.0",  # optuna/visualization/matplotlib
             "pandas",  # optuna/study.py
             "plotly>=4.0.0",  # optuna/visualization.
             "redis",  # optuna/storages/redis.py.


### PR DESCRIPTION
This PR proposes to add ``matplotlib`` to `setup.py` for the `matplotlib` backends based on PR #1756 .

## Motivation
To provide another visualization option for users, who have only ``plotly`` now.
See issue #1539 and PR #1707 for the original motivation.

## Description of the changes
Add `matplotlib>=3.0.0` to `doctest`, `testing` and `optional` in `setup.py`.