### PR TITLE
Change bar colours in the parameter importance plot.

### DIFF
--- a/optuna/visualization/_param_importances.py
+++ b/optuna/visualization/_param_importances.py
@@ -22,7 +22,7 @@ if _imports.is_successful():
 
     from optuna.visualization._plotly_imports import go
 
-    D3 = plotly.colors.sequential.D3
+    D3 = plotly.colors.qualitative.D3
 
     _distribution_colors = {
         UniformDistribution: D3[0],

--- a/optuna/visualization/_param_importances.py
+++ b/optuna/visualization/_param_importances.py
@@ -22,15 +22,15 @@ if _imports.is_successful():
 
     from optuna.visualization._plotly_imports import go
 
-    Blues = plotly.colors.sequential.Blues
+    D3 = plotly.colors.sequential.D3
 
     _distribution_colors = {
-        UniformDistribution: Blues[-1],
-        LogUniformDistribution: Blues[-1],
-        DiscreteUniformDistribution: Blues[-1],
-        IntUniformDistribution: Blues[-2],
-        IntLogUniformDistribution: Blues[-2],
-        CategoricalDistribution: Blues[-4],
+        UniformDistribution: D3[0],
+        LogUniformDistribution: D3[1],
+        DiscreteUniformDistribution: D3[2],
+        IntUniformDistribution: D3[3],
+        IntLogUniformDistribution: D3[4],
+        CategoricalDistribution: D3[5],
     }
 
 logger = get_logger(__name__)

--- a/optuna/visualization/matplotlib/_param_importances.py
+++ b/optuna/visualization/matplotlib/_param_importances.py
@@ -27,14 +27,14 @@ if _imports.is_successful():
     from optuna.visualization.matplotlib._matplotlib_imports import Rectangle
 
     # Color definitions.
-    cmap = cm.get_cmap("tab20c")
+    cmap = cm.get_cmap("tab10")
     _distribution_colors = {
         UniformDistribution: cmap(0),
-        LogUniformDistribution: cmap(0),
-        DiscreteUniformDistribution: cmap(0),
-        IntUniformDistribution: cmap(1),
-        IntLogUniformDistribution: cmap(1),
-        CategoricalDistribution: cmap(3),
+        LogUniformDistribution: cmap(1),
+        DiscreteUniformDistribution: cmap(2),
+        IntUniformDistribution: cmap(3),
+        IntLogUniformDistribution: cmap(4),
+        CategoricalDistribution: cmap(5),
     }
     _legend_elements = [
         Rectangle([0, 0], 0, 0, facecolor=cmap(0), label="Uniform Distribution"),


### PR DESCRIPTION
## Motivation
This PR is to change colours in the parameter importance plot to distinguishing ones for better recognition based on @himkt 's suggestion https://github.com/optuna/optuna/pull/1787#pullrequestreview-521346823 .

## Description of the changes
Change colour palettes used in both the Plotly and Matplotlib backends from blue-based ones to ones with various colours (`D3` and `tab10`). See PR #1756 for details about Matplotlib backends.