### PR TITLE
Improve MLflow callback functionality: allow nesting, and attached study attrs.

### DIFF
--- a/optuna/integration/mlflow.py
+++ b/optuna/integration/mlflow.py
@@ -79,9 +79,9 @@ class MLflowCallback(object):
             Flag indicating whether or not trials should be logged as
             nested runs. This is often helpful for aggregating trials
             to a particular study, under a given experiment.
-        attach_study_attrs:
-            Flag indicating whether or not to attach the study's user attrs
-            to the mlflow trial.
+        tag_study_user_attrs:
+            Flag indicating whether or not to add the study's user attrs
+            to the mlflow trial as tags.
     """
 
     def __init__(
@@ -89,7 +89,7 @@ class MLflowCallback(object):
         tracking_uri: Optional[str] = None,
         metric_name: str = "value",
         nest_trials: Optional[bool] = False,
-        attach_study_attrs: Optional[bool] = False,
+        tag_study_user_attrs: Optional[bool] = False,
     ) -> None:
 
         _imports.check()
@@ -97,7 +97,7 @@ class MLflowCallback(object):
         self._tracking_uri = tracking_uri
         self._metric_name = metric_name
         self._nest_trials = nest_trials
-        self._attach_study_attrs = attach_study_attrs
+        self._tag_study_user_attrs = tag_study_user_attrs
 
     def __call__(self, study: optuna.study.Study, trial: optuna.trial.FrozenTrial) -> None:
 
@@ -133,7 +133,7 @@ class MLflowCallback(object):
             if isinstance(study_direction, StudyDirection):
                 tags["direction"] = str(study_direction).split(".")[-1]
 
-            if self._attach_study_attrs:
+            if self._tag_study_user_attrs:
                 tags.update(study.user_attrs)
             tags.update(trial.user_attrs)
             distributions = {

--- a/optuna/integration/mlflow.py
+++ b/optuna/integration/mlflow.py
@@ -81,7 +81,8 @@ class MLflowCallback(object):
             to a particular study, under a given experiment.
         tag_study_user_attrs:
             Flag indicating whether or not to add the study's user attrs
-            to the mlflow trial as tags.
+            to the mlflow trial as tags. Please note that when this flag is
+            set, key value pairs in study.user_attrs will supersede existing tags.
     """
 
     def __init__(
@@ -89,7 +90,7 @@ class MLflowCallback(object):
         tracking_uri: Optional[str] = None,
         metric_name: str = "value",
         nest_trials: bool = False,
-        tag_study_user_attrs: Optional[bool] = False,
+        tag_study_user_attrs: bool = False,
     ) -> None:
 
         _imports.check()

--- a/optuna/integration/mlflow.py
+++ b/optuna/integration/mlflow.py
@@ -134,13 +134,14 @@ class MLflowCallback(object):
             if isinstance(study_direction, StudyDirection):
                 tags["direction"] = str(study_direction).split(".")[-1]
 
-            if self._tag_study_user_attrs:
-                tags.update(study.user_attrs)
             tags.update(trial.user_attrs)
             distributions = {
                 (k + "_distribution"): str(v) for (k, v) in trial.distributions.items()
             }
             tags.update(distributions)
+
+            if self._tag_study_user_attrs:
+                tags.update(study.user_attrs)
 
             # This is a temporary fix on Optuna side. It avoids an error with user
             # attributes that are too long. It should be fixed on MLflow side later.

--- a/optuna/integration/mlflow.py
+++ b/optuna/integration/mlflow.py
@@ -88,7 +88,7 @@ class MLflowCallback(object):
         self,
         tracking_uri: Optional[str] = None,
         metric_name: str = "value",
-        nest_trials: Optional[bool] = False,
+        nest_trials: bool = False,
         tag_study_user_attrs: Optional[bool] = False,
     ) -> None:
 


### PR DESCRIPTION
This patch provides two optional flags for the MLflow integration callback.
- Allow users to specify whether or not to nest mlflow runs.
- Allow users to indicate that the Optuna's `study.user_attrs` key value pairs should be added as MLflow tags. 

## Motivation
This patch is meant to add additional flexibility/usability for users of the mlflow callback, without changing any of the current default behaviour. 

## Description of the changes
Trial nesting: It often makes sense to group related trial runs within the context of a given experiment, without having to create an entirely new experiment. mlflow's `nested` argument facilitates this, and improves readability in the mlflow ui. This patch adds an optional flag, which defaults to False, to the mlflow integration callback that indicates trial runs should be nested.

Study attrs: For a given study, we may have a number of user defined attributes that we'd like to attach as metadata (tags) to our MLflow trials. This patch adds an optional flag, which defaults to False, to the MLflow integration callback which indicates whether or not to attach the `study.user_attrs` as tags on the MLflow trial.
