### PR TITLE
Hotfix for MNIST download in tutorial

### DIFF
--- a/tutorial/20_recipes/002_multi_objective.py
+++ b/tutorial/20_recipes/002_multi_objective.py
@@ -10,6 +10,8 @@ optimizing the validation accuracy of MNIST dataset and the FLOPS of the model i
 We use `thop <https://github.com/Lyken17/pytorch-OpCounter>`_ to measure FLOPS.
 """
 
+import urllib
+
 import thop
 import torch
 import torch.nn as nn
@@ -18,6 +20,11 @@ import torchvision
 
 import optuna
 
+# Register a global custom opener to avoid HTTP Error 403: Forbidden when downloading MNIST.
+# This is a temporary fix until torchvision v0.9 is released.
+opener = urllib.request.build_opener()
+opener.addheaders = [("User-agent", "Mozilla/5.0")]
+urllib.request.install_opener(opener)
 
 DEVICE = torch.device("cuda") if torch.cuda.is_available() else torch.device("cpu")
 DIR = ".."


### PR DESCRIPTION
## Motivation

Hotfix for broken master since the v2.6 code freeze is near. This fix might not be needed when torchvision 0.9 is released. However, I'm not sure if we can immediately bump the dependency requirement without other incompatibilities.

Please note that examples are excluded since they're not in practice blocking the release.

## Description of the changes

Fixes a `HTTP Error 403: Forbidden` when trying to download MNIST from `torchvision` using the default `urllib` header. 
