### PR TITLE
Bump up scikit-learn version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ def get_extras_require() -> Dict[str, List[str]]:
             "matplotlib>=3.0.0",
             "pandas",
             "plotly>=4.0.0",
-            "scikit-learn>=0.19.0,<0.23.0",
+            "scikit-learn>=0.19.0",
             "scikit-optimize",
             "mlflow",
         ],
@@ -88,7 +88,7 @@ def get_extras_require() -> Dict[str, List[str]]:
             "mxnet",
             "nbval",
             "scikit-image",
-            "scikit-learn>=0.19.0,<0.23.0",  # optuna/visualization/param_importances.py.
+            "scikit-learn>=0.19.0",  # optuna/visualization/param_importances.py.
             "xgboost",
             "keras",
             "tensorflow>=2.0.0",
@@ -129,7 +129,7 @@ def get_extras_require() -> Dict[str, List[str]]:
             "pandas",
             "plotly>=4.0.0",
             "pytest",
-            "scikit-learn>=0.19.0,<0.23.0",
+            "scikit-learn>=0.19.0",
             "scikit-optimize",
             "xgboost",
             "keras",
@@ -158,7 +158,7 @@ def get_extras_require() -> Dict[str, List[str]]:
             "pandas",  # optuna/study.py
             "plotly>=4.0.0",  # optuna/visualization.
             "redis",  # optuna/storages/redis.py.
-            "scikit-learn>=0.19.0,<0.23.0",  # optuna/visualization/param_importances.py.
+            "scikit-learn>=0.19.0",  # optuna/visualization/param_importances.py.
         ],
         "integration": [
             # TODO(toshihikoyanase): Remove the version constraint after resolving the issue
@@ -170,7 +170,7 @@ def get_extras_require() -> Dict[str, List[str]]:
             "mpi4py",
             "mxnet",
             "pandas",
-            "scikit-learn>=0.19.0,<0.23.0",
+            "scikit-learn>=0.19.0",
             "scikit-optimize",
             "xgboost",
             "keras",


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
#2034 

## Description of the changes
<!-- Describe the changes in this PR. -->
Steps followed for this PR:
- A docker container was made from the dockerfile in master optuna branch.
- All the examples related to scikit-learn were tested.
  
The logs are given below:
```
root@81bdd825218a:/workspaces/examples# python -c "import sklearn;print(sklearn.__version__)"
0.24.1
root@81bdd825218a:/workspaces/examples# python sklearn/sklearn_simple.py
[I 2021-03-23 11:12:08,448] A new study created in memory with name: no-name-9fb44ae1-f3ac-4824-bb18-cabcc2f3ddbc
[I 2021-03-23 11:12:12,612] Trial 0 finished with value: 0.96 and parameters: {'classifier': 'RandomForest', 'rf_max_depth': 9}. Best is trial 0 with value: 0.96.
[I 2021-03-23 11:12:12,659] Trial 1 finished with value: 0.9666666666666667 and parameters: {'classifier': 'SVC', 'svc_c': 0.4816028308515409}. Best is trial 1 with value: 0.9666666666666667.
[I 2021-03-23 11:12:12,713] Trial 2 finished with value: 0.32 and parameters: {'classifier': 'SVC', 'svc_c': 2.4404093034126532e-08}. Best is trial 1 with value: 0.9666666666666667.
[I 2021-03-23 11:12:12,814] Trial 3 finished with value: 0.9533333333333333 and parameters: {'classifier': 'RandomForest', 'rf_max_depth': 4}. Best is trial 1 with value: 0.9666666666666667.
[I 2021-03-23 11:12:12,942] Trial 4 finished with value: 0.96 and parameters: {'classifier': 'RandomForest', 'rf_max_depth': 25}. Best is trial 1 with value: 0.9666666666666667.
[I 2021-03-23 11:12:12,989] Trial 5 finished with value: 0.32 and parameters: {'classifier': 'SVC', 'svc_c': 7.692860224989787e-05}. Best is trial 1 with value: 0.9666666666666667.
[I 2021-03-23 11:12:13,053] Trial 6 finished with value: 0.7466666666666667 and parameters: {'classifier': 'SVC', 'svc_c': 0.021690437854430665}. Best is trial 1 with value: 0.9666666666666667.
[I 2021-03-23 11:12:13,181] Trial 7 finished with value: 0.9533333333333333 and parameters: {'classifier': 'RandomForest', 'rf_max_depth': 17}. Best is trial 1 with value: 0.9666666666666667.
[I 2021-03-23 11:12:13,293] Trial 8 finished with value: 0.9466666666666667 and parameters: {'classifier': 'RandomForest', 'rf_max_depth': 30}. Best is trial 1 with value: 0.9666666666666667.
[I 2021-03-23 11:12:13,350] Trial 9 finished with value: 0.32 and parameters: {'classifier': 'SVC', 'svc_c': 0.00023269203467067679}. Best is trial 1 with value: 0.9666666666666667.
[I 2021-03-23 11:12:13,419] Trial 10 finished with value: 0.96 and parameters: {'classifier': 'SVC', 'svc_c': 151216032.64611825}. Best is trial 1 with value: 0.9666666666666667.
[I 2021-03-23 11:12:13,546] Trial 11 finished with value: 0.9533333333333333 and parameters: {'classifier': 'RandomForest', 'rf_max_depth': 8}. Best is trial 1 with value: 0.9666666666666667.
[I 2021-03-23 11:12:13,596] Trial 12 finished with value: 0.96 and parameters: {'classifier': 'SVC', 'svc_c': 41111.00178010331}. Best is trial 1 with value: 0.9666666666666667.
[I 2021-03-23 11:12:13,741] Trial 13 finished with value: 0.9466666666666667 and parameters: {'classifier': 'RandomForest', 'rf_max_depth': 2}. Best is trial 1 with value: 0.9666666666666667.
[I 2021-03-23 11:12:13,787] Trial 14 finished with value: 0.96 and parameters: {'classifier': 'SVC', 'svc_c': 16757.068662373353}. Best is trial 1 with value: 0.9666666666666667.
[I 2021-03-23 11:12:13,932] Trial 15 finished with value: 0.9533333333333333 and parameters: {'classifier': 'RandomForest', 'rf_max_depth': 9}. Best is trial 1 with value: 0.9666666666666667.
[I 2021-03-23 11:12:14,008] Trial 16 finished with value: 0.9466666666666667 and parameters: {'classifier': 'SVC', 'svc_c': 259.9420987519541}. Best is trial 1 with value: 0.9666666666666667.
[I 2021-03-23 11:12:14,141] Trial 17 finished with value: 0.9666666666666667 and parameters: {'classifier': 'RandomForest', 'rf_max_depth': 4}. Best is trial 1 with value: 0.9666666666666667.
[I 2021-03-23 11:12:14,209] Trial 18 finished with value: 0.32 and parameters: {'classifier': 'SVC', 'svc_c': 5.934009118566567e-10}. Best is trial 1 with value: 0.9666666666666667.
[I 2021-03-23 11:12:14,345] Trial 19 finished with value: 0.9266666666666666 and parameters: {'classifier': 'RandomForest', 'rf_max_depth': 2}. Best is trial 1 with value: 0.9666666666666667.
[I 2021-03-23 11:12:14,407] Trial 20 finished with value: 0.96 and parameters: {'classifier': 'SVC', 'svc_c': 5532829102.072467}. Best is trial 1 with value: 0.9666666666666667.
[I 2021-03-23 11:12:14,539] Trial 21 finished with value: 0.9533333333333333 and parameters: {'classifier': 'RandomForest', 'rf_max_depth': 4}. Best is trial 1 with value: 0.9666666666666667.
[I 2021-03-23 11:12:14,645] Trial 22 finished with value: 0.9666666666666667 and parameters: {'classifier': 'RandomForest', 'rf_max_depth': 4}. Best is trial 1 with value: 0.9666666666666667.
[I 2021-03-23 11:12:14,746] Trial 23 finished with value: 0.9466666666666667 and parameters: {'classifier': 'RandomForest', 'rf_max_depth': 4}. Best is trial 1 with value: 0.9666666666666667.
[I 2021-03-23 11:12:14,889] Trial 24 finished with value: 0.9466666666666667 and parameters: {'classifier': 'RandomForest', 'rf_max_depth': 3}. Best is trial 1 with value: 0.9666666666666667.
[I 2021-03-23 11:12:15,012] Trial 25 finished with value: 0.96 and parameters: {'classifier': 'RandomForest', 'rf_max_depth': 6}. Best is trial 1 with value: 0.9666666666666667.
[I 2021-03-23 11:12:15,153] Trial 26 finished with value: 0.94 and parameters: {'classifier': 'RandomForest', 'rf_max_depth': 6}. Best is trial 1 with value: 0.9666666666666667.
[I 2021-03-23 11:12:15,286] Trial 27 finished with value: 0.9666666666666667 and parameters: {'classifier': 'RandomForest', 'rf_max_depth': 3}. Best is trial 1 with value: 0.9666666666666667.
[I 2021-03-23 11:12:15,427] Trial 28 finished with value: 0.96 and parameters: {'classifier': 'RandomForest', 'rf_max_depth': 2}. Best is trial 1 with value: 0.9666666666666667.
[I 2021-03-23 11:12:15,550] Trial 29 finished with value: 0.9333333333333332 and parameters: {'classifier': 'RandomForest', 'rf_max_depth': 2}. Best is trial 1 with value: 0.9666666666666667.
[I 2021-03-23 11:12:15,606] Trial 30 finished with value: 0.9733333333333333 and parameters: {'classifier': 'SVC', 'svc_c': 1.0946776502235702}. Best is trial 30 with value: 0.9733333333333333.
[I 2021-03-23 11:12:15,668] Trial 31 finished with value: 0.9866666666666667 and parameters: {'classifier': 'SVC', 'svc_c': 4.497716153038807}. Best is trial 31 with value: 0.9866666666666667.
[I 2021-03-23 11:12:15,732] Trial 32 finished with value: 0.98 and parameters: {'classifier': 'SVC', 'svc_c': 9.181207167853795}. Best is trial 31 with value: 0.9866666666666667.
[I 2021-03-23 11:12:15,798] Trial 33 finished with value: 0.9866666666666667 and parameters: {'classifier': 'SVC', 'svc_c': 3.7208394135281218}. Best is trial 31 with value: 0.9866666666666667.
[I 2021-03-23 11:12:15,846] Trial 34 finished with value: 0.96 and parameters: {'classifier': 'SVC', 'svc_c': 135.5332392525566}. Best is trial 31 with value: 0.9866666666666667.
[I 2021-03-23 11:12:15,897] Trial 35 finished with value: 0.98 and parameters: {'classifier': 'SVC', 'svc_c': 9.584050045541145}. Best is trial 31 with value: 0.9866666666666667.
[I 2021-03-23 11:12:15,959] Trial 36 finished with value: 0.96 and parameters: {'classifier': 'SVC', 'svc_c': 75.46934238012405}. Best is trial 31 with value: 0.9866666666666667.
[I 2021-03-23 11:12:16,036] Trial 37 finished with value: 0.32 and parameters: {'classifier': 'SVC', 'svc_c': 0.013906635023886444}. Best is trial 31 with value: 0.9866666666666667.
[I 2021-03-23 11:12:16,089] Trial 38 finished with value: 0.96 and parameters: {'classifier': 'SVC', 'svc_c': 56430.2640184946}. Best is trial 31 with value: 0.9866666666666667.
[I 2021-03-23 11:12:16,140] Trial 39 finished with value: 0.9733333333333333 and parameters: {'classifier': 'SVC', 'svc_c': 3.1573271296113656}. Best is trial 31 with value: 0.9866666666666667.
[I 2021-03-23 11:12:16,219] Trial 40 finished with value: 0.32 and parameters: {'classifier': 'SVC', 'svc_c': 0.0031699551998978378}. Best is trial 31 with value: 0.9866666666666667.
[I 2021-03-23 11:12:16,272] Trial 41 finished with value: 0.9666666666666667 and parameters: {'classifier': 'SVC', 'svc_c': 0.6674509724085734}. Best is trial 31 with value: 0.9866666666666667.
[I 2021-03-23 11:12:16,339] Trial 42 finished with value: 0.9733333333333333 and parameters: {'classifier': 'SVC', 'svc_c': 14.43309607824611}. Best is trial 31 with value: 0.9866666666666667.
[I 2021-03-23 11:12:16,403] Trial 43 finished with value: 0.96 and parameters: {'classifier': 'SVC', 'svc_c': 2032.1458621873585}. Best is trial 31 with value: 0.9866666666666667.
[I 2021-03-23 11:12:16,465] Trial 44 finished with value: 0.98 and parameters: {'classifier': 'SVC', 'svc_c': 3.637022397617793}. Best is trial 31 with value: 0.9866666666666667.
[I 2021-03-23 11:12:16,533] Trial 45 finished with value: 0.94 and parameters: {'classifier': 'SVC', 'svc_c': 0.08366697022915771}. Best is trial 31 with value: 0.9866666666666667.
[I 2021-03-23 11:12:16,586] Trial 46 finished with value: 0.98 and parameters: {'classifier': 'SVC', 'svc_c': 9.886224931516658}. Best is trial 31 with value: 0.9866666666666667.
[I 2021-03-23 11:12:16,639] Trial 47 finished with value: 0.96 and parameters: {'classifier': 'SVC', 'svc_c': 880.6424238190167}. Best is trial 31 with value: 0.9866666666666667.
[I 2021-03-23 11:12:16,696] Trial 48 finished with value: 0.32 and parameters: {'classifier': 'SVC', 'svc_c': 0.0006403419105107644}. Best is trial 31 with value: 0.9866666666666667.
[I 2021-03-23 11:12:16,740] Trial 49 finished with value: 0.96 and parameters: {'classifier': 'SVC', 'svc_c': 3785126.8180325204}. Best is trial 31 with value: 0.9866666666666667.
[I 2021-03-23 11:12:16,785] Trial 50 finished with value: 0.9666666666666667 and parameters: {'classifier': 'SVC', 'svc_c': 1.5418287284410828}. Best is trial 31 with value: 0.9866666666666667.
[I 2021-03-23 11:12:16,850] Trial 51 finished with value: 0.98 and parameters: {'classifier': 'SVC', 'svc_c': 11.576856540318019}. Best is trial 31 with value: 0.9866666666666667.
[I 2021-03-23 11:12:16,922] Trial 52 finished with value: 0.9466666666666667 and parameters: {'classifier': 'SVC', 'svc_c': 0.1197740475631339}. Best is trial 31 with value: 0.9866666666666667.
[I 2021-03-23 11:12:16,994] Trial 53 finished with value: 0.9666666666666667 and parameters: {'classifier': 'SVC', 'svc_c': 20.499954144351072}. Best is trial 31 with value: 0.9866666666666667.
[I 2021-03-23 11:12:17,059] Trial 54 finished with value: 0.96 and parameters: {'classifier': 'SVC', 'svc_c': 2842.0079662618255}. Best is trial 31 with value: 0.9866666666666667.
[I 2021-03-23 11:12:17,130] Trial 55 finished with value: 0.32 and parameters: {'classifier': 'SVC', 'svc_c': 3.949163423992752e-06}. Best is trial 31 with value: 0.9866666666666667.
[I 2021-03-23 11:12:17,206] Trial 56 finished with value: 0.96 and parameters: {'classifier': 'SVC', 'svc_c': 0.26532143880377557}. Best is trial 31 with value: 0.9866666666666667.
[I 2021-03-23 11:12:17,278] Trial 57 finished with value: 0.9666666666666667 and parameters: {'classifier': 'SVC', 'svc_c': 24.991101843857415}. Best is trial 31 with value: 0.9866666666666667.
[I 2021-03-23 11:12:17,347] Trial 58 finished with value: 0.9 and parameters: {'classifier': 'SVC', 'svc_c': 0.04227878967945366}. Best is trial 31 with value: 0.9866666666666667.
[I 2021-03-23 11:12:17,400] Trial 59 finished with value: 0.96 and parameters: {'classifier': 'SVC', 'svc_c': 460141.1505655517}. Best is trial 31 with value: 0.9866666666666667.
[I 2021-03-23 11:12:17,475] Trial 60 finished with value: 0.9466666666666667 and parameters: {'classifier': 'SVC', 'svc_c': 217.57572690253457}. Best is trial 31 with value: 0.9866666666666667.
[I 2021-03-23 11:12:17,546] Trial 61 finished with value: 0.98 and parameters: {'classifier': 'SVC', 'svc_c': 6.9912555194440875}. Best is trial 31 with value: 0.9866666666666667.
[I 2021-03-23 11:12:17,624] Trial 62 finished with value: 0.9733333333333333 and parameters: {'classifier': 'SVC', 'svc_c': 2.7479292131353272}. Best is trial 31 with value: 0.9866666666666667.
[I 2021-03-23 11:12:17,694] Trial 63 finished with value: 0.9666666666666667 and parameters: {'classifier': 'SVC', 'svc_c': 27.457856092012914}. Best is trial 31 with value: 0.9866666666666667.
[I 2021-03-23 11:12:17,772] Trial 64 finished with value: 0.9666666666666667 and parameters: {'classifier': 'SVC', 'svc_c': 0.42179094729306255}. Best is trial 31 with value: 0.9866666666666667.
[I 2021-03-23 11:12:17,846] Trial 65 finished with value: 0.96 and parameters: {'classifier': 'SVC', 'svc_c': 907.1623821033672}. Best is trial 31 with value: 0.9866666666666667.
[I 2021-03-23 11:12:17,913] Trial 66 finished with value: 0.32 and parameters: {'classifier': 'SVC', 'svc_c': 0.00588793368208096}. Best is trial 31 with value: 0.9866666666666667.
[I 2021-03-23 11:12:17,988] Trial 67 finished with value: 0.96 and parameters: {'classifier': 'SVC', 'svc_c': 10962.395926487803}. Best is trial 31 with value: 0.9866666666666667.
[I 2021-03-23 11:12:18,047] Trial 68 finished with value: 0.96 and parameters: {'classifier': 'SVC', 'svc_c': 110.80944401437387}. Best is trial 31 with value: 0.9866666666666667.
[I 2021-03-23 11:12:18,106] Trial 69 finished with value: 0.98 and parameters: {'classifier': 'SVC', 'svc_c': 3.598486190474906}. Best is trial 31 with value: 0.9866666666666667.
[I 2021-03-23 11:12:18,158] Trial 70 finished with value: 0.9466666666666667 and parameters: {'classifier': 'SVC', 'svc_c': 185.98431321986652}. Best is trial 31 with value: 0.9866666666666667.
[I 2021-03-23 11:12:18,232] Trial 71 finished with value: 0.9866666666666667 and parameters: {'classifier': 'SVC', 'svc_c': 4.3149636808061835}. Best is trial 31 with value: 0.9866666666666667.
[I 2021-03-23 11:12:18,290] Trial 72 finished with value: 0.9866666666666667 and parameters: {'classifier': 'SVC', 'svc_c': 4.021682154270863}. Best is trial 31 with value: 0.9866666666666667.
[I 2021-03-23 11:12:18,350] Trial 73 finished with value: 0.9666666666666667 and parameters: {'classifier': 'SVC', 'svc_c': 0.7251361406725718}. Best is trial 31 with value: 0.9866666666666667.
[I 2021-03-23 11:12:18,412] Trial 74 finished with value: 0.98 and parameters: {'classifier': 'SVC', 'svc_c': 5.98881868692857}. Best is trial 31 with value: 0.9866666666666667.
[I 2021-03-23 11:12:18,475] Trial 75 finished with value: 0.7600000000000001 and parameters: {'classifier': 'SVC', 'svc_c': 0.03320315664820218}. Best is trial 31 with value: 0.9866666666666667.
[I 2021-03-23 11:12:18,532] Trial 76 finished with value: 0.9666666666666667 and parameters: {'classifier': 'SVC', 'svc_c': 0.15885188707140588}. Best is trial 31 with value: 0.9866666666666667.
[I 2021-03-23 11:12:18,595] Trial 77 finished with value: 0.96 and parameters: {'classifier': 'SVC', 'svc_c': 59.287754373084624}. Best is trial 31 with value: 0.9866666666666667.
[I 2021-03-23 11:12:18,657] Trial 78 finished with value: 0.9666666666666667 and parameters: {'classifier': 'SVC', 'svc_c': 1.3102614930832106}. Best is trial 31 with value: 0.9866666666666667.
[I 2021-03-23 11:12:18,723] Trial 79 finished with value: 0.9733333333333333 and parameters: {'classifier': 'SVC', 'svc_c': 13.28633678393484}. Best is trial 31 with value: 0.9866666666666667.
[I 2021-03-23 11:12:18,775] Trial 80 finished with value: 0.98 and parameters: {'classifier': 'SVC', 'svc_c': 5.2138004943659775}. Best is trial 31 with value: 0.9866666666666667.
[I 2021-03-23 11:12:18,821] Trial 81 finished with value: 0.9733333333333333 and parameters: {'classifier': 'SVC', 'svc_c': 2.564487075367821}. Best is trial 31 with value: 0.9866666666666667.
[I 2021-03-23 11:12:18,895] Trial 82 finished with value: 0.9466666666666667 and parameters: {'classifier': 'SVC', 'svc_c': 452.4251428048077}. Best is trial 31 with value: 0.9866666666666667.
[I 2021-03-23 11:12:18,967] Trial 83 finished with value: 0.9666666666666667 and parameters: {'classifier': 'SVC', 'svc_c': 0.40587975543886606}. Best is trial 31 with value: 0.9866666666666667.
[I 2021-03-23 11:12:19,039] Trial 84 finished with value: 0.96 and parameters: {'classifier': 'SVC', 'svc_c': 57.469274308981475}. Best is trial 31 with value: 0.9866666666666667.
[I 2021-03-23 11:12:19,107] Trial 85 finished with value: 0.98 and parameters: {'classifier': 'SVC', 'svc_c': 11.376422184277866}. Best is trial 31 with value: 0.9866666666666667.
[I 2021-03-23 11:12:19,178] Trial 86 finished with value: 0.32 and parameters: {'classifier': 'SVC', 'svc_c': 0.0014866427241209468}. Best is trial 31 with value: 0.9866666666666667.
[I 2021-03-23 11:12:19,243] Trial 87 finished with value: 0.94 and parameters: {'classifier': 'SVC', 'svc_c': 0.06980565987239899}. Best is trial 31 with value: 0.9866666666666667.
[I 2021-03-23 11:12:19,318] Trial 88 finished with value: 0.9733333333333333 and parameters: {'classifier': 'SVC', 'svc_c': 2.641946742430858}. Best is trial 31 with value: 0.9866666666666667.
[I 2021-03-23 11:12:19,385] Trial 89 finished with value: 0.32 and parameters: {'classifier': 'SVC', 'svc_c': 0.012014889631062996}. Best is trial 31 with value: 0.9866666666666667.
[I 2021-03-23 11:12:19,442] Trial 90 finished with value: 0.96 and parameters: {'classifier': 'SVC', 'svc_c': 3381.7342465675724}. Best is trial 31 with value: 0.9866666666666667.
[I 2021-03-23 11:12:19,520] Trial 91 finished with value: 0.96 and parameters: {'classifier': 'SVC', 'svc_c': 34.0889214956923}. Best is trial 31 with value: 0.9866666666666667.
[I 2021-03-23 11:12:19,588] Trial 92 finished with value: 0.9666666666666667 and parameters: {'classifier': 'SVC', 'svc_c': 0.7586634555033446}. Best is trial 31 with value: 0.9866666666666667.
[I 2021-03-23 11:12:19,667] Trial 93 finished with value: 0.98 and parameters: {'classifier': 'SVC', 'svc_c': 10.58637862972137}. Best is trial 31 with value: 0.9866666666666667.
[I 2021-03-23 11:12:19,738] Trial 94 finished with value: 0.98 and parameters: {'classifier': 'SVC', 'svc_c': 5.24634940515649}. Best is trial 31 with value: 0.9866666666666667.
[I 2021-03-23 11:12:19,798] Trial 95 finished with value: 0.96 and parameters: {'classifier': 'SVC', 'svc_c': 0.23485036442238136}. Best is trial 31 with value: 0.9866666666666667.
[I 2021-03-23 11:12:19,867] Trial 96 finished with value: 0.9666666666666667 and parameters: {'classifier': 'SVC', 'svc_c': 17.410326856030473}. Best is trial 31 with value: 0.9866666666666667.
[I 2021-03-23 11:12:19,931] Trial 97 finished with value: 0.96 and parameters: {'classifier': 'SVC', 'svc_c': 86.24271684483011}. Best is trial 31 with value: 0.9866666666666667.
[I 2021-03-23 11:12:20,001] Trial 98 finished with value: 0.9466666666666667 and parameters: {'classifier': 'SVC', 'svc_c': 398.83506244556975}. Best is trial 31 with value: 0.9866666666666667.
[I 2021-03-23 11:12:20,055] Trial 99 finished with value: 0.98 and parameters: {'classifier': 'SVC', 'svc_c': 1.7714759517804284}. Best is trial 31 with value: 0.9866666666666667.
FrozenTrial(number=31, values=[0.9866666666666667], datetime_start=datetime.datetime(2021, 3, 23, 11, 12, 15, 607301), datetime_complete=datetime.datetime(2021, 3, 23, 11, 12, 15, 668193), params={'classifier': 'SVC', 'svc_c': 4.497716153038807}, distributions={'classifier': CategoricalDistribution(choices=('SVC', 'RandomForest')), 'svc_c': LogUniformDistribution(high=10000000000.0, low=1e-10)}, user_attrs={}, system_attrs={}, intermediate_values={}, trial_id=31, state=TrialState.COMPLETE, value=None)
root@81bdd825218a:/workspaces/examples# python sklearn/sklearn_optuna_search_cv_simple.py
sklearn/sklearn_optuna_search_cv_simple.py:24: ExperimentalWarning: OptunaSearchCV is experimental (supported from v0.17.0). The interface can change in the future.
  clf, param_distributions, n_trials=100, timeout=600, verbose=2
/usr/local/lib/python3.7/site-packages/sklearn/utils/validation.py:72: FutureWarning: Pass classifier=True as keyword args. From version 1.0 (renaming of 0.25) passing these as positional arguments will result in an error
  "will result in an error", FutureWarning)
[I 2021-03-23 11:12:52,914] A new study created in memory with name: no-name-eb801b0e-76ad-4c13-970e-a365070155ac
[I 2021-03-23 11:12:52,915] Searching the best hyperparameters using 150 samples...
[I 2021-03-23 11:12:52,936] Trial 0 finished with value: 0.9400000000000001 and parameters: {'C': 132933.6406418937, 'degree': 4}. Best is trial 0 with value: 0.9400000000000001.
[I 2021-03-23 11:12:52,980] Trial 1 finished with value: 0.9333333333333333 and parameters: {'C': 9.441952789212282e-06, 'degree': 2}. Best is trial 0 with value: 0.9400000000000001.
[I 2021-03-23 11:12:53,021] Trial 2 finished with value: 0.9400000000000001 and parameters: {'C': 185088306.50937447, 'degree': 2}. Best is trial 0 with value: 0.9400000000000001.
[I 2021-03-23 11:12:53,059] Trial 3 finished with value: 0.9400000000000001 and parameters: {'C': 965075370.4554093, 'degree': 5}. Best is trial 0 with value: 0.9400000000000001.
[I 2021-03-23 11:12:53,093] Trial 4 finished with value: 0.9333333333333333 and parameters: {'C': 0.004312110327250924, 'degree': 5}. Best is trial 0 with value: 0.9400000000000001.
[I 2021-03-23 11:12:53,128] Trial 5 finished with value: 0.9400000000000001 and parameters: {'C': 6409.573036755767, 'degree': 1}. Best is trial 0 with value: 0.9400000000000001.
[I 2021-03-23 11:12:53,158] Trial 6 finished with value: 0.9400000000000001 and parameters: {'C': 967840822.161275, 'degree': 2}. Best is trial 0 with value: 0.9400000000000001.
[I 2021-03-23 11:12:53,189] Trial 7 finished with value: 0.9533333333333334 and parameters: {'C': 636.5736906994971, 'degree': 2}. Best is trial 7 with value: 0.9533333333333334.
[I 2021-03-23 11:12:53,226] Trial 8 finished with value: 0.9400000000000001 and parameters: {'C': 2539995.2756219264, 'degree': 2}. Best is trial 7 with value: 0.9533333333333334.
[I 2021-03-23 11:12:53,269] Trial 9 finished with value: 0.9333333333333333 and parameters: {'C': 2.679933643606046e-09, 'degree': 1}. Best is trial 7 with value: 0.9533333333333334.
[I 2021-03-23 11:12:53,323] Trial 10 finished with value: 0.9800000000000001 and parameters: {'C': 8.112908187346795, 'degree': 3}. Best is trial 10 with value: 0.9800000000000001.
[I 2021-03-23 11:12:53,367] Trial 11 finished with value: 0.9733333333333334 and parameters: {'C': 18.960121768444875, 'degree': 3}. Best is trial 10 with value: 0.9800000000000001.
[I 2021-03-23 11:12:53,420] Trial 12 finished with value: 0.96 and parameters: {'C': 0.1680466482978709, 'degree': 4}. Best is trial 10 with value: 0.9800000000000001.
[I 2021-03-23 11:12:53,473] Trial 13 finished with value: 0.9666666666666668 and parameters: {'C': 19.645417954362998, 'degree': 3}. Best is trial 10 with value: 0.9800000000000001.
[I 2021-03-23 11:12:53,544] Trial 14 finished with value: 0.9333333333333333 and parameters: {'C': 0.0002898039587357805, 'degree': 3}. Best is trial 10 with value: 0.9800000000000001.
[I 2021-03-23 11:12:53,585] Trial 15 finished with value: 0.9866666666666667 and parameters: {'C': 3.6032976371316527, 'degree': 4}. Best is trial 15 with value: 0.9866666666666667.
[I 2021-03-23 11:12:53,648] Trial 16 finished with value: 0.9333333333333333 and parameters: {'C': 1.7029036846035432e-07, 'degree': 4}. Best is trial 15 with value: 0.9866666666666667.
[I 2021-03-23 11:12:53,710] Trial 17 finished with value: 0.96 and parameters: {'C': 0.14342146008561768, 'degree': 4}. Best is trial 15 with value: 0.9866666666666667.
[I 2021-03-23 11:12:53,773] Trial 18 finished with value: 0.96 and parameters: {'C': 70.23966381727483, 'degree': 5}. Best is trial 15 with value: 0.9866666666666667.
[I 2021-03-23 11:12:53,830] Trial 19 finished with value: 0.9333333333333333 and parameters: {'C': 0.0030071415940828602, 'degree': 4}. Best is trial 15 with value: 0.9866666666666667.
[I 2021-03-23 11:12:53,898] Trial 20 finished with value: 0.9400000000000001 and parameters: {'C': 120183.17847432097, 'degree': 3}. Best is trial 15 with value: 0.9866666666666667.
[I 2021-03-23 11:12:53,946] Trial 21 finished with value: 0.9800000000000001 and parameters: {'C': 1.446264772589054, 'degree': 3}. Best is trial 15 with value: 0.9866666666666667.
[I 2021-03-23 11:12:53,997] Trial 22 finished with value: 0.9800000000000001 and parameters: {'C': 0.6145960451399484, 'degree': 3}. Best is trial 15 with value: 0.9866666666666667.
[I 2021-03-23 11:12:54,050] Trial 23 finished with value: 0.96 and parameters: {'C': 0.273993213600187, 'degree': 4}. Best is trial 15 with value: 0.9866666666666667.
[I 2021-03-23 11:12:54,110] Trial 24 finished with value: 0.9333333333333333 and parameters: {'C': 6.701755481609785e-05, 'degree': 3}. Best is trial 15 with value: 0.9866666666666667.
[I 2021-03-23 11:12:54,163] Trial 25 finished with value: 0.9333333333333333 and parameters: {'C': 0.02562631082808736, 'degree': 4}. Best is trial 15 with value: 0.9866666666666667.
[I 2021-03-23 11:12:54,224] Trial 26 finished with value: 0.9400000000000001 and parameters: {'C': 1313.4472707500152, 'degree': 3}. Best is trial 15 with value: 0.9866666666666667.
[I 2021-03-23 11:12:54,272] Trial 27 finished with value: 0.9333333333333333 and parameters: {'C': 1.5318868509056974e-06, 'degree': 4}. Best is trial 15 with value: 0.9866666666666667.
[I 2021-03-23 11:12:54,312] Trial 28 finished with value: 0.9800000000000001 and parameters: {'C': 1.9482826436463292, 'degree': 5}. Best is trial 15 with value: 0.9866666666666667.
[I 2021-03-23 11:12:54,373] Trial 29 finished with value: 0.9400000000000001 and parameters: {'C': 30011.97238719635, 'degree': 5}. Best is trial 15 with value: 0.9866666666666667.
[I 2021-03-23 11:12:54,419] Trial 30 finished with value: 0.9400000000000001 and parameters: {'C': 1197441.7860301242, 'degree': 4}. Best is trial 15 with value: 0.9866666666666667.
[I 2021-03-23 11:12:54,474] Trial 31 finished with value: 0.9666666666666668 and parameters: {'C': 0.45271036134956544, 'degree': 5}. Best is trial 15 with value: 0.9866666666666667.
[I 2021-03-23 11:12:54,528] Trial 32 finished with value: 0.96 and parameters: {'C': 206.32711008187096, 'degree': 3}. Best is trial 15 with value: 0.9866666666666667.
[I 2021-03-23 11:12:54,571] Trial 33 finished with value: 0.9733333333333334 and parameters: {'C': 2.775567437918276, 'degree': 5}. Best is trial 15 with value: 0.9866666666666667.
[I 2021-03-23 11:12:54,615] Trial 34 finished with value: 0.9800000000000001 and parameters: {'C': 10.591928609703679, 'degree': 2}. Best is trial 15 with value: 0.9866666666666667.
[I 2021-03-23 11:12:54,676] Trial 35 finished with value: 0.9333333333333333 and parameters: {'C': 0.006700812960752543, 'degree': 2}. Best is trial 15 with value: 0.9866666666666667.
[I 2021-03-23 11:12:54,714] Trial 36 finished with value: 0.9400000000000001 and parameters: {'C': 2574.384818644355, 'degree': 1}. Best is trial 15 with value: 0.9866666666666667.
[I 2021-03-23 11:12:54,765] Trial 37 finished with value: 0.9333333333333333 and parameters: {'C': 0.0005337951378123451, 'degree': 2}. Best is trial 15 with value: 0.9866666666666667.
[I 2021-03-23 11:12:54,810] Trial 38 finished with value: 0.9533333333333334 and parameters: {'C': 240.49707448021599, 'degree': 2}. Best is trial 15 with value: 0.9866666666666667.
[I 2021-03-23 11:12:54,862] Trial 39 finished with value: 0.9333333333333333 and parameters: {'C': 0.04839643662104687, 'degree': 5}. Best is trial 15 with value: 0.9866666666666667.
[I 2021-03-23 11:12:54,896] Trial 40 finished with value: 0.9800000000000001 and parameters: {'C': 2.0713113093245363, 'degree': 2}. Best is trial 15 with value: 0.9866666666666667.
[I 2021-03-23 11:12:54,962] Trial 41 finished with value: 0.9866666666666667 and parameters: {'C': 3.235903476470364, 'degree': 3}. Best is trial 15 with value: 0.9866666666666667.
[I 2021-03-23 11:12:55,013] Trial 42 finished with value: 0.9800000000000001 and parameters: {'C': 2.207455930535386, 'degree': 1}. Best is trial 15 with value: 0.9866666666666667.
[I 2021-03-23 11:12:55,047] Trial 43 finished with value: 0.96 and parameters: {'C': 98.38351413082279, 'degree': 2}. Best is trial 15 with value: 0.9866666666666667.
[I 2021-03-23 11:12:55,095] Trial 44 finished with value: 0.9400000000000001 and parameters: {'C': 11236.685255692839, 'degree': 2}. Best is trial 15 with value: 0.9866666666666667.
[I 2021-03-23 11:12:55,160] Trial 45 finished with value: 0.9333333333333333 and parameters: {'C': 0.024320306383191076, 'degree': 1}. Best is trial 15 with value: 0.9866666666666667.
[I 2021-03-23 11:12:55,220] Trial 46 finished with value: 0.9333333333333333 and parameters: {'C': 0.0030177379060850077, 'degree': 4}. Best is trial 15 with value: 0.9866666666666667.
[I 2021-03-23 11:12:55,258] Trial 47 finished with value: 0.96 and parameters: {'C': 29.455776548555566, 'degree': 3}. Best is trial 15 with value: 0.9866666666666667.
[I 2021-03-23 11:12:55,292] Trial 48 finished with value: 0.9733333333333334 and parameters: {'C': 2.9666473291492674, 'degree': 1}. Best is trial 15 with value: 0.9866666666666667.
[I 2021-03-23 11:12:55,337] Trial 49 finished with value: 0.96 and parameters: {'C': 0.19409572472106112, 'degree': 3}. Best is trial 15 with value: 0.9866666666666667.
[I 2021-03-23 11:12:55,398] Trial 50 finished with value: 0.9333333333333333 and parameters: {'C': 0.0005272802069712297, 'degree': 3}. Best is trial 15 with value: 0.9866666666666667.
[I 2021-03-23 11:12:55,459] Trial 51 finished with value: 0.9800000000000001 and parameters: {'C': 10.275455909116364, 'degree': 3}. Best is trial 15 with value: 0.9866666666666667.
[I 2021-03-23 11:12:55,508] Trial 52 finished with value: 0.9666666666666668 and parameters: {'C': 28.10886452155332, 'degree': 3}. Best is trial 15 with value: 0.9866666666666667.
[I 2021-03-23 11:12:55,557] Trial 53 finished with value: 0.9800000000000001 and parameters: {'C': 0.575588672327516, 'degree': 3}. Best is trial 15 with value: 0.9866666666666667.
[I 2021-03-23 11:12:55,618] Trial 54 finished with value: 0.9466666666666667 and parameters: {'C': 1144.6078801151727, 'degree': 3}. Best is trial 15 with value: 0.9866666666666667.
[I 2021-03-23 11:12:55,664] Trial 55 finished with value: 0.9800000000000001 and parameters: {'C': 9.199993414520293, 'degree': 3}. Best is trial 15 with value: 0.9866666666666667.
[I 2021-03-23 11:12:55,714] Trial 56 finished with value: 0.9333333333333333 and parameters: {'C': 0.05347856828575035, 'degree': 4}. Best is trial 15 with value: 0.9866666666666667.
[I 2021-03-23 11:12:55,760] Trial 57 finished with value: 0.9533333333333334 and parameters: {'C': 275.2079122164435, 'degree': 3}. Best is trial 15 with value: 0.9866666666666667.
[I 2021-03-23 11:12:55,813] Trial 58 finished with value: 0.9800000000000001 and parameters: {'C': 11.478810840516052, 'degree': 4}. Best is trial 15 with value: 0.9866666666666667.
[I 2021-03-23 11:12:55,858] Trial 59 finished with value: 0.9800000000000001 and parameters: {'C': 0.6556331982202113, 'degree': 4}. Best is trial 15 with value: 0.9866666666666667.
[I 2021-03-23 11:12:55,892] Trial 60 finished with value: 0.9800000000000001 and parameters: {'C': 8.809900683789825, 'degree': 4}. Best is trial 15 with value: 0.9866666666666667.
[I 2021-03-23 11:12:55,940] Trial 61 finished with value: 0.9800000000000001 and parameters: {'C': 2.0418956607556766, 'degree': 4}. Best is trial 15 with value: 0.9866666666666667.
[I 2021-03-23 11:12:55,990] Trial 62 finished with value: 0.9333333333333333 and parameters: {'C': 0.016027892685162855, 'degree': 4}. Best is trial 15 with value: 0.9866666666666667.
[I 2021-03-23 11:12:56,039] Trial 63 finished with value: 0.96 and parameters: {'C': 0.27588696959794, 'degree': 3}. Best is trial 15 with value: 0.9866666666666667.
[I 2021-03-23 11:12:56,075] Trial 64 finished with value: 0.96 and parameters: {'C': 73.35377418464108, 'degree': 2}. Best is trial 15 with value: 0.9866666666666667.
[I 2021-03-23 11:12:56,131] Trial 65 finished with value: 0.9866666666666667 and parameters: {'C': 3.3662827559011013, 'degree': 1}. Best is trial 15 with value: 0.9866666666666667.
[I 2021-03-23 11:12:56,214] Trial 66 finished with value: 0.9400000000000001 and parameters: {'C': 0.081574172414783, 'degree': 2}. Best is trial 15 with value: 0.9866666666666667.
[I 2021-03-23 11:12:56,261] Trial 67 finished with value: 0.9533333333333334 and parameters: {'C': 476.71646773058205, 'degree': 1}. Best is trial 15 with value: 0.9866666666666667.
[I 2021-03-23 11:12:56,309] Trial 68 finished with value: 0.9800000000000001 and parameters: {'C': 0.7598003932893314, 'degree': 1}. Best is trial 15 with value: 0.9866666666666667.
[I 2021-03-23 11:12:56,360] Trial 69 finished with value: 0.9400000000000001 and parameters: {'C': 4184.623476004727, 'degree': 4}. Best is trial 15 with value: 0.9866666666666667.
[I 2021-03-23 11:12:56,407] Trial 70 finished with value: 0.96 and parameters: {'C': 45.644985322412005, 'degree': 1}. Best is trial 15 with value: 0.9866666666666667.
[I 2021-03-23 11:12:56,448] Trial 71 finished with value: 0.9800000000000001 and parameters: {'C': 7.004326071660265, 'degree': 1}. Best is trial 15 with value: 0.9866666666666667.
[I 2021-03-23 11:12:56,501] Trial 72 finished with value: 0.9800000000000001 and parameters: {'C': 4.995538037467202, 'degree': 2}. Best is trial 15 with value: 0.9866666666666667.
[I 2021-03-23 11:12:56,541] Trial 73 finished with value: 0.9800000000000001 and parameters: {'C': 5.688271993468469, 'degree': 2}. Best is trial 15 with value: 0.9866666666666667.
[I 2021-03-23 11:12:56,585] Trial 74 finished with value: 0.9800000000000001 and parameters: {'C': 2.534195326366274, 'degree': 2}. Best is trial 15 with value: 0.9866666666666667.
[I 2021-03-23 11:12:56,635] Trial 75 finished with value: 0.9333333333333333 and parameters: {'C': 0.009630553958862684, 'degree': 4}. Best is trial 15 with value: 0.9866666666666667.
[I 2021-03-23 11:12:56,678] Trial 76 finished with value: 0.96 and parameters: {'C': 107.39720693474763, 'degree': 2}. Best is trial 15 with value: 0.9866666666666667.
[I 2021-03-23 11:12:56,720] Trial 77 finished with value: 0.9800000000000001 and parameters: {'C': 1.0703139749882324, 'degree': 5}. Best is trial 15 with value: 0.9866666666666667.
[I 2021-03-23 11:12:56,759] Trial 78 finished with value: 0.9400000000000001 and parameters: {'C': 42167.61284922217, 'degree': 5}. Best is trial 15 with value: 0.9866666666666667.
[I 2021-03-23 11:12:56,804] Trial 79 finished with value: 0.9800000000000001 and parameters: {'C': 0.9101754078778281, 'degree': 3}. Best is trial 15 with value: 0.9866666666666667.
[I 2021-03-23 11:12:56,846] Trial 80 finished with value: 0.96 and parameters: {'C': 0.12209429278112986, 'degree': 3}. Best is trial 15 with value: 0.9866666666666667.
[I 2021-03-23 11:12:56,885] Trial 81 finished with value: 0.9666666666666668 and parameters: {'C': 21.210495725221886, 'degree': 1}. Best is trial 15 with value: 0.9866666666666667.
[I 2021-03-23 11:12:56,929] Trial 82 finished with value: 0.96 and parameters: {'C': 0.2205551797708143, 'degree': 3}. Best is trial 15 with value: 0.9866666666666667.
[I 2021-03-23 11:12:56,972] Trial 83 finished with value: 0.9466666666666667 and parameters: {'C': 883.4228383505482, 'degree': 3}. Best is trial 15 with value: 0.9866666666666667.
[I 2021-03-23 11:12:57,026] Trial 84 finished with value: 0.9333333333333333 and parameters: {'C': 0.0015267286565313384, 'degree': 4}. Best is trial 15 with value: 0.9866666666666667.
[I 2021-03-23 11:12:57,070] Trial 85 finished with value: 0.9800000000000001 and parameters: {'C': 1.005498978806798, 'degree': 1}. Best is trial 15 with value: 0.9866666666666667.
[I 2021-03-23 11:12:57,119] Trial 86 finished with value: 0.9666666666666668 and parameters: {'C': 24.184803466602574, 'degree': 3}. Best is trial 15 with value: 0.9866666666666667.
[I 2021-03-23 11:12:57,172] Trial 87 finished with value: 0.9800000000000001 and parameters: {'C': 2.10751362093132, 'degree': 1}. Best is trial 15 with value: 0.9866666666666667.
[I 2021-03-23 11:12:57,227] Trial 88 finished with value: 0.9333333333333333 and parameters: {'C': 0.03939611328964098, 'degree': 4}. Best is trial 15 with value: 0.9866666666666667.
[I 2021-03-23 11:12:57,267] Trial 89 finished with value: 0.9733333333333334 and parameters: {'C': 16.175196988527293, 'degree': 1}. Best is trial 15 with value: 0.9866666666666667.
[I 2021-03-23 11:12:57,309] Trial 90 finished with value: 0.9800000000000001 and parameters: {'C': 4.391324593611082, 'degree': 2}. Best is trial 15 with value: 0.9866666666666667.
[I 2021-03-23 11:12:57,355] Trial 91 finished with value: 0.9866666666666667 and parameters: {'C': 3.9091714446798775, 'degree': 2}. Best is trial 15 with value: 0.9866666666666667.
[I 2021-03-23 11:12:57,406] Trial 92 finished with value: 0.9800000000000001 and parameters: {'C': 6.786974125695399, 'degree': 2}. Best is trial 15 with value: 0.9866666666666667.
[I 2021-03-23 11:12:57,446] Trial 93 finished with value: 0.9800000000000001 and parameters: {'C': 4.836650099561264, 'degree': 2}. Best is trial 15 with value: 0.9866666666666667.
[I 2021-03-23 11:12:57,485] Trial 94 finished with value: 0.96 and parameters: {'C': 135.97861227356822, 'degree': 2}. Best is trial 15 with value: 0.9866666666666667.
[I 2021-03-23 11:12:57,528] Trial 95 finished with value: 0.9666666666666666 and parameters: {'C': 0.3252403304974683, 'degree': 1}. Best is trial 15 with value: 0.9866666666666667.
[I 2021-03-23 11:12:57,570] Trial 96 finished with value: 0.96 and parameters: {'C': 49.070634908237956, 'degree': 1}. Best is trial 15 with value: 0.9866666666666667.
[I 2021-03-23 11:12:57,628] Trial 97 finished with value: 0.9400000000000001 and parameters: {'C': 0.0814065300062711, 'degree': 1}. Best is trial 15 with value: 0.9866666666666667.
[I 2021-03-23 11:12:57,668] Trial 98 finished with value: 0.9533333333333334 and parameters: {'C': 291.97979681125173, 'degree': 2}. Best is trial 15 with value: 0.9866666666666667.
[I 2021-03-23 11:12:57,714] Trial 99 finished with value: 0.9800000000000001 and parameters: {'C': 1.242976990962637, 'degree': 5}. Best is trial 15 with value: 0.9866666666666667.
[I 2021-03-23 11:12:57,715] Finished hyperparemeter search!
[I 2021-03-23 11:12:57,720] Refitting the estimator using 150 samples...
[I 2021-03-23 11:12:57,722] Finished refitting! (elapsed time: 0.002 sec.)
Best trial:
  Value:  0.9866666666666667
  Params: 
    C: 3.6032976371316527
    degree: 4
root@81bdd825218a:/workspaces/examples# python sklearn/sklearn_additional_args.py 
[I 2021-03-23 11:13:05,927] A new study created in memory with name: no-name-01d5e8d9-7bb8-49f8-b36e-49ce45ddf5d1
[I 2021-03-23 11:13:07,726] Trial 0 finished with value: 0.32 and parameters: {'classifier': 'SVC', 'svc_c': 8.440952094768682e-07}. Best is trial 0 with value: 0.32.
[I 2021-03-23 11:13:07,908] Trial 1 finished with value: 0.9533333333333333 and parameters: {'classifier': 'RandomForest', 'rf_max_depth': 27}. Best is trial 1 with value: 0.9533333333333333.
[I 2021-03-23 11:13:08,006] Trial 2 finished with value: 0.9533333333333333 and parameters: {'classifier': 'RandomForest', 'rf_max_depth': 13}. Best is trial 1 with value: 0.9533333333333333.
[I 2021-03-23 11:13:08,038] Trial 3 finished with value: 0.32 and parameters: {'classifier': 'SVC', 'svc_c': 3.087690358602168e-05}. Best is trial 1 with value: 0.9533333333333333.
[I 2021-03-23 11:13:08,127] Trial 4 finished with value: 0.9533333333333333 and parameters: {'classifier': 'RandomForest', 'rf_max_depth': 3}. Best is trial 1 with value: 0.9533333333333333.
[I 2021-03-23 11:13:08,158] Trial 5 finished with value: 0.96 and parameters: {'classifier': 'SVC', 'svc_c': 1749667.972829318}. Best is trial 5 with value: 0.96.
[I 2021-03-23 11:13:08,196] Trial 6 finished with value: 0.9666666666666667 and parameters: {'classifier': 'SVC', 'svc_c': 0.4014283410531236}. Best is trial 6 with value: 0.9666666666666667.
[I 2021-03-23 11:13:08,243] Trial 7 finished with value: 0.96 and parameters: {'classifier': 'SVC', 'svc_c': 2419930392.352475}. Best is trial 6 with value: 0.9666666666666667.
[I 2021-03-23 11:13:08,390] Trial 8 finished with value: 0.9466666666666667 and parameters: {'classifier': 'RandomForest', 'rf_max_depth': 2}. Best is trial 6 with value: 0.9666666666666667.
[I 2021-03-23 11:13:08,494] Trial 9 finished with value: 0.9533333333333333 and parameters: {'classifier': 'RandomForest', 'rf_max_depth': 4}. Best is trial 6 with value: 0.9666666666666667.
[I 2021-03-23 11:13:08,534] Trial 10 finished with value: 0.96 and parameters: {'classifier': 'SVC', 'svc_c': 30.820946283053352}. Best is trial 6 with value: 0.9666666666666667.
[I 2021-03-23 11:13:08,575] Trial 11 finished with value: 0.96 and parameters: {'classifier': 'SVC', 'svc_c': 4023.8517953082664}. Best is trial 6 with value: 0.9666666666666667.
[I 2021-03-23 11:13:08,620] Trial 12 finished with value: 0.96 and parameters: {'classifier': 'SVC', 'svc_c': 51940636.45917211}. Best is trial 6 with value: 0.9666666666666667.
[I 2021-03-23 11:13:08,661] Trial 13 finished with value: 0.9 and parameters: {'classifier': 'SVC', 'svc_c': 0.05051663704502907}. Best is trial 6 with value: 0.9666666666666667.
[I 2021-03-23 11:13:08,712] Trial 14 finished with value: 0.96 and parameters: {'classifier': 'SVC', 'svc_c': 290982.45527674916}. Best is trial 6 with value: 0.9666666666666667.
[I 2021-03-23 11:13:08,761] Trial 15 finished with value: 0.96 and parameters: {'classifier': 'SVC', 'svc_c': 0.1490335763680222}. Best is trial 6 with value: 0.9666666666666667.
[I 2021-03-23 11:13:08,810] Trial 16 finished with value: 0.32 and parameters: {'classifier': 'SVC', 'svc_c': 2.721584321286829e-10}. Best is trial 6 with value: 0.9666666666666667.
[I 2021-03-23 11:13:08,854] Trial 17 finished with value: 0.96 and parameters: {'classifier': 'SVC', 'svc_c': 21393.02479476945}. Best is trial 6 with value: 0.9666666666666667.
[I 2021-03-23 11:13:08,904] Trial 18 finished with value: 0.96 and parameters: {'classifier': 'SVC', 'svc_c': 96.59261372378317}. Best is trial 6 with value: 0.9666666666666667.
[I 2021-03-23 11:13:08,949] Trial 19 finished with value: 0.32 and parameters: {'classifier': 'SVC', 'svc_c': 0.00018181377877536512}. Best is trial 6 with value: 0.9666666666666667.
[I 2021-03-23 11:13:08,992] Trial 20 finished with value: 0.96 and parameters: {'classifier': 'SVC', 'svc_c': 3888.3647456492417}. Best is trial 6 with value: 0.9666666666666667.
[I 2021-03-23 11:13:09,067] Trial 21 finished with value: 0.98 and parameters: {'classifier': 'SVC', 'svc_c': 9.31408610303682}. Best is trial 21 with value: 0.98.
[I 2021-03-23 11:13:09,142] Trial 22 finished with value: 0.9666666666666667 and parameters: {'classifier': 'SVC', 'svc_c': 16.220196533423405}. Best is trial 21 with value: 0.98.
[I 2021-03-23 11:13:09,227] Trial 23 finished with value: 0.9733333333333333 and parameters: {'classifier': 'SVC', 'svc_c': 1.9903563980895922}. Best is trial 21 with value: 0.98.
[I 2021-03-23 11:13:09,316] Trial 24 finished with value: 0.32 and parameters: {'classifier': 'SVC', 'svc_c': 0.012174470126472126}. Best is trial 21 with value: 0.98.
[I 2021-03-23 11:13:09,369] Trial 25 finished with value: 0.96 and parameters: {'classifier': 'SVC', 'svc_c': 31.40177105168343}. Best is trial 21 with value: 0.98.
[I 2021-03-23 11:13:09,408] Trial 26 finished with value: 0.32 and parameters: {'classifier': 'SVC', 'svc_c': 0.0007538905879598359}. Best is trial 21 with value: 0.98.
[I 2021-03-23 11:13:09,453] Trial 27 finished with value: 0.98 and parameters: {'classifier': 'SVC', 'svc_c': 11.225140975820125}. Best is trial 21 with value: 0.98.
[I 2021-03-23 11:13:09,498] Trial 28 finished with value: 0.9866666666666667 and parameters: {'classifier': 'SVC', 'svc_c': 3.7324694138737793}. Best is trial 28 with value: 0.9866666666666667.
[I 2021-03-23 11:13:09,542] Trial 29 finished with value: 0.32 and parameters: {'classifier': 'SVC', 'svc_c': 7.563434190389959e-07}. Best is trial 28 with value: 0.9866666666666667.
[I 2021-03-23 11:13:09,590] Trial 30 finished with value: 0.96 and parameters: {'classifier': 'SVC', 'svc_c': 967.25719066775}. Best is trial 28 with value: 0.9866666666666667.
[I 2021-03-23 11:13:09,630] Trial 31 finished with value: 0.9666666666666667 and parameters: {'classifier': 'SVC', 'svc_c': 0.8069245451209693}. Best is trial 28 with value: 0.9866666666666667.
[I 2021-03-23 11:13:09,674] Trial 32 finished with value: 0.9866666666666667 and parameters: {'classifier': 'SVC', 'svc_c': 4.735532911956179}. Best is trial 28 with value: 0.9866666666666667.
[I 2021-03-23 11:13:09,717] Trial 33 finished with value: 0.32 and parameters: {'classifier': 'SVC', 'svc_c': 0.0017050055439595973}. Best is trial 28 with value: 0.9866666666666667.
[I 2021-03-23 11:13:09,841] Trial 34 finished with value: 0.9533333333333333 and parameters: {'classifier': 'RandomForest', 'rf_max_depth': 10}. Best is trial 28 with value: 0.9866666666666667.
[I 2021-03-23 11:13:09,890] Trial 35 finished with value: 0.9466666666666667 and parameters: {'classifier': 'SVC', 'svc_c': 203.62742545130476}. Best is trial 28 with value: 0.9866666666666667.
[I 2021-03-23 11:13:09,936] Trial 36 finished with value: 0.96 and parameters: {'classifier': 'SVC', 'svc_c': 82322.03165893021}. Best is trial 28 with value: 0.9866666666666667.
[I 2021-03-23 11:13:10,082] Trial 37 finished with value: 0.94 and parameters: {'classifier': 'RandomForest', 'rf_max_depth': 28}. Best is trial 28 with value: 0.9866666666666667.
[I 2021-03-23 11:13:10,131] Trial 38 finished with value: 0.9733333333333333 and parameters: {'classifier': 'SVC', 'svc_c': 2.595086490159936}. Best is trial 28 with value: 0.9866666666666667.
[I 2021-03-23 11:13:10,190] Trial 39 finished with value: 0.32 and parameters: {'classifier': 'SVC', 'svc_c': 5.437474774509584e-06}. Best is trial 28 with value: 0.9866666666666667.
[I 2021-03-23 11:13:10,266] Trial 40 finished with value: 0.32 and parameters: {'classifier': 'SVC', 'svc_c': 0.007071033167066736}. Best is trial 28 with value: 0.9866666666666667.
[I 2021-03-23 11:13:10,308] Trial 41 finished with value: 0.9733333333333333 and parameters: {'classifier': 'SVC', 'svc_c': 3.1582530465745355}. Best is trial 28 with value: 0.9866666666666667.
[I 2021-03-23 11:13:10,382] Trial 42 finished with value: 0.9733333333333333 and parameters: {'classifier': 'SVC', 'svc_c': 3.010270682961665}. Best is trial 28 with value: 0.9866666666666667.
[I 2021-03-23 11:13:10,441] Trial 43 finished with value: 0.94 and parameters: {'classifier': 'SVC', 'svc_c': 0.10360770752991144}. Best is trial 28 with value: 0.9866666666666667.
[I 2021-03-23 11:13:10,481] Trial 44 finished with value: 0.96 and parameters: {'classifier': 'SVC', 'svc_c': 115.70791874883024}. Best is trial 28 with value: 0.9866666666666667.
[I 2021-03-23 11:13:10,585] Trial 45 finished with value: 0.9533333333333333 and parameters: {'classifier': 'RandomForest', 'rf_max_depth': 2}. Best is trial 28 with value: 0.9866666666666667.
[I 2021-03-23 11:13:10,637] Trial 46 finished with value: 0.96 and parameters: {'classifier': 'SVC', 'svc_c': 576.2144687111429}. Best is trial 28 with value: 0.9866666666666667.
[I 2021-03-23 11:13:10,687] Trial 47 finished with value: 0.98 and parameters: {'classifier': 'SVC', 'svc_c': 5.783046426353863}. Best is trial 28 with value: 0.9866666666666667.
[I 2021-03-23 11:13:10,735] Trial 48 finished with value: 0.9733333333333333 and parameters: {'classifier': 'SVC', 'svc_c': 13.318031623912736}. Best is trial 28 with value: 0.9866666666666667.
[I 2021-03-23 11:13:10,793] Trial 49 finished with value: 0.96 and parameters: {'classifier': 'SVC', 'svc_c': 0.23303711458983092}. Best is trial 28 with value: 0.9866666666666667.
[I 2021-03-23 11:13:10,845] Trial 50 finished with value: 0.96 and parameters: {'classifier': 'SVC', 'svc_c': 3840727.6085320124}. Best is trial 28 with value: 0.9866666666666667.
[I 2021-03-23 11:13:10,918] Trial 51 finished with value: 0.9666666666666667 and parameters: {'classifier': 'SVC', 'svc_c': 20.38449105458962}. Best is trial 28 with value: 0.9866666666666667.
[I 2021-03-23 11:13:10,965] Trial 52 finished with value: 0.7400000000000001 and parameters: {'classifier': 'SVC', 'svc_c': 0.021092478456794624}. Best is trial 28 with value: 0.9866666666666667.
[I 2021-03-23 11:13:11,048] Trial 53 finished with value: 0.96 and parameters: {'classifier': 'SVC', 'svc_c': 4185.189849185914}. Best is trial 28 with value: 0.9866666666666667.
[I 2021-03-23 11:13:11,110] Trial 54 finished with value: 0.9666666666666667 and parameters: {'classifier': 'SVC', 'svc_c': 0.816468190781792}. Best is trial 28 with value: 0.9866666666666667.
[I 2021-03-23 11:13:11,157] Trial 55 finished with value: 0.98 and parameters: {'classifier': 'SVC', 'svc_c': 7.2264261940731185}. Best is trial 28 with value: 0.9866666666666667.
[I 2021-03-23 11:13:11,223] Trial 56 finished with value: 0.96 and parameters: {'classifier': 'SVC', 'svc_c': 0.15176982571906533}. Best is trial 28 with value: 0.9866666666666667.
[I 2021-03-23 11:13:11,277] Trial 57 finished with value: 0.96 and parameters: {'classifier': 'SVC', 'svc_c': 1150.715841795381}. Best is trial 28 with value: 0.9866666666666667.
[I 2021-03-23 11:13:11,402] Trial 58 finished with value: 0.94 and parameters: {'classifier': 'RandomForest', 'rf_max_depth': 6}. Best is trial 28 with value: 0.9866666666666667.
[I 2021-03-23 11:13:11,462] Trial 59 finished with value: 0.96 and parameters: {'classifier': 'SVC', 'svc_c': 150.13361360323884}. Best is trial 28 with value: 0.9866666666666667.
[I 2021-03-23 11:13:11,504] Trial 60 finished with value: 0.98 and parameters: {'classifier': 'SVC', 'svc_c': 8.20347524114838}. Best is trial 28 with value: 0.9866666666666667.
[I 2021-03-23 11:13:11,551] Trial 61 finished with value: 0.98 and parameters: {'classifier': 'SVC', 'svc_c': 10.105696411089466}. Best is trial 28 with value: 0.9866666666666667.
[I 2021-03-23 11:13:11,595] Trial 62 finished with value: 0.9666666666666667 and parameters: {'classifier': 'SVC', 'svc_c': 42.88237687401177}. Best is trial 28 with value: 0.9866666666666667.
[I 2021-03-23 11:13:11,639] Trial 63 finished with value: 0.96 and parameters: {'classifier': 'SVC', 'svc_c': 11781.23438549088}. Best is trial 28 with value: 0.9866666666666667.
[I 2021-03-23 11:13:11,684] Trial 64 finished with value: 0.9666666666666667 and parameters: {'classifier': 'SVC', 'svc_c': 0.48291024673325667}. Best is trial 28 with value: 0.9866666666666667.
[I 2021-03-23 11:13:11,743] Trial 65 finished with value: 0.9133333333333334 and parameters: {'classifier': 'SVC', 'svc_c': 0.05234338632390828}. Best is trial 28 with value: 0.9866666666666667.
[I 2021-03-23 11:13:11,790] Trial 66 finished with value: 0.9466666666666667 and parameters: {'classifier': 'SVC', 'svc_c': 367.7146798966421}. Best is trial 28 with value: 0.9866666666666667.
[I 2021-03-23 11:13:11,840] Trial 67 finished with value: 0.98 and parameters: {'classifier': 'SVC', 'svc_c': 7.843039978989167}. Best is trial 28 with value: 0.9866666666666667.
[I 2021-03-23 11:13:11,885] Trial 68 finished with value: 0.9666666666666667 and parameters: {'classifier': 'SVC', 'svc_c': 0.6288306061055988}. Best is trial 28 with value: 0.9866666666666667.
[I 2021-03-23 11:13:11,950] Trial 69 finished with value: 0.32 and parameters: {'classifier': 'SVC', 'svc_c': 0.003491887593090406}. Best is trial 28 with value: 0.9866666666666667.
[I 2021-03-23 11:13:12,014] Trial 70 finished with value: 0.9866666666666667 and parameters: {'classifier': 'SVC', 'svc_c': 4.46653740614765}. Best is trial 28 with value: 0.9866666666666667.
[I 2021-03-23 11:13:12,046] Trial 71 finished with value: 0.96 and parameters: {'classifier': 'SVC', 'svc_c': 52.06612271663631}. Best is trial 28 with value: 0.9866666666666667.
[I 2021-03-23 11:13:12,095] Trial 72 finished with value: 0.9733333333333333 and parameters: {'classifier': 'SVC', 'svc_c': 2.7258903811708337}. Best is trial 28 with value: 0.9866666666666667.
[I 2021-03-23 11:13:12,156] Trial 73 finished with value: 0.98 and parameters: {'classifier': 'SVC', 'svc_c': 5.111373665975171}. Best is trial 28 with value: 0.9866666666666667.
[I 2021-03-23 11:13:12,227] Trial 74 finished with value: 0.7466666666666667 and parameters: {'classifier': 'SVC', 'svc_c': 0.026156016541173166}. Best is trial 28 with value: 0.9866666666666667.
[I 2021-03-23 11:13:12,291] Trial 75 finished with value: 0.9666666666666667 and parameters: {'classifier': 'SVC', 'svc_c': 24.60300111614407}. Best is trial 28 with value: 0.9866666666666667.
[I 2021-03-23 11:13:12,350] Trial 76 finished with value: 0.96 and parameters: {'classifier': 'SVC', 'svc_c': 1754.97541841284}. Best is trial 28 with value: 0.9866666666666667.
[I 2021-03-23 11:13:12,443] Trial 77 finished with value: 0.96 and parameters: {'classifier': 'SVC', 'svc_c': 0.3514251133221443}. Best is trial 28 with value: 0.9866666666666667.
[I 2021-03-23 11:13:12,508] Trial 78 finished with value: 0.9733333333333333 and parameters: {'classifier': 'SVC', 'svc_c': 3.533340604161346}. Best is trial 28 with value: 0.9866666666666667.
[I 2021-03-23 11:13:12,636] Trial 79 finished with value: 0.96 and parameters: {'classifier': 'RandomForest', 'rf_max_depth': 16}. Best is trial 28 with value: 0.9866666666666667.
[I 2021-03-23 11:13:12,688] Trial 80 finished with value: 0.32 and parameters: {'classifier': 'SVC', 'svc_c': 0.00026678873767077826}. Best is trial 28 with value: 0.9866666666666667.
[I 2021-03-23 11:13:12,730] Trial 81 finished with value: 0.96 and parameters: {'classifier': 'SVC', 'svc_c': 73.82559573189339}. Best is trial 28 with value: 0.9866666666666667.
[I 2021-03-23 11:13:12,790] Trial 82 finished with value: 0.98 and parameters: {'classifier': 'SVC', 'svc_c': 9.471201325123259}. Best is trial 28 with value: 0.9866666666666667.
[I 2021-03-23 11:13:12,869] Trial 83 finished with value: 0.9466666666666667 and parameters: {'classifier': 'SVC', 'svc_c': 326.59699038474093}. Best is trial 28 with value: 0.9866666666666667.
[I 2021-03-23 11:13:12,957] Trial 84 finished with value: 0.9733333333333333 and parameters: {'classifier': 'SVC', 'svc_c': 1.1839924265533326}. Best is trial 28 with value: 0.9866666666666667.
[I 2021-03-23 11:13:13,026] Trial 85 finished with value: 0.94 and parameters: {'classifier': 'SVC', 'svc_c': 0.08772167164981269}. Best is trial 28 with value: 0.9866666666666667.
[I 2021-03-23 11:13:13,080] Trial 86 finished with value: 0.98 and parameters: {'classifier': 'SVC', 'svc_c': 9.516869299587077}. Best is trial 28 with value: 0.9866666666666667.
[I 2021-03-23 11:13:13,151] Trial 87 finished with value: 0.96 and parameters: {'classifier': 'SVC', 'svc_c': 49.25215029602122}. Best is trial 28 with value: 0.9866666666666667.
[I 2021-03-23 11:13:13,206] Trial 88 finished with value: 0.9733333333333333 and parameters: {'classifier': 'SVC', 'svc_c': 0.999798880314006}. Best is trial 28 with value: 0.9866666666666667.
[I 2021-03-23 11:13:13,263] Trial 89 finished with value: 0.9733333333333333 and parameters: {'classifier': 'SVC', 'svc_c': 2.0727763717772993}. Best is trial 28 with value: 0.9866666666666667.
[I 2021-03-23 11:13:13,308] Trial 90 finished with value: 0.96 and parameters: {'classifier': 'SVC', 'svc_c': 120.49249751643796}. Best is trial 28 with value: 0.9866666666666667.
[I 2021-03-23 11:13:13,354] Trial 91 finished with value: 0.98 and parameters: {'classifier': 'SVC', 'svc_c': 6.794149759417349}. Best is trial 28 with value: 0.9866666666666667.
[I 2021-03-23 11:13:13,395] Trial 92 finished with value: 0.98 and parameters: {'classifier': 'SVC', 'svc_c': 6.782588871895221}. Best is trial 28 with value: 0.9866666666666667.
[I 2021-03-23 11:13:13,442] Trial 93 finished with value: 0.9666666666666667 and parameters: {'classifier': 'SVC', 'svc_c': 17.1076478838232}. Best is trial 28 with value: 0.9866666666666667.
[I 2021-03-23 11:13:13,484] Trial 94 finished with value: 0.96 and parameters: {'classifier': 'SVC', 'svc_c': 0.20915761170119795}. Best is trial 28 with value: 0.9866666666666667.
[I 2021-03-23 11:13:13,526] Trial 95 finished with value: 0.9733333333333333 and parameters: {'classifier': 'SVC', 'svc_c': 1.1996816451326346}. Best is trial 28 with value: 0.9866666666666667.
[I 2021-03-23 11:13:13,574] Trial 96 finished with value: 0.32 and parameters: {'classifier': 'SVC', 'svc_c': 2.777234657106943e-10}. Best is trial 28 with value: 0.9866666666666667.
[I 2021-03-23 11:13:13,634] Trial 97 finished with value: 0.94 and parameters: {'classifier': 'SVC', 'svc_c': 229.08879543361695}. Best is trial 28 with value: 0.9866666666666667.
[I 2021-03-23 11:13:13,682] Trial 98 finished with value: 0.98 and parameters: {'classifier': 'SVC', 'svc_c': 6.47548544814151}. Best is trial 28 with value: 0.9866666666666667.
[I 2021-03-23 11:13:13,745] Trial 99 finished with value: 0.96 and parameters: {'classifier': 'SVC', 'svc_c': 2682.2306346525165}. Best is trial 28 with value: 0.9866666666666667.
FrozenTrial(number=28, values=[0.9866666666666667], datetime_start=datetime.datetime(2021, 3, 23, 11, 13, 9, 453765), datetime_complete=datetime.datetime(2021, 3, 23, 11, 13, 9, 498049), params={'classifier': 'SVC', 'svc_c': 3.7324694138737793}, distributions={'classifier': CategoricalDistribution(choices=('SVC', 'RandomForest')), 'svc_c': LogUniformDistribution(high=10000000000.0, low=1e-10)}, user_attrs={}, system_attrs={}, intermediate_values={}, trial_id=28, state=TrialState.COMPLETE, value=None)

```
Please feel free to let me know if I did something wrong or if I missed a test.
