### PR TITLE
Add type conversions for upper/lower whose values are integers

### DIFF
--- a/optuna/distributions.py
+++ b/optuna/distributions.py
@@ -118,8 +118,8 @@ class UniformDistribution(BaseDistribution):
                 "(low={}, high={}).".format(low, high)
             )
 
-        self.low = float(low)
-        self.high = float(high)
+        self.low = low
+        self.high = high
 
     def single(self) -> bool:
 
@@ -162,8 +162,8 @@ class LogUniformDistribution(BaseDistribution):
                 "(low={}, high={}).".format(low, high)
             )
 
-        self.low = float(low)
-        self.high = float(high)
+        self.low = low
+        self.high = high
 
     def single(self) -> bool:
 

--- a/optuna/distributions.py
+++ b/optuna/distributions.py
@@ -118,8 +118,8 @@ class UniformDistribution(BaseDistribution):
                 "(low={}, high={}).".format(low, high)
             )
 
-        self.low = low
-        self.high = high
+        self.low = float(low)
+        self.high = float(high)
 
     def single(self) -> bool:
 
@@ -162,8 +162,8 @@ class LogUniformDistribution(BaseDistribution):
                 "(low={}, high={}).".format(low, high)
             )
 
-        self.low = low
-        self.high = high
+        self.low = float(low)
+        self.high = float(high)
 
     def single(self) -> bool:
 

--- a/optuna/integration/tensorboard.py
+++ b/optuna/integration/tensorboard.py
@@ -71,7 +71,7 @@ class TensorBoardCallback(object):
             if isinstance(param_distribution, real_distributions):
                 self._hp_params[param_name] = hp.HParam(
                     param_name,
-                    hp.RealInterval(param_distribution.low, param_distribution.high),
+                    hp.RealInterval(float(param_distribution.low), float(param_distribution.high)),
                 )
             elif isinstance(param_distribution, int_distributions):
                 self._hp_params[param_name] = hp.HParam(

--- a/optuna/integration/tensorboard.py
+++ b/optuna/integration/tensorboard.py
@@ -59,16 +59,12 @@ class TensorBoardCallback(object):
         real_distributions = (
             optuna.distributions.UniformDistribution,
             optuna.distributions.LogUniformDistribution,
-        )
-        discrete_distributions = (
-            optuna.distributions.IntUniformDistribution,
-        )
-        categorical_distributions = (
-            optuna.distributions.CategoricalDistribution,
             optuna.distributions.DiscreteUniformDistribution,
         )
+        int_distributions = (optuna.distributions.IntUniformDistribution,)
+        categorical_distributions = (optuna.distributions.CategoricalDistribution,)
         supported_distributions = (
-            real_distributions + discrete_distributions + categorical_distributions
+            real_distributions + int_distributions + categorical_distributions
         )
 
         for param_name, param_distribution in distributions.items():
@@ -77,7 +73,7 @@ class TensorBoardCallback(object):
                     param_name,
                     hp.RealInterval(param_distribution.low, param_distribution.high),
                 )
-            elif isinstance(param_distribution, discrete_distributions):
+            elif isinstance(param_distribution, int_distributions):
                 self._hp_params[param_name] = hp.HParam(
                     param_name,
                     hp.IntInterval(param_distribution.low, param_distribution.high),

--- a/optuna/integration/tensorboard.py
+++ b/optuna/integration/tensorboard.py
@@ -61,10 +61,12 @@ class TensorBoardCallback(object):
             optuna.distributions.LogUniformDistribution,
         )
         discrete_distributions = (
-            optuna.distributions.DiscreteUniformDistribution,
             optuna.distributions.IntUniformDistribution,
         )
-        categorical_distributions = (optuna.distributions.CategoricalDistribution,)
+        categorical_distributions = (
+            optuna.distributions.CategoricalDistribution,
+            optuna.distributions.DiscreteUniformDistribution,
+        )
         supported_distributions = (
             real_distributions + discrete_distributions + categorical_distributions
         )

--- a/optuna/integration/tensorboard.py
+++ b/optuna/integration/tensorboard.py
@@ -56,34 +56,38 @@ class TensorBoardCallback(object):
     def _add_distributions(
         self, distributions: Dict[str, optuna.distributions.BaseDistribution]
     ) -> None:
+        real_distributions = (
+            optuna.distributions.UniformDistribution,
+            optuna.distributions.LogUniformDistribution,
+        )
+        discrete_distributions = (
+            optuna.distributions.DiscreteUniformDistribution,
+            optuna.distributions.IntUniformDistribution,
+        )
+        categorical_distributions = (optuna.distributions.CategoricalDistribution,)
+        supported_distributions = (
+            real_distributions + discrete_distributions + categorical_distributions
+        )
+
         for param_name, param_distribution in distributions.items():
-            if isinstance(param_distribution, optuna.distributions.UniformDistribution):
+            if isinstance(param_distribution, real_distributions):
                 self._hp_params[param_name] = hp.HParam(
-                    param_name, hp.RealInterval(param_distribution.low, param_distribution.high)
+                    param_name,
+                    hp.RealInterval(param_distribution.low, param_distribution.high),
                 )
-            elif isinstance(param_distribution, optuna.distributions.LogUniformDistribution):
+            elif isinstance(param_distribution, discrete_distributions):
                 self._hp_params[param_name] = hp.HParam(
-                    param_name, hp.RealInterval(param_distribution.low, param_distribution.high)
+                    param_name,
+                    hp.IntInterval(param_distribution.low, param_distribution.high),
                 )
-            elif isinstance(param_distribution, optuna.distributions.DiscreteUniformDistribution):
+            elif isinstance(param_distribution, categorical_distributions):
                 self._hp_params[param_name] = hp.HParam(
-                    param_name, hp.RealInterval(param_distribution.low, param_distribution.high)
-                )
-            elif isinstance(param_distribution, optuna.distributions.IntUniformDistribution):
-                self._hp_params[param_name] = hp.HParam(
-                    param_name, hp.IntInterval(param_distribution.low, param_distribution.high)
-                )
-            elif isinstance(param_distribution, optuna.distributions.CategoricalDistribution):
-                self._hp_params[param_name] = hp.HParam(
-                    param_name, hp.Discrete(param_distribution.choices)
+                    param_name,
+                    hp.Discrete(param_distribution.choices),
                 )
             else:
                 distribution_list = [
-                    optuna.distributions.UniformDistribution.__name__,
-                    optuna.distributions.LogUniformDistribution.__name__,
-                    optuna.distributions.DiscreteUniformDistribution.__name__,
-                    optuna.distributions.IntUniformDistribution.__name__,
-                    optuna.distributions.CategoricalDistribution.__name__,
+                    distribution.__name__ for distribution in supported_distributions
                 ]
                 raise NotImplementedError(
                     "The distribution {} is not implemented. "

--- a/tests/integration_tests/test_tensorboard.py
+++ b/tests/integration_tests/test_tensorboard.py
@@ -39,6 +39,23 @@ def test_study_name() -> None:
         shutil.rmtree(dirname)
 
 
+def test_cast_float() -> None:
+    def objective(trial: optuna.trial.Trial) -> float:
+        x = trial.suggest_float("x", 1, 2)
+        y = trial.suggest_float("y", 1, 2, log=True)
+        assert isinstance(x, float)
+        assert isinstance(y, float)
+        return x + y
+
+    dirname = tempfile.mkdtemp()
+    metric_name = "target"
+    study_name = "test_tensorboard_integration"
+
+    tbcallback = TensorBoardCallback(dirname, metric_name)
+    study = optuna.create_study(study_name=study_name)
+    study.optimize(objective, n_trials=1, callbacks=[tbcallback])
+
+
 def test_experimental_warning() -> None:
     with pytest.warns(optuna.exceptions.ExperimentalWarning):
         TensorBoardCallback(dirname="", metric_name="")


### PR DESCRIPTION
Resolve #2337.

## Motivation
This PR introduces type conversions for `distribution.high` and `distribution.low` where a distribution is either `UniformDistribution` or `LogUniformDistribution`. Without these conversions, `hp.RealInterval` raises an error reported in #2337.

I think this problem could also be solved by adding type conversions to (a) initializers of `UniformDistribution` and `LogUniformDistribution` or (b) `suggest_float`. I'd like other developer's opinions/suggestions for solving this problem.

https://github.com/optuna/optuna/blob/183bcf6d391325ac9574d7d7ff0d53689a0b9e26/optuna/distributions.py#L121-L122
https://github.com/optuna/optuna/blob/183bcf6d391325ac9574d7d7ff0d53689a0b9e26/optuna/distributions.py#L165-L166
https://github.com/optuna/optuna/blob/183bcf6d391325ac9574d7d7ff0d53689a0b9e26/optuna/trial/_trial.py#L169-L178)

## Description of the changes
- Added type conversion in `_add_distributions`
- Added the test
