### PR TITLE
[RFC] Move typehints to description from signature

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -174,6 +174,7 @@ intersphinx_mapping = {"python": ("https://docs.python.org/3", None)}
 
 # -- Extension configuration -------------------------------------------------
 autosummary_generate = True
+autodoc_typehints = "description"
 autodoc_default_options = {
     "members": True,
     "inherited-members": True,


### PR DESCRIPTION
Personally, typehints in Optuna repository are sort of complicated so
that some of the API documentation doesn't feel comfortable to read.

This pull request moves all typehints to description (Parameters
sections) from signatures.

### this pull request

![image](https://user-images.githubusercontent.com/16191443/103048358-b14c9680-45d1-11eb-94d9-89182c111ea1.png)

### current master

![image](https://user-images.githubusercontent.com/16191443/103048382-c5909380-45d1-11eb-80d1-a7531269d216.png)
