### PR TITLE
Ask and Tell API (`Study.should_prune`) 

### DIFF
--- a/optuna/_optimize.py
+++ b/optuna/_optimize.py
@@ -185,7 +185,7 @@ def _run_trial(
     func: "optuna.study.ObjectiveFuncType",
     catch: Tuple[Type[Exception], ...],
 ) -> trial_module.Trial:
-    trial = study._ask()
+    trial = study.ask()
 
     state: Optional[TrialState] = None
     values: Optional[List[float]] = None
@@ -219,13 +219,12 @@ def _run_trial(
         else:
             state = TrialState.COMPLETE
 
+    # `Study.tell` may raise during trial post-processing.
     try:
-        trial._after_func(state, values)
+        study.tell(trial, values=values, state=state)
     except Exception:
         raise
     finally:
-        study._tell(trial, state, values)
-
         if state == TrialState.COMPLETE:
             study._log_completed_trial(trial, cast(List[float], values))
         elif state == TrialState.PRUNED:

--- a/optuna/_optimize.py
+++ b/optuna/_optimize.py
@@ -212,7 +212,7 @@ def _run_trial(
         func_err_fail_exc_info = sys.exc_info()
     else:
         values, values_conversion_failure_message = _check_and_convert_to_values(
-            len(study.directions), value_or_values, trial
+            len(study.directions), value_or_values, trial.number
         )
         if values_conversion_failure_message is not None:
             state = TrialState.FAIL
@@ -250,14 +250,14 @@ def _run_trial(
 
 
 def _check_and_convert_to_values(
-    n_objectives: int, original_value: Union[float, Sequence[float]], trial: trial_module.Trial
+    n_objectives: int, original_value: Union[float, Sequence[float]], trial_number: int
 ) -> Tuple[Optional[List[float]], Optional[str]]:
     if isinstance(original_value, Sequence):
         if n_objectives != len(original_value):
             return (
                 None,
                 (
-                    f"Trial {trial.number} failed, because the number of the values "
+                    f"Trial {trial_number} failed, because the number of the values "
                     f"{len(original_value)} is did not match the number of the objectives "
                     f"{n_objectives}."
                 ),
@@ -269,7 +269,7 @@ def _check_and_convert_to_values(
 
     _checked_values = []
     for v in _original_values:
-        checked_v, failure_message = _check_single_value(v, trial)
+        checked_v, failure_message = _check_single_value(v, trial_number)
         if failure_message is not None:
             # TODO(Imamura): Construct error message taking into account all values and do not
             #  early return
@@ -284,7 +284,7 @@ def _check_and_convert_to_values(
 
 
 def _check_single_value(
-    original_value: float, trial: trial_module.Trial
+    original_value: float, trial_number: int
 ) -> Tuple[Optional[float], Optional[str]]:
     value = None
     failure_message = None
@@ -296,15 +296,14 @@ def _check_single_value(
         TypeError,
     ):
         failure_message = (
-            f"Trial {trial.number} failed, because the returned value from the "
-            f"objective function cannot be cast to float. Returned value is: "
-            f"{repr(original_value)}"
+            f"Trial {trial_number} failed, because the value {repr(original_value)} could not be "
+            "cast to float."
         )
 
     if value is not None and math.isnan(value):
         value = None
         failure_message = (
-            f"Trial {trial.number} failed, because the objective function returned "
+            f"Trial {trial_number} failed, because the objective function returned "
             f"{original_value}."
         )
 

--- a/optuna/storages/_base.py
+++ b/optuna/storages/_base.py
@@ -377,6 +377,24 @@ class BaseStorage(object, metaclass=abc.ABCMeta):
         """
         raise NotImplementedError
 
+    def get_trial_id_from_study_id_trial_number(self, study_id: int, trial_number: int) -> int:
+        """Read the trial id of a trial.
+
+        Args:
+            study_id:
+                ID of the study.
+            trial_number:
+                Number of the trial.
+
+        Returns:
+            ID of the trial.
+
+        Raises:
+            :exc:`KeyError`:
+                If no trial with the matching ``study_id`` and ``trial_number`` exists.
+        """
+        raise NotImplementedError
+
     @abc.abstractmethod
     def get_trial_number_from_id(self, trial_id: int) -> int:
         """Read the trial number of a trial.

--- a/optuna/storages/_cached_storage.py
+++ b/optuna/storages/_cached_storage.py
@@ -260,6 +260,11 @@ class _CachedStorage(BaseStorage):
 
         self._backend.set_trial_param(trial_id, param_name, param_value_internal, distribution)
 
+    def get_trial_id_from_study_id_trial_number(self, study_id: int, trial_number: int) -> int:
+
+        # TODO(hvy): Optimize to not issue a query to the backend storage.
+        return self._backend.get_trial_id_from_study_id_trial_number(study_id, trial_number)
+
     def get_trial_number_from_id(self, trial_id: int) -> int:
 
         return self.get_trial(trial_id).number

--- a/optuna/storages/_in_memory.py
+++ b/optuna/storages/_in_memory.py
@@ -268,6 +268,26 @@ class InMemoryStorage(BaseStorage):
             trial.distributions[param_name] = distribution
             self._set_trial(trial_id, trial)
 
+    def get_trial_id_from_study_id_trial_number(self, study_id: int, trial_number: int) -> int:
+
+        with self._lock:
+            study = self._studies.get(study_id)
+            if study is None:
+                raise KeyError("No study with study_id {} exists.".format(study_id))
+
+            trials = study.trials
+            if len(trials) <= trial_number:
+                raise KeyError(
+                    "No trial with trial number {} exists in study with study_id {}.".format(
+                        trial_number, study_id
+                    )
+                )
+
+            trial = trials[trial_number]
+            assert trial.number == trial_number
+
+            return trial._trial_id
+
     def get_trial_number_from_id(self, trial_id: int) -> int:
 
         with self._lock:

--- a/optuna/storages/_rdb/storage.py
+++ b/optuna/storages/_rdb/storage.py
@@ -908,6 +908,25 @@ class RDBStorage(BaseStorage):
         else:
             attribute.value_json = json.dumps(value)
 
+    def get_trial_id_from_study_id_trial_number(self, study_id: int, trial_number: int) -> int:
+
+        with _create_scoped_session(self.scoped_session) as session:
+            trial_id = (
+                session.query(models.TrialModel.trial_id)
+                .filter(
+                    models.TrialModel.number == trial_number,
+                    models.TrialModel.study_id == study_id,
+                )
+                .one_or_none()
+            )
+            if trial_id is None:
+                raise KeyError(
+                    "No trial with trial number {} exists in study with study_id {}.".format(
+                        trial_number, study_id
+                    )
+                )
+            return trial_id[0]
+
     def get_trial_number_from_id(self, trial_id: int) -> int:
 
         trial_number = self.get_trial(trial_id).number

--- a/optuna/storages/_redis.py
+++ b/optuna/storages/_redis.py
@@ -396,6 +396,18 @@ class RedisStorage(BaseStorage):
             pipe.set(self._key_trial(trial_id), pickle.dumps(trial))
             pipe.execute()
 
+    def get_trial_id_from_study_id_trial_number(self, study_id: int, trial_number: int) -> int:
+
+        trial_ids = self._get_study_trials(study_id)
+        if len(trial_ids) <= trial_number:
+            raise KeyError(
+                "No trial with trial number {} exists in study with study_id {}.".format(
+                    trial_number, study_id
+                )
+            )
+
+        return trial_ids[trial_number]
+
     def get_trial_number_from_id(self, trial_id: int) -> int:
 
         return self.get_trial(trial_id).number

--- a/optuna/study.py
+++ b/optuna/study.py
@@ -541,7 +541,10 @@ class Study(BaseStudy):
             values, values_conversion_failure_message = _check_and_convert_to_values(
                 len(self.directions), values, trial_number
             )
-            if values_conversion_failure_message is not None:
+            # When called from `Study.optimize` and `state` is pruned, the given `values` contains
+            # the intermediate value with the largest step so far. In this case, the value is
+            # allowed to be NaN and errors should not be raised.
+            if state != TrialState.PRUNED and values_conversion_failure_message is not None:
                 raise ValueError(values_conversion_failure_message)
 
         assert trial_id is not None

--- a/optuna/study.py
+++ b/optuna/study.py
@@ -529,6 +529,12 @@ class Study(BaseStudy):
                 trial_id = self._storage.get_trial_id_from_study_id_trial_number(
                     self._study_id, trial_number
                 )
+            except NotImplementedError as e:
+                raise TypeError(
+                    "Study.tell failed because the trial was represented by its number but the "
+                    f"storage {self._storage.__class__.__name__} does not implement the method "
+                    "required to map numbers back. Please provide the trial object instead."
+                ) from e
             except KeyError as e:
                 raise ValueError(
                     f"Cannot tell for trial with number {trial_number} since it has not been "

--- a/optuna/study.py
+++ b/optuna/study.py
@@ -397,7 +397,7 @@ class Study(BaseStudy):
         values: Optional[Union[float, List[float]]] = None,
         state: TrialState = TrialState.COMPLETE,
     ) -> None:
-        self._validate_tell(trial, values, state)
+        _check_tell_args(trial, values, state)
 
         # TODO(hvy): Do trial post-processing with `after_trial`.
 
@@ -410,27 +410,6 @@ class Study(BaseStudy):
             self._storage.set_trial_values(trial._trial_id, values)
 
         self._storage.set_trial_state(trial._trial_id, state)
-
-    def _validate_tell(
-        self,
-        trial: trial_module.Trial,
-        values: Optional[Union[float, List[float]]],
-        state: TrialState,
-    ) -> None:
-        if state == TrialState.COMPLETE:
-            if values is None:
-                raise ValueError(
-                    "No values were told. Values are required when state is TrialState.COMPLETE."
-                )
-        elif state == TrialState.PRUNED:
-            pass
-        elif state == TrialState.FAIL:
-            if values is not None:
-                raise ValueError(
-                    "Values were told. Values cannot be stored when state is TrialState.FAIL."
-                )
-        else:
-            raise ValueError("Cannot tell with state {state}.")
 
     def set_user_attr(self, key: str, value: Any) -> None:
         """Set a user attribute to the study.
@@ -1034,3 +1013,24 @@ def get_all_study_summaries(storage: Union[str, storages.BaseStorage]) -> List[S
 
     storage = storages.get_storage(storage)
     return storage.get_all_study_summaries()
+
+
+def _check_tell_args(
+    trial: trial_module.Trial,
+    values: Optional[Union[float, List[float]]],
+    state: TrialState,
+) -> None:
+    if state == TrialState.COMPLETE:
+        if values is None:
+            raise ValueError(
+                "No values were told. Values are required when state is TrialState.COMPLETE."
+            )
+    elif state == TrialState.PRUNED:
+        pass
+    elif state == TrialState.FAIL:
+        if values is not None:
+            raise ValueError(
+                "Values were told. Values cannot be stored when state is TrialState.FAIL."
+            )
+    else:
+        raise ValueError(f"Cannot tell with state {state}.")

--- a/optuna/study.py
+++ b/optuna/study.py
@@ -414,15 +414,14 @@ class Study(BaseStudy):
     def _validate_tell(
         self,
         trial: trial_module.Trial,
-        values: Optional[Union[float, List[float]]] = None,
-        state: TrialState = TrialState.COMPLETE,
+        values: Optional[Union[float, List[float]]],
+        state: TrialState,
     ) -> None:
         if state == TrialState.COMPLETE:
             if values is None:
                 raise ValueError(
                     "No values were told. Values are required when state is TrialState.COMPLETE."
                 )
-            state = TrialState.COMPLETE
         elif state == TrialState.PRUNED:
             pass
         elif state == TrialState.FAIL:

--- a/optuna/study.py
+++ b/optuna/study.py
@@ -555,9 +555,9 @@ class Study(BaseStudy):
 
         try:
             # Sampler defined trial post-processing.
-            trial = self._storage.get_trial(trial_id)
-            study = pruners._filter_study(self, trial)
-            self.sampler.after_trial(study, trial, state, values)
+            frozen_trial = self._storage.get_trial(trial_id)
+            study = pruners._filter_study(self, frozen_trial)
+            self.sampler.after_trial(study, frozen_trial, state, values)
         except Exception:
             raise
         finally:

--- a/optuna/study.py
+++ b/optuna/study.py
@@ -455,7 +455,7 @@ class Study(BaseStudy):
                     for step in range(128):
                         y = f(x)
 
-                        trial.report(y, step=step)
+                        study.report(trial, y, step=step)
 
                         if trial.should_prune():
                             # Finish the trial with the pruned state.
@@ -550,6 +550,35 @@ class Study(BaseStudy):
             self._storage.set_trial_state(trial_id, state)
 
     def report(self, trial: Union[trial_module.Trial, int], value: float, step: int) -> None:
+        """Report an objective function value for a given trial and step.
+
+        The reported values are used by the pruners to determine whether this trial should be
+        pruned.
+
+        This method is part of an alternative to :func:`~optuna.study.Study.optimize` that allows
+        controlling the lifetime of a trial outside the scope of ``func`` and can be used instead
+        of :func:`~optuna.trial.Trial.report` in case a :class:`~optuna.trial.Trial` object is not
+        available since ``trial`` can be a trial number.
+
+        .. seealso::
+            Please refer to :func:`~optuna.trial.Trial.report` for more details and
+            :func:`~optuna.study.Study.tell` for an example.
+
+        Args:
+            trial:
+                A :class:`~optuna.trial.Trial` object or a trial number.
+            value:
+                Objective value.
+            step:
+                Step of the trial.
+
+        Raises:
+            TypeError:
+                If ``trial`` is not a :class:`~optuna.trial.Trial` or an :obj:`int`.
+            NotImplementedError:
+                If study is being used for multi-objective optimization.
+        """
+
         if len(self.directions) > 1:
             raise NotImplementedError(
                 "Reporting is not supported for multi-objective optimization."

--- a/optuna/study.py
+++ b/optuna/study.py
@@ -409,7 +409,7 @@ class Study(BaseStudy):
             A :class:`~optuna.trial.Trial`.
         """
 
-        # Sync storage once at the beginning of the objective evaluation.
+        # Sync storage once every trial.
         self._storage.read_trials_from_remote_storage(self._study_id)
 
         trial_id = self._pop_waiting_trial_id()

--- a/optuna/trial/_trial.py
+++ b/optuna/trial/_trial.py
@@ -511,7 +511,8 @@ class Trial(BaseTrial):
         pruned.
 
         .. seealso::
-            Please refer to :class:`~optuna.pruners.BasePruner`.
+            Please refer to :class:`~optuna.pruners.BasePruner` and
+            :func:`~optuna.study.Study.report` for an alternative interface.
 
         .. note::
             The reported value is converted to ``float`` type by applying ``float()``

--- a/optuna/trial/_trial.py
+++ b/optuna/trial/_trial.py
@@ -566,32 +566,7 @@ class Trial(BaseTrial):
                 If trial is being used for multi-objective optimization.
         """
 
-        if len(self.study.directions) > 1:
-            raise NotImplementedError(
-                "Trial.report is not supported for multi-objective optimization."
-            )
-
-        try:
-            # For convenience, we allow users to report a value that can be cast to `float`.
-            value = float(value)
-        except (TypeError, ValueError):
-            message = "The `value` argument is of type '{}' but supposed to be a float.".format(
-                type(value).__name__
-            )
-            raise TypeError(message) from None
-
-        if step < 0:
-            raise ValueError("The `step` argument is {} but cannot be negative.".format(step))
-
-        intermediate_values = self.storage.get_trial(self._trial_id).intermediate_values
-
-        if step in intermediate_values:
-            # Do nothing if already reported.
-            # TODO(hvy): Consider raising a warning or an error.
-            # See https://github.com/optuna/optuna/issues/852.
-            return
-
-        self.storage.set_trial_intermediate_value(self._trial_id, step, value)
+        return self.study.report(self, value=value, step=step)
 
     def should_prune(self) -> bool:
         """Suggest whether the trial should be pruned or not.

--- a/optuna/trial/_trial.py
+++ b/optuna/trial/_trial.py
@@ -582,7 +582,8 @@ class Trial(BaseTrial):
             values, the suggestions will be the same.
 
         .. seealso::
-            Please refer to the example code in :func:`optuna.trial.Trial.report`.
+            Please refer to the example code in :func:`optuna.trial.Trial.report` and
+            :func:`~optuna.study.Study.should_prune` for an alternative interface.
 
         Returns:
             A boolean value. If :obj:`True`, the trial should be pruned according to the
@@ -593,13 +594,7 @@ class Trial(BaseTrial):
                 If trial is being used for multi-objective optimization.
         """
 
-        if len(self.study.directions) > 1:
-            raise NotImplementedError(
-                "Trial.should_prune is not supported for multi-objective optimization."
-            )
-
-        trial = self.study._storage.get_trial(self._trial_id)
-        return self.study.pruner.prune(self.study, trial)
+        return self.study.should_prune(self)
 
     def set_user_attr(self, key: str, value: Any) -> None:
         """Set user attributes to the trial.

--- a/tests/samplers_tests/test_samplers.py
+++ b/tests/samplers_tests/test_samplers.py
@@ -597,3 +597,27 @@ def test_after_trial_failing_in_after_trial() -> None:
 
     assert len(study.trials) == 1
     assert n_calls == 2
+
+
+def test_after_trial_with_study_tell() -> None:
+    n_calls = 0
+
+    class SamplerAfterTrial(DeterministicRelativeSampler):
+        def after_trial(
+            self,
+            study: Study,
+            trial: FrozenTrial,
+            state: TrialState,
+            values: Optional[Sequence[float]],
+        ) -> None:
+            nonlocal n_calls
+            n_calls += 1
+
+    sampler = SamplerAfterTrial({}, {})
+    study = optuna.create_study(sampler=sampler)
+
+    assert n_calls == 0
+
+    study.tell(study.ask(), 1.0)
+
+    assert n_calls == 1

--- a/tests/storages_tests/test_storages.py
+++ b/tests/storages_tests/test_storages.py
@@ -1060,3 +1060,34 @@ def test_get_best_trial_for_multi_objective_optimization(storage_mode: str) -> N
             storage.create_new_trial(study_id, template_trial=template_trial)
         with pytest.raises(ValueError):
             storage.get_best_trial(study_id)
+
+
+@pytest.mark.parametrize("storage_mode", STORAGE_MODES)
+def test_get_trial_id_from_study_id_trial_number(storage_mode: str) -> None:
+
+    with StorageSupplier(storage_mode) as storage:
+        with pytest.raises(KeyError):  # Matching study does not exist.
+            storage.get_trial_id_from_study_id_trial_number(study_id=0, trial_number=0)
+
+        study_id = storage.create_new_study()
+
+        with pytest.raises(KeyError):  # Matching trial does not exist.
+            storage.get_trial_id_from_study_id_trial_number(study_id, trial_number=0)
+
+        trial_id = storage.create_new_trial(study_id)
+
+        assert trial_id == storage.get_trial_id_from_study_id_trial_number(
+            study_id, trial_number=0
+        )
+
+        # Trial IDs are globally unique within a storage but numbers are only unique within a
+        # study. Create a second study within the same storage.
+        study_id = storage.create_new_study()
+
+        storage.create_new_trial(study_id)
+        storage.create_new_trial(study_id)
+        trial_id = storage.create_new_trial(study_id)
+
+        assert trial_id == storage.get_trial_id_from_study_id_trial_number(
+            study_id, trial_number=2
+        )

--- a/tests/test_study.py
+++ b/tests/test_study.py
@@ -10,6 +10,7 @@ from typing import Dict
 from typing import List
 from typing import Optional
 from typing import Tuple
+from typing import Union
 from unittest.mock import Mock  # NOQA
 from unittest.mock import patch
 import uuid
@@ -25,6 +26,7 @@ from optuna import _optimize
 from optuna import create_trial
 from optuna.study import StudyDirection
 from optuna.testing.storage import StorageSupplier
+from optuna.trial import Trial
 from optuna.trial import TrialState
 
 
@@ -1105,3 +1107,25 @@ def test_wrong_n_objectives() -> None:
 
     for trial in study.trials:
         assert trial.state is TrialState.FAIL
+
+
+@pytest.mark.parametrize(
+    "values",
+    [
+        1.0,  # "value" single-objective optimization interface.
+        [1.0],  # "values" multi-objective optimization interface.
+    ],
+)
+def test_ask_and_tell(values: Union[float, List[float]]) -> None:
+    study = optuna.create_study()
+    trial = study.ask()
+
+    assert isinstance(trial, Trial)
+
+    with pytest.raises(ValueError):  # Values missing.
+        study.tell(trial)
+
+    study.tell(trial, values)
+
+    with pytest.raises(RuntimeError):  # Trial already finished.
+        study.tell(trial, values)

--- a/tests/test_study.py
+++ b/tests/test_study.py
@@ -1213,7 +1213,50 @@ def test_tell_values() -> None:
         study.tell(study.ask())
 
 
-def test_tell_storage_not_implemented_trial_number() -> None:
+def test_report() -> None:
+    # See tests/test_trial.py for corresponding tests for `Trial.report`.
+
+    study = optuna.create_study()
+    trial = Trial(study, study._storage.create_new_trial(study._study_id))
+
+    # Report values that can be cast to `float` (OK).
+    study.report(trial, 1.23, 1)
+    study.report(trial, float("nan"), 2)
+    study.report(trial, "1.23", 3)  # type: ignore
+    study.report(trial, "inf", 4)  # type: ignore
+    study.report(trial, 1, 5)
+
+    # Report values that cannot be cast to `float` or steps that are negative (Error).
+    with pytest.raises(TypeError):
+        study.report(trial, None, 7)  # type: ignore
+
+    with pytest.raises(TypeError):
+        study.report(trial, "foo", 7)  # type: ignore
+
+    with pytest.raises(TypeError):
+        study.report(trial, [1, 2, 3], 7)  # type: ignore
+
+    with pytest.raises(TypeError):
+        study.report(trial, "foo", -1)  # type: ignore
+
+    with pytest.raises(ValueError):
+        study.report(trial, 1.23, -1)
+
+
+def test_report_trial_variations() -> None:
+    study = optuna.create_study()
+
+    study.report(study.ask().number, 1.0, 1)
+
+    # Trial that has not been asked for cannot be reported.
+    with pytest.raises(ValueError):
+        study.report(study.ask().number + 1, 1.0, 2)
+
+    with pytest.raises(TypeError):
+        study.report("1", 1.0, 3)  # type: ignore
+
+
+def test_storage_not_implemented_trial_number() -> None:
     with StorageSupplier("inmemory") as storage:
 
         with patch.object(
@@ -1229,3 +1272,6 @@ def test_tell_storage_not_implemented_trial_number() -> None:
             # trial IDs.
             with pytest.raises(TypeError):
                 study.tell(study.ask().number, 1.0)
+
+            with pytest.raises(TypeError):
+                study.report(study.ask().number, 1.0, 1)

--- a/tests/test_study.py
+++ b/tests/test_study.py
@@ -1151,17 +1151,6 @@ def test_tell() -> None:
         study.tell(study.ask(), state=TrialState.WAITING)
 
 
-def test_tell_complete_without_values() -> None:
-    study = optuna.create_study()
-
-    with pytest.raises(ValueError):
-        study.tell(study.ask(), state=TrialState.COMPLETE)
-
-    # Default state is `TrialState.COMPLETE` for which values are required.
-    with pytest.raises(ValueError):
-        study.tell(study.ask())
-
-
 def test_tell_trial_variations() -> None:
     study = optuna.create_study()
 
@@ -1192,6 +1181,10 @@ def test_tell_values() -> None:
 
     study.tell(study.ask(), [1.0])
 
+    # Check invalid values, e.g. ones that cannot be cast to float.
+    with pytest.raises(ValueError):
+        study.tell(study.ask(), "a")  # type: ignore
+
     # Check number of values.
     with pytest.raises(ValueError):
         study.tell(study.ask(), [])
@@ -1210,3 +1203,11 @@ def test_tell_values() -> None:
 
     with pytest.raises(ValueError):
         study.tell(study.ask(), [1.0, 2.0, 3.0])
+
+    # Missing values for completions.
+    with pytest.raises(ValueError):
+        study.tell(study.ask(), state=TrialState.COMPLETE)
+
+    # Default state is `TrialState.COMPLETE` for which values are required.
+    with pytest.raises(ValueError):
+        study.tell(study.ask())

--- a/tests/test_study.py
+++ b/tests/test_study.py
@@ -1211,3 +1211,21 @@ def test_tell_values() -> None:
     # Default state is `TrialState.COMPLETE` for which values are required.
     with pytest.raises(ValueError):
         study.tell(study.ask())
+
+
+def test_tell_storage_not_implemented_trial_number() -> None:
+    with StorageSupplier("inmemory") as storage:
+
+        with patch.object(
+            storage,
+            "get_trial_id_from_study_id_trial_number",
+            side_effect=NotImplementedError,
+        ):
+            study = optuna.create_study(storage=storage)
+
+            study.tell(study.ask(), 1.0)
+
+            # Storage missing implementation for method required to map trial numbers back to
+            # trial IDs.
+            with pytest.raises(TypeError):
+                study.tell(study.ask().number, 1.0)

--- a/tests/test_study.py
+++ b/tests/test_study.py
@@ -1256,6 +1256,13 @@ def test_report_trial_variations() -> None:
         study.report("1", 1.0, 3)  # type: ignore
 
 
+def test_raise_error_for_report_with_multi_objectives() -> None:
+    study = optuna.create_study(directions=["maximize", "maximize"])
+
+    with pytest.raises(NotImplementedError):
+        study.report(study.ask(), 1.0, 0)
+
+
 def test_storage_not_implemented_trial_number() -> None:
     with StorageSupplier("inmemory") as storage:
 


### PR DESCRIPTION
## Motivation

See #2158.

## Description of the changes

Depends on #2176.

Similarly to #2176, introduces `Study.should_prune`. The logic of `Trial.should_prune` is moved to the new method and `Trial.should_prune` just indirects to `Study.should_prune`.

## TODO

- [x] Implement
- [x] Document