### PR TITLE
Warn default target name when target is specified

### DIFF
--- a/optuna/visualization/_contour.py
+++ b/optuna/visualization/_contour.py
@@ -14,6 +14,7 @@ from optuna.study import Study
 from optuna.trial import FrozenTrial
 from optuna.trial import TrialState
 from optuna.visualization._plotly_imports import _imports
+from optuna.visualization._utils import _check_plot_args
 from optuna.visualization._utils import _is_categorical
 from optuna.visualization._utils import _is_log_scale
 
@@ -84,11 +85,7 @@ def plot_contour(
     """
 
     _imports.check()
-    if target is None and study._is_multi_objective():
-        raise ValueError(
-            "If the `study` is being used for multi-objective optimization, "
-            "please specify the `target`."
-        )
+    _check_plot_args(study, target, target_name)
     return _get_contour_plot(study, params, target, target_name)
 
 

--- a/optuna/visualization/_edf.py
+++ b/optuna/visualization/_edf.py
@@ -13,6 +13,7 @@ from optuna.study import Study
 from optuna.trial import FrozenTrial
 from optuna.trial import TrialState
 from optuna.visualization._plotly_imports import _imports
+from optuna.visualization._utils import _check_plot_args
 
 
 if _imports.is_successful():
@@ -110,11 +111,7 @@ def plot_edf(
     else:
         studies = list(study)
 
-    if target is None and any(study._is_multi_objective() for study in studies):
-        raise ValueError(
-            "If the `study` is being used for multi-objective optimization, "
-            "please specify the `target`."
-        )
+    _check_plot_args(studies, target, target_name)
 
     return _get_edf_plot(studies, target, target_name)
 

--- a/optuna/visualization/_optimization_history.py
+++ b/optuna/visualization/_optimization_history.py
@@ -7,6 +7,7 @@ from optuna.study import Study
 from optuna.trial import FrozenTrial
 from optuna.trial import TrialState
 from optuna.visualization._plotly_imports import _imports
+from optuna.visualization._utils import _check_plot_args
 
 
 if _imports.is_successful():
@@ -66,11 +67,7 @@ def plot_optimization_history(
     """
 
     _imports.check()
-    if target is None and study._is_multi_objective():
-        raise ValueError(
-            "If the `study` is being used for multi-objective optimization, "
-            "please specify the `target`."
-        )
+    _check_plot_args(study, target, target_name)
     return _get_optimization_history_plot(study, target, target_name)
 
 

--- a/optuna/visualization/_parallel_coordinate.py
+++ b/optuna/visualization/_parallel_coordinate.py
@@ -13,6 +13,7 @@ from optuna.study import Study
 from optuna.trial import FrozenTrial
 from optuna.trial import TrialState
 from optuna.visualization._plotly_imports import _imports
+from optuna.visualization._utils import _check_plot_args
 
 
 if _imports.is_successful():
@@ -77,11 +78,7 @@ def plot_parallel_coordinate(
     """
 
     _imports.check()
-    if target is None and study._is_multi_objective():
-        raise ValueError(
-            "If the `study` is being used for multi-objective optimization, "
-            "please specify the `target`."
-        )
+    _check_plot_args(study, target, target_name)
     return _get_parallel_coordinate_plot(study, params, target, target_name)
 
 

--- a/optuna/visualization/_param_importances.py
+++ b/optuna/visualization/_param_importances.py
@@ -17,6 +17,7 @@ from optuna.study import Study
 from optuna.trial import FrozenTrial
 from optuna.trial import TrialState
 from optuna.visualization._plotly_imports import _imports
+from optuna.visualization._utils import _check_plot_args
 
 
 if _imports.is_successful():
@@ -105,12 +106,7 @@ def plot_param_importances(
     """
 
     _imports.check()
-
-    if target is None and study._is_multi_objective():
-        raise ValueError(
-            "If the `study` is being used for multi-objective optimization, "
-            "please specify the `target`."
-        )
+    _check_plot_args(study, target, target_name)
 
     layout = go.Layout(
         title="Hyperparameter Importances",

--- a/optuna/visualization/_slice.py
+++ b/optuna/visualization/_slice.py
@@ -8,6 +8,7 @@ from optuna.study import Study
 from optuna.trial import FrozenTrial
 from optuna.trial import TrialState
 from optuna.visualization._plotly_imports import _imports
+from optuna.visualization._utils import _check_plot_args
 from optuna.visualization._utils import _is_log_scale
 
 
@@ -75,11 +76,7 @@ def plot_slice(
     """
 
     _imports.check()
-    if target is None and study._is_multi_objective():
-        raise ValueError(
-            "If the `study` is being used for multi-objective optimization, "
-            "please specify the `target`."
-        )
+    _check_plot_args(study, target, target_name)
     return _get_slice_plot(study, params, target, target_name)
 
 

--- a/optuna/visualization/_utils.py
+++ b/optuna/visualization/_utils.py
@@ -1,7 +1,13 @@
+from typing import Callable
 from typing import List
+from typing import Optional
+from typing import Sequence
+from typing import Union
+import warnings
 
 from optuna.distributions import CategoricalDistribution
 from optuna.distributions import LogUniformDistribution
+from optuna.study import Study
 from optuna.trial import FrozenTrial
 from optuna.visualization import _plotly_imports
 
@@ -24,6 +30,29 @@ def is_available() -> bool:
     """
 
     return _plotly_imports._imports.is_successful()
+
+
+def _check_plot_args(
+    study: Union[Study, Sequence[Study]],
+    target: Optional[Callable[[FrozenTrial], float]],
+    target_name: str,
+) -> None:
+    if isinstance(study, Study):
+        studies = [study]
+    else:
+        studies = list(study)
+
+    if target is None and any(study._is_multi_objective() for study in studies):
+        raise ValueError(
+            "If the `study` is being used for multi-objective optimization, "
+            "please specify the `target`."
+        )
+
+    if target is not None and target_name == "Objective Value":
+        warnings.warn(
+            "`target` is specified, but `target_name` is the default value, 'Objective Value'. "
+            "This setting may confuse a plot."
+        )
 
 
 def _is_log_scale(trials: List[FrozenTrial], param: str) -> bool:

--- a/optuna/visualization/_utils.py
+++ b/optuna/visualization/_utils.py
@@ -40,7 +40,7 @@ def _check_plot_args(
     if isinstance(study, Study):
         studies = [study]
     else:
-        studies = list(study)
+        studies = study
 
     if target is None and any(study._is_multi_objective() for study in studies):
         raise ValueError(

--- a/optuna/visualization/_utils.py
+++ b/optuna/visualization/_utils.py
@@ -37,6 +37,8 @@ def _check_plot_args(
     target: Optional[Callable[[FrozenTrial], float]],
     target_name: str,
 ) -> None:
+
+    studies: Sequence[Study]
     if isinstance(study, Study):
         studies = [study]
     else:
@@ -50,8 +52,7 @@ def _check_plot_args(
 
     if target is not None and target_name == "Objective Value":
         warnings.warn(
-            "`target` is specified, but `target_name` is the default value, 'Objective Value'. "
-            "This setting may confuse a plot."
+            "`target` is specified, but `target_name` is the default value, 'Objective Value'."
         )
 
 

--- a/optuna/visualization/matplotlib/_contour.py
+++ b/optuna/visualization/matplotlib/_contour.py
@@ -15,6 +15,7 @@ from optuna.study import Study
 from optuna.study import StudyDirection
 from optuna.trial import FrozenTrial
 from optuna.trial import TrialState
+from optuna.visualization._utils import _check_plot_args
 from optuna.visualization.matplotlib._matplotlib_imports import _imports
 from optuna.visualization.matplotlib._utils import _is_categorical
 from optuna.visualization.matplotlib._utils import _is_log_scale
@@ -94,11 +95,7 @@ def plot_contour(
     """
 
     _imports.check()
-    if target is None and study._is_multi_objective():
-        raise ValueError(
-            "If the `study` is being used for multi-objective optimization, "
-            "please specify the `target`."
-        )
+    _check_plot_args(study, target, target_name)
     _logger.warning(
         "Output figures of this Matplotlib-based `plot_contour` function would be different from "
         "those of the Plotly-based `plot_contour`."

--- a/optuna/visualization/matplotlib/_edf.py
+++ b/optuna/visualization/matplotlib/_edf.py
@@ -13,6 +13,7 @@ from optuna.logging import get_logger
 from optuna.study import Study
 from optuna.trial import FrozenTrial
 from optuna.trial import TrialState
+from optuna.visualization._utils import _check_plot_args
 from optuna.visualization.matplotlib._matplotlib_imports import _imports
 
 
@@ -104,11 +105,8 @@ def plot_edf(
     else:
         studies = list(study)
 
-    if target is None and any(study._is_multi_objective() for study in studies):
-        raise ValueError(
-            "If the `study` is being used for multi-objective optimization, "
-            "please specify the `target`."
-        )
+    _check_plot_args(studies, target, target_name)
+
     return _get_edf_plot(studies, target, target_name)
 
 

--- a/optuna/visualization/matplotlib/_edf.py
+++ b/optuna/visualization/matplotlib/_edf.py
@@ -106,7 +106,6 @@ def plot_edf(
         studies = list(study)
 
     _check_plot_args(studies, target, target_name)
-
     return _get_edf_plot(studies, target, target_name)
 
 

--- a/optuna/visualization/matplotlib/_optimization_history.py
+++ b/optuna/visualization/matplotlib/_optimization_history.py
@@ -7,6 +7,7 @@ from optuna.study import Study
 from optuna.study import StudyDirection
 from optuna.trial import FrozenTrial
 from optuna.trial import TrialState
+from optuna.visualization._utils import _check_plot_args
 from optuna.visualization.matplotlib._matplotlib_imports import _imports
 
 
@@ -71,11 +72,7 @@ def plot_optimization_history(
     """
 
     _imports.check()
-    if target is None and study._is_multi_objective():
-        raise ValueError(
-            "If the `study` is being used for multi-objective optimization, "
-            "please specify the `target`."
-        )
+    _check_plot_args(study, target, target_name)
     return _get_optimization_history_plot(study, target, target_name)
 
 

--- a/optuna/visualization/matplotlib/_parallel_coordinate.py
+++ b/optuna/visualization/matplotlib/_parallel_coordinate.py
@@ -13,6 +13,7 @@ from optuna.logging import get_logger
 from optuna.study import Study
 from optuna.trial import FrozenTrial
 from optuna.trial import TrialState
+from optuna.visualization._utils import _check_plot_args
 from optuna.visualization.matplotlib._matplotlib_imports import _imports
 
 
@@ -81,11 +82,7 @@ def plot_parallel_coordinate(
     """
 
     _imports.check()
-    if target is None and study._is_multi_objective():
-        raise ValueError(
-            "If the `study` is being used for multi-objective optimization, "
-            "please specify the `target`."
-        )
+    _check_plot_args(study, target, target_name)
     return _get_parallel_coordinate_plot(study, params, target, target_name)
 
 

--- a/optuna/visualization/matplotlib/_param_importances.py
+++ b/optuna/visualization/matplotlib/_param_importances.py
@@ -19,6 +19,7 @@ from optuna.logging import get_logger
 from optuna.study import Study
 from optuna.trial import FrozenTrial
 from optuna.trial import TrialState
+from optuna.visualization._utils import _check_plot_args
 from optuna.visualization.matplotlib._matplotlib_imports import _imports
 
 
@@ -117,13 +118,7 @@ def plot_param_importances(
     """
 
     _imports.check()
-
-    if target is None and study._is_multi_objective():
-        raise ValueError(
-            "If the `study` is being used for multi-objective optimization, "
-            "please specify the `target`."
-        )
-
+    _check_plot_args(study, target, target_name)
     return _get_param_importance_plot(study, evaluator, params, target, target_name)
 
 

--- a/optuna/visualization/matplotlib/_slice.py
+++ b/optuna/visualization/matplotlib/_slice.py
@@ -11,6 +11,7 @@ from optuna.logging import get_logger
 from optuna.study import Study
 from optuna.trial import FrozenTrial
 from optuna.trial import TrialState
+from optuna.visualization._utils import _check_plot_args
 from optuna.visualization.matplotlib._matplotlib_imports import _imports
 from optuna.visualization.matplotlib._utils import _is_categorical
 from optuna.visualization.matplotlib._utils import _is_log_scale
@@ -85,11 +86,7 @@ def plot_slice(
     """
 
     _imports.check()
-    if target is None and study._is_multi_objective():
-        raise ValueError(
-            "If the `study` is being used for multi-objective optimization, "
-            "please specify the `target`."
-        )
+    _check_plot_args(study, target, target_name)
     return _get_slice_plot(study, params, target, target_name)
 
 

--- a/tests/visualization_tests/matplotlib_tests/test_contour.py
+++ b/tests/visualization_tests/matplotlib_tests/test_contour.py
@@ -79,7 +79,8 @@ def test_plot_contour(params: Optional[List[str]]) -> None:
 def test_plot_contour_customized_target(params: List[str]) -> None:
 
     study = prepare_study_with_trials(more_than_three=True)
-    figure = plot_contour(study, params=params, target=lambda t: t.params["param_d"])
+    with pytest.warns(UserWarning):
+        figure = plot_contour(study, params=params, target=lambda t: t.params["param_d"])
     if len(params) == 2:
         assert figure.has_data()
     else:

--- a/tests/visualization_tests/matplotlib_tests/test_edf.py
+++ b/tests/visualization_tests/matplotlib_tests/test_edf.py
@@ -42,7 +42,8 @@ def test_plot_optimization_history(direction: str) -> None:
     # Test with a customized target value.
     study0 = create_study(direction=direction)
     study0.optimize(lambda t: t.suggest_float("x", 0, 5), n_trials=10)
-    figure = plot_edf(study0, target=lambda t: t.params["x"])
+    with pytest.warns(UserWarning):
+        figure = plot_edf(study0, target=lambda t: t.params["x"])
     assert figure.has_data()
 
     # Test with a customized target name.

--- a/tests/visualization_tests/matplotlib_tests/test_optimization_history.py
+++ b/tests/visualization_tests/matplotlib_tests/test_optimization_history.py
@@ -37,7 +37,8 @@ def test_plot_optimization_history(direction: str) -> None:
     assert figure.has_data()
 
     # Test customized target.
-    figure = plot_optimization_history(study, target=lambda t: t.number)
+    with pytest.warns(UserWarning):
+        figure = plot_optimization_history(study, target=lambda t: t.number)
     assert figure.has_data()
 
     # Test customized target name.

--- a/tests/visualization_tests/matplotlib_tests/test_parallel_coordinate.py
+++ b/tests/visualization_tests/matplotlib_tests/test_parallel_coordinate.py
@@ -35,9 +35,10 @@ def test_plot_parallel_coordinate() -> None:
     assert figure.has_data()
 
     # Test with a customized target value.
-    figure = plot_parallel_coordinate(
-        study, params=["param_a"], target=lambda t: t.params["param_b"]
-    )
+    with pytest.warns(UserWarning):
+        figure = plot_parallel_coordinate(
+            study, params=["param_a"], target=lambda t: t.params["param_b"]
+        )
     assert figure.has_data()
 
     # Test with a customized target name.

--- a/tests/visualization_tests/matplotlib_tests/test_param_importances.py
+++ b/tests/visualization_tests/matplotlib_tests/test_param_importances.py
@@ -39,9 +39,10 @@ def test_plot_param_importances() -> None:
     assert figure.has_data()
 
     # Test with a customized target value.
-    figure = plot_param_importances(
-        study, target=lambda t: t.params["param_b"] + t.params["param_d"]
-    )
+    with pytest.warns(UserWarning):
+        figure = plot_param_importances(
+            study, target=lambda t: t.params["param_b"] + t.params["param_d"]
+        )
     assert figure.has_data()
 
     # Test with a customized target name.

--- a/tests/visualization_tests/matplotlib_tests/test_slice.py
+++ b/tests/visualization_tests/matplotlib_tests/test_slice.py
@@ -38,7 +38,8 @@ def test_plot_slice() -> None:
     assert figure.has_data()
 
     # Test with a customized target value.
-    figure = plot_slice(study, params=["param_a"], target=lambda t: t.params["param_b"])
+    with pytest.warns(UserWarning):
+        figure = plot_slice(study, params=["param_a"], target=lambda t: t.params["param_b"])
     assert figure.has_data()
 
     # Test with a customized target name.

--- a/tests/visualization_tests/test_contour.py
+++ b/tests/visualization_tests/test_contour.py
@@ -95,7 +95,8 @@ def test_plot_contour(params: Optional[List[str]]) -> None:
 def test_plot_contour_customized_target(params: List[str]) -> None:
 
     study = prepare_study_with_trials()
-    figure = plot_contour(study, params=params, target=lambda t: t.params["param_d"])
+    with pytest.warns(UserWarning):
+        figure = plot_contour(study, params=params, target=lambda t: t.params["param_d"])
     for data in figure.data:
         if "z" in data:
             assert 4.0 in itertools.chain.from_iterable(data["z"])

--- a/tests/visualization_tests/test_edf.py
+++ b/tests/visualization_tests/test_edf.py
@@ -42,7 +42,8 @@ def test_plot_optimization_history(direction: str) -> None:
     # Test with a customized target value.
     study0 = create_study(direction=direction)
     study0.optimize(lambda t: t.suggest_float("x", 0, 5), n_trials=10)
-    figure = plot_edf(study0, target=lambda t: t.params["x"])
+    with pytest.warns(UserWarning):
+        figure = plot_edf(study0, target=lambda t: t.params["x"])
     assert len(figure.data) == 1
 
     # Test with a customized target name.

--- a/tests/visualization_tests/test_optimization_history.py
+++ b/tests/visualization_tests/test_optimization_history.py
@@ -45,7 +45,8 @@ def test_plot_optimization_history(direction: str) -> None:
     assert figure.layout.yaxis.title.text == "Objective Value"
 
     # Test customized target.
-    figure = plot_optimization_history(study, target=lambda t: t.number)
+    with pytest.warns(UserWarning):
+        figure = plot_optimization_history(study, target=lambda t: t.number)
     assert len(figure.data) == 1
     assert figure.data[0].x == (0, 1, 2)
     assert figure.data[0].y == (0, 1, 2)

--- a/tests/visualization_tests/test_parallel_coordinate.py
+++ b/tests/visualization_tests/test_parallel_coordinate.py
@@ -48,9 +48,10 @@ def test_plot_parallel_coordinate() -> None:
     assert figure.data[0]["dimensions"][1]["values"] == (1.0, 2.5)
 
     # Test with a customized target value.
-    figure = plot_parallel_coordinate(
-        study, params=["param_a"], target=lambda t: t.params["param_b"]
-    )
+    with pytest.warns(UserWarning):
+        figure = plot_parallel_coordinate(
+            study, params=["param_a"], target=lambda t: t.params["param_b"]
+        )
     assert len(figure.data[0]["dimensions"]) == 2
     assert figure.data[0]["dimensions"][0]["label"] == "Objective Value"
     assert figure.data[0]["dimensions"][0]["range"] == (0.0, 2.0)

--- a/tests/visualization_tests/test_param_importances.py
+++ b/tests/visualization_tests/test_param_importances.py
@@ -49,9 +49,10 @@ def test_plot_param_importances() -> None:
     assert math.isclose(1.0, sum(i for i in figure.data[0].x), abs_tol=1e-5)
 
     # Test with a customized target value.
-    figure = plot_param_importances(
-        study, target=lambda t: t.params["param_b"] + t.params["param_d"]
-    )
+    with pytest.warns(UserWarning):
+        figure = plot_param_importances(
+            study, target=lambda t: t.params["param_b"] + t.params["param_d"]
+        )
     assert len(figure.data) == 1
     assert set(figure.data[0].y) == set(
         ("param_b", "param_d")

--- a/tests/visualization_tests/test_slice.py
+++ b/tests/visualization_tests/test_slice.py
@@ -41,7 +41,8 @@ def test_plot_slice() -> None:
     assert figure.data[0]["y"] == (0.0, 1.0)
 
     # Test with a customized target value.
-    figure = plot_slice(study, params=["param_a"], target=lambda t: t.params["param_b"])
+    with pytest.warns(UserWarning):
+        figure = plot_slice(study, params=["param_a"], target=lambda t: t.params["param_b"])
     assert len(figure.data) == 1
     assert figure.data[0]["x"] == (1.0, 2.5)
     assert figure.data[0]["y"] == (2.0, 1.0)

--- a/tests/visualization_tests/test_utils.py
+++ b/tests/visualization_tests/test_utils.py
@@ -1,8 +1,13 @@
+from typing import cast
+
+import pytest
+
 from optuna.distributions import LogUniformDistribution
 from optuna.distributions import UniformDistribution
 from optuna.study import create_study
 from optuna.trial import create_trial
 from optuna.visualization import is_available
+from optuna.visualization._utils import _check_plot_args
 from optuna.visualization._utils import _is_log_scale
 
 
@@ -44,3 +49,13 @@ def _is_plotly_available() -> bool:
 def test_visualization_is_available() -> None:
 
     assert is_available() == _is_plotly_available()
+
+
+def test_check_plot_args() -> None:
+
+    study = create_study(directions=["minimize", "minimize"])
+    with pytest.raises(ValueError):
+        _check_plot_args(study, None, "Objective Value")
+
+    with pytest.warns(UserWarning):
+        _check_plot_args(study, lambda t: cast(float, t.value), "Objective Value")


### PR DESCRIPTION
## Motivation
When users specify the plotting `target`, they may miss changing the `target_name`. This PR adds warning for such cases.
## Description of the changes
- add `optuna.visualization._utils._check_plot_args`, which checks `target` for the multi objective optimization and `target_name` for specified `target`.
- check args of visualization functions.
