### PR TITLE
Use 2.0 style delete API of SQLAlchemy

### DIFF
--- a/optuna/storages/_rdb/alembic/versions/v1.3.0.a.py
+++ b/optuna/storages/_rdb/alembic/versions/v1.3.0.a.py
@@ -58,7 +58,12 @@ def upgrade():
         ]
         session.bulk_update_mappings(TrialModel, mapping)
 
-        session.query(TrialSystemAttributeModel.key == "_number").delete(synchronize_session=False)
+        stmt = (
+            sa.delete(TrialSystemAttributeModel)
+            .where(TrialSystemAttributeModel.key == "_number")
+            .execution_options(synchronize_session=False)
+        )
+        session.execute(stmt)
         session.commit()
     except SQLAlchemyError as e:
         session.rollback()


### PR DESCRIPTION
## Motivation

CI of schema upgrade failed ([log](https://github.com/optuna/optuna/runs/2117130971?check_suite_focus=true)) after the release of sqlalchemy==1.4.0.
It includes the migration from sqlalchemy v1.x to v2.0, and it seems to have some breaking changes.
c.f., https://docs.sqlalchemy.org/en/14/glossary.html#term-1.x-style

## Description of the changes

Currently, the schema migration code uses v1.x style of delete API. This PR replace it with v2.0 style API.

c.f., 
https://docs.sqlalchemy.org/en/14/orm/session_basics.html#update-and-delete-with-arbitrary-where-clause

### Note

#### Do we need to change the requirements of `sqlalchmy`?

No. It worked with `sqlalchemy==1.1.0`.

Please note that we need to re-install `alembic` after we upgrade/downgrade sqlalchemy. Otherwise, the following error will occur.
~Yes. This feature requires `sqlalchem>=1.3.0`, but the current requirement is `sqlalchemy>=1.1.0`.~

```console
venv/lib/python3.8/site-packages/alembic/ddl/mssql.py:8: in <module>
    from .base import AddColumn
venv/lib/python3.8/site-packages/alembic/ddl/base.py:11: in <module>
    from ..util.sqla_compat import _columns_for_constraint  # noqa
venv/lib/python3.8/site-packages/alembic/util/__init__.py:32: in <module>
    raise CommandError("SQLAlchemy 1.3.0 or greater is required.")
E   alembic.util.exc.CommandError: SQLAlchemy 1.3.0 or greater is required.
```

#### Upgrade tests

<details>
<summary>Python script: `sample.py`</summary>

```python
import sys
import optuna


def objective(trial):
    trial.set_user_attr("a", "a")
    trial.set_system_attr("b", "b")
    trial.suggest_categorical("x", [0])
    return 1


study = optuna.create_study(storage=sys.argv[1])
study.set_user_attr("c", "c")
study.set_system_attr("d", "d")
study.optimize(objective, n_trials=1)
```

</details>

SQLite

```console
$ pip install optuna==1.2.0
$ python sample.py sqlite:///tmp.db
$ pip install -U git+https://github.com/toshihikoyanase/optuna.git@fix-delete-with-sqlalchemy-140
$ optuna storage upgrade --storage sqlite:///tmp.db
$ python sample.py sqlite:///tmp.db
```

MySQL

```console
$ MYSQL_HOST=127.0.0.1
$ docker run --name mysql -e MYSQL_ROOT_PASSWORD=test -p 3306:3306 -p 33060:33060 -d mysql:8
$ docker run --network host -it --rm mysql:8  mysql -h ${MYSQL_HOST} -uroot -ptest -e "create database test_optuna;"
$ pip install optuna==1.2.0 PyMySQL
$ python sample.py  mysql+pymysql://root:test@${MYSQL_HOST}:3306/test_optuna
$ pip install -U git+https://github.com/toshihikoyanase/optuna.git@fix-delete-with-sqlalchemy-140
$ optuna storage upgrade --storage mysql+pymysql://root:test@${MYSQL_HOST}:3306/test_optuna
$ python sample.py  mysql+pymysql://root:test@${MYSQL_HOST}:3306/test_optuna
```

PostgreSQL

```console
$ PG_HOST=127.0.0.1
$ docker run -it --rm --name postgres -e POSTGRES_PASSWORD=test -p 15432:5432 -d postgres
$ pip install optuna==1.2.0 psycopg2-binary
$ python sample.py postgresql+psycopg2://postgres:test@${PG_HOST}:15432/postgres
$ pip install -U git+https://github.com/toshihikoyanase/optuna.git@fix-delete-with-sqlalchemy-140
$ optuna storage upgrade --storage postgresql+psycopg2://postgres:test@${PG_HOST}:15432/postgres
$ python sample.py  postgresql+psycopg2://postgres:test@${PG_HOST}:15432/postgres
```



## TODO

- [x] Test with older versions of sqlalchemy
- [x] Upgrade test with sqlite, mysql and postgresql