### PR TITLE
[RFC] Allow `None` as `study_name` when there is only a single study in `load_study`

### DIFF
--- a/optuna/study.py
+++ b/optuna/study.py
@@ -1228,6 +1228,10 @@ def load_study(
                 "contain exactly 1 study. Specify `study_name`."
             )
         study_name = study_summaries[0].study_name
+        _logger.info(
+            f"Study name was omitted but trying to load '{study_name}' because that was the only "
+            "study found in the storage."
+        )
 
     return Study(study_name=study_name, storage=storage, sampler=sampler, pruner=pruner)
 

--- a/optuna/study.py
+++ b/optuna/study.py
@@ -1224,8 +1224,8 @@ def load_study(
         study_summaries = get_all_study_summaries(storage)
         if len(study_summaries) != 1:
             raise ValueError(
-                f"Could not determine the study name since the storage {storage} contains "
-                "multiple studies. Specify `study_name`."
+                f"Could not determine the study name since the storage {storage} does not "
+                "contain exactly 1 study. Specify `study_name`."
             )
         study_name = study_summaries[0].study_name
 

--- a/tests/study_tests/test_study.py
+++ b/tests/study_tests/test_study.py
@@ -388,6 +388,31 @@ def test_load_study(storage_mode: str) -> None:
 
 
 @pytest.mark.parametrize("storage_mode", STORAGE_MODES)
+def test_load_study_study_name_none(storage_mode: str) -> None:
+
+    with StorageSupplier(storage_mode) as storage:
+        if storage is None:
+            # `InMemoryStorage` can not be used with `load_study` function.
+            return
+
+        study_name = str(uuid.uuid4())
+
+        _ = create_study(study_name=study_name, storage=storage)
+
+        loaded_study = load_study(study_name=None, storage=storage)
+
+        assert loaded_study.study_name == study_name
+
+        study_name = str(uuid.uuid4())
+
+        _ = create_study(study_name=study_name, storage=storage)
+
+        # Ambiguous study.
+        with pytest.raises(ValueError):
+            load_study(study_name=None, storage=storage)
+
+
+@pytest.mark.parametrize("storage_mode", STORAGE_MODES)
 def test_delete_study(storage_mode: str) -> None:
 
     with StorageSupplier(storage_mode) as storage:


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation

When loading an existing study from a storage, the name of the study is not necessarily known (see `copy_study` in https://github.com/optuna/optuna/pull/2607). E.g. user A dumps a study to a temporary storage and user B is given only access to that storage.

## Description of the changes

Allows passing `None` as `study_name` to `optuna.load_study` if there is only a single study stored in the storage.

## Notes

- Currently not aligned with `optuna.delete_study`
- Argument cannot be omitted due to the ordering (see also https://github.com/optuna/optuna/issues/1128)