### PR TITLE
Remove unsupported argument from pytorch-lightning example

### DIFF
--- a/examples/pytorch/pytorch_lightning_simple.py
+++ b/examples/pytorch/pytorch_lightning_simple.py
@@ -128,7 +128,7 @@ def objective(trial):
         checkpoint_callback=checkpoint_callback,
         max_epochs=EPOCHS,
         gpus=1 if torch.cuda.is_available() else None,
-        callbacks=[PyTorchLightningPruningCallback(trial, monitor="val_acc", mode="max")],
+        callbacks=[PyTorchLightningPruningCallback(trial, monitor="val_acc")],
     )
 
     model = LightningNet(trial)


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation

See below.

## Description of the changes

Fixes broken example where `PyTorchLightningPruningCallback` is given an unsupported argument. For background on the intended `mode` argument, see https://pytorch-lightning.readthedocs.io/en/stable/_modules/pytorch_lightning/callbacks/early_stopping.html#EarlyStopping. Note that the callback now implements `Callback` and not `EarlyStopping`.