### PR TITLE
Remove unnecessary options of `black` and `isort`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ jobs:
           name: black
           command: |
             . venv/bin/activate
-            black . --check --diff
+            black . --diff
 
       - run:
           name: flake8
@@ -55,7 +55,7 @@ jobs:
           name: isort
           command: |
             . venv/bin/activate
-            isort . --check --diff
+            isort . --diff
 
       - run:
           name: mypy


### PR DESCRIPTION
## Motivation
Not sure if this fix is even necessary, but let me point out that there is a redundant option for both `isort` and `black`. `--diff` option itself includes `--check` option as well, so I believe `--check` is unnecessary.