### PR TITLE
Close sessions at the end of with-clause in Storage.

### DIFF
--- a/optuna/storages/_rdb/storage.py
+++ b/optuna/storages/_rdb/storage.py
@@ -71,6 +71,8 @@ def _create_scoped_session(
     except Exception:
         session.rollback()
         raise
+    finally:
+        session.close()
 
 
 class RDBStorage(BaseStorage):

--- a/optuna/storages/_rdb/storage.py
+++ b/optuna/storages/_rdb/storage.py
@@ -217,9 +217,9 @@ class RDBStorage(BaseStorage):
                 "`--skip-if-exists` flag (for CLI).".format(study_name)
             )
 
-        _logger.info("A new study created in RDB with name: {}".format(study.study_name))
+        _logger.info("A new study created in RDB with name: {}".format(study_name))
 
-        return study.study_id
+        return self.get_study_id_from_name(study_name)
 
     def delete_study(self, study_id: int) -> None:
 
@@ -301,22 +301,25 @@ class RDBStorage(BaseStorage):
 
         with _create_scoped_session(self.scoped_session) as session:
             study = models.StudyModel.find_or_raise_by_name(study_name, session)
+            study_id = study.study_id
 
-        return study.study_id
+        return study_id
 
     def get_study_id_from_trial_id(self, trial_id: int) -> int:
 
         with _create_scoped_session(self.scoped_session) as session:
             trial = models.TrialModel.find_or_raise_by_id(trial_id, session)
+            study_id = trial.study_id
 
-        return trial.study_id
+        return study_id
 
     def get_study_name_from_id(self, study_id: int) -> str:
 
         with _create_scoped_session(self.scoped_session) as session:
             study = models.StudyModel.find_or_raise_by_id(study_id, session)
+            study_name = study.study_name
 
-        return study.study_name
+        return study_name
 
     def get_study_directions(self, study_id: int) -> List[StudyDirection]:
 
@@ -495,9 +498,9 @@ class RDBStorage(BaseStorage):
 
         # Retry a couple of times. Deadlocks may occur in distributed environments.
         n_retries = 0
-        while True:
-            try:
-                with _create_scoped_session(self.scoped_session) as session:
+        with _create_scoped_session(self.scoped_session) as session:
+            while True:
+                try:
                     # Ensure that that study exists.
                     #
                     # Locking within a study is necessary since the creation of a trial is not an
@@ -506,35 +509,35 @@ class RDBStorage(BaseStorage):
                     models.StudyModel.find_or_raise_by_id(study_id, session, for_update=True)
 
                     trial = self._get_prepared_new_trial(study_id, template_trial, session)
-                break  # Successfully created trial.
-            except OperationalError:
-                if n_retries > 2:
-                    raise
+                    break  # Successfully created trial.
+                except OperationalError:
+                    if n_retries > 2:
+                        raise
 
             n_retries += 1
 
-        if template_trial:
-            frozen = copy.deepcopy(template_trial)
-            frozen.number = trial.number
-            frozen.datetime_start = trial.datetime_start
-            frozen._trial_id = trial.trial_id
-        else:
-            frozen = FrozenTrial(
-                number=trial.number,
-                state=trial.state,
-                value=None,
-                values=None,
-                datetime_start=trial.datetime_start,
-                datetime_complete=None,
-                params={},
-                distributions={},
-                user_attrs={},
-                system_attrs={},
-                intermediate_values={},
-                trial_id=trial.trial_id,
-            )
+            if template_trial:
+                frozen = copy.deepcopy(template_trial)
+                frozen.number = trial.number
+                frozen.datetime_start = trial.datetime_start
+                frozen._trial_id = trial.trial_id
+            else:
+                frozen = FrozenTrial(
+                    number=trial.number,
+                    state=trial.state,
+                    value=None,
+                    values=None,
+                    datetime_start=trial.datetime_start,
+                    datetime_complete=None,
+                    params={},
+                    distributions={},
+                    user_attrs={},
+                    system_attrs={},
+                    intermediate_values={},
+                    trial_id=trial.trial_id,
+                )
 
-        return frozen
+            return frozen
 
     def _get_prepared_new_trial(
         self, study_id: int, template_trial: Optional[FrozenTrial], session: orm.Session
@@ -833,8 +836,9 @@ class RDBStorage(BaseStorage):
             trial_param = models.TrialParamModel.find_or_raise_by_trial_and_param_name(
                 trial, param_name, session
             )
+            param_value = trial_param.param_value
 
-        return trial_param.param_value
+        return param_value
 
     def set_trial_values(self, trial_id: int, values: Sequence[float]) -> None:
 
@@ -1087,8 +1091,9 @@ class RDBStorage(BaseStorage):
                 trial = models.TrialModel.find_max_value_trial(study_id, 0, session)
             else:
                 trial = models.TrialModel.find_min_value_trial(study_id, 0, session)
+            trial_id = trial.trial_id
 
-        return self.get_trial(trial.trial_id)
+        return self.get_trial(trial_id)
 
     def read_trials_from_remote_storage(self, study_id: int) -> None:
         # Make sure that the given study exists.
@@ -1266,18 +1271,19 @@ class _VersionManager(object):
             #       it is ensured that a `VersionInfoModel` entry exists.
             version_info = models.VersionInfoModel.find(session)
 
-        assert version_info is not None
+            assert version_info is not None
 
-        current_version = self.get_current_version()
-        head_version = self.get_head_version()
-        if current_version == head_version:
-            return
+            current_version = self.get_current_version()
+            head_version = self.get_head_version()
+            if current_version == head_version:
+                return
 
-        message = (
-            "The runtime optuna version {} is no longer compatible with the table schema "
-            "(set up by optuna {}). ".format(version.__version__, version_info.library_version)
-        )
-        known_versions = self.get_all_versions()
+            message = (
+                "The runtime optuna version {} is no longer compatible with the table schema "
+                "(set up by optuna {}). ".format(version.__version__, version_info.library_version)
+            )
+            known_versions = self.get_all_versions()
+
         if current_version in known_versions:
             message += (
                 "Please execute `$ optuna storage upgrade --storage $STORAGE_URL` "
@@ -1323,11 +1329,11 @@ class _VersionManager(object):
         with _create_scoped_session(self.scoped_session) as session:
             version_info = models.VersionInfoModel.find(session)
 
-        if version_info is None:
-            # `None` means this storage was created just now.
-            return True
+            if version_info is None:
+                # `None` means this storage was created just now.
+                return True
 
-        return version_info.schema_version == models.SCHEMA_VERSION
+            return version_info.schema_version == models.SCHEMA_VERSION
 
     def _create_alembic_script(self) -> alembic.script.ScriptDirectory:
 


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
To follow up https://github.com/optuna/optuna/pull/1628#discussion_r514266589, by this PR the storage will close sessions at the end of with-clause.

## Description of the PR
<!-- Describe the changes in this PR. -->
1. Moved some lines accessing db values into `with` clause.
2. Added `session.close()` in `finally` clause of `_create_scoped_session`.
3. Measured benchmark in my local env by https://gist.github.com/hvy/67a279e843a43a1cfc04c2eb92ea605d. I took them several time and they were close enough to judge there would be no degradation in the DB performance.

#### Bench at master (183bcf6)
| #params | #trials | time(sec) | time/trial(sec) |
| ------- | ------- | --------- | --------------- |
| 1 | 1 | 0.05 | 0.046 |
| 1 | 10 | 0.42 | 0.042 |
| 1 | 100 | 4.37 | 0.044 |
| 1 | 500 | 21.13 | 0.042 |
| 2 | 1 | 0.05 | 0.050 |
| 2 | 10 | 0.53 | 0.053 |
| 2 | 100 | 5.48 | 0.055 |
| 2 | 500 | 26.67 | 0.053 |
| 4 | 1 | 0.07 | 0.071 |
| 4 | 10 | 0.79 | 0.079 |
| 4 | 100 | 7.39 | 0.074 |
| 4 | 500 | 38.04 | 0.076 |
| 8 | 1 | 0.12 | 0.122 |
| 8 | 10 | 1.13 | 0.113 |
| 8 | 100 | 13.47 | 0.135 |
| 8 | 500 | 61.23 | 0.122 |
| 16 | 1 | 0.18 | 0.181 |
| 16 | 10 | 2.09 | 0.209 |
| 16 | 100 | 22.81 | 0.228 |
| 16 | 500 | 106.46 | 0.213 |
| 32 | 1 | 0.38 | 0.376 |
| 32 | 10 | 3.88 | 0.388 |
| 32 | 100 | 38.41 | 0.384 |
| 32 | 500 | 199.65 | 0.399 |

#### Bench at this branch
| #params | #trials | time(sec) | time/trial(sec) |
| ------- | ------- | --------- | --------------- |
| 1 | 1 | 0.05 | 0.047 |
| 1 | 10 | 0.40 | 0.040 |
| 1 | 100 | 4.11 | 0.041 |
| 1 | 500 | 22.27 | 0.045 |
| 2 | 1 | 0.05 | 0.050 |
| 2 | 10 | 0.55 | 0.055 |
| 2 | 100 | 5.63 | 0.056 |
| 2 | 500 | 26.69 | 0.053 |
| 4 | 1 | 0.08 | 0.080 |
| 4 | 10 | 0.74 | 0.074 |
| 4 | 100 | 7.75 | 0.077 |
| 4 | 500 | 39.18 | 0.078 |
| 8 | 1 | 0.11 | 0.108 |
| 8 | 10 | 1.10 | 0.110 |
| 8 | 100 | 10.99 | 0.110 |
| 8 | 500 | 57.50 | 0.115 |
| 16 | 1 | 0.19 | 0.187 |
| 16 | 10 | 2.02 | 0.202 |
| 16 | 100 | 20.09 | 0.201 |
| 16 | 500 | 102.68 | 0.205 |
| 32 | 1 | 0.34 | 0.336 |
| 32 | 10 | 3.78 | 0.378 |
| 32 | 100 | 39.04 | 0.390 |
| 32 | 500 | 195.19 | 0.390 |
