### PR TITLE
Removed with_trace method from docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -172,6 +172,7 @@ autosummary_generate = True
 autodoc_default_options = {
     'members': True,
     'inherited-members': True,
+    'exclude-members': 'with_traceback',
 }
 
 sphinx_gallery_conf = {


### PR DESCRIPTION
<!-- Thank you for creating a pull request! -->

## Motivation
Fixes #1615:  Optuna's exception classes have the documentations of with_traceback method, which is inherited from Exception. It is not informative for readers.

## Description of the changes
Configured sphinx autodoc to ignore all ``with_traceback`` methods while generating documentations.

Closes: #1615