### PR TITLE
Install `torch` from pypi for ReadTheDocs.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
             python -m venv venv || virtualenv venv --python=python3.8
             . venv/bin/activate
             pip install -U pip
-            pip install --progress-bar off .[document] -f https://download.pytorch.org/whl/torch_stable.html
+            pip install --progress-bar off .[document]
 
       - run:
           name: build

--- a/.github/workflows/sphinx-build.yml
+++ b/.github/workflows/sphinx-build.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Install Dependencies
       run: |
         python -m pip install -U pip
-        pip install --progress-bar off -U .[document] -f https://download.pytorch.org/whl/torch_stable.html
+        pip install --progress-bar off -U .[document]
 
     - name: Build Document
       run: |

--- a/setup.py
+++ b/setup.py
@@ -79,10 +79,8 @@ def get_extras_require() -> Dict[str, List[str]]:
             "plotly>=4.0.0",  # optuna/visualization.
             "pandas",
             "lightgbm",
-            "torch==1.7.1 ; sys_platform=='darwin'",
-            "torch==1.7.1+cpu ; sys_platform!='darwin'",
-            "torchvision==0.8.2 ; sys_platform=='darwin'",
-            "torchvision==0.8.2+cpu ; sys_platform!='darwin'",
+            "torch==1.7.1",
+            "torchvision==0.8.2",
             "torchaudio==0.7.2",
             "thop",
         ],


### PR DESCRIPTION
## Motivation

The sphinx-build in RTD failed after we merged #2305.

https://readthedocs.org/projects/optuna/builds/13035450/

> ERROR: Could not find a version that satisfies the requirement torch==1.7.1+cpu; sys_platform != "darwin" and extra == "document" (from optuna[document])
> ERROR: No matching distribution found for torch==1.7.1+cpu; sys_platform != "darwin" and extra == "document"

During the installation, `pip` tried to install `torch==1.7.1+cpu`, but it was not found because `--find-links` option (in short `-f`) is not available.

https://github.com/optuna/optuna/blob/289f1158501ca492ff99f5c0e25fff2f3eeb948e/.github/workflows/sphinx-build.yml#L37

The installation is controlled in `.readthedocs.yaml`, but I couldn't find the way to set `-f` option in the [reference](https://docs.readthedocs.io/en/stable/config-file/v2.html#packages).

https://github.com/optuna/optuna/blob/289f1158501ca492ff99f5c0e25fff2f3eeb948e/.readthedocs.yml#L14-L23

## Description of the changes

This PR will remove `-f` option, and install `torch` from pypi.