### PR TITLE
Fix path for `store_artifacts` step in `document` CircleCI job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,7 +87,7 @@ jobs:
             make html
 
       - store_artifacts:
-          path: ./docs/build
+          path: ./docs/build/html
 
   doctest:
     docker:


### PR DESCRIPTION
<!-- Thank you for creating a pull request! -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

The path for the `store_artifacts` step in the `document` CircleCI job should be `docs/build/html` not `docs/build`.

## Description of the changes
<!-- Describe the changes in this PR. -->

With this change, the document job should finish a bit faster.
