### PR TITLE
Add `constraints_func` argument to NSGA-II.

### DIFF
--- a/optuna/samplers/_nsga2.py
+++ b/optuna/samplers/_nsga2.py
@@ -114,7 +114,7 @@ class NSGAIISampler(BaseSampler):
         if not (0.0 <= swapping_prob <= 1.0):
             raise ValueError("`swapping_prob` must be a float value within the range [0.0, 1.0].")
 
-        if constraints_func:
+        if constraints_func is not None:
             warnings.warn(
                 "The constraints_func option is an experimental feature."
                 " The interface can change in the future.",

--- a/optuna/samplers/_nsga2.py
+++ b/optuna/samplers/_nsga2.py
@@ -353,7 +353,7 @@ class NSGAIISampler(BaseSampler):
                 con = self._constraints_func(trial)
                 if not isinstance(con, (tuple, list)):
                     warnings.warn(
-                        f"Constraints should be a sequence of floats but got {constraints}."
+                        f"Constraints should be a sequence of floats but got {type(con).__name__}."
                     )
                 constraints = tuple(con)
             except Exception:

--- a/optuna/samplers/_nsga2.py
+++ b/optuna/samplers/_nsga2.py
@@ -424,15 +424,18 @@ def _constrained_dominates(
     if trial1.state != TrialState.COMPLETE:
         return True
 
-    if all(v <= 0 for v in constraints0) and all(v <= 0 for v in constraints1):
+    satisfy_constraints0 = all(v <= 0 for v in constraints0)
+    satisfy_constraints1 = all(v <= 0 for v in constraints1)
+
+    if satisfy_constraints0 and satisfy_constraints1:
         # Both trials satisfy the constraints.
         return _dominates(trial0, trial1, directions)
 
-    if all(v <= 0 for v in constraints0):
+    if satisfy_constraints0:
         # trial0 satisfies the constraints, but trial1 violates them.
         return True
 
-    if all(v <= 0 for v in constraints1):
+    if satisfy_constraints1:
         # trial1 satisfies the constraints, but trial0 violates them.
         return False
 

--- a/optuna/samplers/_nsga2.py
+++ b/optuna/samplers/_nsga2.py
@@ -68,13 +68,15 @@ class NSGAIISampler(BaseSampler):
             :class:`~optuna.trial.FrozenTrial` and return the constraints. The return value must
             be a sequence of :obj:`float` s. A value strictly larger than 0 means that a
             constraints is violated. A value equal to or smaller than 0 is considered feasible.
+            If constraints_func returns more than one value for a trial, that trial is considered
+            feasible if and only if all values are equal to 0 or smaller.
 
             The constraints are handled by the constrained domination. A trial x is said to
             constrained-dominate a trial y, if any of the following conditions is true:
 
-            1. Trial x satisfies all constraints and trial y does not.
-            2. Trial x and y both violate constraints, but trial x has a smaller overall violation.
-            3. Trial x and y satisfies all constraints, and trial x dominates trial y.
+            1. Trial x is feasible and trial y is not.
+            2. Trial x and y are both infeasible, but trial x has a smaller overall violation.
+            3. Trial x and y are feasible and trial x dominates trial y.
 
             .. note::
                 Added in v2.5.0 as an experimental feature. The interface may change in newer

--- a/optuna/samplers/_nsga2.py
+++ b/optuna/samplers/_nsga2.py
@@ -1,5 +1,4 @@
 from collections import defaultdict
-import copy
 import hashlib
 import itertools
 from typing import Any
@@ -327,11 +326,8 @@ class NSGAIISampler(BaseSampler):
     ) -> None:
         if self._constraints_func is not None:
             constraints = None
-            _trial = copy.copy(trial)
-            _trial.state = state
-            _trial.values = values
             try:
-                con = self._constraints_func(_trial)
+                con = self._constraints_func(trial)
                 if not isinstance(con, (tuple, list)):
                     warnings.warn(
                         f"Constraints should be a sequence of floats but got {constraints}."

--- a/optuna/samplers/_nsga2.py
+++ b/optuna/samplers/_nsga2.py
@@ -72,9 +72,9 @@ class NSGAIISampler(BaseSampler):
             The constraints are handled by the constrained domination. A trial x is said to
             constrained-dominate a trial y, if any of the following conditions is true:
 
-            1. Trial x is feasible and trial y is not.
-            2. Trial x and y are both infeasible, but trial x has a smaller overall violation.
-            3. Trial x and y are feasible and trial x dominates trial y.
+            1. Trial x satisfies all constraints and trial y does not.
+            2. Trial x and y both violate constraints, but trial x has a smaller overall violation.
+            3. Trial x and y satisfies all constraints, and trial x dominates trial y.
 
             .. note::
                 Added in v2.5.0 as an experimental feature. The interface may change in newer

--- a/optuna/samplers/_nsga2.py
+++ b/optuna/samplers/_nsga2.py
@@ -72,10 +72,9 @@ class NSGAIISampler(BaseSampler):
             The constraints are handled by the constrained domination. A trial x is said to
             constrained-dominate a trial y, if any of the following conditions is true:
 
-            1) Trial x is feasible and trial y is not.
-            2) Trial x and y are both infeasible, but solution x has a smaller overall constraint
-            violation.
-            3) Trial x and y are feasible and trial x dominates trial y.
+            1. Trial x is feasible and trial y is not.
+            2. Trial x and y are both infeasible, but trial x has a smaller overall violation.
+            3. Trial x and y are feasible and trial x dominates trial y.
 
             .. note::
                 Added in v2.5.0 as an experimental feature. The interface may change in newer

--- a/optuna/samplers/_nsga2.py
+++ b/optuna/samplers/_nsga2.py
@@ -15,6 +15,7 @@ import warnings
 import numpy as np
 
 import optuna
+from optuna._experimental import ExperimentalWarning
 from optuna._multi_objective import _dominates
 from optuna.distributions import BaseDistribution
 from optuna.samplers._base import BaseSampler
@@ -67,6 +68,20 @@ class NSGAIISampler(BaseSampler):
             :class:`~optuna.trial.FrozenTrial` and return the constraints. The return value must
             be a sequence of :obj:`float` s. A value strictly larger than 0 means that a
             constraints is violated. A value equal to or smaller than 0 is considered feasible.
+
+            The constraints are handled by the constrained domination. A trial x is said to
+            constrained-dominate a trial y, if any of the following conditions is true:
+
+            1) Trial x is feasible and trial y is not.
+            2) Trial x and y are both infeasible, but solution x has a smaller overall constraint
+            violation.
+            3) Trial x and y are feasible and trial x dominates trial y.
+
+            .. note::
+                Added in v2.5.0 as an experimental feature. The interface may change in newer
+                versions without prior notice. See
+                https://github.com/optuna/optuna/releases/tag/v2.5.0.
+
     """
 
     def __init__(
@@ -97,6 +112,13 @@ class NSGAIISampler(BaseSampler):
 
         if not (0.0 <= swapping_prob <= 1.0):
             raise ValueError("`swapping_prob` must be a float value within the range [0.0, 1.0].")
+
+        if constraints_func:
+            warnings.warn(
+                "The constraints_func option is an experimental feature."
+                " The interface can change in the future.",
+                ExperimentalWarning,
+            )
 
         self._population_size = population_size
         self._mutation_prob = mutation_prob

--- a/tests/samplers_tests/test_nsga2.py
+++ b/tests/samplers_tests/test_nsga2.py
@@ -414,17 +414,12 @@ def test_constraints_func_experimental_warning() -> None:
 def _create_frozen_trial(
     number: int, values: List[float], constraints: Optional[List[float]] = None
 ) -> optuna.trial.FrozenTrial:
-    return optuna.trial.FrozenTrial(
-        number=number,
-        trial_id=number,
-        state=optuna.trial.TrialState.COMPLETE,
-        value=None,
-        datetime_start=None,
-        datetime_complete=None,
-        params={},
-        distributions={},
-        user_attrs={},
-        system_attrs={} if constraints is None else {_CONSTRAINTS_KEY: constraints},
-        intermediate_values={},
-        values=values,
-    )
+    with pytest.warns(optuna.exceptions.ExperimentalWarning):
+        trial = optuna.trial.create_trial(
+            state=optuna.trial.TrialState.COMPLETE,
+            values=values,
+            system_attrs={} if constraints is None else {_CONSTRAINTS_KEY: constraints},
+        )
+    trial.number = number
+    trial._trial_id = number
+    return trial

--- a/tests/samplers_tests/test_nsga2.py
+++ b/tests/samplers_tests/test_nsga2.py
@@ -3,6 +3,7 @@ from typing import List
 from typing import Optional
 from typing import Sequence
 from typing import Tuple
+import warnings
 
 import pytest
 
@@ -110,7 +111,9 @@ def test_constraints_func() -> None:
 
         return (trial.number,)
 
-    sampler = NSGAIISampler(population_size=2, constraints_func=constraints_func)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", optuna.exceptions.ExperimentalWarning)
+        sampler = NSGAIISampler(population_size=2, constraints_func=constraints_func)
 
     study = optuna.create_study(directions=["minimize"] * n_objectives, sampler=sampler)
     study.optimize(
@@ -177,7 +180,9 @@ def test_fast_non_dominated_sort() -> None:
 
 
 def test_fast_non_dominated_sort_constrained_feasible() -> None:
-    sampler = NSGAIISampler(constraints_func=lambda _: [0])
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", optuna.exceptions.ExperimentalWarning)
+        sampler = NSGAIISampler(constraints_func=lambda _: [0])
 
     # Single objective.
     directions = [StudyDirection.MINIMIZE]
@@ -230,7 +235,9 @@ def test_fast_non_dominated_sort_constrained_feasible() -> None:
 
 
 def test_fast_non_dominated_sort_constrained_infeasible() -> None:
-    sampler = NSGAIISampler(constraints_func=lambda _: [0])
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", optuna.exceptions.ExperimentalWarning)
+        sampler = NSGAIISampler(constraints_func=lambda _: [0])
 
     # Single objective.
     directions = [StudyDirection.MINIMIZE]
@@ -283,7 +290,9 @@ def test_fast_non_dominated_sort_constrained_infeasible() -> None:
 
 
 def test_fast_non_dominated_sort_constrained_feasible_infeasible() -> None:
-    sampler = NSGAIISampler(constraints_func=lambda _: [0])
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", optuna.exceptions.ExperimentalWarning)
+        sampler = NSGAIISampler(constraints_func=lambda _: [0])
 
     # Single objective.
     directions = [StudyDirection.MINIMIZE]
@@ -394,6 +403,12 @@ def test_reseed_rng() -> None:
     sampler.reseed_rng()
     assert original_seed != sampler._rng.seed
     assert original_random_sampler_seed != sampler._random_sampler._rng.seed
+
+
+
+def test_constraints_func_experimental_warning() -> None:
+    with pytest.warns(optuna.exceptions.ExperimentalWarning):
+        NSGAIISampler(constraints_func=lambda _: [0])
 
 
 # TODO(ohta): Consider to move this utility function to `optuna.testing` module.

--- a/tests/samplers_tests/test_nsga2.py
+++ b/tests/samplers_tests/test_nsga2.py
@@ -1,5 +1,6 @@
 from collections import Counter
 from typing import List
+from typing import Optional
 from typing import Tuple
 
 import pytest
@@ -7,6 +8,7 @@ import pytest
 import optuna
 from optuna._study_direction import StudyDirection
 from optuna.samplers import NSGAIISampler
+from optuna.samplers._nsga2 import _CONSTRAINTS_KEY
 
 
 def test_population_size() -> None:
@@ -80,6 +82,8 @@ def test_swapping_prob() -> None:
 
 
 def test_fast_non_dominated_sort() -> None:
+    sampler = NSGAIISampler()
+
     # Single objective.
     directions = [StudyDirection.MINIMIZE]
     trials = [
@@ -88,7 +92,7 @@ def test_fast_non_dominated_sort() -> None:
         _create_frozen_trial(2, [20]),
         _create_frozen_trial(3, [30]),
     ]
-    population_per_rank = optuna.samplers._nsga2._fast_non_dominated_sort(trials, directions)
+    population_per_rank = sampler._fast_non_dominated_sort(trials, directions)
     assert [{t.number for t in population} for population in population_per_rank] == [
         {0},
         {1, 2},
@@ -104,7 +108,7 @@ def test_fast_non_dominated_sort() -> None:
         _create_frozen_trial(3, [30, 10]),
         _create_frozen_trial(4, [15, 15]),
     ]
-    population_per_rank = optuna.samplers._nsga2._fast_non_dominated_sort(trials, directions)
+    population_per_rank = sampler._fast_non_dominated_sort(trials, directions)
     assert [{t.number for t in population} for population in population_per_rank] == [
         {0, 2, 3},
         {4},
@@ -121,12 +125,172 @@ def test_fast_non_dominated_sort() -> None:
         _create_frozen_trial(4, [0, 0, 9]),
         _create_frozen_trial(5, [0, 9, 9]),
     ]
-    population_per_rank = optuna.samplers._nsga2._fast_non_dominated_sort(trials, directions)
+    population_per_rank = sampler._fast_non_dominated_sort(trials, directions)
     assert [{t.number for t in population} for population in population_per_rank] == [
         {2},
         {0, 3, 5},
         {1},
         {4},
+    ]
+
+
+def test_fast_non_dominated_sort_constrained_feasible() -> None:
+    sampler = NSGAIISampler(constraints_func=lambda _: [0])
+
+    # Single objective.
+    directions = [StudyDirection.MINIMIZE]
+    trials = [
+        _create_frozen_trial(0, [10], [0]),
+        _create_frozen_trial(1, [20], [0]),
+        _create_frozen_trial(2, [20], [0]),
+        _create_frozen_trial(3, [30], [0]),
+    ]
+    population_per_rank = sampler._fast_non_dominated_sort(trials, directions)
+    assert [{t.number for t in population} for population in population_per_rank] == [
+        {0},
+        {1, 2},
+        {3},
+    ]
+
+    # Two objective.
+    directions = [StudyDirection.MAXIMIZE, StudyDirection.MAXIMIZE]
+    trials = [
+        _create_frozen_trial(0, [10, 30], [0]),
+        _create_frozen_trial(1, [10, 10], [0]),
+        _create_frozen_trial(2, [20, 20], [0]),
+        _create_frozen_trial(3, [30, 10], [0]),
+        _create_frozen_trial(4, [15, 15], [0]),
+    ]
+    population_per_rank = sampler._fast_non_dominated_sort(trials, directions)
+    assert [{t.number for t in population} for population in population_per_rank] == [
+        {0, 2, 3},
+        {4},
+        {1},
+    ]
+
+    # Three objective.
+    directions = [StudyDirection.MAXIMIZE, StudyDirection.MAXIMIZE, StudyDirection.MINIMIZE]
+    trials = [
+        _create_frozen_trial(0, [5, 5, 4], [0]),
+        _create_frozen_trial(1, [5, 5, 5], [0]),
+        _create_frozen_trial(2, [9, 9, 0], [0]),
+        _create_frozen_trial(3, [5, 7, 5], [0]),
+        _create_frozen_trial(4, [0, 0, 9], [0]),
+        _create_frozen_trial(5, [0, 9, 9], [0]),
+    ]
+    population_per_rank = sampler._fast_non_dominated_sort(trials, directions)
+    assert [{t.number for t in population} for population in population_per_rank] == [
+        {2},
+        {0, 3, 5},
+        {1},
+        {4},
+    ]
+
+
+def test_fast_non_dominated_sort_constrained_infeasible() -> None:
+    sampler = NSGAIISampler(constraints_func=lambda _: [0])
+
+    # Single objective.
+    directions = [StudyDirection.MINIMIZE]
+    trials = [
+        _create_frozen_trial(0, [10], [1]),
+        _create_frozen_trial(1, [20], [3]),
+        _create_frozen_trial(2, [20], [2]),
+        _create_frozen_trial(3, [30], [1]),
+    ]
+    population_per_rank = sampler._fast_non_dominated_sort(trials, directions)
+    assert [{t.number for t in population} for population in population_per_rank] == [
+        {0, 3},
+        {2},
+        {1},
+    ]
+
+    # Two objective.
+    directions = [StudyDirection.MAXIMIZE, StudyDirection.MAXIMIZE]
+    trials = [
+        _create_frozen_trial(0, [10, 30], [1, 1]),
+        _create_frozen_trial(1, [10, 10], [2, 2]),
+        _create_frozen_trial(2, [20, 20], [3, 3]),
+        _create_frozen_trial(3, [30, 10], [2, 4]),
+        _create_frozen_trial(4, [15, 15], [4, 4]),
+    ]
+    population_per_rank = sampler._fast_non_dominated_sort(trials, directions)
+    assert [{t.number for t in population} for population in population_per_rank] == [
+        {0},
+        {1},
+        {2, 3},
+        {4},
+    ]
+
+    # Three objective.
+    directions = [StudyDirection.MAXIMIZE, StudyDirection.MAXIMIZE, StudyDirection.MINIMIZE]
+    trials = [
+        _create_frozen_trial(0, [5, 5, 4], [1, 1, 1]),
+        _create_frozen_trial(1, [5, 5, 5], [1, 1, 1]),
+        _create_frozen_trial(2, [9, 9, 0], [3, 3, 3]),
+        _create_frozen_trial(3, [5, 7, 5], [2, 2, 2]),
+        _create_frozen_trial(4, [0, 0, 9], [1, 1, 4]),
+        _create_frozen_trial(5, [0, 9, 9], [2, 1, 3]),
+    ]
+    population_per_rank = sampler._fast_non_dominated_sort(trials, directions)
+    assert [{t.number for t in population} for population in population_per_rank] == [
+        {0, 1},
+        {3, 4, 5},
+        {2},
+    ]
+
+
+def test_fast_non_dominated_sort_constrained_feasible_infeasible() -> None:
+    sampler = NSGAIISampler(constraints_func=lambda _: [0])
+
+    # Single objective.
+    directions = [StudyDirection.MINIMIZE]
+    trials = [
+        _create_frozen_trial(0, [10], [0]),
+        _create_frozen_trial(1, [20], [-1]),
+        _create_frozen_trial(2, [20], [-2]),
+        _create_frozen_trial(3, [30], [1]),
+    ]
+    population_per_rank = sampler._fast_non_dominated_sort(trials, directions)
+    assert [{t.number for t in population} for population in population_per_rank] == [
+        {0},
+        {1, 2},
+        {3},
+    ]
+
+    # Two objective.
+    directions = [StudyDirection.MAXIMIZE, StudyDirection.MAXIMIZE]
+    trials = [
+        _create_frozen_trial(0, [10, 30], [-1, -1]),
+        _create_frozen_trial(1, [10, 10], [-2, -2]),
+        _create_frozen_trial(2, [20, 20], [3, 3]),
+        _create_frozen_trial(3, [30, 10], [6, -1]),
+        _create_frozen_trial(4, [15, 15], [4, 4]),
+    ]
+    population_per_rank = sampler._fast_non_dominated_sort(trials, directions)
+    assert [{t.number for t in population} for population in population_per_rank] == [
+        {0},
+        {1},
+        {2, 3},
+        {4},
+    ]
+
+    # Three objective.
+    directions = [StudyDirection.MAXIMIZE, StudyDirection.MAXIMIZE, StudyDirection.MINIMIZE]
+    trials = [
+        _create_frozen_trial(0, [5, 5, 4], [-1, -1, -1]),
+        _create_frozen_trial(1, [5, 5, 5], [1, 1, -1]),
+        _create_frozen_trial(2, [9, 9, 0], [1, -1, -1]),
+        _create_frozen_trial(3, [5, 7, 5], [-1, -1, -1]),
+        _create_frozen_trial(4, [0, 0, 9], [-1, -1, -1]),
+        _create_frozen_trial(5, [0, 9, 9], [-1, -1, -1]),
+    ]
+    population_per_rank = sampler._fast_non_dominated_sort(trials, directions)
+    assert [{t.number for t in population} for population in population_per_rank] == [
+        {0, 3, 5},
+        {4},
+        {2},
+        {1},
     ]
 
 
@@ -191,7 +355,9 @@ def test_reseed_rng() -> None:
 
 
 # TODO(ohta): Consider to move this utility function to `optuna.testing` module.
-def _create_frozen_trial(number: int, values: List[float]) -> optuna.trial.FrozenTrial:
+def _create_frozen_trial(
+    number: int, values: List[float], constraints: Optional[List[float]] = None
+) -> optuna.trial.FrozenTrial:
     return optuna.trial.FrozenTrial(
         number=number,
         trial_id=number,
@@ -202,7 +368,7 @@ def _create_frozen_trial(number: int, values: List[float]) -> optuna.trial.Froze
         params={},
         distributions={},
         user_attrs={},
-        system_attrs={},
+        system_attrs={} if constraints is None else {_CONSTRAINTS_KEY: constraints},
         intermediate_values={},
         values=values,
     )

--- a/tests/samplers_tests/test_nsga2.py
+++ b/tests/samplers_tests/test_nsga2.py
@@ -405,7 +405,6 @@ def test_reseed_rng() -> None:
     assert original_random_sampler_seed != sampler._random_sampler._rng.seed
 
 
-
 def test_constraints_func_experimental_warning() -> None:
     with pytest.warns(optuna.exceptions.ExperimentalWarning):
         NSGAIISampler(constraints_func=lambda _: [0])


### PR DESCRIPTION
## Motivation
This is an alternative approach of #2174 suggested by @sile in https://github.com/optuna/optuna/pull/2174#issuecomment-755041088. Instead of adding a new sampler, this PR adds `constraints_func` to `NSGAIISampler` to handle constraints. The same algorithm is implemented as #2174.

This design follows `BoTorchSampler` and I think it provides better user experiences than #2174.

## Description of the changes
- Add `constraints_func` argument
- Make `_fast_non_dominated_sort` the method of `NSGAIISampler`
- Use `_constrained_dominates` if `constraints_func` is not `None`

## Example: solving multi-objective knapsack problem

See the following [notebook](https://colab.research.google.com/drive/1xwHwKRsyiM2DvG0ntlvneHGyYDhfopS_?usp=sharing).

## TODO

- [x] Add a simple comparison with NSGA-II 