### PR TITLE
Extract test cases regarding Pareto front to `test_multi_objective.py`

### DIFF
--- a/tests/study_tests/test_study.py
+++ b/tests/study_tests/test_study.py
@@ -9,7 +9,6 @@ from typing import Callable
 from typing import Dict
 from typing import List
 from typing import Optional
-from typing import Tuple
 from unittest.mock import Mock  # NOQA
 from unittest.mock import patch
 import uuid
@@ -822,64 +821,12 @@ def test_optimize_with_multi_objectives(n_objectives: int) -> None:
         assert len(trial.values) == n_objectives
 
 
-def test_pareto_front_2d() -> None:
-    def _trial_to_values(t: FrozenTrial) -> Tuple[float, ...]:
-        assert t.values is not None
-        return tuple(t.values)
-
+def test_best_trials() -> None:
     study = create_study(directions=["minimize", "maximize"])
-    assert {_trial_to_values(t) for t in study.best_trials} == set()
-
     study.optimize(lambda t: [2, 2], n_trials=1)
-    assert {_trial_to_values(t) for t in study.best_trials} == {(2, 2)}
-
     study.optimize(lambda t: [1, 1], n_trials=1)
-    assert {_trial_to_values(t) for t in study.best_trials} == {(1, 1), (2, 2)}
-
     study.optimize(lambda t: [3, 1], n_trials=1)
-    assert {_trial_to_values(t) for t in study.best_trials} == {(1, 1), (2, 2)}
-
-    study.optimize(lambda t: [3, 2], n_trials=1)
-    assert {_trial_to_values(t) for t in study.best_trials} == {(1, 1), (2, 2)}
-
-    study.optimize(lambda t: [1, 3], n_trials=1)
-    assert {_trial_to_values(t) for t in study.best_trials} == {(1, 3)}
-    assert len(study.best_trials) == 1
-
-    study.optimize(lambda t: [1, 3], n_trials=1)  # The trial result is the same as the above one.
-    assert {_trial_to_values(t) for t in study.best_trials} == {(1, 3)}
-    assert len(study.best_trials) == 2
-
-
-def test_pareto_front_3d() -> None:
-    def _trial_to_values(t: FrozenTrial) -> Tuple[float, ...]:
-        assert t.values is not None
-        return tuple(t.values)
-
-    study = create_study(directions=["minimize", "maximize", "minimize"])
-    assert {_trial_to_values(t) for t in study.best_trials} == set()
-
-    study.optimize(lambda t: [2, 2, 2], n_trials=1)
-    assert {_trial_to_values(t) for t in study.best_trials} == {(2, 2, 2)}
-
-    study.optimize(lambda t: [1, 1, 1], n_trials=1)
-    assert {_trial_to_values(t) for t in study.best_trials} == {(1, 1, 1), (2, 2, 2)}
-
-    study.optimize(lambda t: [3, 1, 3], n_trials=1)
-    assert {_trial_to_values(t) for t in study.best_trials} == {(1, 1, 1), (2, 2, 2)}
-
-    study.optimize(lambda t: [3, 2, 3], n_trials=1)
-    assert {_trial_to_values(t) for t in study.best_trials} == {(1, 1, 1), (2, 2, 2)}
-
-    study.optimize(lambda t: [1, 3, 1], n_trials=1)
-    assert {_trial_to_values(t) for t in study.best_trials} == {(1, 3, 1)}
-    assert len(study.best_trials) == 1
-
-    study.optimize(
-        lambda t: [1, 3, 1], n_trials=1
-    )  # The trial result is the same as the above one.
-    assert {_trial_to_values(t) for t in study.best_trials} == {(1, 3, 1)}
-    assert len(study.best_trials) == 2
+    assert {tuple(t.values) for t in study.best_trials} == {(1, 1), (2, 2)}
 
 
 def test_wrong_n_objectives() -> None:

--- a/tests/test_multi_objective.py
+++ b/tests/test_multi_objective.py
@@ -1,0 +1,72 @@
+from typing import Tuple
+
+from optuna import create_study
+from optuna._multi_objective import _get_pareto_front_trials_2d
+from optuna._multi_objective import _get_pareto_front_trials_nd
+from optuna.trial import FrozenTrial
+
+
+def _trial_to_values(t: FrozenTrial) -> Tuple[float, ...]:
+    assert t.values is not None
+    return tuple(t.values)
+
+
+def test_get_pareto_front_trials_2d() -> None:
+    study = create_study(directions=["minimize", "maximize"])
+    assert {_trial_to_values(t) for t in _get_pareto_front_trials_2d(study)} == set()
+
+    study.optimize(lambda t: [2, 2], n_trials=1)
+    assert {_trial_to_values(t) for t in _get_pareto_front_trials_2d(study)} == {(2, 2)}
+
+    study.optimize(lambda t: [1, 1], n_trials=1)
+    assert {_trial_to_values(t) for t in _get_pareto_front_trials_2d(study)} == {(1, 1), (2, 2)}
+
+    study.optimize(lambda t: [3, 1], n_trials=1)
+    assert {_trial_to_values(t) for t in _get_pareto_front_trials_2d(study)} == {(1, 1), (2, 2)}
+
+    study.optimize(lambda t: [3, 2], n_trials=1)
+    assert {_trial_to_values(t) for t in _get_pareto_front_trials_2d(study)} == {(1, 1), (2, 2)}
+
+    study.optimize(lambda t: [1, 3], n_trials=1)
+    assert {_trial_to_values(t) for t in _get_pareto_front_trials_2d(study)} == {(1, 3)}
+    assert len(_get_pareto_front_trials_2d(study)) == 1
+
+    study.optimize(lambda t: [1, 3], n_trials=1)  # The trial result is the same as the above one.
+    assert {_trial_to_values(t) for t in _get_pareto_front_trials_2d(study)} == {(1, 3)}
+    assert len(_get_pareto_front_trials_2d(study)) == 2
+
+
+def test_get_pareto_front_trials_nd() -> None:
+    study = create_study(directions=["minimize", "maximize", "minimize"])
+    assert {_trial_to_values(t) for t in _get_pareto_front_trials_nd(study)} == set()
+
+    study.optimize(lambda t: [2, 2, 2], n_trials=1)
+    assert {_trial_to_values(t) for t in _get_pareto_front_trials_nd(study)} == {(2, 2, 2)}
+
+    study.optimize(lambda t: [1, 1, 1], n_trials=1)
+    assert {_trial_to_values(t) for t in _get_pareto_front_trials_nd(study)} == {
+        (1, 1, 1),
+        (2, 2, 2),
+    }
+
+    study.optimize(lambda t: [3, 1, 3], n_trials=1)
+    assert {_trial_to_values(t) for t in _get_pareto_front_trials_nd(study)} == {
+        (1, 1, 1),
+        (2, 2, 2),
+    }
+
+    study.optimize(lambda t: [3, 2, 3], n_trials=1)
+    assert {_trial_to_values(t) for t in _get_pareto_front_trials_nd(study)} == {
+        (1, 1, 1),
+        (2, 2, 2),
+    }
+
+    study.optimize(lambda t: [1, 3, 1], n_trials=1)
+    assert {_trial_to_values(t) for t in _get_pareto_front_trials_nd(study)} == {(1, 3, 1)}
+    assert len(_get_pareto_front_trials_nd(study)) == 1
+
+    study.optimize(
+        lambda t: [1, 3, 1], n_trials=1
+    )  # The trial result is the same as the above one.
+    assert {_trial_to_values(t) for t in _get_pareto_front_trials_nd(study)} == {(1, 3, 1)}
+    assert len(_get_pareto_front_trials_nd(study)) == 2


### PR DESCRIPTION
This PR extracts 2 test cases regarding Pareto front from `test_study.py` to `test_multi_objective.py`.

## Motivation
I believe this PR makes the codebase more organized and readable because of the following reasons:

- `_multi_objective.py` is mostly responsible to the internal logic of `best_trials`, and the 2d/nd condition highly depends on the internal implementation as well. Thus, those test cases should be put on the corresponding namespace of the filename.
- Extracting those scenarios reduces the number of test cases in `test_study.py`, which is already huge.

## Description of the changes
- Move the test cases of getting Pareto front from `test_study.py` to `test_multi_objective.py`
- Leave the minimal test scenario of `best_trials` in `test_study.py` to test the API call