### PR TITLE
Skip FastAI v2 example in examples job.

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -46,12 +46,14 @@ jobs:
 
         # Install all dependencies needed for examples.
         pip install --progress-bar off $(ls dist/*.tar.gz)[example] -f https://download.pytorch.org/whl/torch_stable.html
+
+        # TODO (crcrpar): Allow fastaiv2 example once https://forums.fast.ai/t/ganlearner-error-no-implementation-found-on-types-that-implement-invisibletensor/83451/7 gets resolved.
     - name: Run examples
       run: |
         if [ ${{ matrix.python-version }} = 3.8 ]; then
-          IGNORES='chainermn_.*|dask_ml_.*|keras_.*|tensorboard_.*|tensorflow_.*|tfkeras_.*|fastaiv1_.*|allennlp|rapids_.*'
+          IGNORES='chainermn_.*|dask_ml_.*|keras_.*|tensorboard_.*|tensorflow_.*|tfkeras_.*|fastai*|allennlp|rapids_.*'
         else
-          IGNORES='chainermn_.*|fastaiv1_.*|rapids_.*'
+          IGNORES='chainermn_.*|fastai*|rapids_.*'
         fi
 
         for file in `find examples -name '*.py' -not -name '*_distributed.py' | grep -vE "$IGNORES"`


### PR DESCRIPTION
See: https://github.com/optuna/optuna/issues/2107.

Skip fastaiv2 because the good version of fastai is >2,<2.1 which requires pytorch1.6. That's incompatible with the other examples, unfortunately.