### PR TITLE
Upload to TestPyPI at the time of release as well

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -24,7 +24,7 @@ jobs:
       run: >-
         python -m pip install -U twine wheel
 
-    - name: Change the version file for TestPyPI upload
+    - name: Change the version file for scheduled TestPyPI upload
       if: (github.repository == 'optuna/optuna') && (github.event_name == 'schedule')
       run: |
         OPTUNA_VERSION=$(cut -d '"' -f 2 optuna/version.py)
@@ -41,7 +41,7 @@ jobs:
 
     - name: Publish distribution to TestPyPI
       # The following upload action cannot be executed in the forked repository.
-      if: (github.repository == 'optuna/optuna') && (github.event_name == 'schedule')
+      if: (github.repository == 'optuna/optuna') && ((github.event_name == 'schedule') || (github.event_name == 'release'))
       uses: pypa/gh-action-pypi-publish@v1.1.0
       with:
         user: __token__


### PR DESCRIPTION
## Motivation
The upload to TestPyPI is scheduled every day, but it is not activated at the time of release. This leads to the strange old version of the [TestPyPI](https://test.pypi.org/project/optuna/) as follows.


<img width="1139" alt="スクリーンショット 2021-04-08 7 32 20" src="https://user-images.githubusercontent.com/38826298/113942872-93cbd180-983c-11eb-9486-f18b6f2ecde1.png">

This PR ensures to upload to TestPyPI at the time of release.

## Description of the changes
- Upload to TestPyPI at the time of release.
