### PR TITLE
`after_trial` implemented for `TPESampler`

### DIFF
--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -151,17 +151,6 @@ class TPESampler(BaseSampler):
             If this is :obj:`True` and ``multivariate=True``, a warning message is emitted when
             the value of a parameter is sampled by using an independent sampler.
             If ``multivariate=False``, this flag has no effect.
-        independent_sampler:
-            A :class:`~optuna.samplers.BaseSampler` instance that is used for independent
-            sampling. The after_trial method of this sampler is used when a fallback occurs.
-
-            If :obj:`None` is specified, :class:`~optuna.samplers.RandomSampler` is used
-            as the default.
-
-            .. seealso::
-                :class:`optuna.samplers` module provides built-in independent samplers
-                such as :class:`~optuna.samplers.RandomSampler` and
-                :class:`~optuna.samplers.TPESampler`.
     """
 
     def __init__(
@@ -178,7 +167,6 @@ class TPESampler(BaseSampler):
         *,
         multivariate: bool = False,
         warn_independent_sampling: bool = True,
-        independent_sampler: Optional[BaseSampler] = None,
     ) -> None:
 
         self._parzen_estimator_parameters = _ParzenEstimatorParameters(
@@ -192,7 +180,7 @@ class TPESampler(BaseSampler):
 
         self._warn_independent_sampling = warn_independent_sampling
         self._rng = np.random.RandomState(seed)
-        self._independent_sampler = independent_sampler or RandomSampler(seed=seed)
+        self._random_sampler = RandomSampler(seed=seed)
 
         self._multivariate = multivariate
         self._search_space = IntersectionSearchSpace()
@@ -207,7 +195,7 @@ class TPESampler(BaseSampler):
     def reseed_rng(self) -> None:
 
         self._rng = np.random.RandomState()
-        self._independent_sampler.reseed_rng()
+        self._random_sampler.reseed_rng()
 
     def infer_relative_search_space(
         self, study: Study, trial: FrozenTrial
@@ -291,7 +279,7 @@ class TPESampler(BaseSampler):
         n = len(values)
 
         if n < self._n_startup_trials:
-            return self._independent_sampler.sample_independent(
+            return self._random_sampler.sample_independent(
                 study, trial, param_name, param_distribution
             )
         below_param_values, above_param_values = self._split_observation_pairs(values, scores)
@@ -761,7 +749,7 @@ class TPESampler(BaseSampler):
         values: Optional[Sequence[float]],
     ) -> None:
 
-        self._independent_sampler.after_trial(study, trial, state, values)
+        self._random_sampler.after_trial(study, trial, state, values)
 
 
 def _get_observation_pairs(

--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -151,6 +151,17 @@ class TPESampler(BaseSampler):
             If this is :obj:`True` and ``multivariate=True``, a warning message is emitted when
             the value of a parameter is sampled by using an independent sampler.
             If ``multivariate=False``, this flag has no effect.
+        independent_sampler:
+            A :class:`~optuna.samplers.BaseSampler` instance that is used for independent
+            sampling. The after_trial method of this sampler is used when a fallback occurs.
+
+            If :obj:`None` is specified, :class:`~optuna.samplers.RandomSampler` is used
+            as the default.
+
+            .. seealso::
+                :class:`optuna.samplers` module provides built-in independent samplers
+                such as :class:`~optuna.samplers.RandomSampler` and
+                :class:`~optuna.samplers.TPESampler`.
     """
 
     def __init__(
@@ -741,7 +752,7 @@ class TPESampler(BaseSampler):
             "gamma": hyperopt_default_gamma,
             "weights": default_weights,
         }
-    
+
     def after_trial(
         self,
         study: Study,
@@ -751,6 +762,7 @@ class TPESampler(BaseSampler):
     ) -> None:
 
         self._independent_sampler.after_trial(study, trial, state, values)
+
 
 def _get_observation_pairs(
     study: Study, param_name: str

--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -4,6 +4,7 @@ from typing import Callable
 from typing import Dict
 from typing import List
 from typing import Optional
+from typing import Sequence
 from typing import Tuple
 from typing import Union
 import warnings
@@ -166,6 +167,7 @@ class TPESampler(BaseSampler):
         *,
         multivariate: bool = False,
         warn_independent_sampling: bool = True,
+        independent_sampler: Optional[BaseSampler] = None,
     ) -> None:
 
         self._parzen_estimator_parameters = _ParzenEstimatorParameters(
@@ -179,7 +181,7 @@ class TPESampler(BaseSampler):
 
         self._warn_independent_sampling = warn_independent_sampling
         self._rng = np.random.RandomState(seed)
-        self._random_sampler = RandomSampler(seed=seed)
+        self._independent_sampler = independent_sampler or RandomSampler(seed=seed)
 
         self._multivariate = multivariate
         self._search_space = IntersectionSearchSpace()
@@ -194,7 +196,7 @@ class TPESampler(BaseSampler):
     def reseed_rng(self) -> None:
 
         self._rng = np.random.RandomState()
-        self._random_sampler.reseed_rng()
+        self._independent_sampler.reseed_rng()
 
     def infer_relative_search_space(
         self, study: Study, trial: FrozenTrial
@@ -278,7 +280,7 @@ class TPESampler(BaseSampler):
         n = len(values)
 
         if n < self._n_startup_trials:
-            return self._random_sampler.sample_independent(
+            return self._independent_sampler.sample_independent(
                 study, trial, param_name, param_distribution
             )
         below_param_values, above_param_values = self._split_observation_pairs(values, scores)
@@ -739,7 +741,16 @@ class TPESampler(BaseSampler):
             "gamma": hyperopt_default_gamma,
             "weights": default_weights,
         }
+    
+    def after_trial(
+        self,
+        study: Study,
+        trial: FrozenTrial,
+        state: TrialState,
+        values: Optional[Sequence[float]],
+    ) -> None:
 
+        self._independent_sampler.after_trial(study, trial, state, values)
 
 def _get_observation_pairs(
     study: Study, param_name: str

--- a/tests/samplers_tests/tpe_tests/test_sampler.py
+++ b/tests/samplers_tests/tpe_tests/test_sampler.py
@@ -14,7 +14,6 @@ import optuna
 from optuna import distributions
 from optuna import TrialPruned
 from optuna.samplers import _tpe
-from optuna.samplers import RandomSampler
 from optuna.samplers import TPESampler
 from optuna.trial import Trial
 
@@ -865,7 +864,7 @@ def test_reseed_rng() -> None:
     original_seed = sampler._rng.seed
 
     with patch.object(
-        sampler._independent_sampler, "reseed_rng", wraps=sampler._independent_sampler.reseed_rng
+        sampler._random_sampler, "reseed_rng", wraps=sampler._random_sampler.reseed_rng
     ) as mock_object:
         sampler.reseed_rng()
         assert mock_object.call_count == 1
@@ -873,13 +872,12 @@ def test_reseed_rng() -> None:
 
 
 def test_call_after_trial_of_independent_sampler() -> None:
-    independent_sampler = RandomSampler()
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", optuna.exceptions.ExperimentalWarning)
-        sampler = TPESampler(independent_sampler=independent_sampler)
+        sampler = TPESampler()
     study = optuna.create_study(sampler=sampler)
     with patch.object(
-        independent_sampler, "after_trial", wraps=independent_sampler.after_trial
+        sampler._random_sampler, "after_trial", wraps=sampler._random_sampler.after_trial
     ) as mock_object:
         study.optimize(lambda _: 1.0, n_trials=1)
         assert mock_object.call_count == 1

--- a/tests/samplers_tests/tpe_tests/test_sampler.py
+++ b/tests/samplers_tests/tpe_tests/test_sampler.py
@@ -871,10 +871,8 @@ def test_reseed_rng() -> None:
         assert original_seed != sampler._rng.seed
 
 
-def test_call_after_trial_of_independent_sampler() -> None:
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", optuna.exceptions.ExperimentalWarning)
-        sampler = TPESampler()
+def test_call_after_trial_of_random_sampler() -> None:
+    sampler = TPESampler()
     study = optuna.create_study(sampler=sampler)
     with patch.object(
         sampler._random_sampler, "after_trial", wraps=sampler._random_sampler.after_trial

--- a/tests/samplers_tests/tpe_tests/test_sampler.py
+++ b/tests/samplers_tests/tpe_tests/test_sampler.py
@@ -14,8 +14,8 @@ import optuna
 from optuna import distributions
 from optuna import TrialPruned
 from optuna.samplers import _tpe
-from optuna.samplers import TPESampler
 from optuna.samplers import RandomSampler
+from optuna.samplers import TPESampler
 from optuna.trial import Trial
 
 


### PR DESCRIPTION
## Motivation
With reference to the issue #2233, and continuation of work PR #2372 I have implemented <code>after_trial</code> method for <code>TPESampler</code> with the corresponding testing function <code>test_call_after_trial_of_independent_sampler</code>

## Description of the changes
 As the <code>independent_sampler</code> didn't exist of now, but <code>random_sampler</code> was there. So, I have implemented <code>after_trial</code> for <code>_random_sampler</code>, the corresponding changes for tests are also included in <code>tests/samplers_tests/tpe_tests/test_sampler.py</code>. 
 ### Samplers

- [x]  `PartialFixedSampler` #2209
- [x]   `CmaEsSampler` #2359 
- [x]   `PyCmaEsampler` #2365 
- [x]  `SkoptSampler` #2372 
- [x]   `BoTorchSampler` #2372 
- [x]  `TPESampler` (this PR)
- [ ]   `NSAGAIISampler`
- [ ]  `MOTPESampler`


If this implementation needs any further modification then let me know.
Thank you!!
 
