### PR TITLE
Avoid `set-env` in GitHub Actions

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -42,7 +42,7 @@ jobs:
         if [ "${{matrix.build_type}}" = 'dev' ]; then
           export TAG_NAME="${TAG_NAME}-dev"
         fi
-        echo "::set-env name=HUB_TAG::${DOCKER_HUB_BASE_NAME}:${TAG_NAME}"
+        echo "HUB_TAG=${DOCKER_HUB_BASE_NAME}:${TAG_NAME}" >> $GITHUB_ENV
 
     - name: Build the Docker image
       run: |


### PR DESCRIPTION
## Motivation

Warnings in https://github.com/optuna/optuna/actions/runs/344859225 should be addressed.

C.f. https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

## Description of the changes

See above article.
