### PR TITLE
Call base sampler's `after_trial` in `PartialFixedSampler`

### DIFF
--- a/optuna/samplers/_partial_fixed.py
+++ b/optuna/samplers/_partial_fixed.py
@@ -1,5 +1,7 @@
 from typing import Any
 from typing import Dict
+from typing import Optional
+from typing import Sequence
 import warnings
 
 from optuna._experimental import experimental
@@ -7,6 +9,7 @@ from optuna.distributions import BaseDistribution
 from optuna.samplers import BaseSampler
 from optuna.study import Study
 from optuna.trial import FrozenTrial
+from optuna.trial import TrialState
 
 
 @experimental("2.4.0")
@@ -108,3 +111,13 @@ class PartialFixedSampler(BaseSampler):
                     f"for distribution {param_distribution}."
                 )
             return param_value
+
+    def after_trial(
+        self,
+        study: Study,
+        trial: FrozenTrial,
+        state: TrialState,
+        values: Optional[Sequence[float]],
+    ) -> None:
+
+        self._base_sampler.after_trial(study, trial, state, values)

--- a/tests/samplers_tests/test_partial_fixed.py
+++ b/tests/samplers_tests/test_partial_fixed.py
@@ -5,7 +5,6 @@ import warnings
 import pytest
 
 import optuna
-from optuna.samplers import GridSampler
 from optuna.samplers import PartialFixedSampler
 from optuna.samplers import RandomSampler
 from optuna.trial import Trial
@@ -118,38 +117,12 @@ def test_reseed_rng() -> None:
         assert original_seed != base_sampler._rng.seed
 
 
-def test_with_grid_sampler() -> None:
-    def objective(trial: Trial) -> float:
-        x = trial.suggest_float("x", -10, 10)
-        y = trial.suggest_float("y", -10, 10)
-        return x ** 2 + y ** 2
-
-    search_space = {"x": list(range(-10, 10, 5)), "y": list(range(-10, 10, 5))}
-    study0 = optuna.create_study()
-    study0.sampler = GridSampler(search_space)
-    study0.optimize(objective, n_trials=20)
-
-    # Fix parameter ``y`` as 0.
-    study1 = optuna.create_study()
+def test_call_after_trial_of_base_sampler() -> None:
+    base_sampler = RandomSampler()
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", optuna.exceptions.ExperimentalWarning)
-        study1.sampler = PartialFixedSampler(
-            fixed_params={"y": 0}, base_sampler=GridSampler(search_space)
-        )
-    study1.optimize(objective, n_trials=20)
-    y_sampled1 = study1.trials[0].params["y"]
-    assert y_sampled1 == 0
-
-    # x_sampled0 = study0.trials[0].params["x"]
-    # x_sampled1 = study1.trials[0].params["x"]
-    # TODO(HideakiImamura): assert x_sampled1 == x_sampled0 if `seed` is introduced to GridSampler
-
-    # The number of grids is 4 * 4 is smaller than the number of trials 20
-    # if GridSampler.after_trial correctly works.
-    assert len(study0.trials) < 20
-    assert len(study1.trials) < 20
-    # In the current implementation of PartialFixedSampler and GridSampler, GridSampler does not
-    # care about the fixed parameters.
-    # TODO(HideakiImamura): assert len(study0.trials) > len(study1.trials) if GridSampler cares
-    #  about the fixed parameters.
-    assert len(study0.trials) == len(study1.trials)
+        sampler = PartialFixedSampler(fixed_params={}, base_sampler=base_sampler)
+    study = optuna.create_study(sampler=sampler)
+    with patch.object(base_sampler, "after_trial", wraps=base_sampler.after_trial) as mock_object:
+        study.optimize(lambda _: 1.0, n_trials=1)
+        assert mock_object.call_count == 1

--- a/tests/samplers_tests/test_partial_fixed.py
+++ b/tests/samplers_tests/test_partial_fixed.py
@@ -148,8 +148,8 @@ def test_with_grid_sampler() -> None:
     # if GridSampler.after_trial correctly works.
     assert len(study0.trials) < 20
     assert len(study1.trials) < 20
-    # In the current implementation of PartialFixedSampler, there is no mechanism to reduce
-    # the number of grids. It is a future work.
-    # TODO(HideakiImamura): assert len(study0.trials) > len(study1.trials) if # of grids reducing
-    #  mechanism is introduced to GridSampler
+    # In the current implementation of PartialFixedSampler and GridSampler, GridSampler does not
+    # care about the fixed parameters.
+    # TODO(HideakiImamura): assert len(study0.trials) > len(study1.trials) if GridSampler cares
+    #  about the fixed parameters.
     assert len(study0.trials) == len(study1.trials)


### PR DESCRIPTION
## Motivations
Currently, the method of `after_trial` is not implemented for `PartialFixedSampler`. This means the base sampler's `after_trial` is not executed if the sampler is wrapped in `PartialFixedSampler`. For example, in the case of the `GridSampler` with `PartialFixedSampler`, the study is not stopped even if all grids are visited as follows.

```python
import optuna


def objective(trial):
    x = trial.suggest_float("x", -10, 10)
    y = trial.suggest_float("y", -10, 10)
    return x ** 2 + y ** 2

# the number of grids is 4 * 4 = 16
search_space = {"x": list(range(-10, 10, 5)), "y": list(range(-10, 10, 5))}

study0 = optuna.create_study()
study0.sampler = optuna.samplers.GridSampler(search_space)
study0.optimize(objective, n_trials=100)

study1 = optuna.create_study()
study1.sampler = optuna.samplers.PartialFixedSampler(
    fixed_params={}, base_sampler=optuna.samplers.GridSampler(search_space)
)
study1.optimize(objective, n_trials=100)

print(len(study0.trials))
print(len(study1.trials))
```

### Output in Optuna v2.4.0
```
16
100
```

### Output in this PR
```
16
16
```