### PR TITLE
plot_contour with target values other than objective value

### DIFF
--- a/optuna/visualization/_contour.py
+++ b/optuna/visualization/_contour.py
@@ -31,6 +31,7 @@ _logger = get_logger(__name__)
 def plot_contour(
     study: Study,
     params: Optional[List[str]] = None,
+    *,
     target: Optional[Callable[[FrozenTrial], float]] = None,
     target_name: str = "Objective Value",
 ) -> "go.Figure":

--- a/optuna/visualization/_contour.py
+++ b/optuna/visualization/_contour.py
@@ -276,9 +276,7 @@ def _generate_contour_subplot(
             value = float(value)
         elif not isinstance(value, float):
             raise ValueError(
-                "Trial{} has COMPLETE state, but its target value is non-numeric.".format(
-                    trial.number
-                )
+                f"Trial{trial.number} has COMPLETE state, but its target value is non-numeric."
             )
         z[y_i][x_i] = value
 

--- a/optuna/visualization/_contour.py
+++ b/optuna/visualization/_contour.py
@@ -68,7 +68,7 @@ def plot_contour(
             A function to specify the value to display. If it is :obj:`None`, the objective values
             are plotted.
         target_name:
-            Target's name to display on the axis label and the legend.
+            Target's name to display on the color bar.
 
     Returns:
         A :class:`plotly.graph_objs.Figure` object.

--- a/optuna/visualization/matplotlib/_contour.py
+++ b/optuna/visualization/matplotlib/_contour.py
@@ -33,6 +33,7 @@ _logger = get_logger(__name__)
 def plot_contour(
     study: Study,
     params: Optional[List[str]] = None,
+    *,
     target: Optional[Callable[[FrozenTrial], float]] = None,
     target_name: str = "Objective Value",
 ) -> "Axes":

--- a/optuna/visualization/matplotlib/_contour.py
+++ b/optuna/visualization/matplotlib/_contour.py
@@ -57,7 +57,7 @@ def plot_contour(
             A function to specify the value to display. If it is :obj:`None`, the objective values
             are plotted.
         target_name:
-            Target's name to display on the axis label and the legend.
+            Target's name to display on the color bar.
 
     Returns:
         A :class:`matplotlib.axes.Axes` object.

--- a/optuna/visualization/matplotlib/_contour.py
+++ b/optuna/visualization/matplotlib/_contour.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+from typing import Callable
 from typing import DefaultDict
 from typing import List
 from typing import Optional
@@ -29,7 +30,12 @@ _logger = get_logger(__name__)
 
 
 @experimental("2.2.0")
-def plot_contour(study: Study, params: Optional[List[str]] = None) -> "Axes":
+def plot_contour(
+    study: Study,
+    params: Optional[List[str]] = None,
+    target: Optional[Callable[[FrozenTrial], float]] = None,
+    target_name: str = "Objective Value",
+) -> "Axes":
     """Plot the parameter relationship as contour plot in a study with Matplotlib.
 
     Note that, if a parameter contains missing values, a trial with missing values is not plotted.
@@ -44,10 +50,14 @@ def plot_contour(study: Study, params: Optional[List[str]] = None) -> "Axes":
 
     Args:
         study:
-            A :class:`~optuna.study.Study` object whose trials are plotted for their objective
-            values.
+            A :class:`~optuna.study.Study` object whose trials are plotted for their target values.
         params:
             Parameter list to visualize. The default is all parameters.
+        target:
+            A function to specify the value to display. If it is :obj:`None`, the objective values
+            are plotted.
+        target_name:
+            Target's name to display on the axis label and the legend.
 
     Returns:
         A :class:`matplotlib.axes.Axes` object.
@@ -58,10 +68,15 @@ def plot_contour(study: Study, params: Optional[List[str]] = None) -> "Axes":
         "Output figures of this Matplotlib-based `plot_contour` function would be different from "
         "those of the Plotly-based `plot_contour`."
     )
-    return _get_contour_plot(study, params)
+    return _get_contour_plot(study, params, target, target_name)
 
 
-def _get_contour_plot(study: Study, params: Optional[List[str]] = None) -> "Axes":
+def _get_contour_plot(
+    study: Study,
+    params: Optional[List[str]] = None,
+    target: Optional[Callable[[FrozenTrial], float]] = None,
+    target_name: str = "Objective Value",
+) -> "Axes":
     # Calculate basic numbers for plotting.
     trials = [trial for trial in study.trials if trial.state == TrialState.COMPLETE]
 
@@ -100,10 +115,12 @@ def _get_contour_plot(study: Study, params: Optional[List[str]] = None) -> "Axes
         else:
             x_param = sorted_params[0]
             y_param = sorted_params[1]
-        cs = _generate_contour_subplot(trials, x_param, y_param, axs, cmap, contour_point_num)
+        cs = _generate_contour_subplot(
+            trials, x_param, y_param, axs, cmap, contour_point_num, target, target_name
+        )
         if isinstance(cs, ContourSet):
             axcb = fig.colorbar(cs)
-            axcb.set_label("Objective Value")
+            axcb.set_label(target_name)
     else:
         # Set up the graph style.
         fig, axs = plt.subplots(n_params, n_params)
@@ -117,13 +134,13 @@ def _get_contour_plot(study: Study, params: Optional[List[str]] = None) -> "Axes
             for y_i, y_param in enumerate(sorted_params):
                 ax = axs[y_i, x_i]
                 cs = _generate_contour_subplot(
-                    trials, x_param, y_param, ax, cmap, contour_point_num
+                    trials, x_param, y_param, ax, cmap, contour_point_num, target, target_name
                 )
                 if isinstance(cs, ContourSet):
                     cs_list.append(cs)
         if cs_list:
             axcb = fig.colorbar(cs_list[0], ax=axs)
-            axcb.set_label("Objective Value")
+            axcb.set_label(target_name)
 
     return axs
 
@@ -151,6 +168,8 @@ def _calculate_griddata(
     y_param: str,
     y_indices: List[Union[str, int, float]],
     contour_point_num: int,
+    target: Optional[Callable[[FrozenTrial], float]],
+    target_name: str,
 ) -> Tuple[
     np.ndarray,
     np.ndarray,
@@ -176,13 +195,19 @@ def _calculate_griddata(
             continue
         x_values.append(trial.params[x_param])
         y_values.append(trial.params[y_param])
-        if isinstance(trial.value, int):
-            value = float(trial.value)
-        elif isinstance(trial.value, float):
+
+        if target is None:
             value = trial.value
         else:
+            value = target(trial)
+
+        if isinstance(value, int):
+            value = float(value)
+        elif not isinstance(value, float):
             raise ValueError(
-                "Trial{} has COMPLETE state, but its value is non-numeric.".format(trial.number)
+                "Trial{} has COMPLETE state, but its target value is non-numeric.".format(
+                    trial.number
+                )
             )
         z_values.append(value)
 
@@ -292,6 +317,8 @@ def _generate_contour_subplot(
     ax: "Axes",
     cmap: "Colormap",
     contour_point_num: int,
+    target: Optional[Callable[[FrozenTrial], float]],
+    target_name: str,
 ) -> "ContourSet":
 
     x_indices = sorted(list({t.params[x_param] for t in trials if x_param in t.params}))
@@ -317,7 +344,9 @@ def _generate_contour_subplot(
         y_cat_param_label,
         x_values_dummy_count,
         y_values_dummy_count,
-    ) = _calculate_griddata(trials, x_param, x_indices, y_param, y_indices, contour_point_num)
+    ) = _calculate_griddata(
+        trials, x_param, x_indices, y_param, y_indices, contour_point_num, target, target_name
+    )
     cs = None
     ax.set(xlabel=x_param, ylabel=y_param)
     if len(zi) > 0:

--- a/tests/visualization_tests/matplotlib_tests/test_contour.py
+++ b/tests/visualization_tests/matplotlib_tests/test_contour.py
@@ -60,3 +60,37 @@ def test_plot_contour(params: Optional[List[str]]) -> None:
     else:
         # TODO(ytknzw): Add more specific assertion with the test case.
         assert figure.shape == (len(params), len(params))
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        ["param_a", "param_b"],
+        ["param_a", "param_b", "param_c"],
+    ],
+)
+def test_plot_contour_customized_target(params: List[str]) -> None:
+
+    study = prepare_study_with_trials(more_than_three=True)
+    figure = plot_contour(study, params=params, target=lambda t: t.params["param_d"])
+    if len(params) == 2:
+        assert figure.has_data()
+    else:
+        assert figure.shape == (len(params), len(params))
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        ["param_a", "param_b"],
+        ["param_a", "param_b", "param_c"],
+    ],
+)
+def test_plot_contour_customized_target_name(params: List[str]) -> None:
+
+    study = prepare_study_with_trials(more_than_three=True)
+    figure = plot_contour(study, params=params, target_name="Target Name")
+    if len(params) == 2:
+        assert figure.has_data()
+    else:
+        assert figure.shape == (len(params), len(params))

--- a/tests/visualization_tests/test_contour.py
+++ b/tests/visualization_tests/test_contour.py
@@ -1,3 +1,4 @@
+import itertools
 from typing import List
 from typing import Optional
 from typing import Tuple
@@ -64,6 +65,9 @@ def test_plot_contour(params: Optional[List[str]]) -> None:
         elif len(params) == 2:
             assert figure.data[0]["x"] == (0.925, 1.0, 2.5, 2.575)
             assert figure.data[0]["y"] == (-0.1, 0.0, 1.0, 2.0, 2.1)
+            assert figure.data[0]["z"][3][1] == 0.0
+            assert figure.data[0]["z"][2][2] == 1.0
+            assert figure.data[0]["colorbar"]["title"]["text"] == "Objective Value"
             assert figure.data[1]["x"] == (1.0, 2.5)
             assert figure.data[1]["y"] == (2.0, 1.0)
             assert figure.layout["xaxis"]["range"] == (0.925, 2.575)
@@ -72,6 +76,42 @@ def test_plot_contour(params: Optional[List[str]]) -> None:
         # TODO(crcrpar): Add more checks. Currently this only checks the number of data.
         n_params = len(params) if params is not None else 4
         assert len(figure.data) == n_params ** 2 + n_params * (n_params - 1)
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        ["param_a", "param_b"],
+        ["param_a", "param_b", "param_c"],
+    ],
+)
+def test_plot_contour_customized_target(params: List[str]) -> None:
+
+    study = prepare_study_with_trials()
+    figure = plot_contour(study, params=params, target=lambda t: t.params["param_d"])
+    for data in figure.data:
+        if "z" in data:
+            assert 4.0 in itertools.chain.from_iterable(data["z"])
+            assert 2.0 in itertools.chain.from_iterable(data["z"])
+    if len(params) == 2:
+        assert figure.data[0]["z"][3][1] == 4.0
+        assert figure.data[0]["z"][2][2] == 2.0
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        ["param_a", "param_b"],
+        ["param_a", "param_b", "param_c"],
+    ],
+)
+def test_plot_contour_customized_target_name(params: List[str]) -> None:
+
+    study = prepare_study_with_trials()
+    figure = plot_contour(study, params=params, target_name="Target Name")
+    for data in figure.data:
+        if "colorbar" in data:
+            assert data["colorbar"]["title"]["text"] == "Target Name"
 
 
 def test_generate_contour_plot_for_few_observations() -> None:


### PR DESCRIPTION
## Motivation
This PR enables flexible plotting in `plot_contour`, same as #2064.
## Description of the changes
Added `target` and `target_name` arguments to `plot_contour`.
