### PR TITLE
Deprecate dashboard

### DIFF
--- a/optuna/_deprecated.py
+++ b/optuna/_deprecated.py
@@ -101,17 +101,18 @@ def deprecated(
             # TODO(mamu): Annotate this correctly.
             @functools.wraps(func)
             def new_func(*args: Any, **kwargs: Any) -> Any:
-                warnings.warn(
+                message = (
                     "{0} has been deprecated in v{1}. "
                     "This feature will be removed in v{2}. "
                     "See https://github.com/optuna/optuna/releases/tag/v{1}.".format(
                         name if name is not None else func.__name__,
                         deprecated_version,
                         removed_version,
-                    ),
-                    FutureWarning,
-                    stacklevel=2,
+                    )
                 )
+                if text is not None:
+                    message += " " + text
+                warnings.warn(message, FutureWarning, stacklevel=2)
 
                 return func(*args, **kwargs)  # type: ignore
 
@@ -126,14 +127,19 @@ def deprecated(
 
             @functools.wraps(_original_init)
             def wrapped_init(self, *args, **kwargs) -> None:  # type: ignore
-                warnings.warn(
+                message = (
                     "{0} has been deprecated in v{1}. "
                     "This feature will be removed in v{2}. "
                     "See https://github.com/optuna/optuna/releases/tag/v{1}.".format(
                         name if name is not None else cls.__name__,
                         deprecated_version,
                         removed_version,
-                    ),
+                    )
+                )
+                if text is not None:
+                    message += " " + text
+                warnings.warn(
+                    message,
                     FutureWarning,
                     stacklevel=2,
                 )

--- a/optuna/cli.py
+++ b/optuna/cli.py
@@ -25,6 +25,7 @@ from cliff.commandmanager import CommandManager
 from cliff.lister import Lister
 
 import optuna
+from optuna._deprecated import deprecated
 from optuna.exceptions import CLIUsageError
 from optuna.storages import RDBStorage
 
@@ -172,7 +173,11 @@ class _Studies(Lister):
 
 
 class _Dashboard(_BaseCommand):
-    """Launch web dashboard (beta)."""
+    """Launch web dashboard (beta).
+
+    This feature is deprecated since version 2.7.0. Please use `optuna-dashboard
+    <https://github.com/optuna/optuna-dashboard>`_ instead.
+    """
 
     def get_parser(self, prog_name: str) -> ArgumentParser:
 
@@ -203,6 +208,12 @@ class _Dashboard(_BaseCommand):
         )
         return parser
 
+    @deprecated(
+        "2.7.0",
+        "4.0.0",
+        name="dashboard",
+        text="Please use optuna-dashboard (https://github.com/optuna/optuna-dashboard) instead.",
+    )
     def take_action(self, parsed_args: Namespace) -> None:
 
         storage_url = _check_storage_url(self.app_args.storage)

--- a/optuna/cli.py
+++ b/optuna/cli.py
@@ -210,7 +210,7 @@ class _Dashboard(_BaseCommand):
 
     @deprecated(
         "2.7.0",
-        "4.0.0",
+        "3.0.0",
         name="dashboard",
         text="Please use optuna-dashboard (https://github.com/optuna/optuna-dashboard) instead.",
     )

--- a/optuna/dashboard.py
+++ b/optuna/dashboard.py
@@ -10,7 +10,6 @@ from typing import Optional
 import numpy as np
 from packaging import version
 
-from optuna._experimental import experimental
 from optuna._imports import try_import
 from optuna._study_direction import StudyDirection
 import optuna.logging
@@ -246,12 +245,6 @@ if _imports.is_successful():
             self.all_trials_widget.update(current_trials, new_trials)
 
 
-@experimental("0.1.0", name="Optuna dashboard")
-def _show_experimental_warning() -> None:
-
-    pass
-
-
 def _get_this_source_path() -> str:
 
     path = __file__
@@ -267,7 +260,6 @@ def _serve(study: optuna.study.Study, bokeh_allow_websocket_origins: List[str]) 
     global _mode, _study
 
     _imports.check()
-    _show_experimental_warning()
 
     # We want to pass the mode (launching a server? or, just writing an HTML?) and a target study
     # to our Bokeh app. Unfortunately, as we are using `bokeh.command.bootstrap.main` to launch
@@ -295,7 +287,6 @@ def _write(study: optuna.study.Study, out_path: str) -> None:
     global _mode, _study
 
     _imports.check()
-    _show_experimental_warning()
 
     _mode = "html"
     _study = study


### PR DESCRIPTION
This PR depends #2558.
## Motivation
The dashboard has not been updated in this half-year, and the new dashboard "[optuna-dashboard](https://github.com/optuna/optuna-dashboard)" has been rolled out. We should encourage migration.
## Description of the changes
Deprecate `optuna dashboard`.