### PR TITLE
Pin `mypy==0.790`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ def get_extras_require() -> Dict[str, List[str]]:
 
     requirements = {
         # TODO(HideakiImamura) Unpin mypy version after fixing "Duplicate modules" error in
-        #  examples and tutorials.
+        # examples and tutorials.
         "checking": ["black", "hacking", "isort", "mypy==0.790", "blackdoc"],
         "codecov": ["codecov", "pytest-cov"],
         "doctest": [

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,8 @@ def get_tests_require() -> List[str]:
 def get_extras_require() -> Dict[str, List[str]]:
 
     requirements = {
+        # TODO(HideakiImamura) Unpin mypy version after fixing "Duplicate modules" error in
+        #  examples and tutorials.
         "checking": ["black", "hacking", "isort", "mypy==0.790", "blackdoc"],
         "codecov": ["codecov", "pytest-cov"],
         "doctest": [

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ def get_tests_require() -> List[str]:
 def get_extras_require() -> Dict[str, List[str]]:
 
     requirements = {
-        "checking": ["black", "hacking", "isort", "mypy", "blackdoc"],
+        "checking": ["black", "hacking", "isort", "mypy==0.790", "blackdoc"],
         "codecov": ["codecov", "pytest-cov"],
         "doctest": [
             "cma",


### PR DESCRIPTION
## Motivation
The current master branch fails in CI since the latest release of `mypy==0.800`. This PR is a hotfix.

## Description of the changes
This PR pins the version of `mypy==0.790`.
