### PR TITLE
Fix improper stopping with the combination of `GridSampler` and `HyperbandPruner`

### DIFF
--- a/optuna/pruners/_hyperband.py
+++ b/optuna/pruners/_hyperband.py
@@ -280,6 +280,8 @@ class HyperbandPruner(BasePruner):
                 "sampler",
                 "trials",
                 "_is_multi_objective",
+                "stop",
+                "_study",
             )
 
             def __init__(self, study: "optuna.study.Study", bracket_id: int) -> None:
@@ -289,6 +291,7 @@ class HyperbandPruner(BasePruner):
                     sampler=study.sampler,
                     pruner=study.pruner,
                 )
+                self._study = study
                 self._bracket_id = bracket_id
 
             def get_trials(
@@ -300,6 +303,11 @@ class HyperbandPruner(BasePruner):
                 pruner = self.pruner
                 assert isinstance(pruner, HyperbandPruner)
                 return [t for t in trials if pruner._get_bracket_id(self, t) == self._bracket_id]
+
+            def stop(self) -> None:
+                # `stop` should stop the original study's optimization loop instead of
+                # `_BracketStudy`.
+                self._study.stop()
 
             def __getattribute__(self, attr_name):  # type: ignore
                 if attr_name not in _BracketStudy._VALID_ATTRS:

--- a/optuna/samplers/_grid.py
+++ b/optuna/samplers/_grid.py
@@ -211,7 +211,11 @@ class GridSampler(BaseSampler):
 
         # List up unvisited grids based on already finished ones.
         visited_grids = []
-        for t in study.trials:
+
+        # When `HyperbandPruner` is used, `study.get_trials` returns filtered trials.
+        trials = study._storage.get_all_trials(study._study_id, deepcopy=False)
+
+        for t in trials:
             if (
                 t.state.is_finished()
                 and "grid_id" in t.system_attrs

--- a/optuna/samplers/_grid.py
+++ b/optuna/samplers/_grid.py
@@ -212,7 +212,9 @@ class GridSampler(BaseSampler):
         # List up unvisited grids based on already finished ones.
         visited_grids = []
 
-        # When `HyperbandPruner` is used, `study.get_trials` returns filtered trials.
+        # We directly query the storage to get trials here instead of `study.get_trials`,
+        # since some pruners such as `HyperbandPruner` use the study transformed
+        # to filter trials. See https://github.com/optuna/optuna/issues/2327 for details.
         trials = study._storage.get_all_trials(study._study_id, deepcopy=False)
 
         for t in trials:

--- a/tests/pruners_tests/test_hyperband.py
+++ b/tests/pruners_tests/test_hyperband.py
@@ -232,11 +232,11 @@ def test_hyperband_pruner_and_grid_sampler() -> None:
         for i in range(N_REPORTS):
             trial.report(i, step=i)
 
-        x = trial.suggest_uniform("x", -100, 100)
+        x = trial.suggest_float("x", -100, 100)
         y = trial.suggest_int("y", -100, 100)
         return x ** 2 + y ** 2
 
-    study.optimize(objective)
+    study.optimize(objective, n_trials=10)
 
     trials = study.trials
     assert len(trials) == 9

--- a/tests/pruners_tests/test_hyperband.py
+++ b/tests/pruners_tests/test_hyperband.py
@@ -216,3 +216,27 @@ def test_hyperband_no_call_of_filter_study_in_should_prune(
 def test_incompatibility_between_bootstrap_count_and_auto_max_resource() -> None:
     with pytest.raises(ValueError):
         optuna.pruners.HyperbandPruner(max_resource="auto", bootstrap_count=1)
+
+
+def test_hyperband_pruner_and_grid_sampler() -> None:
+    pruner = optuna.pruners.HyperbandPruner(
+        min_resource=MIN_RESOURCE, max_resource=MAX_RESOURCE, reduction_factor=REDUCTION_FACTOR
+    )
+
+    search_space = {"x": [-50, 0, 50], "y": [-99, 0, 99]}
+    sampler = optuna.samplers.GridSampler(search_space)
+
+    study = optuna.study.create_study(sampler=sampler, pruner=pruner)
+
+    def objective(trial: optuna.trial.Trial) -> float:
+        for i in range(N_REPORTS):
+            trial.report(i, step=i)
+
+        x = trial.suggest_uniform("x", -100, 100)
+        y = trial.suggest_int("y", -100, 100)
+        return x ** 2 + y ** 2
+
+    study.optimize(objective)
+
+    trials = study.trials
+    assert len(trials) == 9


### PR DESCRIPTION
## Motivation
Resolve #2327 
## Description of the changes
When we use `HyperbandPruner`, `study.trials` is filtered by `bracket_id`. This causes improper stopping bug for `GridSampler` because it cannot check all nodes are visited using `study.trials`.
This PR adds `stop` method for `_BracketStudy` and checks visited nodes using `study._storage.get_all_trials`.