### PR TITLE
Wrap callbacks with try and log exceptions

### DIFF
--- a/optuna/_optimize.py
+++ b/optuna/_optimize.py
@@ -36,6 +36,7 @@ def _optimize(
     callbacks: Optional[List[Callable[["optuna.Study", FrozenTrial], None]]] = None,
     gc_after_trial: bool = False,
     show_progress_bar: bool = False,
+    catch_callback_errors: bool = False,
 ) -> None:
     if not isinstance(catch, tuple):
         raise TypeError(
@@ -63,6 +64,7 @@ def _optimize(
                 reseed_sampler_rng=False,
                 time_start=None,
                 progress_bar=progress_bar,
+                catch_callback_errors=catch_callback_errors,
             )
         else:
             if show_progress_bar:
@@ -129,6 +131,7 @@ def _optimize_sequential(
     reseed_sampler_rng: bool,
     time_start: Optional[datetime.datetime],
     progress_bar: Optional[pbar_module._ProgressBar],
+    catch_callback_errors: bool = False,
 ) -> None:
     if reseed_sampler_rng:
         study.sampler.reseed_rng()
@@ -170,6 +173,8 @@ def _optimize_sequential(
                 try:
                     callback(study, frozen_trial)
                 except Exception as e:
+                    if not catch_callback_errors:
+                        raise
                     _logger.error(
                         "Exception raised while callback execution! "
                         f"Exception: {e} Callback: {callback}",

--- a/optuna/_optimize.py
+++ b/optuna/_optimize.py
@@ -167,7 +167,13 @@ def _optimize_sequential(
         if callbacks is not None:
             frozen_trial = copy.deepcopy(study._storage.get_trial(trial._trial_id))
             for callback in callbacks:
-                callback(study, frozen_trial)
+                try:
+                    callback(study, frozen_trial)
+                except Exception as e:
+                    _logger.error(
+                        f"Exception raised while callback execution! Exception: {e} Callback: {callback}",
+                        exc_info=True,
+                    )
 
         if progress_bar is not None:
             progress_bar.update((datetime.datetime.now() - time_start).total_seconds())

--- a/optuna/_optimize.py
+++ b/optuna/_optimize.py
@@ -171,7 +171,8 @@ def _optimize_sequential(
                     callback(study, frozen_trial)
                 except Exception as e:
                     _logger.error(
-                        f"Exception raised while callback execution! Exception: {e} Callback: {callback}",
+                        "Exception raised while callback execution! "
+                        f"Exception: {e} Callback: {callback}",
                         exc_info=True,
                     )
 

--- a/optuna/study.py
+++ b/optuna/study.py
@@ -235,6 +235,7 @@ class Study(BaseStudy):
         callbacks: Optional[List[Callable[["Study", FrozenTrial], None]]] = None,
         gc_after_trial: bool = False,
         show_progress_bar: bool = False,
+        catch_callback_errors: bool = False,
     ) -> None:
         """Optimize an objective function.
 
@@ -313,6 +314,7 @@ class Study(BaseStudy):
             callbacks=callbacks,
             gc_after_trial=gc_after_trial,
             show_progress_bar=show_progress_bar,
+            catch_callback_errors=catch_callback_errors,
         )
 
     def set_user_attr(self, key: str, value: Any) -> None:


### PR DESCRIPTION
This is the PR ragarding #2012

It wants to avoid a situation where a callback throws an exception and the training is stopped.
This might happen when MLflow Integration wants to use remote logging and can not connect to the tracking server (HTTP timeout) for example. This should not stop the training...

## TODO
- [ ] add docstring for `catch_callback_errors`