### PR TITLE
Cosmetic fix of `xgboost` integration

### DIFF
--- a/optuna/integration/xgboost.py
+++ b/optuna/integration/xgboost.py
@@ -53,7 +53,7 @@ if _imports.is_successful() and use_callback_cls:
             return model
 
         def after_iteration(self, model: Any, epoch: int, evals_log: dict) -> bool:
-            evaluation_result_list = {}
+            evaluation_results = {}
             # Flatten the evaluation history to `{dataset-metric: score}` layout.
             for dataset, metrics in evals_log.items():
                 for metric, scores in metrics.items():
@@ -62,11 +62,11 @@ if _imports.is_successful() and use_callback_cls:
                     if self._is_cv:
                         # Remove stddev of the metric across the cross-valdation
                         # folds.
-                        evaluation_result_list[key] = scores[-1][0]
+                        evaluation_results[key] = scores[-1][0]
                     else:
-                        evaluation_result_list[key] = scores[-1]
+                        evaluation_results[key] = scores[-1]
 
-            current_score = evaluation_result_list[self._observation_key]
+            current_score = evaluation_results[self._observation_key]
             self._trial.report(current_score, step=epoch)
             if self._trial.should_prune():
                 message = "Trial was pruned at iteration {}.".format(epoch)


### PR DESCRIPTION
## Motivation
This is a follow-up PR of #2078.

## Description of the changes
This PR simply changes the variable name since `evaluation_result_list` is not a list but a dictionary.

In addition to that, we can apply `packaging.version` to parse xgboost version as follows:
```python
from packaging import version
...

    xgboost_version = version.parse(xgb.__version__)
    use_callback_cls = xgboost_version.major >= 1 and xgboost_version.minor >= 3
```
But, it may cause errors when the version string does not match [`VERSION_PATTERN`](https://github.com/pypa/packaging/blob/353f270a4e49283c8e98ed8c801b457665774525/packaging/version.py#L256-L285), so I keep it as it is.