### PR TITLE
Fix the range of categorical values.

### DIFF
--- a/optuna/visualization/_contour.py
+++ b/optuna/visualization/_contour.py
@@ -118,7 +118,7 @@ def _get_contour_plot(study: Study, params: Optional[List[str]] = None) -> "go.F
             # Plotly uses indices instead of raw values to generate contours, but the raw values
             # are used to calculate ranges since plotly==4.12.0.
             # See https://github.com/optuna/optuna/issues/1967.
-            # TODO (yanase): Remove this if-clause after resolving the error.
+            # TODO(toshihikoyanase): Remove this if-clause after resolving the error.
             if version.parse(plotly.__version__) >= version.parse("4.12.0"):
                 min_value = 0
                 max_value = len(set(values)) - 1

--- a/optuna/visualization/_contour.py
+++ b/optuna/visualization/_contour.py
@@ -117,7 +117,7 @@ def _get_contour_plot(study: Study, params: Optional[List[str]] = None) -> "go.F
 
             # Plotly uses indices instead of raw values to generate contours, but the raw values
             # are used to calculate ranges since plotly==4.12.0.
-            # See https://github.com/optuna/optuna/pull/1944#issuecomment-716968285.
+            # See https://github.com/optuna/optuna/issues/1967.
             # TODO (yanase): Remove this if-clause after resolving the error.
             if version.parse(plotly.__version__) >= version.parse("4.12.0"):
                 min_value = 0

--- a/optuna/visualization/_contour.py
+++ b/optuna/visualization/_contour.py
@@ -120,10 +120,9 @@ def _get_contour_plot(study: Study, params: Optional[List[str]] = None) -> "go.F
             # For numeric values, plotly does not automatically plot as "category" type.
             update_category_axes[p_name] = any([str(v).isnumeric() for v in set(values)])
 
-            # Plotly uses indices instead of raw values to generate contours, but the raw values
-            # are used to calculate ranges since plotly==4.12.0.
-            # See https://github.com/optuna/optuna/issues/1967.
-            # TODO(toshihikoyanase): Remove this if-clause after resolving the error.
+            # Plotly>=4.12.0 draws contours using the indices of categorical variables instead of
+            # raw values and the range should be updated based on the cardinality of categorical
+            # variables. See https://github.com/optuna/optuna/issues/1967.
             if version.parse(plotly.__version__) >= version.parse("4.12.0"):
                 span = len(set(values)) - 1
                 padding = span * padding_ratio

--- a/tests/visualization_tests/test_contour.py
+++ b/tests/visualization_tests/test_contour.py
@@ -17,6 +17,7 @@ from optuna.trial import Trial
 from optuna.visualization import plot_contour
 from optuna.visualization._contour import _generate_contour_subplot
 
+
 RANGE_TYPE = Union[Tuple[str, str], Tuple[float, float]]
 
 

--- a/tests/visualization_tests/test_contour.py
+++ b/tests/visualization_tests/test_contour.py
@@ -1,6 +1,10 @@
 from typing import List
 from typing import Optional
+from typing import Tuple
+from typing import Union
 
+from packaging import version
+import plotly
 import pytest
 
 from optuna.distributions import CategoricalDistribution
@@ -12,6 +16,8 @@ from optuna.trial import create_trial
 from optuna.trial import Trial
 from optuna.visualization import plot_contour
 from optuna.visualization._contour import _generate_contour_subplot
+
+RANGE_TYPE = Union[Tuple[str, str], Tuple[float, float]]
 
 
 @pytest.mark.parametrize(
@@ -114,7 +120,10 @@ def test_plot_contour_log_scale_and_str_category() -> None:
 
     figure = plot_contour(study)
     assert figure.layout["xaxis"]["range"] == (-6.05, -4.95)
-    assert figure.layout["yaxis"]["range"] == ("100", "101")
+    if version.parse(plotly.__version__) >= version.parse("4.12.0"):
+        assert figure.layout["yaxis"]["range"] == (-0.05, 1.05)
+    else:
+        assert figure.layout["yaxis"]["range"] == ("100", "101")
     assert figure.layout["xaxis_type"] == "log"
     assert figure.layout["yaxis_type"] == "category"
 
@@ -145,8 +154,12 @@ def test_plot_contour_log_scale_and_str_category() -> None:
 
     figure = plot_contour(study)
     param_a_range = (-6.05, -4.95)
-    param_b_range = ("100", "101")
-    param_c_range = ("one", "two")
+    if version.parse(plotly.__version__) >= version.parse("4.12.0"):
+        param_b_range: RANGE_TYPE = (-0.05, 1.05)
+        param_c_range: RANGE_TYPE = (-0.05, 1.05)
+    else:
+        param_b_range = ("100", "101")
+        param_c_range = ("one", "two")
     param_a_type = "log"
     param_b_type = "category"
     param_c_type = None
@@ -199,7 +212,11 @@ def test_plot_contour_mixture_category_types() -> None:
         )
     )
     figure = plot_contour(study)
-    assert figure.layout["xaxis"]["range"] == ("100", "None")
-    assert figure.layout["yaxis"]["range"] == ("101", "102.0")
+    if version.parse(plotly.__version__) >= version.parse("4.12.0"):
+        assert figure.layout["xaxis"]["range"] == (-0.05, 1.05)
+        assert figure.layout["yaxis"]["range"] == (-0.05, 1.05)
+    else:
+        assert figure.layout["xaxis"]["range"] == ("100", "None")
+        assert figure.layout["yaxis"]["range"] == ("101", "102.0")
     assert figure.layout["xaxis"]["type"] == "category"
     assert figure.layout["yaxis"]["type"] == "category"


### PR DESCRIPTION
## Motivation
This PR addresses https://github.com/optuna/optuna/issues/1967.

## Description of the changes
This PR changes the plot range of categorical parameters for `plotly>=4.12.0`. As I mentioned in the comment, plotly seems to generate contours using indices of categorical values, but it determines plot ranges based on raw values. So, I updated the range based on the indices.

Code (from #1819)
```python
import optuna

def objective(trial):
    x = trial.suggest_categorical("x", ["10", "11", "100"])
    y = trial.suggest_categorical("y", ["sigmoid", "relu", "leakyrelu"])
    z = trial.suggest_loguniform("z", 1e-1, 1e2)
    return int("0" in x) + abs(len(y) - 5) + (z/50) ** 2

study = optuna.create_study()
study.optimize(objective, n_trials=30)

optuna.visualization.plot_contour(study).show()
```

This PR:
![image](https://user-images.githubusercontent.com/3255979/97780590-e4257000-1bc8-11eb-8b1b-73b7d7708b55.png)

The current master:
![image](https://user-images.githubusercontent.com/3255979/97780644-36ff2780-1bc9-11eb-98ee-7752e8e0dc39.png)
