### PR TITLE
Add sphinx.ext.imgconverter extention

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -47,6 +47,7 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.autosummary",
     "sphinx.ext.doctest",
+    "sphinx.ext.imgconverter",
     "sphinx.ext.intersphinx",
     "sphinx.ext.mathjax",
     "sphinx.ext.napoleon",


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
https://github.com/optuna/optuna/issues/1795#issuecomment-728605927

> 1. Sphinx’s pdflatex does not support svg graphics

Fix this error.

## Description of the changes 

Add [sphinx.ext.imgconverter extention](https://www.sphinx-doc.org/ja/master/usage/extensions/imgconverter.html) and support svg image.

This extention use [ImageMagick](https://imagemagick.org/) internally, and convert svg image.

We will now need imagemagick to build the tex file.

On [CI environment](https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md), imagemagick is installed already.

### Preview

- pdf build
![Screenshot from 2021-02-07 12-49-59](https://user-images.githubusercontent.com/17472875/107136020-0dca0200-6943-11eb-96ed-86cd7f5cccb7.png)
- html build
![Screenshot from 2021-02-07 12-30-35](https://user-images.githubusercontent.com/17472875/107135782-f8ec6f00-6940-11eb-9e00-a04103644779.png)

## Consider other solutions
<!-- Describe the changes in this PR. -->
There were two ways to solve this problem.
- support svg graphics on sphinx ( this PR )
- use [png badge](https://colab.research.google.com/assets/colab-badge.png) instead of [svg badge](https://colab.research.google.com/assets/colab-badge.svg)

However, png badge is rough. 
![Screenshot from 2021-02-07 12-30-59](https://user-images.githubusercontent.com/17472875/107135784-fbe75f80-6940-11eb-8862-bed6ddf2074b.png)

So I thought it would be better to use svg images as much as possible.
