### PR TITLE
Extract heartbeat-related functions for ask-and-tell interface

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -99,12 +99,21 @@ jobs:
         done
       env:
         OMP_NUM_THREADS: 1
-    - name: Run PyTorch checkpoint example
+    - name: Run PyTorch checkpoint example (optimize)
       run: |
         # Unset errexit temporarily since timeout returns exit code 124.
         set +e
         timeout 20 python examples/pytorch/pytorch_checkpoint.py > /dev/null
         set -e
         python examples/pytorch/pytorch_checkpoint.py > /dev/null
+      env:
+        OMP_NUM_THREADS: 1
+    - name: Run PyTorch checkpoint example (ask-and-tell)
+      run: |
+        # Unset errexit temporarily since timeout returns exit code 124.
+        set +e
+        timeout 20 python examples/pytorch/pytorch_ask_and_tell_checkpoint.py > /dev/null
+        set -e
+        python examples/pytorch/pytorch_ask_and_tell_checkpoint.py > /dev/null
       env:
         OMP_NUM_THREADS: 1

--- a/docs/source/reference/study.rst
+++ b/docs/source/reference/study.rst
@@ -11,8 +11,11 @@ The :mod:`~optuna.study` module implements the :class:`~optuna.study.Study` obje
 
    optuna.study.Study
    optuna.study.create_study
+   optuna.study.create_heartbeat_thread
+   optuna.study.join_heartbeat_thread
    optuna.study.load_study
    optuna.study.delete_study
    optuna.study.get_all_study_summaries
+   optuna.study.run_failed_trial_callback
    optuna.study.StudyDirection
    optuna.study.StudySummary

--- a/examples/pytorch/pytorch_ask_and_tell_checkpoint.py
+++ b/examples/pytorch/pytorch_ask_and_tell_checkpoint.py
@@ -1,0 +1,228 @@
+"""
+Optuna example that optimizes multi-layer perceptrons using PyTorch with checkpoint.
+
+In this example, we optimize the validation accuracy of hand-written digit recognition using
+PyTorch and FashionMNIST. We optimize the neural network architecture as well as the optimizer
+configuration. As it is too time consuming to use the whole FashionMNIST dataset,
+we here use a small subset of it.
+
+Even if the process where the trial is running is killed for some reason, you can restart from
+previous saved checkpoint using heartbeat.
+
+    $ timeout 20 python examples/pytorch/pytorch_checkpoint.py
+    $ python examples/pytorch/pytorch_checkpoint.py
+"""
+
+import copy
+import datetime
+import os
+from threading import TIMEOUT_MAX
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+import torch.optim as optim
+import torch.utils.data
+from torchvision import datasets
+from torchvision import transforms
+
+import optuna
+
+
+DEVICE = torch.device("cpu")
+BATCHSIZE = 128
+CLASSES = 10
+DIR = os.getcwd()
+EPOCHS = 10
+LOG_INTERVAL = 10
+N_TRAIN_EXAMPLES = BATCHSIZE * 30
+N_VALID_EXAMPLES = BATCHSIZE * 10
+
+
+def define_model(trial):
+    # We optimize the number of layers, hidden units and dropout ratio in each layer.
+    n_layers = trial.suggest_int("n_layers", 1, 3)
+    layers = []
+
+    in_features = 28 * 28
+    for i in range(n_layers):
+        out_features = trial.suggest_int("n_units_l{}".format(i), 4, 128)
+        layers.append(nn.Linear(in_features, out_features))
+        layers.append(nn.ReLU())
+        p = trial.suggest_float("dropout_l{}".format(i), 0.2, 0.5)
+        layers.append(nn.Dropout(p))
+
+        in_features = out_features
+    layers.append(nn.Linear(in_features, CLASSES))
+    layers.append(nn.LogSoftmax(dim=1))
+
+    return nn.Sequential(*layers)
+
+
+def get_mnist():
+    # Load FashionMNIST dataset.
+    train_loader = torch.utils.data.DataLoader(
+        datasets.FashionMNIST(DIR, train=True, download=True, transform=transforms.ToTensor()),
+        batch_size=BATCHSIZE,
+        shuffle=True,
+    )
+    valid_loader = torch.utils.data.DataLoader(
+        datasets.FashionMNIST(DIR, train=False, transform=transforms.ToTensor()),
+        batch_size=BATCHSIZE,
+        shuffle=True,
+    )
+
+    return train_loader, valid_loader
+
+
+def objective(trial):
+
+    # Generate the model.
+    model = define_model(trial).to(DEVICE)
+
+    # Generate the optimizers.
+    optimizer_name = trial.suggest_categorical("optimizer", ["Adam", "RMSprop", "SGD"])
+    lr = trial.suggest_float("lr", 1e-5, 1e-1, log=True)
+    optimizer = getattr(optim, optimizer_name)(model.parameters(), lr=lr)
+
+    if "checkpoint_path" in trial.user_attrs:
+        checkpoint = torch.load(trial.user_attrs["checkpoint_path"])
+        epoch_begin = checkpoint["epoch"] + 1
+        model.load_state_dict(checkpoint["model_state_dict"])
+        optimizer.load_state_dict(checkpoint["optimizer_state_dict"])
+        accuracy = checkpoint["accuracy"]
+    else:
+        epoch_begin = 0
+
+    # Get the FashionMNIST dataset.
+    train_loader, valid_loader = get_mnist()
+
+    path = f"pytorch_checkpoint/{trial.number}"
+    os.makedirs(path, exist_ok=True)
+
+    # Training of the model.
+    for epoch in range(epoch_begin, EPOCHS):
+        model.train()
+        for batch_idx, (data, target) in enumerate(train_loader):
+            # Limiting training data for faster epochs.
+            if batch_idx * BATCHSIZE >= N_TRAIN_EXAMPLES:
+                break
+
+            data, target = data.view(data.size(0), -1).to(DEVICE), target.to(DEVICE)
+
+            optimizer.zero_grad()
+            output = model(data)
+            loss = F.nll_loss(output, target)
+            loss.backward()
+            optimizer.step()
+
+        # Validation of the model.
+        model.eval()
+        correct = 0
+        with torch.no_grad():
+            for batch_idx, (data, target) in enumerate(valid_loader):
+                # Limiting validation data.
+                if batch_idx * BATCHSIZE >= N_VALID_EXAMPLES:
+                    break
+                data, target = data.view(data.size(0), -1).to(DEVICE), target.to(DEVICE)
+                output = model(data)
+                # Get the index of the max log-probability.
+                pred = output.argmax(dim=1, keepdim=True)
+                correct += pred.eq(target.view_as(pred)).sum().item()
+
+        accuracy = correct / min(len(valid_loader.dataset), N_VALID_EXAMPLES)
+
+        trial.report(accuracy, epoch)
+
+        # Save optimization status. We should save the objective value because the process may be
+        # killed between saving the last model and recording the objective value to the storage.
+        torch.save(
+            {
+                "epoch": epoch,
+                "model_state_dict": model.state_dict(),
+                "optimizer_state_dict": optimizer.state_dict(),
+                "accuracy": accuracy,
+            },
+            os.path.join(path, "model.pt"),
+        )
+
+        # Handle pruning based on the intermediate value.
+        if trial.should_prune():
+            raise optuna.exceptions.TrialPruned()
+
+    return accuracy
+
+
+def restart_from_checkpoint(study, trial):
+    # Enqueue trial with the same parameters as the stale trial to use saved information.
+
+    path = f"pytorch_checkpoint/{trial.number}/model.pt"
+    user_attrs = copy.deepcopy(trial.user_attrs)
+    if os.path.exists(path):
+        user_attrs["checkpoint_path"] = path
+
+    study.add_trial(
+        optuna.create_trial(
+            state=optuna.trial.TrialState.WAITING,
+            params=trial.params,
+            distributions=trial.distributions,
+            user_attrs=user_attrs,
+            system_attrs=trial.system_attrs,
+        )
+    )
+
+
+if __name__ == "__main__":
+    storage = optuna.storages.RDBStorage(
+        "sqlite:///example.db", heartbeat_interval=1, failed_trial_callback=restart_from_checkpoint
+    )
+    study = optuna.create_study(
+        storage=storage, study_name="pytorch_checkpoint", direction="maximize", load_if_exists=True
+    )
+
+    N_TRIALS = 10
+    TIMEOUT = 600
+    start_time = datetime.datetime.now()
+
+    for _ in range(N_TRIALS):
+        optuna.study.run_failed_trial_callback(study)
+        trial = study.ask()
+        thread, stop_event = optuna.study.create_heartbeat_thread(study, trial)
+
+        try:
+            value = objective(trial)
+            study.tell(trial, value)
+            print(
+                f"Trial {trial.number} finished with value: {value} and parameters: "
+                f"{trial.params}. Best is trial {study.best_trial.number} with "
+                f"value: {study.best_value}."
+            )
+        except optuna.TrialPruned:
+            print(f"Trial {trial.number} was pruned.")
+            study.tell(trial, None, optuna.trial.TrialState.PRUNED)
+
+        optuna.study.join_heartbeat_thread(study, thread, stop_event)
+
+        duration = (datetime.datetime.now() - start_time).total_seconds()
+        if duration >= TIMEOUT:
+            break
+
+    pruned_trials = study.get_trials(states=(optuna.trial.TrialState.PRUNED,))
+    complete_trials = study.get_trials(states=(optuna.trial.TrialState.COMPLETE,))
+
+    print("Study statistics: ")
+    print("  Number of finished trials: ", len(study.trials))
+    print("  Number of pruned trials: ", len(pruned_trials))
+    print("  Number of complete trials: ", len(complete_trials))
+
+    print("Best trial:")
+    trial = study.best_trial
+
+    print("  Value: ", trial.value)
+
+    print("  Params: ")
+    for key, value in trial.params.items():
+        print("    {}: {}".format(key, value))
+
+    # The line of the resumed trial's intermediate values begins with the restarted epoch.
+    optuna.visualization.plot_intermediate_values(study).show()

--- a/examples/pytorch/pytorch_ask_and_tell_checkpoint.py
+++ b/examples/pytorch/pytorch_ask_and_tell_checkpoint.py
@@ -9,14 +9,13 @@ we here use a small subset of it.
 Even if the process where the trial is running is killed for some reason, you can restart from
 previous saved checkpoint using heartbeat.
 
-    $ timeout 20 python examples/pytorch/pytorch_checkpoint.py
-    $ python examples/pytorch/pytorch_checkpoint.py
+    $ timeout 20 python examples/pytorch/pytorch_ask_and_tell_checkpoint.py
+    $ python examples/pytorch/pytorch_ask_and_tell_checkpoint.py
 """
 
 import copy
 import datetime
 import os
-from threading import TIMEOUT_MAX
 
 import torch
 import torch.nn as nn

--- a/examples/pytorch/pytorch_ask_and_tell_checkpoint.py
+++ b/examples/pytorch/pytorch_ask_and_tell_checkpoint.py
@@ -4,9 +4,9 @@ Optuna example that optimizes multi-layer perceptrons using PyTorch with checkpo
 In this example, we optimize the validation accuracy of hand-written digit recognition using
 PyTorch and FashionMNIST. We optimize the neural network architecture as well as the optimizer
 configuration. As it is too time consuming to use the whole FashionMNIST dataset,
-we here use a small subset of it.
+we use a small subset.
 
-Even if the process where the trial is running is killed for some reason, you can restart from
+Even if the process where the trial is running is killed for some reason, it can be restarted from
 previous saved checkpoint using heartbeat.
 
     $ timeout 20 python examples/pytorch/pytorch_ask_and_tell_checkpoint.py

--- a/optuna/_optimize.py
+++ b/optuna/_optimize.py
@@ -30,6 +30,7 @@ from optuna import logging
 from optuna import progress_bar as pbar_module
 from optuna import storages
 from optuna import trial as trial_module
+from optuna._experimental import experimental
 from optuna.trial import FrozenTrial
 from optuna.trial import TrialState
 
@@ -328,6 +329,7 @@ def _record_heartbeat(trial_id: int, storage: storages.BaseStorage, stop_event: 
         time.sleep(heartbeat_interval)
 
 
+@experimental("2.7.0")
 def run_failed_trial_callback(study: "optuna.study.Study") -> None:
     """Execute callback functions for failed trials.
 
@@ -351,6 +353,7 @@ def run_failed_trial_callback(study: "optuna.study.Study") -> None:
                 failed_trial_callback(study, failed_trial)
 
 
+@experimental("2.7.0")
 def create_heartbeat_thread(
     study: "optuna.study.Study", trial: "optuna.trial.Trial"
 ) -> Optional[Tuple[Thread, Event]]:
@@ -384,6 +387,7 @@ def create_heartbeat_thread(
     return None
 
 
+@experimental("2.7.0")
 def join_heartbeat_thread(
     study: "optuna.study.Study", thread: Optional[Thread], stop_event: Optional[Event]
 ) -> None:

--- a/optuna/_optimize.py
+++ b/optuna/_optimize.py
@@ -361,7 +361,7 @@ def create_heartbeat_thread(
 
     This is a utility function for the heartbeat feature of :class:`~optuna.storage.RDBStorage`,
     and it is expected to be used with :meth:`~optuna.study.Study.ask` and
-    :meth:`~optuna.study.Study.tell`. To observe heartbeat, please call this function after
+    :meth:`~optuna.study.Study.tell`. To observe the heartbeat, please call this function after
     :meth:`~optuna.study.Study.ask` and call :func:`~optuna.study.join_heartbeat_thread` after
     the evaluation of your objective function.
 
@@ -395,7 +395,7 @@ def join_heartbeat_thread(
 
     This is a utility function for the heartbeat feature of :class:`~optuna.storage.RDBStorage`,
     and it is expected to be used with :meth:`~optuna.study.Study.ask` and
-    :meth:`~optuna.study.Study.tell`. To observe heartbeat, please call
+    :meth:`~optuna.study.Study.tell`. To observe the heartbeat, please call
     :func:`~optuna.study.create_heartbeat_thread` after :meth:`~optuna.study.Study.ask`
     and call this function after the evaluation of your objective function.
 

--- a/optuna/_optimize.py
+++ b/optuna/_optimize.py
@@ -361,16 +361,16 @@ def create_heartbeat_thread(
     :meth:`~optuna.study.Study.tell`. To observe heartbeat, please call this function after
     :meth:`~optuna.study.Study.ask` and call :func:`~optuna.study.join_heartbeat_thread` after
     the evaluation of your objective function.
-    
+
     See `the example <https://github.com/optuna/
     optuna/blob/master/examples/pytorch/pytorch_ask_and_tell_checkpoint.py>`__ for more details.
 
     Args:
         study: A :class:`~optuna.study.Study` object.
         trial: A :class:`~optuna.trial.Trial` object created by :meth:`~optuna.study.Study.ask`.
-    
+
     Returns:
-        A tuple of :class:`~threading.Thread` and :class:`~threading.Event` to be passed to 
+        A tuple of :class:`~threading.Thread` and :class:`~threading.Event` to be passed to
         :func:`~optuna.study.join_heartbeat_thread` if heartbeat is enabled. Otherwise, return
         :obj:`None`.
     """
@@ -388,11 +388,11 @@ def join_heartbeat_thread(
     study: "optuna.study.Study", thread: Optional[Thread], stop_event: Optional[Event]
 ) -> None:
     """Join a thread for heartbeat.
-    
+
     This is a utility function for the heartbeat feature of :class:`~optuna.storage.RDBStorage`,
     and it is expected to be used with :meth:`~optuna.study.Study.ask` and
     :meth:`~optuna.study.Study.tell`. To observe heartbeat, please call
-    :func:`~optuna.study.create_heartbeat_thread` after :meth:`~optuna.study.Study.ask` 
+    :func:`~optuna.study.create_heartbeat_thread` after :meth:`~optuna.study.Study.ask`
     and call this function after the evaluation of your objective function.
 
     See `the example <https://github.com/optuna/optuna/blob/master/examples/pytorch/

--- a/optuna/study.py
+++ b/optuna/study.py
@@ -25,6 +25,9 @@ from optuna._experimental import experimental
 from optuna._multi_objective import _get_pareto_front_trials
 from optuna._optimize import _check_and_convert_to_values
 from optuna._optimize import _optimize
+from optuna._optimize import create_heartbeat_thread  # NOQA
+from optuna._optimize import join_heartbeat_thread  # NOQA
+from optuna._optimize import run_failed_trial_callback  # NOQA
 from optuna._study_direction import StudyDirection
 from optuna._study_summary import StudySummary  # NOQA
 from optuna.distributions import BaseDistribution


### PR DESCRIPTION
## Motivation

#2190 and #2347 added the heartbeat feature to `RDBStorage`. It is currently enabled when users start optimization using `Study.optimize`, and it is difficult for ask-and-tell API users to use the heatrbeat. This is mainly because the heartbeat implementation is embedded in a private function [`run_trial` in `optuna/_optimize.py`](https://github.com/optuna/optuna/blob/cda6136d5276a8144d5216a49a3f2f3c356bd77c/optuna/_optimize.py#L185).

## Description of the changes

This PR extracts the implementation of the heartbeat feature to the following functions:

- `run_failed_trial_callback`: execute the `failed_trial_callback` functions specified as the argument of `RDBStorage.__init__`. It should be called before `study.ask()`.
- `create_heartbeat_thread`: create and start a heartbeat thread. It is expected to call after `Study.ask`. It is called after `study.ask()`.
- `join_heartbeat_thread`: stop the heatbeat. It is expected to call after objective function evaluation. It is called after objective function evaluation.

Since these methods are not called in `Study.ask` or `Study.tell`, users have to call them by themselves.

```python
    for _ in range(N_TRIALS):
        optuna.study.run_failed_trial_callback(study)  # Here
        trial = study.ask()
        thread, stop_event = optuna.study.create_heartbeat_thread(study, trial)  # Here

        value = objective(trial)
        study.tell(trial, value)
        optuna.study.join_heartbeat_thread(study, thread, stop_event)  # Here
```

Alternatively, we might be able to call them in `Study.ask()` or `Study.tell()`, but the heartbeat threads may be not joined if users want to call ask and tell in the different process.