### PR TITLE
Activate example CI on Python3.9

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -56,7 +56,7 @@ jobs:
           IGNORES='chainermn_.*|dask_ml_.*|keras_.*|tensorboard_.*|tensorflow_.*|tfkeras_.*|fastai*|allennlp|rapids_.*'
           IGNORES='chainermn_.*|dask_ml_.*|keras_.*|tensorboard_.*|tensorflow_.*|tfkeras_.*|fastai*|rapids_.*'
         elif [ ${{ matrix.python-version }} = 3.9 ]; then
-          IGNORES='allennlp_*|botorch_*|catalyst_*|catboost_*|chainer_*|chainermn_.*|dask_ml_.*|fastai*|gluon_*|haiku_*|keras_*|lightgbm_*|mxnet_*|optuna_search_cv_*|pytorch_ignite_*|pytorch_lightning_*|rapids_*|sb3_*|skimage_lbp_*|sklearn_*|skorch_*|tensorboard_*|tensorflow_*|tfkeras_*|xgboost_*|pruning/simple*|enqueue_trial*|visualization/plot_pareto_front*|visualization/plot_study*|multi_objective/pytorch_simple*'
+          IGNORES='allennlp_*|botorch_*|catalyst_*|catboost_*|chainer_*|chainermn_.*|dask_ml_.*|fastai*|gluon_*|haiku_*|hydra_*|keras_*|lightgbm_*|mxnet_*|optuna_search_cv_*|pytorch_ignite_*|pytorch_lightning_*|rapids_*|sb3_*|skimage_lbp_*|sklearn_*|skorch_*|tensorboard_*|tensorflow_*|tfkeras_*|xgboost_*|pruning/simple*|enqueue_trial*|visualization/plot_pareto_front*|visualization/plot_study*|multi_objective/pytorch_simple*'
         else
           IGNORES='chainermn_.*|fastai*|rapids_.*'
         fi

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -55,7 +55,7 @@ jobs:
         elif [ ${{ matrix.python-version }} = 3.8 ]; then
           IGNORES='chainermn_.*|dask_ml_.*|keras_.*|tensorboard_.*|tensorflow_.*|tfkeras_.*|fastai*|allennlp|rapids_.*'
         elif [ ${{ matrix.python-version }} = 3.9 ]; then
-          IGNORES='botorch_*|catalyst_*|catboost_*|chainer_*|chainermn_.*|dask_ml_.*|fastai*|gluon_*|haiku_*|keras_*|lightgbm_*|mxnet_*|optuna_search_cv_*|pytorch_ignite_*|pytorch_lightning_*|rapids_*|skimage_lbp_*|sklearn_*|skorch_*|tensorboard_*|tensorflow_*|tfkeras_*|xgboost_*'
+          IGNORES='allennlp_*|botorch_*|catalyst_*|catboost_*|chainer_*|chainermn_.*|dask_ml_.*|fastai*|gluon_*|haiku_*|keras_*|lightgbm_*|mxnet_*|optuna_search_cv_*|pytorch_ignite_*|pytorch_lightning_*|rapids_*|sb3_*|skimage_lbp_*|sklearn_*|skorch_*|tensorboard_*|tensorflow_*|tfkeras_*|xgboost_*'
         else
           IGNORES='chainermn_.*|fastai*|rapids_.*'
         fi

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -55,7 +55,7 @@ jobs:
         elif [ ${{ matrix.python-version }} = 3.8 ]; then
           IGNORES='chainermn_.*|dask_ml_.*|keras_.*|tensorboard_.*|tensorflow_.*|tfkeras_.*|fastai*|allennlp|rapids_.*'
         elif [ ${{ matrix.python-version }} = 3.9 ]; then
-          IGNORES='allennlp_*|botorch_*|catalyst_*|catboost_*|chainer_*|chainermn_.*|dask_ml_.*|fastai*|gluon_*|haiku_*|keras_*|lightgbm_*|mxnet_*|optuna_search_cv_*|pytorch_ignite_*|pytorch_lightning_*|rapids_*|sb3_*|skimage_lbp_*|sklearn_*|skorch_*|tensorboard_*|tensorflow_*|tfkeras_*|xgboost_*'
+          IGNORES='allennlp_*|botorch_*|catalyst_*|catboost_*|chainer_*|chainermn_.*|dask_ml_.*|fastai*|gluon_*|haiku_*|keras_*|lightgbm_*|mxnet_*|optuna_search_cv_*|pytorch_ignite_*|pytorch_lightning_*|rapids_*|sb3_*|skimage_lbp_*|sklearn_*|skorch_*|tensorboard_*|tensorflow_*|tfkeras_*|xgboost_*|pruning/simple*|enqueue_trial*|visualization/plot_pareto_front*|visualization/plot_study*|multi_objective/pytorch_simple*'
         else
           IGNORES='chainermn_.*|fastai*|rapids_.*'
         fi

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -53,7 +53,6 @@ jobs:
         if [ ${{ matrix.python-version }} = 3.6 ]; then
           IGNORES='chainermn_.*|fastai*|rapids_.*|botorch_.*'
         elif [ ${{ matrix.python-version }} = 3.8 ]; then
-          IGNORES='chainermn_.*|dask_ml_.*|keras_.*|tensorboard_.*|tensorflow_.*|tfkeras_.*|fastai*|allennlp|rapids_.*'
           IGNORES='chainermn_.*|dask_ml_.*|keras_.*|tensorboard_.*|tensorflow_.*|tfkeras_.*|fastai*|rapids_.*'
         elif [ ${{ matrix.python-version }} = 3.9 ]; then
           IGNORES='allennlp_*|botorch_*|catalyst_*|catboost_*|chainer_*|chainermn_.*|dask_ml_.*|fastai*|gluon_*|haiku_*|hydra_*|keras_*|lightgbm_*|mxnet_*|optuna_search_cv_*|pytorch_ignite_*|pytorch_lightning_*|rapids_*|sb3_*|skimage_lbp_*|sklearn_*|skorch_*|tensorboard_*|tensorflow_*|tfkeras_*|xgboost_*|pruning/simple*|enqueue_trial*|visualization/plot_pareto_front*|visualization/plot_study*|multi_objective/pytorch_simple*'

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -7,12 +7,12 @@ on:
 jobs:
   examples:
 
-    # TODO (crcrpar): Run on 3.9.
+    # TODO (crcrpar): Activate more on 3.9.
     # ref: https://github.com/optuna/optuna/issues/2034
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
 
     if: github.repository == 'optuna/optuna'
     steps:
@@ -53,7 +53,9 @@ jobs:
         if [ ${{ matrix.python-version }} = 3.6 ]; then
           IGNORES='chainermn_.*|fastai*|rapids_.*|botorch_.*'
         elif [ ${{ matrix.python-version }} = 3.8 ]; then
-          IGNORES='chainermn_.*|dask_ml_.*|keras_.*|tensorboard_.*|tensorflow_.*|tfkeras_.*|fastai*|rapids_.*'
+          IGNORES='chainermn_.*|dask_ml_.*|keras_.*|tensorboard_.*|tensorflow_.*|tfkeras_.*|fastai*|allennlp|rapids_.*'
+        elif [ ${{ matrix.python-version }} = 3.9 ]; then
+          IGNORES='botorch_*|catalyst_*|catboost_*|chainer_*|chainermn_.*|dask_ml_.*|fastai*|gluon_*|haiku_*|keras_*|lightgbm_*|mxnet_*|optuna_search_cv_*|pytorch_ignite_*|pytorch_lightning_*|rapids_*|skimage_lbp_*|sklearn_*|skorch_*|tensorboard_*|tensorflow_*|tfkeras_*|xgboost_*'
         else
           IGNORES='chainermn_.*|fastai*|rapids_.*'
         fi

--- a/setup.py
+++ b/setup.py
@@ -113,6 +113,14 @@ def get_extras_require() -> Dict[str, List[str]]:
             "jax",
             "optax",
             "dm-haiku",
+        ]
+        if sys.version_info[:2] < (3, 9)
+        else [
+            "torch==1.7.1 ; sys_platform=='darwin'",
+            "torch==1.7.1+cpu ; sys_platform!='darwin'",
+            "torchvision==0.8.2 ; sys_platform=='darwin'",
+            "torchvision==0.8.2+cpu ; sys_platform!='darwin'",
+            "torchaudio==0.7.2",
         ],
         "experimental": ["redis"],
         "testing": [


### PR DESCRIPTION
This pull request only activates PyTorch example, i.e.
`pytorch_simple.py`.
The change to `setup.py` is quite tentative and far from what this
should look like, however, as of now this change is enough given the
number of requirements: it's cumbersome to add the constraints all the
other packages in 'example'.

Related: #2034 