### PR TITLE
Raise `ValueError` if `target` is None and `study` is for multi-objective optimization for `plot_parallel_coordinate`

### DIFF
--- a/optuna/visualization/_parallel_coordinate.py
+++ b/optuna/visualization/_parallel_coordinate.py
@@ -59,16 +59,29 @@ def plot_parallel_coordinate(
         params:
             Parameter list to visualize. The default is all parameters.
         target:
-            A function to specify the value to display. If it is :obj:`None`, the objective values
-            are plotted.
+            A function to specify the value to display. If it is :obj:`None` and ``study`` is being
+            used for single-objective optimization, the objective values are plotted.
+
+            .. note::
+                Specify this argument if ``study`` is being used for multi-objective optimization.
         target_name:
             Target's name to display on the axis label and the legend.
 
     Returns:
         A :class:`plotly.graph_objs.Figure` object.
+
+    Raises:
+        :exc:`ValueError`:
+            If ``target`` is :obj:`None` and ``study`` is being used for multi-objective
+            optimization.
     """
 
     _imports.check()
+    if target is None and len(study.directions) > 1:
+        raise ValueError(
+            "If the `study` is being used for multi-objective optimization, "
+            "please specify the `target`."
+        )
     return _get_parallel_coordinate_plot(study, params, target, target_name)
 
 

--- a/optuna/visualization/matplotlib/_parallel_coordinate.py
+++ b/optuna/visualization/matplotlib/_parallel_coordinate.py
@@ -63,16 +63,29 @@ def plot_parallel_coordinate(
         params:
             Parameter list to visualize. The default is all parameters.
         target:
-            A function to specify the value to display. If it is :obj:`None`, the objective values
-            are plotted.
+            A function to specify the value to display. If it is :obj:`None` and ``study`` is being
+            used for single-objective optimization, the objective values are plotted.
+
+            .. note::
+                Specify this argument if ``study`` is being used for multi-objective optimization.
         target_name:
             Target's name to display on the axis label and the legend.
 
     Returns:
         A :class:`matplotlib.axes.Axes` object.
+
+    Raises:
+        :exc:`ValueError`:
+            If ``target`` is :obj:`None` and ``study`` is being used for multi-objective
+            optimization.
     """
 
     _imports.check()
+    if target is None and len(study.directions) > 1:
+        raise ValueError(
+            "If the `study` is being used for multi-objective optimization, "
+            "please specify the `target`."
+        )
     return _get_parallel_coordinate_plot(study, params, target, target_name)
 
 

--- a/tests/visualization_tests/matplotlib_tests/test_parallel_coordinate.py
+++ b/tests/visualization_tests/matplotlib_tests/test_parallel_coordinate.py
@@ -8,6 +8,13 @@ from optuna.trial import Trial
 from optuna.visualization.matplotlib import plot_parallel_coordinate
 
 
+def test_target_is_none_and_study_is_multi_obj() -> None:
+
+    study = create_study(directions=["minimize", "minimize"])
+    with pytest.raises(ValueError):
+        plot_parallel_coordinate(study)
+
+
 def test_plot_parallel_coordinate() -> None:
 
     # Test with no trial.

--- a/tests/visualization_tests/test_parallel_coordinate.py
+++ b/tests/visualization_tests/test_parallel_coordinate.py
@@ -8,6 +8,13 @@ from optuna.trial import Trial
 from optuna.visualization import plot_parallel_coordinate
 
 
+def test_target_is_none_and_study_is_multi_obj() -> None:
+
+    study = create_study(directions=["minimize", "minimize"])
+    with pytest.raises(ValueError):
+        plot_parallel_coordinate(study)
+
+
 def test_plot_parallel_coordinate() -> None:
 
     # Test with no trial.


### PR DESCRIPTION
## Motivation
Part of works for #1980.
The goal of this PR is to make `plot_parallel_coordinate` work well in multi-objective optimization. See #2112 for details.

## Description of the changes
- Raise `ValueError` if `target` is None and `study` is being used for multi-objective optimization
- Add unit tests

