### PR TITLE
Change caching implementation of MOTPE

### DIFF
--- a/optuna/samplers/_tpe/multi_objective_sampler.py
+++ b/optuna/samplers/_tpe/multi_objective_sampler.py
@@ -293,9 +293,9 @@ class MOTPESampler(TPESampler):
             self._split_cache[trial._trial_id] = attrs
 
         below = cvals[indices_below]
-        self._weights_below[trial._trial_id] = np.asarray([
-            w for w, v in zip(weights_below, below) if v is not None
-        ], dtype=float)
+        self._weights_below[trial._trial_id] = np.asarray(
+            [w for w, v in zip(weights_below, below) if v is not None], dtype=float
+        )
         below = np.asarray([v for v in below if v is not None], dtype=float)
         above = cvals[indices_above]
         above = np.asarray([v for v in above if v is not None], dtype=float)
@@ -397,9 +397,8 @@ class MOTPESampler(TPESampler):
 
         size = (self._n_ehvi_candidates,)
 
-        array_weights_below = np.asarray(self._weights_below[trial._trial_id], dtype=float)
         weights_below: Callable[[int], np.ndarray]
-        weights_below = lambda _: array_weights_below  # NOQA
+        weights_below = lambda _: self._weights_below[trial._trial_id]  # NOQA
 
         parzen_estimator_parameters_below = _ParzenEstimatorParameters(
             self._parzen_estimator_parameters.consider_prior,

--- a/optuna/samplers/_tpe/multi_objective_sampler.py
+++ b/optuna/samplers/_tpe/multi_objective_sampler.py
@@ -225,19 +225,6 @@ class MOTPESampler(TPESampler):
                 )
             )
 
-    def after_trial(
-        self,
-        study: optuna.study.Study,
-        trial: optuna.trial.FrozenTrial,
-        state: optuna.trial.TrialState,
-        values: Optional[Sequence[float]],
-    ) -> None:
-        if trial._trial_id in self._split_cache:
-            del self._split_cache[trial._trial_id]
-        if trial._trial_id in self._weights_below:
-            del self._weights_below[trial._trial_id]
-        self._mo_random_sampler.after_trial(study, trial, state, values)
-
     def _split_mo_observation_pairs(
         self,
         study: optuna.study.Study,
@@ -581,6 +568,10 @@ class MOTPESampler(TPESampler):
         state: optuna.trial.TrialState,
         values: Optional[Sequence[float]],
     ) -> None:
+        if trial._trial_id in self._split_cache:
+            del self._split_cache[trial._trial_id]
+        if trial._trial_id in self._weights_below:
+            del self._weights_below[trial._trial_id]
 
         self._mo_random_sampler.after_trial(study, trial, state, values)
 

--- a/optuna/samplers/_tpe/multi_objective_sampler.py
+++ b/optuna/samplers/_tpe/multi_objective_sampler.py
@@ -241,6 +241,7 @@ class MOTPESampler(TPESampler):
         with self._weights_below_lock:
             if trial._trial_id in self._weights_below:
                 del self._weights_below[trial._trial_id]
+        self._mo_random_sampler.after_trial(study, trial, state, values)
 
     def _split_mo_observation_pairs(
         self,
@@ -421,7 +422,7 @@ class MOTPESampler(TPESampler):
         with self._weights_below_lock:
             array_weights_below = np.asarray(self._weights_below[trial._trial_id], dtype=float)
         weights_below: Callable[[int], np.ndarray]
-        weights_below = lambda _: np.asarray(array_weights_below)  # NOQA
+        weights_below = lambda _: array_weights_below  # NOQA
 
         parzen_estimator_parameters_below = _ParzenEstimatorParameters(
             self._parzen_estimator_parameters.consider_prior,

--- a/optuna/samplers/_tpe/multi_objective_sampler.py
+++ b/optuna/samplers/_tpe/multi_objective_sampler.py
@@ -293,9 +293,9 @@ class MOTPESampler(TPESampler):
             self._split_cache[trial._trial_id] = attrs
 
         below = cvals[indices_below]
-        self._weights_below[trial._trial_id] = [
+        self._weights_below[trial._trial_id] = np.asarray([
             w for w, v in zip(weights_below, below) if v is not None
-        ]
+        ], dtype=float)
         below = np.asarray([v for v in below if v is not None], dtype=float)
         above = cvals[indices_above]
         above = np.asarray([v for v in above if v is not None], dtype=float)


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
This PR fixes issue #2331.

## Description of the changes
This PR changes the caching implementation of MOTPE.

Previously, MOTPE uses `trial.system_attrs` to cache its internal parameters. This causes `optuna.exceptions.StorageInternalError` after hundreds of iterations because of exceeding max length when the cache becomes large.

Now, MOTPE uses its member variables to cache its internal parameters and this fixes the issue mentioned above.
