### PR TITLE
Use `CmaEsSampler` instead of `TPESampler` in the batch optimization example

### DIFF
--- a/tutorial/20_recipes/009_ask_and_tell.py
+++ b/tutorial/20_recipes/009_ask_and_tell.py
@@ -212,7 +212,7 @@ def batched_objective(xs: np.ndarray):
 # :func:`optuna.study.Study.tell` method after the batched evaluations.
 
 batch_size = 10
-study = optuna.create_study()
+study = optuna.create_study(sampler=optuna.samplers.CmaEsSampler())
 
 for _ in range(3):
 

--- a/tutorial/20_recipes/009_ask_and_tell.py
+++ b/tutorial/20_recipes/009_ask_and_tell.py
@@ -223,8 +223,8 @@ for _ in range(3):
     for _ in range(batch_size):
         trial = study.ask()
         trial_ids.append(trial.number)
-        x_batch.append(trial.suggest_int("x", -10, 10))
-        y_batch.append(trial.suggest_int("y", -10, 10))
+        x_batch.append(trial.suggest_float("x", -10, 10))
+        y_batch.append(trial.suggest_float("y", -10, 10))
 
     # evaluate batched objective
     x_batch = np.array(x_batch)

--- a/tutorial/20_recipes/009_ask_and_tell.py
+++ b/tutorial/20_recipes/009_ask_and_tell.py
@@ -196,16 +196,16 @@ for _ in range(n_trials):
 # For example, parallelizable evaluation, operation over vectors, etc.
 
 ###################################################################################################
-# The following objective takes batched hyperparameters ``xs`` instead of a single
-# hyperparameter and calculates the objective over the full vector.
+# The following objective takes batched hyperparameters ``xs`` and ``ys`` instead of a single
+# pair of hyperparameters ``x`` and ``y`` and calculates the objective over the full vectors.
 
 
-def batched_objective(xs: np.ndarray):
-    return xs ** 2 + 1
+def batched_objective(xs: np.ndarray, ys: np.ndarray):
+    return xs ** 2 + ys
 
 
 ###################################################################################################
-# In the following example, the number of hyperparameters in a batch is :math:`10`,
+# In the following example, the number of pairs of hyperparameters in a batch is :math:`10`,
 # and ``batched_objective`` is evaluated three times.
 # Thus, the number of trials is :math:`30`.
 # Note that you need to store either ``trial_ids`` or ``trial`` to call
@@ -218,16 +218,18 @@ for _ in range(3):
 
     # create batch
     trial_ids = []
-    samples = []
+    x_batch = []
+    y_batch = []
     for _ in range(batch_size):
         trial = study.ask()
         trial_ids.append(trial.number)
-        x = trial.suggest_int("x", -10, 10)
-        samples.append(x)
+        x_batch.append(trial.suggest_int("x", -10, 10))
+        y_batch.append(trial.suggest_int("y", -10, 10))
 
     # evaluate batched objective
-    samples = np.array(samples)
-    objectives = batched_objective(samples)
+    x_batch = np.array(x_batch)
+    y_batch = np.array(y_batch)
+    objectives = batched_objective(x_batch, y_batch)
 
     # finish all trials in the batch
     for trial_id, objective in zip(trial_ids, objectives):


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

Due to the default sampler, `TPESampler`, the suggested parameters tend to be the same in a batch. By running the example code, the suggested values are as follows:

```python
[ 3,  3,  9,  6,  7, -5, 10, -5,  0, -8], #  first batch
[ 0, -1, -2, -1,  0, -1, -1, -1, -1, -1], # second batch
[ 3,  2,  3,  3,  4,  2,  3,  2,  3,  2]] #  third batch
```

As we can see from the suggested values in the example, the second and third batches have very similar suggested values.

To give a better example in this tutorial, this pull request replaces the sampler with `CmaEsSampler`.

## Description of the changes
<!-- Describe the changes in this PR. -->

- Specify `CmaEsSampler`
- Improve the example for `CmaEsSampler`
