### PR TITLE
Use whitespace tokenizer instead of spacy tokenizer

### DIFF
--- a/examples/allennlp/classifier.jsonnet
+++ b/examples/allennlp/classifier.jsonnet
@@ -30,7 +30,7 @@ local ENCODER = CNN_FIELDS(
   dataset_reader: {
     type: 'text_classification_json',
     tokenizer: {
-      type: 'spacy',
+      type: 'whitespace',
     },
     token_indexers: {
       tokens: {


### PR DESCRIPTION
This PR updates an AllenNLP example to use a simple rule-based tokenizer instead of a spaCy tokenizer.


## Motivation
CI for example failed due to the extremely large log file (https://github.com/optuna/optuna/actions/runs/658018631).

This problem happens with the recent update of AllenNLP.
https://github.com/allenai/allennlp/issues/5036


## Description of the changes
- ae92576 replace a spaCy tokenizer with a simple whitespace tokenizer
