### PR TITLE
plot_edf with target values other than objective value

### DIFF
--- a/optuna/visualization/_edf.py
+++ b/optuna/visualization/_edf.py
@@ -1,5 +1,8 @@
 import itertools
+from typing import Callable
+from typing import cast
 from typing import List
+from typing import Optional
 from typing import Sequence
 from typing import Union
 
@@ -7,6 +10,7 @@ import numpy as np
 
 from optuna.logging import get_logger
 from optuna.study import Study
+from optuna.trial import FrozenTrial
 from optuna.trial import TrialState
 from optuna.visualization._plotly_imports import _imports
 
@@ -17,7 +21,12 @@ if _imports.is_successful():
 _logger = get_logger(__name__)
 
 
-def plot_edf(study: Union[Study, Sequence[Study]]) -> "go.Figure":
+def plot_edf(
+    study: Union[Study, Sequence[Study]],
+    *,
+    target: Optional[Callable[[FrozenTrial], float]] = None,
+    target_name: str = "Objective Value",
+) -> "go.Figure":
     """Plot the objective value EDF (empirical distribution function) of a study.
 
     Note that only the complete trials are considered when plotting the EDF.
@@ -76,6 +85,11 @@ def plot_edf(study: Union[Study, Sequence[Study]]) -> "go.Figure":
         study:
             A target :class:`~optuna.study.Study` object.
             You can pass multiple studies if you want to compare those EDFs.
+        target:
+            A function to specify the value to display. If it is :obj:`None`, the objective values
+            are plotted.
+        target_name:
+            Target's name to display on the axis label.
 
     Returns:
         A :class:`plotly.graph_objs.Figure` object.
@@ -88,13 +102,17 @@ def plot_edf(study: Union[Study, Sequence[Study]]) -> "go.Figure":
     else:
         studies = list(study)
 
-    return _get_edf_plot(studies)
+    return _get_edf_plot(studies, target, target_name)
 
 
-def _get_edf_plot(studies: List[Study]) -> "go.Figure":
+def _get_edf_plot(
+    studies: List[Study],
+    target: Optional[Callable[[FrozenTrial], float]] = None,
+    target_name: str = "Objective Value",
+) -> "go.Figure":
     layout = go.Layout(
         title="Empirical Distribution Function Plot",
-        xaxis={"title": "Objective Value"},
+        xaxis={"title": target_name},
         yaxis={"title": "Cumulative Probability"},
     )
 
@@ -117,15 +135,22 @@ def _get_edf_plot(studies: List[Study]) -> "go.Figure":
         _logger.warning("There are no complete trials.")
         return go.Figure(data=[], layout=layout)
 
-    min_x_value = min(trial.value for trial in all_trials)
-    max_x_value = max(trial.value for trial in all_trials)
+    if target is None:
+
+        def _target(t: FrozenTrial) -> float:
+            return cast(float, t.value)
+
+        target = _target
+
+    min_x_value = min(target(trial) for trial in all_trials)
+    max_x_value = max(target(trial) for trial in all_trials)
     x_values = np.linspace(min_x_value, max_x_value, 100)
 
     traces = []
     for study in studies:
         values = np.asarray(
             [
-                trial.value
+                target(trial)
                 for trial in study.get_trials(deepcopy=False)
                 if trial.state == TrialState.COMPLETE
             ]

--- a/optuna/visualization/matplotlib/_edf.py
+++ b/optuna/visualization/matplotlib/_edf.py
@@ -1,5 +1,8 @@
 import itertools
+from typing import Callable
+from typing import cast
 from typing import List
+from typing import Optional
 from typing import Sequence
 from typing import Union
 
@@ -8,6 +11,7 @@ import numpy as np
 from optuna._experimental import experimental
 from optuna.logging import get_logger
 from optuna.study import Study
+from optuna.trial import FrozenTrial
 from optuna.trial import TrialState
 from optuna.visualization.matplotlib._matplotlib_imports import _imports
 
@@ -20,7 +24,12 @@ _logger = get_logger(__name__)
 
 
 @experimental("2.2.0")
-def plot_edf(study: Union[Study, Sequence[Study]]) -> "Axes":
+def plot_edf(
+    study: Union[Study, Sequence[Study]],
+    *,
+    target: Optional[Callable[[FrozenTrial], float]] = None,
+    target_name: str = "Objective Value",
+) -> "Axes":
     """Plot the objective value EDF (empirical distribution function) of a study with Matplotlib.
 
     .. seealso::
@@ -70,6 +79,11 @@ def plot_edf(study: Union[Study, Sequence[Study]]) -> "Axes":
         study:
             A target :class:`~optuna.study.Study` object.
             You can pass multiple studies if you want to compare those EDFs.
+        target:
+            A function to specify the value to display. If it is :obj:`None`, the objective values
+            are plotted.
+        target_name:
+            Target's name to display on the axis label.
 
     Returns:
         A :class:`matplotlib.axes.Axes` object.
@@ -82,16 +96,20 @@ def plot_edf(study: Union[Study, Sequence[Study]]) -> "Axes":
     else:
         studies = list(study)
 
-    return _get_edf_plot(studies)
+    return _get_edf_plot(studies, target, target_name)
 
 
-def _get_edf_plot(studies: List[Study]) -> "Axes":
+def _get_edf_plot(
+    studies: List[Study],
+    target: Optional[Callable[[FrozenTrial], float]] = None,
+    target_name: str = "Objective Value",
+) -> "Axes":
 
     # Set up the graph style.
     plt.style.use("ggplot")  # Use ggplot style sheet for similar outputs to plotly.
     _, ax = plt.subplots()
     ax.set_title("Empirical Distribution Function Plot")
-    ax.set_xlabel("Objective Value")
+    ax.set_xlabel(target_name)
     ax.set_ylabel("Cumulative Probability")
     ax.set_ylim(0, 1)
     cmap = plt.get_cmap("tab20")  # Use tab20 colormap for multiple line plots.
@@ -116,15 +134,22 @@ def _get_edf_plot(studies: List[Study]) -> "Axes":
         _logger.warning("There are no complete trials.")
         return ax
 
-    min_x_value = min(trial.value for trial in all_trials)
-    max_x_value = max(trial.value for trial in all_trials)
+    if target is None:
+
+        def _target(t: FrozenTrial) -> float:
+            return cast(float, t.value)
+
+        target = _target
+
+    min_x_value = min(target(trial) for trial in all_trials)
+    max_x_value = max(target(trial) for trial in all_trials)
     x_values = np.linspace(min_x_value, max_x_value, 100)
 
     # Draw multiple line plots.
     for i, study in enumerate(studies):
         values = np.asarray(
             [
-                trial.value
+                target(trial)
                 for trial in study.get_trials(deepcopy=False)
                 if trial.state == TrialState.COMPLETE
             ]

--- a/tests/visualization_tests/matplotlib_tests/test_edf.py
+++ b/tests/visualization_tests/matplotlib_tests/test_edf.py
@@ -31,3 +31,15 @@ def test_plot_optimization_history(direction: str) -> None:
     assert figure.has_data()
     figure = plot_edf((study0, study1))
     assert figure.has_data()
+
+    # Test with a customized target value.
+    study0 = create_study(direction=direction)
+    study0.optimize(lambda t: t.suggest_float("x", 0, 5), n_trials=10)
+    figure = plot_edf(study0, target=lambda t: t.params["x"])
+    assert figure.has_data()
+
+    # Test with a customized target name.
+    study0 = create_study(direction=direction)
+    study0.optimize(lambda t: t.suggest_float("x", 0, 5), n_trials=10)
+    figure = plot_edf(study0, target_name="Target Name")
+    assert figure.has_data()

--- a/tests/visualization_tests/test_edf.py
+++ b/tests/visualization_tests/test_edf.py
@@ -22,6 +22,7 @@ def test_plot_optimization_history(direction: str) -> None:
     study0.optimize(lambda t: t.suggest_float("x", 0, 5), n_trials=10)
     figure = plot_edf(study0)
     assert len(figure.data) == 1
+    assert figure.layout.xaxis.title.text == "Objective Value"
 
     # Test with two studies.
     study1 = create_study(direction=direction)
@@ -30,3 +31,16 @@ def test_plot_optimization_history(direction: str) -> None:
     assert len(figure.data) == 2
     figure = plot_edf((study0, study1))
     assert len(figure.data) == 2
+
+    # Test with a customized target value.
+    study0 = create_study(direction=direction)
+    study0.optimize(lambda t: t.suggest_float("x", 0, 5), n_trials=10)
+    figure = plot_edf(study0, target=lambda t: t.params["x"])
+    assert len(figure.data) == 1
+
+    # Test with a customized target name.
+    study0 = create_study(direction=direction)
+    study0.optimize(lambda t: t.suggest_float("x", 0, 5), n_trials=10)
+    figure = plot_edf(study0, target_name="Target Name")
+    assert len(figure.data) == 1
+    assert figure.layout.xaxis.title.text == "Target Name"


### PR DESCRIPTION
## Motivation
This PR enables flexible plotting in `plot_edf`, same as #2064.

## Description of the changes
Added `target` and `target_name` arguments to `plot_edf`.