### PR TITLE
mypy hotfix voiding latest NumPy 1.20.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ def get_install_requires() -> List[str]:
         "cliff",
         "cmaes>=0.6.0",
         "colorlog",
-        "numpy",
+        "numpy<1.20.0",
         "packaging>=20.0",
         "scipy!=1.4.0",
         "sqlalchemy>=1.1.0",


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation

See belo.

## Description of the changes

Fixes broken master by temporarily avoiding latest NumPy 1.20.0. See also https://github.com/optuna/optuna/pull/2288 for a proper fix.
