### PR TITLE
Replace `sh` with `bash` in README of kubernetes examples

### DIFF
--- a/examples/kubernetes/mlflow/README.md
+++ b/examples/kubernetes/mlflow/README.md
@@ -15,13 +15,13 @@ First run `run.sh` which takes two arguments `$IsMinikube` and `$IMAGE_NAME`
 - If you want to run locally in minikube run the following command
 
  ```bash
-$ sh run.sh True optuna-kubernetes-mlflow:example
+$ bash run.sh True optuna-kubernetes-mlflow:example
  ```
 
 - If you want to run in cloud, please change the `IMAGE_NAME` accordingly in k8s-manifest.yaml and run as follows. Also please make sure that your kubernetes context is set correctly.
 
  ```bash
-$ sh run.sh False $IMAGE_NAME
+$ bash run.sh False $IMAGE_NAME
  ```
 
 - Track the study by checking MLflow dashboard. You can tell the IP address of MLflow dashboard as follows:

--- a/examples/kubernetes/simple/README.md
+++ b/examples/kubernetes/simple/README.md
@@ -15,13 +15,13 @@ Run `run.sh` which takes two arguments `$IsMinikube` and `$IMAGE_NAME`
 - If you want to run locally in minikube run the following command
 
  ```bash
-$ sh run.sh True optuna-kubernetes:example
+$ bash run.sh True optuna-kubernetes:example
  ```
 
 - If you want to run in cloud, please change the IMAGE_NAME accordingly in k8s-manifest.yaml and run as follows. Also please make sure that you kubernetes context is set correctly.
 
  ```bash
-$ sh run.sh False $IMAGE_NAME
+$ bash run.sh False $IMAGE_NAME
  ```
 
 - Track the progress of each worker by checking their logs:


### PR DESCRIPTION
## Motivation

During the review of #2375, I found that the current instruction causes errors because of the inconsistency of shells. The instruction uses `sh`, but the shell script uses `bash` specific syntax (i.e., `function`).

## Description of the changes

This PR simply replaces `sh` in the README.md with `bash`.

Alternatively, we can use `sh` syntax in `run.sh`.

```diff
- function run {
+ run () {
```