### PR TITLE
[RFC] Enable automatic closing of stale issues and pull requests by github actions.

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -19,7 +19,7 @@ jobs:
         close-issue-message: 'This issue was closed automatically because it had not seen any recent activity. If you want to discuss it, you can reopen it freely.'
         close-pr-message: 'This pull request was closed automatically because it had not seen any recent activity. If you want to discuss it, you can reopen it freely.'
         days-before-stale: 14
-        days-before-close: 14
+        days-before-close: 100
         stale-issue-label: 'stale'
         stale-pr-label: 'stale'
         exempt-issue-labels: 'no-stale'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -16,8 +16,10 @@ jobs:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'This issue has not seen any recent activity.'
         stale-pr-message: 'This pull request has not seen any recent activity.'
+        close-issue-message: 'This issue was closed automatically because it had not seen any recent activity. If you want to discuss it, you can reopen it freely.'
+        close-pr-message: 'This pull request was closed automatically because it had not seen any recent activity. If you want to discuss it, you can reopen it freely.'
         days-before-stale: 14
-        days-before-close: -1
+        days-before-close: 14
         stale-issue-label: 'stale'
         stale-pr-label: 'stale'
         exempt-issue-labels: 'no-stale'


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
I thought that issues / PRs (especially issues) that were left without updates for a certain amount of time could be closed automatically, because

1. If you don't want them to be stale, the `no-stale` label is attached.
2. I feel that the number of issues with stale is increasing.

## Description of the changes
<!-- Describe the changes in this PR. -->
Change the configuration of the stale action.