### PR TITLE
Constant liar for `TPESampler`

### DIFF
--- a/tests/samplers_tests/tpe_tests/test_sampler.py
+++ b/tests/samplers_tests/tpe_tests/test_sampler.py
@@ -971,3 +971,42 @@ def test_invalid_multivariate_and_group() -> None:
 def test_group_experimental_warning() -> None:
     with pytest.warns(optuna.exceptions.ExperimentalWarning):
         _ = TPESampler(multivariate=True, group=True)
+
+
+@pytest.mark.parametrize("direction", ["minimize", "maximize"])
+def test_constant_liar_observation_pairs(direction: str) -> None:
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", optuna.exceptions.ExperimentalWarning)
+        sampler = TPESampler(constant_liar=True)
+
+    study = optuna.create_study(sampler=sampler, direction=direction)
+
+    trial = study.ask()
+    trial.suggest_int("x", 2, 2)
+
+    assert (
+        len(study.trials) == 1 and study.trials[0].state == optuna.trial.TrialState.RUNNING
+    ), "Precondition"
+
+    # The value of the constant liar should be penalizing, i.e. `float("inf")` during minimization
+    # and `-float("inf")` during maximization.
+    expected_values = [(-float("inf"), float("inf") * (-1 if direction == "maximize" else 1))]
+
+    assert _tpe.sampler._get_observation_pairs(study, "x", constant_liar=False) == ([], [])
+    assert _tpe.sampler._get_observation_pairs(study, "x", constant_liar=True) == (
+        [2],
+        expected_values,
+    )
+    assert _tpe.sampler._get_multivariate_observation_pairs(study, ["x"], constant_liar=False) == (
+        {"x": []},
+        [],
+    )
+    assert _tpe.sampler._get_multivariate_observation_pairs(study, ["x"], constant_liar=True) == (
+        {"x": [2]},
+        expected_values,
+    )
+
+
+def test_constant_liar_experimental_warning() -> None:
+    with pytest.warns(optuna.exceptions.ExperimentalWarning):
+        _ = TPESampler(constant_liar=True)


### PR DESCRIPTION
## Motivation

Fixes https://github.com/optuna/optuna/issues/892.

See also https://github.com/optuna/optuna/pull/2217.

## Description of the changes

Introduces a `constant_liar: bool` parameter to `TPESampler` to allow turning constant liar on.

When this argument is `False` (default), the previous behavior is kept. If `True`, the values of the running states are penalized with `float("inf")` or `-float("inf")` depending on the direction. A more flexible `Union[bool, Callable[[Sequence[float]], float]]` would allow arbitrary values for penalization but I left it out to keep the behavior simple avoiding confusion with how the direction is impacting the final value.

### Benchmarks

https://colab.research.google.com/drive/1_JaQGl_sCbbujTdZbd9-_MQ9Bj8dROcF?usp=sharing

### Notes

_Note that this PR may conflict with the ongoing TPE refactoring (https://github.com/optuna/optuna/pull/2618)._