### PR TITLE
Raise `ValueError` if `target` is None and `study` is for multi-objective optimization for `get_param_importances`, `BaseImportanceEvaluator.evaluate`, and `plot_param_importances`

### DIFF
--- a/optuna/importance/__init__.py
+++ b/optuna/importance/__init__.py
@@ -66,12 +66,21 @@ def get_param_importances(
             If :obj:`None`, all parameters that are present in all of the completed trials are
             assessed.
         target:
-            A function to specify the value to evaluate importances. If it is :obj:`None`, the
-            objective values are used.
+            A function to specify the value to evaluate importances.
+            If it is :obj:`None` and ``study`` is being used for single-objective optimization,
+            the objective values are used.
+
+            .. note::
+                Specify this argument if ``study`` is being used for multi-objective optimization.
 
     Returns:
         An :class:`collections.OrderedDict` where the keys are parameter names and the values are
         assessed importances.
+
+    Raises:
+        :exc:`ValueError`:
+            If ``target`` is :obj:`None` and ``study`` is being used for multi-objective
+            optimization.
     """
     if evaluator is None:
         evaluator = FanovaImportanceEvaluator()

--- a/optuna/importance/_base.py
+++ b/optuna/importance/_base.py
@@ -46,12 +46,22 @@ class BaseImportanceEvaluator(object, metaclass=abc.ABCMeta):
                 If :obj:`None`, all parameters that are present in all of the completed trials are
                 assessed.
             target:
-                A function to specify the value to evaluate importances. If it is :obj:`None`, the
-                objective values are used.
+                A function to specify the value to evaluate importances.
+                If it is :obj:`None` and ``study`` is being used for single-objective optimization,
+                the objective values are used.
+
+                .. note::
+                    Specify this argument if ``study`` is being used for multi-objective
+                    optimization.
 
         Returns:
             An :class:`collections.OrderedDict` where the keys are parameter names and the values
             are assessed importances.
+
+        Raises:
+            :exc:`ValueError`:
+                If ``target`` is :obj:`None` and ``study`` is being used for multi-objective
+                optimization.
         """
         # TODO(hvy): Reconsider the interface as logic might violate DRY among multiple evaluators.
         raise NotImplementedError

--- a/optuna/importance/_fanova/_evaluator.py
+++ b/optuna/importance/_fanova/_evaluator.py
@@ -82,6 +82,12 @@ class FanovaImportanceEvaluator(BaseImportanceEvaluator):
         *,
         target: Optional[Callable[[FrozenTrial], float]] = None,
     ) -> Dict[str, float]:
+        if target is None and len(study.directions) > 1:
+            raise ValueError(
+                "If the `study` is being used for multi-objective optimization, "
+                "please specify the `target`."
+            )
+
         distributions = _get_distributions(study, params)
         params_data, values_data = _get_study_data(study, distributions, target)
 

--- a/optuna/importance/_mean_decrease_impurity.py
+++ b/optuna/importance/_mean_decrease_impurity.py
@@ -65,6 +65,12 @@ class MeanDecreaseImpurityImportanceEvaluator(BaseImportanceEvaluator):
         *,
         target: Optional[Callable[[FrozenTrial], float]] = None,
     ) -> Dict[str, float]:
+        if target is None and len(study.directions) > 1:
+            raise ValueError(
+                "If the `study` is being used for multi-objective optimization, "
+                "please specify the `target`."
+            )
+
         distributions = _get_distributions(study, params)
         params_data, values_data = _get_study_data(study, distributions, target)
 

--- a/optuna/visualization/_param_importances.py
+++ b/optuna/visualization/_param_importances.py
@@ -87,16 +87,30 @@ def plot_param_importances(
             If :obj:`None`, all parameters that are present in all of the completed trials are
             assessed.
         target:
-            A function to specify the value to evaluate importances. If it is :obj:`None`, the
-            objective values are used.
+            A function to specify the value to display. If it is :obj:`None` and ``study`` is being
+            used for single-objective optimization, the objective values are plotted.
+
+            .. note::
+                Specify this argument if ``study`` is being used for multi-objective optimization.
         target_name:
             Target's name to display on the axis label.
 
     Returns:
         A :class:`plotly.graph_objs.Figure` object.
+
+    Raises:
+        :exc:`ValueError`:
+            If ``target`` is :obj:`None` and ``study`` is being used for multi-objective
+            optimization.
     """
 
     _imports.check()
+
+    if target is None and len(study.directions) > 1:
+        raise ValueError(
+            "If the `study` is being used for multi-objective optimization, "
+            "please specify the `target`."
+        )
 
     layout = go.Layout(
         title="Hyperparameter Importances",

--- a/optuna/visualization/matplotlib/_param_importances.py
+++ b/optuna/visualization/matplotlib/_param_importances.py
@@ -99,16 +99,31 @@ def plot_param_importances(
             If :obj:`None`, all parameters that are present in all of the completed trials are
             assessed.
         target:
-            A function to specify the value to evaluate importances. If it is :obj:`None`, the
-            objective values are used.
+            A function to specify the value to display. If it is :obj:`None` and ``study`` is being
+            used for single-objective optimization, the objective values are plotted.
+
+            .. note::
+                Specify this argument if ``study`` is being used for multi-objective optimization.
         target_name:
             Target's name to display on the axis label.
 
     Returns:
         A :class:`matplotlib.axes.Axes` object.
+
+    Raises:
+        :exc:`ValueError`:
+            If ``target`` is :obj:`None` and ``study`` is being used for multi-objective
+            optimization.
     """
 
     _imports.check()
+
+    if target is None and len(study.directions) > 1:
+        raise ValueError(
+            "If the `study` is being used for multi-objective optimization, "
+            "please specify the `target`."
+        )
+
     return _get_param_importance_plot(study, evaluator, params, target, target_name)
 
 

--- a/tests/importance_tests/test_init.py
+++ b/tests/importance_tests/test_init.py
@@ -2,6 +2,7 @@ from collections import OrderedDict
 import math
 from typing import Callable
 from typing import List
+from typing import Tuple
 
 import pytest
 
@@ -24,6 +25,36 @@ parametrize_storage = pytest.mark.parametrize(
 parametrize_evaluator = pytest.mark.parametrize(
     "evaluator_init_func", [MeanDecreaseImpurityImportanceEvaluator, FanovaImportanceEvaluator]
 )
+
+
+@parametrize_evaluator
+@parametrize_storage
+def test_get_param_importancetarget_target_is_none_and_study_is_multi_obj(
+    storage_init_func: Callable[[], storages.BaseStorage],
+    evaluator_init_func: Callable[[], BaseImportanceEvaluator],
+) -> None:
+    def objective(trial: Trial) -> Tuple[float, float]:
+        x1 = trial.suggest_uniform("x1", 0.1, 3)
+        x2 = trial.suggest_loguniform("x2", 0.1, 3)
+        x3 = trial.suggest_discrete_uniform("x3", 0, 3, 1)
+        x4 = trial.suggest_int("x4", -3, 3)
+        x5 = trial.suggest_int("x5", 1, 5, log=True)
+        x6 = trial.suggest_categorical("x6", [1.0, 1.1, 1.2])
+        if trial.number % 2 == 0:
+            # Conditional parameters are ignored unless `params` is specified and is not `None`.
+            x7 = trial.suggest_uniform("x7", 0.1, 3)
+
+        assert isinstance(x6, float)
+        value = x1 ** 4 + x2 + x3 - x4 ** 2 - x5 + x6
+        if trial.number % 2 == 0:
+            value += x7
+        return value, 0.0
+
+    study = create_study(directions=["minimize", "minimize"], storage=storage_init_func())
+    study.optimize(objective, n_trials=3)
+
+    with pytest.raises(ValueError):
+        _ = get_param_importances(study, evaluator=evaluator_init_func())
 
 
 @parametrize_evaluator

--- a/tests/importance_tests/test_init.py
+++ b/tests/importance_tests/test_init.py
@@ -54,7 +54,7 @@ def test_get_param_importancetarget_target_is_none_and_study_is_multi_obj(
     study.optimize(objective, n_trials=3)
 
     with pytest.raises(ValueError):
-        _ = get_param_importances(study, evaluator=evaluator_init_func())
+        get_param_importances(study, evaluator=evaluator_init_func())
 
 
 @parametrize_evaluator

--- a/tests/visualization_tests/matplotlib_tests/test_param_importances.py
+++ b/tests/visualization_tests/matplotlib_tests/test_param_importances.py
@@ -7,6 +7,13 @@ from optuna.trial import Trial
 from optuna.visualization.matplotlib import plot_param_importances
 
 
+def test_target_is_none_and_study_is_multi_obj() -> None:
+
+    study = create_study(directions=["minimize", "minimize"])
+    with pytest.raises(ValueError):
+        plot_param_importances(study)
+
+
 def test_plot_param_importances() -> None:
 
     # Test with no trial.

--- a/tests/visualization_tests/test_param_importances.py
+++ b/tests/visualization_tests/test_param_importances.py
@@ -9,6 +9,13 @@ from optuna.trial import Trial
 from optuna.visualization import plot_param_importances
 
 
+def test_target_is_none_and_study_is_multi_obj() -> None:
+
+    study = create_study(directions=["minimize", "minimize"])
+    with pytest.raises(ValueError):
+        plot_param_importances(study)
+
+
 def test_plot_param_importances() -> None:
 
     # Test with no trial.


### PR DESCRIPTION
## Motivation
Part of works for #1980.
The goal of this PR is to make `get_param_importances`, `BaseImportanceEvaluator.evaluate`, and `plot_param_importances` work well in multi-objective optimization. See #2112 for details.

## Description of the changes
- Raise `ValueError` if `target` is None and `study` is being used for multi-objective optimization
- Add unit tests