### PR TITLE
Move import lines of the callback recipe (A follow-up of #2125)

### DIFF
--- a/tutorial/20_recipes/007_optuna_callback.py
+++ b/tutorial/20_recipes/007_optuna_callback.py
@@ -24,6 +24,7 @@ it takes :class:`~optuna.study.Study` and :class:`~optuna.trial.FrozenTrial` as 
 
 import optuna
 
+
 class StopWhenTrialKeepBeingPrunedCallback:
     def __init__(self, threshold: int):
         self.threshold = threshold

--- a/tutorial/20_recipes/007_optuna_callback.py
+++ b/tutorial/20_recipes/007_optuna_callback.py
@@ -12,13 +12,6 @@ it takes :class:`~optuna.study.Study` and :class:`~optuna.trial.FrozenTrial` as 
 :class:`~optuna.integration.MLflowCallback` is a great example.
 """
 
-import logging
-import sys
-
-import optuna
-
-# Add stream handler of stdout to show the messages
-optuna.logging.get_logger("optuna").addHandler(logging.StreamHandler(sys.stdout))
 
 ###################################################################################################
 # Stop optimization after some trials are pruned in a row
@@ -28,6 +21,8 @@ optuna.logging.get_logger("optuna").addHandler(logging.StreamHandler(sys.stdout)
 # if a certain number of trials are pruned in a row.
 # The number of trials pruned in a row is specified by ``threshold``.
 
+
+import optuna
 
 class StopWhenTrialKeepBeingPrunedCallback:
     def __init__(self, threshold: int):
@@ -56,6 +51,12 @@ def objective(trial):
 ###################################################################################################
 # Here, we set the threshold to ``2``: optimization finishes once two trials are pruned in a row.
 # So, we expect this study to stop after 7 trials.
+import logging
+import sys
+
+# Add stream handler of stdout to show the messages
+optuna.logging.get_logger("optuna").addHandler(logging.StreamHandler(sys.stdout))
+
 study_stop_cb = StopWhenTrialKeepBeingPrunedCallback(2)
 study = optuna.create_study()
 study.optimize(objective, n_trials=10, callbacks=[study_stop_cb])


### PR DESCRIPTION
## Motivation
This PR moves import lines to improve the readability of the recipe.

## Description of the changes

The current import lines:
![image](https://user-images.githubusercontent.com/3255979/104865609-cbcf2100-597f-11eb-9cf4-f20865ae285f.png)

This PR:

![image](https://user-images.githubusercontent.com/3255979/104865655-ebfee000-597f-11eb-8166-262cf341c85a.png)

![image](https://user-images.githubusercontent.com/3255979/104865677-f8833880-597f-11eb-9ccd-46ea08652ad8.png)
