### PR TITLE
Update a test function of `matplotliv.plot_pareto_front` for consistency

### DIFF
--- a/tests/visualization_tests/matplotlib_tests/test_pareto_front.py
+++ b/tests/visualization_tests/matplotlib_tests/test_pareto_front.py
@@ -157,7 +157,7 @@ def test_plot_pareto_front_3d(
 
 @pytest.mark.filterwarnings("ignore::optuna.exceptions.ExperimentalWarning")
 @pytest.mark.parametrize("include_dominated_trials", [False, True])
-def test_plot_pareto_front_dimensions(include_dominated_trials: bool) -> None:
+def test_plot_pareto_front_unsupported_dimensions(include_dominated_trials: bool) -> None:
     # Unsupported: n_objectives == 1.
     with pytest.raises(ValueError):
         study = optuna.create_study(directions=["minimize"])
@@ -168,18 +168,6 @@ def test_plot_pareto_front_dimensions(include_dominated_trials: bool) -> None:
         study = optuna.create_study(direction="minimize")
         study.optimize(lambda t: [0], n_trials=1)
         plot_pareto_front(study=study, include_dominated_trials=include_dominated_trials)
-
-    # Supported: n_objectives == 2.
-    study = optuna.create_study(directions=["minimize", "minimize"])
-    study.optimize(lambda t: [0, 0], n_trials=1)
-    figure = plot_pareto_front(study=study, include_dominated_trials=include_dominated_trials)
-    assert figure.has_data()
-
-    # Supported: n_objectives == 3.
-    study = optuna.create_study(directions=["minimize", "minimize", "minimize"])
-    study.optimize(lambda t: [0, 0, 0], n_trials=1)
-    figure = plot_pareto_front(study=study, include_dominated_trials=include_dominated_trials)
-    assert figure.has_data()
 
     # Unsupported: n_objectives == 4.
     with pytest.raises(ValueError):


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

Follow-up pull request of #2450 and Matplotlib counterpart of #2578.


## Description of the changes
<!-- Describe the changes in this PR. -->

- Rename the test function name to unify between plotly and matplotlib tests
- Remove supported dimensions: 2d and 3d.