### PR TITLE
Add the missing colon

### DIFF
--- a/optuna/pruners/_threshold.py
+++ b/optuna/pruners/_threshold.py
@@ -61,7 +61,7 @@ class ThresholdPruner(BasePruner):
             study = create_study(pruner=ThresholdPruner(lower=0.0))
             study.optimize(objective_for_lower, n_trials=10)
 
-    Args
+    Args:
         lower:
             A minimum value which determines whether pruner prunes or not.
             If an intermediate value is smaller than lower, it prunes.


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->


[`ThresholdPruner`](https://optuna.readthedocs.io/en/latest/reference/generated/optuna.pruners.ThresholdPruner.html)'s `args` part is not rendered correctly due to a missing `:`.

<img width="651" alt="Screenshot 2021-05-10 at 23 37 06" src="https://user-images.githubusercontent.com/7121753/117677626-95950600-b1e9-11eb-9d4f-b45a5c7d8151.png">


## Description of the changes
<!-- Describe the changes in this PR. -->

Add `:` to fix it. The document looks like this:

<img width="613" alt="Screenshot 2021-05-10 at 23 42 39" src="https://user-images.githubusercontent.com/7121753/117677640-99c12380-b1e9-11eb-98c3-2e6063c88d82.png">
