### PR TITLE
Add note on the behavior of `suggest_float` with `step` argument.

### DIFF
--- a/optuna/trial/_trial.py
+++ b/optuna/trial/_trial.py
@@ -139,8 +139,7 @@ class Trial(BaseTrial):
 
                 .. note::
                     If ``step`` is specified, ``high`` is included as well as ``low`` because
-                    this method falls back to :func:`~optuna.trial.Trial.suggest_discrete_uniform`
-                    with ``step`` argument.
+                    this method falls back to :func:`~optuna.trial.Trial.suggest_discrete_uniform`.
 
             step:
                 A step of discretization.

--- a/optuna/trial/_trial.py
+++ b/optuna/trial/_trial.py
@@ -136,6 +136,12 @@ class Trial(BaseTrial):
             high:
                 Upper endpoint of the range of suggested values. ``high`` is excluded from the
                 range.
+
+                .. note::
+                    If ``step`` is specified, ``high`` is included as well as ``low`` because
+                    this method falls back to :func:`~optuna.trial.Trial.suggest_discrete_uniform`
+                    with ``step`` argument.
+
             step:
                 A step of discretization.
 


### PR DESCRIPTION
When `step` argument is given, `suggest_float` falls back to
`suggest_discrete_uniform` which includes both `low` and `high`.

![Capture from https://64572-122299416-gh.circle-artifacts.com/0/docs/build/html/reference/generated/optuna.trial.Trial.html#optuna.trial.Trial.suggest_float](https://user-images.githubusercontent.com/16191443/101793459-2dae9680-3b49-11eb-8e5b-537629a0f308.png)
^ Capture from https://64572-122299416-gh.circle-artifacts.com/0/docs/build/html/reference/generated/optuna.trial.Trial.html#optuna.trial.Trial.suggest_float]