### PR TITLE
Revert "Ask and Tell API (`Study.report`)"

### DIFF
--- a/optuna/trial/_trial.py
+++ b/optuna/trial/_trial.py
@@ -511,8 +511,7 @@ class Trial(BaseTrial):
         pruned.
 
         .. seealso::
-            Please refer to :class:`~optuna.pruners.BasePruner` and
-            :func:`~optuna.study.Study.report` for an alternative interface.
+            Please refer to :class:`~optuna.pruners.BasePruner`.
 
         .. note::
             The reported value is converted to ``float`` type by applying ``float()``
@@ -567,7 +566,32 @@ class Trial(BaseTrial):
                 If trial is being used for multi-objective optimization.
         """
 
-        return self.study.report(self, value=value, step=step)
+        if len(self.study.directions) > 1:
+            raise NotImplementedError(
+                "Trial.report is not supported for multi-objective optimization."
+            )
+
+        try:
+            # For convenience, we allow users to report a value that can be cast to `float`.
+            value = float(value)
+        except (TypeError, ValueError):
+            message = "The `value` argument is of type '{}' but supposed to be a float.".format(
+                type(value).__name__
+            )
+            raise TypeError(message) from None
+
+        if step < 0:
+            raise ValueError("The `step` argument is {} but cannot be negative.".format(step))
+
+        intermediate_values = self.storage.get_trial(self._trial_id).intermediate_values
+
+        if step in intermediate_values:
+            # Do nothing if already reported.
+            # TODO(hvy): Consider raising a warning or an error.
+            # See https://github.com/optuna/optuna/issues/852.
+            return
+
+        self.storage.set_trial_intermediate_value(self._trial_id, step, value)
 
     def should_prune(self) -> bool:
         """Suggest whether the trial should be pruned or not.

--- a/tests/test_study.py
+++ b/tests/test_study.py
@@ -1245,57 +1245,7 @@ def test_tell_values() -> None:
         study.tell(study.ask())
 
 
-def test_report() -> None:
-    # See tests/test_trial.py for corresponding tests for `Trial.report`.
-
-    study = optuna.create_study()
-    trial = Trial(study, study._storage.create_new_trial(study._study_id))
-
-    # Report values that can be cast to `float` (OK).
-    study.report(trial, 1.23, 1)
-    study.report(trial, float("nan"), 2)
-    study.report(trial, "1.23", 3)  # type: ignore
-    study.report(trial, "inf", 4)  # type: ignore
-    study.report(trial, 1, 5)
-
-    # Report values that cannot be cast to `float` or steps that are negative (Error).
-    with pytest.raises(TypeError):
-        study.report(trial, None, 7)  # type: ignore
-
-    with pytest.raises(TypeError):
-        study.report(trial, "foo", 7)  # type: ignore
-
-    with pytest.raises(TypeError):
-        study.report(trial, [1, 2, 3], 7)  # type: ignore
-
-    with pytest.raises(TypeError):
-        study.report(trial, "foo", -1)  # type: ignore
-
-    with pytest.raises(ValueError):
-        study.report(trial, 1.23, -1)
-
-
-def test_report_trial_variations() -> None:
-    study = optuna.create_study()
-
-    study.report(study.ask().number, 1.0, 1)
-
-    # Trial that has not been asked for cannot be reported.
-    with pytest.raises(ValueError):
-        study.report(study.ask().number + 1, 1.0, 2)
-
-    with pytest.raises(TypeError):
-        study.report("1", 1.0, 3)  # type: ignore
-
-
-def test_raise_error_for_report_with_multi_objectives() -> None:
-    study = optuna.create_study(directions=["maximize", "maximize"])
-
-    with pytest.raises(NotImplementedError):
-        study.report(study.ask(), 1.0, 0)
-
-
-def test_storage_not_implemented_trial_number() -> None:
+def test_tell_storage_not_implemented_trial_number() -> None:
     with StorageSupplier("inmemory") as storage:
 
         with patch.object(
@@ -1312,8 +1262,8 @@ def test_storage_not_implemented_trial_number() -> None:
             with pytest.warns(UserWarning):
                 study.tell(study.ask().number, 1.0)
 
-            with pytest.warns(UserWarning):
-                study.report(study.ask().number, 1.0, 1)
+            with pytest.raises(ValueError):
+                study.tell(study.ask().number + 1, 1.0)
 
 
 def test_tell_pruned_values() -> None:


### PR DESCRIPTION
Reverts optuna/optuna#2176

Changes are automated and I have not made any manual changes. Reviewing should be straight foward.

For background, see the https://github.com/optuna/optuna/pull/2176#issuecomment-760566829 comment and onwards. Being able to restore a `Trial` satisfies needs and is a less intrusive change to Optuna's public API.