### PR TITLE
Fix broken links in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,15 +30,15 @@ Optuna can dynamically construct the search spaces for the hyperparameters.
 
 Optuna has modern functionalities as follows:
 
-- [Lightweight, versatile, and platform agnostic architecture](https://optuna.readthedocs.io/en/stable/tutorial/first.html)
+- [Lightweight, versatile, and platform agnostic architecture](https://optuna.readthedocs.io/en/stable/tutorial/001_first.html)
   - Handle a wide variety of tasks with a simple installation that has few requirements.
-- [Pythonic search spaces](https://optuna.readthedocs.io/en/stable/tutorial/configurations.html)
+- [Pythonic search spaces](https://optuna.readthedocs.io/en/stable/tutorial/002_configurations.html)
   - Define search spaces using familiar Python syntax including conditionals and loops.
-- [Efficient optimization algorithms](https://optuna.readthedocs.io/en/stable/tutorial/pruning.html)
+- [Efficient optimization algorithms](https://optuna.readthedocs.io/en/stable/tutorial/007_pruning.html)
   - Adopt state-of-the-art algorithms for sampling hyper parameters and efficiently pruning unpromising trials.
-- [Easy parallelization](https://optuna.readthedocs.io/en/stable/tutorial/distributed.html)
+- [Easy parallelization](https://optuna.readthedocs.io/en/stable/tutorial/004_distributed.html)
   - Scale studies to tens or hundreds or workers with little or no changes to the code.
-- [Quick visualization](https://optuna.readthedocs.io/en/stable/reference/visualization.html)
+- [Quick visualization](https://optuna.readthedocs.io/en/stable/reference/visualization/index.html)
   - Inspect optimization histories from a variety of plotting functions.
 
 


### PR DESCRIPTION
## Motivation
The filenames of tutorial pages have been changed since v2.2.0. More specifically, the prefix `00x_` was added to the filenames. In addition to that, the link to the `optuna.visualization` reference also changed.

(This issue was originally reported by @y0z. Thanks!)

## Description of the changes
This PR fixes the broken links.