### PR TITLE
Add `deterministic` parameter to make LightGBM training reproducible

### DIFF
--- a/optuna/integration/_lightgbm_tuner/optimize.py
+++ b/optuna/integration/_lightgbm_tuner/optimize.py
@@ -792,8 +792,13 @@ class LightGBMTuner(_LightGBMBaseTuner):
             that affects sampling for ``num_leaves``, ``bagging_fraction``, ``bagging_freq``,
             ``lambda_l1``, and ``lambda_l2``.
 
+            .. note::
+                The `deterministic`_ parameter of LightGBM makes training reproducible.
+                Please enable it when you use this argument.
+
     .. _lightgbm.train(): https://lightgbm.readthedocs.io/en/latest/pythonapi/lightgbm.train.html
     .. _LightGBM's verbosity: https://lightgbm.readthedocs.io/en/latest/Parameters.html#verbosity
+    .. _deterministic: https://lightgbm.readthedocs.io/en/latest/Parameters.html#deterministic
     """
 
     def __init__(

--- a/optuna/integration/_lightgbm_tuner/optimize.py
+++ b/optuna/integration/_lightgbm_tuner/optimize.py
@@ -962,9 +962,14 @@ class LightGBMTunerCV(_LightGBMBaseTuner):
             that affects sampling for ``num_leaves``, ``bagging_fraction``, ``bagging_freq``,
             ``lambda_l1``, and ``lambda_l2``.
 
+            .. note::
+                The `deterministic`_ parameter of LightGBM makes training reproducible.
+                Please enable it when you use this argument.
+
     .. _lightgbm.train(): https://lightgbm.readthedocs.io/en/latest/pythonapi/lightgbm.train.html
     .. _lightgbm.cv(): https://lightgbm.readthedocs.io/en/latest/pythonapi/lightgbm.cv.html
     .. _LightGBM's verbosity: https://lightgbm.readthedocs.io/en/latest/Parameters.html#verbosity
+    .. _deterministic: https://lightgbm.readthedocs.io/en/latest/Parameters.html#deterministic
     """
 
     def __init__(

--- a/tests/integration_tests/lightgbm_tuner_tests/test_optimize.py
+++ b/tests/integration_tests/lightgbm_tuner_tests/test_optimize.py
@@ -743,7 +743,13 @@ class TestLightGBMTuner(object):
 
         train = lgb.Dataset(X_trainval, y_trainval)
         valid = lgb.Dataset(X_test, y_test)
-        params = {"objective": "regression", "metric": "rmse", "random_seed": 0, "deterministic": True, "verbosity": -1}
+        params = {
+            "objective": "regression",
+            "metric": "rmse",
+            "random_seed": 0,
+            "deterministic": True,
+            "verbosity": -1,
+        }
 
         tuner_first_try = lgb.LightGBMTuner(
             params,
@@ -1055,7 +1061,13 @@ class TestLightGBMTunerCV(object):
         )
 
         train = lgb.Dataset(X_trainval, y_trainval)
-        params = {"objective": "regression", "metric": "rmse", "random_seed": 0, "deterministic": True, "verbosity": -1}
+        params = {
+            "objective": "regression",
+            "metric": "rmse",
+            "random_seed": 0,
+            "deterministic": True,
+            "verbosity": -1,
+        }
 
         tuner_first_try = lgb.LightGBMTunerCV(
             params,

--- a/tests/integration_tests/lightgbm_tuner_tests/test_optimize.py
+++ b/tests/integration_tests/lightgbm_tuner_tests/test_optimize.py
@@ -743,7 +743,7 @@ class TestLightGBMTuner(object):
 
         train = lgb.Dataset(X_trainval, y_trainval)
         valid = lgb.Dataset(X_test, y_test)
-        params = {"objective": "regression", "metric": "rmse", "random_seed": 0}
+        params = {"objective": "regression", "metric": "rmse", "random_seed": 0, "deterministic": True, "verbosity": -1}
 
         tuner_first_try = lgb.LightGBMTuner(
             params,
@@ -1055,7 +1055,7 @@ class TestLightGBMTunerCV(object):
         )
 
         train = lgb.Dataset(X_trainval, y_trainval)
-        params = {"objective": "regression", "metric": "rmse", "random_seed": 0}
+        params = {"objective": "regression", "metric": "rmse", "random_seed": 0, "deterministic": True, "verbosity": -1}
 
         tuner_first_try = lgb.LightGBMTunerCV(
             params,


### PR DESCRIPTION
## Motivation

This PR is related to #2620.

## Description of the changes

- Add the `deterministic` parameter of LightGBM in the test cases of the `optuna_seed` argument of `LightGBMTuner`.
- Add note to the docstring of `optuna_seed`