### PR TITLE
Implement `PatientPruner`

### DIFF
--- a/docs/source/reference/pruners.rst
+++ b/docs/source/reference/pruners.rst
@@ -12,6 +12,7 @@ The :mod:`~optuna.pruners` module defines a :class:`~optuna.pruners.BasePruner` 
    optuna.pruners.BasePruner
    optuna.pruners.MedianPruner
    optuna.pruners.NopPruner
+   optuna.pruners.PatientPruner
    optuna.pruners.PercentilePruner
    optuna.pruners.SuccessiveHalvingPruner
    optuna.pruners.HyperbandPruner

--- a/optuna/pruners/__init__.py
+++ b/optuna/pruners/__init__.py
@@ -4,6 +4,7 @@ from optuna.pruners._base import BasePruner
 from optuna.pruners._hyperband import HyperbandPruner
 from optuna.pruners._median import MedianPruner
 from optuna.pruners._nop import NopPruner
+from optuna.pruners._patient import PatientPruner
 from optuna.pruners._percentile import PercentilePruner
 from optuna.pruners._successive_halving import SuccessiveHalvingPruner
 from optuna.pruners._threshold import ThresholdPruner
@@ -19,6 +20,7 @@ __all__ = [
     "HyperbandPruner",
     "MedianPruner",
     "NopPruner",
+    "PatientPruner",
     "PercentilePruner",
     "SuccessiveHalvingPruner",
     "ThresholdPruner",

--- a/optuna/pruners/_patient.py
+++ b/optuna/pruners/_patient.py
@@ -104,7 +104,7 @@ class PatientPruner(BasePruner):
                 scores_after_patience
             )
         else:
-            maybe_prune = np.max(scores_before_patience) + self._min_delta > np.min(
+            maybe_prune = np.max(scores_before_patience) + self._min_delta > np.max(
                 scores_after_patience
             )
 

--- a/optuna/pruners/_patient.py
+++ b/optuna/pruners/_patient.py
@@ -61,8 +61,8 @@ class PatientPruner(BasePruner):
             ``patience`` consecutive steps.
         min_delta:
             Tolerance value to check whether or not the objective improves.
-            This value should be non-negative for minimization,
-            and it should be non-positive for maximization.
+            This value should be non-negative.
+
     """
 
     def __init__(
@@ -71,6 +71,9 @@ class PatientPruner(BasePruner):
 
         if patience < 0:
             raise ValueError(f"patience cannot be negative but got {patience}.")
+
+        if min_delta < 0:
+            raise ValueError(f"min_delta cannot be negative but got {min_delta}.")
 
         self._wrapped_pruner = wrapped_pruner
         self._patience = patience
@@ -106,7 +109,7 @@ class PatientPruner(BasePruner):
                 scores_after_patience
             )
         else:
-            maybe_prune = np.nanmax(scores_before_patience) + self._min_delta > np.nanmax(
+            maybe_prune = np.nanmax(scores_before_patience) - self._min_delta > np.nanmax(
                 scores_after_patience
             )
 

--- a/optuna/pruners/_patient.py
+++ b/optuna/pruners/_patient.py
@@ -44,12 +44,10 @@ class PatientPruner(BasePruner):
 
                 return clf.score(X_valid, y_valid)
 
+
             study = optuna.create_study(
                 direction="maximize",
-                pruner=optuna.pruners.PatientPruner(
-                    optuna.pruners.MedianPruner(),
-                    patience=1
-                ),
+                pruner=optuna.pruners.PatientPruner(optuna.pruners.MedianPruner(), patience=1),
             )
             study.optimize(objective, n_trials=20)
 

--- a/optuna/pruners/_patient.py
+++ b/optuna/pruners/_patient.py
@@ -1,0 +1,119 @@
+from typing import Optional
+
+import numpy as np
+
+import optuna
+from optuna._experimental import experimental
+from optuna._study_direction import StudyDirection
+from optuna.pruners import BasePruner
+
+
+@experimental("2.8.0")
+class PatientPruner(BasePruner):
+    """Pruner which wraps another pruner with tolerance.
+
+    Example:
+
+        .. testcode::
+
+            import numpy as np
+            from sklearn.datasets import load_iris
+            from sklearn.linear_model import SGDClassifier
+            from sklearn.model_selection import train_test_split
+
+            import optuna
+
+            X, y = load_iris(return_X_y=True)
+            X_train, X_valid, y_train, y_valid = train_test_split(X, y)
+            classes = np.unique(y)
+
+
+            def objective(trial):
+                alpha = trial.suggest_float("alpha", 0.0, 1.0)
+                clf = SGDClassifier(alpha=alpha)
+                n_train_iter = 100
+
+                for step in range(n_train_iter):
+                    clf.partial_fit(X_train, y_train, classes=classes)
+
+                    intermediate_value = clf.score(X_valid, y_valid)
+                    trial.report(intermediate_value, step)
+
+                    if trial.should_prune():
+                        raise optuna.TrialPruned()
+
+                return clf.score(X_valid, y_valid)
+
+            study = optuna.create_study(
+                direction="maximize",
+                pruner=optuna.pruners.PatientPruner(
+                    optuna.pruners.MedianPruner(),
+                    patience=1
+                ),
+            )
+            study.optimize(objective, n_trials=20)
+
+    Args:
+        wrapped_pruner:
+            Wrapped pruner to perform pruning when ``PatientPruner`` allows a
+            trial to be pruned. If it is :obj:`None`, this pruner is equivalent to
+            early-stopping taken the intermediate values in the individual trial.
+        patience:
+            Pruning is disabled until the objective doesn't improve for
+            ``patience`` consecutive steps.
+        min_delta:
+            Tolerance value to check whether or not the objective improves.
+            This value should be non-negative for minimization,
+            and it should be non-positive for maximization.
+    """
+
+    def __init__(
+        self, wrapped_pruner: Optional[BasePruner], patience: int, min_delta: float = 0.0
+    ) -> None:
+
+        if patience < 0:
+            raise ValueError("patience cannot be negative but got {}.".format(patience))
+
+        self.wrapped_pruner = wrapped_pruner
+        self._patience = patience
+        self._min_delta = min_delta
+
+    def prune(self, study: "optuna.study.Study", trial: "optuna.trial.FrozenTrial") -> bool:
+
+        intermediate_values = trial.intermediate_values
+
+        steps = np.asarray(list(intermediate_values.keys()))
+
+        # Do not prune if number of step to determine are insufficient.
+        if steps.size < self._patience + 1:
+            return False
+
+        steps.sort()
+        # This is the score patience steps ago
+        steps_before_patience = steps[: -self._patience]
+        scores_before_patience = np.asarray(
+            list(intermediate_values[step] for step in steps_before_patience)
+        )
+        # And these are the scores after that
+        steps_after_patience = steps[-self._patience :]
+        scores_after_patience = np.asarray(
+            list(intermediate_values[step] for step in steps_after_patience)
+        )
+
+        direction = study.direction
+        if direction == StudyDirection.MINIMIZE:
+            maybe_prune = np.min(scores_before_patience) - self._min_delta < np.min(
+                scores_after_patience
+            )
+        else:
+            maybe_prune = np.max(scores_before_patience) + self._min_delta > np.min(
+                scores_after_patience
+            )
+
+        if maybe_prune:
+            if self.wrapped_pruner is not None:
+                return self.wrapped_pruner.prune(study, trial)
+            else:
+                return True
+        else:
+            return False

--- a/optuna/pruners/_patient.py
+++ b/optuna/pruners/_patient.py
@@ -70,7 +70,7 @@ class PatientPruner(BasePruner):
     ) -> None:
 
         if patience < 0:
-            raise ValueError("patience cannot be negative but got {}.".format(patience))
+            raise ValueError(f"patience cannot be negative but got {patience}.")
 
         self._wrapped_pruner = wrapped_pruner
         self._patience = patience

--- a/optuna/pruners/_patient.py
+++ b/optuna/pruners/_patient.py
@@ -53,7 +53,7 @@ class PatientPruner(BasePruner):
 
     Args:
         wrapped_pruner:
-            Wrapped pruner to perform pruning when ``PatientPruner`` allows a
+            Wrapped pruner to perform pruning when :class:`~optuna.pruners.PatientPruner` allows a
             trial to be pruned. If it is :obj:`None`, this pruner is equivalent to
             early-stopping taken the intermediate values in the individual trial.
         patience:

--- a/tests/pruners_tests/test_patient.py
+++ b/tests/pruners_tests/test_patient.py
@@ -1,10 +1,6 @@
-from typing import List
-from typing import Tuple
-
 import pytest
 
 import optuna
-from optuna.trial import TrialState
 
 
 def test_patient_pruner_patience() -> None:

--- a/tests/pruners_tests/test_patient.py
+++ b/tests/pruners_tests/test_patient.py
@@ -19,6 +19,15 @@ def test_patient_pruner_patience() -> None:
         optuna.pruners.PatientPruner(None, -1)
 
 
+def test_patient_pruner_min_delta() -> None:
+
+    optuna.pruners.PatientPruner(None, 0, 0.0)
+    optuna.pruners.PatientPruner(None, 0, 1.0)
+
+    with pytest.raises(ValueError):
+        optuna.pruners.PatientPruner(None, 0, -1)
+
+
 def test_patient_pruner_with_one_trial() -> None:
 
     pruner = optuna.pruners.PatientPruner(None, 0)
@@ -60,8 +69,8 @@ def test_patient_pruner_intermediate_values_nan() -> None:
         (1, 0, "maximize", [2, 1, 0], [2]),
         (0, 0, "minimize", [0, 1], [1]),
         (1, 0, "minimize", [0, 1, 2], [2]),
-        (0, -1.0, "maximize", [1, 0], []),
-        (1, -1.0, "maximize", [3, 2, 1, 0], [3]),
+        (0, 1.0, "maximize", [1, 0], []),
+        (1, 1.0, "maximize", [3, 2, 1, 0], [3]),
         (0, 1.0, "minimize", [0, 1], []),
         (1, 1.0, "minimize", [0, 1, 2, 3], [3]),
     ],

--- a/tests/pruners_tests/test_patient.py
+++ b/tests/pruners_tests/test_patient.py
@@ -1,3 +1,5 @@
+from typing import List
+
 import pytest
 
 import optuna
@@ -17,7 +19,7 @@ def test_patient_pruner_with_one_trial() -> None:
     pruner = optuna.pruners.PatientPruner(None, 0)
     study = optuna.study.create_study(pruner=pruner)
     trial = study.ask()
-    trial.report(1, 1)
+    trial.report(1, 0)
 
     # The pruner is not activated at a first trial.
     assert not trial.should_prune()
@@ -33,18 +35,47 @@ def test_patient_pruner_intermediate_values_nan() -> None:
     # A pruner is not activated if a trial does not have any intermediate values.
     assert not trial.should_prune()
 
-    trial.report(float("nan"), 1)
+    trial.report(float("nan"), 0)
     # A pruner is not activated if a trial has only one intermediate value.
+    assert not trial.should_prune()
+
+    trial.report(1.0, 1)
+    # A pruner is not activated if a trial has only nan in intermediate values.
     assert not trial.should_prune()
 
     trial.report(float("nan"), 2)
     # A pruner is not activated if a trial has only nan in intermediate values.
     assert not trial.should_prune()
 
-    trial.report(1.0, 3)
-    # A pruner is not activated if a trial has only nan in intermediate values.
-    assert not trial.should_prune()
 
-    trial.report(float("nan"), 3)
-    # A pruner is not activated if a trial has only nan in intermediate values.
-    assert not trial.should_prune()
+@pytest.mark.parametrize(
+    "patience,min_delta,direction,intermediates,expected_prune_steps",
+    [
+        (0, 0, "maximize", [1, 0], [1]),
+        (1, 0, "maximize", [2, 1, 0], [2]),
+        (0, 0, "minimize", [0, 1], [1]),
+        (1, 0, "minimize", [0, 1, 2], [2]),
+        (0, -1.0, "maximize", [1, 0], []),
+        (1, -1.0, "maximize", [3, 2, 1, 0], [3]),
+        (0, 1.0, "minimize", [0, 1], []),
+        (1, 1.0, "minimize", [0, 1, 2, 3], [3]),
+    ],
+)
+def test_patient_pruner_intermediate_values(
+    patience: int,
+    min_delta: float,
+    direction: str,
+    intermediates: List[int],
+    expected_prune_steps: List[int],
+) -> None:
+    pruner = optuna.pruners.PatientPruner(None, patience, min_delta)
+    study = optuna.study.create_study(pruner=pruner, direction=direction)
+
+    trial = study.ask()
+
+    pruned = []
+    for step, value in enumerate(intermediates):
+        trial.report(value, step)
+        if trial.should_prune():
+            pruned.append(step)
+    assert pruned == expected_prune_steps

--- a/tests/pruners_tests/test_patient.py
+++ b/tests/pruners_tests/test_patient.py
@@ -1,0 +1,54 @@
+from typing import List
+from typing import Tuple
+
+import pytest
+
+import optuna
+from optuna.trial import TrialState
+
+
+def test_patient_pruner_patience() -> None:
+
+    optuna.pruners.PatientPruner(None, 0)
+    optuna.pruners.PatientPruner(None, 1)
+
+    with pytest.raises(ValueError):
+        optuna.pruners.PatientPruner(None, -1)
+
+
+def test_patient_pruner_with_one_trial() -> None:
+
+    pruner = optuna.pruners.PatientPruner(None, 0)
+    study = optuna.study.create_study(pruner=pruner)
+    trial = study.ask()
+    trial.report(1, 1)
+
+    # The pruner is not activated at a first trial.
+    assert not trial.should_prune()
+
+
+def test_patient_pruner_intermediate_values_nan() -> None:
+
+    pruner = optuna.pruners.PatientPruner(None, 0, 0)
+    study = optuna.study.create_study(pruner=pruner)
+
+    trial = study.ask()
+
+    # A pruner is not activated if a trial does not have any intermediate values.
+    assert not trial.should_prune()
+
+    trial.report(float("nan"), 1)
+    # A pruner is not activated if a trial has only one intermediate value.
+    assert not trial.should_prune()
+
+    trial.report(float("nan"), 2)
+    # A pruner is not activated if a trial has only nan in intermediate values.
+    assert not trial.should_prune()
+
+    trial.report(1.0, 3)
+    # A pruner is not activated if a trial has only nan in intermediate values.
+    assert not trial.should_prune()
+
+    trial.report(float("nan"), 3)
+    # A pruner is not activated if a trial has only nan in intermediate values.
+    assert not trial.should_prune()

--- a/tests/pruners_tests/test_patient.py
+++ b/tests/pruners_tests/test_patient.py
@@ -5,6 +5,11 @@ import pytest
 import optuna
 
 
+def test_patient_pruner_experimental_warning() -> None:
+    with pytest.warns(optuna.exceptions.ExperimentalWarning):
+        optuna.pruners.PatientPruner(None, 0)
+
+
 def test_patient_pruner_patience() -> None:
 
     optuna.pruners.PatientPruner(None, 0)


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

Optuna's pruners sometimes prune a trial too aggressively. So, if the objective looks like a noisy loss curve over steps, this aggressive pruning is undesirable because the pruner prunes a promising trial.

For example

- the validation accuracy on neural networks especially, with stochastic procedures; stochastic gradient, dropout, data-augmentation, etc.
- online optimisation

To address this issue, this pull request introduces a wrapper class, `PatientPruner`, of Optuna's pruners based on the discussion in #1447.


`PatientPruner` calls the wrapped pruner the objective function does not improve for `patience` consecutive steps. 

Without `wrapped`, `PatientPruner` can be viewed as the early-stopping mechanism. So the default parameters follow the convention of neural network frameworks such as [`Pytorch ignite`](https://pytorch.org/ignite/master/generated/ignite.handlers.early_stopping.EarlyStopping.html) or [Keras](https://keras.io/api/callbacks/early_stopping/).


Please see #1447 for more details.

## Description of the changes
<!-- Describe the changes in this PR. -->

- [x] Implement PatientPruner
- [x] Documentation
- [x] Add test
