### PR TITLE
Apply code-fix to `LightGBMTuner` (Follow-up #2267)

### DIFF
--- a/optuna/integration/_lightgbm_tuner/optimize.py
+++ b/optuna/integration/_lightgbm_tuner/optimize.py
@@ -146,14 +146,7 @@ class _BaseTuner(object):
     def higher_is_better(self) -> bool:
 
         metric_name = self.lgbm_params.get("metric", "binary_logloss")
-        supported_higher_is_better = [
-            "auc",
-            "auc_mu",
-            "ndcg",
-            "map",
-            "average_precision",
-        ]
-        return metric_name in supported_higher_is_better
+        return metric_name in ("auc", "auc_mu", "ndcg", "map", "average_precision")
 
     def compare_validation_metrics(self, val_score: float, best_score: float) -> bool:
 


### PR DESCRIPTION
## Motivation

This is a follow-up PR for #2267. It applies a simple code-fix to LightGBMTuner.

## Description of the changes

It removes a local variable definition and reduces 7 lines.