### PR TITLE
Added RL and Multi-Objective examples to `examples/README.md`

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -95,7 +95,7 @@ In addition, integration modules are available for the following libraries, prov
 
 ### Examples of Reinforcement Learning
 
-* [Optimizating Hyperparameters for Stable-Baslines Agent](./rl/sb3_simple.py)
+* [Optimization of Hyperparameters for Stable-Baslines Agent](./rl/sb3_simple.py)
 
 ### External projects using Optuna
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -68,6 +68,11 @@ In addition, integration modules are available for the following libraries, prov
 
 * [SimulatedAnnealingSampler](./samplers/simulated_annealing_sampler.py)
 
+### Examples of Multi-Objective Optimization
+
+* [Optimization with BoTorch](./multi_objective/botorch_simple.py)
+* [Optimization of MLP with PyTorch](./multi_objective/pytorch_simple.py)
+
 ### Examples of Visualization
 
 * [Visualizing study](https://colab.research.google.com/github/optuna/optuna/blob/master/examples/visualization/plot_study.ipynb)
@@ -87,6 +92,10 @@ In addition, integration modules are available for the following libraries, prov
 ### Examples of Distributed Optimization
 
 * [Optimizing on Kubernetes](./kubernetes/README.md)
+
+### Examples of Reinforcement Learning
+
+* [Optimizating Hyperparameters for Stable-Baslines Agent](./rl/sb3_simple.py)
 
 ### External projects using Optuna
 


### PR DESCRIPTION
## Motivation
With reference to issue #2306, I have added the link for RL and Multi-objective examples to the <code>examples/README.md</code> file.

## Description of the changes
Previously unlinked three examples were added to the readme file of the example folder. Let me know if I need to add more modifications while working on <code>examples/README.md</code> file.
Thank you!
