### PR TITLE
Safe decode of system/usr attributes for optuna studies

### DIFF
--- a/optuna/storages/_rdb/storage.py
+++ b/optuna/storages/_rdb/storage.py
@@ -283,7 +283,7 @@ class RDBStorage(BaseStorage):
         # Ensure that that study exists.
         models.StudyModel.find_or_raise_by_id(study_id, session)
         attributes = models.StudyUserAttributeModel.where_study_id(study_id, session)
-        user_attrs = {attr.key: self._decode_json(attr.value_json) for attr in attributes}
+        user_attrs = {attr.key: RDBStorage._decode_json(attr.value_json) for attr in attributes}
         # Terminate transaction explicitly to avoid connection timeout during transaction.
         self._commit(session)
 
@@ -296,7 +296,7 @@ class RDBStorage(BaseStorage):
         # Ensure that that study exists.
         models.StudyModel.find_or_raise_by_id(study_id, session)
         attributes = models.StudySystemAttributeModel.where_study_id(study_id, session)
-        system_attrs = {attr.key: self._deck_json(attr.value_json) for attr in attributes}
+        system_attrs = {attr.key: RDBStorage._deck_json(attr.value_json) for attr in attributes}
         # Terminate transaction explicitly to avoid connection timeout during transaction.
         self._commit(session)
 
@@ -310,7 +310,7 @@ class RDBStorage(BaseStorage):
         models.TrialModel.find_or_raise_by_id(trial_id, session)
 
         attributes = models.TrialUserAttributeModel.where_trial_id(trial_id, session)
-        user_attrs = {attr.key: self._decode_json(attr.value_json) for attr in attributes}
+        user_attrs = {attr.key: RDBStorage._decode_json(attr.value_json) for attr in attributes}
         # Terminate transaction explicitly to avoid connection timeout during transaction.
         self._commit(session)
 
@@ -324,7 +324,7 @@ class RDBStorage(BaseStorage):
         models.TrialModel.find_or_raise_by_id(trial_id, session)
 
         attributes = models.TrialSystemAttributeModel.where_trial_id(trial_id, session)
-        system_attrs = {attr.key: self._decode_json(attr.value_json) for attr in attributes}
+        system_attrs = {attr.key: RDBStorage._decode_json(attr.value_json) for attr in attributes}
         # Terminate transaction explicitly to avoid connection timeout during transaction.
         self._commit(session)
 
@@ -396,8 +396,8 @@ class RDBStorage(BaseStorage):
                     best_trial.datetime_complete,
                     param_dict,
                     param_distributions,
-                    {i.key: self._decode_json(i.value_json) for i in user_attrs},
-                    {i.key: self._decode_json(i.value_json) for i in system_attrs},
+                    {i.key: RDBStorage._decode_json(i.value_json) for i in user_attrs},
+                    {i.key: RDBStorage._decode_json(i.value_json) for i in system_attrs},
                     {value.step: value.value for value in intermediate},
                     best_trial.trial_id,
                 )
@@ -412,8 +412,8 @@ class RDBStorage(BaseStorage):
                     study_name=study.study_name,
                     direction=study.direction,
                     best_trial=best_trial_frozen,
-                    user_attrs={i.key: self._decode_json(i.value_json) for i in user_attrs},
-                    system_attrs={i.key: elf._decode_json(i.value_json) for i in system_attrs},
+                    user_attrs={i.key: RDBStorage._decode_json(i.value_json) for i in user_attrs},
+                    system_attrs={i.key: RDBStorage._decode_json(i.value_json) for i in system_attrs},
                     n_trials=study.n_trial,
                     datetime_start=study.datetime_start,
                     study_id=study.study_id,
@@ -1018,9 +1018,9 @@ class RDBStorage(BaseStorage):
                 p.param_name: distributions.json_to_distribution(p.distribution_json)
                 for p in trial.params
             },
-            user_attrs={attr.key: self._decode_json(attr.value_json) for attr in trial.user_attributes},
+            user_attrs={attr.key: RDBStorage._decode_json(attr.value_json) for attr in trial.user_attributes},
             system_attrs={
-                attr.key: self._decode_json(attr.value_json) for attr in trial.system_attributes
+                attr.key: RDBStorage._decode_json(attr.value_json) for attr in trial.system_attributes
             },
             intermediate_values={value.step: value.value for value in trial.values},
             trial_id=trial.trial_id,


### PR DESCRIPTION
## Motivation
We encountered issues where very large callstacks were being serialized into remote storage (as part of the `fail_system` system attr).  Unfortunately, because the system_attr serializer converts things to json before storing them, the column truncation caused by the database caused these simple "string" attributes to no longer be decodeable as 'json'. This causes the trial to fail to load, rendering the study inoperable for future trials or later analysis.

## Description of the changes
The code here wraps the current usage of `json.loads` with a simple try/except block to catch bad JSON decoding. If bad JSON is encountered, it simply treats the value as a string (not ideal in all situations, but arguably preferable behavior to rendering the trial/study inoperable.  For very long string fields this seems okay, for objects it might not be ideal but it should still be quite apparent that they are broken (as opposed to today where it fails when reading them back).

An alternate approach could try to prevent very long strings from entering the system, but defensive reads seems worthwhile regardless.