### PR TITLE
Fix TensorBoard integration for `suggest_float`

### DIFF
--- a/optuna/integration/tensorboard.py
+++ b/optuna/integration/tensorboard.py
@@ -67,7 +67,7 @@ class TensorBoardCallback(object):
                 )
             elif isinstance(param_distribution, optuna.distributions.DiscreteUniformDistribution):
                 self._hp_params[param_name] = hp.HParam(
-                    param_name, hp.Discrete(param_distribution.low, param_distribution.high)
+                    param_name, hp.RealInterval(param_distribution.low, param_distribution.high)
                 )
             elif isinstance(param_distribution, optuna.distributions.IntUniformDistribution):
                 self._hp_params[param_name] = hp.HParam(

--- a/tests/integration_tests/test_tensorboard.py
+++ b/tests/integration_tests/test_tensorboard.py
@@ -13,9 +13,10 @@ def _objective_func(trial: optuna.trial.Trial) -> float:
     x = trial.suggest_uniform("x", -1.0, 1.0)
     y = trial.suggest_loguniform("y", 20.0, 30.0)
     z = trial.suggest_categorical("z", (-1.0, 1.0))
+    w = trial.suggest_float("w", -1.0, 1.0, step=0.1)
     assert isinstance(z, float)
     trial.set_user_attr("my_user_attr", "my_user_attr_value")
-    return (x - 2) ** 2 + (y - 25) ** 2 + z
+    return (x - 2) ** 2 + (y - 25) ** 2 + z + w
 
 
 def test_study_name() -> None:


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

The current tensorboard integration does not work for hyper-parameters sampled by using `suggest_float` with `step` argument.

See https://github.com/optuna/optuna/issues/2334 for the reproducible code and the reported issue.


## Description of the changes 
<!-- Describe the changes in this PR. -->

- Replace `hp.Discrete` with `hp.RealInterval`.
  - Fix the argument of `hp.Discrete` is another option, but it takes an iterable objective as the argument, so I believe `RealInterval` is simpler.
- Add a test for `suggest_float`

