### PR TITLE
Sort categorical values on axis that contains only numerical values in `visualization.plot_contour`

### DIFF
--- a/optuna/visualization/_contour.py
+++ b/optuna/visualization/_contour.py
@@ -137,8 +137,12 @@ def _get_contour_plot(
             min_value = math.pow(10, math.log10(min_value) - padding)
             max_value = math.pow(10, math.log10(max_value) + padding)
 
-        elif not _is_numerical(trials, p_name):
+        elif _is_numerical(trials, p_name):
+            padding = (max_value - min_value) * padding_ratio
+            min_value = min_value - padding
+            max_value = max_value + padding
 
+        else:
             # Plotly>=4.12.0 draws contours using the indices of categorical variables instead of
             # raw values and the range should be updated based on the cardinality of categorical
             # variables. See https://github.com/optuna/optuna/issues/1967.
@@ -148,10 +152,6 @@ def _get_contour_plot(
                 min_value = -padding
                 max_value = span + padding
 
-        else:
-            padding = (max_value - min_value) * padding_ratio
-            min_value = min_value - padding
-            max_value = max_value + padding
         param_values_range[p_name] = (min_value, max_value)
 
     if len(sorted_params) == 2:

--- a/optuna/visualization/_contour.py
+++ b/optuna/visualization/_contour.py
@@ -15,8 +15,8 @@ from optuna.trial import FrozenTrial
 from optuna.trial import TrialState
 from optuna.visualization._plotly_imports import _imports
 from optuna.visualization._utils import _check_plot_args
-from optuna.visualization._utils import _is_categorical
 from optuna.visualization._utils import _is_log_scale
+from optuna.visualization._utils import _is_numerical
 
 
 if _imports.is_successful():
@@ -92,7 +92,7 @@ def plot_contour(
 
 def _get_param_values(trials: List[FrozenTrial], p_name: str) -> List[Any]:
     values = [t.params[p_name] for t in trials if p_name in t.params]
-    if not _is_categorical(trials, p_name):
+    if _is_numerical(trials, p_name):
         return values
     return list(map(str, values))
 
@@ -137,7 +137,7 @@ def _get_contour_plot(
             min_value = math.pow(10, math.log10(min_value) - padding)
             max_value = math.pow(10, math.log10(max_value) + padding)
 
-        elif _is_categorical(trials, p_name):
+        elif not _is_numerical(trials, p_name):
 
             # Plotly>=4.12.0 draws contours using the indices of categorical variables instead of
             # raw values and the range should be updated based on the cardinality of categorical
@@ -164,9 +164,9 @@ def _get_contour_plot(
         figure.update_xaxes(title_text=x_param, range=param_values_range[x_param])
         figure.update_yaxes(title_text=y_param, range=param_values_range[y_param])
 
-        if _is_categorical(trials, x_param):
+        if not _is_numerical(trials, x_param):
             figure.update_xaxes(type="category")
-        if _is_categorical(trials, y_param):
+        if not _is_numerical(trials, y_param):
             figure.update_yaxes(type="category")
 
         if _is_log_scale(trials, x_param):
@@ -206,9 +206,9 @@ def _get_contour_plot(
                 figure.update_xaxes(range=param_values_range[x_param], row=y_i + 1, col=x_i + 1)
                 figure.update_yaxes(range=param_values_range[y_param], row=y_i + 1, col=x_i + 1)
 
-                if _is_categorical(trials, x_param):
+                if not _is_numerical(trials, x_param):
                     figure.update_xaxes(type="category", row=y_i + 1, col=x_i + 1)
-                if _is_categorical(trials, y_param):
+                if not _is_numerical(trials, y_param):
                     figure.update_yaxes(type="category", row=y_i + 1, col=x_i + 1)
 
                 if _is_log_scale(trials, x_param):
@@ -250,11 +250,11 @@ def _generate_contour_subplot(
 
     # Padding to the plot for non-categorical params.
     x_range = param_values_range[x_param]
-    if not _is_categorical(trials, x_param):
+    if _is_numerical(trials, x_param):
         x_indices = [x_range[0]] + x_indices + [x_range[1]]
 
     y_range = param_values_range[y_param]
-    if not _is_categorical(trials, y_param):
+    if _is_numerical(trials, y_param):
         y_indices = [y_range[0]] + y_indices + [y_range[1]]
 
     z = [[float("nan") for _ in range(len(x_indices))] for _ in range(len(y_indices))]
@@ -266,9 +266,9 @@ def _generate_contour_subplot(
             continue
         x_value = trial.params[x_param]
         y_value = trial.params[y_param]
-        if _is_categorical(trials, x_param):
+        if not _is_numerical(trials, x_param):
             x_value = str(x_value)
-        if _is_categorical(trials, y_param):
+        if not _is_numerical(trials, y_param):
             y_value = str(y_value)
         x_values.append(x_value)
         y_values.append(y_value)

--- a/optuna/visualization/_utils.py
+++ b/optuna/visualization/_utils.py
@@ -72,3 +72,12 @@ def _is_categorical(trials: List[FrozenTrial], param: str) -> bool:
         for t in trials
         if param in t.params
     )
+
+
+def _is_numerical(trials: List[FrozenTrial], param: str) -> bool:
+    return all(
+        (isinstance(t.params[param], int) or isinstance(t.params[param], float))
+        and not isinstance(t.params[param], bool)
+        for t in trials
+        if param in t.params
+    )

--- a/tests/visualization_tests/test_contour.py
+++ b/tests/visualization_tests/test_contour.py
@@ -261,11 +261,13 @@ def test_plot_contour_mixture_category_types() -> None:
         )
     )
     figure = plot_contour(study)
+
+    # yaxis is treated as non-categorical
     if version.parse(plotly.__version__) >= version.parse("4.12.0"):
         assert figure.layout["xaxis"]["range"] == (-0.05, 1.05)
-        assert figure.layout["yaxis"]["range"] == (-0.05, 1.05)
+        assert figure.layout["yaxis"]["range"] == (100.95, 102.05)
     else:
         assert figure.layout["xaxis"]["range"] == ("100", "None")
-        assert figure.layout["yaxis"]["range"] == ("101", "102.0")
+        assert figure.layout["yaxis"]["range"] == (100.95, 102.05)
     assert figure.layout["xaxis"]["type"] == "category"
-    assert figure.layout["yaxis"]["type"] == "category"
+    assert figure.layout["yaxis"]["type"] != "category"


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

The contour plot's axis can be improved when a categorical distribution suggests only `int` or `float` values. 

See also a user request as in https://github.com/optuna/optuna/issues/2544.

### Example

```python
import optuna


def objective(trial):
    x = trial.suggest_uniform('x', -100, 100)
    y = trial.suggest_categorical('y', list(range(-10, 10)))
    z = trial.suggest_uniform('z', -100, 100)
    return x ** 2 + y - z

study = optuna.create_study()
study.optimize(objective, n_trials=200)

optuna.visualization.plot_contour(study, params=['y', 'z'])
```

Parameter `y`'s axis is sorted as `str`:

![newplot (2)](https://user-images.githubusercontent.com/7121753/113716568-b4553800-9725-11eb-80f3-045309757c06.png)


## Description of the changes
<!-- Describe the changes in this PR. -->

 if suggested values contain only `int` or `float`, then the parameter is not treated as a categorical distribution.

---

### Improved plot

The generated plot on this pull request is as follows.
![newplot (4)](https://user-images.githubusercontent.com/7121753/113718054-3bef7680-9727-11eb-9781-f7b39ec09deb.png)

## Note

I will send another PR for matplotlib backend.

I think there is room to improve the speed of `visualization.plot_contour`. `_is_categorical` or `_is_numerical` looks expensive if the number of trials is large. We can use a cache to store the evaluated value of `_is_numerical`.

In terms of this point, I think this speed-up should be separated from this pull request because it might be difficult for assignees to review both points.

