### PR TITLE
`after_trial` implemented for `BotorchSampler` and `SkoptSampler`

### DIFF
--- a/optuna/integration/botorch.py
+++ b/optuna/integration/botorch.py
@@ -565,3 +565,4 @@ class BoTorchSampler(BaseSampler):
                     "botorch:constraints",
                     constraints,
                 )
+        self._independent_sampler.after_trial(study, trial, state, values)

--- a/optuna/integration/skopt.py
+++ b/optuna/integration/skopt.py
@@ -3,6 +3,7 @@ from typing import Any
 from typing import Dict
 from typing import List
 from typing import Optional
+from typing import Sequence
 from typing import Tuple
 import warnings
 
@@ -221,6 +222,16 @@ class SkoptSampler(BaseSampler):
                 copied_t.value = value
                 complete_trials.append(copied_t)
         return complete_trials
+
+    def after_trial(
+        self,
+        study: Study,
+        trial: FrozenTrial,
+        state: TrialState,
+        values: Optional[Sequence[float]],
+    ) -> None:
+
+        self._independent_sampler.after_trial(study, trial, state, values)
 
 
 class _Optimizer(object):

--- a/tests/integration_tests/test_botorch.py
+++ b/tests/integration_tests/test_botorch.py
@@ -440,6 +440,7 @@ def test_reseed_rng() -> None:
         != cast(RandomSampler, sampler._independent_sampler)._rng.seed
     )
 
+
 def test_call_after_trial_of_independent_sampler() -> None:
     independent_sampler = optuna.samplers.RandomSampler()
     with warnings.catch_warnings():

--- a/tests/integration_tests/test_botorch.py
+++ b/tests/integration_tests/test_botorch.py
@@ -3,6 +3,7 @@ from typing import Optional
 from typing import Sequence
 from typing import Tuple
 from unittest.mock import patch
+import warnings
 
 import pytest
 import torch
@@ -438,3 +439,15 @@ def test_reseed_rng() -> None:
         original_independent_sampler_seed
         != cast(RandomSampler, sampler._independent_sampler)._rng.seed
     )
+
+def test_call_after_trial_of_independent_sampler() -> None:
+    independent_sampler = optuna.samplers.RandomSampler()
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", optuna.exceptions.ExperimentalWarning)
+        sampler = BoTorchSampler(independent_sampler=independent_sampler)
+    study = optuna.create_study(sampler=sampler)
+    with patch.object(
+        independent_sampler, "after_trial", wraps=independent_sampler.after_trial
+    ) as mock_object:
+        study.optimize(lambda _: 1.0, n_trials=1)
+        assert mock_object.call_count == 1


### PR DESCRIPTION
## Motivation
With reference to the issue #2233, and continuation of work PR #2365 I have implemented <code>after_trial</code> method for <code>SkoptSampler</code> and <code>BoTorchsampler</code> with the corresponding testing function <code>test_call_after_trial_of_independent_sampler</code>

## Description of the changes
There are two major changes for <code>SkoptSampler</code>, first I have included a new function <code>after_trial</code> and second I have included the test function code for the corresponding <code>after_trial</code>.
The <code>after_trial</code> in <code>BoTorchsampler</code> is already implemented, so I have just added one line of <code>independent_sampler.after_trial</code> calling with related arguments. The corresponding <code>test_call_after_trial_of_independent_sampler</code> is also implemented for <code>BoTorchSampler</code>
 ### Samplers

- [x]  `PartialFixedSampler` #2209
- [x]   `CmaEsSampler` #2359 
- [x]   `PyCmaEsampler` #2365 
- [x]  `SkoptSampler` (this PR)
- [x]   `BoTorchSampler` (this PR)
- [ ]  `TPESampler`
- [ ]   `NSAGAIISampler`
- [ ]  `MOTPESampler`


If this implementation needs any further modification then let me know.
Thank you!!
 
