### PR TITLE
Drop unnecessary constraint from upgraded `trial_values` table

### DIFF
--- a/optuna/storages/_rdb/alembic/versions/v2.4.0.a.py
+++ b/optuna/storages/_rdb/alembic/versions/v2.4.0.a.py
@@ -175,6 +175,7 @@ def upgrade():
                 batch_op.drop_constraint(c["name"], type_="unique")
             break
 
+
 # TODO(imamura): Implement downgrade
 def downgrade():
     pass

--- a/optuna/storages/_rdb/alembic/versions/v2.4.0.a.py
+++ b/optuna/storages/_rdb/alembic/versions/v2.4.0.a.py
@@ -77,7 +77,8 @@ class TrialIntermediateValueModel(BaseModel):
 
 def upgrade():
     bind = op.get_bind()
-    tables = Inspector.from_engine(bind).get_table_names()
+    inspector = Inspector.from_engine(bind)
+    tables = inspector.get_table_names()
 
     if "study_directions" not in tables:
         op.create_table(
@@ -168,7 +169,7 @@ def upgrade():
     with op.batch_alter_table("trials", schema=None) as batch_op:
         batch_op.drop_column("value")
 
-    for c in Inspector.from_engine(bind).get_unique_constraints("trial_values"):
+    for c in inspector.get_unique_constraints("trial_values"):
         # MySQL changes the uniq constraint of (trial_id, step) to that of trial_id.
         if c["column_names"] == ["trial_id"]:
             with op.batch_alter_table("trial_values", schema=None) as batch_op:

--- a/optuna/storages/_rdb/alembic/versions/v2.4.0.a.py
+++ b/optuna/storages/_rdb/alembic/versions/v2.4.0.a.py
@@ -144,6 +144,7 @@ def upgrade():
             batch_op.create_unique_constraint(
                 "uq_trial_values_trial_id_objective", ["trial_id", "objective"]
             )
+            batch_op.drop_constraint("trial_id", type_="unique")
 
         trials_records = session.query(TrialModel).all()
         objects = [


### PR DESCRIPTION
## Motivation

Addresses #2179.

## Description of the changes

This PR removes the `trial_id` from the unique constraint of the `trial_values` table. It is not unique since v2.4.0 because of the support of multi-objective optimization. A pair of `trial_id` and `objective` is the unique key of `trial_values` now.

## TODO

- [x] Manual test with MySQL
- [x] Manual test with PostgreSQL
- [x] Manual test with SQLite

Test for SQLite

<details>
<summary>Python scripts for tests</summary>

single.py
```python
import sys
import optuna

def objective(trial):
    return trial.suggest_float("x", 0, 1)

study = optuna.create_study(study_name=sys.argv[1], storage=sys.argv[2], load_if_exists=True)
study.optimize(objective, n_trials=1)
```

multi.py
```python
import sys
import optuna

def objective(trial):
    return trial.suggest_float("x", 0, 1), trial.suggest_float("y", 0, 1)

study = optuna.create_study(directions=["maximize", "minimize"], study_name=sys.argv[1], storage=sys.argv[2], load_if_exists=True)
study.optimize(objective, n_trials=1)
```

</details>

Test for MySQL

```console
docker run --name mysql -e MYSQL_ROOT_PASSWORD=test -p 3306:3306 -p 33060:33060 -d mysql:8.0.22
docker run --network host -it --rm mysql:8.0.22  mysql -h 127.0.0.1 -uroot -ptest -e "create database test_optuna;"

pip uninstall optuna
pip install optuna
python single.py single mysql+pymysql://root:test@localhost:3306/test_optuna
pip install git+https://github.com/toshihikoyanase/optuna.git@fix-rdb-upgrade-v2.4.0
optuna storage upgrade --storage mysql+pymysql://root:test@localhost:3306/test_optuna
python multi.py multi mysql+pymysql://root:test@localhost:3306/test_optuna
```

Test for MySQL

```console
docker run -it --rm --name postgres-test -e POSTGRES_PASSWORD=test -p 15432:5432 -d postgres

pip uninstall optuna
pip install optuna
python single.py single postgres+psycopg2://postgres:test@localhost:15432/postgres
pip install git+https://github.com/toshihikoyanase/optuna.git@fix-rdb-upgrade-v2.4.0
optuna storage upgrade --storage postgres+psycopg2://postgres:test@localhost:15432/postgres
python multi.py multi postgres+psycopg2://postgres:test@localhost:15432/postgres
```


Test for SQLite

```console
pip uninstall optuna
pip install optuna
python single.py single sqlite:///example.db
pip install git+https://github.com/toshihikoyanase/optuna.git@fix-rdb-upgrade-v2.4.0
optuna storage upgrade --storage sqlite:///example.db
python multi.py multi sqlite:///example.db
```

