### PR TITLE
Warn if constraints are missing in constrained NSGA-II

### DIFF
--- a/optuna/samplers/_nsga2.py
+++ b/optuna/samplers/_nsga2.py
@@ -410,8 +410,20 @@ def _constrained_dominates(
     3) Trial x and y are feasible and trial x dominates trial y.
     """
 
-    constraints0 = trial0.system_attrs[_CONSTRAINTS_KEY]
-    constraints1 = trial1.system_attrs[_CONSTRAINTS_KEY]
+    constraints0 = trial0.system_attrs.get(_CONSTRAINTS_KEY)
+    constraints1 = trial1.system_attrs.get(_CONSTRAINTS_KEY)
+
+    if constraints0 is None and constraints1 is None:
+        # Neither Trial x nor y has constraints values
+        return _dominates(trial0, trial1, directions)
+
+    if constraints0 is not None and constraints1 is None:
+        # Trial x has constraint values, but y doesn't.
+        return True
+
+    if constraints0 is None and constraints1 is not None:
+        # If Trial y has constraint values, but x doesn't.
+        return False
 
     assert isinstance(constraints0, (list, tuple))
     assert isinstance(constraints1, (list, tuple))

--- a/optuna/samplers/_nsga2.py
+++ b/optuna/samplers/_nsga2.py
@@ -414,7 +414,7 @@ def _constrained_dominates(
     constraints1 = trial1.system_attrs.get(_CONSTRAINTS_KEY)
 
     if constraints0 is None and constraints1 is None:
-        # Neither Trial x nor y has constraints values
+        # Neither trial x nor y has constraints values
         return _dominates(trial0, trial1, directions)
 
     if constraints0 is not None and constraints1 is None:

--- a/optuna/samplers/_nsga2.py
+++ b/optuna/samplers/_nsga2.py
@@ -413,17 +413,11 @@ def _constrained_dominates(
     constraints0 = trial0.system_attrs.get(_CONSTRAINTS_KEY)
     constraints1 = trial1.system_attrs.get(_CONSTRAINTS_KEY)
 
-    if constraints0 is None and constraints1 is None:
-        # Neither trial x nor y has constraints values
-        return _dominates(trial0, trial1, directions)
+    if constraints0 is None:
+        raise ValueError(f"Trial {trial0.number} does not have constraint values.")
 
-    if constraints0 is not None and constraints1 is None:
-        # Trial x has constraint values, but y doesn't.
-        return True
-
-    if constraints0 is None and constraints1 is not None:
-        # If Trial y has constraint values, but x doesn't.
-        return False
+    if constraints1 is None:
+        raise ValueError(f"Trial {trial1.number} does not have constraint values.")
 
     assert isinstance(constraints0, (list, tuple))
     assert isinstance(constraints1, (list, tuple))

--- a/optuna/samplers/_nsga2.py
+++ b/optuna/samplers/_nsga2.py
@@ -414,10 +414,28 @@ def _constrained_dominates(
     constraints1 = trial1.system_attrs.get(_CONSTRAINTS_KEY)
 
     if constraints0 is None:
-        raise ValueError(f"Trial {trial0.number} does not have constraint values.")
+        warnings.warn(
+            f"Trial {trial0.number} does not have constraint values."
+            " It will be dominated by the other trials."
+        )
 
     if constraints1 is None:
-        raise ValueError(f"Trial {trial1.number} does not have constraint values.")
+        warnings.warn(
+            f"Trial {trial1.number} does not have constraint values."
+            " It will be dominated by the other trials."
+        )
+
+    if constraints0 is None and constraints1 is None:
+        # Neither Trial x nor y has constraints values
+        return _dominates(trial0, trial1, directions)
+
+    if constraints0 is not None and constraints1 is None:
+        # Trial x has constraint values, but y doesn't.
+        return True
+
+    if constraints0 is None and constraints1 is not None:
+        # If Trial y has constraint values, but x doesn't.
+        return False
 
     assert isinstance(constraints0, (list, tuple))
     assert isinstance(constraints1, (list, tuple))

--- a/tests/samplers_tests/test_nsga2.py
+++ b/tests/samplers_tests/test_nsga2.py
@@ -345,6 +345,47 @@ def test_fast_non_dominated_sort_constrained_feasible_infeasible() -> None:
     ]
 
 
+def test_fast_non_dominated_sort_missing_constraint_values() -> None:
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", optuna.exceptions.ExperimentalWarning)
+        sampler = NSGAIISampler(constraints_func=lambda _: [0])
+
+    # Single objective.
+    directions = [StudyDirection.MINIMIZE]
+    trials = [
+        _create_frozen_trial(0, [10]),
+        _create_frozen_trial(1, [20]),
+        _create_frozen_trial(2, [20], [0]),
+        _create_frozen_trial(3, [20], [1]),
+        _create_frozen_trial(4, [30], [-1]),
+    ]
+    population_per_rank = sampler._fast_non_dominated_sort(trials, directions)
+    assert [{t.number for t in population} for population in population_per_rank] == [
+        {2},
+        {4},
+        {3},
+        {0},
+        {1},
+    ]
+
+    # Two objectives.
+    directions = [StudyDirection.MAXIMIZE, StudyDirection.MAXIMIZE]
+    trials = [
+        _create_frozen_trial(0, [50, 30]),
+        _create_frozen_trial(1, [30, 50]),
+        _create_frozen_trial(2, [20, 20], [3, 3]),
+        _create_frozen_trial(3, [30, 10], [0, -1]),
+        _create_frozen_trial(4, [15, 15], [4, 4]),
+    ]
+    population_per_rank = sampler._fast_non_dominated_sort(trials, directions)
+    assert [{t.number for t in population} for population in population_per_rank] == [
+        {3},
+        {2},
+        {4},
+        {0, 1},
+    ]
+
+
 def test_crowding_distance_sort() -> None:
     trials = [
         _create_frozen_trial(0, [5]),

--- a/tests/samplers_tests/test_nsga2.py
+++ b/tests/samplers_tests/test_nsga2.py
@@ -345,45 +345,19 @@ def test_fast_non_dominated_sort_constrained_feasible_infeasible() -> None:
     ]
 
 
-def test_fast_non_dominated_sort_missing_constraint_values() -> None:
+def test_missing_constraint_values() -> None:
+
+    sampler = NSGAIISampler(population_size=10)
+
+    study = optuna.create_study(directions=["minimize"], sampler=sampler)
+    study.optimize(lambda t: [t.suggest_float("x", 0, 9)], n_trials=10)
+
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", optuna.exceptions.ExperimentalWarning)
-        sampler = NSGAIISampler(constraints_func=lambda _: [0])
+        study.sampler = NSGAIISampler(population_size=10, constraints_func=lambda _: [0])
 
-    # Single objective.
-    directions = [StudyDirection.MINIMIZE]
-    trials = [
-        _create_frozen_trial(0, [10]),
-        _create_frozen_trial(1, [20]),
-        _create_frozen_trial(2, [20], [0]),
-        _create_frozen_trial(3, [20], [1]),
-        _create_frozen_trial(4, [30], [-1]),
-    ]
-    population_per_rank = sampler._fast_non_dominated_sort(trials, directions)
-    assert [{t.number for t in population} for population in population_per_rank] == [
-        {2},
-        {4},
-        {3},
-        {0},
-        {1},
-    ]
-
-    # Two objectives.
-    directions = [StudyDirection.MAXIMIZE, StudyDirection.MAXIMIZE]
-    trials = [
-        _create_frozen_trial(0, [50, 30]),
-        _create_frozen_trial(1, [30, 50]),
-        _create_frozen_trial(2, [20, 20], [3, 3]),
-        _create_frozen_trial(3, [30, 10], [0, -1]),
-        _create_frozen_trial(4, [15, 15], [4, 4]),
-    ]
-    population_per_rank = sampler._fast_non_dominated_sort(trials, directions)
-    assert [{t.number for t in population} for population in population_per_rank] == [
-        {3},
-        {2},
-        {4},
-        {0, 1},
-    ]
+    with pytest.raises(ValueError):
+        study.optimize(lambda t: [t.suggest_float("x", 0, 9)], n_trials=10)
 
 
 def test_crowding_distance_sort() -> None:


### PR DESCRIPTION
## Motivation

Depends on #2175. Addresses https://github.com/optuna/optuna/pull/2175#discussion_r556374965.

### Adding custom rules to constrained domination

Add domination relationship between trials without constraint values:
1. If neither trial x nor y have constraint values, x does not dominate y and vise versa.
2. If trial x has constraint values but y doesn't, x dominates y.
3. If trial y has constraint value but x doesn't, x does not dominate y.

These rules penalize the trials without constraint values during the non-dominated sort. They will be moved to the tail of the sorted list. Please note that these rules are not described in the original NSGA-II paper.

~I thought we can modify the definition of constrained-domination, but found out that it may degrade the optimization performance implicitly. So, I reverted the change and chose to raise errors.~

## Alternative approach

We can simply raises `ValueError` or `RuntimeError` if trials' constraints are missing.


