### PR TITLE
Added test and fix for relative sampling failure in multivariate TPE

### DIFF
--- a/optuna/samplers/_search_space.py
+++ b/optuna/samplers/_search_space.py
@@ -126,6 +126,8 @@ def intersection_search_space(
             If :obj:`False`, the returned object will be a :obj:`dict`.
             If :obj:`True`, the returned object will be an :obj:`collections.OrderedDict` sorted by
             keys, i.e. parameter names.
+        include_pruned:
+            Whether pruned trials should be included in the search space.
 
     Returns:
         A dictionary containing the parameter names and parameter's distributions.

--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -838,11 +838,7 @@ def _get_multivariate_observation_pairs(
 
         # We extract param_value from the trial.
         for param_name in param_names:
-            assert (
-                param_name in trial.params
-            ), "Parameter {} not found in trial {}, which has parameters {}".format(
-                param_name, trial.number, list(trial.params)
-            )
+            assert param_name in trial.params
             distribution = trial.distributions[param_name]
             param_value = distribution.to_internal_repr(trial.params[param_name])
             values[param_name].append(param_value)

--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -183,7 +183,7 @@ class TPESampler(BaseSampler):
         self._random_sampler = RandomSampler(seed=seed)
 
         self._multivariate = multivariate
-        self._search_space = IntersectionSearchSpace()
+        self._search_space = IntersectionSearchSpace(include_pruned=True)
 
         if multivariate:
             warnings.warn(
@@ -838,7 +838,11 @@ def _get_multivariate_observation_pairs(
 
         # We extract param_value from the trial.
         for param_name in param_names:
-            assert param_name in trial.params
+            assert (
+                param_name in trial.params
+            ), "Parameter {} not found in trial {}, which has parameters {}".format(
+                param_name, trial.number, list(trial.params)
+            )
             distribution = trial.distributions[param_name]
             param_value = distribution.to_internal_repr(trial.params[param_name])
             values[param_name].append(param_value)

--- a/tests/samplers_tests/tpe_tests/test_sampler.py
+++ b/tests/samplers_tests/tpe_tests/test_sampler.py
@@ -879,3 +879,21 @@ def test_call_after_trial_of_random_sampler() -> None:
     ) as mock_object:
         study.optimize(lambda _: 1.0, n_trials=1)
         assert mock_object.call_count == 1
+
+
+def test_mixed_relative_search_space_pruned_and_completed_trials() -> None:
+    def objective(trial: Trial) -> float:
+        if trial.number == 0:
+            trial.suggest_uniform("param1", 0, 1)
+            raise optuna.exceptions.TrialPruned()
+
+        if trial.number == 1:
+            trial.suggest_uniform("param2", 0, 1)
+            return 0
+
+        return 0
+
+    sampler = TPESampler(n_startup_trials=1, multivariate=True)
+    study = optuna.create_study(sampler=sampler)
+
+    study.optimize(objective, 3)


### PR DESCRIPTION
## Motivation
Currently, on the master branch, the following minimal example fails:

```
import optuna

def mwe(trial):
	if trial.number == 0:
		trial.suggest_uniform("param1", 0, 1)
		raise optuna.exceptions.TrialPruned()
	
	if trial.number == 1:
		trial.suggest_uniform("param2", 0, 1)
		return 0
	
	return 0

sampler = optuna.samplers.TPESampler(n_startup_trials = 1, multivariate = True)
study = optuna.create_study(sampler = sampler)

study.optimize(mwe, 3)
```

This is because the multivariate TPE uses pruned and completed trials for its relative sampling, but the search space computation only looks at completed trials. Therefore, it can include parameters missing from the pruned trials, which the TPE can't handle. This leads to the assertion `assert param_name in trial.params` in sampler.py to fail.

## Description of the changes
This PR contains three modifications:
- Modifies the assertion param_name in trial.params to be a bit more explanatory
- Adds an optional argument `include_pruned` (default False) to IntersectionSearchSpace.calculate and intersection_search_space, and sets this to True in the TPESampler.
- Adds the above failing example as a test.