### PR TITLE
Add copy button to all the code examples

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -53,6 +53,7 @@ extensions = [
     "sphinx.ext.viewcode",
     "sphinx.ext.githubpages",
     "cliff.sphinxext",
+    "sphinx_copybutton",
     "sphinx_gallery.gen_gallery",
     "matplotlib.sphinxext.plot_directive",
     "sphinx_plotly_directive",

--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,7 @@ def get_extras_require() -> Dict[str, List[str]]:
         "document": [
             "sphinx",
             "sphinx_rtd_theme",
+            "sphinx-copybutton",
             "sphinx-gallery",
             "sphinx-plotly-directive",
             "pillow",


### PR DESCRIPTION
This pull request enables readers to copy all the code examples in
the API documentation by incorporating
`sphinx-copybutton`[https://sphinx-copybutton.readthedocs.io/en/latest/].