### PR TITLE
Make `MOTPEMultiObjectiveSampler` a thin wrapper for `MOTPESampler`

### DIFF
--- a/optuna/multi_objective/samplers/_motpe.py
+++ b/optuna/multi_objective/samplers/_motpe.py
@@ -1,44 +1,29 @@
-import math
 from typing import Any
 from typing import Callable
-from typing import cast
 from typing import Dict
-from typing import List
 from typing import Optional
-from typing import Tuple
-from typing import Union
+import warnings
 
 import numpy as np
 
 import optuna
-from optuna import distributions
 from optuna import multi_objective
 from optuna._deprecated import deprecated
 from optuna.distributions import BaseDistribution
-from optuna.multi_objective import _hypervolume
+from optuna.exceptions import ExperimentalWarning
+from optuna.multi_objective.samplers import _MultiObjectiveSamplerAdapter
 from optuna.multi_objective.samplers import BaseMultiObjectiveSampler
-from optuna.multi_objective.samplers._random import RandomMultiObjectiveSampler
-from optuna.samplers import TPESampler
-from optuna.samplers._tpe.parzen_estimator import _ParzenEstimator
-from optuna.samplers._tpe.parzen_estimator import _ParzenEstimatorParameters
-from optuna.study import StudyDirection
-
-
-EPS = 1e-12
-_SPLITCACHE_KEY = "multi_objective:motpe:splitcache"
-_WEIGHTS_BELOW_KEY = "multi_objective:motpe:weights_below"
-
-
-def default_gamma(x: int) -> int:
-    return int(np.floor(0.1 * x))
-
-
-def _default_weights_above(x: int) -> np.ndarray:
-    return np.ones(x)
+from optuna.pruners import NopPruner
+from optuna.samplers import MOTPESampler
+from optuna.samplers._tpe.multi_objective_sampler import _default_weights_above
+from optuna.samplers._tpe.multi_objective_sampler import default_gamma
+from optuna.study import create_study
+from optuna.trial import create_trial
+from optuna.trial import FrozenTrial
 
 
 @deprecated("2.4.0", "4.0.0")
-class MOTPEMultiObjectiveSampler(TPESampler, BaseMultiObjectiveSampler):
+class MOTPEMultiObjectiveSampler(BaseMultiObjectiveSampler):
     """Multi-objective sampler using the MOTPE algorithm.
 
     This sampler is a multiobjective version of :class:`~optuna.samplers.TPESampler`.
@@ -132,508 +117,85 @@ class MOTPEMultiObjectiveSampler(TPESampler, BaseMultiObjectiveSampler):
         seed: Optional[int] = None,
     ) -> None:
 
-        super().__init__(
-            consider_prior=consider_prior,
-            prior_weight=prior_weight,
-            consider_magic_clip=consider_magic_clip,
-            consider_endpoints=consider_endpoints,
-            n_startup_trials=n_startup_trials,
-            n_ei_candidates=n_ehvi_candidates,
-            gamma=gamma,
-            weights=weights_above,
-            seed=seed,
-        )
-        self._n_ehvi_candidates = n_ehvi_candidates
-        self._mo_random_sampler = RandomMultiObjectiveSampler(seed=seed)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", ExperimentalWarning)
+            self._motpe_sampler = MOTPESampler(
+                consider_prior=consider_prior,
+                prior_weight=prior_weight,
+                consider_magic_clip=consider_magic_clip,
+                consider_endpoints=consider_endpoints,
+                n_startup_trials=n_startup_trials,
+                n_ehvi_candidates=n_ehvi_candidates,
+                gamma=gamma,
+                weights_above=weights_above,
+                seed=seed,
+            )
 
     def reseed_rng(self) -> None:
-        self._rng = np.random.RandomState()
-        self._mo_random_sampler.reseed_rng()
+        self._motpe_sampler.reseed_rng()
 
     def infer_relative_search_space(
         self,
-        study: Union[optuna.study.Study, "multi_objective.study.MultiObjectiveStudy"],
-        trial: Union[optuna.trial.FrozenTrial, "multi_objective.trial.FrozenMultiObjectiveTrial"],
+        study: "multi_objective.study.MultiObjectiveStudy",
+        trial: "multi_objective.trial.FrozenMultiObjectiveTrial",
     ) -> Dict[str, BaseDistribution]:
         return {}
 
     def sample_relative(
         self,
-        study: Union[optuna.study.Study, "multi_objective.study.MultiObjectiveStudy"],
-        trial: Union[optuna.trial.FrozenTrial, "multi_objective.trial.FrozenMultiObjectiveTrial"],
+        study: "multi_objective.study.MultiObjectiveStudy",
+        trial: "multi_objective.trial.FrozenMultiObjectiveTrial",
         search_space: Dict[str, BaseDistribution],
     ) -> Dict[str, Any]:
         return {}
 
     def sample_independent(
         self,
-        study: Union[optuna.study.Study, "multi_objective.study.MultiObjectiveStudy"],
-        trial: Union[optuna.trial.FrozenTrial, "multi_objective.trial.FrozenMultiObjectiveTrial"],
+        study: "multi_objective.study.MultiObjectiveStudy",
+        trial: "multi_objective.trial.FrozenMultiObjectiveTrial",
         param_name: str,
         param_distribution: BaseDistribution,
     ) -> Any:
-        assert isinstance(study, multi_objective.study.MultiObjectiveStudy)
-        assert isinstance(trial, multi_objective.trial.FrozenMultiObjectiveTrial)
-        if len(study.directions) < 2:
-            raise ValueError(
-                "Number of objectives must be >= 2. "
-                "Please use optuna.samplers.TPESampler for single-objective optimization."
-            ) from None
 
-        values, scores = _get_observation_pairs(study, param_name)
-        n = len(values)
-        if n < self._n_startup_trials:
-            return self._mo_random_sampler.sample_independent(
-                study, trial, param_name, param_distribution
-            )
-        below_param_values, above_param_values = self._split_mo_observation_pairs(
-            study, trial, values, scores
+        return self._motpe_sampler.sample_independent(
+            _create_study(study), _create_trial(trial), param_name, param_distribution
         )
 
-        if isinstance(param_distribution, distributions.UniformDistribution):
-            return self._sample_mo_uniform(
-                study, trial, param_distribution, below_param_values, above_param_values
-            )
-        elif isinstance(param_distribution, distributions.LogUniformDistribution):
-            return self._sample_mo_loguniform(
-                study, trial, param_distribution, below_param_values, above_param_values
-            )
-        elif isinstance(param_distribution, distributions.DiscreteUniformDistribution):
-            return self._sample_mo_discrete_uniform(
-                study, trial, param_distribution, below_param_values, above_param_values
-            )
-        elif isinstance(param_distribution, distributions.IntUniformDistribution):
-            return self._sample_mo_int(
-                study, trial, param_distribution, below_param_values, above_param_values
-            )
-        elif isinstance(param_distribution, distributions.IntLogUniformDistribution):
-            return self._sample_mo_int_loguniform(
-                study, trial, param_distribution, below_param_values, above_param_values
-            )
-        elif isinstance(param_distribution, distributions.CategoricalDistribution):
-            index = self._sample_mo_categorical_index(
-                study, trial, param_distribution, below_param_values, above_param_values
-            )
-            return param_distribution.choices[index]
-        else:
-            distribution_list = [
-                distributions.UniformDistribution.__name__,
-                distributions.LogUniformDistribution.__name__,
-                distributions.DiscreteUniformDistribution.__name__,
-                distributions.IntUniformDistribution.__name__,
-                distributions.IntLogUniformDistribution.__name__,
-                distributions.CategoricalDistribution.__name__,
-            ]
-            raise NotImplementedError(
-                "The distribution {} is not implemented. "
-                "The parameter distribution should be one of the {}".format(
-                    param_distribution, distribution_list
+
+def _create_study(mo_study: "multi_objective.study.MultiObjectiveStudy") -> "optuna.Study":
+    study = create_study(
+        storage=None,
+        sampler=_MultiObjectiveSamplerAdapter(mo_study.sampler),
+        pruner=NopPruner(),
+        study_name="motpe-" + mo_study._storage.get_study_name_from_id(mo_study._study_id),
+        directions=mo_study.directions,
+        load_if_exists=True,
+    )
+    for mo_trial in mo_study.trials:
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", ExperimentalWarning)
+            study.add_trial(
+                create_trial(
+                    state=mo_trial.state,
+                    values=mo_trial.values,
+                    params=mo_trial.params,
+                    distributions=mo_trial.distributions,
+                    user_attrs=mo_trial.user_attrs,
+                    system_attrs=mo_trial.system_attrs,
                 )
             )
+    return study
 
-    def _split_mo_observation_pairs(
-        self,
-        study: "multi_objective.study.MultiObjectiveStudy",
-        trial: "multi_objective.trial.FrozenMultiObjectiveTrial",
-        config_vals: List[Optional[float]],
-        loss_vals: List[List[float]],
-    ) -> Tuple[np.ndarray, np.ndarray]:
-        """Split observations into observations for l(x) and g(x) with the ratio of gamma:1-gamma.
 
-        Weights for l(x) are also calculated in this method.
-
-        This splitting strategy consists of the following two steps:
-            1. Nondonation rank-based selection
-            2. Hypervolume subset selection problem (HSSP)-based selection
-
-        Please refer to the `original paper <https://dl.acm.org/doi/abs/10.1145/3377930.3389817>`_
-        for more details.
-        """
-        cvals = np.asarray(config_vals)
-        lvals = np.asarray(loss_vals)
-
-        # Solving HSSP for variables number of times is a waste of time.
-        # We cache the result of splitting.
-        if _SPLITCACHE_KEY in trial.system_attrs:
-            split_cache = trial.system_attrs[_SPLITCACHE_KEY]
-            indices_below = np.asarray(split_cache["indices_below"])
-            weights_below = np.asarray(split_cache["weights_below"])
-            indices_above = np.asarray(split_cache["indices_above"])
-        else:
-            nondomination_ranks = _calculate_nondomination_rank(lvals)
-            n_below = self._gamma(len(lvals))
-            assert 0 <= n_below <= len(lvals)
-
-            indices = np.array(range(len(lvals)))
-            indices_below = np.array([], dtype=int)
-
-            # Nondomination rank-based selection
-            i = 0
-            while len(indices_below) + sum(nondomination_ranks == i) <= n_below:
-                indices_below = np.append(indices_below, indices[nondomination_ranks == i])
-                i += 1
-
-            # Hypervolume subset selection problem (HSSP)-based selection
-            subset_size = n_below - len(indices_below)
-            if subset_size > 0:
-                rank_i_lvals = lvals[nondomination_ranks == i]
-                rank_i_indices = indices[nondomination_ranks == i]
-                worst_point = np.max(rank_i_lvals, axis=0)
-                reference_point = np.maximum(1.1 * worst_point, 0.9 * worst_point)
-                reference_point[reference_point == 0] = EPS
-                selected_indices = self._solve_hssp(
-                    rank_i_lvals, rank_i_indices, subset_size, reference_point
-                )
-                indices_below = np.append(indices_below, selected_indices)
-            assert len(indices_below) == n_below
-
-            indices_above = np.setdiff1d(indices, indices_below)
-
-            attrs = {
-                "indices_below": indices_below.tolist(),
-                "indices_above": indices_above.tolist(),
-            }
-            weights_below = self._calculate_weights_below(lvals, indices_below)
-            attrs["weights_below"] = weights_below.tolist()
-            study._storage.set_trial_system_attr(trial._trial_id, _SPLITCACHE_KEY, attrs)
-
-        below = cvals[indices_below]
-        study._storage.set_trial_system_attr(
-            trial._trial_id,
-            _WEIGHTS_BELOW_KEY,
-            [w for w, v in zip(weights_below, below) if v is not None],
+def _create_trial(mo_trial: "multi_objective.trial.FrozenMultiObjectiveTrial") -> FrozenTrial:
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", ExperimentalWarning)
+        trial = create_trial(
+            state=mo_trial.state,
+            values=mo_trial.values,
+            params=mo_trial.params,
+            distributions=mo_trial.distributions,
+            user_attrs=mo_trial.user_attrs,
+            system_attrs=mo_trial.system_attrs,
         )
-        below = np.asarray([v for v in below if v is not None], dtype=float)
-        above = cvals[indices_above]
-        above = np.asarray([v for v in above if v is not None], dtype=float)
-        return below, above
-
-    def _sample_mo_uniform(
-        self,
-        study: "multi_objective.study.MultiObjectiveStudy",
-        trial: "multi_objective.trial.FrozenMultiObjectiveTrial",
-        distribution: distributions.UniformDistribution,
-        below: np.ndarray,
-        above: np.ndarray,
-    ) -> float:
-        low = distribution.low
-        high = distribution.high
-        return self._sample_mo_numerical(study, trial, low, high, below, above)
-
-    def _sample_mo_loguniform(
-        self,
-        study: "multi_objective.study.MultiObjectiveStudy",
-        trial: "multi_objective.trial.FrozenMultiObjectiveTrial",
-        distribution: distributions.LogUniformDistribution,
-        below: np.ndarray,
-        above: np.ndarray,
-    ) -> float:
-        low = distribution.low
-        high = distribution.high
-        return self._sample_mo_numerical(study, trial, low, high, below, above, is_log=True)
-
-    def _sample_mo_discrete_uniform(
-        self,
-        study: "multi_objective.study.MultiObjectiveStudy",
-        trial: "multi_objective.trial.FrozenMultiObjectiveTrial",
-        distribution: distributions.DiscreteUniformDistribution,
-        below: np.ndarray,
-        above: np.ndarray,
-    ) -> float:
-        q = distribution.q
-        r = distribution.high - distribution.low
-        # [low, high] is shifted to [0, r] to align sampled values at regular intervals.
-        low = 0 - 0.5 * q
-        high = r + 0.5 * q
-
-        # Shift below and above to [0, r]
-        above -= distribution.low
-        below -= distribution.low
-
-        best_sample = (
-            self._sample_mo_numerical(study, trial, low, high, below, above, q=q)
-            + distribution.low
-        )
-        return min(max(best_sample, distribution.low), distribution.high)
-
-    def _sample_mo_int(
-        self,
-        study: "multi_objective.study.MultiObjectiveStudy",
-        trial: "multi_objective.trial.FrozenMultiObjectiveTrial",
-        distribution: distributions.IntUniformDistribution,
-        below: np.ndarray,
-        above: np.ndarray,
-    ) -> int:
-        d = distributions.DiscreteUniformDistribution(
-            low=distribution.low, high=distribution.high, q=distribution.step
-        )
-        return int(self._sample_mo_discrete_uniform(study, trial, d, below, above))
-
-    def _sample_mo_int_loguniform(
-        self,
-        study: "multi_objective.study.MultiObjectiveStudy",
-        trial: "multi_objective.trial.FrozenMultiObjectiveTrial",
-        distribution: distributions.IntLogUniformDistribution,
-        below: np.ndarray,
-        above: np.ndarray,
-    ) -> int:
-        low = distribution.low - 0.5
-        high = distribution.high + 0.5
-
-        sample = self._sample_mo_numerical(study, trial, low, high, below, above, is_log=True)
-        best_sample = np.round(sample)
-
-        return int(min(max(best_sample, distribution.low), distribution.high))
-
-    def _sample_mo_numerical(
-        self,
-        study: "multi_objective.study.MultiObjectiveStudy",
-        trial: "multi_objective.trial.FrozenMultiObjectiveTrial",
-        low: float,
-        high: float,
-        below: np.ndarray,
-        above: np.ndarray,
-        q: Optional[float] = None,
-        is_log: bool = False,
-    ) -> float:
-        if is_log:
-            low = np.log(low)
-            high = np.log(high)
-            below = np.log(below)
-            above = np.log(above)
-
-        size = (self._n_ehvi_candidates,)
-
-        weights_below: Callable[[int], np.ndarray]
-
-        weights_below = lambda _: np.asarray(  # NOQA
-            study._storage.get_trial(trial._trial_id).system_attrs[_WEIGHTS_BELOW_KEY],
-            dtype=float,
-        )
-
-        parzen_estimator_parameters_below = _ParzenEstimatorParameters(
-            self._parzen_estimator_parameters.consider_prior,
-            self._parzen_estimator_parameters.prior_weight,
-            self._parzen_estimator_parameters.consider_magic_clip,
-            self._parzen_estimator_parameters.consider_endpoints,
-            weights_below,
-        )
-        parzen_estimator_below = _ParzenEstimator(
-            mus=below, low=low, high=high, parameters=parzen_estimator_parameters_below
-        )
-        samples_below = self._sample_from_gmm(
-            parzen_estimator=parzen_estimator_below,
-            low=low,
-            high=high,
-            q=q,
-            size=size,
-        )
-        log_likelihoods_below = self._gmm_log_pdf(
-            samples=samples_below,
-            parzen_estimator=parzen_estimator_below,
-            low=low,
-            high=high,
-            q=q,
-        )
-
-        weights_above = self._weights
-        parzen_estimator_parameters_above = _ParzenEstimatorParameters(
-            self._parzen_estimator_parameters.consider_prior,
-            self._parzen_estimator_parameters.prior_weight,
-            self._parzen_estimator_parameters.consider_magic_clip,
-            self._parzen_estimator_parameters.consider_endpoints,
-            weights_above,
-        )
-        parzen_estimator_above = _ParzenEstimator(
-            mus=above, low=low, high=high, parameters=parzen_estimator_parameters_above
-        )
-        log_likelihoods_above = self._gmm_log_pdf(
-            samples=samples_below,
-            parzen_estimator=parzen_estimator_above,
-            low=low,
-            high=high,
-            q=q,
-        )
-
-        ret = float(
-            TPESampler._compare(
-                samples=samples_below, log_l=log_likelihoods_below, log_g=log_likelihoods_above
-            )[0]
-        )
-        return math.exp(ret) if is_log else ret
-
-    def _sample_mo_categorical_index(
-        self,
-        study: "multi_objective.study.MultiObjectiveStudy",
-        trial: "multi_objective.trial.FrozenMultiObjectiveTrial",
-        distribution: distributions.CategoricalDistribution,
-        below: np.ndarray,
-        above: np.ndarray,
-    ) -> int:
-        choices = distribution.choices
-        below = np.asarray(list(map(int, below)))
-        above = np.asarray(list(map(int, above)))
-        upper = len(choices)
-        size = (self._n_ehvi_candidates,)
-
-        weights_below = study._storage.get_trial(trial._trial_id).system_attrs[_WEIGHTS_BELOW_KEY]
-        counts_below = np.bincount(below, minlength=upper, weights=weights_below)
-        weighted_below = counts_below + self._prior_weight
-        weighted_below /= weighted_below.sum()
-        samples_below = self._sample_from_categorical_dist(weighted_below, size)
-        log_likelihoods_below = TPESampler._categorical_log_pdf(samples_below, weighted_below)
-
-        weights_above = self._weights(len(above))
-        counts_above = np.bincount(above, minlength=upper, weights=weights_above)
-        weighted_above = counts_above + self._prior_weight
-        weighted_above /= weighted_above.sum()
-        log_likelihoods_above = TPESampler._categorical_log_pdf(samples_below, weighted_above)
-
-        return int(
-            TPESampler._compare(
-                samples=samples_below, log_l=log_likelihoods_below, log_g=log_likelihoods_above
-            )[0]
-        )
-
-    @staticmethod
-    def _compute_hypervolume(solution_set: np.ndarray, reference_point: np.ndarray) -> float:
-        return _hypervolume.WFG().compute(solution_set, reference_point)
-
-    def _solve_hssp(
-        self,
-        rank_i_loss_vals: np.ndarray,
-        rank_i_indices: np.ndarray,
-        subset_size: int,
-        reference_point: np.ndarray,
-    ) -> np.ndarray:
-        """Solve a hypervolume subset selection problem (HSSP) via a greedy algorithm.
-
-        This method is a 1-1/e approximation algorithm to solve HSSP.
-
-        For further information about algorithms to solve HSSP, please refer to the following
-        paper:
-
-        - `Greedy Hypervolume Subset Selection in Low Dimensions
-           <https://ieeexplore.ieee.org/document/7570501>`_
-        """
-        selected_vecs = []  # type: List[np.ndarray]
-        selected_indices = []  # type: List[int]
-        contributions = [
-            self._compute_hypervolume(np.asarray([v]), reference_point) for v in rank_i_loss_vals
-        ]
-        hv_selected = 0.0
-        while len(selected_indices) < subset_size:
-            max_index = np.argmax(contributions)
-            contributions[int(max_index)] = -1  # mark as selected
-            selected_index = rank_i_indices[max_index]
-            selected_vec = rank_i_loss_vals[max_index]
-            for j, v in enumerate(rank_i_loss_vals):
-                if contributions[j] == -1:
-                    continue
-                p = np.max([selected_vec, v], axis=0)
-                contributions[j] -= (
-                    self._compute_hypervolume(np.asarray(selected_vecs + [p]), reference_point)
-                    - hv_selected
-                )
-            selected_vecs += [selected_vec]
-            selected_indices += [selected_index]
-            hv_selected = self._compute_hypervolume(np.asarray(selected_vecs), reference_point)
-
-        return np.asarray(selected_indices, dtype=int)
-
-    def _calculate_weights_below(
-        self,
-        lvals: np.ndarray,
-        indices_below: np.ndarray,
-    ) -> np.ndarray:
-        # Calculate weights based on hypervolume contributions.
-        n_below = len(indices_below)
-        if n_below == 0:
-            return np.asarray([])
-        elif n_below == 1:
-            return np.asarray([1.0])
-        else:
-            lvals_below = lvals[indices_below].tolist()
-            worst_point = np.max(lvals_below, axis=0)
-            reference_point = np.maximum(1.1 * worst_point, 0.9 * worst_point)
-            reference_point[reference_point == 0] = EPS
-            hv = self._compute_hypervolume(np.asarray(lvals_below), reference_point)
-            contributions = np.asarray(
-                [
-                    hv
-                    - self._compute_hypervolume(
-                        np.asarray(lvals_below[:i] + lvals_below[i + 1 :]), reference_point
-                    )
-                    for i in range(len(lvals))
-                ]
-            )
-            weights_below = np.clip(contributions / np.max(contributions), 0, 1)
-            return weights_below
-
-
-def _calculate_nondomination_rank(loss_vals: np.ndarray) -> np.ndarray:
-    vecs = loss_vals.copy()
-
-    # Normalize values
-    lb = vecs.min(axis=0, keepdims=True)
-    ub = vecs.max(axis=0, keepdims=True)
-    vecs = (vecs - lb) / (ub - lb)
-
-    ranks = np.zeros(len(vecs))
-    num_unranked = len(vecs)
-    rank = 0
-    while num_unranked > 0:
-        extended = np.tile(vecs, (vecs.shape[0], 1, 1))
-        counts = np.sum(
-            np.logical_and(
-                np.all(extended <= np.swapaxes(extended, 0, 1), axis=2),
-                np.any(extended < np.swapaxes(extended, 0, 1), axis=2),
-            ),
-            axis=1,
-        )
-        vecs[counts == 0] = 1.1  # mark as ranked
-        ranks[counts == 0] = rank
-        rank += 1
-        num_unranked -= np.sum(counts == 0)
-    return ranks
-
-
-def _get_observation_pairs(
-    study: "multi_objective.study.MultiObjectiveStudy",
-    param_name: str,
-) -> Tuple[List[Optional[float]], List[List[float]]]:
-    """Get observation pairs from the study.
-
-    This function collects observation pairs from the complete trials of the study.
-    Pruning is currently not supported.
-    The values for trials that don't contain the parameter named ``param_name`` are set to None.
-
-    Objective values are negated if their directions are maximization and all objectives are
-    treated as minimization in the MOTPE algorithm.
-    """
-
-    trials = [
-        multi_objective.trial.FrozenMultiObjectiveTrial(study.n_objectives, trial)
-        for trial in study._storage.get_all_trials(study._study_id, deepcopy=False)
-    ]
-    values = []
-    scores = []
-    for trial in trials:
-        if trial.state != optuna.trial.TrialState.COMPLETE or None in trial.values:
-            continue
-
-        param_value = None  # type: Optional[float]
-        if param_name in trial.params:
-            distribution = trial.distributions[param_name]
-            param_value = distribution.to_internal_repr(trial.params[param_name])
-
-        # Convert all objectives to minimization
-        score = [
-            cast(float, v) if d == StudyDirection.MINIMIZE else -cast(float, v)
-            for d, v in zip(study.directions, trial.values)
-        ]
-
-        values.append(param_value)
-        scores.append(score)
-
-    return values, scores
+    return trial

--- a/optuna/multi_objective/samplers/_motpe.py
+++ b/optuna/multi_objective/samplers/_motpe.py
@@ -167,7 +167,7 @@ def _create_study(mo_study: "multi_objective.study.MultiObjectiveStudy") -> "opt
         storage=None,
         sampler=_MultiObjectiveSamplerAdapter(mo_study.sampler),
         pruner=NopPruner(),
-        study_name="motpe-" + mo_study._storage.get_study_name_from_id(mo_study._study_id),
+        study_name="_motpe-" + mo_study._storage.get_study_name_from_id(mo_study._study_id),
         directions=mo_study.directions,
         load_if_exists=True,
     )

--- a/optuna/multi_objective/samplers/_motpe.py
+++ b/optuna/multi_objective/samplers/_motpe.py
@@ -164,7 +164,7 @@ class MOTPEMultiObjectiveSampler(BaseMultiObjectiveSampler):
 
 def _create_study(mo_study: "multi_objective.study.MultiObjectiveStudy") -> "optuna.Study":
     study = create_study(
-        storage=None,
+        storage=mo_study._storage,
         sampler=_MultiObjectiveSamplerAdapter(mo_study.sampler),
         pruner=NopPruner(),
         study_name="_motpe-" + mo_study._storage.get_study_name_from_id(mo_study._study_id),
@@ -174,16 +174,7 @@ def _create_study(mo_study: "multi_objective.study.MultiObjectiveStudy") -> "opt
     for mo_trial in mo_study.trials:
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", ExperimentalWarning)
-            study.add_trial(
-                create_trial(
-                    state=mo_trial.state,
-                    values=mo_trial.values,
-                    params=mo_trial.params,
-                    distributions=mo_trial.distributions,
-                    user_attrs=mo_trial.user_attrs,
-                    system_attrs=mo_trial.system_attrs,
-                )
-            )
+            study.add_trial(_create_trial(mo_trial))
     return study
 
 

--- a/tests/multi_objective_tests/samplers_tests/test_motpe.py
+++ b/tests/multi_objective_tests/samplers_tests/test_motpe.py
@@ -1,21 +1,17 @@
-import itertools
 import random
 from typing import Callable
 from typing import Dict
 from typing import List
 from typing import Optional
-from typing import Tuple
 from typing import Union
 from unittest.mock import Mock
 from unittest.mock import patch
 from unittest.mock import PropertyMock
 
-import numpy as np
 import pytest
 
 import optuna
 from optuna import multi_objective
-from optuna.multi_objective.samplers import _motpe
 from optuna.multi_objective.samplers import MOTPEMultiObjectiveSampler
 
 
@@ -27,6 +23,20 @@ class MockSystemAttr:
         self.value[key] = value
 
 
+@pytest.mark.filterwarnings("ignore::FutureWarning")
+def test_reseed_rng() -> None:
+    sampler = MOTPEMultiObjectiveSampler()
+    original_seed = sampler._motpe_sampler._rng.seed
+
+    with patch.object(
+        sampler._motpe_sampler, "reseed_rng", wraps=sampler._motpe_sampler.reseed_rng
+    ) as mock_object:
+        sampler.reseed_rng()
+        assert mock_object.call_count == 1
+        assert original_seed != sampler._motpe_sampler._rng.seed
+
+
+@pytest.mark.filterwarnings("ignore::FutureWarning")
 def test_sample_relative() -> None:
     sampler = MOTPEMultiObjectiveSampler()
     # Study and frozen-trial are not supposed to be accessed.
@@ -35,6 +45,7 @@ def test_sample_relative() -> None:
     assert sampler.sample_relative(study, frozen_trial, {}) == {}
 
 
+@pytest.mark.filterwarnings("ignore::FutureWarning")
 def test_infer_relative_search_space() -> None:
     sampler = MOTPEMultiObjectiveSampler()
     # Study and frozen-trial are not supposed to be accessed.
@@ -43,7 +54,8 @@ def test_infer_relative_search_space() -> None:
     assert sampler.infer_relative_search_space(study, frozen_trial) == {}
 
 
-def test_sample_independent_seed_fix() -> None:
+@pytest.mark.filterwarnings("ignore::FutureWarning")
+def test_sample_independent() -> None:
     study = optuna.multi_objective.create_study(directions=["minimize", "maximize"])
     dist = optuna.distributions.UniformDistribution(1.0, 100.0)
 
@@ -63,545 +75,7 @@ def test_sample_independent_seed_fix() -> None:
     ) as mock2:
         mock1.return_value = attrs.value
         mock2.return_value = attrs.value
-        suggestion = sampler.sample_independent(study, trial, "param-a", dist)
-
-    sampler = MOTPEMultiObjectiveSampler(seed=0)
-    attrs = MockSystemAttr()
-    with patch.object(study._storage, "get_all_trials", return_value=past_trials), patch.object(
-        study._storage, "set_trial_system_attr", side_effect=attrs.set_trial_system_attr
-    ), patch.object(study._storage, "get_trial", return_value=trial), patch(
-        "optuna.multi_objective.trial.MultiObjectiveTrial.system_attrs", new_callable=PropertyMock
-    ) as mock1, patch(
-        "optuna.multi_objective.trial.FrozenMultiObjectiveTrial.system_attrs",
-        new_callable=PropertyMock,
-    ) as mock2:
-        mock1.return_value = attrs.value
-        mock2.return_value = attrs.value
-        assert sampler.sample_independent(study, trial, "param-a", dist) == suggestion
-
-    sampler = MOTPEMultiObjectiveSampler(seed=1)
-    attrs = MockSystemAttr()
-    with patch.object(study._storage, "get_all_trials", return_value=past_trials), patch.object(
-        study._storage, "set_trial_system_attr", side_effect=attrs.set_trial_system_attr
-    ), patch.object(study._storage, "get_trial", return_value=trial), patch(
-        "optuna.multi_objective.trial.MultiObjectiveTrial.system_attrs", new_callable=PropertyMock
-    ) as mock1, patch(
-        "optuna.multi_objective.trial.FrozenMultiObjectiveTrial.system_attrs",
-        new_callable=PropertyMock,
-    ) as mock2:
-        mock1.return_value = attrs.value
-        mock2.return_value = attrs.value
-        assert sampler.sample_independent(study, trial, "param-a", dist) != suggestion
-
-
-def test_sample_independent_prior() -> None:
-    study = optuna.multi_objective.create_study(directions=["minimize", "maximize"])
-    dist = optuna.distributions.UniformDistribution(1.0, 100.0)
-
-    random.seed(128)
-    past_trials = [frozen_trial_factory(i, [random.random(), random.random()]) for i in range(16)]
-
-    # Prepare a trial and a sample for later checks.
-    trial = multi_objective.trial.FrozenMultiObjectiveTrial(2, frozen_trial_factory(16, [0, 0]))
-    sampler = MOTPEMultiObjectiveSampler(seed=0)
-    attrs = MockSystemAttr()
-    with patch.object(study._storage, "get_all_trials", return_value=past_trials), patch.object(
-        study._storage, "set_trial_system_attr", side_effect=attrs.set_trial_system_attr
-    ), patch.object(study._storage, "get_trial", return_value=trial), patch(
-        "optuna.multi_objective.trial.MultiObjectiveTrial.system_attrs", new_callable=PropertyMock
-    ) as mock1, patch(
-        "optuna.multi_objective.trial.FrozenMultiObjectiveTrial.system_attrs",
-        new_callable=PropertyMock,
-    ) as mock2:
-        mock1.return_value = attrs.value
-        mock2.return_value = attrs.value
-        suggestion = sampler.sample_independent(study, trial, "param-a", dist)
-
-    sampler = MOTPEMultiObjectiveSampler(consider_prior=False, seed=0)
-    attrs = MockSystemAttr()
-    with patch.object(study._storage, "get_all_trials", return_value=past_trials), patch.object(
-        study._storage, "set_trial_system_attr", side_effect=attrs.set_trial_system_attr
-    ), patch.object(study._storage, "get_trial", return_value=trial), patch(
-        "optuna.multi_objective.trial.MultiObjectiveTrial.system_attrs", new_callable=PropertyMock
-    ) as mock1, patch(
-        "optuna.multi_objective.trial.FrozenMultiObjectiveTrial.system_attrs",
-        new_callable=PropertyMock,
-    ) as mock2:
-        mock1.return_value = attrs.value
-        mock2.return_value = attrs.value
-        assert sampler.sample_independent(study, trial, "param-a", dist) != suggestion
-
-    sampler = MOTPEMultiObjectiveSampler(prior_weight=0.5, seed=0)
-    attrs = MockSystemAttr()
-    with patch.object(study._storage, "get_all_trials", return_value=past_trials), patch.object(
-        study._storage, "set_trial_system_attr", side_effect=attrs.set_trial_system_attr
-    ), patch.object(study._storage, "get_trial", return_value=trial), patch(
-        "optuna.multi_objective.trial.MultiObjectiveTrial.system_attrs", new_callable=PropertyMock
-    ) as mock1, patch(
-        "optuna.multi_objective.trial.FrozenMultiObjectiveTrial.system_attrs",
-        new_callable=PropertyMock,
-    ) as mock2:
-        mock1.return_value = attrs.value
-        mock2.return_value = attrs.value
-        assert sampler.sample_independent(study, trial, "param-a", dist) != suggestion
-
-
-def test_sample_independent_n_startup_trial() -> None:
-    study = optuna.multi_objective.create_study(directions=["minimize", "maximize"])
-    dist = optuna.distributions.UniformDistribution(1.0, 100.0)
-    random.seed(128)
-    past_trials = [frozen_trial_factory(i, [random.random(), random.random()]) for i in range(16)]
-
-    trial = multi_objective.trial.FrozenMultiObjectiveTrial(2, frozen_trial_factory(16, [0, 0]))
-    sampler = MOTPEMultiObjectiveSampler(n_startup_trials=16, seed=0)
-    attrs = MockSystemAttr()
-    with patch.object(
-        study._storage, "get_all_trials", return_value=past_trials[:15]
-    ), patch.object(
-        study._storage, "set_trial_system_attr", side_effect=attrs.set_trial_system_attr
-    ), patch.object(
-        study._storage, "get_trial", return_value=trial
-    ), patch(
-        "optuna.multi_objective.trial.MultiObjectiveTrial.system_attrs", new_callable=PropertyMock
-    ) as mock1, patch(
-        "optuna.multi_objective.trial.FrozenMultiObjectiveTrial.system_attrs",
-        new_callable=PropertyMock,
-    ) as mock2, patch.object(
-        optuna.multi_objective.samplers.RandomMultiObjectiveSampler,
-        "sample_independent",
-        return_value=1.0,
-    ) as sample_method:
-        mock1.return_value = attrs.value
-        mock2.return_value = attrs.value
-        sampler.sample_independent(study, trial, "param-a", dist)
-    assert sample_method.call_count == 1
-
-    sampler = MOTPEMultiObjectiveSampler(n_startup_trials=16, seed=0)
-    attrs = MockSystemAttr()
-    with patch.object(study._storage, "get_all_trials", return_value=past_trials), patch.object(
-        study._storage, "set_trial_system_attr", side_effect=attrs.set_trial_system_attr
-    ), patch.object(study._storage, "get_trial", return_value=trial), patch(
-        "optuna.multi_objective.trial.MultiObjectiveTrial.system_attrs", new_callable=PropertyMock
-    ) as mock1, patch(
-        "optuna.multi_objective.trial.FrozenMultiObjectiveTrial.system_attrs",
-        new_callable=PropertyMock,
-    ) as mock2, patch.object(
-        optuna.multi_objective.samplers.RandomMultiObjectiveSampler,
-        "sample_independent",
-        return_value=1.0,
-    ) as sample_method:
-        mock1.return_value = attrs.value
-        mock2.return_value = attrs.value
-        sampler.sample_independent(study, trial, "param-a", dist)
-    assert sample_method.call_count == 0
-
-
-def test_sample_independent_misc_arguments() -> None:
-    study = optuna.multi_objective.create_study(directions=["minimize", "maximize"])
-    dist = optuna.distributions.UniformDistribution(1.0, 100.0)
-    random.seed(128)
-    past_trials = [frozen_trial_factory(i, [random.random(), random.random()]) for i in range(32)]
-
-    # Prepare a trial and a sample for later checks.
-    trial = multi_objective.trial.FrozenMultiObjectiveTrial(2, frozen_trial_factory(16, [0, 0]))
-    sampler = MOTPEMultiObjectiveSampler(seed=0)
-    attrs = MockSystemAttr()
-    with patch.object(study._storage, "get_all_trials", return_value=past_trials), patch.object(
-        study._storage, "set_trial_system_attr", side_effect=attrs.set_trial_system_attr
-    ), patch.object(study._storage, "get_trial", return_value=trial), patch(
-        "optuna.multi_objective.trial.MultiObjectiveTrial.system_attrs", new_callable=PropertyMock
-    ) as mock1, patch(
-        "optuna.multi_objective.trial.FrozenMultiObjectiveTrial.system_attrs",
-        new_callable=PropertyMock,
-    ) as mock2:
-        mock1.return_value = attrs.value
-        mock2.return_value = attrs.value
-        suggestion = sampler.sample_independent(study, trial, "param-a", dist)
-
-    # Test misc. parameters.
-    sampler = MOTPEMultiObjectiveSampler(n_ehvi_candidates=13, seed=0)
-    attrs = MockSystemAttr()
-    with patch.object(study._storage, "get_all_trials", return_value=past_trials), patch.object(
-        study._storage, "set_trial_system_attr", side_effect=attrs.set_trial_system_attr
-    ), patch.object(study._storage, "get_trial", return_value=trial), patch(
-        "optuna.multi_objective.trial.MultiObjectiveTrial.system_attrs", new_callable=PropertyMock
-    ) as mock1, patch(
-        "optuna.multi_objective.trial.FrozenMultiObjectiveTrial.system_attrs",
-        new_callable=PropertyMock,
-    ) as mock2:
-        mock1.return_value = attrs.value
-        mock2.return_value = attrs.value
-        assert sampler.sample_independent(study, trial, "param-a", dist) != suggestion
-
-    sampler = MOTPEMultiObjectiveSampler(gamma=lambda _: 5, seed=0)
-    attrs = MockSystemAttr()
-    with patch.object(study._storage, "get_all_trials", return_value=past_trials), patch.object(
-        study._storage, "set_trial_system_attr", side_effect=attrs.set_trial_system_attr
-    ), patch.object(study._storage, "get_trial", return_value=trial), patch(
-        "optuna.multi_objective.trial.MultiObjectiveTrial.system_attrs", new_callable=PropertyMock
-    ) as mock1, patch(
-        "optuna.multi_objective.trial.FrozenMultiObjectiveTrial.system_attrs",
-        new_callable=PropertyMock,
-    ) as mock2:
-        mock1.return_value = attrs.value
-        mock2.return_value = attrs.value
-        assert sampler.sample_independent(study, trial, "param-a", dist) != suggestion
-
-    sampler = MOTPEMultiObjectiveSampler(weights_above=lambda n: np.zeros(n), seed=0)
-    attrs = MockSystemAttr()
-    with patch.object(study._storage, "get_all_trials", return_value=past_trials), patch.object(
-        study._storage, "set_trial_system_attr", side_effect=attrs.set_trial_system_attr
-    ), patch.object(study._storage, "get_trial", return_value=trial), patch(
-        "optuna.multi_objective.trial.MultiObjectiveTrial.system_attrs", new_callable=PropertyMock
-    ) as mock1, patch(
-        "optuna.multi_objective.trial.FrozenMultiObjectiveTrial.system_attrs",
-        new_callable=PropertyMock,
-    ) as mock2:
-        mock1.return_value = attrs.value
-        mock2.return_value = attrs.value
-        assert sampler.sample_independent(study, trial, "param-a", dist) != suggestion
-
-
-def test_sample_independent_uniform_distributions() -> None:
-    # Prepare sample from uniform distribution for cheking other distributions.
-    study = optuna.multi_objective.create_study(directions=["minimize", "maximize"])
-    random.seed(128)
-    past_trials = [frozen_trial_factory(i, [random.random(), random.random()]) for i in range(16)]
-
-    uni_dist = optuna.distributions.UniformDistribution(1.0, 100.0)
-    trial = multi_objective.trial.FrozenMultiObjectiveTrial(2, frozen_trial_factory(16, [0, 0]))
-    sampler = MOTPEMultiObjectiveSampler(seed=0)
-    attrs = MockSystemAttr()
-    with patch.object(study._storage, "get_all_trials", return_value=past_trials), patch.object(
-        study._storage, "set_trial_system_attr", side_effect=attrs.set_trial_system_attr
-    ), patch.object(study._storage, "get_trial", return_value=trial), patch(
-        "optuna.multi_objective.trial.MultiObjectiveTrial.system_attrs", new_callable=PropertyMock
-    ) as mock1, patch(
-        "optuna.multi_objective.trial.FrozenMultiObjectiveTrial.system_attrs",
-        new_callable=PropertyMock,
-    ) as mock2:
-        mock1.return_value = attrs.value
-        mock2.return_value = attrs.value
-        uniform_suggestion = sampler.sample_independent(study, trial, "param-a", uni_dist)
-    assert 1.0 <= uniform_suggestion < 100.0
-
-
-def test_sample_independent_log_uniform_distributions() -> None:
-    """Prepare sample from uniform distribution for cheking other distributions."""
-
-    study = optuna.multi_objective.create_study(directions=["minimize", "maximize"])
-    random.seed(128)
-
-    uni_dist = optuna.distributions.UniformDistribution(1.0, 100.0)
-    past_trials = [frozen_trial_factory(i, [random.random(), random.random()]) for i in range(16)]
-    trial = multi_objective.trial.FrozenMultiObjectiveTrial(2, frozen_trial_factory(16, [0, 0]))
-    sampler = MOTPEMultiObjectiveSampler(seed=0)
-    attrs = MockSystemAttr()
-    with patch.object(study._storage, "get_all_trials", return_value=past_trials), patch.object(
-        study._storage, "set_trial_system_attr", side_effect=attrs.set_trial_system_attr
-    ), patch.object(study._storage, "get_trial", return_value=trial), patch(
-        "optuna.multi_objective.trial.MultiObjectiveTrial.system_attrs", new_callable=PropertyMock
-    ) as mock1, patch(
-        "optuna.multi_objective.trial.FrozenMultiObjectiveTrial.system_attrs",
-        new_callable=PropertyMock,
-    ) as mock2:
-        mock1.return_value = attrs.value
-        mock2.return_value = attrs.value
-        uniform_suggestion = sampler.sample_independent(study, trial, "param-a", uni_dist)
-
-    # Test sample from log-uniform is different from uniform.
-    log_dist = optuna.distributions.LogUniformDistribution(1.0, 100.0)
-    past_trials = [
-        frozen_trial_factory(i, [random.random(), random.random()], log_dist) for i in range(16)
-    ]
-    trial = multi_objective.trial.FrozenMultiObjectiveTrial(2, frozen_trial_factory(16, [0, 0]))
-    sampler = MOTPEMultiObjectiveSampler(seed=0)
-    attrs = MockSystemAttr()
-    with patch.object(study._storage, "get_all_trials", return_value=past_trials), patch.object(
-        study._storage, "set_trial_system_attr", side_effect=attrs.set_trial_system_attr
-    ), patch.object(study._storage, "get_trial", return_value=trial), patch(
-        "optuna.multi_objective.trial.MultiObjectiveTrial.system_attrs", new_callable=PropertyMock
-    ) as mock1, patch(
-        "optuna.multi_objective.trial.FrozenMultiObjectiveTrial.system_attrs",
-        new_callable=PropertyMock,
-    ) as mock2:
-        mock1.return_value = attrs.value
-        mock2.return_value = attrs.value
-        loguniform_suggestion = sampler.sample_independent(study, trial, "param-a", log_dist)
-    assert 1.0 <= loguniform_suggestion < 100.0
-    assert uniform_suggestion != loguniform_suggestion
-
-
-def test_sample_independent_disrete_uniform_distributions() -> None:
-    """Test samples from discrete have expected intervals."""
-
-    study = optuna.multi_objective.create_study(directions=["minimize", "maximize"])
-    random.seed(128)
-
-    disc_dist = optuna.distributions.DiscreteUniformDistribution(1.0, 100.0, 0.1)
-
-    def value_fn(idx: int) -> float:
-        return int(random.random() * 1000) * 0.1
-
-    past_trials = [
-        frozen_trial_factory(
-            i, [random.random(), random.random()], dist=disc_dist, value_fn=value_fn
-        )
-        for i in range(16)
-    ]
-
-    trial = multi_objective.trial.FrozenMultiObjectiveTrial(2, frozen_trial_factory(16, [0, 0]))
-    sampler = MOTPEMultiObjectiveSampler(seed=0)
-    attrs = MockSystemAttr()
-    with patch.object(study._storage, "get_all_trials", return_value=past_trials), patch.object(
-        study._storage, "set_trial_system_attr", side_effect=attrs.set_trial_system_attr
-    ), patch.object(study._storage, "get_trial", return_value=trial), patch(
-        "optuna.multi_objective.trial.MultiObjectiveTrial.system_attrs", new_callable=PropertyMock
-    ) as mock1, patch(
-        "optuna.multi_objective.trial.FrozenMultiObjectiveTrial.system_attrs",
-        new_callable=PropertyMock,
-    ) as mock2:
-        mock1.return_value = attrs.value
-        mock2.return_value = attrs.value
-        discrete_uniform_suggestion = sampler.sample_independent(
-            study, trial, "param-a", disc_dist
-        )
-    assert 1.0 <= discrete_uniform_suggestion <= 100.0
-    assert abs(int(discrete_uniform_suggestion * 10) - discrete_uniform_suggestion * 10) < 1e-3
-
-
-def test_sample_independent_categorical_distributions() -> None:
-    """Test samples are drawn from the specified category."""
-
-    study = optuna.multi_objective.create_study(directions=["minimize", "maximize"])
-    random.seed(128)
-
-    categories = [i * 0.3 + 1.0 for i in range(330)]
-
-    def cat_value_fn(idx: int) -> float:
-        return categories[random.randint(0, len(categories) - 1)]
-
-    cat_dist = optuna.distributions.CategoricalDistribution(categories)
-    past_trials = [
-        frozen_trial_factory(
-            i, [random.random(), random.random()], dist=cat_dist, value_fn=cat_value_fn
-        )
-        for i in range(16)
-    ]
-
-    trial = multi_objective.trial.FrozenMultiObjectiveTrial(2, frozen_trial_factory(16, [0, 0]))
-    sampler = MOTPEMultiObjectiveSampler(seed=0)
-    attrs = MockSystemAttr()
-    with patch.object(study._storage, "get_all_trials", return_value=past_trials), patch.object(
-        study._storage, "set_trial_system_attr", side_effect=attrs.set_trial_system_attr
-    ), patch.object(study._storage, "get_trial", return_value=trial), patch(
-        "optuna.multi_objective.trial.MultiObjectiveTrial.system_attrs", new_callable=PropertyMock
-    ) as mock1, patch(
-        "optuna.multi_objective.trial.FrozenMultiObjectiveTrial.system_attrs",
-        new_callable=PropertyMock,
-    ) as mock2:
-        mock1.return_value = attrs.value
-        mock2.return_value = attrs.value
-        categorical_suggestion = sampler.sample_independent(study, trial, "param-a", cat_dist)
-    assert categorical_suggestion in categories
-
-
-def test_sample_int_uniform_distributions() -> None:
-    """Test sampling from int distribution returns integer."""
-
-    study = optuna.multi_objective.create_study(directions=["minimize", "maximize"])
-    random.seed(128)
-
-    def int_value_fn(idx: int) -> float:
-        return random.randint(0, 100)
-
-    int_dist = optuna.distributions.IntUniformDistribution(1, 100)
-    past_trials = [
-        frozen_trial_factory(
-            i, [random.random(), random.random()], dist=int_dist, value_fn=int_value_fn
-        )
-        for i in range(16)
-    ]
-
-    trial = multi_objective.trial.FrozenMultiObjectiveTrial(2, frozen_trial_factory(16, [0, 0]))
-    sampler = MOTPEMultiObjectiveSampler(seed=0)
-    attrs = MockSystemAttr()
-    with patch.object(study._storage, "get_all_trials", return_value=past_trials), patch.object(
-        study._storage, "set_trial_system_attr", side_effect=attrs.set_trial_system_attr
-    ), patch.object(study._storage, "get_trial", return_value=trial), patch(
-        "optuna.multi_objective.trial.MultiObjectiveTrial.system_attrs", new_callable=PropertyMock
-    ) as mock1, patch(
-        "optuna.multi_objective.trial.FrozenMultiObjectiveTrial.system_attrs",
-        new_callable=PropertyMock,
-    ) as mock2:
-        mock1.return_value = attrs.value
-        mock2.return_value = attrs.value
-        int_suggestion = sampler.sample_independent(study, trial, "param-a", int_dist)
-    assert 1 <= int_suggestion <= 100
-    assert isinstance(int_suggestion, int)
-
-
-@pytest.mark.parametrize(
-    "state",
-    [
-        (optuna.trial.TrialState.FAIL,),
-        (optuna.trial.TrialState.PRUNED,),
-        (optuna.trial.TrialState.RUNNING,),
-        (optuna.trial.TrialState.WAITING,),
-    ],
-)
-def test_sample_independent_handle_unsuccessful_states(state: optuna.trial.TrialState) -> None:
-    study = optuna.multi_objective.create_study(directions=["minimize", "maximize"])
-    dist = optuna.distributions.UniformDistribution(1.0, 100.0)
-    random.seed(128)
-
-    # Prepare sampling result for later tests.
-    past_trials = [frozen_trial_factory(i, [random.random(), random.random()]) for i in range(32)]
-
-    trial = multi_objective.trial.FrozenMultiObjectiveTrial(2, frozen_trial_factory(32, [0, 0]))
-    sampler = MOTPEMultiObjectiveSampler(seed=0)
-    attrs = MockSystemAttr()
-    with patch.object(study._storage, "get_all_trials", return_value=past_trials), patch.object(
-        study._storage, "set_trial_system_attr", side_effect=attrs.set_trial_system_attr
-    ), patch.object(study._storage, "get_trial", return_value=trial), patch(
-        "optuna.multi_objective.trial.MultiObjectiveTrial.system_attrs", new_callable=PropertyMock
-    ) as mock1, patch(
-        "optuna.multi_objective.trial.FrozenMultiObjectiveTrial.system_attrs",
-        new_callable=PropertyMock,
-    ) as mock2:
-        mock1.return_value = attrs.value
-        mock2.return_value = attrs.value
-        all_success_suggestion = sampler.sample_independent(study, trial, "param-a", dist)
-
-    # Test unsuccessful trials are handled differently.
-    state_fn = build_state_fn(state)
-    past_trials = [
-        frozen_trial_factory(i, [random.random(), random.random()], state_fn=state_fn)
-        for i in range(32)
-    ]
-
-    trial = multi_objective.trial.FrozenMultiObjectiveTrial(2, frozen_trial_factory(32, [0, 0]))
-    sampler = MOTPEMultiObjectiveSampler(seed=0)
-    attrs = MockSystemAttr()
-    with patch.object(study._storage, "get_all_trials", return_value=past_trials), patch.object(
-        study._storage, "set_trial_system_attr", side_effect=attrs.set_trial_system_attr
-    ), patch.object(study._storage, "get_trial", return_value=trial), patch(
-        "optuna.multi_objective.trial.MultiObjectiveTrial.system_attrs", new_callable=PropertyMock
-    ) as mock1, patch(
-        "optuna.multi_objective.trial.FrozenMultiObjectiveTrial.system_attrs",
-        new_callable=PropertyMock,
-    ) as mock2:
-        mock1.return_value = attrs.value
-        mock2.return_value = attrs.value
-        partial_unsuccessful_suggestion = sampler.sample_independent(study, trial, "param-a", dist)
-    assert partial_unsuccessful_suggestion != all_success_suggestion
-
-
-def test_sample_independent_ignored_states() -> None:
-    """Tests FAIL, RUNNING, and WAITING states are equally."""
-    study = optuna.multi_objective.create_study(directions=["minimize", "maximize"])
-    dist = optuna.distributions.UniformDistribution(1.0, 100.0)
-
-    suggestions = []
-    for state in [
-        optuna.trial.TrialState.FAIL,
-        optuna.trial.TrialState.RUNNING,
-        optuna.trial.TrialState.WAITING,
-    ]:
-        random.seed(128)
-        state_fn = build_state_fn(state)
-        past_trials = [
-            frozen_trial_factory(i, [random.random(), random.random()], state_fn=state_fn)
-            for i in range(32)
-        ]
-        trial = multi_objective.trial.FrozenMultiObjectiveTrial(
-            2, frozen_trial_factory(32, [0, 0])
-        )
-        sampler = MOTPEMultiObjectiveSampler(seed=0)
-    attrs = MockSystemAttr()
-    with patch.object(study._storage, "get_all_trials", return_value=past_trials), patch.object(
-        study._storage, "set_trial_system_attr", side_effect=attrs.set_trial_system_attr
-    ), patch.object(study._storage, "get_trial", return_value=trial), patch(
-        "optuna.multi_objective.trial.MultiObjectiveTrial.system_attrs", new_callable=PropertyMock
-    ) as mock1, patch(
-        "optuna.multi_objective.trial.FrozenMultiObjectiveTrial.system_attrs",
-        new_callable=PropertyMock,
-    ) as mock2:
-        mock1.return_value = attrs.value
-        mock2.return_value = attrs.value
-        suggestions.append(sampler.sample_independent(study, trial, "param-a", dist))
-
-    assert len(set(suggestions)) == 1
-
-
-def test_get_observation_pairs() -> None:
-    def objective(trial: optuna.multi_objective.trial.Trial) -> Tuple[float, float]:
-        trial.suggest_int("x", 5, 5)
-        return 5.0, 5.0
-
-    sampler = MOTPEMultiObjectiveSampler(seed=0)
-    study = optuna.multi_objective.create_study(
-        directions=["minimize", "maximize"], sampler=sampler
-    )
-    study.optimize(objective, n_trials=5)
-
-    assert _motpe._get_observation_pairs(study, "x") == (
-        [5.0, 5.0, 5.0, 5.0, 5.0],
-        [[5.0, -5.0], [5.0, -5.0], [5.0, -5.0], [5.0, -5.0], [5.0, -5.0]],
-    )
-    assert _motpe._get_observation_pairs(study, "y") == (
-        [None, None, None, None, None],
-        [[5.0, -5.0], [5.0, -5.0], [5.0, -5.0], [5.0, -5.0], [5.0, -5.0]],
-    )
-
-
-def test_calculate_nondomination_rank() -> None:
-    # Single objective
-    test_case = np.asarray([[10], [20], [20], [30]])
-    ranks = list(_motpe._calculate_nondomination_rank(test_case))
-    assert ranks == [0, 1, 1, 2]
-
-    # Two objectives
-    test_case = np.asarray([[10, 30], [10, 10], [20, 20], [30, 10], [15, 15]])
-    ranks = list(_motpe._calculate_nondomination_rank(test_case))
-    assert ranks == [1, 0, 2, 1, 1]
-
-    # Three objectives
-    test_case = np.asarray([[5, 5, 4], [5, 5, 5], [9, 9, 0], [5, 7, 5], [0, 0, 9], [0, 9, 9]])
-    ranks = list(_motpe._calculate_nondomination_rank(test_case))
-    assert ranks == [0, 1, 0, 2, 0, 1]
-
-
-def test_solve_hssp() -> None:
-    sampler = MOTPEMultiObjectiveSampler(seed=0)
-
-    random.seed(128)
-
-    # Two dimensions
-    for i in range(8):
-        subset_size = int(random.random() * i) + 1
-        test_case = np.asarray([[random.random(), random.random()] for _ in range(8)])
-        r = 1.1 * np.max(test_case, axis=0)
-        truth = 0.0
-        for subset in itertools.permutations(test_case, subset_size):
-            truth = max(truth, sampler._compute_hypervolume(np.asarray(subset), r))
-        indices = sampler._solve_hssp(test_case, np.arange(len(test_case)), subset_size, r)
-        approx = sampler._compute_hypervolume(test_case[indices], r)
-        assert approx / truth > 0.6321  # 1 - 1/e
-
-    # Three dimensions
-    for i in range(8):
-        subset_size = int(random.random() * i) + 1
-        test_case = np.asarray(
-            [[random.random(), random.random(), random.random()] for _ in range(8)]
-        )
-        r = 1.1 * np.max(test_case, axis=0)
-        truth = 0
-        for subset in itertools.permutations(test_case, subset_size):
-            truth = max(truth, sampler._compute_hypervolume(np.asarray(subset), r))
-        indices = sampler._solve_hssp(test_case, np.arange(len(test_case)), subset_size, r)
-        approx = sampler._compute_hypervolume(test_case[indices], r)
-        assert approx / truth > 0.6321  # 1 - 1/e
+        _ = sampler.sample_independent(study, trial, "param-a", dist)
 
 
 def frozen_trial_factory(
@@ -611,9 +85,6 @@ def frozen_trial_factory(
         1.0, 100.0
     ),
     value_fn: Optional[Callable[[int], Union[int, float]]] = None,
-    state_fn: Callable[
-        [int], optuna.trial.TrialState
-    ] = lambda _: optuna.trial.TrialState.COMPLETE,
 ) -> multi_objective.trial.FrozenTrial:
     if value_fn is None:
         value = random.random() * 99.0 + 1.0
@@ -634,22 +105,3 @@ def frozen_trial_factory(
         intermediate_values=dict(enumerate(values)),
     )
     return trial
-
-
-def build_state_fn(state: optuna.trial.TrialState) -> Callable[[int], optuna.trial.TrialState]:
-    def state_fn(idx: int) -> optuna.trial.TrialState:
-        return [optuna.trial.TrialState.COMPLETE, state][idx % 2]
-
-    return state_fn
-
-
-def test_reseed_rng() -> None:
-    sampler = MOTPEMultiObjectiveSampler()
-    original_seed = sampler._rng.seed
-
-    with patch.object(
-        sampler._mo_random_sampler, "reseed_rng", wraps=sampler._mo_random_sampler.reseed_rng
-    ) as mock_object:
-        sampler.reseed_rng()
-        assert mock_object.call_count == 1
-        assert original_seed != sampler._rng.seed


### PR DESCRIPTION
Part of works for #2614.

## Motivation
The `optuna.multi_objective.samplers.MOTPEMultiObjectiveSampler` is deprecated but its implementation is redundant for `optuna.samplers.MOTPESampler`. This PR aims to eliminate that redundancy by making the former a thin wrapper for the latter.

## Description of the changes
- Make `MOTPEMultiObjectiveSampler` a thin wrapper for `MOTPESampler`.
- Simplify the tests of `MOTPEMultiObjectiveSampler`.
