### PR TITLE
`TFKerasPruningCallback` to warn when an evaluation metric does not exist

### DIFF
--- a/optuna/integration/tfkeras.py
+++ b/optuna/integration/tfkeras.py
@@ -1,6 +1,7 @@
 from typing import Any
 from typing import Dict
 from typing import Optional
+import warnings
 
 import optuna
 
@@ -45,6 +46,11 @@ class TFKerasPruningCallback(Callback):
         current_score = logs.get(self._monitor)
 
         if current_score is None:
+            message = (
+                "The metric '{}' is not in the evaluation logs for pruning. "
+                "Please make sure you set the correct metric name.".format(self._monitor)
+            )
+            warnings.warn(message)
             return
 
         # Report current score and epoch to Optuna's trial.

--- a/tests/integration_tests/test_tfkeras.py
+++ b/tests/integration_tests/test_tfkeras.py
@@ -56,7 +56,7 @@ def test_tfkeras_pruning_callback_observation_isnan() -> None:
 
 
 def test_tfkeras_pruning_callback_monitor_is_invalid() -> None:
-    
+
     study = optuna.create_study(pruner=DeterministicPruner(True))
     trial = create_running_trial(study, 1.0)
     callback = TFKerasPruningCallback(trial, "InvalidMonitor")

--- a/tests/integration_tests/test_tfkeras.py
+++ b/tests/integration_tests/test_tfkeras.py
@@ -53,3 +53,13 @@ def test_tfkeras_pruning_callback_observation_isnan() -> None:
 
     with pytest.raises(optuna.TrialPruned):
         callback.on_epoch_end(0, {"loss": float("nan")})
+
+
+def test_tfkeras_pruning_callback_monitor_is_invalid() -> None:
+    
+    study = optuna.create_study(pruner=DeterministicPruner(True))
+    trial = create_running_trial(study, 1.0)
+    callback = TFKerasPruningCallback(trial, "InvalidMonitor")
+
+    with pytest.warns(UserWarning):
+        callback.on_epoch_end(0, {"loss": 1.0})


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
Please refer to the issue #1226 .

## Description of the changes
<!-- Describe the changes in this PR. -->
I added a warning message which will be displayed to users when there is no evaluation metric for pruning specified by them.