### PR TITLE
Enable blackdoc `--diff` option

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -28,7 +28,7 @@ jobs:
       run: flake8 .
     - name: isort
       run: isort . --check --diff
-    - name: mypy 
+    - name: mypy
       run: mypy .
     - name: blackdoc
-      run: blackdoc . --check
+      run: blackdoc . --check --diff

--- a/checks.sh
+++ b/checks.sh
@@ -51,7 +51,7 @@ else
   echo "black succeeded."
 fi
 
-res_blackdoc=$(blackdoc $target --check 2>&1)
+res_blackdoc=$(blackdoc $target --check --diff 2>&1)
 if [ $? -eq 1 ] ; then
   if [ $update -eq 1 ] ; then
     echo "blackdoc failed. The docstrings will be formatted by blackdoc."


### PR DESCRIPTION
As of https://github.com/keewis/blackdoc/releases/tag/v0.3,
blackdoc supports `--diff` option.

<!-- Thank you for creating a pull request! -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

Closes #1976

<!-- ## Description of the changes
Describe the changes in this PR. -->
