### PR TITLE
Fix `trials_dataframe` for multi-objective optimization with fail or pruned trials

### DIFF
--- a/optuna/_dataframe.py
+++ b/optuna/_dataframe.py
@@ -68,6 +68,12 @@ def _trials_dataframe(
                 for nested_attr, nested_value in enumerate(value):
                     record[(df_column, nested_attr)] = nested_value
                     column_agg[attr].add((df_column, nested_attr))
+            elif attr == "values":
+                # trial.values should be None when the trial's state is FAIL or PRUNED.
+                assert value is None
+                for nested_attr in range(len(study.directions)):
+                    record[(df_column, nested_attr)] = None
+                    column_agg[attr].add((df_column, nested_attr))
             else:
                 record[(df_column, non_nested_attr)] = value
                 column_agg[attr].add((df_column, non_nested_attr))


### PR DESCRIPTION
## Motivation
Fix #2227.
## Description of the changes
When the trial's state is `FAIL` or `PRUNED`, `values_*` is set to `None`.