### PR TITLE
Immediately persist suggested parameters with `_CachedStorage`

### DIFF
--- a/optuna/storages/_base.py
+++ b/optuna/storages/_base.py
@@ -81,7 +81,8 @@ class BaseStorage(object, metaclass=abc.ABCMeta):
     of `Study` and writes on `state` of `Trial` are guaranteed to be persistent.
     Additionally, any preceding writes on any attributes of `Trial` are guaranteed to
     be written into a persistent storage before writes on `state` of `Trial` succeed.
-    The same applies for `user_attrs', 'system_attrs' and 'intermediate_values` attributes.
+    The same applies for `param`, `user_attrs', 'system_attrs' and 'intermediate_values`
+    attributes.
 
     .. note::
 

--- a/optuna/storages/_cached_storage.py
+++ b/optuna/storages/_cached_storage.py
@@ -256,6 +256,7 @@ class _CachedStorage(BaseStorage):
                     updates = self._get_updates(trial_id)
                     updates.params[param_name] = param_value_internal
                     updates.distributions[param_name] = distribution
+                    self._flush_trial(trial_id)
                 return
 
         self._backend.set_trial_param(trial_id, param_name, param_value_internal, distribution)

--- a/tests/storages_tests/test_cached_storage.py
+++ b/tests/storages_tests/test_cached_storage.py
@@ -32,23 +32,13 @@ def test_cached_set() -> None:
 
     """Test CachedStorage does not flush to persistent storages.
 
-    The CachedStorage does not flush when it modifies trial updates of params or value.
+    The CachedStorage does not flush when it modifies trial updates of values.
 
     """
 
     base_storage = RDBStorage("sqlite:///:memory:")
     storage = _CachedStorage(base_storage)
     study_id = storage.create_new_study("test-study")
-
-    trial_id = storage.create_new_trial(study_id)
-    with patch.object(
-        base_storage, "_update_trial", return_value=True
-    ) as update_mock, patch.object(base_storage, "set_trial_param", return_value=True) as set_mock:
-        storage.set_trial_param(
-            trial_id, "paramA", 1.2, optuna.distributions.UniformDistribution(-0.2, 2.3)
-        )
-        assert update_mock.call_count == 0
-        assert set_mock.call_count == 0
 
     trial_id = storage.create_new_trial(study_id)
     with patch.object(
@@ -66,13 +56,35 @@ def test_uncached_set() -> None:
     """Test CachedStorage does flush to persistent storages.
 
     The CachedStorage flushes modifications of trials to a persistent storage when
-    it modifies either intermediate_values, state, user_attrs, or system_attrs.
+    it modifies either params, intermediate_values, state, user_attrs, or system_attrs.
 
     """
 
     base_storage = RDBStorage("sqlite:///:memory:")
     storage = _CachedStorage(base_storage)
     study_id = storage.create_new_study("test-study")
+
+    trial_id = storage.create_new_trial(study_id)
+    with patch.object(
+        base_storage, "_update_trial", return_value=True
+    ) as update_mock, patch.object(
+        base_storage, "_check_and_set_param_distribution", return_value=True
+    ) as set_mock:
+        storage.set_trial_param(
+            trial_id, "paramA", 1.2, optuna.distributions.UniformDistribution(-0.2, 2.3)
+        )
+        assert update_mock.call_count == 0
+        assert set_mock.call_count == 1
+
+    trial_id = storage.create_new_trial(study_id)
+    with patch.object(
+        base_storage, "_update_trial", return_value=True
+    ) as update_mock, patch.object(base_storage, "set_trial_param", return_value=True) as set_mock:
+        storage.set_trial_param(
+            trial_id, "paramA", 1.2, optuna.distributions.UniformDistribution(-0.2, 2.3)
+        )
+        assert update_mock.call_count == 1
+        assert set_mock.call_count == 0
 
     for state in [TrialState.COMPLETE, TrialState.PRUNED, TrialState.FAIL, TrialState.WAITING]:
         trial_id = storage.create_new_trial(study_id)

--- a/tests/test_trial.py
+++ b/tests/test_trial.py
@@ -1,6 +1,7 @@
 import copy
 import datetime
 import math
+import tempfile
 from typing import Any
 from typing import Callable
 from typing import cast
@@ -26,6 +27,7 @@ from optuna.distributions import IntUniformDistribution
 from optuna.distributions import LogUniformDistribution
 from optuna.distributions import UniformDistribution
 from optuna.study import create_study
+from optuna.study import load_study
 from optuna.testing.integration import DeterministicPruner
 from optuna.testing.sampler import DeterministicRelativeSampler
 from optuna.trial import BaseTrial
@@ -1341,3 +1343,22 @@ def test_raise_error_for_should_prune_multi_objectives() -> None:
         return 1.0, 1.0
 
     study.optimize(objective, n_trials=1)
+
+
+def test_persisted_param() -> None:
+    study_name = "my_study"
+
+    with tempfile.NamedTemporaryFile() as fp:
+        storage = f"sqlite:///{fp.name}"
+        study = create_study(storage=storage, study_name=study_name)
+        assert isinstance(study._storage, optuna.storages._CachedStorage), "Pre-condition."
+
+        # Test more than one trial. The `_CachedStorage` does a cache miss for the first trial and
+        # thus behaves differently for the first trial in comparisons to the following.
+        for _ in range(3):
+            trial = study.ask()
+            trial.suggest_float("x", 0, 1)
+
+        study = load_study(storage=storage, study_name=study_name)
+
+        assert all("x" in t.params for t in study.trials)


### PR DESCRIPTION
## Motivation

When using the `_CachedStorage` (which by default wraps any `RDBStorage`), trial parameter suggestion are not immediately flushed to the DB (on cache hit). This is for performance reasons reducing DB access. However, this behavior may manifest like a bug when using the recent ask and tell API. 

```python
# Process A
storage = ...  # `RDBStorage`.
study = optuna.create_study(storage=storage, study_name=study_name)
assert isinstance(study._storage, _CachedStorage), "Automatically wrapped for performance reasons."
trial = study.ask()
x = trial.suggest_...  # Any parameter suggestion.
# Exit without flushing, e.g. just save the value of "x" to a file. `Study.tell` WOULD trigger a flush.

# Process B
storage = ... # Same storage.
study = optuna.load_study(storage=storage, study_name=study_name)
trial = study.trials[0]
trial.params["x"]  # master: KeyError: 'x', PR: pass
```

## Description of the changes

Changes `_CachedStorage. set_trial_param` to always flush to the underlying `RDBStorage`.

## Note

Performance degradation reports with MySQL are available [here](https://gist.github.com/hvy/67a279e843a43a1cfc04c2eb92ea605d#gistcomment-3594701) with reproduction code. There is a rough ~5ms addition per trial, per parameter.