### PR TITLE
Add how to suggest proportion to FAQ

### DIFF
--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -337,7 +337,7 @@ How do I suggest variables which represent the proportion, that is, are in accor
 ------------------------------------------------------------------------------------------------------------------
 
 When you want to suggest `n` variables which represent the proportion, that is, `p[0], p[1], ..., p[n-1]` which satisfy `0 <= p[k] <= 1` for any `k` and `p[0] + p[1] + ... + p[n-1] = 1`, try the following.
-These variables are in accordance with
+These variables are in accordance with the Dirichlet distribution.
 
 .. code-block:: python
 
@@ -381,7 +381,7 @@ These variables are in accordance with
             axes[j][i].set_xlabel(f"p_{i}")
             axes[j][i].set_ylabel(f"p_{j}")
 
-    plt.savefig("ratio.png")
+    plt.plot()
 
 This method is justified in the following way.
 First, if we apply the transformation `x = - log(u)` to the variable `u` sampled from the uniform distribution `Uni(0, 1)` in the interval [0, 1], the variable `x` will follow the exponential distribution `Exp(1)` with scale parameter 1.

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -336,7 +336,7 @@ Note that the above examples are similar to running the garbage collector inside
 How do I suggest variables which represent the proportion, that is, are in accordance with Dirichlet distribution?
 ------------------------------------------------------------------------------------------------------------------
 
-When you want to suggest :math:`n` variables which represent the proportion, that is, :math:`p[0], p[1], ..., p[n-1]` which satisfy :math:`0 \le p[k] \le 1` for any :math:`k` and :math:`p[0] + p[1] + ... + p[n-1] = 1`, try the following.
+When you want to suggest :math:`n` variables which represent the proportion, that is, :math:`p[0], p[1], ..., p[n-1]` which satisfy :math:`0 \le p[k] \le 1` for any :math:`k` and :math:`p[0] + p[1] + ... + p[n-1] = 1`, try the below.
 For example, these variables can be used as weights when interpolating the loss functions.
 These variables are in accordance with the flat `Dirichlet distribution <https://en.wikipedia.org/wiki/Dirichlet_distribution>`_.
 
@@ -381,7 +381,7 @@ These variables are in accordance with the flat `Dirichlet distribution <https:/
 
     plt.savefig("sampled_ps.png")
 
-This method is justified in the following way.
+This method is justified in the following way:
 First, if we apply the transformation :math:`x = - \log (u)` to the variable :math:`u` sampled from the uniform distribution :math:`Uni(0, 1)` in the interval :math:`[0, 1]`, the variable :math:`x` will follow the exponential distribution :math:`Exp(1)` with scale parameter :math:`1`.
 Furthermore, for :math:`n` variables :math:`x[0], ..., x[n-1]` that follow the exponential distribution of scale parameter :math:`1` independently, normalizing them with :math:`p[i] = x[i] / \sum_i x[i]`, the vector :math:`p` follows the Dirichlet distribution :math:`Dir(\alpha)` of scale parameter :math:`\alpha = (1, ..., 1)`.
-You can verify the transformation by elemental calculation of Jacobian.
+You can verify the transformation by calculating the elements of the Jacobian.

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -342,6 +342,7 @@ These variables are in accordance with the Dirichlet distribution.
 .. code-block:: python
 
     import numpy as np
+    import matplotlib.pyplot as plt
     import optuna
     ​
 
@@ -354,6 +355,12 @@ These variables are in accordance with the Dirichlet distribution.
         p = []
         for i in range(n):
             p.append(x[i] / sum(x))
+
+        return 0
+
+
+    study = optuna.create_study(sampler=optuna.samplers.RandomSampler())
+    study.optimize(objective, n_trials=1000)
 
 This method is justified in the following way.
 First, if we apply the transformation `x = - log(u)` to the variable `u` sampled from the uniform distribution `Uni(0, 1)` in the interval [0, 1], the variable `x` will follow the exponential distribution `Exp(1)` with scale parameter 1.

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -351,7 +351,7 @@ These variables are in accordance with the Dirichlet distribution.
     x = []
     for i in range(n):
         x.append(- np.log(trial.suggest_float(f"x_{i}", 0, 1)))
-        ​
+
         p = []
         for i in range(n):
             p.append(x[i] / sum(x))

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -342,14 +342,13 @@ These variables are in accordance with the Dirichlet distribution.
 .. code-block:: python
 
     import numpy as np
-    import matplotlib.pyplot as plt
     import optuna
-    ​
+
 
     def objective(trial):
         n = 5
         x = []
-        for i in range(n - 1):
+        for i in range(n):
             x.append(- np.log(trial.suggest_float(f"x_{i}", 0, 1)))
 
         p = []

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -334,7 +334,7 @@ Note that the above examples are similar to running the garbage collector inside
     When using this class, you will have to call the garbage collector inside the objective function.
 
 How do I suggest variables which represent the proportion, that is, are in accordance with Dirichlet distribution?
-----------------------------------------------------------
+------------------------------------------------------------------------------------------------------------------
 
 When you want to suggest `n` variables which represent the proportion, that is, `p[0], p[1], ..., p[n-1]` which satisfy `0 <= p[k] <= 1` for any `k` and `p[0] + p[1] + ... + p[n-1] = 1`, try the following.
 These variables are in accordance with

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -336,7 +336,7 @@ Note that the above examples are similar to running the garbage collector inside
 How do I suggest variables which represent the proportion, that is, are in accordance with Dirichlet distribution?
 ------------------------------------------------------------------------------------------------------------------
 
-When you want to suggest :math:`n` variables which represent the proportion, that is, :math:`p[0], p[1], ..., p[n-1]` which satisfy :math:`0 \le p[k] \le 1` for any `k` and :math:`p[0] + p[1] + ... + p[n-1] = 1`, try the following.
+When you want to suggest :math:`n` variables which represent the proportion, that is, :math:`p[0], p[1], ..., p[n-1]` which satisfy :math:`0 \le p[k] \le 1` for any :math:`k` and :math:`p[0] + p[1] + ... + p[n-1] = 1`, try the following.
 For example, these variables can be used as weights when interpolating the loss functions.
 These variables are in accordance with the flat `Dirichlet distribution <https://en.wikipedia.org/wiki/Dirichlet_distribution>`_.
 
@@ -382,6 +382,6 @@ These variables are in accordance with the flat `Dirichlet distribution <https:/
     plt.savefig("sampled_ps.png")
 
 This method is justified in the following way.
-First, if we apply the transformation :math:`x = - \log (u)` to the variable :math:`u` sampled from the uniform distribution :math:`Uni(0, 1)` in the interval [0, 1], the variable :math:`x` will follow the exponential distribution :math:`Exp(1)` with scale parameter 1.
-Furthermore, for :math:`n` variables :math:`x[0], ..., x[n-1]` that follow the exponential distribution of scale parameter 1 independently, normalizing them with :math:`p[i] = x[i] / sum(x)`, the vector :math:`p` follows the Dirichlet distribution :math:`Dir(\alpha)` of scale parameter :math:`\alpha = (1, ..., 1)`.
+First, if we apply the transformation :math:`x = - \log (u)` to the variable :math:`u` sampled from the uniform distribution :math:`Uni(0, 1)` in the interval :math:`[0, 1]`, the variable :math:`x` will follow the exponential distribution :math:`Exp(1)` with scale parameter :math:`1`.
+Furthermore, for :math:`n` variables :math:`x[0], ..., x[n-1]` that follow the exponential distribution of scale parameter :math:`1` independently, normalizing them with :math:`p[i] = x[i] / \sum_i x[i]`, the vector :math:`p` follows the Dirichlet distribution :math:`Dir(\alpha)` of scale parameter :math:`\alpha = (1, ..., 1)`.
 You can verify the transformation by elemental calculation of Jacobian.

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -336,8 +336,9 @@ Note that the above examples are similar to running the garbage collector inside
 How do I suggest variables which represent the proportion, that is, are in accordance with Dirichlet distribution?
 ------------------------------------------------------------------------------------------------------------------
 
-When you want to suggest `n` variables which represent the proportion, that is, `p[0], p[1], ..., p[n-1]` which satisfy `0 <= p[k] <= 1` for any `k` and `p[0] + p[1] + ... + p[n-1] = 1`, try the following.
-These variables are in accordance with the flat Dirichlet distribution.
+When you want to suggest :math:`n` variables which represent the proportion, that is, :math:`p[0], p[1], ..., p[n-1]` which satisfy :math:`0 \le p[k] \le 1` for any `k` and :math:`p[0] + p[1] + ... + p[n-1] = 1`, try the following.
+For example, these variables can be used as weights when interpolating the loss functions.
+These variables are in accordance with the flat `Dirichlet distribution <https://en.wikipedia.org/wiki/Dirichlet_distribution>`_.
 
 .. code-block:: python
 
@@ -381,6 +382,6 @@ These variables are in accordance with the flat Dirichlet distribution.
     plt.savefig("sampled_ps.png")
 
 This method is justified in the following way.
-First, if we apply the transformation `x = - log(u)` to the variable `u` sampled from the uniform distribution `Uni(0, 1)` in the interval [0, 1], the variable `x` will follow the exponential distribution `Exp(1)` with scale parameter 1.
-Furthermore, for `n` variables `x[0], ..., x[n-1]` that follow the exponential distribution of scale parameter 1 independently, normalizing them with `p[i] = x[i] / sum(x)`, the vector `p` follows the Dirichlet distribution `Dir(\alpha)` of scale parameter `\alpha = (1, ..., 1)`.
+First, if we apply the transformation :math:`x = - \log (u)` to the variable :math:`u` sampled from the uniform distribution :math:`Uni(0, 1)` in the interval [0, 1], the variable :math:`x` will follow the exponential distribution :math:`Exp(1)` with scale parameter 1.
+Furthermore, for :math:`n` variables :math:`x[0], ..., x[n-1]` that follow the exponential distribution of scale parameter 1 independently, normalizing them with :math:`p[i] = x[i] / sum(x)`, the vector :math:`p` follows the Dirichlet distribution :math:`Dir(\alpha)` of scale parameter :math:`\alpha = (1, ..., 1)`.
 You can verify the transformation by elemental calculation of Jacobian.

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -342,24 +342,42 @@ These variables are in accordance with the Dirichlet distribution.
 .. code-block:: python
 
     import numpy as np
+    import matplotlib.pyplot as plt
     import optuna
 
 
     def objective(trial):
-        n = 5
-        x = []
-        for i in range(n):
-            x.append(- np.log(trial.suggest_float(f"x_{i}", 0, 1)))
-
+    n = 5
+    x = []
+    for i in range(n):
+        x.append(- np.log(trial.suggest_float(f"x_{i}", 0, 1)))
+        ​
         p = []
         for i in range(n):
             p.append(x[i] / sum(x))
 
+        for i in range(n):
+            trial.set_user_attr(f"p_{i}", p[i])
         return 0
-
 
     study = optuna.create_study(sampler=optuna.samplers.RandomSampler())
     study.optimize(objective, n_trials=1000)
+
+    n = 5
+    p = []
+    for i in range(n):
+        p.append([trial.user_attrs[f"p_{i}"] for trial in study.trials])
+    axes= plt.subplots(n, n, figsize=(20, 20))[1]
+
+    for i in range(n):
+        for j in range(n):
+            axes[j][i].scatter(p[i], p[j], marker='.')
+            axes[j][i].set_xlim(0, 1)
+            axes[j][i].set_ylim(0, 1)
+            axes[j][i].set_xlabel(f"p_{i}")
+            axes[j][i].set_ylabel(f"p_{j}")
+
+    plt.savefig("ratio2.png")
 
 This method is justified in the following way.
 First, if we apply the transformation `x = - log(u)` to the variable `u` sampled from the uniform distribution `Uni(0, 1)` in the interval [0, 1], the variable `x` will follow the exponential distribution `Exp(1)` with scale parameter 1.

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -377,7 +377,7 @@ These variables are in accordance with the Dirichlet distribution.
             axes[j][i].set_xlabel(f"p_{i}")
             axes[j][i].set_ylabel(f"p_{j}")
 
-    plt.savefig("ratio2.png")
+    plt.savefig("sampled_ps.png")
 
 This method is justified in the following way.
 First, if we apply the transformation `x = - log(u)` to the variable `u` sampled from the uniform distribution `Uni(0, 1)` in the interval [0, 1], the variable `x` will follow the exponential distribution `Exp(1)` with scale parameter 1.

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -337,7 +337,7 @@ How do I suggest variables which represent the proportion, that is, are in accor
 ------------------------------------------------------------------------------------------------------------------
 
 When you want to suggest `n` variables which represent the proportion, that is, `p[0], p[1], ..., p[n-1]` which satisfy `0 <= p[k] <= 1` for any `k` and `p[0] + p[1] + ... + p[n-1] = 1`, try the following.
-These variables are in accordance with the Dirichlet distribution.
+These variables are in accordance with the flat Dirichlet distribution.
 
 .. code-block:: python
 
@@ -347,10 +347,10 @@ These variables are in accordance with the Dirichlet distribution.
 
 
     def objective(trial):
-    n = 5
-    x = []
-    for i in range(n):
-        x.append(- np.log(trial.suggest_float(f"x_{i}", 0, 1)))
+        n = 5
+        x = []
+        for i in range(n):
+            x.append(- np.log(trial.suggest_float(f"x_{i}", 0, 1)))
 
         p = []
         for i in range(n):
@@ -358,6 +358,7 @@ These variables are in accordance with the Dirichlet distribution.
 
         for i in range(n):
             trial.set_user_attr(f"p_{i}", p[i])
+
         return 0
 
     study = optuna.create_study(sampler=optuna.samplers.RandomSampler())
@@ -367,11 +368,11 @@ These variables are in accordance with the Dirichlet distribution.
     p = []
     for i in range(n):
         p.append([trial.user_attrs[f"p_{i}"] for trial in study.trials])
-    axes= plt.subplots(n, n, figsize=(20, 20))[1]
+    axes = plt.subplots(n, n, figsize=(20, 20))[1]
 
     for i in range(n):
         for j in range(n):
-            axes[j][i].scatter(p[i], p[j], marker='.')
+            axes[j][i].scatter(p[i], p[j], marker=".")
             axes[j][i].set_xlim(0, 1)
             axes[j][i].set_ylim(0, 1)
             axes[j][i].set_xlabel(f"p_{i}")

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -342,7 +342,6 @@ These variables are in accordance with the Dirichlet distribution.
 .. code-block:: python
 
     import numpy as np
-    import matplotlib.pyplot as plt
     import optuna
     ​
 
@@ -355,33 +354,6 @@ These variables are in accordance with the Dirichlet distribution.
         p = []
         for i in range(n):
             p.append(x[i] / sum(x))
-
-        # Store `p` to visualize.
-        for i in range(n):
-            trial.set_user_attr(f"p_{i}", p[i])
-
-        return 0
-
-
-    study = optuna.create_study(sampler=optuna.samplers.RandomSampler())
-    study.optimize(objective, n_trials=1000)
-
-    # Visualize sampled proportions.
-    n = 5
-    p = []
-    for i in range(n):
-        p.append([trial.user_attrs[f"p_{i}"] for trial in study.trials])
-    ​
-    axes= plt.subplots(n, n, figsize=(20, 20))[1]
-    for i in range(n):
-        for j in range(n):
-            axes[j][i].scatter(p[i], p[j], marker='.')
-            axes[j][i].set_xlim(0, 1)
-            axes[j][i].set_ylim(0, 1)
-            axes[j][i].set_xlabel(f"p_{i}")
-            axes[j][i].set_ylabel(f"p_{j}")
-
-    plt.plot()
 
 This method is justified in the following way.
 First, if we apply the transformation `x = - log(u)` to the variable `u` sampled from the uniform distribution `Uni(0, 1)` in the interval [0, 1], the variable `x` will follow the exponential distribution `Exp(1)` with scale parameter 1.


### PR DESCRIPTION
## Motivation
In Optuna, we can suggest variables that represent proportion, that is, are in accordance with the Dirichlet distribution.
This PR adds an explanation of how to do that in the FAQ.

## Description of the changes
- Add an explanation of how to suggest proportion in the FAQ.
