### PR TITLE
Raise `RuntimeError` in TPE and CMA-ES if `study` is being used for multi-objective optimization

### DIFF
--- a/optuna/samplers/_base.py
+++ b/optuna/samplers/_base.py
@@ -149,11 +149,10 @@ class BaseSampler(object, metaclass=abc.ABCMeta):
 
         pass
 
-    @staticmethod
-    def _raise_error_if_multi_objective(study: Study) -> None:
+    def _raise_error_if_multi_objective(self, study: Study) -> None:
 
         if len(study.directions) > 1:
-            raise RuntimeError(
-                "If the `study` is being used for multi-objective optimization, "
-                "this sampler cannot be used."
+            raise ValueError(
+                "If the study is being used for multi-objective optimization, "
+                f"{self.__class__.__name__} cannot be used."
             )

--- a/optuna/samplers/_base.py
+++ b/optuna/samplers/_base.py
@@ -148,3 +148,12 @@ class BaseSampler(object, metaclass=abc.ABCMeta):
         """
 
         pass
+
+    @staticmethod
+    def _raise_error_if_multi_objective(study: Study) -> None:
+
+        if len(study.directions) > 1:
+            raise RuntimeError(
+                "If the `study` is being used for multi-objective optimization, "
+                "this sampler cannot be used."
+            )

--- a/optuna/samplers/_cmaes.py
+++ b/optuna/samplers/_cmaes.py
@@ -234,6 +234,9 @@ class CmaEsSampler(BaseSampler):
         trial: "optuna.trial.FrozenTrial",
         search_space: Dict[str, BaseDistribution],
     ) -> Dict[str, Any]:
+
+        self._raise_error_if_multi_objective(study)
+
         if len(search_space) == 0:
             return {}
 
@@ -393,6 +396,9 @@ class CmaEsSampler(BaseSampler):
         param_name: str,
         param_distribution: BaseDistribution,
     ) -> Any:
+
+        self._raise_error_if_multi_objective(study)
+
         if self._warn_independent_sampling:
             complete_trials = self._get_trials(study)
             if len(complete_trials) >= self._n_startup_trials:

--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -229,6 +229,8 @@ class TPESampler(BaseSampler):
         self, study: Study, trial: FrozenTrial, search_space: Dict[str, BaseDistribution]
     ) -> Dict[str, Any]:
 
+        self._raise_error_if_multi_objective(study)
+
         if search_space == {}:
             return {}
 
@@ -268,6 +270,8 @@ class TPESampler(BaseSampler):
         param_name: str,
         param_distribution: BaseDistribution,
     ) -> Any:
+
+        self._raise_error_if_multi_objective(study)
 
         values, scores = _get_observation_pairs(study, param_name)
 

--- a/tests/samplers_tests/test_samplers.py
+++ b/tests/samplers_tests/test_samplers.py
@@ -39,6 +39,31 @@ parametrize_sampler = pytest.mark.parametrize(
 )
 
 
+@pytest.mark.parametrize(
+    "sampler_class",
+    [
+        lambda: optuna.samplers.TPESampler(n_startup_trials=0),
+        lambda: optuna.samplers.TPESampler(n_startup_trials=0, multivariate=True),
+        lambda: optuna.samplers.CmaEsSampler(n_startup_trials=0),
+    ],
+)
+def test_raise_error_for_samplers_during_multi_objectives(
+    sampler_class: Callable[[], BaseSampler]
+) -> None:
+
+    study = optuna.study.create_study(directions=["maximize", "maximize"], sampler=sampler_class())
+
+    distribution = UniformDistribution(0.0, 1.0)
+    with pytest.raises(RuntimeError):
+        study.sampler.sample_independent(study, _create_new_trial(study), "x", distribution)
+
+    with pytest.raises(RuntimeError):
+        trial = _create_new_trial(study)
+        study.sampler.sample_relative(
+            study, trial, study.sampler.infer_relative_search_space(study, trial)
+        )
+
+
 @pytest.mark.parametrize("seed", [None, 0, 169208])
 def test_pickle_random_sampler(seed: Optional[int]) -> None:
 

--- a/tests/samplers_tests/test_samplers.py
+++ b/tests/samplers_tests/test_samplers.py
@@ -54,10 +54,10 @@ def test_raise_error_for_samplers_during_multi_objectives(
     study = optuna.study.create_study(directions=["maximize", "maximize"], sampler=sampler_class())
 
     distribution = UniformDistribution(0.0, 1.0)
-    with pytest.raises(RuntimeError):
+    with pytest.raises(ValueError):
         study.sampler.sample_independent(study, _create_new_trial(study), "x", distribution)
 
-    with pytest.raises(RuntimeError):
+    with pytest.raises(ValueError):
         trial = _create_new_trial(study)
         study.sampler.sample_relative(
             study, trial, study.sampler.infer_relative_search_space(study, trial)

--- a/tests/samplers_tests/tpe_tests/test_sampler.py
+++ b/tests/samplers_tests/tpe_tests/test_sampler.py
@@ -77,7 +77,7 @@ def test_sample_relative_empty_input(multivariate: bool) -> None:
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", optuna.exceptions.ExperimentalWarning)
         sampler = TPESampler(multivariate=multivariate)
-    # Frozen-trial are not supposed to be accessed.
+    # A frozen-trial is not supposed to be accessed.
     study = optuna.create_study()
     frozen_trial = Mock(spec=[])
     assert sampler.sample_relative(study, frozen_trial, {}) == {}

--- a/tests/samplers_tests/tpe_tests/test_sampler.py
+++ b/tests/samplers_tests/tpe_tests/test_sampler.py
@@ -77,8 +77,8 @@ def test_sample_relative_empty_input(multivariate: bool) -> None:
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", optuna.exceptions.ExperimentalWarning)
         sampler = TPESampler(multivariate=multivariate)
-    # Study and frozen-trial are not supposed to be accessed.
-    study = Mock(spec=[])
+    # Frozen-trial are not supposed to be accessed.
+    study = optuna.create_study()
     frozen_trial = Mock(spec=[])
     assert sampler.sample_relative(study, frozen_trial, {}) == {}
 


### PR DESCRIPTION
## Motivation
Part of works for #1980.
Some samplers may not support multi-objective optimization, in that case, we need to raise the error.
Where to raise the error is a matter of debate. Considering that there will be more samplers in the future, I decided to raise the error in the `sample_independent` and `sample_relative` of each sampler.

## Description of the changes
- Add `_raise_error_if_multi_objective` to `BaseSampler`
- Apply `_raise_error_if_multi_objective` to the `sample_independent` and `sample_relative` of `TPESampler` and `CmaEsSampler`.
- Add unit tests.
