### PR TITLE
Remove -f option from doctest pip installation

### DIFF
--- a/.github/workflows/sphinx-build.yml
+++ b/.github/workflows/sphinx-build.yml
@@ -84,7 +84,7 @@ jobs:
     - name: Install Dependencies
       run: |
         python -m pip install -U pip
-        pip install --progress-bar off -U .[document,doctest] -f https://download.pytorch.org/whl/torch_stable.html
+        pip install --progress-bar off -U .[document,doctest]
 
     - name: Run Doctest
       run: |


### PR DESCRIPTION
This pull request aims at resolving weird failures of AMD device not found errors, which previously #2408 tried to solve.

Background: Unexpectedly, `pip install torch==1.7.1 -f https://download.pytorch.org/whl/torch_stable.html` could install rocm compatible
version. as follows

```console
venv $ pip install torch==1.7.1 -f https://download.pytorch.org/whl/torch_stable.html
Looking in links: https://download.pytorch.org/whl/torch_stable.html
Collecting torch==1.7.1
  Using cached https://download.pytorch.org/whl/rocm3.8/torch-1.7.1%2Brocm3.8-cp37-cp37m-linux_x86_64.whl (588.0 MB)
```