### PR TITLE
Ignore `tests` directory on install 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -203,7 +203,7 @@ setup(
     author="Takuya Akiba",
     author_email="akiba@preferred.jp",
     url="https://optuna.org/",
-    packages=find_packages(),
+    packages=find_packages(exclude=("tests", "tests.*")),
     package_data={
         "optuna": [
             "storages/_rdb/alembic.ini",


### PR DESCRIPTION
<!-- Thank you for creating a pull request! -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
This PR fixes the issue described here: https://github.com/optuna/optuna/issues/2014
In short, it prevents `tests` installation.

## Description of the changes
<!-- Describe the changes in this PR. -->
`tests` directory and its modules are not being discovered by `find_packages`