### PR TITLE
[DO NOT MERGE] A prototypical implementation of step-wise sampler

### DIFF
--- a/examples/stepwise_simple.py
+++ b/examples/stepwise_simple.py
@@ -1,5 +1,7 @@
 import optuna
 import optuna.samplers._stepwise
+from optuna.samplers._stepwise import Step
+from optuna.samplers._stepwise import StepwiseSampler
 
 
 def objective(trial):
@@ -22,18 +24,21 @@ def search_z(params):
 
 
 def search_x_y(params):
-    return {"x": optuna.distributions.UniformDistribution(0, 100), "y": optuna.distributions.UniformDistribution(0, 100)}
+    return {
+        "x": optuna.distributions.UniformDistribution(0, 100),
+        "y": optuna.distributions.UniformDistribution(0, 100),
+    }
 
 
 steps = [
-    optuna.samplers._stepwise.Step(search_x_y, optuna.samplers.CmaEsSampler(), n_trials=25),
-    optuna.samplers._stepwise.Step(search_x, optuna.samplers.TPESampler(), n_trials=50),
-    optuna.samplers._stepwise.Step(search_y, optuna.samplers.RandomSampler(), n_trials=25),
-    optuna.samplers._stepwise.Step(search_z, optuna.samplers.TPESampler(), n_trials=25),
-    optuna.samplers._stepwise.Step(search_x_y, optuna.samplers.CmaEsSampler(), n_trials=25),
+    Step(search_x_y, lambda _: optuna.samplers.CmaEsSampler(), n_trials=25),
+    Step(search_x, lambda _: optuna.samplers.TPESampler(), n_trials=50),
+    Step(search_y, lambda _: optuna.samplers.RandomSampler(), n_trials=25),
+    Step(search_z, lambda _: optuna.samplers.TPESampler(), n_trials=25),
+    Step(search_x_y, lambda _: optuna.samplers.CmaEsSampler(), n_trials=25),
 ]
 
-sampler = optuna.samplers._stepwise.StepwiseSampler(steps=steps, default_params={"x": 0, "y": 0, "z": 0})
+sampler = StepwiseSampler(steps=steps, default_params={"x": 0, "y": 0, "z": 0})
 study = optuna.create_study(sampler=sampler)
 study.optimize(objective, n_jobs=2)
 

--- a/examples/stepwise_simple.py
+++ b/examples/stepwise_simple.py
@@ -6,7 +6,8 @@ import optuna.samplers._stepwise
 def objective(trial):
     x = trial.suggest_float("x", 0, 100)
     y = trial.suggest_float("y", 0, 100)
-    return (x - 20) ** 2 + (y - 80) ** 2
+    z = trial.suggest_float("z", 0, 100)
+    return (x - 20) ** 2 + (y - 80) ** 2 + (z - 50) ** 2
 
 
 def search_x(params):
@@ -17,14 +18,24 @@ def search_y(params):
     return {"y": optuna.distributions.UniformDistribution(0, 100)}
 
 
+def search_z(params):
+    return {"z": optuna.distributions.UniformDistribution(0, 100)}
+
+def search_x_y(params):
+    return {"x": optuna.distributions.UniformDistribution(0, 100), "y": optuna.distributions.UniformDistribution(0, 100)}
+
+
 steps = [
+    optuna.samplers._stepwise.Step(search_x_y, optuna.samplers.CmaEsSampler(), n_trials=25),
     optuna.samplers._stepwise.Step(search_x, optuna.samplers.TPESampler(), n_trials=50),
     optuna.samplers._stepwise.Step(search_y, optuna.samplers.RandomSampler(), n_trials=25),
-    optuna.samplers._stepwise.Step(search_y, optuna.samplers.TPESampler(), n_trials=25),
+    optuna.samplers._stepwise.Step(search_z, optuna.samplers.TPESampler(), n_trials=25),
+    optuna.samplers._stepwise.Step(search_x_y, optuna.samplers.CmaEsSampler(), n_trials=25),
 ]
 
-sampler = optuna.samplers._stepwise.StepwiseSampler(steps=steps, default_params={"x": 0, "y": 0})
+sampler = optuna.samplers._stepwise.StepwiseSampler(steps=steps, default_params={"x": 0, "y": 0, "z": 0})
 study = optuna.create_study(sampler=sampler)
 study.optimize(objective)
 
 print(study.best_trial)
+print(study.trials_dataframe(["number", "value", "params"]))

--- a/examples/stepwise_simple.py
+++ b/examples/stepwise_simple.py
@@ -1,4 +1,3 @@
-from optuna.samplers._tpe.sampler import default_gamma
 import optuna
 import optuna.samplers._stepwise
 
@@ -21,6 +20,7 @@ def search_y(params):
 def search_z(params):
     return {"z": optuna.distributions.UniformDistribution(0, 100)}
 
+
 def search_x_y(params):
     return {"x": optuna.distributions.UniformDistribution(0, 100), "y": optuna.distributions.UniformDistribution(0, 100)}
 
@@ -35,7 +35,7 @@ steps = [
 
 sampler = optuna.samplers._stepwise.StepwiseSampler(steps=steps, default_params={"x": 0, "y": 0, "z": 0})
 study = optuna.create_study(sampler=sampler)
-study.optimize(objective)
+study.optimize(objective, n_jobs=2)
 
 print(study.best_trial)
 print(study.trials_dataframe(["number", "value", "params"]))

--- a/examples/stepwise_simple.py
+++ b/examples/stepwise_simple.py
@@ -1,0 +1,30 @@
+from optuna.samplers._tpe.sampler import default_gamma
+import optuna
+import optuna.samplers._stepwise
+
+
+def objective(trial):
+    x = trial.suggest_float("x", 0, 100)
+    y = trial.suggest_float("y", 0, 100)
+    return (x - 20) ** 2 + (y - 80) ** 2
+
+
+def search_x(params):
+    return {"x": optuna.distributions.UniformDistribution(0, 100)}
+
+
+def search_y(params):
+    return {"y": optuna.distributions.UniformDistribution(0, 100)}
+
+
+steps = [
+    optuna.samplers._stepwise.Step(search_x, optuna.samplers.TPESampler(), n_trials=50),
+    optuna.samplers._stepwise.Step(search_y, optuna.samplers.RandomSampler(), n_trials=25),
+    optuna.samplers._stepwise.Step(search_y, optuna.samplers.TPESampler(), n_trials=25),
+]
+
+sampler = optuna.samplers._stepwise.StepwiseSampler(steps=steps, default_params={"x": 0, "y": 0})
+study = optuna.create_study(sampler=sampler)
+study.optimize(objective)
+
+print(study.best_trial)

--- a/examples/stepwise_tuner.py
+++ b/examples/stepwise_tuner.py
@@ -1,0 +1,249 @@
+import copy
+from typing import Any
+from typing import Callable
+from typing import Dict
+from typing import List
+from typing import Optional
+from typing import Union
+
+import lightgbm as lgb
+
+import optuna
+from optuna.distributions import UniformDistribution
+from optuna.integration._lightgbm_tuner.optimize import _DEFAULT_LIGHTGBM_PARAMETERS
+from optuna.integration._lightgbm_tuner.optimize import _DEFAULT_TUNER_TREE_DEPTH
+from optuna.integration._lightgbm_tuner.optimize import _EPS
+from optuna.integration._lightgbm_tuner.optimize import VALID_SET_TYPE
+from optuna.samplers._stepwise import Step
+from optuna.samplers._stepwise import StepwiseSampler
+
+
+class Tuner:
+    def __init__(
+        self,
+        params: Dict[str, Any],
+        train_set: "lgb.Dataset",
+        num_boost_round: int = 1000,
+        valid_sets: Optional["VALID_SET_TYPE"] = None,
+        valid_names: Optional[Any] = None,
+        fobj: Optional[Callable[..., Any]] = None,
+        feval: Optional[Callable[..., Any]] = None,
+        feature_name: str = "auto",
+        categorical_feature: str = "auto",
+        early_stopping_rounds: Optional[int] = None,
+        verbose_eval: Optional[Union[bool, int]] = True,
+        callbacks: Optional[List[Callable[..., Any]]] = None,
+        time_budget: Optional[int] = None,
+        sample_size: Optional[int] = None,
+        study: Optional[optuna.study.Study] = None,
+    ):
+        self._lgbm_params = params
+        self.train_set = train_set
+        self.lgbm_kwargs: Dict[str, Any] = dict(
+            num_boost_round=num_boost_round,
+            fobj=fobj,
+            feval=feval,
+            feature_name=feature_name,
+            categorical_feature=categorical_feature,
+            early_stopping_rounds=early_stopping_rounds,
+            verbose_eval=verbose_eval,
+            callbacks=callbacks,
+            valid_sets=valid_sets,
+            valid_names=valid_names,
+        )
+
+    def suggest_lgbm_params(self, trial):
+        lgbm_params = self._lgbm_params
+        lgbm_params["lambda_l1"] = trial.suggest_float("lambda_l1", 1e-8, 10.0, log=True)
+        lgbm_params["lambda_l2"] = trial.suggest_float("lambda_l2", 1e-8, 10.0, log=True)
+
+        tree_depth = lgbm_params.get("max_depth", _DEFAULT_TUNER_TREE_DEPTH)
+        max_num_leaves = 2 ** tree_depth if tree_depth > 0 else 2 ** _DEFAULT_TUNER_TREE_DEPTH
+        lgbm_params["num_leaves"] = trial.suggest_int("num_leaves", 2, max_num_leaves)
+
+        lgbm_params["feature_fraction"] = min(
+            trial.suggest_float("feature_fraction", 0.4, 1.0 + _EPS), 1.0
+        )
+        lgbm_params["bagging_fraction"] = min(
+            trial.suggest_float("bagging_fraction", 0.4, 1.0 + _EPS), 1.0
+        )
+        lgbm_params["bagging_freq"] = trial.suggest_int("bagging_freq", 1, 7)
+
+        lgbm_params["min_child_samples"] = trial.suggest_int("min_child_samples", 5, 100)
+        return
+
+    def _copy_valid_sets(self, valid_sets: "VALID_SET_TYPE") -> "VALID_SET_TYPE":
+        if isinstance(valid_sets, list):
+            return [copy.copy(d) for d in valid_sets]
+        if isinstance(valid_sets, tuple):
+            return tuple([copy.copy(d) for d in valid_sets])
+        return copy.copy(valid_sets)
+
+    def _metric_with_eval_at(self, metric: str) -> str:
+
+        lgbm_params = self._lgbm_params
+        if metric != "ndcg" and metric != "map":
+            return metric
+
+        eval_at = lgbm_params.get("eval_at")
+        if eval_at is None:
+            eval_at = lgbm_params.get("{}_at".format(metric))
+        if eval_at is None:
+            eval_at = lgbm_params.get("{}_eval_at".format(metric))
+        if eval_at is None:
+            # Set default value of LightGBM.
+            # See https://lightgbm.readthedocs.io/en/latest/Parameters.html#eval_at.
+            eval_at = [1, 2, 3, 4, 5]
+
+        # Optuna can handle only a single metric. Choose first one.
+        if type(eval_at) in [list, tuple]:
+            return "{}@{}".format(metric, eval_at[0])
+        if type(eval_at) is int:
+            return "{}@{}".format(metric, eval_at)
+        raise ValueError(
+            "The value of eval_at is expected to be int or a list/tuple of int."
+            "'{}' is specified.".format(eval_at)
+        )
+
+    def _get_metric_for_objective(self) -> str:
+        metric = self._lgbm_params.get("metric", "binary_logloss")
+
+        # todo (smly): This implementation is different logic from the LightGBM's python bindings.
+        if type(metric) is str:
+            pass
+        elif type(metric) is list:
+            metric = metric[-1]
+        elif type(metric) is set:
+            metric = list(metric)[-1]
+        else:
+            raise NotImplementedError
+        metric = self._metric_with_eval_at(metric)
+
+        return metric
+
+    def _get_booster_best_score(self, booster: "lgb.Booster") -> float:
+
+        metric = self._get_metric_for_objective()
+        valid_sets: Optional[VALID_SET_TYPE] = self.lgbm_kwargs.get("valid_sets")
+
+        if self.lgbm_kwargs.get("valid_names") is not None:
+            if type(self.lgbm_kwargs["valid_names"]) is str:
+                valid_name = self.lgbm_kwargs["valid_names"]
+            elif type(self.lgbm_kwargs["valid_names"]) in [list, tuple]:
+                valid_name = self.lgbm_kwargs["valid_names"][-1]
+            else:
+                raise NotImplementedError
+
+        elif type(valid_sets) is lgb.Dataset:
+            valid_name = "valid_0"
+
+        elif isinstance(valid_sets, (list, tuple)) and len(valid_sets) > 0:
+            valid_set_idx = len(valid_sets) - 1
+            valid_name = "valid_{}".format(valid_set_idx)
+
+        else:
+            raise NotImplementedError
+
+        val_score = booster.best_score[valid_name][metric]
+        return val_score
+
+    def objective(self, trial):
+        self.suggest_lgbm_params(trial)
+
+        train_set = copy.copy(self.train_set)
+        kwargs = copy.copy(self.lgbm_kwargs)
+        kwargs["valid_sets"] = self._copy_valid_sets(kwargs["valid_sets"])
+        booster = lgb.train(self._lgbm_params, train_set, **kwargs)
+
+        val_score = self._get_booster_best_score(booster)
+        return val_score
+
+    def tune_feature_fraction(self, n_trials=7):
+        param_name = "feature_fraction"
+        param_values = np.linspace(0.4, 1.0, n_trials).tolist()
+        search_space = {param_name: UniformDistribution(0.4, 1.0 + _EPS)}
+        sampler = optuna.samplers.GridSampler({param_name: param_values})
+        return lambda _: search_space, lambda _: sampler, n_trials
+
+    def tune_num_leaves(self, n_trials: int = 20):
+        tree_depth = self._lgbm_params.get("max_depth", _DEFAULT_TUNER_TREE_DEPTH)
+        max_num_leaves = 2 ** tree_depth if tree_depth > 0 else 2 ** _DEFAULT_TUNER_TREE_DEPTH
+        search_space = {
+            "num_leaves": optuna.distributions.IntUniformDistribution(2, max_num_leaves)
+        }
+        return lambda _: search_space, lambda _: optuna.samplers.TPESampler(), n_trials
+
+    def tune_bagging(self, n_trials: int = 10):
+        search_space = {
+            "bagging_fraction": optuna.distributions.UniformDistribution(0.4, 1.0 + _EPS),
+            "bagging_freq": optuna.distributions.IntUniformDistribution(1, 7),
+        }
+        return lambda _: search_space, lambda _: optuna.samplers.TPESampler(), n_trials
+
+    def tune_feature_fraction_stage2(self, n_trials: int = 6):
+        param_name = "feature_fraction"
+
+        def search_space_fn(params):
+            search_space = {param_name: UniformDistribution(0.4, 1.0 + _EPS)}
+            return search_space
+
+        def sampler_fn(params):
+            best_feature_fraction = params[param_name]
+            param_values = np.linspace(
+                best_feature_fraction - 0.08, best_feature_fraction + 0.08, n_trials
+            ).tolist()
+            param_values = [val for val in param_values if val >= 0.4 and val <= 1.0]
+            return optuna.samplers.GridSampler({"feature_fraction": param_values})
+
+        return search_space_fn, sampler_fn, n_trials
+
+    def tune_regularization_factors(self, n_trials: int = 20):
+        search_space = {
+            "lambda_l1": optuna.distributions.LogUniformDistribution(1e-8, 10.0),
+            "lambda_l2": optuna.distributions.LogUniformDistribution(1e-8, 10.0),
+        }
+        return lambda _: search_space, lambda _: optuna.samplers.TPESampler(), n_trials
+
+    def tune_min_data_in_leaf(self):
+        param_name = "min_child_samples"
+        param_values = [5, 10, 25, 50, 100]
+        search_space = {param_name: optuna.distributions.IntUniformDistribution(5, 100)}
+
+        sampler = optuna.samplers.GridSampler({param_name: param_values})
+        return lambda _: search_space, lambda _: sampler, len(param_values)
+
+    def run(self):
+        steps = [
+            Step(*self.tune_feature_fraction()),
+            Step(*self.tune_num_leaves()),
+            Step(*self.tune_bagging()),
+            Step(*self.tune_feature_fraction_stage2()),
+            Step(*self.tune_regularization_factors()),
+            Step(*self.tune_min_data_in_leaf()),
+        ]
+        sampler = StepwiseSampler(steps, default_params=_DEFAULT_LIGHTGBM_PARAMETERS)
+        study = optuna.create_study(sampler=sampler)
+        study.optimize(self.objective)
+
+
+if __name__ == "__main__":
+    import numpy as np
+    import sklearn.datasets
+    from sklearn.model_selection import train_test_split
+
+    data, target = sklearn.datasets.load_breast_cancer(return_X_y=True)
+    train_x, val_x, train_y, val_y = train_test_split(data, target, test_size=0.25)
+    dtrain = lgb.Dataset(train_x, label=train_y)
+    dval = lgb.Dataset(val_x, label=val_y)
+
+    params = {
+        "objective": "binary",
+        "metric": "binary_logloss",
+        "verbosity": -1,
+        "boosting_type": "gbdt",
+    }
+
+    tuner = Tuner(
+        params, dtrain, valid_sets=[dtrain, dval], verbose_eval=100, early_stopping_rounds=100
+    )
+    tuner.run()

--- a/optuna/samplers/_stepwise.py
+++ b/optuna/samplers/_stepwise.py
@@ -24,7 +24,8 @@ class StepwiseSampler(optuna.samplers.BaseSampler):
         self.default_params = default_params
 
     def reseed_rng(self) -> None:
-        pass
+        for step in self.steps:
+            step._sampler.reseed_rng()
 
     def _get_step(self, study, trial) -> Step:
         number = trial.number

--- a/optuna/samplers/_stepwise.py
+++ b/optuna/samplers/_stepwise.py
@@ -1,0 +1,69 @@
+from typing import Any
+from typing import Dict
+from typing import List
+
+import optuna
+from optuna.distributions import BaseDistribution
+from optuna.study import Study
+from optuna.trial import FrozenTrial
+
+
+class Step:
+    def __init__(self, search_space_fn, sampler, n_trials) -> None:
+        self._search_space_fn = search_space_fn
+        self._sampler = sampler
+        self._n_trials = n_trials
+
+    def get_search_space(self, current_params: Dict[str, Any]) -> Dict[str, BaseDistribution]:
+        return self._search_space_fn(current_params)
+
+
+class StepwiseSampler(optuna.samplers.BaseSampler):
+    def __init__(self, steps: List[Step], default_params: Dict[str, Any]) -> None:
+        self.steps = steps
+        self.default_params = default_params
+
+    def reseed_rng(self) -> None:
+        pass
+
+    def _get_step(self, study, trial) -> Step:
+        number = trial.number
+        cum_steps = 0
+        for step in self.steps:
+            if cum_steps <= number < cum_steps + step._n_trials:
+                return step
+            cum_steps += step._n_trials
+        study.stop()
+        return self.steps[-1]
+
+    def _get_default_params(self, study: Study):
+        if len([t for t in study.trials if t.state == optuna.trial.TrialState.COMPLETE]) > 0:
+            return study.best_params
+        return self.default_params
+
+    def infer_relative_search_space(
+        self, study: Study, trial: FrozenTrial
+    ) -> Dict[str, BaseDistribution]:
+
+        return {}
+
+    def sample_relative(
+        self, study: Study, trial: FrozenTrial, search_space: Dict[str, BaseDistribution]
+    ) -> Dict[str, Any]:
+
+        return {}
+
+    def sample_independent(
+        self,
+        study: Study,
+        trial: FrozenTrial,
+        param_name: str,
+        param_distribution: BaseDistribution,
+    ) -> Any:
+        step = self._get_step(study, trial)
+        search_space = step.get_search_space(self._get_default_params(study))
+        if param_name in search_space:
+            return step._sampler.sample_independent(
+                study, trial, param_name, search_space[param_name]
+            )
+        return self._get_default_params(study)[param_name]

--- a/optuna/samplers/_stepwise.py
+++ b/optuna/samplers/_stepwise.py
@@ -1,43 +1,74 @@
 from typing import Any
+from typing import Callable
 from typing import Dict
 from typing import List
+from typing import Optional
 
 import optuna
 from optuna.distributions import BaseDistribution
+from optuna.samplers import BaseSampler
 from optuna.study import Study
 from optuna.trial import FrozenTrial
 
 
 class Step:
-    def __init__(self, search_space_fn, sampler, n_trials) -> None:
+    def __init__(
+        self,
+        search_space_fn: Callable[[Dict[str, Any]], Dict[str, BaseDistribution]],
+        sampler_fn: Callable[[Dict[str, Any]], BaseSampler],
+        n_trials: int,
+    ) -> None:
         self._search_space_fn = search_space_fn
-        self._sampler = sampler
+        self._sampler_fn = sampler_fn
+        self._sampler: Optional[BaseSampler] = None
         self._n_trials = n_trials
 
     def get_search_space(self, current_params: Dict[str, Any]) -> Dict[str, BaseDistribution]:
         return self._search_space_fn(current_params)
+
+    def get_sampler(self, current_params: Dict[str, Any]) -> BaseSampler:
+        if self._sampler:
+            return self._sampler
+
+        self._sampler = self._sampler_fn(current_params)
+        return self._sampler
+
+    def update_n_trials(self, steps: List["Step"], trial: FrozenTrial) -> None:
+        cum_trials = 0
+        for step in steps:
+            if step is self:
+                break
+            cum_trials += step._n_trials
+        # Note that trial.number starts from zero.
+        self._n_trials = trial.number - cum_trials + 1
 
 
 class StepwiseSampler(optuna.samplers.BaseSampler):
     def __init__(self, steps: List[Step], default_params: Dict[str, Any]) -> None:
         self.steps = steps
         self.default_params = default_params
+        self.stop_flag = False
 
     def reseed_rng(self) -> None:
         for step in self.steps:
-            step._sampler.reseed_rng()
+            if step._sampler:
+                step._sampler.reseed_rng()
 
-    def _get_step(self, study, trial) -> Step:
+    def _get_step(self, study: optuna.study.Study, trial: FrozenTrial) -> Step:
         number = trial.number
         cum_steps = 0
+        ret_step = self.steps[-1]
         for step in self.steps:
             if cum_steps <= number < cum_steps + step._n_trials:
-                return step
+                ret_step = step
+                break
             cum_steps += step._n_trials
-        study.stop()
-        return self.steps[-1]
+        if ret_step == self.steps[-1] and number >= cum_steps + ret_step._n_trials - 1:
+            self.stop_flag = True
+            study.stop()
+        return ret_step
 
-    def _get_default_params(self, study: Study):
+    def _get_default_params(self, study: Study) -> Dict[str, Any]:
         if len([t for t in study.trials if t.state == optuna.trial.TrialState.COMPLETE]) > 0:
             return study.best_params
         return self.default_params
@@ -48,19 +79,19 @@ class StepwiseSampler(optuna.samplers.BaseSampler):
 
         step = self._get_step(study, trial)
         search_space = step.get_search_space(self._get_default_params(study))
-        if len(search_space) < 2:
-            return {}
         return search_space
 
     def sample_relative(
         self, study: Study, trial: FrozenTrial, search_space: Dict[str, BaseDistribution]
     ) -> Dict[str, Any]:
 
-        if len(search_space) < 2:
-            return {}
-
         step = self._get_step(study, trial)
-        return step._sampler.sample_relative(study, trial, search_space)
+        sampler = step.get_sampler(self._get_default_params(study))
+        value = sampler.sample_relative(study, trial, search_space)
+        if study._stop_flag and not self.stop_flag:
+            study._stop_flag = False
+            step.update_n_trials(self.steps, trial)
+        return value
 
     def sample_independent(
         self,
@@ -71,8 +102,12 @@ class StepwiseSampler(optuna.samplers.BaseSampler):
     ) -> Any:
         step = self._get_step(study, trial)
         search_space = step.get_search_space(self._get_default_params(study))
-        if param_name in search_space:
-            return step._sampler.sample_independent(
-                study, trial, param_name, search_space[param_name]
-            )
-        return self._get_default_params(study)[param_name]
+        if param_name not in search_space:
+            return self._get_default_params(study)[param_name]
+
+        sampler = step.get_sampler(self._get_default_params(study))
+        value = sampler.sample_independent(study, trial, param_name, search_space[param_name])
+        if study._stop_flag and not self.stop_flag:
+            study._stop_flag = False
+            step.update_n_trials(self.steps, trial)
+        return value

--- a/optuna/samplers/_stepwise.py
+++ b/optuna/samplers/_stepwise.py
@@ -45,13 +45,21 @@ class StepwiseSampler(optuna.samplers.BaseSampler):
         self, study: Study, trial: FrozenTrial
     ) -> Dict[str, BaseDistribution]:
 
-        return {}
+        step = self._get_step(study, trial)
+        search_space = step.get_search_space(self._get_default_params(study))
+        if len(search_space) < 2:
+            return {}
+        return search_space
 
     def sample_relative(
         self, study: Study, trial: FrozenTrial, search_space: Dict[str, BaseDistribution]
     ) -> Dict[str, Any]:
 
-        return {}
+        if len(search_space) < 2:
+            return {}
+
+        step = self._get_step(study, trial)
+        return step._sampler.sample_relative(study, trial, search_space)
 
     def sample_independent(
         self,

--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -236,6 +236,7 @@ class TPESampler(BaseSampler):
 
         param_names = list(search_space.keys())
         values, scores = _get_multivariate_observation_pairs(study, param_names)
+        values, scores = _filter_out_multivariate_observation_pairs(values, scores, search_space)
 
         # If the number of samples is insufficient, we run random trial.
         n = len(scores)
@@ -272,6 +273,7 @@ class TPESampler(BaseSampler):
     ) -> Any:
 
         values, scores = _get_observation_pairs(study, param_name)
+        values, scores = _filter_out_observation_pairs(values, scores, param_distribution)
 
         n = len(values)
 
@@ -827,3 +829,40 @@ def _get_multivariate_observation_pairs(
             values[param_name].append(param_value)
 
     return values, scores
+
+
+def _filter_out_observation_pairs(
+    values: List[Optional[float]],
+    scores: List[Tuple[float, float]],
+    distribution: BaseDistribution,
+) -> Tuple[List[Optional[float]], List[Tuple[float, float]]]:
+    ret_values = []
+    ret_scores = []
+    for value, score in zip(values, scores):
+        if value is None or distribution._contains(value):
+            ret_values.append(value)
+            ret_scores.append(score)
+    return ret_values, ret_scores
+
+
+def _filter_out_multivariate_observation_pairs(
+    values: Dict[str, List[Optional[float]]],
+    scores: List[Tuple[float, float]],
+    search_space: Dict[str, BaseDistribution],
+) -> Tuple[Dict[str, List[Optional[float]]], List[Tuple[float, float]]]:
+    ret_values: Dict[str, List[Optional[float]]] = {name: [] for name in values}
+    ret_scores = []
+    includes = [True for _ in range(len(scores))]
+    for name, distribution in search_space.items():
+        for i, value in enumerate(values[name]):
+            if value is not None and distribution._contains(value):
+                continue
+            includes[i] = False
+    for name in search_space:
+        for include, value in zip(includes, values[name]):
+            if include:
+                ret_values[name].append(value)
+    for include, score in zip(includes, scores):
+        if include:
+            ret_scores.append(score)
+    return ret_values, ret_scores


### PR DESCRIPTION
## Motivation

In #1632, we discuss the design of the customizable `LightGBMTuner`.  #1947 implements it on top of `optuna.stepwise.StepwiseTuner`, which is a newly introduced concept to invoke optimization in a step-wise manner.

Alternatively, I used a sampler (`StepwiseSampler`) to implement step-wise tuning in this PR. `StepwiseSampler` receives a list of steps, and a step consists of a search space, sampler, and `n_trials`.  Using `StepwiseSampler`, IMO, we can implement `LightGBMTuner` with the usual `Study` and `Sampler`. 

Please note that this is just a prototypical implementation to discuss the design of step tuning. Please let me know if you have any comments.

## Description of the changes

- Add `optuna.samplers.StepwiseSampler`
- Add an example to minimize a quadratic function using `StepwiseSampler`
- Add an example of `LightGBMTuner` using `StepwiseSampler`
- Add filter functions to `TPESampler` to exclude observations that are out of the target distribution. It is required by `LightGBMTuner`

## Comments on API design

- Currently, `Step.__init__` receives the generator functions of search spaces and samplers. It can be helpful if it can also handle the search spaces and samplers.
- We can also omit the distributions from the search spaces. For example, `Step({"x"}, TPESampler(), n_trials=10)` is simpler than `Step({"x": UniformDistribution(0, 100)}, TPESampler, n_trials=10)`.
- I sometimes want a callback mechanism which is called after a step finished.
- All trials include all parameters while the `LightGBMTuner` in the master branch includes only a part of parameters tuned at the step.
- If `steps` have `GridSampler`, the study will be stopped even if `StepwiseSampler` has remaining `steps`. To continue the tuning, `StepwiseSampler` turns off the `Study.stop_flag`, but such implementation may be ad-hoc.