### PR TITLE
add some jitters in `_MultivariateParzenEstimators`

### DIFF
--- a/optuna/samplers/_tpe/multivariate_parzen_estimator.py
+++ b/optuna/samplers/_tpe/multivariate_parzen_estimator.py
@@ -155,7 +155,7 @@ class _MultivariateParzenEstimator:
                 p_accept = cdf_func(high, mus, sigmas) - cdf_func(low, mus, sigmas)
                 if q is None:
                     distance = samples[:, None] - mus
-                    mahalanobis = distance / sigmas
+                    mahalanobis = distance / np.maximum(sigmas, EPS)
                     z = np.sqrt(2 * np.pi) * sigmas
                     coefficient = 1 / z / p_accept
                     log_pdf = -0.5 * mahalanobis ** 2 + np.log(coefficient)
@@ -165,7 +165,7 @@ class _MultivariateParzenEstimator:
                     cdf = cdf_func(upper_bound[:, None], mus[None], sigmas[None]) - cdf_func(
                         lower_bound[:, None], mus[None], sigmas[None]
                     )
-                    log_pdf = np.log(cdf) - np.log(p_accept)
+                    log_pdf = np.log(cdf + EPS) - np.log(p_accept + EPS)
             component_log_pdf += log_pdf
         ret = scipy.special.logsumexp(component_log_pdf + np.log(self._weights), axis=1)
         return ret


### PR DESCRIPTION
<!-- Thank you for creating a pull request! -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
As discussed in #1917, the multivariate TPE lacks some of the jitters (jitters `EPS` are often added to variables before division or logarithm for avoiding errors) that independent TPE has. This PR aims to make the use of jitters consistent between multivariate and independent TPEs.

## Description of the changes
<!-- Describe the changes in this PR. -->
