### PR TITLE
Remove specification of `n_trials` from example of `GridSampler`

### DIFF
--- a/optuna/samplers/_grid.py
+++ b/optuna/samplers/_grid.py
@@ -46,7 +46,7 @@ class GridSampler(BaseSampler):
 
             search_space = {"x": [-50, 0, 50], "y": [-99, 0, 99]}
             study = optuna.create_study(sampler=optuna.samplers.GridSampler(search_space))
-            study.optimize(objective, n_trials=3 * 3)
+            study.optimize(objective)
 
     Note:
 


### PR DESCRIPTION
## Motivation
`GridSampler` automatically stops the optimization if all combinations have already been evaluated. Therefore, the specification of `n_trials` is not necessary.
## Description of the changes
Remove the specification of `n_trials` from the example of `GridSampler`.