### PR TITLE
Add RDB support to `MoTPEMultiObjectiveSampler`

### DIFF
--- a/optuna/multi_objective/samplers/_motpe.py
+++ b/optuna/multi_objective/samplers/_motpe.py
@@ -402,13 +402,19 @@ class MOTPEMultiObjectiveSampler(TPESampler, BaseMultiObjectiveSampler):
             above = np.log(above)
 
         size = (self._n_ehvi_candidates,)
+
+        weights_below: Callable[[int], np.ndarray]
+
         if self._weights is _default_weights_above:
+
             weights_below = lambda _: np.asarray(
                 study._storage.get_trial(trial._trial_id).system_attrs[_WEIGHTS_BELOW_KEY],
                 dtype=float,
             )
+
         else:
             weights_below = self._weights
+
         parzen_estimator_parameters_below = _ParzenEstimatorParameters(
             self._parzen_estimator_parameters.consider_prior,
             self._parzen_estimator_parameters.prior_weight,

--- a/optuna/multi_objective/samplers/_motpe.py
+++ b/optuna/multi_objective/samplers/_motpe.py
@@ -286,10 +286,10 @@ class MOTPEMultiObjectiveSampler(TPESampler, BaseMultiObjectiveSampler):
 
             indices_above = np.setdiff1d(indices, indices_below)
 
-            attrs = {"indices_below": indices_below, "indices_above": indices_above}
+            attrs = {"indices_below": indices_below.tolist(), "indices_above": indices_above.tolist()}
             if self._weights is _default_weights_above:
                 weights_below = self._calculate_default_weights_below(lvals, indices_below)
-                attrs["weights_below"] = weights_below
+                attrs["weights_below"] = weights_below.tolist()
             study._storage.set_trial_system_attr(trial._trial_id, _SPLITCACHE_KEY, attrs)
 
         below = cvals[indices_below]
@@ -297,9 +297,7 @@ class MOTPEMultiObjectiveSampler(TPESampler, BaseMultiObjectiveSampler):
             study._storage.set_trial_system_attr(
                 trial._trial_id,
                 _WEIGHTS_BELOW_KEY,
-                lambda _: np.asarray(
-                    [w for w, v in zip(weights_below, below) if v is not None], dtype=float
-                ),
+                [w for w, v in zip(weights_below, below) if v is not None],
             )
         below = np.asarray([v for v in below if v is not None], dtype=float)
         above = cvals[indices_above]
@@ -402,9 +400,9 @@ class MOTPEMultiObjectiveSampler(TPESampler, BaseMultiObjectiveSampler):
 
         size = (self._n_ehvi_candidates,)
         if self._weights is _default_weights_above:
-            weights_below = study._storage.get_trial(trial._trial_id).system_attrs[
+            weights_below = lambda _: np.asarray(study._storage.get_trial(trial._trial_id).system_attrs[
                 _WEIGHTS_BELOW_KEY
-            ]
+            ], dtype=float)
         else:
             weights_below = self._weights
         parzen_estimator_parameters_below = _ParzenEstimatorParameters(
@@ -475,7 +473,7 @@ class MOTPEMultiObjectiveSampler(TPESampler, BaseMultiObjectiveSampler):
         if self._weights is _default_weights_above:
             weights_below = study._storage.get_trial(trial._trial_id).system_attrs[
                 _WEIGHTS_BELOW_KEY
-            ](len(below))
+            ]
         else:
             weights_below = self._weights(len(below))
         counts_below = np.bincount(below, minlength=upper, weights=weights_below)

--- a/optuna/multi_objective/samplers/_motpe.py
+++ b/optuna/multi_objective/samplers/_motpe.py
@@ -407,7 +407,7 @@ class MOTPEMultiObjectiveSampler(TPESampler, BaseMultiObjectiveSampler):
 
         if self._weights is _default_weights_above:
 
-            weights_below = lambda _: np.asarray(
+            weights_below = lambda _: np.asarray(  # NOQA
                 study._storage.get_trial(trial._trial_id).system_attrs[_WEIGHTS_BELOW_KEY],
                 dtype=float,
             )

--- a/optuna/multi_objective/samplers/_motpe.py
+++ b/optuna/multi_objective/samplers/_motpe.py
@@ -286,7 +286,10 @@ class MOTPEMultiObjectiveSampler(TPESampler, BaseMultiObjectiveSampler):
 
             indices_above = np.setdiff1d(indices, indices_below)
 
-            attrs = {"indices_below": indices_below.tolist(), "indices_above": indices_above.tolist()}
+            attrs = {
+                "indices_below": indices_below.tolist(),
+                "indices_above": indices_above.tolist(),
+            }
             if self._weights is _default_weights_above:
                 weights_below = self._calculate_default_weights_below(lvals, indices_below)
                 attrs["weights_below"] = weights_below.tolist()
@@ -400,9 +403,10 @@ class MOTPEMultiObjectiveSampler(TPESampler, BaseMultiObjectiveSampler):
 
         size = (self._n_ehvi_candidates,)
         if self._weights is _default_weights_above:
-            weights_below = lambda _: np.asarray(study._storage.get_trial(trial._trial_id).system_attrs[
-                _WEIGHTS_BELOW_KEY
-            ], dtype=float)
+            weights_below = lambda _: np.asarray(
+                study._storage.get_trial(trial._trial_id).system_attrs[_WEIGHTS_BELOW_KEY],
+                dtype=float,
+            )
         else:
             weights_below = self._weights
         parzen_estimator_parameters_below = _ParzenEstimatorParameters(

--- a/optuna/multi_objective/samplers/_motpe.py
+++ b/optuna/multi_objective/samplers/_motpe.py
@@ -253,9 +253,9 @@ class MOTPEMultiObjectiveSampler(TPESampler, BaseMultiObjectiveSampler):
         # We cache the result of splitting.
         if _SPLITCACHE_KEY in trial.system_attrs:
             split_cache = trial.system_attrs[_SPLITCACHE_KEY]
-            indices_below = split_cache["indices_below"]
-            weights_below = split_cache["weights_below"]
-            indices_above = split_cache["indices_above"]
+            indices_below = np.asarray(split_cache["indices_below"])
+            weights_below = np.asarray(split_cache["weights_below"])
+            indices_above = np.asarray(split_cache["indices_above"])
         else:
             nondomination_ranks = _calculate_nondomination_rank(lvals)
             n_below = self._gamma(len(lvals))


### PR DESCRIPTION
## Motivation
This is a follow-up task of #1530. It fixes the error regarding MoTPE with RDB in this comment https://github.com/optuna/optuna/pull/1530/files#r503843954.

## Description of the changes

It make `trial.system_attrs` JSON serializable.

The example code is as follows:
```python
import optuna


def objective(trial):
    # Binh and Korn function.
    x = trial.suggest_float("x", 0, 5)
    y = trial.suggest_float("y", 0, 3)

    v0 = 4 * x ** 2 + 4 * y ** 2
    v1 = (x - 5) ** 2 + (y - 5) ** 2
    return v0, v1


study = optuna.multi_objective.create_study(
    ["minimize", "minimize"],
    sampler=optuna.multi_objective.samplers.MOTPEMultiObjectiveSampler(),
    storage="sqlite:///foo.db",
)
study.optimize(objective, n_trials=100)

optuna.multi_objective.visualization.plot_pareto_front(study).show()
```