### PR TITLE
Remove `_get_distribution` from `visualization/matplotlib/_param_importances.py`

### DIFF
--- a/optuna/visualization/matplotlib/_param_importances.py
+++ b/optuna/visualization/matplotlib/_param_importances.py
@@ -7,7 +7,6 @@ import numpy as np
 
 import optuna
 from optuna._experimental import experimental
-from optuna.distributions import BaseDistribution
 from optuna.importance._base import BaseImportanceEvaluator
 from optuna.logging import get_logger
 from optuna.study import Study
@@ -141,10 +140,3 @@ def _get_param_importance_plot(
     )
 
     return ax
-
-
-def _get_distribution(param_name: str, study: Study) -> "BaseDistribution":
-    for trial in study.trials:
-        if param_name in trial.distributions:
-            return trial.distributions[param_name]
-    assert False


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

The internal method, `_get_distribution`, has never been used in optuna since #2576.

## Description of the changes
<!-- Describe the changes in this PR. -->

Remove `_get_distribution`.