### PR TITLE
Allow filtering trials from `Study` and `BaseStorage` based on `TrialState`

### DIFF
--- a/optuna/integration/_lightgbm_tuner/optimize.py
+++ b/optuna/integration/_lightgbm_tuner/optimize.py
@@ -25,6 +25,7 @@ from optuna.integration._lightgbm_tuner.alias import _handling_alias_metrics
 from optuna.integration._lightgbm_tuner.alias import _handling_alias_parameters
 from optuna.study import Study
 from optuna.trial import FrozenTrial
+from optuna.trial import TrialState
 
 
 with try_import() as _imports:
@@ -614,7 +615,11 @@ class _LightGBMBaseTuner(_BaseTuner):
                 )
                 self._step_name = step_name
 
-            def get_trials(self, deepcopy: bool = True) -> List[optuna.trial.FrozenTrial]:
+            def get_trials(
+                self,
+                deepcopy: bool = True,
+                state: Optional[Union[Tuple[TrialState, ...], TrialState]] = None,
+            ) -> List[optuna.trial.FrozenTrial]:
 
                 trials = super().get_trials(deepcopy=deepcopy)
                 return [t for t in trials if t.system_attrs.get(_STEP_NAME_KEY) == self._step_name]

--- a/optuna/integration/_lightgbm_tuner/optimize.py
+++ b/optuna/integration/_lightgbm_tuner/optimize.py
@@ -684,10 +684,10 @@ class _LightGBMBaseTuner(_BaseTuner):
             def get_trials(
                 self,
                 deepcopy: bool = True,
-                state: Optional[Union[Tuple[TrialState, ...], TrialState]] = None,
+                states: Optional[Tuple[TrialState, ...]] = None,
             ) -> List[optuna.trial.FrozenTrial]:
 
-                trials = super().get_trials(deepcopy=deepcopy, state=state)
+                trials = super().get_trials(deepcopy=deepcopy, states=states)
                 return [t for t in trials if t.system_attrs.get(_STEP_NAME_KEY) == self._step_name]
 
             @property

--- a/optuna/integration/_lightgbm_tuner/optimize.py
+++ b/optuna/integration/_lightgbm_tuner/optimize.py
@@ -621,7 +621,7 @@ class _LightGBMBaseTuner(_BaseTuner):
                 state: Optional[Union[Tuple[TrialState, ...], TrialState]] = None,
             ) -> List[optuna.trial.FrozenTrial]:
 
-                trials = super().get_trials(deepcopy=deepcopy)
+                trials = super().get_trials(deepcopy=deepcopy, state=state)
                 return [t for t in trials if t.system_attrs.get(_STEP_NAME_KEY) == self._step_name]
 
             @property

--- a/optuna/multi_objective/study.py
+++ b/optuna/multi_objective/study.py
@@ -408,24 +408,22 @@ class MultiObjectiveStudy(object):
 
         The returned trials are ordered by trial number.
 
-        This is a short form of ``self.get_trials(deepcopy=True)``.
+        This is a short form of ``self.get_trials(deepcopy=True, states=None)``.
 
         Returns:
             A list of :class:`~optuna.multi_objective.trial.FrozenMultiObjectiveTrial` objects.
         """
 
-        return self.get_trials(deepcopy=True)
+        return self.get_trials(deepcopy=True, states=None)
 
     def get_trials(
-        self, deepcopy: bool = True
+        self,
+        deepcopy: bool = True,
+        states: Optional[Tuple[TrialState, ...]] = None,
     ) -> List["multi_objective.trial.FrozenMultiObjectiveTrial"]:
         """Return all trials in the study.
 
         The returned trials are ordered by trial number.
-
-        For library users, it's recommended to use more handy
-        :attr:`~optuna.multi_objective.study.MultiObjectiveStudy.trials`
-        property to get the trials instead.
 
         Args:
             deepcopy:
@@ -433,6 +431,8 @@ class MultiObjectiveStudy(object):
                 Note that if you set the flag to :obj:`False`, you shouldn't mutate
                 any fields of the returned trial. Otherwise the internal state of
                 the study may corrupt and unexpected behavior may happen.
+            states:
+                Trial states to filter on. If :obj:`None`, include all states.
 
         Returns:
             A list of :class:`~optuna.multi_objective.trial.FrozenMultiObjectiveTrial` objects.
@@ -440,7 +440,7 @@ class MultiObjectiveStudy(object):
 
         return [
             multi_objective.trial.FrozenMultiObjectiveTrial(self.n_objectives, t)
-            for t in self._study.get_trials(deepcopy=deepcopy)
+            for t in self._study.get_trials(deepcopy=deepcopy, states=states)
         ]
 
     def get_pareto_front_trials(self) -> List["multi_objective.trial.FrozenMultiObjectiveTrial"]:

--- a/optuna/pruners/_hyperband.py
+++ b/optuna/pruners/_hyperband.py
@@ -1,6 +1,7 @@
 import math
 from typing import List
 from typing import Optional
+from typing import Tuple
 from typing import Union
 
 import optuna
@@ -275,8 +276,12 @@ class HyperbandPruner(BasePruner):
                 )
                 self._bracket_id = bracket_id
 
-            def get_trials(self, deepcopy: bool = True) -> List["optuna.trial.FrozenTrial"]:
-                trials = super().get_trials(deepcopy=deepcopy)
+            def get_trials(
+                self,
+                deepcopy: bool = True,
+                state: Optional[Union[Tuple[TrialState, ...], TrialState]] = None,
+            ) -> List["optuna.trial.FrozenTrial"]:
+                trials = super().get_trials(deepcopy=deepcopy, state=state)
                 pruner = self.pruner
                 assert isinstance(pruner, HyperbandPruner)
                 return [t for t in trials if pruner._get_bracket_id(self, t) == self._bracket_id]

--- a/optuna/pruners/_hyperband.py
+++ b/optuna/pruners/_hyperband.py
@@ -279,9 +279,9 @@ class HyperbandPruner(BasePruner):
             def get_trials(
                 self,
                 deepcopy: bool = True,
-                state: Optional[Union[Tuple[TrialState, ...], TrialState]] = None,
+                states: Optional[Tuple[TrialState, ...]] = None,
             ) -> List["optuna.trial.FrozenTrial"]:
-                trials = super().get_trials(deepcopy=deepcopy, state=state)
+                trials = super().get_trials(deepcopy=deepcopy, states=states)
                 pruner = self.pruner
                 assert isinstance(pruner, HyperbandPruner)
                 return [t for t in trials if pruner._get_bracket_id(self, t) == self._bracket_id]

--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -763,7 +763,7 @@ def _get_observation_pairs(
 
     values = []
     scores = []
-    for trial in study.get_trials(deepcopy=False, state=(TrialState.COMPLETE, TrialState.PRUNED)):
+    for trial in study.get_trials(deepcopy=False, states=(TrialState.COMPLETE, TrialState.PRUNED)):
         if trial.state is TrialState.COMPLETE:
             if trial.value is None:
                 continue
@@ -801,7 +801,7 @@ def _get_multivariate_observation_pairs(
 
     scores = []
     values: Dict[str, List[Optional[float]]] = {param_name: [] for param_name in param_names}
-    for trial in study.get_trials(deepcopy=False, state=(TrialState.COMPLETE, TrialState.PRUNED)):
+    for trial in study.get_trials(deepcopy=False, states=(TrialState.COMPLETE, TrialState.PRUNED)):
 
         # We extract score from the trial.
         if trial.state is TrialState.COMPLETE:

--- a/optuna/storages/_base.py
+++ b/optuna/storages/_base.py
@@ -527,7 +527,7 @@ class BaseStorage(object, metaclass=abc.ABCMeta):
         self,
         study_id: int,
         deepcopy: bool = True,
-        state: Optional[Union[Tuple[TrialState, ...], TrialState]] = None,
+        states: Optional[Tuple[TrialState, ...]] = None,
     ) -> List[FrozenTrial]:
         """Read all trials in a study.
 
@@ -537,7 +537,7 @@ class BaseStorage(object, metaclass=abc.ABCMeta):
             deepcopy:
                 Whether to copy the list of trials before returning.
                 Set to :obj:`True` if you intend to update the list or elements of the list.
-            state:
+            states:
                 Trial states to filter on. If :obj:`None`, include all states.
 
         Returns:
@@ -567,7 +567,11 @@ class BaseStorage(object, metaclass=abc.ABCMeta):
             :exc:`KeyError`:
                 If no study with the matching ``study_id`` exists.
         """
-        return len(self.get_all_trials(study_id, deepcopy=False, state=state))
+        # TODO(hvy): Align the name and the behavior or the `state` parameter with
+        # `get_all_trials`'s `states`.
+        if isinstance(state, TrialState):
+            state = (state,)
+        return len(self.get_all_trials(study_id, deepcopy=False, states=state))
 
     def get_best_trial(self, study_id: int) -> FrozenTrial:
         """Return the trial with the best value in a study.

--- a/optuna/storages/_base.py
+++ b/optuna/storages/_base.py
@@ -558,7 +558,7 @@ class BaseStorage(object, metaclass=abc.ABCMeta):
             study_id:
                 ID of the study.
             state:
-                :class:`~optuna.trial.TrialState` to filter trials.
+                Trial states to filter on. If :obj:`None`, include all states.
 
         Returns:
             Number of trials in the study.

--- a/optuna/storages/_base.py
+++ b/optuna/storages/_base.py
@@ -3,6 +3,8 @@ from typing import Any
 from typing import Dict
 from typing import List
 from typing import Optional
+from typing import Tuple
+from typing import Union
 
 from optuna._study_direction import StudyDirection
 from optuna._study_summary import StudySummary
@@ -521,7 +523,12 @@ class BaseStorage(object, metaclass=abc.ABCMeta):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def get_all_trials(self, study_id: int, deepcopy: bool = True) -> List[FrozenTrial]:
+    def get_all_trials(
+        self,
+        study_id: int,
+        deepcopy: bool = True,
+        state: Optional[Union[Tuple[TrialState, ...], TrialState]] = None,
+    ) -> List[FrozenTrial]:
         """Read all trials in a study.
 
         Args:
@@ -530,6 +537,8 @@ class BaseStorage(object, metaclass=abc.ABCMeta):
             deepcopy:
                 Whether to copy the list of trials before returning.
                 Set to :obj:`True` if you intend to update the list or elements of the list.
+            state:
+                Trial states to filter on. If :obj:`None`, include all states.
 
         Returns:
             List of trials in the study.
@@ -540,7 +549,9 @@ class BaseStorage(object, metaclass=abc.ABCMeta):
         """
         raise NotImplementedError
 
-    def get_n_trials(self, study_id: int, state: Optional[TrialState] = None) -> int:
+    def get_n_trials(
+        self, study_id: int, state: Optional[Union[Tuple[TrialState, ...], TrialState]] = None
+    ) -> int:
         """Count the number of trials in a study.
 
         Args:
@@ -556,10 +567,7 @@ class BaseStorage(object, metaclass=abc.ABCMeta):
             :exc:`KeyError`:
                 If no study with the matching ``study_id`` exists.
         """
-        if state is None:
-            return len(self.get_all_trials(study_id, deepcopy=False))
-
-        return len([t for t in self.get_all_trials(study_id, deepcopy=False) if t.state == state])
+        return len(self.get_all_trials(study_id, deepcopy=False, state=state))
 
     def get_best_trial(self, study_id: int) -> FrozenTrial:
         """Return the trial with the best value in a study.

--- a/optuna/storages/_cached_storage.py
+++ b/optuna/storages/_cached_storage.py
@@ -7,6 +7,7 @@ from typing import List
 from typing import Optional
 from typing import Set
 from typing import Tuple
+from typing import Union
 
 from optuna import distributions
 from optuna._study_direction import StudyDirection
@@ -356,7 +357,12 @@ class _CachedStorage(BaseStorage):
 
         return self._backend.get_trial(trial_id)
 
-    def get_all_trials(self, study_id: int, deepcopy: bool = True) -> List[FrozenTrial]:
+    def get_all_trials(
+        self,
+        study_id: int,
+        deepcopy: bool = True,
+        state: Optional[Union[Tuple[TrialState, ...], TrialState]] = None,
+    ) -> List[FrozenTrial]:
         if study_id not in self._studies:
             self.read_trials_from_remote_storage(study_id)
 
@@ -364,7 +370,17 @@ class _CachedStorage(BaseStorage):
             study = self._studies[study_id]
             # We need to sort trials by their number because some samplers assume this behavior.
             # The following two lines are latency-sensitive.
-            trials = list(sorted(study.trials.values(), key=lambda t: t.number))
+
+            trials: Union[Dict[int, FrozenTrial], List[FrozenTrial]]
+
+            if state is not None:
+                if isinstance(state, TrialState):
+                    state = (state,)
+                assert state is not None and isinstance(state, tuple)
+                trials = {number: t for number, t in study.trials.items() if t.state in state}
+            else:
+                trials = study.trials
+            trials = list(sorted(trials.values(), key=lambda t: t.number))
             return copy.deepcopy(trials) if deepcopy else trials
 
     def read_trials_from_remote_storage(self, study_id: int) -> None:
@@ -373,7 +389,7 @@ class _CachedStorage(BaseStorage):
                 self._studies[study_id] = _StudyInfo()
             study = self._studies[study_id]
             trials = self._backend._get_trials(
-                study_id, excluded_trial_ids=study.owned_or_finished_trial_ids
+                study_id, state=None, excluded_trial_ids=study.owned_or_finished_trial_ids
             )
             if trials:
                 self._add_trials_to_cache(study_id, trials)

--- a/optuna/storages/_cached_storage.py
+++ b/optuna/storages/_cached_storage.py
@@ -361,7 +361,7 @@ class _CachedStorage(BaseStorage):
         self,
         study_id: int,
         deepcopy: bool = True,
-        state: Optional[Union[Tuple[TrialState, ...], TrialState]] = None,
+        states: Optional[Tuple[TrialState, ...]] = None,
     ) -> List[FrozenTrial]:
         if study_id not in self._studies:
             self.read_trials_from_remote_storage(study_id)
@@ -373,11 +373,8 @@ class _CachedStorage(BaseStorage):
 
             trials: Union[Dict[int, FrozenTrial], List[FrozenTrial]]
 
-            if state is not None:
-                if isinstance(state, TrialState):
-                    state = (state,)
-                assert state is not None and isinstance(state, tuple)
-                trials = {number: t for number, t in study.trials.items() if t.state in state}
+            if states is not None:
+                trials = {number: t for number, t in study.trials.items() if t.state in states}
             else:
                 trials = study.trials
             trials = list(sorted(trials.values(), key=lambda t: t.number))
@@ -389,7 +386,7 @@ class _CachedStorage(BaseStorage):
                 self._studies[study_id] = _StudyInfo()
             study = self._studies[study_id]
             trials = self._backend._get_trials(
-                study_id, state=None, excluded_trial_ids=study.owned_or_finished_trial_ids
+                study_id, states=None, excluded_trial_ids=study.owned_or_finished_trial_ids
             )
             if trials:
                 self._add_trials_to_cache(study_id, trials)

--- a/optuna/storages/_in_memory.py
+++ b/optuna/storages/_in_memory.py
@@ -3,9 +3,11 @@ from datetime import datetime
 import threading
 from typing import Any
 from typing import Dict
+from typing import Iterator
 from typing import List
 from typing import Optional
 from typing import Tuple
+from typing import Union
 import uuid
 
 import optuna
@@ -378,25 +380,31 @@ class InMemoryStorage(BaseStorage):
         study_id, trial_number = self._trial_id_to_study_id_and_number[trial_id]
         self._studies[study_id].trials[trial_number] = trial
 
-    def get_all_trials(self, study_id: int, deepcopy: bool = True) -> List[FrozenTrial]:
+    def get_all_trials(
+        self,
+        study_id: int,
+        deepcopy: bool = True,
+        state: Optional[Union[Tuple[TrialState, ...], TrialState]] = None,
+    ) -> List[FrozenTrial]:
 
         with self._lock:
             self._check_study_id(study_id)
+
+            trials = self._studies[
+                study_id
+            ].trials  # type: Union[List[FrozenTrial], Iterator[FrozenTrial]]
+
+            if state is not None:
+                if isinstance(state, TrialState):
+                    state = (state,)
+                trials = filter(lambda t: t.state in state, trials)
+
             if deepcopy:
-                return copy.deepcopy(self._studies[study_id].trials)
+                trials = copy.deepcopy(list(trials))
             else:
-                return self._studies[study_id].trials[:]
+                trials = list(trials)
 
-    def get_n_trials(self, study_id: int, state: Optional[TrialState] = None) -> int:
-
-        with self._lock:
-            self._check_study_id(study_id)
-            if state is None:
-                return len(self._studies[study_id].trials)
-
-            return sum(
-                trial.state == state for trial in self.get_all_trials(study_id, deepcopy=False)
-            )
+        return trials
 
     def read_trials_from_remote_storage(self, study_id: int) -> None:
         self._check_study_id(study_id)

--- a/optuna/storages/_in_memory.py
+++ b/optuna/storages/_in_memory.py
@@ -384,7 +384,7 @@ class InMemoryStorage(BaseStorage):
         self,
         study_id: int,
         deepcopy: bool = True,
-        state: Optional[Union[Tuple[TrialState, ...], TrialState]] = None,
+        states: Optional[Tuple[TrialState, ...]] = None,
     ) -> List[FrozenTrial]:
 
         with self._lock:
@@ -394,10 +394,8 @@ class InMemoryStorage(BaseStorage):
                 study_id
             ].trials  # type: Union[List[FrozenTrial], Iterator[FrozenTrial]]
 
-            if state is not None:
-                if isinstance(state, TrialState):
-                    state = (state,)
-                trials = filter(lambda t: t.state in state, trials)
+            if states is not None:
+                trials = filter(lambda t: t.state in states, trials)
 
             if deepcopy:
                 trials = copy.deepcopy(list(trials))

--- a/optuna/storages/_rdb/storage.py
+++ b/optuna/storages/_rdb/storage.py
@@ -9,7 +9,6 @@ from typing import List
 from typing import Optional
 from typing import Set
 from typing import Tuple
-from typing import Union
 import uuid
 import weakref
 
@@ -942,17 +941,17 @@ class RDBStorage(BaseStorage):
         self,
         study_id: int,
         deepcopy: bool = True,
-        state: Optional[Union[Tuple[TrialState, ...], TrialState]] = None,
+        states: Optional[Tuple[TrialState, ...]] = None,
     ) -> List[FrozenTrial]:
 
-        trials = self._get_trials(study_id, state, set())
+        trials = self._get_trials(study_id, states, set())
 
         return copy.deepcopy(trials) if deepcopy else trials
 
     def _get_trials(
         self,
         study_id: int,
-        state: Optional[Union[Tuple[TrialState, ...], TrialState]],
+        states: Optional[Tuple[TrialState, ...]],
         excluded_trial_ids: Set[int],
     ) -> List[FrozenTrial]:
 
@@ -965,10 +964,8 @@ class RDBStorage(BaseStorage):
             models.TrialModel.study_id == study_id
         )
 
-        if state is not None:
-            if isinstance(state, TrialState):
-                state = (state,)
-            query = query.filter(models.TrialModel.state.in_(state))
+        if states is not None:
+            query = query.filter(models.TrialModel.state.in_(states))
 
         trial_ids = query.all()
 

--- a/optuna/storages/_redis.py
+++ b/optuna/storages/_redis.py
@@ -1,10 +1,12 @@
 import copy
 from datetime import datetime
 import pickle
-from typing import Any  # NOQA
-from typing import Dict  # NOQA
-from typing import List  # NOQA
-from typing import Optional  # NOQA
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import Optional
+from typing import Tuple
+from typing import Union
 
 import optuna
 from optuna import distributions
@@ -531,15 +533,25 @@ class RedisStorage(BaseStorage):
         study_trial_list_key = "study_id:{:010d}:trial_list".format(study_id)
         return [int(tid) for tid in self._redis.lrange(study_trial_list_key, 0, -1)]
 
-    def get_all_trials(self, study_id: int, deepcopy: bool = True) -> List[FrozenTrial]:
+    def get_all_trials(
+        self,
+        study_id: int,
+        deepcopy: bool = True,
+        state: Optional[Union[Tuple[TrialState, ...], TrialState]] = None,
+    ) -> List[FrozenTrial]:
 
         self._check_study_id(study_id)
+
+        if state is not None and isinstance(state, TrialState):
+            state = (state,)
 
         trials = []
         trial_ids = self._get_study_trials(study_id)
         for trial_id in trial_ids:
             frozen_trial = self.get_trial(trial_id)
-            trials.append(frozen_trial)
+
+            if state is None or frozen_trial.state in state:
+                trials.append(frozen_trial)
 
         if deepcopy:
             return copy.deepcopy(trials)

--- a/optuna/storages/_redis.py
+++ b/optuna/storages/_redis.py
@@ -6,7 +6,6 @@ from typing import Dict
 from typing import List
 from typing import Optional
 from typing import Tuple
-from typing import Union
 
 import optuna
 from optuna import distributions
@@ -537,20 +536,17 @@ class RedisStorage(BaseStorage):
         self,
         study_id: int,
         deepcopy: bool = True,
-        state: Optional[Union[Tuple[TrialState, ...], TrialState]] = None,
+        states: Optional[Tuple[TrialState, ...]] = None,
     ) -> List[FrozenTrial]:
 
         self._check_study_id(study_id)
-
-        if state is not None and isinstance(state, TrialState):
-            state = (state,)
 
         trials = []
         trial_ids = self._get_study_trials(study_id)
         for trial_id in trial_ids:
             frozen_trial = self.get_trial(trial_id)
 
-            if state is None or frozen_trial.state in state:
+            if states is None or frozen_trial.state in states:
                 trials.append(frozen_trial)
 
         if deepcopy:

--- a/optuna/study.py
+++ b/optuna/study.py
@@ -104,9 +104,6 @@ class BaseStudy(object):
 
         The returned trials are ordered by trial number.
 
-        For library users, it's recommended to use more handy
-        :attr:`~optuna.study.Study.trials` property to get the trials instead.
-
         Example:
             .. testcode::
 

--- a/optuna/study.py
+++ b/optuna/study.py
@@ -98,7 +98,7 @@ class BaseStudy(object):
     def get_trials(
         self,
         deepcopy: bool = True,
-        state: Optional[Union[Tuple[TrialState, ...], TrialState]] = None,
+        states: Optional[Tuple[TrialState, ...]] = None,
     ) -> List[FrozenTrial]:
         """Return all trials in the study.
 
@@ -129,7 +129,7 @@ class BaseStudy(object):
                 Note that if you set the flag to :obj:`False`, you shouldn't mutate
                 any fields of the returned trial. Otherwise the internal state of
                 the study may corrupt and unexpected behavior may happen.
-            state:
+            states:
                 Trial states to filter on. If :obj:`None`, include all states.
 
         Returns:
@@ -137,7 +137,7 @@ class BaseStudy(object):
         """
 
         self._storage.read_trials_from_remote_storage(self._study_id)
-        return self._storage.get_all_trials(self._study_id, deepcopy=deepcopy, state=state)
+        return self._storage.get_all_trials(self._study_id, deepcopy=deepcopy, states=states)
 
 
 class Study(BaseStudy):

--- a/optuna/study.py
+++ b/optuna/study.py
@@ -95,7 +95,11 @@ class BaseStudy(object):
 
         return self.get_trials()
 
-    def get_trials(self, deepcopy: bool = True) -> List[FrozenTrial]:
+    def get_trials(
+        self,
+        deepcopy: bool = True,
+        state: Optional[Union[Tuple[TrialState, ...], TrialState]] = None,
+    ) -> List[FrozenTrial]:
         """Return all trials in the study.
 
         The returned trials are ordered by trial number.
@@ -125,13 +129,15 @@ class BaseStudy(object):
                 Note that if you set the flag to :obj:`False`, you shouldn't mutate
                 any fields of the returned trial. Otherwise the internal state of
                 the study may corrupt and unexpected behavior may happen.
+            state:
+                Trial states to filter on. If :obj:`None`, include all states.
 
         Returns:
             A list of :class:`~optuna.FrozenTrial` objects.
         """
 
         self._storage.read_trials_from_remote_storage(self._study_id)
-        return self._storage.get_all_trials(self._study_id, deepcopy=deepcopy)
+        return self._storage.get_all_trials(self._study_id, deepcopy=deepcopy, state=state)
 
 
 class Study(BaseStudy):

--- a/optuna/study.py
+++ b/optuna/study.py
@@ -87,13 +87,13 @@ class BaseStudy(object):
 
         The returned trials are ordered by trial number.
 
-        This is a short form of ``self.get_trials(deepcopy=True)``.
+        This is a short form of ``self.get_trials(deepcopy=True, states=None)``.
 
         Returns:
             A list of :class:`~optuna.FrozenTrial` objects.
         """
 
-        return self.get_trials()
+        return self.get_trials(deepcopy=True, states=None)
 
     def get_trials(
         self,

--- a/tests/samplers_tests/tpe_tests/test_sampler.py
+++ b/tests/samplers_tests/tpe_tests/test_sampler.py
@@ -330,43 +330,46 @@ def test_sample_relative_int_loguniform_distributions() -> None:
 @pytest.mark.parametrize(
     "state",
     [
-        (optuna.trial.TrialState.FAIL,),
-        (optuna.trial.TrialState.PRUNED,),
-        (optuna.trial.TrialState.RUNNING,),
-        (optuna.trial.TrialState.WAITING,),
+        optuna.trial.TrialState.FAIL,
+        optuna.trial.TrialState.PRUNED,
+        optuna.trial.TrialState.RUNNING,
+        optuna.trial.TrialState.WAITING,
     ],
 )
 def test_sample_relative_handle_unsuccessful_states(
     state: optuna.trial.TrialState,
 ) -> None:
-    study = optuna.create_study()
     dist = optuna.distributions.UniformDistribution(1.0, 100.0)
 
     # Prepare sampling result for later tests.
-    past_trials = [frozen_trial_factory(i, dist=dist) for i in range(1, 100)]
+    study = optuna.create_study()
+    for i in range(1, 100):
+        trial = frozen_trial_factory(i, dist=dist)
+        study._storage.create_new_trial(study._study_id, template_trial=trial)
     trial = frozen_trial_factory(100)
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", optuna.exceptions.ExperimentalWarning)
         sampler = TPESampler(n_startup_trials=5, seed=0, multivariate=True)
-    with patch.object(study._storage, "get_all_trials", return_value=past_trials):
-        all_success_suggestion = sampler.sample_relative(study, trial, {"param-a": dist})
+    all_success_suggestion = sampler.sample_relative(study, trial, {"param-a": dist})
 
     # Test unsuccessful trials are handled differently.
+    study = optuna.create_study()
     state_fn = build_state_fn(state)
-    past_trials = [frozen_trial_factory(i, dist=dist, state_fn=state_fn) for i in range(1, 100)]
+    for i in range(1, 100):
+        trial = frozen_trial_factory(i, dist=dist, state_fn=state_fn)
+        study._storage.create_new_trial(study._study_id, template_trial=trial)
     trial = frozen_trial_factory(100)
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", optuna.exceptions.ExperimentalWarning)
         sampler = TPESampler(n_startup_trials=5, seed=0, multivariate=True)
-    with patch.object(study._storage, "get_all_trials", return_value=past_trials):
-        partial_unsuccessful_suggestion = sampler.sample_relative(study, trial, {"param-a": dist})
+    partial_unsuccessful_suggestion = sampler.sample_relative(study, trial, {"param-a": dist})
+
     assert partial_unsuccessful_suggestion != all_success_suggestion
 
 
 def test_sample_relative_ignored_states() -> None:
     """Tests FAIL, RUNNING, and WAITING states are equally."""
 
-    study = optuna.create_study()
     dist = optuna.distributions.UniformDistribution(1.0, 100.0)
 
     suggestions = []
@@ -375,14 +378,15 @@ def test_sample_relative_ignored_states() -> None:
         optuna.trial.TrialState.RUNNING,
         optuna.trial.TrialState.WAITING,
     ]:
+        study = optuna.create_study()
         state_fn = build_state_fn(state)
-        past_trials = [frozen_trial_factory(i, dist=dist, state_fn=state_fn) for i in range(1, 30)]
-        trial = frozen_trial_factory(30)
+        for i in range(1, 30):
+            trial = frozen_trial_factory(i, dist=dist, state_fn=state_fn)
+            study._storage.create_new_trial(study._study_id, template_trial=trial)
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", optuna.exceptions.ExperimentalWarning)
             sampler = TPESampler(n_startup_trials=5, seed=0, multivariate=True)
-        with patch.object(study._storage, "get_all_trials", return_value=past_trials):
-            suggestions.append(sampler.sample_relative(study, trial, {"param-a": dist})["param-a"])
+        suggestions.append(sampler.sample_relative(study, trial, {"param-a": dist})["param-a"])
 
     assert len(set(suggestions)) == 1
 
@@ -390,7 +394,6 @@ def test_sample_relative_ignored_states() -> None:
 def test_sample_relative_pruned_state() -> None:
     """Tests PRUNED state is treated differently from both FAIL and COMPLETE."""
 
-    study = optuna.create_study()
     dist = optuna.distributions.UniformDistribution(1.0, 100.0)
 
     suggestions = []
@@ -399,14 +402,16 @@ def test_sample_relative_pruned_state() -> None:
         optuna.trial.TrialState.FAIL,
         optuna.trial.TrialState.PRUNED,
     ]:
+        study = optuna.create_study()
         state_fn = build_state_fn(state)
-        past_trials = [frozen_trial_factory(i, dist=dist, state_fn=state_fn) for i in range(1, 40)]
+        for i in range(1, 40):
+            trial = frozen_trial_factory(i, dist=dist, state_fn=state_fn)
+            study._storage.create_new_trial(study._study_id, template_trial=trial)
         trial = frozen_trial_factory(40)
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", optuna.exceptions.ExperimentalWarning)
             sampler = TPESampler(n_startup_trials=5, seed=0, multivariate=True)
-        with patch.object(study._storage, "get_all_trials", return_value=past_trials):
-            suggestions.append(sampler.sample_relative(study, trial, {"param-a": dist})["param-a"])
+        suggestions.append(sampler.sample_relative(study, trial, {"param-a": dist})["param-a"])
 
     assert len(set(suggestions)) == 3
 
@@ -623,37 +628,40 @@ def test_sample_independent_int_loguniform_distributions() -> None:
 @pytest.mark.parametrize(
     "state",
     [
-        (optuna.trial.TrialState.FAIL,),
-        (optuna.trial.TrialState.PRUNED,),
-        (optuna.trial.TrialState.RUNNING,),
-        (optuna.trial.TrialState.WAITING,),
+        optuna.trial.TrialState.FAIL,
+        optuna.trial.TrialState.PRUNED,
+        optuna.trial.TrialState.RUNNING,
+        optuna.trial.TrialState.WAITING,
     ],
 )
 def test_sample_independent_handle_unsuccessful_states(state: optuna.trial.TrialState) -> None:
-    study = optuna.create_study()
     dist = optuna.distributions.UniformDistribution(1.0, 100.0)
 
     # Prepare sampling result for later tests.
-    past_trials = [frozen_trial_factory(i, dist=dist) for i in range(1, 30)]
+    study = optuna.create_study()
+    for i in range(1, 30):
+        trial = frozen_trial_factory(i, dist=dist)
+        study._storage.create_new_trial(study._study_id, template_trial=trial)
     trial = frozen_trial_factory(30)
     sampler = TPESampler(n_startup_trials=5, seed=0)
-    with patch.object(study._storage, "get_all_trials", return_value=past_trials):
-        all_success_suggestion = sampler.sample_independent(study, trial, "param-a", dist)
+    all_success_suggestion = sampler.sample_independent(study, trial, "param-a", dist)
 
     # Test unsuccessful trials are handled differently.
     state_fn = build_state_fn(state)
-    past_trials = [frozen_trial_factory(i, dist=dist, state_fn=state_fn) for i in range(1, 30)]
+    study = optuna.create_study()
+    for i in range(1, 30):
+        trial = frozen_trial_factory(i, dist=dist, state_fn=state_fn)
+        study._storage.create_new_trial(study._study_id, template_trial=trial)
     trial = frozen_trial_factory(30)
     sampler = TPESampler(n_startup_trials=5, seed=0)
-    with patch.object(study._storage, "get_all_trials", return_value=past_trials):
-        partial_unsuccessful_suggestion = sampler.sample_independent(study, trial, "param-a", dist)
+    partial_unsuccessful_suggestion = sampler.sample_independent(study, trial, "param-a", dist)
+
     assert partial_unsuccessful_suggestion != all_success_suggestion
 
 
 def test_sample_independent_ignored_states() -> None:
     """Tests FAIL, RUNNING, and WAITING states are equally."""
 
-    study = optuna.create_study()
     dist = optuna.distributions.UniformDistribution(1.0, 100.0)
 
     suggestions = []
@@ -662,12 +670,14 @@ def test_sample_independent_ignored_states() -> None:
         optuna.trial.TrialState.RUNNING,
         optuna.trial.TrialState.WAITING,
     ]:
+        study = optuna.create_study()
         state_fn = build_state_fn(state)
-        past_trials = [frozen_trial_factory(i, dist=dist, state_fn=state_fn) for i in range(1, 30)]
+        for i in range(1, 30):
+            trial = frozen_trial_factory(i, dist=dist, state_fn=state_fn)
+            study._storage.create_new_trial(study._study_id, template_trial=trial)
         trial = frozen_trial_factory(30)
         sampler = TPESampler(n_startup_trials=5, seed=0)
-        with patch.object(study._storage, "get_all_trials", return_value=past_trials):
-            suggestions.append(sampler.sample_independent(study, trial, "param-a", dist))
+        suggestions.append(sampler.sample_independent(study, trial, "param-a", dist))
 
     assert len(set(suggestions)) == 1
 
@@ -675,7 +685,6 @@ def test_sample_independent_ignored_states() -> None:
 def test_sample_independent_pruned_state() -> None:
     """Tests PRUNED state is treated differently from both FAIL and COMPLETE."""
 
-    study = optuna.create_study()
     dist = optuna.distributions.UniformDistribution(1.0, 100.0)
 
     suggestions = []
@@ -684,12 +693,14 @@ def test_sample_independent_pruned_state() -> None:
         optuna.trial.TrialState.FAIL,
         optuna.trial.TrialState.PRUNED,
     ]:
+        study = optuna.create_study()
         state_fn = build_state_fn(state)
-        past_trials = [frozen_trial_factory(i, dist=dist, state_fn=state_fn) for i in range(1, 30)]
+        for i in range(1, 30):
+            trial = frozen_trial_factory(i, dist=dist, state_fn=state_fn)
+            study._storage.create_new_trial(study._study_id, template_trial=trial)
         trial = frozen_trial_factory(30)
         sampler = TPESampler(n_startup_trials=5, seed=0)
-        with patch.object(study._storage, "get_all_trials", return_value=past_trials):
-            suggestions.append(sampler.sample_independent(study, trial, "param-a", dist))
+        suggestions.append(sampler.sample_independent(study, trial, "param-a", dist))
 
     assert len(set(suggestions)) == 3
 

--- a/tests/storages_tests/rdb_tests/test_storage.py
+++ b/tests/storages_tests/rdb_tests/test_storage.py
@@ -275,10 +275,10 @@ def test_get_trials_excluded_trial_ids() -> None:
 
     storage.create_new_trial(study_id)
 
-    trials = storage._get_trials(study_id, state=None, excluded_trial_ids=set())
+    trials = storage._get_trials(study_id, states=None, excluded_trial_ids=set())
     assert len(trials) == 1
 
     # A large exclusion list used to raise errors. Check that it is not an issue.
     # See https://github.com/optuna/optuna/issues/1457.
-    trials = storage._get_trials(study_id, state=None, excluded_trial_ids=set(range(500000)))
+    trials = storage._get_trials(study_id, states=None, excluded_trial_ids=set(range(500000)))
     assert len(trials) == 0

--- a/tests/storages_tests/rdb_tests/test_storage.py
+++ b/tests/storages_tests/rdb_tests/test_storage.py
@@ -275,10 +275,10 @@ def test_get_trials_excluded_trial_ids() -> None:
 
     storage.create_new_trial(study_id)
 
-    trials = storage._get_trials(study_id, excluded_trial_ids=set())
+    trials = storage._get_trials(study_id, state=None, excluded_trial_ids=set())
     assert len(trials) == 1
 
     # A large exclusion list used to raise errors. Check that it is not an issue.
     # See https://github.com/optuna/optuna/issues/1457.
-    trials = storage._get_trials(study_id, excluded_trial_ids=set(range(500000)))
+    trials = storage._get_trials(study_id, state=None, excluded_trial_ids=set(range(500000)))
     assert len(trials) == 0

--- a/tests/storages_tests/test_storages.py
+++ b/tests/storages_tests/test_storages.py
@@ -840,29 +840,25 @@ def test_get_all_trials_state_option(storage_mode: str) -> None:
             t.state = s
             storage.create_new_trial(study_id, template_trial=t)
 
-        trials = storage.get_all_trials(study_id, state=None)
+        trials = storage.get_all_trials(study_id, states=None)
         assert len(trials) == 3
 
-        trials = storage.get_all_trials(study_id, state=TrialState.COMPLETE)
+        trials = storage.get_all_trials(study_id, states=(TrialState.COMPLETE,))
         assert len(trials) == 2
         assert all(t.state == TrialState.COMPLETE for t in trials)
 
-        trials = storage.get_all_trials(study_id, state=(TrialState.COMPLETE,))
-        assert len(trials) == 2
-        assert all(t.state == TrialState.COMPLETE for t in trials)
-
-        trials = storage.get_all_trials(study_id, state=(TrialState.COMPLETE, TrialState.PRUNED))
+        trials = storage.get_all_trials(study_id, states=(TrialState.COMPLETE, TrialState.PRUNED))
         assert len(trials) == 3
         assert all(t.state in (TrialState.COMPLETE, TrialState.PRUNED) for t in trials)
 
-        trials = storage.get_all_trials(study_id, state=())
+        trials = storage.get_all_trials(study_id, states=())
         assert len(trials) == 0
 
         other_states = [
             s for s in ALL_STATES if s != TrialState.COMPLETE and s != TrialState.PRUNED
         ]
         for s in other_states:
-            trials = storage.get_all_trials(study_id, state=s)
+            trials = storage.get_all_trials(study_id, states=(s,))
             assert len(trials) == 0
 
 

--- a/tests/storages_tests/test_storages.py
+++ b/tests/storages_tests/test_storages.py
@@ -829,15 +829,15 @@ def test_get_all_trials_state_option(storage_mode: str) -> None:
         storage.set_study_direction(study_id, StudyDirection.MAXIMIZE)
         generator = random.Random(51)
 
-        states = [
+        states = (
             TrialState.COMPLETE,
             TrialState.COMPLETE,
             TrialState.PRUNED,
-        ]
+        )
 
-        for s in states:
+        for state in states:
             t = _generate_trial(generator)
-            t.state = s
+            t.state = state
             storage.create_new_trial(study_id, template_trial=t)
 
         trials = storage.get_all_trials(study_id, states=None)
@@ -857,8 +857,8 @@ def test_get_all_trials_state_option(storage_mode: str) -> None:
         other_states = [
             s for s in ALL_STATES if s != TrialState.COMPLETE and s != TrialState.PRUNED
         ]
-        for s in other_states:
-            trials = storage.get_all_trials(study_id, states=(s,))
+        for state in other_states:
+            trials = storage.get_all_trials(study_id, states=(state,))
             assert len(trials) == 0
 
 

--- a/tests/storages_tests/test_storages.py
+++ b/tests/storages_tests/test_storages.py
@@ -822,6 +822,51 @@ def test_get_all_trials_deepcopy_option(storage_mode: str) -> None:
 
 
 @pytest.mark.parametrize("storage_mode", STORAGE_MODES)
+def test_get_all_trials_state_option(storage_mode: str) -> None:
+
+    with StorageSupplier(storage_mode) as storage:
+        study_id = storage.create_new_study()
+        storage.set_study_direction(study_id, StudyDirection.MAXIMIZE)
+        generator = random.Random(51)
+
+        states = [
+            TrialState.COMPLETE,
+            TrialState.COMPLETE,
+            TrialState.PRUNED,
+        ]
+
+        for s in states:
+            t = _generate_trial(generator)
+            t.state = s
+            storage.create_new_trial(study_id, template_trial=t)
+
+        trials = storage.get_all_trials(study_id, state=None)
+        assert len(trials) == 3
+
+        trials = storage.get_all_trials(study_id, state=TrialState.COMPLETE)
+        assert len(trials) == 2
+        assert all(t.state == TrialState.COMPLETE for t in trials)
+
+        trials = storage.get_all_trials(study_id, state=(TrialState.COMPLETE,))
+        assert len(trials) == 2
+        assert all(t.state == TrialState.COMPLETE for t in trials)
+
+        trials = storage.get_all_trials(study_id, state=(TrialState.COMPLETE, TrialState.PRUNED))
+        assert len(trials) == 3
+        assert all(t.state in (TrialState.COMPLETE, TrialState.PRUNED) for t in trials)
+
+        trials = storage.get_all_trials(study_id, state=())
+        assert len(trials) == 0
+
+        other_states = [
+            s for s in ALL_STATES if s != TrialState.COMPLETE and s != TrialState.PRUNED
+        ]
+        for s in other_states:
+            trials = storage.get_all_trials(study_id, state=s)
+            assert len(trials) == 0
+
+
+@pytest.mark.parametrize("storage_mode", STORAGE_MODES)
 def test_get_n_trials(storage_mode: str) -> None:
 
     with StorageSupplier(storage_mode) as storage:

--- a/tests/test_study.py
+++ b/tests/test_study.py
@@ -915,29 +915,25 @@ def test_get_trials_state_option(storage_mode: str) -> None:
 
         study.optimize(objective, n_trials=3)
 
-        trials = study.get_trials(state=None)
+        trials = study.get_trials(states=None)
         assert len(trials) == 3
 
-        trials = study.get_trials(state=TrialState.COMPLETE)
+        trials = study.get_trials(states=(TrialState.COMPLETE,))
         assert len(trials) == 2
         assert all(t.state == TrialState.COMPLETE for t in trials)
 
-        trials = study.get_trials(state=(TrialState.COMPLETE,))
-        assert len(trials) == 2
-        assert all(t.state == TrialState.COMPLETE for t in trials)
-
-        trials = study.get_trials(state=(TrialState.COMPLETE, TrialState.PRUNED))
+        trials = study.get_trials(states=(TrialState.COMPLETE, TrialState.PRUNED))
         assert len(trials) == 3
         assert all(t.state in (TrialState.COMPLETE, TrialState.PRUNED) for t in trials)
 
-        trials = study.get_trials(state=())
+        trials = study.get_trials(states=())
         assert len(trials) == 0
 
         other_states = [
             s for s in list(TrialState) if s != TrialState.COMPLETE and s != TrialState.PRUNED
         ]
         for s in other_states:
-            trials = study.get_trials(state=s)
+            trials = study.get_trials(states=(s,))
             assert len(trials) == 0
 
 

--- a/tests/test_study.py
+++ b/tests/test_study.py
@@ -23,6 +23,7 @@ import optuna
 from optuna import _optimize
 from optuna import create_trial
 from optuna.testing.storage import StorageSupplier
+from optuna.trial import TrialState
 
 
 CallbackFuncType = Callable[[optuna.study.Study, optuna.trial.FrozenTrial], None]
@@ -81,7 +82,7 @@ def check_value(value: Optional[float]) -> None:
 
 def check_frozen_trial(frozen_trial: optuna.trial.FrozenTrial) -> None:
 
-    if frozen_trial.state == optuna.trial.TrialState.COMPLETE:
+    if frozen_trial.state == TrialState.COMPLETE:
         check_params(frozen_trial.params)
         check_value(frozen_trial.value)
 
@@ -91,7 +92,7 @@ def check_study(study: optuna.Study) -> None:
     for trial in study.trials:
         check_frozen_trial(trial)
 
-    complete_trials = [t for t in study.trials if t.state == optuna.trial.TrialState.COMPLETE]
+    complete_trials = [t for t in study.trials if t.state == TrialState.COMPLETE]
     if len(complete_trials) == 0:
         with pytest.raises(ValueError):
             study.best_params
@@ -201,18 +202,18 @@ def test_optimize_with_catch(storage_mode: str) -> None:
         with pytest.raises(ValueError):
             study.optimize(func_value_error, n_trials=20)
         assert len(study.trials) == 1
-        assert all(trial.state == optuna.trial.TrialState.FAIL for trial in study.trials)
+        assert all(trial.state == TrialState.FAIL for trial in study.trials)
 
         # Test acceptable exception.
         study.optimize(func_value_error, n_trials=20, catch=(ValueError,))
         assert len(study.trials) == 21
-        assert all(trial.state == optuna.trial.TrialState.FAIL for trial in study.trials)
+        assert all(trial.state == TrialState.FAIL for trial in study.trials)
 
         # Test trial with unacceptable exception.
         with pytest.raises(ValueError):
             study.optimize(func_value_error, n_trials=20, catch=(ArithmeticError,))
         assert len(study.trials) == 22
-        assert all(trial.state == optuna.trial.TrialState.FAIL for trial in study.trials)
+        assert all(trial.state == TrialState.FAIL for trial in study.trials)
 
 
 @pytest.mark.parametrize("catch", [[], [Exception], None, 1])
@@ -353,7 +354,7 @@ def test_run_trial(storage_mode: str) -> None:
         frozen_trial = study._storage.get_trial(trial._trial_id)
 
         expected_message = "Trial 1 failed because of the following error: ValueError()"
-        assert frozen_trial.state == optuna.trial.TrialState.FAIL
+        assert frozen_trial.state == TrialState.FAIL
         assert frozen_trial.system_attrs["fail_reason"] == expected_message
 
         # Test trial with unacceptable exception.
@@ -373,7 +374,7 @@ def test_run_trial(storage_mode: str) -> None:
             "value from the objective function cannot be cast to float. "
             "Returned value is: None"
         )
-        assert frozen_trial.state == optuna.trial.TrialState.FAIL
+        assert frozen_trial.state == TrialState.FAIL
         assert frozen_trial.system_attrs["fail_reason"] == expected_message
 
         # Test trial with invalid objective value: nan
@@ -385,7 +386,7 @@ def test_run_trial(storage_mode: str) -> None:
         frozen_trial = study._storage.get_trial(trial._trial_id)
 
         expected_message = "Trial 4 failed, because the objective function returned nan."
-        assert frozen_trial.state == optuna.trial.TrialState.FAIL
+        assert frozen_trial.state == TrialState.FAIL
         assert frozen_trial.system_attrs["fail_reason"] == expected_message
 
 
@@ -411,7 +412,7 @@ def test_run_trial_with_trial_pruned(
     trial = _optimize._run_trial(study, func_with_trial_pruned, catch=())
     frozen_trial = study._storage.get_trial(trial._trial_id)
     assert frozen_trial.value == report_value
-    assert frozen_trial.state == optuna.trial.TrialState.PRUNED
+    assert frozen_trial.state == TrialState.PRUNED
 
 
 def test_study_pickle() -> None:
@@ -858,7 +859,7 @@ def test_callbacks(n_jobs: int) -> None:
         n_jobs=n_jobs,
         catch=(ZeroDivisionError,),
     )
-    assert states == [optuna.trial.TrialState.FAIL] * 10
+    assert states == [TrialState.FAIL] * 10
 
     # If a trial is failed with an exception and the exception isn't caught by the study,
     # callbacks aren't invoked.
@@ -892,6 +893,52 @@ def test_get_trials(storage_mode: str) -> None:
             trials2 = study.trials
             assert mock_object.call_count > old_count
             assert trials0 == trials2
+
+
+@pytest.mark.parametrize("storage_mode", STORAGE_MODES)
+def test_get_trials_state_option(storage_mode: str) -> None:
+
+    with StorageSupplier(storage_mode) as storage:
+        storage = optuna.storages.get_storage(storage=storage)
+
+        study = optuna.create_study(storage=storage)
+
+        def objective(trial: optuna.trial.Trial) -> float:
+            if trial.number == 0:
+                return 0.0  # TrialState.COMPLETE.
+            elif trial.number == 1:
+                return 0.0  # TrialState.COMPLETE.
+            elif trial.number == 2:
+                raise optuna.exceptions.TrialPruned  # TrialState.PRUNED.
+            else:
+                assert False
+
+        study.optimize(objective, n_trials=3)
+
+        trials = study.get_trials(state=None)
+        assert len(trials) == 3
+
+        trials = study.get_trials(state=TrialState.COMPLETE)
+        assert len(trials) == 2
+        assert all(t.state == TrialState.COMPLETE for t in trials)
+
+        trials = study.get_trials(state=(TrialState.COMPLETE,))
+        assert len(trials) == 2
+        assert all(t.state == TrialState.COMPLETE for t in trials)
+
+        trials = study.get_trials(state=(TrialState.COMPLETE, TrialState.PRUNED))
+        assert len(trials) == 3
+        assert all(t.state in (TrialState.COMPLETE, TrialState.PRUNED) for t in trials)
+
+        trials = study.get_trials(state=())
+        assert len(trials) == 0
+
+        other_states = [
+            s for s in list(TrialState) if s != TrialState.COMPLETE and s != TrialState.PRUNED
+        ]
+        for s in other_states:
+            trials = study.get_trials(state=s)
+            assert len(trials) == 0
 
 
 def test_study_summary_eq_ne() -> None:


### PR DESCRIPTION
## Motivation

It is common to filter trials based on state (`TrialState`). For instance, in several samplers, visualization functions, hyperparameter importance helper functions, we do that after querying all trials from `Study.get_trials` or `BaseStorage.get_all_trials`. Introducing a state parameter to these methods would simplify the code, make it less error prone, and allow for optimization on the storage layer. 

## Description of the changes

Introduces an optional state (`state`) parameter to `Study.get_trials` and `BaseStorage.get_all_trials`. Also, demonstrates how this parameter should be used by simplifying the code in the `TPESampler`.

## Note

- Changes might be controversial in the sense that user might want to filter on other attributes than the state as well
- `BaseStorage.get_n_trials` already had a `state` parameter
- Could break for users inheriting `Study` and/or `BaseStorage`