### PR TITLE
Set the default value of `state` of `create_trial` as `COMPLETE`

### DIFF
--- a/optuna/trial/_frozen.py
+++ b/optuna/trial/_frozen.py
@@ -589,7 +589,6 @@ def create_trial(
     user_attrs = user_attrs or {}
     system_attrs = system_attrs or {}
     intermediate_values = intermediate_values or {}
-    state = state
 
     if state == TrialState.WAITING:
         datetime_start = None

--- a/optuna/trial/_frozen.py
+++ b/optuna/trial/_frozen.py
@@ -506,7 +506,7 @@ class FrozenTrial(BaseTrial):
 @experimental("2.0.0")
 def create_trial(
     *,
-    state: Optional[TrialState] = None,
+    state: TrialState = TrialState.COMPLETE,
     value: Optional[float] = None,
     values: Optional[Sequence[float]] = None,
     params: Optional[Dict[str, Any]] = None,
@@ -549,7 +549,7 @@ def create_trial(
         functions are created inside :func:`~optuna.study.Study.optimize`.
 
     .. note::
-        When ``state`` is :obj:`None` or ``TrialState.COMPLETE``, the following parameters are
+        When ``state`` is ``TrialState.COMPLETE``, the following parameters are
         required:
         * ``params``
         * ``distributions``
@@ -589,7 +589,7 @@ def create_trial(
     user_attrs = user_attrs or {}
     system_attrs = system_attrs or {}
     intermediate_values = intermediate_values or {}
-    state = state or TrialState.COMPLETE
+    state = state
 
     if state == TrialState.WAITING:
         datetime_start = None

--- a/tests/trial_tests/test_trial.py
+++ b/tests/trial_tests/test_trial.py
@@ -610,7 +610,7 @@ def test_study_id() -> None:
 
 # TODO(hvy): Write exhaustive test include invalid combinations when feature is no longer
 # experimental.
-@pytest.mark.parametrize("state", [None, TrialState.COMPLETE, TrialState.FAIL])
+@pytest.mark.parametrize("state", [TrialState.COMPLETE, TrialState.FAIL])
 def test_create_trial(state: TrialState) -> None:
     value = 0.2
     params = {"x": 10}
@@ -630,7 +630,7 @@ def test_create_trial(state: TrialState) -> None:
     )
 
     assert isinstance(trial, FrozenTrial)
-    assert trial.state == (state if state is not None else TrialState.COMPLETE)
+    assert trial.state == state
     assert trial.value == value
     assert trial.params == params
     assert trial.distributions == distributions
@@ -638,19 +638,10 @@ def test_create_trial(state: TrialState) -> None:
     assert trial.system_attrs == system_attrs
     assert trial.intermediate_values == intermediate_values
     assert trial.datetime_start is not None
-    assert (trial.datetime_complete is not None) == (state is None or state.is_finished())
+    assert (trial.datetime_complete is not None) == state.is_finished()
 
     with pytest.raises(ValueError):
         create_trial(state=state, value=value, values=(value,))
-
-    if state is None:
-        with pytest.raises(ValueError):
-            create_trial(state=state, value=None, values=None)
-        # Raise `ValueError` when either `params` or `distributions` is `None`.
-        with pytest.raises(ValueError):
-            create_trial(state=state, value=value, params=params, distributions=None)
-        with pytest.raises(ValueError):
-            create_trial(state=state, value=value, params=None, distributions=distributions)
 
 
 def test_suggest_with_multi_objectives() -> None:


### PR DESCRIPTION
## Motivation
Currently, the default value of `state` of `create_trial` is `None` and implicitly set `COMPLETE` when it is `None`. This behavior is not documented, so it is confusing. If we make `COMPLETE` the default value, users will be able to understand the behavior from the documentation without changing the API.

## Description of the changes
- Set the default value of `state` of `create_trial` as `COMPLETE`.
