### PR TITLE
Update docstring of CmaEsSampler

### DIFF
--- a/optuna/samplers/_cmaes.py
+++ b/optuna/samplers/_cmaes.py
@@ -68,7 +68,7 @@ class CmaEsSampler(BaseSampler):
       <http://www.cmap.polytechnique.fr/~nikolaus.hansen/cec2005ipopcmaes.pdf>`_
 
     .. seealso::
-        You can also use :class:`optuna.integration.CmaEsSampler` which is a sampler using cma
+        You can also use :class:`optuna.integration.PyCmaSampler` which is a sampler using cma
         library as the backend.
 
     Args:


### PR DESCRIPTION
<!-- Thank you for creating a pull request! -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

The docstring of CmaEsSampler refers `optuna.integration.CmaEsSampler` which is already deprecated.

## Description of the changes
<!-- Describe the changes in this PR. -->

* Replace `optuna.integration.CmaEsSampler` to `optuna.integration.PyCmaSampler`.
