### PR TITLE
updated examples for `study.get_trials` for states filtering

### DIFF
--- a/examples/chainer/chainer_integration.py
+++ b/examples/chainer/chainer_integration.py
@@ -18,6 +18,7 @@ import numpy as np
 from packaging import version
 
 import optuna
+from optuna.trial import TrialState
 
 
 if version.parse(chainer.__version__) < version.parse("4.0.0"):
@@ -105,8 +106,8 @@ def objective(trial):
 if __name__ == "__main__":
     study = optuna.create_study(direction="maximize", pruner=optuna.pruners.MedianPruner())
     study.optimize(objective, n_trials=100)
-    pruned_trials = [t for t in study.trials if t.state == optuna.trial.TrialState.PRUNED]
-    complete_trials = [t for t in study.trials if t.state == optuna.trial.TrialState.COMPLETE]
+    pruned_trials = study.get_trials(deepcopy=False, states=[TrialState.PRUNED])
+    complete_trials = study.get_trials(deepcopy=False, states=[TrialState.COMPLETE])
     print("Study statistics: ")
     print("  Number of finished trials: ", len(study.trials))
     print("  Number of pruned trials: ", len(pruned_trials))

--- a/examples/chainer/chainermn_integration.py
+++ b/examples/chainer/chainermn_integration.py
@@ -22,6 +22,7 @@ import chainermn
 import numpy as np
 
 import optuna
+from optuna.trial import TrialState
 
 
 N_TRAIN_EXAMPLES = 3000
@@ -123,8 +124,8 @@ if __name__ == "__main__":
     chainermn_study.optimize(objective, n_trials=25)
 
     if comm.rank == 0:
-        pruned_trials = [t for t in study.trials if t.state == optuna.trial.TrialState.PRUNED]
-        complete_trials = [t for t in study.trials if t.state == optuna.trial.TrialState.COMPLETE]
+        pruned_trials = study.get_trials(deepcopy=False, states=[TrialState.PRUNED])
+        complete_trials = study.get_trials(deepcopy=False, states=[TrialState.COMPLETE])
         print("Study statistics: ")
         print("  Number of finished trials: ", len(study.trials))
         print("  Number of pruned trials: ", len(pruned_trials))

--- a/examples/keras/keras_integration.py
+++ b/examples/keras/keras_integration.py
@@ -24,6 +24,7 @@ from keras.models import Sequential
 
 import optuna
 from optuna.integration import KerasPruningCallback
+from optuna.trial import TrialState
 
 
 N_TRAIN_EXAMPLES = 3000
@@ -102,8 +103,8 @@ if __name__ == "__main__":
     )
     study = optuna.create_study(direction="maximize", pruner=optuna.pruners.MedianPruner())
     study.optimize(objective, n_trials=100)
-    pruned_trials = [t for t in study.trials if t.state == optuna.trial.TrialState.PRUNED]
-    complete_trials = [t for t in study.trials if t.state == optuna.trial.TrialState.COMPLETE]
+    pruned_trials = study.get_trials(deepcopy=False, states=[TrialState.PRUNED])
+    complete_trials = study.get_trials(deepcopy=False, states=[TrialState.COMPLETE])
     print("Study statistics: ")
     print("  Number of finished trials: ", len(study.trials))
     print("  Number of pruned trials: ", len(pruned_trials))

--- a/examples/mxnet/mxnet_integration.py
+++ b/examples/mxnet/mxnet_integration.py
@@ -18,6 +18,7 @@ import numpy as np
 
 import optuna
 from optuna.integration import MXNetPruningCallback
+from optuna.trial import TrialState
 
 
 N_TRAIN_EXAMPLES = 3000
@@ -109,8 +110,8 @@ def objective(trial):
 if __name__ == "__main__":
     study = optuna.create_study(direction="maximize", pruner=optuna.pruners.MedianPruner())
     study.optimize(objective, n_trials=100, timeout=600)
-    pruned_trials = [t for t in study.trials if t.state == optuna.trial.TrialState.PRUNED]
-    complete_trials = [t for t in study.trials if t.state == optuna.trial.TrialState.COMPLETE]
+    pruned_trials = study.get_trials(deepcopy=False, states=[TrialState.PRUNED])
+    complete_trials = study.get_trials(deepcopy=False, states=[TrialState.COMPLETE])
 
     print("Study statistics: ")
     print("  Number of finished trials: ", len(study.trials))

--- a/examples/pytorch/pytorch_distributed_simple.py
+++ b/examples/pytorch/pytorch_distributed_simple.py
@@ -27,6 +27,7 @@ from torchvision import datasets
 from torchvision import transforms
 
 import optuna
+from optuna.trial import TrialState
 
 
 DEVICE = torch.device("cpu")
@@ -179,8 +180,8 @@ if __name__ == "__main__":
 
     if rank == 0:
         assert study is not None
-        pruned_trials = [t for t in study.trials if t.state == optuna.trial.TrialState.PRUNED]
-        complete_trials = [t for t in study.trials if t.state == optuna.trial.TrialState.COMPLETE]
+        pruned_trials = study.get_trials(deepcopy=False, states=[TrialState.PRUNED])
+        complete_trials = study.get_trials(deepcopy=False, states=[TrialState.COMPLETE])
 
         print("Study statistics: ")
         print("  Number of finished trials: ", len(study.trials))

--- a/examples/pytorch/pytorch_simple.py
+++ b/examples/pytorch/pytorch_simple.py
@@ -19,6 +19,7 @@ from torchvision import datasets
 from torchvision import transforms
 
 import optuna
+from optuna.trial import TrialState
 
 
 DEVICE = torch.device("cpu")
@@ -125,8 +126,8 @@ if __name__ == "__main__":
     study = optuna.create_study(direction="maximize")
     study.optimize(objective, n_trials=100, timeout=600)
 
-    pruned_trials = [t for t in study.trials if t.state == optuna.trial.TrialState.PRUNED]
-    complete_trials = [t for t in study.trials if t.state == optuna.trial.TrialState.COMPLETE]
+    pruned_trials = study.get_trials(deepcopy=False, states=[TrialState.PRUNED])
+    complete_trials = study.get_trials(deepcopy=False, states=[TrialState.COMPLETE])
 
     print("Study statistics: ")
     print("  Number of finished trials: ", len(study.trials))

--- a/examples/samplers/simulated_annealing_sampler.py
+++ b/examples/samplers/simulated_annealing_sampler.py
@@ -97,7 +97,7 @@ class SimulatedAnnealingSampler(BaseSampler):
 
     @staticmethod
     def _get_last_complete_trial(study):
-        complete_trials = [t for t in study.trials if t.state == TrialState.COMPLETE]
+        complete_trials = study.get_trials(deepcopy=False, states=[TrialState.COMPLETE])
         return complete_trials[-1]
 
     def sample_independent(self, study, trial, param_name, param_distribution):

--- a/examples/simple_pruning.py
+++ b/examples/simple_pruning.py
@@ -17,6 +17,7 @@ import sklearn.linear_model
 import sklearn.model_selection
 
 import optuna
+from optuna.trial import TrialState
 
 
 # FYI: Objective functions can take additional arguments
@@ -49,8 +50,8 @@ if __name__ == "__main__":
     study = optuna.create_study(direction="maximize")
     study.optimize(objective, n_trials=100)
 
-    pruned_trials = [t for t in study.trials if t.state == optuna.trial.TrialState.PRUNED]
-    complete_trials = [t for t in study.trials if t.state == optuna.trial.TrialState.COMPLETE]
+    pruned_trials = study.get_trials(deepcopy=False, states=[TrialState.PRUNED])
+    complete_trials = study.get_trials(deepcopy=False, states=[TrialState.COMPLETE])
 
     print("Study statistics: ")
     print("  Number of finished trials: ", len(study.trials))

--- a/examples/tensorflow/tensorflow_estimator_integration.py
+++ b/examples/tensorflow/tensorflow_estimator_integration.py
@@ -18,6 +18,7 @@ import tensorflow as tf
 import tensorflow_datasets as tfds
 
 import optuna
+from optuna.trial import TrialState
 
 
 MODEL_DIR = tempfile.mkdtemp()
@@ -100,8 +101,8 @@ def objective(trial):
 def main():
     study = optuna.create_study(direction="maximize")
     study.optimize(objective, n_trials=25)
-    pruned_trials = [t for t in study.trials if t.state == optuna.trial.TrialState.PRUNED]
-    complete_trials = [t for t in study.trials if t.state == optuna.trial.TrialState.COMPLETE]
+    pruned_trials = study.get_trials(deepcopy=False, states=[TrialState.PRUNED])
+    complete_trials = study.get_trials(deepcopy=False, states=[TrialState.COMPLETE])
     print("Study statistics: ")
     print("  Number of finished trials: ", len(study.trials))
     print("  Number of pruned trials: ", len(pruned_trials))

--- a/examples/tfkeras/tfkeras_integration.py
+++ b/examples/tfkeras/tfkeras_integration.py
@@ -17,6 +17,7 @@ import tensorflow_datasets as tfds
 
 import optuna
 from optuna.integration import TFKerasPruningCallback
+from optuna.trial import TrialState
 
 
 BATCHSIZE = 128
@@ -108,8 +109,8 @@ def objective(trial):
 
 def show_result(study):
 
-    pruned_trials = [t for t in study.trials if t.state == optuna.trial.TrialState.PRUNED]
-    complete_trials = [t for t in study.trials if t.state == optuna.trial.TrialState.COMPLETE]
+    pruned_trials = study.get_trials(deepcopy=False, states=[TrialState.PRUNED])
+    complete_trials = study.get_trials(deepcopy=False, states=[TrialState.COMPLETE])
 
     print("Study statistics: ")
     print("  Number of finished trials: ", len(study.trials))


### PR DESCRIPTION
## Motivation
With reference to issue #2384, I have updated the following examples: 

 * `examples/simple_pruning.py`
 * `examples/chainer/chainer_integration.py`
 * `examples/chainer/chainermn_integration.py`
 * `examples/keras/keras_integration.py`
 * `examples/mxnet/mxnet_integration.py`
 * `examples/pytorch/pytorch_distributed_simple.py`
 * `examples/pytorch/pytorch_simple.py`
 * `examples/samplers/simulated_annealing_sampler.py`
  * `examples/tensorflow/tensorflow_estimator_integration.py`
 * `examples/tfkeras/tfkeras_integration.py`
## Description of the changes
<!-- Describe the changes in this PR. -->

there are two changes for most of them:
<code>pruned_trials</code> and <code>complete_trials</code>, I have replaced previous stale implementations with 
<code>study.get_trials(deepcopy=False, states=[TrialState.*State*])</code>

Let me know if it needs any modification.