### PR TITLE
Remove `CudaCallback` from the fastai test

### DIFF
--- a/tests/integration_tests/test_fastaiv2.py
+++ b/tests/integration_tests/test_fastaiv2.py
@@ -1,6 +1,5 @@
 from typing import Any
 
-from fastai.callback.data import CudaCallback
 from fastai.data.core import DataLoader
 from fastai.data.core import DataLoaders
 from fastai.learner import Learner
@@ -42,7 +41,6 @@ def test_fastai_pruning_callback(tmpdir: Any) -> None:
             model,
             loss_func=F.nll_loss,
             metrics=[accuracy],
-            cbs=[CudaCallback],
         )
         learn.fit(1, cbs=FastAIV2PruningCallback(trial))
 


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

`CudaCallback` has been removed from fastai's API since v2.3.1. It causes Optuna's CI error.

## Description of the changes
<!-- Describe the changes in this PR. -->

Remove `CudaCallback`.

`examples` tests look good as in https://github.com/nzw0301/optuna/actions/runs/812637746. (thank @himkt to guide me.)