### PR TITLE
Add axis order for plot_pareto_front

### DIFF
--- a/optuna/multi_objective/visualization/_pareto_front.py
+++ b/optuna/multi_objective/visualization/_pareto_front.py
@@ -186,7 +186,7 @@ def _get_pareto_front_3d(
                 f"Size of `axis_order` {axis_order}. Expect: 3, Actual: {len(axis_order)}"
             )
         if np.unique(axis_order).size != 3:
-            raise ValueError(f"Elements of given `axis_order` {axis_order} are not unique!")
+            raise ValueError(f"Elements of given `axis_order` {axis_order} are not unique!.")
         if max(axis_order) > 2:
             raise ValueError(
                 f"Given `axis_order` {axis_order} contains invalid index {max(axis_order)} "

--- a/optuna/multi_objective/visualization/_pareto_front.py
+++ b/optuna/multi_objective/visualization/_pareto_front.py
@@ -195,7 +195,7 @@ def _get_pareto_front_3d(
         if min(axis_order) < 0:
             raise ValueError(
                 f"Given `axis_order` {axis_order} contains invalid index {min(axis_order)} "
-                "lower than 0"
+                "lower than 0."
             )
 
     data = go.Scatter3d(

--- a/optuna/multi_objective/visualization/_pareto_front.py
+++ b/optuna/multi_objective/visualization/_pareto_front.py
@@ -183,7 +183,7 @@ def _get_pareto_front_3d(
     else:
         if len(axis_order) != 3:
             raise ValueError(
-                f"Size of `axis_order` {axis_order}. Expect: 3, Actual: {len(axis_order)}"
+                f"Size of `axis_order` {axis_order}. Expect: 3, Actual: {len(axis_order)}."
             )
         if np.unique(axis_order).size != 3:
             raise ValueError(f"Elements of given `axis_order` {axis_order} are not unique!.")

--- a/optuna/multi_objective/visualization/_pareto_front.py
+++ b/optuna/multi_objective/visualization/_pareto_front.py
@@ -138,7 +138,7 @@ def _get_pareto_front_2d(
         if min(axis_order) < 0:
             raise ValueError(
                 f"Given `axis_order` {axis_order} contains invalid index {min(axis_order)} "
-                "lower than 0"
+                "lower than 0."
             )
 
     data = go.Scatter(

--- a/optuna/multi_objective/visualization/_pareto_front.py
+++ b/optuna/multi_objective/visualization/_pareto_front.py
@@ -126,7 +126,7 @@ def _get_pareto_front_2d(
     else:
         if len(axis_order) != 2:
             raise ValueError(
-                f"Size of `axis_order` {axis_order}. Expect: 2, Actual: {len(axis_order)}"
+                f"Size of `axis_order` {axis_order}. Expect: 2, Actual: {len(axis_order)}."
             )
         if np.unique(axis_order).size != 2:
             raise ValueError(f"Elements of given `axis_order` {axis_order} are not unique!")

--- a/optuna/multi_objective/visualization/_pareto_front.py
+++ b/optuna/multi_objective/visualization/_pareto_front.py
@@ -2,8 +2,6 @@ import json
 from typing import List
 from typing import Optional
 
-import numpy as np
-
 import optuna
 from optuna import multi_objective
 from optuna._experimental import experimental
@@ -128,7 +126,7 @@ def _get_pareto_front_2d(
             raise ValueError(
                 f"Size of `axis_order` {axis_order}. Expect: 2, Actual: {len(axis_order)}."
             )
-        if np.unique(axis_order).size != 2:
+        if len(set(axis_order)) != 2:
             raise ValueError(f"Elements of given `axis_order` {axis_order} are not unique!")
         if max(axis_order) > 1:
             raise ValueError(
@@ -185,7 +183,7 @@ def _get_pareto_front_3d(
             raise ValueError(
                 f"Size of `axis_order` {axis_order}. Expect: 3, Actual: {len(axis_order)}."
             )
-        if np.unique(axis_order).size != 3:
+        if len(set(axis_order)) != 3:
             raise ValueError(f"Elements of given `axis_order` {axis_order} are not unique!.")
         if max(axis_order) > 2:
             raise ValueError(

--- a/optuna/multi_objective/visualization/_pareto_front.py
+++ b/optuna/multi_objective/visualization/_pareto_front.py
@@ -133,7 +133,7 @@ def _get_pareto_front_2d(
         if max(axis_order) > 1:
             raise ValueError(
                 f"Given `axis_order` {axis_order} contains invalid index {max(axis_order)} "
-                "higher than 1"
+                "higher than 1."
             )
         if min(axis_order) < 0:
             raise ValueError(

--- a/optuna/multi_objective/visualization/_pareto_front.py
+++ b/optuna/multi_objective/visualization/_pareto_front.py
@@ -2,6 +2,8 @@ import json
 from typing import List
 from typing import Optional
 
+import numpy as np
+
 import optuna
 from optuna import multi_objective
 from optuna._experimental import experimental
@@ -123,13 +125,21 @@ def _get_pareto_front_2d(
         axis_order = list(range(2))
     else:
         if len(axis_order) != 2:
-            raise ValueError(f"Size of `axis_order`. Expect: 2, Actual: {len(axis_order)}")
-        if (np.unique(axis_order).size != 2):
+            raise ValueError(
+                f"Size of `axis_order` {axis_order}. Expect: 2, Actual: {len(axis_order)}"
+            )
+        if np.unique(axis_order).size != 2:
             raise ValueError(f"Elements of given `axis_order` {axis_order} are not unique!")
         if max(axis_order) > 1:
-            _logger.warning("axis_order contains invalid index higher than 1")
-        elif min(axis_order) < 0:
-            _logger.warning("axis_order contains invalid index lower than 0")
+            raise ValueError(
+                f"Given `axis_order` {axis_order} contains invalid index {max(axis_order)} "
+                "higher than 1"
+            )
+        if min(axis_order) < 0:
+            raise ValueError(
+                f"Given `axis_order` {axis_order} contains invalid index {min(axis_order)} "
+                "lower than 0"
+            )
 
     data = go.Scatter(
         x=[t.values[axis_order[0]] for t in trials],
@@ -170,10 +180,23 @@ def _get_pareto_front_3d(
 
     if axis_order is None:
         axis_order = list(range(3))
-    elif max(axis_order) > 2:
-        _logger.warning("axis_order contains invalid index higher than 2")
-    elif min(axis_order) < 0:
-        _logger.warning("axis_order contains invalid index lower than 0")
+    else:
+        if len(axis_order) != 3:
+            raise ValueError(
+                f"Size of `axis_order` {axis_order}. Expect: 3, Actual: {len(axis_order)}"
+            )
+        if np.unique(axis_order).size != 3:
+            raise ValueError(f"Elements of given `axis_order` {axis_order} are not unique!")
+        if max(axis_order) > 2:
+            raise ValueError(
+                f"Given `axis_order` {axis_order} contains invalid index {max(axis_order)} "
+                "higher than 2"
+            )
+        if min(axis_order) < 0:
+            raise ValueError(
+                f"Given `axis_order` {axis_order} contains invalid index {min(axis_order)} "
+                "lower than 0"
+            )
 
     data = go.Scatter3d(
         x=[t.values[axis_order[0]] for t in trials],

--- a/optuna/multi_objective/visualization/_pareto_front.py
+++ b/optuna/multi_objective/visualization/_pareto_front.py
@@ -99,8 +99,10 @@ def _get_non_pareto_front_trials(
 
 
 def _get_pareto_front_2d(
-    study: MultiObjectiveStudy, names: Optional[List[str]], include_dominated_trials: bool = False,
-    axis_order: Optional[List[int]] = None
+    study: MultiObjectiveStudy,
+    names: Optional[List[str]],
+    include_dominated_trials: bool = False,
+    axis_order: Optional[List[int]] = None,
 ) -> "go.Figure":
     if names is None:
         names = ["Objective 0", "Objective 1"]
@@ -135,14 +137,16 @@ def _get_pareto_front_2d(
     layout = go.Layout(
         title="Pareto-front Plot",
         xaxis_title=names[axis_order[0]],
-        yaxis_title=names[axis_order[1]]
+        yaxis_title=names[axis_order[1]],
     )
     return go.Figure(data=data, layout=layout)
 
 
 def _get_pareto_front_3d(
-    study: MultiObjectiveStudy, names: Optional[List[str]], include_dominated_trials: bool = False,
-    axis_order: Optional[List[int]] = None
+    study: MultiObjectiveStudy,
+    names: Optional[List[str]],
+    include_dominated_trials: bool = False,
+    axis_order: Optional[List[int]] = None,
 ) -> "go.Figure":
     if names is None:
         names = ["Objective 0", "Objective 1", "Objective 2"]
@@ -180,7 +184,7 @@ def _get_pareto_front_3d(
         scene={
             "xaxis_title": names[axis_order[0]],
             "yaxis_title": names[axis_order[1]],
-            "zaxis_title": names[axis_order[2]]
+            "zaxis_title": names[axis_order[2]],
         },
     )
     return go.Figure(data=data, layout=layout)

--- a/optuna/multi_objective/visualization/_pareto_front.py
+++ b/optuna/multi_objective/visualization/_pareto_front.py
@@ -121,10 +121,15 @@ def _get_pareto_front_2d(
 
     if axis_order is None:
         axis_order = list(range(2))
-    elif max(axis_order) > 1:
-        _logger.warning("axis_order contains invalid index higher than 1")
-    elif min(axis_order) < 0:
-        _logger.warning("axis_order contains invalid index lower than 0")
+    else:
+        if len(axis_order) != 2:
+            raise ValueError(f"Size of `axis_order`. Expect: 2, Actual: {len(axis_order)}")
+        if (np.unique(axis_order).size != 2):
+            raise ValueError(f"Elements of given `axis_order` {axis_order} are not unique!")
+        if max(axis_order) > 1:
+            _logger.warning("axis_order contains invalid index higher than 1")
+        elif min(axis_order) < 0:
+            _logger.warning("axis_order contains invalid index lower than 0")
 
     data = go.Scatter(
         x=[t.values[axis_order[0]] for t in trials],

--- a/optuna/multi_objective/visualization/_pareto_front.py
+++ b/optuna/multi_objective/visualization/_pareto_front.py
@@ -190,7 +190,7 @@ def _get_pareto_front_3d(
         if max(axis_order) > 2:
             raise ValueError(
                 f"Given `axis_order` {axis_order} contains invalid index {max(axis_order)} "
-                "higher than 2"
+                "higher than 2."
             )
         if min(axis_order) < 0:
             raise ValueError(

--- a/optuna/multi_objective/visualization/_pareto_front.py
+++ b/optuna/multi_objective/visualization/_pareto_front.py
@@ -66,7 +66,7 @@ def plot_pareto_front(
         include_dominated_trials:
             A flag to include all dominated trial's objective values.
         axis_order:
-            A list of axis index indicating the order of axis. If :obj:`None` is specified,
+            A list of indices indicating the axis order. If :obj:`None` is specified,
             default order is used.
 
 

--- a/tests/multi_objective_tests/visualization_tests/test_pareto_front.py
+++ b/tests/multi_objective_tests/visualization_tests/test_pareto_front.py
@@ -93,7 +93,9 @@ def test_plot_pareto_front_2d(
 
 
 @pytest.mark.parametrize("include_dominated_trials", [False, True])
-@pytest.mark.parametrize("axis_order", [None] + list(itertools.permutations(range(3), 3)))  # type: ignore
+@pytest.mark.parametrize(
+    "axis_order", [None] + list(itertools.permutations(range(3), 3))  # type: ignore
+)
 def test_plot_pareto_front_3d(
     include_dominated_trials: bool, axis_order: Optional[List[int]]
 ) -> None:

--- a/tests/multi_objective_tests/visualization_tests/test_pareto_front.py
+++ b/tests/multi_objective_tests/visualization_tests/test_pareto_front.py
@@ -1,14 +1,26 @@
 import pytest
 
+from typing import List
+from typing import Optional
+
+import itertools
+
 import optuna
 from optuna.multi_objective.visualization import plot_pareto_front
 
 
 @pytest.mark.parametrize("include_dominated_trials", [False, True])
-def test_plot_pareto_front_2d(include_dominated_trials: bool) -> None:
+@pytest.mark.parametrize("axis_order", [None, [0, 1], [1, 0]])
+def test_plot_pareto_front_2d(
+    include_dominated_trials: bool, axis_order: Optional[List[int]]
+) -> None:
     # Test with no trial.
     study = optuna.multi_objective.create_study(["minimize", "minimize"])
-    figure = plot_pareto_front(study, include_dominated_trials=include_dominated_trials)
+    figure = plot_pareto_front(
+        study,
+        include_dominated_trials=include_dominated_trials,
+        axis_order=axis_order,
+    )
     assert len(figure.data) == 1
     assert figure.data[0]["x"] == ()
     assert figure.data[0]["y"] == ()
@@ -19,18 +31,37 @@ def test_plot_pareto_front_2d(include_dominated_trials: bool) -> None:
     study.enqueue_trial({"x": 0, "y": 1})
     study.optimize(lambda t: [t.suggest_int("x", 0, 1), t.suggest_int("y", 0, 1)], n_trials=3)
 
-    figure = plot_pareto_front(study, include_dominated_trials=include_dominated_trials)
+    figure = plot_pareto_front(
+        study,
+        include_dominated_trials=include_dominated_trials,
+        axis_order=axis_order,
+    )
     assert len(figure.data) == 1
     if include_dominated_trials:
         # The last elements come from dominated trial that is enqueued firstly.
-        assert figure.data[0]["x"] == (1, 0, 1)
-        assert figure.data[0]["y"] == (0, 1, 1)
+        data = [(1, 0, 1), (0, 1, 1)]
+        if axis_order is None:
+            assert figure.data[0]["x"] == data[0]
+            assert figure.data[0]["y"] == data[1]
+        else:
+            assert figure.data[0]["x"] == data[axis_order[0]]
+            assert figure.data[0]["y"] == data[axis_order[1]]
     else:
-        assert figure.data[0]["x"] == (1, 0)
-        assert figure.data[0]["y"] == (0, 1)
+        data = [(1, 0), (0, 1)]
+        if axis_order is None:
+            assert figure.data[0]["x"] == data[0]
+            assert figure.data[0]["y"] == data[1]
+        else:
+            assert figure.data[0]["x"] == data[axis_order[0]]
+            assert figure.data[0]["y"] == data[axis_order[1]]
 
-    assert figure.layout.xaxis.title.text == "Objective 0"
-    assert figure.layout.yaxis.title.text == "Objective 1"
+    titles = ["Objective {}".format(i) for i in range(2)]
+    if axis_order is None:
+        assert figure.layout.xaxis.title.text == titles[0]
+        assert figure.layout.yaxis.title.text == titles[1]
+    else:
+        assert figure.layout.xaxis.title.text == titles[axis_order[0]]
+        assert figure.layout.yaxis.title.text == titles[axis_order[1]]
 
     # Test with `names` argument.
     with pytest.raises(ValueError):
@@ -44,22 +75,36 @@ def test_plot_pareto_front_2d(include_dominated_trials: bool) -> None:
             study,
             names=["Foo", "Bar", "Baz"],
             include_dominated_trials=include_dominated_trials,
+            axis_order=axis_order,
         )
 
+    names = ["Foo", "Bar"]
     figure = plot_pareto_front(
         study,
-        names=["Foo", "Bar"],
+        names=names,
         include_dominated_trials=include_dominated_trials,
+        axis_order=axis_order,
     )
-    assert figure.layout.xaxis.title.text == "Foo"
-    assert figure.layout.yaxis.title.text == "Bar"
+    if axis_order is None:
+        assert figure.layout.xaxis.title.text == names[0]
+        assert figure.layout.yaxis.title.text == names[1]
+    else:
+        assert figure.layout.xaxis.title.text == names[axis_order[0]]
+        assert figure.layout.yaxis.title.text == names[axis_order[1]]
 
 
 @pytest.mark.parametrize("include_dominated_trials", [False, True])
-def test_plot_pareto_front_3d(include_dominated_trials: bool) -> None:
+@pytest.mark.parametrize("axis_order", [None] + list(itertools.permutations(range(3), 3)))
+def test_plot_pareto_front_3d(
+    include_dominated_trials: bool, axis_order: Optional[List[int]]
+) -> None:
     # Test with no trial.
     study = optuna.multi_objective.create_study(["minimize", "minimize", "minimize"])
-    figure = plot_pareto_front(study, include_dominated_trials=include_dominated_trials)
+    figure = plot_pareto_front(
+        study,
+        include_dominated_trials=include_dominated_trials,
+        axis_order=axis_order,
+    )
     assert len(figure.data) == 1
     assert figure.data[0]["x"] == ()
     assert figure.data[0]["y"] == ()
@@ -74,34 +119,67 @@ def test_plot_pareto_front_3d(include_dominated_trials: bool) -> None:
         n_trials=3,
     )
 
-    figure = plot_pareto_front(study, include_dominated_trials=include_dominated_trials)
+    figure = plot_pareto_front(
+        study,
+        include_dominated_trials=include_dominated_trials,
+        axis_order=axis_order,
+    )
     assert len(figure.data) == 1
     if include_dominated_trials:
         # The last elements come from dominated trial that is enqueued firstly.
-        assert figure.data[0]["x"] == (1, 1, 1)
-        assert figure.data[0]["y"] == (0, 1, 1)
-        assert figure.data[0]["z"] == (1, 0, 1)
+        data = [(1, 1, 1), (0, 1, 1), (1, 0, 1)]
+        if axis_order is None:
+            assert figure.data[0]["x"] == data[0]
+            assert figure.data[0]["y"] == data[1]
+            assert figure.data[0]["z"] == data[2]
+        else:
+            assert figure.data[0]["x"] == data[axis_order[0]]
+            assert figure.data[0]["y"] == data[axis_order[1]]
+            assert figure.data[0]["z"] == data[axis_order[2]]
     else:
-        assert figure.data[0]["x"] == (1, 1)
-        assert figure.data[0]["y"] == (0, 1)
-        assert figure.data[0]["z"] == (1, 0)
+        data = [(1, 1), (0, 1), (1, 0)]
+        if axis_order is None:
+            assert figure.data[0]["x"] == data[0]
+            assert figure.data[0]["y"] == data[1]
+            assert figure.data[0]["z"] == data[2]
+        else:
+            assert figure.data[0]["x"] == data[axis_order[0]]
+            assert figure.data[0]["y"] == data[axis_order[1]]
+            assert figure.data[0]["z"] == data[axis_order[2]]
 
-    assert figure.layout.scene.xaxis.title.text == "Objective 0"
-    assert figure.layout.scene.yaxis.title.text == "Objective 1"
-    assert figure.layout.scene.zaxis.title.text == "Objective 2"
+    titles = ["Objective {}".format(i) for i in range(3)]
+    if axis_order is None:
+        assert figure.layout.scene.xaxis.title.text == titles[0]
+        assert figure.layout.scene.yaxis.title.text == titles[1]
+        assert figure.layout.scene.zaxis.title.text == titles[2]
+    else:
+        assert figure.layout.scene.xaxis.title.text == titles[axis_order[0]]
+        assert figure.layout.scene.yaxis.title.text == titles[axis_order[1]]
+        assert figure.layout.scene.zaxis.title.text == titles[axis_order[2]]
 
     # Test with `names` argument.
     with pytest.raises(ValueError):
-        plot_pareto_front(study, names=[], include_dominated_trials=include_dominated_trials)
+        plot_pareto_front(
+            study,
+            names=[],
+            include_dominated_trials=include_dominated_trials,
+            axis_order=axis_order,
+        )
 
     with pytest.raises(ValueError):
-        plot_pareto_front(study, names=["Foo"], include_dominated_trials=include_dominated_trials)
+        plot_pareto_front(
+            study,
+            names=["Foo"],
+            include_dominated_trials=include_dominated_trials,
+            axis_order=axis_order,
+        )
 
     with pytest.raises(ValueError):
         plot_pareto_front(
             study,
             names=["Foo", "Bar"],
             include_dominated_trials=include_dominated_trials,
+            axis_order=axis_order,
         )
 
     with pytest.raises(ValueError):
@@ -109,12 +187,19 @@ def test_plot_pareto_front_3d(include_dominated_trials: bool) -> None:
             study,
             names=["Foo", "Bar", "Baz", "Qux"],
             include_dominated_trials=include_dominated_trials,
+            axis_order=axis_order,
         )
 
-    figure = plot_pareto_front(study, names=["Foo", "Bar", "Baz"])
-    assert figure.layout.scene.xaxis.title.text == "Foo"
-    assert figure.layout.scene.yaxis.title.text == "Bar"
-    assert figure.layout.scene.zaxis.title.text == "Baz"
+    names = ["Foo", "Bar", "Baz"]
+    figure = plot_pareto_front(study, names=names, axis_order=axis_order)
+    if axis_order is None:
+        assert figure.layout.scene.xaxis.title.text == names[0]
+        assert figure.layout.scene.yaxis.title.text == names[1]
+        assert figure.layout.scene.zaxis.title.text == names[2]
+    else:
+        assert figure.layout.scene.xaxis.title.text == names[axis_order[0]]
+        assert figure.layout.scene.yaxis.title.text == names[axis_order[1]]
+        assert figure.layout.scene.zaxis.title.text == names[axis_order[2]]
 
 
 @pytest.mark.parametrize("include_dominated_trials", [False, True])

--- a/tests/multi_objective_tests/visualization_tests/test_pareto_front.py
+++ b/tests/multi_objective_tests/visualization_tests/test_pareto_front.py
@@ -38,7 +38,7 @@ def test_plot_pareto_front_2d(
     assert len(figure.data) == 1
     if include_dominated_trials:
         # The last elements come from dominated trial that is enqueued firstly.
-        data = [(1, 0, 1), (0, 1, 1)]
+        data = [(1, 0, 1), (0, 1, 1)]  # type: ignore
         if axis_order is None:
             assert figure.data[0]["x"] == data[0]
             assert figure.data[0]["y"] == data[1]
@@ -46,7 +46,7 @@ def test_plot_pareto_front_2d(
             assert figure.data[0]["x"] == data[axis_order[0]]
             assert figure.data[0]["y"] == data[axis_order[1]]
     else:
-        data = [(1, 0), (0, 1)]
+        data = [(1, 0), (0, 1)]  # type: ignore
         if axis_order is None:
             assert figure.data[0]["x"] == data[0]
             assert figure.data[0]["y"] == data[1]
@@ -93,7 +93,7 @@ def test_plot_pareto_front_2d(
 
 
 @pytest.mark.parametrize("include_dominated_trials", [False, True])
-@pytest.mark.parametrize("axis_order", [None] + list(itertools.permutations(range(3), 3)))
+@pytest.mark.parametrize("axis_order", [None] + list(itertools.permutations(range(3), 3)))  # type: ignore
 def test_plot_pareto_front_3d(
     include_dominated_trials: bool, axis_order: Optional[List[int]]
 ) -> None:
@@ -126,7 +126,7 @@ def test_plot_pareto_front_3d(
     assert len(figure.data) == 1
     if include_dominated_trials:
         # The last elements come from dominated trial that is enqueued firstly.
-        data = [(1, 1, 1), (0, 1, 1), (1, 0, 1)]
+        data = [(1, 1, 1), (0, 1, 1), (1, 0, 1)]  # type: ignore
         if axis_order is None:
             assert figure.data[0]["x"] == data[0]
             assert figure.data[0]["y"] == data[1]
@@ -136,7 +136,7 @@ def test_plot_pareto_front_3d(
             assert figure.data[0]["y"] == data[axis_order[1]]
             assert figure.data[0]["z"] == data[axis_order[2]]
     else:
-        data = [(1, 1), (0, 1), (1, 0)]
+        data = [(1, 1), (0, 1), (1, 0)]  # type: ignore
         if axis_order is None:
             assert figure.data[0]["x"] == data[0]
             assert figure.data[0]["y"] == data[1]

--- a/tests/multi_objective_tests/visualization_tests/test_pareto_front.py
+++ b/tests/multi_objective_tests/visualization_tests/test_pareto_front.py
@@ -1,9 +1,8 @@
-import pytest
-
+import itertools
 from typing import List
 from typing import Optional
 
-import itertools
+import pytest
 
 import optuna
 from optuna.multi_objective.visualization import plot_pareto_front


### PR DESCRIPTION
<!-- Thank you for creating a pull request! -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
Current `plot_pareto_front` function can not transpose axis.

## Description of the changes
<!-- Describe the changes in this PR. -->
Add `axis_order` argument by which users can handle axis order. It takes a list of index of axes.