### PR TITLE
Add logging levels to `optuna.logging.set_verbosity`

### DIFF
--- a/optuna/logging.py
+++ b/optuna/logging.py
@@ -109,6 +109,15 @@ def set_verbosity(verbosity: int) -> None:
     Args:
         verbosity:
             Logging level, e.g., ``optuna.logging.DEBUG`` and ``optuna.logging.INFO``.
+
+    .. note::
+        Optuna has following logging levels:
+
+        - ``optuna.logging.CRITICAL``, ``optuna.logging.FATAL``
+        - ``optuna.logging.ERROR``
+        - ``optuna.logging.WARNING``, ``optuna.logging.WARN``
+        - ``optuna.logging.INFO``
+        - ``optuna.logging.DEBUG``
     """
 
     _configure_library_root_logger()


### PR DESCRIPTION
<!-- Thank you for creating a pull request! -->
Fix #1879

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

[`optuna.logging.set_verbosity`](https://optuna.readthedocs.io/en/latest/reference/generated/optuna.logging.set_verbosity.html) does not contain all logging levels defined by optuna like [`optuna.logging.get_verbosity`](https://optuna.readthedocs.io/en/latest/reference/generated/optuna.logging.get_verbosity.html). It is supposed to be unclear to use this function.

## Description of the changes
<!-- Describe the changes in this PR. -->

Add all logging levels on the page of [`optuna.logging.get_verbosity`](https://optuna.readthedocs.io/en/latest/reference/generated/optuna.logging.get_verbosity.html) to the docstring of the `optuna.logging.set_verbosity` as `Note`.