### PR TITLE
Allow passing additional arguments when running tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ extras =
 deps =
     scikit-optimize
     cma
-commands = pytest tests --ignore tests/integration_tests
+commands = pytest tests --ignore tests/integration_tests {posargs}
 
 [testenv:test-py37]
 basepython = python3.7
@@ -26,7 +26,7 @@ extras =
 deps =
     scikit-optimize
     cma
-commands = pytest tests --ignore tests/integration_tests
+commands = pytest tests --ignore tests/integration_tests {posargs}
 
 [testenv:test-py38]
 basepython = python3.8
@@ -36,45 +36,45 @@ extras =
 deps =
     scikit-optimize
     cma
-commands = pytest tests --ignore tests/integration_tests
+commands = pytest tests --ignore tests/integration_tests {posargs}
 
 [testenv:integration-test-py36]
 basepython = python3.6
 extras =
     tests
     integration
-commands = pytest -s tests/integration_tests
+commands = pytest -s tests/integration_tests {posargs}
 
 [testenv:integration-test-py37]
 basepython = python3.7
 extras =
     tests
     integration
-commands = pytest -s tests/integration_tests
+commands = pytest -s tests/integration_tests {posargs}
 
 [testenv:integration-test-py38]
 basepython = python3.8
 extras =
     tests
     integration
-commands = pytest tests/integration_tests --ignore tests/integration_tests/test_fastai.py --ignore tests/integration_tests/allennlp_tests/test_allennlp.py
+commands = pytest tests/integration_tests --ignore tests/integration_tests/test_fastai.py --ignore tests/integration_tests/allennlp_tests/test_allennlp.py {posargs}
 
 [testenv:flake8]
 deps = flake8
-commands = flake8 .
+commands = flake8 . {posargs}
 
 [testenv:isort]
 deps = isort
-commands = isort . --check --diff
+commands = isort . --check --diff {posargs}
 
 [testenv:black]
 deps = black
-commands = black . --check --diff
+commands = black . --check --diff {posargs}
 
 [testenv:blackdoc]
 deps = blackdoc
-commands = blackdoc . --check --diff
+commands = blackdoc . --check --diff {posargs}
 
 [testenv:mypy]
 deps = mypy==0.782
-commands = mypy .
+commands = mypy . {posargs}


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

<!-- Thank you for creating a pull request! -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

Allows passing additional argumetns when running tox like ([ref](https://tox.readthedocs.io/en/latest/example/general.html#interactively-passing-positional-arguments)):

```
tox -e test-py38 -- --verbose
```

## Description of the changes
<!-- Describe the changes in this PR. -->
