### PR TITLE
Use CPU device in multi-objective optimization tutorial.

### DIFF
--- a/tutorial/20_recipes/002_multi_objective.py
+++ b/tutorial/20_recipes/002_multi_objective.py
@@ -19,7 +19,7 @@ import torchvision
 import optuna
 
 
-DEVICE = torch.device("cuda") if torch.cuda.is_available() else torch.device("cpu")
+DEVICE = torch.device("cpu")
 DIR = ".."
 BATCHSIZE = 128
 N_TRAIN_EXAMPLES = BATCHSIZE * 30


### PR DESCRIPTION
## Motivation

Recently, the document jobs in CircleCI fail due to the CUDA device errors. This may be because of `torch.cuda.is_available()` returns `True` even if actual device is not available.

https://app.circleci.com/pipelines/github/optuna/optuna/4634/workflows/63937e62-d2d1-46a9-8cc2-2bb09c139e1e/jobs/66186

```console
[I 2021-02-17 08:29:13,350] A new study created in memory with name: no-name-32f5bfc2-7f83-4020-8f9e-b2ad4c652222
terminate called after throwing an instance of 'c10::Error'
  what():  HIP error: hipErrorNoDevice
Exception raised from deviceCount at /pytorch/aten/src/ATen/hip/impl/HIPGuardImplMasqueradingAsCUDA.h:98 (most recent call first):
frame #0: c10::Error::Error(c10::SourceLocation, std::string) + 0x42 (0x7f08b7302d12 in /home/docs/project/venv/lib/python3.8/site-packages/torch/lib/libc10.so)
frame #1: <unknown function> + 0x57d4f1 (0x7f08b7cfb4f1 in /home/docs/project/venv/lib/python3.8/site-packages/torch/lib/libtorch_hip.so)
frame #2: torch::autograd::Engine::start_device_threads() + 0x442 (0x7f08e938e252 in /home/docs/project/venv/lib/python3.8/site-packages/torch/lib/libtorch_cpu.so)
frame #3: <unknown function> + 0xf827 (0x7f0932166827 in /lib/x86_64-linux-gnu/libpthread.so.0)
```

## Description of the changes

This PR simply fixes the device to CPU.
I'm not sure if we can add TODO comment to revert the change after resolving CircleCI issue without showing the message to users.