### PR TITLE
Fix log format for single objective optimization to include best trial

### DIFF
--- a/optuna/multi_objective/study.py
+++ b/optuna/multi_objective/study.py
@@ -480,13 +480,13 @@ class MultiObjectiveStudy(object):
         return self._study._study_id
 
 
-def _log_completed_trial(self: Study, trial: Trial, value: float) -> None:
+def _log_completed_trial(self: Study, trial: Trial, values: Sequence[float]) -> None:
     if not _logger.isEnabledFor(logging.INFO):
         return
 
-    values = multi_objective.trial.MultiObjectiveTrial(trial)._get_values()
+    actual_values = multi_objective.trial.MultiObjectiveTrial(trial)._get_values()
     _logger.info(
         "Trial {} finished with values: {} with parameters: {}.".format(
-            trial.number, values, trial.params
+            trial.number, actual_values, trial.params
         )
     )

--- a/optuna/study.py
+++ b/optuna/study.py
@@ -661,30 +661,30 @@ class Study(BaseStudy):
             self._storage.set_trial_values(trial._trial_id, values)
         self._storage.set_trial_state(trial._trial_id, state)
 
-    def _log_completed_trial(
-        self, trial: trial_module.Trial, value_or_values: Union[float, Sequence[float]]
-    ) -> None:
+    def _log_completed_trial(self, trial: trial_module.Trial, values: Sequence[float]) -> None:
 
         if not _logger.isEnabledFor(logging.INFO):
             return
 
-        if isinstance(value_or_values, Sequence):
+        if len(values) > 1:
             _logger.info(
-                "Trial {} finished with value: {} and parameters: {}. ".format(
-                    trial.number, value_or_values, trial.params
+                "Trial {} finished with values: {} and parameters: {}. ".format(
+                    trial.number, values, trial.params
                 )
             )
-        else:
+        elif len(values) == 1:
             _logger.info(
                 "Trial {} finished with value: {} and parameters: {}. "
                 "Best is trial {} with value: {}.".format(
                     trial.number,
-                    value_or_values,
+                    values[0],
                     trial.params,
                     self.best_trial.number,
                     self.best_value,
                 )
             )
+        else:
+            assert False, "Should not reach."
 
 
 def create_study(

--- a/tests/multi_objective_tests/test_study.py
+++ b/tests/multi_objective_tests/test_study.py
@@ -176,16 +176,16 @@ def test_log_completed_trial_skip_storage_access() -> None:
     storage = study._storage
 
     with patch.object(storage, "get_trial", wraps=storage.get_trial) as mock_object:
-        optuna.multi_objective.study._log_completed_trial(study, trial, 1.0)
+        optuna.multi_objective.study._log_completed_trial(study, trial, [1.0])
         # Trial.params and MultiObjectiveTrial._get_values access storage.
         assert mock_object.call_count == 2
 
     optuna.logging.set_verbosity(optuna.logging.WARNING)
     with patch.object(storage, "get_trial", wraps=storage.get_trial) as mock_object:
-        optuna.multi_objective.study._log_completed_trial(study, trial, 1.0)
+        optuna.multi_objective.study._log_completed_trial(study, trial, [1.0])
         assert mock_object.call_count == 0
 
     optuna.logging.set_verbosity(optuna.logging.DEBUG)
     with patch.object(storage, "get_trial", wraps=storage.get_trial) as mock_object:
-        optuna.multi_objective.study._log_completed_trial(study, trial, 1.0)
+        optuna.multi_objective.study._log_completed_trial(study, trial, [1.0])
         assert mock_object.call_count == 2

--- a/tests/test_study.py
+++ b/tests/test_study.py
@@ -1015,18 +1015,18 @@ def test_log_completed_trial_skip_storage_access() -> None:
     storage = study._storage
 
     with patch.object(storage, "get_best_trial", wraps=storage.get_best_trial) as mock_object:
-        study._log_completed_trial(trial, 1.0)
+        study._log_completed_trial(trial, [1.0])
         # Trial.best_trial and Trial.best_params access storage.
         assert mock_object.call_count == 2
 
     optuna.logging.set_verbosity(optuna.logging.WARNING)
     with patch.object(storage, "get_best_trial", wraps=storage.get_best_trial) as mock_object:
-        study._log_completed_trial(trial, 1.0)
+        study._log_completed_trial(trial, [1.0])
         assert mock_object.call_count == 0
 
     optuna.logging.set_verbosity(optuna.logging.DEBUG)
     with patch.object(storage, "get_best_trial", wraps=storage.get_best_trial) as mock_object:
-        study._log_completed_trial(trial, 1.0)
+        study._log_completed_trial(trial, [1.0])
         assert mock_object.call_count == 2
 
 


### PR DESCRIPTION
## Motivation

See description.

## Description of the changes

Fixes the log format for completed trials in the single objective case to include the best trial so far to be more consistent with the previous format. Also fixed the somewhat misleading type hints where the actual arguments were always sequenes.

## Note

`master`

```python
[I 2020-12-21 10:37:01,564] Trial 547 finished with value: [75.5492125920354] and parameters: {'x': -8.749240686598775, 'y': -1}.
[I 2020-12-21 10:37:01,570] Trial 548 finished with value: [194.16162389787212] and parameters: {'x': -13.970025908990724, 'y': -1}.
```

This change

```python
[I 2020-12-21 10:35:45,144] Trial 535 finished with value: 33.65026436862357 and parameters: {'x': 5.886447516849493, 'y': -1}. Best is trial 362 with value: -0.9987830125105095.
[I 2020-12-21 10:35:45,151] Trial 536 finished with value: 8.644800507321802 and parameters: {'x': -3.1056079126834093, 'y': -1}. Best is trial 362 with value: -0.9987830125105095.
```