### PR TITLE
Fix `mypy` local fails in `tests/test_deprecated.py` and `tests/test_experimental.py`

### DIFF
--- a/tests/test_deprecated.py
+++ b/tests/test_deprecated.py
@@ -99,6 +99,7 @@ def test_deprecation_class_decorator_name() -> None:
     with pytest.warns(FutureWarning) as record:
         decorated_sample("a", "b", "c")
 
+    assert isinstance(record.list[0].message, Warning)
     assert name in record.list[0].message.args[0]
 
 
@@ -114,6 +115,7 @@ def test_deprecation_decorator_name() -> None:
     with pytest.warns(FutureWarning) as record:
         decorated_sample_func()
 
+    assert isinstance(record.list[0].message, Warning)
     assert name in record.list[0].message.args[0]
 
 

--- a/tests/test_experimental.py
+++ b/tests/test_experimental.py
@@ -89,6 +89,7 @@ def test_experimental_class_decorator_name() -> None:
     with pytest.warns(ExperimentalWarning) as record:
         decorated_sample("a", "b", "c")
 
+    assert isinstance(record.list[0].message, Warning)
     assert name in record.list[0].message.args[0]
 
 
@@ -101,4 +102,5 @@ def test_experimental_decorator_name() -> None:
     with pytest.warns(ExperimentalWarning) as record:
         decorated_sample_func()
 
+    assert isinstance(record.list[0].message, Warning)
     assert name in record.list[0].message.args[0]


### PR DESCRIPTION
## Motivation
This PR aims to fix the `mypy .` command failure in the local environment.

- Before
<img width="701" alt="スクリーンショット 2021-01-13 7 18 34" src="https://user-images.githubusercontent.com/38826298/104381284-8f5e8800-556f-11eb-8336-281da020f575.png">

- After
<img width="319" alt="スクリーンショット 2021-01-13 7 20 26" src="https://user-images.githubusercontent.com/38826298/104381465-d187c980-556f-11eb-9b08-04a158562b7b.png">

## Description of the changes
- Add several assertions to ensure the message is `Warning`.
