### PR TITLE
Fix grammatical error in failure message

### DIFF
--- a/optuna/_optimize.py
+++ b/optuna/_optimize.py
@@ -278,7 +278,7 @@ def _check_and_convert_to_values(
                 None,
                 (
                     f"Trial {trial_number} failed, because the number of the values "
-                    f"{len(original_value)} is did not match the number of the objectives "
+                    f"{len(original_value)} did not match the number of the objectives "
                     f"{n_objectives}."
                 ),
             )


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
I got the below error when I returned a string instead of a numeric value from an objective function:
` WARNING - optuna._optimize - Trial 1 failed, because the number of the values 7 is did not match the number of the objectives 1`
There is a slight grammatical error in the failure message above, i.e., the `is` word, which makes the sentence construction wrong.

## Description of the changes
<!-- Describe the changes in this PR. -->
Removed the `is` word from failure message.