### PR TITLE
Raise `ValueError` if `target` is None and `study` is for multi-objective optimization for `plot_contour`

### DIFF
--- a/optuna/visualization/_contour.py
+++ b/optuna/visualization/_contour.py
@@ -66,16 +66,27 @@ def plot_contour(
         params:
             Parameter list to visualize. The default is all parameters.
         target:
-            A function to specify the value to display. If it is :obj:`None`, the objective values
-            are plotted.
+            A function to specify the value to display. If it is :obj:`None` and ``study`` is for
+            single-objective optimization, the objective values are plotted.
+
+            .. note::
+                Specify this argument if ``study`` is for multi-objective optimization.
         target_name:
             Target's name to display on the color bar.
 
     Returns:
         A :class:`plotly.graph_objs.Figure` object.
+
+    Raises:
+        :exc:`ValueError`:
+            If ``target`` is :obj:`None` and ``study`` is for multi-objective optimization.
     """
 
     _imports.check()
+    if target is None and len(study.directions) > 1:
+        raise ValueError(
+            "If the `study` is for multi-objective optimization, please specify the `target`."
+        )
     return _get_contour_plot(study, params, target, target_name)
 
 

--- a/optuna/visualization/_contour.py
+++ b/optuna/visualization/_contour.py
@@ -66,11 +66,11 @@ def plot_contour(
         params:
             Parameter list to visualize. The default is all parameters.
         target:
-            A function to specify the value to display. If it is :obj:`None` and ``study`` is for
-            single-objective optimization, the objective values are plotted.
+            A function to specify the value to display. If it is :obj:`None` and ``study`` is being
+            used for single-objective optimization, the objective values are plotted.
 
             .. note::
-                Specify this argument if ``study`` is for multi-objective optimization.
+                Specify this argument if ``study`` is being used for multi-objective optimization.
         target_name:
             Target's name to display on the color bar.
 
@@ -79,13 +79,15 @@ def plot_contour(
 
     Raises:
         :exc:`ValueError`:
-            If ``target`` is :obj:`None` and ``study`` is for multi-objective optimization.
+            If ``target`` is :obj:`None` and ``study`` is being used for multi-objective
+            optimization.
     """
 
     _imports.check()
     if target is None and len(study.directions) > 1:
         raise ValueError(
-            "If the `study` is for multi-objective optimization, please specify the `target`."
+            "If the `study` is being used for multi-objective optimization, "
+            "please specify the `target`."
         )
     return _get_contour_plot(study, params, target, target_name)
 

--- a/optuna/visualization/matplotlib/_contour.py
+++ b/optuna/visualization/matplotlib/_contour.py
@@ -76,16 +76,27 @@ def plot_contour(
         params:
             Parameter list to visualize. The default is all parameters.
         target:
-            A function to specify the value to display. If it is :obj:`None`, the objective values
-            are plotted.
+            A function to specify the value to display. If it is :obj:`None` and ``study`` is for
+            single-objective optimization, the objective values are plotted.
+
+            .. note::
+                Specify this argument if ``study`` is for multi-objective optimization.
         target_name:
             Target's name to display on the color bar.
 
     Returns:
         A :class:`matplotlib.axes.Axes` object.
+
+    Raises:
+        :exc:`ValueError`:
+            If ``target`` is :obj:`None` and ``study`` is for multi-objective optimization.
     """
 
     _imports.check()
+    if target is None and len(study.directions) > 1:
+        raise ValueError(
+            "If the `study` is for multi-objective optimization, please specify the `target`."
+        )
     _logger.warning(
         "Output figures of this Matplotlib-based `plot_contour` function would be different from "
         "those of the Plotly-based `plot_contour`."

--- a/optuna/visualization/matplotlib/_contour.py
+++ b/optuna/visualization/matplotlib/_contour.py
@@ -76,11 +76,11 @@ def plot_contour(
         params:
             Parameter list to visualize. The default is all parameters.
         target:
-            A function to specify the value to display. If it is :obj:`None` and ``study`` is for
-            single-objective optimization, the objective values are plotted.
+            A function to specify the value to display. If it is :obj:`None` and ``study`` is being
+            used for single-objective optimization, the objective values are plotted.
 
             .. note::
-                Specify this argument if ``study`` is for multi-objective optimization.
+                Specify this argument if ``study`` is being used for multi-objective optimization.
         target_name:
             Target's name to display on the color bar.
 
@@ -89,13 +89,15 @@ def plot_contour(
 
     Raises:
         :exc:`ValueError`:
-            If ``target`` is :obj:`None` and ``study`` is for multi-objective optimization.
+            If ``target`` is :obj:`None` and ``study`` is being used for multi-objective
+            optimization.
     """
 
     _imports.check()
     if target is None and len(study.directions) > 1:
         raise ValueError(
-            "If the `study` is for multi-objective optimization, please specify the `target`."
+            "If the `study` is being used for multi-objective optimization, "
+            "please specify the `target`."
         )
     _logger.warning(
         "Output figures of this Matplotlib-based `plot_contour` function would be different from "

--- a/tests/visualization_tests/matplotlib_tests/test_contour.py
+++ b/tests/visualization_tests/matplotlib_tests/test_contour.py
@@ -9,6 +9,13 @@ from optuna.trial import Trial
 from optuna.visualization.matplotlib import plot_contour
 
 
+def test_target_is_none_and_study_is_multi_obj() -> None:
+
+    study = create_study(directions=["minimize", "minimize"])
+    with pytest.raises(ValueError):
+        plot_contour(study)
+
+
 @pytest.mark.parametrize(
     "params",
     [

--- a/tests/visualization_tests/test_contour.py
+++ b/tests/visualization_tests/test_contour.py
@@ -22,6 +22,13 @@ from optuna.visualization._contour import _generate_contour_subplot
 RANGE_TYPE = Union[Tuple[str, str], Tuple[float, float]]
 
 
+def test_target_is_none_and_study_is_multi_obj() -> None:
+
+    study = create_study(directions=["minimize", "minimize"])
+    with pytest.raises(ValueError):
+        plot_contour(study)
+
+
 @pytest.mark.parametrize(
     "params",
     [


### PR DESCRIPTION
## Motivation
Part of works for #1980.
The goal of this PR is to make `plot_contour` work well in multi-objective optimization. Recently, the `target` argument is introduced in `plot_contour`, so users can use this function in multi-objective optimization as follows.
```python
def target(trial)
    return trial.values[0]

plot_contour(study, target=target, target_name="First objective values")
```
However, as a default, if `target` is None, it is set to be `trial.value` which is unavailable for multi-objective optimization, so the current `plot_contour` fails in this situation. Therefore, I've decided to raise a `ValueError` then the `target` is None and `study` is for multi-objective optimization.
 
## Description of the changes
- Raise `ValueError` if `target` is None and `study` is for multi-objective optimization for `plot_contour`
- Add unittests