### PR TITLE
Deprecate `n_jobs` in `Study.optimize`

### DIFF
--- a/optuna/integration/sklearn.py
+++ b/optuna/integration/sklearn.py
@@ -407,6 +407,13 @@ class OptunaSearchCV(BaseEstimator):
                     It is recommended to use :ref:`process-based parallelization<distributed>`
                     if ``func`` is CPU bound.
 
+                .. warning::
+                    Deprecated in v2.7.0. This feature will be removed in the future.
+                    It is recommended to use :ref:`process-based parallelization<distributed>`.
+                    The removal of this feature is currently scheduled for v4.0.0, but this
+                    schedule is subject to change.
+                    See https://github.com/optuna/optuna/releases/tag/v2.7.0.
+
         n_trials:
             Number of trials. If :obj:`None`, there is no limitation on the
             number of trials. If :obj:`timeout` is also set to :obj:`None`,

--- a/optuna/study.py
+++ b/optuna/study.py
@@ -354,6 +354,13 @@ class Study(BaseStudy):
                     It is recommended to use :ref:`process-based parallelization<distributed>`
                     if ``func`` is CPU bound.
 
+                .. warning::
+                    Deprecated in v2.7.0. This feature will be removed in the future.
+                    It is recommended to use :ref:`process-based parallelization<distributed>`.
+                    The removal of this feature is currently scheduled for v4.0.0, but this
+                    schedule is subject to change.
+                    See https://github.com/optuna/optuna/releases/tag/v2.7.0.
+
             catch:
                 A study continues to run even when a trial raises one of the exceptions specified
                 in this argument. Default is an empty tuple, i.e. the study will stop for any
@@ -382,6 +389,14 @@ class Study(BaseStudy):
             RuntimeError:
                 If nested invocation of this method occurs.
         """
+        if n_jobs != 1:
+            warnings.warn(
+                "`n_jobs` argument has been deprecated in v2.7.0. "
+                "This feature will be removed in v4.0.0. "
+                "See https://github.com/optuna/optuna/releases/tag/v2.7.0.",
+                FutureWarning,
+            )
+
         _optimize(
             study=self,
             func=func,

--- a/tests/study_tests/test_study.py
+++ b/tests/study_tests/test_study.py
@@ -110,6 +110,13 @@ def check_study(study: Study) -> None:
         check_frozen_trial(study.best_trial)
 
 
+def test_optimize_n_jobs_warning() -> None:
+
+    study = create_study()
+    with pytest.warns(FutureWarning):
+        study.optimize(func, n_trials=1, n_jobs=2)
+
+
 def test_optimize_trivial_in_memory_new() -> None:
 
     study = create_study()


### PR DESCRIPTION
## Motivation
Optuna recommends process-level parallelization as shown in the [tutorial](https://optuna.readthedocs.io/en/stable/tutorial/10_key_features/004_distributed.html#sphx-glr-tutorial-10-key-features-004-distributed-py), rather than thread-level parallelization using the `n_jobs` argument of `Study.optimize`. This PR deprecates the argument to avoid confusing users.

## Description of the changes
- Deprecate `n_jobs` in `Study.optimize`.
- Add test
