### PR TITLE
Add MaxTrialsCallback class to enable stopping after fixed number of trials

### DIFF
--- a/docs/source/reference/study.rst
+++ b/docs/source/reference/study.rst
@@ -14,5 +14,6 @@ The :mod:`~optuna.study` module implements the :class:`~optuna.study.Study` obje
    optuna.study.load_study
    optuna.study.delete_study
    optuna.study.get_all_study_summaries
+   optuna.study.MaxTrialsCallback
    optuna.study.StudyDirection
    optuna.study.StudySummary

--- a/examples/max_trials_callback.py
+++ b/examples/max_trials_callback.py
@@ -12,19 +12,8 @@ regardless of the number of workers/scripts running the Trials.
 from time import sleep
 
 import optuna
+from optuna.study import MaxTrialsCallback
 from optuna.trial import TrialState
-
-
-num_completed_trials = 10
-
-
-def max_trial_callback(study, trial):
-    # we consider all the running states and already completed states.
-    n_complete = len(
-        study.get_trials(deepcopy=False, states=[TrialState.COMPLETE, TrialState.RUNNING])
-    )
-    if n_complete >= num_completed_trials:
-        study.stop()
 
 
 def objective(trial):
@@ -40,7 +29,9 @@ if __name__ == "__main__":
         load_if_exists=True,
     )
 
-    study.optimize(objective, n_trials=50, callbacks=[max_trial_callback])
+    study.optimize(
+        objective, n_trials=50, callbacks=[MaxTrialsCallback(10, states=(TrialState.COMPLETE,))]
+    )
     trials = study.trials_dataframe()
     print("Number of completed trials: {}".format(len(trials[trials.state == "COMPLETE"])))
 

--- a/optuna/_callbacks.py
+++ b/optuna/_callbacks.py
@@ -1,0 +1,59 @@
+from typing import Tuple
+
+import optuna
+from optuna._experimental import experimental
+from optuna.trial import FrozenTrial
+from optuna.trial import TrialState
+
+
+@experimental("2.8.0")
+class MaxTrialsCallback:
+    """Set a maximum number of trials before ending the study.
+
+    While the :obj:`n_trials` argument of :obj:`optuna.optimize` sets the number of trials that
+    will be run, you may want to continue running until you have a certain number of successfullly
+    completed trials or stop the study when you have a certain number of trials that fail.
+    This :obj:`MaxTrialsCallback` class allows you to set a maximum number of trials for a
+    particular :class:`~optuna.trial.TrialState` before stopping the study.
+
+    Example:
+
+        .. testcode::
+
+            import optuna
+            from optuna.study import MaxTrialsCallback
+            from optuna.trial import TrialState
+
+
+            def objective(trial):
+                x = trial.suggest_float("x", -1, 1)
+                return x ** 2
+
+
+            study = optuna.create_study()
+            study.optimize(
+                objective,
+                callbacks=[MaxTrialsCallback(10, states=(TrialState.COMPLETE,))],
+            )
+
+    Args:
+        n_trials:
+            The max number of trials. Must be set to an integer.
+        states:
+            Tuple of the :class:`~optuna.trial.TrialState` to be counted
+            towards the max trials limit. Default value is :obj:`(TrialState.COMPLETE,)`.
+    """
+
+    def __init__(
+        self, n_trials: int, states: Tuple[TrialState, ...] = (TrialState.COMPLETE,)
+    ) -> None:
+        self._n_trials = n_trials
+        self._states = states
+
+    def __call__(
+        self, study: "optuna.study.Study", trial: FrozenTrial
+    ) -> None:
+        trials = study.get_trials(deepcopy=False, states=self._states)
+        n_complete = len(trials)
+        if n_complete >= self._n_trials:
+            study.stop()

--- a/optuna/_callbacks.py
+++ b/optuna/_callbacks.py
@@ -50,9 +50,7 @@ class MaxTrialsCallback:
         self._n_trials = n_trials
         self._states = states
 
-    def __call__(
-        self, study: "optuna.study.Study", trial: FrozenTrial
-    ) -> None:
+    def __call__(self, study: "optuna.study.Study", trial: FrozenTrial) -> None:
         trials = study.get_trials(deepcopy=False, states=self._states)
         n_complete = len(trials)
         if n_complete >= self._n_trials:

--- a/optuna/study.py
+++ b/optuna/study.py
@@ -18,6 +18,7 @@ from optuna import pruners
 from optuna import samplers
 from optuna import storages
 from optuna import trial as trial_module
+from optuna._callbacks import MaxTrialsCallback  # NOQA
 from optuna._dataframe import _trials_dataframe
 from optuna._dataframe import pd
 from optuna._deprecated import deprecated

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -1,0 +1,25 @@
+from optuna import create_study
+from optuna import Trial
+from optuna import TrialPruned
+from optuna.study import MaxTrialsCallback
+from optuna.trial import TrialState
+
+
+def test_stop_with_MaxTrialsCallback() -> None:
+    # Test stopping the optimization with MaxTrialsCallback.
+    study = create_study()
+    study.optimize(lambda _: 1.0, n_trials=10, callbacks=[MaxTrialsCallback(5)])
+    assert len(study.trials) == 5
+
+    # Test stopping the optimization with MaxTrialsCallback with pruned trials
+
+    def pruned_objective(trial: Trial) -> float:
+        raise TrialPruned()
+
+    study = create_study()
+    study.optimize(
+        pruned_objective,
+        n_trials=10,
+        callbacks=[MaxTrialsCallback(5, states=(TrialState.PRUNED,))],
+    )
+    assert len(study.trials) == 5


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
Users may want to stop trials after a certain number of complete or incomplete trials.

## Description of the changes
<!-- Describe the changes in this PR. -->
Create an `optuna.study` class for call backs, which stops after the user set `n_trials` exceeds the number of trials according to the user set `TrialState` list. Default is `TrialState.COMPLETE`.

Todo:

- [x] Documentation
- [x] Test for failed
- [x] Create testing