### PR TITLE
Fix plotly figure iframe paths

### DIFF
--- a/optuna/multi_objective/visualization/_pareto_front.py
+++ b/optuna/multi_objective/visualization/_pareto_front.py
@@ -50,7 +50,7 @@ def plot_pareto_front(
 
         .. raw:: html
 
-            <iframe src="../../../_static/plot_pareto_front.html" width="100%" height="500px"
+            <iframe src="../../../../_static/plot_pareto_front.html" width="100%" height="500px"
             frameborder="0"></iframe>
 
     Args:

--- a/optuna/multi_objective/visualization/_pareto_front.py
+++ b/optuna/multi_objective/visualization/_pareto_front.py
@@ -50,7 +50,7 @@ def plot_pareto_front(
 
         .. raw:: html
 
-            <iframe src="../../../../_static/plot_pareto_front.html" width="100%" height="500px"
+            <iframe src="../../../_static/plot_pareto_front.html" width="100%" height="500px"
             frameborder="0"></iframe>
 
     Args:

--- a/optuna/visualization/_contour.py
+++ b/optuna/visualization/_contour.py
@@ -51,7 +51,7 @@ def plot_contour(study: Study, params: Optional[List[str]] = None) -> "go.Figure
 
         .. raw:: html
 
-            <iframe src="../../_static/plot_contour.html"
+            <iframe src="../../../_static/plot_contour.html"
                 width="100%" height="500px" frameborder="0">
             </iframe>
 

--- a/optuna/visualization/_edf.py
+++ b/optuna/visualization/_edf.py
@@ -74,7 +74,7 @@ def plot_edf(study: Union[Study, Sequence[Study]]) -> "go.Figure":
 
         .. raw:: html
 
-            <iframe src="../../_static/plot_edf.html"
+            <iframe src="../../../_static/plot_edf.html"
              width="100%" height="500px" frameborder="0">
             </iframe>
 

--- a/optuna/visualization/_intermediate_values.py
+++ b/optuna/visualization/_intermediate_values.py
@@ -54,7 +54,7 @@ def plot_intermediate_values(study: Study) -> "go.Figure":
 
         .. raw:: html
 
-            <iframe src="../../_static/plot_intermediate_values.html"
+            <iframe src="../../../_static/plot_intermediate_values.html"
              width="100%" height="500px" frameborder="0">
             </iframe>
 

--- a/optuna/visualization/_optimization_history.py
+++ b/optuna/visualization/_optimization_history.py
@@ -36,7 +36,7 @@ def plot_optimization_history(study: Study) -> "go.Figure":
 
         .. raw:: html
 
-            <iframe src="../../_static/plot_optimization_history.html"
+            <iframe src="../../../_static/plot_optimization_history.html"
              width="100%" height="500px" frameborder="0">
             </iframe>
 

--- a/optuna/visualization/_parallel_coordinate.py
+++ b/optuna/visualization/_parallel_coordinate.py
@@ -45,7 +45,7 @@ def plot_parallel_coordinate(study: Study, params: Optional[List[str]] = None) -
 
         .. raw:: html
 
-            <iframe src="../../_static/plot_parallel_coordinate.html"
+            <iframe src="../../../_static/plot_parallel_coordinate.html"
              width="100%" height="500px" frameborder="0">
             </iframe>
 

--- a/optuna/visualization/_param_importances.py
+++ b/optuna/visualization/_param_importances.py
@@ -66,7 +66,7 @@ def plot_param_importances(
 
         .. raw:: html
 
-            <iframe src="../../_static/plot_param_importances.html"
+            <iframe src="../../../_static/plot_param_importances.html"
              width="100%" height="500px" frameborder="0">
             </iframe>
 

--- a/optuna/visualization/_slice.py
+++ b/optuna/visualization/_slice.py
@@ -44,7 +44,7 @@ def plot_slice(study: Study, params: Optional[List[str]] = None) -> "go.Figure":
 
         .. raw:: html
 
-            <iframe src="../../_static/plot_slice.html"
+            <iframe src="../../../_static/plot_slice.html"
                 width="100%" height="500px" frameborder="0">
             </iframe>
 


### PR DESCRIPTION
<!-- Thank you for creating a pull request! -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

The latest doc fails to display the plotly figures:

![Screen Shot 2020-10-06 at 20 15 36](https://user-images.githubusercontent.com/17039389/95194853-c0ad1680-0810-11eb-95ed-f0584aaf528a.png)

https://optuna.readthedocs.io/en/v2.2.0/reference/visualization/generated/optuna.visualization.plot_contour.html

## Description of the changes
<!-- Describe the changes in this PR. -->
