### PR TITLE
Fix - remove args of python2 super().__init__

### DIFF
--- a/examples/catalyst_simple.py
+++ b/examples/catalyst_simple.py
@@ -30,7 +30,7 @@ CLASSES = 10
 
 class Net(nn.Module):
     def __init__(self, trial):
-        super(Net, self).__init__()
+        super().__init__()
         self.layers = []
         self.dropouts = []
 

--- a/examples/pytorch/pytorch_ignite_simple.py
+++ b/examples/pytorch/pytorch_ignite_simple.py
@@ -42,7 +42,7 @@ N_VALID_EXAMPLES = 1000
 class Net(nn.Module):
     def __init__(self, trial):
         # We optimize dropout rate in a convolutional neural network.
-        super(Net, self).__init__()
+        super().__init__()
         self.conv1 = nn.Conv2d(1, 10, kernel_size=5)
         self.conv2 = nn.Conv2d(10, 20, kernel_size=5)
         dropout_rate = trial.suggest_float("dropout_rate", 0, 1)

--- a/examples/pytorch/pytorch_lightning_simple.py
+++ b/examples/pytorch/pytorch_lightning_simple.py
@@ -42,7 +42,7 @@ DIR = os.getcwd()
 
 class Net(nn.Module):
     def __init__(self, dropout: float, output_dims: List[int]):
-        super(Net, self).__init__()
+        super().__init__()
         layers: List[nn.Module] = []
 
         input_dim: int = 28 * 28
@@ -63,7 +63,7 @@ class Net(nn.Module):
 
 class LightningNet(pl.LightningModule):
     def __init__(self, dropout: float, output_dims: List[int]):
-        super(LightningNet, self).__init__()
+        super().__init__()
         self.model = Net(dropout, output_dims)
 
     def forward(self, data: torch.Tensor) -> torch.Tensor:

--- a/optuna/__init__.py
+++ b/optuna/__init__.py
@@ -68,7 +68,7 @@ class _LazyImport(types.ModuleType):
     """
 
     def __init__(self, name: str) -> None:
-        super(_LazyImport, self).__init__(name)
+        super().__init__(name)
         self._name = name
 
     def _load(self) -> types.ModuleType:

--- a/optuna/cli.py
+++ b/optuna/cli.py
@@ -39,7 +39,7 @@ def _check_storage_url(storage_url: Optional[str]) -> str:
 class _BaseCommand(Command):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
 
-        super(_BaseCommand, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.logger = optuna.logging.get_logger(__name__)
 
 
@@ -350,7 +350,7 @@ class _StorageUpgrade(_BaseCommand):
 class _OptunaApp(App):
     def __init__(self) -> None:
 
-        super(_OptunaApp, self).__init__(
+        super().__init__(
             description="",
             version=optuna.__version__,
             command_manager=CommandManager("optuna.command"),

--- a/optuna/integration/_lightgbm_tuner/optimize.py
+++ b/optuna/integration/_lightgbm_tuner/optimize.py
@@ -294,7 +294,7 @@ class _OptunaObjectiveCV(_OptunaObjective):
         pbar: Optional[tqdm.tqdm] = None,
     ):
 
-        super(_OptunaObjectiveCV, self).__init__(
+        super().__init__(
             target_param_names,
             lgbm_params,
             train_set,
@@ -803,7 +803,7 @@ class LightGBMTuner(_LightGBMBaseTuner):
         show_progress_bar: bool = True,
     ) -> None:
 
-        super(LightGBMTuner, self).__init__(
+        super().__init__(
             params,
             train_set,
             num_boost_round=num_boost_round,
@@ -961,7 +961,7 @@ class LightGBMTunerCV(_LightGBMBaseTuner):
         return_cvbooster: Optional[bool] = None,
     ) -> None:
 
-        super(LightGBMTunerCV, self).__init__(
+        super().__init__(
             params,
             train_set,
             num_boost_round,

--- a/optuna/integration/_lightgbm_tuner/sklearn.py
+++ b/optuna/integration/_lightgbm_tuner/sklearn.py
@@ -16,7 +16,7 @@ class LGBMModel(lgb.LGBMModel):
             "LightGBMTuner doesn't support sklearn API. "
             "Use `train()` or `LightGBMTuner` for hyperparameter tuning."
         )
-        super(LGBMModel, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
 
 class LGBMClassifier(lgb.LGBMClassifier):
@@ -31,7 +31,7 @@ class LGBMClassifier(lgb.LGBMClassifier):
             "LightGBMTuner doesn't support sklearn API. "
             "Use `train()` or `LightGBMTuner` for hyperparameter tuning."
         )
-        super(LGBMClassifier, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
 
 class LGBMRegressor(lgb.LGBMRegressor):
@@ -46,4 +46,4 @@ class LGBMRegressor(lgb.LGBMRegressor):
             "LightGBMTuner doesn't support sklearn API. "
             "Use `train()` or `LightGBMTuner` for hyperparameter tuning."
         )
-        super(LGBMRegressor, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)

--- a/optuna/integration/catalyst.py
+++ b/optuna/integration/catalyst.py
@@ -35,7 +35,7 @@ class CatalystPruningCallback(Callback):
         # set order=1000 to run pruning callback after other callbacks
         # refer to `catalyst.core.CallbackOrder`
         _imports.check()
-        super(CatalystPruningCallback, self).__init__(order=1000)
+        super().__init__(order=1000)
 
         self._trial = trial
         self.metric = metric

--- a/optuna/integration/cma.py
+++ b/optuna/integration/cma.py
@@ -485,7 +485,7 @@ class CmaEsSampler(PyCmaSampler):
         warn_independent_sampling: bool = True,
     ) -> None:
 
-        super(CmaEsSampler, self).__init__(
+        super().__init__(
             x0=x0,
             sigma0=sigma0,
             cma_stds=cma_stds,

--- a/optuna/integration/fastaiv1.py
+++ b/optuna/integration/fastaiv1.py
@@ -63,7 +63,7 @@ class FastAIV1PruningCallback(TrackerCallback):
 
     def __init__(self, learn: "Learner", trial: optuna.trial.Trial, monitor: str) -> None:
 
-        super(FastAIV1PruningCallback, self).__init__(learn, monitor)
+        super().__init__(learn, monitor)
 
         _imports.check()
 

--- a/optuna/integration/fastaiv2.py
+++ b/optuna/integration/fastaiv2.py
@@ -59,7 +59,7 @@ class FastAIV2PruningCallback(TrackerCallback):
     # when to run (after the Recorder callback), when not to (like with lr_find), etc.
 
     def __init__(self, trial: optuna.Trial, monitor: str = "valid_loss"):
-        super(FastAIV2PruningCallback, self).__init__(monitor=monitor)
+        super().__init__(monitor=monitor)
         _imports.check()
         self.trial = trial
 

--- a/optuna/integration/keras.py
+++ b/optuna/integration/keras.py
@@ -44,7 +44,7 @@ class KerasPruningCallback(Callback):
     """
 
     def __init__(self, trial: optuna.trial.Trial, monitor: str, interval: int = 1) -> None:
-        super(KerasPruningCallback, self).__init__()
+        super().__init__()
 
         _imports.check()
 

--- a/optuna/integration/pytorch_lightning.py
+++ b/optuna/integration/pytorch_lightning.py
@@ -33,7 +33,7 @@ class PyTorchLightningPruningCallback(Callback):
 
     def __init__(self, trial: optuna.trial.Trial, monitor: str) -> None:
         _imports.check()
-        super(PyTorchLightningPruningCallback, self).__init__()
+        super().__init__()
 
         self._trial = trial
         self.monitor = monitor

--- a/optuna/integration/tfkeras.py
+++ b/optuna/integration/tfkeras.py
@@ -33,7 +33,7 @@ class TFKerasPruningCallback(Callback):
 
     def __init__(self, trial: optuna.trial.Trial, monitor: str) -> None:
 
-        super(TFKerasPruningCallback, self).__init__()
+        super().__init__()
 
         _imports.check()
 

--- a/optuna/pruners/_median.py
+++ b/optuna/pruners/_median.py
@@ -66,4 +66,4 @@ class MedianPruner(PercentilePruner):
         self, n_startup_trials: int = 5, n_warmup_steps: int = 0, interval_steps: int = 1
     ) -> None:
 
-        super(MedianPruner, self).__init__(50.0, n_startup_trials, n_warmup_steps, interval_steps)
+        super().__init__(50.0, n_startup_trials, n_warmup_steps, interval_steps)

--- a/optuna/study.py
+++ b/optuna/study.py
@@ -229,7 +229,7 @@ class Study(BaseStudy):
         self.study_name = study_name
         storage = storages.get_storage(storage)
         study_id = storage.get_study_id_from_name(study_name)
-        super(Study, self).__init__(study_id, storage)
+        super().__init__(study_id, storage)
 
         self.sampler = sampler or samplers.TPESampler()
         self.pruner = pruner or pruners.MedianPruner()

--- a/tests/integration_tests/test_chainermn.py
+++ b/tests/integration_tests/test_chainermn.py
@@ -62,7 +62,7 @@ class Func(object):
 class MultiNodeStorageSupplier(StorageSupplier):
     def __init__(self, storage_specifier: str, comm: CommunicatorBase) -> None:
 
-        super(MultiNodeStorageSupplier, self).__init__(storage_specifier)
+        super().__init__(storage_specifier)
         self.comm = comm
         self.storage: Optional[RDBStorage] = None
 

--- a/tests/integration_tests/test_pytorch_lightning.py
+++ b/tests/integration_tests/test_pytorch_lightning.py
@@ -15,7 +15,7 @@ from optuna.testing.integration import DeterministicPruner
 class Model(pl.LightningModule):
     def __init__(self) -> None:
 
-        super(Model, self).__init__()
+        super().__init__()
         self._model = nn.Sequential(nn.Linear(4, 8))
 
     def forward(self, data: torch.Tensor) -> torch.Tensor:

--- a/tests/integration_tests/test_skorch.py
+++ b/tests/integration_tests/test_skorch.py
@@ -11,7 +11,7 @@ from optuna.testing.integration import DeterministicPruner
 
 class ClassifierModule(nn.Module):
     def __init__(self) -> None:
-        super(ClassifierModule, self).__init__()
+        super().__init__()
         self.dense0 = nn.Linear(4, 8)
 
     def forward(self, X: torch.Tensor, **kwargs: Any) -> torch.Tensor:


### PR DESCRIPTION
## Motivation
This PR is going to change arguments for python2-like super() `super(type, object or type).__init__(*args)` to `super().__init__(*args)` for better readability.