### PR TITLE
`after_trial` modified for `NSGAIISampler` 

### DIFF
--- a/optuna/samplers/_nsga2.py
+++ b/optuna/samplers/_nsga2.py
@@ -366,6 +366,7 @@ class NSGAIISampler(BaseSampler):
                     _CONSTRAINTS_KEY,
                     constraints,
                 )
+        self._random_sampler.after_trial(study, trial, state, values)
 
 
 def _crowding_distance_sort(population: List[FrozenTrial]) -> None:

--- a/tests/samplers_tests/test_nsga2.py
+++ b/tests/samplers_tests/test_nsga2.py
@@ -3,6 +3,7 @@ from typing import List
 from typing import Optional
 from typing import Sequence
 from typing import Tuple
+from unittest.mock import patch
 import warnings
 
 import pytest
@@ -466,3 +467,13 @@ def _create_frozen_trial(
     trial.number = number
     trial._trial_id = number
     return trial
+
+
+def test_call_after_trial_of_random_sampler() -> None:
+    sampler = NSGAIISampler()
+    study = optuna.create_study(sampler=sampler)
+    with patch.object(
+        sampler._random_sampler, "after_trial", wraps=sampler._random_sampler.after_trial
+    ) as mock_object:
+        study.optimize(lambda _: 1.0, n_trials=1)
+        assert mock_object.call_count == 1


### PR DESCRIPTION
## Motivation
With reference to the issue #2233, and continuation of work PR #2425 I have modified <code>after_trial</code> method for <code>NSGAIISampler</code> with the corresponding testing function <code>test_call_after_trial_of_random_sampler</code>.

## Description of the changes
 As the <code>independent_sampler</code> didn't exist of now, but <code>_random_sampler</code> was there. So, I have implemented <code>after_trial</code> for <code>_random_sampler</code>, the corresponding changes for tests are also included in <code>tests/samplers_tests/test__nsga2.py</code>. 
 ### Samplers

- [x]  `PartialFixedSampler` #2209
- [x]   `CmaEsSampler` #2359 
- [x]   `PyCmaEsampler` #2365 
- [x]  `SkoptSampler` #2372 
- [x]   `BoTorchSampler` #2372  
- [x]  `TPESampler` #2376 
- [x]   `NSGAIISampler` (this PR)
- [x]  `MOTPESampler` #2425 

**Note**: There are two `NSGAIISampler` in optuna, one is at <code>optuna/samplers/_nsga2.py</code> and the other is at <code>optuna/multi_objective/samplers/_nsga2.py</code>, as per my knowledge, the <code>multi_objective</code> is deprecated, so I have not included the <code>after_trial</code> modification in that file, but only in <code>samplers</code> directory file (with required test function).
Finally, with this PR, issue #2233 have been resolved(hopefully if merged)
 If this implementation needs any further modification then let me know. 
Thank you!!
 
