### PR TITLE
Make `create_trial`'s documentation and tests richer

### DIFF
--- a/optuna/trial/_frozen.py
+++ b/optuna/trial/_frozen.py
@@ -546,15 +546,23 @@ def create_trial(
         Please note that this is a low-level API. In general, trials that are passed to objective
         functions are created inside :func:`~optuna.study.Study.optimize`.
 
+    .. note::
+        When ``state`` is :obj:`None` or ``TrialState.COMPLETE``, the following parameters are
+        required:
+        * ``params``
+        * ``distributions``
+        * ``value`` or ``values``
+
     Args:
         state:
             Trial state.
         value:
-            Trial objective value. Must be specified if ``state`` is :class:`TrialState.COMPLETE`.
+            Trial objective value. Must be specified if ``state`` is ``None``
+            or :class:`TrialState.COMPLETE`.
         values:
             Sequence of the trial objective values. The length is greater than 1 if the problem is
             multi-objective optimization.
-            Must be specified if ``state`` is :class:`TrialState.COMPLETE`.
+            Must be specified if ``state`` is ``None`` or :class:`TrialState.COMPLETE`.
         params:
             Dictionary with suggested parameters of the trial.
         distributions:

--- a/tests/trial_tests/test_trial.py
+++ b/tests/trial_tests/test_trial.py
@@ -627,6 +627,18 @@ def test_create_trial(state: TrialState) -> None:
     assert trial.datetime_start is not None
     assert (trial.datetime_complete is not None) == (state is None or state.is_finished())
 
+    with pytest.raises(ValueError):
+        create_trial(state=state, value=value, values=(value,))
+
+    if state is None:
+        with pytest.raises(ValueError):
+            create_trial(state=state, value=None, values=None)
+        # Raise `ValueError` when either `params` or `distributions` is `None`.
+        with pytest.raises(ValueError):
+            create_trial(state=state, value=value, params=params, distributions=None)
+        with pytest.raises(ValueError):
+            create_trial(state=state, value=value, params=None, distributions=distributions)
+
 
 def test_suggest_with_multi_objectives() -> None:
     study = create_study(directions=["maximize", "maximize"])


### PR DESCRIPTION
The motivation is to make the documentation more friendly to users and to add some tests.
