### PR TITLE
[RFC] Pareto front visualization to visualize study progress with color scales

### DIFF
--- a/optuna/visualization/_pareto_front.py
+++ b/optuna/visualization/_pareto_front.py
@@ -160,7 +160,7 @@ def _get_pareto_front_2d(
                 "colorscale": "Reds",
                 "colorbar": {
                     "title": "#Best trials",
-                    "x": 1.1,  # Offset the colorbar position with a fixed width `xpad`.
+                    "x": 1.1 if include_dominated_trials else 1,
                     "xpad": 40,
                 },
             },
@@ -245,7 +245,7 @@ def _get_pareto_front_3d(
                 "colorscale": "Reds",
                 "colorbar": {
                     "title": "#Best trials",
-                    "x": 1.1,  # Offset the colorbar position with a fixed width `xpad`.
+                    "x": 1.1 if include_dominated_trials else 1,
                     "xpad": 40,
                 },
             },

--- a/optuna/visualization/_pareto_front.py
+++ b/optuna/visualization/_pareto_front.py
@@ -104,6 +104,7 @@ def _get_pareto_front_2d(
         raise ValueError("The length of `target_names` is supposed to be 2.")
 
     trials = study.best_trials
+    n_best_trials = len(trials)
     if len(trials) == 0:
         _logger.warning("Your study does not have any completed trials.")
 
@@ -133,14 +134,14 @@ def _get_pareto_front_2d(
 
     data = [
         go.Scatter(
-            x=[t.values[axis_order[0]] for t in trials[len(study.best_trials) :]],
-            y=[t.values[axis_order[1]] for t in trials[len(study.best_trials) :]],
-            text=[_make_hovertext(t) for t in trials[len(study.best_trials) :]],
+            x=[t.values[axis_order[0]] for t in trials[n_best_trials:]],
+            y=[t.values[axis_order[1]] for t in trials[n_best_trials:]],
+            text=[_make_hovertext(t) for t in trials[n_best_trials:]],
             mode="markers",
             hovertemplate="%{text}<extra>Trial</extra>",
             marker={
                 "line": {"width": 0.5, "color": "Grey"},
-                "color": [t.number for t in trials[len(study.best_trials) :]],
+                "color": [t.number for t in trials[n_best_trials:]],
                 "colorscale": "Blues",
                 "colorbar": {
                     "title": "#Trials",
@@ -149,14 +150,14 @@ def _get_pareto_front_2d(
             showlegend=False,
         ),
         go.Scatter(
-            x=[t.values[axis_order[0]] for t in trials[: len(study.best_trials)]],
-            y=[t.values[axis_order[1]] for t in trials[: len(study.best_trials)]],
-            text=[_make_hovertext(t) for t in trials[: len(study.best_trials)]],
+            x=[t.values[axis_order[0]] for t in trials[:n_best_trials]],
+            y=[t.values[axis_order[1]] for t in trials[:n_best_trials]],
+            text=[_make_hovertext(t) for t in trials[:n_best_trials]],
             mode="markers",
             hovertemplate="%{text}<extra>Best Trial</extra>",
             marker={
                 "line": {"width": 0.5, "color": "Grey"},
-                "color": [t.number for t in trials[: len(study.best_trials)]],
+                "color": [t.number for t in trials[:n_best_trials]],
                 "colorscale": "Reds",
                 "colorbar": {
                     "title": "#Best trials",
@@ -187,6 +188,7 @@ def _get_pareto_front_3d(
         raise ValueError("The length of `target_names` is supposed to be 3.")
 
     trials = study.best_trials
+    n_best_trials = len(trials)
     if len(trials) == 0:
         _logger.warning("Your study does not have any completed trials.")
 
@@ -216,15 +218,15 @@ def _get_pareto_front_3d(
 
     data = [
         go.Scatter3d(
-            x=[t.values[axis_order[0]] for t in trials[len(study.best_trials) :]],
-            y=[t.values[axis_order[1]] for t in trials[len(study.best_trials) :]],
-            z=[t.values[axis_order[2]] for t in trials[len(study.best_trials) :]],
-            text=[_make_hovertext(t) for t in trials[len(study.best_trials) :]],
+            x=[t.values[axis_order[0]] for t in trials[n_best_trials:]],
+            y=[t.values[axis_order[1]] for t in trials[n_best_trials:]],
+            z=[t.values[axis_order[2]] for t in trials[n_best_trials:]],
+            text=[_make_hovertext(t) for t in trials[n_best_trials:]],
             hovertemplate="%{text}<extra>Trial</extra>",
             mode="markers",
             marker={
                 "line": {"width": 0.5, "color": "Grey"},
-                "color": [t.number for t in trials[len(study.best_trials) :]],
+                "color": [t.number for t in trials[n_best_trials:]],
                 "colorscale": "Blues",
                 "colorbar": {
                     "title": "#Trials",
@@ -233,15 +235,15 @@ def _get_pareto_front_3d(
             showlegend=False,
         ),
         go.Scatter3d(
-            x=[t.values[axis_order[0]] for t in trials[: len(study.best_trials)]],
-            y=[t.values[axis_order[1]] for t in trials[: len(study.best_trials)]],
-            z=[t.values[axis_order[2]] for t in trials[: len(study.best_trials)]],
-            text=[_make_hovertext(t) for t in trials[: len(study.best_trials)]],
+            x=[t.values[axis_order[0]] for t in trials[:n_best_trials]],
+            y=[t.values[axis_order[1]] for t in trials[:n_best_trials]],
+            z=[t.values[axis_order[2]] for t in trials[:n_best_trials]],
+            text=[_make_hovertext(t) for t in trials[:n_best_trials]],
             hovertemplate="%{text}<extra>Best Trial</extra>",
             mode="markers",
             marker={
                 "line": {"width": 0.5, "color": "Grey"},
-                "color": [t.number for t in trials[: len(study.best_trials)]],
+                "color": [t.number for t in trials[:n_best_trials]],
                 "colorscale": "Reds",
                 "colorbar": {
                     "title": "#Best trials",

--- a/optuna/visualization/_pareto_front.py
+++ b/optuna/visualization/_pareto_front.py
@@ -138,7 +138,15 @@ def _get_pareto_front_2d(
             text=[_make_hovertext(t) for t in trials[len(study.best_trials) :]],
             mode="markers",
             hovertemplate="%{text}<extra>Trial</extra>",
-            name="Trial",
+            marker={
+                "line": {"width": 0.5, "color": "Grey"},
+                "color": [t.number for t in trials[len(study.best_trials) :]],
+                "colorscale": "Blues",
+                "colorbar": {
+                    "title": "#Trials",
+                },
+            },
+            showlegend=False,
         ),
         go.Scatter(
             x=[t.values[axis_order[0]] for t in trials[: len(study.best_trials)]],
@@ -146,7 +154,17 @@ def _get_pareto_front_2d(
             text=[_make_hovertext(t) for t in trials[: len(study.best_trials)]],
             mode="markers",
             hovertemplate="%{text}<extra>Best Trial</extra>",
-            name="Best Trial",
+            marker={
+                "line": {"width": 0.5, "color": "Grey"},
+                "color": [t.number for t in trials[: len(study.best_trials)]],
+                "colorscale": "Reds",
+                "colorbar": {
+                    "title": "#Best trials",
+                    "x": 1.1,  # Offset the colorbar position with a fixed width `xpad`.
+                    "xpad": 40,
+                },
+            },
+            showlegend=False,
         ),
     ]
     layout = go.Layout(
@@ -202,18 +220,36 @@ def _get_pareto_front_3d(
             y=[t.values[axis_order[1]] for t in trials[len(study.best_trials) :]],
             z=[t.values[axis_order[2]] for t in trials[len(study.best_trials) :]],
             text=[_make_hovertext(t) for t in trials[len(study.best_trials) :]],
-            mode="markers",
             hovertemplate="%{text}<extra>Trial</extra>",
-            name="Trial",
+            mode="markers",
+            marker={
+                "line": {"width": 0.5, "color": "Grey"},
+                "color": [t.number for t in trials[len(study.best_trials) :]],
+                "colorscale": "Blues",
+                "colorbar": {
+                    "title": "#Trials",
+                },
+            },
+            showlegend=False,
         ),
         go.Scatter3d(
             x=[t.values[axis_order[0]] for t in trials[: len(study.best_trials)]],
             y=[t.values[axis_order[1]] for t in trials[: len(study.best_trials)]],
             z=[t.values[axis_order[2]] for t in trials[: len(study.best_trials)]],
             text=[_make_hovertext(t) for t in trials[: len(study.best_trials)]],
-            mode="markers",
             hovertemplate="%{text}<extra>Best Trial</extra>",
-            name="Best Trial",
+            mode="markers",
+            marker={
+                "line": {"width": 0.5, "color": "Grey"},
+                "color": [t.number for t in trials[: len(study.best_trials)]],
+                "colorscale": "Reds",
+                "colorbar": {
+                    "title": "#Best trials",
+                    "x": 1.1,  # Offset the colorbar position with a fixed width `xpad`.
+                    "xpad": 40,
+                },
+            },
+            showlegend=False,
         ),
     ]
     layout = go.Layout(


### PR DESCRIPTION
## Motivation

The Pareto front visualizations (2d, 3d in `plot_pareto_front`) visualize trials with scatter plots, distinguishing between trial in the front and ones that are not using two different colors. Similar to [`plot_slice`](https://optuna.readthedocs.io/en/stable/reference/visualization/generated/optuna.visualization.plot_slice.html#optuna.visualization.plot_slice), they could additionally show the study progress using color scales in Plotly. This information is e.g. useful to study what tendencies the search algorithms have and how the search changes during the course of the study.

## Description of the changes

### `master`

https://optuna.readthedocs.io/en/stable/reference/visualization/generated/optuna.visualization.plot_pareto_front.html#optuna.visualization.plot_pareto_front

### This PR

<!-- Describe the changes in this PR. -->
![newplot (37)](https://user-images.githubusercontent.com/5983694/113469738-06c6f800-948b-11eb-989f-119327e9a7da.png)

![newplot (36)](https://user-images.githubusercontent.com/5983694/113469737-0595cb00-948b-11eb-8c13-57aa001458e6.png)


