### PR TITLE
Add automatic retry callback

### DIFF
--- a/docs/source/reference/storages.rst
+++ b/docs/source/reference/storages.rst
@@ -11,3 +11,4 @@ The :mod:`~optuna.storages` module defines a :class:`~optuna.storages.BaseStorag
 
    optuna.storages.RDBStorage
    optuna.storages.RedisStorage
+   optuna.storages.RetryFailedTrialCallback

--- a/optuna/_callbacks.py
+++ b/optuna/_callbacks.py
@@ -86,9 +86,14 @@ class RetryFailedTrialCallback:
                 storage=storage,
             )
 
+    Args:
+        max_retry:
+            The max number of times a trial can be retried. Must be set to :obj:`None` or an
+            integer. If set to the default value of :obj:`None` will retry indefinitely.
+            If set to an integer, will only retry that many times.
     """
 
-    def __init__(self, max_retry: int) -> None:
+    def __init__(self, max_retry: Optional[int] = None) -> None:
         self._max_retry = max_retry
 
     def __call__(self, study: "optuna.study.Study", trial: FrozenTrial) -> None:
@@ -104,7 +109,7 @@ class RetryFailedTrialCallback:
             for s in study.trials
         )
 
-        if retries + 1 > self._max_retry:
+        if self._max_retry is not None and retries + 1 > self._max_retry:
             return
 
         study.add_trial(

--- a/optuna/_callbacks.py
+++ b/optuna/_callbacks.py
@@ -75,7 +75,7 @@ class RetryFailedTrialCallback:
             from optuna.storages import RetryFailedTrialCallback
 
             storage = optuna.storages.RDBStorage(
-                url='sqlite:///:memory:',
+                url="sqlite:///:memory:",
                 heartbeat_interval=60,
                 grace_period=120,
                 failed_trial_callback=RetryFailedTrialCallback(max_retry=3),

--- a/optuna/_callbacks.py
+++ b/optuna/_callbacks.py
@@ -119,7 +119,7 @@ class RetryFailedTrialCallback:
 
     @staticmethod
     def retried_trial_number(trial: FrozenTrial) -> Optional[int]:
-        """Return the number of the trail being retried.
+        """Return the number of the trial being retried.
 
         Args:
             trial:

--- a/optuna/_callbacks.py
+++ b/optuna/_callbacks.py
@@ -123,7 +123,7 @@ class RetryFailedTrialCallback:
 
         Args:
             trial:
-                The :obj:`trial` object.
+                The trial object.
 
         Returns:
             The number of the previous trial. If not retry of a previous trial,

--- a/optuna/_callbacks.py
+++ b/optuna/_callbacks.py
@@ -105,8 +105,8 @@ class RetryFailedTrialCallback:
         system_attrs.update(trial.system_attrs)
 
         retries = sum(
-            ("failed_trial", system_attrs["failed_trial"]) in s.system_attrs.items()
-            for s in study.trials
+            ("failed_trial", system_attrs["failed_trial"]) in t.system_attrs.items()
+            for t in study.trials
         )
 
         if self._max_retry is not None and retries + 1 > self._max_retry:

--- a/optuna/_callbacks.py
+++ b/optuna/_callbacks.py
@@ -118,7 +118,7 @@ class RetryFailedTrialCallback:
         )
 
     @staticmethod
-    def retried_trial_number(trial) -> Optional[int]:
+    def retried_trial_number(trial: FrozenTrial) -> Optional[int]:
         """Return the number of the trail being retried.
 
         Args:

--- a/optuna/_callbacks.py
+++ b/optuna/_callbacks.py
@@ -59,7 +59,7 @@ class MaxTrialsCallback:
 
 @experimental("2.8.0")
 class RetryFailedTrialCallback:
-    """Retry a failed trial up to a maximum number of times
+    """Retry a failed trial up to a maximum number of times.
 
     When a trial fails, this callback can be used with the :class:`optuna.storage` class to
     recreate the trial in :obj:`TrialState.WAITING` to queue up the trial to be run again.

--- a/optuna/_callbacks.py
+++ b/optuna/_callbacks.py
@@ -91,20 +91,22 @@ class RetryFailedTrialCallback:
         self._max_retry = max_retry
 
     def __call__(self, study: "optuna.study.Study", trial: FrozenTrial) -> None:
-        retries = sum(("failed_trial", trial.number) in s.user_attrs.items() for s in study.trials)
+        retries = sum(
+            ("failed_trial", trial.number) in s.system_attrs.items() for s in study.trials
+        )
 
         if retries + 1 > self._max_retry:
             return
 
-        user_attrs = {"failed_trial": trial.number}
-        user_attrs.update(trial.user_attrs)
+        system_attrs = {"failed_trial": trial.number}
+        system_attrs.update(trial.system_attrs)
 
         study.add_trial(
             optuna.create_trial(
                 state=optuna.trial.TrialState.WAITING,
                 params=trial.params,
                 distributions=trial.distributions,
-                user_attrs=user_attrs,
-                system_attrs=trial.system_attrs,
+                user_attrs=trial.user_attrs,
+                system_attrs=system_attrs,
             )
         )

--- a/optuna/_callbacks.py
+++ b/optuna/_callbacks.py
@@ -1,3 +1,4 @@
+from typing import Optional
 from typing import Tuple
 
 import optuna
@@ -115,3 +116,17 @@ class RetryFailedTrialCallback:
                 system_attrs=system_attrs,
             )
         )
+
+    def retried_trial_number(trial) -> Optional[int]:
+        """Return the number of the trail being retried.
+
+        Args:
+            trial:
+                The :obj:`trial` object.
+
+        Returns:
+            The number of the previous trial. If not retry of a previous trial,
+            returns :obj:`None`.
+        """
+
+        return trial.system_attrs.get("failed_trial", None)

--- a/optuna/_callbacks.py
+++ b/optuna/_callbacks.py
@@ -117,6 +117,7 @@ class RetryFailedTrialCallback:
             )
         )
 
+    @experimental("2.8.0")
     @staticmethod
     def retried_trial_number(trial: FrozenTrial) -> Optional[int]:
         """Return the number of the trial being retried.

--- a/optuna/_callbacks.py
+++ b/optuna/_callbacks.py
@@ -96,8 +96,8 @@ class RetryFailedTrialCallback:
             study.user_attrs["failed_trials"] if "failed_trials" in study.user_attrs else []
         )
         failed_trials.append(user_attrs["failed_trial"])
-        study.user_attrs.update({"failed_trials": failed_trials})
-        print(study.user_attrs, user_attrs, failed_trials)
+        study.set_user_attr("failed_trials", failed_trials)
+
         if failed_trials.count(trial.number) > self._max_retry:
             return
 
@@ -106,7 +106,7 @@ class RetryFailedTrialCallback:
                 state=optuna.trial.TrialState.WAITING,
                 params=trial.params,
                 distributions=trial.distributions,
-                user_attrs=trial.user_attrs,
+                user_attrs=user_attrs,
                 system_attrs=trial.system_attrs,
             )
         )

--- a/optuna/_callbacks.py
+++ b/optuna/_callbacks.py
@@ -66,7 +66,7 @@ class RetryFailedTrialCallback:
     recreate the trial in :obj:`TrialState.WAITING` to queue up the trial to be run again.
 
     This is helpful in environments where trials may fail due to external conditions, such as
-    being pre-empted by other processes.
+    being preempted by other processes.
 
     Usage:
 

--- a/optuna/_callbacks.py
+++ b/optuna/_callbacks.py
@@ -91,15 +91,20 @@ class RetryFailedTrialCallback:
         self._max_retry = max_retry
 
     def __call__(self, study: "optuna.study.Study", trial: FrozenTrial) -> None:
+        system_attrs = {"failed_trial": trial.number}
+
+        # Update the new object with the values in the trial.system_attrs.
+        # By doing this, if this failed try is already a rety, the 'failed_trial' value
+        # will be the first failed trial number.
+        system_attrs.update(trial.system_attrs)
+
         retries = sum(
-            ("failed_trial", trial.number) in s.system_attrs.items() for s in study.trials
+            ("failed_trial", system_attrs["failed_trial"]) in s.system_attrs.items()
+            for s in study.trials
         )
 
         if retries + 1 > self._max_retry:
             return
-
-        system_attrs = {"failed_trial": trial.number}
-        system_attrs.update(trial.system_attrs)
 
         study.add_trial(
             optuna.create_trial(

--- a/optuna/_callbacks.py
+++ b/optuna/_callbacks.py
@@ -117,6 +117,7 @@ class RetryFailedTrialCallback:
             )
         )
 
+    @staticmethod
     def retried_trial_number(trial) -> Optional[int]:
         """Return the number of the trail being retried.
 

--- a/optuna/_callbacks.py
+++ b/optuna/_callbacks.py
@@ -71,10 +71,10 @@ class RetryFailedTrialCallback:
 
         .. testcode::
 
+            import optuna
             from optuna.storages import RetryFailedTrialCallback
 
             storage = optuna.storages.RDBStorage(
-                args.optuna_storage,
                 heartbeat_interval=60,
                 grace_period=120,
                 failed_trial_callback=RetryFailedTrialCallback(max_retry=3),

--- a/optuna/_callbacks.py
+++ b/optuna/_callbacks.py
@@ -117,8 +117,8 @@ class RetryFailedTrialCallback:
             )
         )
 
-    @experimental("2.8.0")
     @staticmethod
+    @experimental("2.8.0")
     def retried_trial_number(trial: FrozenTrial) -> Optional[int]:
         """Return the number of the trial being retried.
 

--- a/optuna/_callbacks.py
+++ b/optuna/_callbacks.py
@@ -75,6 +75,7 @@ class RetryFailedTrialCallback:
             from optuna.storages import RetryFailedTrialCallback
 
             storage = optuna.storages.RDBStorage(
+                url='sqlite:///:memory:',
                 heartbeat_interval=60,
                 grace_period=120,
                 failed_trial_callback=RetryFailedTrialCallback(max_retry=3),

--- a/optuna/_callbacks.py
+++ b/optuna/_callbacks.py
@@ -58,8 +58,10 @@ class MaxTrialsCallback:
 
 
 @experimental("2.8.0")
-def RetryFailedTrialCallback(study, trial):
-    """When a trail fails, this callback can be used with the :class:`optuna.storage` class to
+class RetryFailedTrialCallback:
+    """Retry a failed trial up to a maximum number of times
+
+    When a trail fails, this callback can be used with the :class:`optuna.storage` class to
     recreate the trial in :obj:`TrialState.WAITING` to queue up the trial to be run again.
 
     This is helpful in environments where trials may fail due to external conditions, such as
@@ -68,6 +70,8 @@ def RetryFailedTrialCallback(study, trial):
     Usage:
 
         .. testcode::
+
+            from optuna.storage import RetryFailedTrialCallback
 
             storage = optuna.storages.RDBStorage(
                 args.optuna_storage,
@@ -79,6 +83,7 @@ def RetryFailedTrialCallback(study, trial):
             study = optuna.create_study(
                 storage=storage,
             )
+
     """
 
     def __init__(self, max_retry: int) -> None:

--- a/optuna/_callbacks.py
+++ b/optuna/_callbacks.py
@@ -61,7 +61,7 @@ class MaxTrialsCallback:
 class RetryFailedTrialCallback:
     """Retry a failed trial up to a maximum number of times
 
-    When a trail fails, this callback can be used with the :class:`optuna.storage` class to
+    When a trial fails, this callback can be used with the :class:`optuna.storage` class to
     recreate the trial in :obj:`TrialState.WAITING` to queue up the trial to be run again.
 
     This is helpful in environments where trials may fail due to external conditions, such as

--- a/optuna/storages/__init__.py
+++ b/optuna/storages/__init__.py
@@ -1,5 +1,6 @@
 from typing import Union
 
+from optuna._callbacks import MaxTrialsCallback  # NOQA
 from optuna.storages._base import BaseStorage
 from optuna.storages._cached_storage import _CachedStorage
 from optuna.storages._in_memory import InMemoryStorage

--- a/optuna/storages/__init__.py
+++ b/optuna/storages/__init__.py
@@ -1,6 +1,6 @@
 from typing import Union
 
-from optuna._callbacks import MaxTrialsCallback  # NOQA
+from optuna._callbacks import RetryFailedTrialCallback  # NOQA
 from optuna.storages._base import BaseStorage
 from optuna.storages._cached_storage import _CachedStorage
 from optuna.storages._in_memory import InMemoryStorage

--- a/tests/storages_tests/rdb_tests/test_storage.py
+++ b/tests/storages_tests/rdb_tests/test_storage.py
@@ -423,7 +423,7 @@ def test_RetryFailedTrialCallback() -> None:
 
             # Exceptions raised in spawned threads are caught by `_TestableThread`.
             with patch("optuna._optimize.Thread", _TestableThread):
-                study.optimize(lambda _: n, n_trials=1)
+                study.optimize(lambda _: 1.0, n_trials=1)
 
             retried_trials = sum("failed_trial" in s.system_attrs for s in study.trials)
             assert retried_trials == n

--- a/tests/storages_tests/rdb_tests/test_storage.py
+++ b/tests/storages_tests/rdb_tests/test_storage.py
@@ -410,17 +410,20 @@ def test_RetryFailedTrialCallback() -> None:
         assert isinstance(storage, RDBStorage)
         storage.heartbeat_interval = heartbeat_interval
         storage.grace_period = grace_period
-        storage.failed_trial_callback = RetryFailedTrialCallback(max_retry=2)
-        study = create_study(storage=storage)
 
-        trial = study.ask()
-        storage.record_heartbeat(trial._trial_id)
-        time.sleep(grace_period + 1)
+        # Test with n = 0 to make sure if max_rety=0 no retries are done
+        # Test with n = 1 to make sure if max_rety=1 one trial is retried
+        for n in range(2):
+            storage.failed_trial_callback = RetryFailedTrialCallback(max_retry=n)
+            study = create_study(storage=storage)
 
-        # Exceptions raised in spawned threads are caught by `_TestableThread`.
-        with patch("optuna._optimize.Thread", _TestableThread):
-            with patch.object(
-                storage, "failed_trial_callback", wraps=RetryFailedTrialCallback(max_retry=2)
-            ):
-                study.optimize(lambda _: 1.0, n_trials=3)
-                assert study.user_attrs.failed_trials.count(study.user_attrs.failed_trials[0]) == 2
+            trial = study.ask()
+            storage.record_heartbeat(trial._trial_id)
+            time.sleep(grace_period + 1)
+
+            # Exceptions raised in spawned threads are caught by `_TestableThread`.
+            with patch("optuna._optimize.Thread", _TestableThread):
+                study.optimize(lambda _: n, n_trials=1)
+
+            retried_trials = sum("failed_trial" in s.user_attrs for s in study.trials)
+            assert retried_trials == n

--- a/tests/storages_tests/rdb_tests/test_storage.py
+++ b/tests/storages_tests/rdb_tests/test_storage.py
@@ -431,4 +431,3 @@ def test_RetryFailedTrialCallback() -> None:
             )
             retried_trials = sum("failed_trial" in s.system_attrs for s in study.trials)
             assert retried_trials == n
-        assert False

--- a/tests/storages_tests/rdb_tests/test_storage.py
+++ b/tests/storages_tests/rdb_tests/test_storage.py
@@ -423,10 +423,10 @@ def test_retry_failed_trial_callback(max_retry: Optional[int]) -> None:
         with patch("optuna._optimize.Thread", _TestableThread):
             study.optimize(lambda _: 1.0, n_trials=1)
 
-        # Test the last trial to see if it was a retry of the first trial or not
-        # Test max_rety=None to see if trial is retried
-        # Test max_rety=0 to see if no trials are retried
-        # Test max_rety=1 to see if trial is retried
+        # Test the last trial to see if it was a retry of the first trial or not.
+        # Test max_rety=None to see if trial is retried.
+        # Test max_rety=0 to see if no trials are retried.
+        # Test max_rety=1 to see if trial is retried.
         assert RetryFailedTrialCallback.retried_trial_number(study.trials[1]) == (
             None if max_retry == 0 else 0
         )

--- a/tests/storages_tests/rdb_tests/test_storage.py
+++ b/tests/storages_tests/rdb_tests/test_storage.py
@@ -425,5 +425,5 @@ def test_RetryFailedTrialCallback() -> None:
             with patch("optuna._optimize.Thread", _TestableThread):
                 study.optimize(lambda _: n, n_trials=1)
 
-            retried_trials = sum("failed_trial" in s.user_attrs for s in study.trials)
+            retried_trials = sum("failed_trial" in s.system_attrs for s in study.trials)
             assert retried_trials == n

--- a/tests/storages_tests/rdb_tests/test_storage.py
+++ b/tests/storages_tests/rdb_tests/test_storage.py
@@ -402,7 +402,7 @@ def test_failed_trial_callback() -> None:
                 m.assert_called_once()
 
 
-def test_RetryFailedTrialCallback() -> None:
+def test_retry_failed_trial_callback() -> None:
     heartbeat_interval = 1
     grace_period = 2
 

--- a/tests/storages_tests/rdb_tests/test_storage.py
+++ b/tests/storages_tests/rdb_tests/test_storage.py
@@ -425,5 +425,10 @@ def test_RetryFailedTrialCallback() -> None:
             with patch("optuna._optimize.Thread", _TestableThread):
                 study.optimize(lambda _: 1.0, n_trials=1)
 
+            # Test the last trial to see if it was a retry of the first trial or not
+            assert RetryFailedTrialCallback.retried_trial_number(study.trials[1]) == (
+                0 if n == 1 else None
+            )
             retried_trials = sum("failed_trial" in s.system_attrs for s in study.trials)
             assert retried_trials == n
+        assert False


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
In some evironments, pre-emption or server disruption may be common, and it would be helpful to have Optuna able to automatically queue up trials that were interupted.

## Description of the changes
<!-- Describe the changes in this PR. -->
Add RetryFailedTrialCallback to the optuna/_callbacks.py for the storage trial_failed_callbacks.

Todo:

- [x] Convert to class to enable max retries
- [x] Add documentation
- [x] Add testing 