### PR TITLE
filtered `ExperimentalWarning` 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,3 +26,7 @@ lines_after_imports = 2
 force_single_line = 'True'
 force_sort_within_sections = 'True'
 order_by_type = 'False'
+
+[tool.pytest.ini_options]
+addopts = "--color=yes"
+filterwarnings = 'ignore::optuna.exceptions.ExperimentalWarning'

--- a/tests/study_tests/test_study.py
+++ b/tests/study_tests/test_study.py
@@ -461,7 +461,6 @@ def test_stop_outside_optimize() -> None:
     study.optimize(lambda _: 1.0, n_trials=1)
 
 
-@pytest.mark.filterwarnings("ignore::optuna.exceptions.ExperimentalWarning")
 @pytest.mark.parametrize("storage_mode", STORAGE_MODES)
 def test_add_trial(storage_mode: str) -> None:
 
@@ -476,7 +475,6 @@ def test_add_trial(storage_mode: str) -> None:
         assert study.best_value == 0.8
 
 
-@pytest.mark.filterwarnings("ignore::optuna.exceptions.ExperimentalWarning")
 @pytest.mark.parametrize("storage_mode", STORAGE_MODES)
 def test_add_trials(storage_mode: str) -> None:
 
@@ -502,7 +500,6 @@ def test_add_trials(storage_mode: str) -> None:
             assert trial.value == i
 
 
-@pytest.mark.filterwarnings("ignore::optuna.exceptions.ExperimentalWarning")
 @pytest.mark.parametrize("storage_mode", STORAGE_MODES)
 def test_enqueue_trial_properly_sets_param_values(storage_mode: str) -> None:
 
@@ -529,7 +526,6 @@ def test_enqueue_trial_properly_sets_param_values(storage_mode: str) -> None:
         assert t1.params["y"] == 0
 
 
-@pytest.mark.filterwarnings("ignore::optuna.exceptions.ExperimentalWarning")
 @pytest.mark.parametrize("storage_mode", STORAGE_MODES)
 def test_enqueue_trial_with_unfixed_parameters(storage_mode: str) -> None:
 
@@ -551,7 +547,6 @@ def test_enqueue_trial_with_unfixed_parameters(storage_mode: str) -> None:
         assert -10 <= t.params["y"] <= 10
 
 
-@pytest.mark.filterwarnings("ignore::optuna.exceptions.ExperimentalWarning")
 @pytest.mark.parametrize("storage_mode", STORAGE_MODES)
 def test_enqueue_trial_with_out_of_range_parameters(storage_mode: str) -> None:
 
@@ -819,7 +814,6 @@ def test_optimize_with_multi_objectives(n_objectives: int) -> None:
         assert len(trial.values) == n_objectives
 
 
-@pytest.mark.filterwarnings("ignore::optuna.exceptions.ExperimentalWarning")
 def test_pareto_front() -> None:
     def _trial_to_values(t: FrozenTrial) -> Tuple[float, ...]:
         assert t.values is not None
@@ -860,7 +854,6 @@ def test_wrong_n_objectives() -> None:
         assert trial.state is TrialState.FAIL
 
 
-@pytest.mark.filterwarnings("ignore::optuna.exceptions.ExperimentalWarning")
 def test_ask() -> None:
     study = create_study()
 
@@ -868,7 +861,6 @@ def test_ask() -> None:
     assert isinstance(trial, Trial)
 
 
-@pytest.mark.filterwarnings("ignore::optuna.exceptions.ExperimentalWarning")
 def test_ask_enqueue_trial() -> None:
     study = create_study()
 
@@ -930,10 +922,9 @@ def test_tell_trial_variations() -> None:
         study.tell(study.ask().number + 1, 1.0)
 
     with pytest.raises(TypeError):
-        study.tell("1", 1.0)  # type: ignore::optuna.exceptions.ExperimentalWarning
+        study.tell("1", 1.0)  # type: ignore
 
 
-@pytest.mark.filterwarnings("ignore::optuna.exceptions.ExperimentalWarning")
 def test_tell_duplicate_tell() -> None:
     study = create_study()
 
@@ -953,7 +944,7 @@ def test_tell_values() -> None:
 
     # Check invalid values, e.g. ones that cannot be cast to float.
     with pytest.raises(ValueError):
-        study.tell(study.ask(), "a")  # type: ignore::optuna.exceptions.ExperimentalWarning
+        study.tell(study.ask(), "a")  # type: ignore
 
     # Check number of values.
     with pytest.raises(ValueError):
@@ -1021,7 +1012,6 @@ def test_tell_pruned_values() -> None:
     assert study.trials[-1].value is None
 
 
-@pytest.mark.filterwarnings("ignore::optuna.exceptions.ExperimentalWarning")
 @pytest.mark.parametrize("storage_mode", STORAGE_MODES)
 def test_enqueued_trial_datetime_start(storage_mode: str) -> None:
 
@@ -1040,7 +1030,6 @@ def test_enqueued_trial_datetime_start(storage_mode: str) -> None:
         assert study.trials[0].datetime_start is not None
 
 
-@pytest.mark.filterwarnings("ignore::optuna.exceptions.ExperimentalWarning")
 @pytest.mark.parametrize("storage_mode", STORAGE_MODES)
 def test_study_summary_datetime_start_calculation(storage_mode: str) -> None:
 

--- a/tests/study_tests/test_study.py
+++ b/tests/study_tests/test_study.py
@@ -461,6 +461,7 @@ def test_stop_outside_optimize() -> None:
     study.optimize(lambda _: 1.0, n_trials=1)
 
 
+@pytest.mark.filterwarnings("ignore::optuna.exceptions.ExperimentalWarning")
 @pytest.mark.parametrize("storage_mode", STORAGE_MODES)
 def test_add_trial(storage_mode: str) -> None:
 
@@ -475,6 +476,7 @@ def test_add_trial(storage_mode: str) -> None:
         assert study.best_value == 0.8
 
 
+@pytest.mark.filterwarnings("ignore::optuna.exceptions.ExperimentalWarning")
 @pytest.mark.parametrize("storage_mode", STORAGE_MODES)
 def test_add_trials(storage_mode: str) -> None:
 
@@ -500,6 +502,7 @@ def test_add_trials(storage_mode: str) -> None:
             assert trial.value == i
 
 
+@pytest.mark.filterwarnings("ignore::optuna.exceptions.ExperimentalWarning")
 @pytest.mark.parametrize("storage_mode", STORAGE_MODES)
 def test_enqueue_trial_properly_sets_param_values(storage_mode: str) -> None:
 
@@ -526,6 +529,7 @@ def test_enqueue_trial_properly_sets_param_values(storage_mode: str) -> None:
         assert t1.params["y"] == 0
 
 
+@pytest.mark.filterwarnings("ignore::optuna.exceptions.ExperimentalWarning")
 @pytest.mark.parametrize("storage_mode", STORAGE_MODES)
 def test_enqueue_trial_with_unfixed_parameters(storage_mode: str) -> None:
 
@@ -547,6 +551,7 @@ def test_enqueue_trial_with_unfixed_parameters(storage_mode: str) -> None:
         assert -10 <= t.params["y"] <= 10
 
 
+@pytest.mark.filterwarnings("ignore::optuna.exceptions.ExperimentalWarning")
 @pytest.mark.parametrize("storage_mode", STORAGE_MODES)
 def test_enqueue_trial_with_out_of_range_parameters(storage_mode: str) -> None:
 
@@ -814,6 +819,7 @@ def test_optimize_with_multi_objectives(n_objectives: int) -> None:
         assert len(trial.values) == n_objectives
 
 
+@pytest.mark.filterwarnings("ignore::optuna.exceptions.ExperimentalWarning")
 def test_pareto_front() -> None:
     def _trial_to_values(t: FrozenTrial) -> Tuple[float, ...]:
         assert t.values is not None
@@ -854,6 +860,7 @@ def test_wrong_n_objectives() -> None:
         assert trial.state is TrialState.FAIL
 
 
+@pytest.mark.filterwarnings("ignore::optuna.exceptions.ExperimentalWarning")
 def test_ask() -> None:
     study = create_study()
 
@@ -861,6 +868,7 @@ def test_ask() -> None:
     assert isinstance(trial, Trial)
 
 
+@pytest.mark.filterwarnings("ignore::optuna.exceptions.ExperimentalWarning")
 def test_ask_enqueue_trial() -> None:
     study = create_study()
 
@@ -922,9 +930,10 @@ def test_tell_trial_variations() -> None:
         study.tell(study.ask().number + 1, 1.0)
 
     with pytest.raises(TypeError):
-        study.tell("1", 1.0)  # type: ignore
+        study.tell("1", 1.0)  # type: ignore::optuna.exceptions.ExperimentalWarning
 
 
+@pytest.mark.filterwarnings("ignore::optuna.exceptions.ExperimentalWarning")
 def test_tell_duplicate_tell() -> None:
     study = create_study()
 
@@ -944,7 +953,7 @@ def test_tell_values() -> None:
 
     # Check invalid values, e.g. ones that cannot be cast to float.
     with pytest.raises(ValueError):
-        study.tell(study.ask(), "a")  # type: ignore
+        study.tell(study.ask(), "a")  # type: ignore::optuna.exceptions.ExperimentalWarning
 
     # Check number of values.
     with pytest.raises(ValueError):
@@ -1012,6 +1021,7 @@ def test_tell_pruned_values() -> None:
     assert study.trials[-1].value is None
 
 
+@pytest.mark.filterwarnings("ignore::optuna.exceptions.ExperimentalWarning")
 @pytest.mark.parametrize("storage_mode", STORAGE_MODES)
 def test_enqueued_trial_datetime_start(storage_mode: str) -> None:
 
@@ -1030,6 +1040,7 @@ def test_enqueued_trial_datetime_start(storage_mode: str) -> None:
         assert study.trials[0].datetime_start is not None
 
 
+@pytest.mark.filterwarnings("ignore::optuna.exceptions.ExperimentalWarning")
 @pytest.mark.parametrize("storage_mode", STORAGE_MODES)
 def test_study_summary_datetime_start_calculation(storage_mode: str) -> None:
 


### PR DESCRIPTION
## Motivation
Reduce unnecessary warnings that appear when you run pytest, making it easier to find errrors and warnings that really need improvement

## Description of the changes
Prevent `Experimental Warning` from appearing when you run pytest.