### PR TITLE
Convert comment style type hints

### DIFF
--- a/optuna/_dataframe.py
+++ b/optuna/_dataframe.py
@@ -30,7 +30,7 @@ def _trials_dataframe(
     if not len(trials):
         return pd.DataFrame()
 
-    attrs_to_df_columns = collections.OrderedDict()  # type: Dict[str, str]
+    attrs_to_df_columns: Dict[str, str] = collections.OrderedDict()
     for attr in attrs:
         if attr.startswith("_"):
             # Python conventional underscores are omitted in the dataframe.
@@ -42,7 +42,7 @@ def _trials_dataframe(
     # column_agg is an aggregator of column names.
     # Keys of column agg are attributes of `FrozenTrial` such as 'trial_id' and 'params'.
     # Values are dataframe columns such as ('trial_id', '') and ('params', 'n_layers').
-    column_agg = collections.defaultdict(set)  # type: Dict[str, Set]
+    column_agg: Dict[str, Set] = collections.defaultdict(set)
     non_nested_attr = ""
 
     def _create_record_and_aggregate_column(
@@ -66,9 +66,9 @@ def _trials_dataframe(
 
     records = list([_create_record_and_aggregate_column(trial) for trial in trials])
 
-    columns = sum(
+    columns: List[Tuple[str, str]] = sum(
         (sorted(column_agg[k]) for k in attrs if k in column_agg), []
-    )  # type: List[Tuple[str, str]]
+    )
 
     df = pd.DataFrame(records, columns=pd.MultiIndex.from_tuples(columns))
 

--- a/optuna/_imports.py
+++ b/optuna/_imports.py
@@ -13,7 +13,7 @@ class _DeferredImportExceptionContextManager(object):
     """
 
     def __init__(self) -> None:
-        self._deferred = None  # type: Optional[Tuple[Exception, str]]
+        self._deferred: Optional[Tuple[Exception, str]] = None
 
     def __enter__(self) -> "_DeferredImportExceptionContextManager":
         """Enter the context manager.

--- a/optuna/_optimize.py
+++ b/optuna/_optimize.py
@@ -76,7 +76,7 @@ def _optimize(
 
                 if timeout is not None:
                     # This is needed for mypy.
-                    t = timeout  # type: float
+                    t: float = timeout
                     return (datetime.datetime.now() - time_start).total_seconds() > t
 
                 return False

--- a/optuna/dashboard.py
+++ b/optuna/dashboard.py
@@ -38,8 +38,8 @@ with try_import() as _imports:
         )
 
 
-_mode = None  # type: Optional[str]
-_study = None  # type: Optional[optuna.study.Study]
+_mode: Optional[str] = None
+_study: Optional[optuna.study.Study] = None
 
 _HEADER_FORMAT = """
 <style>
@@ -99,7 +99,7 @@ if _imports.is_successful():
 
         def update(self, new_trials: List[optuna.trial.FrozenTrial]) -> None:
 
-            stream_dict = collections.defaultdict(list)  # type: Dict[str, List[Any]]
+            stream_dict: Dict[str, List[Any]] = collections.defaultdict(list)
 
             for trial in new_trials:
                 if trial.state != optuna.trial.TrialState.COMPLETE:
@@ -192,10 +192,10 @@ if _imports.is_successful():
         def __call__(self, doc: bokeh.document.Document) -> None:
 
             self.doc = doc
-            self.current_trials = (
+            self.current_trials: Optional[List[optuna.trial.FrozenTrial]] = (
                 self.study.trials
-            )  # type: Optional[List[optuna.trial.FrozenTrial]]
-            self.new_trials = None  # type: Optional[List[optuna.trial.FrozenTrial]]
+            )
+            self.new_trials: Optional[List[optuna.trial.FrozenTrial]] = None
             self.complete_trials_widget = _CompleteTrialsWidget(
                 self.current_trials, self.study.direction
             )

--- a/optuna/dashboard.py
+++ b/optuna/dashboard.py
@@ -192,9 +192,7 @@ if _imports.is_successful():
         def __call__(self, doc: bokeh.document.Document) -> None:
 
             self.doc = doc
-            self.current_trials: Optional[List[optuna.trial.FrozenTrial]] = (
-                self.study.trials
-            )
+            self.current_trials: Optional[List[optuna.trial.FrozenTrial]] = self.study.trials
             self.new_trials: Optional[List[optuna.trial.FrozenTrial]] = None
             self.complete_trials_widget = _CompleteTrialsWidget(
                 self.current_trials, self.study.direction

--- a/optuna/importance/_fanova/_fanova.py
+++ b/optuna/importance/_fanova/_fanova.py
@@ -56,9 +56,9 @@ class _Fanova(object):
             min_samples_leaf=min_samples_leaf,
             random_state=seed,
         )
-        self._trees = None  # type: Optional[List[_FanovaTree]]
-        self._variances = None  # type: Optional[Dict[Tuple[int, ...], numpy.ndarray]]
-        self._features_to_raw_features = None  # type: Optional[List[numpy.ndarray]]
+        self._trees: Optional[List[_FanovaTree]] = None
+        self._variances: Optional[Dict[Tuple[int, ...], numpy.ndarray]] = None
+        self._features_to_raw_features: Optional[List[numpy.ndarray]] = None
 
     def fit(
         self,
@@ -93,7 +93,7 @@ class _Fanova(object):
 
         self._compute_variances(features)
 
-        fractions = []  # type: Union[List[float], numpy.ndarray]
+        fractions: Union[List[float], numpy.ndarray] = []
 
         for tree_index, tree in enumerate(self._trees):
             tree_variance = tree.variance
@@ -140,7 +140,7 @@ class _CategoricalFeaturesOneHotEncoder(object):
     def __init__(self) -> None:
         # `features_to_raw_features["column index in original matrix"]
         #     == "numpy.ndarray with corresponding columns in the transformed matrix"`
-        self.features_to_raw_features = None  # type: Optional[List[numpy.ndarray]]
+        self.features_to_raw_features: Optional[List[numpy.ndarray]] = None
 
     def fit_transform(
         self,
@@ -185,7 +185,7 @@ class _CategoricalFeaturesOneHotEncoder(object):
         # `ColumnTransformer.fit_transform`.
         X = transformer.fit_transform(X)
 
-        features_to_raw_features = [None for _ in range(n_features)]  # type: List[numpy.ndarray]
+        features_to_raw_features: List[numpy.ndarray] = [None for _ in range(n_features)]
         i = 0
         if len(categorical_features) > 0:
             categories = transformer.transformers_[0][1].categories_

--- a/optuna/importance/_fanova/_tree.py
+++ b/optuna/importance/_fanova/_tree.py
@@ -65,8 +65,8 @@ class _FanovaTree(object):
 
         sample = numpy.full(self._n_features, fill_value=numpy.nan, dtype=numpy.float64)
 
-        values = []  # type: Union[List[float], numpy.ndarray]
-        weights = []  # type: Union[List[float], numpy.ndarray]
+        values: Union[List[float], numpy.ndarray] = []
+        weights: Union[List[float], numpy.ndarray] = []
 
         for midpoints, sizes in zip(product_midpoints, product_sizes):
             sample[features] = numpy.array(midpoints)
@@ -213,7 +213,7 @@ class _FanovaTree(object):
         return midpoints, sizes
 
     def _compute_features_split_values(self) -> List[numpy.ndarray]:
-        all_split_values = [set() for _ in range(self._n_features)]  # type: List[Set[float]]
+        all_split_values: List[Set[float]] = [set() for _ in range(self._n_features)]
 
         for node_index in range(self._n_nodes):
             feature = self._get_node_split_feature(node_index)
@@ -221,7 +221,7 @@ class _FanovaTree(object):
                 threshold = self._get_node_split_threshold(node_index)
                 all_split_values[feature].add(threshold)
 
-        sorted_all_split_values = []  # type: List[numpy.ndarray]
+        sorted_all_split_values: List[numpy.ndarray] = []
 
         for split_values in all_split_values:
             split_values_array = numpy.array(list(split_values), dtype=numpy.float64)

--- a/optuna/integration/_lightgbm_tuner/alias.py
+++ b/optuna/integration/_lightgbm_tuner/alias.py
@@ -3,7 +3,7 @@ from typing import Dict
 from typing import List  # NOQA
 
 
-_ALIAS_GROUP_LIST = [
+_ALIAS_GROUP_LIST: List[Dict[str, Any]] = [
     {"param_name": "bagging_fraction", "alias_names": ["sub_row", "subsample", "bagging"]},
     {"param_name": "learning_rate", "alias_names": ["shrinkage_rate", "eta"]},
     {
@@ -24,7 +24,7 @@ _ALIAS_GROUP_LIST = [
     {"param_name": "lambda_l1", "alias_names": ["reg_alpha"]},
     {"param_name": "lambda_l2", "alias_names": ["reg_lambda", "lambda"]},
     {"param_name": "min_gain_to_split", "alias_names": ["min_split_gain"]},
-]  # type: List[Dict[str, Any]]
+]
 
 
 def _handling_alias_parameters(lgbm_params: Dict[str, Any]) -> None:
@@ -40,7 +40,7 @@ def _handling_alias_parameters(lgbm_params: Dict[str, Any]) -> None:
                 del lgbm_params[alias_name]
 
 
-_ALIAS_METRIC_LIST = [
+_ALIAS_METRIC_LIST: List[Dict[str, Any]] = [
     # The list `alias_names` do not include the `metric_name` itself.
     {
         "metric_name": "ndcg",
@@ -101,7 +101,7 @@ _ALIAS_METRIC_LIST = [
         "metric_name": "rmse",
         "alias_names": ["l2_root", "root_mean_squared_error"],
     },
-]  # type: List[Dict[str, Any]]
+]
 
 
 def _handling_alias_metrics(lgbm_params: Dict[str, Any]) -> None:

--- a/optuna/integration/_lightgbm_tuner/optimize.py
+++ b/optuna/integration/_lightgbm_tuner/optimize.py
@@ -395,9 +395,9 @@ class _LightGBMBaseTuner(_BaseTuner):
         self._parse_args(*args, **kwargs)
         self._start_time: Optional[float] = None
         self._optuna_callbacks = optuna_callbacks
-        self._best_booster_with_trial_number: Optional[Tuple[Union[lgb.Booster, lgb.CVBooster], int]] = (
-            None
-        )
+        self._best_booster_with_trial_number: Optional[
+            Tuple[Union[lgb.Booster, lgb.CVBooster], int]
+        ] = None
         self._model_dir = model_dir
 
         # Should not alter data since `min_data_in_leaf` is tuned.

--- a/optuna/integration/_lightgbm_tuner/optimize.py
+++ b/optuna/integration/_lightgbm_tuner/optimize.py
@@ -93,7 +93,7 @@ class _BaseTuner(object):
     def _get_booster_best_score(self, booster: "lgb.Booster") -> float:
 
         metric = self._get_metric_for_objective()
-        valid_sets = self.lgbm_kwargs.get("valid_sets")  # type: Optional[VALID_SET_TYPE]
+        valid_sets: Optional[VALID_SET_TYPE] = self.lgbm_kwargs.get("valid_sets")
 
         if self.lgbm_kwargs.get("valid_names") is not None:
             if type(self.lgbm_kwargs["valid_names"]) is str:
@@ -177,7 +177,7 @@ class _OptunaObjective(_BaseTuner):
 
         self.trial_count = 0
         self.best_score = best_score
-        self.best_booster_with_trial_number = None  # type: Optional[Tuple["lgb.Booster", int]]
+        self.best_booster_with_trial_number: Optional[Tuple["lgb.Booster", int]] = None
         self.step_name = step_name
         self.model_dir = model_dir
 
@@ -378,7 +378,7 @@ class _LightGBMBaseTuner(_BaseTuner):
         _handling_alias_metrics(params)
 
         args = [params, train_set]
-        kwargs = dict(
+        kwargs: Dict[str, Any] = dict(
             num_boost_round=num_boost_round,
             fobj=fobj,
             feval=feval,
@@ -391,13 +391,13 @@ class _LightGBMBaseTuner(_BaseTuner):
             sample_size=sample_size,
             verbosity=verbosity,
             show_progress_bar=show_progress_bar,
-        )  # type: Dict[str, Any]
+        )
         self._parse_args(*args, **kwargs)
-        self._start_time = None  # type: Optional[float]
+        self._start_time: Optional[float] = None
         self._optuna_callbacks = optuna_callbacks
-        self._best_booster_with_trial_number = (
+        self._best_booster_with_trial_number: Optional[Tuple[Union[lgb.Booster, lgb.CVBooster], int]] = (
             None
-        )  # type: Optional[Tuple[Union[lgb.Booster, lgb.CVBooster], int]]
+        )
         self._model_dir = model_dir
 
         # Should not alter data since `min_data_in_leaf` is tuned.
@@ -823,7 +823,7 @@ class LightGBMTuner(_LightGBMBaseTuner):
         self.lgbm_kwargs["learning_rates"] = learning_rates
         self.lgbm_kwargs["keep_training_booster"] = keep_training_booster
 
-        self._best_booster_with_trial_number = None  # type: Optional[Tuple[lgb.Booster, int]]
+        self._best_booster_with_trial_number: Optional[Tuple[lgb.Booster, int]] = None
         self._model_dir = model_dir
 
         if self._model_dir is not None and not os.path.exists(self._model_dir):

--- a/optuna/integration/allennlp.py
+++ b/optuna/integration/allennlp.py
@@ -144,7 +144,7 @@ def _get_environment_variables_for_pruner() -> Dict[str, Optional[Union[str, int
 
 def _fetch_pruner_config(trial: optuna.Trial) -> Dict[str, Any]:
     pruner = trial.study.pruner
-    kwargs = {}  # type: Dict[str, Any]
+    kwargs: Dict[str, Any] = {}
 
     if isinstance(pruner, optuna.pruners.HyperbandPruner):
         kwargs["min_resource"] = pruner._min_resource

--- a/optuna/integration/mlflow.py
+++ b/optuna/integration/mlflow.py
@@ -123,7 +123,7 @@ class MLflowCallback(object):
             mlflow.log_params(trial.params)
 
             # This sets the tags for MLflow.
-            tags = {}  # type: Dict[str, str]
+            tags: Dict[str, str] = {}
             tags["number"] = str(trial.number)
             tags["datetime_start"] = str(trial.datetime_start)
             tags["datetime_complete"] = str(trial.datetime_complete)

--- a/optuna/integration/tensorboard.py
+++ b/optuna/integration/tensorboard.py
@@ -34,7 +34,7 @@ class TensorBoardCallback(object):
         _imports.check()
         self._dirname = dirname
         self._metric_name = metric_name
-        self._hp_params = dict()  # type: Dict[str, hp.HParam]
+        self._hp_params: Dict[str, hp.HParam] = dict()
 
     def __call__(self, study: optuna.study.Study, trial: optuna.trial.FrozenTrial) -> None:
         if len(self._hp_params) == 0:

--- a/optuna/multi_objective/samplers/_nsga2.py
+++ b/optuna/multi_objective/samplers/_nsga2.py
@@ -184,7 +184,7 @@ class NSGAIIMultiObjectiveSampler(BaseMultiObjectiveSampler):
             generation_to_population[generation].append(trial)
 
         hasher = hashlib.sha256()
-        parent_population = []  # type: List[multi_objective.trial.FrozenMultiObjectiveTrial]
+        parent_population: List[multi_objective.trial.FrozenMultiObjectiveTrial] = []
         parent_generation = -1
         while True:
             generation = parent_generation + 1
@@ -242,7 +242,7 @@ class NSGAIIMultiObjectiveSampler(BaseMultiObjectiveSampler):
         study: "multi_objective.study.MultiObjectiveStudy",
         population: List["multi_objective.trial.FrozenMultiObjectiveTrial"],
     ) -> List["multi_objective.trial.FrozenMultiObjectiveTrial"]:
-        elite_population = []  # type: List[multi_objective.trial.FrozenMultiObjectiveTrial]
+        elite_population: List[multi_objective.trial.FrozenMultiObjectiveTrial] = []
         population_per_rank = _fast_non_dominated_sort(population, study.directions)
         for population in population_per_rank:
             if len(elite_population) + len(population) < self._population_size:
@@ -275,7 +275,7 @@ def _fast_non_dominated_sort(
     population: List["multi_objective.trial.FrozenMultiObjectiveTrial"],
     directions: List[optuna.study.StudyDirection],
 ) -> List[List["multi_objective.trial.FrozenMultiObjectiveTrial"]]:
-    dominated_count = defaultdict(int)  # type: DefaultDict[int, int]
+    dominated_count: DefaultDict[int, int] = defaultdict(int)
     dominates_list = defaultdict(list)
 
     for p, q in itertools.combinations(population, 2):

--- a/optuna/multi_objective/trial.py
+++ b/optuna/multi_objective/trial.py
@@ -278,7 +278,7 @@ class FrozenMultiObjectiveTrial(object):
 
         self.values = tuple(trial.intermediate_values.get(i) for i in range(n_objectives))
 
-        intermediate_values = {}  # type: Dict[int, List[Optional[float]]]
+        intermediate_values: Dict[int, List[Optional[float]]] = {}
         for key, value in trial.intermediate_values.items():
             if key < n_objectives:
                 continue

--- a/optuna/progress_bar.py
+++ b/optuna/progress_bar.py
@@ -8,7 +8,7 @@ from optuna import logging as optuna_logging
 from optuna._experimental import experimental
 
 
-_tqdm_handler = None  # type: Optional[_TqdmLoggingHandler]
+_tqdm_handler: Optional[_TqdmLoggingHandler] = None
 
 
 # Reference: https://gist.github.com/hvy/8b80c2cedf02b15c24f85d1fa17ebe02

--- a/optuna/progress_bar.py
+++ b/optuna/progress_bar.py
@@ -8,7 +8,7 @@ from optuna import logging as optuna_logging
 from optuna._experimental import experimental
 
 
-_tqdm_handler: Optional[_TqdmLoggingHandler] = None
+_tqdm_handler: Optional["_TqdmLoggingHandler"] = None
 
 
 # Reference: https://gist.github.com/hvy/8b80c2cedf02b15c24f85d1fa17ebe02

--- a/optuna/pruners/__init__.py
+++ b/optuna/pruners/__init__.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 def _filter_study(study: "Study", trial: "FrozenTrial") -> "Study":
     if isinstance(study.pruner, HyperbandPruner):
         # Create `_BracketStudy` to use trials that have the same bracket id.
-        pruner = study.pruner  # type: HyperbandPruner
+        pruner: HyperbandPruner = study.pruner
         return pruner._create_bracket_study(study, pruner._get_bracket_id(study, trial))
     else:
         return study

--- a/optuna/pruners/_hyperband.py
+++ b/optuna/pruners/_hyperband.py
@@ -141,10 +141,10 @@ class HyperbandPruner(BasePruner):
         self._min_resource = min_resource
         self._max_resource = max_resource
         self._reduction_factor = reduction_factor
-        self._pruners = []  # type: List[SuccessiveHalvingPruner]
+        self._pruners: List[SuccessiveHalvingPruner] = []
         self._total_trial_allocation_budget = 0
-        self._trial_allocation_budgets = []  # type: List[int]
-        self._n_brackets = None  # type: Optional[int]
+        self._trial_allocation_budgets: List[int] = []
+        self._n_brackets: Optional[int] = None
 
         if not isinstance(self._max_resource, int) and self._max_resource != "auto":
             raise ValueError(

--- a/optuna/pruners/_successive_halving.py
+++ b/optuna/pruners/_successive_halving.py
@@ -137,7 +137,7 @@ class SuccessiveHalvingPruner(BasePruner):
                 "but must be `min_early_stopping_rate >= 0`".format(min_early_stopping_rate)
             )
 
-        self._min_resource = None  # type: Optional[int]
+        self._min_resource: Optional[int] = None
         if isinstance(min_resource, int):
             self._min_resource = min_resource
         self._reduction_factor = reduction_factor
@@ -151,7 +151,7 @@ class SuccessiveHalvingPruner(BasePruner):
 
         rung = _get_current_rung(trial)
         value = trial.intermediate_values[step]
-        trials = None  # type: Optional[List["optuna.trial.FrozenTrial"]]
+        trials: Optional[List["optuna.trial.FrozenTrial"]] = None
 
         while True:
             if self._min_resource is None:

--- a/optuna/samplers/_cmaes.py
+++ b/optuna/samplers/_cmaes.py
@@ -200,7 +200,7 @@ class CmaEsSampler(BaseSampler):
     def infer_relative_search_space(
         self, study: "optuna.Study", trial: "optuna.trial.FrozenTrial"
     ) -> Dict[str, BaseDistribution]:
-        search_space = {}  # type: Dict[str, BaseDistribution]
+        search_space: Dict[str, BaseDistribution] = {}
         for name, distribution in self._search_space.calculate(study).items():
             if distribution.single():
                 # `cma` cannot handle distributions that contain just a single value, so we skip
@@ -280,7 +280,7 @@ class CmaEsSampler(BaseSampler):
             if optimizer.generation == t.system_attrs.get(generation_attr_key, -1)
         ]
         if len(solution_trials) >= optimizer.population_size:
-            solutions = []  # type: List[Tuple[np.ndarray, float]]
+            solutions: List[Tuple[np.ndarray, float]] = []
             for t in solution_trials[: optimizer.population_size]:
                 assert t.value is not None, "completed trials must have a value"
                 x = np.array(
@@ -339,7 +339,7 @@ class CmaEsSampler(BaseSampler):
             if optimizer_str is None:
                 optimizer_str = _concat_optimizer_attrs(optimizer_attrs)
 
-            n_restarts = trial.system_attrs.get("cma:n_restarts", 0)  # type: int
+            n_restarts: int = trial.system_attrs.get("cma:n_restarts", 0)
             return pickle.loads(bytes.fromhex(optimizer_str)), n_restarts
         return None, 0
 

--- a/optuna/samplers/_search_space.py
+++ b/optuna/samplers/_search_space.py
@@ -23,9 +23,9 @@ class IntersectionSearchSpace(object):
     """
 
     def __init__(self) -> None:
-        self._cursor = -1  # type: int
-        self._search_space = None  # type: Optional[Dict[str, BaseDistribution]]
-        self._study_id = None  # type: Optional[int]
+        self._cursor: int = -1
+        self._search_space: Optional[Dict[str, BaseDistribution]] = None
+        self._study_id: Optional[int] = None
 
     def calculate(
         self, study: BaseStudy, ordered_dict: bool = False

--- a/optuna/samplers/_tpe/multivariate_parzen_estimator.py
+++ b/optuna/samplers/_tpe/multivariate_parzen_estimator.py
@@ -44,9 +44,9 @@ class _MultivariateParzenEstimator:
         self._n_observations = next(iter(multivariate_observations.values())).size
         self._weights = self._calculate_weights()
 
-        self._low = {}  # type: Dict[str, Optional[float]]
-        self._high = {}  # type: Dict[str, Optional[float]]
-        self._q = {}  # type: Dict[str, Optional[float]]
+        self._low: Dict[str, Optional[float]] = {}
+        self._high: Dict[str, Optional[float]] = {}
+        self._q: Dict[str, Optional[float]] = {}
         for param_name, dist in search_space.items():
             if isinstance(dist, distributions.CategoricalDistribution):
                 low = high = q = None
@@ -62,9 +62,9 @@ class _MultivariateParzenEstimator:
         # Transformed `multivariate_observations` might be needed for following operations.
         self._sigmas0 = self._precompute_sigmas0(multivariate_observations)
 
-        self._mus = {}  # type: Dict[str, Optional[np.ndarray]]
-        self._sigmas = {}  # type: Dict[str, Optional[np.ndarray]]
-        self._categorical_weights = {}  # type: Dict[str, Optional[np.ndarray]]
+        self._mus: Dict[str, Optional[np.ndarray]] = {}
+        self._sigmas: Dict[str, Optional[np.ndarray]] = {}
+        self._categorical_weights: Dict[str, Optional[np.ndarray]] = {}
         for param_name, dist in search_space.items():
             observations = multivariate_observations[param_name]
             if isinstance(dist, distributions.CategoricalDistribution):

--- a/optuna/samplers/_tpe/parzen_estimator.py
+++ b/optuna/samplers/_tpe/parzen_estimator.py
@@ -77,7 +77,7 @@ class _ParzenEstimator(object):
                 sorted_mus[0] = prior_mu
                 sigma = numpy.asarray([prior_sigma])
                 prior_pos = 0
-                order = []  # type: List[int]
+                order: List[int] = []
             else:  # When mus.size is greater than 0.
                 # We decide the place of the  prior.
                 order = numpy.argsort(mus).astype(int)

--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -203,7 +203,7 @@ class TPESampler(BaseSampler):
         if not self._multivariate:
             return {}
 
-        search_space = {}  # type: Dict[str, BaseDistribution]
+        search_space: Dict[str, BaseDistribution] = {}
         for name, distribution in self._search_space.calculate(study).items():
             if not isinstance(distribution, _DISTRIBUTION_CLASSES):
                 if self._warn_independent_sampling:
@@ -780,7 +780,7 @@ def _get_observation_pairs(
         else:
             continue
 
-        param_value = None  # type: Optional[float]
+        param_value: Optional[float] = None
         if param_name in trial.params:
             distribution = trial.distributions[param_name]
             param_value = distribution.to_internal_repr(trial.params[param_name])
@@ -800,9 +800,9 @@ def _get_multivariate_observation_pairs(
         sign = -1
 
     scores = []
-    values = {
+    values: Dict[str, List[Optional[float]]] = {
         param_name: [] for param_name in param_names
-    }  # type: Dict[str, List[Optional[float]]]
+    }
     for trial in study._storage.get_all_trials(study._study_id, deepcopy=False):
 
         # We extract score from the trial.

--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -800,9 +800,7 @@ def _get_multivariate_observation_pairs(
         sign = -1
 
     scores = []
-    values: Dict[str, List[Optional[float]]] = {
-        param_name: [] for param_name in param_names
-    }
+    values: Dict[str, List[Optional[float]]] = {param_name: [] for param_name in param_names}
     for trial in study._storage.get_all_trials(study._study_id, deepcopy=False):
 
         # We extract score from the trial.

--- a/optuna/storages/_cached_storage.py
+++ b/optuna/storages/_cached_storage.py
@@ -19,28 +19,28 @@ from optuna.trial import TrialState
 
 class _TrialUpdate:
     def __init__(self) -> None:
-        self.state = None  # type: Optional[TrialState]
-        self.value = None  # type: Optional[float]
-        self.intermediate_values = dict()  # type: Dict[int, float]
-        self.user_attrs = dict()  # type: Dict[str, Any]
-        self.system_attrs = dict()  # type: Dict[str, Any]
-        self.params = dict()  # type: Dict[str, Any]
-        self.distributions = dict()  # type: Dict[str, distributions.BaseDistribution]
-        self.datetime_complete = None  # type: Optional[datetime.datetime]
+        self.state: Optional[TrialState] = None
+        self.value: Optional[float] = None
+        self.intermediate_values: Dict[int, float] = dict()
+        self.user_attrs: Dict[str, Any] = dict()
+        self.system_attrs: Dict[str, Any] = dict()
+        self.params: Dict[str, Any] = dict()
+        self.distributions: Dict[str, distributions.BaseDistribution] = dict()
+        self.datetime_complete: Optional[datetime.datetime] = None
 
 
 class _StudyInfo:
     def __init__(self) -> None:
         # Trial number to corresponding FrozenTrial.
-        self.trials = {}  # type: Dict[int, FrozenTrial]
+        self.trials: Dict[int, FrozenTrial] = {}
         # A list of trials which do not require storage access to read latest attributes.
-        self.owned_or_finished_trial_ids = set()  # type: Set[int]
+        self.owned_or_finished_trial_ids: Set[int] = set()
         # Cache any writes which are not reflected to the actual storage yet in updates.
-        self.updates = dict()  # type: Dict[int, _TrialUpdate]
+        self.updates: Dict[int, _TrialUpdate] = dict()
         # Cache distributions to avoid storage access on distribution consistency check.
-        self.param_distribution = {}  # type: Dict[str, distributions.BaseDistribution]
-        self.direction = StudyDirection.NOT_SET  # type: StudyDirection
-        self.name = None  # type: Optional[str]
+        self.param_distribution: Dict[str, distributions.BaseDistribution] = {}
+        self.direction: StudyDirection = StudyDirection.NOT_SET
+        self.name: Optional[str] = None
 
 
 class _CachedStorage(BaseStorage):
@@ -56,8 +56,8 @@ class _CachedStorage(BaseStorage):
 
     def __init__(self, backend: RDBStorage) -> None:
         self._backend = backend
-        self._studies = {}  # type: Dict[int, _StudyInfo]
-        self._trial_id_to_study_id_and_number = dict()  # type: Dict[int, Tuple[int, int]]
+        self._studies: Dict[int, _StudyInfo] = {}
+        self._trial_id_to_study_id_and_number: Dict[int, Tuple[int, int]] = dict()
         self._lock = threading.Lock()
 
     def __getstate__(self) -> Dict[Any, Any]:

--- a/optuna/storages/_in_memory.py
+++ b/optuna/storages/_in_memory.py
@@ -29,9 +29,9 @@ class InMemoryStorage(BaseStorage):
     """
 
     def __init__(self) -> None:
-        self._trial_id_to_study_id_and_number = {}  # type: Dict[int, Tuple[int, int]]
-        self._study_name_to_id = {}  # type: Dict[str, int]
-        self._studies = {}  # type: Dict[int, _StudyInfo]
+        self._trial_id_to_study_id_and_number: Dict[int, Tuple[int, int]] = {}
+        self._study_name_to_id: Dict[str, int] = {}
+        self._studies: Dict[int, _StudyInfo] = {}
 
         self._max_study_id = -1
         self._max_trial_id = -1
@@ -414,10 +414,10 @@ class InMemoryStorage(BaseStorage):
 
 class _StudyInfo:
     def __init__(self, name: str) -> None:
-        self.trials = []  # type: List[FrozenTrial]
-        self.param_distribution = {}  # type: Dict[str, distributions.BaseDistribution]
-        self.user_attrs = {}  # type: Dict[str, Any]
-        self.system_attrs = {}  # type: Dict[str, Any]
-        self.name = name  # type: str
+        self.trials: List[FrozenTrial] = []
+        self.param_distribution: Dict[str, distributions.BaseDistribution] = {}
+        self.user_attrs: Dict[str, Any] = {}
+        self.system_attrs: Dict[str, Any] = {}
+        self.name: str = name
         self.direction = StudyDirection.NOT_SET
-        self.best_trial_id = None  # type: Optional[int]
+        self.best_trial_id: Optional[int] = None

--- a/optuna/storages/_rdb/models.py
+++ b/optuna/storages/_rdb/models.py
@@ -33,7 +33,7 @@ MAX_VERSION_LENGTH = 256
 
 NOT_FOUND_MSG = "Record does not exist."
 
-BaseModel = declarative_base()  # type: Any
+BaseModel: Any = declarative_base()
 
 
 class StudyModel(BaseModel):
@@ -89,7 +89,7 @@ class StudyModel(BaseModel):
 
 class StudyUserAttributeModel(BaseModel):
     __tablename__ = "study_user_attributes"
-    __table_args__ = (UniqueConstraint("study_id", "key"),)  # type: Any
+    __table_args__: Any = (UniqueConstraint("study_id", "key"),)
     study_user_attribute_id = Column(Integer, primary_key=True)
     study_id = Column(Integer, ForeignKey("studies.study_id"))
     key = Column(String(MAX_INDEXED_STRING_LENGTH))
@@ -123,7 +123,7 @@ class StudyUserAttributeModel(BaseModel):
 
 class StudySystemAttributeModel(BaseModel):
     __tablename__ = "study_system_attributes"
-    __table_args__ = (UniqueConstraint("study_id", "key"),)  # type: Any
+    __table_args__: Any = (UniqueConstraint("study_id", "key"),)
     study_system_attribute_id = Column(Integer, primary_key=True)
     study_id = Column(Integer, ForeignKey("studies.study_id"))
     key = Column(String(MAX_INDEXED_STRING_LENGTH))
@@ -277,7 +277,7 @@ class TrialModel(BaseModel):
 
 class TrialUserAttributeModel(BaseModel):
     __tablename__ = "trial_user_attributes"
-    __table_args__ = (UniqueConstraint("trial_id", "key"),)  # type: Any
+    __table_args__: Any = (UniqueConstraint("trial_id", "key"),)
     trial_user_attribute_id = Column(Integer, primary_key=True)
     trial_id = Column(Integer, ForeignKey("trials.trial_id"))
     key = Column(String(MAX_INDEXED_STRING_LENGTH))
@@ -334,7 +334,7 @@ class TrialUserAttributeModel(BaseModel):
 
 class TrialSystemAttributeModel(BaseModel):
     __tablename__ = "trial_system_attributes"
-    __table_args__ = (UniqueConstraint("trial_id", "key"),)  # type: Any
+    __table_args__: Any = (UniqueConstraint("trial_id", "key"),)
     trial_system_attribute_id = Column(Integer, primary_key=True)
     trial_id = Column(Integer, ForeignKey("trials.trial_id"))
     key = Column(String(MAX_INDEXED_STRING_LENGTH))
@@ -391,7 +391,7 @@ class TrialSystemAttributeModel(BaseModel):
 
 class TrialParamModel(BaseModel):
     __tablename__ = "trial_params"
-    __table_args__ = (UniqueConstraint("trial_id", "param_name"),)  # type: Any
+    __table_args__: Any = (UniqueConstraint("trial_id", "param_name"),)
     param_id = Column(Integer, primary_key=True)
     trial_id = Column(Integer, ForeignKey("trials.trial_id"))
     param_name = Column(String(MAX_INDEXED_STRING_LENGTH))
@@ -476,7 +476,7 @@ class TrialParamModel(BaseModel):
 
 class TrialValueModel(BaseModel):
     __tablename__ = "trial_values"
-    __table_args__ = (UniqueConstraint("trial_id", "step"),)  # type: Any
+    __table_args__: Any = (UniqueConstraint("trial_id", "step"),)
     trial_value_id = Column(Integer, primary_key=True)
     trial_id = Column(Integer, ForeignKey("trials.trial_id"))
     step = Column(Integer)
@@ -525,7 +525,7 @@ class TrialValueModel(BaseModel):
 class VersionInfoModel(BaseModel):
     __tablename__ = "version_info"
     # setting check constraint to ensure the number of rows is at most 1
-    __table_args__ = (CheckConstraint("version_info_id=1"),)  # type: Any
+    __table_args__: Any = (CheckConstraint("version_info_id=1"),)
     version_info_id = Column(Integer, primary_key=True, autoincrement=False, default=1)
     schema_version = Column(Integer)
     library_version = Column(String(MAX_VERSION_LENGTH))

--- a/optuna/storages/_rdb/storage.py
+++ b/optuna/storages/_rdb/storage.py
@@ -355,14 +355,14 @@ class RDBStorage(BaseStorage):
         study_summary = study_summary_stmt.all()
         study_summaries = []
         for study in study_summary:
-            best_trial = None  # type: Optional[models.TrialModel]
+            best_trial: Optional[models.TrialModel] = None
             try:
                 if study.direction == StudyDirection.MAXIMIZE:
                     best_trial = models.TrialModel.find_max_value_trial(study.study_id, session)
                 else:
                     best_trial = models.TrialModel.find_min_value_trial(study.study_id, session)
             except ValueError:
-                best_trial_frozen = None  # type: Optional[FrozenTrial]
+                best_trial_frozen: Optional[FrozenTrial] = None
             if best_trial:
                 params = (
                     session.query(

--- a/optuna/testing/sampler.py
+++ b/optuna/testing/sampler.py
@@ -38,7 +38,7 @@ class DeterministicRelativeSampler(optuna.samplers.BaseSampler):
     ) -> Any:
 
         if isinstance(param_distribution, distributions.UniformDistribution):
-            param_value = param_distribution.low  # type: Any
+            param_value: Any = param_distribution.low
         elif isinstance(param_distribution, distributions.LogUniformDistribution):
             param_value = param_distribution.low
         elif isinstance(param_distribution, distributions.DiscreteUniformDistribution):

--- a/optuna/testing/storage.py
+++ b/optuna/testing/storage.py
@@ -17,7 +17,7 @@ class StorageSupplier(object):
     def __init__(self, storage_specifier: str) -> None:
 
         self.storage_specifier = storage_specifier
-        self.tempfile = None  # type: Optional[IO[Any]]
+        self.tempfile: Optional[IO[Any]] = None
 
     def __enter__(self) -> optuna.storages.BaseStorage:
 

--- a/optuna/trial/_fixed.py
+++ b/optuna/trial/_fixed.py
@@ -106,9 +106,9 @@ class FixedTrial(BaseTrial):
                     "The specified `step` is {}.".format(step)
                 )
             else:
-                distribution: Union[IntUniformDistribution, IntLogUniformDistribution] = IntUniformDistribution(
-                    low=low, high=high, step=step
-                )
+                distribution: Union[
+                    IntUniformDistribution, IntLogUniformDistribution
+                ] = IntUniformDistribution(low=low, high=high, step=step)
         else:
             if log:
                 distribution = IntLogUniformDistribution(low=low, high=high)

--- a/optuna/trial/_fixed.py
+++ b/optuna/trial/_fixed.py
@@ -58,10 +58,10 @@ class FixedTrial(BaseTrial):
     def __init__(self, params: Dict[str, Any], number: int = 0) -> None:
 
         self._params = params
-        self._suggested_params = {}  # type: Dict[str, Any]
-        self._distributions = {}  # type: Dict[str, BaseDistribution]
-        self._user_attrs = {}  # type: Dict[str, Any]
-        self._system_attrs = {}  # type: Dict[str, Any]
+        self._suggested_params: Dict[str, Any] = {}
+        self._distributions: Dict[str, BaseDistribution] = {}
+        self._user_attrs: Dict[str, Any] = {}
+        self._system_attrs: Dict[str, Any] = {}
         self._datetime_start = datetime.datetime.now()
         self._number = number
 
@@ -106,9 +106,9 @@ class FixedTrial(BaseTrial):
                     "The specified `step` is {}.".format(step)
                 )
             else:
-                distribution = IntUniformDistribution(
+                distribution: Union[IntUniformDistribution, IntLogUniformDistribution] = IntUniformDistribution(
                     low=low, high=high, step=step
-                )  # type: Union[IntUniformDistribution, IntLogUniformDistribution]
+                )
         else:
             if log:
                 distribution = IntLogUniformDistribution(low=low, high=high)

--- a/optuna/trial/_frozen.py
+++ b/optuna/trial/_frozen.py
@@ -239,9 +239,9 @@ class FrozenTrial(BaseTrial):
                     "The specified `step` is {}.".format(step)
                 )
             else:
-                distribution = IntUniformDistribution(
+                distribution: Union[IntUniformDistribution, IntLogUniformDistribution] = IntUniformDistribution(
                     low=low, high=high, step=step
-                )  # type: Union[IntUniformDistribution, IntLogUniformDistribution]
+                )
         else:
             if log:
                 distribution = IntLogUniformDistribution(low=low, high=high)
@@ -517,7 +517,7 @@ def create_trial(
 
     datetime_start = datetime.datetime.now()
     if state.is_finished():
-        datetime_complete = datetime_start  # type: Optional[datetime.datetime]
+        datetime_complete: Optional[datetime.datetime] = datetime_start
     else:
         datetime_complete = None
 

--- a/optuna/trial/_frozen.py
+++ b/optuna/trial/_frozen.py
@@ -239,9 +239,9 @@ class FrozenTrial(BaseTrial):
                     "The specified `step` is {}.".format(step)
                 )
             else:
-                distribution: Union[IntUniformDistribution, IntLogUniformDistribution] = IntUniformDistribution(
-                    low=low, high=high, step=step
-                )
+                distribution: Union[
+                    IntUniformDistribution, IntLogUniformDistribution
+                ] = IntUniformDistribution(low=low, high=high, step=step)
         else:
             if log:
                 distribution = IntLogUniformDistribution(low=low, high=high)

--- a/optuna/trial/_trial.py
+++ b/optuna/trial/_trial.py
@@ -432,9 +432,9 @@ class Trial(BaseTrial):
                     "The specified `step` is {}.".format(step)
                 )
             else:
-                distribution: Union[IntUniformDistribution, IntLogUniformDistribution] = IntUniformDistribution(
-                    low=low, high=high, step=step
-                )
+                distribution: Union[
+                    IntUniformDistribution, IntLogUniformDistribution
+                ] = IntUniformDistribution(low=low, high=high, step=step)
         else:
             if log:
                 distribution = IntLogUniformDistribution(low=low, high=high)

--- a/optuna/trial/_trial.py
+++ b/optuna/trial/_trial.py
@@ -432,9 +432,9 @@ class Trial(BaseTrial):
                     "The specified `step` is {}.".format(step)
                 )
             else:
-                distribution = IntUniformDistribution(
+                distribution: Union[IntUniformDistribution, IntLogUniformDistribution] = IntUniformDistribution(
                     low=low, high=high, step=step
-                )  # type: Union[IntUniformDistribution, IntLogUniformDistribution]
+                )
         else:
             if log:
                 distribution = IntLogUniformDistribution(low=low, high=high)

--- a/optuna/visualization/_parallel_coordinate.py
+++ b/optuna/visualization/_parallel_coordinate.py
@@ -82,13 +82,13 @@ def _get_parallel_coordinate_plot(study: Study, params: Optional[List[str]] = No
         all_params = set(params)
     sorted_params = sorted(list(all_params))
 
-    dims = [
+    dims: List[Dict[str, Any]] = [
         {
             "label": "Objective Value",
             "values": tuple([t.value for t in trials]),
             "range": (min([t.value for t in trials]), max([t.value for t in trials])),
         }
-    ]  # type: List[Dict[str, Any]]
+    ]
     for p_name in sorted_params:
         values = []
         for t in trials:
@@ -98,7 +98,7 @@ def _get_parallel_coordinate_plot(study: Study, params: Optional[List[str]] = No
         try:
             tuple(map(float, values))
         except (TypeError, ValueError):
-            vocab = defaultdict(lambda: len(vocab))  # type: DefaultDict[str, int]
+            vocab: DefaultDict[str, int] = defaultdict(lambda: len(vocab))
             values = [vocab[v] for v in values]
             is_categorical = True
         dim = {

--- a/tests/importance_tests/fanova_tests/test_tree.py
+++ b/tests/importance_tests/fanova_tests/test_tree.py
@@ -207,7 +207,7 @@ def test_tree_split_sizes(tree: _FanovaTree, node_index: NodeIndex, expected: Li
 def test_tree_subtree_active_features(
     tree: _FanovaTree, node_index: NodeIndex, expected: List[bool]
 ) -> None:
-    active_features = tree._subtree_active_features[node_index] == expected  # type: numpy.ndarray
+    active_features: numpy.ndarray = tree._subtree_active_features[node_index] == expected
     assert active_features.all()
 
 

--- a/tests/integration_tests/lightgbm_tuner_tests/test_optimize.py
+++ b/tests/integration_tests/lightgbm_tuner_tests/test_optimize.py
@@ -69,7 +69,7 @@ class TestOptunaObjective(object):
     def test_call(self) -> None:
 
         target_param_names = ["lambda_l1"]
-        lgbm_params = {}  # type: Dict[str, Any]
+        lgbm_params: Dict[str, Any] = {}
         train_set = lgb.Dataset(None)
         val_set = lgb.Dataset(None)
 
@@ -95,9 +95,9 @@ class TestOptunaObjective(object):
 class TestOptunaObjectiveCV(object):
     def test_call(self) -> None:
         target_param_names = ["lambda_l1"]
-        lgbm_params = {}  # type: Dict[str, Any]
+        lgbm_params: Dict[str, Any] = {}
         train_set = lgb.Dataset(None)
-        lgbm_kwargs = {}  # type: Dict[str, Any]
+        lgbm_kwargs: Dict[str, Any] = {}
         best_score = -np.inf
 
         with turnoff_cv():
@@ -245,7 +245,7 @@ class TestBaseTuner(object):
         self, metric: str, eval_at_param: Dict[str, Union[int, List[int]]], expected: str
     ) -> None:
 
-        params = {"metric": metric}  # type: Dict[str, Union[str, int, List[int]]]
+        params: Dict[str, Union[str, int, List[int]]] = {"metric": metric}
         params.update(eval_at_param)
         tuner = _BaseTuner(lgbm_params=params)
         assert tuner._metric_with_eval_at(metric) == expected
@@ -285,7 +285,7 @@ class TestLightGBMTuner(object):
 
     def test_no_eval_set_args(self) -> None:
 
-        params = {}  # type: Dict[str, Any]
+        params: Dict[str, Any] = {}
         train_set = lgb.Dataset(None)
         with pytest.raises(ValueError) as excinfo:
             lgb.LightGBMTuner(params, train_set, num_boost_round=5, early_stopping_rounds=2)
@@ -303,7 +303,7 @@ class TestLightGBMTuner(object):
     )
     def test_inconsistent_study_direction(self, metric: str, study_direction: str) -> None:
 
-        params = {}  # type: Dict[str, Any]
+        params: Dict[str, Any] = {}
         if metric is not None:
             params["metric"] = metric
         train_set = lgb.Dataset(None)
@@ -331,7 +331,7 @@ class TestLightGBMTuner(object):
 
     def test__parse_args_wrapper_args(self) -> None:
 
-        params = {}  # type: Dict[str, Any]
+        params: Dict[str, Any] = {}
         train_set = lgb.Dataset(None)
         val_set = lgb.Dataset(None)
         kwargs = dict(
@@ -436,10 +436,10 @@ class TestLightGBMTuner(object):
 
     def test_tune_num_leaves_negative_max_depth(self) -> None:
 
-        params = {
+        params: Dict[str, Any] = {
             "metric": "binary_logloss",
             "max_depth": -1,
-        }  # type: Dict[str, Any]
+        }
         X_trn = np.random.uniform(10, size=(10, 5))
         y_trn = np.random.randint(2, size=10)
         train_dataset = lgb.Dataset(X_trn, label=y_trn)
@@ -511,7 +511,7 @@ class TestLightGBMTuner(object):
 
     def test_when_a_step_does_not_improve_best_score(self) -> None:
 
-        params = {}  # type: Dict
+        params: Dict = {}
         valid_data = np.zeros((10, 10))
         valid_sets = lgb.Dataset(valid_data)
 
@@ -533,7 +533,7 @@ class TestLightGBMTuner(object):
             tuner.tune_num_leaves()
 
     def test_resume_run(self) -> None:
-        params = {"verbose": -1}  # type: Dict
+        params: Dict = {"verbose": -1}
         dataset = lgb.Dataset(np.zeros((10, 10)))
 
         study = optuna.create_study()
@@ -566,7 +566,7 @@ class TestLightGBMTuner(object):
         optuna.logging._reset_library_root_logger()
         optuna.logging.set_verbosity(optuna.logging.INFO)
 
-        params = {"verbose": -1}  # type: Dict
+        params: Dict = {"verbose": -1}
         dataset = lgb.Dataset(np.zeros((10, 10)))
 
         study = optuna.create_study()
@@ -589,7 +589,7 @@ class TestLightGBMTuner(object):
 
     @pytest.mark.parametrize("show_progress_bar, expected", [(True, 6), (False, 0)])
     def test_run_show_progress_bar(self, show_progress_bar: bool, expected: int) -> None:
-        params = {"verbose": -1}  # type: Dict
+        params: Dict = {"verbose": -1}
         dataset = lgb.Dataset(np.zeros((10, 10)))
 
         study = optuna.create_study()
@@ -612,7 +612,7 @@ class TestLightGBMTuner(object):
     def test_get_best_booster(self) -> None:
         unexpected_value = 20  # out of scope.
 
-        params = {"verbose": -1, "lambda_l1": unexpected_value}  # type: Dict
+        params: Dict = {"verbose": -1, "lambda_l1": unexpected_value}
         dataset = lgb.Dataset(np.zeros((10, 10)))
 
         study = optuna.create_study()
@@ -638,7 +638,7 @@ class TestLightGBMTuner(object):
             tuner2.get_best_booster()
 
     def test_best_booster_with_model_dir(self) -> None:
-        params = {"verbose": -1}  # type: Dict
+        params: Dict = {"verbose": -1}
         dataset = lgb.Dataset(np.zeros((10, 10)))
 
         study = optuna.create_study()
@@ -697,7 +697,7 @@ class TestLightGBMTuner(object):
         assert study.best_trial.value == overall_best
 
     def test_optuna_callback(self) -> None:
-        params = {"verbose": -1}  # type: Dict[str, Any]
+        params: Dict[str, Any] = {"verbose": -1}
         dataset = lgb.Dataset(np.zeros((10, 10)))
 
         callback_mock = mock.MagicMock()
@@ -723,9 +723,9 @@ class TestLightGBMTunerCV(object):
     ) -> LightGBMTunerCV:
 
         # Required keyword arguments.
-        kwargs = dict(
+        kwargs: Dict[str, Any] = dict(
             num_boost_round=5, early_stopping_rounds=2, study=study
-        )  # type: Dict[str, Any]
+        )
         kwargs.update(kwargs_options)
 
         runner = LightGBMTunerCV(params, train_set, **kwargs)
@@ -747,7 +747,7 @@ class TestLightGBMTunerCV(object):
     )
     def test_inconsistent_study_direction(self, metric: str, study_direction: str) -> None:
 
-        params = {}  # type: Dict[str, Any]
+        params: Dict[str, Any] = {}
         if metric is not None:
             params["metric"] = metric
         train_set = lgb.Dataset(None)
@@ -844,7 +844,7 @@ class TestLightGBMTunerCV(object):
             assert len(runner.study.trials) == 5
 
     def test_resume_run(self) -> None:
-        params = {"verbose": -1}  # type: Dict
+        params: Dict = {"verbose": -1}
         dataset = lgb.Dataset(np.zeros((10, 10)))
 
         study = optuna.create_study()
@@ -877,7 +877,7 @@ class TestLightGBMTunerCV(object):
         optuna.logging._reset_library_root_logger()
         optuna.logging.set_verbosity(optuna.logging.INFO)
 
-        params = {"verbose": -1}  # type: Dict
+        params: Dict = {"verbose": -1}
         dataset = lgb.Dataset(np.zeros((10, 10)))
 
         study = optuna.create_study()
@@ -895,7 +895,7 @@ class TestLightGBMTunerCV(object):
 
     @pytest.mark.parametrize("show_progress_bar, expected", [(True, 6), (False, 0)])
     def test_run_show_progress_bar(self, show_progress_bar: bool, expected: int) -> None:
-        params = {"verbose": -1}  # type: Dict
+        params: Dict = {"verbose": -1}
         dataset = lgb.Dataset(np.zeros((10, 10)))
 
         study = optuna.create_study()
@@ -911,7 +911,7 @@ class TestLightGBMTunerCV(object):
         assert mock_tqdm.call_count == expected
 
     def test_optuna_callback(self) -> None:
-        params = {"verbose": -1}  # type: Dict[str, Any]
+        params: Dict[str, Any] = {"verbose": -1}
         dataset = lgb.Dataset(np.zeros((10, 10)))
 
         callback_mock = mock.MagicMock()
@@ -927,7 +927,7 @@ class TestLightGBMTunerCV(object):
     def test_get_best_booster(self) -> None:
         unexpected_value = 20  # out of scope.
 
-        params = {"verbose": -1, "lambda_l1": unexpected_value}  # type: Dict
+        params: Dict = {"verbose": -1, "lambda_l1": unexpected_value}
         dataset = lgb.Dataset(np.zeros((10, 10)))
         study = optuna.create_study()
 
@@ -954,7 +954,7 @@ class TestLightGBMTunerCV(object):
                 assert booster.params == booster2.params
 
     def test_get_best_booster_with_error(self) -> None:
-        params = {"verbose": -1}  # type: Dict
+        params: Dict = {"verbose": -1}
         dataset = lgb.Dataset(np.zeros((10, 10)))
         study = optuna.create_study()
 

--- a/tests/integration_tests/lightgbm_tuner_tests/test_optimize.py
+++ b/tests/integration_tests/lightgbm_tuner_tests/test_optimize.py
@@ -723,9 +723,7 @@ class TestLightGBMTunerCV(object):
     ) -> LightGBMTunerCV:
 
         # Required keyword arguments.
-        kwargs: Dict[str, Any] = dict(
-            num_boost_round=5, early_stopping_rounds=2, study=study
-        )
+        kwargs: Dict[str, Any] = dict(num_boost_round=5, early_stopping_rounds=2, study=study)
         kwargs.update(kwargs_options)
 
         runner = LightGBMTunerCV(params, train_set, **kwargs)

--- a/tests/integration_tests/test_chainermn.py
+++ b/tests/integration_tests/test_chainermn.py
@@ -43,7 +43,7 @@ PRUNER_INIT_FUNCS = [lambda: pruners.MedianPruner(), lambda: pruners.SuccessiveH
 class Func(object):
     def __init__(self) -> None:
 
-        self.suggested_values = {}  # type: Dict[int, Dict[str, Any]]
+        self.suggested_values: Dict[int, Dict[str, Any]] = {}
 
     def __call__(self, trial: ChainerMNTrial, comm: CommunicatorBase) -> float:
 
@@ -64,7 +64,7 @@ class MultiNodeStorageSupplier(StorageSupplier):
 
         super(MultiNodeStorageSupplier, self).__init__(storage_specifier)
         self.comm = comm
-        self.storage = None  # type: Optional[RDBStorage]
+        self.storage: Optional[RDBStorage] = None
 
     def __enter__(self) -> RDBStorage:
 

--- a/tests/samplers_tests/test_cmaes.py
+++ b/tests/samplers_tests/test_cmaes.py
@@ -246,7 +246,7 @@ def test_restore_optimizer_from_substrings() -> None:
     optimizer = CMA(np.zeros(10), sigma=1.3)
     optimizer_str = pickle.dumps(optimizer).hex()
 
-    system_attrs = _split_optimizer_str(optimizer_str)  # type: Dict[str, Any]
+    system_attrs: Dict[str, Any] = _split_optimizer_str(optimizer_str)
     assert len(system_attrs) > 1
     system_attrs["cma:n_restarts"] = 1
 

--- a/tests/samplers_tests/test_grid.py
+++ b/tests/samplers_tests/test_grid.py
@@ -85,7 +85,7 @@ def test_study_optimize_with_exceeding_number_of_trials() -> None:
         return trial.suggest_int("a", 0, 100)
 
     # When `n_trials` is `None`, the optimization stops just after all grids are evaluated.
-    search_space = {"a": [0, 50]}  # type: Dict[str, List[GridValueType]]
+    search_space: Dict[str, List[GridValueType]] = {"a": [0, 50]}
     study = optuna.create_study(sampler=samplers.GridSampler(search_space))
     study.optimize(objective, n_trials=None)
     assert len(study.trials) == 2
@@ -156,7 +156,7 @@ def test_cast_value() -> None:
 
 def test_has_same_search_space() -> None:
 
-    search_space = {"x": [3, 2, 1], "y": ["a", "b", "c"]}  # type: Dict[str, List[Union[int, str]]]
+    search_space: Dict[str, List[Union[int, str]]] = {"x": [3, 2, 1], "y": ["a", "b", "c"]}
     sampler = samplers.GridSampler(search_space)
     assert sampler._same_search_space(search_space)
     assert sampler._same_search_space({"x": np.array([3, 2, 1]), "y": ["a", "b", "c"]})

--- a/tests/samplers_tests/test_samplers.py
+++ b/tests/samplers_tests/test_samplers.py
@@ -231,11 +231,11 @@ class FixedSampler(BaseSampler):
 
 def test_sample_relative() -> None:
 
-    relative_search_space = {
+    relative_search_space: Dict[str, BaseDistribution] = {
         "a": UniformDistribution(low=0, high=5),
         "b": CategoricalDistribution(choices=("foo", "bar", "baz")),
         "c": IntUniformDistribution(low=20, high=50),  # Not exist in `relative_params`.
-    }  # type: Dict[str, BaseDistribution]
+    }
     relative_params = {
         "a": 3.2,
         "b": "baz",

--- a/tests/storages_tests/rdb_tests/test_storage.py
+++ b/tests/storages_tests/rdb_tests/test_storage.py
@@ -94,7 +94,7 @@ def test_set_default_engine_kwargs_for_mysql(
 def test_set_default_engine_kwargs_for_mysql_with_other_rdb() -> None:
 
     # Do not change engine_kwargs if database is not MySQL.
-    engine_kwargs = {}  # type: Dict[str, Any]
+    engine_kwargs: Dict[str, Any] = {}
     RDBStorage._set_default_engine_kwargs_for_mysql("sqlite:///example.db", engine_kwargs)
     assert "pool_pre_ping" not in engine_kwargs
     RDBStorage._set_default_engine_kwargs_for_mysql("postgres:///example.db", engine_kwargs)

--- a/tests/storages_tests/test_storages.py
+++ b/tests/storages_tests/test_storages.py
@@ -747,7 +747,7 @@ def test_get_all_study_summaries(storage_mode: str) -> None:
         summaries = storage.get_all_study_summaries()
         assert len(summaries) == len(expected_summaries)
         for _, expected_summary in expected_summaries.items():
-            summary = None  # type: Optional[StudySummary]
+            summary: Optional[StudySummary] = None
             for s in summaries:
                 if s.study_name == expected_summary.study_name:
                     summary = s
@@ -892,8 +892,8 @@ def _setup_studies(
     direction: Optional[StudyDirection] = None,
 ) -> Tuple[Dict[int, StudySummary], Dict[int, Dict[int, FrozenTrial]]]:
     generator = random.Random(seed)
-    study_id_to_summary = {}  # type: Dict[int, StudySummary]
-    study_id_to_trials = {}  # type: Dict[int, Dict[int, FrozenTrial]]
+    study_id_to_summary: Dict[int, StudySummary] = {}
+    study_id_to_trials: Dict[int, Dict[int, FrozenTrial]] = {}
     for i in range(n_study):
         study_name = "test-study-name-{}".format(i)
         study_id = storage.create_new_study(study_name=study_name)

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -10,7 +10,7 @@ import pytest
 from optuna import distributions
 
 
-EXAMPLE_DISTRIBUTIONS = {
+EXAMPLE_DISTRIBUTIONS: Dict[str, Any] = {
     "u": distributions.UniformDistribution(low=1.0, high=2.0),
     "l": distributions.LogUniformDistribution(low=0.001, high=100),
     "du": distributions.DiscreteUniformDistribution(low=1.0, high=9.0, q=2.0),
@@ -19,7 +19,7 @@ EXAMPLE_DISTRIBUTIONS = {
     "c2": distributions.CategoricalDistribution(choices=("Roppongi", "Azabu")),
     "c3": distributions.CategoricalDistribution(choices=["Roppongi", "Azabu"]),
     "ilu": distributions.IntLogUniformDistribution(low=2, high=12, step=2),
-}  # type: Dict[str, Any]
+}
 
 EXAMPLE_JSONS = {
     "u": '{"name": "UniformDistribution", "attributes": {"low": 1.0, "high": 2.0}}',
@@ -222,7 +222,7 @@ def test_single() -> None:
     with warnings.catch_warnings():
         # UserWarning will be raised since the range is not divisible by step.
         warnings.simplefilter("ignore", category=UserWarning)
-        single_distributions = [
+        single_distributions: List[distributions.BaseDistribution] = [
             distributions.UniformDistribution(low=1.0, high=1.0),
             distributions.LogUniformDistribution(low=7.3, high=7.3),
             distributions.DiscreteUniformDistribution(low=2.22, high=2.22, q=0.1),
@@ -231,11 +231,11 @@ def test_single() -> None:
             distributions.IntUniformDistribution(low=-123, high=-120, step=4),
             distributions.CategoricalDistribution(choices=("foo",)),
             distributions.IntLogUniformDistribution(low=2, high=2),
-        ]  # type: List[distributions.BaseDistribution]
+        ]
     for distribution in single_distributions:
         assert distribution.single()
 
-    nonsingle_distributions = [
+    nonsingle_distributions: List[distributions.BaseDistribution] = [
         distributions.UniformDistribution(low=1.0, high=1.001),
         distributions.LogUniformDistribution(low=7.3, high=10),
         distributions.DiscreteUniformDistribution(low=-30, high=-20, q=2),
@@ -247,7 +247,7 @@ def test_single() -> None:
         distributions.IntUniformDistribution(low=-123, high=0, step=123),
         distributions.CategoricalDistribution(choices=("foo", "bar")),
         distributions.IntLogUniformDistribution(low=2, high=4),
-    ]  # type: List[distributions.BaseDistribution]
+    ]
     for distribution in nonsingle_distributions:
         assert not distribution.single()
 

--- a/tests/test_trial.py
+++ b/tests/test_trial.py
@@ -688,7 +688,7 @@ def test_relative_parameters(storage_init_func: Callable[[], storages.BaseStorag
 @parametrize_storage
 def test_datetime_start(storage_init_func: Callable[[], storages.BaseStorage]) -> None:
 
-    trial_datetime_start = [None]  # type: List[Optional[datetime.datetime]]
+    trial_datetime_start: List[Optional[datetime.datetime]] = [None]
 
     def objective(trial: Trial) -> float:
 
@@ -1086,14 +1086,14 @@ def test_frozen_trial_validate() -> None:
         invalid_trial._validate()
 
     # Invalid: Inconsistent `params` and `distributions`
-    inconsistent_pairs = [
+    inconsistent_pairs: List[Tuple[Dict[str, Any], Dict[str, BaseDistribution]]] = [
         # `params` has an extra element.
         ({"x": 0.1, "y": 0.5}, {"x": UniformDistribution(0, 1)}),
         # `distributions` has an extra element.
         ({"x": 0.1}, {"x": UniformDistribution(0, 1), "y": LogUniformDistribution(0.1, 1.0)}),
         # The value of `x` isn't contained in the distribution.
         ({"x": -0.5}, {"x": UniformDistribution(0, 1)}),
-    ]  # type: List[Tuple[Dict[str, Any], Dict[str, BaseDistribution]]]
+    ]
 
     for params, distributions in inconsistent_pairs:
         invalid_trial = copy.copy(valid_trial)


### PR DESCRIPTION
## Motivation
See #1897.

## Description of the changes
Converts comment style type hints (e.g. `a = 1  # type: int`) using new variable annotation syntax (e.g. `a: int = 1`) with [com2ann](https://github.com/ilevkivskyi/com2ann).