### PR TITLE
Only fail trials associated with the current study

### DIFF
--- a/optuna/_optimize.py
+++ b/optuna/_optimize.py
@@ -199,7 +199,7 @@ def _run_trial(
     thread: Optional[Thread] = None
 
     if study._storage.is_heartbeat_enabled():
-        study._storage.fail_stale_trials()
+        study._storage.fail_stale_trials(study._study_id)
         stop_event = Event()
         thread = Thread(
             target=_record_heartbeat, args=(trial._trial_id, study._storage, stop_event)

--- a/optuna/storages/_base.py
+++ b/optuna/storages/_base.py
@@ -730,13 +730,16 @@ class BaseStorage(object, metaclass=abc.ABCMeta):
         """
         pass
 
-    def fail_stale_trials(self) -> List[int]:
+    def fail_stale_trials(self, study_id: int) -> List[int]:
         """Fail stale trials.
 
         The running trials whose heartbeat has not been updated for a long time will be failed,
         that is, those states will be changed to :obj:`~optuna.trial.TrialState.FAIL`.
         The grace period is ``2 * heartbeat_interval``.
 
+        Args:
+            study_id:
+                ID of the related study.
         Returns:
             List of trial IDs of the failed trials.
         """

--- a/optuna/storages/_cached_storage.py
+++ b/optuna/storages/_cached_storage.py
@@ -446,8 +446,8 @@ class _CachedStorage(BaseStorage):
     def record_heartbeat(self, trial_id: int) -> None:
         self._backend.record_heartbeat(trial_id)
 
-    def fail_stale_trials(self) -> List[int]:
-        stale_trial_ids = self._backend._get_stale_trial_ids()
+    def fail_stale_trials(self, study_id: int) -> List[int]:
+        stale_trial_ids = self._backend._get_stale_trial_ids(study_id)
         confirmed_stale_trial_ids = []
 
         for trial_id in stale_trial_ids:

--- a/tests/storages_tests/rdb_tests/test_storage.py
+++ b/tests/storages_tests/rdb_tests/test_storage.py
@@ -338,12 +338,10 @@ def test_fail_stale_trials() -> None:
         study1 = create_study(storage=storage)
         study2 = create_study(storage=storage)
 
-        trial = study1.ask()
-        storage.record_heartbeat(trial._trial_id)
-        time.sleep(grace_period + 1)
-
-        trial = study2.ask()
-        storage.record_heartbeat(trial._trial_id)
+        trial1 = study1.ask()
+        trial2 = study2.ask()
+        storage.record_heartbeat(trial1._trial_id)
+        storage.record_heartbeat(trial2._trial_id)
         time.sleep(grace_period + 1)
 
         assert study1.trials[0].state is TrialState.RUNNING

--- a/tests/storages_tests/rdb_tests/test_storage.py
+++ b/tests/storages_tests/rdb_tests/test_storage.py
@@ -335,21 +335,28 @@ def test_fail_stale_trials() -> None:
         assert isinstance(storage, RDBStorage)
         storage.heartbeat_interval = heartbeat_interval
         storage.grace_period = grace_period
-        study = create_study(storage=storage)
+        study1 = create_study(storage=storage)
+        study2 = create_study(storage=storage)
 
-        trial = study.ask()
+        trial = study1.ask()
         storage.record_heartbeat(trial._trial_id)
         time.sleep(grace_period + 1)
 
-        t = study.trials[0]
-        assert t.state is TrialState.RUNNING
+        trial = study2.ask()
+        storage.record_heartbeat(trial._trial_id)
+        time.sleep(grace_period + 1)
+
+        assert study1.trials[0].state is TrialState.RUNNING
+        assert study2.trials[0].state is TrialState.RUNNING
+
+        assert storage._get_stale_trial_ids(study1._study_id) == [study1.trials[0]._trial_id]
 
         # Exceptions raised in spawned threads are caught by `_TestableThread`.
         with patch("optuna._optimize.Thread", _TestableThread):
-            study.optimize(lambda _: 1.0, n_trials=1)
+            study1.optimize(lambda _: 1.0, n_trials=1)
 
-        t = study.trials[0]
-        assert t.state is TrialState.FAIL
+        assert study1.trials[0].state is TrialState.FAIL
+        assert study2.trials[0].state is TrialState.RUNNING
 
 
 def test_invalid_heartbeat_interval_and_grace_period() -> None:


### PR DESCRIPTION
## Motivation
Currently, if we specify `heartbeat_interval` for `RDBStorage`, the stale trials are searched for from all studies associated with the specified storage. This can lead to confusing behavior if you specify a different `heartbeat_interval` for each study you create. This PR aims to only fail trials associated with the current study.

## Description of the changes
- Only fail trials associated with the current study
