### PR TITLE
Add log-linear algorithm for 2d Pareto front.

### DIFF
--- a/optuna/_multi_objective.py
+++ b/optuna/_multi_objective.py
@@ -34,7 +34,7 @@ def _get_pareto_front_trials_2d(study: "optuna.study.BaseStudy") -> List[FrozenT
         if curr_x != x:
             set_mask(width, hi=i)
             width = 0
-        if y > best_y:
+        if y > best_y or (y == best_y and width == 0):
             continue
         if y < best_y:
             width = 0

--- a/optuna/_multi_objective.py
+++ b/optuna/_multi_objective.py
@@ -15,26 +15,23 @@ def _get_pareto_front_trials_2d(study: "optuna.study.BaseStudy") -> List[FrozenT
     if n_trials == 0:
         return []
 
-    numbered_trials = sorted(
-        enumerate(trials),
-        key=lambda pair: (
-            _normalize_value(pair[1].values[0], study.directions[0]),
-            _normalize_value(pair[1].values[1], study.directions[1]),
+    trials.sort(
+        key=lambda trial: (
+            _normalize_value(trial.values[0], study.directions[0]),
+            _normalize_value(trial.values[1], study.directions[1]),
         ),
     )
 
-    mask = [False] * n_trials
-
-    index, last_nondominated_trial = numbered_trials[0]
-    mask[index] = True
+    last_nondominated_trial = trials[0]
+    pareto_front = [last_nondominated_trial]
     for i in range(1, n_trials):
-        index, trial = numbered_trials[i]
+        trial = trials[i]
         if _dominates(last_nondominated_trial, trial, study.directions):
             continue
-        mask[index] = True
+        pareto_front.append(trial)
         last_nondominated_trial = trial
 
-    pareto_front = [trial for trial, keep in zip(trials, mask) if keep]
+    pareto_front.sort(key=lambda trial: trial.number)
     return pareto_front
 
 

--- a/tests/study_tests/test_study.py
+++ b/tests/study_tests/test_study.py
@@ -831,6 +831,9 @@ def test_pareto_front() -> None:
     study.optimize(lambda t: [3, 1], n_trials=1)
     assert {_trial_to_values(t) for t in study.best_trials} == {(1, 1), (2, 2)}
 
+    study.optimize(lambda t: [3, 2], n_trials=1)
+    assert {_trial_to_values(t) for t in study.best_trials} == {(1, 1), (2, 2)}
+
     study.optimize(lambda t: [1, 3], n_trials=1)
     assert {_trial_to_values(t) for t in study.best_trials} == {(1, 3)}
     assert len(study.best_trials) == 1

--- a/tests/study_tests/test_study.py
+++ b/tests/study_tests/test_study.py
@@ -814,7 +814,7 @@ def test_optimize_with_multi_objectives(n_objectives: int) -> None:
         assert len(trial.values) == n_objectives
 
 
-def test_pareto_front() -> None:
+def test_pareto_front_2d() -> None:
     def _trial_to_values(t: FrozenTrial) -> Tuple[float, ...]:
         assert t.values is not None
         return tuple(t.values)
@@ -840,6 +840,37 @@ def test_pareto_front() -> None:
 
     study.optimize(lambda t: [1, 3], n_trials=1)  # The trial result is the same as the above one.
     assert {_trial_to_values(t) for t in study.best_trials} == {(1, 3)}
+    assert len(study.best_trials) == 2
+
+
+def test_pareto_front_3d() -> None:
+    def _trial_to_values(t: FrozenTrial) -> Tuple[float, ...]:
+        assert t.values is not None
+        return tuple(t.values)
+
+    study = create_study(directions=["minimize", "maximize", "minimize"])
+    assert {_trial_to_values(t) for t in study.best_trials} == set()
+
+    study.optimize(lambda t: [2, 2, 2], n_trials=1)
+    assert {_trial_to_values(t) for t in study.best_trials} == {(2, 2, 2)}
+
+    study.optimize(lambda t: [1, 1, 1], n_trials=1)
+    assert {_trial_to_values(t) for t in study.best_trials} == {(1, 1, 1), (2, 2, 2)}
+
+    study.optimize(lambda t: [3, 1, 3], n_trials=1)
+    assert {_trial_to_values(t) for t in study.best_trials} == {(1, 1, 1), (2, 2, 2)}
+
+    study.optimize(lambda t: [3, 2, 3], n_trials=1)
+    assert {_trial_to_values(t) for t in study.best_trials} == {(1, 1, 1), (2, 2, 2)}
+
+    study.optimize(lambda t: [1, 3, 1], n_trials=1)
+    assert {_trial_to_values(t) for t in study.best_trials} == {(1, 3, 1)}
+    assert len(study.best_trials) == 1
+
+    study.optimize(
+        lambda t: [1, 3, 1], n_trials=1
+    )  # The trial result is the same as the above one.
+    assert {_trial_to_values(t) for t in study.best_trials} == {(1, 3, 1)}
     assert len(study.best_trials) == 2
 
 


### PR DESCRIPTION
## Motivation
`study.best_trials` can be made faster when there are only two objectives.

## Description of the changes
Uses a log-linear algorithm algorithm to construct the Pareto frontier in the case of two objectives that works as follows:

1. Sort trials by their x coordinate.
2. Iterate through the sorted trials and drop any trial that does not have a better y coordinate than the current best y coordinate.