### PR TITLE
fix outdated docstring of TFKerasPruningCallback

### DIFF
--- a/optuna/integration/tfkeras.py
+++ b/optuna/integration/tfkeras.py
@@ -16,7 +16,7 @@ if not _imports.is_successful():
 class TFKerasPruningCallback(Callback):
     """tf.keras callback to prune unpromising trials.
 
-    This callback is intend to be compatible for TensorFlow v2 and v1,
+    This callback is intend to be compatible for TensorFlow v1 and v2,
     but only tested with TensorFlow v2.
 
     See `the example <https://github.com/optuna/optuna/blob/master/

--- a/optuna/integration/tfkeras.py
+++ b/optuna/integration/tfkeras.py
@@ -16,8 +16,8 @@ if not _imports.is_successful():
 class TFKerasPruningCallback(Callback):
     """tf.keras callback to prune unpromising trials.
 
-    This callback is intend to be compatible for TensorFlow v1 and v2,
-    but only tested with TensorFlow v1.
+    This callback is intend to be compatible for TensorFlow v2 and v1,
+    but only tested with TensorFlow v2.
 
     See `the example <https://github.com/optuna/optuna/blob/master/
     examples/tfkeras/tfkeras_integration.py>`__


### PR DESCRIPTION
## Description of the changes

Currently, Optuna is tested with TensorFlow v2 and the statement `This callback is intend to be compatible for TensorFlow v1 and v2, but only tested with TensorFlow v1.` is outdated as mentioned here: https://github.com/optuna/optuna/issues/1936#issuecomment-710783063.

The packages used for test are below:
https://github.com/optuna/optuna/blob/ddc4af84e6eabce18f9dabdaee49fd4f1db28c3e/setup.py#L126-L146

When the version of TensorFlow is not specified, TensorFlow v2 is used.