### PR TITLE
Support AllenNLP v2

### DIFF
--- a/examples/allennlp/allennlp_jsonnet.py
+++ b/examples/allennlp/allennlp_jsonnet.py
@@ -44,7 +44,8 @@ def objective(trial):
 if __name__ == "__main__":
     if version.parse(allennlp.__version__) < version.parse("2.0.0"):
         raise RuntimeError(
-            "If you want to use `allennlp<2.0.0`, please install `optuna==2.5.0`"
+            "`allennlp>=2.0.0` is required for this example."
+            " If you want to use `allennlp<2.0.0`, please install `optuna==2.5.0`"
             " and refer to the following example:"
             " https://github.com/optuna/optuna/blob/v2.5.0/examples/allennlp/allennlp_jsonnet.py"
         )

--- a/examples/allennlp/allennlp_jsonnet.py
+++ b/examples/allennlp/allennlp_jsonnet.py
@@ -42,8 +42,12 @@ def objective(trial):
 
 
 if __name__ == "__main__":
-    if version.parse(allennlp.__version__) < version.parse("1.0.0"):
-        raise RuntimeError("AllenNLP>=1.0.0 is required for this example.")
+    if version.parse(allennlp.__version__) < version.parse("2.0.0"):
+        raise RuntimeError(
+            "If you want to use `allennlp<2.0.0`, please install `optuna==2.5.0`"
+            " and refer to the following example:"
+            " https://github.com/optuna/optuna/blob/v2.5.0/examples/allennlp/allennlp_jsonnet.py"
+        )
 
     study = optuna.create_study(
         direction="maximize",

--- a/examples/allennlp/allennlp_simple.py
+++ b/examples/allennlp/allennlp_simple.py
@@ -114,6 +114,7 @@ def objective(trial):
     metrics = trainer.train()
     return metrics["best_validation_" + TARGET_METRIC]
 
+
 if __name__ == "__main__":
     random.seed(41)
     torch.manual_seed(41)

--- a/examples/allennlp/allennlp_simple.py
+++ b/examples/allennlp/allennlp_simple.py
@@ -17,6 +17,7 @@ import allennlp.data
 import allennlp.models
 import allennlp.modules
 import numpy
+from packaging import version
 import torch
 
 import optuna
@@ -116,6 +117,9 @@ def objective(trial):
 
 
 if __name__ == "__main__":
+    if version.parse(allennlp.__version__) < version.parse("2.0.0"):
+        raise RuntimeError("AllenNLP>=2.0.0 is required for this example.")
+
     random.seed(41)
     torch.manual_seed(41)
     numpy.random.seed(41)

--- a/examples/allennlp/allennlp_simple.py
+++ b/examples/allennlp/allennlp_simple.py
@@ -118,7 +118,11 @@ def objective(trial):
 
 if __name__ == "__main__":
     if version.parse(allennlp.__version__) < version.parse("2.0.0"):
-        raise RuntimeError("AllenNLP>=2.0.0 is required for this example.")
+        raise RuntimeError(
+            "If you want to use `allennlp<2.0.0`, please install `optuna==2.5.0`"
+            " and refer to the following example:"
+            " https://github.com/optuna/optuna/blob/v2.5.0/examples/allennlp/allennlp_simple.py"
+        )
 
     random.seed(41)
     torch.manual_seed(41)

--- a/examples/allennlp/allennlp_simple.py
+++ b/examples/allennlp/allennlp_simple.py
@@ -119,7 +119,8 @@ def objective(trial):
 if __name__ == "__main__":
     if version.parse(allennlp.__version__) < version.parse("2.0.0"):
         raise RuntimeError(
-            "If you want to use `allennlp<2.0.0`, please install `optuna==2.5.0`"
+            "`allennlp>=2.0.0` is required for this example."
+            " If you want to use `allennlp<2.0.0`, please install `optuna==2.5.0`"
             " and refer to the following example:"
             " https://github.com/optuna/optuna/blob/v2.5.0/examples/allennlp/allennlp_simple.py"
         )

--- a/examples/allennlp/classifier.jsonnet
+++ b/examples/allennlp/classifier.jsonnet
@@ -28,7 +28,6 @@ local ENCODER = CNN_FIELDS(
   pytorch_seed: 42,
   random_seed: 42,
   dataset_reader: {
-    lazy: false,
     type: 'text_classification_json',
     tokenizer: {
       type: 'spacy',
@@ -68,7 +67,7 @@ local ENCODER = CNN_FIELDS(
     },
     patience: 2,
     validation_metric: '+accuracy',
-    epoch_callbacks: [
+    callbacks: [
       {
         type: 'optuna_pruner',
       },

--- a/optuna/integration/allennlp.py
+++ b/optuna/integration/allennlp.py
@@ -7,6 +7,8 @@ from typing import List
 from typing import Optional
 from typing import Union
 
+from packaging import version
+
 import optuna
 from optuna import load_study
 from optuna import Trial
@@ -413,6 +415,13 @@ class AllenNLPPruningCallback(TrainerCallback):
         monitor: Optional[str] = None,
     ):
         _imports.check()
+
+        if version.parse(allennlp.__version__) < version.parse("2.0.0"):
+            raise ImportError(
+                "`AllenNLPPruningCallback` requires AllenNLP>=v2.0.0."
+                "If you want to use a callback with an old version of AllenNLP, "
+                "please install Optuna v2.5.0 by executing `pip install 'optuna==2.5.0'`."
+            )
 
         # When `AllenNLPPruningCallback` is instantiated in Python script,
         # trial and monitor should not be `None`.

--- a/optuna/integration/allennlp.py
+++ b/optuna/integration/allennlp.py
@@ -383,7 +383,7 @@ class AllenNLPPruningCallback(TrainerCallback):
 
     See `the example <https://github.com/optuna/optuna/blob/master/
     examples/allennlp/allennlp_simple.py>`__
-    if you want to add a proning callback which observes a metric.
+    if you want to add a pruning callback which observes a metric.
 
     You can also see the tutorial of our AllenNLP integration on
     `AllenNLP Guide <https://guide.allennlp.org/hyperparameter-optimization>`_.

--- a/optuna/integration/allennlp.py
+++ b/optuna/integration/allennlp.py
@@ -357,13 +357,8 @@ class AllenNLPExecutor(object):
 
     def run(self) -> float:
         """Train a model using AllenNLP."""
-        try:
-            import_func = allennlp.common.util.import_submodules  # type: ignore
-        except AttributeError:
-            import_func = allennlp.common.util.import_module_and_submodules
-
         for package_name in self._include_package:
-            import_func(package_name)
+            allennlp.common.util.import_module_and_submodules(package_name)
 
         self._set_environment_variables()
         params = allennlp.common.params.Params(self._build_params())
@@ -417,9 +412,6 @@ class AllenNLPPruningCallback(EpochCallback):
         monitor: Optional[str] = None,
     ):
         _imports.check()
-
-        if allennlp.__version__ < "1.0.0":
-            raise Exception("AllenNLPPruningCallback requires `allennlp`>=1.0.0.")
 
         # When `AllenNLPPruningCallback` is instantiated in Python script,
         # trial and monitor should not be `None`.

--- a/optuna/integration/allennlp.py
+++ b/optuna/integration/allennlp.py
@@ -455,13 +455,30 @@ class AllenNLPPruningCallback(TrainerCallback):
                 self._trial = Trial(study, int(trial_id))
                 self._monitor = monitor
 
-    def __call__(
+    def on_epoch(
         self,
         trainer: "allennlp.training.GradientDescentTrainer",
         metrics: Dict[str, Any],
         epoch: int,
-        is_master: bool,
+        is_primary: bool = True,
+        **kwargs,
     ) -> None:
+        """Check if a training reaches saturation.
+
+        Args:
+            trainer:
+                AllenNLP's trainer
+            metrics:
+                Dictionary of metrics.
+            epoch:
+                Number of current epoch.
+            is_primary:
+                A flag for AllenNLP internal.
+
+        """
+        if not is_primary:
+            return None
+
         value = metrics.get(self._monitor)
         if value is None:
             return

--- a/optuna/integration/allennlp.py
+++ b/optuna/integration/allennlp.py
@@ -19,21 +19,21 @@ with try_import() as _imports:
     import allennlp.commands
     import allennlp.common.util
 
-# EpochCallback is conditionally imported because allennlp may be unavailable in
+# TrainerCallback is conditionally imported because allennlp may be unavailable in
 # the environment that builds the documentation.
 if _imports.is_successful():
     import _jsonnet
-    from allennlp.training import EpochCallback
+    from allennlp.training import TrainerCallback
 else:
-    # I disable mypy here since `allennlp.training.EpochCallback` is a subclass of `Registrable`
-    # (https://docs.allennlp.org/master/api/training/trainer/#epochcallback) but `EpochCallback`
+    # I disable mypy here since `allennlp.training.TrainerCallback` is a subclass of `Registrable`
+    # (https://docs.allennlp.org/main/api/training/trainer/#trainercallback) but `TrainerCallback`
     # defined here is not `Registrable`, which causes a mypy checking failure.
-    class EpochCallback:  # type: ignore
-        """Stub for EpochCallback."""
+    class TrainerCallback:  # type: ignore
+        """Stub for TrainerCallback."""
 
         @classmethod
         def register(cls: Any, *args: Any, **kwargs: Any) -> Callable:
-            """Stub method for `EpochCallback.register`.
+            """Stub method for `TrainerCallback.register`.
 
             This method has the same signature as
             `Registrable.register <https://docs.allennlp.org/master/
@@ -205,18 +205,18 @@ def dump_best_config(input_config_file: str, output_config_file: str, study: opt
     # It removes when dumping configuration since
     # the result of `dump_best_config` can be passed to
     # `allennlp train`.
-    if "epoch_callbacks" in best_config["trainer"]:
-        new_epoch_callbacks = []
-        epoch_callbacks = best_config["trainer"]["epoch_callbacks"]
-        for callback in epoch_callbacks:
+    if "callbacks" in best_config["trainer"]:
+        new_callbacks = []
+        callbacks = best_config["trainer"]["callbacks"]
+        for callback in callbacks:
             if callback["type"] == "optuna_pruner":
                 continue
-            new_epoch_callbacks.append(callback)
+            new_callbacks.append(callback)
 
-        if len(new_epoch_callbacks) == 0:
-            best_config["trainer"].pop("epoch_callbacks")
+        if len(new_callbacks) == 0:
+            best_config["trainer"].pop("callbacks")
         else:
-            best_config["trainer"]["epoch_callbacks"] = new_epoch_callbacks
+            best_config["trainer"]["callbacks"] = new_callbacks
 
     with open(output_config_file, "w") as f:
         json.dump(best_config, f, indent=4)
@@ -374,8 +374,8 @@ class AllenNLPExecutor(object):
 
 
 @experimental("2.0.0")
-@EpochCallback.register("optuna_pruner")
-class AllenNLPPruningCallback(EpochCallback):
+@TrainerCallback.register("optuna_pruner")
+class AllenNLPPruningCallback(TrainerCallback):
     """AllenNLP callback to prune unpromising trials.
 
     See `the example <https://github.com/optuna/optuna/blob/master/

--- a/optuna/integration/allennlp.py
+++ b/optuna/integration/allennlp.py
@@ -23,6 +23,7 @@ with try_import() as _imports:
 # the environment that builds the documentation.
 if _imports.is_successful():
     import _jsonnet
+    from allennlp.training import GradientDescentTrainer
     from allennlp.training import TrainerCallback
 else:
     # I disable mypy here since `allennlp.training.TrainerCallback` is a subclass of `Registrable`
@@ -457,11 +458,11 @@ class AllenNLPPruningCallback(TrainerCallback):
 
     def on_epoch(
         self,
-        trainer: "allennlp.training.GradientDescentTrainer",
+        trainer: "GradientDescentTrainer",
         metrics: Dict[str, Any],
         epoch: int,
         is_primary: bool = True,
-        **kwargs,
+        **kwargs: Any,
     ) -> None:
         """Check if a training reaches saturation.
 

--- a/setup.py
+++ b/setup.py
@@ -109,7 +109,7 @@ def get_extras_require() -> Dict[str, List[str]]:
             "torchvision==0.8.2 ; sys_platform=='darwin'",
             "torchvision==0.8.2+cpu ; sys_platform!='darwin'",
             "torchaudio==0.7.2",
-            "allennlp<2.0.0",
+            "allennlp",
             "dask[dataframe]",
             "dask-ml",
             # TODO(crcrpar): Support botorch v0.4.0.
@@ -151,7 +151,7 @@ def get_extras_require() -> Dict[str, List[str]]:
             "torchvision==0.8.2 ; sys_platform=='darwin'",
             "torchvision==0.8.2+cpu ; sys_platform!='darwin'",
             "torchaudio==0.7.2",
-            "allennlp<2.0.0",
+            "allennlp",
             # TODO(crcrpar): Support botorch v0.4.0.
             # See: https://github.com/optuna/optuna/issues/2381
             "botorch<0.4.0 ; python_version>'3.6'",
@@ -191,7 +191,7 @@ def get_extras_require() -> Dict[str, List[str]]:
             "torchvision==0.8.2 ; sys_platform=='darwin'",
             "torchvision==0.8.2+cpu ; sys_platform!='darwin'",
             "torchaudio==0.7.2",
-            "allennlp<2.0.0",
+            "allennlp",
             # TODO(crcrpar): Support botorch v0.4.0.
             # See: https://github.com/optuna/optuna/issues/2381
             "botorch<0.4.0 ; python_version>'3.6'",

--- a/tests/integration_tests/allennlp_tests/example_with_executor_and_pruner.jsonnet
+++ b/tests/integration_tests/allennlp_tests/example_with_executor_and_pruner.jsonnet
@@ -57,7 +57,7 @@ local DROPOUT = std.parseJson(std.extVar('DROPOUT'));
     num_epochs: 1,
     patience: 10,
     cuda_device: -1,
-    epoch_callbacks: [
+    callbacks: [
       {
         type: 'optuna_pruner',
       }


### PR DESCRIPTION
## Motivation
This PR adds support for AllenNLP v2.x.
- It also drops supports for:
  - AllenNLP v0.x (entirely)
  - AllenNLP v1.x (partially: a pruning callback no longer works with v1.x.x).

## Description of the changes
- b091848 remove version constraint
- c82bebb 1fef7c8 replace `EpochCallback` with `TrainerCallback`
- 371ba52 update examples and test (introduce `MultiProcessDataLoader`)
- 79bfaaf check AllenNLP version and raise an exception if it needs