### PR TITLE
Fix contour plot with multi-objective study and `target` being specified

### DIFF
--- a/optuna/testing/visualization.py
+++ b/optuna/testing/visualization.py
@@ -9,6 +9,7 @@ def prepare_study_with_trials(
     less_than_two: bool = False,
     more_than_three: bool = False,
     with_c_d: bool = True,
+    n_objectives: int = 1,
 ) -> Study:
 
     """Prepare a study for tests.
@@ -30,12 +31,12 @@ def prepare_study_with_trials(
 
     """
 
-    study = create_study()
+    study = create_study(directions=["minimize"] * n_objectives)
     if no_trials:
         return study
     study.add_trial(
         create_trial(
-            value=0.0,
+            values=[0.0] * n_objectives,
             params={"param_a": 1.0, "param_b": 2.0, "param_c": 3.0, "param_d": 4.0}
             if with_c_d
             else {"param_a": 1.0, "param_b": 2.0},
@@ -54,7 +55,7 @@ def prepare_study_with_trials(
     )
     study.add_trial(
         create_trial(
-            value=2.0,
+            values=[2.0] * n_objectives,
             params={"param_b": 0.0, "param_d": 4.0} if with_c_d else {"param_b": 0.0},
             distributions={
                 "param_b": UniformDistribution(0.0, 3.0),
@@ -69,7 +70,7 @@ def prepare_study_with_trials(
 
     study.add_trial(
         create_trial(
-            value=1.0,
+            values=[1.0] * n_objectives,
             params={"param_a": 2.5, "param_b": 1.0, "param_c": 4.5, "param_d": 2.0}
             if with_c_d
             else {"param_a": 2.5, "param_b": 1.0},
@@ -90,7 +91,7 @@ def prepare_study_with_trials(
     if more_than_three:
         study.add_trial(
             create_trial(
-                value=1.5,
+                values=[1.5] * n_objectives,
                 params={"param_a": 0.5, "param_b": 1.5, "param_c": 2.0, "param_d": 3.0}
                 if with_c_d
                 else {"param_a": 0.5, "param_b": 1.5},

--- a/optuna/testing/visualization.py
+++ b/optuna/testing/visualization.py
@@ -25,6 +25,7 @@ def prepare_study_with_trials(
         with_c_d: If ``True``, the study has four hyperparameters named 'param_a',
             'param_b', 'param_c', and 'param_d'. Otherwise, there are only two
             hyperparameters ('param_a' and 'param_b').
+        n_objectives: Number of objective values.
 
     Returns:
         :class:`~optuna.study.Study`

--- a/optuna/visualization/_contour.py
+++ b/optuna/visualization/_contour.py
@@ -158,7 +158,7 @@ def _get_contour_plot(
         x_param = sorted_params[0]
         y_param = sorted_params[1]
         sub_plots = _generate_contour_subplot(
-            trials, x_param, y_param, study.direction, param_values_range, target, target_name
+            trials, x_param, y_param, study.directions[0], param_values_range, target, target_name
         )
         figure = go.Figure(data=sub_plots, layout=layout)
         figure.update_xaxes(title_text=x_param, range=param_values_range[x_param])
@@ -190,7 +190,7 @@ def _get_contour_plot(
                         trials,
                         x_param,
                         y_param,
-                        study.direction,
+                        study.directions[0],
                         param_values_range,
                         target,
                         target_name,
@@ -298,7 +298,7 @@ def _generate_contour_subplot(
         contours_coloring="heatmap",
         hoverinfo="none",
         line_smoothing=1.3,
-        reversescale=True if direction == StudyDirection.MINIMIZE else False,
+        reversescale=target is None and direction == StudyDirection.MINIMIZE,
     )
 
     scatter = go.Scatter(

--- a/optuna/visualization/matplotlib/_contour.py
+++ b/optuna/visualization/matplotlib/_contour.py
@@ -137,7 +137,7 @@ def _get_contour_plot(
         # Set up the graph style.
         fig, axs = plt.subplots()
         axs.set_title("Contour Plot")
-        cmap = _set_cmap(study)
+        cmap = _set_cmap(study, target)
         contour_point_num = 1000
 
         # Prepare data and draw contour plots.
@@ -157,7 +157,7 @@ def _get_contour_plot(
         # Set up the graph style.
         fig, axs = plt.subplots(n_params, n_params)
         fig.suptitle("Contour Plot")
-        cmap = _set_cmap(study)
+        cmap = _set_cmap(study, target)
         contour_point_num = 100
 
         # Prepare data and draw contour plots.
@@ -177,8 +177,8 @@ def _get_contour_plot(
     return axs
 
 
-def _set_cmap(study: Study) -> "Colormap":
-    cmap = "Blues_r" if study.direction == StudyDirection.MINIMIZE else "Blues"
+def _set_cmap(study: Study, target: Optional[Callable[[FrozenTrial], float]]) -> "Colormap":
+    cmap = "Blues_r" if target is None and study.direction == StudyDirection.MINIMIZE else "Blues"
     return plt.get_cmap(cmap)
 
 

--- a/tests/visualization_tests/matplotlib_tests/test_contour.py
+++ b/tests/visualization_tests/matplotlib_tests/test_contour.py
@@ -16,6 +16,17 @@ def test_target_is_none_and_study_is_multi_obj() -> None:
         plot_contour(study)
 
 
+def test_target_is_not_none_and_study_is_multi_obj() -> None:
+
+    # Multiple sub-figures.
+    study = prepare_study_with_trials(more_than_three=True, n_objectives=2, with_c_d=True)
+    plot_contour(study, target=lambda t: t.values[0])
+
+    # Single figure.
+    study = prepare_study_with_trials(more_than_three=True, n_objectives=2, with_c_d=False)
+    plot_contour(study, target=lambda t: t.values[0])
+
+
 @pytest.mark.parametrize(
     "params",
     [

--- a/tests/visualization_tests/test_contour.py
+++ b/tests/visualization_tests/test_contour.py
@@ -29,6 +29,17 @@ def test_target_is_none_and_study_is_multi_obj() -> None:
         plot_contour(study)
 
 
+def test_target_is_not_none_and_study_is_multi_obj() -> None:
+
+    # Multiple sub-figures.
+    study = prepare_study_with_trials(more_than_three=True, n_objectives=2, with_c_d=True)
+    plot_contour(study, target=lambda t: t.values[0])
+
+    # Single figure.
+    study = prepare_study_with_trials(more_than_three=True, n_objectives=2, with_c_d=False)
+    plot_contour(study, target=lambda t: t.values[0])
+
+
 @pytest.mark.parametrize(
     "params",
     [


### PR DESCRIPTION
## Motivation

Contour plots should work even for multi objective studies as long as the `target` argument is specified. Currently, they do not.

## Description of the changes

Fixes contour plot to ignore the direction if `target` is specified.