### PR TITLE
Read environment variables in dump_best_config

### DIFF
--- a/optuna/integration/allennlp.py
+++ b/optuna/integration/allennlp.py
@@ -183,6 +183,15 @@ def _fetch_pruner_config(trial: optuna.Trial) -> Dict[str, Any]:
     return kwargs
 
 
+def _is_encodable(value: str) -> bool:
+    # https://github.com/allenai/allennlp/blob/master/allennlp/common/params.py#L77-L85
+    return (value == "") or (value.encode("utf-8", "ignore") != b"")
+
+
+def _environment_variables() -> Dict[str, str]:
+    return {key: value for key, value in os.environ.items() if _is_encodable(value)}
+
+
 def dump_best_config(input_config_file: str, output_config_file: str, study: optuna.Study) -> None:
     """Save JSON config file after updating with parameters from the best trial in the study.
 
@@ -199,10 +208,19 @@ def dump_best_config(input_config_file: str, output_config_file: str, study: opt
     """
     _imports.check()
 
+    # environment variables
+    ext_vars = _environment_variables()
+
+    # hyperparameters
     best_params = study.best_params
     for key, value in best_params.items():
         best_params[key] = str(value)
-    best_config = json.loads(_jsonnet.evaluate_file(input_config_file, ext_vars=best_params))
+
+    # If keys both appear in environment variables and best_params,
+    # values in environment variables are overwritten, which means best_params is prioritized.
+    ext_vars.update(best_params)
+
+    best_config = json.loads(_jsonnet.evaluate_file(input_config_file, ext_vars=ext_vars))
 
     # `optuna_pruner` only works with Optuna.
     # It removes when dumping configuration since
@@ -341,7 +359,7 @@ class AllenNLPExecutor(object):
         https://github.com/allenai/allentune/blob/master/allentune/modules/allennlp_runner.py#L34-L65
 
         """
-        params = self._environment_variables()
+        params = _environment_variables()
         params.update({key: str(value) for key, value in self._params.items()})
         params.update(self._system_attrs)
         return json.loads(_jsonnet.evaluate_file(self._config_file, ext_vars=params))
@@ -349,14 +367,6 @@ class AllenNLPExecutor(object):
     def _set_environment_variables(self) -> None:
         for key, value in self._system_attrs.items():
             os.environ[key] = value
-
-    @staticmethod
-    def _is_encodable(value: str) -> bool:
-        # https://github.com/allenai/allennlp/blob/master/allennlp/common/params.py#L77-L85
-        return (value == "") or (value.encode("utf-8", "ignore") != b"")
-
-    def _environment_variables(self) -> Dict[str, str]:
-        return {key: value for key, value in os.environ.items() if self._is_encodable(value)}
 
     def run(self) -> float:
         """Train a model using AllenNLP."""

--- a/optuna/integration/allennlp.py
+++ b/optuna/integration/allennlp.py
@@ -208,10 +208,10 @@ def dump_best_config(input_config_file: str, output_config_file: str, study: opt
     """
     _imports.check()
 
-    # environment variables
+    # Get environment variables.
     ext_vars = _environment_variables()
 
-    # hyperparameters
+    # Get the best hyperparameters.
     best_params = study.best_params
     for key, value in best_params.items():
         best_params[key] = str(value)

--- a/optuna/integration/allennlp.py
+++ b/optuna/integration/allennlp.py
@@ -193,7 +193,7 @@ def _environment_variables() -> Dict[str, str]:
 
 
 def dump_best_config(input_config_file: str, output_config_file: str, study: optuna.Study) -> None:
-    """Save JSON config file after updating with parameters from the best trial in the study.
+    """Save JSON config file with environment variables and best performing hyperparameters.
 
     Args:
         input_config_file:

--- a/tests/integration_tests/allennlp_tests/example_with_environment_variables.jsonnet
+++ b/tests/integration_tests/allennlp_tests/example_with_environment_variables.jsonnet
@@ -54,8 +54,10 @@ local LEARNING_RATE = std.parseJson(std.extVar('LEARNING_RATE'));
     batch_size: 32,
   },
   trainer: {
-    optimizer: 'adam',
-    lr: LEARNING_RATE,
+    optimizer: {
+      type: 'adam',
+      lr: LEARNING_RATE,
+    },
     num_epochs: 1,
     patience: 10,
     cuda_device: -1,

--- a/tests/integration_tests/allennlp_tests/test_allennlp.py
+++ b/tests/integration_tests/allennlp_tests/test_allennlp.py
@@ -256,9 +256,9 @@ def test_dump_best_config_with_environment_variables() -> None:
         best_config = json.loads(_jsonnet.evaluate_file(output_config_file))
         assert os.getenv("TRAIN_PATH") == best_config["train_data_path"]
         assert os.getenv("VALID_PATH") == best_config["validation_data_path"]
+        os.environ.pop("TRAIN_PATH")
+        os.environ.pop("VALID_PATH")
 
-        del os.environ["TRAIN_PATH"]
-        del os.environ["VALID_PATH"]
 
 def test_allennlp_pruning_callback() -> None:
     with tempfile.TemporaryDirectory() as tmp_dir:

--- a/tests/integration_tests/allennlp_tests/test_allennlp.py
+++ b/tests/integration_tests/allennlp_tests/test_allennlp.py
@@ -257,6 +257,8 @@ def test_dump_best_config_with_environment_variables() -> None:
         assert os.getenv("TRAIN_PATH") == best_config["train_data_path"]
         assert os.getenv("VALID_PATH") == best_config["validation_data_path"]
 
+        del os.environ["TRAIN_PATH"]
+        del os.environ["VALID_PATH"]
 
 def test_allennlp_pruning_callback() -> None:
     with tempfile.TemporaryDirectory() as tmp_dir:


### PR DESCRIPTION
Ref. https://github.com/himkt/allennlp-optuna/issues/41

## Motivation
AllenNLP supports reading some parameters from environment variables.
Thus, a config file could contain some external variables that are not related to hyperparameters.
When invoking `dump_best_config`, we have to read environment variables as well as best-performing hyperparameters.

```jsonnet
local dropout = std.parseJson(std.extVar('dropout'));
local embedding_dim = std.parseInt(std.extVar('embedding_dim'));
local lr = std.parseJson(std.extVar('lr'));


{
  dataset_reader: {
    ...
  },
  train_data_path: std.extVar('train_data_path'),       // these are not hyperparameter but simple external parameter
  validation_data_path: std.extVar('valid_data_path'),  // which are given from environment variables
  model: {
    type: 'basic_classifier',
    text_field_embedder: {
      token_embedders: {
        tokens: {
          type: 'embedding',
          embedding_dim: embedding_dim,  // it is hyperparameter defined at the top of configuration
        },
      },
    },
    seq2vec_encoder: {
      ....
    }
  },
  data_loader: {
    batch_size: 1,
  },
  ...
}
```


## Description of the changes
- 59dbd75 reads environment variables in `dump_best_config`
