### PR TITLE
Replace builtin `isnumerical` to capture float values in `plot_contour`.

### DIFF
--- a/optuna/visualization/_contour.py
+++ b/optuna/visualization/_contour.py
@@ -129,7 +129,7 @@ def _get_contour_plot(
 
         elif _is_categorical(trials, p_name):
             # For numeric values, plotly does not automatically plot as "category" type.
-            update_category_axes[p_name] = any([str(v).isnumeric() for v in set(values)])
+            update_category_axes[p_name] = any([_is_numeric(str(v)) for v in set(values)])
 
             # Plotly>=4.12.0 draws contours using the indices of categorical variables instead of
             # raw values and the range should be updated based on the cardinality of categorical
@@ -216,6 +216,14 @@ def _get_contour_plot(
                     figure.update_xaxes(title_text=x_param, row=y_i + 1, col=x_i + 1)
 
     return figure
+
+
+def _is_numeric(s: str) -> bool:
+    try:
+        float(s)
+        return True
+    except ValueError:
+        return False
 
 
 def _generate_contour_subplot(

--- a/optuna/visualization/_contour.py
+++ b/optuna/visualization/_contour.py
@@ -129,7 +129,7 @@ def _get_contour_plot(
 
         elif _is_categorical(trials, p_name):
             # For numeric values, plotly does not automatically plot as "category" type.
-            update_category_axes[p_name] = any([_is_numeric(str(v)) for v in set(values)])
+            update_category_axes[p_name] = any(_is_numeric(str(v)) for v in set(values))
 
             # Plotly>=4.12.0 draws contours using the indices of categorical variables instead of
             # raw values and the range should be updated based on the cardinality of categorical


### PR DESCRIPTION
<!-- Thank you for creating a pull request! -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

If the categorical candidates contain only `float` and `None`,  the `plot_contour` generate [a blank plot](https://user-images.githubusercontent.com/7121753/97346796-403d7b00-18cf-11eb-952e-06cd5b89e01e.png) with older `plotly`, which may be older than `4.12.0`. Note that the latest plotly is fine.

Please see #1834 for more details.

## Description of the changes
<!-- Describe the changes in this PR. -->

Just apply https://github.com/optuna/optuna/issues/1834#issuecomment-719941511.