### PR TITLE
Fixed 'Mean of empty slice' warning

### DIFF
--- a/optuna/pruners/_percentile.py
+++ b/optuna/pruners/_percentile.py
@@ -33,19 +33,22 @@ def _get_percentile_intermediate_result_over_trials(
     if len(completed_trials) == 0:
         raise ValueError("No trials have been completed.")
 
-    if direction == StudyDirection.MAXIMIZE:
+    intermediate_values = [
+        t.intermediate_values[step]
+        for t in completed_trials
+        if step in t.intermediate_values
+    ]
+    is_maximize = direction == StudyDirection.MAXIMIZE
+
+    if not intermediate_values:
+        return -math.inf if is_maximize else math.inf
+
+    if is_maximize:
         percentile = 100 - percentile
 
     return float(
         np.nanpercentile(
-            np.array(
-                [
-                    t.intermediate_values[step]
-                    for t in completed_trials
-                    if step in t.intermediate_values
-                ],
-                np.float,
-            ),
+            np.array(intermediate_values, np.float),
             percentile,
         )
     )

--- a/optuna/pruners/_percentile.py
+++ b/optuna/pruners/_percentile.py
@@ -36,12 +36,11 @@ def _get_percentile_intermediate_result_over_trials(
     intermediate_values = [
         t.intermediate_values[step] for t in completed_trials if step in t.intermediate_values
     ]
-    is_maximize = direction == StudyDirection.MAXIMIZE
 
     if not intermediate_values:
         return math.nan
 
-    if is_maximize:
+    if direction == StudyDirection.MAXIMIZE:
         percentile = 100 - percentile
 
     return float(

--- a/optuna/pruners/_percentile.py
+++ b/optuna/pruners/_percentile.py
@@ -39,7 +39,7 @@ def _get_percentile_intermediate_result_over_trials(
     is_maximize = direction == StudyDirection.MAXIMIZE
 
     if not intermediate_values:
-        return -math.inf if is_maximize else math.inf
+        return math.nan
 
     if is_maximize:
         percentile = 100 - percentile

--- a/optuna/pruners/_percentile.py
+++ b/optuna/pruners/_percentile.py
@@ -34,9 +34,7 @@ def _get_percentile_intermediate_result_over_trials(
         raise ValueError("No trials have been completed.")
 
     intermediate_values = [
-        t.intermediate_values[step]
-        for t in completed_trials
-        if step in t.intermediate_values
+        t.intermediate_values[step] for t in completed_trials if step in t.intermediate_values
     ]
     is_maximize = direction == StudyDirection.MAXIMIZE
 


### PR DESCRIPTION
## Motivation

When using `optuna`'s pruning strategy with `n_jobs > 1`, the following warning happens to occur frequently:

```python
...\site-packages\numpy\lib\nanfunctions.py:1366: RuntimeWarning:

Mean of empty slice
```

## Description of the changes

It's easy to be fixed with a simple condition statement. I've realized that you are using `black` to format your codes, so I've tried my best to follow it 😉

> BTW: I'm not sure whether you prefer returning `nan` of `inf` in such condition. I've chosen `inf` but feel free to change it to `nan` if you like 😆
