### PR TITLE
Show legend of `optuna.visualization.matplotlib.plot_intermediate_values`

### DIFF
--- a/optuna/visualization/matplotlib/_intermediate_values.py
+++ b/optuna/visualization/matplotlib/_intermediate_values.py
@@ -81,7 +81,7 @@ def _get_intermediate_plot(study: Study) -> "Axes":
 
     # Set up the graph style.
     plt.style.use("ggplot")  # Use ggplot style sheet for similar outputs to plotly.
-    _, ax = plt.subplots()
+    _, ax = plt.subplots(tight_layout=True)
     ax.set_title("Intermediate Values Plot")
     ax.set_xlabel("Step")
     ax.set_ylabel("Intermediate Value")

--- a/optuna/visualization/matplotlib/_intermediate_values.py
+++ b/optuna/visualization/matplotlib/_intermediate_values.py
@@ -110,4 +110,7 @@ def _get_intermediate_plot(study: Study) -> "Axes":
         )
         return ax
 
+    if len(trials) >= 2:
+        ax.legend(bbox_to_anchor=(1.05, 1), loc="upper left", borderaxespad=0.0)
+
     return ax

--- a/optuna/visualization/matplotlib/_intermediate_values.py
+++ b/optuna/visualization/matplotlib/_intermediate_values.py
@@ -76,7 +76,7 @@ def _get_intermediate_plot(study: Study) -> "Axes":
 
     # Set up the graph style.
     plt.style.use("ggplot")  # Use ggplot style sheet for similar outputs to plotly.
-    fig, ax = plt.subplots()
+    _, ax = plt.subplots()
     ax.set_title("Intermediate Values Plot")
     ax.set_xlabel("Step")
     ax.set_ylabel("Intermediate Value")

--- a/optuna/visualization/matplotlib/_intermediate_values.py
+++ b/optuna/visualization/matplotlib/_intermediate_values.py
@@ -16,6 +16,11 @@ _logger = get_logger(__name__)
 def plot_intermediate_values(study: Study) -> "Axes":
     """Plot intermediate values of all trials in a study with Matplotlib.
 
+    .. note::
+        Please refer to `matplotlib.pyplot.legend
+        <https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.legend.html>`_
+        to adjust the style of the generated legend.
+
     Example:
 
         The following code snippet shows how to plot intermediate values.


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

As in [`optuna.visualization.matplotlib.plot_intermediate_values`](https://optuna.readthedocs.io/en/stable/reference/visualization/generated/optuna.visualization.matplotlib.plot_intermediate_values.html), we cannot know which trial corresponds to each line plot since there is no legend on the generated plot.

## Description of the changes
<!-- Describe the changes in this PR. -->

Call `ax.legend()` explicitly.

If we have too long legend, users can remove `legend` by calling `ax.get_legend().remove()`, for example,

```python
ax = optuna.visualization.matplotlib.plot_intermediate_values(study)
ax.get_legend().remove()
```


---

# Examples

## Reproducible code snippet

```python
import optuna


def f(x):
    return (x - 2) ** 2


def df(x):
    return 2 * x - 4


def objective(trial):
    lr = trial.suggest_float("lr", 1e-5, 1e-1, log=True)

    x = 3
    for step in range(128):
        y = f(x)

        trial.report(y, step=step)
        if trial.should_prune():
            raise optuna.TrialPruned()

        gy = df(x)
        x -= gy * lr

    return y


sampler = optuna.samplers.TPESampler(seed=10)
study = optuna.create_study(sampler=sampler)
study.optimize(objective, n_trials=16)

optuna.visualization.matplotlib.plot_intermediate_values(study)
```

## Master 

![download (11)](https://user-images.githubusercontent.com/7121753/115264672-7a4a5400-a171-11eb-9f84-4c733f895b59.png)

## This PR
![download (10)](https://user-images.githubusercontent.com/7121753/115264658-78809080-a171-11eb-9a94-ba872e7129a3.png)

