### PR TITLE
Update CmaEsSampler's warning message

### DIFF
--- a/optuna/integration/cma.py
+++ b/optuna/integration/cma.py
@@ -277,6 +277,7 @@ class PyCmaSampler(BaseSampler):
         _logger.warning(
             "The parameter '{}' in trial#{} is sampled independently "
             "by using `{}` instead of `PyCmaSampler` "
+            "because it does not support `CategoricalDistribution`"
             "(optimization performance may be degraded). "
             "You can suppress this warning by setting `warn_independent_sampling` "
             "to `False` in the constructor of `PyCmaSampler`, "

--- a/optuna/integration/cma.py
+++ b/optuna/integration/cma.py
@@ -277,8 +277,8 @@ class PyCmaSampler(BaseSampler):
         _logger.warning(
             "The parameter '{}' in trial#{} is sampled independently "
             "by using `{}` instead of `PyCmaSampler` "
-            "because it does not support `CategoricalDistribution`"
             "(optimization performance may be degraded). "
+            "`PyCmaSampler` does not support dynamic search space or `CategoricalDistribution`. "
             "You can suppress this warning by setting `warn_independent_sampling` "
             "to `False` in the constructor of `PyCmaSampler`, "
             "if this independent sampling is intended behavior.".format(

--- a/optuna/samplers/_cmaes.py
+++ b/optuna/samplers/_cmaes.py
@@ -406,6 +406,7 @@ class CmaEsSampler(BaseSampler):
         _logger.warning(
             "The parameter '{}' in trial#{} is sampled independently "
             "by using `{}` instead of `CmaEsSampler` "
+            "because it does not support `CategoricalDistribution`"
             "(optimization performance may be degraded). "
             "You can suppress this warning by setting `warn_independent_sampling` "
             "to `False` in the constructor of `CmaEsSampler`, "

--- a/optuna/samplers/_cmaes.py
+++ b/optuna/samplers/_cmaes.py
@@ -406,8 +406,8 @@ class CmaEsSampler(BaseSampler):
         _logger.warning(
             "The parameter '{}' in trial#{} is sampled independently "
             "by using `{}` instead of `CmaEsSampler` "
-            "because it does not support `CategoricalDistribution`"
             "(optimization performance may be degraded). "
+            "`CmaEsSampler` does not support dynamic search space or `CategoricalDistribution`. "
             "You can suppress this warning by setting `warn_independent_sampling` "
             "to `False` in the constructor of `CmaEsSampler`, "
             "if this independent sampling is intended behavior.".format(


### PR DESCRIPTION
## Motivation
Related to #1656 

## Description of the changes
Updated warning message that generated when `CmaEsSampler` or `PyCmaSampler` samples categorical variables.
I naively hard-coded it, because there is currently only one scenario in which that message occurs.
Also I think there's no need to add tests. 