### PR TITLE
Mitigate string-length limitation of `RDBStorage`

### DIFF
--- a/optuna/storages/_rdb/alembic/versions/v2.6.0.a_.py
+++ b/optuna/storages/_rdb/alembic/versions/v2.6.0.a_.py
@@ -1,0 +1,44 @@
+"""empty message
+
+Revision ID: v2.6.0.a
+Revises: v2.4.0.a
+Create Date: 2021-03-01 11:30:32.214196
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "v2.6.0.a"
+down_revision = "v2.4.0.a"
+branch_labels = None
+depends_on = None
+
+MAX_STRING_LENGTH = 2048
+
+
+def upgrade():
+    with op.batch_alter_table("study_user_attributes") as batch_op:
+        batch_op.alter_column("value_json", type_=sa.TEXT)
+    with op.batch_alter_table("study_system_attributes") as batch_op:
+        batch_op.alter_column("value_json", type_=sa.TEXT)
+    with op.batch_alter_table("trial_user_attributes") as batch_op:
+        batch_op.alter_column("value_json", type_=sa.TEXT)
+    with op.batch_alter_table("trial_system_attributes") as batch_op:
+        batch_op.alter_column("value_json", type_=sa.TEXT)
+    with op.batch_alter_table("trial_params") as batch_op:
+        batch_op.alter_column("distribution_json", type_=sa.TEXT)
+
+
+def downgrade():
+    with op.batch_alter_table("study_user_attributes") as batch_op:
+        batch_op.alter_column("value_json", type_=sa.String(MAX_STRING_LENGTH))
+    with op.batch_alter_table("study_system_attributes") as batch_op:
+        batch_op.alter_column("value_json", type_=sa.String(MAX_STRING_LENGTH))
+    with op.batch_alter_table("trial_user_attributes") as batch_op:
+        batch_op.alter_column("value_json", type_=sa.String(MAX_STRING_LENGTH))
+    with op.batch_alter_table("trial_system_attributes") as batch_op:
+        batch_op.alter_column("value_json", type_=sa.String(MAX_STRING_LENGTH))
+    with op.batch_alter_table("trial_params") as batch_op:
+        batch_op.alter_column("distribution_json", type_=sa.String(MAX_STRING_LENGTH))

--- a/optuna/storages/_rdb/models.py
+++ b/optuna/storages/_rdb/models.py
@@ -28,7 +28,6 @@ from optuna.trial import TrialState
 SCHEMA_VERSION = 12
 
 MAX_INDEXED_STRING_LENGTH = 512
-MAX_STRING_LENGTH = 2048
 MAX_VERSION_LENGTH = 256
 
 NOT_FOUND_MSG = "Record does not exist."

--- a/optuna/storages/_rdb/models.py
+++ b/optuna/storages/_rdb/models.py
@@ -14,6 +14,7 @@ from sqlalchemy import func
 from sqlalchemy import Integer
 from sqlalchemy import orm
 from sqlalchemy import String
+from sqlalchemy import Text
 from sqlalchemy import UniqueConstraint
 from sqlalchemy.ext.declarative import declarative_base
 
@@ -110,7 +111,7 @@ class StudyUserAttributeModel(BaseModel):
     study_user_attribute_id = Column(Integer, primary_key=True)
     study_id = Column(Integer, ForeignKey("studies.study_id"))
     key = Column(String(MAX_INDEXED_STRING_LENGTH))
-    value_json = Column(String(MAX_STRING_LENGTH))
+    value_json = Column(Text())
 
     study = orm.relationship(
         StudyModel, backref=orm.backref("user_attributes", cascade="all, delete-orphan")
@@ -144,7 +145,7 @@ class StudySystemAttributeModel(BaseModel):
     study_system_attribute_id = Column(Integer, primary_key=True)
     study_id = Column(Integer, ForeignKey("studies.study_id"))
     key = Column(String(MAX_INDEXED_STRING_LENGTH))
-    value_json = Column(String(MAX_STRING_LENGTH))
+    value_json = Column(Text())
 
     study = orm.relationship(
         StudyModel, backref=orm.backref("system_attributes", cascade="all, delete-orphan")
@@ -274,7 +275,7 @@ class TrialUserAttributeModel(BaseModel):
     trial_user_attribute_id = Column(Integer, primary_key=True)
     trial_id = Column(Integer, ForeignKey("trials.trial_id"))
     key = Column(String(MAX_INDEXED_STRING_LENGTH))
-    value_json = Column(String(MAX_STRING_LENGTH))
+    value_json = Column(Text())
 
     trial = orm.relationship(
         TrialModel, backref=orm.backref("user_attributes", cascade="all, delete-orphan")
@@ -308,7 +309,7 @@ class TrialSystemAttributeModel(BaseModel):
     trial_system_attribute_id = Column(Integer, primary_key=True)
     trial_id = Column(Integer, ForeignKey("trials.trial_id"))
     key = Column(String(MAX_INDEXED_STRING_LENGTH))
-    value_json = Column(String(MAX_STRING_LENGTH))
+    value_json = Column(Text())
 
     trial = orm.relationship(
         TrialModel, backref=orm.backref("system_attributes", cascade="all, delete-orphan")
@@ -343,7 +344,7 @@ class TrialParamModel(BaseModel):
     trial_id = Column(Integer, ForeignKey("trials.trial_id"))
     param_name = Column(String(MAX_INDEXED_STRING_LENGTH))
     param_value = Column(Float)
-    distribution_json = Column(String(MAX_STRING_LENGTH))
+    distribution_json = Column(Text())
 
     trial = orm.relationship(
         TrialModel, backref=orm.backref("params", cascade="all, delete-orphan")

--- a/tests/storages_tests/rdb_tests/test_storage.py
+++ b/tests/storages_tests/rdb_tests/test_storage.py
@@ -38,7 +38,13 @@ def test_init() -> None:
     assert version_info.library_version == version.__version__
 
     assert storage.get_current_version() == storage.get_head_version()
-    assert storage.get_all_versions() == ["v2.6.0.a", "v2.4.0.a", "v1.3.0.a", "v1.2.0.a", "v0.9.0.a"]
+    assert storage.get_all_versions() == [
+        "v2.6.0.a",
+        "v2.4.0.a",
+        "v1.3.0.a",
+        "v1.2.0.a",
+        "v0.9.0.a",
+    ]
 
 
 def test_init_url_template() -> None:

--- a/tests/storages_tests/rdb_tests/test_storage.py
+++ b/tests/storages_tests/rdb_tests/test_storage.py
@@ -38,7 +38,7 @@ def test_init() -> None:
     assert version_info.library_version == version.__version__
 
     assert storage.get_current_version() == storage.get_head_version()
-    assert storage.get_all_versions() == ["v2.4.0.a", "v1.3.0.a", "v1.2.0.a", "v0.9.0.a"]
+    assert storage.get_all_versions() == ["v2.6.0.a", "v2.4.0.a", "v1.3.0.a", "v1.2.0.a", "v0.9.0.a"]
 
 
 def test_init_url_template() -> None:


### PR DESCRIPTION
## Motivation
This PR relates to #1860.

SQLAlchemy has multiple types for string data. Currently, [`sqlalchemy.types.String`](https://docs.sqlalchemy.org/en/13/core/type_basics.html#sqlalchemy.types.String) is used for variable-length strings such as `Trial.system_attr` and `Trial.user_attr`. It has strict length limitation, i.e., 2048 characters.
On the other hand, [`sqlalchemy.types.Text`](https://docs.sqlalchemy.org/en/13/core/type_basics.html#sqlalchemy.types.Text) may be suitable for such variable-length strings. It is corresponding to `TEXT` type of each database system, which is designed for large text objects.

Although `TEXT` is not a standard type of SQL, many database systems implement it.

| Database | Corresponding type | Length limitation|
| --- | --- | --- |
|SQLite| [TEXT](https://github.com/sqlalchemy/sqlalchemy/blob/2ce1f1d9a8011a4673428850f01b04196e070957/lib/sqlalchemy/dialects/sqlite/base.py#L2166-L2167) | [SQLITE_MAX_LENGTH](https://www.sqlite.org/limits.html#max_length) |
|PostgreSQL| [text](https://github.com/sqlalchemy/sqlalchemy/blob/2ce1f1d9a8011a4673428850f01b04196e070957/lib/sqlalchemy/dialects/postgresql/base.py#L2042) | [unlimited](https://www.postgresqltutorial.com/postgresql-char-varchar-text/)|
|MySQL| [text](https://github.com/sqlalchemy/sqlalchemy/blob/2ce1f1d9a8011a4673428850f01b04196e070957/lib/sqlalchemy/dialects/mysql/base.py#L1375) | [2^16 + 2](https://dev.mysql.com/doc/refman/8.0/en/blob.html) bytes |
|SQL Server| [text](https://github.com/sqlalchemy/sqlalchemy/blob/2ce1f1d9a8011a4673428850f01b04196e070957/lib/sqlalchemy/dialects/mssql/base.py#L1344) | [2^31-1](https://docs.microsoft.com/en-us/sql/t-sql/data-types/ntext-text-and-image-transact-sql?view=sql-server-ver15) bytes |
|Oracle| [CLOB](https://github.com/sqlalchemy/sqlalchemy/blob/2ce1f1d9a8011a4673428850f01b04196e070957/lib/sqlalchemy/dialects/oracle/cx_oracle.py#L559-L561) | [128TB depending on database block size](https://docs.oracle.com/cd/B28359_01/server.111/b28318/datatype.htm)|

## Description of the changes

This PR replace `String` type with `Text` type.

### TODO

- [x] schema migration script for MySQL

### Example script


```python
import sys
import optuna


def objective(trial):
    trial.set_user_attr("a", "a" * 10000)
    trial.set_system_attr("b", "b" * 10000)
    trial.suggest_categorical("x", [i for i in range(10000)])
    return 1

study = optuna.create_study(storage=sys.argv[1])
study.set_user_attr("c", "c" * 10000)
study.set_system_attr("d", "d" * 10000)
study.optimize(objective, n_trials=1)
```

```console
$ MYSQL_HOST=localhost
$ docker run --name mysql -e MYSQL_ROOT_PASSWORD=test -p 3306:3306 -p 33060:33060 -d mysql:8
$ docker run --network host -it --rm mysql:8  mysql -h ${MYSQL_HOST} -uroot -ptest -e "create database test_optuna;"
$ python long-string.py mysql+pymysql://root:test@${MYSQL_HOST}:3306/test_optuna
```

**Output**

`master`

```console
$ python long-string.py mysql+pymysql://root:test@${MYSQL_HOST}:3306/test_optuna
sqlalchemy.exc.DataError: (pymysql.err.DataError) (1406, "Data too long for column 'value_json' at row 1")
[SQL: INSERT INTO study_user_attributes (study_id, `key`, value_json) VALUES (%(study_id)s, %(key)s, %(value_json)s)]
[parameters: {'study_id': 1, 'key': 'c', 'value_json': '"cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc ... (9704 characters truncated) ... cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"'}]
(Background on this error at: http://sqlalche.me/e/13/9h9h)
```

This PR
```console
$ python long-string.py mysql+pymysql://root:test@${MYSQL_HOST}:3306/test_optuna
[I 2021-02-26 14:48:12,410] A new study created in RDB with name: no-name-18194847-bf32-4258-b6f3-65919c2fefaa
[I 2021-02-26 14:48:12,563] Trial 0 finished with value: 1.0 and parameters: {'x': 8993}. Best is trial 0 with value: 1.0.
```
