### PR TITLE
Align the usage of type hints and instantiation of dictionaries

### DIFF
--- a/optuna/_dataframe.py
+++ b/optuna/_dataframe.py
@@ -1,5 +1,6 @@
 import collections
 from typing import Any
+from typing import DefaultDict
 from typing import Dict
 from typing import List
 from typing import Set
@@ -42,7 +43,7 @@ def _trials_dataframe(
     # column_agg is an aggregator of column names.
     # Keys of column agg are attributes of `FrozenTrial` such as 'trial_id' and 'params'.
     # Values are dataframe columns such as ('trial_id', '') and ('params', 'n_layers').
-    column_agg: Dict[str, Set] = collections.defaultdict(set)
+    column_agg: DefaultDict[str, Set] = collections.defaultdict(set)
     non_nested_attr = ""
 
     def _create_record_and_aggregate_column(

--- a/optuna/dashboard.py
+++ b/optuna/dashboard.py
@@ -2,6 +2,7 @@ import collections
 import threading
 import time
 from typing import Any
+from typing import DefaultDict
 from typing import Dict
 from typing import List
 from typing import Optional
@@ -99,7 +100,7 @@ if _imports.is_successful():
 
         def update(self, new_trials: List[optuna.trial.FrozenTrial]) -> None:
 
-            stream_dict: Dict[str, List[Any]] = collections.defaultdict(list)
+            stream_dict: DefaultDict[str, List[Any]] = collections.defaultdict(list)
 
             for trial in new_trials:
                 if trial.state != optuna.trial.TrialState.COMPLETE:

--- a/optuna/integration/tensorboard.py
+++ b/optuna/integration/tensorboard.py
@@ -34,7 +34,7 @@ class TensorBoardCallback(object):
         _imports.check()
         self._dirname = dirname
         self._metric_name = metric_name
-        self._hp_params: Dict[str, hp.HParam] = dict()
+        self._hp_params: Dict[str, hp.HParam] = {}
 
     def __call__(self, study: optuna.study.Study, trial: optuna.trial.FrozenTrial) -> None:
         if len(self._hp_params) == 0:
@@ -42,7 +42,7 @@ class TensorBoardCallback(object):
         if trial.state != optuna.trial.TrialState.COMPLETE:
             return
         trial_value = trial.value if trial.value is not None else float("nan")
-        hparams = dict()
+        hparams = {}
         for param_name, param_value in trial.params.items():
             if param_name not in self._hp_params:
                 self._add_distributions(trial.distributions)

--- a/optuna/storages/_cached_storage.py
+++ b/optuna/storages/_cached_storage.py
@@ -21,11 +21,11 @@ class _TrialUpdate:
     def __init__(self) -> None:
         self.state: Optional[TrialState] = None
         self.value: Optional[float] = None
-        self.intermediate_values: Dict[int, float] = dict()
-        self.user_attrs: Dict[str, Any] = dict()
-        self.system_attrs: Dict[str, Any] = dict()
-        self.params: Dict[str, Any] = dict()
-        self.distributions: Dict[str, distributions.BaseDistribution] = dict()
+        self.intermediate_values: Dict[int, float] = {}
+        self.user_attrs: Dict[str, Any] = {}
+        self.system_attrs: Dict[str, Any] = {}
+        self.params: Dict[str, Any] = {}
+        self.distributions: Dict[str, distributions.BaseDistribution] = {}
         self.datetime_complete: Optional[datetime.datetime] = None
 
 
@@ -36,7 +36,7 @@ class _StudyInfo:
         # A list of trials which do not require storage access to read latest attributes.
         self.owned_or_finished_trial_ids: Set[int] = set()
         # Cache any writes which are not reflected to the actual storage yet in updates.
-        self.updates: Dict[int, _TrialUpdate] = dict()
+        self.updates: Dict[int, _TrialUpdate] = {}
         # Cache distributions to avoid storage access on distribution consistency check.
         self.param_distribution: Dict[str, distributions.BaseDistribution] = {}
         self.direction: StudyDirection = StudyDirection.NOT_SET
@@ -57,7 +57,7 @@ class _CachedStorage(BaseStorage):
     def __init__(self, backend: RDBStorage) -> None:
         self._backend = backend
         self._studies: Dict[int, _StudyInfo] = {}
-        self._trial_id_to_study_id_and_number: Dict[int, Tuple[int, int]] = dict()
+        self._trial_id_to_study_id_and_number: Dict[int, Tuple[int, int]] = {}
         self._lock = threading.Lock()
 
     def __getstate__(self) -> Dict[Any, Any]:


### PR DESCRIPTION
## Motivation
This is a follow-up PR of #1950. cc: @hvy 

As pointed out in https://github.com/optuna/optuna/pull/1950#issuecomment-714341537, there are inconsistencies in instantiating dictionary and type hints for `defaultdict`s. 
> Purely a side note but you realize how `dict()` is mixed with `{}` and how we sometime use `Dict` for `defaultdict`s while there are some occurrences of DefaultDict. Nits but they could be aligned/corrected.

## Description of the changes
Use the type `DefaultDict` for `defaultdict`s.
Use `{}` to generate an empty instance of `dict`.