### PR TITLE
Add Python 3.9 to README badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Optuna: A hyperparameter optimization framework
 
-[![Python](https://img.shields.io/badge/python-3.6%20%7C%203.7%20%7C%203.8-blue)](https://www.python.org)
+[![Python](https://img.shields.io/badge/python-3.6%20%7C%203.7%20%7C%203.8%20%7C%203.9-blue)](https://www.python.org)
 [![pypi](https://img.shields.io/pypi/v/optuna.svg)](https://pypi.python.org/pypi/optuna)
 [![conda](https://img.shields.io/conda/vn/conda-forge/optuna.svg)](https://anaconda.org/conda-forge/optuna)
 [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/optuna/optuna)


### PR DESCRIPTION
## Motivation

Optuna works with Python 3.9, if integration modules are excluded. Integration modules are optional in Optuna and dependent on third party libraries so it might be reasonable to consider 3.9 as supported.

C.f. https://github.com/optuna/optuna/pull/1908 for the inclusion of 3.9 in the CI and https://github.com/optuna/optuna/issues/2034 for tracking integration module support.

## Description of the changes

Adds Python 3.9 to the list of supported versions in the badge in README.md.