### PR TITLE
Using the "log" key is deprecated in mlflow

### DIFF
--- a/examples/kubernetes/mlflow/pytorch_lightning_distributed.py
+++ b/examples/kubernetes/mlflow/pytorch_lightning_distributed.py
@@ -74,7 +74,7 @@ class LightningNet(pl.LightningModule):
     def validation_epoch_end(self, outputs):
         accuracy = sum(x["batch_val_acc"] for x in outputs) / len(outputs)
         # Pass the accuracy to the `DictLogger` via the `'log'` key.
-        return {"log": {"val_acc": accuracy}}
+        self.log("val_acc", accuracy)
 
     def configure_optimizers(self):
         return Adam(self.model.parameters())


### PR DESCRIPTION
## Motivation
The mlflow example does not work with the newest mlflow.

## Description of the changes
This mlflow makes use of `self.log` as required by latest mlflow API.
