### PR TITLE
Install blackdoc in `formats.sh`

### DIFF
--- a/formats.sh
+++ b/formats.sh
@@ -9,6 +9,9 @@ missing_dependencies=()
 if [ ! "$(echo $res_pip_list | grep black)" ] ; then
   missing_dependencies+=(black)
 fi
+if [ ! "$(echo $res_pip_list | grep blackdoc)" ] ; then
+  missing_dependencies+=(blackdoc)
+fi
 if [ ! "$(echo $res_pip_list | grep flake8)" ] ; then
   missing_dependencies+=(hacking)
 fi


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

In my understanding, `blackdoc` won't be installed in `formats.sh` if `blackdoc` isn't installed. In addition, even if `blackdoc` isn't installed, `formats.sh` says `blackdoc succeeded.`. It might confuse some contributors.

## Description of the changes
<!-- Describe the changes in this PR. -->

Install `blackdoc` in `formats.sh` if it is missing.


## Examples

### Master branch

```zsh
$ pip uninstall isort mypy black blackdoc flake8

$ ./formats.sh
The following dependencies are missing: black hacking isort
Would you like to install the missing dependencies? (y/N): y
Collecting black
  Using cached black-21.4b2-py3-none-any.whl (130 kB)
Requirement already satisfied: hacking in /opt/homebrew/Caskroom/miniconda/base/envs/optuna/lib/python3.8/site-packages (4.1.0)
Collecting isort
  Using cached isort-5.8.0-py3-none-any.whl (103 kB)
Requirement already satisfied: mypy-extensions>=0.4.3 in /opt/homebrew/Caskroom/miniconda/base/envs/optuna/lib/python3.8/site-packages (from black) (0.4.3)
Requirement already satisfied: toml>=0.10.1 in /opt/homebrew/Caskroom/miniconda/base/envs/optuna/lib/python3.8/site-packages (from black) (0.10.2)
Requirement already satisfied: regex>=2020.1.8 in /opt/homebrew/Caskroom/miniconda/base/envs/optuna/lib/python3.8/site-packages (from black) (2021.4.4)
Requirement already satisfied: appdirs in /opt/homebrew/Caskroom/miniconda/base/envs/optuna/lib/python3.8/site-packages (from black) (1.4.4)
Requirement already satisfied: click>=7.1.2 in /opt/homebrew/Caskroom/miniconda/base/envs/optuna/lib/python3.8/site-packages (from black) (7.1.2)
Requirement already satisfied: pathspec<1,>=0.8.1 in /opt/homebrew/Caskroom/miniconda/base/envs/optuna/lib/python3.8/site-packages (from black) (0.8.1)
Collecting flake8<3.9.0,>=3.8.0
  Using cached flake8-3.8.4-py2.py3-none-any.whl (72 kB)
Requirement already satisfied: mccabe<0.7.0,>=0.6.0 in /opt/homebrew/Caskroom/miniconda/base/envs/optuna/lib/python3.8/site-packages (from flake8<3.9.0,>=3.8.0->hacking) (0.6.1)
Requirement already satisfied: pyflakes<2.3.0,>=2.2.0 in /opt/homebrew/Caskroom/miniconda/base/envs/optuna/lib/python3.8/site-packages (from flake8<3.9.0,>=3.8.0->hacking) (2.2.0)
Requirement already satisfied: pycodestyle<2.7.0,>=2.6.0a1 in /opt/homebrew/Caskroom/miniconda/base/envs/optuna/lib/python3.8/site-packages (from flake8<3.9.0,>=3.8.0->hacking) (2.6.0)
Installing collected packages: flake8, isort, black
Successfully installed black-21.4b2 flake8-3.8.4 isort-5.8.0
black succeeded.
blackdoc succeeded.
flake8 succeeded.
isort succeeded.

$ blackdoc
zsh: command not found: blackdoc
```

### This PR

```zsh
./formats.sh
The following dependencies are missing: black blackdoc hacking isort
Would you like to install the missing dependencies? (y/N):
...
```


## Sidenote

If I remove `black` after running `formats.sh`, similar issue might happen: `black` is not applied to the codebase but `formats.sh` says `black succeeded.`.
