### PR TITLE
Use `repr` and `eval` to restore pruner parameters in AllenNLP integration

### DIFF
--- a/optuna/integration/allennlp.py
+++ b/optuna/integration/allennlp.py
@@ -399,7 +399,8 @@ class AllenNLPPruningCallback(TrainerCallback):
         loads them to restore ``trial`` and ``monitor``.
 
     .. note::
-        Currently, build-in pruners are supported except for :class:`~optuna.pruners.PatientPruner`.
+        Currently, build-in pruners are supported except for
+        :class:`~optuna.pruners.PatientPruner`.
 
     Args:
         trial:

--- a/optuna/integration/allennlp.py
+++ b/optuna/integration/allennlp.py
@@ -398,6 +398,9 @@ class AllenNLPPruningCallback(TrainerCallback):
         Then :class:`~optuna.integration.AllenNLPPruningCallback`
         loads them to restore ``trial`` and ``monitor``.
 
+    .. note::
+        Currently, build-in pruners are supported except to `~optuna.pruners.PatientPruner`.
+
     Args:
         trial:
             A :class:`~optuna.trial.Trial` corresponding to the current evaluation of the

--- a/optuna/integration/allennlp.py
+++ b/optuna/integration/allennlp.py
@@ -399,7 +399,7 @@ class AllenNLPPruningCallback(TrainerCallback):
         loads them to restore ``trial`` and ``monitor``.
 
     .. note::
-        Currently, build-in pruners are supported except to `~optuna.pruners.PatientPruner`.
+        Currently, build-in pruners are supported except for :class:`~optuna.pruners.PatientPruner`.
 
     Args:
         trial:

--- a/optuna/integration/allennlp.py
+++ b/optuna/integration/allennlp.py
@@ -116,7 +116,8 @@ def _get_environment_variables_for_pruner() -> Dict[str, Optional[Union[str, int
     for key in keys.split(","):
         key_without_prefix = key.replace("{}_".format(_PREFIX), "")
         value = os.getenv(key)
-        assert value is not None
+        if value is None:
+            raise ValueError("{key} is not found in environment variables.")
         kwargs[key_without_prefix] = eval(value)
 
     return kwargs

--- a/optuna/integration/allennlp.py
+++ b/optuna/integration/allennlp.py
@@ -96,32 +96,6 @@ def _create_pruner() -> Optional[optuna.pruners.BasePruner]:
     return pruner(**pruner_params)
 
 
-def _infer_and_cast(value: Optional[str]) -> Optional[Union[str, int, float, bool]]:
-    """Infer and cast a string to desired types.
-
-    We are only able to set strings as environment variables.
-    However, parameters of a pruner could be integer, float,
-    boolean, or else. We infer and cast environment variables
-    to desired types.
-
-    """
-    if value is None:
-        return None
-
-    try:
-        return int(value)
-    except ValueError:
-        try:
-            return float(value)
-        except ValueError:
-            if value == "True":
-                return True
-            if value == "False":
-                return False
-
-    return value
-
-
 def _get_environment_variables_for_trial() -> Dict[str, Optional[str]]:
     return {
         "study_name": os.getenv(_STUDY_NAME),
@@ -141,7 +115,9 @@ def _get_environment_variables_for_pruner() -> Dict[str, Optional[Union[str, int
     kwargs = {}
     for key in keys.split(","):
         key_without_prefix = key.replace("{}_".format(_PREFIX), "")
-        kwargs[key_without_prefix] = _infer_and_cast(os.getenv(key))
+        value = os.getenv(key)
+        assert value is not None
+        kwargs[key_without_prefix] = eval(value)
 
     return kwargs
 
@@ -335,7 +311,7 @@ class AllenNLPExecutor(object):
 
         pruner_params = _fetch_pruner_config(trial)
         pruner_params = {
-            "{}_{}".format(_PREFIX, key): str(value) for key, value in pruner_params.items()
+            "{}_{}".format(_PREFIX, key): repr(value) for key, value in pruner_params.items()
         }
 
         system_attrs = {

--- a/tests/integration_tests/allennlp_tests/test_allennlp.py
+++ b/tests/integration_tests/allennlp_tests/test_allennlp.py
@@ -410,12 +410,3 @@ def test_allennlp_pruning_callback_with_invalid_executor() -> None:
 
         with pytest.raises(ValueError):
             optuna.integration.AllenNLPExecutor(trial, input_config_file, serialization_dir)
-
-
-def test_infer_and_cast() -> None:
-    assert optuna.integration.allennlp._infer_and_cast(None) is None
-    assert optuna.integration.allennlp._infer_and_cast("True") is True
-    assert optuna.integration.allennlp._infer_and_cast("False") is False
-    assert optuna.integration.allennlp._infer_and_cast("3.14") == 3.14
-    assert optuna.integration.allennlp._infer_and_cast("42") == 42
-    assert optuna.integration.allennlp._infer_and_cast("auto") == "auto"


### PR DESCRIPTION
The current implementation of AllenNLP integration doesn't handle `None` correctly.
When `None` is given as a parameter, it is saved as a string value of `"None"`.
This causes an error in `AllenNLPPruningCallback`.

In advance of this PR, we explored another approach to save a repr value of pruner and
restore it using eval. But this approach could induce some restriction to future implementation of the pruner.
Then we decided to fix the current implementation instead of changing the way of saving/restoring pruners.
For a detailed discussion, please see https://github.com/optuna/optuna/pull/2707.

## Motivation
Resolve https://github.com/himkt/allennlp-optuna/issues/39.

## Description of the changes
- a06cfae removes `infer_and_cast` and add `repr` and `eval` to restore pruner parameters
