### PR TITLE
add params in test_tune_best_score_reproducibility to avoid numerical…

### DIFF
--- a/tests/integration_tests/lightgbm_tuner_tests/test_optimize.py
+++ b/tests/integration_tests/lightgbm_tuner_tests/test_optimize.py
@@ -748,6 +748,7 @@ class TestLightGBMTuner(object):
             "metric": "rmse",
             "random_seed": 0,
             "deterministic": True,
+            "force_col_wise": True,
             "verbosity": -1,
         }
 
@@ -1066,6 +1067,7 @@ class TestLightGBMTunerCV(object):
             "metric": "rmse",
             "random_seed": 0,
             "deterministic": True,
+            "force_col_wise": True,
             "verbosity": -1,
         }
 


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
This PR is related to #2623.
## Description of the changes
<!-- Describe the changes in this PR. -->
- Add the force_col_wise parameter of LightGBM in the test cases of the optuna_seed argument of LightGBMTuner and LightGBMTuner CV.