### PR TITLE
Add `reseed_rng` to `NSGAIIMultiObjectiveSampler`

### DIFF
--- a/optuna/multi_objective/samplers/_nsga2.py
+++ b/optuna/multi_objective/samplers/_nsga2.py
@@ -90,6 +90,10 @@ class NSGAIIMultiObjectiveSampler(BaseMultiObjectiveSampler):
         self._random_sampler = multi_objective.samplers.RandomMultiObjectiveSampler(seed=seed)
         self._rng = np.random.RandomState(seed)
 
+    def reseed_rng(self) -> None:
+        self._random_sampler.reseed_rng()
+        self._rng = np.random.RandomState()
+
     def infer_relative_search_space(
         self,
         study: "multi_objective.study.MultiObjectiveStudy",

--- a/tests/multi_objective_tests/samplers_tests/test_nsga2.py
+++ b/tests/multi_objective_tests/samplers_tests/test_nsga2.py
@@ -186,6 +186,16 @@ def test_study_system_attr_for_population_cache() -> None:
     assert len(cached_entries[0][1]) == 10  # Population size.
 
 
+def test_reseed_rng() -> None:
+    sampler = multi_objective.samplers.NSGAIIMultiObjectiveSampler(population_size=10)
+    original_seed = sampler._rng.seed
+    original_random_sampler_seed = sampler._random_sampler._sampler._rng.seed
+
+    sampler.reseed_rng()
+    assert original_seed != sampler._rng.seed
+    assert original_random_sampler_seed != sampler._random_sampler._sampler._rng.seed
+
+
 # TODO(ohta): Consider to move this utility function to `optuna.testing` module.
 def _create_frozen_trial(
     number: int, values: List[float]


### PR DESCRIPTION
## Description of the changes

This PR simply adds the `reseed_rng` method to `NSGAIIMultiObjectiveSampler`. 
c.f.,  #1831
