### PR TITLE
[Opinion Wanted] Set value and state to trial passed to `constraints_func` of `BotorchSampler`

### DIFF
--- a/optuna/integration/botorch.py
+++ b/optuna/integration/botorch.py
@@ -1,4 +1,5 @@
 from collections import OrderedDict
+import copy
 import math
 from typing import Any
 from typing import Callable
@@ -563,6 +564,10 @@ class BoTorchSampler(BaseSampler):
             constraints = None
 
             try:
+                # Trial does not have state and values since they are not persisted in the sotrage.
+                _trial = copy.copy(trial)
+                _trial.state = state
+                _trial.values = values
                 con = self._constraints_func(trial)
                 if not isinstance(con, (tuple, list)):
                     warnings.warn(

--- a/optuna/integration/botorch.py
+++ b/optuna/integration/botorch.py
@@ -568,7 +568,7 @@ class BoTorchSampler(BaseSampler):
                 _trial = copy.copy(trial)
                 _trial.state = state
                 _trial.values = values
-                con = self._constraints_func(trial)
+                con = self._constraints_func(_trial)
                 if not isinstance(con, (tuple, list)):
                     warnings.warn(
                         f"Constraints should be a sequence of floats but got {constraints}."

--- a/tests/integration_tests/test_botorch.py
+++ b/tests/integration_tests/test_botorch.py
@@ -153,6 +153,8 @@ def test_botorch_constraints_func_none(n_objectives: int) -> None:
 
         nonlocal constraints_func_call_count
         constraints_func_call_count += 1
+        assert trial.state == optuna.trial.TrialState.COMPLETE
+        assert len(trial.values) == n_objectives
 
         return (xs - 0.5,)
 


### PR DESCRIPTION
## Motivation

In `constraints_func`, users cannot obtain trial values with the `trial` argument. In my understanding, this is because `after_trial` method is called before persisting the trial. Due to this limitation, we need to store objective values to `trial.user_attrs` to access them in `constraint_func`.

This design is quite consistent, but I guess it may not be intuitive for novice users of `BoTorchSampler`. They may want to access `trial.values` directly. Unlike `after_trial`, users cannot access the `study` object and I think they will not face any inconsistency of trial states even if we overwrite the `value` of `trial`.

## Description of the changes

Set `value` and `state` to `trial` before it is passed to the `constraints_func`.