### PR TITLE
Remove redundant lines in CI settings of `examples`

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -52,8 +52,6 @@ jobs:
       run: |
         if [ ${{ matrix.python-version }} = 3.6 ]; then
           IGNORES='chainermn_.*|fastai*|pytorch_distributed_.*|rapids_.*|botorch_.*|pytorch/pytorch_checkpoint*'
-        elif [ ${{ matrix.python-version }} = 3.8 ]; then
-          IGNORES='chainermn_.*|pytorch_distributed_.*|fastai*|rapids_.*|pytorch/pytorch_checkpoint*'
         else
           IGNORES='chainermn_.*|fastai*|pytorch_distributed_.*|rapids_.*|pytorch/pytorch_checkpoint*'
         fi


### PR DESCRIPTION
## Motivation

This is a follow up PR for #2368.
Please refer to https://github.com/optuna/optuna/pull/2368#pullrequestreview-624916406 for details.

## Description of the changes

The IGNORES value for Python 3.8 is identical to the one for Python 3.7. So, I removed redundant lines.  