### PR TITLE
Improve `param_importances`

### DIFF
--- a/optuna/visualization/_param_importances.py
+++ b/optuna/visualization/_param_importances.py
@@ -5,12 +5,6 @@ from typing import Optional
 
 import optuna
 from optuna.distributions import BaseDistribution
-from optuna.distributions import CategoricalDistribution
-from optuna.distributions import DiscreteUniformDistribution
-from optuna.distributions import IntLogUniformDistribution
-from optuna.distributions import IntUniformDistribution
-from optuna.distributions import LogUniformDistribution
-from optuna.distributions import UniformDistribution
 from optuna.importance._base import BaseImportanceEvaluator
 from optuna.logging import get_logger
 from optuna.study import Study
@@ -25,16 +19,8 @@ if _imports.is_successful():
 
     from optuna.visualization._plotly_imports import go
 
-    Blues = plotly.colors.sequential.Blues
+    bar_color = plotly.colors.sequential.Blues[-4]
 
-    _distribution_colors = {
-        UniformDistribution: Blues[-1],
-        LogUniformDistribution: Blues[-1],
-        DiscreteUniformDistribution: Blues[-1],
-        IntUniformDistribution: Blues[-2],
-        IntLogUniformDistribution: Blues[-2],
-        CategoricalDistribution: Blues[-4],
-    }
 
 logger = get_logger(__name__)
 
@@ -144,7 +130,7 @@ def plot_param_importances(
                     _make_hovertext(param_name, importance, study)
                     for param_name, importance in importances.items()
                 ],
-                marker_color=[_get_color(param_name, study) for param_name in param_names],
+                marker_color=bar_color,
                 orientation="h",
             )
         ],
@@ -159,10 +145,6 @@ def _get_distribution(param_name: str, study: Study) -> BaseDistribution:
         if param_name in trial.distributions:
             return trial.distributions[param_name]
     assert False
-
-
-def _get_color(param_name: str, study: Study) -> str:
-    return _distribution_colors[type(_get_distribution(param_name, study))]
 
 
 def _make_hovertext(param_name: str, importance: float, study: Study) -> str:

--- a/optuna/visualization/_param_importances.py
+++ b/optuna/visualization/_param_importances.py
@@ -19,8 +19,6 @@ if _imports.is_successful():
 
     from optuna.visualization._plotly_imports import go
 
-    bar_color = plotly.colors.sequential.Blues[-4]
-
 
 logger = get_logger(__name__)
 
@@ -130,7 +128,7 @@ def plot_param_importances(
                     _make_hovertext(param_name, importance, study)
                     for param_name, importance in importances.items()
                 ],
-                marker_color=bar_color,
+                marker_color=plotly.colors.sequential.Blues[-4],
                 orientation="h",
             )
         ],

--- a/optuna/visualization/matplotlib/_param_importances.py
+++ b/optuna/visualization/matplotlib/_param_importances.py
@@ -22,9 +22,6 @@ if _imports.is_successful():
     from optuna.visualization.matplotlib._matplotlib_imports import cm
     from optuna.visualization.matplotlib._matplotlib_imports import plt
 
-    # fix single color for bars
-    cmap = cm.get_cmap("tab20c")
-    bar_color = cmap(0)
 
 _logger = get_logger(__name__)
 
@@ -137,7 +134,7 @@ def _get_param_importance_plot(
         pos,
         importance_values,
         align="center",
-        color=bar_color,
+        color=cm.get_cmap("tab20c")(0),
         tick_label=param_names,
     )
 

--- a/optuna/visualization/matplotlib/_param_importances.py
+++ b/optuna/visualization/matplotlib/_param_importances.py
@@ -8,12 +8,6 @@ import numpy as np
 import optuna
 from optuna._experimental import experimental
 from optuna.distributions import BaseDistribution
-from optuna.distributions import CategoricalDistribution
-from optuna.distributions import DiscreteUniformDistribution
-from optuna.distributions import IntLogUniformDistribution
-from optuna.distributions import IntUniformDistribution
-from optuna.distributions import LogUniformDistribution
-from optuna.distributions import UniformDistribution
 from optuna.importance._base import BaseImportanceEvaluator
 from optuna.logging import get_logger
 from optuna.study import Study
@@ -27,26 +21,10 @@ if _imports.is_successful():
     from optuna.visualization.matplotlib._matplotlib_imports import Axes
     from optuna.visualization.matplotlib._matplotlib_imports import cm
     from optuna.visualization.matplotlib._matplotlib_imports import plt
-    from optuna.visualization.matplotlib._matplotlib_imports import Rectangle
 
-    # Color definitions.
+    # fix single color for bars
     cmap = cm.get_cmap("tab20c")
-    _distribution_colors = {
-        UniformDistribution: cmap(0),
-        LogUniformDistribution: cmap(0),
-        DiscreteUniformDistribution: cmap(0),
-        IntUniformDistribution: cmap(1),
-        IntLogUniformDistribution: cmap(1),
-        CategoricalDistribution: cmap(3),
-    }
-    _legend_elements = [
-        Rectangle([0, 0], 0, 0, facecolor=cmap(0), label="Uniform Distribution"),
-        Rectangle([0, 0], 0, 0, facecolor=cmap(0), label="Log Uniform Distribution"),
-        Rectangle([0, 0], 0, 0, facecolor=cmap(0), label="Discrete Uniform Distribution"),
-        Rectangle([0, 0], 0, 0, facecolor=cmap(1), label="Int Uniform Distribution"),
-        Rectangle([0, 0], 0, 0, facecolor=cmap(1), label="Int Log Uniform Distribution"),
-        Rectangle([0, 0], 0, 0, facecolor=cmap(3), label="Categorical Distribution"),
-    ]
+    bar_color = cmap(0)
 
 _logger = get_logger(__name__)
 
@@ -159,10 +137,10 @@ def _get_param_importance_plot(
         pos,
         importance_values,
         align="center",
-        color=[_get_color(param_name, study) for param_name in param_names],
+        color=bar_color,
         tick_label=param_names,
     )
-    ax.legend(handles=_legend_elements, title="Distributions", loc="lower right")
+
     return ax
 
 
@@ -171,7 +149,3 @@ def _get_distribution(param_name: str, study: Study) -> "BaseDistribution":
         if param_name in trial.distributions:
             return trial.distributions[param_name]
     assert False
-
-
-def _get_color(param_name: str, study: Study) -> str:
-    return _distribution_colors[type(_get_distribution(param_name, study))]


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

The current `param_importances` add different colors depending on the distribution class that users may not access directly. In addition, single color among distributions is enough to visualize important hyperparameters when we think about the role of this plot -- the distribution does not matter.

See also https://github.com/optuna/optuna/pull/1991#issuecomment-816726700.

## Description of the changes
<!-- Describe the changes in this PR. -->

- use a single color map for both Plotly and Matplolib backends.
- Remove legend from Matplolib backend.


---

```python
import optuna


def objective(trial):
    x = trial.suggest_int("x", 0, 2)
    y = trial.suggest_float("y", -1.0, 1.0)
    z = trial.suggest_float("z", 0.0, 1.5)
    return x ** 2 + y ** 3 - z ** 4


sampler = optuna.samplers.RandomSampler(seed=10)
study = optuna.create_study(sampler=sampler)
study.optimize(objective, n_trials=10)

optuna.visualization.matplotlib.plot_param_importances(study)
```

## Plotly

![newplot (1)](https://user-images.githubusercontent.com/7121753/114199246-149ae280-998f-11eb-98d0-05a8fcbb3d6f.png)

## Matplotlib

![download](https://user-images.githubusercontent.com/7121753/114199234-12388880-998f-11eb-85c1-506a450ac82d.png)
