### PR TITLE
Add `-f` option to `make clean` command idempotent

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -30,4 +30,4 @@ clean:
 	rm -rf source/reference/multi_objective/generated/
 	rm -rf source/reference/visualization/generated/
 	rm -rf source/tutorial/
-	rm ../tutorial/**/*.db
+	rm -f ../tutorial/**/*.db


### PR DESCRIPTION
## Motivation
In the `docs` directory, the following error raised if I execute `make clean` command twice. I think it is not necessary for us to raise such errors since we can keep the directories clean even if we run `make clean` multiple times.

```console
$ make clean
rm -rf build/*
rm -rf source/reference/generated/
rm -rf source/reference/multi_objective/generated/
rm -rf source/reference/visualization/generated/
rm -rf source/tutorial/
rm ../tutorial/**/*.db
rm: cannot remove '../tutorial/**/*.db': No such file or directory
make: *** [Makefile:33: clean] Error 1
```

## Description of the changes

I add `-f` option to `rm ../tutorial/**/*.db` in order to make the command idempotent.