### PR TITLE
Resolve conflict of `job-id` of GitHub Action workflows

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -19,7 +19,7 @@ env:
 
 jobs:
 
-  build:
+  dockerimage:
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -5,7 +5,7 @@ on:
     - cron: '0 15 * * *'
 
 jobs:
-  build:
+  examples:
 
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/tests-integration.yml
+++ b/.github/workflows/tests-integration.yml
@@ -9,7 +9,7 @@ on:
     - cron: '0 23 * * SUN-THU'
 
 jobs:
-  build:
+  tests-integration:
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ on:
     - cron: '0 23 * * SUN-THU'
 
 jobs:
-  build:
+  tests:
     runs-on: ubuntu-latest
 
     strategy:


### PR DESCRIPTION
## Motivation
- Four workflows use `build` as `job-id`, and the conflict of `job-id` prevents fine-grained management of CI.

![image](https://user-images.githubusercontent.com/3255979/95038920-44c8a680-070a-11eb-92b6-a1bf14368f1c.png)

## Description of the changes

This PR renames conflicted `job-id`.