### PR TITLE
Concatenate the argument text after the deprecation warning

### DIFF
--- a/optuna/_deprecated.py
+++ b/optuna/_deprecated.py
@@ -21,6 +21,13 @@ _DEPRECATION_NOTE_TEMPLATE = """
 """
 
 
+_DEPRECATION_WARNING_TEMPLATE = (
+    "{name} has been deprecated in v{d_ver}. "
+    "This feature will be removed in v{r_ver}. "
+    "See https://github.com/optuna/optuna/releases/tag/v{d_ver}."
+)
+
+
 def _validate_two_version(old_version: str, new_version: str) -> None:
     if version.parse(old_version) > version.parse(new_version):
         raise ValueError(
@@ -101,14 +108,10 @@ def deprecated(
             # TODO(mamu): Annotate this correctly.
             @functools.wraps(func)
             def new_func(*args: Any, **kwargs: Any) -> Any:
-                message = (
-                    "{0} has been deprecated in v{1}. "
-                    "This feature will be removed in v{2}. "
-                    "See https://github.com/optuna/optuna/releases/tag/v{1}.".format(
-                        name if name is not None else func.__name__,
-                        deprecated_version,
-                        removed_version,
-                    )
+                message = _DEPRECATION_WARNING_TEMPLATE.format(
+                    name=(name if name is not None else func.__name__),
+                    d_ver=deprecated_version,
+                    r_ver=removed_version,
                 )
                 if text is not None:
                     message += " " + text
@@ -127,14 +130,10 @@ def deprecated(
 
             @functools.wraps(_original_init)
             def wrapped_init(self, *args, **kwargs) -> None:  # type: ignore
-                message = (
-                    "{0} has been deprecated in v{1}. "
-                    "This feature will be removed in v{2}. "
-                    "See https://github.com/optuna/optuna/releases/tag/v{1}.".format(
-                        name if name is not None else cls.__name__,
-                        deprecated_version,
-                        removed_version,
-                    )
+                message = _DEPRECATION_WARNING_TEMPLATE.format(
+                    name=(name if name is not None else cls.__name__),
+                    d_ver=deprecated_version,
+                    r_ver=removed_version,
                 )
                 if text is not None:
                     message += " " + text

--- a/optuna/_deprecated.py
+++ b/optuna/_deprecated.py
@@ -101,17 +101,18 @@ def deprecated(
             # TODO(mamu): Annotate this correctly.
             @functools.wraps(func)
             def new_func(*args: Any, **kwargs: Any) -> Any:
-                warnings.warn(
+                message = (
                     "{0} has been deprecated in v{1}. "
                     "This feature will be removed in v{2}. "
                     "See https://github.com/optuna/optuna/releases/tag/v{1}.".format(
                         name if name is not None else func.__name__,
                         deprecated_version,
                         removed_version,
-                    ),
-                    FutureWarning,
-                    stacklevel=2,
+                    )
                 )
+                if text is not None:
+                    message += " " + text
+                warnings.warn(message, FutureWarning, stacklevel=2)
 
                 return func(*args, **kwargs)  # type: ignore
 
@@ -126,14 +127,19 @@ def deprecated(
 
             @functools.wraps(_original_init)
             def wrapped_init(self, *args, **kwargs) -> None:  # type: ignore
-                warnings.warn(
+                message = (
                     "{0} has been deprecated in v{1}. "
                     "This feature will be removed in v{2}. "
                     "See https://github.com/optuna/optuna/releases/tag/v{1}.".format(
                         name if name is not None else cls.__name__,
                         deprecated_version,
                         removed_version,
-                    ),
+                    )
+                )
+                if text is not None:
+                    message += " " + text
+                warnings.warn(
+                    message,
                     FutureWarning,
                     stacklevel=2,
                 )

--- a/tests/test_deprecated.py
+++ b/tests/test_deprecated.py
@@ -137,6 +137,16 @@ def test_deprecation_text_specified(text: Optional[str]) -> None:
     assert decorated_func.__name__ == _func.__name__
     assert decorated_func.__doc__ == expected_func_doc
 
+    with pytest.warns(FutureWarning) as record:
+        decorated_func()
+    assert isinstance(record.list[0].message, Warning)
+    expected_warning_message = _deprecated._DEPRECATION_WARNING_TEMPLATE.format(
+        name="_func", d_ver="1.1.0", r_ver="3.0.0"
+    )
+    if text is not None:
+        expected_warning_message += " " + text
+    assert record.list[0].message.args[0] == expected_warning_message
+
 
 @pytest.mark.parametrize("text", [None, "", "test", "test" * 100])
 def test_deprecation_class_text_specified(text: Optional[str]) -> None:
@@ -157,6 +167,16 @@ def test_deprecation_class_text_specified(text: Optional[str]) -> None:
         expected_class_doc += "\n\n\n"
     assert decorated_class.__name__ == _Class.__name__
     assert decorated_class.__doc__ == expected_class_doc
+
+    with pytest.warns(FutureWarning) as record:
+        decorated_class(None, None, None)
+    assert isinstance(record.list[0].message, Warning)
+    expected_warning_message = _deprecated._DEPRECATION_WARNING_TEMPLATE.format(
+        name="_Class", d_ver="1.1.0", r_ver="3.0.0"
+    )
+    if text is not None:
+        expected_warning_message += " " + text
+    assert record.list[0].message.args[0] == expected_warning_message
 
 
 def test_deprecation_decorator_default_removed_version() -> None:

--- a/tests/test_deprecated.py
+++ b/tests/test_deprecated.py
@@ -119,14 +119,13 @@ def test_deprecation_decorator_name() -> None:
     assert name in record.list[0].message.args[0]
 
 
-@pytest.mark.parametrize("name", [None, "test_func"])
 @pytest.mark.parametrize("text", [None, "", "test", "test" * 100])
-def test_deprecation_text_specified(name: Optional[str], text: Optional[str]) -> None:
+def test_deprecation_text_specified(text: Optional[str]) -> None:
     def _func() -> int:
 
         return 10
 
-    decorator_deprecation = _deprecated.deprecated("1.1.0", "3.0.0", name=name, text=text)
+    decorator_deprecation = _deprecated.deprecated("1.1.0", "3.0.0", text=text)
     decorated_func = decorator_deprecation(_func)
     expected_func_doc = _deprecated._DEPRECATION_NOTE_TEMPLATE.format(d_ver="1.1.0", r_ver="3.0.0")
     if text is None:
@@ -142,21 +141,20 @@ def test_deprecation_text_specified(name: Optional[str], text: Optional[str]) ->
         decorated_func()
     assert isinstance(record.list[0].message, Warning)
     expected_warning_message = _deprecated._DEPRECATION_WARNING_TEMPLATE.format(
-        name=(name if name is not None else "_func"), d_ver="1.1.0", r_ver="3.0.0"
+        name="_func", d_ver="1.1.0", r_ver="3.0.0"
     )
     if text is not None:
         expected_warning_message += " " + text
     assert record.list[0].message.args[0] == expected_warning_message
 
 
-@pytest.mark.parametrize("name", [None, "test_class"])
 @pytest.mark.parametrize("text", [None, "", "test", "test" * 100])
-def test_deprecation_class_text_specified(name: Optional[str], text: Optional[str]) -> None:
+def test_deprecation_class_text_specified(text: Optional[str]) -> None:
     class _Class(object):
         def __init__(self, a: Any, b: Any, c: Any) -> None:
             pass
 
-    decorator_deprecation = _deprecated.deprecated("1.1.0", "3.0.0", name=name, text=text)
+    decorator_deprecation = _deprecated.deprecated("1.1.0", "3.0.0", text=text)
     decorated_class = decorator_deprecation(_Class)
     expected_class_doc = _deprecated._DEPRECATION_NOTE_TEMPLATE.format(
         d_ver="1.1.0", r_ver="3.0.0"
@@ -174,7 +172,7 @@ def test_deprecation_class_text_specified(name: Optional[str], text: Optional[st
         decorated_class(None, None, None)
     assert isinstance(record.list[0].message, Warning)
     expected_warning_message = _deprecated._DEPRECATION_WARNING_TEMPLATE.format(
-        name=(name if name is not None else "_Class"), d_ver="1.1.0", r_ver="3.0.0"
+        name="_Class", d_ver="1.1.0", r_ver="3.0.0"
     )
     if text is not None:
         expected_warning_message += " " + text

--- a/tests/test_deprecated.py
+++ b/tests/test_deprecated.py
@@ -119,13 +119,14 @@ def test_deprecation_decorator_name() -> None:
     assert name in record.list[0].message.args[0]
 
 
+@pytest.mark.parametrize("name", [None, "test_func"])
 @pytest.mark.parametrize("text", [None, "", "test", "test" * 100])
-def test_deprecation_text_specified(text: Optional[str]) -> None:
+def test_deprecation_text_specified(name: Optional[str], text: Optional[str]) -> None:
     def _func() -> int:
 
         return 10
 
-    decorator_deprecation = _deprecated.deprecated("1.1.0", "3.0.0", text=text)
+    decorator_deprecation = _deprecated.deprecated("1.1.0", "3.0.0", name=name, text=text)
     decorated_func = decorator_deprecation(_func)
     expected_func_doc = _deprecated._DEPRECATION_NOTE_TEMPLATE.format(d_ver="1.1.0", r_ver="3.0.0")
     if text is None:
@@ -141,20 +142,21 @@ def test_deprecation_text_specified(text: Optional[str]) -> None:
         decorated_func()
     assert isinstance(record.list[0].message, Warning)
     expected_warning_message = _deprecated._DEPRECATION_WARNING_TEMPLATE.format(
-        name="_func", d_ver="1.1.0", r_ver="3.0.0"
+        name=(name if name is not None else "_func"), d_ver="1.1.0", r_ver="3.0.0"
     )
     if text is not None:
         expected_warning_message += " " + text
     assert record.list[0].message.args[0] == expected_warning_message
 
 
+@pytest.mark.parametrize("name", [None, "test_class"])
 @pytest.mark.parametrize("text", [None, "", "test", "test" * 100])
-def test_deprecation_class_text_specified(text: Optional[str]) -> None:
+def test_deprecation_class_text_specified(name: Optional[str], text: Optional[str]) -> None:
     class _Class(object):
         def __init__(self, a: Any, b: Any, c: Any) -> None:
             pass
 
-    decorator_deprecation = _deprecated.deprecated("1.1.0", "3.0.0", text=text)
+    decorator_deprecation = _deprecated.deprecated("1.1.0", "3.0.0", name=name, text=text)
     decorated_class = decorator_deprecation(_Class)
     expected_class_doc = _deprecated._DEPRECATION_NOTE_TEMPLATE.format(
         d_ver="1.1.0", r_ver="3.0.0"
@@ -172,7 +174,7 @@ def test_deprecation_class_text_specified(text: Optional[str]) -> None:
         decorated_class(None, None, None)
     assert isinstance(record.list[0].message, Warning)
     expected_warning_message = _deprecated._DEPRECATION_WARNING_TEMPLATE.format(
-        name="_Class", d_ver="1.1.0", r_ver="3.0.0"
+        name=(name if name is not None else "_Class"), d_ver="1.1.0", r_ver="3.0.0"
     )
     if text is not None:
         expected_warning_message += " " + text


### PR DESCRIPTION
## Motivation
To display the additional text in the warning message is helpful for the migration from the deprecated feature.
## Description of the changes
Concatenate the argument text after the deprecation warning.