### PR TITLE
Fix `matplotlib.plot_parallel_coordinate` with only one suggested parameter.

### DIFF
--- a/optuna/visualization/matplotlib/_parallel_coordinate.py
+++ b/optuna/visualization/matplotlib/_parallel_coordinate.py
@@ -144,12 +144,8 @@ def _get_parallel_coordinate_plot(
         values = [t.params[p_name] if p_name in t.params else np.nan for t in trials]
 
         if _is_log_scale(trials, p_name):
-            p_min = math.log10(min(values))
-            p_max = math.log10(max(values))
-            p_w = p_max - p_min
+            values = [math.log10(v) for v in values]
             log_param_names.append(p_name)
-            for i, v in enumerate(values):
-                dims_obj_base[i].append((math.log10(v) - p_min) / p_w * obj_w + obj_min)
         elif _is_categorical(trials, p_name):
             vocab = defaultdict(lambda: len(vocab))  # type: DefaultDict[str, int]
             values = [vocab[v] for v in values]
@@ -157,16 +153,15 @@ def _get_parallel_coordinate_plot(
             vocab_item_sorted = sorted(vocab.items(), key=lambda x: x[1])
             cat_param_values.append([v[0] for v in vocab_item_sorted])
             cat_param_ticks.append([v[1] for v in vocab_item_sorted])
-            p_min = min(values)
-            p_max = max(values)
-            p_w = p_max - p_min
-            for i, v in enumerate(values):
-                dims_obj_base[i].append((v - p_min) / p_w * obj_w + obj_min)
-        else:
-            p_min = min(values)
-            p_max = max(values)
-            p_w = p_max - p_min
 
+        p_min = min(values)
+        p_max = max(values)
+        p_w = p_max - p_min
+
+        if p_w == 0.0:
+            for i in range(len(values)):
+                dims_obj_base[i].append(obj_w / 2 + obj_min)
+        else:
             for i, v in enumerate(values):
                 dims_obj_base[i].append((v - p_min) / p_w * obj_w + obj_min)
 
@@ -177,13 +172,13 @@ def _get_parallel_coordinate_plot(
     # Ref: https://stackoverflow.com/a/50029441
     ax.set_xlim(0, len(sorted_params))
     ax.set_ylim(obj_min, obj_max)
-    xs = [range(0, len(sorted_params) + 1) for i in range(len(dims_obj_base))]
+    xs = [range(len(sorted_params) + 1) for _ in range(len(dims_obj_base))]
     segments = [np.column_stack([x, y]) for x, y in zip(xs, dims_obj_base)]
     lc = LineCollection(segments, cmap=cmap)
     lc.set_array(np.asarray([target(t) for t in trials] + [0]))
     axcb = fig.colorbar(lc, pad=0.1)
     axcb.set_label(target_name)
-    plt.xticks(range(0, len(sorted_params) + 1), var_names, rotation=330)
+    plt.xticks(range(len(sorted_params) + 1), var_names, rotation=330)
 
     for i, p_name in enumerate(sorted_params):
         ax2 = ax.twinx()

--- a/tests/visualization_tests/matplotlib_tests/test_parallel_coordinate.py
+++ b/tests/visualization_tests/matplotlib_tests/test_parallel_coordinate.py
@@ -124,3 +124,38 @@ def test_plot_parallel_coordinate_log_params() -> None:
     )
     figure = plot_parallel_coordinate(study_log_params)
     assert figure.has_data()
+
+
+def test_plot_parallel_coordinate_unique_hyper_param() -> None:
+    # Test case when one unique value is suggested during the optimization.
+
+    study_categorical_params = create_study()
+    study_categorical_params.add_trial(
+        create_trial(
+            value=0.0,
+            params={"category_a": "preferred", "param_b": 30},
+            distributions={
+                "category_a": CategoricalDistribution(("preferred", "opt")),
+                "param_b": LogUniformDistribution(1, 1000),
+            },
+        )
+    )
+
+    # both hyper-parameter contains unique value
+    figure = plot_parallel_coordinate(study_categorical_params)
+    assert figure.has_data()
+
+    study_categorical_params.add_trial(
+        create_trial(
+            value=2.0,
+            params={"category_a": "preferred", "param_b": 20},
+            distributions={
+                "category_a": CategoricalDistribution(("preferred", "opt")),
+                "param_b": LogUniformDistribution(1, 1000),
+            },
+        )
+    )
+
+    # still "category_a" contains unique suggested value during the optimization.
+    figure = plot_parallel_coordinate(study_categorical_params)
+    assert figure.has_data()


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
As discussed in https://github.com/optuna/optuna/issues/2011, `matplotlib.plot_parallel_coordinate` raises the error if a hyper-parameter contains only one unique value.

## Description of the changes
<!-- Describe the changes in this PR. -->

To avoid the zero-divide, if a hyper-parameter contains only one unique value, set a middle value based on objective values.
