### PR TITLE
Partial support of python 3.9

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -23,10 +23,14 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    # TODO (crcrpar): Remove `exclude` once integration works with Python 3.9.
     strategy:
       matrix:
-        python_version: ['3.6', '3.7', '3.8']
+        python_version: ['3.6', '3.7', '3.8', '3.9']
         build_type: ['', 'dev']  # "dev" installs all the dependencies including pytest.
+        exclude:
+        - python_version: '3.9'
+          build_type: 'dev'
 
     # This action cannot be executed in the forked repository.
     if: github.repository == 'optuna/optuna'
@@ -50,10 +54,11 @@ jobs:
           # Cache is not available because the image tag includes the Optuna version.
           CACHE_FROM=""
         else
-          docker pull "${HUB_TAG}"
           CACHE_FROM="--cache-from=${HUB_TAG}"
         fi
         docker build ${CACHE_FROM} . --build-arg PYTHON_VERSION=${{ matrix.python_version }} --build-arg BUILD_TYPE=${{ matrix.build_type }} --file Dockerfile --tag "${HUB_TAG}"
+      env:
+        DOCKER_BUILDKIT: 1
 
     - name: Verify the built image
       run: |

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   examples:
 
+    # TODO (crcrpar): Run on 3.9.
+    # ref: https://github.com/optuna/optuna/issues/2034
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/tests-integration.yml
+++ b/.github/workflows/tests-integration.yml
@@ -12,6 +12,8 @@ jobs:
   tests-integration:
     runs-on: ubuntu-latest
 
+    # TODO (crcrpar): Add 3.9 to python-version matrix once libraries support it.
+    # As far as I know, PyTorch still does not support it.
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8]

--- a/.github/workflows/tests-integration.yml
+++ b/.github/workflows/tests-integration.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     # TODO (crcrpar): Add 3.9 to python-version matrix once libraries support it.
-    # As far as I know, PyTorch still does not support it.
+    # ref: https://github.com/optuna/optuna/issues/2034
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
 
     services:
       redis:

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ def get_long_description() -> str:
 
 def get_install_requires() -> List[str]:
 
-    return [
+    requirements = [
         "alembic",
         "cliff",
         "cmaes>=0.6.0",
@@ -40,6 +40,9 @@ def get_install_requires() -> List[str]:
         "sqlalchemy>=1.1.0",
         "tqdm",
     ]
+    if sys.version_info[:2] > (3, 8):
+        requirements.append("Cython")
+    return requirements
 
 
 def get_tests_require() -> List[str]:
@@ -237,6 +240,7 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3 :: Only",
         "Topic :: Scientific/Engineering",
         "Topic :: Scientific/Engineering :: Mathematics",

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,8 @@ def get_install_requires() -> List[str]:
         "sqlalchemy>=1.1.0",
         "tqdm",
     ]
+    # NOTE (crcrpar): Some of the above libraries require Cython to be installed.
+    # I hope they will obviate it in the future releases.
     if sys.version_info[:2] > (3, 8):
         requirements.append("Cython")
     return requirements


### PR DESCRIPTION
## Changes

- add Python 3.9 to tests except for integration as there are outstanding libraries for Python 3.9
- add Python 3.9 to Docker build workflow
- enable Docker BuildKit as it better deals `--cache-from`

## TODOs
- monitor integration libraries to keep setup.py and CI workflows up-to-date.