### PR TITLE
Remove circular reference of study.

### DIFF
--- a/optuna/storages/_rdb/storage.py
+++ b/optuna/storages/_rdb/storage.py
@@ -12,7 +12,6 @@ from typing import Optional
 from typing import Set
 from typing import Tuple
 import uuid
-import weakref
 
 import alembic.command
 import alembic.config
@@ -150,8 +149,6 @@ class RDBStorage(BaseStorage):
         self._version_manager = _VersionManager(self.url, self.engine, self.scoped_session)
         if not skip_compatibility_check:
             self._version_manager.check_table_schema_compatibility()
-
-        weakref.finalize(self, self._finalize)
 
     def __getstate__(self) -> Dict[Any, Any]:
 
@@ -1114,16 +1111,6 @@ class RDBStorage(BaseStorage):
         """
 
         self.scoped_session.remove()
-
-    def _finalize(self) -> None:
-
-        # This destructor calls remove_session to explicitly close the DB connection. We need this
-        # because DB connections created in SQLAlchemy are not automatically closed by reference
-        # counters, so it is not guaranteed that they are released by correct threads (for more
-        # information, please see the docstring of remove_session).
-
-        if hasattr(self, "scoped_session"):
-            self.remove_session()
 
     def upgrade(self) -> None:
         """Upgrade the storage schema."""


### PR DESCRIPTION
<!-- Thank you for creating a pull request! -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
To solve the issue 2 written in https://github.com/optuna/optuna/issues/1347#issuecomment-650852619.

Actually, in the previous code, study is never garbage collected and `_finalize` is never called, because weakref is used wrongly c.f. [note at the bottom](https://docs.python.org/3/library/weakref.html#weakref.finalize). So, in my understanding, `_finalize` is not needed. Also, [SQL alchemy documentation](https://docs.sqlalchemy.org/en/13/orm/contextual.html#thread-local-scope) says that we do not need to call scoped_session.remove().

> The scoped_session.remove() method, as always, removes the current Session associated with the thread, if any. However, one advantage of the threading.local() object is that if the application thread itself ends, the “storage” for that thread is also garbage collected. So it is in fact “safe” to use thread local scope with an application that spawns and tears down threads, without the need to call scoped_session.remove().

## Description of the changes
<!-- Describe the changes in this PR. -->
- [x] Remove weakref which make circular reference. c.f. [note at the bottom](https://docs.python.org/3/library/weakref.html#weakref.finalize)

## checks
```
import optuna

conn_str= "postgresql://localhost:5432/foo"

for i in range(101):  # 100 is the maximum allowed number of connections for postgresql by default.
    study = optuna.create_study(conn_str, study_name=f"test_{i}")
    study._storage._backend.delete_study(study._study_id)
```

The above code run correctly.