### PR TITLE
Raise `ValueError` if `target` is None and `study` is for multi-objective optimization for `plot_edf`

### DIFF
--- a/optuna/visualization/_edf.py
+++ b/optuna/visualization/_edf.py
@@ -86,13 +86,20 @@ def plot_edf(
             A target :class:`~optuna.study.Study` object.
             You can pass multiple studies if you want to compare those EDFs.
         target:
-            A function to specify the value to display. If it is :obj:`None`, the objective values
-            are plotted.
+            A function to specify the value to display. If it is :obj:`None` and ``study`` is being
+            used for single-objective optimization, the objective values are plotted.
+            .. note::
+                Specify this argument if ``study`` is being used for multi-objective optimization.
         target_name:
             Target's name to display on the axis label.
 
     Returns:
         A :class:`plotly.graph_objs.Figure` object.
+
+    Raises:
+        :exc:`ValueError`:
+            If ``target`` is :obj:`None` and ``study`` is being used for multi-objective
+            optimization.
     """
 
     _imports.check()
@@ -101,6 +108,12 @@ def plot_edf(
         studies = [study]
     else:
         studies = list(study)
+
+    if target is None and any(len(s.directions) > 1 for s in studies):
+        raise ValueError(
+            "If the `study` is being used for multi-objective optimization, "
+            "please specify the `target`."
+        )
 
     return _get_edf_plot(studies, target, target_name)
 

--- a/optuna/visualization/_edf.py
+++ b/optuna/visualization/_edf.py
@@ -88,6 +88,7 @@ def plot_edf(
         target:
             A function to specify the value to display. If it is :obj:`None` and ``study`` is being
             used for single-objective optimization, the objective values are plotted.
+
             .. note::
                 Specify this argument if ``study`` is being used for multi-objective optimization.
         target_name:

--- a/optuna/visualization/matplotlib/_edf.py
+++ b/optuna/visualization/matplotlib/_edf.py
@@ -82,6 +82,7 @@ def plot_edf(
         target:
             A function to specify the value to display. If it is :obj:`None` and ``study`` is being
             used for single-objective optimization, the objective values are plotted.
+
             .. note::
                 Specify this argument if ``study`` is being used for multi-objective optimization.
         target_name:

--- a/optuna/visualization/matplotlib/_edf.py
+++ b/optuna/visualization/matplotlib/_edf.py
@@ -80,13 +80,20 @@ def plot_edf(
             A target :class:`~optuna.study.Study` object.
             You can pass multiple studies if you want to compare those EDFs.
         target:
-            A function to specify the value to display. If it is :obj:`None`, the objective values
-            are plotted.
+            A function to specify the value to display. If it is :obj:`None` and ``study`` is being
+            used for single-objective optimization, the objective values are plotted.
+            .. note::
+                Specify this argument if ``study`` is being used for multi-objective optimization.
         target_name:
             Target's name to display on the axis label.
 
     Returns:
         A :class:`matplotlib.axes.Axes` object.
+
+    Raises:
+        :exc:`ValueError`:
+            If ``target`` is :obj:`None` and ``study`` is being used for multi-objective
+            optimization.
     """
 
     _imports.check()
@@ -96,6 +103,11 @@ def plot_edf(
     else:
         studies = list(study)
 
+    if target is None and any(len(s.directions) > 1 for s in studies):
+        raise ValueError(
+            "If the `study` is being used for multi-objective optimization, "
+            "please specify the `target`."
+        )
     return _get_edf_plot(studies, target, target_name)
 
 

--- a/tests/visualization_tests/matplotlib_tests/test_edf.py
+++ b/tests/visualization_tests/matplotlib_tests/test_edf.py
@@ -4,6 +4,13 @@ from optuna.study import create_study
 from optuna.visualization.matplotlib import plot_edf
 
 
+def test_target_is_none_and_study_is_multi_obj() -> None:
+
+    study = create_study(directions=["minimize", "minimize"])
+    with pytest.raises(ValueError):
+        plot_edf(study)
+
+
 @pytest.mark.parametrize("direction", ["minimize", "maximize"])
 def test_plot_optimization_history(direction: str) -> None:
     # Test with no studies.

--- a/tests/visualization_tests/test_edf.py
+++ b/tests/visualization_tests/test_edf.py
@@ -4,6 +4,13 @@ from optuna.study import create_study
 from optuna.visualization import plot_edf
 
 
+def test_target_is_none_and_study_is_multi_obj() -> None:
+
+    study = create_study(directions=["minimize", "minimize"])
+    with pytest.raises(ValueError):
+        plot_edf(study)
+
+
 @pytest.mark.parametrize("direction", ["minimize", "maximize"])
 def test_plot_optimization_history(direction: str) -> None:
     # Test with no studies.


### PR DESCRIPTION
## Motivation
Part of works for #1980.
The goal of this PR is to make `plot_edf` work well in multi-objective optimization. See #2112 for details.

## Description of the changes
- Raise `ValueError` if `target` is None and `study` is being used for multi-objective optimization for `plot_edf`
- Add unittests
