### PR TITLE
Release wheel package via PyPI

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -19,11 +19,12 @@ jobs:
 
     - name: Install twine
       run: >-
-        python -m pip install -U twine
+        python -m pip install -U twine wheel
 
     - name: Build a tar ball
       run: >-
         python setup.py sdist
+        python setup.py bdist_wheel
 
     - name: Verify the distributions
       run: twine check dist/*

--- a/setup.py
+++ b/setup.py
@@ -107,22 +107,16 @@ def get_extras_require() -> Dict[str, List[str]]:
             "skorch",
             "stable-baselines3>=0.7.0",
             "catalyst",
-        ]
-        + (
-            ["torch==1.7.0", "torchvision==0.8.1", "torchaudio==0.7.0"]
-            if sys.platform == "darwin"
-            else ["torch==1.7.0+cpu", "torchvision==0.8.1+cpu", "torchaudio==0.7.0"]
-        )
-        + (
-            [
-                "allennlp==1.2.0",
-                "fastai",
-                "dask[dataframe]",
-                "dask-ml",
-            ]
-            if sys.version_info[:2] < (3, 8)
-            else ["fastai"]
-        ),
+            "torch==1.7.0 ; sys_platform=='darwin'",
+            "torch==1.7.0+cpu ; sys_platform!='darwin'",
+            "torchvision==0.8.1 ; sys_platform=='darwin'",
+            "torchvision==0.8.1+cpu ; sys_platform!='darwin'",
+            "torchaudio==0.7.0",
+            "allennlp==1.2.0 ; python_version<'3.8'",
+            "dask[dataframe] ; python_version<'3.8'",
+            "dask-ml ; python_version<'3.8'",
+            "fastai",
+        ],
         "experimental": ["redis"],
         "testing": [
             # TODO(toshihikoyanase): Remove the version constraint after resolving the issue
@@ -149,13 +143,14 @@ def get_extras_require() -> Dict[str, List[str]]:
             "pytorch-lightning>=1.0.2",
             "skorch",
             "catalyst",
-        ]
-        + (
-            ["torch==1.7.0", "torchvision==0.8.1", "torchaudio==0.7.0"]
-            if sys.platform == "darwin"
-            else ["torch==1.7.0+cpu", "torchvision==0.8.1+cpu", "torchaudio==0.7.0"]
-        )
-        + (["allennlp==1.2.0", "fastai"] if sys.version_info[:2] < (3, 8) else ["fastai"]),
+            "torch==1.7.0 ; sys_platform=='darwin'",
+            "torch==1.7.0+cpu ; sys_platform!='darwin'",
+            "torchvision==0.8.1 ; sys_platform=='darwin'",
+            "torchvision==0.8.1+cpu ; sys_platform!='darwin'",
+            "torchaudio==0.7.0",
+            "allennlp==1.2.0 ; python_version<'3.8'",
+            "fastai",
+        ],
         "tests": ["fakeredis", "pytest"],
         "optional": [
             "bokeh<2.0.0",  # optuna/cli.py, optuna/dashboard.py.
@@ -185,13 +180,14 @@ def get_extras_require() -> Dict[str, List[str]]:
             "pytorch-lightning>=1.0.2",
             "skorch",
             "catalyst",
-        ]
-        + (
-            ["torch==1.7.0", "torchvision==0.8.1", "torchaudio==0.7.0"]
-            if sys.platform == "darwin"
-            else ["torch==1.7.0+cpu", "torchvision==0.8.1+cpu", "torchaudio==0.7.0"]
-        )
-        + (["allennlp==1.2.0", "fastai"] if sys.version_info[:2] < (3, 8) else ["fastai"]),
+            "torch==1.7.0 ; sys_platform=='darwin'",
+            "torch==1.7.0+cpu ; sys_platform!='darwin'",
+            "torchvision==0.8.1 ; sys_platform=='darwin'",
+            "torchvision==0.8.1+cpu ; sys_platform!='darwin'",
+            "torchaudio==0.7.0",
+            "allennlp==1.2.0 ; python_version<'3.8'",
+            "fastai",
+        ],
     }
 
     return requirements


### PR DESCRIPTION
## Motivation
This PR adds [Python wheel](https://pythonwheels.com/)-format package of Optuna to the [PyPI release](https://pypi.org/project/optuna/).

Currently, Optuna only provides source packages in [pypi](https://pypi.org/project/optuna/). When we install optuna from the source packages, the build of the wheel package is executed as follows:

```console
$ docker run -it -v $(pwd):/prj --rm -w /prj python:3.8 bash
$ pip install optuna
...
Building wheels for collected packages: optuna, PrettyTable, pyperclip, PyYAML
  Building wheel for optuna (PEP 517) ... done
  Created wheel for optuna: filename=optuna-2.3.0-py3-none-any.whl size=359705 sha256=cd8d7872a7d23de7923affeebcbe80ecd05a9a303c2051a1d0bb8f7fe876812d
```

The build process may fail depending on the user environments. For example, if users have installed `typing`, the installation will fail as reported in https://github.com/optuna/optuna/issues/1739. 

```
$ pip install typing
root@5c7aa57fc51b:/prj# pip install optuna
Collecting optuna
  Downloading optuna-2.3.0.tar.gz (258 kB)
     |████████████████████████████████| 258 kB 1.9 MB/s
  Installing build dependencies ... error
  ERROR: Command errored out with exit status 1:
   command: /usr/local/bin/python /usr/local/lib/python3.8/site-packages/pip install --ignore-installed --no-user --prefix /tmp/pip-build-env-auvtcqrn/overlay --no-warn-script-location --no-binary :none: --only-binary :none: -i https://pypi.org/simple -- 'setuptools>=40.8.0' wheel
       cwd: None
  Complete output (42 lines):
  Traceback (most recent call last):
...
      self._abc_registry = extra._abc_registry
  AttributeError: type object 'Callable' has no attribute '_abc_registry'
```

We can avoid such errors by providing the wheel package in addition to the source package.

```console
$ pip install dist/optuna-2.3.0-py3-none-any.whl
Processing ./dist/optuna-2.3.0-py3-none-any.whl
...
Successfully installed Mako-1.1.3 MarkupSafe-1.1.1 PrettyTable-0.7.2 PyYAML-5.3.1 alembic-1.4.3 attrs-20.3.0 cliff-3.5.0 cmaes-0.7.0 cmd2-1.4.0 colorama-0.4.4 colorlog-4.6.2 joblib-0.17.0 numpy-1.19.4 optuna-2.3.0 packaging-20.8 pbr-5.5.1 pyparsing-2.4.7 pyperclip-1.8.1 python-dateutil-2.8.1 python-editor-1.0.4 scipy-1.5.4 six-1.15.0 sqlalchemy-1.3.20 stevedore-3.3.0 tqdm-4.54.1 wcwidth-0.2.5
```

## Description of the changes

This PR installs the `wheel` package and runs `python setup.py bdist_wheel`.
We may need to fix `setup.cfg` if we want to add LICENSE to the package (c.f., https://pythonwheels.com/).

Update 1: The license file has been included without adding `license_file` option to `setup.cfg`.

```console
...
adding license file "LICENSE" (matched pattern "LICEN[CS]E*")
```