### PR TITLE
Remove example of catboost from pruning section

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -50,7 +50,6 @@ The following example demonstrates how to implement pruning logic with Optuna.
 In addition, integration modules are available for the following libraries, providing simpler interfaces to utilize pruning.
 
 * [Pruning with Catalyst integration module](https://github.com/optuna/optuna-examples/blob/main/pytorch/catalyst_simple.py)
-* [Pruning with Catboost integration module](https://github.com/optuna/optuna-examples/blob/main/catboost/catboost_simple.py)
 * [Pruning with Chainer integration module](https://github.com/optuna/optuna-examples/blob/main/chainer/chainer_integration.py)
 * [Pruning with ChainerMN integration module](https://github.com/optuna/optuna-examples/blob/main/chainer/chainermn_integration.py)
 * [Pruning with FastAI V1 integration module](https://github.com/optuna/optuna-examples/blob/main/fastai/fastaiv1_simple.py)


### PR DESCRIPTION
`catboost_simple.py` is listed on `Examples of Pruning`. But it seems not to use Optuna pruning integration.
This PR removes the item from the pruning section of the documentation.  We can still find this catboost example on `Examples with ML Libraries`. 😸 