### PR TITLE
Sort categorical values on axis that contains only numerical values in `visualization.matplotlib.plot_contour`

### DIFF
--- a/optuna/visualization/matplotlib/_contour.py
+++ b/optuna/visualization/matplotlib/_contour.py
@@ -17,8 +17,8 @@ from optuna.trial import FrozenTrial
 from optuna.trial import TrialState
 from optuna.visualization._utils import _check_plot_args
 from optuna.visualization.matplotlib._matplotlib_imports import _imports
-from optuna.visualization.matplotlib._utils import _is_numerical
 from optuna.visualization.matplotlib._utils import _is_log_scale
+from optuna.visualization.matplotlib._utils import _is_numerical
 
 
 if _imports.is_successful():

--- a/optuna/visualization/matplotlib/_contour.py
+++ b/optuna/visualization/matplotlib/_contour.py
@@ -17,7 +17,7 @@ from optuna.trial import FrozenTrial
 from optuna.trial import TrialState
 from optuna.visualization._utils import _check_plot_args
 from optuna.visualization.matplotlib._matplotlib_imports import _imports
-from optuna.visualization.matplotlib._utils import _is_categorical
+from optuna.visualization.matplotlib._utils import _is_numerical
 from optuna.visualization.matplotlib._utils import _is_log_scale
 
 
@@ -279,14 +279,14 @@ def _calculate_griddata(
     cat_param_pos_x = []  # type: List[int]
     cat_param_labels_y = []  # type: List[str]
     cat_param_pos_y = []  # type: List[int]
-    if _is_categorical(trials, x_param):
+    if not _is_numerical(trials, x_param):
         x_values = [str(x) for x in x_values]
         (
             x_values,
             cat_param_labels_x,
             cat_param_pos_x,
         ) = _convert_categorical2int(x_values)
-    if _is_categorical(trials, y_param):
+    if not _is_numerical(trials, y_param):
         y_values = [str(y) for y in y_values]
         (
             y_values,

--- a/optuna/visualization/matplotlib/_utils.py
+++ b/optuna/visualization/matplotlib/_utils.py
@@ -44,3 +44,12 @@ def _is_categorical(trials: List[FrozenTrial], param: str) -> bool:
         for t in trials
         if param in t.params
     )
+
+
+def _is_numerical(trials: List[FrozenTrial], param: str) -> bool:
+    return all(
+        (isinstance(t.params[param], int) or isinstance(t.params[param], float))
+        and not isinstance(t.params[param], bool)
+        for t in trials
+        if param in t.params
+    )


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

The contour plot's axis can be improved when a categorical distribution suggests only `int` or `float` values. Plotly's contour plot has sorted such values by #2569.

## Description of the changes
<!-- Describe the changes in this PR. -->

if suggested values contain only int or float, then the parameter is not treated as a categorical distribution.


---

## Example 

```python
import optuna



def objective(trial):
    x = trial.suggest_uniform('x', -100, 100)
    y = trial.suggest_categorical('y', list(range(-10, 10)))
    z = trial.suggest_uniform('z', -100, 100)
    return x ** 2 + y - z

study = optuna.create_study(sampler=optuna.samplers.TPESampler(seed=7))
study.optimize(objective, n_trials=200)

optuna.visualization.matplotlib.plot_contour(study, params=['y', 'z'])
optuna.visualization.plot_contour(study, params=['y', 'z']) # plotly
```

## Main branch
![download (2)](https://user-images.githubusercontent.com/7121753/114876635-79e04f00-9e39-11eb-97c6-3b7b16e89456.png)

## This PR
![download (1)](https://user-images.githubusercontent.com/7121753/114876615-75b43180-9e39-11eb-9e21-87a8c31dfe38.png)

## Reference: plotly backend
![newplot (2)](https://user-images.githubusercontent.com/7121753/114876650-7baa1280-9e39-11eb-9c3e-554d16ed2496.png)
