### PR TITLE
Implemented `after_trial` method in `CmaEsSampler`

### DIFF
--- a/optuna/samplers/_cmaes.py
+++ b/optuna/samplers/_cmaes.py
@@ -5,6 +5,7 @@ from typing import Any
 from typing import Dict
 from typing import List
 from typing import Optional
+from typing import Sequence
 from typing import Tuple
 import warnings
 
@@ -430,6 +431,16 @@ class CmaEsSampler(BaseSampler):
                 copied_t.value = value
                 complete_trials.append(copied_t)
         return complete_trials
+
+    def after_trial(
+        self,
+        study: "optuna.Study",
+        trial: "optuna.trial.FrozenTrial",
+        state: TrialState,
+        values: Optional[Sequence[float]],
+    ) -> None:
+
+        self._independent_sampler.after_trial(study, trial, state, values)
 
 
 def _split_optimizer_str(optimizer_str: str) -> Dict[str, str]:

--- a/tests/samplers_tests/test_cmaes.py
+++ b/tests/samplers_tests/test_cmaes.py
@@ -5,6 +5,7 @@ from typing import List
 from unittest.mock import MagicMock
 from unittest.mock import Mock
 from unittest.mock import patch
+import warnings
 
 from cmaes import CMA
 import numpy as np
@@ -261,3 +262,16 @@ def test_split_and_concat_optimizer_string(dummy_optimizer_str: str, attr_len: i
         assert len(attrs) == attr_len
         actual = _concat_optimizer_attrs(attrs)
         assert dummy_optimizer_str == actual
+
+
+def test_call_after_trial_of_base_sampler() -> None:
+    independent_sampler = optuna.samplers.RandomSampler()
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", optuna.exceptions.ExperimentalWarning)
+        sampler = optuna.samplers.CmaEsSampler(independent_sampler=independent_sampler)
+    study = optuna.create_study(sampler=sampler)
+    with patch.object(
+        independent_sampler, "after_trial", wraps=independent_sampler.after_trial
+    ) as mock_object:
+        study.optimize(lambda _: 1.0, n_trials=1)
+        assert mock_object.call_count == 1


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
With reference to the issue #2233, I have implemented <code>after_trial</code> method for <code>CmaEsSampler</code> with the corresponding testing function <code>test_call_after_trial_of_base_sampler</code>

## Description of the changes
The <code>after_trial</code> method and <code>test_call_after_trial_of_base_sampler</code> implementation was inspired by the previous <code>after_trial</code> method in <code>PartialFixedSampler</code> with PR #2209 , currently the <code>after_trial</code> method is implemented only in these samplers,
 ### Samplers

- [x]  `PartialFixedSampler` #2209
- [x]   `CmaEsSampler` (this PR)
- [ ]  `TPESampler`
- [ ]   `PyCmaEsampler`
- [ ]  `SkoptSampler`
- [ ]   `BoTorchSampler`
- [ ]   `NSAGAIISampler`
- [ ]  `MOTPESampler`

The current addition in CmaEsSampler's <code>after_trial</code> method  calls <code>after_trial</code> of <code>independent_sampler</code> described with the example in PR #2209 .

If this implementation needs any further modification then let me know,
Further changes in different samplers will be implemented accordingly. 