### PR TITLE
Introduce speed benchmarks using asv

### DIFF
--- a/.github/workflows/speed-benchmarks.yml
+++ b/.github/workflows/speed-benchmarks.yml
@@ -1,9 +1,6 @@
 name: Speed benchmarks
 
 on:
-  push:
-    branches:
-      - asv
   schedule:
     - cron: '0 23 * * SUN-THU'
 
@@ -12,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
 
     # Not intended for forks.
-    # if: github.repository == 'optuna/optuna'
+    if: github.repository == 'optuna/optuna'
 
     steps:
     - name: Checkout

--- a/.github/workflows/speed-benchmarks.yml
+++ b/.github/workflows/speed-benchmarks.yml
@@ -15,10 +15,10 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
 
-    - name: Setup Python3.7
+    - name: Setup Python3.9
       uses: actions/setup-python@v2
       with:
-        python-version: 3.7
+        python-version: 3.9
 
     - name: Setup cache
       uses: actions/cache@v2
@@ -26,9 +26,9 @@ jobs:
         cache-name: speed-benchmarks
       with:
         path: ~/.cache/pip
-        key: ${{ runner.os }}-3.7-${{ env.cache-name }}-${{ hashFiles('**/setup.py') }}-v1
+        key: ${{ runner.os }}-3.9-${{ env.cache-name }}-${{ hashFiles('**/setup.py') }}-v1
         restore-keys: |
-          ${{ runner.os }}-3.7-${{ env.cache-name }}-${{ hashFiles('**/setup.py') }}
+          ${{ runner.os }}-3.9-${{ env.cache-name }}-${{ hashFiles('**/setup.py') }}
 
     - name: Install
       run: |

--- a/.github/workflows/speed-benchmarks.yml
+++ b/.github/workflows/speed-benchmarks.yml
@@ -1,0 +1,51 @@
+name: Speed benchmarks
+
+on:
+  push:
+    branches:
+      - asv
+  schedule:
+    - cron: '0 23 * * SUN-THU'
+
+jobs:
+  speed-benchmarks:
+    runs-on: ubuntu-latest
+
+    # Not intended for forks.
+    # if: github.repository == 'optuna/optuna'
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Setup Python3.7
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.7
+
+    - name: Setup cache
+      uses: actions/cache@v2
+      env:
+        cache-name: speed-benchmarks
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-3.7-${{ env.cache-name }}-${{ hashFiles('**/setup.py') }}-v1
+        restore-keys: |
+          ${{ runner.os }}-3.7-${{ env.cache-name }}-${{ hashFiles('**/setup.py') }}
+
+    - name: Install
+      run: |
+        python -m pip install --upgrade pip
+        pip install --use-deprecated=legacy-resolver --progress-bar off -U setuptools
+
+        # Install minimal dependencies and confirm that `import optuna` is successful.
+        pip install --use-deprecated=legacy-resolver --progress-bar off .
+        python -c 'import optuna'
+        optuna --version
+
+        pip install --use-deprecated=legacy-resolver --progress-bar off .[benchmark]
+        asv machine --yes
+
+    - name: Speed benchmarks
+      run: |
+        asv run

--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,6 @@ docs/source/reference/generated/
 docs/source/reference/multi_objective/generated/
 docs/source/reference/visualization/generated/
 docs/source/tutorial/
+
+# asv
+.asv

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -30,7 +30,7 @@
 
     // List of branches to benchmark. If not provided, defaults to "master"
     // (for git) or "default" (for mercurial).
-    "branches": ["asv"], // for git
+    // "branches": ["master"], // for git
     // "branches": ["default"],    // for mercurial
 
     // The DVCS being used.  If not set, it will be automatically

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -1,0 +1,158 @@
+{
+    // The version of the config file format.  Do not change, unless
+    // you know what you are doing.
+    "version": 1,
+
+    // The name of the project being benchmarked
+    "project": "Optuna",
+
+    // The project's homepage
+    "project_url": "https://optuna.org/",
+
+    // The URL or local path of the source code repository for the
+    // project being benchmarked
+    "repo": ".",
+
+    // The Python project's subdirectory in your repo.  If missing or
+    // the empty string, the project is assumed to be located at the root
+    // of the repository.
+    // "repo_subdir": "",
+
+    // Customizable commands for building, installing, and
+    // uninstalling the project. See asv.conf.json documentation.
+    //
+    // "install_command": ["in-dir={env_dir} python -mpip install {wheel_file}"],
+    // "uninstall_command": ["return-code=any python -mpip uninstall -y {project}"],
+    // "build_command": [
+    //     "python setup.py build",
+    //     "PIP_NO_BUILD_ISOLATION=false python -mpip wheel --no-deps --no-index -w {build_cache_dir} {build_dir}"
+    // ],
+
+    // List of branches to benchmark. If not provided, defaults to "master"
+    // (for git) or "default" (for mercurial).
+    "branches": ["asv"], // for git
+    // "branches": ["default"],    // for mercurial
+
+    // The DVCS being used.  If not set, it will be automatically
+    // determined from "repo" by looking at the protocol in the URL
+    // (if remote), or by looking for special directories, such as
+    // ".git" (if local).
+    // "dvcs": "git",
+
+    // The tool to use to create environments.  May be "conda",
+    // "virtualenv" or other value depending on the plugins in use.
+    // If missing or the empty string, the tool will be automatically
+    // determined by looking for tools on the PATH environment
+    // variable.
+    "environment_type": "virtualenv",
+
+    // timeout in seconds for installing any dependencies in environment
+    // defaults to 10 min
+    //"install_timeout": 600,
+
+    // the base URL to show a commit for the project.
+    "show_commit_url": "https://github.com/optuna/optuna/commit/",
+
+    // The Pythons you'd like to test against.  If not provided, defaults
+    // to the current version of Python used to run `asv`.
+    // "pythons": ["2.7", "3.6"],
+
+    // The list of conda channel names to be searched for benchmark
+    // dependency packages in the specified order
+    // "conda_channels": ["conda-forge", "defaults"],
+
+    // The matrix of dependencies to test.  Each key is the name of a
+    // package (in PyPI) and the values are version numbers.  An empty
+    // list or empty string indicates to just test against the default
+    // (latest) version. null indicates that the package is to not be
+    // installed. If the package to be tested is only available from
+    // PyPi, and the 'environment_type' is conda, then you can preface
+    // the package name by 'pip+', and the package will be installed via
+    // pip (with all the conda available packages installed first,
+    // followed by the pip installed packages).
+    //
+    "matrix": {
+        "fakeredis": [""],
+    },
+
+    // Combinations of libraries/python versions can be excluded/included
+    // from the set to test. Each entry is a dictionary containing additional
+    // key-value pairs to include/exclude.
+    //
+    // An exclude entry excludes entries where all values match. The
+    // values are regexps that should match the whole string.
+    //
+    // An include entry adds an environment. Only the packages listed
+    // are installed. The 'python' key is required. The exclude rules
+    // do not apply to includes.
+    //
+    // In addition to package names, the following keys are available:
+    //
+    // - python
+    //     Python version, as in the *pythons* variable above.
+    // - environment_type
+    //     Environment type, as above.
+    // - sys_platform
+    //     Platform, as in sys.platform. Possible values for the common
+    //     cases: 'linux2', 'win32', 'cygwin', 'darwin'.
+    //
+    // "exclude": [
+    //     {"python": "3.2", "sys_platform": "win32"}, // skip py3.2 on windows
+    //     {"environment_type": "conda", "six": null}, // don't run without six on conda
+    // ],
+    //
+    // "include": [
+    //     // additional env for python2.7
+    //     {"python": "2.7", "numpy": "1.8"},
+    //     // additional env if run on windows+conda
+    //     {"platform": "win32", "environment_type": "conda", "python": "2.7", "libpython": ""},
+    // ],
+
+    // The directory (relative to the current directory) that benchmarks are
+    // stored in.  If not provided, defaults to "benchmarks"
+    // "benchmark_dir": "benchmarks",
+
+    // The directory (relative to the current directory) to cache the Python
+    // environments in.  If not provided, defaults to "env"
+    "env_dir": ".asv/env",
+
+    // The directory (relative to the current directory) that raw benchmark
+    // results are stored in.  If not provided, defaults to "results".
+    "results_dir": ".asv/results",
+
+    // The directory (relative to the current directory) that the html tree
+    // should be written to.  If not provided, defaults to "html".
+    "html_dir": ".asv/html",
+
+    // The number of characters to retain in the commit hashes.
+    // "hash_length": 8,
+
+    // `asv` will cache results of the recent builds in each
+    // environment, making them faster to install next time.  This is
+    // the number of builds to keep, per environment.
+    // "build_cache_size": 2,
+
+    // The commits after which the regression search in `asv publish`
+    // should start looking for regressions. Dictionary whose keys are
+    // regexps matching to benchmark names, and values corresponding to
+    // the commit (exclusive) after which to start looking for
+    // regressions.  The default is to start from the first commit
+    // with results. If the commit is `null`, regression detection is
+    // skipped for the matching benchmark.
+    //
+    // "regressions_first_commits": {
+    //    "some_benchmark": "352cdf",  // Consider regressions only after this commit
+    //    "another_benchmark": null,   // Skip regression detection altogether
+    // },
+
+    // The thresholds for relative change in results, after which `asv
+    // publish` starts reporting regressions. Dictionary of the same
+    // form as in ``regressions_first_commits``, with values
+    // indicating the thresholds.  If multiple entries match, the
+    // maximum is taken. If no entry matches, the default is 5%.
+    //
+    // "regressions_thresholds": {
+    //    "some_benchmark": 0.01,     // Threshold of 1%
+    //    "another_benchmark": 0.5,   // Threshold of 50%
+    // },
+}

--- a/benchmarks/optimize.py
+++ b/benchmarks/optimize.py
@@ -1,0 +1,70 @@
+from typing import cast
+from typing import List
+from typing import Union
+
+import optuna
+from optuna.samplers import BaseSampler
+from optuna.samplers import CmaEsSampler
+from optuna.samplers import RandomSampler
+from optuna.samplers import TPESampler
+from optuna.testing.storage import StorageSupplier
+
+
+def parse_args(args: str) -> List[Union[int, str]]:
+    ret: List[Union[int, str]] = []
+    for arg in map(lambda s: s.strip(), args.split(",")):
+        try:
+            ret.append(int(arg))
+        except ValueError:
+            ret.append(arg)
+    return ret
+
+
+SAMPLER_MODES = [
+    "random",
+    "tpe",
+    "cmaes",
+]
+
+
+def create_sampler(sampler_mode: str) -> BaseSampler:
+    if sampler_mode == "random":
+        return RandomSampler()
+    elif sampler_mode == "tpe":
+        return TPESampler()
+    elif sampler_mode == "cmaes":
+        return CmaEsSampler()
+    else:
+        assert False
+
+
+class TimeOptimize:
+    def objective(self, trial: optuna.Trial) -> float:
+        x = trial.suggest_float("x", -100, 100)
+        y = trial.suggest_int("y", -100, 100)
+        return x ** 2 + y ** 2
+
+    def optimize(self, storage_mode: str, sampler_mode: str, n_trials: int) -> None:
+        with StorageSupplier(storage_mode) as storage:
+            sampler = create_sampler(sampler_mode)
+            study = optuna.create_study(storage=storage, sampler=sampler)
+            study.optimize(self.objective, n_trials=n_trials)
+
+    def time_optimize(self, args: str) -> None:
+        storage_mode, sampler_mode, n_trials = parse_args(args)
+        storage_mode = cast(str, storage_mode)
+        sampler_mode = cast(str, sampler_mode)
+        n_trials = cast(int, n_trials)
+        self.optimize(storage_mode, sampler_mode, n_trials)
+
+    params = (
+        "inmemory, random, 1000",
+        "inmemory, random, 10000",
+        "inmemory, tpe, 1000",
+        "inmemory, cmaes, 1000",
+        "sqlite, random, 1000",
+        "cache, random, 1000",
+        "redis, random, 1000",
+    )
+    param_names = "storage, sampler, n_trials"
+    timeout = 600

--- a/benchmarks/optimize.py
+++ b/benchmarks/optimize.py
@@ -64,7 +64,7 @@ class OptimizeSuite:
         "inmemory, cmaes, 1000",
         "sqlite, random, 1000",
         "cache, random, 1000",
-        "redis, random, 1000",
+        "redis, random, 1000",  # This benchmark uses fakeredis instead of Redis.
     )
     param_names = "storage, sampler, n_trials"
     timeout = 600

--- a/benchmarks/optimize.py
+++ b/benchmarks/optimize.py
@@ -38,7 +38,7 @@ def create_sampler(sampler_mode: str) -> BaseSampler:
         assert False
 
 
-class TimeOptimize:
+class OptimizeSuite:
     def objective(self, trial: optuna.Trial) -> float:
         x = trial.suggest_float("x", -100, 100)
         y = trial.suggest_int("y", -100, 100)

--- a/benchmarks/optimize.py
+++ b/benchmarks/optimize.py
@@ -66,5 +66,5 @@ class OptimizeSuite:
         "cache, random, 1000",
         "redis, random, 1000",  # This benchmark uses fakeredis instead of Redis.
     )
-    param_names = "storage, sampler, n_trials"
+    param_names = ["storage, sampler, n_trials"]
     timeout = 600

--- a/formats.sh
+++ b/formats.sh
@@ -40,8 +40,8 @@ do
   esac
 done
 
-target="examples optuna tests"
-mypy_target="optuna tests"
+target="examples optuna tests benchmarks"
+mypy_target="optuna tests benchmarks"
 res_all=0
 
 res_black=$(black $target --check --diff 2>&1)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ exclude = '''
 
 [tool.isort]
 profile = 'black'
-src_paths = ['optuna', 'tests', 'docs']
+src_paths = ['optuna', 'tests', 'docs', 'benchmarks']
 skip_glob = ['docs/source/conf.py', '**/alembic/versions/*.py', 'tutorial/**/*.py']
 line_length = 99
 lines_after_imports = 2

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,7 @@ ignore =
     H306
 max-line-length = 99
 statistics = True
-exclude = venv,build,tutorial,.tox
+exclude = venv,build,tutorial,.tox,.asv
 
 # This section is for mypy.
 [mypy]

--- a/setup.py
+++ b/setup.py
@@ -192,6 +192,10 @@ def get_extras_require() -> Dict[str, List[str]]:
             "botorch>=0.4.0 ; python_version>'3.6'",
             "fastai",
         ],
+        "benchmark": [
+            "asv",
+            "virtualenv",
+        ],
     }
 
     return requirements

--- a/setup.py
+++ b/setup.py
@@ -220,7 +220,7 @@ setup(
     author="Takuya Akiba",
     author_email="akiba@preferred.jp",
     url="https://optuna.org/",
-    packages=find_packages(exclude=("tests", "tests.*")),
+    packages=find_packages(exclude=("tests", "tests.*", "benchmarks")),
     package_data={
         "optuna": [
             "storages/_rdb/alembic.ini",


### PR DESCRIPTION
## Motivation
Benchmarking speed can help us implement speedups and detect slowdowns. This PR introduces benchmarks using [asv](https://asv.readthedocs.io/en/stable/).

## Description of the changes
- Add benchmarks
- Add speed benchmarks in GitHub Actions ([Result](https://github.com/not522/optuna/runs/2563402752))
- Configuration

## Discussion
The Redis benchmark use fakeredis. It may be misleading, but developers easily run benchmarks without setting up a Redis server.