### PR TITLE
Add type conversion for reference point and solution set

### DIFF
--- a/optuna/multi_objective/_hypervolume/wfg.py
+++ b/optuna/multi_objective/_hypervolume/wfg.py
@@ -20,7 +20,7 @@ class WFG(BaseHypervolume):
         self._reference_point: Optional[np.ndarray] = None
 
     def _compute(self, solution_set: np.ndarray, reference_point: np.ndarray) -> float:
-        self._reference_point = reference_point.copy().astype(np.float64)
+        self._reference_point = reference_point.astype(np.float64)
         return self._compute_rec(solution_set.astype(np.float64))
 
     def _compute_rec(self, solution_set: np.ndarray) -> float:

--- a/optuna/multi_objective/_hypervolume/wfg.py
+++ b/optuna/multi_objective/_hypervolume/wfg.py
@@ -20,8 +20,8 @@ class WFG(BaseHypervolume):
         self._reference_point: Optional[np.ndarray] = None
 
     def _compute(self, solution_set: np.ndarray, reference_point: np.ndarray) -> float:
-        self._reference_point = reference_point.copy()
-        return self._compute_rec(solution_set)
+        self._reference_point = reference_point.copy().astype(np.float64)
+        return self._compute_rec(solution_set.astype(np.float64))
 
     def _compute_rec(self, solution_set: np.ndarray) -> float:
         assert self._reference_point is not None


### PR DESCRIPTION
## Motivation
This PR is sent for #2421.

When `np.ndarray` of integers is passed to `optuna.multi_objective._hypervolume.WFG.compute()`, the result become incorrect. This PR adds explicitly type conversions for `reference_point` and `solution_set` to make `optuna.multi_objective._hypervolume.WFG._compute_rec` takes only ndarray of floating points.

## Description of the changes
- Add type conversion for `reference_point` and `solution_set` in `optuna.multi_objective._hypervolume.WFG.compute()`
