### PR TITLE
Fix unit test of median pruner.

### DIFF
--- a/tests/pruners_tests/test_median.py
+++ b/tests/pruners_tests/test_median.py
@@ -121,14 +121,14 @@ def test_median_pruner_interval_steps(
     pruner = optuna.pruners.MedianPruner(0, n_warmup_steps, interval_steps)
     study = optuna.study.create_study()
 
-    trial = optuna.trial.Trial(study, study._storage.create_new_trial(study._study_id))
+    trial = study.ask()
     last_step = max(expected_prune_steps) + 1
 
     for i in range(last_step):
         trial.report(0, i)
     study._storage.set_trial_state(trial._trial_id, TrialState.COMPLETE)
 
-    trial = optuna.trial.Trial(study, study._storage.create_new_trial(study._study_id))
+    trial = study.ask()
 
     pruned = []
     for i in range(last_step):


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
In the current master branch,  I think that there are some issues in `test_median_pruner_interval_steps` of `tests/pruners_tests/test_median.py`.

I explained the situation by using `"n_warmup_steps,interval_steps,report_steps,expected_prune_steps" = (1, 2, 1, [1, 3])` as an example.
* It only checks `i` from `0` to `2`, not including the last element of `expected_prune_steps`, 3, because `n_steps = max(expected_prune_steps)` and `i` was ranged by `range(n_steps)`. So, `expected_prune_steps` are not actually expected pruned steps here.
* Also, when someone sees this test case, they expected that it only passes only when pruning runs at at `i ==  1` and `i == 3`. However, the current test passes even when pruning does not run at `i ==  1` or `i == 3`, because it checks `i in expected_prune_steps`.

## Description of the changes
<!-- Describe the changes in this PR. -->
> * It only checks `i` from `0` to `2`, not including the last element of `expected_prune_steps` 3, because `n_steps = max(expected_prune_steps)` and `i` was ranged by `range(n_steps)`. So, `expected_prune_steps` are not actually expected pruned steps here.

To solve the above, I changed the code as https://github.com/optuna/optuna/pull/2171/files#diff-7945f3f629a92b7cd2958d1ee6b51816c7072f396447485a8db6704a6abbfd7aR125

> * Also, when someone sees this test case, they expected that it only passes only when pruning runs at at `i ==  1` and `i == 3`. However, the current test passes even when pruning does not run at `i ==  1` or `i == 3`, because it checks `i in expected_prune_steps`.

To solve the above, I changed the code as https://github.com/optuna/optuna/pull/2171/files#diff-7945f3f629a92b7cd2958d1ee6b51816c7072f396447485a8db6704a6abbfd7aR139.