### PR TITLE
BUG: Changed interpolation type to make numeric range consistant with plotly

### DIFF
--- a/optuna/visualization/matplotlib/_contour.py
+++ b/optuna/visualization/matplotlib/_contour.py
@@ -315,13 +315,13 @@ def _calculate_griddata(
         else:
             yi = np.linspace(y_values_min, y_values_max, contour_point_num)
 
-        # Interpolate z-axis data on a grid with cubic interpolator.
+        # Interpolate z-axis data on a grid with linear interpolator.
         # TODO(ytknzw): Implement Plotly-like interpolation algorithm.
         zi = griddata(
             np.column_stack((x_values, y_values)),
             z_values,
             (xi[None, :], yi[:, None]),
-            method="cubic",
+            method="linear",
         )
 
     return (


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
The range of objective in `optuna.visualization.matplotlib.plot_contour` should have a similar range to `optuna.visualization.plot_contour`. 

## Description of the changes
<!-- Describe the changes in this PR. -->
I read the provided [link](https://matplotlib.org/stable/gallery/images_contours_and_fields/irregulardatagrid.html) for interpolation of irregular space data and tried the [CubicInterpolation](https://matplotlib.org/stable/api/tri_api.html#matplotlib.tri.CubicTriInterpolator) code [interpolating z], still got the same results (incorrect numeric range).  The [Linear interpolation](https://matplotlib.org/stable/api/tri_api.html#matplotlib.tri.LinearTriInterpolator) and the option `linear` in the `griddata function` work and corrects the numeric range as well, in the same way, so I went with linear interpolation. 

Before_Cubic_Interpolation:
![Before_Cubic](https://user-images.githubusercontent.com/46242526/120229474-d7eeb780-c26a-11eb-8ff4-4e0796213661.png)

After_Linear_Interpolation:
![After_Linear](https://user-images.githubusercontent.com/46242526/120229486-dde49880-c26a-11eb-994b-83a147f90d14.png)

Plotly Results:
![plotly](https://user-images.githubusercontent.com/46242526/120229661-3451d700-c26b-11eb-8b14-998065546363.png)

As for the colour scale, I have addressed that issue in this PR: #2711 

Final Results after colour scale and interpolation correction after merging both the PRs:
![Final_Result](https://user-images.githubusercontent.com/46242526/120229634-28feab80-c26b-11eb-9837-60ef760df14c.png)

closes #2595 