### PR TITLE
Run Dask ML example on Python3.8

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -53,7 +53,7 @@ jobs:
         if [ ${{ matrix.python-version }} = 3.6 ]; then
           IGNORES='chainermn_.*|fastai*|pytorch_distributed_.*|rapids_.*|botorch_.*|pytorch/pytorch_checkpoint*|allennlp*'
         elif [ ${{ matrix.python-version }} = 3.8 ]; then
-          IGNORES='chainermn_.*|dask_ml_.*|keras_.*|pytorch_distributed_.*|tensorboard_.*|tensorflow_.*|tfkeras_.*|fastai*|rapids_.*|pytorch/pytorch_checkpoint*|allennlp*'
+          IGNORES='chainermn_.*|keras_.*|pytorch_distributed_.*|tensorboard_.*|tensorflow_.*|tfkeras_.*|fastai*|rapids_.*|pytorch/pytorch_checkpoint*|allennlp*'
         else
           IGNORES='chainermn_.*|fastai*|pytorch_distributed_.*|rapids_.*|pytorch/pytorch_checkpoint*|allennlp*'
         fi


### PR DESCRIPTION
The example runs as follows:

```
~/ghq/github.com/crcrpar/optuna master* ⇡ 2m 1s
optuna ❯ docker run -it -v $(pwd):/workspaces optuna/optuna:py3.8-dev /bin/bash -c "python examples/dask_ml_simple.py > /dev/null"
[I 2021-03-18 01:11:09,841] A new study created in memory with name: no-name-6c122fe3-b9cb-4de1-9586-4f0ab8826d6c
[I 2021-03-18 01:11:10,274] Trial 0 finished with value: 0.6666666666666666 and parameters: {'solver': 'admm', 'C': 0.292874885074065, 'penalty': 'l2'}. Best is trial 0 with value: 0.6666666666666666.
[I 2021-03-18 01:11:13,107] Trial 1 finished with value: 0.6666666666666666 and parameters: {'solver': 'proximal_grad', 'C': 0.7620618661989864, 'penalty': 'l2'}. Best is trial 0 with value: 0.6666666666666666.
[I 2021-03-18 01:11:13,407] Trial 2 finished with value: 0.6666666666666666 and parameters: {'solver': 'proximal_grad', 'C': 0.5346060617813856, 'penalty': 'elastic_net'}. Best is trial 0 with value: 0.6666666666666666.
[I 2021-03-18 01:11:13,689] Trial 3 finished with value: 0.6 and parameters: {'solver': 'gradient_descent', 'C': 0.4105443154726218}. Best is trial 0 with value: 0.6666666666666666.
[I 2021-03-18 01:11:13,979] Trial 4 finished with value: 0.6666666666666666 and parameters: {'solver': 'proximal_grad', 'C': 0.4309551506600031, 'penalty': 'l1'}. Best is trial 0 with value: 0.6666666666666666.
[I 2021-03-18 01:11:14,287] Trial 5 finished with value: 0.6666666666666666 and parameters: {'solver': 'gradient_descent', 'C': 0.6438661784394061}. Best is trial 0 with value: 0.6666666666666666.
[I 2021-03-18 01:11:14,548] Trial 6 finished with value: 0.6666666666666666 and parameters: {'solver': 'proximal_grad', 'C': 0.11968516643461413, 'penalty': 'elastic_net'}. Best is trial 0 with value: 0.6666666666666666.
[I 2021-03-18 01:11:17,337] Trial 7 finished with value: 0.6666666666666666 and parameters: {'solver': 'proximal_grad', 'C': 0.6809906979073747, 'penalty': 'l2'}. Best is trial 0 with value: 0.6666666666666666.
[I 2021-03-18 01:11:17,599] Trial 8 finished with value: 0.6666666666666666 and parameters: {'solver': 'proximal_grad', 'C': 0.7741168383220245, 'penalty': 'elastic_net'}. Best is trial 0 with value: 0.6666666666666666.
[I 2021-03-18 01:11:20,500] Trial 9 finished with value: 0.6666666666666666 and parameters: {'solver': 'proximal_grad', 'C': 0.4779962981048428, 'penalty': 'l2'}. Best is trial 0 with value: 0.6666666666666666.
[I 2021-03-18 01:11:21,793] Trial 10 finished with value: 0.6 and parameters: {'solver': 'admm', 'C': 0.017149307402701486, 'penalty': 'l1'}. Best is trial 0 with value: 0.6666666666666666.
[I 2021-03-18 01:11:22,527] Trial 11 finished with value: 0.7333333333333333 and parameters: {'solver': 'admm', 'C': 0.9776209893587797, 'penalty': 'l2'}. Best is trial 11 with value: 0.7333333333333333.
[I 2021-03-18 01:11:22,879] Trial 12 finished with value: 0.6666666666666666 and parameters: {'solver': 'admm', 'C': 0.21875523087403195, 'penalty': 'l2'}. Best is trial 11 with value: 0.7333333333333333.
[I 2021-03-18 01:11:23,311] Trial 13 finished with value: 0.6 and parameters: {'solver': 'admm', 'C': 0.2669092381957682, 'penalty': 'l2'}. Best is trial 11 with value: 0.7333333333333333.
[I 2021-03-18 01:11:24,016] Trial 14 finished with value: 0.6666666666666666 and parameters: {'solver': 'admm', 'C': 0.9549019378303191, 'penalty': 'l2'}. Best is trial 11 with value: 0.7333333333333333.
[I 2021-03-18 01:11:24,733] Trial 15 finished with value: 0.6 and parameters: {'solver': 'admm', 'C': 0.9110833690753988, 'penalty': 'l2'}. Best is trial 11 with value: 0.7333333333333333.
[I 2021-03-18 01:11:25,106] Trial 16 finished with value: 0.6666666666666666 and parameters: {'solver': 'admm', 'C': 0.309160284687381, 'penalty': 'l2'}. Best is trial 11 with value: 0.7333333333333333.
/usr/local/lib/python3.8/site-packages/dask_glm/utils.py:52: RuntimeWarning: overflow encountered in exp
  return np.exp(A)
[I 2021-03-18 01:11:31,955] Trial 17 finished with value: 0.7333333333333333 and parameters: {'solver': 'admm', 'C': 0.11497161720840565, 'penalty': 'l1'}. Best is trial 11 with value: 0.7333333333333333.
/usr/local/lib/python3.8/site-packages/dask_glm/utils.py:52: RuntimeWarning: overflow encountered in exp
  return np.exp(A)
[I 2021-03-18 01:11:38,950] Trial 18 finished with value: 0.6666666666666666 and parameters: {'solver': 'admm', 'C': 0.8636964637368587, 'penalty': 'l1'}. Best is trial 11 with value: 0.7333333333333333.
[I 2021-03-18 01:11:39,251] Trial 19 finished with value: 0.7333333333333333 and parameters: {'solver': 'gradient_descent', 'C': 0.07045604540756553}. Best is trial 11 with value: 0.7333333333333333.
[I 2021-03-18 01:11:39,544] Trial 20 finished with value: 0.7333333333333333 and parameters: {'solver': 'gradient_descent', 'C': 0.018900956000872778}. Best is trial 11 with value: 0.7333333333333333.
[I 2021-03-18 01:11:39,842] Trial 21 finished with value: 0.5333333333333333 and parameters: {'solver': 'gradient_descent', 'C': 0.14596629460361146}. Best is trial 11 with value: 0.7333333333333333.
[I 2021-03-18 01:11:40,139] Trial 22 finished with value: 0.6 and parameters: {'solver': 'gradient_descent', 'C': 0.05294908062899507}. Best is trial 11 with value: 0.7333333333333333.
[I 2021-03-18 01:11:40,428] Trial 23 finished with value: 0.6 and parameters: {'solver': 'gradient_descent', 'C': 0.006758867141055266}. Best is trial 11 with value: 0.7333333333333333.
[I 2021-03-18 01:11:40,712] Trial 24 finished with value: 0.6666666666666666 and parameters: {'solver': 'gradient_descent', 'C': 0.1808957233622674}. Best is trial 11 with value: 0.7333333333333333.
[I 2021-03-18 01:11:41,008] Trial 25 finished with value: 0.7333333333333333 and parameters: {'solver': 'gradient_descent', 'C': 0.0895340031035531}. Best is trial 11 with value: 0.7333333333333333.
[I 2021-03-18 01:11:41,311] Trial 26 finished with value: 0.6 and parameters: {'solver': 'gradient_descent', 'C': 0.07105730266052598}. Best is trial 11 with value: 0.7333333333333333.
[I 2021-03-18 01:11:41,593] Trial 27 finished with value: 0.6666666666666666 and parameters: {'solver': 'gradient_descent', 'C': 0.006361651249784231}. Best is trial 11 with value: 0.7333333333333333.
[I 2021-03-18 01:11:41,898] Trial 28 finished with value: 0.6 and parameters: {'solver': 'gradient_descent', 'C': 0.35100677445543493}. Best is trial 11 with value: 0.7333333333333333.
[I 2021-03-18 01:11:42,190] Trial 29 finished with value: 0.8 and parameters: {'solver': 'gradient_descent', 'C': 0.22437624477985207}. Best is trial 29 with value: 0.8.
[I 2021-03-18 01:11:42,498] Trial 30 finished with value: 0.6666666666666666 and parameters: {'solver': 'gradient_descent', 'C': 0.21919703513170297}. Best is trial 29 with value: 0.8.
[I 2021-03-18 01:11:42,776] Trial 31 finished with value: 0.7333333333333333 and parameters: {'solver': 'gradient_descent', 'C': 0.0746820075408201}. Best is trial 29 with value: 0.8.
[I 2021-03-18 01:11:43,071] Trial 32 finished with value: 0.6666666666666666 and parameters: {'solver': 'gradient_descent', 'C': 0.17799992297335515}. Best is trial 29 with value: 0.8.
[I 2021-03-18 01:11:43,379] Trial 33 finished with value: 0.7333333333333333 and parameters: {'solver': 'gradient_descent', 'C': 0.2448650394774576}. Best is trial 29 with value: 0.8.
[I 2021-03-18 01:11:43,669] Trial 34 finished with value: 0.6666666666666666 and parameters: {'solver': 'gradient_descent', 'C': 0.24470642058917502}. Best is trial 29 with value: 0.8.
[I 2021-03-18 01:11:43,953] Trial 35 finished with value: 0.6 and parameters: {'solver': 'gradient_descent', 'C': 0.12030395916190056}. Best is trial 29 with value: 0.8.
[I 2021-03-18 01:11:44,267] Trial 36 finished with value: 0.6666666666666666 and parameters: {'solver': 'gradient_descent', 'C': 0.3418520598109398}. Best is trial 29 with value: 0.8.
[I 2021-03-18 01:11:44,558] Trial 37 finished with value: 0.6 and parameters: {'solver': 'gradient_descent', 'C': 0.3820185289524235}. Best is trial 29 with value: 0.8.
[I 2021-03-18 01:11:44,866] Trial 38 finished with value: 0.7333333333333333 and parameters: {'solver': 'gradient_descent', 'C': 0.46719092614125196}. Best is trial 29 with value: 0.8.
[I 2021-03-18 01:11:45,148] Trial 39 finished with value: 0.6666666666666666 and parameters: {'solver': 'gradient_descent', 'C': 0.5609778610182862}. Best is trial 29 with value: 0.8.
[I 2021-03-18 01:11:45,458] Trial 40 finished with value: 0.7333333333333333 and parameters: {'solver': 'gradient_descent', 'C': 0.2891984449164049}. Best is trial 29 with value: 0.8.
[I 2021-03-18 01:11:45,734] Trial 41 finished with value: 0.6 and parameters: {'solver': 'gradient_descent', 'C': 0.45849208039911354}. Best is trial 29 with value: 0.8.
[I 2021-03-18 01:11:46,022] Trial 42 finished with value: 0.6666666666666666 and parameters: {'solver': 'gradient_descent', 'C': 0.06012015961998177}. Best is trial 29 with value: 0.8.
[I 2021-03-18 01:11:46,315] Trial 43 finished with value: 0.6666666666666666 and parameters: {'solver': 'proximal_grad', 'C': 0.0039062432502556116, 'penalty': 'elastic_net'}. Best is trial 29 with value: 0.8.
[I 2021-03-18 01:11:46,602] Trial 44 finished with value: 0.6 and parameters: {'solver': 'gradient_descent', 'C': 0.5297656760114073}. Best is trial 29 with value: 0.8.
/usr/local/lib/python3.8/site-packages/dask_glm/utils.py:52: RuntimeWarning: overflow encountered in exp
  return np.exp(A)
[I 2021-03-18 01:11:53,542] Trial 45 finished with value: 0.6666666666666666 and parameters: {'solver': 'admm', 'C': 0.14497853622389317, 'penalty': 'l1'}. Best is trial 29 with value: 0.8.
[I 2021-03-18 01:11:53,833] Trial 46 finished with value: 0.6666666666666666 and parameters: {'solver': 'gradient_descent', 'C': 0.2964217609818742}. Best is trial 29 with value: 0.8.
/usr/local/lib/python3.8/site-packages/dask_glm/utils.py:52: RuntimeWarning: overflow encountered in exp
  return np.exp(A)
[I 2021-03-18 01:12:00,876] Trial 47 finished with value: 0.6 and parameters: {'solver': 'admm', 'C': 0.1822692110343725, 'penalty': 'l1'}. Best is trial 29 with value: 0.8.
[I 2021-03-18 01:12:01,150] Trial 48 finished with value: 0.6666666666666666 and parameters: {'solver': 'proximal_grad', 'C': 0.24740897264399717, 'penalty': 'l1'}. Best is trial 29 with value: 0.8.
/usr/local/lib/python3.8/site-packages/dask_glm/utils.py:52: RuntimeWarning: overflow encountered in exp
  return np.exp(A)
[I 2021-03-18 01:12:08,033] Trial 49 finished with value: 0.6666666666666666 and parameters: {'solver': 'admm', 'C': 0.11302884310980588, 'penalty': 'l1'}. Best is trial 29 with value: 0.8.
[I 2021-03-18 01:12:08,344] Trial 50 finished with value: 0.6666666666666666 and parameters: {'solver': 'gradient_descent', 'C': 0.20892122254423195}. Best is trial 29 with value: 0.8.
[I 2021-03-18 01:12:08,645] Trial 51 finished with value: 0.6666666666666666 and parameters: {'solver': 'gradient_descent', 'C': 0.08605795813085809}. Best is trial 29 with value: 0.8.
[I 2021-03-18 01:12:08,924] Trial 52 finished with value: 0.6 and parameters: {'solver': 'gradient_descent', 'C': 0.03808902215860456}. Best is trial 29 with value: 0.8.
[I 2021-03-18 01:12:09,235] Trial 53 finished with value: 0.6666666666666666 and parameters: {'solver': 'gradient_descent', 'C': 0.6081009367898588}. Best is trial 29 with value: 0.8.
[I 2021-03-18 01:12:09,525] Trial 54 finished with value: 0.6666666666666666 and parameters: {'solver': 'gradient_descent', 'C': 0.14140147915435358}. Best is trial 29 with value: 0.8.
/usr/local/lib/python3.8/site-packages/dask_glm/utils.py:52: RuntimeWarning: overflow encountered in exp
  return np.exp(A)
[I 2021-03-18 01:12:16,588] Trial 55 finished with value: 0.6666666666666666 and parameters: {'solver': 'admm', 'C': 0.751387757886984, 'penalty': 'l1'}. Best is trial 29 with value: 0.8.
[I 2021-03-18 01:12:16,879] Trial 56 finished with value: 0.6666666666666666 and parameters: {'solver': 'gradient_descent', 'C': 0.09201995516846403}. Best is trial 29 with value: 0.8.
[I 2021-03-18 01:12:17,170] Trial 57 finished with value: 0.6666666666666666 and parameters: {'solver': 'gradient_descent', 'C': 0.04601187925898864}. Best is trial 29 with value: 0.8.
[I 2021-03-18 01:12:17,478] Trial 58 finished with value: 0.6 and parameters: {'solver': 'gradient_descent', 'C': 0.32057710878296664}. Best is trial 29 with value: 0.8.
[I 2021-03-18 01:12:17,773] Trial 59 finished with value: 0.6666666666666666 and parameters: {'solver': 'gradient_descent', 'C': 0.02426859710252209}. Best is trial 29 with value: 0.8.
[I 2021-03-18 01:12:18,062] Trial 60 finished with value: 0.6 and parameters: {'solver': 'gradient_descent', 'C': 0.43931217557947305}. Best is trial 29 with value: 0.8.
[I 2021-03-18 01:12:18,370] Trial 61 finished with value: 0.7333333333333333 and parameters: {'solver': 'gradient_descent', 'C': 0.40430092167528175}. Best is trial 29 with value: 0.8.
[I 2021-03-18 01:12:18,652] Trial 62 finished with value: 0.6 and parameters: {'solver': 'gradient_descent', 'C': 0.17690109364282752}. Best is trial 29 with value: 0.8.
[I 2021-03-18 01:12:18,946] Trial 63 finished with value: 0.6666666666666666 and parameters: {'solver': 'gradient_descent', 'C': 0.36544191094025363}. Best is trial 29 with value: 0.8.
[I 2021-03-18 01:12:19,275] Trial 64 finished with value: 0.6 and parameters: {'solver': 'gradient_descent', 'C': 0.27174983966753014}. Best is trial 29 with value: 0.8.
[I 2021-03-18 01:12:19,552] Trial 65 finished with value: 0.6 and parameters: {'solver': 'gradient_descent', 'C': 0.4007695221907588}. Best is trial 29 with value: 0.8.
[I 2021-03-18 01:12:19,841] Trial 66 finished with value: 0.6666666666666666 and parameters: {'solver': 'gradient_descent', 'C': 0.49032040905316604}. Best is trial 29 with value: 0.8.
/usr/local/lib/python3.8/site-packages/dask_glm/utils.py:52: RuntimeWarning: overflow encountered in exp
  return np.exp(A)
[I 2021-03-18 01:12:26,483] Trial 67 finished with value: 0.6 and parameters: {'solver': 'admm', 'C': 0.11572002921758384, 'penalty': 'l1'}. Best is trial 29 with value: 0.8.
[I 2021-03-18 01:12:26,767] Trial 68 finished with value: 0.6666666666666666 and parameters: {'solver': 'gradient_descent', 'C': 0.21683421303038244}. Best is trial 29 with value: 0.8.
[I 2021-03-18 01:12:27,039] Trial 69 finished with value: 0.6666666666666666 and parameters: {'solver': 'proximal_grad', 'C': 0.4162111809955066, 'penalty': 'elastic_net'}. Best is trial 29 with value: 0.8.
[I 2021-03-18 01:12:27,346] Trial 70 finished with value: 0.6 and parameters: {'solver': 'gradient_descent', 'C': 0.27098455858587545}. Best is trial 29 with value: 0.8.
[I 2021-03-18 01:12:27,632] Trial 71 finished with value: 0.6666666666666666 and parameters: {'solver': 'gradient_descent', 'C': 0.08044183791951953}. Best is trial 29 with value: 0.8.
[I 2021-03-18 01:12:27,917] Trial 72 finished with value: 0.7333333333333333 and parameters: {'solver': 'gradient_descent', 'C': 0.3232322654421745}. Best is trial 29 with value: 0.8.
[I 2021-03-18 01:12:28,204] Trial 73 finished with value: 0.6666666666666666 and parameters: {'solver': 'gradient_descent', 'C': 0.16241898727447296}. Best is trial 29 with value: 0.8.
[I 2021-03-18 01:12:28,986] Trial 74 finished with value: 0.6666666666666666 and parameters: {'solver': 'admm', 'C': 0.995308666180721, 'penalty': 'l2'}. Best is trial 29 with value: 0.8.
/usr/local/lib/python3.8/site-packages/dask_glm/utils.py:52: RuntimeWarning: overflow encountered in exp
  return np.exp(A)
[I 2021-03-18 01:12:35,838] Trial 75 finished with value: 0.6 and parameters: {'solver': 'admm', 'C': 0.12603524888642298, 'penalty': 'l1'}. Best is trial 29 with value: 0.8.
[I 2021-03-18 01:12:36,120] Trial 76 finished with value: 0.6 and parameters: {'solver': 'gradient_descent', 'C': 0.20843512485577712}. Best is trial 29 with value: 0.8.
[I 2021-03-18 01:12:36,429] Trial 77 finished with value: 0.6666666666666666 and parameters: {'solver': 'gradient_descent', 'C': 0.24478961191680101}. Best is trial 29 with value: 0.8.
[I 2021-03-18 01:12:36,717] Trial 78 finished with value: 0.6666666666666666 and parameters: {'solver': 'gradient_descent', 'C': 0.0943822515537383}. Best is trial 29 with value: 0.8.
/usr/local/lib/python3.8/site-packages/dask_glm/utils.py:52: RuntimeWarning: overflow encountered in exp
  return np.exp(A)
[I 2021-03-18 01:12:43,604] Trial 79 finished with value: 0.6666666666666666 and parameters: {'solver': 'admm', 'C': 0.5342337482302518, 'penalty': 'l1'}. Best is trial 29 with value: 0.8.
[I 2021-03-18 01:12:43,863] Trial 80 finished with value: 0.5333333333333333 and parameters: {'solver': 'proximal_grad', 'C': 0.06083993568775025, 'penalty': 'elastic_net'}. Best is trial 29 with value: 0.8.
[I 2021-03-18 01:12:44,155] Trial 81 finished with value: 0.7333333333333333 and parameters: {'solver': 'gradient_descent', 'C': 0.005957518107562565}. Best is trial 29 with value: 0.8.
[I 2021-03-18 01:12:44,472] Trial 82 finished with value: 0.6666666666666666 and parameters: {'solver': 'gradient_descent', 'C': 0.32106221152313247}. Best is trial 29 with value: 0.8.
[I 2021-03-18 01:12:44,752] Trial 83 finished with value: 0.6 and parameters: {'solver': 'gradient_descent', 'C': 0.007046942926605706}. Best is trial 29 with value: 0.8.
[I 2021-03-18 01:12:45,055] Trial 84 finished with value: 0.6666666666666666 and parameters: {'solver': 'gradient_descent', 'C': 0.029472090263432213}. Best is trial 29 with value: 0.8.
[I 2021-03-18 01:12:45,375] Trial 85 finished with value: 0.6 and parameters: {'solver': 'gradient_descent', 'C': 0.15877438781393644}. Best is trial 29 with value: 0.8.
[I 2021-03-18 01:12:45,664] Trial 86 finished with value: 0.6666666666666666 and parameters: {'solver': 'gradient_descent', 'C': 0.28549418254400105}. Best is trial 29 with value: 0.8.
[I 2021-03-18 01:12:45,948] Trial 87 finished with value: 0.6 and parameters: {'solver': 'gradient_descent', 'C': 0.19532946307701501}. Best is trial 29 with value: 0.8.
[I 2021-03-18 01:12:46,255] Trial 88 finished with value: 0.6 and parameters: {'solver': 'gradient_descent', 'C': 0.10042964896369545}. Best is trial 29 with value: 0.8.
[I 2021-03-18 01:12:46,835] Trial 89 finished with value: 0.7333333333333333 and parameters: {'solver': 'admm', 'C': 0.6751604244704069, 'penalty': 'l2'}. Best is trial 29 with value: 0.8.
[I 2021-03-18 01:12:47,391] Trial 90 finished with value: 0.6666666666666666 and parameters: {'solver': 'admm', 'C': 0.6701520732501504, 'penalty': 'l2'}. Best is trial 29 with value: 0.8.
[I 2021-03-18 01:12:47,878] Trial 91 finished with value: 0.6 and parameters: {'solver': 'admm', 'C': 0.566054998114322, 'penalty': 'l2'}. Best is trial 29 with value: 0.8.
/usr/local/lib/python3.8/site-packages/dask_glm/utils.py:52: RuntimeWarning: overflow encountered in exp
  return np.exp(A)
[I 2021-03-18 01:12:54,928] Trial 92 finished with value: 0.6666666666666666 and parameters: {'solver': 'admm', 'C': 0.34094308239509785, 'penalty': 'l1'}. Best is trial 29 with value: 0.8.
[I 2021-03-18 01:12:55,234] Trial 93 finished with value: 0.6666666666666666 and parameters: {'solver': 'gradient_descent', 'C': 0.37867395243203017}. Best is trial 29 with value: 0.8.
[I 2021-03-18 01:12:55,562] Trial 94 finished with value: 0.6666666666666666 and parameters: {'solver': 'gradient_descent', 'C': 0.24994621857118213}. Best is trial 29 with value: 0.8.
[I 2021-03-18 01:12:55,852] Trial 95 finished with value: 0.6 and parameters: {'solver': 'gradient_descent', 'C': 0.5064127164374531}. Best is trial 29 with value: 0.8.
[I 2021-03-18 01:12:56,135] Trial 96 finished with value: 0.6666666666666666 and parameters: {'solver': 'gradient_descent', 'C': 0.9031604600482435}. Best is trial 29 with value: 0.8.
[I 2021-03-18 01:12:56,457] Trial 97 finished with value: 0.7333333333333333 and parameters: {'solver': 'admm', 'C': 0.06532090334183291, 'penalty': 'l2'}. Best is trial 29 with value: 0.8.
[I 2021-03-18 01:12:56,739] Trial 98 finished with value: 0.6 and parameters: {'solver': 'admm', 'C': 0.07462391891461814, 'penalty': 'l2'}. Best is trial 29 with value: 0.8.
[I 2021-03-18 01:12:57,192] Trial 99 finished with value: 0.6 and parameters: {'solver': 'admm', 'C': 0.468622593910408, 'penalty': 'l2'}. Best is trial 29 with value: 0.8.
```

<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

## Description of the changes
<!-- Describe the changes in this PR. -->
