### PR TITLE
Restore original params for pruners in AllenNLP integration

### DIFF
--- a/optuna/integration/allennlp.py
+++ b/optuna/integration/allennlp.py
@@ -166,7 +166,8 @@ def _fetch_pruner_config(trial: optuna.Trial) -> Dict[str, Any]:
         kwargs["interval_steps"] = pruner._interval_steps
 
     elif isinstance(pruner, optuna.pruners.SuccessiveHalvingPruner):
-        kwargs["min_resource"] = pruner._min_resource
+        min_resource = pruner._min_resource if pruner._min_resource is not None else "auto"
+        kwargs["min_resource"] = min_resource
         kwargs["reduction_factor"] = pruner._reduction_factor
         kwargs["min_early_stopping_rate"] = pruner._min_early_stopping_rate
 

--- a/optuna/integration/allennlp.py
+++ b/optuna/integration/allennlp.py
@@ -14,12 +14,12 @@ from optuna import load_study
 from optuna import Trial
 from optuna._experimental import experimental
 from optuna._imports import try_import
-from optuna.pruners import ThresholdPruner  # NOQA
-from optuna.pruners import SuccessiveHalvingPruner  # NOQA
 from optuna.pruners import HyperbandPruner  # NOQA
+from optuna.pruners import MedianPruner  # NOQA
 from optuna.pruners import NopPruner  # NOQA
 from optuna.pruners import PercentilePruner  # NOQA
-from optuna.pruners import MedianPruner  # NOQA
+from optuna.pruners import SuccessiveHalvingPruner  # NOQA
+from optuna.pruners import ThresholdPruner  # NOQA
 
 
 with try_import() as _imports:

--- a/optuna/pruners/_base.py
+++ b/optuna/pruners/_base.py
@@ -28,9 +28,8 @@ class BasePruner(object, metaclass=abc.ABCMeta):
 
         raise NotImplementedError
 
-    @abc.abstractclassmethod
     def _arguments(self) -> List[str]:
-        raise NotImplementedError
+        raise []
 
     def __repr__(self) -> str:
         arguments = ", ".join(self._arguments())

--- a/optuna/pruners/_base.py
+++ b/optuna/pruners/_base.py
@@ -1,4 +1,5 @@
 import abc
+from typing import List
 
 import optuna
 
@@ -26,3 +27,11 @@ class BasePruner(object, metaclass=abc.ABCMeta):
         """
 
         raise NotImplementedError
+
+    @abc.abstractclassmethod
+    def _arguments(self) -> List[str]:
+        raise NotImplementedError
+
+    def __repr__(self) -> str:
+        arguments = ", ".join(self._arguments())
+        return f"{self.__class__.__name__}({arguments})"

--- a/optuna/pruners/_hyperband.py
+++ b/optuna/pruners/_hyperband.py
@@ -165,6 +165,14 @@ class HyperbandPruner(BasePruner):
                 "are mutually incompatible, bootstrap_count is {}".format(self._bootstrap_count)
             )
 
+    def _arguments(self) -> List[str]:
+        return [
+            f"min_resource={repr(self._min_resource)}",
+            f"max_resource={repr(self._max_resource)}",
+            f"reduction_factor={repr(self._reduction_factor)}",
+            f"bootstrap_count={repr(self._bootstrap_count)}",
+        ]
+
     def prune(self, study: "optuna.study.Study", trial: "optuna.trial.FrozenTrial") -> bool:
         if len(self._pruners) == 0:
             self._try_initialization(study)

--- a/optuna/pruners/_median.py
+++ b/optuna/pruners/_median.py
@@ -1,3 +1,5 @@
+from typing import List
+
 from optuna.pruners._percentile import PercentilePruner
 
 
@@ -79,3 +81,11 @@ class MedianPruner(PercentilePruner):
         super().__init__(
             50.0, n_startup_trials, n_warmup_steps, interval_steps, n_min_trials=n_min_trials
         )
+
+    def _arguments(self) -> List[str]:
+        return [
+            f"n_startup_trials={repr(self._n_startup_trials)}",
+            f"n_warmup_steps={repr(self._n_warmup_steps)}",
+            f"interval_steps={repr(self._interval_steps)}",
+            f"n_min_trials={repr(self._n_min_trials)}",
+        ]

--- a/optuna/pruners/_nop.py
+++ b/optuna/pruners/_nop.py
@@ -1,3 +1,5 @@
+from typing import List
+
 import optuna
 from optuna.pruners import BasePruner
 
@@ -46,3 +48,6 @@ class NopPruner(BasePruner):
     def prune(self, study: "optuna.study.Study", trial: "optuna.trial.FrozenTrial") -> bool:
 
         return False
+
+    def _arguments(self) -> List[str]:
+        return []

--- a/optuna/pruners/_percentile.py
+++ b/optuna/pruners/_percentile.py
@@ -174,6 +174,15 @@ class PercentilePruner(BasePruner):
         self._interval_steps = interval_steps
         self._n_min_trials = n_min_trials
 
+    def _arguments(self) -> List[str]:
+        return [
+            f"percentile={repr(self._percentile)}",
+            f"n_startup_trials={repr(self._n_startup_trials)}",
+            f"n_warmup_steps={repr(self._n_warmup_steps)}",
+            f"interval_steps={repr(self._interval_steps)}",
+            f"n_min_trials={repr(self._n_min_trials)}",
+        ]
+
     def prune(self, study: "optuna.study.Study", trial: "optuna.trial.FrozenTrial") -> bool:
 
         all_trials = study.get_trials(deepcopy=False)

--- a/optuna/pruners/_successive_halving.py
+++ b/optuna/pruners/_successive_halving.py
@@ -160,6 +160,15 @@ class SuccessiveHalvingPruner(BasePruner):
         self._min_early_stopping_rate = min_early_stopping_rate
         self._bootstrap_count = bootstrap_count
 
+    def _arguments(self) -> List[str]:
+        min_resource = "auto" if self._min_resource is None else self._min_resource
+        return [
+            f"min_resource={repr(min_resource)}",
+            f"reduction_factor={repr(self._reduction_factor)}",
+            f"min_early_stopping_rate={repr(self._min_early_stopping_rate)}",
+            f"bootstrap_count={repr(self._bootstrap_count)}",
+        ]
+
     def prune(self, study: "optuna.study.Study", trial: "optuna.trial.FrozenTrial") -> bool:
 
         step = trial.last_step

--- a/optuna/pruners/_threshold.py
+++ b/optuna/pruners/_threshold.py
@@ -1,7 +1,7 @@
 import math
 from typing import Any
-from typing import Optional
 from typing import List
+from typing import Optional
 
 import optuna
 from optuna.pruners import BasePruner

--- a/optuna/pruners/_threshold.py
+++ b/optuna/pruners/_threshold.py
@@ -1,6 +1,7 @@
 import math
 from typing import Any
 from typing import Optional
+from typing import List
 
 import optuna
 from optuna.pruners import BasePruner
@@ -110,6 +111,16 @@ class ThresholdPruner(BasePruner):
         self._upper = upper
         self._n_warmup_steps = n_warmup_steps
         self._interval_steps = interval_steps
+
+    def _arguments(self) -> List[str]:
+        lower = None if self._lower == -float("inf") else self._lower
+        upper = None if self._upper == float("inf") else self._upper
+        return [
+            f"lower={repr(lower)}",
+            f"upper={repr(upper)}",
+            f"n_warmup_steps={repr(self._n_warmup_steps)}",
+            f"interval_steps={repr(self._interval_steps)}",
+        ]
 
     def prune(self, study: "optuna.study.Study", trial: "optuna.trial.FrozenTrial") -> bool:
 

--- a/optuna/testing/integration.py
+++ b/optuna/testing/integration.py
@@ -1,3 +1,5 @@
+from typing import List
+
 import optuna
 
 
@@ -5,6 +7,9 @@ class DeterministicPruner(optuna.pruners.BasePruner):
     def __init__(self, is_pruning: bool) -> None:
 
         self.is_pruning = is_pruning
+
+    def _arguments(self) -> List[str]:
+        return []
 
     def prune(self, study: "optuna.study.Study", trial: "optuna.trial.FrozenTrial") -> bool:
 

--- a/tests/integration_tests/allennlp_tests/test_allennlp.py
+++ b/tests/integration_tests/allennlp_tests/test_allennlp.py
@@ -370,18 +370,10 @@ def test_allennlp_pruning_callback_with_executor(
             ):
                 assert getattr(ret_pruner, "_{}".format(key)) is None
 
-            elif (
-                isinstance(pruner, ThresholdPruner)
-                and key == "upper"
-                and value is None
-            ):
+            elif isinstance(pruner, ThresholdPruner) and key == "upper" and value is None:
                 assert getattr(ret_pruner, "_{}".format(key)) == float("inf")
 
-            elif (
-                isinstance(pruner, ThresholdPruner)
-                and key == "lower"
-                and value is None
-            ):
+            elif isinstance(pruner, ThresholdPruner) and key == "lower" and value is None:
                 assert getattr(ret_pruner, "_{}".format(key)) == -float("inf")
 
             else:

--- a/tests/integration_tests/allennlp_tests/test_allennlp.py
+++ b/tests/integration_tests/allennlp_tests/test_allennlp.py
@@ -380,31 +380,6 @@ def test_allennlp_pruning_callback_with_executor(
                 assert getattr(ret_pruner, "_{}".format(key)) == value
 
 
-def test_allennlp_pruning_callback_with_invalid_executor() -> None:
-    class SomeNewPruner(optuna.pruners.BasePruner):
-        def __init__(self) -> None:
-            pass
-
-        def prune(self, study: optuna.study.Study, trial: optuna.trial.FrozenTrial) -> bool:
-            return False
-
-    input_config_file = (
-        "tests/integration_tests/allennlp_tests/example_with_executor_and_pruner.jsonnet"
-    )
-
-    with tempfile.TemporaryDirectory() as tmp_dir:
-        storage = "sqlite:///" + os.path.join(tmp_dir, "result.db")
-        serialization_dir = os.path.join(tmp_dir, "allennlp")
-        pruner = SomeNewPruner()
-
-        study = optuna.create_study(direction="maximize", pruner=pruner, storage=storage)
-        trial = optuna.trial.Trial(study, study._storage.create_new_trial(study._study_id))
-        trial.suggest_float("DROPOUT", 0.0, 0.5)
-
-        with pytest.raises(ValueError):
-            optuna.integration.AllenNLPExecutor(trial, input_config_file, serialization_dir)
-
-
 def test_infer_and_cast() -> None:
     assert optuna.integration.allennlp._infer_and_cast(None) is None
     assert optuna.integration.allennlp._infer_and_cast("True") is True

--- a/tests/integration_tests/allennlp_tests/test_allennlp.py
+++ b/tests/integration_tests/allennlp_tests/test_allennlp.py
@@ -378,12 +378,3 @@ def test_allennlp_pruning_callback_with_executor(
 
             else:
                 assert getattr(ret_pruner, "_{}".format(key)) == value
-
-
-def test_infer_and_cast() -> None:
-    assert optuna.integration.allennlp._infer_and_cast(None) is None
-    assert optuna.integration.allennlp._infer_and_cast("True") is True
-    assert optuna.integration.allennlp._infer_and_cast("False") is False
-    assert optuna.integration.allennlp._infer_and_cast("3.14") == 3.14
-    assert optuna.integration.allennlp._infer_and_cast("42") == 42
-    assert optuna.integration.allennlp._infer_and_cast("auto") == "auto"


### PR DESCRIPTION
Ref. https://github.com/himkt/allennlp-optuna/issues/39


## Motivation

### 1. `SuccessiveHalvingPruner`

`SuccessiveHalvingPruner` doesn't save `min_resource` parameter when it is `"auto"`.
ref. https://github.com/optuna/optuna/blob/853b94b459ecf9e434fb1e28dda7f07349eec20c/optuna/pruners/_successive_halving.py#L157-L158

However, `AllenNLPExecutor` doesn't take care of it.
ref. https://github.com/optuna/optuna/blob/853b94b459ecf9e434fb1e28dda7f07349eec20c/optuna/integration/allennlp.py#L169

This PR update `min_resource` to `"auto"` when `pruner._min_resource` is `None`.

### 2. `ThresholdPruner`

`SuccessiveHalvingPruner` internally updates `lower` or `upper` before saving them in the initializer.
I also add restoring logics for them.

ref. https://github.com/optuna/optuna/blob/853b94b459ecf9e434fb1e28dda7f07349eec20c/optuna/pruners/_threshold.py#L95-L96


## Discussion

I'm not sure whether it would be better to change the initialization logic of `SuccessiveHalvingPruner` and `ThresholdPruner`. I'd other developers' opinion.


## Description of the changes
- 2d002cc updates `min_resource` when `pruner._min_resource` is `None`
- aaaf60f updates `lower` or `upper` when `pruner._lower` or `pruner._upper` is `None`, respectively
- 6b5ade5 adds test cases
- ef9370d fixes style
