### PR TITLE
[dev ex] Provide `docs/source/tutorial` for faster local documentation build

### DIFF
--- a/.github/workflows/sphinx-build.yml
+++ b/.github/workflows/sphinx-build.yml
@@ -44,8 +44,15 @@ jobs:
 
     - uses: actions/upload-artifact@v2
       with:
-        name: built-document
-        path: docs/build
+        name: built-html
+        path: |
+            docs/build/html
+
+    - uses: actions/upload-artifact@v2
+      with:
+        name: executed-tutorial
+        path: |
+            docs/source/tutorial
 
   doctest:
 

--- a/.github/workflows/sphinx-build.yml
+++ b/.github/workflows/sphinx-build.yml
@@ -15,9 +15,14 @@ jobs:
 
     - uses: actions/checkout@v2
 
+    # note (crcrpar): `readthedocs/build:latest` seems to use Python3.8.
+    # Optuna uses that image in CircleCI documentation build,
+    # so we can use Python3.7 here for the backward compatibility
+    # of Pickle's protocol version (Python3.8's pickle's default protocol version
+    # is not compatible completely with Python3.7 and Python3.6).
     - uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: 3.7
 
     # note (crcrpar): We've not updated tutorial frequently enough so far thus
     # it'd be okay to discard cache by any small changes including typo fix under tutorial directory.
@@ -29,7 +34,7 @@ jobs:
         path: |
           tutorial/MNIST
           docs/source/tutorial
-        key: py3.8-${{ env.cache-name }}-${{ hashFiles('tutorial/**/*') }}
+        key: py3.7-${{ env.cache-name }}-${{ hashFiles('tutorial/**/*') }}
 
     - name: Install Dependencies
       run: |
@@ -47,6 +52,12 @@ jobs:
         name: built-html
         path: |
             docs/build/html
+
+    - uses: actions/upload-artifact@v2
+      with:
+        name: tutorial
+        path: |
+            docs/source/tutorial
 
   doctest:
 
@@ -79,50 +90,3 @@ jobs:
       run: |
         cd docs
         make doctest
-
-  # note (crcrpar): Sphinx Gallery internally uses Pickle.
-  # We found that the default protocol version of Python 3.8's pickle is incompatible with
-  # that of Python3.6/3.7's pickle.
-  # So, to make the artifact of executed tutorial backward-compatible as possible,
-  # we employ Python3.7 and build tutorial artifacts only on master push.
-  tutorial-artifacts:
-
-    runs-on: ubuntu-latest
-    if: ${{ github.event.pull_request.merged == true }}
-
-    steps:
-
-    - uses: actions/checkout@v2
-
-    - uses: actions/setup-python@v2
-      with:
-        python-version: 3.7
-
-    # note (crcrpar): We've not updated tutorial frequently enough so far thus
-    # it'd be okay to discard cache by any small changes including typo fix under tutorial directory.
-    - name: Sphinx Gallery Cache
-      uses: actions/cache@v2
-      env:
-        cache-name: sphx-glry-documentation
-      with:
-        path: |
-          tutorial/MNIST
-          docs/source/tutorial
-        key: py3.7-${{ env.cache-name }}-${{ hashFiles('tutorial/**/*') }}
-
-    - name: Install Dependencies
-      run: |
-        python -m pip install -U pip
-        pip install --progress-bar off -U .[document] -f https://download.pytorch.org/whl/torch_stable.html
-
-    - name: Build Document
-      run: |
-        cd docs
-        make html
-        cd ../
-
-    - uses: actions/upload-artifact@v2
-      with:
-        name: tutorial
-        path: |
-            docs/source/tutorial

--- a/.github/workflows/sphinx-build.yml
+++ b/.github/workflows/sphinx-build.yml
@@ -50,7 +50,7 @@ jobs:
 
     - uses: actions/upload-artifact@v2
       with:
-        name: executed-tutorial
+        name: tutorial
         path: |
             docs/source/tutorial
 

--- a/.github/workflows/sphinx-build.yml
+++ b/.github/workflows/sphinx-build.yml
@@ -48,12 +48,6 @@ jobs:
         path: |
             docs/build/html
 
-    - uses: actions/upload-artifact@v2
-      with:
-        name: tutorial
-        path: |
-            docs/source/tutorial
-
   doctest:
 
     runs-on: ubuntu-latest
@@ -85,3 +79,50 @@ jobs:
       run: |
         cd docs
         make doctest
+
+  # note (crcrpar): Sphinx Gallery internally uses Pickle.
+  # We found that the default protocol version of Python 3.8's pickle is incompatible with
+  # that of Python3.6/3.7's pickle.
+  # So, to make the artifact of executed tutorial backward-compatible as possible,
+  # we employ Python3.7 and build tutorial artifacts only on master push.
+  tutorial-artifacts:
+
+    runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.merged == true }}
+
+    steps:
+
+    - uses: actions/checkout@v2
+
+    - uses: actions/setup-python@v2
+      with:
+        python-version: 3.7
+
+    # note (crcrpar): We've not updated tutorial frequently enough so far thus
+    # it'd be okay to discard cache by any small changes including typo fix under tutorial directory.
+    - name: Sphinx Gallery Cache
+      uses: actions/cache@v2
+      env:
+        cache-name: sphx-glry-documentation
+      with:
+        path: |
+          tutorial/MNIST
+          docs/source/tutorial
+        key: py3.7-${{ env.cache-name }}-${{ hashFiles('tutorial/**/*') }}
+
+    - name: Install Dependencies
+      run: |
+        python -m pip install -U pip
+        pip install --progress-bar off -U .[document] -f https://download.pytorch.org/whl/torch_stable.html
+
+    - name: Build Document
+      run: |
+        cd docs
+        make html
+        cd ../
+
+    - uses: actions/upload-artifact@v2
+      with:
+        name: tutorial
+        path: |
+            docs/source/tutorial

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,6 +100,14 @@ pytest
 pytest tests/${TARGET_TEST_FILE_NAME}
 ```
 
+## Documentation
+Optuna's tutorial is built with [Sphinx-Gallery](https://sphinx-gallery.github.io/stable/index.html) and
+some other requirements like [LightGBM](https://github.com/microsoft/LightGBM) meaning that
+all .py files in `tutorial` directory are run during the documentation build if there's no build cache.
+Whether you edit any tutorial or not doesn't matter.
+
+To avoid the run of tutorial, we recommend that you download build artifacts from our CI and put them to `docs/build`.
+
 ## Continuous Integration and Local Verification
 
 Optuna repository uses GitHub Actions and CircleCI.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,6 +84,14 @@ make html
 HTML files are generated under `build/html` directory. Open `index.html` with the browser and see
 if it is rendered as expected.
 
+Optuna's tutorial is built with [Sphinx-Gallery](https://sphinx-gallery.github.io/stable/index.html) and
+some other requirements like [LightGBM](https://github.com/microsoft/LightGBM) meaning that
+all .py files in `tutorial` directory are run during the documentation build if there's no build cache.
+Whether you edit any tutorial or not doesn't matter.
+
+To avoid having to run the tutorials, you may download build artifacts from our CI and put them in `docs/build`.
+
+
 ## Unit Tests
 
 When adding a new feature or fixing a bug, you also need to write sufficient test code.
@@ -99,14 +107,6 @@ pytest
 # Run all the unit tests defined in the specified test file.
 pytest tests/${TARGET_TEST_FILE_NAME}
 ```
-
-## Documentation
-Optuna's tutorial is built with [Sphinx-Gallery](https://sphinx-gallery.github.io/stable/index.html) and
-some other requirements like [LightGBM](https://github.com/microsoft/LightGBM) meaning that
-all .py files in `tutorial` directory are run during the documentation build if there's no build cache.
-Whether you edit any tutorial or not doesn't matter.
-
-To avoid having to run the tutorials, you may download build artifacts from our CI and put them in `docs/build`.
 
 ## Continuous Integration and Local Verification
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,9 +90,10 @@ some other requirements like [LightGBM](https://github.com/microsoft/LightGBM) a
 all .py files in `tutorial` directory are run during the documentation build if there's no build cache.
 Whether you edit any tutorial or not doesn't matter.
 
-To avoid having to run the tutorials, you may download executed tutorial artifacts nanmed "tutorial.zip" from our CI and put them in `docs/build` before
+To avoid having to run the tutorials, you may download executed tutorial artifacts nanmed "tutorial" from our CI (see the capture below) and put them in `docs/build` before
 extract the files in the zip to `docs/source/tutorial` directory.
 
+![image](https://user-images.githubusercontent.com/16191443/107472296-0b211400-6bb2-11eb-9203-e2c42ce499ad.png)
 
 ## Unit Tests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,7 +106,7 @@ some other requirements like [LightGBM](https://github.com/microsoft/LightGBM) m
 all .py files in `tutorial` directory are run during the documentation build if there's no build cache.
 Whether you edit any tutorial or not doesn't matter.
 
-To avoid the run of tutorial, we recommend that you download build artifacts from our CI and put them to `docs/build`.
+To avoid having to run the tutorials, you may download build artifacts from our CI and put them in `docs/build`.
 
 ## Continuous Integration and Local Verification
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,8 +71,9 @@ The documentation source is stored under the [docs](./docs) directory and writte
 To build the documentation, you need to run:
 
 ```bash
-pip install -e ".[document]"
+pip install -e ".[document]" -f https://download.pytorch.org/whl/torch_stable.html
 ```
+Note that the above command might try to install PyTorch without CUDA to your environment even if your environment has CUDA version already.
 
 Then you can build the documentation in HTML format locally:
 
@@ -85,11 +86,12 @@ HTML files are generated under `build/html` directory. Open `index.html` with th
 if it is rendered as expected.
 
 Optuna's tutorial is built with [Sphinx-Gallery](https://sphinx-gallery.github.io/stable/index.html) and
-some other requirements like [LightGBM](https://github.com/microsoft/LightGBM) meaning that
+some other requirements like [LightGBM](https://github.com/microsoft/LightGBM) and [PyTorch](https://pytorch.org) meaning that
 all .py files in `tutorial` directory are run during the documentation build if there's no build cache.
 Whether you edit any tutorial or not doesn't matter.
 
-To avoid having to run the tutorials, you may download build artifacts from our CI and put them in `docs/build`.
+To avoid having to run the tutorials, you may download executed tutorial artifacts nanmed "tutorial.zip" from our CI and put them in `docs/build` before
+extract the files in the zip to `docs/source/tutorial` directory.
 
 
 ## Unit Tests


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
Now that build of our documentation is not that simple: long build time due to the run of tutorial but we can avoid the long build by downloading artifacts I guess, which can be helpful.
