### PR TITLE
Move away from .scoring imports

### DIFF
--- a/optuna/integration/sklearn.py
+++ b/optuna/integration/sklearn.py
@@ -35,7 +35,7 @@ with try_import() as _imports:
     from sklearn.base import BaseEstimator
     from sklearn.base import clone
     from sklearn.base import is_classifier
-    from sklearn.metrics.scorer import check_scoring
+    from sklearn.metrics import check_scoring
     from sklearn.model_selection import BaseCrossValidator
     from sklearn.model_selection import check_cv
     from sklearn.model_selection import cross_validate


### PR DESCRIPTION
## Motivation
`FutureWarning` occured in `OptunaSearchCV`.

## Description of the changes
The `sklearn.metrics.scorer` module is  deprecated in version 0.22 and will be removed in version 0.24. 
The corresponding classes / functions should instead be imported from `sklearn.metrics`.

## Same problems in skorch
https://github.com/skorch-dev/skorch/issues/573
https://github.com/skorch-dev/skorch/pull/575