### PR TITLE
News sections about introduction of isort

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Optuna can dynamically construct the search spaces for the hyperparameters.
 
 ## News
 
+- **2020-09-17** `isort` has been incorporated to keep import statements consistent. Read more about it in [CONTRIBUTING.md](./CONTRIBUTING.md)
 - **2020-08-07** We are welcoming [contributions](#contribution) and are working on streamlining the experience. Read more about it in the [blog](https://medium.com/optuna/optuna-wants-your-pull-request-ff619572302c)
 
 ## Key Features


### PR DESCRIPTION
## Motivation

The news section in `README.md` is somewhat experimental and only contains a single entry. The introduction of isort could be a second entry. It's at least relevant to existing developers of Optuna. Should be merged if to be merged after https://github.com/optuna/optuna/pull/1842.

## Description of the changes

Adds a bullet in the news section in `README.md` about the introduction of isort.
