### PR TITLE
Adds missing lightgbm tuner metrics for the case of higher is better

### DIFF
--- a/optuna/integration/_lightgbm_tuner/optimize.py
+++ b/optuna/integration/_lightgbm_tuner/optimize.py
@@ -146,7 +146,14 @@ class _BaseTuner(object):
     def higher_is_better(self) -> bool:
 
         metric_name = self.lgbm_params.get("metric", "binary_logloss")
-        return metric_name in ("auc", "auc_mu", "ndcg", "map", "average_precision")
+        supported_higher_is_better = [
+            "auc",
+            "auc_mu",
+            "ndcg",
+            "map",
+            "average_precision",
+        ]
+        return metric_name in supported_higher_is_better
 
     def compare_validation_metrics(self, val_score: float, best_score: float) -> bool:
 

--- a/optuna/integration/_lightgbm_tuner/optimize.py
+++ b/optuna/integration/_lightgbm_tuner/optimize.py
@@ -146,7 +146,7 @@ class _BaseTuner(object):
     def higher_is_better(self) -> bool:
 
         metric_name = self.lgbm_params.get("metric", "binary_logloss")
-        return metric_name in ("auc", "ndcg", "map")
+        return metric_name in ("auc", "auc_mu", "ndcg", "map", "average_precision")
 
     def compare_validation_metrics(self, val_score: float, best_score: float) -> bool:
 

--- a/tests/integration_tests/lightgbm_tuner_tests/test_optimize.py
+++ b/tests/integration_tests/lightgbm_tuner_tests/test_optimize.py
@@ -137,6 +137,7 @@ class TestBaseTuner(object):
 
         for metric in [
             "auc",
+            "auc_mu",
             "ndcg",
             "lambdarank",
             "rank_xendcg",
@@ -146,11 +147,20 @@ class TestBaseTuner(object):
             "xendcg_mart",
             "map",
             "mean_average_precision",
+            "average_precision",
         ]:
             tuner = _BaseTuner(lgbm_params={"metric": metric})
             assert tuner.higher_is_better()
 
-        for metric in ["rmsle", "rmse", "binary_logloss", "mape"]:
+        for metric in [
+            "mae",
+            "rmse",
+            "quantile",
+            "mape",
+            "binary_logloss",
+            "multi_logloss",
+            "cross_entropy",
+        ]:
             tuner = _BaseTuner(lgbm_params={"metric": metric})
             assert not tuner.higher_is_better()
 


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
Missing [higher_is_better] metrics in LightGBMTuner.

## Description of the changes

When instantiating a LightGBMTuner with metrics `auc_mu` or `average_precision` and an study with direction equal to `maximize` you get this error:

```
ValueError: Study direction is inconsistent with the metric auc_mu. Please set 'minimize' as the direction.
```

I just added the missing metrics to the `self.higher_is_better` method of `LightGBMTuner`
