### PR TITLE
Use `trainer.callback_metrics` in the Pytorch-Lightning exapmle

### DIFF
--- a/examples/pytorch_lightning_simple.py
+++ b/examples/pytorch_lightning_simple.py
@@ -128,7 +128,7 @@ def objective(trial):
         checkpoint_callback=checkpoint_callback,
         max_epochs=EPOCHS,
         gpus=1 if torch.cuda.is_available() else None,
-        callbacks=[PyTorchLightningPruningCallback(trial, monitor="val_acc")],
+        callbacks=[PyTorchLightningPruningCallback(trial, monitor="val_acc", mode="max")],
     )
 
     model = LightningNet(trial)

--- a/examples/pytorch_lightning_simple.py
+++ b/examples/pytorch_lightning_simple.py
@@ -17,7 +17,6 @@ import shutil
 
 from packaging import version
 import pytorch_lightning as pl
-from pytorch_lightning import Callback
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
@@ -39,17 +38,6 @@ CLASSES = 10
 EPOCHS = 10
 DIR = os.getcwd()
 MODEL_DIR = os.path.join(DIR, "result")
-
-
-class MetricsCallback(Callback):
-    """PyTorch Lightning metric callback."""
-
-    def __init__(self):
-        super().__init__()
-        self.metrics = []
-
-    def on_validation_end(self, trainer, pl_module):
-        self.metrics.append(trainer.callback_metrics)
 
 
 class Net(nn.Module):
@@ -134,23 +122,19 @@ def objective(trial):
         os.path.join(MODEL_DIR, "trial_{}".format(trial.number), "{epoch}"), monitor="val_acc"
     )
 
-    # The default logger in PyTorch Lightning writes to event files to be consumed by
-    # TensorBoard. We don't use any logger here as it requires us to implement several abstract
-    # methods. Instead we setup a simple callback, that saves metrics from each validation step.
-    metrics_callback = MetricsCallback()
     trainer = pl.Trainer(
         logger=False,
         limit_val_batches=PERCENT_VALID_EXAMPLES,
         checkpoint_callback=checkpoint_callback,
         max_epochs=EPOCHS,
         gpus=1 if torch.cuda.is_available() else None,
-        callbacks=[metrics_callback, PyTorchLightningPruningCallback(trial, monitor="val_acc")],
+        callbacks=[PyTorchLightningPruningCallback(trial, monitor="val_acc")],
     )
 
     model = LightningNet(trial)
     trainer.fit(model)
 
-    return metrics_callback.metrics[-1]["val_acc"].item()
+    return trainer.callback_metrics["val_acc"].item()
 
 
 if __name__ == "__main__":

--- a/optuna/integration/pytorch_lightning.py
+++ b/optuna/integration/pytorch_lightning.py
@@ -1,5 +1,3 @@
-from typing import Any
-
 import optuna
 
 

--- a/optuna/integration/pytorch_lightning.py
+++ b/optuna/integration/pytorch_lightning.py
@@ -29,18 +29,21 @@ class PyTorchLightningPruningCallback(EarlyStopping):
             ``pytorch_lightning.LightningModule.training_step`` or
             ``pytorch_lightning.LightningModule.validation_epoch_end`` and the names thus depend on
             how this dictionary is formatted.
+        **kwargs: Additional kwargs for ``pytorch_lightning.callbacks.EarlyStopping``
     """
 
-    def __init__(self, trial: optuna.trial.Trial, monitor: str) -> None:
+    def __init__(self, trial: optuna.trial.Trial, monitor: str, **kwargs) -> None:
 
         _imports.check()
 
-        super(PyTorchLightningPruningCallback, self).__init__(monitor=monitor)
+        super(PyTorchLightningPruningCallback, self).__init__(monitor=monitor, **kwargs)
 
         self._trial = trial
 
     def on_validation_end(self, trainer: Trainer, pl_module: LightningModule) -> None:
 
+        # To correct check if need to stop TPU and save train metrics
+        super().on_validation_end(trainer=trainer, pl_module=pl_module)
         logs = trainer.callback_metrics
         epoch = pl_module.current_epoch
         current_score = logs.get(self.monitor)

--- a/optuna/integration/pytorch_lightning.py
+++ b/optuna/integration/pytorch_lightning.py
@@ -40,7 +40,7 @@ class PyTorchLightningPruningCallback(EarlyStopping):
             training will stop when the quantity
             monitored has stopped decreasing; in ``max``
             mode it will stop when the quantity
-            monitored has stopped increasing.
+            monitored has stopped increasing. Default: ``min``.
         strict: whether to crash the training if ``monitor`` is
             not found in the validation metrics. Default: ``True``.
     """

--- a/optuna/integration/pytorch_lightning.py
+++ b/optuna/integration/pytorch_lightning.py
@@ -29,14 +29,43 @@ class PyTorchLightningPruningCallback(EarlyStopping):
             ``pytorch_lightning.LightningModule.training_step`` or
             ``pytorch_lightning.LightningModule.validation_epoch_end`` and the names thus depend on
             how this dictionary is formatted.
-        **kwargs: Additional kwargs for ``pytorch_lightning.callbacks.EarlyStopping``
+        min_delta: minimum change in the monitored quantity
+            to qualify as an improvement, i.e. an absolute
+            change of less than ``min_delta``, will count as no
+            improvement. Default: ``0.0``.
+        patience: number of validation epochs with no improvement
+            after which training will be stopped. Default: ``3``.
+        verbose: verbosity mode. Default: ``False``.
+        mode: one of {``min``, ``max``}. In ``min`` mode,
+            training will stop when the quantity
+            monitored has stopped decreasing; in ``max``
+            mode it will stop when the quantity
+            monitored has stopped increasing.
+        strict: whether to crash the training if ``monitor`` is
+            not found in the validation metrics. Default: ``True``.
     """
 
-    def __init__(self, trial: optuna.trial.Trial, monitor: str, **kwargs) -> None:
+    def __init__(
+        self,
+        trial: optuna.trial.Trial,
+        monitor: str,
+        min_delta: float = 0.0,
+        patience: int = 3,
+        verbose: bool = False,
+        mode: str = "min",
+        strict: bool = True,
+    ) -> None:
 
         _imports.check()
 
-        super(PyTorchLightningPruningCallback, self).__init__(monitor=monitor, **kwargs)
+        super(PyTorchLightningPruningCallback, self).__init__(
+            monitor=monitor,
+            min_delta=min_delta,
+            patience=patience,
+            verbose=verbose,
+            mode=mode,
+            strict=strict,
+        )
 
         self._trial = trial
 

--- a/optuna/integration/pytorch_lightning.py
+++ b/optuna/integration/pytorch_lightning.py
@@ -29,50 +29,18 @@ class PyTorchLightningPruningCallback(EarlyStopping):
             ``pytorch_lightning.LightningModule.training_step`` or
             ``pytorch_lightning.LightningModule.validation_epoch_end`` and the names thus depend on
             how this dictionary is formatted.
-        min_delta: minimum change in the monitored quantity
-            to qualify as an improvement, i.e. an absolute
-            change of less than ``min_delta``, will count as no
-            improvement. Default: ``0.0``.
-        patience: number of validation epochs with no improvement
-            after which training will be stopped. Default: ``3``.
-        verbose: verbosity mode. Default: ``False``.
-        mode: one of {``min``, ``max``}. In ``min`` mode,
-            training will stop when the quantity
-            monitored has stopped decreasing; in ``max``
-            mode it will stop when the quantity
-            monitored has stopped increasing. Default: ``min``.
-        strict: whether to crash the training if ``monitor`` is
-            not found in the validation metrics. Default: ``True``.
     """
 
-    def __init__(
-        self,
-        trial: optuna.trial.Trial,
-        monitor: str,
-        min_delta: float = 0.0,
-        patience: int = 3,
-        verbose: bool = False,
-        mode: str = "min",
-        strict: bool = True,
-    ) -> None:
+    def __init__(self, trial: optuna.trial.Trial, monitor: str) -> None:
 
         _imports.check()
 
-        super(PyTorchLightningPruningCallback, self).__init__(
-            monitor=monitor,
-            min_delta=min_delta,
-            patience=patience,
-            verbose=verbose,
-            mode=mode,
-            strict=strict,
-        )
+        super(PyTorchLightningPruningCallback, self).__init__(monitor=monitor)
 
         self._trial = trial
 
     def on_validation_end(self, trainer: Trainer, pl_module: LightningModule) -> None:
 
-        # To check if we saved the internal states correctly, moved states from TPU to CPU etc.
-        super().on_validation_end(trainer=trainer, pl_module=pl_module)
         logs = trainer.callback_metrics
         epoch = pl_module.current_epoch
         current_score = logs.get(self.monitor)

--- a/optuna/integration/pytorch_lightning.py
+++ b/optuna/integration/pytorch_lightning.py
@@ -42,7 +42,7 @@ class PyTorchLightningPruningCallback(EarlyStopping):
 
     def on_validation_end(self, trainer: Trainer, pl_module: LightningModule) -> None:
 
-        # To correct check if need to stop TPU and save train metrics
+        # To check if we saved the internal states correctly, moved states from TPU to CPU etc.
         super().on_validation_end(trainer=trainer, pl_module=pl_module)
         logs = trainer.callback_metrics
         epoch = pl_module.current_epoch


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

1. In examples you can remove one extra class `MetricsCallback`. Pytorch-Lightning itself saves metrics states in `trainer.callback_metrics`.
1. In the `PyTorchLightningPruningCallback` we can add another `init` parameters for supper class and make sure we save inner states properly 

## Description of the changes
<!-- Describe the changes in this PR. -->
1. I remover `MetricsCallback` and used the native PL functions to achieve the same result.
2. I added `**kwargs` in init and added `super().on_validation_end(trainer=trainer, pl_module=pl_module)` in validation step
