### PR TITLE
Pin `mypy==0.782`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ def get_tests_require() -> List[str]:
 def get_extras_require() -> Dict[str, List[str]]:
 
     requirements = {
-        "checking": ["black", "hacking", "isort", "mypy"],
+        "checking": ["black", "hacking", "isort", "mypy==0.782"],
         "codecov": ["codecov", "pytest-cov"],
         "doctest": [
             "cma",


### PR DESCRIPTION
## Motivation

CI seems to fail with the latest `mypy` (v0.790).
(I tested the behavior on https://github.com/himkt/optuna/pull/4)

The following issue may be related to the CI failures.
https://github.com/python/mypy/issues/9122#issuecomment-691285527

## Description of the changes
This PR pins the version of `mypy==0.782`.