### PR TITLE
Diet `tests/test_study.py`

### DIFF
--- a/tests/study_tests/test_dataframe.py
+++ b/tests/study_tests/test_dataframe.py
@@ -1,0 +1,192 @@
+from typing import Tuple
+
+import pandas as pd
+import pytest
+
+from optuna import create_study
+from optuna import Trial
+from optuna.testing.storage import StorageSupplier
+
+
+STORAGE_MODES = [
+    "inmemory",
+    "sqlite",
+    "cache",
+    "redis",
+]
+
+
+def test_study_trials_dataframe_with_no_trials() -> None:
+
+    study_with_no_trials = create_study()
+    trials_df = study_with_no_trials.trials_dataframe()
+    assert trials_df.empty
+
+
+@pytest.mark.parametrize("storage_mode", STORAGE_MODES)
+@pytest.mark.parametrize(
+    "attrs",
+    [
+        (
+            "number",
+            "value",
+            "datetime_start",
+            "datetime_complete",
+            "params",
+            "user_attrs",
+            "system_attrs",
+            "state",
+        ),
+        (
+            "number",
+            "value",
+            "datetime_start",
+            "datetime_complete",
+            "duration",
+            "params",
+            "user_attrs",
+            "system_attrs",
+            "state",
+            "intermediate_values",
+            "_trial_id",
+            "distributions",
+        ),
+    ],
+)
+@pytest.mark.parametrize("multi_index", [True, False])
+def test_trials_dataframe(storage_mode: str, attrs: Tuple[str, ...], multi_index: bool) -> None:
+    def f(trial: Trial) -> float:
+
+        x = trial.suggest_int("x", 1, 1)
+        y = trial.suggest_categorical("y", (2.5,))
+        assert isinstance(y, float)
+        trial.set_user_attr("train_loss", 3)
+        trial.set_system_attr("foo", "bar")
+        value = x + y  # 3.5
+
+        # Test reported intermediate values, although it in practice is not "intermediate".
+        trial.report(value, step=0)
+
+        return value
+
+    with StorageSupplier(storage_mode) as storage:
+        study = create_study(storage=storage)
+        study.optimize(f, n_trials=3)
+        df = study.trials_dataframe(attrs=attrs, multi_index=multi_index)
+        # Change index to access rows via trial number.
+        if multi_index:
+            df.set_index(("number", ""), inplace=True, drop=False)
+        else:
+            df.set_index("number", inplace=True, drop=False)
+        assert len(df) == 3
+
+        # Number columns are as follows (total of 13):
+        #   non-nested: 6 (number, value, state, datetime_start, datetime_complete, duration)
+        #   params: 2
+        #   distributions: 2
+        #   user_attrs: 1
+        #   system_attrs: 1
+        #   intermediate_values: 1
+        expected_n_columns = len(attrs)
+        if "params" in attrs:
+            expected_n_columns += 1
+        if "distributions" in attrs:
+            expected_n_columns += 1
+        assert len(df.columns) == expected_n_columns
+
+        for i in range(3):
+            assert df.number[i] == i
+            assert df.state[i] == "COMPLETE"
+            assert df.value[i] == 3.5
+            assert isinstance(df.datetime_start[i], pd.Timestamp)
+            assert isinstance(df.datetime_complete[i], pd.Timestamp)
+
+            if multi_index:
+                if "distributions" in attrs:
+                    assert ("distributions", "x") in df.columns
+                    assert ("distributions", "y") in df.columns
+                if "_trial_id" in attrs:
+                    assert ("trial_id", "") in df.columns  # trial_id depends on other tests.
+                if "duration" in attrs:
+                    assert ("duration", "") in df.columns
+
+                assert df.params.x[i] == 1
+                assert df.params.y[i] == 2.5
+                assert df.user_attrs.train_loss[i] == 3
+                assert df.system_attrs.foo[i] == "bar"
+            else:
+                if "distributions" in attrs:
+                    assert "distributions_x" in df.columns
+                    assert "distributions_y" in df.columns
+                if "_trial_id" in attrs:
+                    assert "trial_id" in df.columns  # trial_id depends on other tests.
+                if "duration" in attrs:
+                    assert "duration" in df.columns
+
+                assert df.params_x[i] == 1
+                assert df.params_y[i] == 2.5
+                assert df.user_attrs_train_loss[i] == 3
+                assert df.system_attrs_foo[i] == "bar"
+
+
+@pytest.mark.parametrize("storage_mode", STORAGE_MODES)
+def test_trials_dataframe_with_failure(storage_mode: str) -> None:
+    def f(trial: Trial) -> float:
+
+        x = trial.suggest_int("x", 1, 1)
+        y = trial.suggest_categorical("y", (2.5,))
+        trial.set_user_attr("train_loss", 3)
+        raise ValueError()
+        return x + y  # 3.5
+
+    with StorageSupplier(storage_mode) as storage:
+        study = create_study(storage=storage)
+        study.optimize(f, n_trials=3, catch=(ValueError,))
+        df = study.trials_dataframe()
+        # Change index to access rows via trial number.
+        df.set_index("number", inplace=True, drop=False)
+        assert len(df) == 3
+        # non-nested: 6, params: 2, user_attrs: 1 system_attrs: 0
+        assert len(df.columns) == 9
+        for i in range(3):
+            assert df.number[i] == i
+            assert df.state[i] == "FAIL"
+            assert df.value[i] is None
+            assert isinstance(df.datetime_start[i], pd.Timestamp)
+            assert isinstance(df.datetime_complete[i], pd.Timestamp)
+            assert isinstance(df.duration[i], pd.Timedelta)
+            assert df.params_x[i] == 1
+            assert df.params_y[i] == 2.5
+            assert df.user_attrs_train_loss[i] == 3
+
+
+@pytest.mark.parametrize(
+    "attrs",
+    [
+        ("value",),
+        ("values",),
+    ],
+)
+@pytest.mark.parametrize("multi_index", [True, False])
+def test_trials_dataframe_with_multi_objective_optimization(
+    attrs: Tuple[str, ...], multi_index: bool
+) -> None:
+    def f(trial: Trial) -> Tuple[float, float]:
+
+        x = trial.suggest_float("x", 1, 1)
+        y = trial.suggest_float("y", 2, 2)
+
+        return x + y, x ** 2 + y ** 2  # 3, 5
+
+    study = create_study(directions=["minimize", "maximize"])
+    study.optimize(f, n_trials=3)
+    df = study.trials_dataframe(attrs=attrs, multi_index=multi_index)
+
+    if multi_index:
+        for i in range(3):
+            assert df.get("values")[0][i] == 3
+            assert df.get("values")[1][i] == 5
+    else:
+        for i in range(3):
+            assert df.values_0[i] == 3
+            assert df.values_1[i] == 5

--- a/tests/study_tests/test_optimize.py
+++ b/tests/study_tests/test_optimize.py
@@ -1,0 +1,143 @@
+from typing import Any
+from typing import Callable
+from typing import Dict
+from typing import Optional
+
+import pytest
+
+from optuna import _optimize
+from optuna import create_study
+from optuna import Study
+from optuna import Trial
+from optuna import TrialPruned
+from optuna.exceptions import TrialPruned as TrialPruned_in_exceptions
+from optuna.structs import TrialPruned as TrialPruned_in_structs
+from optuna.testing.storage import StorageSupplier
+from optuna.trial import FrozenTrial
+from optuna.trial import TrialState
+
+
+STORAGE_MODES = [
+    "inmemory",
+    "sqlite",
+    "cache",
+    "redis",
+]
+
+
+def func(trial: Trial, x_max: float = 1.0) -> float:
+
+    x = trial.suggest_uniform("x", -x_max, x_max)
+    y = trial.suggest_loguniform("y", 20, 30)
+    z = trial.suggest_categorical("z", (-1.0, 1.0))
+    assert isinstance(z, float)
+    return (x - 2) ** 2 + (y - 25) ** 2 + z
+
+
+def check_params(params: Dict[str, Any]) -> None:
+
+    assert sorted(params.keys()) == ["x", "y", "z"]
+
+
+def check_value(value: Optional[float]) -> None:
+
+    assert isinstance(value, float)
+    assert -1.0 <= value <= 12.0 ** 2 + 5.0 ** 2 + 1.0
+
+
+def check_frozen_trial(frozen_trial: FrozenTrial) -> None:
+
+    if frozen_trial.state == TrialState.COMPLETE:
+        check_params(frozen_trial.params)
+        check_value(frozen_trial.value)
+
+
+def check_study(study: Study) -> None:
+
+    for trial in study.trials:
+        check_frozen_trial(trial)
+
+    assert not study._is_multi_objective()
+
+    complete_trials = [t for t in study.trials if t.state == TrialState.COMPLETE]
+    if len(complete_trials) == 0:
+        with pytest.raises(ValueError):
+            study.best_params
+        with pytest.raises(ValueError):
+            study.best_value
+        with pytest.raises(ValueError):
+            study.best_trial
+    else:
+        check_params(study.best_params)
+        check_value(study.best_value)
+        check_frozen_trial(study.best_trial)
+
+
+@pytest.mark.parametrize("storage_mode", STORAGE_MODES)
+def test_run_trial(storage_mode: str) -> None:
+
+    with StorageSupplier(storage_mode) as storage:
+        study = create_study(storage=storage)
+
+        # Test trial without exception.
+        _optimize._run_trial(study, func, catch=(Exception,))
+        check_study(study)
+
+        # Test trial with acceptable exception.
+        def func_value_error(_: Trial) -> float:
+
+            raise ValueError
+
+        trial = _optimize._run_trial(study, func_value_error, catch=(ValueError,))
+        frozen_trial = study._storage.get_trial(trial._trial_id)
+
+        assert frozen_trial.state == TrialState.FAIL
+
+        # Test trial with unacceptable exception.
+        with pytest.raises(ValueError):
+            _optimize._run_trial(study, func_value_error, catch=(ArithmeticError,))
+
+        # Test trial with invalid objective value: None
+        def func_none(_: Trial) -> float:
+
+            return None  # type: ignore
+
+        trial = _optimize._run_trial(study, func_none, catch=(Exception,))
+        frozen_trial = study._storage.get_trial(trial._trial_id)
+
+        assert frozen_trial.state == TrialState.FAIL
+
+        # Test trial with invalid objective value: nan
+        def func_nan(_: Trial) -> float:
+
+            return float("nan")
+
+        trial = _optimize._run_trial(study, func_nan, catch=(Exception,))
+        frozen_trial = study._storage.get_trial(trial._trial_id)
+
+        assert frozen_trial.state == TrialState.FAIL
+
+
+# TODO(Yanase): Remove this test function after removing `optuna.structs.TrialPruned`.
+@pytest.mark.parametrize(
+    "trial_pruned_class",
+    [TrialPruned, TrialPruned_in_exceptions, TrialPruned_in_structs],
+)
+@pytest.mark.parametrize("report_value", [None, 1.2])
+def test_run_trial_with_trial_pruned(
+    trial_pruned_class: Callable[[], TrialPruned], report_value: Optional[float]
+) -> None:
+
+    study = create_study()
+
+    def func_with_trial_pruned(trial: Trial) -> float:
+
+        if report_value is not None:
+            trial.report(report_value, 1)
+
+        raise trial_pruned_class()
+
+    trial = _optimize._run_trial(study, func_with_trial_pruned, catch=())
+    frozen_trial = study._storage.get_trial(trial._trial_id)
+    assert frozen_trial.value == report_value
+    assert frozen_trial.state == TrialState.PRUNED

--- a/tests/study_tests/test_study.py
+++ b/tests/study_tests/test_study.py
@@ -17,19 +17,26 @@ import uuid
 import _pytest.capture
 from _pytest.recwarn import WarningsRecorder
 import joblib
-import pandas as pd
 import pytest
 
-import optuna
-from optuna import _optimize
+from optuna import create_study
 from optuna import create_trial
+from optuna import delete_study
+from optuna import get_all_study_summaries
+from optuna import load_study
+from optuna import logging
+from optuna import Study
+from optuna import Trial
+from optuna import TrialPruned
+from optuna.exceptions import DuplicatedStudyError
+from optuna.storages import get_storage
 from optuna.study import StudyDirection
 from optuna.testing.storage import StorageSupplier
-from optuna.trial import Trial
+from optuna.trial import FrozenTrial
 from optuna.trial import TrialState
 
 
-CallbackFuncType = Callable[[optuna.study.Study, optuna.trial.FrozenTrial], None]
+CallbackFuncType = Callable[[Study, FrozenTrial], None]
 
 STORAGE_MODES = [
     "inmemory",
@@ -39,7 +46,7 @@ STORAGE_MODES = [
 ]
 
 
-def func(trial: optuna.trial.Trial, x_max: float = 1.0) -> float:
+def func(trial: Trial, x_max: float = 1.0) -> float:
 
     x = trial.suggest_uniform("x", -x_max, x_max)
     y = trial.suggest_loguniform("y", 20, 30)
@@ -56,7 +63,7 @@ class Func(object):
         self.lock = threading.Lock()
         self.x_max = 10.0
 
-    def __call__(self, trial: optuna.trial.Trial) -> float:
+    def __call__(self, trial: Trial) -> float:
 
         with self.lock:
             self.n_calls += 1
@@ -83,14 +90,14 @@ def check_value(value: Optional[float]) -> None:
     assert -1.0 <= value <= 12.0 ** 2 + 5.0 ** 2 + 1.0
 
 
-def check_frozen_trial(frozen_trial: optuna.trial.FrozenTrial) -> None:
+def check_frozen_trial(frozen_trial: FrozenTrial) -> None:
 
     if frozen_trial.state == TrialState.COMPLETE:
         check_params(frozen_trial.params)
         check_value(frozen_trial.value)
 
 
-def check_study(study: optuna.Study) -> None:
+def check_study(study: Study) -> None:
 
     for trial in study.trials:
         check_frozen_trial(trial)
@@ -113,14 +120,14 @@ def check_study(study: optuna.Study) -> None:
 
 def test_optimize_trivial_in_memory_new() -> None:
 
-    study = optuna.create_study()
+    study = create_study()
     study.optimize(func, n_trials=10)
     check_study(study)
 
 
 def test_optimize_trivial_in_memory_resume() -> None:
 
-    study = optuna.create_study()
+    study = create_study()
     study.optimize(func, n_trials=10)
     study.optimize(func, n_trials=10)
     check_study(study)
@@ -128,25 +135,25 @@ def test_optimize_trivial_in_memory_resume() -> None:
 
 def test_optimize_trivial_rdb_resume_study() -> None:
 
-    study = optuna.create_study("sqlite:///:memory:")
+    study = create_study("sqlite:///:memory:")
     study.optimize(func, n_trials=10)
     check_study(study)
 
 
 def test_optimize_with_direction() -> None:
 
-    study = optuna.create_study(direction="minimize")
+    study = create_study(direction="minimize")
     study.optimize(func, n_trials=10)
-    assert study.direction == optuna.study.StudyDirection.MINIMIZE
+    assert study.direction == StudyDirection.MINIMIZE
     check_study(study)
 
-    study = optuna.create_study(direction="maximize")
+    study = create_study(direction="maximize")
     study.optimize(func, n_trials=10)
-    assert study.direction == optuna.study.StudyDirection.MAXIMIZE
+    assert study.direction == StudyDirection.MAXIMIZE
     check_study(study)
 
     with pytest.raises(ValueError):
-        optuna.create_study(direction="test")
+        create_study(direction="test")
 
 
 @pytest.mark.parametrize(
@@ -158,7 +165,7 @@ def test_optimize_parallel(n_trials: int, n_jobs: int, storage_mode: str) -> Non
     f = Func()
 
     with StorageSupplier(storage_mode) as storage:
-        study = optuna.create_study(storage=storage)
+        study = create_study(storage=storage)
         study.optimize(f, n_trials=n_trials, n_jobs=n_jobs)
         assert f.n_calls == len(study.trials) == n_trials
         check_study(study)
@@ -177,7 +184,7 @@ def test_optimize_parallel_timeout(n_trials: int, n_jobs: int, storage_mode: str
     f = Func(sleep_sec=sleep_sec)
 
     with StorageSupplier(storage_mode) as storage:
-        study = optuna.create_study(storage=storage)
+        study = create_study(storage=storage)
         study.optimize(f, n_trials=n_trials, n_jobs=n_jobs, timeout=timeout_sec)
 
         assert f.n_calls == len(study.trials)
@@ -197,9 +204,9 @@ def test_optimize_parallel_timeout(n_trials: int, n_jobs: int, storage_mode: str
 def test_optimize_with_catch(storage_mode: str) -> None:
 
     with StorageSupplier(storage_mode) as storage:
-        study = optuna.create_study(storage=storage)
+        study = create_study(storage=storage)
 
-        def func_value_error(_: optuna.trial.Trial) -> float:
+        def func_value_error(_: Trial) -> float:
 
             raise ValueError
 
@@ -224,9 +231,9 @@ def test_optimize_with_catch(storage_mode: str) -> None:
 @pytest.mark.parametrize("catch", [[], [Exception], None, 1])
 def test_optimize_with_catch_invalid_type(catch: Any) -> None:
 
-    study = optuna.create_study()
+    study = create_study()
 
-    def func_value_error(_: optuna.trial.Trial) -> float:
+    def func_value_error(_: Trial) -> float:
 
         raise ValueError
 
@@ -236,7 +243,7 @@ def test_optimize_with_catch_invalid_type(catch: Any) -> None:
 
 def test_optimize_parallel_storage_warning(recwarn: WarningsRecorder) -> None:
 
-    study = optuna.create_study()
+    study = create_study()
 
     # Default joblib backend is threading and no warnings will be captured.
     study.optimize(lambda t: t.suggest_uniform("x", 0, 1), n_trials=20, n_jobs=2)
@@ -255,7 +262,7 @@ def test_optimize_with_reseeding(n_jobs: int, storage_mode: str) -> None:
     f = Func()
 
     with StorageSupplier(storage_mode) as storage:
-        study = optuna.create_study(storage=storage)
+        study = create_study(storage=storage)
         sampler = study.sampler
         with patch.object(sampler, "reseed_rng", wraps=sampler.reseed_rng) as mock_object:
             study.optimize(f, n_trials=1, n_jobs=2)
@@ -266,7 +273,7 @@ def test_optimize_with_reseeding(n_jobs: int, storage_mode: str) -> None:
 def test_study_set_and_get_user_attrs(storage_mode: str) -> None:
 
     with StorageSupplier(storage_mode) as storage:
-        study = optuna.create_study(storage=storage)
+        study = create_study(storage=storage)
 
         study.set_user_attr("dataset", "MNIST")
         assert study.user_attrs["dataset"] == "MNIST"
@@ -276,7 +283,7 @@ def test_study_set_and_get_user_attrs(storage_mode: str) -> None:
 def test_study_set_and_get_system_attrs(storage_mode: str) -> None:
 
     with StorageSupplier(storage_mode) as storage:
-        study = optuna.create_study(storage=storage)
+        study = create_study(storage=storage)
 
         study.set_system_attr("system_message", "test")
         assert study.system_attrs["system_message"] == "test"
@@ -284,14 +291,14 @@ def test_study_set_and_get_system_attrs(storage_mode: str) -> None:
 
 @pytest.mark.parametrize("storage_mode", STORAGE_MODES)
 def test_trial_set_and_get_user_attrs(storage_mode: str) -> None:
-    def f(trial: optuna.trial.Trial) -> float:
+    def f(trial: Trial) -> float:
 
         trial.set_user_attr("train_accuracy", 1)
         assert trial.user_attrs["train_accuracy"] == 1
         return 0.0
 
     with StorageSupplier(storage_mode) as storage:
-        study = optuna.create_study(storage=storage)
+        study = create_study(storage=storage)
         study.optimize(f, n_trials=1)
         frozen_trial = study.trials[0]
         assert frozen_trial.user_attrs["train_accuracy"] == 1
@@ -299,14 +306,14 @@ def test_trial_set_and_get_user_attrs(storage_mode: str) -> None:
 
 @pytest.mark.parametrize("storage_mode", STORAGE_MODES)
 def test_trial_set_and_get_system_attrs(storage_mode: str) -> None:
-    def f(trial: optuna.trial.Trial) -> float:
+    def f(trial: Trial) -> float:
 
         trial.set_system_attr("system_message", "test")
         assert trial.system_attrs["system_message"] == "test"
         return 0.0
 
     with StorageSupplier(storage_mode) as storage:
-        study = optuna.create_study(storage=storage)
+        study = create_study(storage=storage)
         study.optimize(f, n_trials=1)
         frozen_trial = study.trials[0]
         assert frozen_trial.system_attrs["system_message"] == "test"
@@ -316,10 +323,10 @@ def test_trial_set_and_get_system_attrs(storage_mode: str) -> None:
 def test_get_all_study_summaries(storage_mode: str) -> None:
 
     with StorageSupplier(storage_mode) as storage:
-        study = optuna.create_study(storage=storage)
+        study = create_study(storage=storage)
         study.optimize(Func(), n_trials=5)
 
-        summaries = optuna.get_all_study_summaries(study._storage)
+        summaries = get_all_study_summaries(study._storage)
         summary = [s for s in summaries if s._study_id == study._study_id][0]
 
         assert summary.study_name == study.study_name
@@ -330,9 +337,9 @@ def test_get_all_study_summaries(storage_mode: str) -> None:
 def test_get_all_study_summaries_with_no_trials(storage_mode: str) -> None:
 
     with StorageSupplier(storage_mode) as storage:
-        study = optuna.create_study(storage=storage)
+        study = create_study(storage=storage)
 
-        summaries = optuna.get_all_study_summaries(study._storage)
+        summaries = get_all_study_summaries(study._storage)
         summary = [s for s in summaries if s._study_id == study._study_id][0]
 
         assert summary.study_name == study.study_name
@@ -340,79 +347,9 @@ def test_get_all_study_summaries_with_no_trials(storage_mode: str) -> None:
         assert summary.datetime_start is None
 
 
-@pytest.mark.parametrize("storage_mode", STORAGE_MODES)
-def test_run_trial(storage_mode: str) -> None:
-
-    with StorageSupplier(storage_mode) as storage:
-        study = optuna.create_study(storage=storage)
-
-        # Test trial without exception.
-        _optimize._run_trial(study, func, catch=(Exception,))
-        check_study(study)
-
-        # Test trial with acceptable exception.
-        def func_value_error(_: optuna.trial.Trial) -> float:
-
-            raise ValueError
-
-        trial = _optimize._run_trial(study, func_value_error, catch=(ValueError,))
-        frozen_trial = study._storage.get_trial(trial._trial_id)
-
-        assert frozen_trial.state == TrialState.FAIL
-
-        # Test trial with unacceptable exception.
-        with pytest.raises(ValueError):
-            _optimize._run_trial(study, func_value_error, catch=(ArithmeticError,))
-
-        # Test trial with invalid objective value: None
-        def func_none(_: optuna.trial.Trial) -> float:
-
-            return None  # type: ignore
-
-        trial = _optimize._run_trial(study, func_none, catch=(Exception,))
-        frozen_trial = study._storage.get_trial(trial._trial_id)
-
-        assert frozen_trial.state == TrialState.FAIL
-
-        # Test trial with invalid objective value: nan
-        def func_nan(_: optuna.trial.Trial) -> float:
-
-            return float("nan")
-
-        trial = _optimize._run_trial(study, func_nan, catch=(Exception,))
-        frozen_trial = study._storage.get_trial(trial._trial_id)
-
-        assert frozen_trial.state == TrialState.FAIL
-
-
-# TODO(Yanase): Remove this test function after removing `optuna.structs.TrialPruned`.
-@pytest.mark.parametrize(
-    "trial_pruned_class",
-    [optuna.TrialPruned, optuna.exceptions.TrialPruned, optuna.structs.TrialPruned],
-)
-@pytest.mark.parametrize("report_value", [None, 1.2])
-def test_run_trial_with_trial_pruned(
-    trial_pruned_class: Callable[[], optuna.exceptions.TrialPruned], report_value: Optional[float]
-) -> None:
-
-    study = optuna.create_study()
-
-    def func_with_trial_pruned(trial: optuna.trial.Trial) -> float:
-
-        if report_value is not None:
-            trial.report(report_value, 1)
-
-        raise trial_pruned_class()
-
-    trial = _optimize._run_trial(study, func_with_trial_pruned, catch=())
-    frozen_trial = study._storage.get_trial(trial._trial_id)
-    assert frozen_trial.value == report_value
-    assert frozen_trial.state == TrialState.PRUNED
-
-
 def test_study_pickle() -> None:
 
-    study_1 = optuna.create_study()
+    study_1 = create_study()
     study_1.optimize(func, n_trials=10)
     check_study(study_1)
     assert len(study_1.trials) == 10
@@ -427,194 +364,18 @@ def test_study_pickle() -> None:
     assert len(study_2.trials) == 20
 
 
-def test_study_trials_dataframe_with_no_trials() -> None:
-
-    study_with_no_trials = optuna.create_study()
-    trials_df = study_with_no_trials.trials_dataframe()
-    assert trials_df.empty
-
-
-@pytest.mark.parametrize("storage_mode", STORAGE_MODES)
-@pytest.mark.parametrize(
-    "attrs",
-    [
-        (
-            "number",
-            "value",
-            "datetime_start",
-            "datetime_complete",
-            "params",
-            "user_attrs",
-            "system_attrs",
-            "state",
-        ),
-        (
-            "number",
-            "value",
-            "datetime_start",
-            "datetime_complete",
-            "duration",
-            "params",
-            "user_attrs",
-            "system_attrs",
-            "state",
-            "intermediate_values",
-            "_trial_id",
-            "distributions",
-        ),
-    ],
-)
-@pytest.mark.parametrize("multi_index", [True, False])
-def test_trials_dataframe(storage_mode: str, attrs: Tuple[str, ...], multi_index: bool) -> None:
-    def f(trial: optuna.trial.Trial) -> float:
-
-        x = trial.suggest_int("x", 1, 1)
-        y = trial.suggest_categorical("y", (2.5,))
-        assert isinstance(y, float)
-        trial.set_user_attr("train_loss", 3)
-        trial.set_system_attr("foo", "bar")
-        value = x + y  # 3.5
-
-        # Test reported intermediate values, although it in practice is not "intermediate".
-        trial.report(value, step=0)
-
-        return value
-
-    with StorageSupplier(storage_mode) as storage:
-        study = optuna.create_study(storage=storage)
-        study.optimize(f, n_trials=3)
-        df = study.trials_dataframe(attrs=attrs, multi_index=multi_index)
-        # Change index to access rows via trial number.
-        if multi_index:
-            df.set_index(("number", ""), inplace=True, drop=False)
-        else:
-            df.set_index("number", inplace=True, drop=False)
-        assert len(df) == 3
-
-        # Number columns are as follows (total of 13):
-        #   non-nested: 6 (number, value, state, datetime_start, datetime_complete, duration)
-        #   params: 2
-        #   distributions: 2
-        #   user_attrs: 1
-        #   system_attrs: 1
-        #   intermediate_values: 1
-        expected_n_columns = len(attrs)
-        if "params" in attrs:
-            expected_n_columns += 1
-        if "distributions" in attrs:
-            expected_n_columns += 1
-        assert len(df.columns) == expected_n_columns
-
-        for i in range(3):
-            assert df.number[i] == i
-            assert df.state[i] == "COMPLETE"
-            assert df.value[i] == 3.5
-            assert isinstance(df.datetime_start[i], pd.Timestamp)
-            assert isinstance(df.datetime_complete[i], pd.Timestamp)
-
-            if multi_index:
-                if "distributions" in attrs:
-                    assert ("distributions", "x") in df.columns
-                    assert ("distributions", "y") in df.columns
-                if "_trial_id" in attrs:
-                    assert ("trial_id", "") in df.columns  # trial_id depends on other tests.
-                if "duration" in attrs:
-                    assert ("duration", "") in df.columns
-
-                assert df.params.x[i] == 1
-                assert df.params.y[i] == 2.5
-                assert df.user_attrs.train_loss[i] == 3
-                assert df.system_attrs.foo[i] == "bar"
-            else:
-                if "distributions" in attrs:
-                    assert "distributions_x" in df.columns
-                    assert "distributions_y" in df.columns
-                if "_trial_id" in attrs:
-                    assert "trial_id" in df.columns  # trial_id depends on other tests.
-                if "duration" in attrs:
-                    assert "duration" in df.columns
-
-                assert df.params_x[i] == 1
-                assert df.params_y[i] == 2.5
-                assert df.user_attrs_train_loss[i] == 3
-                assert df.system_attrs_foo[i] == "bar"
-
-
-@pytest.mark.parametrize("storage_mode", STORAGE_MODES)
-def test_trials_dataframe_with_failure(storage_mode: str) -> None:
-    def f(trial: optuna.trial.Trial) -> float:
-
-        x = trial.suggest_int("x", 1, 1)
-        y = trial.suggest_categorical("y", (2.5,))
-        trial.set_user_attr("train_loss", 3)
-        raise ValueError()
-        return x + y  # 3.5
-
-    with StorageSupplier(storage_mode) as storage:
-        study = optuna.create_study(storage=storage)
-        study.optimize(f, n_trials=3, catch=(ValueError,))
-        df = study.trials_dataframe()
-        # Change index to access rows via trial number.
-        df.set_index("number", inplace=True, drop=False)
-        assert len(df) == 3
-        # non-nested: 6, params: 2, user_attrs: 1 system_attrs: 0
-        assert len(df.columns) == 9
-        for i in range(3):
-            assert df.number[i] == i
-            assert df.state[i] == "FAIL"
-            assert df.value[i] is None
-            assert isinstance(df.datetime_start[i], pd.Timestamp)
-            assert isinstance(df.datetime_complete[i], pd.Timestamp)
-            assert isinstance(df.duration[i], pd.Timedelta)
-            assert df.params_x[i] == 1
-            assert df.params_y[i] == 2.5
-            assert df.user_attrs_train_loss[i] == 3
-
-
-@pytest.mark.parametrize(
-    "attrs",
-    [
-        ("value",),
-        ("values",),
-    ],
-)
-@pytest.mark.parametrize("multi_index", [True, False])
-def test_trials_dataframe_with_multi_objective_optimization(
-    attrs: Tuple[str, ...], multi_index: bool
-) -> None:
-    def f(trial: optuna.trial.Trial) -> Tuple[float, float]:
-
-        x = trial.suggest_float("x", 1, 1)
-        y = trial.suggest_float("y", 2, 2)
-
-        return x + y, x ** 2 + y ** 2  # 3, 5
-
-    study = optuna.create_study(directions=["minimize", "maximize"])
-    study.optimize(f, n_trials=3)
-    df = study.trials_dataframe(attrs=attrs, multi_index=multi_index)
-
-    if multi_index:
-        for i in range(3):
-            assert df.get("values")[0][i] == 3
-            assert df.get("values")[1][i] == 5
-    else:
-        for i in range(3):
-            assert df.values_0[i] == 3
-            assert df.values_1[i] == 5
-
-
 @pytest.mark.parametrize("storage_mode", STORAGE_MODES)
 def test_create_study(storage_mode: str) -> None:
 
     with StorageSupplier(storage_mode) as storage:
         # Test creating a new study.
-        study = optuna.create_study(storage=storage, load_if_exists=False)
+        study = create_study(storage=storage, load_if_exists=False)
 
         # Test `load_if_exists=True` with existing study.
-        optuna.create_study(study_name=study.study_name, storage=storage, load_if_exists=True)
+        create_study(study_name=study.study_name, storage=storage, load_if_exists=True)
 
-        with pytest.raises(optuna.exceptions.DuplicatedStudyError):
-            optuna.create_study(study_name=study.study_name, storage=storage, load_if_exists=False)
+        with pytest.raises(DuplicatedStudyError):
+            create_study(study_name=study.study_name, storage=storage, load_if_exists=False)
 
 
 @pytest.mark.parametrize("storage_mode", STORAGE_MODES)
@@ -629,13 +390,13 @@ def test_load_study(storage_mode: str) -> None:
 
         with pytest.raises(KeyError):
             # Test loading an unexisting study.
-            optuna.study.load_study(study_name=study_name, storage=storage)
+            load_study(study_name=study_name, storage=storage)
 
         # Create a new study.
-        created_study = optuna.study.create_study(study_name=study_name, storage=storage)
+        created_study = create_study(study_name=study_name, storage=storage)
 
         # Test loading an existing study.
-        loaded_study = optuna.study.load_study(study_name=study_name, storage=storage)
+        loaded_study = load_study(study_name=study_name, storage=storage)
         assert created_study._study_id == loaded_study._study_id
 
 
@@ -644,43 +405,43 @@ def test_delete_study(storage_mode: str) -> None:
 
     with StorageSupplier(storage_mode) as storage:
         # Get storage object because delete_study does not accept None.
-        storage = optuna.storages.get_storage(storage=storage)
+        storage = get_storage(storage=storage)
         assert storage is not None
 
         # Test deleting a non-existing study.
         with pytest.raises(KeyError):
-            optuna.delete_study("invalid-study-name", storage)
+            delete_study("invalid-study-name", storage)
 
         # Test deleting an existing study.
-        study = optuna.create_study(storage=storage, load_if_exists=False)
-        optuna.delete_study(study.study_name, storage)
+        study = create_study(storage=storage, load_if_exists=False)
+        delete_study(study.study_name, storage)
 
         # Test failed to delete the study which is already deleted.
         with pytest.raises(KeyError):
-            optuna.delete_study(study.study_name, storage)
+            delete_study(study.study_name, storage)
 
 
 def test_nested_optimization() -> None:
-    def objective(trial: optuna.trial.Trial) -> float:
+    def objective(trial: Trial) -> float:
 
         with pytest.raises(RuntimeError):
             trial.study.optimize(lambda _: 0.0, n_trials=1)
 
         return 1.0
 
-    study = optuna.create_study()
+    study = create_study()
     study.optimize(objective, n_trials=10, catch=())
 
 
 def test_stop_in_objective() -> None:
-    def objective(trial: optuna.trial.Trial, threshold_number: int) -> float:
+    def objective(trial: Trial, threshold_number: int) -> float:
         if trial.number >= threshold_number:
             trial.study.stop()
 
         return trial.number
 
     # Test stopping the optimization: it should stop once the trial number reaches 4.
-    study = optuna.create_study()
+    study = create_study()
     study.optimize(lambda x: objective(x, 4), n_trials=10)
     assert len(study.trials) == 5
 
@@ -690,29 +451,29 @@ def test_stop_in_objective() -> None:
 
 
 def test_stop_in_callback() -> None:
-    def callback(study: optuna.study.Study, trial: optuna.trial.FrozenTrial) -> None:
+    def callback(study: Study, trial: FrozenTrial) -> None:
         if trial.number >= 4:
             study.stop()
 
     # Test stopping the optimization inside a callback.
-    study = optuna.create_study()
+    study = create_study()
     study.optimize(lambda _: 1.0, n_trials=10, callbacks=[callback])
     assert len(study.trials) == 5
 
 
 def test_stop_n_jobs() -> None:
-    def callback(study: optuna.study.Study, trial: optuna.trial.FrozenTrial) -> None:
+    def callback(study: Study, trial: FrozenTrial) -> None:
         if trial.number >= 4:
             study.stop()
 
-    study = optuna.create_study()
+    study = create_study()
     study.optimize(lambda _: 1.0, n_trials=None, callbacks=[callback], n_jobs=2)
     assert 5 <= len(study.trials) <= 6
 
 
 def test_stop_outside_optimize() -> None:
     # Test stopping outside the optimization: it should raise `RuntimeError`.
-    study = optuna.create_study()
+    study = create_study()
     with pytest.raises(RuntimeError):
         study.stop()
 
@@ -724,7 +485,7 @@ def test_stop_outside_optimize() -> None:
 def test_add_trial(storage_mode: str) -> None:
 
     with StorageSupplier(storage_mode) as storage:
-        study = optuna.create_study(storage=storage)
+        study = create_study(storage=storage)
         assert len(study.trials) == 0
 
         trial = create_trial(value=0.8)
@@ -738,13 +499,13 @@ def test_add_trial(storage_mode: str) -> None:
 def test_enqueue_trial_properly_sets_param_values(storage_mode: str) -> None:
 
     with StorageSupplier(storage_mode) as storage:
-        study = optuna.create_study(storage=storage)
+        study = create_study(storage=storage)
         assert len(study.trials) == 0
 
         study.enqueue_trial(params={"x": -5, "y": 5})
         study.enqueue_trial(params={"x": -1, "y": 0})
 
-        def objective(trial: optuna.trial.Trial) -> float:
+        def objective(trial: Trial) -> float:
 
             x = trial.suggest_int("x", -10, 10)
             y = trial.suggest_int("y", -10, 10)
@@ -764,12 +525,12 @@ def test_enqueue_trial_properly_sets_param_values(storage_mode: str) -> None:
 def test_enqueue_trial_with_unfixed_parameters(storage_mode: str) -> None:
 
     with StorageSupplier(storage_mode) as storage:
-        study = optuna.create_study(storage=storage)
+        study = create_study(storage=storage)
         assert len(study.trials) == 0
 
         study.enqueue_trial(params={"x": -5})
 
-        def objective(trial: optuna.trial.Trial) -> float:
+        def objective(trial: Trial) -> float:
 
             x = trial.suggest_int("x", -10, 10)
             y = trial.suggest_int("y", -10, 10)
@@ -785,12 +546,12 @@ def test_enqueue_trial_with_unfixed_parameters(storage_mode: str) -> None:
 def test_enqueue_trial_with_out_of_range_parameters(storage_mode: str) -> None:
 
     with StorageSupplier(storage_mode) as storage:
-        study = optuna.create_study(storage=storage)
+        study = create_study(storage=storage)
         assert len(study.trials) == 0
 
         study.enqueue_trial(params={"x": 11})
 
-        def objective(trial: optuna.trial.Trial) -> float:
+        def objective(trial: Trial) -> float:
 
             return trial.suggest_int("x", -10, 10)
 
@@ -802,12 +563,12 @@ def test_enqueue_trial_with_out_of_range_parameters(storage_mode: str) -> None:
     # Internal logic might differ when distribution contains a single element.
     # Test it explicitly.
     with StorageSupplier(storage_mode) as storage:
-        study = optuna.create_study(storage=storage)
+        study = create_study(storage=storage)
         assert len(study.trials) == 0
 
         study.enqueue_trial(params={"x": 11})
 
-        def objective(trial: optuna.trial.Trial) -> float:
+        def objective(trial: Trial) -> float:
 
             return trial.suggest_int("x", 1, 1)  # Single element.
 
@@ -820,7 +581,7 @@ def test_enqueue_trial_with_out_of_range_parameters(storage_mode: str) -> None:
 @patch("optuna._optimize.gc.collect")
 def test_optimize_with_gc(collect_mock: Mock) -> None:
 
-    study = optuna.create_study()
+    study = create_study()
     study.optimize(func, n_trials=10, gc_after_trial=True)
     check_study(study)
     assert collect_mock.call_count == 10
@@ -829,7 +590,7 @@ def test_optimize_with_gc(collect_mock: Mock) -> None:
 @patch("optuna._optimize.gc.collect")
 def test_optimize_without_gc(collect_mock: Mock) -> None:
 
-    study = optuna.create_study()
+    study = create_study()
     study.optimize(func, n_trials=10, gc_after_trial=False)
     check_study(study)
     assert collect_mock.call_count == 0
@@ -841,16 +602,16 @@ def test_callbacks(n_jobs: int) -> None:
     lock = threading.Lock()
 
     def with_lock(f: CallbackFuncType) -> CallbackFuncType:
-        def callback(study: optuna.study.Study, trial: optuna.trial.FrozenTrial) -> None:
+        def callback(study: Study, trial: FrozenTrial) -> None:
 
             with lock:
                 f(study, trial)
 
         return callback
 
-    study = optuna.create_study()
+    study = create_study()
 
-    def objective(trial: optuna.trial.Trial) -> float:
+    def objective(trial: Trial) -> float:
 
         return trial.suggest_int("x", 1, 1)
 
@@ -900,9 +661,9 @@ def test_callbacks(n_jobs: int) -> None:
 def test_get_trials(storage_mode: str) -> None:
 
     with StorageSupplier(storage_mode) as storage:
-        storage = optuna.storages.get_storage(storage=storage)
+        storage = get_storage(storage=storage)
 
-        study = optuna.create_study(storage=storage)
+        study = create_study(storage=storage)
         study.optimize(lambda t: t.suggest_int("x", 1, 5), n_trials=5)
 
         with patch("copy.deepcopy", wraps=copy.deepcopy) as mock_object:
@@ -925,17 +686,17 @@ def test_get_trials(storage_mode: str) -> None:
 def test_get_trials_state_option(storage_mode: str) -> None:
 
     with StorageSupplier(storage_mode) as storage:
-        storage = optuna.storages.get_storage(storage=storage)
+        storage = get_storage(storage=storage)
 
-        study = optuna.create_study(storage=storage)
+        study = create_study(storage=storage)
 
-        def objective(trial: optuna.trial.Trial) -> float:
+        def objective(trial: Trial) -> float:
             if trial.number == 0:
                 return 0.0  # TrialState.COMPLETE.
             elif trial.number == 1:
                 return 0.0  # TrialState.COMPLETE.
             elif trial.number == 2:
-                raise optuna.exceptions.TrialPruned  # TrialState.PRUNED.
+                raise TrialPruned  # TrialState.PRUNED.
             else:
                 assert False
 
@@ -963,75 +724,23 @@ def test_get_trials_state_option(storage_mode: str) -> None:
             assert len(trials) == 0
 
 
-def test_study_summary_eq_ne() -> None:
-
-    storage = optuna.storages.RDBStorage("sqlite:///:memory:")
-
-    optuna.create_study(storage=storage)
-    study = optuna.create_study(storage=storage)
-
-    summaries = study._storage.get_all_study_summaries()
-    assert len(summaries) == 2
-
-    assert summaries[0] == copy.deepcopy(summaries[0])
-    assert not summaries[0] != copy.deepcopy(summaries[0])
-
-    assert not summaries[0] == summaries[1]
-    assert summaries[0] != summaries[1]
-
-    assert not summaries[0] == 1
-    assert summaries[0] != 1
-
-
-def test_study_summary_lt_le() -> None:
-
-    storage = optuna.storages.RDBStorage("sqlite:///:memory:")
-
-    optuna.create_study(storage=storage)
-    study = optuna.create_study(storage=storage)
-
-    summaries = study._storage.get_all_study_summaries()
-    assert len(summaries) == 2
-
-    summary_0 = summaries[0]
-    summary_1 = summaries[1]
-
-    assert summary_0 < summary_1
-    assert not summary_1 < summary_0
-
-    with pytest.raises(TypeError):
-        summary_0 < 1
-
-    assert summary_0 <= summary_0
-    assert not summary_1 <= summary_0
-
-    with pytest.raises(TypeError):
-        summary_0 <= 1
-
-    # A list of StudySummaries is sortable.
-    summaries.reverse()
-    summaries.sort()
-    assert summaries[0] == summary_0
-    assert summaries[1] == summary_1
-
-
 def test_log_completed_trial(capsys: _pytest.capture.CaptureFixture) -> None:
 
     # We need to reconstruct our default handler to properly capture stderr.
-    optuna.logging._reset_library_root_logger()
-    optuna.logging.set_verbosity(optuna.logging.INFO)
+    logging._reset_library_root_logger()
+    logging.set_verbosity(logging.INFO)
 
-    study = optuna.create_study()
+    study = create_study()
     study.optimize(lambda _: 1.0, n_trials=1)
     _, err = capsys.readouterr()
     assert "Trial 0" in err
 
-    optuna.logging.set_verbosity(optuna.logging.WARNING)
+    logging.set_verbosity(logging.WARNING)
     study.optimize(lambda _: 1.0, n_trials=1)
     _, err = capsys.readouterr()
     assert "Trial 1" not in err
 
-    optuna.logging.set_verbosity(optuna.logging.DEBUG)
+    logging.set_verbosity(logging.DEBUG)
     study.optimize(lambda _: 1.0, n_trials=1)
     _, err = capsys.readouterr()
     assert "Trial 2" in err
@@ -1039,11 +748,11 @@ def test_log_completed_trial(capsys: _pytest.capture.CaptureFixture) -> None:
 
 def test_log_completed_trial_skip_storage_access() -> None:
 
-    study = optuna.create_study()
+    study = create_study()
 
     # Create a trial to retrieve it as the `study.best_trial`.
     study.optimize(lambda _: 0.0, n_trials=1)
-    trial = optuna.Trial(study, study._storage.create_new_trial(study._study_id))
+    trial = Trial(study, study._storage.create_new_trial(study._study_id))
 
     storage = study._storage
 
@@ -1052,43 +761,43 @@ def test_log_completed_trial_skip_storage_access() -> None:
         # Trial.best_trial and Trial.best_params access storage.
         assert mock_object.call_count == 2
 
-    optuna.logging.set_verbosity(optuna.logging.WARNING)
+    logging.set_verbosity(logging.WARNING)
     with patch.object(storage, "get_best_trial", wraps=storage.get_best_trial) as mock_object:
         study._log_completed_trial(trial, [1.0])
         assert mock_object.call_count == 0
 
-    optuna.logging.set_verbosity(optuna.logging.DEBUG)
+    logging.set_verbosity(logging.DEBUG)
     with patch.object(storage, "get_best_trial", wraps=storage.get_best_trial) as mock_object:
         study._log_completed_trial(trial, [1.0])
         assert mock_object.call_count == 2
 
 
 def test_create_study_with_multi_objectives() -> None:
-    study = optuna.create_study(directions=["maximize"])
+    study = create_study(directions=["maximize"])
     assert study.direction == StudyDirection.MAXIMIZE
     assert not study._is_multi_objective()
 
-    study = optuna.create_study(directions=["maximize", "minimize"])
+    study = create_study(directions=["maximize", "minimize"])
     assert study.directions == [StudyDirection.MAXIMIZE, StudyDirection.MINIMIZE]
     assert study._is_multi_objective()
 
     with pytest.raises(ValueError):
         # Empty `direction` isn't allowed.
-        _ = optuna.create_study(directions=[])
+        _ = create_study(directions=[])
 
     with pytest.raises(ValueError):
-        _ = optuna.create_study(direction="minimize", directions=["maximize"])
+        _ = create_study(direction="minimize", directions=["maximize"])
 
     with pytest.raises(ValueError):
-        _ = optuna.create_study(direction="minimize", directions=[])
+        _ = create_study(direction="minimize", directions=[])
 
 
 @pytest.mark.parametrize("n_objectives", [2, 3])
 def test_optimize_with_multi_objectives(n_objectives: int) -> None:
     directions = ["minimize" for _ in range(n_objectives)]
-    study = optuna.create_study(directions=directions)
+    study = create_study(directions=directions)
 
-    def objective(trial: optuna.trial.Trial) -> List[float]:
+    def objective(trial: Trial) -> List[float]:
         return [trial.suggest_uniform("v{}".format(i), 0, 5) for i in range(n_objectives)]
 
     study.optimize(objective, n_trials=10)
@@ -1101,11 +810,11 @@ def test_optimize_with_multi_objectives(n_objectives: int) -> None:
 
 
 def test_pareto_front() -> None:
-    def _trial_to_values(t: optuna.trial.FrozenTrial) -> Tuple[float, ...]:
+    def _trial_to_values(t: FrozenTrial) -> Tuple[float, ...]:
         assert t.values is not None
         return tuple(t.values)
 
-    study = optuna.create_study(directions=["minimize", "maximize"])
+    study = create_study(directions=["minimize", "maximize"])
     assert {_trial_to_values(t) for t in study.best_trials} == set()
 
     study.optimize(lambda t: [2, 2], n_trials=1)
@@ -1129,9 +838,9 @@ def test_pareto_front() -> None:
 def test_wrong_n_objectives() -> None:
     n_objectives = 2
     directions = ["minimize" for _ in range(n_objectives)]
-    study = optuna.create_study(directions=directions)
+    study = create_study(directions=directions)
 
-    def objective(trial: optuna.trial.Trial) -> List[float]:
+    def objective(trial: Trial) -> List[float]:
         return [trial.suggest_uniform("v{}".format(i), 0, 5) for i in range(n_objectives + 1)]
 
     study.optimize(objective, n_trials=10)
@@ -1141,14 +850,14 @@ def test_wrong_n_objectives() -> None:
 
 
 def test_ask() -> None:
-    study = optuna.create_study()
+    study = create_study()
 
     trial = study.ask()
     assert isinstance(trial, Trial)
 
 
 def test_ask_enqueue_trial() -> None:
-    study = optuna.create_study()
+    study = create_study()
 
     study.enqueue_trial({"x": 0.5})
 
@@ -1157,7 +866,7 @@ def test_ask_enqueue_trial() -> None:
 
 
 def test_tell() -> None:
-    study = optuna.create_study()
+    study = create_study()
     assert len(study.trials) == 0
 
     trial = study.ask()
@@ -1184,7 +893,7 @@ def test_tell() -> None:
 
 
 def test_tell_trial_variations() -> None:
-    study = optuna.create_study()
+    study = create_study()
 
     study.tell(study.ask().number, 1.0)
 
@@ -1197,7 +906,7 @@ def test_tell_trial_variations() -> None:
 
 
 def test_tell_duplicate_tell() -> None:
-    study = optuna.create_study()
+    study = create_study()
 
     trial = study.ask()
     study.tell(trial, 1.0)
@@ -1207,7 +916,7 @@ def test_tell_duplicate_tell() -> None:
 
 
 def test_tell_values() -> None:
-    study = optuna.create_study()
+    study = create_study()
 
     study.tell(study.ask(), 1.0)
 
@@ -1224,7 +933,7 @@ def test_tell_values() -> None:
     with pytest.raises(ValueError):
         study.tell(study.ask(), [1.0, 2.0])
 
-    study = optuna.create_study(directions=["minimize", "maximize"])
+    study = create_study(directions=["minimize", "maximize"])
     study.tell(study.ask(), [1.0, 2.0])
 
     with pytest.raises(ValueError):
@@ -1253,7 +962,7 @@ def test_tell_storage_not_implemented_trial_number() -> None:
             "get_trial_id_from_study_id_trial_number",
             side_effect=NotImplementedError,
         ):
-            study = optuna.create_study(storage=storage)
+            study = create_study(storage=storage)
 
             study.tell(study.ask(), 1.0)
 
@@ -1268,7 +977,7 @@ def test_tell_storage_not_implemented_trial_number() -> None:
 
 def test_tell_pruned_values() -> None:
     # See also `test_run_trial_with_trial_pruned`.
-    study = optuna.create_study()
+    study = create_study()
 
     trial = study.ask()
 

--- a/tests/study_tests/test_study_summary.py
+++ b/tests/study_tests/test_study_summary.py
@@ -1,0 +1,58 @@
+import copy
+
+import pytest
+
+from optuna import create_study
+from optuna.storages import RDBStorage
+
+
+def test_study_summary_eq_ne() -> None:
+
+    storage = RDBStorage("sqlite:///:memory:")
+
+    create_study(storage=storage)
+    study = create_study(storage=storage)
+
+    summaries = study._storage.get_all_study_summaries()
+    assert len(summaries) == 2
+
+    assert summaries[0] == copy.deepcopy(summaries[0])
+    assert not summaries[0] != copy.deepcopy(summaries[0])
+
+    assert not summaries[0] == summaries[1]
+    assert summaries[0] != summaries[1]
+
+    assert not summaries[0] == 1
+    assert summaries[0] != 1
+
+
+def test_study_summary_lt_le() -> None:
+
+    storage = RDBStorage("sqlite:///:memory:")
+
+    create_study(storage=storage)
+    study = create_study(storage=storage)
+
+    summaries = study._storage.get_all_study_summaries()
+    assert len(summaries) == 2
+
+    summary_0 = summaries[0]
+    summary_1 = summaries[1]
+
+    assert summary_0 < summary_1
+    assert not summary_1 < summary_0
+
+    with pytest.raises(TypeError):
+        summary_0 < 1
+
+    assert summary_0 <= summary_0
+    assert not summary_1 <= summary_0
+
+    with pytest.raises(TypeError):
+        summary_0 <= 1
+
+    # A list of StudySummaries is sortable.
+    summaries.reverse()
+    summaries.sort()
+    assert summaries[0] == summary_0
+    assert summaries[1] == summary_1


### PR DESCRIPTION
## Motivation
The current `tests/test_study.py` is too big. This PR aims to diet the test by dividing it into several files.

## Description of the changes
- Create `tests/study_tests` directory.
- Divide `tests/test_study.py` into `tests/study_tests/{test_dataframe.py, test_optimize.py, test_study.py, test_study_summary.py}`.
- Obviously import each function or class, e.g. `from optuna import Study`, to align the majority of tests.
