### PR TITLE
Add callback argument for heartbeat functionality

### DIFF
--- a/optuna/_optimize.py
+++ b/optuna/_optimize.py
@@ -199,7 +199,12 @@ def _run_trial(
     thread: Optional[Thread] = None
 
     if study._storage.is_heartbeat_enabled():
-        study._storage.fail_stale_trials(study._study_id)
+        failed_trial_ids = study._storage.fail_stale_trials(study._study_id)
+        failed_trial_callback = study._storage.get_failed_trial_callback()
+        if failed_trial_callback is not None:
+            for trial_id in failed_trial_ids:
+                failed_trial = copy.deepcopy(study._storage.get_trial(trial_id))
+                failed_trial_callback(study, failed_trial)
         stop_event = Event()
         thread = Thread(
             target=_record_heartbeat, args=(trial._trial_id, study._storage, stop_event)

--- a/optuna/_optimize.py
+++ b/optuna/_optimize.py
@@ -187,6 +187,14 @@ def _run_trial(
     func: "optuna.study.ObjectiveFuncType",
     catch: Tuple[Type[Exception], ...],
 ) -> trial_module.Trial:
+    if study._storage.is_heartbeat_enabled():
+        failed_trial_ids = study._storage.fail_stale_trials(study._study_id)
+        failed_trial_callback = study._storage.get_failed_trial_callback()
+        if failed_trial_callback is not None:
+            for trial_id in failed_trial_ids:
+                failed_trial = copy.deepcopy(study._storage.get_trial(trial_id))
+                failed_trial_callback(study, failed_trial)
+
     trial = study.ask()
 
     state: Optional[TrialState] = None
@@ -199,12 +207,6 @@ def _run_trial(
     thread: Optional[Thread] = None
 
     if study._storage.is_heartbeat_enabled():
-        failed_trial_ids = study._storage.fail_stale_trials(study._study_id)
-        failed_trial_callback = study._storage.get_failed_trial_callback()
-        if failed_trial_callback is not None:
-            for trial_id in failed_trial_ids:
-                failed_trial = copy.deepcopy(study._storage.get_trial(trial_id))
-                failed_trial_callback(study, failed_trial)
         stop_event = Event()
         thread = Thread(
             target=_record_heartbeat, args=(trial._trial_id, study._storage, stop_event)

--- a/optuna/storages/_base.py
+++ b/optuna/storages/_base.py
@@ -1,5 +1,6 @@
 import abc
 from typing import Any
+from typing import Callable
 from typing import cast
 from typing import Dict
 from typing import List
@@ -8,6 +9,7 @@ from typing import Sequence
 from typing import Tuple
 from typing import Union
 
+import optuna
 from optuna._study_direction import StudyDirection
 from optuna._study_summary import StudySummary
 from optuna.distributions import BaseDistribution
@@ -763,5 +765,13 @@ class BaseStorage(object, metaclass=abc.ABCMeta):
 
         Returns:
             The heartbeat interval if it is set, otherwise :obj:`None`.
+        """
+        return None
+
+    def get_failed_trial_callback(self) -> Optional[Callable[["optuna.Study", FrozenTrial], None]]:
+        """Get the failed trial callback function.
+
+        Returns:
+            The failed trial callback function if it is set, otherwise :obj:`None`.
         """
         return None

--- a/optuna/storages/_cached_storage.py
+++ b/optuna/storages/_cached_storage.py
@@ -2,6 +2,7 @@ import copy
 import datetime
 import threading
 from typing import Any
+from typing import Callable
 from typing import Dict
 from typing import List
 from typing import Optional
@@ -10,6 +11,7 @@ from typing import Set
 from typing import Tuple
 from typing import Union
 
+import optuna
 from optuna import distributions
 from optuna._study_direction import StudyDirection
 from optuna._study_summary import StudySummary
@@ -461,3 +463,6 @@ class _CachedStorage(BaseStorage):
 
     def get_heartbeat_interval(self) -> Optional[int]:
         return self._backend.get_heartbeat_interval()
+
+    def get_failed_trial_callback(self) -> Optional[Callable[["optuna.Study", FrozenTrial], None]]:
+        return self._backend.failed_trial_callback

--- a/optuna/storages/_rdb/storage.py
+++ b/optuna/storages/_rdb/storage.py
@@ -116,14 +116,14 @@ class RDBStorage(BaseStorage):
             Grace period before a running trial is failed from the last heartbeat.
             If it is :obj:`None`, the grace period will be `2 * heartbeat_interval`.
         failed_trial_callback:
-            A callback function that are invoked after failing each stale trial.
+            A callback function that is invoked after failing each stale trial.
             The function must accept two parameters with the following types in this order:
             :class:`~optuna.study.Study` and :class:`~optuna.FrozenTrial`.
 
             .. note::
                 The procedure to fail existing stale trials is called immediately after asking the
                 study for a new trial. In other words, this procedure is called just before
-                executing the objective function defined by the user.
+                executing the objective function.
 
     .. _sqlalchemy.engine.create_engine:
         https://docs.sqlalchemy.org/en/latest/core/engines.html#sqlalchemy.create_engine

--- a/optuna/storages/_rdb/storage.py
+++ b/optuna/storages/_rdb/storage.py
@@ -5,6 +5,7 @@ import json
 import logging
 import os
 from typing import Any
+from typing import Callable
 from typing import Dict
 from typing import Generator
 from typing import List
@@ -114,6 +115,10 @@ class RDBStorage(BaseStorage):
         grace_period:
             Grace period before a running trial is failed from the last heartbeat.
             If it is :obj:`None`, the grace period will be `2 * heartbeat_interval`.
+        failed_trial_callback:
+            A callback function that are invoked after failing each stale trial. The function
+                must accept two parameters with the following types in this order:
+                :class:`~optuna.study.Study` and :class:`~optuna.FrozenTrial`.
 
     .. _sqlalchemy.engine.create_engine:
         https://docs.sqlalchemy.org/en/latest/core/engines.html#sqlalchemy.create_engine
@@ -143,6 +148,7 @@ class RDBStorage(BaseStorage):
         *,
         heartbeat_interval: Optional[int] = None,
         grace_period: Optional[int] = None,
+        failed_trial_callback: Optional[Callable[["optuna.Study", FrozenTrial], None]] = None,
     ) -> None:
 
         self.engine_kwargs = engine_kwargs or {}
@@ -154,6 +160,7 @@ class RDBStorage(BaseStorage):
             raise ValueError("The value of `grace_period` should be a positive integer.")
         self.heartbeat_interval = heartbeat_interval
         self.grace_period = grace_period
+        self.failed_trial_callback = failed_trial_callback
 
         self._set_default_engine_kwargs_for_mysql(url, self.engine_kwargs)
 
@@ -1211,6 +1218,10 @@ class RDBStorage(BaseStorage):
     def get_heartbeat_interval(self) -> Optional[int]:
 
         return self.heartbeat_interval
+
+    def get_failed_trial_callback(self) -> Optional[Callable[["optuna.Study", FrozenTrial], None]]:
+
+        return self.failed_trial_callback
 
 
 class _VersionManager(object):

--- a/optuna/storages/_rdb/storage.py
+++ b/optuna/storages/_rdb/storage.py
@@ -121,9 +121,8 @@ class RDBStorage(BaseStorage):
             :class:`~optuna.study.Study` and :class:`~optuna.FrozenTrial`.
 
             .. note::
-                The procedure to fail existing stale trials is called immediately after asking the
-                study for a new trial. In other words, this procedure is called just before
-                executing the objective function.
+                The procedure to fail existing stale trials is called just before asking the
+                study for a new trial.
 
     .. _sqlalchemy.engine.create_engine:
         https://docs.sqlalchemy.org/en/latest/core/engines.html#sqlalchemy.create_engine

--- a/optuna/storages/_rdb/storage.py
+++ b/optuna/storages/_rdb/storage.py
@@ -116,9 +116,14 @@ class RDBStorage(BaseStorage):
             Grace period before a running trial is failed from the last heartbeat.
             If it is :obj:`None`, the grace period will be `2 * heartbeat_interval`.
         failed_trial_callback:
-            A callback function that are invoked after failing each stale trial. The function
-                must accept two parameters with the following types in this order:
-                :class:`~optuna.study.Study` and :class:`~optuna.FrozenTrial`.
+            A callback function that are invoked after failing each stale trial.
+            The function must accept two parameters with the following types in this order:
+            :class:`~optuna.study.Study` and :class:`~optuna.FrozenTrial`.
+
+            .. note::
+                The procedure to fail existing stale trials is called immediately after asking the
+                study for a new trial. In other words, this procedure is called just before
+                executing the objective function defined by the user.
 
     .. _sqlalchemy.engine.create_engine:
         https://docs.sqlalchemy.org/en/latest/core/engines.html#sqlalchemy.create_engine

--- a/tests/storages_tests/rdb_tests/test_storage.py
+++ b/tests/storages_tests/rdb_tests/test_storage.py
@@ -12,6 +12,7 @@ import pytest
 from sqlalchemy.exc import IntegrityError
 
 from optuna import create_study
+from optuna import Study
 from optuna import version
 from optuna.distributions import CategoricalDistribution
 from optuna.distributions import UniformDistribution
@@ -364,3 +365,29 @@ def test_invalid_heartbeat_interval_and_grace_period() -> None:
 
     with pytest.raises(ValueError):
         _ = RDBStorage("sqlite:///:memory:", grace_period=-1)
+
+
+def test_failed_trial_callback() -> None:
+    heartbeat_interval = 1
+    grace_period = 2
+
+    def failed_trial_callback(study: Study, trial: FrozenTrial) -> None:
+        assert study.system_attrs["test"] == "A"
+        assert trial.system_attrs["test"] == "B"
+
+    with StorageSupplier("sqlite") as storage:
+        assert isinstance(storage, RDBStorage)
+        storage.heartbeat_interval = heartbeat_interval
+        storage.grace_period = grace_period
+        storage.failed_trial_callback = failed_trial_callback
+        study = create_study(storage=storage)
+        study.set_system_attr("test", "A")
+
+        trial = study.ask()
+        trial.set_system_attr("test", "B")
+        storage.record_heartbeat(trial._trial_id)
+        time.sleep(grace_period + 1)
+
+        # Exceptions raised in spawned threads are caught by `_TestableThread`.
+        with patch("optuna._optimize.Thread", _TestableThread):
+            study.optimize(lambda _: 1.0, n_trials=1)

--- a/tests/storages_tests/rdb_tests/test_storage.py
+++ b/tests/storages_tests/rdb_tests/test_storage.py
@@ -390,4 +390,6 @@ def test_failed_trial_callback() -> None:
 
         # Exceptions raised in spawned threads are caught by `_TestableThread`.
         with patch("optuna._optimize.Thread", _TestableThread):
-            study.optimize(lambda _: 1.0, n_trials=1)
+            with patch.object(storage, "failed_trial_callback", wraps=failed_trial_callback) as m:
+                study.optimize(lambda _: 1.0, n_trials=1)
+                m.assert_called_once()


### PR DESCRIPTION
## Motivation
The heartbeat feature was introduced in v2.5.0, and stale trials will automatically fail. In this PR, we will not only fail the trial but also allow to add a user-specified callback function to process the trial.

## Description of the changes
Add `failed_trial_callback` argument to `RDBStorage` and use it in `_optimize.py`.