### PR TITLE
Add `matplotlib` directory to `optuna.visualization.__init__.py`

### DIFF
--- a/optuna/visualization/__init__.py
+++ b/optuna/visualization/__init__.py
@@ -1,3 +1,4 @@
+from optuna.visualization import matplotlib  # NOQA
 from optuna.visualization._contour import plot_contour  # NOQA
 from optuna.visualization._edf import plot_edf  # NOQA
 from optuna.visualization._intermediate_values import plot_intermediate_values  # NOQA

--- a/optuna/visualization/matplotlib/_edf.py
+++ b/optuna/visualization/matplotlib/_edf.py
@@ -42,7 +42,7 @@ def plot_edf(study: Union[Study, Sequence[Study]]) -> "Axes":
     return _get_edf_plot(studies)
 
 
-def _get_edf_plot(studies: List[Study]) -> Axes:
+def _get_edf_plot(studies: List[Study]) -> "Axes":
 
     # Set up the graph style.
     plt.style.use("ggplot")  # Use ggplot style sheet for similar outputs to plotly.

--- a/optuna/visualization/matplotlib/_edf.py
+++ b/optuna/visualization/matplotlib/_edf.py
@@ -18,7 +18,7 @@ if _imports.is_successful():
 _logger = get_logger(__name__)
 
 
-def plot_edf(study: Union[Study, Sequence[Study]]) -> Axes:
+def plot_edf(study: Union[Study, Sequence[Study]]) -> "Axes":
     """Plot the objective value EDF (empirical distribution function) of a study with Matplotlib.
 
     .. seealso::  optuna.visualization.plot_edf


### PR DESCRIPTION
## Motivation
`matplotlib` is missed in `optuna.visualization.__init__.py`.

## Description of the changes
Add `matplotlib` directory to `optuna.visualization.__init__.py`.

## Before
```python
In [1]: import optuna

In [2]: optuna.visualization.matplotlib.plot_edf
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-2-e8d69a155978> in <module>
----> 1 optuna.visualization.matplotlib.plot_edf

AttributeError: module 'optuna.visualization' has no attribute 'matplotlib'
```

## After
```python
In [1]: import optuna

In [2]: optuna.visualization.matplotlib.plot_edf
Out[2]: <function optuna.visualization.matplotlib._edf.plot_edf(study: Union[optuna.study.Study, Sequence[optuna.study.Study]]) -> matplotlib.axes._axes.Axes>
```
