### PR TITLE
Fix MOTPEMultiObjectiveSampler's example

### DIFF
--- a/optuna/multi_objective/samplers/_motpe.py
+++ b/optuna/multi_objective/samplers/_motpe.py
@@ -112,7 +112,8 @@ class MOTPEMultiObjectiveSampler(TPESampler, BaseMultiObjectiveSampler):
             sampler = optuna.multi_objective.samplers.MOTPEMultiObjectiveSampler(
                 n_startup_trials=n_startup_trials, n_ehvi_candidates=24, seed=seed
             )
-            study = optuna.multi_objective.create_study(["minimize"] * num_variables, sampler=sampler)
+            study = optuna.multi_objective.create_study(
+                ["minimize"] * num_variables, sampler=sampler)
             study.optimize(objective, n_trials=250)
     """
 

--- a/optuna/multi_objective/samplers/_motpe.py
+++ b/optuna/multi_objective/samplers/_motpe.py
@@ -112,7 +112,7 @@ class MOTPEMultiObjectiveSampler(TPESampler, BaseMultiObjectiveSampler):
             sampler = optuna.multi_objective.samplers.MOTPEMultiObjectiveSampler(
                 n_startup_trials=n_startup_trials, n_ehvi_candidates=24, seed=seed
             )
-            study = optuna.multi_objective.create_study(["minimize"] * num_variables)
+            study = optuna.multi_objective.create_study(["minimize"] * num_variables, sampler=sampler)
             study.optimize(objective, n_trials=250)
     """
 

--- a/optuna/multi_objective/samplers/_motpe.py
+++ b/optuna/multi_objective/samplers/_motpe.py
@@ -113,7 +113,8 @@ class MOTPEMultiObjectiveSampler(TPESampler, BaseMultiObjectiveSampler):
                 n_startup_trials=n_startup_trials, n_ehvi_candidates=24, seed=seed
             )
             study = optuna.multi_objective.create_study(
-                ["minimize"] * num_variables, sampler=sampler)
+                ["minimize"] * num_variables, sampler=sampler
+            )
             study.optimize(objective, n_trials=250)
     """
 


### PR DESCRIPTION
## Motivation
Related to #2006 

## Description of the changes
Changed the example code.
In `MOTPEMultiObjectiveSampler`'s example, the default `NSGAIIMultiObjectiveSampler` was used because `sampler` was not specified.