### PR TITLE
Avoid global study in `Study.stop` testcode

### DIFF
--- a/optuna/study.py
+++ b/optuna/study.py
@@ -558,7 +558,7 @@ class Study(BaseStudy):
 
                 def objective(trial):
                     if trial.number == 4:
-                        study.stop()
+                        trial.study.stop()
                     x = trial.suggest_uniform("x", 0, 10)
                     return x ** 2
 


### PR DESCRIPTION
## Motivation

Python variable scoping isn't necessarily trivial, especially the testcode in `Study.stop`. The testcode should be as pedagogical as possible.

## Description of the changes

Avoids accessing the study object from a global in the objective function of the testcode in `Study.stop`. Instead, accesses the study object via the local trial.