### PR TITLE
Deprecate previous multi-objective module

### DIFF
--- a/optuna/multi_objective/samplers/_base.py
+++ b/optuna/multi_objective/samplers/_base.py
@@ -3,11 +3,11 @@ from typing import Any
 from typing import Dict
 
 from optuna import multi_objective
-from optuna._experimental import experimental
+from optuna._deprecated import deprecated
 from optuna.distributions import BaseDistribution
 
 
-@experimental("1.4.0")
+@deprecated("2.4.0", "4.0.0")
 class BaseMultiObjectiveSampler(object, metaclass=abc.ABCMeta):
     """Base class for multi-objective samplers.
 

--- a/optuna/multi_objective/samplers/_motpe.py
+++ b/optuna/multi_objective/samplers/_motpe.py
@@ -12,7 +12,7 @@ import numpy as np
 import optuna
 from optuna import distributions
 from optuna import multi_objective
-from optuna._experimental import experimental
+from optuna._deprecated import deprecated
 from optuna.distributions import BaseDistribution
 from optuna.multi_objective import _hypervolume
 from optuna.multi_objective.samplers import BaseMultiObjectiveSampler
@@ -36,7 +36,7 @@ def _default_weights_above(x: int) -> np.ndarray:
     return np.ones(x)
 
 
-@experimental("2.3.0")
+@deprecated("2.4.0", "4.0.0")
 class MOTPEMultiObjectiveSampler(TPESampler, BaseMultiObjectiveSampler):
     """Multi-objective sampler using the MOTPE algorithm.
 

--- a/optuna/multi_objective/samplers/_nsga2.py
+++ b/optuna/multi_objective/samplers/_nsga2.py
@@ -12,7 +12,7 @@ import numpy as np
 
 import optuna
 from optuna import multi_objective
-from optuna._experimental import experimental
+from optuna._deprecated import deprecated
 from optuna.distributions import BaseDistribution
 from optuna.multi_objective.samplers import BaseMultiObjectiveSampler
 
@@ -23,7 +23,7 @@ _PARENTS_KEY = "multi_objective:nsga2:parents"
 _POPULATION_CACHE_KEY_PREFIX = "multi_objective:nsga2:population"
 
 
-@experimental("1.5.0")
+@deprecated("2.4.0", "4.0.0")
 class NSGAIIMultiObjectiveSampler(BaseMultiObjectiveSampler):
     """Multi-objective sampler using the NSGA-II algorithm.
 

--- a/optuna/multi_objective/samplers/_random.py
+++ b/optuna/multi_objective/samplers/_random.py
@@ -4,12 +4,12 @@ from typing import Optional
 
 import optuna
 from optuna import multi_objective
-from optuna._experimental import experimental
+from optuna._deprecated import deprecated
 from optuna.distributions import BaseDistribution
 from optuna.multi_objective.samplers import BaseMultiObjectiveSampler
 
 
-@experimental("1.4.0")
+@deprecated("2.4.0", "4.0.0")
 class RandomMultiObjectiveSampler(BaseMultiObjectiveSampler):
     """Multi-objective sampler using random sampling.
 

--- a/optuna/multi_objective/study.py
+++ b/optuna/multi_objective/study.py
@@ -12,7 +12,7 @@ from typing import Union
 
 from optuna import logging
 from optuna import multi_objective
-from optuna._experimental import experimental
+from optuna._deprecated import deprecated
 from optuna._study_direction import StudyDirection
 from optuna.pruners import NopPruner
 from optuna.storages import BaseStorage
@@ -41,7 +41,7 @@ _logger = logging.get_logger(__name__)
 #
 # TODO(ohta): Consider to add `objective_labels` argument.
 # See: https://github.com/optuna/optuna/pull/1054#issuecomment-616382152
-@experimental("1.4.0")
+@deprecated("2.4.0", "4.0.0")
 def create_study(
     directions: List[str],
     study_name: Optional[str] = None,
@@ -133,7 +133,7 @@ def create_study(
     return MultiObjectiveStudy(study)
 
 
-@experimental("1.4.0")
+@deprecated("2.4.0", "4.0.0")
 def load_study(
     study_name: str,
     storage: Union[str, BaseStorage],
@@ -205,7 +205,7 @@ def load_study(
     return MultiObjectiveStudy(study)
 
 
-@experimental("1.4.0")
+@deprecated("2.4.0", "4.0.0")
 class MultiObjectiveStudy(object):
     """A study corresponds to a multi-objective optimization task, i.e., a set of trials.
 

--- a/optuna/multi_objective/trial.py
+++ b/optuna/multi_objective/trial.py
@@ -7,7 +7,7 @@ from typing import Sequence
 from typing import Union
 
 from optuna import multi_objective
-from optuna._experimental import experimental
+from optuna._deprecated import deprecated
 from optuna._study_direction import StudyDirection
 from optuna.distributions import BaseDistribution
 from optuna.trial import FrozenTrial
@@ -18,7 +18,7 @@ from optuna.trial import TrialState
 CategoricalChoiceType = Union[None, bool, int, float, str]
 
 
-@experimental("1.4.0")
+@deprecated("2.4.0", "4.0.0")
 class MultiObjectiveTrial(object):
     """A trial is a process of evaluating an objective function.
 
@@ -240,7 +240,7 @@ class MultiObjectiveTrial(object):
         return [trial.intermediate_values.get(i) for i in range(self._n_objectives)]
 
 
-@experimental("1.4.0")
+@deprecated("2.4.0", "4.0.0")
 class FrozenMultiObjectiveTrial(object):
     """Status and results of a :class:`~optuna.multi_objective.trial.MultiObjectiveTrial`.
 

--- a/optuna/multi_objective/visualization/_pareto_front.py
+++ b/optuna/multi_objective/visualization/_pareto_front.py
@@ -4,7 +4,7 @@ from typing import Optional
 
 import optuna
 from optuna import multi_objective
-from optuna._experimental import experimental
+from optuna._deprecated import deprecated
 from optuna.multi_objective.study import MultiObjectiveStudy
 from optuna.multi_objective.trial import FrozenMultiObjectiveTrial
 from optuna.trial import TrialState
@@ -17,7 +17,7 @@ if _imports.is_successful():
 _logger = optuna.logging.get_logger(__name__)
 
 
-@experimental("2.0.0")
+@deprecated("2.4.0", "4.0.0")
 def plot_pareto_front(
     study: MultiObjectiveStudy,
     names: Optional[List[str]] = None,


### PR DESCRIPTION
## Motivation
Part of works for #1980. This PR deprecates the previous multi-objective module.

## Description of the changes
- Deprecate all public classes and functions under the `optuna/multi_objective` directory.
