### PR TITLE
[Proposal] Add option `--diff` to black

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ jobs:
           name: black
           command: |
             . venv/bin/activate
-            black . --check
+            black . --check --diff
 
       - run:
           name: flake8


### PR DESCRIPTION
## Motivation
I want to add `--diff` for making CI explaining why `checks` fails.

## Description of the changes
Add `--diff` option to `black`.

- without `--diff`

```
#!/bin/bash -eo pipefail
. venv/bin/activate
black . --check

would reformat /home/circleci/project/tests/integration_tests/allennlp_tests/test_allennlp.py
Oh no! 💥 💔 💥
1 file would be reformatted, 253 files would be left unchanged.

Exited with code exit status 1
CircleCI received exit code 1
```

https://app.circleci.com/pipelines/github/optuna/optuna/2803/workflows/1b17586d-2224-42b5-8c89-79a3ce82173b/jobs/58556

```
#!/bin/bash -eo pipefail
. venv/bin/activate
black . --check --diff

would reformat optuna/integration/allennlp.py
--- tests/integration_tests/allennlp_tests/test_allennlp.py	2020-09-16 13:36:05.507515 +0000
+++ tests/integration_tests/allennlp_tests/test_allennlp.py	2020-09-16 13:37:09.880963 +0000
@@ -255,11 +255,13 @@
             trial.suggest_float("DROPOUT", 0.0, 0.5)
             executor = optuna.integration.AllenNLPExecutor(trial, input_config_file, tmp_dir)
             return executor.run()
 
         study = optuna.create_study(
-            direction="maximize", pruner=optuna.pruners.HyperbandPruner(), storage=None,
+            direction="maximize",
+            pruner=optuna.pruners.HyperbandPruner(),
+            storage=None,
         )
 
         with pytest.raises(RuntimeErro
...
```


https://app.circleci.com/pipelines/github/optuna/optuna/2807/workflows/da85c238-1884-46aa-9e42-1152df6966b4/jobs/58579