### PR TITLE
Simplify `add_distributions` in `_SearchSpaceGroup`

### DIFF
--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -158,33 +158,6 @@ class TPESampler(BaseSampler):
             is a maximal subset of the whole search space, which satisfies the following:
             for a trial in completed trials, the intersection of the subspace and the search space
             of the trial becomes subspace itself or an empty set.
-
-            The search space is decomposed based on the following recursive rules.
-
-            - Initialize the group of the search space with the empty set. The elements of the
-              group are the subset of the search space, and the type is the dictionary of
-              :class:`~optuna.distributions.BaseDistribution`.
-            - Update the group with the following procedure `ADD(trial)` by looking at past trials.
-
-            The procedure of `Add(trial)` is
-
-            - Let ``T = trial.distributions``.
-            - If the intersection of any element of the group and ``T`` is empty, add ``T`` to the
-              group.
-            - If an element ``S`` of the group is contained in ``T``, then add ``T-S`` to the
-              group. We recursively add ``T-S`` to the group because the intersection of ``T-S``
-              and some other elements of the group may not be empty.
-            - If an element ``S`` of a group contains ``T``, remove ``S`` from the group and add
-              ``T`` and ``S-T`` to the group.
-            - If the intersection of an element ``S`` of the group and ``T`` is not empty, remove
-              ``S`` from the group and add ``S∩T``, ``S-T``, and ``T-S`` to the group.
-              We recursively add ``T-S`` to the group because the intersection of ``T-S`` and
-              some other elements of the group may not be empty.
-
-            The group of the search space recursively constructed based on the above rules are
-            disjoint and the union is the entire search space. We perform sampling from the joint
-            distribution for each element of this decomposed group of the search space.
-
             Sampling from the joint distribution on the subspace is realized by multivariate TPE.
 
             .. note::

--- a/tests/samplers_tests/search_space_tests/test_group_decomposed.py
+++ b/tests/samplers_tests/search_space_tests/test_group_decomposed.py
@@ -88,10 +88,10 @@ def test_search_space_group() -> None:
     )
     assert search_space_group.search_spaces == [
         {"x": IntUniformDistribution(low=0, high=10)},
-        {"u": LogUniformDistribution(low=1e-2, high=1e2)},
-        {"v": CategoricalDistribution(choices=["A", "B", "C"])},
         {"y": IntUniformDistribution(low=0, high=10)},
         {"z": UniformDistribution(low=-3, high=3)},
+        {"u": LogUniformDistribution(low=1e-2, high=1e2)},
+        {"v": CategoricalDistribution(choices=["A", "B", "C"])},
         {"w": IntLogUniformDistribution(low=2, high=8)},
     ]
 
@@ -105,10 +105,10 @@ def test_search_space_group() -> None:
     )
     assert search_space_group.search_spaces == [
         {"x": IntUniformDistribution(low=0, high=10)},
-        {"u": LogUniformDistribution(low=1e-2, high=1e2)},
-        {"v": CategoricalDistribution(choices=["A", "B", "C"])},
         {"y": IntUniformDistribution(low=0, high=10)},
         {"z": UniformDistribution(low=-3, high=3)},
+        {"u": LogUniformDistribution(low=1e-2, high=1e2)},
+        {"v": CategoricalDistribution(choices=["A", "B", "C"])},
         {"w": IntLogUniformDistribution(low=2, high=8)},
         {"t": UniformDistribution(low=10, high=100)},
     ]
@@ -148,8 +148,8 @@ def test_group_decomposed_search_space() -> None:
     assert search_space.calculate(study).search_spaces == [
         {"x": IntUniformDistribution(low=0, high=10)},
         {
-            "y": IntUniformDistribution(low=0, high=10),
             "z": UniformDistribution(low=-3, high=3),
+            "y": IntUniformDistribution(low=0, high=10),
         },
         {
             "u": LogUniformDistribution(low=1e-2, high=1e2),
@@ -174,11 +174,11 @@ def test_group_decomposed_search_space() -> None:
         lambda t: t.suggest_int("y", 0, 10) + t.suggest_int("w", 2, 8, log=True), n_trials=1
     )
     assert search_space.calculate(study).search_spaces == [
-        {"v": CategoricalDistribution(choices=["A", "B", "C"])},
         {"x": IntUniformDistribution(low=0, high=10)},
-        {"u": LogUniformDistribution(low=1e-2, high=1e2)},
         {"y": IntUniformDistribution(low=0, high=10)},
         {"z": UniformDistribution(low=-3, high=3)},
+        {"u": LogUniformDistribution(low=1e-2, high=1e2)},
+        {"v": CategoricalDistribution(choices=["A", "B", "C"])},
         {"w": IntLogUniformDistribution(low=2, high=8)},
     ]
 


### PR DESCRIPTION
## Motivation
This is a follow-up PR of #2526. It replaces the recursive implementation of `_add_distributions` with a non-recursive one.

## Description of the changes
- Implement non-recursive `add_distributions`
- Remove the implementation detail from the document.