### PR TITLE
Upgrade AllenNLP to `v2.2.0`

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -57,8 +57,7 @@ jobs:
       env:
         OMP_NUM_THREADS: 1
       run: |
-        pytest --cov=optuna --cov-report=xml tests \
-            --ignore tests/integration_tests/allennlp_tests
+        pytest --cov=optuna --cov-report=xml tests
 
     - name: Multi-node tests
       env:

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -53,30 +53,12 @@ jobs:
         if [ ${{ matrix.python-version }} = 3.6 ]; then
           IGNORES='chainermn_.*|fastai*|pytorch_distributed_.*|rapids_.*|botorch_.*|pytorch/pytorch_checkpoint*|allennlp*'
         elif [ ${{ matrix.python-version }} = 3.8 ]; then
-          IGNORES='chainermn_.*|keras_.*|pytorch_distributed_.*|tensorboard_.*|tensorflow_.*|tfkeras_.*|fastai*|rapids_.*|pytorch/pytorch_checkpoint*|allennlp*'
+          IGNORES='chainermn_.*|keras_.*|pytorch_distributed_.*|tensorboard_.*|tensorflow_.*|tfkeras_.*|fastai*|rapids_.*|pytorch/pytorch_checkpoint*'
         else
-          IGNORES='chainermn_.*|fastai*|pytorch_distributed_.*|rapids_.*|pytorch/pytorch_checkpoint*|allennlp*'
+          IGNORES='chainermn_.*|fastai*|pytorch_distributed_.*|rapids_.*|pytorch/pytorch_checkpoint*'
         fi
 
         for file in `find examples -name '*.py' -not -name '*_distributed.py' | grep -vE "$IGNORES"`
-        do
-          echo $file
-          python $file > /dev/null
-          if grep -e '\-\-pruning' $file > /dev/null; then
-            echo $file --pruning
-            python $file --pruning > /dev/null
-          fi
-        done
-      env:
-        OMP_NUM_THREADS: 1
-    - name: Run examples (AllenNLP)
-      run: |
-        pip uninstall torch torchvision torchaudio -y
-        pip install --use-deprecated=legacy-resolver --progress-bar off allennlp
-
-        IGNORES=''
-
-        for file in `find examples -name 'allennlp*.py' -not -name '*_distributed.py' | grep -vE "$IGNORES"`
         do
           echo $file
           python $file > /dev/null

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -51,7 +51,7 @@ jobs:
     - name: Run examples
       run: |
         if [ ${{ matrix.python-version }} = 3.6 ]; then
-          IGNORES='chainermn_.*|fastai*|pytorch_distributed_.*|rapids_.*|botorch_.*|pytorch/pytorch_checkpoint*|allennlp*'
+          IGNORES='chainermn_.*|fastai*|pytorch_distributed_.*|rapids_.*|botorch_.*|pytorch/pytorch_checkpoint*'
         elif [ ${{ matrix.python-version }} = 3.8 ]; then
           IGNORES='chainermn_.*|keras_.*|pytorch_distributed_.*|tensorboard_.*|tensorflow_.*|tfkeras_.*|fastai*|rapids_.*|pytorch/pytorch_checkpoint*'
         else

--- a/.github/workflows/tests-integration.yml
+++ b/.github/workflows/tests-integration.yml
@@ -65,17 +65,8 @@ jobs:
             --ignore tests/integration_tests/allennlp_tests \
             --ignore tests/integration_tests/test_botorch.py
         else
-          # pytest cannot collect allennlp tests with allennlp==1.0.0.
-          pytest -s tests/integration_tests \
-            --ignore tests/integration_tests/allennlp_tests
+          pytest -s tests/integration_tests
         fi
-
-    - name: Tests (AllenNLP)
-      run: |
-        pip uninstall torch torchvision torchaudio -y
-        pip install --use-deprecated=legacy-resolver --progress-bar off allennlp
-
-        pytest -s tests/integration_tests/allennlp_tests
 
     - name: Tests MPI
       run: |

--- a/.github/workflows/tests-integration.yml
+++ b/.github/workflows/tests-integration.yml
@@ -62,7 +62,6 @@ jobs:
       run: |
         if [ ${{ matrix.python-version }} = 3.6 ]; then
           pytest tests/integration_tests \
-            --ignore tests/integration_tests/allennlp_tests \
             --ignore tests/integration_tests/test_botorch.py
         else
           pytest -s tests/integration_tests

--- a/setup.py
+++ b/setup.py
@@ -104,7 +104,7 @@ def get_extras_require() -> Dict[str, List[str]]:
             "torchvision==0.9.0 ; sys_platform=='darwin'",
             "torchvision==0.9.0+cpu ; sys_platform!='darwin'",
             "torchaudio==0.8.0",
-            # "allennlp>=2.0.0",  # See https://github.com/optuna/optuna/pull/2442.
+            "allennlp>=2.2.0",
             "dask[dataframe]",
             "dask-ml",
             "botorch>=0.4.0 ; python_version>'3.6'",
@@ -145,7 +145,7 @@ def get_extras_require() -> Dict[str, List[str]]:
             "torchvision==0.9.0 ; sys_platform=='darwin'",
             "torchvision==0.9.0+cpu ; sys_platform!='darwin'",
             "torchaudio==0.8.0",
-            # "allennlp>=2.0.0",  # See https://github.com/optuna/optuna/pull/2442.
+            "allennlp>=2.2.0",
             "botorch>=0.4.0 ; python_version>'3.6'",
             "fastai",
         ],
@@ -186,7 +186,7 @@ def get_extras_require() -> Dict[str, List[str]]:
             "torchvision==0.9.0 ; sys_platform=='darwin'",
             "torchvision==0.9.0+cpu ; sys_platform!='darwin'",
             "torchaudio==0.8.0",
-            # "allennlp>=2.0.0",  # See https://github.com/optuna/optuna/pull/2442.
+            "allennlp>=2.2.0",
             "botorch>=0.4.0 ; python_version>'3.6'",
             "fastai",
         ],


### PR DESCRIPTION
This PR re-introduces AllenNLP to the dependencies.
(AllenNLP v2.2.0 supports PyTorch v1.8.0)

## Motivation
- restore AllenNLP in `setup.py`
- remove specific test configuration for AllenNLP

## Description of the changes
- 4a91efc updates `setup.py`
- 88311e9 changes GitHub Actions

(~verifying on https://github.com/himkt/optuna/pull/13, after the examples finish successfully, I'll remove WIP~ => done!)