### PR TITLE
Ask and Tell API (`Study.ask`, `Study.tell`)

### DIFF
--- a/optuna/_optimize.py
+++ b/optuna/_optimize.py
@@ -185,7 +185,7 @@ def _run_trial(
     func: "optuna.study.ObjectiveFuncType",
     catch: Tuple[Type[Exception], ...],
 ) -> trial_module.Trial:
-    trial = study._ask()
+    trial = study.ask()
 
     state: Optional[TrialState] = None
     values: Optional[List[float]] = None
@@ -219,13 +219,12 @@ def _run_trial(
         else:
             state = TrialState.COMPLETE
 
+    # `Study.tell` may raise during trial post-processing.
     try:
-        trial._after_func(state, values)
+        study.tell(trial, values=values, state=state)
     except Exception:
         raise
     finally:
-        study._tell(trial, state, values)
-
         if state == TrialState.COMPLETE:
             study._log_completed_trial(trial, cast(List[float], values))
         elif state == TrialState.PRUNED:

--- a/optuna/_optimize.py
+++ b/optuna/_optimize.py
@@ -198,19 +198,14 @@ def _run_trial(
         value_or_values = func(trial)
     except exceptions.TrialPruned as e:
         # TODO(mamu): Handle multi-objective cases.
-        # Register the last intermediate value if present as the value of the trial.
-        # TODO(hvy): Whether a pruned trials should have an actual value can be discussed.
         state = TrialState.PRUNED
-        frozen_trial = study._storage.get_trial(trial._trial_id)
-        last_step = frozen_trial.last_step
-        if last_step is not None:
-            values = [frozen_trial.intermediate_values[last_step]]
         func_err = e
     except Exception as e:
         state = TrialState.FAIL
         func_err = e
         func_err_fail_exc_info = sys.exc_info()
     else:
+        # TODO(hvy): Avoid checking the values both here and inside `Study.tell`.
         values, values_conversion_failure_message = _check_and_convert_to_values(
             len(study.directions), value_or_values, trial.number
         )

--- a/optuna/_optimize.py
+++ b/optuna/_optimize.py
@@ -212,7 +212,7 @@ def _run_trial(
         func_err_fail_exc_info = sys.exc_info()
     else:
         values, values_conversion_failure_message = _check_and_convert_to_values(
-            len(study.directions), value_or_values, trial
+            len(study.directions), value_or_values, trial.number
         )
         if values_conversion_failure_message is not None:
             state = TrialState.FAIL
@@ -250,14 +250,14 @@ def _run_trial(
 
 
 def _check_and_convert_to_values(
-    n_objectives: int, original_value: Union[float, Sequence[float]], trial: trial_module.Trial
+    n_objectives: int, original_value: Union[float, Sequence[float]], trial_number: int
 ) -> Tuple[Optional[List[float]], Optional[str]]:
     if isinstance(original_value, Sequence):
         if n_objectives != len(original_value):
             return (
                 None,
                 (
-                    f"Trial {trial.number} failed, because the number of the values "
+                    f"Trial {trial_number} failed, because the number of the values "
                     f"{len(original_value)} is did not match the number of the objectives "
                     f"{n_objectives}."
                 ),
@@ -269,7 +269,7 @@ def _check_and_convert_to_values(
 
     _checked_values = []
     for v in _original_values:
-        checked_v, failure_message = _check_single_value(v, trial)
+        checked_v, failure_message = _check_single_value(v, trial_number)
         if failure_message is not None:
             # TODO(Imamura): Construct error message taking into account all values and do not
             #  early return
@@ -284,7 +284,7 @@ def _check_and_convert_to_values(
 
 
 def _check_single_value(
-    original_value: float, trial: trial_module.Trial
+    original_value: float, trial_number: int
 ) -> Tuple[Optional[float], Optional[str]]:
     value = None
     failure_message = None
@@ -296,15 +296,14 @@ def _check_single_value(
         TypeError,
     ):
         failure_message = (
-            f"Trial {trial.number} failed, because the returned value from the "
-            f"objective function cannot be cast to float. Returned value is: "
-            f"{repr(original_value)}"
+            f"Trial {trial_number} failed, because the value {repr(original_value)} could not be "
+            "cast to float."
         )
 
     if value is not None and math.isnan(value):
         value = None
         failure_message = (
-            f"Trial {trial.number} failed, because the objective function returned "
+            f"Trial {trial_number} failed, because the objective function returned "
             f"{original_value}."
         )
 

--- a/optuna/study.py
+++ b/optuna/study.py
@@ -541,7 +541,10 @@ class Study(BaseStudy):
             values, values_conversion_failure_message = _check_and_convert_to_values(
                 len(self.directions), values, trial_number
             )
-            if values_conversion_failure_message is not None:
+            # When called from `Study.optimize` and `state` is pruned, the given `values` contains
+            # the intermediate value with the largest step so far. In this case, the value is
+            # allowed to be NaN and errors should not be raised.
+            if state != TrialState.PRUNED and values_conversion_failure_message is not None:
                 raise ValueError(values_conversion_failure_message)
 
         assert trial_id is not None

--- a/optuna/study.py
+++ b/optuna/study.py
@@ -529,6 +529,12 @@ class Study(BaseStudy):
                 trial_id = self._storage.get_trial_id_from_study_id_trial_number(
                     self._study_id, trial_number
                 )
+            except NotImplementedError as e:
+                raise TypeError(
+                    "Study.tell failed because the trial was represented by its number but the "
+                    f"storage {self._storage.__class__.__name__} does not implement the method "
+                    "required to map numbers back. Please provide the trial object instead."
+                ) from e
             except KeyError as e:
                 raise ValueError(
                     f"Cannot tell for trial with number {trial_number} since it has not been "

--- a/optuna/study.py
+++ b/optuna/study.py
@@ -397,7 +397,7 @@ class Study(BaseStudy):
         values: Optional[Union[float, List[float]]] = None,
         state: TrialState = TrialState.COMPLETE,
     ) -> None:
-        self._validate_tell(trial, values, state)
+        _check_tell_args(trial, values, state)
 
         # TODO(hvy): Do trial post-processing with `after_trial`.
 
@@ -410,27 +410,6 @@ class Study(BaseStudy):
             self._storage.set_trial_values(trial._trial_id, values)
 
         self._storage.set_trial_state(trial._trial_id, state)
-
-    def _validate_tell(
-        self,
-        trial: trial_module.Trial,
-        values: Optional[Union[float, List[float]]],
-        state: TrialState,
-    ) -> None:
-        if state == TrialState.COMPLETE:
-            if values is None:
-                raise ValueError(
-                    "No values were told. Values are required when state is TrialState.COMPLETE."
-                )
-        elif state == TrialState.PRUNED:
-            pass
-        elif state == TrialState.FAIL:
-            if values is not None:
-                raise ValueError(
-                    "Values were told. Values cannot be stored when state is TrialState.FAIL."
-                )
-        else:
-            raise ValueError("Cannot tell with state {state}.")
 
     def set_user_attr(self, key: str, value: Any) -> None:
         """Set a user attribute to the study.
@@ -1034,3 +1013,24 @@ def get_all_study_summaries(storage: Union[str, storages.BaseStorage]) -> List[S
 
     storage = storages.get_storage(storage)
     return storage.get_all_study_summaries()
+
+
+def _check_tell_args(
+    trial: trial_module.Trial,
+    values: Optional[Union[float, List[float]]],
+    state: TrialState,
+) -> None:
+    if state == TrialState.COMPLETE:
+        if values is None:
+            raise ValueError(
+                "No values were told. Values are required when state is TrialState.COMPLETE."
+            )
+    elif state == TrialState.PRUNED:
+        pass
+    elif state == TrialState.FAIL:
+        if values is not None:
+            raise ValueError(
+                "Values were told. Values cannot be stored when state is TrialState.FAIL."
+            )
+    else:
+        raise ValueError(f"Cannot tell with state {state}.")

--- a/optuna/study.py
+++ b/optuna/study.py
@@ -19,6 +19,7 @@ from optuna import storages
 from optuna import trial as trial_module
 from optuna._dataframe import _trials_dataframe
 from optuna._dataframe import pd
+from optuna._deprecated import deprecated
 from optuna._experimental import experimental
 from optuna._multi_objective import _get_pareto_front_trials
 from optuna._optimize import _check_and_convert_to_values
@@ -862,14 +863,14 @@ class Study(BaseStudy):
 
         return None
 
+    @deprecated("2.5.0")
     def _ask(self) -> trial_module.Trial:
-        # TODO(hvy): Remove this method since `Study.ask` has been implemented.
         return self.ask()
 
+    @deprecated("2.5.0")
     def _tell(
         self, trial: trial_module.Trial, state: TrialState, values: Optional[List[float]]
     ) -> None:
-        # TODO(hvy): Remove this method since `Study.tell` has been implemented.
         self.tell(trial, values, state)
 
     def _log_completed_trial(self, trial: trial_module.Trial, values: Sequence[float]) -> None:

--- a/optuna/study.py
+++ b/optuna/study.py
@@ -414,15 +414,14 @@ class Study(BaseStudy):
     def _validate_tell(
         self,
         trial: trial_module.Trial,
-        values: Optional[Union[float, List[float]]] = None,
-        state: TrialState = TrialState.COMPLETE,
+        values: Optional[Union[float, List[float]]],
+        state: TrialState,
     ) -> None:
         if state == TrialState.COMPLETE:
             if values is None:
                 raise ValueError(
                     "No values were told. Values are required when state is TrialState.COMPLETE."
                 )
-            state = TrialState.COMPLETE
         elif state == TrialState.PRUNED:
             pass
         elif state == TrialState.FAIL:

--- a/optuna/study.py
+++ b/optuna/study.py
@@ -555,9 +555,9 @@ class Study(BaseStudy):
 
         try:
             # Sampler defined trial post-processing.
-            trial = self._storage.get_trial(trial_id)
-            study = pruners._filter_study(self, trial)
-            self.sampler.after_trial(study, trial, state, values)
+            frozen_trial = self._storage.get_trial(trial_id)
+            study = pruners._filter_study(self, frozen_trial)
+            self.sampler.after_trial(study, frozen_trial, state, values)
         except Exception:
             raise
         finally:

--- a/optuna/study.py
+++ b/optuna/study.py
@@ -409,7 +409,7 @@ class Study(BaseStudy):
             A :class:`~optuna.trial.Trial`.
         """
 
-        # Sync storage once at the beginning of the objective evaluation.
+        # Sync storage once every trial.
         self._storage.read_trials_from_remote_storage(self._study_id)
 
         trial_id = self._pop_waiting_trial_id()

--- a/tests/samplers_tests/test_samplers.py
+++ b/tests/samplers_tests/test_samplers.py
@@ -597,3 +597,27 @@ def test_after_trial_failing_in_after_trial() -> None:
 
     assert len(study.trials) == 1
     assert n_calls == 2
+
+
+def test_after_trial_with_study_tell() -> None:
+    n_calls = 0
+
+    class SamplerAfterTrial(DeterministicRelativeSampler):
+        def after_trial(
+            self,
+            study: Study,
+            trial: FrozenTrial,
+            state: TrialState,
+            values: Optional[Sequence[float]],
+        ) -> None:
+            nonlocal n_calls
+            n_calls += 1
+
+    sampler = SamplerAfterTrial({}, {})
+    study = optuna.create_study(sampler=sampler)
+
+    assert n_calls == 0
+
+    study.tell(study.ask(), 1.0)
+
+    assert n_calls == 1

--- a/tests/test_study.py
+++ b/tests/test_study.py
@@ -10,6 +10,7 @@ from typing import Dict
 from typing import List
 from typing import Optional
 from typing import Tuple
+from typing import Union
 from unittest.mock import Mock  # NOQA
 from unittest.mock import patch
 import uuid
@@ -25,6 +26,7 @@ from optuna import _optimize
 from optuna import create_trial
 from optuna.study import StudyDirection
 from optuna.testing.storage import StorageSupplier
+from optuna.trial import Trial
 from optuna.trial import TrialState
 
 
@@ -1105,3 +1107,25 @@ def test_wrong_n_objectives() -> None:
 
     for trial in study.trials:
         assert trial.state is TrialState.FAIL
+
+
+@pytest.mark.parametrize(
+    "values",
+    [
+        1.0,  # "value" single-objective optimization interface.
+        [1.0],  # "values" multi-objective optimization interface.
+    ],
+)
+def test_ask_and_tell(values: Union[float, List[float]]) -> None:
+    study = optuna.create_study()
+    trial = study.ask()
+
+    assert isinstance(trial, Trial)
+
+    with pytest.raises(ValueError):  # Values missing.
+        study.tell(trial)
+
+    study.tell(trial, values)
+
+    with pytest.raises(RuntimeError):  # Trial already finished.
+        study.tell(trial, values)

--- a/tests/test_study.py
+++ b/tests/test_study.py
@@ -1151,17 +1151,6 @@ def test_tell() -> None:
         study.tell(study.ask(), state=TrialState.WAITING)
 
 
-def test_tell_complete_without_values() -> None:
-    study = optuna.create_study()
-
-    with pytest.raises(ValueError):
-        study.tell(study.ask(), state=TrialState.COMPLETE)
-
-    # Default state is `TrialState.COMPLETE` for which values are required.
-    with pytest.raises(ValueError):
-        study.tell(study.ask())
-
-
 def test_tell_trial_variations() -> None:
     study = optuna.create_study()
 
@@ -1192,6 +1181,10 @@ def test_tell_values() -> None:
 
     study.tell(study.ask(), [1.0])
 
+    # Check invalid values, e.g. ones that cannot be cast to float.
+    with pytest.raises(ValueError):
+        study.tell(study.ask(), "a")  # type: ignore
+
     # Check number of values.
     with pytest.raises(ValueError):
         study.tell(study.ask(), [])
@@ -1210,3 +1203,11 @@ def test_tell_values() -> None:
 
     with pytest.raises(ValueError):
         study.tell(study.ask(), [1.0, 2.0, 3.0])
+
+    # Missing values for completions.
+    with pytest.raises(ValueError):
+        study.tell(study.ask(), state=TrialState.COMPLETE)
+
+    # Default state is `TrialState.COMPLETE` for which values are required.
+    with pytest.raises(ValueError):
+        study.tell(study.ask())

--- a/tests/test_study.py
+++ b/tests/test_study.py
@@ -1229,3 +1229,20 @@ def test_tell_storage_not_implemented_trial_number() -> None:
             # trial IDs.
             with pytest.raises(TypeError):
                 study.tell(study.ask().number, 1.0)
+
+
+def test_tell_pruned_values() -> None:
+    # See also `test_run_trial_with_trial_pruned`.
+    study = optuna.create_study()
+
+    trial = study.ask()
+
+    trial.report(2.0, step=1)
+
+    study.tell(trial, state=TrialState.PRUNED)
+    assert study.trials[-1].value == 2.0
+
+    trial = study.ask()
+
+    study.tell(trial, state=TrialState.PRUNED)
+    assert study.trials[-1].value is None

--- a/tests/test_study.py
+++ b/tests/test_study.py
@@ -1211,3 +1211,21 @@ def test_tell_values() -> None:
     # Default state is `TrialState.COMPLETE` for which values are required.
     with pytest.raises(ValueError):
         study.tell(study.ask())
+
+
+def test_tell_storage_not_implemented_trial_number() -> None:
+    with StorageSupplier("inmemory") as storage:
+
+        with patch.object(
+            storage,
+            "get_trial_id_from_study_id_trial_number",
+            side_effect=NotImplementedError,
+        ):
+            study = optuna.create_study(storage=storage)
+
+            study.tell(study.ask(), 1.0)
+
+            # Storage missing implementation for method required to map trial numbers back to
+            # trial IDs.
+            with pytest.raises(TypeError):
+                study.tell(study.ask().number, 1.0)

--- a/tests/test_study.py
+++ b/tests/test_study.py
@@ -1227,8 +1227,11 @@ def test_tell_storage_not_implemented_trial_number() -> None:
 
             # Storage missing implementation for method required to map trial numbers back to
             # trial IDs.
-            with pytest.raises(TypeError):
+            with pytest.warns(UserWarning):
                 study.tell(study.ask().number, 1.0)
+
+            with pytest.raises(ValueError):
+                study.tell(study.ask().number + 1, 1.0)
 
 
 def test_tell_pruned_values() -> None:


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation

`Study.optimize` is a high-level API that takes care of trial creation, objective function evaluation, parallelism, etc. Sometimes, lower level operations are useful to gain finer control of the lifetime of a trial. Such cases involve arbitrary scheduling of trial suggestion, objective evaluation, for instance to have those two run on different processes.

## Description of the changes

Introduces an ask and tell API to provide a lower level alternative to `Study.optimize`.

~Depends on https://github.com/optuna/optuna/pull/2168.~ Edit: Merged.

### Example Usage

```python
# NOTE: Where `Trial`s are passed as arguments, trial numbers can be passed as well.

# Example 1: Simple case without pruning and no error handling.
trial = study.ask()
values = objective(trial)
study.tell(trial, values)

# Example 2: With error handling.
trial = study.ask()

values = None
try:
    values = objective(trial)
except TrialPruned:
    state = TrialState.PRUNED
except Exception:
    state = TrialState.FAIL
else:
    state = TrialState.COMPLETE
finally:
    study.tell(trial, values=values, state=state)

# Example 3: No `func` objective function.
trial = study.ask()

loss = None
state = TrialState.COMPLETE

lr = trial.suggest_float("lr", 1e-5, 1e-3, log=True)
n_layers = trial.suggest_int("n_layers", 3, 5)
# Evaluation follows. This can be scheduled arbitrarily by the user to other workers.
for epoch in range(epochs):
    loss = ...
    study.report(trial, loss, step=epoch)  # `Trial.report` also possible.
    if study.should_prune(trial):
        state = TrialState.PRUNED
        break

loss = ...  # Validation.

study.tell(trial, values=loss, state=state)
```

## TODO

- [x] Design
- [ ] ~Reporting (`Study.report`)~ Will be a separate PR
- [ ] ~Pruning (`Study.should_prune`)~ Will be a separate PR
- [x] Refactoring e.g. `_optimize.py`, delete usages of `Study._{ask,tell}`
- [x] Documentation
- [x] Tests
- [x] Example