### PR TITLE
Fix parameter section of RandomSampler in docs

### DIFF
--- a/optuna/samplers/_random.py
+++ b/optuna/samplers/_random.py
@@ -33,8 +33,8 @@ class RandomSampler(BaseSampler):
             study = optuna.create_study(sampler=RandomSampler())
             study.optimize(objective, n_trials=10)
 
-        Args:
-            seed: Seed for random number generator.
+    Args:
+        seed: Seed for random number generator.
     """
 
     def __init__(self, seed: Optional[int] = None) -> None:


### PR DESCRIPTION
I'd like to suggest a small fix in the docs. https://optuna.readthedocs.io/en/latest/reference/generated/optuna.samplers.RandomSampler.html#optuna.samplers.RandomSampler

## Description of the changes
*Before the change*
![20201206-014324](https://user-images.githubusercontent.com/20610905/101258239-93270f80-3764-11eb-8236-10c1afea78ca.png)

*After the change*
![20201206-014328](https://user-images.githubusercontent.com/20610905/101258238-928e7900-3764-11eb-9863-0f67f1542505.png)
