### PR TITLE
Increase API request limit for stale bot

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -24,3 +24,4 @@ jobs:
         stale-pr-label: 'stale'
         exempt-issue-labels: 'no-stale'
         exempt-pr-labels: 'no-stale'
+        operations-per-run: 1000


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation

Stale bot was recently updated to close old tickets. However, no ticket are being closed. It seems like the bot is hitting its default API cap of 30 (e.g. https://github.com/optuna/optuna/runs/1947955670?check_suite_focus=true). This PR changes the cap to 1000. I have not been able to locally verify that this will solve the issue.

C.f.

- About the option `operations-per-run` https://github.com/actions/stale
- GitHub API limit is 5000 per hour, and this job only runs once per day https://docs.github.com/en/rest/overview/resources-in-the-rest-api#rate-limiting

I think that we can reduce this cap after its first execution.

## Description of the changes

See above
