### PR TITLE
Migrate `optuna.multi_objective.visualization.plot_pareto_front`

### DIFF
--- a/docs/source/reference/visualization/index.rst
+++ b/docs/source/reference/visualization/index.rst
@@ -23,6 +23,7 @@ The :mod:`~optuna.visualization` module provides utility functions for plotting 
    optuna.visualization.plot_optimization_history
    optuna.visualization.plot_parallel_coordinate
    optuna.visualization.plot_param_importances
+   optuna.visualization.plot_pareto_front
    optuna.visualization.plot_slice
    optuna.visualization.is_available
 

--- a/optuna/visualization/__init__.py
+++ b/optuna/visualization/__init__.py
@@ -5,6 +5,7 @@ from optuna.visualization._intermediate_values import plot_intermediate_values
 from optuna.visualization._optimization_history import plot_optimization_history
 from optuna.visualization._parallel_coordinate import plot_parallel_coordinate
 from optuna.visualization._param_importances import plot_param_importances
+from optuna.visualization._pareto_front import plot_pareto_front
 from optuna.visualization._slice import plot_slice
 from optuna.visualization._utils import is_available
 
@@ -18,5 +19,6 @@ __all__ = [
     "plot_optimization_history",
     "plot_parallel_coordinate",
     "plot_param_importances",
+    "plot_pareto_front",
     "plot_slice",
 ]

--- a/optuna/visualization/_pareto_front.py
+++ b/optuna/visualization/_pareto_front.py
@@ -1,0 +1,216 @@
+import json
+from typing import List
+from typing import Optional
+
+import optuna
+from optuna._experimental import experimental
+from optuna.study import Study
+from optuna.trial import FrozenTrial
+from optuna.trial import TrialState
+from optuna.visualization._plotly_imports import _imports
+
+
+if _imports.is_successful():
+    from optuna.visualization._plotly_imports import go
+
+_logger = optuna.logging.get_logger(__name__)
+
+
+@experimental("2.4.0")
+def plot_pareto_front(
+    study: Study,
+    names: Optional[List[str]] = None,
+    include_dominated_trials: bool = False,
+    axis_order: Optional[List[int]] = None,
+) -> "go.Figure":
+    """Plot the pareto front of a study.
+
+    Example:
+
+        The following code snippet shows how to plot the pareto front of a study.
+
+        .. plotly::
+
+            import optuna
+
+
+            def objective(trial):
+                x = trial.suggest_float("x", 0, 5)
+                y = trial.suggest_float("y", 0, 3)
+
+                v0 = 4 * x ** 2 + 4 * y ** 2
+                v1 = (x - 5) ** 2 + (y - 5) ** 2
+                return v0, v1
+
+
+            study = optuna.create_study(directions=["minimize", "minimize"])
+            study.optimize(objective, n_trials=50)
+
+            optuna.visualization.plot_pareto_front(study)
+
+    Args:
+        study:
+            A :class:`~optuna.study.Study` object whose trials are plotted for their objective
+            values.
+        names:
+            Objective name list used as the axis titles. If :obj:`None` is specified,
+            "Objective {objective_index}" is used instead.
+        include_dominated_trials:
+            A flag to include all dominated trial's objective values.
+        axis_order:
+            A list of indices indicating the axis order. If :obj:`None` is specified,
+            default order is used.
+
+
+    Returns:
+        A :class:`plotly.graph_objs.Figure` object.
+
+    Raises:
+        :exc:`ValueError`:
+            If the number of objectives of ``study`` isn't 2 or 3.
+    """
+
+    _imports.check()
+
+    if len(study.directions) == 2:
+        return _get_pareto_front_2d(study, names, include_dominated_trials, axis_order)
+    elif len(study.directions) == 3:
+        return _get_pareto_front_3d(study, names, include_dominated_trials, axis_order)
+    else:
+        raise ValueError("`plot_pareto_front` function only supports 2 or 3 objective studies.")
+
+
+def _get_non_pareto_front_trials(
+    study: Study, pareto_trials: List[FrozenTrial]
+) -> List[FrozenTrial]:
+
+    non_pareto_trials = []
+    for trial in study.get_trials():
+        if trial.state == TrialState.COMPLETE and trial not in pareto_trials:
+            non_pareto_trials.append(trial)
+    return non_pareto_trials
+
+
+def _get_pareto_front_2d(
+    study: Study,
+    names: Optional[List[str]],
+    include_dominated_trials: bool = False,
+    axis_order: Optional[List[int]] = None,
+) -> "go.Figure":
+    if names is None:
+        names = ["Objective 0", "Objective 1"]
+    elif len(names) != 2:
+        raise ValueError("The length of `names` is supposed to be 2.")
+
+    trials = study.best_trials
+    if len(trials) == 0:
+        _logger.warning("Your study does not have any completed trials.")
+
+    point_colors = ["blue"] * len(trials)
+    if include_dominated_trials:
+        non_pareto_trials = _get_non_pareto_front_trials(study, trials)
+        point_colors += ["red"] * len(non_pareto_trials)
+        trials += non_pareto_trials
+
+    if axis_order is None:
+        axis_order = list(range(2))
+    else:
+        if len(axis_order) != 2:
+            raise ValueError(
+                f"Size of `axis_order` {axis_order}. Expect: 2, Actual: {len(axis_order)}."
+            )
+        if len(set(axis_order)) != 2:
+            raise ValueError(f"Elements of given `axis_order` {axis_order} are not unique!")
+        if max(axis_order) > 1:
+            raise ValueError(
+                f"Given `axis_order` {axis_order} contains invalid index {max(axis_order)} "
+                "higher than 1."
+            )
+        if min(axis_order) < 0:
+            raise ValueError(
+                f"Given `axis_order` {axis_order} contains invalid index {min(axis_order)} "
+                "lower than 0."
+            )
+
+    data = go.Scatter(
+        x=[t.values[axis_order[0]] for t in trials],
+        y=[t.values[axis_order[1]] for t in trials],
+        text=[_make_hovertext(t) for t in trials],
+        mode="markers",
+        hovertemplate="%{text}<extra></extra>",
+        marker={"color": point_colors},
+    )
+    layout = go.Layout(
+        title="Pareto-front Plot",
+        xaxis_title=names[axis_order[0]],
+        yaxis_title=names[axis_order[1]],
+    )
+    return go.Figure(data=data, layout=layout)
+
+
+def _get_pareto_front_3d(
+    study: Study,
+    names: Optional[List[str]],
+    include_dominated_trials: bool = False,
+    axis_order: Optional[List[int]] = None,
+) -> "go.Figure":
+    if names is None:
+        names = ["Objective 0", "Objective 1", "Objective 2"]
+    elif len(names) != 3:
+        raise ValueError("The length of `names` is supposed to be 3.")
+
+    trials = study.best_trials
+    if len(trials) == 0:
+        _logger.warning("Your study does not have any completed trials.")
+
+    point_colors = ["blue"] * len(trials)
+    if include_dominated_trials:
+        non_pareto_trials = _get_non_pareto_front_trials(study, trials)
+        point_colors += ["red"] * len(non_pareto_trials)
+        trials += non_pareto_trials
+
+    if axis_order is None:
+        axis_order = list(range(3))
+    else:
+        if len(axis_order) != 3:
+            raise ValueError(
+                f"Size of `axis_order` {axis_order}. Expect: 3, Actual: {len(axis_order)}."
+            )
+        if len(set(axis_order)) != 3:
+            raise ValueError(f"Elements of given `axis_order` {axis_order} are not unique!.")
+        if max(axis_order) > 2:
+            raise ValueError(
+                f"Given `axis_order` {axis_order} contains invalid index {max(axis_order)} "
+                "higher than 2."
+            )
+        if min(axis_order) < 0:
+            raise ValueError(
+                f"Given `axis_order` {axis_order} contains invalid index {min(axis_order)} "
+                "lower than 0."
+            )
+
+    data = go.Scatter3d(
+        x=[t.values[axis_order[0]] for t in trials],
+        y=[t.values[axis_order[1]] for t in trials],
+        z=[t.values[axis_order[2]] for t in trials],
+        text=[_make_hovertext(t) for t in trials],
+        mode="markers",
+        hovertemplate="%{text}<extra></extra>",
+        marker={"color": point_colors},
+    )
+    layout = go.Layout(
+        title="Pareto-front Plot",
+        scene={
+            "xaxis_title": names[axis_order[0]],
+            "yaxis_title": names[axis_order[1]],
+            "zaxis_title": names[axis_order[2]],
+        },
+    )
+    return go.Figure(data=data, layout=layout)
+
+
+def _make_hovertext(trial: FrozenTrial) -> str:
+    text = json.dumps(
+        {"number": trial.number, "values": trial.values, "params": trial.params}, indent=2
+    )
+    return text.replace("\n", "<br>")

--- a/optuna/visualization/_pareto_front.py
+++ b/optuna/visualization/_pareto_front.py
@@ -18,16 +18,17 @@ _logger = optuna.logging.get_logger(__name__)
 
 @experimental("2.4.0")
 def plot_pareto_front(
+    *,
     study: Study,
-    names: Optional[List[str]] = None,
+    target_names: Optional[List[str]] = None,
     include_dominated_trials: bool = False,
     axis_order: Optional[List[int]] = None,
 ) -> "go.Figure":
-    """Plot the pareto front of a study.
+    """Plot the Pareto front of a study.
 
     Example:
 
-        The following code snippet shows how to plot the pareto front of a study.
+        The following code snippet shows how to plot the Pareto front of a study.
 
         .. plotly::
 
@@ -52,7 +53,7 @@ def plot_pareto_front(
         study:
             A :class:`~optuna.study.Study` object whose trials are plotted for their objective
             values.
-        names:
+        target_names:
             Objective name list used as the axis titles. If :obj:`None` is specified,
             "Objective {objective_index}" is used instead.
         include_dominated_trials:
@@ -60,7 +61,6 @@ def plot_pareto_front(
         axis_order:
             A list of indices indicating the axis order. If :obj:`None` is specified,
             default order is used.
-
 
     Returns:
         A :class:`plotly.graph_objs.Figure` object.
@@ -73,9 +73,9 @@ def plot_pareto_front(
     _imports.check()
 
     if len(study.directions) == 2:
-        return _get_pareto_front_2d(study, names, include_dominated_trials, axis_order)
+        return _get_pareto_front_2d(study, target_names, include_dominated_trials, axis_order)
     elif len(study.directions) == 3:
-        return _get_pareto_front_3d(study, names, include_dominated_trials, axis_order)
+        return _get_pareto_front_3d(study, target_names, include_dominated_trials, axis_order)
     else:
         raise ValueError("`plot_pareto_front` function only supports 2 or 3 objective studies.")
 
@@ -93,14 +93,14 @@ def _get_non_pareto_front_trials(
 
 def _get_pareto_front_2d(
     study: Study,
-    names: Optional[List[str]],
+    target_names: Optional[List[str]],
     include_dominated_trials: bool = False,
     axis_order: Optional[List[int]] = None,
 ) -> "go.Figure":
-    if names is None:
-        names = ["Objective 0", "Objective 1"]
-    elif len(names) != 2:
-        raise ValueError("The length of `names` is supposed to be 2.")
+    if target_names is None:
+        target_names = ["Objective 0", "Objective 1"]
+    elif len(target_names) != 2:
+        raise ValueError("The length of `target_names` is supposed to be 2.")
 
     trials = study.best_trials
     if len(trials) == 0:
@@ -142,22 +142,22 @@ def _get_pareto_front_2d(
     )
     layout = go.Layout(
         title="Pareto-front Plot",
-        xaxis_title=names[axis_order[0]],
-        yaxis_title=names[axis_order[1]],
+        xaxis_title=target_names[axis_order[0]],
+        yaxis_title=target_names[axis_order[1]],
     )
     return go.Figure(data=data, layout=layout)
 
 
 def _get_pareto_front_3d(
     study: Study,
-    names: Optional[List[str]],
+    target_names: Optional[List[str]],
     include_dominated_trials: bool = False,
     axis_order: Optional[List[int]] = None,
 ) -> "go.Figure":
-    if names is None:
-        names = ["Objective 0", "Objective 1", "Objective 2"]
-    elif len(names) != 3:
-        raise ValueError("The length of `names` is supposed to be 3.")
+    if target_names is None:
+        target_names = ["Objective 0", "Objective 1", "Objective 2"]
+    elif len(target_names) != 3:
+        raise ValueError("The length of `target_names` is supposed to be 3.")
 
     trials = study.best_trials
     if len(trials) == 0:
@@ -201,9 +201,9 @@ def _get_pareto_front_3d(
     layout = go.Layout(
         title="Pareto-front Plot",
         scene={
-            "xaxis_title": names[axis_order[0]],
-            "yaxis_title": names[axis_order[1]],
-            "zaxis_title": names[axis_order[2]],
+            "xaxis_title": target_names[axis_order[0]],
+            "yaxis_title": target_names[axis_order[1]],
+            "zaxis_title": target_names[axis_order[2]],
         },
     )
     return go.Figure(data=data, layout=layout)

--- a/optuna/visualization/_pareto_front.py
+++ b/optuna/visualization/_pareto_front.py
@@ -21,7 +21,7 @@ def plot_pareto_front(
     *,
     study: Study,
     target_names: Optional[List[str]] = None,
-    include_dominated_trials: bool = False,
+    include_dominated_trials: bool = True,
     axis_order: Optional[List[int]] = None,
 ) -> "go.Figure":
     """Plot the Pareto front of a study.

--- a/optuna/visualization/_pareto_front.py
+++ b/optuna/visualization/_pareto_front.py
@@ -18,8 +18,8 @@ _logger = optuna.logging.get_logger(__name__)
 
 @experimental("2.4.0")
 def plot_pareto_front(
-    *,
     study: Study,
+    *,
     target_names: Optional[List[str]] = None,
     include_dominated_trials: bool = True,
     axis_order: Optional[List[int]] = None,

--- a/tests/visualization_tests/test_pareto_front.py
+++ b/tests/visualization_tests/test_pareto_front.py
@@ -63,34 +63,34 @@ def test_plot_pareto_front_2d(
         assert figure.layout.xaxis.title.text == titles[axis_order[0]]
         assert figure.layout.yaxis.title.text == titles[axis_order[1]]
 
-    # Test with `names` argument.
+    # Test with `target_names` argument.
     with pytest.raises(ValueError):
-        plot_pareto_front(study, names=[], include_dominated_trials=include_dominated_trials)
+        plot_pareto_front(study, target_names=[], include_dominated_trials=include_dominated_trials)
 
     with pytest.raises(ValueError):
-        plot_pareto_front(study, names=["Foo"], include_dominated_trials=include_dominated_trials)
+        plot_pareto_front(study, target_names=["Foo"], include_dominated_trials=include_dominated_trials)
 
     with pytest.raises(ValueError):
         plot_pareto_front(
             study,
-            names=["Foo", "Bar", "Baz"],
+            target_names=["Foo", "Bar", "Baz"],
             include_dominated_trials=include_dominated_trials,
             axis_order=axis_order,
         )
 
-    names = ["Foo", "Bar"]
+    target_names = ["Foo", "Bar"]
     figure = plot_pareto_front(
         study,
-        names=names,
+        target_names=target_names,
         include_dominated_trials=include_dominated_trials,
         axis_order=axis_order,
     )
     if axis_order is None:
-        assert figure.layout.xaxis.title.text == names[0]
-        assert figure.layout.yaxis.title.text == names[1]
+        assert figure.layout.xaxis.title.text == target_names[0]
+        assert figure.layout.yaxis.title.text == target_names[1]
     else:
-        assert figure.layout.xaxis.title.text == names[axis_order[0]]
-        assert figure.layout.yaxis.title.text == names[axis_order[1]]
+        assert figure.layout.xaxis.title.text == target_names[axis_order[0]]
+        assert figure.layout.yaxis.title.text == target_names[axis_order[1]]
 
 
 @pytest.mark.parametrize("include_dominated_trials", [False, True])
@@ -159,11 +159,11 @@ def test_plot_pareto_front_3d(
         assert figure.layout.scene.yaxis.title.text == titles[axis_order[1]]
         assert figure.layout.scene.zaxis.title.text == titles[axis_order[2]]
 
-    # Test with `names` argument.
+    # Test with `target_names` argument.
     with pytest.raises(ValueError):
         plot_pareto_front(
             study,
-            names=[],
+            target_names=[],
             include_dominated_trials=include_dominated_trials,
             axis_order=axis_order,
         )
@@ -171,7 +171,7 @@ def test_plot_pareto_front_3d(
     with pytest.raises(ValueError):
         plot_pareto_front(
             study,
-            names=["Foo"],
+            target_names=["Foo"],
             include_dominated_trials=include_dominated_trials,
             axis_order=axis_order,
         )
@@ -179,7 +179,7 @@ def test_plot_pareto_front_3d(
     with pytest.raises(ValueError):
         plot_pareto_front(
             study,
-            names=["Foo", "Bar"],
+            target_names=["Foo", "Bar"],
             include_dominated_trials=include_dominated_trials,
             axis_order=axis_order,
         )
@@ -187,21 +187,21 @@ def test_plot_pareto_front_3d(
     with pytest.raises(ValueError):
         plot_pareto_front(
             study,
-            names=["Foo", "Bar", "Baz", "Qux"],
+            target_names=["Foo", "Bar", "Baz", "Qux"],
             include_dominated_trials=include_dominated_trials,
             axis_order=axis_order,
         )
 
-    names = ["Foo", "Bar", "Baz"]
-    figure = plot_pareto_front(study, names=names, axis_order=axis_order)
+    target_names = ["Foo", "Bar", "Baz"]
+    figure = plot_pareto_front(study, target_names=target_names, axis_order=axis_order)
     if axis_order is None:
-        assert figure.layout.scene.xaxis.title.text == names[0]
-        assert figure.layout.scene.yaxis.title.text == names[1]
-        assert figure.layout.scene.zaxis.title.text == names[2]
+        assert figure.layout.scene.xaxis.title.text == target_names[0]
+        assert figure.layout.scene.yaxis.title.text == target_names[1]
+        assert figure.layout.scene.zaxis.title.text == target_names[2]
     else:
-        assert figure.layout.scene.xaxis.title.text == names[axis_order[0]]
-        assert figure.layout.scene.yaxis.title.text == names[axis_order[1]]
-        assert figure.layout.scene.zaxis.title.text == names[axis_order[2]]
+        assert figure.layout.scene.xaxis.title.text == target_names[axis_order[0]]
+        assert figure.layout.scene.yaxis.title.text == target_names[axis_order[1]]
+        assert figure.layout.scene.zaxis.title.text == target_names[axis_order[2]]
 
 
 @pytest.mark.parametrize("include_dominated_trials", [False, True])

--- a/tests/visualization_tests/test_pareto_front.py
+++ b/tests/visualization_tests/test_pareto_front.py
@@ -17,7 +17,7 @@ def test_plot_pareto_front_2d(
     # Test with no trial.
     study = optuna.create_study(directions=["minimize", "minimize"])
     figure = plot_pareto_front(
-        study,
+        study=study,
         include_dominated_trials=include_dominated_trials,
         axis_order=axis_order,
     )
@@ -32,7 +32,7 @@ def test_plot_pareto_front_2d(
     study.optimize(lambda t: [t.suggest_int("x", 0, 1), t.suggest_int("y", 0, 1)], n_trials=3)
 
     figure = plot_pareto_front(
-        study,
+        study=study,
         include_dominated_trials=include_dominated_trials,
         axis_order=axis_order,
     )
@@ -65,14 +65,18 @@ def test_plot_pareto_front_2d(
 
     # Test with `target_names` argument.
     with pytest.raises(ValueError):
-        plot_pareto_front(study, target_names=[], include_dominated_trials=include_dominated_trials)
-
-    with pytest.raises(ValueError):
-        plot_pareto_front(study, target_names=["Foo"], include_dominated_trials=include_dominated_trials)
+        plot_pareto_front(
+            study=study, target_names=[], include_dominated_trials=include_dominated_trials
+        )
 
     with pytest.raises(ValueError):
         plot_pareto_front(
-            study,
+            study=study, target_names=["Foo"], include_dominated_trials=include_dominated_trials
+        )
+
+    with pytest.raises(ValueError):
+        plot_pareto_front(
+            study=study,
             target_names=["Foo", "Bar", "Baz"],
             include_dominated_trials=include_dominated_trials,
             axis_order=axis_order,
@@ -80,7 +84,7 @@ def test_plot_pareto_front_2d(
 
     target_names = ["Foo", "Bar"]
     figure = plot_pareto_front(
-        study,
+        study=study,
         target_names=target_names,
         include_dominated_trials=include_dominated_trials,
         axis_order=axis_order,
@@ -103,7 +107,7 @@ def test_plot_pareto_front_3d(
     # Test with no trial.
     study = optuna.create_study(directions=["minimize", "minimize", "minimize"])
     figure = plot_pareto_front(
-        study,
+        study=study,
         include_dominated_trials=include_dominated_trials,
         axis_order=axis_order,
     )
@@ -122,7 +126,7 @@ def test_plot_pareto_front_3d(
     )
 
     figure = plot_pareto_front(
-        study,
+        study=study,
         include_dominated_trials=include_dominated_trials,
         axis_order=axis_order,
     )
@@ -162,7 +166,7 @@ def test_plot_pareto_front_3d(
     # Test with `target_names` argument.
     with pytest.raises(ValueError):
         plot_pareto_front(
-            study,
+            study=study,
             target_names=[],
             include_dominated_trials=include_dominated_trials,
             axis_order=axis_order,
@@ -170,7 +174,7 @@ def test_plot_pareto_front_3d(
 
     with pytest.raises(ValueError):
         plot_pareto_front(
-            study,
+            study=study,
             target_names=["Foo"],
             include_dominated_trials=include_dominated_trials,
             axis_order=axis_order,
@@ -178,7 +182,7 @@ def test_plot_pareto_front_3d(
 
     with pytest.raises(ValueError):
         plot_pareto_front(
-            study,
+            study=study,
             target_names=["Foo", "Bar"],
             include_dominated_trials=include_dominated_trials,
             axis_order=axis_order,
@@ -186,14 +190,14 @@ def test_plot_pareto_front_3d(
 
     with pytest.raises(ValueError):
         plot_pareto_front(
-            study,
+            study=study,
             target_names=["Foo", "Bar", "Baz", "Qux"],
             include_dominated_trials=include_dominated_trials,
             axis_order=axis_order,
         )
 
     target_names = ["Foo", "Bar", "Baz"]
-    figure = plot_pareto_front(study, target_names=target_names, axis_order=axis_order)
+    figure = plot_pareto_front(study=study, target_names=target_names, axis_order=axis_order)
     if axis_order is None:
         assert figure.layout.scene.xaxis.title.text == target_names[0]
         assert figure.layout.scene.yaxis.title.text == target_names[1]
@@ -210,28 +214,28 @@ def test_plot_pareto_front_unsupported_dimensions(include_dominated_trials: bool
     with pytest.raises(ValueError):
         study = optuna.create_study(directions=["minimize"])
         study.optimize(lambda t: [0], n_trials=1)
-        plot_pareto_front(study, include_dominated_trials=include_dominated_trials)
+        plot_pareto_front(study=study, include_dominated_trials=include_dominated_trials)
 
     with pytest.raises(ValueError):
         study = optuna.create_study(direction="minimize")
         study.optimize(lambda t: [0], n_trials=1)
-        plot_pareto_front(study, include_dominated_trials=include_dominated_trials)
+        plot_pareto_front(study=study, include_dominated_trials=include_dominated_trials)
 
     # Supported: n_objectives == 2.
     study = optuna.create_study(directions=["minimize", "minimize"])
     study.optimize(lambda t: [0, 0], n_trials=1)
-    plot_pareto_front(study, include_dominated_trials=include_dominated_trials)
+    plot_pareto_front(study=study, include_dominated_trials=include_dominated_trials)
 
     # Supported: n_objectives == 3.
     study = optuna.create_study(directions=["minimize", "minimize", "minimize"])
     study.optimize(lambda t: [0, 0, 0], n_trials=1)
-    plot_pareto_front(study, include_dominated_trials=include_dominated_trials)
+    plot_pareto_front(study=study, include_dominated_trials=include_dominated_trials)
 
     # Unsupported: n_objectives == 4.
     with pytest.raises(ValueError):
         study = optuna.create_study(directions=["minimize", "minimize", "minimize", "minimize"])
         study.optimize(lambda t: [0, 0, 0, 0], n_trials=1)
-        plot_pareto_front(study, include_dominated_trials=include_dominated_trials)
+        plot_pareto_front(study=study, include_dominated_trials=include_dominated_trials)
 
 
 @pytest.mark.parametrize("dimension", [2, 3])
@@ -246,7 +250,7 @@ def test_plot_pareto_front_invalid_axis_order(
         invalid_axis_order = list(range(dimension + 1))
         assert len(invalid_axis_order) != dimension
         plot_pareto_front(
-            study,
+            study=study,
             include_dominated_trials=include_dominated_trials,
             axis_order=invalid_axis_order,
         )
@@ -257,7 +261,7 @@ def test_plot_pareto_front_invalid_axis_order(
         invalid_axis_order[1] = invalid_axis_order[0]
         assert np.unique(invalid_axis_order).size != dimension
         plot_pareto_front(
-            study,
+            study=study,
             include_dominated_trials=include_dominated_trials,
             axis_order=invalid_axis_order,
         )
@@ -268,7 +272,7 @@ def test_plot_pareto_front_invalid_axis_order(
         invalid_axis_order[-1] += 1
         assert max(invalid_axis_order) > (dimension - 1)
         plot_pareto_front(
-            study,
+            study=study,
             include_dominated_trials=include_dominated_trials,
             axis_order=invalid_axis_order,
         )
@@ -280,7 +284,7 @@ def test_plot_pareto_front_invalid_axis_order(
         invalid_axis_order[0] -= 1
         assert min(invalid_axis_order) < 0
         plot_pareto_front(
-            study,
+            study=study,
             include_dominated_trials=include_dominated_trials,
             axis_order=invalid_axis_order,
         )

--- a/tests/visualization_tests/test_pareto_front.py
+++ b/tests/visualization_tests/test_pareto_front.py
@@ -1,0 +1,286 @@
+import itertools
+from typing import List
+from typing import Optional
+
+import numpy as np
+import pytest
+
+import optuna
+from optuna.visualization import plot_pareto_front
+
+
+@pytest.mark.parametrize("include_dominated_trials", [False, True])
+@pytest.mark.parametrize("axis_order", [None, [0, 1], [1, 0]])
+def test_plot_pareto_front_2d(
+    include_dominated_trials: bool, axis_order: Optional[List[int]]
+) -> None:
+    # Test with no trial.
+    study = optuna.create_study(directions=["minimize", "minimize"])
+    figure = plot_pareto_front(
+        study,
+        include_dominated_trials=include_dominated_trials,
+        axis_order=axis_order,
+    )
+    assert len(figure.data) == 1
+    assert figure.data[0]["x"] == ()
+    assert figure.data[0]["y"] == ()
+
+    # Test with three trials.
+    study.enqueue_trial({"x": 1, "y": 1})
+    study.enqueue_trial({"x": 1, "y": 0})
+    study.enqueue_trial({"x": 0, "y": 1})
+    study.optimize(lambda t: [t.suggest_int("x", 0, 1), t.suggest_int("y", 0, 1)], n_trials=3)
+
+    figure = plot_pareto_front(
+        study,
+        include_dominated_trials=include_dominated_trials,
+        axis_order=axis_order,
+    )
+    assert len(figure.data) == 1
+    if include_dominated_trials:
+        # The last elements come from dominated trial that is enqueued firstly.
+        data = [(1, 0, 1), (0, 1, 1)]  # type: ignore
+        if axis_order is None:
+            assert figure.data[0]["x"] == data[0]
+            assert figure.data[0]["y"] == data[1]
+        else:
+            assert figure.data[0]["x"] == data[axis_order[0]]
+            assert figure.data[0]["y"] == data[axis_order[1]]
+    else:
+        data = [(1, 0), (0, 1)]  # type: ignore
+        if axis_order is None:
+            assert figure.data[0]["x"] == data[0]
+            assert figure.data[0]["y"] == data[1]
+        else:
+            assert figure.data[0]["x"] == data[axis_order[0]]
+            assert figure.data[0]["y"] == data[axis_order[1]]
+
+    titles = ["Objective {}".format(i) for i in range(2)]
+    if axis_order is None:
+        assert figure.layout.xaxis.title.text == titles[0]
+        assert figure.layout.yaxis.title.text == titles[1]
+    else:
+        assert figure.layout.xaxis.title.text == titles[axis_order[0]]
+        assert figure.layout.yaxis.title.text == titles[axis_order[1]]
+
+    # Test with `names` argument.
+    with pytest.raises(ValueError):
+        plot_pareto_front(study, names=[], include_dominated_trials=include_dominated_trials)
+
+    with pytest.raises(ValueError):
+        plot_pareto_front(study, names=["Foo"], include_dominated_trials=include_dominated_trials)
+
+    with pytest.raises(ValueError):
+        plot_pareto_front(
+            study,
+            names=["Foo", "Bar", "Baz"],
+            include_dominated_trials=include_dominated_trials,
+            axis_order=axis_order,
+        )
+
+    names = ["Foo", "Bar"]
+    figure = plot_pareto_front(
+        study,
+        names=names,
+        include_dominated_trials=include_dominated_trials,
+        axis_order=axis_order,
+    )
+    if axis_order is None:
+        assert figure.layout.xaxis.title.text == names[0]
+        assert figure.layout.yaxis.title.text == names[1]
+    else:
+        assert figure.layout.xaxis.title.text == names[axis_order[0]]
+        assert figure.layout.yaxis.title.text == names[axis_order[1]]
+
+
+@pytest.mark.parametrize("include_dominated_trials", [False, True])
+@pytest.mark.parametrize(
+    "axis_order", [None] + list(itertools.permutations(range(3), 3))  # type: ignore
+)
+def test_plot_pareto_front_3d(
+    include_dominated_trials: bool, axis_order: Optional[List[int]]
+) -> None:
+    # Test with no trial.
+    study = optuna.create_study(directions=["minimize", "minimize", "minimize"])
+    figure = plot_pareto_front(
+        study,
+        include_dominated_trials=include_dominated_trials,
+        axis_order=axis_order,
+    )
+    assert len(figure.data) == 1
+    assert figure.data[0]["x"] == ()
+    assert figure.data[0]["y"] == ()
+    assert figure.data[0]["z"] == ()
+
+    # Test with three trials.
+    study.enqueue_trial({"x": 1, "y": 1, "z": 1})
+    study.enqueue_trial({"x": 1, "y": 0, "z": 1})
+    study.enqueue_trial({"x": 1, "y": 1, "z": 0})
+    study.optimize(
+        lambda t: [t.suggest_int("x", 0, 1), t.suggest_int("y", 0, 1), t.suggest_int("z", 0, 1)],
+        n_trials=3,
+    )
+
+    figure = plot_pareto_front(
+        study,
+        include_dominated_trials=include_dominated_trials,
+        axis_order=axis_order,
+    )
+    assert len(figure.data) == 1
+    if include_dominated_trials:
+        # The last elements come from dominated trial that is enqueued firstly.
+        data = [(1, 1, 1), (0, 1, 1), (1, 0, 1)]  # type: ignore
+        if axis_order is None:
+            assert figure.data[0]["x"] == data[0]
+            assert figure.data[0]["y"] == data[1]
+            assert figure.data[0]["z"] == data[2]
+        else:
+            assert figure.data[0]["x"] == data[axis_order[0]]
+            assert figure.data[0]["y"] == data[axis_order[1]]
+            assert figure.data[0]["z"] == data[axis_order[2]]
+    else:
+        data = [(1, 1), (0, 1), (1, 0)]  # type: ignore
+        if axis_order is None:
+            assert figure.data[0]["x"] == data[0]
+            assert figure.data[0]["y"] == data[1]
+            assert figure.data[0]["z"] == data[2]
+        else:
+            assert figure.data[0]["x"] == data[axis_order[0]]
+            assert figure.data[0]["y"] == data[axis_order[1]]
+            assert figure.data[0]["z"] == data[axis_order[2]]
+
+    titles = ["Objective {}".format(i) for i in range(3)]
+    if axis_order is None:
+        assert figure.layout.scene.xaxis.title.text == titles[0]
+        assert figure.layout.scene.yaxis.title.text == titles[1]
+        assert figure.layout.scene.zaxis.title.text == titles[2]
+    else:
+        assert figure.layout.scene.xaxis.title.text == titles[axis_order[0]]
+        assert figure.layout.scene.yaxis.title.text == titles[axis_order[1]]
+        assert figure.layout.scene.zaxis.title.text == titles[axis_order[2]]
+
+    # Test with `names` argument.
+    with pytest.raises(ValueError):
+        plot_pareto_front(
+            study,
+            names=[],
+            include_dominated_trials=include_dominated_trials,
+            axis_order=axis_order,
+        )
+
+    with pytest.raises(ValueError):
+        plot_pareto_front(
+            study,
+            names=["Foo"],
+            include_dominated_trials=include_dominated_trials,
+            axis_order=axis_order,
+        )
+
+    with pytest.raises(ValueError):
+        plot_pareto_front(
+            study,
+            names=["Foo", "Bar"],
+            include_dominated_trials=include_dominated_trials,
+            axis_order=axis_order,
+        )
+
+    with pytest.raises(ValueError):
+        plot_pareto_front(
+            study,
+            names=["Foo", "Bar", "Baz", "Qux"],
+            include_dominated_trials=include_dominated_trials,
+            axis_order=axis_order,
+        )
+
+    names = ["Foo", "Bar", "Baz"]
+    figure = plot_pareto_front(study, names=names, axis_order=axis_order)
+    if axis_order is None:
+        assert figure.layout.scene.xaxis.title.text == names[0]
+        assert figure.layout.scene.yaxis.title.text == names[1]
+        assert figure.layout.scene.zaxis.title.text == names[2]
+    else:
+        assert figure.layout.scene.xaxis.title.text == names[axis_order[0]]
+        assert figure.layout.scene.yaxis.title.text == names[axis_order[1]]
+        assert figure.layout.scene.zaxis.title.text == names[axis_order[2]]
+
+
+@pytest.mark.parametrize("include_dominated_trials", [False, True])
+def test_plot_pareto_front_unsupported_dimensions(include_dominated_trials: bool) -> None:
+    # Unsupported: n_objectives == 1.
+    with pytest.raises(ValueError):
+        study = optuna.create_study(directions=["minimize"])
+        study.optimize(lambda t: [0], n_trials=1)
+        plot_pareto_front(study, include_dominated_trials=include_dominated_trials)
+
+    with pytest.raises(ValueError):
+        study = optuna.create_study(direction="minimize")
+        study.optimize(lambda t: [0], n_trials=1)
+        plot_pareto_front(study, include_dominated_trials=include_dominated_trials)
+
+    # Supported: n_objectives == 2.
+    study = optuna.create_study(directions=["minimize", "minimize"])
+    study.optimize(lambda t: [0, 0], n_trials=1)
+    plot_pareto_front(study, include_dominated_trials=include_dominated_trials)
+
+    # Supported: n_objectives == 3.
+    study = optuna.create_study(directions=["minimize", "minimize", "minimize"])
+    study.optimize(lambda t: [0, 0, 0], n_trials=1)
+    plot_pareto_front(study, include_dominated_trials=include_dominated_trials)
+
+    # Unsupported: n_objectives == 4.
+    with pytest.raises(ValueError):
+        study = optuna.create_study(directions=["minimize", "minimize", "minimize", "minimize"])
+        study.optimize(lambda t: [0, 0, 0, 0], n_trials=1)
+        plot_pareto_front(study, include_dominated_trials=include_dominated_trials)
+
+
+@pytest.mark.parametrize("dimension", [2, 3])
+@pytest.mark.parametrize("include_dominated_trials", [False, True])
+def test_plot_pareto_front_invalid_axis_order(
+    dimension: int, include_dominated_trials: bool
+) -> None:
+    study = optuna.create_study(directions=["minimize"] * dimension)
+
+    # Invalid: len(axis_order) != dimension
+    with pytest.raises(ValueError):
+        invalid_axis_order = list(range(dimension + 1))
+        assert len(invalid_axis_order) != dimension
+        plot_pareto_front(
+            study,
+            include_dominated_trials=include_dominated_trials,
+            axis_order=invalid_axis_order,
+        )
+
+    # Invalid: np.unique(axis_order).size != dimension
+    with pytest.raises(ValueError):
+        invalid_axis_order = list(range(dimension))
+        invalid_axis_order[1] = invalid_axis_order[0]
+        assert np.unique(invalid_axis_order).size != dimension
+        plot_pareto_front(
+            study,
+            include_dominated_trials=include_dominated_trials,
+            axis_order=invalid_axis_order,
+        )
+
+    # Invalid: max(axis_order) > (dimension - 1)
+    with pytest.raises(ValueError):
+        invalid_axis_order = list(range(dimension))
+        invalid_axis_order[-1] += 1
+        assert max(invalid_axis_order) > (dimension - 1)
+        plot_pareto_front(
+            study,
+            include_dominated_trials=include_dominated_trials,
+            axis_order=invalid_axis_order,
+        )
+
+    # Invalid: min(axis_order) < 0
+    with pytest.raises(ValueError):
+        study = optuna.create_study(directions=["minimize", "minimize"])
+        invalid_axis_order = list(range(dimension))
+        invalid_axis_order[0] -= 1
+        assert min(invalid_axis_order) < 0
+        plot_pareto_front(
+            study,
+            include_dominated_trials=include_dominated_trials,
+            axis_order=invalid_axis_order,
+        )


### PR DESCRIPTION
## Motivation
Part of works for https://github.com/optuna/optuna/issues/1980.
This PR aims to migrate the current `optuna.multi_objective.visualization.plot_pareto_front` to the standard visualization module.

## Description of the changes
- Move `optuna.multi_objective.visualization.plot_pareto_front` to `optuna.visualization.plot_pareto_front`
- Move the unit test with a small test case addition
