### PR TITLE
Clarify `n_jobs` for `OptunaSearchCV`

### DIFF
--- a/optuna/integration/sklearn.py
+++ b/optuna/integration/sklearn.py
@@ -398,7 +398,14 @@ class OptunaSearchCV(BaseEstimator):
             estimator supports ``partial_fit``.
 
         n_jobs:
-            Number of parallel jobs. :obj:`-1` means using all processors.
+            Number of :obj:`threading` based parallel jobs. :obj:`-1` means
+            using the number is set to CPU count.
+
+                .. note::
+                    ``n_jobs`` allows parallelization using :obj:`threading` and may suffer from
+                    `Python's GIL <https://wiki.python.org/moin/GlobalInterpreterLock>`_.
+                    It is recommended to use :ref:`process-based parallelization<distributed>`
+                    if ``func`` is CPU bound.
 
         n_trials:
             Number of trials. If :obj:`None`, there is no limitation on the


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

In my understanding, `OptunaSearchCV`'s `n_jobs` means the number of threads rather than processes because `n_jobs` is passed to `study.optimize` that uses thread-based parallelization.

See also https://github.com/optuna/optuna/issues/2424

## Description of the changes
<!-- Describe the changes in this PR. -->

Clarify the description and copy the `note` section from `study.optimize`.
