### PR TITLE
Fix for PyTorch Lightning 1.0

### DIFF
--- a/examples/pytorch_lightning_simple.py
+++ b/examples/pytorch_lightning_simple.py
@@ -149,8 +149,7 @@ def objective(trial):
         checkpoint_callback=checkpoint_callback,
         max_epochs=EPOCHS,
         gpus=1 if torch.cuda.is_available() else None,
-        callbacks=[metrics_callback],
-        early_stop_callback=PyTorchLightningPruningCallback(trial, monitor="val_acc"),
+        callbacks=[metrics_callback, PyTorchLightningPruningCallback(trial, monitor="val_acc")],
     )
 
     model = LightningNet(trial)

--- a/tests/integration_tests/test_pytorch_lightning.py
+++ b/tests/integration_tests/test_pytorch_lightning.py
@@ -68,10 +68,10 @@ def test_pytorch_lightning_pruning_callback() -> None:
     def objective(trial: optuna.trial.Trial) -> float:
 
         trainer = pl.Trainer(
-            early_stop_callback=PyTorchLightningPruningCallback(trial, monitor="accuracy"),
             min_epochs=0,  # Required to fire the callback after the first epoch.
             max_epochs=2,
             checkpoint_callback=False,
+            callbacks=[PyTorchLightningPruningCallback(trial, monitor="accuracy")],
         )
 
         model = Model()


### PR DESCRIPTION
I didn't know `early_stop_callback` was deprecated https://github.com/PyTorchLightning/pytorch-lightning/pull/3982/commits/4ef56484c34292a6660d136727d247bf7f98c627.