### PR TITLE
Pass `include_package` to AllenNLP for distributed setting

### DIFF
--- a/optuna/integration/allennlp.py
+++ b/optuna/integration/allennlp.py
@@ -372,6 +372,7 @@ class AllenNLPExecutor(object):
             serialization_dir=self._serialization_dir,
             file_friendly_logging=self._file_friendly_logging,
             force=self._force,
+            include_package=self._include_package,
         )
         metrics = json.load(open(os.path.join(self._serialization_dir, "metrics.json")))
         return metrics[self._metrics]

--- a/tests/integration_tests/allennlp_tests/test_allennlp.py
+++ b/tests/integration_tests/allennlp_tests/test_allennlp.py
@@ -177,6 +177,7 @@ def test_allennlp_executor_with_options() -> None:
     study = optuna.create_study(direction="maximize")
     trial = optuna.trial.Trial(study, study._storage.create_new_trial(study._study_id))
     trial.suggest_uniform("DROPOUT", 0.0, 0.5)
+    package_name = "tests.integration_tests.allennlp_tests.tiny_single_id"
 
     with tempfile.TemporaryDirectory() as tmp_dir:
         executor = optuna.integration.AllenNLPExecutor(
@@ -185,7 +186,7 @@ def test_allennlp_executor_with_options() -> None:
             tmp_dir,
             force=True,
             file_friendly_logging=True,
-            include_package=["tests.integration_tests.allennlp_tests.tiny_single_id"],
+            include_package=package_name,
         )
 
         # ``executor.run`` loads ``metrics.json``
@@ -197,6 +198,7 @@ def test_allennlp_executor_with_options() -> None:
             executor.run()
             assert mock_obj.call_args[1]["force"]
             assert mock_obj.call_args[1]["file_friendly_logging"]
+            assert mock_obj.call_args[1]["include_package"] == [package_name]
 
 
 def test_dump_best_config() -> None:


### PR DESCRIPTION
This PR should be merged after #1959.
Related to https://github.com/himkt/allennlp-optuna/issues/18.

## Motivation

This PR passes `self._include_package` to `train_model`.
AllenNLP requires passing `include_package` to `train_model` when a distributed training setting.

https://github.com/allenai/allennlp/blob/0d8873cfef628eaf0457bee02422bbf8dae475a2/allennlp/commands/train.py#L406-L407

## Description of the changes

This PR only contains a commit:

- 45dea1c: specify `include_package`

Other changes belongs to #1959.
