### PR TITLE
Fix `StudyDirection` of `mape` in `LightGBMTuner`

### DIFF
--- a/optuna/integration/_lightgbm_tuner/optimize.py
+++ b/optuna/integration/_lightgbm_tuner/optimize.py
@@ -144,7 +144,7 @@ class _BaseTuner(object):
     def higher_is_better(self) -> bool:
 
         metric_name = self.lgbm_params.get("metric", "binary_logloss")
-        return metric_name.startswith(("auc", "ndcg", "map"))
+        return metric_name in ("auc", "ndcg", "map")
 
     def compare_validation_metrics(self, val_score: float, best_score: float) -> bool:
 

--- a/tests/integration_tests/lightgbm_tuner_tests/test_optimize.py
+++ b/tests/integration_tests/lightgbm_tuner_tests/test_optimize.py
@@ -150,7 +150,7 @@ class TestBaseTuner(object):
             tuner = _BaseTuner(lgbm_params={"metric": metric})
             assert tuner.higher_is_better()
 
-        for metric in ["rmsle", "rmse", "binary_logloss"]:
+        for metric in ["rmsle", "rmse", "binary_logloss", "mape"]:
             tuner = _BaseTuner(lgbm_params={"metric": metric})
             assert not tuner.higher_is_better()
 


### PR DESCRIPTION
## Motivation
Fixes #1858. I found that `mape` `startswith` `map` when I read the code in #1947 . 

https://github.com/optuna/optuna/blob/9fc26c2277b347788d5554dad66dba81585716b2/optuna/integration/_lightgbm_tuner/optimize.py#L146

## Description of the changes
- Use `in` instead of `startswith` to check the metrics. I assumed that the metrics are converted by `_handling_alias_metrics`.
- Add `mape` to the test case.