### PR TITLE
Compile/upload tutorial docs and use it in readthedocs

### DIFF
--- a/.github/workflows/read-the-docs.yml
+++ b/.github/workflows/read-the-docs.yml
@@ -1,0 +1,41 @@
+name: Build/upload docs and trigger ReadTheDocs building
+
+on:
+  push:
+    branches:
+      - master
+  pull_request: {}
+
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - uses: actions/setup-python@v2
+      with:
+        python-version: 3.7
+
+    - name: Install
+      run: |
+        python -m pip install -U pip
+        pip install --progress-bar off -U .[document]
+    - name: Build
+      run: |
+        cd docs
+        make html
+      env:
+        OMP_NUM_THREADS: 1
+
+    - uses: actions/upload-artifact@v2
+      with:
+        name: artifacts-${{ github.sha }}
+        path: docs/source/tutorial
+
+    - uses: dfm/rtds-action@v1
+      with:
+        webhook_url: ${{ secrets.RTDS_WEBHOOK_URL }}
+        webhook_token: ${{ secrets.RTDS_WEBHOOK_TOKEN }}
+        commit_ref: ${{ github.ref }}
+

--- a/.github/workflows/read-the-docs.yml
+++ b/.github/workflows/read-the-docs.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - master
+    tags:
+      - "v*"
   pull_request: {}
 
 jobs:
@@ -38,4 +40,3 @@ jobs:
         webhook_url: ${{ secrets.RTDS_WEBHOOK_URL }}
         webhook_token: ${{ secrets.RTDS_WEBHOOK_TOKEN }}
         commit_ref: ${{ github.ref }}
-

--- a/.github/workflows/read-the-docs.yml
+++ b/.github/workflows/read-the-docs.yml
@@ -6,7 +6,6 @@ on:
       - master
     tags:
       - "v*"
-  pull_request: {}
 
 jobs:
   build:

--- a/.github/workflows/read-the-docs.yml
+++ b/.github/workflows/read-the-docs.yml
@@ -7,7 +7,7 @@ on:
   pull_request: {}
 
 jobs:
-  checks:
+  build:
     runs-on: ubuntu-latest
 
     steps:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -17,6 +17,7 @@
 # sys.path.insert(0, os.path.abspath('.'))
 
 from typing import Any
+from typing import List
 from io import BytesIO
 import os
 import pkg_resources
@@ -38,6 +39,12 @@ if github_token is not None:
         output = subprocess.check_output(["git", "rev-parse", "HEAD"])
         return output.strip().decode("ascii")
 
+    def retrieve_artifacts() -> List[Any]:
+        return requests.get(
+            "https://api.github.com/repos/optuna/optuna/actions/artifacts",
+            params=dict(per_page=20),
+        ).json()["artifacts"]
+
     def search_artifact(artifacts: Any, hash: str) -> str:
         target_name = f"artifacts-{hash}"
         artifact_names = [a["name"] for a in artifacts]
@@ -48,11 +55,7 @@ if github_token is not None:
         raise RuntimeError(f"Not found {target_name} on {artifact_names}")
 
     def download_artifact() -> None:
-        artifacts = requests.get(
-            "https://api.github.com/repos/himkt/optuna-test-rtds/actions/artifacts",
-            params=dict(per_page=20),
-        ).json()["artifacts"]
-
+        artifacts = retrieve_artifacts()
         target_artifact_url = search_artifact(artifacts, commit_id)
         artifact = requests.get(
             target_artifact_url,

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -32,6 +32,8 @@ from sphinx_gallery.sorting import FileNameSortKey
 
 __version__ = pkg_resources.get_distribution("optuna").version
 
+
+# Note: GITHUB_TOKEN is set on readthedocs, which is used to fetch artifacts from GitHub.
 github_token = os.getenv("GITHUB_TOKEN")
 if github_token is not None:
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -56,7 +56,7 @@ if github_token is not None:
                 return artifact["archive_download_url"]
         raise RuntimeError(f"Not found {target_name} on {artifact_names}")
 
-    def download_artifact() -> None:
+    def download_artifact(commit_id: str) -> None:
         artifacts = retrieve_artifacts()
         target_artifact_url = search_artifact(artifacts, commit_id)
         artifact = requests.get(
@@ -80,7 +80,7 @@ if github_token is not None:
     commit_id = get_commit_id()
     for _ in range(num_retries):
         try:
-            download_artifact()
+            download_artifact(commit_id)
             break
         except Exception as e:
             print("Error: ", e)

--- a/setup.py
+++ b/setup.py
@@ -80,6 +80,7 @@ def get_extras_require() -> Dict[str, List[str]]:
             "torchvision==0.9.0",
             "torchaudio==0.8.0",
             "thop",
+            "requests",
         ],
         "example": [
             "catboost",


### PR DESCRIPTION
## Motivation
ReadTheDocs has an execution time limit for each build (5min).
Optuna uses sphinx-gallery and it means that some scripts are run on readthedocs, which takes a long time.
(ref. https://sphinx-gallery.github.io/stable/getting_started.html#create-simple-gallery)
Instead, GitHub Actions is relatively forgiving about execution time.
So, this PR changes a way to built a document: use GitHub Actions/Artifacts to running shinx-gallery to avoid running sphinx-gallery on readthedocs.

## Description of the changes
- 69424d9: edit `conf.py` to download artifacts when `GITHUB_TOKEN` is specified
- 9d44e53: add workflow to build document and upload pre-compiled tutorial to GitHub Artifacts

---

I confirmed it worked well in my personal repository:
- https://github.com/himkt/optuna-test-rtds/runs/2369939431
- https://readthedocs.org/projects/himktoptuna/builds/13536913/
