### PR TITLE
Fix duplicate stack traces

### DIFF
--- a/optuna/storages/_rdb/storage.py
+++ b/optuna/storages/_rdb/storage.py
@@ -3,7 +3,6 @@ from datetime import datetime
 import json
 import logging
 import os
-import sys
 from typing import Any
 from typing import Dict
 from typing import List

--- a/optuna/storages/_rdb/storage.py
+++ b/optuna/storages/_rdb/storage.py
@@ -1096,9 +1096,7 @@ class RDBStorage(BaseStorage):
                 "This typically happens due to invalid data in the commit, "
                 "e.g. exceeding max length."
             )
-            raise optuna.exceptions.StorageInternalError(message).with_traceback(
-                sys.exc_info()[2]
-            ) from e
+            raise optuna.exceptions.StorageInternalError(message) from e
 
     def remove_session(self) -> None:
         """Removes the current session.


### PR DESCRIPTION
## Motivation
There is currently a duplicate traceback in the error message when `StorageInternalError` is raised at: https://github.com/optuna/optuna/blob/e857b09ff65e8ba32b21023318345d08f4c4c830/optuna/storages/_rdb/storage.py#L1099

<details><summary>Example</summary><p>
Below is a brief version of the above. Run:

```python
import sys
from sqlalchemy.exc import SQLAlchemyError
try:
    raise SQLAlchemyError("Unexpected SQLAlchemyError occurs here!")
except SQLAlchemyError as e:
    message = (
        "An exception is raised during the commit. "
        "This typically happens due to invalid data in the commit, "
        "e.g. exceeding max length."
        )
    raise Exception(message).with_traceback(
        sys.exc_info()[2]
        ) from e
```
, and you'll get:
```shell
Traceback (most recent call last):
  File "/tmp/test.py", line 4, in <module>
    raise SQLAlchemyError("Unexpected SQLAlchemyError occurs here!")
sqlalchemy.exc.SQLAlchemyError: Unexpected SQLAlchemyError occurs here!

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/tmp/test.py", line 13, in <module>
    ) from e
  File "/tmp/test.py", line 4, in <module>
    raise SQLAlchemyError("Unexpected SQLAlchemyError occurs here!")
Exception: An exception is raised during the commit. This typically happens due to invalid data in the commit, e.g. exceeding max length.
```

Note that there are duplicate lines in the error message:
```shell
  File "/tmp/test.py", line 4, in <module>
    raise SQLAlchemyError("Unexpected SQLAlchemyError occurs here!")
```

</p></details>

## Description of the changes
Removes `with_traceback()` to get rid of the duplicate.