### PR TITLE
Storages to query trial IDs from numbers

### DIFF
--- a/optuna/storages/_base.py
+++ b/optuna/storages/_base.py
@@ -377,6 +377,24 @@ class BaseStorage(object, metaclass=abc.ABCMeta):
         """
         raise NotImplementedError
 
+    def get_trial_id_from_study_id_trial_number(self, study_id: int, trial_number: int) -> int:
+        """Read the trial id of a trial.
+
+        Args:
+            study_id:
+                ID of the study.
+            trial_number:
+                Number of the trial.
+
+        Returns:
+            ID of the trial.
+
+        Raises:
+            :exc:`KeyError`:
+                If no trial with the matching ``study_id`` and ``trial_number`` exists.
+        """
+        raise NotImplementedError
+
     @abc.abstractmethod
     def get_trial_number_from_id(self, trial_id: int) -> int:
         """Read the trial number of a trial.

--- a/optuna/storages/_cached_storage.py
+++ b/optuna/storages/_cached_storage.py
@@ -260,6 +260,11 @@ class _CachedStorage(BaseStorage):
 
         self._backend.set_trial_param(trial_id, param_name, param_value_internal, distribution)
 
+    def get_trial_id_from_study_id_trial_number(self, study_id: int, trial_number: int) -> int:
+
+        # TODO(hvy): Optimize to not issue a query to the backend storage.
+        return self._backend.get_trial_id_from_study_id_trial_number(study_id, trial_number)
+
     def get_trial_number_from_id(self, trial_id: int) -> int:
 
         return self.get_trial(trial_id).number

--- a/optuna/storages/_in_memory.py
+++ b/optuna/storages/_in_memory.py
@@ -268,6 +268,26 @@ class InMemoryStorage(BaseStorage):
             trial.distributions[param_name] = distribution
             self._set_trial(trial_id, trial)
 
+    def get_trial_id_from_study_id_trial_number(self, study_id: int, trial_number: int) -> int:
+
+        with self._lock:
+            study = self._studies.get(study_id)
+            if study is None:
+                raise KeyError("No study with study_id {} exists.".format(study_id))
+
+            trials = study.trials
+            if len(trials) <= trial_number:
+                raise KeyError(
+                    "No trial with trial number {} exists in study with study_id {}.".format(
+                        trial_number, study_id
+                    )
+                )
+
+            trial = trials[trial_number]
+            assert trial.number == trial_number
+
+            return trial._trial_id
+
     def get_trial_number_from_id(self, trial_id: int) -> int:
 
         with self._lock:

--- a/optuna/storages/_rdb/storage.py
+++ b/optuna/storages/_rdb/storage.py
@@ -908,6 +908,25 @@ class RDBStorage(BaseStorage):
         else:
             attribute.value_json = json.dumps(value)
 
+    def get_trial_id_from_study_id_trial_number(self, study_id: int, trial_number: int) -> int:
+
+        with _create_scoped_session(self.scoped_session) as session:
+            trial_id = (
+                session.query(models.TrialModel.trial_id)
+                .filter(
+                    models.TrialModel.number == trial_number,
+                    models.TrialModel.study_id == study_id,
+                )
+                .one_or_none()
+            )
+            if trial_id is None:
+                raise KeyError(
+                    "No trial with trial number {} exists in study with study_id {}.".format(
+                        trial_number, study_id
+                    )
+                )
+            return trial_id[0]
+
     def get_trial_number_from_id(self, trial_id: int) -> int:
 
         trial_number = self.get_trial(trial_id).number

--- a/optuna/storages/_redis.py
+++ b/optuna/storages/_redis.py
@@ -396,6 +396,18 @@ class RedisStorage(BaseStorage):
             pipe.set(self._key_trial(trial_id), pickle.dumps(trial))
             pipe.execute()
 
+    def get_trial_id_from_study_id_trial_number(self, study_id: int, trial_number: int) -> int:
+
+        trial_ids = self._get_study_trials(study_id)
+        if len(trial_ids) <= trial_number:
+            raise KeyError(
+                "No trial with trial number {} exists in study with study_id {}.".format(
+                    trial_number, study_id
+                )
+            )
+
+        return trial_ids[trial_number]
+
     def get_trial_number_from_id(self, trial_id: int) -> int:
 
         return self.get_trial(trial_id).number

--- a/tests/storages_tests/test_storages.py
+++ b/tests/storages_tests/test_storages.py
@@ -1084,10 +1084,8 @@ def test_get_trial_id_from_study_id_trial_number(storage_mode: str) -> None:
         # study. Create a second study within the same storage.
         study_id = storage.create_new_study()
 
-        storage.create_new_trial(study_id)
-        storage.create_new_trial(study_id)
         trial_id = storage.create_new_trial(study_id)
 
         assert trial_id == storage.get_trial_id_from_study_id_trial_number(
-            study_id, trial_number=2
+            study_id, trial_number=0
         )

--- a/tests/storages_tests/test_storages.py
+++ b/tests/storages_tests/test_storages.py
@@ -1060,3 +1060,34 @@ def test_get_best_trial_for_multi_objective_optimization(storage_mode: str) -> N
             storage.create_new_trial(study_id, template_trial=template_trial)
         with pytest.raises(ValueError):
             storage.get_best_trial(study_id)
+
+
+@pytest.mark.parametrize("storage_mode", STORAGE_MODES)
+def test_get_trial_id_from_study_id_trial_number(storage_mode: str) -> None:
+
+    with StorageSupplier(storage_mode) as storage:
+        with pytest.raises(KeyError):  # Matching study does not exist.
+            storage.get_trial_id_from_study_id_trial_number(study_id=0, trial_number=0)
+
+        study_id = storage.create_new_study()
+
+        with pytest.raises(KeyError):  # Matching trial does not exist.
+            storage.get_trial_id_from_study_id_trial_number(study_id, trial_number=0)
+
+        trial_id = storage.create_new_trial(study_id)
+
+        assert trial_id == storage.get_trial_id_from_study_id_trial_number(
+            study_id, trial_number=0
+        )
+
+        # Trial IDs are globally unique within a storage but numbers are only unique within a
+        # study. Create a second study within the same storage.
+        study_id = storage.create_new_study()
+
+        storage.create_new_trial(study_id)
+        storage.create_new_trial(study_id)
+        trial_id = storage.create_new_trial(study_id)
+
+        assert trial_id == storage.get_trial_id_from_study_id_trial_number(
+            study_id, trial_number=2
+        )


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation

It is sometimes necessary in the internals (e.g. https://github.com/optuna/optuna/pull/2158) to be able to query for the trial ID given a trial number. The reason is that the latter is part of the public API while the ID is private and conversions are needed.

## Description of the changes

Introduces a method to the storage. This method return the trial ID given a study ID and a trial number.
