### PR TITLE
Round objective values of `LightGBMTuner` and `LightGBMTunerCV` for reproducibility.

### DIFF
--- a/optuna/integration/_lightgbm_tuner/optimize.py
+++ b/optuna/integration/_lightgbm_tuner/optimize.py
@@ -41,9 +41,14 @@ _ELAPSED_SECS_KEY = "lightgbm_tuner:elapsed_secs"
 _AVERAGE_ITERATION_TIME_KEY = "lightgbm_tuner:average_iteration_time"
 _STEP_NAME_KEY = "lightgbm_tuner:step_name"
 _LGBM_PARAMS_KEY = "lightgbm_tuner:lgbm_params"
+_LGBM_ORIGINAL_SCORE = "lightgbm_tuner:original_score"
 
 # EPS is used to ensure that a sampled parameter value is in pre-defined value range.
 _EPS = 1e-12
+
+# The scores returned by LightGBM may fluctuate at the last digits.
+# For reproducibility, LightGBM Tuner rounds them at the following digit.
+ROUND_NDIGITS = 14
 
 # Default value of tree_depth, used for upper bound of num_leaves.
 _DEFAULT_TUNER_TREE_DEPTH = 8
@@ -264,7 +269,9 @@ class _OptunaObjective(_BaseTuner):
 
         self._postprocess(trial, elapsed_secs, average_iteration_time)
 
-        return val_score
+        trial.set_system_attr(_LGBM_ORIGINAL_SCORE, val_score)
+
+        return round(val_score, ROUND_NDIGITS)
 
     def _postprocess(
         self, trial: optuna.trial.Trial, elapsed_secs: float, average_iteration_time: float
@@ -340,7 +347,9 @@ class _OptunaObjectiveCV(_OptunaObjective):
 
         self._postprocess(trial, elapsed_secs, average_iteration_time)
 
-        return val_score
+        trial.set_system_attr(_LGBM_ORIGINAL_SCORE, val_score)
+
+        return round(val_score, ROUND_NDIGITS)
 
 
 class _LightGBMBaseTuner(_BaseTuner):

--- a/tests/integration_tests/lightgbm_tuner_tests/test_optimize.py
+++ b/tests/integration_tests/lightgbm_tuner_tests/test_optimize.py
@@ -18,6 +18,7 @@ from sklearn.model_selection import train_test_split
 
 import optuna
 from optuna.integration._lightgbm_tuner.optimize import _BaseTuner
+from optuna.integration._lightgbm_tuner.optimize import _LGBM_ORIGINAL_SCORE
 from optuna.integration._lightgbm_tuner.optimize import _OptunaObjective
 from optuna.integration._lightgbm_tuner.optimize import _OptunaObjectiveCV
 from optuna.integration._lightgbm_tuner.optimize import LightGBMTuner
@@ -755,6 +756,9 @@ class TestLightGBMTuner(object):
         tuner_first_try.run()
         best_score_first_try = tuner_first_try.best_score
 
+        original_score = tuner_first_try.study.best_trial.system_attrs[_LGBM_ORIGINAL_SCORE]
+        assert abs(original_score - best_score_first_try) < 1e-13
+
         tuner_second_try = lgb.LightGBMTuner(
             params,
             train,
@@ -764,6 +768,9 @@ class TestLightGBMTuner(object):
         )
         tuner_second_try.run()
         best_score_second_try = tuner_second_try.best_score
+
+        original_score = tuner_second_try.study.best_trial.system_attrs[_LGBM_ORIGINAL_SCORE]
+        assert abs(original_score - best_score_second_try) < 1e-13
 
         assert best_score_second_try == best_score_first_try
 
@@ -1067,6 +1074,9 @@ class TestLightGBMTunerCV(object):
         tuner_first_try.run()
         best_score_first_try = tuner_first_try.best_score
 
+        original_score = tuner_first_try.study.best_trial.system_attrs[_LGBM_ORIGINAL_SCORE]
+        assert abs(original_score - best_score_first_try) < 1e-13
+
         tuner_second_try = lgb.LightGBMTunerCV(
             params,
             train,
@@ -1076,5 +1086,8 @@ class TestLightGBMTunerCV(object):
         )
         tuner_second_try.run()
         best_score_second_try = tuner_second_try.best_score
+
+        original_score = tuner_second_try.study.best_trial.system_attrs[_LGBM_ORIGINAL_SCORE]
+        assert abs(original_score - best_score_second_try) < 1e-13
 
         assert best_score_second_try == best_score_first_try


### PR DESCRIPTION
## Motivation

This PR is related to #2620. LightGBM sometimes returns slightly different scores, and `LightGBMTuner` loses the reproducibility due to the differences of objective value history.

## Description of the changes

This PR applies `round` to ignore such differences and keep the original scores in the system attrs.

## Opinion wanted

I'm not sure if this workaround works when the score is quite small like `1e-10`, but I believe that the usual scores are as large as 1e-2.