### PR TITLE
allow allennlp in py3.8 integration tests

### DIFF
--- a/.github/workflows/tests-integration.yml
+++ b/.github/workflows/tests-integration.yml
@@ -63,9 +63,6 @@ jobs:
         if [ ${{ matrix.python-version }} = 3.6 ]; then
           pytest tests/integration_tests \
             --ignore tests/integration_tests/test_botorch.py
-        elif [ ${{ matrix.python-version }} = 3.8 ]; then
-          pytest tests/integration_tests \
-            --ignore tests/integration_tests/allennlp_tests/test_allennlp.py
         else
           # pytest cannot collect allennlp tests with allennlp==1.0.0.
           pytest -s tests/integration_tests


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->
Enables AllenNLP integration test in Python 3.8 environment.
