### PR TITLE
Update logging in pytorch lightning example

### DIFF
--- a/examples/pytorch_lightning_simple.py
+++ b/examples/pytorch_lightning_simple.py
@@ -30,8 +30,8 @@ import optuna
 from optuna.integration import PyTorchLightningPruningCallback
 
 
-if version.parse(pl.__version__) < version.parse("0.8.1"):
-    raise RuntimeError("PyTorch Lightning>=0.8.1 is required for this example.")
+if version.parse(pl.__version__) < version.parse("1.0.2"):
+    raise RuntimeError("PyTorch Lightning>=1.0.2 is required for this example.")
 
 PERCENT_VALID_EXAMPLES = 0.1
 BATCHSIZE = 128
@@ -108,12 +108,7 @@ class LightningNet(pl.LightningModule):
         output = self.forward(data)
         pred = output.argmax(dim=1, keepdim=True)
         accuracy = pred.eq(target.view_as(pred)).float().mean()
-        return {"batch_val_acc": accuracy}
-
-    def validation_epoch_end(self, outputs):
-        accuracy = sum(x["batch_val_acc"] for x in outputs) / len(outputs)
-        # Pass the accuracy to the `DictLogger` via the `'log'` key.
-        return {"log": {"val_acc": accuracy}}
+        self.log("val_acc", accuracy)
 
     def configure_optimizers(self):
         return Adam(self.model.parameters())

--- a/setup.py
+++ b/setup.py
@@ -89,7 +89,7 @@ def get_extras_require() -> Dict[str, List[str]]:
             "tensorflow>=2.0.0",
             "tensorflow-datasets",
             "pytorch-ignite",
-            "pytorch-lightning>=0.8.1",
+            "pytorch-lightning>=1.0.2",
             "thop",
             "skorch",
             "stable-baselines3>=0.7.0",
@@ -133,7 +133,7 @@ def get_extras_require() -> Dict[str, List[str]]:
             "tensorflow",
             "tensorflow-datasets",
             "pytorch-ignite",
-            "pytorch-lightning>=0.8.1",
+            "pytorch-lightning>=1.0.2",
             "skorch",
             "catalyst",
         ]
@@ -169,7 +169,7 @@ def get_extras_require() -> Dict[str, List[str]]:
             "tensorflow",
             "tensorflow-datasets",
             "pytorch-ignite",
-            "pytorch-lightning>=0.8.1",
+            "pytorch-lightning>=1.0.2",
             "skorch",
             "catalyst",
         ]


### PR DESCRIPTION
<!-- Thank you for creating a pull request! -->

## Motivation

I've been using optuna with Pytorch Lightning - been working great so far. I noticed that the pytorch lightning example is outdated, i.e. pytorch lightning has introduced a new API for logging and the old method of logging has been deprecated. For reference, the new logging [documentation](https://pytorch-lightning.readthedocs.io/en/latest/logging.html#) and the [mnist example](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/pl_examples/basic_examples/mnist_classifier.py) from the lightning repo.

## Description of the changes

Logging by returning  `{log: dict}` from an `epoch_end` method is deprecated in pl and has been updated to use `self.log(...)`. Using `self.log(...)` also means that the `validation_epoch_end` method is no longer required as metrics are aggregated automatically.

The minimum pytorch lightning version to run the example would now be 1.0.2. 
