### PR TITLE
Fix suggest_int method when using a large number

### DIFF
--- a/optuna/distributions.py
+++ b/optuna/distributions.py
@@ -508,6 +508,7 @@ def _adjust_discrete_uniform_high(low: float, high: float, q: float) -> float:
     d_q = decimal.Decimal(str(q))
 
     d_r = d_high - d_low
+    decimal.getcontext().prec = 10000
 
     if d_r % d_q != decimal.Decimal("0"):
         old_high = high

--- a/optuna/distributions.py
+++ b/optuna/distributions.py
@@ -508,9 +508,8 @@ def _adjust_discrete_uniform_high(low: float, high: float, q: float) -> float:
     d_q = decimal.Decimal(str(q))
 
     d_r = d_high - d_low
-    decimal.getcontext().prec = 10000
 
-    if d_r % d_q != decimal.Decimal("0"):
+    if decimal.Context(prec=1000).remainder(d_r, d_q) != decimal.Decimal("0"):
         old_high = high
         high = float((d_r // d_q) * d_q + d_low)
         warnings.warn(

--- a/optuna/samplers/_random.py
+++ b/optuna/samplers/_random.py
@@ -1,9 +1,9 @@
+import random
 from typing import Any
 from typing import Dict
 from typing import Optional
 
 import numpy
-import random
 
 from optuna import distributions
 from optuna.distributions import BaseDistribution

--- a/optuna/samplers/_random.py
+++ b/optuna/samplers/_random.py
@@ -3,6 +3,7 @@ from typing import Dict
 from typing import Optional
 
 import numpy
+import random
 
 from optuna import distributions
 from optuna.distributions import BaseDistribution
@@ -39,6 +40,7 @@ class RandomSampler(BaseSampler):
 
     def __init__(self, seed: Optional[int] = None) -> None:
 
+        random.seed(seed)
         self._rng = numpy.random.RandomState(seed)
 
     def reseed_rng(self) -> None:
@@ -83,9 +85,9 @@ class RandomSampler(BaseSampler):
             return float(min(max(v, param_distribution.low), param_distribution.high))
         elif isinstance(param_distribution, distributions.IntUniformDistribution):
             # [low, high] is shifted to [0, r] to align sampled values at regular intervals.
-            r = (param_distribution.high - param_distribution.low) / param_distribution.step
+            r = (param_distribution.high - param_distribution.low) // param_distribution.step
             # numpy.random.randint includes low but excludes high.
-            s = self._rng.randint(0, r + 1)
+            s = random.randint(0, r)
             v = s * param_distribution.step + param_distribution.low
             return int(v)
         elif isinstance(param_distribution, distributions.IntLogUniformDistribution):

--- a/tests/samplers_tests/test_samplers.py
+++ b/tests/samplers_tests/test_samplers.py
@@ -1,5 +1,6 @@
 from collections import OrderedDict
 import pickle
+import sys
 from typing import Any
 from typing import Callable
 from typing import Dict
@@ -8,7 +9,6 @@ from typing import Sequence
 
 import numpy as np
 import pytest
-import sys
 
 import optuna
 from optuna.distributions import BaseDistribution

--- a/tests/samplers_tests/test_samplers.py
+++ b/tests/samplers_tests/test_samplers.py
@@ -143,7 +143,7 @@ def test_discrete_uniform(
         IntUniformDistribution(-10, 10, 2),
         IntUniformDistribution(0, 10, 2),
         IntUniformDistribution(-10, 0, 2),
-        IntUniformDistribution(0, sys.float_info.max, 1),
+        IntUniformDistribution(0, int(sys.float_info.max), 1),
     ],
 )
 def test_int(

--- a/tests/samplers_tests/test_samplers.py
+++ b/tests/samplers_tests/test_samplers.py
@@ -8,6 +8,7 @@ from typing import Sequence
 
 import numpy as np
 import pytest
+import sys
 
 import optuna
 from optuna.distributions import BaseDistribution
@@ -142,6 +143,7 @@ def test_discrete_uniform(
         IntUniformDistribution(-10, 10, 2),
         IntUniformDistribution(0, 10, 2),
         IntUniformDistribution(-10, 0, 2),
+        IntUniformDistribution(0, sys.float_info.max, 1),
     ],
 )
 def test_int(


### PR DESCRIPTION
## Motivation
I want to use a large number, for example a factorial of 50, as the upper endpoint of the range of suggested value of the `suggest_int` method. But I got the following error.

```
optuna/samplers/_random.py in sample_independent(self, study, trial, param_name, param_distribution)
     86             r = (param_distribution.high - param_distribution.low) / param_distribution.step
     87             # numpy.random.randint includes low but excludes high.
---> 88             s = self._rng.randint(0, r + 1)
     89             v = s * param_distribution.step + param_distribution.low
     90             return int(v)

mtrand.pyx in numpy.random.mtrand.RandomState.randint()

_bounded_integers.pyx in numpy.random._bounded_integers._rand_int64()

ValueError: high is out of bounds for int64
```

## Description of the changes
- Changed standard library instead of numpy for random numbers.
- Changed the result of the division from a float to an int.
- Changed the precision of decimal.
- Add test.

I am not confident in this change. Sorry if I have made the wrong changes.