### PR TITLE
Unpin mypy version

### DIFF
--- a/optuna/integration/_lightgbm_tuner/optimize.py
+++ b/optuna/integration/_lightgbm_tuner/optimize.py
@@ -6,6 +6,7 @@ import pickle
 import time
 from typing import Any
 from typing import Callable
+from typing import cast
 from typing import Dict
 from typing import Generator
 from typing import Iterator
@@ -704,9 +705,9 @@ class _LightGBMBaseTuner(_BaseTuner):
                     raise ValueError("No trials are completed yet.")
 
                 if self.direction == optuna.study.StudyDirection.MINIMIZE:
-                    best_trial = min(trials, key=lambda t: t.value)
+                    best_trial = min(trials, key=lambda t: cast(float, t.value))
                 else:
-                    best_trial = max(trials, key=lambda t: t.value)
+                    best_trial = max(trials, key=lambda t: cast(float, t.value))
                 return copy.deepcopy(best_trial)
 
         return _StepwiseStudy(study, step_name)

--- a/optuna/integration/allennlp.py
+++ b/optuna/integration/allennlp.py
@@ -358,7 +358,7 @@ class AllenNLPExecutor(object):
     def run(self) -> float:
         """Train a model using AllenNLP."""
         try:
-            import_func = allennlp.common.util.import_submodules
+            import_func = allennlp.common.util.import_submodules  # type: ignore
         except AttributeError:
             import_func = allennlp.common.util.import_module_and_submodules
 

--- a/optuna/multi_objective/samplers/_motpe.py
+++ b/optuna/multi_objective/samplers/_motpe.py
@@ -641,7 +641,7 @@ def _get_observation_pairs(
 
         # Convert all objectives to minimization
         score = [
-            cast(float, v) if d == StudyDirection.MINIMIZE else -v
+            cast(float, v) if d == StudyDirection.MINIMIZE else -cast(float, v)
             for d, v in zip(study.directions, trial.values)
         ]
 

--- a/optuna/multi_objective/samplers/_motpe.py
+++ b/optuna/multi_objective/samplers/_motpe.py
@@ -1,6 +1,7 @@
 import math
 from typing import Any
 from typing import Callable
+from typing import cast
 from typing import Dict
 from typing import List
 from typing import Optional
@@ -640,7 +641,7 @@ def _get_observation_pairs(
 
         # Convert all objectives to minimization
         score = [
-            v if d == StudyDirection.MINIMIZE else -v  # type: ignore
+            cast(float, v) if d == StudyDirection.MINIMIZE else -v
             for d, v in zip(study.directions, trial.values)
         ]
 

--- a/optuna/multi_objective/samplers/_nsga2.py
+++ b/optuna/multi_objective/samplers/_nsga2.py
@@ -2,6 +2,7 @@ from collections import defaultdict
 import hashlib
 import itertools
 from typing import Any
+from typing import cast
 from typing import DefaultDict
 from typing import Dict
 from typing import List
@@ -316,7 +317,7 @@ def _crowding_distance_sort(
 ) -> None:
     manhattan_distances = defaultdict(float)
     for i in range(len(population[0].values)):
-        population.sort(key=lambda x: x.values[i])
+        population.sort(key=lambda x: cast(float, x.values[i]))
 
         v_min = population[0].values[i]
         v_max = population[-1].values[i]

--- a/optuna/samplers/_grid.py
+++ b/optuna/samplers/_grid.py
@@ -2,6 +2,7 @@ import collections
 import itertools
 import random
 from typing import Any
+from typing import cast
 from typing import Dict
 from typing import List
 from typing import Mapping
@@ -16,6 +17,7 @@ from optuna.trial import FrozenTrial
 
 
 GridValueType = Union[str, float, int, bool, None]
+SortableParamValueSequenceType = Union[List[str], List[float], List[int], List[bool]]
 
 
 _logger = get_logger(__name__)
@@ -98,6 +100,8 @@ class GridSampler(BaseSampler):
 
         self._search_space = collections.OrderedDict()
         for param_name, param_values in sorted(search_space.items(), key=lambda x: x[0]):
+            param_values = cast(SortableParamValueSequenceType, param_values)
+
             self._search_space[param_name] = sorted(param_values)
 
         self._all_grids = list(itertools.product(*self._search_space.values()))
@@ -218,7 +222,8 @@ class GridSampler(BaseSampler):
             if len(search_space[param_name]) != len(self._search_space[param_name]):
                 return False
 
-            for i, param_value in enumerate(sorted(search_space[param_name])):
+            param_values = cast(SortableParamValueSequenceType, search_space[param_name])
+            for i, param_value in enumerate(sorted(param_values)):
                 if param_value != self._search_space[param_name][i]:
                     return False
 

--- a/optuna/storages/_base.py
+++ b/optuna/storages/_base.py
@@ -1,5 +1,6 @@
 import abc
 from typing import Any
+from typing import cast
 from typing import Dict
 from typing import List
 from typing import Optional
@@ -609,9 +610,9 @@ class BaseStorage(object, metaclass=abc.ABCMeta):
         direction = directions[0]
 
         if direction == StudyDirection.MAXIMIZE:
-            best_trial = max(all_trials, key=lambda t: t.value)
+            best_trial = max(all_trials, key=lambda t: cast(float, t.value))
         else:
-            best_trial = min(all_trials, key=lambda t: t.value)
+            best_trial = min(all_trials, key=lambda t: cast(float, t.value))
 
         return best_trial
 

--- a/optuna/storages/_in_memory.py
+++ b/optuna/storages/_in_memory.py
@@ -2,6 +2,7 @@ import copy
 from datetime import datetime
 import threading
 from typing import Any
+from typing import cast
 from typing import Dict
 from typing import Iterator
 from typing import List
@@ -167,7 +168,10 @@ class InMemoryStorage(BaseStorage):
             system_attrs=copy.deepcopy(study.system_attrs),
             n_trials=len(study.trials),
             datetime_start=min(
-                [trial.datetime_start for trial in self.get_all_trials(study_id, deepcopy=False)]
+                [
+                    cast(datetime, trial.datetime_start)
+                    for trial in self.get_all_trials(study_id, deepcopy=False)
+                ]
             )
             if study.trials
             else None,

--- a/optuna/storages/_redis.py
+++ b/optuna/storages/_redis.py
@@ -2,6 +2,7 @@ import copy
 from datetime import datetime
 import pickle
 from typing import Any
+from typing import cast
 from typing import Dict
 from typing import List
 from typing import Optional
@@ -312,7 +313,9 @@ class RedisStorage(BaseStorage):
             pipe.multi()
             study_summary = self._get_study_summary(study_id)
             study_summary.n_trials = len(self._get_study_trials(study_id))
-            min_datetime_start = min([t.datetime_start for t in self.get_all_trials(study_id)])
+            min_datetime_start = min(
+                [cast(datetime, t.datetime_start) for t in self.get_all_trials(study_id)]
+            )
             study_summary.datetime_start = min_datetime_start
             pipe.set(self._key_study_summary(study_id), pickle.dumps(study_summary))
             pipe.execute()
@@ -419,9 +422,9 @@ class RedisStorage(BaseStorage):
             direction = _direction[0]
 
             if direction == StudyDirection.MAXIMIZE:
-                best_trial = max(all_trials, key=lambda t: t.value)
+                best_trial = max(all_trials, key=lambda t: cast(float, t.value))
             else:
-                best_trial = min(all_trials, key=lambda t: t.value)
+                best_trial = min(all_trials, key=lambda t: cast(float, t.value))
 
             self._set_best_trial(study_id, best_trial.number)
         else:

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ def get_tests_require() -> List[str]:
 def get_extras_require() -> Dict[str, List[str]]:
 
     requirements = {
-        "checking": ["black", "hacking", "isort", "mypy==0.782", "blackdoc"],
+        "checking": ["black", "hacking", "isort", "mypy", "blackdoc"],
         "codecov": ["codecov", "pytest-cov"],
         "doctest": [
             "cma",

--- a/tests/integration_tests/allennlp_tests/tiny_single_id.py
+++ b/tests/integration_tests/allennlp_tests/tiny_single_id.py
@@ -34,6 +34,8 @@ class SingleIdTokenIndexer(TokenIndexer):
 
     def count_vocab_items(self, token: Token, counter: Dict[str, Dict[str, int]]) -> None:
         text = token.text
+        assert isinstance(text, str)
+
         if self.lowercase_tokens:
             text = text.lower()
         counter["tokens"][text] += 1
@@ -45,6 +47,8 @@ class SingleIdTokenIndexer(TokenIndexer):
 
         for token in itertools.chain(self._start_tokens, tokens, self._end_tokens):
             text = token.text
+            assert isinstance(text, str)
+
             if self.lowercase_tokens:
                 text = text.lower()
             indices.append(vocabulary.get_token_index(text, "tokens"))

--- a/tox.ini
+++ b/tox.ini
@@ -76,5 +76,5 @@ deps = blackdoc
 commands = blackdoc . --check --diff {posargs}
 
 [testenv:mypy]
-deps = mypy==0.782
+deps = mypy
 commands = mypy . {posargs}


### PR DESCRIPTION
Close #1914 

## Motivation
This PR unpins the mypy version.
For upgrading mypy to v0.790, we have to update some source codes for considering `_SupportLessThan` introduced in https://github.com/python/typeshed/pull/4192 (see also: https://github.com/python/typeshed/pull/4155).

I use `typing.cast`, which has no performance impact on run-time.
(ref. https://docs.python.org/3/library/typing.html#typing.cast)

## Description of the changes
- 0521520 Unpin mypy version
- 5496213 df51b19 AllenNLP specific changes
- 32c454c Explicitly casting values to `float`
- 2f80a57 Introduce `SortableParamValueSequenceType` and cast variables