### PR TITLE
Use `command` to check the existence of the libraries to avoid partially matching

### DIFF
--- a/formats.sh
+++ b/formats.sh
@@ -9,19 +9,19 @@ command -v black &> /dev/null
 if [ $? -eq 1 ] ; then
   missing_dependencies+=(black)
 fi
-command -v blackdoc &> /dev/null;
+command -v blackdoc &> /dev/null
 if [ $? -eq 1 ] ; then
   missing_dependencies+=(blackdoc)
 fi
-command -v flake8 &> /dev/null;
+command -v flake8 &> /dev/null
 if [ $? -eq 1 ] ; then
   missing_dependencies+=(hacking)
 fi
-command -v isort &> /dev/null;
+command -v isort &> /dev/null
 if [ $? -eq 1 ] ; then
   missing_dependencies+=(isort)
 fi
-command -v mypy &> /dev/null;
+command -v mypy &> /dev/null
 if [ $? -eq 1 ] ; then
   # TODO(toshihikoyanase): Unpin mypy after resolving the following issue:
   # https://github.com/optuna/optuna/issues/2240.

--- a/formats.sh
+++ b/formats.sh
@@ -5,7 +5,7 @@
 
 
 missing_dependencies=()
-command -v black &> /dev/null;
+command -v black &> /dev/null
 if [ $? -eq 1 ] ; then
   missing_dependencies+=(black)
 fi

--- a/formats.sh
+++ b/formats.sh
@@ -4,21 +4,25 @@
 # without updating codebase.
 
 
-res_pip_list=$(pip freeze)
 missing_dependencies=()
-if [ ! "$(echo $res_pip_list | grep black)" ] ; then
+command -v black &> /dev/null;
+if [ $? -eq 1 ] ; then
   missing_dependencies+=(black)
 fi
-if [ ! "$(echo $res_pip_list | grep blackdoc)" ] ; then
+command -v blackdoc &> /dev/null;
+if [ $? -eq 1 ] ; then
   missing_dependencies+=(blackdoc)
 fi
-if [ ! "$(echo $res_pip_list | grep flake8)" ] ; then
+command -v flake8 &> /dev/null;
+if [ $? -eq 1 ] ; then
   missing_dependencies+=(hacking)
 fi
-if [ ! "$(echo $res_pip_list | grep isort)" ] ; then
+command -v isort &> /dev/null;
+if [ $? -eq 1 ] ; then
   missing_dependencies+=(isort)
 fi
-if [ ! "$(echo $res_pip_list | grep mypy)" ] ; then
+command -v mypy &> /dev/null;
+if [ $? -eq 1 ] ; then
   # TODO(toshihikoyanase): Unpin mypy after resolving the following issue:
   # https://github.com/optuna/optuna/issues/2240.
   missing_dependencies+=(mypy==0.790)


### PR DESCRIPTION
CC: @hvy 

<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

As mentioned in https://github.com/optuna/optuna/pull/2637#issuecomment-833354539, `formats.sh` tries to install missing libraries by combining `pip freeze` and `grep`. However, `grep` can match another library name since it is partial matching. For example, `grep mypy` matches `mypy-extensions` even if `mypy` is not installed.

## Description of the changes
<!-- Describe the changes in this PR. -->
Use `command` to check the existence of libraries by following  https://github.com/optuna/optuna/pull/2637#issuecomment-833998737.

