### PR TITLE
Rung promotion limitation in ASHA/Hyperband to enable arbitrary unknown length runs

### DIFF
--- a/optuna/pruners/_hyperband.py
+++ b/optuna/pruners/_hyperband.py
@@ -131,7 +131,7 @@ class HyperbandPruner(BasePruner):
             See the details for :class:`~optuna.pruners.SuccessiveHalvingPruner`.
         bootstrap_count:
             Parameter specifying the number of trials required in a rung before any trial can be
-            promoted. Incompatible with max_resouce == 'auto'.
+            promoted. Incompatible with ``max_resouce`` is ``"auto"``.
             See the details for :class:`~optuna.pruners.SuccessiveHalvingPruner`.
     """
 

--- a/optuna/pruners/_hyperband.py
+++ b/optuna/pruners/_hyperband.py
@@ -129,6 +129,10 @@ class HyperbandPruner(BasePruner):
             A parameter for specifying reduction factor of promotable trials noted as
             :math:`\\eta` in the paper.
             See the details for :class:`~optuna.pruners.SuccessiveHalvingPruner`.
+        bootstrap_count:
+            Parameter specifying the number of trials required in a rung before any trial can be
+            promoted. Incompatible with max_resouce == 'auto'.
+            See the details for :class:`~optuna.pruners.SuccessiveHalvingPruner`.
     """
 
     def __init__(
@@ -136,12 +140,14 @@ class HyperbandPruner(BasePruner):
         min_resource: int = 1,
         max_resource: Union[str, int] = "auto",
         reduction_factor: int = 3,
+        bootstrap_count: int = 0,
     ) -> None:
 
         self._min_resource = min_resource
         self._max_resource = max_resource
         self._reduction_factor = reduction_factor
         self._pruners: List[SuccessiveHalvingPruner] = []
+        self._bootstrap_count = bootstrap_count
         self._total_trial_allocation_budget = 0
         self._trial_allocation_budgets: List[int] = []
         self._n_brackets: Optional[int] = None
@@ -150,6 +156,12 @@ class HyperbandPruner(BasePruner):
             raise ValueError(
                 "The 'max_resource' should be integer or 'auto'. "
                 "But max_resource = {}".format(self._max_resource)
+            )
+
+        if self._bootstrap_count > 0 and self._max_resource == "auto":
+            raise ValueError(
+                "bootstrap_count > 0 and max_resource == 'auto' "
+                "are mutually incompatible, bootstrap_count is {}".format(self._bootstrap_count)
             )
 
     def prune(self, study: "optuna.study.Study", trial: "optuna.trial.FrozenTrial") -> bool:
@@ -205,6 +217,7 @@ class HyperbandPruner(BasePruner):
                 min_resource=self._min_resource,
                 reduction_factor=self._reduction_factor,
                 min_early_stopping_rate=bracket_id,
+                bootstrap_count=self._bootstrap_count,
             )
             self._pruners.append(pruner)
 

--- a/tests/pruners_tests/test_hyperband.py
+++ b/tests/pruners_tests/test_hyperband.py
@@ -211,3 +211,8 @@ def test_hyperband_no_call_of_filter_study_in_should_prune(
     )
     study = optuna.study.create_study(sampler=sampler, pruner=pruner)
     study.optimize(objective, n_trials=10)
+
+
+def test_hyperband_boostrap_parameter() -> None:
+    with pytest.raises(ValueError):
+        optuna.pruners.HyperbandPruner(max_resource="auto", bootstrap_count=1)

--- a/tests/pruners_tests/test_hyperband.py
+++ b/tests/pruners_tests/test_hyperband.py
@@ -213,6 +213,6 @@ def test_hyperband_no_call_of_filter_study_in_should_prune(
     study.optimize(objective, n_trials=10)
 
 
-def test_hyperband_boostrap_parameter() -> None:
+def test_incompatibility_between_bootstrap_count_and_auto_max_resource() -> None:
     with pytest.raises(ValueError):
         optuna.pruners.HyperbandPruner(max_resource="auto", bootstrap_count=1)

--- a/tests/pruners_tests/test_successive_halving.py
+++ b/tests/pruners_tests/test_successive_halving.py
@@ -249,3 +249,26 @@ def test_successive_halving_pruner_min_early_stopping_rate_parameter() -> None:
     assert not pruner.prune(study=study, trial=study._storage.get_trial(trial._trial_id))
     assert "completed_rung_0" in trial.system_attrs
     assert "completed_rung_1" not in trial.system_attrs
+
+
+def test_successive_halving_pruner_bootstrap_parameter() -> None:
+
+    with pytest.raises(ValueError):
+        optuna.pruners.SuccessiveHalvingPruner(bootstrap_count=-1)
+
+    with pytest.raises(ValueError):
+        optuna.pruners.SuccessiveHalvingPruner(bootstrap_count=1, min_resource="auto")
+
+    pruner = optuna.pruners.SuccessiveHalvingPruner(
+        min_resource=1, reduction_factor=2, bootstrap_count=1
+    )
+    study = optuna.study.create_study(pruner=pruner)
+
+    trial1 = optuna.trial.Trial(study, study._storage.create_new_trial(study._study_id))
+    trial2 = optuna.trial.Trial(study, study._storage.create_new_trial(study._study_id))
+
+    trial1.report(1, step=1)
+    assert pruner.prune(study=study, trial=study._storage.get_trial(trial1._trial_id))
+
+    trial2.report(1, step=1)
+    assert not pruner.prune(study=study, trial=study._storage.get_trial(trial2._trial_id))


### PR DESCRIPTION
## Motivation
Currently, the ASHA and Hyperband pruners have no mechanism to limit the duration of a run by themselves. This is a problem when the length of a run is not capped by the user and the number of parallel processes is not high enough to afford wasting a few of them on runs that never terminate. This is particularly an issue in serial runs, as the initial run will just continue forever. Furthermore, when using hyperband in conjunction with the TPE sampler, the first runs which bootstrap TPE probably usually end up comparatively poor anyway, as the sampler operates fully randomly until bootstrap samples are collected.

This is however not inherently neccessary. This issue can be mitigated by just setting an expanding horizon for the run length, starting first with shorter runs and then expanding. It would be natural to include this expanding horizon into the pruner. As a side effect, this could make ASHA a more or less complete competitor for PBT, as one could now simply leave the scans running and let ASHA explore progressively deeper paths into the training space.

## Description of the changes
This pull request proposes a simple implementation strategy for the finite expanding horizon mentioned above. A new setting is introduced, which specifies a number of trials which must have terminated in a rung before any trial can be promoted into the next rung. At its default value (0), the ASHA and Hyperband pruners behave as usual. The proposed name for this setting is 'bootstrap_count', but that's just a suggestion.

The current implementation is incompatible with Hyperband's max_resource='auto', as the early stopping prohibits the pruner from determining max_resource as usual. This is acceptable, as this setting is primarily intended to be used with effectively infinite runs, where the run length is not predetermined. max_resource would therefore simply represent a point where Hyperband would transition into a usual ASHA pruner. One could potentially consider having other bracket scheduling techniques which would allow an infinite no. of brackets (e.g. exponential probability distribution over the brackets), but such considerations are beyond the scope of this PR.