### PR TITLE
Add experimental decorator to `matplotlib.*`

### DIFF
--- a/optuna/visualization/matplotlib/_contour.py
+++ b/optuna/visualization/matplotlib/_contour.py
@@ -1,3 +1,4 @@
+from optuna._experimental import experimental
 from optuna.visualization.matplotlib._matplotlib_imports import _imports
 
 
@@ -5,5 +6,6 @@ if _imports.is_successful():
     from optuna.visualization.matplotlib._matplotlib_imports import Axes
 
 
+@experimental("2.2.0")
 def plot_contour() -> Axes:
     raise NotImplementedError("To be implemented soon.")

--- a/optuna/visualization/matplotlib/_edf.py
+++ b/optuna/visualization/matplotlib/_edf.py
@@ -5,6 +5,7 @@ from typing import Union
 
 import numpy as np
 
+from optuna._experimental import experimental
 from optuna.logging import get_logger
 from optuna.study import Study
 from optuna.trial import TrialState
@@ -18,6 +19,7 @@ if _imports.is_successful():
 _logger = get_logger(__name__)
 
 
+@experimental("2.2.0")
 def plot_edf(study: Union[Study, Sequence[Study]]) -> Axes:
     """Plot the objective value EDF (empirical distribution function) of a study with Matplotlib.
 

--- a/optuna/visualization/matplotlib/_intermediate_values.py
+++ b/optuna/visualization/matplotlib/_intermediate_values.py
@@ -1,3 +1,4 @@
+from optuna._experimental import experimental
 from optuna.visualization.matplotlib._matplotlib_imports import _imports
 
 
@@ -5,5 +6,6 @@ if _imports.is_successful():
     from optuna.visualization.matplotlib._matplotlib_imports import Axes
 
 
+@experimental("2.2.0")
 def plot_intermediate_values() -> Axes:
     raise NotImplementedError("To be implemented soon.")

--- a/optuna/visualization/matplotlib/_optimization_history.py
+++ b/optuna/visualization/matplotlib/_optimization_history.py
@@ -1,3 +1,4 @@
+from optuna._experimental import experimental
 from optuna.visualization.matplotlib._matplotlib_imports import _imports
 
 
@@ -5,5 +6,6 @@ if _imports.is_successful():
     from optuna.visualization.matplotlib._matplotlib_imports import Axes
 
 
+@experimental("2.2.0")
 def plot_optimization_history() -> Axes:
     raise NotImplementedError("To be implemented soon.")

--- a/optuna/visualization/matplotlib/_parallel_coordinate.py
+++ b/optuna/visualization/matplotlib/_parallel_coordinate.py
@@ -1,3 +1,4 @@
+from optuna._experimental import experimental
 from optuna.visualization.matplotlib._matplotlib_imports import _imports
 
 
@@ -5,5 +6,6 @@ if _imports.is_successful():
     from optuna.visualization.matplotlib._matplotlib_imports import Axes
 
 
+@experimental("2.2.0")
 def plot_parallel_coordinate() -> Axes:
     raise NotImplementedError("To be implemented soon.")

--- a/optuna/visualization/matplotlib/_param_importances.py
+++ b/optuna/visualization/matplotlib/_param_importances.py
@@ -1,3 +1,4 @@
+from optuna._experimental import experimental
 from optuna.visualization.matplotlib._matplotlib_imports import _imports
 
 
@@ -5,5 +6,6 @@ if _imports.is_successful():
     from optuna.visualization.matplotlib._matplotlib_imports import Axes
 
 
+@experimental("2.2.0")
 def plot_param_importances() -> Axes:
     raise NotImplementedError("To be implemented soon.")

--- a/optuna/visualization/matplotlib/_slice.py
+++ b/optuna/visualization/matplotlib/_slice.py
@@ -1,3 +1,4 @@
+from optuna._experimental import experimental
 from optuna.visualization.matplotlib._matplotlib_imports import _imports
 
 
@@ -5,5 +6,6 @@ if _imports.is_successful():
     from optuna.visualization.matplotlib._matplotlib_imports import Axes
 
 
+@experimental("2.2.0")
 def plot_slice() -> Axes:
     raise NotImplementedError("To be implemented soon.")

--- a/optuna/visualization/matplotlib/_utils.py
+++ b/optuna/visualization/matplotlib/_utils.py
@@ -1,5 +1,6 @@
 from typing import List
 
+from optuna._experimental import experimental
 from optuna.distributions import LogUniformDistribution
 from optuna.trial import FrozenTrial
 from optuna.visualization.matplotlib import _matplotlib_imports
@@ -8,6 +9,7 @@ from optuna.visualization.matplotlib import _matplotlib_imports
 __all__ = ["is_available"]
 
 
+@experimental("2.2.0")
 def is_available() -> bool:
     """Returns whether visualization with ``matplotlib`` is available or not.
 


### PR DESCRIPTION
## Motivation
Recently, some functions in `optuna.visualization.matplotlib` are introduced. These functionalities should be noted as experimental. 

## Description of the changes
Add an experimental decorator to each `matplotlib.*` function.
