### PR TITLE
DOC: Updated command for installing auto-formatters

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,7 +71,7 @@ If you catch format errors, you can automatically fix them by auto-formatters.
 
 ```bash
 # Install auto-formatters.
-$ pip install .[checking]
+$ pip install ".[checking]"
 
 $ ./formats.sh
 ```


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
While installing auto-formatters for optuna, I was getting an error the following error: no matches found: .[checking] . So, I added quotes to the command and it worked. The non-quote command works for bash but doesn't work in zsh.
## Description of the changes
<!-- Describe the changes in this PR. -->
Changed the command for installing auto-formatters, added " " to support installation in all shells.

closes #2708 