### PR TITLE
importance with target values other than objective value

### DIFF
--- a/optuna/importance/__init__.py
+++ b/optuna/importance/__init__.py
@@ -1,3 +1,4 @@
+from typing import Callable
 from typing import Dict
 from typing import List
 from typing import Optional
@@ -6,6 +7,7 @@ from optuna.importance._base import BaseImportanceEvaluator
 from optuna.importance._fanova import FanovaImportanceEvaluator
 from optuna.importance._mean_decrease_impurity import MeanDecreaseImpurityImportanceEvaluator
 from optuna.study import Study
+from optuna.trial import FrozenTrial
 
 
 __all__ = [
@@ -21,6 +23,7 @@ def get_param_importances(
     *,
     evaluator: Optional[BaseImportanceEvaluator] = None,
     params: Optional[List[str]] = None,
+    target: Optional[Callable[[FrozenTrial], float]] = None,
 ) -> Dict[str, float]:
     """Evaluate parameter importances based on completed trials in the given study.
 
@@ -62,6 +65,9 @@ def get_param_importances(
             A list of names of parameters to assess.
             If :obj:`None`, all parameters that are present in all of the completed trials are
             assessed.
+        target:
+            A function to specify the value to evaluate importances. If it is :obj:`None`, the
+            objective values are used.
 
     Returns:
         An :class:`collections.OrderedDict` where the keys are parameter names and the values are
@@ -73,4 +79,4 @@ def get_param_importances(
     if not isinstance(evaluator, BaseImportanceEvaluator):
         raise TypeError("Evaluator must be a subclass of BaseImportanceEvaluator.")
 
-    return evaluator.evaluate(study, params=params)
+    return evaluator.evaluate(study, params=params, target=target)

--- a/optuna/importance/_fanova/_evaluator.py
+++ b/optuna/importance/_fanova/_evaluator.py
@@ -1,4 +1,5 @@
 from collections import OrderedDict
+from typing import Callable
 from typing import Dict
 from typing import List
 from typing import Optional
@@ -16,6 +17,7 @@ from optuna.importance._base import _get_study_data
 from optuna.importance._base import BaseImportanceEvaluator
 from optuna.importance._fanova._fanova import _Fanova
 from optuna.study import Study
+from optuna.trial import FrozenTrial
 
 
 class FanovaImportanceEvaluator(BaseImportanceEvaluator):
@@ -73,9 +75,15 @@ class FanovaImportanceEvaluator(BaseImportanceEvaluator):
             seed=seed,
         )
 
-    def evaluate(self, study: Study, params: Optional[List[str]] = None) -> Dict[str, float]:
+    def evaluate(
+        self,
+        study: Study,
+        params: Optional[List[str]] = None,
+        *,
+        target: Optional[Callable[[FrozenTrial], float]] = None,
+    ) -> Dict[str, float]:
         distributions = _get_distributions(study, params)
-        params_data, values_data = _get_study_data(study, distributions)
+        params_data, values_data = _get_study_data(study, distributions, target)
 
         if params_data.size == 0:  # `params` were given but as an empty list.
             return OrderedDict()

--- a/optuna/importance/_mean_decrease_impurity.py
+++ b/optuna/importance/_mean_decrease_impurity.py
@@ -1,4 +1,5 @@
 from collections import OrderedDict
+from typing import Callable
 from typing import Dict
 from typing import List
 from typing import Optional
@@ -14,6 +15,7 @@ from optuna.importance._base import _get_distributions
 from optuna.importance._base import _get_study_data
 from optuna.importance._base import BaseImportanceEvaluator
 from optuna.study import Study
+from optuna.trial import FrozenTrial
 
 
 with try_import() as _imports:
@@ -56,9 +58,15 @@ class MeanDecreaseImpurityImportanceEvaluator(BaseImportanceEvaluator):
             random_state=seed,
         )
 
-    def evaluate(self, study: Study, params: Optional[List[str]] = None) -> Dict[str, float]:
+    def evaluate(
+        self,
+        study: Study,
+        params: Optional[List[str]] = None,
+        *,
+        target: Optional[Callable[[FrozenTrial], float]] = None,
+    ) -> Dict[str, float]:
         distributions = _get_distributions(study, params)
-        params_data, values_data = _get_study_data(study, distributions)
+        params_data, values_data = _get_study_data(study, distributions, target)
 
         if params_data.size == 0:  # `params` were given but as an empty list.
             return OrderedDict()

--- a/tests/importance_tests/test_fanova.py
+++ b/tests/importance_tests/test_fanova.py
@@ -55,3 +55,20 @@ def test_fanova_importance_evaluator_seed() -> None:
     evaluator = FanovaImportanceEvaluator(seed=3)
     param_importance_different_seed = evaluator.evaluate(study)
     assert param_importance != param_importance_different_seed
+
+
+def test_fanova_importance_evaluator_with_target() -> None:
+    # Assumes that `seed` can be fixed to reproduce identical results.
+
+    study = create_study(sampler=RandomSampler(seed=0))
+    study.optimize(objective, n_trials=100)
+
+    evaluator = FanovaImportanceEvaluator(seed=0)
+    param_importance = evaluator.evaluate(study)
+    param_importance_with_target = evaluator.evaluate(
+        study,
+        target=lambda t: t.params["x1"] + t.params["x2"],
+    )
+
+    assert param_importance != param_importance_with_target
+    assert param_importance_with_target["x3"] == min(param_importance_with_target.values())

--- a/tests/importance_tests/test_fanova.py
+++ b/tests/importance_tests/test_fanova.py
@@ -61,7 +61,7 @@ def test_fanova_importance_evaluator_with_target() -> None:
     # Assumes that `seed` can be fixed to reproduce identical results.
 
     study = create_study(sampler=RandomSampler(seed=0))
-    study.optimize(objective, n_trials=100)
+    study.optimize(objective, n_trials=3)
 
     evaluator = FanovaImportanceEvaluator(seed=0)
     param_importance = evaluator.evaluate(study)
@@ -71,4 +71,3 @@ def test_fanova_importance_evaluator_with_target() -> None:
     )
 
     assert param_importance != param_importance_with_target
-    assert param_importance_with_target["x3"] == min(param_importance_with_target.values())

--- a/tests/importance_tests/test_init.py
+++ b/tests/importance_tests/test_init.py
@@ -122,7 +122,7 @@ def test_get_param_importances_with_target(
         return value
 
     study = create_study(storage_init_func())
-    study.optimize(objective, n_trials=100)
+    study.optimize(objective, n_trials=3)
 
     param_importance = get_param_importances(
         study,
@@ -139,7 +139,6 @@ def test_get_param_importances_with_target(
         assert isinstance(importance, float)
         assert importance <= prev_importance
         prev_importance = importance
-    assert param_importance["x3"] == min(param_importance.values())
     assert math.isclose(1.0, sum(param_importance.values()), abs_tol=1e-5)
 
 

--- a/tests/importance_tests/test_init.py
+++ b/tests/importance_tests/test_init.py
@@ -104,6 +104,46 @@ def test_get_param_importances_with_params(
 
 
 @parametrize_evaluator
+@parametrize_storage
+def test_get_param_importances_with_target(
+    storage_init_func: Callable[[], storages.BaseStorage],
+    evaluator_init_func: Callable[[], BaseImportanceEvaluator],
+) -> None:
+    def objective(trial: Trial) -> float:
+        x1 = trial.suggest_uniform("x1", 0.1, 3)
+        x2 = trial.suggest_loguniform("x2", 0.1, 3)
+        x3 = trial.suggest_discrete_uniform("x3", 0, 3, 1)
+        if trial.number % 2 == 0:
+            x4 = trial.suggest_uniform("x4", 0.1, 3)
+
+        value = x1 ** 4 + x2 + x3
+        if trial.number % 2 == 0:
+            value += x4
+        return value
+
+    study = create_study(storage_init_func())
+    study.optimize(objective, n_trials=100)
+
+    param_importance = get_param_importances(
+        study,
+        evaluator=evaluator_init_func(),
+        target=lambda t: t.params["x1"] + t.params["x2"],
+    )
+
+    assert isinstance(param_importance, OrderedDict)
+    assert len(param_importance) == 3
+    assert all(param_name in param_importance for param_name in ["x1", "x2", "x3"])
+    prev_importance = float("inf")
+    for param_name, importance in param_importance.items():
+        assert isinstance(param_name, str)
+        assert isinstance(importance, float)
+        assert importance <= prev_importance
+        prev_importance = importance
+    assert param_importance["x3"] == min(param_importance.values())
+    assert math.isclose(1.0, sum(param_importance.values()), abs_tol=1e-5)
+
+
+@parametrize_evaluator
 def test_get_param_importances_invalid_empty_study(
     evaluator_init_func: Callable[[], BaseImportanceEvaluator]
 ) -> None:

--- a/tests/importance_tests/test_mean_decrease_impurity.py
+++ b/tests/importance_tests/test_mean_decrease_impurity.py
@@ -61,7 +61,7 @@ def test_mean_decrease_impurity_importance_evaluator_with_target() -> None:
     # Assumes that `seed` can be fixed to reproduce identical results.
 
     study = create_study(sampler=RandomSampler(seed=0))
-    study.optimize(objective, n_trials=100)
+    study.optimize(objective, n_trials=3)
 
     evaluator = MeanDecreaseImpurityImportanceEvaluator(seed=0)
     param_importance = evaluator.evaluate(study)
@@ -71,4 +71,3 @@ def test_mean_decrease_impurity_importance_evaluator_with_target() -> None:
     )
 
     assert param_importance != param_importance_with_target
-    assert param_importance_with_target["x3"] == min(param_importance_with_target.values())

--- a/tests/importance_tests/test_mean_decrease_impurity.py
+++ b/tests/importance_tests/test_mean_decrease_impurity.py
@@ -55,3 +55,20 @@ def test_mean_decrease_impurity_importance_evaluator_seed() -> None:
     evaluator = MeanDecreaseImpurityImportanceEvaluator(seed=3)
     param_importance_different_seed = evaluator.evaluate(study)
     assert param_importance != param_importance_different_seed
+
+
+def test_mean_decrease_impurity_importance_evaluator_with_target() -> None:
+    # Assumes that `seed` can be fixed to reproduce identical results.
+
+    study = create_study(sampler=RandomSampler(seed=0))
+    study.optimize(objective, n_trials=100)
+
+    evaluator = MeanDecreaseImpurityImportanceEvaluator(seed=0)
+    param_importance = evaluator.evaluate(study)
+    param_importance_with_target = evaluator.evaluate(
+        study,
+        target=lambda t: t.params["x1"] + t.params["x2"],
+    )
+
+    assert param_importance != param_importance_with_target
+    assert param_importance_with_target["x3"] == min(param_importance_with_target.values())


### PR DESCRIPTION
## Motivation
This PR enables us to evaluate hyperparameter importance for customized target values, e.g., duration or scores in other metrics.
related to #2064.

## Description of the changes
Added `target` argument to `get_param_importances` and `evaluate` of evaluators.