### PR TITLE
Support multi-objective optimization in CLI (`optuna create-study`)

### DIFF
--- a/optuna/cli.py
+++ b/optuna/cli.py
@@ -77,7 +77,7 @@ class _CreateStudy(_BaseCommand):
             choices=("minimize", "maximize"),
             help="Set directions of optimization to a new study."
             " Put whitespace between directions. Each direction should be"
-            " either `minimize` or `maximize`.",
+            " either \"minimize\" or \"maximize\".",
             nargs="+",
         )
         return parser

--- a/optuna/cli.py
+++ b/optuna/cli.py
@@ -74,7 +74,7 @@ class _CreateStudy(_BaseCommand):
             default=None,
             help="Set directions of optimization to a new study."
             " Put comma between directions. Each direction should be"
-            " either `minimize` or `maximize`."
+            " either `minimize` or `maximize`.",
         )
         return parser
 

--- a/optuna/cli.py
+++ b/optuna/cli.py
@@ -58,8 +58,6 @@ class _CreateStudy(_BaseCommand):
         parser.add_argument(
             "--direction",
             type=str,
-            choices=("minimize", "maximize"),
-            default="minimize",
             help="Set direction of optimization to a new study. Set 'minimize' "
             "for minimization and 'maximize' for maximization.",
         )
@@ -70,16 +68,38 @@ class _CreateStudy(_BaseCommand):
             help="If specified, the creation of the study is skipped "
             "without any error when the study name is duplicated.",
         )
+        parser.add_argument(
+            "--directions",
+            type=str,
+            default=None,
+            help="Set directions of optimization to a new study."
+            " Put comma between directions. Each direction should be"
+            " either `minimize` or `maximize`."
+        )
         return parser
 
     def take_action(self, parsed_args: Namespace) -> None:
+
+        if parsed_args.direction is not None:
+            if parsed_args.directions is not None:
+                raise ValueError("Specify only one of `direction` and `directions`.")
+            else:
+                directions = [parsed_args.direction]
+        else:
+            if parsed_args.directions is not None:
+                directions = parsed_args.directions.split(",")
+            else:
+                directions = ["minimize"]  # default value
+
+        if any(direction not in ("maximize", "minimize") for direction in directions):
+            raise ValueError("Each direction must be `minimize` or `maximize`")
 
         storage_url = _check_storage_url(self.app_args.storage)
         storage = optuna.storages.get_storage(storage_url)
         study_name = optuna.create_study(
             storage=storage,
             study_name=parsed_args.study_name,
-            direction=parsed_args.direction,
+            directions=directions,
             load_if_exists=parsed_args.skip_if_exists,
         ).study_name
         print(study_name)

--- a/optuna/cli.py
+++ b/optuna/cli.py
@@ -57,6 +57,7 @@ class _CreateStudy(_BaseCommand):
         )
         parser.add_argument(
             "--direction",
+            default=None,
             type=str,
             choices=("minimize", "maximize"),
             help="Set direction of optimization to a new study. Set 'minimize' "
@@ -83,23 +84,13 @@ class _CreateStudy(_BaseCommand):
 
     def take_action(self, parsed_args: Namespace) -> None:
 
-        if parsed_args.direction is not None:
-            if parsed_args.directions is not None:
-                raise ValueError("Specify only one of `direction` and `directions`.")
-            else:
-                directions = [parsed_args.direction]
-        else:
-            if parsed_args.directions is not None:
-                directions = parsed_args.directions
-            else:
-                directions = ["minimize"]  # default value
-
         storage_url = _check_storage_url(self.app_args.storage)
         storage = optuna.storages.get_storage(storage_url)
         study_name = optuna.create_study(
             storage=storage,
             study_name=parsed_args.study_name,
-            directions=directions,
+            direction=parsed_args.direction,
+            directions=parsed_args.directions,
             load_if_exists=parsed_args.skip_if_exists,
         ).study_name
         print(study_name)

--- a/optuna/cli.py
+++ b/optuna/cli.py
@@ -91,9 +91,6 @@ class _CreateStudy(_BaseCommand):
             else:
                 directions = ["minimize"]  # default value
 
-        if any(direction not in ("maximize", "minimize") for direction in directions):
-            raise ValueError("Each direction must be `minimize` or `maximize`")
-
         storage_url = _check_storage_url(self.app_args.storage)
         storage = optuna.storages.get_storage(storage_url)
         study_name = optuna.create_study(

--- a/optuna/cli.py
+++ b/optuna/cli.py
@@ -77,7 +77,7 @@ class _CreateStudy(_BaseCommand):
             choices=("minimize", "maximize"),
             help="Set directions of optimization to a new study."
             " Put whitespace between directions. Each direction should be"
-            " either \"minimize\" or \"maximize\".",
+            ' either "minimize" or "maximize".',
             nargs="+",
         )
         return parser

--- a/optuna/cli.py
+++ b/optuna/cli.py
@@ -58,6 +58,7 @@ class _CreateStudy(_BaseCommand):
         parser.add_argument(
             "--direction",
             type=str,
+            choices=("minimize", "maximize"),
             help="Set direction of optimization to a new study. Set 'minimize' "
             "for minimization and 'maximize' for maximization.",
         )
@@ -72,9 +73,11 @@ class _CreateStudy(_BaseCommand):
             "--directions",
             type=str,
             default=None,
+            choices=("minimize", "maximize"),
             help="Set directions of optimization to a new study."
-            " Put comma between directions. Each direction should be"
+            " Put whitespace between directions. Each direction should be"
             " either `minimize` or `maximize`.",
+            nargs="+",
         )
         return parser
 
@@ -87,7 +90,7 @@ class _CreateStudy(_BaseCommand):
                 directions = [parsed_args.direction]
         else:
             if parsed_args.directions is not None:
-                directions = parsed_args.directions.split(",")
+                directions = parsed_args.directions
             else:
                 directions = ["minimize"]  # default value
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -94,7 +94,8 @@ def test_create_study_command_with_multiple_directions() -> None:
             "--storage",
             storage_url,
             "--directions",
-            "minimize,maximize",
+            "minimize",
+            "maximize",
         ]
 
         study_name = str(subprocess.check_output(command).decode().strip())
@@ -108,7 +109,9 @@ def test_create_study_command_with_multiple_directions() -> None:
             "--storage",
             storage_url,
             "--directions",
-            "minimize,maximize,test",
+            "minimize",
+            "maximize",
+            "test",
         ]
 
         # Each direction in --directions should be either `minimize` or `maximize`.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -118,6 +118,23 @@ def test_create_study_command_with_multiple_directions() -> None:
         with pytest.raises(subprocess.CalledProcessError):
             subprocess.check_call(command)
 
+        command = [
+            "optuna",
+            "create-study",
+            "--storage",
+            storage_url,
+            "--direction",
+            "minimize",
+            "--directions",
+            "minimize",
+            "maximize",
+            "test",
+        ]
+
+        # It can't specify both --direction and --directions
+        with pytest.raises(subprocess.CalledProcessError):
+            subprocess.check_call(command)
+
 
 def test_delete_study_command() -> None:
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -83,6 +83,39 @@ def test_create_study_command_with_direction() -> None:
             subprocess.check_call(command)
 
 
+def test_create_study_command_with_multiple_directions() -> None:
+
+    with StorageSupplier("sqlite") as storage:
+        assert isinstance(storage, RDBStorage)
+        storage_url = str(storage.engine.url)
+        command = [
+            "optuna",
+            "create-study",
+            "--storage",
+            storage_url,
+            "--directions",
+            "minimize,maximize",
+        ]
+
+        study_name = str(subprocess.check_output(command).decode().strip())
+        study_id = storage.get_study_id_from_name(study_name)
+        expected_directions = [StudyDirection.MINIMIZE, StudyDirection.MAXIMIZE]
+        assert storage.get_study_directions(study_id) == expected_directions
+
+        command = [
+            "optuna",
+            "create-study",
+            "--storage",
+            storage_url,
+            "--directions",
+            "minimize,maximize,test",
+        ]
+
+        # Each direction in --directions should be either `minimize` or `maximize`.
+        with pytest.raises(subprocess.CalledProcessError):
+            subprocess.check_call(command)
+
+
 def test_delete_study_command() -> None:
 
     with StorageSupplier("sqlite") as storage:


### PR DESCRIPTION
For https://github.com/optuna/optuna/issues/2629.
This PR allows `optuna create-study` to specify a directions option.

## Motivation
Current Optuna `create-study` command doesn't support multi-objective optimization, since
it doesn't provide an option for `directions`.

## Description of the changes
- c4b1a54 creates test
- 2a315dd adds `directions` to `create-study`