### PR TITLE
Minor code fix of XGBoost examples

### DIFF
--- a/examples/xgboost_cv.py
+++ b/examples/xgboost_cv.py
@@ -1,18 +1,11 @@
 """
-Optuna example that performs Cross Validation for cancer dataset using XGBoost.
+Optuna example that performs cross-validation for cancer dataset using XGBoost.
 
-In this example, we perform cross-validation to accuracy of cancer detection
-using XGBoost. We optimize both the choice of booster model and their hyper
-parameters.
-
-We have following way to execute this example:
-
-(1) Execute this code directly.
-    $ python xgboost_cv.py
-
+In this example, we optimize the accuracy of cancer detection using the XGBoost. The accuracy is
+estimated by cross-validation. We optimize both the choice of booster model and their
+hyperparameters.
 
 """
-
 
 import os
 import shutil
@@ -24,13 +17,9 @@ import xgboost as xgb
 import optuna
 
 
-# Set constants
 SEED = 108
 N_FOLDS = 3
 CV_RESULT_DIR = "./xgboost_cv_results"
-
-if not os.path.exists(CV_RESULT_DIR):
-    os.mkdir(CV_RESULT_DIR)
 
 
 # FYI: Objective functions can take additional arguments
@@ -40,7 +29,7 @@ def objective(trial):
     dtrain = xgb.DMatrix(data, label=target)
 
     param = {
-        "silent": 1,
+        "verbosity": 0,
         "objective": "binary:logistic",
         "eval_metric": "auc",
         "booster": trial.suggest_categorical("booster", ["gbtree", "gblinear", "dart"]),
@@ -84,14 +73,17 @@ def objective(trial):
 
 
 if __name__ == "__main__":
+    if not os.path.exists(CV_RESULT_DIR):
+        os.mkdir(CV_RESULT_DIR)
 
     study = optuna.create_study(direction="maximize")
-    study.optimize(objective, n_trials=20)
+    study.optimize(objective, n_trials=20, timeout=600)
+
+    print("Number of finished trials: ", len(study.trials))
     print("Best trial:")
     trial = study.best_trial
 
     print("  Value: {}".format(trial.value))
-
     print("  Params: ")
     for key, value in trial.params.items():
         print("    {}: {}".format(key, value))

--- a/examples/xgboost_cv.py
+++ b/examples/xgboost_cv.py
@@ -1,5 +1,5 @@
 """
-Optuna example that performs cross-validation for cancer dataset using XGBoost.
+Optuna example that optimizes a classifier configuration for cancer dataset using XGBoost.
 
 In this example, we optimize the accuracy of cancer detection using the XGBoost. The accuracy is
 estimated by cross-validation. We optimize both the choice of booster model and their

--- a/examples/xgboost_simple.py
+++ b/examples/xgboost_simple.py
@@ -26,7 +26,7 @@ def objective(trial):
     dvalid = xgb.DMatrix(valid_x, label=valid_y)
 
     param = {
-        "silent": 1,
+        "verbosity": 0,
         "objective": "binary:logistic",
         "booster": trial.suggest_categorical("booster", ["gbtree", "gblinear", "dart"]),
         "lambda": trial.suggest_float("lambda", 1e-8, 1.0, log=True),
@@ -53,5 +53,13 @@ def objective(trial):
 
 if __name__ == "__main__":
     study = optuna.create_study(direction="maximize")
-    study.optimize(objective, n_trials=100)
-    print(study.best_trial)
+    study.optimize(objective, n_trials=100, timeout=600)
+
+    print("Number of finished trials: ", len(study.trials))
+    print("Best trial:")
+    trial = study.best_trial
+
+    print("  Value: {}".format(trial.value))
+    print("  Params: ")
+    for key, value in trial.params.items():
+        print("    {}: {}".format(key, value))


### PR DESCRIPTION
## Motivation
This is follow-up PR of #1836 .

## Description of the changes
- Update code comments according to the other examples.
- Remove unnecessary blank lines
- The `silent`parameter is deprecated and it was replaced by `verbosity` (see this [reference](https://xgboost.readthedocs.io/en/latest/parameter.html#general-parameters))
- I applied similar changes to `examples/xgboost_simple.py`.