### PR TITLE
Add ray to requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -112,6 +112,7 @@ def get_extras_require() -> Dict[str, List[str]]:
             "optax",
             "dm-haiku",
             "hydra-optuna-sweeper",
+            "ray",
         ],
         "experimental": ["redis"],
         "testing": [


### PR DESCRIPTION
Related: https://github.com/optuna/optuna/pull/2298

See: https://github.com/optuna/optuna/runs/2185368386?check_suite_focus=true#step:7:338

![image](https://user-images.githubusercontent.com/16191443/112400263-57cc4300-8d4b-11eb-95a4-1e45e045ac3d.png)

Capture from the CI result mentioned above.


Also, I've confirmed this example is compatible with Python3.6, 3.7, 3.8.
The process is as follows:
1. `docker pull optuna/optuna:py<version>-dev`
2. `docker run -it -v $(pwd):/workspaces optuna/optuna:py3.8-dev /bin/bash`
3. `pip install ray`
4. `python examples/ray-joblib.py`
5. Watch the example finishes expectedly (no error happens).