### PR TITLE
Remove py35 from black config in pyproject.toml

### DIFF
--- a/optuna/importance/__init__.py
+++ b/optuna/importance/__init__.py
@@ -20,7 +20,7 @@ def get_param_importances(
     study: Study,
     *,
     evaluator: Optional[BaseImportanceEvaluator] = None,
-    params: Optional[List[str]] = None
+    params: Optional[List[str]] = None,
 ) -> Dict[str, float]:
     """Evaluate parameter importances based on completed trials in the given study.
 

--- a/optuna/integration/allennlp.py
+++ b/optuna/integration/allennlp.py
@@ -275,7 +275,7 @@ class AllenNLPExecutor(object):
         serialization_dir: str,
         metrics: str = "best_validation_accuracy",
         *,
-        include_package: Optional[Union[str, List[str]]] = None
+        include_package: Optional[Union[str, List[str]]] = None,
     ):
         _imports.check()
 

--- a/optuna/integration/chainermn.py
+++ b/optuna/integration/chainermn.py
@@ -170,7 +170,7 @@ class ChainerMNTrial(BaseTrial):
         high: float,
         *,
         step: Optional[float] = None,
-        log: bool = False
+        log: bool = False,
     ) -> float:
         def func() -> float:
             assert self.delegate is not None

--- a/optuna/integration/sklearn.py
+++ b/optuna/integration/sklearn.py
@@ -737,7 +737,7 @@ class OptunaSearchCV(BaseEstimator):
         self,
         X: TwoDimArrayLikeType,
         y: Optional[Union[OneDimArrayLikeType, TwoDimArrayLikeType]] = None,
-        **fit_params: Any
+        **fit_params: Any,
     ) -> "OptunaSearchCV":
 
         n_samples = _num_samples(X)
@@ -766,7 +766,7 @@ class OptunaSearchCV(BaseEstimator):
         X: TwoDimArrayLikeType,
         y: Optional[Union[OneDimArrayLikeType, TwoDimArrayLikeType]] = None,
         groups: Optional[OneDimArrayLikeType] = None,
-        **fit_params: Any
+        **fit_params: Any,
     ) -> "OptunaSearchCV":
         """Run fit with all sets of parameters.
 

--- a/optuna/integration/skopt.py
+++ b/optuna/integration/skopt.py
@@ -106,7 +106,7 @@ class SkoptSampler(BaseSampler):
         skopt_kwargs: Optional[Dict[str, Any]] = None,
         n_startup_trials: int = 1,
         *,
-        consider_pruned_trials: bool = False
+        consider_pruned_trials: bool = False,
     ) -> None:
 
         _imports.check()

--- a/optuna/multi_objective/trial.py
+++ b/optuna/multi_objective/trial.py
@@ -49,7 +49,7 @@ class MultiObjectiveTrial(object):
         high: float,
         *,
         step: Optional[float] = None,
-        log: bool = False
+        log: bool = False,
     ) -> float:
         """Suggest a value for the floating point parameter.
 

--- a/optuna/samplers/_cmaes.py
+++ b/optuna/samplers/_cmaes.py
@@ -159,7 +159,7 @@ class CmaEsSampler(BaseSampler):
         *,
         consider_pruned_trials: bool = False,
         restart_strategy: Optional[str] = None,
-        inc_popsize: int = 2
+        inc_popsize: int = 2,
     ) -> None:
         self._x0 = x0
         self._sigma0 = sigma0

--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -165,7 +165,7 @@ class TPESampler(BaseSampler):
         seed: Optional[int] = None,
         *,
         multivariate: bool = False,
-        warn_independent_sampling: bool = True
+        warn_independent_sampling: bool = True,
     ) -> None:
 
         self._parzen_estimator_parameters = _ParzenEstimatorParameters(

--- a/optuna/trial/_base.py
+++ b/optuna/trial/_base.py
@@ -23,7 +23,7 @@ class BaseTrial(object, metaclass=abc.ABCMeta):
         high: float,
         *,
         step: Optional[float] = None,
-        log: bool = False
+        log: bool = False,
     ) -> float:
 
         raise NotImplementedError

--- a/optuna/trial/_fixed.py
+++ b/optuna/trial/_fixed.py
@@ -72,7 +72,7 @@ class FixedTrial(BaseTrial):
         high: float,
         *,
         step: Optional[float] = None,
-        log: bool = False
+        log: bool = False,
     ) -> float:
 
         if step is not None:

--- a/optuna/trial/_frozen.py
+++ b/optuna/trial/_frozen.py
@@ -203,7 +203,7 @@ class FrozenTrial(BaseTrial):
         high: float,
         *,
         step: Optional[float] = None,
-        log: bool = False
+        log: bool = False,
     ) -> float:
 
         if step is not None:
@@ -452,7 +452,7 @@ def create_trial(
     distributions: Optional[Dict[str, BaseDistribution]] = None,
     user_attrs: Optional[Dict[str, Any]] = None,
     system_attrs: Optional[Dict[str, Any]] = None,
-    intermediate_values: Optional[Dict[int, float]] = None
+    intermediate_values: Optional[Dict[int, float]] = None,
 ) -> FrozenTrial:
     """Create a new :class:`~optuna.trial.FrozenTrial`.
 

--- a/optuna/trial/_trial.py
+++ b/optuna/trial/_trial.py
@@ -73,7 +73,7 @@ class Trial(BaseTrial):
         high: float,
         *,
         step: Optional[float] = None,
-        log: bool = False
+        log: bool = False,
     ) -> float:
         """Suggest a value for the floating point parameter.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.black]
 line-length = 99
-target-version = ['py37', 'py35']
+target-version = ['py37']
 exclude = '''
 /(
     \.eggs


### PR DESCRIPTION
<!-- Thank you for creating a pull request! -->

Changes

- remove py35 from black's targets
- add trailing commas to multiline arguments (ref: https://www.python.org/dev/peps/pep-0008/#when-to-use-trailing-commas)

ref: #1067 