### PR TITLE
Upgrade pip in PyPI and Test PyPI workflow

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -22,6 +22,7 @@ jobs:
 
     - name: Install twine
       run: >-
+        python -m pip install --upgrade pip
         python -m pip install -U twine wheel
 
     - name: Change the version file for scheduled TestPyPI upload

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -22,7 +22,7 @@ jobs:
 
     - name: Install twine
       run: >-
-        python -m pip install --upgrade pip
+        python -m pip install -U pip
         python -m pip install -U twine wheel
 
     - name: Change the version file for scheduled TestPyPI upload


### PR DESCRIPTION
## Motivation

Related to the issue reported in https://github.com/optuna/optuna/pull/2431#issuecomment-821919625.
The pip seems to fail to resolve the appropriate version of `twine`. This may be due to the old pip.

## Description of the changes

Upgrade pip to the latest version.