### PR TITLE
Sorts categorical values on axis that contains only numerical values in visualization.matplotlib.plot_slice

### DIFF
--- a/optuna/visualization/matplotlib/_slice.py
+++ b/optuna/visualization/matplotlib/_slice.py
@@ -182,10 +182,7 @@ def _generate_slice_subplot(
     if _is_log_scale(trials, param):
         ax.set_xscale("log")
         scale = "log"
-    elif _is_numerical(trials, param):
-        x_values = [x for x in x_values]
-        scale = "numerical"
-    elif _is_categorical(trials, param):
+    elif not _is_numerical(trials, param):
         x_values = [str(x) for x in x_values]
         scale = "categorical"
     xlim = _calc_lim_with_padding(x_values, padding_ratio, scale)

--- a/optuna/visualization/matplotlib/_slice.py
+++ b/optuna/visualization/matplotlib/_slice.py
@@ -13,7 +13,6 @@ from optuna.trial import FrozenTrial
 from optuna.trial import TrialState
 from optuna.visualization._utils import _check_plot_args
 from optuna.visualization.matplotlib._matplotlib_imports import _imports
-from optuna.visualization.matplotlib._utils import _is_categorical
 from optuna.visualization.matplotlib._utils import _is_log_scale
 from optuna.visualization.matplotlib._utils import _is_numerical
 

--- a/optuna/visualization/matplotlib/_slice.py
+++ b/optuna/visualization/matplotlib/_slice.py
@@ -15,6 +15,7 @@ from optuna.visualization._utils import _check_plot_args
 from optuna.visualization.matplotlib._matplotlib_imports import _imports
 from optuna.visualization.matplotlib._utils import _is_categorical
 from optuna.visualization.matplotlib._utils import _is_log_scale
+from optuna.visualization.matplotlib._utils import _is_numerical
 
 
 if _imports.is_successful():
@@ -181,6 +182,9 @@ def _generate_slice_subplot(
     if _is_log_scale(trials, param):
         ax.set_xscale("log")
         scale = "log"
+    elif _is_numerical(trials, param):
+        x_values = [x for x in x_values]
+        scale = "numerical"
     elif _is_categorical(trials, param):
         x_values = [str(x) for x in x_values]
         scale = "categorical"


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
The slice plot's axis can be improved (by sorting) when a categorical distribution suggests only int or float values. #2605 

## Description of the changes
<!-- Describe the changes in this PR. -->
Now the y axis is sorted if it only contains numerical values. 
Before:
![image](https://user-images.githubusercontent.com/31338369/120082664-d0e86d80-c0e1-11eb-95f2-fbad789639bf.png)

After:
![image](https://user-images.githubusercontent.com/31338369/120082673-df368980-c0e1-11eb-9c11-157688c96fb9.png)

Also, if y contains mix of categorical and the numerical e.g. y = trial.suggest_categorical("y", [1,"2asd","3asd","asd"])
previous and current result remains same as follows:
![image](https://user-images.githubusercontent.com/31338369/120082764-5e2bc200-c0e2-11eb-897a-89ed2605b5a3.png)

Can be reviewed by: @nzw0301 