### PR TITLE
Make new visualization parameters keyword only

### DIFF
--- a/optuna/visualization/_optimization_history.py
+++ b/optuna/visualization/_optimization_history.py
@@ -17,6 +17,7 @@ _logger = get_logger(__name__)
 
 def plot_optimization_history(
     study: Study,
+    *,
     target: Optional[Callable[[FrozenTrial], float]] = None,
     target_name: str = "Objective Value",
 ) -> "go.Figure":

--- a/optuna/visualization/matplotlib/_optimization_history.py
+++ b/optuna/visualization/matplotlib/_optimization_history.py
@@ -20,6 +20,7 @@ _logger = get_logger(__name__)
 @experimental("2.2.0")
 def plot_optimization_history(
     study: Study,
+    *,
     target: Optional[Callable[[FrozenTrial], float]] = None,
     target_name: str = "Objective Value",
 ) -> "Axes":


### PR DESCRIPTION
## Motivation

What parameters to provide in the visualization functions is often open for discussion, e.g. what types of figure customization such as titles, legends, etc. Given that it might change in the future, it's safer to make new parameters keyword-only.

## Description of the changes

Makes not yet released new parameters introduced for visualization functions in v2.4.0 keyword-only
