### PR TITLE
Include the upper bound of uniform/loguniform distributions.

### DIFF
--- a/optuna/distributions.py
+++ b/optuna/distributions.py
@@ -128,10 +128,7 @@ class UniformDistribution(BaseDistribution):
     def _contains(self, param_value_in_internal_repr: float) -> bool:
 
         value = param_value_in_internal_repr
-        if self.low == self.high:
-            return value == self.low
-        else:
-            return self.low <= value <= self.high
+        return self.low <= value <= self.high
 
 
 class LogUniformDistribution(BaseDistribution):
@@ -175,10 +172,7 @@ class LogUniformDistribution(BaseDistribution):
     def _contains(self, param_value_in_internal_repr: float) -> bool:
 
         value = param_value_in_internal_repr
-        if self.low == self.high:
-            return value == self.low
-        else:
-            return self.low <= value <= self.high
+        return self.low <= value <= self.high
 
 
 class DiscreteUniformDistribution(BaseDistribution):

--- a/optuna/distributions.py
+++ b/optuna/distributions.py
@@ -131,7 +131,7 @@ class UniformDistribution(BaseDistribution):
         if self.low == self.high:
             return value == self.low
         else:
-            return self.low <= value < self.high
+            return self.low <= value <= self.high
 
 
 class LogUniformDistribution(BaseDistribution):
@@ -178,7 +178,7 @@ class LogUniformDistribution(BaseDistribution):
         if self.low == self.high:
             return value == self.low
         else:
-            return self.low <= value < self.high
+            return self.low <= value <= self.high
 
 
 class DiscreteUniformDistribution(BaseDistribution):

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -110,12 +110,14 @@ def test_contains() -> None:
     assert u._contains(1)
     assert u._contains(1.5)
     assert u._contains(2)
+    assert not u._contains(2.1)
 
     lu = distributions.LogUniformDistribution(low=0.001, high=100)
     assert not lu._contains(0.0)
     assert lu._contains(0.001)
     assert lu._contains(12.3)
     assert lu._contains(100)
+    assert not lu._contains(1000)
 
     with warnings.catch_warnings():
         # UserWarning will be raised since the range is not divisible by 2.

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -109,13 +109,13 @@ def test_contains() -> None:
     assert not u._contains(0.9)
     assert u._contains(1)
     assert u._contains(1.5)
-    assert not u._contains(2)
+    assert u._contains(2)
 
     lu = distributions.LogUniformDistribution(low=0.001, high=100)
     assert not lu._contains(0.0)
     assert lu._contains(0.001)
     assert lu._contains(12.3)
-    assert not lu._contains(100)
+    assert lu._contains(100)
 
     with warnings.catch_warnings():
         # UserWarning will be raised since the range is not divisible by 2.


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

In the current specification of UniformDistribution and LogUniformDistribution, the upper bounds are excluded.

```python
>>> import optuna
>>> d = optuna.distributions.UniformDistribution(low=0.0, high=1.0)
>>> d._contains(1.0)
False
>>> d = optuna.distributions.LogUniformDistribution(low=0.01, high=1.0)
>>> d._contains(1.0)
False
```

This behavior is based on the specification of [stdlib](https://docs.python.org/3/library/random.html#random.uniform) and/or [numpy](https://numpy.org/doc/stable/reference/random/generated/numpy.random.uniform.html) random modules. But it confuses the users and the developers in some situation.

* `enqueue_trial({'x': 1.0})` is not evaluated when `x` is defined as `x = suggest_float('x', 0, 1.0)`. I actually bumped this problem several times and it is difficult to notice this bug until it runs.
* https://github.com/optuna/optuna/pull/619
* https://github.com/optuna/optuna/pull/1558

In this PR, I propose to include the upper bound.

## Description of the changes
<!-- Describe the changes in this PR. -->

* Include the upper bound of uniform/loguniform distributions.