### PR TITLE
Fix CI examples for Py3.6

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -51,7 +51,7 @@ jobs:
     - name: Run examples
       run: |
         if [ ${{ matrix.python-version }} = 3.6 ]; then
-          IGNORES='botorch_.*'
+          IGNORES='chainermn_.*|fastai*|rapids_.*|botorch_.*'
         elif [ ${{ matrix.python-version }} = 3.8 ]; then
           IGNORES='chainermn_.*|dask_ml_.*|keras_.*|tensorboard_.*|tensorflow_.*|tfkeras_.*|fastai*|allennlp|rapids_.*'
         else


### PR DESCRIPTION
## Motivation

Unintended examples are currently executed in CI. This was caused by the recent `BoTorchSampler` PR.

## Description of the changes

Fixes CI configuration to omit examples as expected.
