### PR TITLE
Ensure uniform and loguniform distributions less than high boundary

### DIFF
--- a/optuna/_transform.py
+++ b/optuna/_transform.py
@@ -238,7 +238,8 @@ def _transform_search_space(
 
 
 def _transform_numerical_param(
-    param: Union[int, float], distribution: BaseDistribution, transform_log: bool, clip=False
+        param: Union[int, float], distribution: BaseDistribution, transform_log: bool,
+        clip: bool = False
 ) -> float:
     d = distribution
 

--- a/optuna/_transform.py
+++ b/optuna/_transform.py
@@ -238,8 +238,10 @@ def _transform_search_space(
 
 
 def _transform_numerical_param(
-        param: Union[int, float], distribution: BaseDistribution, transform_log: bool,
-        clip: bool = False
+    param: Union[int, float],
+    distribution: BaseDistribution,
+    transform_log: bool,
+    clip: bool = False,
 ) -> float:
     d = distribution
 

--- a/optuna/_transform.py
+++ b/optuna/_transform.py
@@ -268,10 +268,10 @@ def _untransform_numerical_param(
     if isinstance(d, CategoricalDistribution):
         assert False, "Should not reach. Should be one-hot encoded."
     elif isinstance(d, UniformDistribution):
-        param = min(trans_param, numpy.next_after(d.high, d.high - 1))
+        param = min(trans_param, numpy.nextafter(d.high, d.high - 1))
     elif isinstance(d, LogUniformDistribution):
         param = math.exp(trans_param) if transform_log else trans_param
-        param = min(param, numpy.next_after(d.high, d.high - 1))
+        param = min(param, numpy.nextafter(d.high, d.high - 1))
     elif isinstance(d, DiscreteUniformDistribution):
         # Clip since result may slightly exceed range due to round-off errors.
         param = float(

--- a/optuna/_transform.py
+++ b/optuna/_transform.py
@@ -45,7 +45,12 @@ class _SearchSpaceTransform:
 
     Attributes:
         bounds:
-            Constructed bounds from the given search space.
+            Constructed bounds from the given search space. For
+            :class:`~optuna.distributions.UniformDistribution` and
+            :class:`~optuna.distributions.LogUniformDistribution`,
+            the high bound of the search space is reduced by the
+            minimal amount possible, to ensure the high boundary value is not suggested, as
+            per the definitions of those distributions.
         column_to_encoded_columns:
             Constructed mapping from original parameter column index to encoded column indices.
         encoded_column_to_column:

--- a/optuna/_transform.py
+++ b/optuna/_transform.py
@@ -196,12 +196,12 @@ def _transform_search_space(
             if isinstance(d, UniformDistribution):
                 bds = (
                     _transform_numerical_param(d.low, d, transform_log),
-                    _transform_numerical_param(d.high, d, transform_log),
+                    _transform_numerical_param(d.high, d, transform_log, clip=True),
                 )
             elif isinstance(d, LogUniformDistribution):
                 bds = (
                     _transform_numerical_param(d.low, d, transform_log),
-                    _transform_numerical_param(d.high, d, transform_log),
+                    _transform_numerical_param(d.high, d, transform_log, clip=True),
                 )
             elif isinstance(d, DiscreteUniformDistribution):
                 half_step = 0.5 * d.q if transform_step else 0.0
@@ -238,7 +238,7 @@ def _transform_search_space(
 
 
 def _transform_numerical_param(
-    param: Union[int, float], distribution: BaseDistribution, transform_log: bool
+    param: Union[int, float], distribution: BaseDistribution, transform_log: bool, clip=False
 ) -> float:
     d = distribution
 
@@ -256,6 +256,9 @@ def _transform_numerical_param(
         trans_param = math.log(param) if transform_log else float(param)
     else:
         assert False, "Should not reach. Unexpected distribution."
+
+    if clip:
+        trans_param = numpy.nextafter(trans_param, trans_param - 1)
 
     return trans_param
 

--- a/optuna/_transform.py
+++ b/optuna/_transform.py
@@ -45,12 +45,7 @@ class _SearchSpaceTransform:
 
     Attributes:
         bounds:
-            Constructed bounds from the given search space. For
-            :class:`~optuna.distributions.UniformDistribution` and
-            :class:`~optuna.distributions.LogUniformDistribution`,
-            the high bound of the search space is reduced by the
-            minimal amount possible, to ensure the high boundary value is not suggested, as
-            per the definitions of those distributions.
+            Constructed bounds from the given search space.
         column_to_encoded_columns:
             Constructed mapping from original parameter column index to encoded column indices.
         encoded_column_to_column:
@@ -107,7 +102,10 @@ class _SearchSpaceTransform:
 
         Returns:
             A 1-dimensional ``numpy.ndarray`` holding the transformed parameters in the
-            configuration.
+            configuration. For :class:`~optuna.distributions.UniformDistribution` and
+            :class:`~optuna.distributions.LogUniformDistribution`, the high bound of the
+            search space is reduced by the minimal amount possible, to ensure the high
+            boundary value is not suggested, as per the definitions of those distributions.
 
         """
         trans_params = numpy.zeros(self._bounds.shape[0], dtype=numpy.float64)

--- a/optuna/integration/botorch.py
+++ b/optuna/integration/botorch.py
@@ -525,15 +525,6 @@ class BoTorchSampler(BaseSampler):
 
         params = trans.untransform(candidates)
 
-        # Exclude upper bounds for parameters that should have their upper bounds excluded.
-        # TODO(hvy): Remove this exclusion logic when it is handled by the data transformer.
-        for name, param in params.items():
-            distribution = search_space[name]
-            if isinstance(distribution, UniformDistribution):
-                params[name] = min(params[name], distribution.high - 1e-8)
-            elif isinstance(distribution, LogUniformDistribution):
-                params[name] = min(params[name], math.exp(math.log(distribution.high) - 1e-8))
-
         return params
 
     def sample_independent(

--- a/optuna/integration/botorch.py
+++ b/optuna/integration/botorch.py
@@ -1,5 +1,4 @@
 from collections import OrderedDict
-import math
 from typing import Any
 from typing import Callable
 from typing import Dict
@@ -14,8 +13,6 @@ from optuna._experimental import experimental
 from optuna._imports import try_import
 from optuna._transform import _SearchSpaceTransform
 from optuna.distributions import BaseDistribution
-from optuna.distributions import LogUniformDistribution
-from optuna.distributions import UniformDistribution
 from optuna.samplers import BaseSampler
 from optuna.samplers import IntersectionSearchSpace
 from optuna.samplers import RandomSampler

--- a/optuna/samplers/_cmaes.py
+++ b/optuna/samplers/_cmaes.py
@@ -320,17 +320,6 @@ class CmaEsSampler(BaseSampler):
 
         external_values = trans.untransform(params)
 
-        # Exclude upper bounds for parameters that should have their upper bounds excluded.
-        # TODO(hvy): Remove this exclusion logic when it is handled by the data transformer.
-        for name, param in external_values.items():
-            distribution = search_space[name]
-            if isinstance(distribution, optuna.distributions.UniformDistribution):
-                external_values[name] = min(external_values[name], distribution.high - _EPS)
-            elif isinstance(distribution, optuna.distributions.LogUniformDistribution):
-                external_values[name] = min(
-                    external_values[name], math.exp(math.log(distribution.high) - _EPS)
-                )
-
         return external_values
 
     def _restore_optimizer(

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -85,7 +85,10 @@ def test_search_space_transform_encoding() -> None:
     ],
 )
 def test_search_space_transform_numerical(
-    transform_log: bool, transform_step: bool, param: Any, distribution: BaseDistribution,
+    transform_log: bool,
+    transform_step: bool,
+    param: Any,
+    distribution: BaseDistribution,
 ) -> None:
     trans = _SearchSpaceTransform({"x0": distribution}, transform_log, transform_step)
 

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -95,6 +95,9 @@ def test_search_space_transform_numerical(
     expected_low = distribution.low  # type: ignore
     expected_high = distribution.high  # type: ignore
 
+    if isinstance(distribution, UniformDistribution) or isinstance(distribution, LogUniformDistribution):
+        expected_high = numpy.nextafter(expected_high, expected_high + 1)
+
     if isinstance(distribution, LogUniformDistribution):
         if transform_log:
             expected_low = math.log(expected_low)

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -85,17 +85,16 @@ def test_search_space_transform_encoding() -> None:
     ],
 )
 def test_search_space_transform_numerical(
-    transform_log: bool,
-    transform_step: bool,
-    param: Any,
-    distribution: BaseDistribution,
+    transform_log: bool, transform_step: bool, param: Any, distribution: BaseDistribution,
 ) -> None:
     trans = _SearchSpaceTransform({"x0": distribution}, transform_log, transform_step)
 
     expected_low = distribution.low  # type: ignore
     expected_high = distribution.high  # type: ignore
 
-    if isinstance(distribution, UniformDistribution) or isinstance(distribution, LogUniformDistribution):
+    if isinstance(distribution, UniformDistribution) or isinstance(
+        distribution, LogUniformDistribution
+    ):
         expected_high = numpy.nextafter(expected_high, expected_high - 1)
 
     if isinstance(distribution, LogUniformDistribution):

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -95,9 +95,6 @@ def test_search_space_transform_numerical(
     expected_low = distribution.low  # type: ignore
     expected_high = distribution.high  # type: ignore
 
-    if isinstance(distribution, (UniformDistribution, LogUniformDistribution)):
-        expected_high = numpy.nextafter(expected_high, expected_high - 1)
-
     if isinstance(distribution, LogUniformDistribution):
         if transform_log:
             expected_low = math.log(expected_low)

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -96,7 +96,7 @@ def test_search_space_transform_numerical(
     expected_high = distribution.high  # type: ignore
 
     if isinstance(distribution, UniformDistribution) or isinstance(distribution, LogUniformDistribution):
-        expected_high = numpy.nextafter(expected_high, expected_high + 1)
+        expected_high = numpy.nextafter(expected_high, expected_high - 1)
 
     if isinstance(distribution, LogUniformDistribution):
         if transform_log:


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
When using uniform or loguniform distributions, the high boundary should be excluded. Moving this logic to the search space transform module to centralize.

## Description of the changes
<!-- Describe the changes in this PR. -->
Use `numpy.nextafter` to subtract the numpy eps from the higher boundary of uniform and loguniform distributions.