### PR TITLE
Move `examples/multi_objective/plot_pareto_front.py` to `examples/visualization/plot_pareto_front.py`

### DIFF
--- a/examples/visualization/plot_pareto_front.py
+++ b/examples/visualization/plot_pareto_front.py
@@ -11,7 +11,7 @@ def objective(trial):
     return v0, v1
 
 
-study = optuna.multi_objective.create_study(["minimize", "minimize"])
+study = optuna.create_study(directions=["minimize", "minimize"])
 study.optimize(objective, n_trials=100)
 
-optuna.multi_objective.visualization.plot_pareto_front(study).show()
+optuna.visualization.plot_pareto_front(study).show()


### PR DESCRIPTION
Depends on #2110.

## Motivation
Part of works for #1980. This PR update the example of `plot_pareto_front`.

## Description of the changes
- Move `examples/multi_objective/plot_pareto_front.py` to `examples/visualization/plot_pareto_front.py`.
- Change `examples/visualization/plot_pareto_front.py` not use the multi-objective module.
