### PR TITLE
Support options available on AllenNLP except to `node_rank` and `dry_run`

### DIFF
--- a/examples/allennlp/allennlp_jsonnet.py
+++ b/examples/allennlp/allennlp_jsonnet.py
@@ -36,7 +36,7 @@ def objective(trial):
     trial.suggest_int("HIDDEN_SIZE", 16, 32)
 
     serialization_dir = os.path.join(MODEL_DIR, "test_{}".format(trial.number))
-    executor = AllenNLPExecutor(trial, CONFIG_PATH, serialization_dir, recover=True)
+    executor = AllenNLPExecutor(trial, CONFIG_PATH, serialization_dir, force=True)
 
     return executor.run()
 

--- a/examples/allennlp/allennlp_jsonnet.py
+++ b/examples/allennlp/allennlp_jsonnet.py
@@ -36,7 +36,7 @@ def objective(trial):
     trial.suggest_int("HIDDEN_SIZE", 16, 32)
 
     serialization_dir = os.path.join(MODEL_DIR, "test_{}".format(trial.number))
-    executor = AllenNLPExecutor(trial, CONFIG_PATH, serialization_dir)
+    executor = AllenNLPExecutor(trial, CONFIG_PATH, serialization_dir, recover=True)
 
     return executor.run()
 
@@ -49,7 +49,9 @@ if __name__ == "__main__":
         direction="maximize",
         storage="sqlite:///allennlp.db",
         pruner=optuna.pruners.HyperbandPruner(),
+        sampler=optuna.samplers.TPESampler(seed=10),
     )
+
     study.optimize(objective, n_trials=50, timeout=600)
 
     print("Number of finished trials: ", len(study.trials))

--- a/optuna/integration/allennlp.py
+++ b/optuna/integration/allennlp.py
@@ -411,7 +411,9 @@ class AllenNLPPruningCallback(EpochCallback):
     """
 
     def __init__(
-        self, trial: Optional[optuna.trial.Trial] = None, monitor: Optional[str] = None,
+        self,
+        trial: Optional[optuna.trial.Trial] = None,
+        monitor: Optional[str] = None,
     ):
         _imports.check()
 

--- a/optuna/integration/allennlp.py
+++ b/optuna/integration/allennlp.py
@@ -261,13 +261,6 @@ class AllenNLPExecutor(object):
             A path which model weights and logs are saved.
         metrics:
             An evaluation metric for the result of ``objective``.
-        recover:
-            If recover is ``True``, an executor resumes training
-            from the state in ``serialization_dir``.
-            Note that recovering training in ``AllenNLPExecurot`` needs to fix random seed
-            in a sampler for obtaining reproducible optimization result.
-            Please see `the FAQ <https://optuna.readthedocs.io/en/stable/
-            faq.html#how-can-i-obtain-reproducible-optimization-results>`_ for more information.
         force:
             If True, an executor overwrite the output directory if it exists.
         file_friendly_logging:
@@ -285,7 +278,6 @@ class AllenNLPExecutor(object):
         config_file: str,
         serialization_dir: str,
         metrics: str = "best_validation_accuracy",
-        recover: bool = False,
         force: bool = False,
         file_friendly_logging: bool = False,
         *,
@@ -297,7 +289,6 @@ class AllenNLPExecutor(object):
         self._config_file = config_file
         self._serialization_dir = serialization_dir
         self._metrics = metrics
-        self._recover = recover
         self._force = force
         self._file_friendly_logging = file_friendly_logging
 
@@ -380,7 +371,6 @@ class AllenNLPExecutor(object):
             params=params,
             serialization_dir=self._serialization_dir,
             file_friendly_logging=self._file_friendly_logging,
-            recover=self._recover,
             force=self._force,
         )
         metrics = json.load(open(os.path.join(self._serialization_dir, "metrics.json")))

--- a/optuna/integration/allennlp.py
+++ b/optuna/integration/allennlp.py
@@ -264,7 +264,7 @@ class AllenNLPExecutor(object):
         force:
             If :obj:`True`, an executor overwrites the output directory if it exists.
         file_friendly_logging:
-            If True, tqdm status is printed on separate lines and slows tqdm refresh rate.
+            If :obj:`True`, tqdm status is printed on separate lines and slows tqdm refresh rate.
         include_package:
             Additional packages to include.
             For more information, please see

--- a/optuna/integration/allennlp.py
+++ b/optuna/integration/allennlp.py
@@ -262,7 +262,7 @@ class AllenNLPExecutor(object):
         metrics:
             An evaluation metric for the result of ``objective``.
         force:
-            If True, an executor overwrite the output directory if it exists.
+            If :obj:`True`, an executor overwrites the output directory if it exists.
         file_friendly_logging:
             If True, tqdm status is printed on separate lines and slows tqdm refresh rate.
         include_package:

--- a/optuna/integration/allennlp.py
+++ b/optuna/integration/allennlp.py
@@ -278,10 +278,10 @@ class AllenNLPExecutor(object):
         config_file: str,
         serialization_dir: str,
         metrics: str = "best_validation_accuracy",
-        force: bool = False,
-        file_friendly_logging: bool = False,
         *,
         include_package: Optional[Union[str, List[str]]] = None,
+        force: bool = False,
+        file_friendly_logging: bool = False,
     ):
         _imports.check()
 

--- a/tests/integration_tests/allennlp_tests/test_allennlp.py
+++ b/tests/integration_tests/allennlp_tests/test_allennlp.py
@@ -276,7 +276,9 @@ def test_allennlp_pruning_callback_with_invalid_storage() -> None:
             return executor.run()
 
         study = optuna.create_study(
-            direction="maximize", pruner=optuna.pruners.HyperbandPruner(), storage=None,
+            direction="maximize",
+            pruner=optuna.pruners.HyperbandPruner(),
+            storage=None,
         )
 
         with pytest.raises(RuntimeError):

--- a/tests/integration_tests/allennlp_tests/test_allennlp.py
+++ b/tests/integration_tests/allennlp_tests/test_allennlp.py
@@ -183,13 +183,11 @@ def test_allennlp_executor_with_options() -> None:
             trial,
             "tests/integration_tests/allennlp_tests/example_with_include_package.jsonnet",
             tmp_dir,
-            recover=True,
             force=True,
             file_friendly_logging=True,
             include_package=["tests.integration_tests.allennlp_tests.tiny_single_id"],
         )
 
-        assert executor._recover
         assert executor._force
         assert executor._file_friendly_logging
 

--- a/tests/integration_tests/allennlp_tests/test_allennlp.py
+++ b/tests/integration_tests/allennlp_tests/test_allennlp.py
@@ -173,6 +173,27 @@ def test_allennlp_executor_with_include_package_arr() -> None:
         assert isinstance(result, float)
 
 
+def test_allennlp_executor_with_options() -> None:
+    study = optuna.create_study(direction="maximize")
+    trial = optuna.trial.Trial(study, study._storage.create_new_trial(study._study_id))
+    trial.suggest_uniform("DROPOUT", 0.0, 0.5)
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        executor = optuna.integration.AllenNLPExecutor(
+            trial,
+            "tests/integration_tests/allennlp_tests/example_with_include_package.jsonnet",
+            tmp_dir,
+            recover=True,
+            force=True,
+            file_friendly_logging=True,
+            include_package=["tests.integration_tests.allennlp_tests.tiny_single_id"],
+        )
+
+        assert executor._recover
+        assert executor._force
+        assert executor._file_friendly_logging
+
+
 def test_dump_best_config() -> None:
     with tempfile.TemporaryDirectory() as tmp_dir:
 
@@ -257,9 +278,7 @@ def test_allennlp_pruning_callback_with_invalid_storage() -> None:
             return executor.run()
 
         study = optuna.create_study(
-            direction="maximize",
-            pruner=optuna.pruners.HyperbandPruner(),
-            storage=None,
+            direction="maximize", pruner=optuna.pruners.HyperbandPruner(), storage=None,
         )
 
         with pytest.raises(RuntimeError):


### PR DESCRIPTION
## Motivation
This PR adds `AllenNLPExecutor` support options available on [`allennlp.commands.train`](https://docs.allennlp.org/master/api/commands/train/).

## Description of the changes
Add options ~`recover`~, `force`, and `file_friendly_logging` to `AllenNLPExecutor`.
