### PR TITLE
Fix retuned type of MultivariateTPE samplers

### DIFF
--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -672,7 +672,7 @@ class TPESampler(BaseSampler):
                     "But (samples.size, score.size) = ({}, {})".format(sample_size, score.size)
                 )
             best = np.argmax(score)
-            return {k: v[best] for k, v in multivariate_samples.items()}
+            return {k: v[best].item() for k, v in multivariate_samples.items()}
         else:
             raise ValueError(
                 "The size of 'samples' should be more than 0."


### PR DESCRIPTION
<!-- Thank you for creating a pull request! -->


## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

Solve #1952

## Description of the changes
<!-- Describe the changes in this PR. -->

Apply the change suggested in https://github.com/optuna/optuna/issues/1952#issuecomment-715014449 by @toshihikoyanase.

---

Now, the returned types in the example code in the issue are as follows.

```bash
Univariate:
<class 'float'>
<class 'float'>
<class 'float'>
<class 'float'>
<class 'float'>
<class 'float'>
<class 'float'>
<class 'float'>
<class 'float'>
<class 'float'>
<class 'float'>
<class 'float'>
<class 'float'>
<class 'float'>
<class 'float'>
Multivariate:
<class 'float'>
<class 'float'>
<class 'float'>
<class 'float'>
<class 'float'>
<class 'float'>
<class 'float'>
<class 'float'>
<class 'float'>
<class 'float'>
<class 'float'>
<class 'float'>
<class 'float'>
<class 'float'>
<class 'float'>
```