### PR TITLE
Use `find_or_raise_by_id` instead of `find_by_id` to raise if a study does not exist

### DIFF
--- a/optuna/storages/_rdb/storage.py
+++ b/optuna/storages/_rdb/storage.py
@@ -769,7 +769,7 @@ class RDBStorage(BaseStorage):
             # Acquire lock.
             #
             # Assume that study exists.
-            models.StudyModel.find_by_id(study_id, session, for_update=True)
+            models.StudyModel.find_or_raise_by_id(study_id, session, for_update=True)
 
             models.TrialModel.find_or_raise_by_id(trial_id, session)
 


### PR DESCRIPTION
<!-- Thank you for creating a pull request! -->

## Motivation
If a study does not exist, `KeyError` should be raised for `RDBStorage._check_and_set_param_distribution`.

## Description of the changes
Use `find_or_raise_by_id` instead of `find_by_id`.
