### PR TITLE
Apply urllib patch for MNIST download

### DIFF
--- a/examples/catalyst_simple.py
+++ b/examples/catalyst_simple.py
@@ -11,6 +11,7 @@ argument.
 
 import argparse
 import os
+import urllib
 
 from catalyst.dl import AccuracyCallback
 from catalyst.dl import SupervisedRunner
@@ -23,6 +24,13 @@ from torchvision import transforms
 
 import optuna
 from optuna.integration import CatalystPruningCallback
+
+
+# Register a global custom opener to avoid HTTP Error 403: Forbidden when downloading MNIST.
+# This is a temporary fix until torchvision v0.9 is released.
+opener = urllib.request.build_opener()
+opener.addheaders = [("User-agent", "Mozilla/5.0")]
+urllib.request.install_opener(opener)
 
 
 CLASSES = 10

--- a/examples/chainer/chainer_integration.py
+++ b/examples/chainer/chainer_integration.py
@@ -11,6 +11,8 @@ You can run this example as follows:
 
 """
 
+import urllib
+
 import chainer
 import chainer.functions as F
 import chainer.links as L
@@ -19,6 +21,13 @@ from packaging import version
 
 import optuna
 from optuna.trial import TrialState
+
+
+# TODO(crcrpar): Remove the below three lines once everything is ok.
+# Register a global custom opener to avoid HTTP Error 403: Forbidden when downloading MNIST.
+opener = urllib.request.build_opener()
+opener.addheaders = [("User-agent", "Mozilla/5.0")]
+urllib.request.install_opener(opener)
 
 
 if version.parse(chainer.__version__) < version.parse("4.0.0"):

--- a/examples/chainer/chainer_simple.py
+++ b/examples/chainer/chainer_simple.py
@@ -8,6 +8,8 @@ subset of it.
 
 """
 
+import urllib
+
 import chainer
 import chainer.functions as F
 import chainer.links as L
@@ -16,6 +18,13 @@ from packaging import version
 
 import optuna
 from optuna.integration import ChainerPruningExtension
+
+
+# TODO(crcrpar): Remove the below three lines once everything is ok.
+# Register a global custom opener to avoid HTTP Error 403: Forbidden when downloading MNIST.
+opener = urllib.request.build_opener()
+opener.addheaders = [("User-agent", "Mozilla/5.0")]
+urllib.request.install_opener(opener)
 
 
 if version.parse(chainer.__version__) < version.parse("4.0.0"):

--- a/examples/chainer/chainermn_integration.py
+++ b/examples/chainer/chainermn_integration.py
@@ -14,6 +14,7 @@ as follows:
 """
 
 import sys
+import urllib
 
 import chainer
 import chainer.functions as F
@@ -23,6 +24,13 @@ import numpy as np
 
 import optuna
 from optuna.trial import TrialState
+
+
+# TODO(crcrpar): Remove the below three lines once everything is ok.
+# Register a global custom opener to avoid HTTP Error 403: Forbidden when downloading MNIST.
+opener = urllib.request.build_opener()
+opener.addheaders = [("User-agent", "Mozilla/5.0")]
+urllib.request.install_opener(opener)
 
 
 N_TRAIN_EXAMPLES = 3000

--- a/examples/chainer/chainermn_simple.py
+++ b/examples/chainer/chainermn_simple.py
@@ -12,6 +12,7 @@ as follows:
 
 """
 import sys
+import urllib
 
 import chainer
 import chainer.functions as F
@@ -20,6 +21,13 @@ import chainermn
 import numpy as np
 
 import optuna
+
+
+# TODO(crcrpar): Remove the below three lines once everything is ok.
+# Register a global custom opener to avoid HTTP Error 403: Forbidden when downloading MNIST.
+opener = urllib.request.build_opener()
+opener.addheaders = [("User-agent", "Mozilla/5.0")]
+urllib.request.install_opener(opener)
 
 
 N_TRAIN_EXAMPLES = 3000

--- a/examples/fastai/fastaiv1_simple.py
+++ b/examples/fastai/fastaiv1_simple.py
@@ -16,11 +16,18 @@ argument.
 
 import argparse
 from functools import partial
+import urllib
 
 from fastai import vision
 
 import optuna
 from optuna.integration import FastAIV1PruningCallback
+
+
+# Register a global custom opener to avoid HTTP Error 403: Forbidden when downloading MNIST.
+opener = urllib.request.build_opener()
+opener.addheaders = [("User-agent", "Mozilla/5.0")]
+urllib.request.install_opener(opener)
 
 
 BATCHSIZE = 128

--- a/examples/fastai/fastaiv2_simple.py
+++ b/examples/fastai/fastaiv2_simple.py
@@ -15,6 +15,7 @@ argument.
 """
 
 import argparse
+import urllib
 
 from fastai.vision.all import accuracy
 from fastai.vision.all import aug_transforms
@@ -26,6 +27,14 @@ from fastai.vision.all import URLs
 
 import optuna
 from optuna.integration import FastAIPruningCallback
+
+
+# TODO(crcrpar): Remove the below three lines once fastai gets compatible with torchvision v0.9.
+# Register a global custom opener to avoid HTTP Error 403: Forbidden when downloading MNIST.
+# This is a temporary fix until torchvision v0.9 is released.
+opener = urllib.request.build_opener()
+opener.addheaders = [("User-agent", "Mozilla/5.0")]
+urllib.request.install_opener(opener)
 
 
 BATCHSIZE = 128

--- a/examples/haiku_simple.py
+++ b/examples/haiku_simple.py
@@ -13,6 +13,7 @@ from typing import Any
 from typing import Generator
 from typing import Mapping
 from typing import Tuple
+import urllib
 
 import haiku as hk
 import jax
@@ -22,6 +23,13 @@ import optax
 import tensorflow_datasets as tfds
 
 import optuna
+
+
+# TODO(crcrpar): Remove the below three lines once everything is ok.
+# Register a global custom opener to avoid HTTP Error 403: Forbidden when downloading MNIST.
+opener = urllib.request.build_opener()
+opener.addheaders = [("User-agent", "Mozilla/5.0")]
+urllib.request.install_opener(opener)
 
 
 OptState = Any

--- a/examples/keras/keras_integration.py
+++ b/examples/keras/keras_integration.py
@@ -14,6 +14,7 @@ see the following link:
     https://github.com/optuna/optuna/blob/master/examples/mlflow/keras_mlflow.py
 
 """
+import urllib
 import warnings
 
 import keras
@@ -25,6 +26,13 @@ from keras.models import Sequential
 import optuna
 from optuna.integration import KerasPruningCallback
 from optuna.trial import TrialState
+
+
+# TODO(crcrpar): Remove the below three lines once everything is ok.
+# Register a global custom opener to avoid HTTP Error 403: Forbidden when downloading MNIST.
+opener = urllib.request.build_opener()
+opener.addheaders = [("User-agent", "Mozilla/5.0")]
+urllib.request.install_opener(opener)
 
 
 N_TRAIN_EXAMPLES = 3000

--- a/examples/keras/keras_simple.py
+++ b/examples/keras/keras_simple.py
@@ -6,6 +6,7 @@ In this example, we optimize the validation accuracy of MNIST classification usi
 Keras. We optimize the filter and kernel size, kernel stride and layer activation.
 
 """
+import urllib
 import warnings
 
 from keras.backend import clear_session
@@ -17,6 +18,13 @@ from keras.models import Sequential
 from keras.optimizers import RMSprop
 
 import optuna
+
+
+# TODO(crcrpar): Remove the below three lines once everything is ok.
+# Register a global custom opener to avoid HTTP Error 403: Forbidden when downloading MNIST.
+opener = urllib.request.build_opener()
+opener.addheaders = [("User-agent", "Mozilla/5.0")]
+urllib.request.install_opener(opener)
 
 
 N_TRAIN_EXAMPLES = 3000

--- a/examples/multi_objective/pytorch_simple.py
+++ b/examples/multi_objective/pytorch_simple.py
@@ -9,6 +9,7 @@ we here use a small subset of it.
 """
 
 import os
+import urllib
 
 import thop
 import torch
@@ -20,6 +21,13 @@ from torchvision import datasets
 from torchvision import transforms
 
 import optuna
+
+
+# Register a global custom opener to avoid HTTP Error 403: Forbidden when downloading MNIST.
+# This is a temporary fix until torchvision v0.9 is released.
+opener = urllib.request.build_opener()
+opener.addheaders = [("User-agent", "Mozilla/5.0")]
+urllib.request.install_opener(opener)
 
 
 DEVICE = torch.device("cpu")

--- a/examples/mxnet/gluon_simple.py
+++ b/examples/mxnet/gluon_simple.py
@@ -1,3 +1,5 @@
+import urllib
+
 import mxnet as mx
 from mxnet import autograd
 from mxnet import gluon
@@ -5,6 +7,13 @@ from mxnet.gluon import nn
 import numpy as np
 
 import optuna
+
+
+# TODO(crcrpar): Remove the below three lines once everything is ok.
+# Register a global custom opener to avoid HTTP Error 403: Forbidden when downloading MNIST.
+opener = urllib.request.build_opener()
+opener.addheaders = [("User-agent", "Mozilla/5.0")]
+urllib.request.install_opener(opener)
 
 
 CUDA = False

--- a/examples/mxnet/mxnet_integration.py
+++ b/examples/mxnet/mxnet_integration.py
@@ -12,6 +12,7 @@ You can run this example as follows:
 """
 
 import logging
+import urllib
 
 import mxnet as mx
 import numpy as np
@@ -19,6 +20,13 @@ import numpy as np
 import optuna
 from optuna.integration import MXNetPruningCallback
 from optuna.trial import TrialState
+
+
+# TODO(crcrpar): Remove the below three lines once everything is ok.
+# Register a global custom opener to avoid HTTP Error 403: Forbidden when downloading MNIST.
+opener = urllib.request.build_opener()
+opener.addheaders = [("User-agent", "Mozilla/5.0")]
+urllib.request.install_opener(opener)
 
 
 N_TRAIN_EXAMPLES = 3000

--- a/examples/mxnet/mxnet_simple.py
+++ b/examples/mxnet/mxnet_simple.py
@@ -9,11 +9,19 @@ subset of it.
 """
 
 import logging
+import urllib
 
 import mxnet as mx
 import numpy as np
 
 import optuna
+
+
+# TODO(crcrpar): Remove the below three lines once everything is ok.
+# Register a global custom opener to avoid HTTP Error 403: Forbidden when downloading MNIST.
+opener = urllib.request.build_opener()
+opener.addheaders = [("User-agent", "Mozilla/5.0")]
+urllib.request.install_opener(opener)
 
 
 N_TRAIN_EXAMPLES = 3000

--- a/examples/pytorch/skorch_simple.py
+++ b/examples/pytorch/skorch_simple.py
@@ -12,6 +12,7 @@ argument.
 """
 
 import argparse
+import urllib
 
 import numpy as np
 from sklearn.datasets import fetch_openml
@@ -24,6 +25,13 @@ import torch.nn.functional as F
 
 import optuna
 from optuna.integration import SkorchPruningCallback
+
+
+# Register a global custom opener to avoid HTTP Error 403: Forbidden when downloading MNIST.
+# This is a temporary fix until torchvision v0.9 is released.
+opener = urllib.request.build_opener()
+opener.addheaders = [("User-agent", "Mozilla/5.0")]
+urllib.request.install_opener(opener)
 
 
 SUBSET_RATIO = 0.4

--- a/examples/tensorboard_simple.py
+++ b/examples/tensorboard_simple.py
@@ -1,7 +1,16 @@
+import urllib
+
 import tensorflow as tf
 
 import optuna
 from optuna.integration.tensorboard import TensorBoardCallback
+
+
+# TODO(crcrpar): Remove the below three lines once everything is ok.
+# Register a global custom opener to avoid HTTP Error 403: Forbidden when downloading MNIST.
+opener = urllib.request.build_opener()
+opener.addheaders = [("User-agent", "Mozilla/5.0")]
+urllib.request.install_opener(opener)
 
 
 fashion_mnist = tf.keras.datasets.fashion_mnist

--- a/examples/tensorflow/tensorflow_eager_simple.py
+++ b/examples/tensorflow/tensorflow_eager_simple.py
@@ -7,11 +7,20 @@ configuration.
 
 """
 
+import urllib
+
 from packaging import version
 import tensorflow as tf
 from tensorflow.keras.datasets import mnist
 
 import optuna
+
+
+# TODO(crcrpar): Remove the below three lines once everything is ok.
+# Register a global custom opener to avoid HTTP Error 403: Forbidden when downloading MNIST.
+opener = urllib.request.build_opener()
+opener.addheaders = [("User-agent", "Mozilla/5.0")]
+urllib.request.install_opener(opener)
 
 
 if version.parse(tf.__version__) < version.parse("2.0.0"):

--- a/examples/tensorflow/tensorflow_estimator_integration.py
+++ b/examples/tensorflow/tensorflow_estimator_integration.py
@@ -13,12 +13,20 @@ You can run this example as follows:
 
 import shutil
 import tempfile
+import urllib
 
 import tensorflow as tf
 import tensorflow_datasets as tfds
 
 import optuna
 from optuna.trial import TrialState
+
+
+# TODO(crcrpar): Remove the below three lines once everything is ok.
+# Register a global custom opener to avoid HTTP Error 403: Forbidden when downloading MNIST.
+opener = urllib.request.build_opener()
+opener.addheaders = [("User-agent", "Mozilla/5.0")]
+urllib.request.install_opener(opener)
 
 
 MODEL_DIR = tempfile.mkdtemp()

--- a/examples/tensorflow/tensorflow_estimator_simple.py
+++ b/examples/tensorflow/tensorflow_estimator_simple.py
@@ -10,11 +10,19 @@ subset of it.
 
 import shutil
 import tempfile
+import urllib
 
 import tensorflow as tf
 import tensorflow_datasets as tfds
 
 import optuna
+
+
+# TODO(crcrpar): Remove the below three lines once everything is ok.
+# Register a global custom opener to avoid HTTP Error 403: Forbidden when downloading MNIST.
+opener = urllib.request.build_opener()
+opener.addheaders = [("User-agent", "Mozilla/5.0")]
+urllib.request.install_opener(opener)
 
 
 MODEL_DIR = tempfile.mkdtemp()

--- a/examples/tfkeras/tfkeras_integration.py
+++ b/examples/tfkeras/tfkeras_integration.py
@@ -12,12 +12,21 @@ You can run this example as follows:
 
 """
 
+import urllib
+
 import tensorflow as tf
 import tensorflow_datasets as tfds
 
 import optuna
 from optuna.integration import TFKerasPruningCallback
 from optuna.trial import TrialState
+
+
+# TODO(crcrpar): Remove the below three lines once everything is ok.
+# Register a global custom opener to avoid HTTP Error 403: Forbidden when downloading MNIST.
+opener = urllib.request.build_opener()
+opener.addheaders = [("User-agent", "Mozilla/5.0")]
+urllib.request.install_opener(opener)
 
 
 BATCHSIZE = 128

--- a/examples/tfkeras/tfkeras_simple.py
+++ b/examples/tfkeras/tfkeras_simple.py
@@ -7,6 +7,8 @@ tf.keras. We optimize the filter and kernel size, kernel stride and layer activa
 
 """
 
+import urllib
+
 from tensorflow.keras.backend import clear_session
 from tensorflow.keras.datasets import mnist
 from tensorflow.keras.layers import Conv2D
@@ -16,6 +18,13 @@ from tensorflow.keras.models import Sequential
 from tensorflow.keras.optimizers import RMSprop
 
 import optuna
+
+
+# TODO(crcrpar): Remove the below three lines once everything is ok.
+# Register a global custom opener to avoid HTTP Error 403: Forbidden when downloading MNIST.
+opener = urllib.request.build_opener()
+opener.addheaders = [("User-agent", "Mozilla/5.0")]
+urllib.request.install_opener(opener)
 
 
 N_TRAIN_EXAMPLES = 3000

--- a/examples/visualization/plot_study.py
+++ b/examples/visualization/plot_study.py
@@ -12,6 +12,7 @@ We can execute this example as follows.
 **Note:** If a parameter contains missing values, a trial with missing values is not plotted.
 """
 
+import urllib
 
 from sklearn.datasets import fetch_openml
 from sklearn.model_selection import train_test_split
@@ -24,6 +25,13 @@ from optuna.visualization import plot_optimization_history
 from optuna.visualization import plot_parallel_coordinate
 from optuna.visualization import plot_param_importances
 from optuna.visualization import plot_slice
+
+
+# TODO(crcrpar): Remove the below three lines once everything is ok.
+# Register a global custom opener to avoid HTTP Error 403: Forbidden when downloading MNIST.
+opener = urllib.request.build_opener()
+opener.addheaders = [("User-agent", "Mozilla/5.0")]
+urllib.request.install_opener(opener)
 
 
 def objective(trial):


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

403 could occur anywhere we try to download MNIST from yann.lecun.com like https://github.com/optuna/optuna/runs/2067792885?check_suite_focus=true#step:7:8298.

Related: #2438 #2453

## Description of the changes
<!-- Describe the changes in this PR. -->
Apply the same patch with some comments changed to examples downloading MNIST however I'm not completely sure every single file downloads the dataset from yann.lecun.com.