### PR TITLE
Remove the news section in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,6 @@ for machine learning. It features an imperative, *define-by-run* style user API.
 *define-by-run* API, the code written with Optuna enjoys high modularity, and the user of
 Optuna can dynamically construct the search spaces for the hyperparameters.
 
-## News
-
-- **2020-12-02** Python 3.9 is now supported. Integration modules are still being worked on and is tracked by [#2034](https://github.com/optuna/optuna/issues/2034)
-- **2020-09-17** `isort` has been incorporated to keep import statements consistent. Read more about it in [CONTRIBUTING.md](./CONTRIBUTING.md)
-- **2020-08-07** We are welcoming [contributions](#contribution) and are working on streamlining the experience. Read more about it in the [blog](https://medium.com/optuna/optuna-wants-your-pull-request-ff619572302c)
-
 ## Key Features
 
 Optuna has modern functionalities as follows:


### PR DESCRIPTION
This PR removes the news section in `README.md`, since the items have been left out-of-date for a while. We can add the section again once we get new items to be announced.