### PR TITLE
Make trials stale only when succeeded to fail

### DIFF
--- a/optuna/storages/_cached_storage.py
+++ b/optuna/storages/_cached_storage.py
@@ -450,7 +450,8 @@ class _CachedStorage(BaseStorage):
         stale_trial_ids = self._backend._get_stale_trial_ids()
 
         for trial_id in stale_trial_ids:
-            self.set_trial_state(trial_id, TrialState.FAIL)
+            if not self.set_trial_state(trial_id, TrialState.FAIL):
+                stale_trial_ids.remove(trial_id)
 
         return stale_trial_ids
 

--- a/optuna/storages/_cached_storage.py
+++ b/optuna/storages/_cached_storage.py
@@ -454,7 +454,7 @@ class _CachedStorage(BaseStorage):
             if self.set_trial_state(trial_id, TrialState.FAIL):
                 confirmed_stale_trial_ids.append(trial_id)
 
-        return stale_trial_ids
+        return confirmed_stale_trial_ids
 
     def _is_heartbeat_supported(self) -> bool:
         return self._backend._is_heartbeat_supported()

--- a/optuna/storages/_cached_storage.py
+++ b/optuna/storages/_cached_storage.py
@@ -448,10 +448,11 @@ class _CachedStorage(BaseStorage):
 
     def fail_stale_trials(self) -> List[int]:
         stale_trial_ids = self._backend._get_stale_trial_ids()
+        confirmed_stale_trial_ids = []
 
         for trial_id in stale_trial_ids:
-            if not self.set_trial_state(trial_id, TrialState.FAIL):
-                stale_trial_ids.remove(trial_id)
+            if self.set_trial_state(trial_id, TrialState.FAIL):
+                confirmed_stale_trial_ids.append(trial_id)
 
         return stale_trial_ids
 

--- a/optuna/storages/_rdb/storage.py
+++ b/optuna/storages/_rdb/storage.py
@@ -1166,7 +1166,8 @@ class RDBStorage(BaseStorage):
         stale_trial_ids = self._get_stale_trial_ids()
 
         for trial_id in stale_trial_ids:
-            self.set_trial_state(trial_id, TrialState.FAIL)
+            if not self.set_trial_state(trial_id, TrialState.FAIL):
+                stale_trial_ids.remove(trial_id)
 
         return stale_trial_ids
 

--- a/optuna/storages/_rdb/storage.py
+++ b/optuna/storages/_rdb/storage.py
@@ -1164,10 +1164,11 @@ class RDBStorage(BaseStorage):
 
     def fail_stale_trials(self) -> List[int]:
         stale_trial_ids = self._get_stale_trial_ids()
+        confirmed_stale_trial_ids = []
 
         for trial_id in stale_trial_ids:
-            if not self.set_trial_state(trial_id, TrialState.FAIL):
-                stale_trial_ids.remove(trial_id)
+            if self.set_trial_state(trial_id, TrialState.FAIL):
+                confirmed_stale_trial_ids.append(trial_id)
 
         return stale_trial_ids
 

--- a/optuna/storages/_rdb/storage.py
+++ b/optuna/storages/_rdb/storage.py
@@ -1170,7 +1170,7 @@ class RDBStorage(BaseStorage):
             if self.set_trial_state(trial_id, TrialState.FAIL):
                 confirmed_stale_trial_ids.append(trial_id)
 
-        return stale_trial_ids
+        return confirmed_stale_trial_ids
 
     def _get_stale_trial_ids(self) -> List[int]:
         assert self.heartbeat_interval is not None


### PR DESCRIPTION
## Motivation
In the current heartbeat functionality, the stale trial IDs are returned by `storages.fail_stale_trials()` but there is a possibility to return the trial IDs which are already failed by another process. In this PR, we make trials stale only when we succeeded fail the trials.

## Description of the changes
- Make trials stale only when succeeded to fail