### PR TITLE
Fix `scipy==1.6.0` test failure with `LogisticRegression`

### DIFF
--- a/tests/integration_tests/test_sklearn.py
+++ b/tests/integration_tests/test_sklearn.py
@@ -77,7 +77,7 @@ def test_optuna_search(enable_pruning: bool, fit_params: str) -> None:
 def test_optuna_search_properties() -> None:
 
     X, y = make_blobs(n_samples=10)
-    est = LogisticRegression(max_iter=5, tol=1e-03)
+    est = LogisticRegression(tol=1e-03)
     param_dist = {"C": distributions.LogUniformDistribution(1e-04, 1e03)}
 
     optuna_search = integration.OptunaSearchCV(


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation

See below.

## Description of the changes

Fixes a failing unit test due to the recent update of SciPy to 1.6.0. I'm not too confident that this is the correct solution.

Example https://github.com/optuna/optuna/pull/2158/checks?check_run_id=1642335680

```
________________________ test_optuna_search_properties _________________________

    @pytest.mark.filterwarnings("ignore::UserWarning")
    def test_optuna_search_properties() -> None:
    
        X, y = make_blobs(n_samples=10)
        est = LogisticRegression(max_iter=5, tol=1e-03)
        param_dist = {"C": distributions.LogUniformDistribution(1e-04, 1e03)}
    
        optuna_search = integration.OptunaSearchCV(
            est, param_dist, cv=3, error_score="raise", random_state=0, return_train_score=True
        )
>       optuna_search.fit(X, y)

tests/integration_tests/test_sklearn.py:86: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
optuna/integration/sklearn.py:861: in fit
    self.study_.optimize(
optuna/study.py:372: in optimize
    _optimize(
optuna/_optimize.py:60: in _optimize
    _optimize_sequential(
optuna/_optimize.py:161: in _optimize_sequential
    trial = _run_trial(study, func, catch)
optuna/_optimize.py:249: in _run_trial
    raise func_err
optuna/_optimize.py:198: in _run_trial
    value_or_values = func(trial)
optuna/integration/sklearn.py:229: in __call__
    scores = cross_validate(
/opt/hostedtoolcache/Python/3.8.6/x64/lib/python3.8/site-packages/sklearn/model_selection/_validation.py:230: in cross_validate
    scores = parallel(
/opt/hostedtoolcache/Python/3.8.6/x64/lib/python3.8/site-packages/joblib/parallel.py:1041: in __call__
    if self.dispatch_one_batch(iterator):
/opt/hostedtoolcache/Python/3.8.6/x64/lib/python3.8/site-packages/joblib/parallel.py:859: in dispatch_one_batch
    self._dispatch(tasks)
/opt/hostedtoolcache/Python/3.8.6/x64/lib/python3.8/site-packages/joblib/parallel.py:777: in _dispatch
    job = self._backend.apply_async(batch, callback=cb)
/opt/hostedtoolcache/Python/3.8.6/x64/lib/python3.8/site-packages/joblib/_parallel_backends.py:208: in apply_async
    result = ImmediateResult(func)
/opt/hostedtoolcache/Python/3.8.6/x64/lib/python3.8/site-packages/joblib/_parallel_backends.py:572: in __init__
    self.results = batch()
/opt/hostedtoolcache/Python/3.8.6/x64/lib/python3.8/site-packages/joblib/parallel.py:262: in __call__
    return [func(*args, **kwargs)
/opt/hostedtoolcache/Python/3.8.6/x64/lib/python3.8/site-packages/joblib/parallel.py:262: in <listcomp>
    return [func(*args, **kwargs)
/opt/hostedtoolcache/Python/3.8.6/x64/lib/python3.8/site-packages/sklearn/model_selection/_validation.py:515: in _fit_and_score
    estimator.fit(X_train, y_train, **fit_params)
/opt/hostedtoolcache/Python/3.8.6/x64/lib/python3.8/site-packages/sklearn/linear_model/_logistic.py:1591: in fit
    fold_coefs_ = Parallel(n_jobs=self.n_jobs, verbose=self.verbose,
/opt/hostedtoolcache/Python/3.8.6/x64/lib/python3.8/site-packages/joblib/parallel.py:1041: in __call__
    if self.dispatch_one_batch(iterator):
/opt/hostedtoolcache/Python/3.8.6/x64/lib/python3.8/site-packages/joblib/parallel.py:859: in dispatch_one_batch
    self._dispatch(tasks)
/opt/hostedtoolcache/Python/3.8.6/x64/lib/python3.8/site-packages/joblib/parallel.py:777: in _dispatch
    job = self._backend.apply_async(batch, callback=cb)
/opt/hostedtoolcache/Python/3.8.6/x64/lib/python3.8/site-packages/joblib/_parallel_backends.py:208: in apply_async
    result = ImmediateResult(func)
/opt/hostedtoolcache/Python/3.8.6/x64/lib/python3.8/site-packages/joblib/_parallel_backends.py:572: in __init__
    self.results = batch()
/opt/hostedtoolcache/Python/3.8.6/x64/lib/python3.8/site-packages/joblib/parallel.py:262: in __call__
    return [func(*args, **kwargs)
/opt/hostedtoolcache/Python/3.8.6/x64/lib/python3.8/site-packages/joblib/parallel.py:262: in <listcomp>
    return [func(*args, **kwargs)
/opt/hostedtoolcache/Python/3.8.6/x64/lib/python3.8/site-packages/sklearn/linear_model/_logistic.py:938: in _logistic_regression_path
    n_iter_i = _check_optimize_result(
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

solver = 'lbfgs'
result =       fun: 2.9209438347317094
 hess_inv: <9x9 LbfgsInvHessProduct with dtype=float64>
      jac: array([ 0.51057579,  ...356798,  0.15329435,  0.02658693,  0.16680465,  0.12760519,
       -0.03215521, -0.03323667, -0.28089955,  0.00556828])
max_iter = 5
extra_warning_msg = 'Please also refer to the documentation for alternative solver options:\n    https://scikit-learn.org/stable/modules/linear_model.html#logistic-regression'

    def _check_optimize_result(solver, result, max_iter=None,
                               extra_warning_msg=None):
        """Check the OptimizeResult for successful convergence
    
        Parameters
        ----------
        solver: str
           solver name. Currently only `lbfgs` is supported.
        result: OptimizeResult
           result of the scipy.optimize.minimize function
        max_iter: {int, None}
           expected maximum number of iterations
    
        Returns
        -------
        n_iter: int
           number of iterations
        """
        # handle both scipy and scikit-learn solver names
        if solver == "lbfgs":
            if result.status != 0:
                warning_msg = (
                    "{} failed to converge (status={}):\n{}.\n\n"
                    "Increase the number of iterations (max_iter) "
                    "or scale the data as shown in:\n"
                    "    https://scikit-learn.org/stable/modules/"
                    "preprocessing.html"
>               ).format(solver, result.status, result.message.decode("latin1"))
E               AttributeError: 'str' object has no attribute 'decode'

/opt/hostedtoolcache/Python/3.8.6/x64/lib/python3.8/site-packages/sklearn/utils/optimize.py:243: AttributeError
----------------------------- Captured stderr call -----------------------------
[I 2021-01-04 07:19:18,383] A new study created in memory with name: no-name-623f13fa-4953-44e7-aaa7-a0d11a52aba2
[W 2021-01-04 07:19:18,389] Trial 0 failed because of the following error: AttributeError("'str' object has no attribute 'decode'")
```
