### PR TITLE
Enable act to run for other workflows

### DIFF
--- a/.github/workflows/mac-tests.yml
+++ b/.github/workflows/mac-tests.yml
@@ -9,7 +9,7 @@ on:
       - master
 
 jobs:
-  tests:
+  tests-mac:
     runs-on: macos-latest
 
     # Not intended for forks.
@@ -52,7 +52,7 @@ jobs:
       run: |
         pytest tests --ignore tests/integration_tests
 
-  tests-integration:
+  tests-integration-mac:
     runs-on: macos-latest
 
     # Not intended for forks.

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -13,6 +13,10 @@ jobs:
   build-n-publish:
     name: Build and publish Python distributions to PyPI or TestPyPI
     runs-on: ubuntu-18.04
+
+    # Not intended for forks.
+    if: github.repository == 'optuna/optuna'
+
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python 3.7

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -30,7 +30,7 @@ jobs:
         python -m pip install -U twine wheel
 
     - name: Change the version file for scheduled TestPyPI upload
-      if: (github.repository == 'optuna/optuna') && (github.event_name == 'schedule')
+      if: github.event_name == 'schedule'
       run: |
         OPTUNA_VERSION=$(cut -d '"' -f 2 optuna/version.py)
         DATE=`date +"%Y%m%d"`
@@ -46,7 +46,7 @@ jobs:
 
     - name: Publish distribution to TestPyPI
       # The following upload action cannot be executed in the forked repository.
-      if: (github.repository == 'optuna/optuna') && ((github.event_name == 'schedule') || (github.event_name == 'release'))
+      if: (github.event_name == 'schedule') || (github.event_name == 'release')
       uses: pypa/gh-action-pypi-publish@v1.1.0
       with:
         user: __token__
@@ -55,7 +55,7 @@ jobs:
 
     - name: Publish distribution to PyPI
       # The following upload action cannot be executed in the forked repository.
-      if: (github.repository == 'optuna/optuna') && (github.event_name == 'release')
+      if: github.event_name == 'release'
       uses: pypa/gh-action-pypi-publish@v1.1.0
       with:
         user: __token__

--- a/.github/workflows/tests-integration.yml
+++ b/.github/workflows/tests-integration.yml
@@ -18,9 +18,6 @@ jobs:
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9]
 
-    # Not intended for forks.
-    if: github.repository == 'optuna/optuna'
-
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/.github/workflows/tests-rdbstorage.yml
+++ b/.github/workflows/tests-rdbstorage.yml
@@ -45,9 +45,6 @@ jobs:
           --health-timeout 5s
           --health-retries 5
 
-    # Not intended for forks.
-    if: github.repository == 'optuna/optuna'
-
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,9 +25,6 @@ jobs:
           --health-timeout 5s
           --health-retries 5
 
-    # Not intended for forks.
-    if: github.repository == 'optuna/optuna'
-
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -164,6 +164,8 @@ Currently, you can run the following jobs: `documentation` and `doctest` may not
 
 - `checks`
   - Checking the format, coding style, and type hints
+- `tests`
+  - Runs unit tests
 - `documentation`
   - Builds documentation including tutorial
 - `doctest`


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
Currently, `act` can run only checks, documentation and doctest c.f. https://github.com/optuna/optuna/blob/master/CONTRIBUTING.md#local-verification . By the PR, I would like to run `tests`, `tests-integration` and `tests-rdbstorage`, which are mandatory checks in PR reviews.

## Description of the changes
<!-- Describe the changes in this PR. -->
To run a workflow on act, the workflow must not have a line `if: github.repository == 'optuna/optuna'`, because it stops running the workflow. 

## TODOs
- [x] Remove `if: github.repository == 'optuna/optuna'`
- [x] Check they can be run with act
- [x] Update readme according to the above result