### PR TITLE
Add `n_min_trials` argument for `PercentilePruner` and `MedianPruner`

### DIFF
--- a/optuna/pruners/_median.py
+++ b/optuna/pruners/_median.py
@@ -63,7 +63,11 @@ class MedianPruner(PercentilePruner):
     """
 
     def __init__(
-        self, n_startup_trials: int = 5, n_warmup_steps: int = 0, interval_steps: int = 1
+        self,
+        n_startup_trials: int = 5,
+        n_warmup_steps: int = 0,
+        interval_steps: int = 1,
+        n_min_trials: int = 1,
     ) -> None:
 
-        super().__init__(50.0, n_startup_trials, n_warmup_steps, interval_steps)
+        super().__init__(50.0, n_startup_trials, n_warmup_steps, interval_steps, n_min_trials)

--- a/optuna/pruners/_median.py
+++ b/optuna/pruners/_median.py
@@ -61,9 +61,10 @@ class MedianPruner(PercentilePruner):
             If no value has been reported at the time of a pruning check, that particular check
             will be postponed until a value is reported.
         n_min_trials:
-            Minimum number of trials to perform pruning at each step. If the number of reported
-            intermediate values in a trial is less than ``n_min_trials`` at a step,
-            the trial is not pruned at this step.
+            Minimum number of reported trial results at a step to judge whether to prune.
+            If the number of reported intermediate values from all trials at the current step
+            is less than ``n_min_trials``, the trial will not be pruned. This can be used to ensure
+            that a minimum number of trials are run to completion without being pruned.
     """
 
     def __init__(

--- a/optuna/pruners/_median.py
+++ b/optuna/pruners/_median.py
@@ -71,6 +71,7 @@ class MedianPruner(PercentilePruner):
         n_startup_trials: int = 5,
         n_warmup_steps: int = 0,
         interval_steps: int = 1,
+        *,
         n_min_trials: int = 1,
     ) -> None:
 

--- a/optuna/pruners/_median.py
+++ b/optuna/pruners/_median.py
@@ -60,6 +60,10 @@ class MedianPruner(PercentilePruner):
             Interval in number of steps between the pruning checks, offset by the warmup steps.
             If no value has been reported at the time of a pruning check, that particular check
             will be postponed until a value is reported.
+        n_min_trials:
+            Minimum number of trials to perform pruning at each step. If the number of reported
+            intermediate values in a trial is less than ``n_min_trials`` at a step,
+            the trial is not pruned at this step.
     """
 
     def __init__(

--- a/optuna/pruners/_median.py
+++ b/optuna/pruners/_median.py
@@ -75,4 +75,6 @@ class MedianPruner(PercentilePruner):
         n_min_trials: int = 1,
     ) -> None:
 
-        super().__init__(50.0, n_startup_trials, n_warmup_steps, interval_steps, n_min_trials)
+        super().__init__(
+            50.0, n_startup_trials, n_warmup_steps, interval_steps, n_min_trials=n_min_trials
+        )

--- a/optuna/pruners/_percentile.py
+++ b/optuna/pruners/_percentile.py
@@ -131,9 +131,10 @@ class PercentilePruner(BasePruner):
             If no value has been reported at the time of a pruning check, that particular check
             will be postponed until a value is reported. Value must be at least 1.
         n_min_trials:
-            Minimum number of trials to perform pruning at each step. If the number of reported
-            intermediate values in a trial is less than ``n_min_trials`` at a step,
-            the trial is not pruned at this step.
+            Minimum number of reported trial results at a step to judge whether to prune.
+            If the number of reported intermediate values from all trials at the current step
+            is less than ``n_min_trials``, the trial will not be pruned. This can be used to ensure
+            that a minimum number of trials are run to completion without being pruned.
     """
 
     def __init__(

--- a/optuna/pruners/_percentile.py
+++ b/optuna/pruners/_percentile.py
@@ -130,6 +130,10 @@ class PercentilePruner(BasePruner):
             Interval in number of steps between the pruning checks, offset by the warmup steps.
             If no value has been reported at the time of a pruning check, that particular check
             will be postponed until a value is reported. Value must be at least 1.
+        n_min_trials:
+            Minimum number of trials to perform pruning at each step. If the number of reported
+            intermediate values in a trial is less than ``n_min_trials`` at a step,
+            the trial is not pruned at this step.
     """
 
     def __init__(

--- a/optuna/pruners/_percentile.py
+++ b/optuna/pruners/_percentile.py
@@ -142,6 +142,7 @@ class PercentilePruner(BasePruner):
         n_startup_trials: int = 5,
         n_warmup_steps: int = 0,
         interval_steps: int = 1,
+        *,
         n_min_trials: int = 1,
     ) -> None:
 

--- a/tests/pruners_tests/test_median.py
+++ b/tests/pruners_tests/test_median.py
@@ -140,7 +140,7 @@ def test_median_pruner_interval_steps(
 
 
 def test_median_pruner_n_min_trials() -> None:
-    pruner = optuna.pruners.MedianPruner(2, 0, 1, 2)
+    pruner = optuna.pruners.MedianPruner(2, 0, 1, n_min_trials=2)
     study = optuna.study.create_study()
 
     trial = optuna.trial.Trial(study, study._storage.create_new_trial(study._study_id))

--- a/tests/pruners_tests/test_percentile.py
+++ b/tests/pruners_tests/test_percentile.py
@@ -176,7 +176,7 @@ def test_get_percentile_intermediate_result_over_trials() -> None:
                 _all_trials = _study.get_trials()
                 _direction = _study.direction
                 _percentile._get_percentile_intermediate_result_over_trials(
-                    _all_trials, _direction, step, 25
+                    _all_trials, _direction, step, 25, 1
                 )
 
             for i in range(trial_num):
@@ -196,7 +196,7 @@ def test_get_percentile_intermediate_result_over_trials() -> None:
     all_trials = study.get_trials()
     direction = study.direction
     assert 0.3 == _percentile._get_percentile_intermediate_result_over_trials(
-        all_trials, direction, 0, 25.0
+        all_trials, direction, 0, 25.0, 1
     )
 
     # Input value has a float value and NaNs (step=1).
@@ -207,7 +207,7 @@ def test_get_percentile_intermediate_result_over_trials() -> None:
     all_trials = study.get_trials()
     direction = study.direction
     assert 0.2 == _percentile._get_percentile_intermediate_result_over_trials(
-        all_trials, direction, 1, 25.0
+        all_trials, direction, 1, 25.0, 1
     )
 
     # Input value has NaNs only (step=2).
@@ -228,5 +228,7 @@ def test_get_percentile_intermediate_result_over_trials() -> None:
     all_trials = study.get_trials()
     direction = study.direction
     assert math.isnan(
-        _percentile._get_percentile_intermediate_result_over_trials(all_trials, direction, 2, 75)
+        _percentile._get_percentile_intermediate_result_over_trials(
+            all_trials, direction, 2, 75, 1
+        )
     )

--- a/tests/pruners_tests/test_percentile.py
+++ b/tests/pruners_tests/test_percentile.py
@@ -232,3 +232,10 @@ def test_get_percentile_intermediate_result_over_trials() -> None:
             all_trials, direction, 2, 75, 1
         )
     )
+
+    # n_min_trials = 2
+    assert math.isnan(
+        _percentile._get_percentile_intermediate_result_over_trials(
+            all_trials, direction, 2, 75, 2
+        )
+    )


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation

<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

If a study has trials whose numbers of reported intermediate values are not uniform, `PercentilePruner` and `MedianPruner` may prune a promising trial based on a few reported values.

Suppose a minimization study with `MedianPruner` that has `n_startup_trials=2, n_warmup_steps=1`. When we observe the following trials, the third trial, `trial_2` is pruned at `step_2`.

| trial_id | step_0 | step_1 | step_2 | 
| ------:|--------:|-------:|-------:|
| 0         |      4.0   |      2.0 | 
| 1         |      3.0   |  
| 2         |      4.0   |     3.0 |  (1.0) | 

However, `trial_2` may have a better objective value: `1` at `step_3`. It will happen when we perform optimization with a stopping criterion such as early-stopping.

See also user's feedbacks: https://github.com/optuna/optuna/issues/2441 and https://github.com/optuna/optuna/issues/2506

## Description of the changes
<!-- Describe the changes in this PR. -->

Introduce a new argument such that the pruner does not stop the trial at a step if the number of reported values is less than `n_min_trials` at the step among trials.

### TODO

- [x] implement feature
- [x] add tests