### PR TITLE
Additional docs about `optuna.multi_objective` deprecation

### DIFF
--- a/docs/source/reference/multi_objective/index.rst
+++ b/docs/source/reference/multi_objective/index.rst
@@ -3,6 +3,8 @@
 optuna.multi_objective
 ======================
 
+This module is deprecated, with former functionality moved to :class:`optuna.trial`, :class:`optuna.study`, :class:`optuna.samplers` and :class:`optuna.visualization`.
+
 .. toctree::
     :maxdepth: 1
 

--- a/docs/source/reference/multi_objective/index.rst
+++ b/docs/source/reference/multi_objective/index.rst
@@ -3,7 +3,7 @@
 optuna.multi_objective
 ======================
 
-This module is deprecated, with former functionality moved to :class:`optuna.trial`, :class:`optuna.study`, :class:`optuna.samplers` and :class:`optuna.visualization`.
+This module is deprecated, with former functionality moved to :mod:`optuna.samplers`, :mod:`optuna.study`, :mod:`optuna.trial` and :mod:`optuna.visualization`.
 
 .. toctree::
     :maxdepth: 1


### PR DESCRIPTION
## Motivation

Follow-up to https://github.com/optuna/optuna/pull/2124.

## Description of the changes

Adds additional explanatory docs about the deprecation of `optuna.multi_objective`. Format mimics https://github.com/optuna/optuna/blob/master/docs/source/reference/structs.rst.

## Note

It might be open for discussion whether this is the correct formulation since the submodule might come to include other MO features.