### PR TITLE
Unset `errexit` temporarily in CI job for PyTorch checkpoint example

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -119,7 +119,10 @@ jobs:
         OMP_NUM_THREADS: 1
     - name: Run PyTorch checkpoint example
       run: |
+        # Unset errexit temporarily since timeout returns exit code 124.
+        set +e
         timeout 20 python examples/pytorch/pytorch_checkpoint.py > /dev/null
+        set -e
         python examples/pytorch/pytorch_checkpoint.py > /dev/null
       env:
         OMP_NUM_THREADS: 1


### PR DESCRIPTION
## Motivation

This PR fixes the CI job for PyTorch checkpoint example, which uses the `timeout` command to terminates the pytorch training. If the timeout occurs, the exit code will be `124` and `bash` will stop CI execution there.

c.f., https://github.com/optuna/optuna/pull/2505/checks?check_run_id=2171452246

## Description of the changes

This PR adds `set +e` to inhibit `errexit` to continue CI execution.