### PR TITLE
Fix lt symbol

### DIFF
--- a/optuna/distributions.py
+++ b/optuna/distributions.py
@@ -190,7 +190,7 @@ class DiscreteUniformDistribution(BaseDistribution):
     .. note::
         If the range :math:`[\\mathsf{low}, \\mathsf{high}]` is not divisible by :math:`q`,
         :math:`\\mathsf{high}` will be replaced with the maximum of :math:`k q + \\mathsf{low}
-        \\lt \\mathsf{high}`, where :math:`k` is an integer.
+        < \\mathsf{high}`, where :math:`k` is an integer.
 
     Attributes:
         low:
@@ -244,7 +244,7 @@ class IntUniformDistribution(BaseDistribution):
     .. note::
         If the range :math:`[\\mathsf{low}, \\mathsf{high}]` is not divisible by
         :math:`\\mathsf{step}`, :math:`\\mathsf{high}` will be replaced with the maximum of
-        :math:`k \\times \\mathsf{step} + \\mathsf{low} \\lt \\mathsf{high}`, where :math:`k` is
+        :math:`k \\times \\mathsf{step} + \\mathsf{low} < \\mathsf{high}`, where :math:`k` is
         an integer.
 
     Attributes:


### PR DESCRIPTION
<!-- Thank you for creating a pull request! -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

https://github.com/optuna/optuna/issues/1795#issuecomment-728605927

> 2. Syntax error of math expression

```
! Undefined control sequence.
l.2213 \lt
           \mathsf{high}\), where \(k\) is an integer.
The control sequence at the end of the top line
of your error message was never \def'ed. If you have
misspelled it (e.g., `\hobx'), type `I' and the correct
spelling (e.g., `I\hbox'). Otherwise just continue,
and I'll forget about whatever was undefined.
```
Fix this syntax error.

## Description of the changes
<!-- Describe the changes in this PR. -->
`\lt` means  __less than__  in ~~TeX~~ MathJax (not LaTeX) , so replace `\\lt` with `<`.

Related: 
http://docs.mathjax.org/en/latest/input/tex/html.html?highlight=lt#html-special-characters

Sphinx escape `<` to `&lt;`  on html building , so we need not using `\lt`.

## Preview

-  html build

![Screenshot from 2020-12-04 15-29-11](https://user-images.githubusercontent.com/17472875/101129796-a2636b80-3645-11eb-823b-7a692997c5a9.png)


- pdf build

![Screenshot from 2020-12-04 15-38-30](https://user-images.githubusercontent.com/17472875/101130442-d12e1180-3646-11eb-96bc-5e0c7992553f.png)
