### PR TITLE
Trial post processing

### DIFF
--- a/optuna/_optimize.py
+++ b/optuna/_optimize.py
@@ -224,8 +224,8 @@ def _run_trial(
     except Exception as e:
         state = TrialState.FAIL
         values = None
-        err = e
-        exc_info = sys.exc_info()
+        func_err = e
+        func_err_fail_exc_info = sys.exc_info()
 
     study._tell(trial, state, values)
 

--- a/optuna/_optimize.py
+++ b/optuna/_optimize.py
@@ -210,6 +210,14 @@ def _run_trial(
             len(study.directions), value_or_values, trial
         )
 
+    try:
+        trial._after_func(state, values)
+    except Exception as e:
+        state = TrialState.FAIL
+        values = None
+        err = e
+        exc_info = sys.exc_info()
+
     study._tell(trial, state, values)
 
     if state == TrialState.COMPLETE:

--- a/optuna/integration/botorch.py
+++ b/optuna/integration/botorch.py
@@ -463,14 +463,12 @@ class BoTorchSampler(BaseSampler):
                 constraints = study._storage.get_trial_system_attrs(trial._trial_id)[
                     "botorch:constraints"
                 ]
-                # `constraints` can be `None` if `constraints_func` raised an error. The best we
-                # can do is to fill with NaN.
-                if constraints is not None:
+                assert isinstance(constraints, tuple)
+                if con is None:
                     n_constraints = len(constraints)
-                    if con is None:
-                        con = numpy.full((n_trials, n_constraints), numpy.nan, dtype=numpy.float64)
+                    con = numpy.empty((n_trials, n_constraints), dtype=numpy.float64)
 
-                    con[trial_idx] = constraints
+                con[trial_idx] = constraints
 
         values = torch.from_numpy(values)
         params = torch.from_numpy(params)

--- a/optuna/integration/botorch.py
+++ b/optuna/integration/botorch.py
@@ -460,9 +460,9 @@ class BoTorchSampler(BaseSampler):
                 values[trial_idx, obj_idx] = value
 
             if self._constraints_func is not None:
-                constraints = study._storage.get_trial_system_attrs(trial._trial_id)[
+                constraints = study._storage.get_trial_system_attrs(trial._trial_id).get(
                     "botorch:constraints"
-                ]
+                )
                 if constraints is not None:
                     n_constraints = len(constraints)
 

--- a/optuna/integration/botorch.py
+++ b/optuna/integration/botorch.py
@@ -3,10 +3,9 @@ import math
 from typing import Any
 from typing import Callable
 from typing import Dict
-from typing import List
 from typing import Optional
 from typing import Sequence
-from typing import Tuple
+import warnings
 
 import numpy
 
@@ -356,7 +355,8 @@ class BoTorchSampler(BaseSampler):
             data, the objectives, the constraints, the search space bounds and return the next
             candidates. The arguments are of type ``torch.Tensor``. The return value must be a
             ``torch.Tensor``. However, if ``constraints_func`` is omitted, constraints will be
-            :obj:`None`.
+            :obj:`None`. For any constraints that failed to compute, the tensor will contain
+            NaN.
 
             If omitted, is determined automatically based on the number of objectives. If the
             number of objectives is one, Quasi MC-based batch Expected Improvement (qEI) is used.
@@ -376,11 +376,6 @@ class BoTorchSampler(BaseSampler):
 
             If omitted, no constraints will be passed to ``candidates_func`` nor taken into
             account during suggestion if ``candidates_func`` is omitted.
-
-            .. note::
-                ``constraints_func`` is called once per trial for each trial on each worker during
-                distributed optimization. Therefore, during distributed optimization, this
-                function should be deterministic to ensure that all workers hold the same values.
         n_startup_trials:
             Number of initial trials, that is the number of trials to resort to independent
             sampling.
@@ -412,7 +407,6 @@ class BoTorchSampler(BaseSampler):
         self._independent_sampler = independent_sampler or RandomSampler()
         self._n_startup_trials = n_startup_trials
 
-        self._trial_constraints: Dict[int, Tuple[float, ...]] = {}
         self._study_id: Optional[int] = None
         self._search_space = IntersectionSearchSpace()
 
@@ -430,23 +424,6 @@ class BoTorchSampler(BaseSampler):
 
         return self._search_space.calculate(study, ordered_dict=True)  # type: ignore
 
-    def _update_trial_constraints(self, trials: List[FrozenTrial]) -> None:
-        # Since trial constraints are computed on each worker, constraints should be computed
-        # deterministically.
-
-        assert self._constraints_func is not None
-
-        for trial in trials:
-            number = trial.number
-            if number not in self._trial_constraints:
-                constraints = self._constraints_func(trial)
-
-                if not isinstance(constraints, (tuple, list)):
-                    raise TypeError("Constraints must be a tuple or list.")
-
-                constraints = tuple(constraints)
-                self._trial_constraints[number] = constraints
-
     def sample_relative(
         self,
         study: Study,
@@ -455,12 +432,10 @@ class BoTorchSampler(BaseSampler):
     ) -> Dict[str, Any]:
         assert isinstance(search_space, OrderedDict)
 
-        trials = [t for t in study.get_trials(deepcopy=False) if t.state == TrialState.COMPLETE]
-        if self._constraints_func is not None:
-            self._update_trial_constraints(trials)
-
         if len(search_space) == 0:
             return {}
+
+        trials = [t for t in study.get_trials(deepcopy=False) if t.state == TrialState.COMPLETE]
 
         n_trials = len(trials)
         if n_trials < self._n_startup_trials:
@@ -471,11 +446,7 @@ class BoTorchSampler(BaseSampler):
         n_objectives = len(study.directions)
         values = numpy.empty((n_trials, n_objectives), dtype=numpy.float64)
         params = numpy.empty((n_trials, trans.bounds.shape[0]), dtype=numpy.float64)
-        if self._constraints_func is not None:
-            n_constraints = len(next(iter(self._trial_constraints.values())))
-            con = numpy.empty((n_trials, n_constraints), dtype=numpy.float64)
-        else:
-            con = None
+        con = None
         bounds = trans.bounds
 
         for trial_idx, trial in enumerate(trials):
@@ -488,8 +459,18 @@ class BoTorchSampler(BaseSampler):
                     value *= -1
                 values[trial_idx, obj_idx] = value
 
-            if con is not None:
-                con[trial_idx] = self._trial_constraints[trial_idx]
+            if self._constraints_func is not None:
+                constraints = study._storage.get_trial_system_attrs(trial._trial_id)[
+                    "botorch:constraints"
+                ]
+                # `constraints` can be `None` if `constraints_func` raised an error. The best we
+                # can do is to fill with NaN.
+                if constraints is not None:
+                    n_constraints = len(constraints)
+                    if con is None:
+                        con = numpy.full((n_trials, n_constraints), numpy.nan, dtype=numpy.float64)
+
+                    con[trial_idx] = constraints
 
         values = torch.from_numpy(values)
         params = torch.from_numpy(params)
@@ -555,3 +536,32 @@ class BoTorchSampler(BaseSampler):
 
     def reseed_rng(self) -> None:
         self._independent_sampler.reseed_rng()
+
+    @experimental("2.4.0")
+    def after_trial(
+        self,
+        study: Study,
+        trial: FrozenTrial,
+        state: TrialState,
+        values: Optional[Sequence[float]],
+    ) -> None:
+        if self._constraints_func is not None:
+            constraints = None
+
+            try:
+                con = self._constraints_func(trial)
+                if not isinstance(con, (tuple, list)):
+                    warnings.warn(
+                        f"Constraints should be a sequence of floats but got {constraints}."
+                    )
+                constraints = tuple(con)
+            except Exception:
+                raise
+            finally:
+                assert constraints is None or isinstance(constraints, tuple)
+
+                study._storage.set_trial_system_attr(
+                    trial._trial_id,
+                    "botorch:constraints",
+                    constraints,
+                )

--- a/optuna/samplers/_base.py
+++ b/optuna/samplers/_base.py
@@ -1,10 +1,14 @@
 import abc
 from typing import Any
 from typing import Dict
+from typing import Optional
+from typing import Sequence
 
+from optuna._experimental import experimental
 from optuna.distributions import BaseDistribution
 from optuna.study import Study
 from optuna.trial import FrozenTrial
+from optuna.trial import TrialState
 
 
 class BaseSampler(object, metaclass=abc.ABCMeta):
@@ -136,6 +140,35 @@ class BaseSampler(object, metaclass=abc.ABCMeta):
         """
 
         raise NotImplementedError
+
+    @experimental("2.4.0")
+    def after_trial(
+        self,
+        study: Study,
+        trial: FrozenTrial,
+        state: TrialState,
+        values: Optional[Sequence[float]],
+    ) -> None:
+        """Trial post-processing.
+
+        This method is called after the objective function returns and right before the trials is
+        finished and its state is stored. If this method raises an error, the trial will be
+        considered failed and the state and values will be updated accordingly.
+
+        Args:
+            study:
+                Target study object.
+            trial:
+                Target trial object.
+                Take a copy before modifying this object.
+            state:
+                Resulting trial state.
+            values:
+                Resulting trial values. Guaranteed to not be :obj:`None` if trial succeeded.
+
+        """
+
+        pass
 
     def reseed_rng(self) -> None:
         """Reseed sampler's random number generator.

--- a/optuna/samplers/_base.py
+++ b/optuna/samplers/_base.py
@@ -4,7 +4,6 @@ from typing import Dict
 from typing import Optional
 from typing import Sequence
 
-from optuna._experimental import experimental
 from optuna.distributions import BaseDistribution
 from optuna.study import Study
 from optuna.trial import FrozenTrial
@@ -141,7 +140,6 @@ class BaseSampler(object, metaclass=abc.ABCMeta):
 
         raise NotImplementedError
 
-    @experimental("2.4.0")
     def after_trial(
         self,
         study: Study,
@@ -154,6 +152,10 @@ class BaseSampler(object, metaclass=abc.ABCMeta):
         This method is called after the objective function returns and right before the trials is
         finished and its state is stored. If this method raises an error, the trial will be
         considered failed and the state and values will be updated accordingly.
+
+        .. note::
+            Added in v2.4.0 as an experimental feature. The interface may change in newer versions
+            without prior notice. See https://github.com/optuna/optuna/releases/tag/v2.4.0.
 
         Args:
             study:

--- a/optuna/samplers/_base.py
+++ b/optuna/samplers/_base.py
@@ -150,8 +150,7 @@ class BaseSampler(object, metaclass=abc.ABCMeta):
         """Trial post-processing.
 
         This method is called after the objective function returns and right before the trials is
-        finished and its state is stored. If this method raises an error, the trial will be
-        considered failed and the state and values will be updated accordingly.
+        finished and its state is stored.
 
         .. note::
             Added in v2.4.0 as an experimental feature. The interface may change in newer versions

--- a/optuna/samplers/_grid.py
+++ b/optuna/samplers/_grid.py
@@ -191,10 +191,9 @@ class GridSampler(BaseSampler):
         if len(target_grids) == 0:
             study.stop()
         elif len(target_grids) == 1:
-            if state.is_finished():
-                grid_id = study._storage.get_trial_system_attrs(trial._trial_id)["grid_id"]
-                if grid_id == target_grids[0]:
-                    study.stop()
+            grid_id = study._storage.get_trial_system_attrs(trial._trial_id)["grid_id"]
+            if grid_id == target_grids[0]:
+                study.stop()
 
     @staticmethod
     def _check_value(param_name: str, param_value: Any) -> None:

--- a/optuna/samplers/_grid.py
+++ b/optuna/samplers/_grid.py
@@ -10,7 +10,6 @@ from typing import Optional
 from typing import Sequence
 from typing import Union
 
-from optuna._experimental import experimental
 from optuna.distributions import BaseDistribution
 from optuna.logging import get_logger
 from optuna.samplers import BaseSampler
@@ -180,7 +179,6 @@ class GridSampler(BaseSampler):
 
         return param_value
 
-    @experimental("2.4.0")
     def after_trial(
         self,
         study: Study,

--- a/optuna/samplers/_grid.py
+++ b/optuna/samplers/_grid.py
@@ -191,7 +191,7 @@ class GridSampler(BaseSampler):
         if len(target_grids) == 0:
             study.stop()
         elif len(target_grids) == 1:
-            if state == TrialState.COMPLETE:
+            if state.is_finished():
                 grid_id = study._storage.get_trial_system_attrs(trial._trial_id)["grid_id"]
                 if grid_id == target_grids[0]:
                     study.stop()

--- a/optuna/trial/_trial.py
+++ b/optuna/trial/_trial.py
@@ -20,6 +20,7 @@ from optuna.distributions import IntUniformDistribution
 from optuna.distributions import LogUniformDistribution
 from optuna.distributions import UniformDistribution
 from optuna.trial._base import BaseTrial
+from optuna.trial._state import TrialState
 
 
 _logger = logging.get_logger(__name__)
@@ -757,6 +758,16 @@ class Trial(BaseTrial):
                 "Using these values: {}".format(name, old_distribution._asdict()),
                 RuntimeWarning,
             )
+
+    def _after_func(self, state: TrialState, values: Optional[Sequence[float]]) -> None:
+        # This method is called right before `Study._tell`.
+        storage = self.storage
+        trial_id = self._trial_id
+
+        trial = storage.get_trial(trial_id)
+
+        study = pruners._filter_study(self.study, trial)
+        self.study.sampler.after_trial(study, trial, state, values)
 
     @property
     def params(self) -> Dict[str, Any]:

--- a/tests/integration_tests/test_botorch.py
+++ b/tests/integration_tests/test_botorch.py
@@ -183,6 +183,19 @@ def test_botorch_constraints_func_invalid_type() -> None:
         study.optimize(lambda t: t.suggest_float("x0", 0, 1), n_trials=3)
 
 
+def test_botorch_constraints_func_invalid_inconsistent_n_constraints() -> None:
+    def constraints_func(trial: FrozenTrial) -> Sequence[float]:
+        x0 = trial.params["x0"]
+        return [x0 - 0.5] * trial.number  # Number of constraints may not change.
+
+    sampler = BoTorchSampler(constraints_func=constraints_func, n_startup_trials=1)
+
+    study = optuna.create_study(direction="minimize", sampler=sampler)
+
+    with pytest.raises(RuntimeError):
+        study.optimize(lambda t: t.suggest_float("x0", 0, 1), n_trials=3)
+
+
 def test_botorch_constraints_func_raises() -> None:
     def constraints_func(trial: FrozenTrial) -> Sequence[float]:
         if trial.number == 1:

--- a/tests/samplers_tests/test_grid.py
+++ b/tests/samplers_tests/test_grid.py
@@ -95,6 +95,17 @@ def test_study_optimize_with_exceeding_number_of_trials() -> None:
     assert len(study.trials) == 3
 
 
+def test_study_optimize_with_pruning() -> None:
+    def objective(trial: Trial) -> float:
+        raise optuna.TrialPruned
+
+    # Pruned trials should count towards grid consumption.
+    search_space: Dict[str, List[GridValueType]] = {"a": [0, 50]}
+    study = optuna.create_study(sampler=samplers.GridSampler(search_space))
+    study.optimize(objective, n_trials=None)
+    assert len(study.trials) == 2
+
+
 def test_study_optimize_with_multiple_search_spaces() -> None:
     def objective(trial: Trial) -> float:
 

--- a/tests/samplers_tests/test_samplers.py
+++ b/tests/samplers_tests/test_samplers.py
@@ -21,9 +21,11 @@ from optuna.distributions import UniformDistribution
 from optuna.samplers import BaseSampler
 from optuna.samplers import PartialFixedSampler
 from optuna.study import Study
+from optuna.testing.sampler import DeterministicRelativeSampler
 from optuna.testing.storage import StorageSupplier
 from optuna.trial import FrozenTrial
 from optuna.trial import Trial
+from optuna.trial import TrialState
 
 
 parametrize_sampler = pytest.mark.parametrize(
@@ -382,3 +384,134 @@ def test_partial_fixed_sampling(sampler_class: Callable[[], BaseSampler]) -> Non
     study.optimize(objective, n_trials=1)
     trial_params = study.trials[-1].params
     assert trial_params["y"] == fixed_params["y"]
+
+
+def test_after_trial() -> None:
+    n_calls = 0
+    n_trials = 3
+
+    class SamplerAfterTrial(DeterministicRelativeSampler):
+        def after_trial(
+            self,
+            study: Study,
+            trial: FrozenTrial,
+            state: TrialState,
+            values: Optional[Sequence[float]],
+        ) -> None:
+            assert len(study.trials) - 1 == trial.number
+            assert trial.state == TrialState.RUNNING
+            assert trial.values is None
+            assert state == TrialState.COMPLETE
+            assert values is not None
+            assert len(values) == 2
+            nonlocal n_calls
+            n_calls += 1
+
+    sampler = SamplerAfterTrial({}, {})
+    study = optuna.create_study(directions=["minimize", "minimize"], sampler=sampler)
+
+    study.optimize(
+        lambda t: [t.suggest_uniform("y", -3, 3), t.suggest_int("x", 0, 10)], n_trials=3
+    )
+
+    assert n_calls == n_trials
+
+
+def test_after_trial_pruning() -> None:
+    n_calls = 0
+    n_trials = 3
+
+    class SamplerAfterTrial(DeterministicRelativeSampler):
+        def after_trial(
+            self,
+            study: Study,
+            trial: FrozenTrial,
+            state: TrialState,
+            values: Optional[Sequence[float]],
+        ) -> None:
+            assert len(study.trials) - 1 == trial.number
+            assert trial.state == TrialState.RUNNING
+            assert trial.values is None
+            assert state == TrialState.PRUNED
+            assert values is None
+            nonlocal n_calls
+            n_calls += 1
+
+    sampler = SamplerAfterTrial({}, {})
+    study = optuna.create_study(directions=["minimize", "minimize"], sampler=sampler)
+
+    def objective(trial: Trial) -> Any:
+        raise optuna.TrialPruned
+
+    study.optimize(objective, n_trials=n_trials)
+
+    assert n_calls == n_trials
+
+
+def test_after_trial_failing() -> None:
+    n_calls = 0
+    n_trials = 3
+
+    class SamplerAfterTrial(DeterministicRelativeSampler):
+        def after_trial(
+            self,
+            study: Study,
+            trial: FrozenTrial,
+            state: TrialState,
+            values: Optional[Sequence[float]],
+        ) -> None:
+            assert len(study.trials) - 1 == trial.number
+            assert trial.state == TrialState.RUNNING
+            assert trial.values is None
+            assert state == TrialState.FAIL
+            assert values is None
+            nonlocal n_calls
+            n_calls += 1
+
+    sampler = SamplerAfterTrial({}, {})
+    study = optuna.create_study(directions=["minimize", "minimize"], sampler=sampler)
+
+    def objective(trial: Trial) -> Any:
+        raise NotImplementedError  # Arbitrary error for testing purpose.
+
+    with pytest.raises(NotImplementedError):
+        study.optimize(objective, n_trials=n_trials)
+
+    # Called once after the first failing trial before returning from optimize.
+    assert n_calls == 1
+
+
+def test_after_trial_failing_in_after_trial() -> None:
+    n_calls = 0
+    n_trials = 3
+
+    class SamplerAfterTrialAlwaysFail(DeterministicRelativeSampler):
+        def after_trial(
+            self,
+            study: Study,
+            trial: FrozenTrial,
+            state: TrialState,
+            values: Optional[Sequence[float]],
+        ) -> None:
+            nonlocal n_calls
+            n_calls += 1
+            raise NotImplementedError  # Arbitrary error for testing purpose.
+
+    sampler = SamplerAfterTrialAlwaysFail({}, {})
+    study = optuna.create_study(sampler=sampler)
+
+    with pytest.raises(NotImplementedError):
+        study.optimize(lambda t: t.suggest_int("x", 0, 10), n_trials=n_trials)
+
+    assert len(study.trials) == 1
+    assert n_calls == 1
+
+    sampler = SamplerAfterTrialAlwaysFail({}, {})
+    study = optuna.create_study(sampler=sampler)
+
+    study.optimize(
+        lambda t: t.suggest_int("x", 0, 10), n_trials=n_trials, catch=(NotImplementedError,)
+    )
+
+    assert len(study.trials) == n_trials
+    assert n_calls == 1 + n_trials

--- a/tests/samplers_tests/test_samplers.py
+++ b/tests/samplers_tests/test_samplers.py
@@ -509,9 +509,11 @@ def test_after_trial_failing_in_after_trial() -> None:
     sampler = SamplerAfterTrialAlwaysFail({}, {})
     study = optuna.create_study(sampler=sampler)
 
-    study.optimize(
-        lambda t: t.suggest_int("x", 0, 10), n_trials=n_trials, catch=(NotImplementedError,)
-    )
+    # Not affected by `catch`.
+    with pytest.raises(NotImplementedError):
+        study.optimize(
+            lambda t: t.suggest_int("x", 0, 10), n_trials=n_trials, catch=(NotImplementedError,)
+        )
 
-    assert len(study.trials) == n_trials
-    assert n_calls == 1 + n_trials
+    assert len(study.trials) == 1
+    assert n_calls == 2


### PR DESCRIPTION
## Motivation

~Depends on https://github.com/optuna/optuna/pull/2133.~ (edit: merged)

Allow experimental trial post post-processing. As a consequence, the `BoTorchSampler` constraints callback assumptions are relaxed and they no longer have to be deterministic since they'll only be computed once per trial. The `GridSampler` can also make use of this change to stop the study.

## Description of the changes

Introduces `BaseSampler.after_trial` to allow trial post-processing by each sampler.

## TODO

- [x] Make sure API looks okay. Ensure compatibility with possible future ask-and-tell API.
- [x] Tests. Verify error handling and edge cases. 