### PR TITLE
[CircleCI] Cache tutorial artifacts for faster documentation build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,6 +35,15 @@ jobs:
             pip install --progress-bar off .[document] -f https://download.pytorch.org/whl/torch_stable.html
 
       - run:
+          name: Calculate hash
+          command: |
+            find tutorial -type f -print0 | xargs -0 md5sum > /tmp/tutorial_files.md5
+
+      - restore_cache:
+          keys:
+            - tutorial-{{ checksum "/tmp/tutorial_files.md5" }}
+
+      - run:
           name: build
           command: |
             . venv/bin/activate
@@ -43,6 +52,12 @@ jobs:
 
       - store_artifacts:
           path: ./docs/build/html
+
+      - save_cache:
+          key: tutorial-{{ checksum "/tmp/tutorial_files.md5" }}
+          paths:
+            - tutorial/MNIST
+            - docs/source/tutorial
 
   # Unit tests
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,6 @@ jobs:
       - save_cache:
           key: tutorial-{{ checksum "/tmp/tutorial_files.md5" }}
           paths:
-            - tutorial/MNIST
             - docs/source/tutorial
 
   # Unit tests


### PR DESCRIPTION
This aims at making it faster to build documentation by cacheing tutotorial following GitHub Actions job.