### PR TITLE
Remove Cython from `install_requires`.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 import os
-import sys
 from typing import Dict
 from typing import List
 from typing import Optional
@@ -121,6 +120,8 @@ def get_extras_require() -> Dict[str, List[str]]:
             "bokeh<2.0.0",
             "chainer>=5.0.0",
             "cma",
+            # TODO(c-bata): Remove Cython after removing version constraints of sklearn.
+            "Cython; python_version > '3.8'",
             "fakeredis",
             "lightgbm",
             "matplotlib>=3.0.0",
@@ -163,6 +164,8 @@ def get_extras_require() -> Dict[str, List[str]]:
             # https://github.com/optuna/optuna/issues/1000.
             "chainer>=5.0.0",
             "cma",
+            # TODO(c-bata): Remove Cython after removing version constraints of sklearn.
+            "Cython; python_version > '3.8'",
             "lightgbm",
             "mlflow",
             "mpi4py",

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,8 @@ def get_extras_require() -> Dict[str, List[str]]:
         "codecov": ["codecov", "pytest-cov"],
         "doctest": [
             "cma",
+            # TODO(c-bata): Remove Cython after removing version constraints of sklearn.
+            "Cython; python_version > '3.8'",
             "matplotlib>=3.0.0",
             "pandas",
             "plotly>=4.0.0",
@@ -82,6 +84,8 @@ def get_extras_require() -> Dict[str, List[str]]:
         "example": [
             "catboost",
             "chainer",
+            # TODO(c-bata): Remove Cython after removing version constraints of sklearn.
+            "Cython; python_version > '3.8'",
             "lightgbm",
             "mlflow",
             "mpi4py",

--- a/setup.py
+++ b/setup.py
@@ -151,14 +151,13 @@ def get_extras_require() -> Dict[str, List[str]]:
             "fastai",
         ],
         "tests": [
-            # TODO(c-bata): Remove Cython after removing version constraints of sklearn
-            # from 'optional' in extra_requires.
-            "Cython; python_version > '3.8'",
             "fakeredis",
             "pytest",
         ],
         "optional": [
             "bokeh<2.0.0",  # optuna/cli.py, optuna/dashboard.py.
+            # TODO(c-bata): Remove Cython after removing version constraints of sklearn.
+            "Cython; python_version > '3.8'",
             "matplotlib>=3.0.0",  # optuna/visualization/matplotlib
             "pandas",  # optuna/study.py
             "plotly>=4.0.0",  # optuna/visualization.
@@ -170,6 +169,8 @@ def get_extras_require() -> Dict[str, List[str]]:
             # https://github.com/optuna/optuna/issues/1000.
             "chainer>=5.0.0",
             "cma",
+            # TODO(c-bata): Remove Cython after removing version constraints of sklearn.
+            "Cython; python_version > '3.8'",
             "lightgbm",
             "mlflow",
             "mpi4py",

--- a/setup.py
+++ b/setup.py
@@ -150,7 +150,13 @@ def get_extras_require() -> Dict[str, List[str]]:
             "botorch>=0.4.0 ; python_version>'3.6'",
             "fastai",
         ],
-        "tests": ["fakeredis", "pytest"],
+        "tests": [
+            # TODO(c-bata): Remove Cython after removing version constraints of sklearn
+            # from 'optional' in extra_requires.
+            "Cython; python_version > '3.8'",
+            "fakeredis",
+            "pytest",
+        ],
         "optional": [
             "bokeh<2.0.0",  # optuna/cli.py, optuna/dashboard.py.
             "matplotlib>=3.0.0",  # optuna/visualization/matplotlib
@@ -164,8 +170,6 @@ def get_extras_require() -> Dict[str, List[str]]:
             # https://github.com/optuna/optuna/issues/1000.
             "chainer>=5.0.0",
             "cma",
-            # TODO(c-bata): Remove Cython after removing version constraints of sklearn.
-            "Cython; python_version > '3.8'",
             "lightgbm",
             "mlflow",
             "mpi4py",

--- a/setup.py
+++ b/setup.py
@@ -39,10 +39,6 @@ def get_install_requires() -> List[str]:
         "sqlalchemy>=1.1.0",
         "tqdm",
     ]
-    # NOTE (crcrpar): Some of the above libraries require Cython to be installed.
-    # I hope they will obviate it in the future releases.
-    if sys.version_info[:2] > (3, 8):
-        requirements.append("Cython")
     return requirements
 
 


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
Cython is not a dependency of Optuna so I think it should not be listed here even though some optional dependencies don't provide Python 3.9 wheel. 
Refs https://github.com/conda-forge/optuna-feedstock/pull/24

## Description of the changes
<!-- Describe the changes in this PR. -->

Move Cython from `install_requires` to `extra_requires` for tests.