### PR TITLE
Fix indents in the ask-and-tell tutorial

### DIFF
--- a/tutorial/20_recipes/009_ask_and_tell.py
+++ b/tutorial/20_recipes/009_ask_and_tell.py
@@ -134,11 +134,11 @@ for _ in range(n_trials):
 #                pruned_trial = True
 #                break
 #
-#    if pruned_trial:
-#        study.tell(trial, state=optuna.trial.TrialState.PRUNED)  # tell the pruned state
-#    else:
-#        score = clf.score(X_valid, y_valid)
-#        study.tell(trial, score)  # tell objective value
+#        if pruned_trial:
+#            study.tell(trial, state=optuna.trial.TrialState.PRUNED)  # tell the pruned state
+#        else:
+#            score = clf.score(X_valid, y_valid)
+#            study.tell(trial, score)  # tell objective value
 
 ###################################################################################################
 # .. note::


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

The code examples' indents around `tell` [on this tutorial](https://optuna.readthedocs.io/en/latest/tutorial/20_recipes/009_ask_and_tell.html#define-and-run) are wrong: the `tell` part is out of the trial loop.

<img width="653" alt="Screenshot 2021-05-19 at 20 48 51" src="https://user-images.githubusercontent.com/7121753/118807803-b80ed980-b8e3-11eb-9306-01700018c346.png">


## Description of the changes
<!-- Describe the changes in this PR. -->

Add one level indent (4 spaces).

The generated page is as follows:
<img width="642" alt="Screenshot 2021-05-19 at 21 14 20" src="https://user-images.githubusercontent.com/7121753/118810892-57819b80-b8e7-11eb-936a-5497d6fdb9fa.png">


ref: 
https://67222-122299416-gh.circle-artifacts.com/0/docs/build/html/tutorial/20_recipes/009_ask_and_tell.html#apply-optuna-to-an-existing-optimization-problem-with-minimum-modifications
