### PR TITLE
Relax `GridSampler` allowing not-contained parameters during `suggest_*`

### DIFF
--- a/optuna/samplers/_grid.py
+++ b/optuna/samplers/_grid.py
@@ -9,6 +9,7 @@ from typing import Mapping
 from typing import Optional
 from typing import Sequence
 from typing import Union
+import warnings
 
 from optuna.distributions import BaseDistribution
 from optuna.logging import get_logger
@@ -168,13 +169,9 @@ class GridSampler(BaseSampler):
         param_value = self._all_grids[grid_id][self._param_names.index(param_name)]
         contains = param_distribution._contains(param_distribution.to_internal_repr(param_value))
         if not contains:
-            raise ValueError(
-                "The value `{}` is out of range of the parameter `{}`. Please make "
-                "sure the search space of the `GridSampler` only contains values "
-                "consistent with the distribution specified in the objective "
-                "function. The distribution is: `{}`.".format(
-                    param_value, param_name, param_distribution
-                )
+            warnings.warn(
+                f"The value `{param_value}` is out of range of the parameter `{param_name}`. "
+                f"The value will be used but the actual distribution is: `{param_distribution}`."
             )
 
         return param_value

--- a/tests/samplers_tests/test_grid.py
+++ b/tests/samplers_tests/test_grid.py
@@ -66,7 +66,7 @@ def test_study_optimize_with_single_search_space() -> None:
         "e": [0.1],
     }
     study = optuna.create_study(sampler=samplers.GridSampler(search_space))
-    with pytest.raises(ValueError):
+    with pytest.warns(UserWarning):
         study.optimize(objective)
 
 


### PR DESCRIPTION
## Motivation

See https://github.com/optuna/optuna/pull/2652#issuecomment-836384264.

## Description of the changes

Relaxes `GridSampler` to allow parameter values in its search space that are not contained within the domain defined by `suggest_*`.
