### PR TITLE
Change return type of `training_step` of PyTorch Lightning example

### DIFF
--- a/examples/pytorch_lightning_simple.py
+++ b/examples/pytorch_lightning_simple.py
@@ -101,7 +101,7 @@ class LightningNet(pl.LightningModule):
     def training_step(self, batch, batch_nb):
         data, target = batch
         output = self.forward(data)
-        return {"loss": F.nll_loss(output, target)}
+        return F.nll_loss(output, target)
 
     def validation_step(self, batch, batch_nb):
         data, target = batch


### PR DESCRIPTION
## Motivation
Please refer to https://github.com/optuna/optuna/pull/2037#issuecomment-731514935.

## Description of the changes
This PR changed the return type of `LightningNet.training_step` from `Dict` to `Tensor`.

CC @pbmstrk I'm not sure this change follows the lightning's convention. Please feel free to add your comments.
