### PR TITLE
Run documentation build and doctest in GitHub Actions.

### DIFF
--- a/.github/workflows/sphinx-build.yml
+++ b/.github/workflows/sphinx-build.yml
@@ -17,7 +17,7 @@ jobs:
 
     - uses: actions/setup-python@v2
       with:
-        python_version: 3.8
+        python-version: 3.8
 
     - name: Install Dependencies
       run: |
@@ -45,7 +45,7 @@ jobs:
 
     - uses: actions/setup-python@v2
       with:
-        python_version: 3.8
+        python-version: 3.8
 
     - name: Install Dependencies
       run: |

--- a/.github/workflows/sphinx-build.yml
+++ b/.github/workflows/sphinx-build.yml
@@ -1,0 +1,59 @@
+name: Sphinx
+
+on:
+  push:
+    branches:
+      - master
+  pull_request: {}
+
+jobs:
+  documentation:
+
+    runs-on: ubuntu-latest
+
+    steps:
+
+    - uses: actions/checkout@v2
+
+    - uses: actions/setup-python@v2
+      with:
+        python_version: 3.8
+
+    - name: Install Dependencies
+      run: |
+        python -m pip install -U pip
+        pip install --progress-bar off -U .[document]
+
+    - name: Build Document
+      run: |
+        cd docs
+        make html -j
+        cd ../
+
+    - uses: actions/upload-artifact@v2
+      with:
+        name: built-document
+        path: docs/build
+
+  doctest:
+
+    runs-on: ubuntu-latest
+
+    steps:
+
+    - uses: actions/checkout@v2
+
+    - uses: actions/setup-python@v2
+      with:
+        python_version: 3.8
+
+    - name: Install Dependencies
+      run: |
+        python -m pip install -U pip
+        pip install --progress-bar off -U .[document,doctest]
+
+    # TODO (crcrpar): Prevent sphinx-gallery build
+    - name: Run Doctest
+      run: |
+        cd docs
+        make doctest -j

--- a/.github/workflows/sphinx-build.yml
+++ b/.github/workflows/sphinx-build.yml
@@ -11,29 +11,21 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    container: readthedocs/build:latest
-
     steps:
-
-    - name: Update Git
-      run: |
-        add-apt-repository ppa:git-core/ppa -y
-        apt-get update
-        apt-get install -y git
-      shell: bash {0}
 
     - uses: actions/checkout@v2
 
+    - uses: actions/setup-python@v2
+      with:
+        python_version: 3.8
+
     - name: Install Dependencies
       run: |
-        python -m venv venv || virtualenv venv --python=python3.8
-        . venv/bin/activate
-        pip install -U pip
+        python -m pip install -U pip
         pip install --progress-bar off -U .[document]
 
     - name: Build Document
       run: |
-        . venv/bin/activate
         cd docs
         make html
         cd ../
@@ -47,24 +39,17 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    container: readthedocs/build:latest
-
     steps:
-
-    - name: Update Git
-      run: |
-        add-apt-repository ppa:git-core/ppa -y
-        apt-get update
-        apt-get install -y git
-      shell: bash {0}
 
     - uses: actions/checkout@v2
 
+    - uses: actions/setup-python@v2
+      with:
+        python_version: 3.8
+
     - name: Install Dependencies
       run: |
-        python -m venv venv || virtualenv venv --python=python3.8
-        . venv/bin/activate
-        pip install -U pip
+        python -m pip install -U pip
         pip install --progress-bar off -U .[document,doctest]
 
     # TODO (crcrpar): Prevent sphinx-gallery build

--- a/.github/workflows/sphinx-build.yml
+++ b/.github/workflows/sphinx-build.yml
@@ -11,21 +11,29 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    container: readthedocs/build:latest
+
     steps:
+
+    - name: Update Git
+      run: |
+        add-apt-repository ppa:git-core/ppa -y
+        apt-get update
+        apt-get install -y git
+      shell: bash {0}
 
     - uses: actions/checkout@v2
 
-    - uses: actions/setup-python@v2
-      with:
-        python_version: 3.8
-
     - name: Install Dependencies
       run: |
-        python -m pip install -U pip
+        python -m venv venv || virtualenv venv --python=python3.8
+        . venv/bin/activate
+        pip install -U pip
         pip install --progress-bar off -U .[document]
 
     - name: Build Document
       run: |
+        . venv/bin/activate
         cd docs
         make html
         cd ../
@@ -39,17 +47,24 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    container: readthedocs/build:latest
+
     steps:
+
+    - name: Update Git
+      run: |
+        add-apt-repository ppa:git-core/ppa -y
+        apt-get update
+        apt-get install -y git
+      shell: bash {0}
 
     - uses: actions/checkout@v2
 
-    - uses: actions/setup-python@v2
-      with:
-        python_version: 3.8
-
     - name: Install Dependencies
       run: |
-        python -m pip install -U pip
+        python -m venv venv || virtualenv venv --python=python3.8
+        . venv/bin/activate
+        pip install -U pip
         pip install --progress-bar off -U .[document,doctest]
 
     # TODO (crcrpar): Prevent sphinx-gallery build

--- a/.github/workflows/sphinx-build.yml
+++ b/.github/workflows/sphinx-build.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Build Document
       run: |
         cd docs
-        make html -j
+        make html
         cd ../
 
     - uses: actions/upload-artifact@v2
@@ -56,4 +56,4 @@ jobs:
     - name: Run Doctest
       run: |
         cd docs
-        make doctest -j
+        make doctest


### PR DESCRIPTION
We want to migrate all the required checks to github actions as we saw some weird connection problems with Circle CI (at least twice).

It may or may not be better to use [the official images of readthedocs](https://hub.docker.com/r/readthedocs/build).