### PR TITLE
Fix ideographic space

### DIFF
--- a/optuna/pruners/_hyperband.py
+++ b/optuna/pruners/_hyperband.py
@@ -54,8 +54,8 @@ class HyperbandPruner(BasePruner):
         of Hyperband and is automatically determined by ``min_resource``, ``max_resource`` and
         ``reduction_factor`` as
         `The number of brackets = floor(log_{reduction_factor}(max_resource / min_resource)) + 1`.
-        Please set ``reduction_factor`` so that the number of brackets is not too large　(about 4 ~
-        6 in most use cases).　Please see Section 3.6 of the `original paper
+        Please set ``reduction_factor`` so that the number of brackets is not too large (about 4 ~
+        6 in most use cases). Please see Section 3.6 of the `original paper
         <http://www.jmlr.org/papers/volume18/16-558/16-558.pdf>`_ for the detail.
 
     .. seealso::


### PR DESCRIPTION
<!-- Thank you for creating a pull request! -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

https://github.com/optuna/optuna/issues/1795#issuecomment-728605927

> 3. Illegal character

```
! Package inputenc Error: Unicode char 　 (U+3000)
(inputenc)                not set up for use with LaTeX.

See the inputenc package documentation for explanation.
Type  H <return>  for immediate help.
 ...
```

Fix this Illegal character.

## Description of the changes
<!-- Describe the changes in this PR. -->
U+3000 character is '　' (ideographic space), and this character is not supported in LaTeX.
So replace with Normal space.