### PR TITLE
Update `examples/kubernetes/mlflow/check_study.sh` to match whole words

### DIFF
--- a/examples/kubernetes/mlflow/check_study.sh
+++ b/examples/kubernetes/mlflow/check_study.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-optuna studies --storage "postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}" | grep k8s_mlflow > /dev/null
+optuna studies --storage "postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}" | grep -w k8s_mlflow > /dev/null
 echo $?


### PR DESCRIPTION
## Motivation
Follows from issue #2356. The previous implementation of `check_study.sh` could succeed when another study with the desired study name as a substring existed but the desired study did not exist. This update matches on whole words and correctly ensures the existence of the desired study.

## Description of the changes
Minor change from the use of `grep PATTERN` in `check_study.sh` to `grep -w PATTERN`.

https://github.com/optuna/optuna/blob/7cd4fa3c764b5ef8c0e9d14096ebe2453ba3b651/examples/kubernetes/mlflow/check_study.sh#L2
