### PR TITLE
BUG: Changed colour scale of contour plot by matplotlib for consistancy with plotly results

### DIFF
--- a/optuna/visualization/matplotlib/_contour.py
+++ b/optuna/visualization/matplotlib/_contour.py
@@ -390,7 +390,7 @@ def _generate_contour_subplot(
         if x_param != y_param:
             # Contour the gridded data.
             ax.contour(xi, yi, zi, 15, linewidths=0.5, colors="k")
-            cs = ax.contourf(xi, yi, zi, 15, cmap=cmap)
+            cs = ax.contourf(xi, yi, zi, 15, cmap=cmap.reversed())
             # Plot data points.
             if x_values_dummy_count > 0:
                 x_org_len = int(len(x_values) / (x_values_dummy_count + 1))


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
The colour scale for plotly and matplotlib was different: https://github.com/optuna/optuna/issues/2595#issuecomment-822151302
## Description of the changes
<!-- Describe the changes in this PR. -->
reversed cmap: `cmap = cmap.reversed()`

Before MatplotLib results:
![Before_Color_Scale](https://user-images.githubusercontent.com/46242526/120158365-aeee0880-c211-11eb-95c7-11c45e109b52.png)

After MatplotLib results: 
![After_Color_Scale](https://user-images.githubusercontent.com/46242526/120158410-ba413400-c211-11eb-870b-a03e58765c4d.png)

Plotly Scale Results:
![plotly](https://user-images.githubusercontent.com/46242526/120158449-c6c58c80-c211-11eb-8833-d49704147bf0.png)
