### PR TITLE
Add StepwiseTuner and StepwiseLightGBMTuner

### DIFF
--- a/optuna/integration/__init__.py
+++ b/optuna/integration/__init__.py
@@ -14,7 +14,13 @@ _import_structure = {
     "cma": ["CmaEsSampler", "PyCmaSampler"],
     "mlflow": ["MLflowCallback"],
     "keras": ["KerasPruningCallback"],
-    "lightgbm": ["LightGBMPruningCallback", "LightGBMTuner", "LightGBMTunerCV"],
+    "lightgbm": [
+        "LightGBMPruningCallback",
+        "LightGBMTuner",
+        "LightGBMTunerCV",
+        "StepwiseLightGBMTuner",
+        "StepwiseLightGBMTunerCV",
+    ],
     "pytorch_ignite": ["PyTorchIgnitePruningHandler"],
     "pytorch_lightning": ["PyTorchLightningPruningCallback"],
     "sklearn": ["OptunaSearchCV"],
@@ -45,6 +51,8 @@ if TYPE_CHECKING:
     from optuna.integration.lightgbm import LightGBMPruningCallback  # NOQA
     from optuna.integration.lightgbm import LightGBMTuner  # NOQA
     from optuna.integration.lightgbm import LightGBMTunerCV  # NOQA
+    from optuna.integration.lightgbm import StepwiseLightGBMTuner  # NOQA
+    from optuna.integration.lightgbm import StepwiseLightGBMTunerCV  # NOQA
     from optuna.integration.mlflow import MLflowCallback  # NOQA
     from optuna.integration.mxnet import MXNetPruningCallback  # NOQA
     from optuna.integration.pytorch_ignite import PyTorchIgnitePruningHandler  # NOQA

--- a/optuna/integration/_lightgbm_tuner/__init__.py
+++ b/optuna/integration/_lightgbm_tuner/__init__.py
@@ -3,8 +3,8 @@ from typing import Any
 from optuna.integration._lightgbm_tuner.optimize import _imports as _imports
 from optuna.integration._lightgbm_tuner.optimize import LightGBMTuner
 from optuna.integration._lightgbm_tuner.optimize import LightGBMTunerCV  # NOQA
-from optuna.integration._lightgbm_tuner.steps import *
-from optuna.integration._lightgbm_tuner.stepwise import StepwiseLightGBMTuner
+from optuna.integration._lightgbm_tuner.steps import *  # NOQA
+from optuna.integration._lightgbm_tuner.stepwise import StepwiseLightGBMTuner  # NOQA
 from optuna.integration._lightgbm_tuner.stepwise import StepwiseLightGBMTunerCV  # NOQA
 
 

--- a/optuna/integration/_lightgbm_tuner/__init__.py
+++ b/optuna/integration/_lightgbm_tuner/__init__.py
@@ -3,6 +3,9 @@ from typing import Any
 from optuna.integration._lightgbm_tuner.optimize import _imports as _imports
 from optuna.integration._lightgbm_tuner.optimize import LightGBMTuner
 from optuna.integration._lightgbm_tuner.optimize import LightGBMTunerCV  # NOQA
+from optuna.integration._lightgbm_tuner.steps import *
+from optuna.integration._lightgbm_tuner.stepwise import StepwiseLightGBMTuner
+from optuna.integration._lightgbm_tuner.stepwise import StepwiseLightGBMTunerCV  # NOQA
 
 
 if _imports.is_successful():

--- a/optuna/integration/_lightgbm_tuner/steps.py
+++ b/optuna/integration/_lightgbm_tuner/steps.py
@@ -1,0 +1,194 @@
+from typing import Any
+from typing import Dict
+from typing import Optional
+from typing import Tuple
+
+import numpy as np
+
+from optuna import distributions
+from optuna import pruners
+from optuna import samplers
+from optuna import stepwise
+from optuna.trial import Trial
+
+
+__all__ = [
+    "step_feature_fraction",
+    "step_num_leaves",
+    "step_bagging",
+    "step_feature_fraction_stage2",
+    "step_regularization_factors",
+    "step_min_data_in_leaf",
+    "default_lgb_steps",
+]
+
+
+class _MakeStep:
+    def __init__(
+        self,
+        sampler: Optional[samplers.BaseSampler] = None,
+        pruner: Optional[pruners.BasePruner] = None,
+        n_trials: Optional[int] = None,
+        timeout: Optional[int] = None,
+    ):
+        self.sampler = sampler
+        self.pruner = pruner
+        self.n_trials = n_trials
+        self.timeout = timeout
+
+
+class _InclusiveUniformStep(stepwise.Step):
+    """Include `high` value from uniform distributions."""
+
+    _eps = 1e-12
+
+    def suggest(self, trial: Trial) -> Dict[str, Any]:
+        values = {}
+        for name, dist in self.distributions.items():
+            if isinstance(dist, distributions.UniformDistribution):
+                dist.high += self._eps
+                value = trial._suggest(name, dist)
+                value = min(value, dist.high)
+            else:
+                value = trial._suggest(name, dist)
+            values[name] = value
+        return values
+
+
+def step_feature_fraction(
+    pruner: Optional[pruners.BasePruner] = None,
+    n_trials: Optional[int] = None,
+    timeout: Optional[int] = None,
+) -> Tuple[str, stepwise.GridStep]:
+    return "feature_fraction", stepwise.GridStep(
+        search_space={"feature_fraction": np.round(np.linspace(0.4, 1, 7), decimals=1).tolist()},
+        pruner=pruner,
+        n_trials=n_trials,
+        timeout=timeout,
+    )
+
+
+class _FeatureFractionStage2(_MakeStep):
+    _interval_size = 0.16
+
+    def __call__(self, params: Dict[str, Any]) -> stepwise.Step:
+        feature_fraction = params.get("feature_fraction", 1.0)
+        search_space = np.linspace(
+            feature_fraction - self._interval_size / 2,
+            feature_fraction + self._interval_size / 2,
+            self.n_trials,
+        )
+        search_space = search_space[(search_space >= 0.4) & (search_space <= 1.0)]
+        search_space = np.round(search_space, decimals=2).tolist()
+        return stepwise.GridStep(
+            search_space={"feature_fraction": search_space},
+            pruner=self.pruner,
+            n_trials=self.n_trials,
+            timeout=self.timeout,
+        )
+
+
+def step_feature_fraction_stage2(
+    pruner: Optional[pruners.BasePruner] = None,
+    n_trials: Optional[int] = 6,
+    timeout: Optional[int] = None,
+) -> Tuple[str, stepwise.StepType]:
+    return (
+        "feature_fraction_stage2",
+        _FeatureFractionStage2(pruner=pruner, n_trials=n_trials, timeout=timeout),
+    )
+
+
+class _NumLeavesStep(_MakeStep):
+    _default_tree_depth: int = 8
+
+    def __call__(self, params: Dict[str, Any]) -> stepwise.Step:
+        tree_depth = params.get("max_depth", self._default_tree_depth)
+        max_num_leaves = 2 ** tree_depth
+
+        return stepwise.Step(
+            distributions={"max_depth": distributions.IntUniformDistribution(2, max_num_leaves)},
+            pruner=self.pruner,
+            n_trials=self.n_trials,
+            timeout=self.timeout,
+        )
+
+
+def step_num_leaves(
+    sampler: Optional[samplers.BaseSampler] = None,
+    pruner: Optional[pruners.BasePruner] = None,
+    n_trials: Optional[int] = 20,
+    timeout: Optional[int] = None,
+) -> Tuple[str, stepwise.StepType]:
+    return "num_leaves", _NumLeavesStep(sampler, pruner, n_trials, timeout)
+
+
+def step_bagging(
+    sampler: Optional[samplers.BaseSampler] = None,
+    pruner: Optional[pruners.BasePruner] = None,
+    n_trials: Optional[int] = 10,
+    timeout: Optional[int] = None,
+) -> Tuple[str, stepwise.Step]:
+    dists = {
+        "bagging_fraction": distributions.UniformDistribution(0.4, 1.0),
+        "bagging_freq": distributions.IntUniformDistribution(1, 7),
+    }
+    return (
+        "bagging",
+        _InclusiveUniformStep(
+            distributions=dists,
+            sampler=sampler,
+            pruner=pruner,
+            n_trials=n_trials,
+            timeout=timeout,
+        ),
+    )
+
+
+def step_regularization_factors(
+    sampler: Optional[samplers.BaseSampler] = None,
+    pruner: Optional[pruners.BasePruner] = None,
+    n_trials: Optional[int] = 20,
+    timeout: Optional[int] = None,
+) -> Tuple[str, stepwise.Step]:
+    return (
+        "regularization_factors",
+        stepwise.Step(
+            distributions={
+                "lambda_l1": distributions.LogUniformDistribution(1e-8, 10.0),
+                "lambda_l2": distributions.LogUniformDistribution(1e-8, 10.0),
+            },
+            sampler=sampler,
+            pruner=pruner,
+            n_trials=n_trials,
+            timeout=timeout,
+        ),
+    )
+
+
+def step_min_data_in_leaf(
+    pruner: Optional[pruners.BasePruner] = None,
+    n_trials: Optional[int] = None,
+    timeout: Optional[int] = None,
+) -> Tuple[str, stepwise.GridStep]:
+
+    return (
+        "min_data_in_leaf",
+        stepwise.GridStep(
+            search_space={"min_child_samples": [5, 10, 25, 50, 100]},
+            pruner=pruner,
+            n_trials=n_trials,
+            timeout=timeout,
+        ),
+    )
+
+
+def default_lgb_steps() -> stepwise.StepListType:
+    return [
+        step_feature_fraction(),
+        step_num_leaves(),
+        step_bagging(),
+        step_feature_fraction_stage2(),
+        step_regularization_factors(),
+        step_min_data_in_leaf(),
+    ]

--- a/optuna/integration/_lightgbm_tuner/stepwise.py
+++ b/optuna/integration/_lightgbm_tuner/stepwise.py
@@ -69,8 +69,6 @@ class _LgbStepObjective:
         self.direction = direction
         self.train_set = train_set
         self.train_kwargs = train_kwargs
-        self.first_dataset: str = None
-        self.first_metric: str = None
 
     def __call__(self, trial: Trial, params: Dict[str, Any]) -> float:
         train_kwargs = copy.copy(self.train_kwargs)

--- a/optuna/integration/_lightgbm_tuner/stepwise.py
+++ b/optuna/integration/_lightgbm_tuner/stepwise.py
@@ -1,0 +1,426 @@
+from collections.abc import Sequence
+import copy
+from typing import Any
+from typing import Callable
+from typing import Dict
+from typing import Generator
+from typing import Iterator
+from typing import List
+from typing import Optional
+from typing import Tuple
+from typing import Type
+from typing import Union
+
+import optuna
+from optuna import stepwise
+from optuna._imports import try_import
+from optuna.integration._lightgbm_tuner.alias import _handling_alias_parameters
+from optuna.integration._lightgbm_tuner.steps import default_lgb_steps
+from optuna.study import Study
+from optuna.study import StudyDirection
+from optuna.trial import FrozenTrial
+from optuna.trial import Trial
+
+
+with try_import() as _imports:
+    import lightgbm as lgb
+    from sklearn.model_selection import BaseCrossValidator
+
+    ValidSet = Union[List[lgb.Dataset], Tuple[lgb.Dataset, ...], lgb.Dataset]
+    _IntPair = Tuple[int, int]
+    Folds = Union[Generator[_IntPair, None, None], Iterator[_IntPair], "BaseCrossValidator"]
+
+
+_BOOSTER_KEY = "__Lgb_BOOSTER__"
+_BEST_ITERATION_KEY = "__Lgb_BEST_ITERATION__"
+
+# Default parameter values described in the official webpage.
+_DEFAULT_LIGHTGBM_PARAMETERS = {
+    "lambda_l1": 0.0,
+    "lambda_l2": 0.0,
+    "num_leaves": 31,
+    "feature_fraction": 1.0,
+    "bagging_fraction": 1.0,
+    "bagging_freq": 0,
+    "min_child_samples": 20,
+    "feature_pre_filter": False,
+}
+
+_MAXIMIZED_METRICS = (
+    "ndcg",
+    "lambdarank",
+    "rank_xendcg",
+    "xendcg",
+    "xe_ndcg",
+    "xe_ndcg_mart",
+    "xendcg_mart",
+    "map",
+    "mean_average_precision",
+    "auc",
+)
+
+_AnyCallable = Callable[..., Any]
+
+
+class _LgbStepObjective:
+    def __init__(
+        self, direction: StudyDirection, train_set: "lgb.Dataset", train_kwargs: Dict[str, Any]
+    ) -> None:
+        self.direction = direction
+        self.train_set = train_set
+
+        self.train_kwargs = copy.deepcopy(train_kwargs)
+        callbacks = train_kwargs.pop("callbacks", None) or []
+        self.train_kwargs["callbacks"] = callbacks + [self._extract_first_metric_info()]
+
+    def __call__(self, trial: Trial, params: Dict[str, Any]) -> float:
+        booster = lgb.train(params, self.train_set, **self.train_kwargs)
+        self._serialize_booster(booster, trial)
+        score = booster.best_score[self.first_dataset][self.first_metric]
+        return score
+
+    def _serialize_booster(self, booster: "lgb.Booster", trial: Trial) -> None:
+        serialized_model = booster.model_to_string()
+        trial.set_system_attr(_BOOSTER_KEY, serialized_model)
+        trial.set_system_attr(_BEST_ITERATION_KEY, booster.best_iteration)
+
+    def _extract_first_metric_info(self) -> Callable[["lgb.callback.CallbackEnv"], None]:
+        """Retrieve the first metric of the first dataset, in the order defined by LightGBM.
+
+        Note:
+            LightGBM order when 'first_metric_only'=True:
+                1. If 'metrics' is in params, take first metric
+                2. If 'metrics' is not in params, use a default metric based on the objective
+                3. When using a custom evaluation function feval, 'metrics' must be set to the
+                   string "None".
+
+            The callback retrieves the first metric from LightGBM internals to avoid
+            harcoding the above logic.
+        """
+
+        def _callback(env: "lgb.callback.CallbackEnv") -> None:
+            dataset_name, eval_name, score, is_higher_better, *_ = env.evaluation_result_list[0]
+            self.first_dataset = dataset_name
+            # split is needed for "<dataset type> <metric>" case (e.g. "train l1")
+            self.first_metric = eval_name.split(" ")[-1]
+
+            direction = StudyDirection.MAXIMIZE if is_higher_better else StudyDirection.MINIMIZE
+            if direction != self.direction:
+                raise ValueError(
+                    f"Study direction is inconsistent with the metric '{self.first_metric}'. "
+                    + f"Please set '{direction.name.lower()}' as the direction."
+                )
+
+        _callback.order = 99  # type: ignore
+        return _callback
+
+
+class _LgbStepObjectiveCV(_LgbStepObjective):
+    def __call__(self, trial: Trial, params: Dict[str, Any]) -> float:
+        cv_results = lgb.cv(params, self.train_set, **self.train_kwargs)
+        metric_key = f"{self.first_metric}-mean"
+
+        if "return_cvbooster" in self.train_kwargs:
+            booster = cv_results["cvbooster"]
+            self._serialize_booster(booster, trial)
+
+        return cv_results[metric_key][-1]
+
+    def _serialize_booster(self, booster: "lgb.CVBooster", trial: Trial) -> None:
+        serialized_models = [bst.model_to_string() for bst in booster.boosters]
+        trial.set_system_attr(_BOOSTER_KEY, serialized_models)
+        trial.set_system_attr(_BEST_ITERATION_KEY, booster.best_iteration)
+
+
+def _infer_direction(params: Dict[str, Any], feval: _AnyCallable = None) -> str:
+    metric = "binary_logloss"
+    for alias in ("metric", "metrics", "metric_types"):
+        if alias in params:
+            metric = params[alias]
+            break  # keep first alias found (similar to lgb logic)
+
+    if isinstance(metric, Sequence):
+        metric = metric[0]  # first_metric_only is mandatory
+
+    if metric in {"None", "na", "null", "custom"} and feval:
+        raise ValueError(
+            "Direction cannot be automatically inferred from 'feval'. "
+            + "Please specify a study with an appropriate direction."
+        )
+
+    if metric.startswith(_MAXIMIZED_METRICS) and metric != "mape":
+        return "maximize"
+    else:
+        return "minimize"
+
+
+def _keep_best_model(study: Study, trial: FrozenTrial) -> None:
+    """Avoid bloating memory with non-optimal boosters."""
+    if not stepwise.is_better(study.direction, trial.value, study.best_value):
+        del trial.system_attrs[_BOOSTER_KEY]
+        del trial.system_attrs[_BEST_ITERATION_KEY]
+
+
+class _BaseLGBTuner(stepwise.StepwiseTuner):
+    def __init__(
+        self,
+        lgb_objective: Type[_LgbStepObjective],
+        params: Dict[str, Any],
+        train_set: "lgb.Dataset",
+        steps: Optional[stepwise.StepListType] = None,
+        study: Optional[Study] = None,
+        default_params: Dict[str, Any] = None,
+        **train_kwargs: Any,
+    ) -> None:
+        _imports.check()
+
+        if not params.get("first_metric_only", True):
+            raise ValueError(
+                "Optuna only handles a single metric. Please set 'first_metric_only' to True."
+            )
+
+        # Should not alter data since `min_data_in_leaf` is tuned.
+        # https://lightgbm.readthedocs.io/en/latest/Parameters.html#feature_pre_filter
+        if params.get("feature_pre_filter", False):
+            self.logger.warn(
+                "feature_pre_filter is given as True but will be set to False. This is required "
+                "for the tuner to tune min_data_in_leaf."
+            )
+
+        params = copy.deepcopy(params)
+        _handling_alias_parameters(params)
+        base_params = copy.deepcopy(default_params or _DEFAULT_LIGHTGBM_PARAMETERS)
+        base_params.update(params)
+        base_params["first_metric_only"] = True
+        base_params["feature_pre_filter"] = False
+
+        if not study:
+            feval = train_kwargs.get("feval", None)
+            direction = _infer_direction(params, feval)
+            study = optuna.create_study(direction=direction)
+
+        objective = lgb_objective(study.direction, train_set, train_kwargs)
+
+        if not steps:
+            steps = default_lgb_steps()
+
+        super().__init__(objective, steps, base_params, study)
+
+    def _check_best_booster(self) -> None:
+        if not self.study.trials:
+            raise ValueError("The best booster is not available because no trials completed.")
+
+    def get_best_booster(self) -> "lgb.Booster":
+        """Return the best booster."""
+        self._check_best_booster()
+        serialized_model = self.study.best_trial.system_attrs[_BOOSTER_KEY]
+        params = {**self.default_params, **self.best_params}
+        booster = lgb.Booster(params=params, model_str=serialized_model, silent=True)
+
+        # LightGBM does not serialize best_iteration and best_score.
+        booster.best_iteration = self.study.best_trial.system_attrs[_BEST_ITERATION_KEY]
+        booster.best_score = self.study.best_value
+
+        return booster
+
+    def _optimize_step(
+        self,
+        step_name: str,
+        step: stepwise.Step,
+        n_trials: Optional[int] = None,
+        timeout: Optional[float] = None,
+        n_jobs: int = 1,
+        catch: Tuple[Type[Exception], ...] = (),
+        callbacks: Optional[List[stepwise._OptunaCallback]] = None,
+        gc_after_trial: bool = False,
+        show_progress_bar: bool = False,
+    ) -> None:
+        callbacks = callbacks or []
+        callbacks.append(_keep_best_model)
+        super()._optimize_step(
+            step_name,
+            step,
+            n_trials,
+            timeout,
+            n_jobs,
+            catch,
+            callbacks,
+            gc_after_trial,
+            show_progress_bar,
+        )
+
+
+class StepwiseLightGBMTuner(_BaseLGBTuner):
+    """Hyperparameter tuner for LightGBM.
+
+    By default, it optimizes the following hyperparameters in a stepwise manner:
+    ``lambda_l1``, ``lambda_l2``, ``num_leaves``, ``feature_fraction``, ``bagging_fraction``,
+    ``bagging_freq`` and ``min_child_samples``.
+
+    You can find the details of the algorithm and benchmark results in `this blog article <https:/
+    /medium.com/optuna/lightgbm-tuner-new-optuna-integration-for-hyperparameter-optimization-8b709
+    5e99258>`_ by `Kohei Ozaki <https://www.kaggle.com/confirm>`_, a Kaggle Grandmaster.
+
+    Any positional and keyword arguments for `lightgbm.train()`_ can be passed.
+    The arguments specific to :class:`~.StepwiseLightGBMTuner` are listed below:
+
+    Args:
+        objective:
+             A callable that implements objective function. The callable must accept
+             a class:`~optuna.Trial` object and a dictionary of parameters to optimize.
+        steps:
+            List of (step_name, :class:`~.Step`) tuples that will be optimized in the
+            in the order in which they are listed.
+        default_params:
+            The parameters that will serve as a baseline for the optimization in order
+            to avoid performance regression. If :obj:`None`, default `LightGBM parameters`_
+            are used.
+        study:
+            The study that will hold the trials for the sequence of steps. If :obj:`None`,
+            a default study is created.
+
+    Attributes:
+        study:
+            The study holding the trials.
+
+    Notes:
+        * If more than one ``metric`` is supplied in the ``params``, only the first one is used
+          for the optimization. Consequently, `first_metric_only`_ must be omitted or set to
+          d``True``.
+        * If more than one ``valid_sets`` is supplied in the ``params``, only the first one is
+          used for the optimization.
+
+    .. _lightgbm.train(): https://lightgbm.readthedocs.io/en/latest/pythonapi/lightgbm.train.html
+    .. _LightGBM parameters: https://lightgbm.readthedocs.io/en/latest/Parameters.html
+    .. _first_metric_only: https://lightgbm.readthedocs.io/en/latest/Parameters.html#first_metric_only # noqa: E501
+    """
+
+    def __init__(
+        self,
+        params: Dict[str, Any],
+        train_set: "lgb.Dataset",
+        steps: Optional[stepwise.StepListType] = None,
+        default_params: Optional[Dict[str, Any]] = None,
+        study: Optional[Study] = None,
+        num_boost_round: int = 1000,
+        valid_sets: Optional["ValidSet"] = None,
+        valid_names: Optional[Any] = None,
+        fobj: Optional[_AnyCallable] = None,
+        feval: Optional[_AnyCallable] = None,
+        init_model: Optional[Union[str, "lgb.Booster"]] = None,
+        feature_name: str = "auto",
+        categorical_feature: str = "auto",
+        early_stopping_rounds: Optional[int] = None,
+        evals_result: Optional[Dict[Any, Any]] = None,
+        verbose_eval: Optional[Union[bool, int]] = True,
+        learning_rates: Optional[List[float]] = None,
+        keep_training_booster: bool = False,
+        callbacks: Optional[List[_AnyCallable]] = None,
+    ) -> None:
+        train_kwargs = locals()
+        for non_kwarg in ("self", "__class__", "params", "train_set"):
+            del train_kwargs[non_kwarg]
+
+        super().__init__(_LgbStepObjective, params, train_set, **train_kwargs)
+
+        if valid_sets is None:
+            raise ValueError("'valid_sets' is required.")
+
+        if isinstance(valid_sets, Sequence) and len(valid_sets) > 1:
+            self.logger.warning(
+                "Only the first dataset in 'valid_sets' will be used for the optimization."
+            )
+
+
+class StepwiseLightGBMTunerCV(_BaseLGBTuner):
+    """Hyperparameter tuner for LightGBM with cross-validation.
+
+    It employs the same stepwise approach as :class:`~.StepwiseLightGBMTuner`.
+    :class:`~.StepwiseLightGBMTunerCV` invokes `lightgbm.cv()`_ to train and validate boosters while
+    :class:`~StepwiseLightGBMTuner` invokes `lightgbm.train()`_.
+
+    Any positional and keyword arguments for `lightgbm.cv()`_ can be passed.
+    The arguments specific to :class:`~.StepwiseLightGBMTuner` are listed below:
+
+    Args:
+        objective:
+             A callable that implements objective function. The callable must accept
+             a class:`~optuna.Trial` object and a dictionary of parameters to optimize.
+        steps:
+            List of (step_name, :class:`~.Step`) tuples that will be optimized in the
+            in the order in which they are listed.
+        default_params:
+            The parameters that will serve as a baseline for the optimization in order
+            to avoid performance regression. If :obj:`None`, default `LightGBM parameters`_
+            are used.
+        study:
+            The study that will hold the trials for the sequence of steps. If :obj:`None`,
+            a default study is created.
+
+    Attributes:
+        study:
+            The study holding the trials.
+
+    Notes:
+        If more than one ``metric`` is supplied, only the first one is used for the optimization.
+        Consequently, `first_metric_only`_ must be omitted or set to ``True`` in the ``params``.
+
+    .. _lightgbm.train(): https://lightgbm.readthedocs.io/en/latest/pythonapi/lightgbm.train.html
+    .. _lightgbm.cv(): https://lightgbm.readthedocs.io/en/latest/pythonapi/lightgbm.cv.html
+    .. _LightGBM parameters: https://lightgbm.readthedocs.io/en/latest/Parameters.html
+    .. _first_metric_only: https://lightgbm.readthedocs.io/en/latest/Parameters.html#first_metric_only # noqa: E501
+    """
+
+    def __init__(
+        self,
+        params: Dict[str, Any],
+        train_set: "lgb.Dataset",
+        steps: Optional[stepwise.StepListType] = None,
+        study: Optional[Study] = None,
+        num_boost_round: int = 1000,
+        folds: Optional["Folds"] = None,
+        nfold: int = 5,
+        stratified: bool = True,
+        shuffle: bool = True,
+        metrics: Optional[Union[str, List[str]]] = None,
+        fobj: Optional[_AnyCallable] = None,
+        feval: Optional[_AnyCallable] = None,
+        init_model: Optional[Union[str, "lgb.Booster"]] = None,
+        feature_name: str = "auto",
+        categorical_feature: str = "auto",
+        early_stopping_rounds: Optional[int] = None,
+        fpreproc: Optional[_AnyCallable] = None,
+        verbose_eval: Optional[Union[bool, int]] = True,
+        show_stdv: bool = True,
+        seed: int = 0,
+        callbacks: Optional[List[_AnyCallable]] = None,
+        eval_train_metric: Optional[bool] = False,
+    ) -> None:
+        cv_kwargs = locals()
+        for non_kwarg in ("self", "__class__", "params", "train_set"):
+            del cv_kwargs[non_kwarg]
+
+        if lgb.__version__ >= "3.0.0":
+            cv_kwargs["return_cvbooster"] = True
+
+        super().__init__(_LgbStepObjectiveCV, params, train_set, **cv_kwargs)
+
+    def get_best_booster(self) -> "lgb.Booster":
+        """Return the best booster. Requires lightgbm >= 3.0.0 (addition of ``CVBooster``)."""
+        self._check_best_booster()
+        if lgb.__version__ < "3.0.0":
+            raise ValueError("'get_best_booster' requires lightgbm >= 3.0.0")
+
+        params = {**self.default_params, **self.best_params}
+        boosters = []
+        for serialized_model in self.study.best_trial.system_attrs[_BOOSTER_KEY]:
+            bst = lgb.Booster(params=params, model_str=serialized_model, silent=True)
+            boosters.append(bst)
+        booster = lgb.CVBooster()
+        booster.boosters = boosters
+
+        # LightGBM does not serialize best_iteration and best_score.
+        setattr(booster, "best_iteration", self.study.best_trial.system_attrs[_BEST_ITERATION_KEY])
+        setattr(booster, "best_score", self.study.best_value)
+
+        return booster

--- a/optuna/integration/lightgbm.py
+++ b/optuna/integration/lightgbm.py
@@ -16,7 +16,6 @@ if _imports.is_successful():
 
     from optuna.integration._lightgbm_tuner import LightGBMTuner  # NOQA
     from optuna.integration._lightgbm_tuner import LightGBMTunerCV  # NOQA
-
     from optuna.integration._lightgbm_tuner import StepwiseLightGBMTuner  # NOQA
     from optuna.integration._lightgbm_tuner import StepwiseLightGBMTunerCV  # NOQA
     from optuna.integration._lightgbm_tuner.steps import *  # NOQA

--- a/optuna/integration/lightgbm.py
+++ b/optuna/integration/lightgbm.py
@@ -19,7 +19,7 @@ if _imports.is_successful():
 
     from optuna.integration._lightgbm_tuner import StepwiseLightGBMTuner  # NOQA
     from optuna.integration._lightgbm_tuner import StepwiseLightGBMTunerCV  # NOQA
-    from optuna.integration._lightgbm_tuner.steps import *
+    from optuna.integration._lightgbm_tuner.steps import *  # NOQA
 
     _names_from_tuners = ["train", "LGBMModel", "LGBMClassifier", "LGBMRegressor"]
 

--- a/optuna/integration/lightgbm.py
+++ b/optuna/integration/lightgbm.py
@@ -17,6 +17,10 @@ if _imports.is_successful():
     from optuna.integration._lightgbm_tuner import LightGBMTuner  # NOQA
     from optuna.integration._lightgbm_tuner import LightGBMTunerCV  # NOQA
 
+    from optuna.integration._lightgbm_tuner import StepwiseLightGBMTuner  # NOQA
+    from optuna.integration._lightgbm_tuner import StepwiseLightGBMTunerCV  # NOQA
+    from optuna.integration._lightgbm_tuner.steps import *
+
     _names_from_tuners = ["train", "LGBMModel", "LGBMClassifier", "LGBMRegressor"]
 
     # API from lightgbm.

--- a/optuna/stepwise.py
+++ b/optuna/stepwise.py
@@ -14,7 +14,7 @@ from typing import Sequence
 from typing import Tuple
 from typing import Type
 from typing import TypeVar
-from typing import Union, Sequence
+from typing import Union
 
 import numpy as np
 
@@ -23,7 +23,8 @@ from optuna import distributions
 from optuna import logging
 from optuna import pruners
 from optuna import samplers
-from optuna.study import StudyDirection, ObjectiveFuncType
+from optuna.study import ObjectiveFuncType
+from optuna.study import StudyDirection
 from optuna.trial import FrozenTrial
 
 
@@ -243,7 +244,8 @@ class StepwiseTuner:
              A callable that implements objective function. The callable must accept
              a class:`~optuna.Trial` object and a dictionary of parameters to optimize.
         steps:
-            List of (step_name, :class:`~.Step`) tuples that will be optimized in the
+            List of (step_name, :class:`~.Step` or Callable[[Dict[str, Any]], class:`~.Step`])
+            tuples that will be optimized in the
             in the order in which they are listed.
         default_params:
             The parameters that will serve as a baseline for the optimization in order

--- a/optuna/stepwise.py
+++ b/optuna/stepwise.py
@@ -202,17 +202,14 @@ class GridStep(Step):
         dists = {}
         for name, values in search_space.items():
             if isinstance(values[0], (str, bool)):
-                dist = distributions.CategoricalDistribution(values)
+                dists[name] = distributions.CategoricalDistribution(values)
             elif isinstance(values[0], int):
-                dist = distributions.IntUniformDistribution(
-                    min(values), max(values)  # type: ignore
-                )
+                low, high = min(values), max(values)  # type: ignore
+                dists[name] = distributions.IntUniformDistribution(low, high)  # type: ignore
             else:
                 # add 1 to high to include higher bound
-                dist = distributions.UniformDistribution(
-                    min(values), max(values) + 1  # type: ignore
-                )
-            dists[name] = dist
+                low, high = min(values), max(values) + 1  # type: ignore
+                dists[name] = distributions.UniformDistribution(low, high)  # type: ignore
         return dists
 
 

--- a/optuna/stepwise.py
+++ b/optuna/stepwise.py
@@ -1,0 +1,486 @@
+import copy
+import functools
+import operator
+import time
+from typing import Any
+from typing import Callable
+from typing import Dict
+from typing import Generic
+from typing import Iterable
+from typing import List
+from typing import Mapping
+from typing import Optional
+from typing import Sequence
+from typing import Tuple
+from typing import Type
+from typing import TypeVar
+from typing import Union, Sequence
+
+import numpy as np
+
+import optuna
+from optuna import distributions
+from optuna import logging
+from optuna import pruners
+from optuna import samplers
+from optuna.study import StudyDirection, ObjectiveFuncType
+from optuna.trial import FrozenTrial
+
+
+SuggesterType = Callable[[optuna.Trial], Dict[str, Any]]
+GridValueType = Union[str, float, int, bool, None]
+
+MakeStepType = Callable[[Dict[str, Any]], "Step"]
+StepType = Union["Step", MakeStepType]
+StepListType = Sequence[Tuple[str, StepType]]
+StepObjectiveType = Callable[[optuna.Trial, Dict[str, Any]], float]
+
+_OptunaCallback = Callable[[optuna.Study, FrozenTrial], None]
+_NumericType = TypeVar("_NumericType", int, float)
+
+
+class _BaseBudget(Generic[_NumericType]):
+    """Manage a resource budget, None represents infinite."""
+
+    def __init__(self, unit_name: str, value: Optional[_NumericType]):
+        self.unit_name = unit_name
+        self.initial: Optional[_NumericType] = value
+        self._remaining: Optional[_NumericType] = value
+
+    @property
+    def remaining(self) -> Optional[_NumericType]:
+        return self._remaining
+
+    @property
+    def is_depleted(self) -> bool:
+        return self.remaining is not None and self.remaining <= 0
+
+    def try_spend(self, value: Optional[_NumericType]) -> Optional[_NumericType]:
+        if self.remaining is None:
+            return value
+
+        if value is None:
+            return self.remaining
+
+        value = min(self.remaining, value)
+        self._remaining = self.remaining - value
+        return value
+
+
+class _TrialBudget(_BaseBudget[int]):
+    def __init__(self, timeout: Optional[int]):
+        super().__init__("trial", timeout)
+
+
+class _TimeBudget(_BaseBudget[float]):
+    def __init__(self, timeout: Optional[float]):
+        super().__init__("second", timeout)
+        self._start: Optional[float] = None
+        self._elapsed: Optional[float] = None
+
+    @property
+    def elapsed(self) -> float:
+        if self._start is None:
+            raise RuntimeError(f"Timer is not running. Use {type(self).__name__}.start() first.")
+        return time.perf_counter() - self._start
+
+    @property
+    def remaining(self) -> Optional[float]:
+        if self.initial is None:
+            return None
+        return self.initial - self.elapsed
+
+    def start(self) -> None:
+        if self._start is not None:
+            raise RuntimeError(f"Timer is running. Use {type(self).__name__}.stop() first.")
+        self._start = time.perf_counter()
+
+    def stop(self) -> None:
+        if self._start is None:
+            raise RuntimeError(f"Timer is not running. Use {type(self).__name__}.start() first.")
+        self._elapsed = time.perf_counter() - self._start
+        self._start = None
+
+    def __enter__(self) -> "_TimeBudget":
+        self.start()
+        return self
+
+    def __exit__(self, *exc_info: Any) -> None:
+        self.stop()
+
+
+class Step:
+    """A Step encampsulates the specific parameters of one specific optimization task.
+
+    It also defines which parameters to optimize and from which distributions to suggest
+    their values.
+
+    Common parameters for the sequence, such as the objective function are defined on a
+    :class:`.StepwiseTuner`.
+
+    Args:
+        distributions:
+            A dictionary whose key and value are a parameter name and the corresponding
+            distributions to suggest from.
+        sampler:
+            A sampler object that implements background algorithm for value suggestion.
+            If :obj:`None` is specified, :class:`~optuna.samplers.TPESampler` is used
+            as the default. See also :class:`~optuna.samplers`.
+        pruner:
+            A pruner object that decides early stopping of unpromising trials. If :obj:`None`
+            is specified, :class:`~optuna.pruners.MedianPruner` is used as the default. See
+            also :class:`~optuna.pruners`.
+        n_trials:
+            The number of trials. If this argument is set to :obj:`None`, there is no
+            limitation on the number of trials for this step.
+        timeout:
+            Stop study after the given number of second(s). If this argument is set to
+            :obj:`None`, the step is executed without time limitation.
+
+    """
+
+    def __init__(
+        self,
+        distributions: Mapping[str, distributions.BaseDistribution],
+        sampler: Optional[samplers.BaseSampler] = None,
+        pruner: Optional[pruners.BasePruner] = None,
+        n_trials: Optional[int] = None,
+        timeout: Optional[int] = None,
+    ):
+        self.distributions = distributions
+        self.sampler = sampler
+        self.pruner = pruner
+        self.n_trials = n_trials
+        self.timeout = timeout
+
+    def suggest(self, trial: optuna.Trial) -> Dict[str, Any]:
+        """Suggest a value for each parameters."""
+        return {name: trial._suggest(name, dist) for name, dist in self.distributions.items()}
+
+
+class GridStep(Step):
+    """A Step that samples using grid search.
+
+    Args:
+        search_space:
+            A dictionary whose key and value are a parameter name and the corresponding candidates
+            of values, respectively.
+        pruner:
+            A pruner object that decides early stopping of unpromising trials. If :obj:`None`
+            is specified, :class:`~optuna.pruners.MedianPruner` is used as the default. See
+            also :class:`~optuna.pruners`.
+        n_trials:
+            The number of trials. If this argument is set to :obj:`None`, there is no
+            limitation on the number of trials for this step.
+        timeout:
+            Stop study after the given number of second(s). If this argument is set to
+            :obj:`None`, the step is executed without time limitation.
+
+    """
+
+    def __init__(
+        self,
+        search_space: Mapping[str, List[GridValueType]],
+        pruner: Optional[pruners.BasePruner] = None,
+        n_trials: Optional[int] = None,
+        timeout: Optional[int] = None,
+    ):
+        if not n_trials:
+            n_trials = functools.reduce(operator.mul, map(len, search_space.values()))
+        super().__init__(
+            self._get_distributions(search_space),
+            samplers.GridSampler(search_space),
+            pruner,
+            n_trials,
+            timeout,
+        )
+
+    def _get_distributions(
+        self, search_space: Mapping[str, List[GridValueType]]
+    ) -> Mapping[str, distributions.BaseDistribution]:
+        dists = {}
+        for name, values in search_space.items():
+            if isinstance(values[0], (str, bool)):
+                dist = distributions.CategoricalDistribution(values)
+            elif isinstance(values[0], int):
+                dist = distributions.IntUniformDistribution(
+                    min(values), max(values)  # type: ignore
+                )
+            else:
+                # add 1 to high to include higher bound
+                dist = distributions.UniformDistribution(
+                    min(values), max(values) + 1  # type: ignore
+                )
+            dists[name] = dist
+        return dists
+
+
+class _NoOpStep(Step):
+    def __init__(self, base_params: Dict[str, Any], timeout: Optional[int] = None):
+        super().__init__(distributions={}, sampler=None, pruner=None, n_trials=1, timeout=timeout)
+        self.base_params = base_params
+
+    def suggest(self, trial: optuna.Trial) -> Dict[str, Any]:
+        return self.base_params
+
+
+def is_better(
+    direction: StudyDirection, val_score: Optional[float], best_score: Optional[float]
+) -> bool:
+    if val_score is None or best_score is None:
+        return False
+
+    if direction == StudyDirection.MINIMIZE:
+        return val_score < best_score
+    return val_score > best_score
+
+
+class StepwiseTuner:
+    """A StepwiseTuner corresponds to a sequence of optimization tasks.
+
+    Args:
+        objective:
+             A callable that implements objective function. The callable must accept
+             a class:`~optuna.Trial` object and a dictionary of parameters to optimize.
+        steps:
+            List of (step_name, :class:`~.Step`) tuples that will be optimized in the
+            in the order in which they are listed.
+        default_params:
+            The parameters that will serve as a baseline for the optimization in order
+            to avoid performance regression.
+        study:
+            The study that will hold the trials for the sequence of steps.  If this argument
+            is set to :obj:`None`, a default study is created.
+
+    Attributes:
+        study:
+            Return the study holding the trials.
+        best_params:
+            Return the dictionary of best parameters found.
+    """
+
+    def __init__(
+        self,
+        objective: StepObjectiveType,
+        steps: Sequence[Tuple[str, StepType]],
+        default_params: Optional[Dict[str, Any]] = None,
+        study: Optional[optuna.Study] = None,
+    ):
+        self.steps = steps
+        self.objective = objective
+        self.default_params = copy.deepcopy(default_params or {})
+        self.best_params = copy.deepcopy(self.default_params)
+        self.study = study or optuna.create_study()
+
+        self.logger = logging.get_logger(__name__)
+
+    @property
+    def step_name_key(self) -> str:
+        """Return the trials'`system_attrs` key indicating the name of the step."""
+        return f"{type(self).__name__}:step_name"
+
+    @property
+    def best_value(self) -> float:
+        """Return the best objective value in the study.
+
+        Returns:
+            A float representing the best objective value.
+
+        """
+        try:
+            return self.study.best_value
+        except ValueError:
+            # Return the default score because no trials have completed.
+            return -np.inf if self.study.direction == "minimize" else np.inf
+
+    def optimize(
+        self,
+        n_trials: Optional[int] = None,
+        timeout: Optional[float] = None,
+        n_jobs: int = 1,
+        catch: Tuple[Type[Exception], ...] = (),
+        callbacks: Optional[List[_OptunaCallback]] = None,
+        gc_after_trial: bool = False,
+        show_progress_bar: bool = False,
+    ) -> None:
+        """Optimize the objective function by executing each step sequentially.
+
+        A pre-step will be added in order to establish a baseline with default parameters
+        and avoid performance regression. Therefore,
+
+        Args:
+            n_trials:
+                The number of trials. If this argument is set to :obj:`None`, there is no
+                limitation on the number of trials. If :obj:`timeout` is also set to :obj:`None`,
+                the study continues to create trials until it receives a termination signal such
+                as Ctrl+C or SIGTERM.
+            timeout:
+                Stop study after the given number of second(s). If this argument is set to
+                :obj:`None`, the study is executed without time limitation. If :obj:`n_trials` is
+                also set to :obj:`None`, the study continues to create trials until it receives a
+                termination signal such as Ctrl+C or SIGTERM.
+            n_jobs:
+                The number of parallel jobs. If this argument is set to :obj:`-1`, the number is
+                set to CPU count.
+            catch:
+                A study continues to run even when a trial raises one of the exceptions specified
+                in this argument. Default is an empty tuple, i.e. the study will stop for any
+                exception except for :class:`~optuna.exceptions.TrialPruned`.
+            callbacks:
+                List of callback functions that are invoked at the end of each trial. Each function
+                must accept two parameters with the following types in this order:
+                :class:`~optuna.study.Study` and :class:`~optuna.FrozenTrial`.
+            gc_after_trial:
+                Flag to determine whether to automatically run garbage collection after each trial.
+                Set to :obj:`True` to run the garbage collection, :obj:`False` otherwise.
+                When it runs, it runs a full collection by internally calling :func:`gc.collect`.
+                If you see an increase in memory consumption over several trials, try setting this
+                flag to :obj:`True`.
+
+                .. seealso::
+
+                    :ref:`out-of-memory-gc-collect`
+
+            show_progress_bar:
+                Flag to show progress bars or not. To disable progress bar, set this ``False``.
+                Currently, progress bar is experimental feature and disabled
+                when ``n_jobs`` :math:`\\ne 1`.
+
+        Raises:
+            RuntimeError:
+                If nested invocation of this method occurs.
+
+        """
+        self._check_n_trials(n_trials)
+        optimize_kwargs = {
+            "n_jobs": n_jobs,
+            "catch": catch,
+            "callbacks": callbacks,
+            "gc_after_trial": gc_after_trial,
+            "show_progress_bar": show_progress_bar,
+        }
+
+        steps: Sequence[Tuple[str, StepType]] = self.steps
+        if not self.study.trials:
+            # Establish a baseline to avoid performance regression
+            baseline_step = (f"{self.step_name_key}:baseline", _NoOpStep(self.best_params))
+            steps = [baseline_step, *steps]
+            if n_trials is not None:
+                n_trials += 1
+
+        with _TimeBudget(timeout) as time_budget:
+            trial_budget = _TrialBudget(n_trials)
+
+            for step_name, step in steps:
+                if self._check_depleted_budgets(step_name, (trial_budget, time_budget)):
+                    break
+
+                if callable(step):
+                    step = step(self.best_params)
+
+                if not any((n_trials, timeout, step.n_trials, step.timeout)):
+                    raise ValueError(
+                        "When 'n_trials' and 'timeout' are both None, all steps should "
+                        + "at least specify 'n_trials' or 'timeout'. "
+                        + f"Found unconstrained step: {step_name}."
+                    )
+
+                self._optimize_step(
+                    step_name,
+                    step,
+                    n_trials=trial_budget.try_spend(step.n_trials or n_trials),
+                    timeout=time_budget.try_spend(step.timeout or timeout),
+                    **optimize_kwargs,  # type: ignore
+                )
+
+        if self.study.trials:
+            self.logger.info(
+                f"Finished optimization. Best value is {self.study.best_trial.value} "
+                + f"with parameters: {self.best_params}."
+            )
+
+    def _optimize_step(
+        self,
+        step_name: str,
+        step: Step,
+        n_trials: Optional[int] = None,
+        timeout: Optional[float] = None,
+        n_jobs: int = 1,
+        catch: Tuple[Type[Exception], ...] = (),
+        callbacks: Optional[List[_OptunaCallback]] = None,
+        gc_after_trial: bool = False,
+        show_progress_bar: bool = False,
+    ) -> None:
+        if show_progress_bar:
+            callbacks = callbacks or []
+            callbacks.append(self._progress_bar_callback(step_name))
+
+        default_sampler = self.study.sampler
+        default_pruner = self.study.pruner
+        self.study.sampler = step.sampler or default_sampler
+        self.study.pruner = step.pruner or default_pruner
+
+        prev_best_value = self.best_value
+        self.study.optimize(
+            self._create_objective(self.best_params, step_name, step),
+            n_trials=n_trials or step.n_trials,
+            timeout=timeout or step.timeout,
+            n_jobs=n_jobs,
+            catch=catch,
+            callbacks=callbacks,
+            gc_after_trial=gc_after_trial,
+            show_progress_bar=show_progress_bar,
+        )
+        if is_better(self.study.direction, self.study.best_trial.value, prev_best_value):
+            self.best_params.update(self.study.best_trial.params)
+
+        self.study.sampler = default_sampler
+        self.study.pruner = default_pruner
+
+    def _create_objective(
+        self, base_params: Dict[str, Any], step_name: str, step: Step
+    ) -> ObjectiveFuncType:
+        def objective(trial: optuna.Trial) -> float:
+            trial.set_system_attr(self.step_name_key, step_name)
+
+            params = copy.deepcopy(base_params)
+            params.update(step.suggest(trial))
+            return self.objective(trial, params)
+
+        return objective
+
+    def _progress_bar_callback(self, step_name: str) -> _OptunaCallback:
+        def _callback(study: optuna.Study, trial: FrozenTrial) -> None:
+            pbar = study._progress_bar  # type: ignore
+            step_desc = f"{step_name}, validation score: {study.best_value:.6f}"
+            pbar._progress_bar.set_description(step_desc)
+
+        return _callback
+
+    def _check_n_trials(self, n_trials: Optional[int]) -> None:
+        if n_trials is None:
+            return
+
+        n_steps = len(self.steps)
+        if self.study.trials:
+            step_mg = f"{n_steps} steps"
+        else:
+            step_mg = (
+                f"{n_steps} + 1 steps "
+                + "(one extra trial is required for establishing a baseline)"
+            )
+            n_steps += 1
+
+        if n_trials < n_steps:
+            self.logger.warning(f"{n_trials} n_trials < {step_mg}.")
+
+    def _check_depleted_budgets(self, step_name: str, budgets: Iterable[_BaseBudget]) -> bool:
+        is_depleted = False
+        for budget in budgets:
+            if budget.is_depleted:
+                is_depleted = True
+                self.logger.warning(
+                    f"Not enough {budget.unit_name}s remaining. "
+                    + f"Skipping step '{step_name}' and following steps."
+                )
+        return is_depleted

--- a/tests/integration_tests/lightgbm_tuner_tests/test_stepwise_lightgbm.py
+++ b/tests/integration_tests/lightgbm_tuner_tests/test_stepwise_lightgbm.py
@@ -1,0 +1,259 @@
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import NoReturn
+from typing import Tuple
+
+import lightgbm as lgb
+import numpy as np
+import pytest
+from sklearn.datasets import load_breast_cancer
+from sklearn.model_selection import train_test_split
+
+from optuna import stepwise
+import optuna.distributions
+from optuna.integration.lightgbm import default_lgb_steps
+from optuna.integration.lightgbm import StepwiseLightGBMTuner
+from optuna.integration.lightgbm import StepwiseLightGBMTunerCV
+
+
+SEED = 42
+METRIC = "binary_logloss"
+VALID_NAME = "valid_set"
+
+
+def get_train_val() -> Tuple[lgb.Dataset, lgb.Dataset]:
+    # cannnot be a fixture because lgbm keeps pointer references.
+    X_train, X_test, y_train, y_test = train_test_split(
+        *load_breast_cancer(return_X_y=True), test_size=0.1, random_state=SEED
+    )
+    train_set = lgb.Dataset(X_train, label=y_train)
+    val_set = train_set.create_valid(X_test, label=y_test, silent=True)
+    return train_set, val_set
+
+
+def get_train() -> lgb.Dataset:
+    # cannnot be a fixture because lgbm keeps pointer references.
+    X_train, y_train = load_breast_cancer(return_X_y=True)
+    return lgb.Dataset(X_train, label=y_train)
+
+
+@pytest.fixture
+def train_kwargs() -> Dict[str, Any]:
+    return {"num_boost_round": 10, "verbose_eval": False}
+
+
+@pytest.fixture
+def cv_kwargs() -> Dict[str, Any]:
+    return {"num_boost_round": 10, "verbose_eval": False, "early_stopping_rounds": 1, "seed": SEED}
+
+
+@pytest.fixture
+def params() -> Dict[str, Any]:
+    return {"objective": "binary", "metric": METRIC, "verbose": -1, "seed": SEED}
+
+
+@pytest.fixture
+def dummy_steps() -> stepwise.StepListType:
+    dists = {"_NOT_EXIST_": optuna.distributions.IntUniformDistribution(1, 1)}
+    steps = [("1", stepwise.Step(dists, n_trials=1))]
+    return steps
+
+
+@pytest.fixture
+def default_train_score(params: Dict[str, Any], train_kwargs: Dict[str, Any]) -> float:
+    train_set, val_set = get_train_val()
+    booster = lgb.train(
+        params, train_set, valid_sets=val_set, valid_names=VALID_NAME, **train_kwargs
+    )
+    return booster.best_score[VALID_NAME][METRIC]
+
+
+@pytest.fixture
+def default_cv_score(params: Dict[str, Any], cv_kwargs: Dict[str, Any]) -> float:
+    train_set = get_train()
+    cv_results = lgb.cv(params, train_set, **cv_kwargs)
+    return cv_results[f"{METRIC}-mean"][-1]
+
+
+def test_first_metric_only(params: Dict[str, Any]) -> None:
+    params["first_metric_only"] = False
+    train_set, val_set = get_train_val()
+    with pytest.raises(ValueError, match="Optuna only handles a single metric"):
+        StepwiseLightGBMTuner(params, train_set=train_set, valid_sets=val_set)
+
+
+def _optimize_train(
+    params: Dict[str, Any],
+    train_kwargs: Dict[str, Any],
+    steps: stepwise.StepListType,
+    n_trials: int = 2,
+) -> StepwiseLightGBMTuner:
+    train_set, val_set = get_train_val()
+    tuner = StepwiseLightGBMTuner(
+        params, train_set=train_set, steps=steps, valid_sets=val_set, **train_kwargs
+    )
+    tuner.optimize(n_trials=n_trials)
+    return tuner
+
+
+def _check_optimize_train(
+    params: Dict[str, Any],
+    train_kwargs: Dict[str, Any],
+    default_train_score: float,
+    steps: stepwise.StepListType,
+) -> None:
+    tuner = _optimize_train(params, train_kwargs, steps, n_trials=100)
+    assert (
+        np.isclose(default_train_score, tuner.best_value)
+        or tuner.best_value <= default_train_score
+    )
+
+    model = tuner.get_best_booster()
+    assert model.best_score == tuner.best_value
+
+    for name, value in tuner.best_params.items():
+        assert model.params[name] == value
+
+
+@pytest.mark.parametrize(
+    "named_step",
+    [named_step for named_step in default_lgb_steps()],
+    ids=[step_name for step_name, _ in default_lgb_steps()],
+)
+def test_train_single_step(
+    params: Dict[str, Any],
+    train_kwargs: Dict[str, Any],
+    default_train_score: float,
+    named_step: Tuple[str, stepwise.StepType],
+) -> None:
+    _check_optimize_train(params, train_kwargs, default_train_score, [named_step])
+
+
+def test_train_all_steps(
+    params: Dict[str, Any],
+    train_kwargs: Dict[str, Any],
+    default_train_score: float,
+) -> None:
+    _check_optimize_train(params, train_kwargs, default_train_score, default_lgb_steps())
+
+
+def _check_optimize_cv(
+    params: Dict[str, Any],
+    cv_kwargs: Dict[str, Any],
+    default_cv_score: float,
+    steps: stepwise.StepListType,
+) -> None:
+    train_set = get_train()
+    tuner = StepwiseLightGBMTunerCV(params, train_set=train_set, steps=steps, **cv_kwargs)
+    tuner.optimize(n_trials=100)
+    assert np.isclose(default_cv_score, tuner.best_value) or tuner.best_value <= default_cv_score
+
+    if lgb.__version__ >= "3.0.0":
+        model = tuner.get_best_booster()
+        assert model.best_score == tuner.best_value
+
+        for name, value in tuner.best_params.items():
+            for booster in model.boosters:
+                assert booster.params[name] == value
+
+
+@pytest.mark.parametrize(
+    "named_step",
+    [named_step for named_step in default_lgb_steps()],
+    ids=[step_name for step_name, _ in default_lgb_steps()],
+)
+def test_cv_single_step(
+    params: Dict[str, Any],
+    cv_kwargs: Dict[str, Any],
+    default_cv_score: float,
+    named_step: Tuple[str, stepwise.StepType],
+) -> None:
+    _check_optimize_cv(params, cv_kwargs, default_cv_score, [named_step])
+
+
+def test_cv_all_steps(
+    params: Dict[str, Any], cv_kwargs: Dict[str, Any], default_cv_score: float
+) -> None:
+    _check_optimize_cv(params, cv_kwargs, default_cv_score, default_lgb_steps())
+
+
+def test_multiple_metrics(
+    params: Dict[str, Any], train_kwargs: Dict[str, Any], dummy_steps: stepwise.StepListType
+) -> None:
+    expected = _optimize_train(params, train_kwargs, dummy_steps, n_trials=2).best_value
+
+    params["metric"] = ["binary_logloss", "mape"]
+    actual = _optimize_train(params, train_kwargs, dummy_steps, n_trials=2).best_value
+    assert np.isclose(actual, expected)
+
+    params["metric"] = ["mape", "binary_logloss"]
+    actual = _optimize_train(params, train_kwargs, dummy_steps, n_trials=2).best_value
+    assert not np.isclose(actual, expected)
+
+
+def custom_obj(preds: np.ndarray, train_data: lgb.Dataset) -> Tuple[str, np.ndarray, bool]:
+    y = train_data.get_label()
+    error_sum = (preds - y).sum()
+    return ("custom_obj", error_sum, False)
+
+
+def test_train_feval(train_kwargs: Dict[str, Any]) -> None:
+    params = {"objective": "binary", "metric": "None", "verbose": -1, "seed": SEED}
+    train_kwargs["feval"] = custom_obj
+    train_set, val_set = get_train_val()
+
+    booster = lgb.train(
+        params, train_set, valid_sets=val_set, valid_names=VALID_NAME, **train_kwargs
+    )
+    expected = booster.best_score[VALID_NAME]["custom_obj"]
+
+    _check_optimize_train(
+        params, train_kwargs, default_train_score=expected, steps=default_lgb_steps()
+    )
+
+
+def test_cv_feval(train_kwargs: Dict[str, Any]) -> None:
+    params = {"objective": "binary", "metric": "None", "verbose": -1, "seed": SEED}
+    train_kwargs["feval"] = custom_obj
+    train_set = get_train()
+
+    cv_results = lgb.cv(params, train_set, **train_kwargs)
+    expected = cv_results["custom_obj-mean"][-1]
+
+    _check_optimize_cv(params, train_kwargs, default_cv_score=expected, steps=default_lgb_steps())
+
+
+def test_direction(params: Dict[str, Any], dummy_steps: stepwise.StepListType) -> None:
+    params["metric"] = ["auc"]
+    study = optuna.create_study(direction="minimize")
+    with pytest.raises(ValueError, match="Study direction is inconsistent with the metric 'auc'"):
+        train_set, val_set = get_train_val()
+        tuner = StepwiseLightGBMTuner(
+            params, train_set=train_set, steps=dummy_steps, study=study, valid_sets=val_set
+        )
+        tuner.optimize(n_trials=2)
+
+
+def test_multiple_valid_sets(
+    params: Dict[str, Any], train_kwargs: Dict[str, Any], dummy_steps: stepwise.StepListType
+) -> None:
+    train_set, val_set = get_train_val()
+    tuner = StepwiseLightGBMTuner(
+        params, train_set=train_set, valid_sets=val_set, steps=dummy_steps, **train_kwargs
+    )
+    tuner.optimize(n_trials=2)
+    expected = tuner.best_value
+
+    train_set, val_set = get_train_val()
+    tuner = StepwiseLightGBMTuner(
+        params,
+        train_set=train_set,
+        valid_sets=[val_set, train_set],
+        steps=dummy_steps,
+        **train_kwargs,
+    )
+    tuner.optimize(n_trials=2)
+    actual = tuner.best_value
+
+    assert np.isclose(actual, expected)

--- a/tests/integration_tests/lightgbm_tuner_tests/test_stepwise_lightgbm.py
+++ b/tests/integration_tests/lightgbm_tuner_tests/test_stepwise_lightgbm.py
@@ -1,7 +1,5 @@
 from typing import Any
 from typing import Dict
-from typing import List
-from typing import NoReturn
 from typing import Tuple
 
 import lightgbm as lgb

--- a/tests/test_stepwise.py
+++ b/tests/test_stepwise.py
@@ -1,0 +1,184 @@
+from collections import Counter
+import itertools
+import math
+import random
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import Tuple
+
+import numpy as np
+import pytest
+
+import optuna
+from optuna import stepwise
+from optuna import study
+import optuna.distributions
+import optuna.study
+import optuna.trial
+
+
+PARAM_KEY = "x"
+
+
+@pytest.fixture(scope="module", autouse=True)
+def set_logging() -> None:
+    optuna.logging.set_verbosity(optuna.logging.WARNING)
+
+
+def test_step() -> None:
+    seed = 42
+    random.seed(seed)
+    sampler = optuna.samplers.RandomSampler(seed=seed)
+    study = optuna.create_study(sampler=sampler)
+    trial = optuna.Trial(study, study._storage.create_new_trial(study._study_id))
+
+    low, high = 0, 10
+    dists = {PARAM_KEY: optuna.distributions.IntUniformDistribution(low, high)}
+    step = stepwise.Step(distributions=dists)
+
+    actual = step.suggest(trial)[PARAM_KEY]
+    expected = trial.suggest_int(PARAM_KEY, low, high)
+
+    assert actual == expected
+
+
+@pytest.mark.parametrize(
+    "x, y",
+    [
+        ([-50, 50], [-99, 0]),
+        (["-50", " 50"], ["-99", "0"]),
+        ([True, False], [False, True]),
+        ([-50.0, 50.0], [-99.0, 0.0]),
+    ],
+)
+def test_grid_step(x: Any, y: Any) -> None:
+    search_space = {"x": x, "y": y}
+
+    step = stepwise.GridStep(search_space, n_trials=1)
+    assert step.n_trials == 1
+
+    step = stepwise.GridStep(search_space)
+    assert step.n_trials == 2 * 2
+
+    def grid_objective(trial: optuna.trial.Trial) -> float:
+        values = step.suggest(trial)
+        return int(values["x"]) + int(values["y"])
+
+    study = optuna.create_study(sampler=optuna.samplers.GridSampler(search_space))
+    study.optimize(grid_objective, n_trials=step.n_trials)
+    actual = {trial.value for trial in study.trials}
+
+    grid = itertools.product(search_space["x"], search_space["y"])
+    expected = set(int(values[0]) + int(values[1]) for values in grid)
+
+    assert actual == expected
+
+
+def make_int_steps(n_steps: int, low: int = 0, high: int = 10) -> List[Tuple[str, stepwise.Step]]:
+    """Return  a list of tuples [(0, step_0), ..., (n, step_n)]
+    where each step's n_trials argument is set to the index in the list.
+    """
+    dists = {PARAM_KEY: optuna.distributions.IntUniformDistribution(low, high)}
+    return [(str(i), stepwise.Step(dists, n_trials=i)) for i in range(1, n_steps + 1)]
+
+
+def objective(trial: optuna.Trial, params: Dict[str, Any]) -> float:
+    return params.get(PARAM_KEY, -1)
+
+
+@pytest.mark.parametrize("n_trials", range(-1, 10))
+def test_global_n_trials(n_trials: int) -> None:
+    n_steps = 3
+    tuner = stepwise.StepwiseTuner(objective, steps=make_int_steps(n_steps))
+    tuner.optimize(n_trials=n_trials)
+
+    if n_trials < 0:
+        assert len(tuner.study.trials) == 0
+    else:
+        max_n_trials = math.factorial(n_steps)  # by definition of make_int_steps
+        assert len(tuner.study.trials) == min(n_trials, max_n_trials) + 1  # add baseline step
+
+
+@pytest.mark.parametrize("timeout", [-1, 0, 0.5, 1])
+def test_global_n_timeout(timeout: float) -> None:
+    tuner = stepwise.StepwiseTuner(objective, steps=make_int_steps(1000))
+    tuner.optimize(timeout=timeout)
+
+    if timeout > 0:
+        duration = sum(
+            trial.duration.total_seconds() for trial in tuner.study.trials  # type:ignore
+        )
+        assert np.isclose(duration, timeout, atol=0.1)
+    else:
+        assert len(tuner.study.trials) == 0
+
+
+def check_optimize(tuner: stepwise.StepwiseTuner, expected: float) -> None:
+    tuner.optimize(n_trials=99)
+
+    assert tuner.best_params[PARAM_KEY] == expected
+    assert tuner.best_value == expected
+
+    step_keys = [trial.system_attrs[tuner.step_name_key] for trial in tuner.study.trials]
+    step_counter = Counter(step_keys)
+    baseline = step_counter.pop(f"{tuner.step_name_key}:baseline")
+    assert baseline == 1
+
+    for step_name, n_trials in step_counter.items():
+        step = [step for name, step in tuner.steps if step_name == name][0]  # type:ignore
+        if callable(step):
+            step = step({})
+        assert step.n_trials == n_trials
+
+
+def test_optimize_default() -> None:
+    default_value = 0
+    tuner = stepwise.StepwiseTuner(
+        objective=objective,
+        steps=make_int_steps(n_steps=3, low=1, high=1),
+        default_params={PARAM_KEY: default_value},
+    )
+    check_optimize(tuner, expected=default_value)
+
+
+def test_optimize() -> None:
+    tuner = stepwise.StepwiseTuner(
+        objective=objective,
+        steps=make_int_steps(n_steps=3, low=1, high=1),
+        default_params={PARAM_KEY: 99},
+    )
+    check_optimize(tuner, expected=1)
+
+
+def test_callable_step() -> None:
+    def make_step(params: Dict[str, Any]) -> stepwise.Step:
+        dists = {PARAM_KEY: optuna.distributions.IntUniformDistribution(low=1, high=1)}
+        return stepwise.Step(dists, n_trials=1)
+
+    tuner = stepwise.StepwiseTuner(
+        objective=objective,
+        steps=[("1", make_step)],
+        default_params={PARAM_KEY: 99},
+    )
+    check_optimize(tuner, expected=1)
+
+
+def test_resume_optimize() -> None:
+    steps = make_int_steps(n_steps=1)
+
+    tuner = stepwise.StepwiseTuner(objective=objective, steps=steps)
+    tuner.optimize(n_trials=2)
+    n_trials = len(tuner.study.trials)
+
+    tuner2 = stepwise.StepwiseTuner(objective=objective, steps=steps, study=tuner.study)
+    tuner.optimize(n_trials=1)
+    assert len(tuner2.study.trials) == n_trials + 1
+
+
+def test_all_budgets_none() -> None:
+    dists = {PARAM_KEY: optuna.distributions.IntUniformDistribution(0, 1)}
+    steps = [("step", stepwise.Step(dists))]
+    tuner = stepwise.StepwiseTuner(objective=objective, steps=steps)
+    with pytest.raises(ValueError):
+        tuner.optimize()


### PR DESCRIPTION
## Motivation

This PR is related to the discussion in #1632. The steps of `LightGBMTuner` are fixed and its implementation
is tightly coupled to a sequence of pre-defined steps, and to LightGBM in general.

The objective of this PR is twofold:

1. Define a customizable stepwise approach that could be used for multiple integration targets.
2. Refactor the LightGBM tuners to conform to 1. and test that its design is relevant.

## Description of the changes

### 1. StepwiseTuner

Introduce new concepts:

- `Step`: A [Step](https://github.com/jeffzi/optuna/blob/b96f4077b9958e308fea9e88eb47cb68688145b6/optuna/stepwise.py#L112) encampsulates the specific parameters of one specific optimization task.
- `StepwiseTuner`: A [StepwiseTuner](https://github.com/jeffzi/optuna/blob/b96f4077b9958e308fea9e88eb47cb68688145b6/optuna/stepwise.py#L238) corresponds to a sequence of optimization tasks (steps).
- `Step Objective`: Similar to a regular study objective but takes an extra dictionary of parameters to optimize.

A step holds:

- sampler
- pruner
- n_trials
- timeout
- distributions: A dictionary whose key and value are a parameter name and the corresponding distributions (`BaseDistribution`) to suggest from.

`BaseDistribution` is not usually exposed to end-users elsewhere in Optuna but it allows to defer the "suggestion" to a later time.
Implementations should provide reasonable pre-defined steps.

I chose to replicate the `Study` interface to feel natural. `StepwiseTuner` has a method `optimize()` that accepts the same 
arguments as `Study.optimize`, except the objective `func`. The `timeout` and `n_trials` passed to `optimize` controls the global budgets for all steps. 

`StepwiseTuner` also adds a pre-step that runs a single trial with default parameters to establish a baseline. Some users reported that LightGBMTuner does not always improve upon defaults, this solves the issue.

### 2. StepwiseLightGBMTuner & StepwiseLightGBMTuner

They subclass `StepwiseTuner`. [Pre-defined steps](https://github.com/jeffzi/optuna/blob/stepwise/optuna/integration/_lightgbm_tuner/steps.py) are offered, with the [default sequence](https://github.com/jeffzi/optuna/blob/d7b756371e453aeb5797b17770ba5d55b2f7e48e/optuna/integration/_lightgbm_tuner/steps.py#L186) replicating `LightGBMTuner`'s steps.

In addition to customizable steps, this implementation is further streamlined thanks to:
- Inference of the study's direction from a LightGBM [callback](https://github.com/jeffzi/optuna/blob/b96f4077b9958e308fea9e88eb47cb68688145b6/optuna/integration/_lightgbm_tuner/stepwise.py#L87). It decouples the tuner greatly from LightGBM internals and makes the code more robust.
- Serialization of the model as a string via LightGBM's [model_to_string](https://lightgbm.readthedocs.io/en/latest/pythonapi/lightgbm.Booster.html#lightgbm.Booster.model_to_string). Consequently, I've not implemented file serialization. This is probably up to debate.

`StepwiseLightGBMTuner` fixes:
- #1351, #1636: `feval` is verified to work in the tests.
- #1550: parametrizable n_trials per step
- #1858: MAPE metric should be minimized, not maximized.
- Accepts a list of `metric` params but warns that only the first one will be used for optimization.

Lastly, I did not implement `sample_size`. From the code, I understand that it takes the last 'sample_size' rows of the dataset.
In my opinion, this could be easily handled by the user, not the tuner.

Example:
```python
import lightgbm as lgb
import numpy as np
import sklearn.datasets
from sklearn.metrics import accuracy_score
from sklearn.model_selection import train_test_split

from optuna.integration.lightgbm import StepwiseLightGBMTuner, step_feature_fraction


data, target = sklearn.datasets.load_breast_cancer(return_X_y=True)
train_x, val_x, train_y, val_y = train_test_split(data, target, test_size=0.25, random_state=42)
dtrain = lgb.Dataset(train_x, label=train_y)
dval = lgb.Dataset(val_x, label=val_y)

params = {
    "objective": "binary",
    "metric": "binary_logloss",
    "boosting_type": "gbdt",
    "verbosity": -1,
}
tuner = StepwiseLightGBMTuner(
    params,
    dtrain,
    steps=[step_feature_fraction(n_trials=2)], # use a predefined step
    valid_sets=[dval],
    verbose_eval=False,
    num_boost_round=50,
    early_stopping_rounds=5,
)
tuner.optimize()

model = tuner.get_best_booster()
prediction = np.rint(model.predict(val_x, num_iteration=model.best_iteration))
accuracy = accuracy_score(val_y, prediction)

print("Best params:", tuner.best_params)
print("  Accuracy = {}".format(accuracy))
```
### Other considerations

I wrote tests and docstrings but did not add the documentation to sphinx (waiting for your opinion on the PR).

I realize it may not be ideal to break the `LightGBMTuner` API but I think the proposed API homogenizes better with the rest of Optuna. If the PR is accepted, I propose to start by keeping both `LightGBMTuner` and `StepwiseLightGBMTuner` and scheduling `LightGBMTuner`'s deprecation.

The interface to scikit-learn and the alias for `lgb.train` should also be refactored in the future.

That's all for my proposal. I hope that you like it and that it opens a good discussion. :tada:
