### PR TITLE
Fix flipped colormap in matplotlib backend plot_parallel_coordinate

### DIFF
--- a/optuna/visualization/matplotlib/_parallel_coordinate.py
+++ b/optuna/visualization/matplotlib/_parallel_coordinate.py
@@ -6,6 +6,7 @@ from typing import Optional
 import numpy as np
 
 from optuna._experimental import experimental
+from optuna._study_direction import StudyDirection
 from optuna.logging import get_logger
 from optuna.study import Study
 from optuna.trial import TrialState
@@ -46,7 +47,7 @@ def _get_parallel_coordinate_plot(study: Study, params: Optional[List[str]] = No
 
     # Set up the graph style.
     fig, ax = plt.subplots()
-    cmap = plt.get_cmap("Blues")
+    cmap = plt.get_cmap("Blues_r" if study.direction == StudyDirection.MINIMIZE else "Blues")
     ax.set_title("Parallel Coordinate Plot")
     ax.spines["top"].set_visible(False)
     ax.spines["bottom"].set_visible(False)


### PR DESCRIPTION
## Motivation
The colormap in matplotlib backend `plot_parallel_coordinate` is flipped.
## Description of the changes
Use `Blues_r` if the study direction is `minimize`. This PR does not add unit tests because I don't know how to check it...
- plotly
![plotly](https://user-images.githubusercontent.com/1255726/101853155-81010300-3ba2-11eb-82bf-d8707f976b94.png)
- matplotlib (master)
![master](https://user-images.githubusercontent.com/1255726/101853207-94ac6980-3ba2-11eb-8ba6-0ce12c34a723.png)
- matplotlib (PR)
![PR](https://user-images.githubusercontent.com/1255726/101853218-97a75a00-3ba2-11eb-8929-bcbd6bd57e27.png)