### PR TITLE
Add a new example `max_trial_callback` to `optuna/examples` 

### DIFF
--- a/examples/max_trials_callback.py
+++ b/examples/max_trials_callback.py
@@ -1,37 +1,42 @@
 """
-Optuna example that demonstrates setting maximum number of trials in shared database when multiple workers are used.
+Optuna example that demonstrates setting maximum number of trials in
+a shared database when multiple workers are used.
 
-In this example, we optimize a simple quadratic function. We use multiple script runs(workers)
-to demonstrate the use of max_trial_callbacks, which essentially allows user to set maximum number of trials
-regardless of the number of workers/scripts running the Trials. This example also demonstrates the flexibility of 
-using max_trial_callbacks with shared database for parallel runs.
+In this example, we optimize a simple quadratic function.We use multiple
+script runs(workers) to demonstrate the use of max_trial_callbacks,
+which essentially allows user to set maximum number of trials
+regardless of the number of workers/scripts running the Trials.
 
 """
 
 import optuna
 from optuna.trial import TrialState
 
+
 max_trials = 10
 
+
 def max_trial_callback(study, trial):
-    #we consider all the running states and already completed states in account for estimating number of n_complete.
-    n_complete = len(study.get_trials(deepcopy=False, states=[TrialState.COMPLETE, TrialState.RUNNING]))
+    # we consider all the running states and already completed states.
+    n_complete = len(
+        study.get_trials(deepcopy=False, states=[TrialState.COMPLETE, TrialState.RUNNING])
+    )
     if n_complete >= max_trials:
         study.stop()
-        
+
 
 def objective(trial):
     x = trial.suggest_uniform("x", 0, 10)
     return x ** 2
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     _ = optuna.create_study(
         study_name="test",
         storage="sqlite:///database.sqlite",
     )
-    
+
     study = optuna.load_study(study_name="test", storage="sqlite:///database.sqlite")
-    study.optimize(objective, n_trials=50,callbacks=[max_trial_callback])
+    study.optimize(objective, n_trials=50, callbacks=[max_trial_callback])
     trials = study.trials_dataframe()
     assert len(trials[trials.state == "COMPLETE"]) == max_trials

--- a/examples/max_trials_callback.py
+++ b/examples/max_trials_callback.py
@@ -1,0 +1,37 @@
+"""
+Optuna example that demonstrates setting maximum number of trials in shared database when multiple workers are used.
+
+In this example, we optimize a simple quadratic function. We use multiple script runs(workers)
+to demonstrate the use of max_trial_callbacks, which essentially allows user to set maximum number of trials
+regardless of the number of workers/scripts running the Trials. This example also demonstrates the flexibility of 
+using max_trial_callbacks with shared database for parallel runs.
+
+"""
+
+import optuna
+from optuna.trial import TrialState
+
+max_trials = 10
+
+def max_trial_callback(study, trial):
+    #we consider all the running states and already completed states in account for estimating number of n_complete.
+    n_complete = len(study.get_trials(deepcopy=False, states=[TrialState.COMPLETE, TrialState.RUNNING]))
+    if n_complete >= max_trials:
+        study.stop()
+        
+
+def objective(trial):
+    x = trial.suggest_uniform("x", 0, 10)
+    return x ** 2
+
+
+if __name__ == '__main__':
+    _ = optuna.create_study(
+        study_name="test",
+        storage="sqlite:///database.sqlite",
+    )
+    
+    study = optuna.load_study(study_name="test", storage="sqlite:///database.sqlite")
+    study.optimize(objective, n_trials=50,callbacks=[max_trial_callback])
+    trials = study.trials_dataframe()
+    assert len(trials[trials.state == "COMPLETE"]) == max_trials

--- a/examples/max_trials_callback.py
+++ b/examples/max_trials_callback.py
@@ -10,6 +10,7 @@ regardless of the number of workers/scripts running the Trials.
 """
 
 from time import sleep
+
 import optuna
 from optuna.trial import TrialState
 
@@ -36,13 +37,13 @@ if __name__ == "__main__":
     study = optuna.create_study(
         study_name="test",
         storage="sqlite:///database.sqlite",
-         load_if_exists=True,
+        load_if_exists=True,
     )
 
     study.optimize(objective, n_trials=50, callbacks=[max_trial_callback])
     trials = study.trials_dataframe()
     print("Number of completed trials: {}".format(len(trials[trials.state == "COMPLETE"])))
-    
+
     print("Best trial:")
     trial = study.best_trial
 
@@ -51,5 +52,3 @@ if __name__ == "__main__":
     print("  Params: ")
     for key, value in trial.params.items():
         print("    {}: {}".format(key, value))
-    
-    

--- a/examples/max_trials_callback.py
+++ b/examples/max_trials_callback.py
@@ -2,7 +2,7 @@
 Optuna example that demonstrates setting maximum number of trials in
 a shared database when multiple workers are used.
 
-In this example, we optimize a simple quadratic function.We use multiple
+In this example, we optimize a simple quadratic function. We use multiple
 script runs(workers) to demonstrate the use of max_trial_callbacks,
 which essentially allows user to set maximum number of trials
 regardless of the number of workers/scripts running the Trials.

--- a/examples/max_trials_callback.py
+++ b/examples/max_trials_callback.py
@@ -1,10 +1,10 @@
 """
-Optuna example that demonstrates setting maximum number of trials in
+Optuna example to demonstrate setting the maximum number of trials in
 a shared database when multiple workers are used.
 
 In this example, we optimize a simple quadratic function. We use multiple
-script runs(workers) to demonstrate the use of max_trial_callbacks,
-which essentially allows user to set maximum number of trials
+script runs (workers) to demonstrate the use of max_trial_callbacks,
+which allows the user to set a maximum number of trials
 regardless of the number of workers/scripts running the Trials.
 
 """

--- a/examples/simple_pruning.py
+++ b/examples/simple_pruning.py
@@ -8,7 +8,7 @@ the pruning feature, the following 2 methods are invoked after each step of the 
 (2) :func:`optuna.trial.Trial.should_prune`
 
 You can run this example as follows:
-    $ python simple.py
+    $ python simple_prunning.py
 
 """
 


### PR DESCRIPTION
## Motivation
With reference to issue #1883, I have added a new example regarding the discussion on that issue. 

## Description of the changes
 Currently, I have implemented a very simple <code>objective</code> function which uses <code>max_trial_callback</code> for checking maximum number of trial, including completed as well as running.

**Note**:
This implementation is still very minimal, but I think there is some room for improvements, such as using <code>LinearRegression</code> from sklearn with Iris dataset (or any other dataset) and printing more information to the user. I am open to discussion and would like to know everyone's views on this example. 
I also have fixed a minor typo in another example file <code>simple_prunning.py</code>.

