### PR TITLE
Replace MNIST with Fashion MNIST in multi-objective optimization tutorial

### DIFF
--- a/tutorial/20_recipes/002_multi_objective.py
+++ b/tutorial/20_recipes/002_multi_objective.py
@@ -5,12 +5,10 @@ Multi-objective Optimization with Optuna
 ========================================
 
 This tutorial showcases Optuna's multi-objective optimization feature by
-optimizing the validation accuracy of MNIST dataset and the FLOPS of the model implemented in PyTorch.
+optimizing the validation accuracy of Fashion MNIST dataset and the FLOPS of the model implemented in PyTorch.
 
 We use `thop <https://github.com/Lyken17/pytorch-OpCounter>`_ to measure FLOPS.
 """
-
-import urllib
 
 import thop
 import torch
@@ -20,11 +18,6 @@ import torchvision
 
 import optuna
 
-# Register a global custom opener to avoid HTTP Error 403: Forbidden when downloading MNIST.
-# This is a temporary fix until torchvision v0.9 is released.
-opener = urllib.request.build_opener()
-opener.addheaders = [("User-agent", "Mozilla/5.0")]
-urllib.request.install_opener(opener)
 
 DEVICE = torch.device("cuda") if torch.cuda.is_available() else torch.device("cpu")
 DIR = ".."
@@ -82,7 +75,7 @@ def eval_model(model, valid_loader):
 # Define multi-objective objective function.
 # Objectives are FLOPS and accuracy.
 def objective(trial):
-    train_dataset = torchvision.datasets.MNIST(
+    train_dataset = torchvision.datasets.FashionMNIST(
         DIR, train=True, download=True, transform=torchvision.transforms.ToTensor()
     )
     train_loader = torch.utils.data.DataLoader(
@@ -91,7 +84,7 @@ def objective(trial):
         shuffle=True,
     )
 
-    val_dataset = torchvision.datasets.MNIST(
+    val_dataset = torchvision.datasets.FashionMNIST(
         DIR, train=False, transform=torchvision.transforms.ToTensor()
     )
     val_loader = torch.utils.data.DataLoader(


### PR DESCRIPTION
## Motivation
Recently, we are facing the failures of MNIST download, and it prevents CI jobs as follows:

https://app.circleci.com/pipelines/github/optuna/optuna/4979/workflows/0eeda58f-fce2-4afb-82a8-68d1aa6b8ea2/jobs/66556

This PR addresses the problem by changing the dataset.

## Description of the changes

It simply replaces MNIST with Fashion MNIST. The data format of Fashion MNIST is the same as that of MNIST and I don't think we need to change the network and training settings.