### PR TITLE
Raise `NotImplementedError` for `trial.report` and `trial.should_prune` during multi-objective optimization

### DIFF
--- a/optuna/trial/_trial.py
+++ b/optuna/trial/_trial.py
@@ -562,12 +562,12 @@ class Trial(BaseTrial):
 
         Raises:
             :exc:`NotImplementedError`:
-                If study is being used for multi-objective optimization.
+                If trial is being used for multi-objective optimization.
         """
 
         if len(self.study.directions) > 1:
             raise NotImplementedError(
-                "Trial.report is not supported for multi-objective optimization"
+                "Trial.report is not supported for multi-objective optimization."
             )
 
         try:
@@ -613,12 +613,12 @@ class Trial(BaseTrial):
 
         Raises:
             :exc:`NotImplementedError`:
-                If study is being used for multi-objective optimization.
+                If trial is being used for multi-objective optimization.
         """
 
         if len(self.study.directions) > 1:
             raise NotImplementedError(
-                "Trial.should_prune is not supported for multi-objective optimization"
+                "Trial.should_prune is not supported for multi-objective optimization."
             )
 
         trial = self.study._storage.get_trial(self._trial_id)

--- a/optuna/trial/_trial.py
+++ b/optuna/trial/_trial.py
@@ -565,8 +565,9 @@ class Trial(BaseTrial):
         """
 
         if len(self.study.directions) > 1:
-            _logger.warning(
-                "When the problem is multi-objective optimization, Trial.report does nothing."
+            warnings.warn(
+                "When the problem is multi-objective optimization, Trial.report does nothing.",
+                RuntimeWarning,
             )
             return
 
@@ -617,9 +618,10 @@ class Trial(BaseTrial):
         """
 
         if len(self.study.directions) > 1:
-            _logger.warning(
+            warnings.warn(
                 "When the problem is multi-objective optimization, "
-                "Trial.should_prune always returns `False`."
+                "Trial.should_prune always returns False.",
+                RuntimeWarning,
             )
             return False
 

--- a/optuna/trial/_trial.py
+++ b/optuna/trial/_trial.py
@@ -566,7 +566,7 @@ class Trial(BaseTrial):
 
         if len(self.study.directions) > 1:
             _logger.warning(
-                "When the problem is multi-objective optimization, this function does nothing."
+                "When the problem is multi-objective optimization, Trial.report does nothing."
             )
             return
 
@@ -618,8 +618,8 @@ class Trial(BaseTrial):
 
         if len(self.study.directions) > 1:
             _logger.warning(
-                "When the problem is multi-objective optimization, this function always returns "
-                "`False`."
+                "When the problem is multi-objective optimization, "
+                "Trial.should_prune always returns `False`."
             )
             return False
 

--- a/optuna/trial/_trial.py
+++ b/optuna/trial/_trial.py
@@ -509,9 +509,6 @@ class Trial(BaseTrial):
         The reported values are used by the pruners to determine whether this trial should be
         pruned.
 
-        .. warning::
-            When the problem is multi-objective optimization, this function does nothing.
-
         .. seealso::
             Please refer to :class:`~optuna.pruners.BasePruner`.
 
@@ -562,14 +559,16 @@ class Trial(BaseTrial):
                 assume that ``step`` starts at zero. For example,
                 :class:`~optuna.pruners.MedianPruner` simply checks if ``step`` is less than
                 ``n_warmup_steps`` as the warmup mechanism.
+
+        Raises:
+            :exc:`NotImplementedError`:
+                If study is being used for multi-objective optimization.
         """
 
         if len(self.study.directions) > 1:
-            warnings.warn(
-                "When the problem is multi-objective optimization, Trial.report does nothing.",
-                RuntimeWarning,
+            raise NotImplementedError(
+                "Trial.report is not supported for multi-objective optimization"
             )
-            return
 
         try:
             # For convenience, we allow users to report a value that can be cast to `float`.
@@ -600,10 +599,6 @@ class Trial(BaseTrial):
         previously reported values. The algorithm can be specified when constructing a
         :class:`~optuna.study.Study`.
 
-        .. warning::
-            When the problem is multi-objective optimization, this function always returns
-            :obj:`False`.
-
         .. note::
             If no values have been reported, the algorithm cannot make meaningful suggestions.
             Similarly, if this method is called multiple times with the exact same set of reported
@@ -615,15 +610,16 @@ class Trial(BaseTrial):
         Returns:
             A boolean value. If :obj:`True`, the trial should be pruned according to the
             configured pruning algorithm. Otherwise, the trial should continue.
+
+        Raises:
+            :exc:`NotImplementedError`:
+                If study is being used for multi-objective optimization.
         """
 
         if len(self.study.directions) > 1:
-            warnings.warn(
-                "When the problem is multi-objective optimization, "
-                "Trial.should_prune always returns False.",
-                RuntimeWarning,
+            raise NotImplementedError(
+                "Trial.should_prune is not supported for multi-objective optimization"
             )
-            return False
 
         trial = self.study._storage.get_trial(self._trial_id)
         return self.study.pruner.prune(self.study, trial)

--- a/optuna/trial/_trial.py
+++ b/optuna/trial/_trial.py
@@ -509,6 +509,9 @@ class Trial(BaseTrial):
         The reported values are used by the pruners to determine whether this trial should be
         pruned.
 
+        .. warning::
+            When the problem is multi-objective optimization, this function does nothing.
+
         .. seealso::
             Please refer to :class:`~optuna.pruners.BasePruner`.
 
@@ -561,6 +564,12 @@ class Trial(BaseTrial):
                 ``n_warmup_steps`` as the warmup mechanism.
         """
 
+        if len(self.study.directions) > 1:
+            _logger.warning(
+                "When the problem is multi-objective optimization, this function does nothing."
+            )
+            return
+
         try:
             # For convenience, we allow users to report a value that can be cast to `float`.
             value = float(value)
@@ -590,6 +599,10 @@ class Trial(BaseTrial):
         previously reported values. The algorithm can be specified when constructing a
         :class:`~optuna.study.Study`.
 
+        .. warning::
+            When the problem is multi-objective optimization, this function always returns
+            :obj:`False`.
+
         .. note::
             If no values have been reported, the algorithm cannot make meaningful suggestions.
             Similarly, if this method is called multiple times with the exact same set of reported
@@ -602,6 +615,13 @@ class Trial(BaseTrial):
             A boolean value. If :obj:`True`, the trial should be pruned according to the
             configured pruning algorithm. Otherwise, the trial should continue.
         """
+
+        if len(self.study.directions) > 1:
+            _logger.warning(
+                "When the problem is multi-objective optimization, this function always returns "
+                "`False`."
+            )
+            return False
 
         trial = self.study._storage.get_trial(self._trial_id)
         return self.study.pruner.prune(self.study, trial)

--- a/tests/test_trial.py
+++ b/tests/test_trial.py
@@ -1321,33 +1321,23 @@ def test_suggest_with_multi_objectives() -> None:
     study.optimize(objective, n_trials=10)
 
 
-@pytest.mark.filterwarnings("ignore::optuna.exceptions.ExperimentalWarning")
-def test_report_with_multi_objectives() -> None:
+def test_raise_error_for_report_with_multi_objectives() -> None:
+    study = optuna.create_study(directions=["maximize", "maximize"])
+
     def objective(trial: Trial) -> Tuple[float, float]:
-        # Try to report values but nothing happens.
-        with pytest.warns(RuntimeWarning):
+        with pytest.raises(NotImplementedError):
             trial.report(1.0, 0)
-        with pytest.warns(RuntimeWarning):
-            trial.report([1.0, 1.0], 1)  # type: ignore
         return 1.0, 1.0
 
-    study = optuna.create_study(directions=["maximize", "maximize"])
     study.optimize(objective, n_trials=1)
-    assert study.trials[0].intermediate_values == {}
 
 
-@pytest.mark.filterwarnings("ignore::optuna.exceptions.ExperimentalWarning")
-def test_should_prune_multi_objectives() -> None:
+def test_raise_error_for_should_prune_multi_objectives() -> None:
     study = optuna.create_study(directions=["maximize", "maximize"])
-    trials = [
-        create_trial(value=0.0, intermediate_values={i: 0.0 for i in range(10)}) for _ in range(10)
-    ]
-    for t in trials:
-        study.add_trial(t)
 
     def objective(trial: Trial) -> Tuple[float, float]:
-        with pytest.warns(RuntimeWarning):
-            assert trial.should_prune() is False
+        with pytest.raises(NotImplementedError):
+            trial.should_prune()
         return 1.0, 1.0
 
     study.optimize(objective, n_trials=1)

--- a/tests/test_trial.py
+++ b/tests/test_trial.py
@@ -1319,3 +1319,25 @@ def test_suggest_with_multi_objectives() -> None:
         )
 
     study.optimize(objective, n_trials=10)
+
+
+def test_report_with_multi_objectives() -> None:
+    study = optuna.create_study(directions=["maximize", "maximize"])
+    trial = Trial(study, study._storage.create_new_trial(study._study_id))
+
+    # Try to report values but nothing happens.
+    trial.report(1.0, 0)
+    trial.report([1.0, 1.0], 1)  # type: ignore
+    assert study.trials[0].intermediate_values == {}
+
+
+def test_should_prune_multi_objectives() -> None:
+    study = optuna.create_study(directions=["maximize", "maximize"])
+    trials = [
+        create_trial(value=0.0, intermediate_values={i: 0.0 for i in range(10)}) for _ in range(10)
+    ]
+    for t in trials:
+        study.add_trial(t)
+
+    trial = Trial(study, study._storage.create_new_trial(study._study_id))
+    assert trial.should_prune() is False


### PR DESCRIPTION
## Motivation
Part of works for #1980.
Currently, Optuna's pruning system such as intermediate values or pruners only supports single-objective optimization. This PR makes `trial.report()` and `trial.should_prund()` do nothing during multi-objective optimization.

## Description of the changes
- Make `trial.report()` and `trial.should_prund()` do nothing during multi-objective optimization.
- Add unit tests.