### PR TITLE
Introduce waiting trials queue

### DIFF
--- a/optuna/_updated_trials_queue.py
+++ b/optuna/_updated_trials_queue.py
@@ -1,0 +1,115 @@
+from collections import deque
+import threading
+from typing import Any
+from typing import Deque
+from typing import Dict
+from typing import List
+from typing import Tuple
+from typing import TYPE_CHECKING
+
+
+if TYPE_CHECKING:
+    from optuna import Study
+    from optuna.trial import FrozenTrial
+    from optuna.trial import TrialState
+
+
+class UpdatedTrialsQueue(object):
+    """A virtual queue of trials in the specified states.
+
+    This class imitates a queue that trial is added when it goes into specified states.
+
+    It is not supposed to be directly accessed by library users except to write user-defined
+    samplers.
+
+    Note that the ``states`` argument should consist of the same stage states.
+    """
+
+    def __init__(self, study: "Study", states: Tuple["TrialState", ...]) -> None:
+        for state in states:
+            if state < states[0] or states[0] < state:
+                raise RuntimeError("The states should be in the same stage.")
+
+        self._study = study
+        self._states = states
+
+        self._queue: Deque[int] = deque()
+        self._watching_trial_indices: List[int] = []
+        self._next_min_trial_index = 0
+
+        self._lock = threading.Lock()
+
+    def __getstate__(self) -> Dict[Any, Any]:
+
+        state = self.__dict__.copy()
+        del state["_lock"]
+        return state
+
+    def __setstate__(self, state: Dict[Any, Any]) -> None:
+
+        self.__dict__.update(state)
+        self._lock = threading.Lock()
+
+    def _fetch_trials(self, deepcopy: bool) -> List["FrozenTrial"]:
+        trials = self._study.get_trials(deepcopy=deepcopy)
+        next_watching_trial_indices: List[int] = []
+
+        for trial_index in self._watching_trial_indices:
+            if trials[trial_index].state in self._states:
+                self._queue.append(trial_index)
+            elif trials[trial_index].state < self._states[0]:
+                next_watching_trial_indices.append(trial_index)
+
+        for trial_index in range(self._next_min_trial_index, len(trials)):
+            trial = trials[trial_index]
+            if trial.state in self._states:
+                self._queue.append(trial_index)
+            elif trial.state < self._states[0]:
+                next_watching_trial_indices.append(trial_index)
+
+        self._watching_trial_indices = next_watching_trial_indices
+        self._next_min_trial_index = len(trials)
+
+        return trials
+
+    def get(self, deepcopy: bool = True) -> "FrozenTrial":
+        """Returns an unseen trial whose state is as specified.
+
+        Args:
+            deepcopy:
+                Flag to control whether to apply ``copy.deepcopy()`` to the trials.
+
+        Returns:
+            An unseen :class:`~optuna.Trial` object with the specified state.
+
+        Raises:
+            IndexError:
+                If no trial is in the queue.
+        """
+
+        with self._lock:
+            trials = self._fetch_trials(deepcopy=deepcopy)
+            while True:
+                trial_index = self._queue.popleft()
+                if trials[trial_index].state in self._states:
+                    return trials[trial_index]
+
+    def get_trials(self, deepcopy: bool = True) -> List["FrozenTrial"]:
+        """Returns a list of unseen trials whose states are as specified.
+
+        Args:
+            deepcopy:
+                Flag to control whether to apply ``copy.deepcopy()`` to the trials.
+
+        Returns:
+            A list of unseen :class:`~optuna.Trial` objects with the specified state.
+        """
+
+        with self._lock:
+            trials = self._fetch_trials(deepcopy=deepcopy)
+            ret = []
+            for trial_index in self._queue:
+                if trials[trial_index].state in self._states:
+                    ret.append(trials[trial_index])
+            self._queue.clear()
+            return ret

--- a/optuna/study.py
+++ b/optuna/study.py
@@ -27,6 +27,7 @@ from optuna._optimize import _check_and_convert_to_values
 from optuna._optimize import _optimize
 from optuna._study_direction import StudyDirection
 from optuna._study_summary import StudySummary  # NOQA
+from optuna._updated_trials_queue import UpdatedTrialsQueue  # NOQA
 from optuna.distributions import BaseDistribution
 from optuna.trial import create_trial
 from optuna.trial import FrozenTrial

--- a/optuna/trial/_state.py
+++ b/optuna/trial/_state.py
@@ -29,3 +29,13 @@ class TrialState(enum.Enum):
     def is_finished(self) -> bool:
 
         return self != TrialState.RUNNING and self != TrialState.WAITING
+
+    def __lt__(self, state: "TrialState") -> bool:
+        """Returns whether the left state can promote to the right state."""
+
+        if self == TrialState.WAITING:
+            return state == TrialState.RUNNING or state.is_finished()
+        elif self == TrialState.RUNNING:
+            return state.is_finished()
+        else:
+            return False

--- a/tests/study_tests/test_updated_trials_queue.py
+++ b/tests/study_tests/test_updated_trials_queue.py
@@ -1,0 +1,265 @@
+import itertools
+from typing import Tuple
+
+import pytest
+
+import optuna
+from optuna.study import UpdatedTrialsQueue
+from optuna.trial import TrialState
+
+
+@pytest.mark.parametrize(
+    "states, deepcopy",
+    itertools.product(
+        (
+            (TrialState.WAITING,),
+            (TrialState.RUNNING,),
+            (TrialState.COMPLETE,),
+            (TrialState.COMPLETE, TrialState.PRUNED, TrialState.FAIL),
+        ),
+        (True, False),
+    ),
+)
+def test_updated_trials_queue(states: Tuple[TrialState], deepcopy: bool) -> None:
+    study = optuna.create_study()
+    queue = UpdatedTrialsQueue(study, states)
+
+    # Test empty queue.
+    with pytest.raises(IndexError):
+        queue.get(deepcopy=deepcopy)
+
+    study.enqueue_trial({})
+    if TrialState.WAITING in states:
+        queue.get(deepcopy=deepcopy).state == TrialState.WAITING
+    else:
+        with pytest.raises(IndexError):
+            queue.get(deepcopy=deepcopy)
+
+    trial = study.ask()
+    if TrialState.RUNNING in states:
+        queue.get(deepcopy=deepcopy).state == TrialState.RUNNING
+    else:
+        with pytest.raises(IndexError):
+            queue.get(deepcopy=deepcopy)
+
+    study.tell(trial, 0)
+    if TrialState.COMPLETE in states:
+        queue.get(deepcopy=deepcopy).state == TrialState.COMPLETE
+    else:
+        with pytest.raises(IndexError):
+            queue.get(deepcopy=deepcopy)
+
+    # The queue is empty.
+    with pytest.raises(IndexError):
+        queue.get(deepcopy=deepcopy)
+
+
+@pytest.mark.parametrize(
+    "states, deepcopy",
+    itertools.product(
+        (
+            (TrialState.WAITING,),
+            (TrialState.RUNNING,),
+            (TrialState.COMPLETE,),
+            (TrialState.COMPLETE, TrialState.PRUNED, TrialState.FAIL),
+        ),
+        (True, False),
+    ),
+)
+def test_get_trials(states: Tuple[TrialState], deepcopy: bool) -> None:
+    study = optuna.create_study()
+    queue = UpdatedTrialsQueue(study, states)
+
+    # Test empty queue.
+    assert queue.get_trials(deepcopy=deepcopy) == []
+
+    study.enqueue_trial({})
+    if TrialState.WAITING in states:
+        assert len(queue.get_trials(deepcopy=deepcopy)) == 1
+    else:
+        assert queue.get_trials(deepcopy=deepcopy) == []
+
+    trial = study.ask()
+    if TrialState.RUNNING in states:
+        assert len(queue.get_trials(deepcopy=deepcopy)) == 1
+    else:
+        assert queue.get_trials(deepcopy=deepcopy) == []
+
+    study.tell(trial, 0)
+    if TrialState.COMPLETE in states:
+        assert len(queue.get_trials(deepcopy=deepcopy)) == 1
+    else:
+        assert queue.get_trials(deepcopy=deepcopy) == []
+
+    # The queue is empty.
+    assert queue.get_trials(deepcopy=deepcopy) == []
+
+
+@pytest.mark.parametrize(
+    "states, deepcopy",
+    itertools.product(
+        (
+            (TrialState.WAITING,),
+            (TrialState.RUNNING,),
+            (TrialState.COMPLETE,),
+            (TrialState.COMPLETE, TrialState.PRUNED, TrialState.FAIL),
+        ),
+        (True, False),
+    ),
+)
+def test_updated_trials_queue_with_multi_trials(states: Tuple[TrialState], deepcopy: bool) -> None:
+    study = optuna.create_study()
+    queue = UpdatedTrialsQueue(study, states)
+
+    study.enqueue_trial({})
+    study.enqueue_trial({})
+    if TrialState.WAITING in states:
+        queue.get(deepcopy=deepcopy).state == TrialState.WAITING
+        queue.get(deepcopy=deepcopy).state == TrialState.WAITING
+    else:
+        with pytest.raises(IndexError):
+            queue.get(deepcopy=deepcopy)
+
+    trial0 = study.ask()
+    trial1 = study.ask()
+    if TrialState.RUNNING in states:
+        queue.get(deepcopy=deepcopy).state == TrialState.RUNNING
+        queue.get(deepcopy=deepcopy).state == TrialState.RUNNING
+    else:
+        with pytest.raises(IndexError):
+            queue.get(deepcopy=deepcopy)
+
+    study.tell(trial1, 0)
+    if TrialState.COMPLETE in states:
+        trial = queue.get(deepcopy=deepcopy)
+        trial.state == TrialState.COMPLETE
+        trial.number == 1
+    else:
+        with pytest.raises(IndexError):
+            queue.get(deepcopy=deepcopy)
+
+    study.tell(trial0, 0)
+    if TrialState.COMPLETE in states:
+        trial = queue.get(deepcopy=deepcopy)
+        trial.state == TrialState.COMPLETE
+        trial.number == 0
+    else:
+        with pytest.raises(IndexError):
+            queue.get(deepcopy=deepcopy)
+
+    # The queue is empty.
+    with pytest.raises(IndexError):
+        queue.get(deepcopy=deepcopy)
+
+
+@pytest.mark.parametrize(
+    "states, deepcopy",
+    itertools.product(
+        (
+            (TrialState.WAITING,),
+            (TrialState.RUNNING,),
+            (TrialState.COMPLETE,),
+            (TrialState.COMPLETE, TrialState.PRUNED, TrialState.FAIL),
+        ),
+        (True, False),
+    ),
+)
+def test_get_trials_with_multi_trials(states: Tuple[TrialState], deepcopy: bool) -> None:
+    study = optuna.create_study()
+    queue = UpdatedTrialsQueue(study, states)
+
+    study.enqueue_trial({})
+    study.enqueue_trial({})
+    if TrialState.WAITING in states:
+        assert len(queue.get_trials(deepcopy=deepcopy)) == 2
+    else:
+        assert queue.get_trials(deepcopy=deepcopy) == []
+
+    trial0 = study.ask()
+    trial1 = study.ask()
+    if TrialState.RUNNING in states:
+        assert len(queue.get_trials(deepcopy=deepcopy)) == 2
+    else:
+        assert queue.get_trials(deepcopy=deepcopy) == []
+
+    study.tell(trial1, 0)
+    if TrialState.COMPLETE in states:
+        trials = queue.get_trials(deepcopy=deepcopy)
+        assert len(trials) == 1
+        assert trials[0].number == 1
+    else:
+        assert queue.get_trials(deepcopy=deepcopy) == []
+
+    study.tell(trial0, 0)
+    if TrialState.COMPLETE in states:
+        trials = queue.get_trials(deepcopy=deepcopy)
+        assert len(trials) == 1
+        assert trials[0].number == 0
+    else:
+        assert queue.get_trials(deepcopy=deepcopy) == []
+
+    # The queue is empty.
+    assert queue.get_trials(deepcopy=deepcopy) == []
+
+
+@pytest.mark.parametrize(
+    "states, deepcopy",
+    itertools.product(
+        (
+            (TrialState.WAITING,),
+            (TrialState.RUNNING,),
+            (TrialState.COMPLETE,),
+            (TrialState.COMPLETE, TrialState.PRUNED, TrialState.FAIL),
+        ),
+        (True, False),
+    ),
+)
+def test_updated_trials_queue_with_partial_get(states: Tuple[TrialState], deepcopy: bool) -> None:
+    study = optuna.create_study()
+    queue = UpdatedTrialsQueue(study, states)
+
+    study.enqueue_trial({})
+    study.enqueue_trial({})
+    if TrialState.WAITING in states:
+        queue.get(deepcopy=deepcopy).state == TrialState.WAITING
+    else:
+        with pytest.raises(IndexError):
+            queue.get(deepcopy=deepcopy)
+
+    trial0 = study.ask()
+    trial1 = study.ask()
+    if TrialState.RUNNING in states:
+        queue.get(deepcopy=deepcopy).state == TrialState.RUNNING
+    else:
+        with pytest.raises(IndexError):
+            queue.get(deepcopy=deepcopy)
+
+    study.tell(trial0, 0)
+    study.tell(trial1, 0)
+    if TrialState.COMPLETE in states:
+        queue.get(deepcopy=deepcopy).state == TrialState.COMPLETE
+    else:
+        with pytest.raises(IndexError):
+            queue.get(deepcopy=deepcopy)
+
+
+@pytest.mark.parametrize(
+    "states",
+    (
+        (TrialState.WAITING, TrialState.RUNNING),
+        (TrialState.WAITING, TrialState.COMPLETE),
+        (TrialState.RUNNING, TrialState.COMPLETE),
+        (TrialState.WAITING, TrialState.RUNNING, TrialState.COMPLETE),
+        (
+            TrialState.WAITING,
+            TrialState.RUNNING,
+            TrialState.COMPLETE,
+            TrialState.PRUNED,
+            TrialState.FAIL,
+        ),
+    ),
+)
+def test_invalid_states_combination(states: Tuple[TrialState]) -> None:
+    study = optuna.create_study()
+    with pytest.raises(RuntimeError):
+        UpdatedTrialsQueue(study, states)


### PR DESCRIPTION
This PR depends on #2647.

## Motivation
The current implementation of `_pop_waiting_trial_id` requires O(n_trials^2) time complexity. It may not be negligible when `n_trials` is over 10,000. This PR reduces the complexity to linear when we use in-memory storage.

## Description of the changes
- Use `UpdatedTrialsQueue` in `_pop_waiting_trial_id`