### PR TITLE
Treat `None` as special value in AllenNLP integration

### DIFF
--- a/optuna/integration/allennlp.py
+++ b/optuna/integration/allennlp.py
@@ -111,7 +111,7 @@ def _infer_and_cast(value: Optional[str]) -> Optional[Union[str, int, float, boo
     to desired types.
 
     """
-    if value in (None, _NONE):
+    if value is None or value == _NONE:
         return None
 
     try:

--- a/optuna/integration/allennlp.py
+++ b/optuna/integration/allennlp.py
@@ -72,7 +72,6 @@ _STUDY_NAME = "{}_STUDY_NAME".format(_PREFIX)
 _TRIAL_ID = "{}_TRIAL_ID".format(_PREFIX)
 
 
-
 def _encode_param(value: Any) -> str:
     if value is None:
         return _NONE
@@ -324,7 +323,8 @@ class AllenNLPExecutor(object):
 
         pruner_params = _fetch_pruner_config(trial)
         pruner_params = {
-            "{}_{}".format(_PREFIX, key): _encode_param(value) for key, value in pruner_params.items()
+            "{}_{}".format(_PREFIX, key): _encode_param(value)
+            for key, value in pruner_params.items()
         }
 
         system_attrs = {

--- a/optuna/integration/allennlp.py
+++ b/optuna/integration/allennlp.py
@@ -51,6 +51,7 @@ else:
 
 
 _PPID = os.getppid()
+_NONE = "<PYTHON_NONE_OBJECT>"
 
 """
 User might want to launch multiple studies that uses `AllenNLPExecutor`.
@@ -69,6 +70,13 @@ _PRUNER_KEYS = "{}_PRUNER_KEYS".format(_PREFIX)
 _STORAGE_NAME = "{}_STORAGE_NAME".format(_PREFIX)
 _STUDY_NAME = "{}_STUDY_NAME".format(_PREFIX)
 _TRIAL_ID = "{}_TRIAL_ID".format(_PREFIX)
+
+
+
+def _encode_param(value: Any) -> str:
+    if value is None:
+        return _NONE
+    return str(value)
 
 
 def _create_pruner() -> Optional[optuna.pruners.BasePruner]:
@@ -104,7 +112,7 @@ def _infer_and_cast(value: Optional[str]) -> Optional[Union[str, int, float, boo
     to desired types.
 
     """
-    if value is None:
+    if value in (None, _NONE):
         return None
 
     try:
@@ -316,7 +324,7 @@ class AllenNLPExecutor(object):
 
         pruner_params = _fetch_pruner_config(trial)
         pruner_params = {
-            "{}_{}".format(_PREFIX, key): str(value) for key, value in pruner_params.items()
+            "{}_{}".format(_PREFIX, key): _encode_param(value) for key, value in pruner_params.items()
         }
 
         system_attrs = {

--- a/tests/integration_tests/allennlp_tests/test_allennlp.py
+++ b/tests/integration_tests/allennlp_tests/test_allennlp.py
@@ -315,11 +315,11 @@ def test_allennlp_pruning_callback_with_invalid_storage() -> None:
         ),
         (
             optuna.pruners.SuccessiveHalvingPruner,
-            {"min_resource": 3, "reduction_factor": 5, "min_early_stopping_rate": 1},
+            {"min_resource": "auto", "reduction_factor": 5, "min_early_stopping_rate": 1},
         ),
         (
             optuna.pruners.ThresholdPruner,
-            {"lower": 0.0, "upper": 1.0, "n_warmup_steps": 3, "interval_steps": 2},
+            {"lower": 0.0, "upper": None, "n_warmup_steps": 3, "interval_steps": 2},
         ),
     ],
 )


### PR DESCRIPTION
- Ref: https://github.com/himkt/allennlp-optuna/issues/39

## Motivation
Optuna pruning integration for AllenNLP creates a pruner using environment variables.
If a value None (None object) is specified in config, it would be parsed as "None" (string literal) when constructing a pruner. It causes the problem you encountered (referred from https://github.com/himkt/allennlp-optuna/issues/39#issuecomment-841614525).

This PR fixes a bug to parse the `None` object.

If `None` is passed to AllenNLP integration, Optuna rewrites it to the special symbol `_NONE` (`"<PYTHON_NONE_OBJECT>"`) and sets it to environment variable. When constructing a pruner from environment variables, the symbol is parsed as Python `None` object.

## Description of the changes
- 1d22815 updates a test to check if a pruner works well with `None`
- c410a0a adds a special logic to treat Python `None` object

---

before: https://github.com/optuna/optuna/runs/2589537538
after: https://github.com/optuna/optuna/runs/2589569845
