### PR TITLE
Add constrained NSGA-II sampler

### DIFF
--- a/docs/source/reference/samplers.rst
+++ b/docs/source/reference/samplers.rst
@@ -16,5 +16,6 @@ The :mod:`~optuna.samplers` module defines a base class for parameter sampling a
    optuna.samplers.CmaEsSampler
    optuna.samplers.PartialFixedSampler
    optuna.samplers.NSGAIISampler
+   optuna.samplers.CNSGAIISampler
    optuna.samplers.IntersectionSearchSpace
    optuna.samplers.intersection_search_space

--- a/optuna/samplers/__init__.py
+++ b/optuna/samplers/__init__.py
@@ -7,11 +7,13 @@ from optuna.samplers._random import RandomSampler
 from optuna.samplers._search_space import intersection_search_space
 from optuna.samplers._search_space import IntersectionSearchSpace
 from optuna.samplers._tpe.sampler import TPESampler
+from optuna.samplers._cnsga2 import CNSGAIISampler
 
 
 __all__ = [
     "BaseSampler",
     "CmaEsSampler",
+    "CNSGAIISampler",
     "GridSampler",
     "NSGAIISampler",
     "IntersectionSearchSpace",

--- a/optuna/samplers/__init__.py
+++ b/optuna/samplers/__init__.py
@@ -1,5 +1,6 @@
 from optuna.samplers._base import BaseSampler
 from optuna.samplers._cmaes import CmaEsSampler
+from optuna.samplers._cnsga2 import CNSGAIISampler
 from optuna.samplers._grid import GridSampler
 from optuna.samplers._nsga2 import NSGAIISampler
 from optuna.samplers._partial_fixed import PartialFixedSampler
@@ -7,7 +8,6 @@ from optuna.samplers._random import RandomSampler
 from optuna.samplers._search_space import intersection_search_space
 from optuna.samplers._search_space import IntersectionSearchSpace
 from optuna.samplers._tpe.sampler import TPESampler
-from optuna.samplers._cnsga2 import CNSGAIISampler
 
 
 __all__ = [

--- a/optuna/samplers/_cnsga2.py
+++ b/optuna/samplers/_cnsga2.py
@@ -1,0 +1,173 @@
+from collections import defaultdict
+import copy
+import itertools
+from typing import Callable
+from typing import DefaultDict
+from typing import List
+from typing import Optional
+from typing import Sequence
+import warnings
+
+import optuna
+from optuna._multi_objective import _dominates
+from optuna.samplers import NSGAIISampler
+from optuna.study import Study
+from optuna.study import StudyDirection
+from optuna.trial import FrozenTrial
+from optuna.trial import TrialState
+
+_CONSTRAINTS_KEY = "cnsga2:constraints"
+
+
+class CNSGAIISampler(NSGAIISampler):
+    def __init__(
+        self,
+        *,
+        population_size: int = 50,
+        mutation_prob: Optional[float] = None,
+        crossover_prob: float = 0.9,
+        swapping_prob: float = 0.5,
+        seed: Optional[int] = None,
+        constraints_func: Optional[Callable[[FrozenTrial], Sequence[float]]] = None,
+    ) -> None:
+        super().__init__(
+            population_size=population_size,
+            mutation_prob=mutation_prob,
+            crossover_prob=crossover_prob,
+            swapping_prob=swapping_prob,
+            seed=seed,
+        )
+        self._constraints_func = constraints_func
+
+    def after_trial(
+        self,
+        study: Study,
+        trial: FrozenTrial,
+        state: TrialState,
+        values: Optional[Sequence[float]],
+    ) -> None:
+        if self._constraints_func is not None:
+            constraints = None
+            _trial = copy.copy(trial)
+            _trial.state = state
+            _trial.values = values
+            try:
+                con = self._constraints_func(_trial)
+                if not isinstance(con, (tuple, list)):
+                    warnings.warn(
+                        f"Constraints should be a sequence of floats but got {constraints}."
+                    )
+                constraints = tuple(con)
+            except Exception:
+                raise
+            finally:
+                assert constraints is None or isinstance(constraints, tuple)
+
+                study._storage.set_trial_system_attr(
+                    trial._trial_id,
+                    _CONSTRAINTS_KEY,
+                    constraints,
+                )
+
+    def _select_elite_population(
+        self, study: Study, population: List[FrozenTrial]
+    ) -> List[FrozenTrial]:
+        elite_population: List[FrozenTrial] = []
+        population_per_rank = _fast_non_dominated_sort(population, study.directions)
+        for population in population_per_rank:
+            if len(elite_population) + len(population) < self._population_size:
+                elite_population.extend(population)
+            else:
+                n = self._population_size - len(elite_population)
+                optuna.samplers._nsga2._crowding_distance_sort(population)
+                elite_population.extend(population[:n])
+                break
+
+        return elite_population
+
+    def _select_parent(self, study: Study, population: List[FrozenTrial]) -> FrozenTrial:
+        # TODO(ohta): Consider to allow users to specify the number of parent candidates.
+        candidate0 = self._rng.choice(population)
+        candidate1 = self._rng.choice(population)
+
+        # TODO(ohta): Consider crowding distance.
+        if _sigma_dominates(candidate0, candidate1, study.directions):
+            return candidate0
+        else:
+            return candidate1
+
+
+def _sigma_dominates(
+    trial0: FrozenTrial, trial1: FrozenTrial, directions: Sequence[StudyDirection]
+) -> bool:
+    constraints0 = trial0.system_attrs[_CONSTRAINTS_KEY]
+    constraints1 = trial1.system_attrs[_CONSTRAINTS_KEY]
+
+    assert isinstance(constraints0, (list, tuple))
+    assert isinstance(constraints1, (list, tuple))
+
+    if len(constraints1) != len(constraints1):
+        raise ValueError("Trials with different numbers of constraints cannot be compared.")
+
+    if trial0.state != TrialState.COMPLETE:
+        return False
+
+    if trial1.state != TrialState.COMPLETE:
+        return True
+
+    if all(v <= 0 for v in constraints0) and all(v <= 0 for v in constraints1):
+        # Both trials satisfy the constraints.
+        return _dominates(trial0, trial1, directions)
+
+    if all(v <= 0 for v in constraints0):
+        # trial0 satisfies the constraints, but trial1 violates them.
+        return True
+
+    if all(v <= 0 for v in constraints1):
+        # trial1 satisfies the constraints, but trial0 violates them.
+        return False
+
+    # Both trials violate the constraints.
+    violation0 = sum(v for v in constraints0 if v > 0)
+    violation1 = sum(v for v in constraints1 if v > 0)
+    return violation0 < violation1
+
+
+def _fast_non_dominated_sort(
+    population: List[FrozenTrial],
+    directions: List[StudyDirection],
+) -> List[List[FrozenTrial]]:
+    dominated_count: DefaultDict[int, int] = defaultdict(int)
+    dominates_list = defaultdict(list)
+
+    for p, q in itertools.combinations(population, 2):
+        if _sigma_dominates(p, q, directions):
+            dominates_list[p.number].append(q.number)
+            dominated_count[q.number] += 1
+        elif _sigma_dominates(q, p, directions):
+            dominates_list[q.number].append(p.number)
+            dominated_count[p.number] += 1
+
+    population_per_rank = []
+    while population:
+        non_dominated_population = []
+        i = 0
+        while i < len(population):
+            if dominated_count[population[i].number] == 0:
+                individual = population[i]
+                if i == len(population) - 1:
+                    population.pop()
+                else:
+                    population[i] = population.pop()
+                non_dominated_population.append(individual)
+            else:
+                i += 1
+
+        for x in non_dominated_population:
+            for y in dominates_list[x.number]:
+                dominated_count[y] -= 1
+
+        assert non_dominated_population
+        population_per_rank.append(non_dominated_population)
+
+    return population_per_rank

--- a/tests/samplers_tests/test_cnsga2.py
+++ b/tests/samplers_tests/test_cnsga2.py
@@ -1,0 +1,179 @@
+from typing import List
+
+import optuna
+from optuna.samplers import CNSGAIISampler
+from optuna.samplers._cnsga2 import _CONSTRAINTS_KEY
+from optuna.study import StudyDirection
+
+
+def test_dominates_feasible() -> None:
+    # Single objective.
+    directions = [StudyDirection.MINIMIZE]
+    trials = [
+        _create_frozen_trial(0, [10], [0]),
+        _create_frozen_trial(1, [20], [0]),
+        _create_frozen_trial(2, [20], [0]),
+        _create_frozen_trial(3, [30], [0]),
+    ]
+    population_per_rank = CNSGAIISampler._fast_non_dominated_sort(trials, directions)
+    assert [{t.number for t in population} for population in population_per_rank] == [
+        {0},
+        {1, 2},
+        {3},
+    ]
+
+    # Two objective.
+    directions = [StudyDirection.MAXIMIZE, StudyDirection.MAXIMIZE]
+    trials = [
+        _create_frozen_trial(0, [10, 30], [0]),
+        _create_frozen_trial(1, [10, 10], [0]),
+        _create_frozen_trial(2, [20, 20], [0]),
+        _create_frozen_trial(3, [30, 10], [0]),
+        _create_frozen_trial(4, [15, 15], [0]),
+    ]
+    population_per_rank = CNSGAIISampler._fast_non_dominated_sort(trials, directions)
+    assert [{t.number for t in population} for population in population_per_rank] == [
+        {0, 2, 3},
+        {4},
+        {1},
+    ]
+
+    # Three objective.
+    directions = [StudyDirection.MAXIMIZE, StudyDirection.MAXIMIZE, StudyDirection.MINIMIZE]
+    trials = [
+        _create_frozen_trial(0, [5, 5, 4], [0]),
+        _create_frozen_trial(1, [5, 5, 5], [0]),
+        _create_frozen_trial(2, [9, 9, 0], [0]),
+        _create_frozen_trial(3, [5, 7, 5], [0]),
+        _create_frozen_trial(4, [0, 0, 9], [0]),
+        _create_frozen_trial(5, [0, 9, 9], [0]),
+    ]
+    population_per_rank = CNSGAIISampler._fast_non_dominated_sort(trials, directions)
+    assert [{t.number for t in population} for population in population_per_rank] == [
+        {2},
+        {0, 3, 5},
+        {1},
+        {4},
+    ]
+
+
+def test_dominates_infeasible() -> None:
+    # Single objective.
+    directions = [StudyDirection.MINIMIZE]
+    trials = [
+        _create_frozen_trial(0, [10], [1]),
+        _create_frozen_trial(1, [20], [3]),
+        _create_frozen_trial(2, [20], [2]),
+        _create_frozen_trial(3, [30], [1]),
+    ]
+    population_per_rank = CNSGAIISampler._fast_non_dominated_sort(trials, directions)
+    assert [{t.number for t in population} for population in population_per_rank] == [
+        {0, 3},
+        {2},
+        {1},
+    ]
+
+    # Two objective.
+    directions = [StudyDirection.MAXIMIZE, StudyDirection.MAXIMIZE]
+    trials = [
+        _create_frozen_trial(0, [10, 30], [1, 1]),
+        _create_frozen_trial(1, [10, 10], [2, 2]),
+        _create_frozen_trial(2, [20, 20], [3, 3]),
+        _create_frozen_trial(3, [30, 10], [2, 4]),
+        _create_frozen_trial(4, [15, 15], [4, 4]),
+    ]
+    population_per_rank = CNSGAIISampler._fast_non_dominated_sort(trials, directions)
+    assert [{t.number for t in population} for population in population_per_rank] == [
+        {0},
+        {1},
+        {2, 3},
+        {4},
+    ]
+
+    # Three objective.
+    directions = [StudyDirection.MAXIMIZE, StudyDirection.MAXIMIZE, StudyDirection.MINIMIZE]
+    trials = [
+        _create_frozen_trial(0, [5, 5, 4], [1, 1, 1]),
+        _create_frozen_trial(1, [5, 5, 5], [1, 1, 1]),
+        _create_frozen_trial(2, [9, 9, 0], [3, 3, 3]),
+        _create_frozen_trial(3, [5, 7, 5], [2, 2, 2]),
+        _create_frozen_trial(4, [0, 0, 9], [1, 1, 4]),
+        _create_frozen_trial(5, [0, 9, 9], [2, 1, 3]),
+    ]
+    population_per_rank = CNSGAIISampler._fast_non_dominated_sort(trials, directions)
+    assert [{t.number for t in population} for population in population_per_rank] == [
+        {0, 1},
+        {3, 4, 5},
+        {2},
+    ]
+
+
+def test_dominates_feasible_infeasible() -> None:
+    # Single objective.
+    directions = [StudyDirection.MINIMIZE]
+    trials = [
+        _create_frozen_trial(0, [10], [0]),
+        _create_frozen_trial(1, [20], [-1]),
+        _create_frozen_trial(2, [20], [-2]),
+        _create_frozen_trial(3, [30], [1]),
+    ]
+    population_per_rank = CNSGAIISampler._fast_non_dominated_sort(trials, directions)
+    assert [{t.number for t in population} for population in population_per_rank] == [
+        {0},
+        {1, 2},
+        {3},
+    ]
+
+    # Two objective.
+    directions = [StudyDirection.MAXIMIZE, StudyDirection.MAXIMIZE]
+    trials = [
+        _create_frozen_trial(0, [10, 30], [-1, -1]),
+        _create_frozen_trial(1, [10, 10], [-2, -2]),
+        _create_frozen_trial(2, [20, 20], [3, 3]),
+        _create_frozen_trial(3, [30, 10], [6, -1]),
+        _create_frozen_trial(4, [15, 15], [4, 4]),
+    ]
+    population_per_rank = CNSGAIISampler._fast_non_dominated_sort(trials, directions)
+    assert [{t.number for t in population} for population in population_per_rank] == [
+        {0},
+        {1},
+        {2, 3},
+        {4},
+    ]
+
+    # Three objective.
+    directions = [StudyDirection.MAXIMIZE, StudyDirection.MAXIMIZE, StudyDirection.MINIMIZE]
+    trials = [
+        _create_frozen_trial(0, [5, 5, 4], [-1, -1, -1]),
+        _create_frozen_trial(1, [5, 5, 5], [1, 1, -1]),
+        _create_frozen_trial(2, [9, 9, 0], [1, -1, -1]),
+        _create_frozen_trial(3, [5, 7, 5], [-1, -1, -1]),
+        _create_frozen_trial(4, [0, 0, 9], [-1, -1, -1]),
+        _create_frozen_trial(5, [0, 9, 9], [-1, -1, -1]),
+    ]
+    population_per_rank = CNSGAIISampler._fast_non_dominated_sort(trials, directions)
+    assert [{t.number for t in population} for population in population_per_rank] == [
+        {0, 3, 5},
+        {4},
+        {2},
+        {1},
+    ]
+
+
+def _create_frozen_trial(
+    number: int, values: List[float], constraints: List[float]
+) -> optuna.trial.FrozenTrial:
+    return optuna.trial.FrozenTrial(
+        number=number,
+        trial_id=number,
+        state=optuna.trial.TrialState.COMPLETE,
+        value=None,
+        datetime_start=None,
+        datetime_complete=None,
+        params={},
+        distributions={},
+        user_attrs={},
+        system_attrs={_CONSTRAINTS_KEY: constraints},
+        intermediate_values={},
+        values=values,
+    )

--- a/tests/samplers_tests/test_nsga2.py
+++ b/tests/samplers_tests/test_nsga2.py
@@ -88,7 +88,7 @@ def test_fast_non_dominated_sort() -> None:
         _create_frozen_trial(2, [20]),
         _create_frozen_trial(3, [30]),
     ]
-    population_per_rank = optuna.samplers._nsga2._fast_non_dominated_sort(trials, directions)
+    population_per_rank = NSGAIISampler._fast_non_dominated_sort(trials, directions)
     assert [{t.number for t in population} for population in population_per_rank] == [
         {0},
         {1, 2},
@@ -104,7 +104,7 @@ def test_fast_non_dominated_sort() -> None:
         _create_frozen_trial(3, [30, 10]),
         _create_frozen_trial(4, [15, 15]),
     ]
-    population_per_rank = optuna.samplers._nsga2._fast_non_dominated_sort(trials, directions)
+    population_per_rank = NSGAIISampler._fast_non_dominated_sort(trials, directions)
     assert [{t.number for t in population} for population in population_per_rank] == [
         {0, 2, 3},
         {4},
@@ -121,7 +121,7 @@ def test_fast_non_dominated_sort() -> None:
         _create_frozen_trial(4, [0, 0, 9]),
         _create_frozen_trial(5, [0, 9, 9]),
     ]
-    population_per_rank = optuna.samplers._nsga2._fast_non_dominated_sort(trials, directions)
+    population_per_rank = NSGAIISampler._fast_non_dominated_sort(trials, directions)
     assert [{t.number for t in population} for population in population_per_rank] == [
         {2},
         {0, 3, 5},


### PR DESCRIPTION
## Motivation
This PR extends NSGA-II sampler to handle constraints similarly to BoTorch sampler. The constrained NSGA-II is proposed by Deb et al. in the [original NSGA-II paper](https://ieeexplore.ieee.org/document/996017). It simply overwrites domination check as follows:

A trial `x` is said to constrained-dominate a trial `y`, if any of the following conditions is true:
1) Trial `x` is feasible and trial `y` is not.
2) Trial `x` and `y` are both infeasible, but solution `x` has a smaller overall constraint violation.
3) Trial `x` and `y` are feasible and trial `x` dominates trial `y`.

## Description of the changes
- Add `optuna.samplers.CNSGAIISampler`
- Make `optuna.samplers._nsga2._fast_non_dominated_sort` a  class method of `NSGAIISampler`
- Add a class method `NSGAIISampler._dominates`
- Add unit tests for `optuna.samplers.CNSGAIISampler`