### PR TITLE
Fix RDB test to avoid deadlock when creating study

### DIFF
--- a/tests/storages_tests/rdb_tests/test_with_server.py
+++ b/tests/storages_tests/rdb_tests/test_with_server.py
@@ -30,7 +30,7 @@ def run_optimize(args: Tuple[str, str]) -> None:
     study_name = args[0]
     storage_url = args[1]
     # Create a study
-    study = optuna.create_study(study_name=study_name, storage=storage_url, load_if_exists=True)
+    study = optuna.load_study(study_name=study_name, storage=storage_url)
     # Run optimization
     study.optimize(objective, n_trials=20)
 
@@ -105,6 +105,7 @@ def test_loaded_trials(storage_url: str) -> None:
 def test_multiprocess(storage_url: str) -> None:
     n_workers = 8
     study_name = _STUDY_NAME
+    optuna.create_study(storage=storage_url, study_name=study_name)
     with Pool(n_workers) as pool:
         pool.map(run_optimize, [(study_name, storage_url)] * n_workers)
 


### PR DESCRIPTION
## Motivation
CI sometimes failed at the following line:

https://github.com/optuna/optuna/blob/3fae91c3c9f48f9111c590143da472bd3883c887/tests/storages_tests/rdb_tests/test_with_server.py#L109

In this line, multiple workers try to create studies, and the deadlock occurs depending on the timing.

https://github.com/optuna/optuna/blob/3fae91c3c9f48f9111c590143da472bd3883c887/tests/storages_tests/rdb_tests/test_with_server.py#L33

## Description of the changes

I think we can fix `optuna.create_study` to avoid deadlock, but this PR only updates the test case.
It creates a study in a single (parent) process and shares it with workers.