### PR TITLE
Add `Study.add_trials` to simplify creating customized study

### DIFF
--- a/optuna/study.py
+++ b/optuna/study.py
@@ -848,6 +848,49 @@ class Study(BaseStudy):
 
         self._storage.create_new_trial(self._study_id, template_trial=trial)
 
+    @experimental("2.5.0")
+    def add_trials(self, trials: Sequence[FrozenTrial]) -> "Study":
+        """Add trials to study.
+
+        The trials are validated before being added.
+
+        Example:
+
+            .. testcode::
+
+                import optuna
+                from optuna.distributions import UniformDistribution
+
+
+                def objective(trial):
+                    x = trial.suggest_uniform("x", 0, 10)
+                    return x ** 2
+
+
+                study = optuna.create_study()
+                study.optimize(objective, n_trials=3)
+                assert len(study.trials) == 3
+
+                other_study = optuna.create_study().add_trials(study.trials)
+                assert len(other_study.trials) == len(study.trials)
+
+                other_study.optimize(objective, n_trials=2)
+                assert len(other_study.trials) == len(study.trials) + 2
+
+        .. seealso::
+
+            See :func:`~optuna.study.add_trial` for addition of each trial.
+
+        Args:
+            trials: Trials to add.
+
+        """
+
+        for trial in trials:
+            self.add_trial(trial)
+
+        return self
+
     def _pop_waiting_trial_id(self) -> Optional[int]:
 
         # TODO(c-bata): Reduce database query counts for extracting waiting trials.

--- a/optuna/study.py
+++ b/optuna/study.py
@@ -3,6 +3,7 @@ import threading
 from typing import Any
 from typing import Callable
 from typing import Dict
+from typing import Iterable
 from typing import List
 from typing import Optional
 from typing import Sequence
@@ -849,7 +850,7 @@ class Study(BaseStudy):
         self._storage.create_new_trial(self._study_id, template_trial=trial)
 
     @experimental("2.5.0")
-    def add_trials(self, trials: Sequence[FrozenTrial]) -> "Study":
+    def add_trials(self, trials: Iterable[FrozenTrial]) -> "Study":
         """Add trials to study.
 
         The trials are validated before being added.

--- a/optuna/study.py
+++ b/optuna/study.py
@@ -850,7 +850,7 @@ class Study(BaseStudy):
         self._storage.create_new_trial(self._study_id, template_trial=trial)
 
     @experimental("2.5.0")
-    def add_trials(self, trials: Iterable[FrozenTrial]) -> "Study":
+    def add_trials(self, trials: Iterable[FrozenTrial]) -> None:
         """Add trials to study.
 
         The trials are validated before being added.
@@ -872,7 +872,8 @@ class Study(BaseStudy):
                 study.optimize(objective, n_trials=3)
                 assert len(study.trials) == 3
 
-                other_study = optuna.create_study().add_trials(study.trials)
+                other_study = optuna.create_study()
+                other_study.add_trials(study.trials)
                 assert len(other_study.trials) == len(study.trials)
 
                 other_study.optimize(objective, n_trials=2)
@@ -885,9 +886,6 @@ class Study(BaseStudy):
         Args:
             trials: Trials to add.
 
-        Returns:
-            Return self.
-
         Raises:
             :exc:`ValueError`:
                 If ``trials`` include invalid trial.
@@ -895,8 +893,6 @@ class Study(BaseStudy):
 
         for trial in trials:
             self.add_trial(trial)
-
-        return self
 
     def _pop_waiting_trial_id(self) -> Optional[int]:
 

--- a/optuna/study.py
+++ b/optuna/study.py
@@ -879,7 +879,7 @@ class Study(BaseStudy):
 
         .. seealso::
 
-            See :func:`~optuna.study.add_trial` for addition of each trial.
+            See :func:`~optuna.study.Study.add_trial` for addition of each trial.
 
         Args:
             trials: Trials to add.

--- a/optuna/study.py
+++ b/optuna/study.py
@@ -884,6 +884,12 @@ class Study(BaseStudy):
         Args:
             trials: Trials to add.
 
+        Returns:
+            Return self.
+
+        Raises:
+            :exc:`ValueError`:
+                If ``trials`` include invalid trial.
         """
 
         for trial in trials:

--- a/tests/study_tests/test_study.py
+++ b/tests/study_tests/test_study.py
@@ -506,7 +506,8 @@ def test_add_trials(storage_mode: str) -> None:
             assert trial.number == i
             assert trial.value == i
 
-        other_study = create_study(storage=storage).add_trials(study.trials)
+        other_study = create_study(storage=storage)
+        other_study.add_trials(study.trials)
         assert len(other_study.trials) == 3
         for i, trial in enumerate(other_study.trials):
             assert trial.number == i

--- a/tests/study_tests/test_study.py
+++ b/tests/study_tests/test_study.py
@@ -490,6 +490,30 @@ def test_add_trial(storage_mode: str) -> None:
 
 
 @pytest.mark.parametrize("storage_mode", STORAGE_MODES)
+def test_add_trials(storage_mode: str) -> None:
+
+    with StorageSupplier(storage_mode) as storage:
+        study = create_study(storage=storage)
+        assert len(study.trials) == 0
+
+        study.add_trials([])
+        assert len(study.trials) == 0
+
+        trials = [create_trial(value=i) for i in range(3)]
+        study.add_trials(trials)
+        assert len(study.trials) == 3
+        for i, trial in enumerate(study.trials):
+            assert trial.number == i
+            assert trial.value == i
+
+        other_study = create_study(storage=storage).add_trials(study.trials)
+        assert len(other_study.trials) == 3
+        for i, trial in enumerate(other_study.trials):
+            assert trial.number == i
+            assert trial.value == i
+
+
+@pytest.mark.parametrize("storage_mode", STORAGE_MODES)
 def test_enqueue_trial_properly_sets_param_values(storage_mode: str) -> None:
 
     with StorageSupplier(storage_mode) as storage:


### PR DESCRIPTION
## Motivation
`Study.add_trial` was introduced to create a custom study. But, we still need to write a bit long code in some cases, e.g., visualization with filtered trials.

```
study_x0 = create_study()
for trial in study.trials:
    if trial.params["x"] > 0:
        study_x0.add_trial(trial)
plot_slice(study_x0)
```

This PR adds `Study.add_trials` and enables to simplify the above code as follows.

```
study_x0 = create_study()
study_x0.add_trials(filter(lambda t: t.params["x"] > 0, study.trials))
plot_slice(study_x0)
```

## Description of the changes
- Add `Study.add_trials`.
- Add test.