### PR TITLE
Add tox to dependencies for developers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ def get_tests_require() -> List[str]:
 def get_extras_require() -> Dict[str, List[str]]:
 
     requirements = {
-        "checking": ["black", "hacking", "isort", "mypy==0.782", "blackdoc"],
+        "checking": ["black", "hacking", "isort", "mypy==0.782", "blackdoc", "tox"],
         "codecov": ["codecov", "pytest-cov"],
         "doctest": [
             "cma",


### PR DESCRIPTION
I opened this PR as I just noticed `tox` doesn't appear in `setup.py`.

@c-bata 
What do you think about adding the new package to dependencies for checking?
If you had something intention for not including this change in your PR (#2024), I'd like your opinion.