### PR TITLE
Fix axis labels of `optuna.visualization.matplotlib.plot_pareto_front` when `axis_order` is specified

### DIFF
--- a/optuna/visualization/matplotlib/_pareto_front.py
+++ b/optuna/visualization/matplotlib/_pareto_front.py
@@ -112,14 +112,10 @@ def _get_pareto_front_2d(
     elif len(target_names) != 2:
         raise ValueError("The length of `target_names` is supposed to be 2.")
 
-    ax.set_xlabel(target_names[0])
-    ax.set_ylabel(target_names[1])
-
     # Prepare data for plotting.
     trials = study.best_trials
     if len(trials) == 0:
         _logger.warning("Your study does not have any completed trials.")
-        return ax
 
     if include_dominated_trials:
         non_pareto_trials = _get_non_pareto_front_trials(study, trials)
@@ -145,20 +141,25 @@ def _get_pareto_front_2d(
                 "lower than 0."
             )
 
-    ax.scatter(
-        x=[t.values[axis_order[0]] for t in trials[len(study.best_trials) :]],
-        y=[t.values[axis_order[1]] for t in trials[len(study.best_trials) :]],
-        color=cmap(0),
-        label="Trial",
-    )
-    ax.scatter(
-        x=[t.values[axis_order[0]] for t in trials[: len(study.best_trials)]],
-        y=[t.values[axis_order[1]] for t in trials[: len(study.best_trials)]],
-        color=cmap(3),
-        label="Best Trial",
-    )
+    ax.set_xlabel(target_names[axis_order[0]])
+    ax.set_ylabel(target_names[axis_order[1]])
 
-    if include_dominated_trials:
+    if len(trials) - len(study.best_trials) != 0:
+        ax.scatter(
+            x=[t.values[axis_order[0]] for t in trials[len(study.best_trials) :]],
+            y=[t.values[axis_order[1]] for t in trials[len(study.best_trials) :]],
+            color=cmap(0),
+            label="Trial",
+        )
+    if len(study.best_trials):
+        ax.scatter(
+            x=[t.values[axis_order[0]] for t in trials[: len(study.best_trials)]],
+            y=[t.values[axis_order[1]] for t in trials[: len(study.best_trials)]],
+            color=cmap(3),
+            label="Best Trial",
+        )
+
+    if include_dominated_trials and ax.has_data():
         ax.legend()
 
     return ax
@@ -183,14 +184,9 @@ def _get_pareto_front_3d(
     elif len(target_names) != 3:
         raise ValueError("The length of `target_names` is supposed to be 3.")
 
-    ax.set_xlabel(target_names[0])
-    ax.set_ylabel(target_names[1])
-    ax.set_zlabel(target_names[2])
-
     trials = study.best_trials
     if len(trials) == 0:
         _logger.warning("Your study does not have any completed trials.")
-        return ax
 
     if include_dominated_trials:
         non_pareto_trials = _get_non_pareto_front_trials(study, trials)
@@ -216,22 +212,29 @@ def _get_pareto_front_3d(
                 "lower than 0."
             )
 
-    ax.scatter(
-        xs=[t.values[axis_order[0]] for t in trials[len(study.best_trials) :]],
-        ys=[t.values[axis_order[1]] for t in trials[len(study.best_trials) :]],
-        zs=[t.values[axis_order[2]] for t in trials[len(study.best_trials) :]],
-        color=cmap(0),
-        label="Trial",
-    )
-    ax.scatter(
-        xs=[t.values[axis_order[0]] for t in trials[: len(study.best_trials)]],
-        ys=[t.values[axis_order[1]] for t in trials[: len(study.best_trials)]],
-        zs=[t.values[axis_order[2]] for t in trials[: len(study.best_trials)]],
-        color=cmap(3),
-        label="Best Trial",
-    )
+    ax.set_xlabel(target_names[axis_order[0]])
+    ax.set_ylabel(target_names[axis_order[1]])
+    ax.set_zlabel(target_names[axis_order[2]])
 
-    if include_dominated_trials:
+    if len(trials) - len(study.best_trials) != 0:
+        ax.scatter(
+            xs=[t.values[axis_order[0]] for t in trials[len(study.best_trials) :]],
+            ys=[t.values[axis_order[1]] for t in trials[len(study.best_trials) :]],
+            zs=[t.values[axis_order[2]] for t in trials[len(study.best_trials) :]],
+            color=cmap(0),
+            label="Trial",
+        )
+
+    if len(study.best_trials):
+        ax.scatter(
+            xs=[t.values[axis_order[0]] for t in trials[: len(study.best_trials)]],
+            ys=[t.values[axis_order[1]] for t in trials[: len(study.best_trials)]],
+            zs=[t.values[axis_order[2]] for t in trials[: len(study.best_trials)]],
+            color=cmap(3),
+            label="Best Trial",
+        )
+
+    if include_dominated_trials and ax.has_data():
         ax.legend()
 
     return ax

--- a/tests/visualization_tests/matplotlib_tests/test_pareto_front.py
+++ b/tests/visualization_tests/matplotlib_tests/test_pareto_front.py
@@ -9,6 +9,7 @@ import optuna
 from optuna.visualization.matplotlib import plot_pareto_front
 
 
+@pytest.mark.filterwarnings("ignore::optuna.exceptions.ExperimentalWarning")
 @pytest.mark.parametrize("include_dominated_trials", [False, True])
 @pytest.mark.parametrize("axis_order", [None, [0, 1], [1, 0]])
 def test_plot_pareto_front_2d(
@@ -64,8 +65,15 @@ def test_plot_pareto_front_2d(
         axis_order=axis_order,
     )
     assert figure.has_data()
+    if axis_order is None:
+        assert figure.get_xlabel() == target_names[0]
+        assert figure.get_ylabel() == target_names[1]
+    else:
+        assert figure.get_xlabel() == target_names[axis_order[0]]
+        assert figure.get_ylabel() == target_names[axis_order[1]]
 
 
+@pytest.mark.filterwarnings("ignore::optuna.exceptions.ExperimentalWarning")
 @pytest.mark.parametrize("include_dominated_trials", [False, True])
 @pytest.mark.parametrize(
     "axis_order", [None] + list(itertools.permutations(range(3), 3))  # type: ignore
@@ -137,7 +145,17 @@ def test_plot_pareto_front_3d(
 
     assert figure.has_data()
 
+    if axis_order is None:
+        assert figure.get_xlabel() == target_names[0]
+        assert figure.get_ylabel() == target_names[1]
+        assert figure.get_zlabel() == target_names[2]
+    else:
+        assert figure.get_xlabel() == target_names[axis_order[0]]
+        assert figure.get_ylabel() == target_names[axis_order[1]]
+        assert figure.get_zlabel() == target_names[axis_order[2]]
 
+
+@pytest.mark.filterwarnings("ignore::optuna.exceptions.ExperimentalWarning")
 @pytest.mark.parametrize("include_dominated_trials", [False, True])
 def test_plot_pareto_front_dimensions(include_dominated_trials: bool) -> None:
     # Unsupported: n_objectives == 1.
@@ -170,6 +188,7 @@ def test_plot_pareto_front_dimensions(include_dominated_trials: bool) -> None:
         plot_pareto_front(study=study, include_dominated_trials=include_dominated_trials)
 
 
+@pytest.mark.filterwarnings("ignore::optuna.exceptions.ExperimentalWarning")
 @pytest.mark.parametrize("dimension", [2, 3])
 @pytest.mark.parametrize("include_dominated_trials", [False, True])
 def test_plot_pareto_front_invalid_axis_order(


### PR DESCRIPTION
## Motivation
This is a follow-up PR for #2450. It addresses https://github.com/optuna/optuna/pull/2450#discussion_r610673249.

## Description of the changes

- Fix axis labels when `axis_order` is specified
- Add unit test.