### PR TITLE
Mention isort in the contribution guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ If you choose to write some code, we have some conventions as follows.
 
 ### Coding Style
 
-Coding style is checked with [flake8](http://flake8.pycqa.org).
+Coding style is checked with [flake8](http://flake8.pycqa.org) and [isort](https://pycqa.github.io/isort/).
 Additional conventions are described in the [Wiki](https://github.com/optuna/optuna/wiki/Coding-Style-Conventions).
 
 ### Documentation


### PR DESCRIPTION
## Motivation

See below.

## Description of the changes

Updates the contribution guidelines to mention isort which was introduced in https://github.com/optuna/optuna/pull/1695.
