### PR TITLE
Support `IntLogUniformDistribution` for TensorBoard

### DIFF
--- a/optuna/integration/tensorboard.py
+++ b/optuna/integration/tensorboard.py
@@ -61,7 +61,10 @@ class TensorBoardCallback(object):
             optuna.distributions.LogUniformDistribution,
             optuna.distributions.DiscreteUniformDistribution,
         )
-        int_distributions = (optuna.distributions.IntUniformDistribution,)
+        int_distributions = (
+            optuna.distributions.IntUniformDistribution,
+            optuna.distributions.IntLogUniformDistribution,
+        )
         categorical_distributions = (optuna.distributions.CategoricalDistribution,)
         supported_distributions = (
             real_distributions + int_distributions + categorical_distributions

--- a/tests/integration_tests/test_tensorboard.py
+++ b/tests/integration_tests/test_tensorboard.py
@@ -18,7 +18,7 @@ def _objective_func(trial: optuna.trial.Trial) -> float:
     z = trial.suggest_categorical("z", (-1.0, 1.0))
     assert isinstance(z, float)
     trial.set_user_attr("my_user_attr", "my_user_attr_value")
-    return v + w + (x - 2) ** 2 + (y - 25) ** 2 + z
+    return u + v + w + (x - 2) ** 2 + (y - 25) ** 2 + z
 
 
 def test_study_name() -> None:

--- a/tests/integration_tests/test_tensorboard.py
+++ b/tests/integration_tests/test_tensorboard.py
@@ -10,13 +10,14 @@ from optuna.integration.tensorboard import TensorBoardCallback
 
 
 def _objective_func(trial: optuna.trial.Trial) -> float:
+    v = trial.suggest_int("v", 1, 10, log=True)
+    w = trial.suggest_float("w", -1.0, 1.0, step=0.1)
     x = trial.suggest_uniform("x", -1.0, 1.0)
     y = trial.suggest_loguniform("y", 20.0, 30.0)
     z = trial.suggest_categorical("z", (-1.0, 1.0))
-    w = trial.suggest_float("w", -1.0, 1.0, step=0.1)
     assert isinstance(z, float)
     trial.set_user_attr("my_user_attr", "my_user_attr_value")
-    return (x - 2) ** 2 + (y - 25) ** 2 + z + w
+    return v + w + (x - 2) ** 2 + (y - 25) ** 2 + z
 
 
 def test_study_name() -> None:

--- a/tests/integration_tests/test_tensorboard.py
+++ b/tests/integration_tests/test_tensorboard.py
@@ -10,6 +10,7 @@ from optuna.integration.tensorboard import TensorBoardCallback
 
 
 def _objective_func(trial: optuna.trial.Trial) -> float:
+    u = trial.suggest_int("u", 0, 10, step=2)
     v = trial.suggest_int("v", 1, 10, log=True)
     w = trial.suggest_float("w", -1.0, 1.0, step=0.1)
     x = trial.suggest_uniform("x", -1.0, 1.0)


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
 
The currently TensorBoard integration does not support `IntLogUniformDistribution` that is used when `suggest_int` with `log=True` (#2336).  

## Description of the changes
<!-- Describe the changes in this PR. -->

Support `IntLogUniformDistributiin` for tensorboard and update the sampling test in the tensorboard tests.