### PR TITLE
Support object representation of `StudyDirection` for `create_study` arguments

### DIFF
--- a/optuna/study.py
+++ b/optuna/study.py
@@ -1111,15 +1111,9 @@ def create_study(
     ):
         raise ValueError("Please set either 'minimize' or 'maximize' to direction.")
 
-    direction_objects = []
-    for d in directions:
-        if d == "minimize":
-            direction_objects.append(StudyDirection.MINIMIZE)
-        elif d == "maximize":
-            direction_objects.append(StudyDirection.MAXIMIZE)
-        else:
-            assert isinstance(d, StudyDirection)
-            direction_objects.append(d)
+    direction_objects = [
+        d if isinstance(d, StudyDirection) else StudyDirection[d.upper()] for d in directions
+    ]
 
     storage = storages.get_storage(storage)
     try:

--- a/optuna/study.py
+++ b/optuna/study.py
@@ -1109,7 +1109,10 @@ def create_study(
         d not in ["minimize", "maximize", StudyDirection.MINIMIZE, StudyDirection.MAXIMIZE]
         for d in directions
     ):
-        raise ValueError("Please set either 'minimize' or 'maximize' to direction.")
+        raise ValueError(
+            "Please set either 'minimize' or 'maximize' to direction. You can also set the "
+            "corresponding `StudyDirection` member."
+        )
 
     direction_objects = [
         d if isinstance(d, StudyDirection) else StudyDirection[d.upper()] for d in directions

--- a/optuna/study.py
+++ b/optuna/study.py
@@ -1009,10 +1009,10 @@ def create_study(
     sampler: Optional["samplers.BaseSampler"] = None,
     pruner: Optional[pruners.BasePruner] = None,
     study_name: Optional[str] = None,
-    direction: Optional[str] = None,
+    direction: Optional[Union[str, StudyDirection]] = None,
     load_if_exists: bool = False,
     *,
-    directions: Optional[Sequence[str]] = None,
+    directions: Optional[Sequence[Union[str, StudyDirection]]] = None,
 ) -> Study:
     """Create a new :class:`~optuna.study.Study`.
 
@@ -1062,7 +1062,8 @@ def create_study(
             automatically.
         direction:
             Direction of optimization. Set ``minimize`` for minimization and ``maximize`` for
-            maximization.
+            maximization. You can also pass the corresponding :class:`~optuna.study.StudyDirection`
+            object.
 
             .. note::
                 If none of `direction` and `directions` are specified, the direction of the study
@@ -1104,12 +1105,20 @@ def create_study(
 
     if len(directions) < 1:
         raise ValueError("The number of objectives must be greater than 0.")
-    elif any(d != "minimize" and d != "maximize" for d in directions):
+    elif any(
+        d not in ["minimize", "maximize", StudyDirection.MINIMIZE, StudyDirection.MAXIMIZE]
+        for d in directions
+    ):
         raise ValueError("Please set either 'minimize' or 'maximize' to direction.")
 
-    direction_objects = [
-        StudyDirection.MINIMIZE if d == "minimize" else StudyDirection.MAXIMIZE for d in directions
-    ]
+    direction_objects = []
+    for d in directions:
+        if d == "minimize":
+            direction_objects.append(StudyDirection.MINIMIZE)
+        elif d == "maximize":
+            direction_objects.append(StudyDirection.MAXIMIZE)
+        else:
+            direction_objects.append(d)
 
     storage = storages.get_storage(storage)
     try:

--- a/optuna/study.py
+++ b/optuna/study.py
@@ -1118,6 +1118,7 @@ def create_study(
         elif d == "maximize":
             direction_objects.append(StudyDirection.MAXIMIZE)
         else:
+            assert isinstance(d, StudyDirection)
             direction_objects.append(d)
 
     storage = storages.get_storage(storage)

--- a/tests/study_tests/test_study.py
+++ b/tests/study_tests/test_study.py
@@ -797,6 +797,14 @@ def test_create_study_with_multi_objectives() -> None:
         _ = create_study(direction="minimize", directions=[])
 
 
+def test_create_study_with_direction_object() -> None:
+    study = create_study(direction=StudyDirection.MAXIMIZE)
+    assert study.direction == StudyDirection.MAXIMIZE
+
+    study = create_study(directions=[StudyDirection.MAXIMIZE, StudyDirection.MINIMIZE])
+    assert study.directions == [StudyDirection.MAXIMIZE, StudyDirection.MINIMIZE]
+
+
 @pytest.mark.parametrize("n_objectives", [2, 3])
 def test_optimize_with_multi_objectives(n_objectives: int) -> None:
     directions = ["minimize" for _ in range(n_objectives)]


### PR DESCRIPTION
This PR enables to pass `StudyDirection` objects to the `direction`/`directions` argument of `optuna.create_study`.

## Motivation
Supporting `StudyDirection` objects sometimes simplifies the user’s code especially when the user already has the `StudyDirection` objects when creating the study, e.g., copying an existing study to new one as follows.

```python
study_src = optuna.load_study(study_name=study_name, storage=storage_url)
study_dist = optuna.create_study(directions=study_src.directions)

for t in study_src.trials:
    study_dist.add_trial(t)
```
Note that the code above raises an error in the second line without applying this PR, and the user has to convert the direction objects to the string representation.