### PR TITLE
Fix TODO comment about orders of `dict`s

### DIFF
--- a/optuna/trial/_frozen.py
+++ b/optuna/trial/_frozen.py
@@ -144,7 +144,7 @@ class FrozenTrial(BaseTrial):
         self._trial_id = trial_id
 
     # Ordered list of fields required for `__repr__`, `__hash__` and dataframe creation.
-    # TODO(hvy): Remove this list in Python 3.6 as the order of `self.__dict__` is preserved.
+    # TODO(hvy): Remove this list in Python 3.7 as the order of `self.__dict__` is preserved.
     _ordered_fields = [
         "number",
         "value",


### PR DESCRIPTION
## Motivation

See below.

## Description of the changes

Fix misleading TODO comment about guarantees of orders of dicts in Python. It's not guaranteed until 3.7.
