### PR TITLE
Fix `Nan` cast bug in `TPESampler`

### DIFF
--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -569,7 +569,9 @@ def _get_observation_pairs(
 
 
 def _split_observation_pairs(
-    config_vals: Dict[str, List[Optional[float]]], loss_vals: List[Tuple[float, float]], gamma: Callable[[int], int]
+    config_vals: Dict[str, List[Optional[float]]],
+    loss_vals: List[Tuple[float, float]],
+    gamma: Callable[[int], int],
 ) -> Tuple[Dict[str, np.ndarray], Dict[str, np.ndarray]]:
 
     # `None` items are intentionally converted to `nan` and then filtered out.

--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -412,7 +412,7 @@ class TPESampler(BaseSampler):
         self, config_vals: Dict[str, List[Optional[float]]], loss_vals: List[Tuple[float, float]]
     ) -> Tuple[Dict[str, np.ndarray], Dict[str, np.ndarray]]:
 
-        # `None` items are intentionally converted to `nan` and then filter out.
+        # `None` items are intentionally converted to `nan` and then filtered out.
         # For `nan` conversion, the dtype must be float.
         config_values = {k: np.asarray(v, dtype=float) for k, v in config_vals.items()}
         loss_values = np.asarray(loss_vals, dtype=[("step", float), ("score", float)])

--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -412,7 +412,7 @@ class TPESampler(BaseSampler):
         self, config_vals: Dict[str, List[Optional[float]]], loss_vals: List[Tuple[float, float]]
     ) -> Tuple[Dict[str, np.ndarray], Dict[str, np.ndarray]]:
 
-        config_values = {k: np.asarray(v, dtype=float) for k, v in config_vals.items()}
+        config_values = {k: np.asarray(v) for k, v in config_vals.items()}
         loss_values = np.asarray(loss_vals, dtype=[("step", float), ("score", float)])
 
         n_below = self._gamma(len(loss_values))

--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -359,7 +359,7 @@ class TPESampler(BaseSampler):
             return {}
 
         # We divide data into below and above.
-        below, above = _split_observation_pairs(values, scores, self._gamma)
+        below, above = _split_observation_pairs(values, scores, self._gamma(n))
         # We then sample by maximizing log likelihood ratio.
         mpe_below = _ParzenEstimator(below, search_space, self._parzen_estimator_parameters)
         mpe_above = _ParzenEstimator(above, search_space, self._parzen_estimator_parameters)
@@ -394,7 +394,7 @@ class TPESampler(BaseSampler):
                 study, trial, param_name, param_distribution
             )
 
-        below, above = _split_observation_pairs(values, scores, self._gamma)
+        below, above = _split_observation_pairs(values, scores, self._gamma(n))
         mpe_below = _ParzenEstimator(
             below, {param_name: param_distribution}, self._parzen_estimator_parameters
         )
@@ -571,7 +571,7 @@ def _get_observation_pairs(
 def _split_observation_pairs(
     config_vals: Dict[str, List[Optional[float]]],
     loss_vals: List[Tuple[float, float]],
-    gamma: Callable[[int], int],
+    n_below: int,
 ) -> Tuple[Dict[str, np.ndarray], Dict[str, np.ndarray]]:
 
     # `None` items are intentionally converted to `nan` and then filtered out.
@@ -579,7 +579,6 @@ def _split_observation_pairs(
     config_values = {k: np.asarray(v, dtype=float) for k, v in config_vals.items()}
     loss_values = np.asarray(loss_vals, dtype=[("step", float), ("score", float)])
 
-    n_below = gamma(len(loss_values))
     index_loss_ascending = np.argsort(loss_values)
     # `np.sort` is used to keep chronological order.
     index_below = np.sort(index_loss_ascending[:n_below])

--- a/tests/samplers_tests/tpe_tests/test_sampler.py
+++ b/tests/samplers_tests/tpe_tests/test_sampler.py
@@ -1017,7 +1017,9 @@ def test_sample_independent_with_branch_division() -> None:
         if trial.number < 3:
             return trial.suggest_float("x", 0, 1)
         else:
-            return trial.suggest_categorical("c", [0, 1, 2])
+            c = trial.suggest_categorical("c", [0., 1., 2.])
+            assert isinstance(c, float)
+            return c
 
     study = optuna.create_study(sampler=sampler)
     study.optimize(objective, n_trials=10)

--- a/tests/samplers_tests/tpe_tests/test_sampler.py
+++ b/tests/samplers_tests/tpe_tests/test_sampler.py
@@ -824,17 +824,17 @@ def test_split_observation_pairs() -> None:
     below, above = _tpe.sampler._split_observation_pairs(
         {"x": [1.0, 2.0, 3.0, 4.0], "y": [10.0, None, 20.0, None]},
         [
-            (-float("inf"), -5.0),  # COMPLETE
             (-7, -2),  # PRUNED (with intermediate values)
-            (-3, float("inf")),  # PRUNED (with a NaN intermediate value; it's treated as infinity)
             (float("inf"), 0.0),  # PRUNED (without intermediate values)
+            (-3, float("inf")),  # PRUNED (with a NaN intermediate value; it's treated as infinity)
+            (-float("inf"), -5.0),  # COMPLETE
         ],
         2,
     )
-    assert (below["x"] == np.asarray([1.0, 2.0])).all()
-    assert (above["x"] == np.asarray([3.0, 4.0])).all()
-    assert (below["y"] == np.asarray([10.0])).all()
-    assert (above["y"] == np.asarray([20.0])).all()
+    np.testing.assert_array_equal(below["x"], np.asarray([1.0, 4.0]))
+    np.testing.assert_array_equal(above["x"], np.asarray([2.0, 3.0]))
+    np.testing.assert_array_equal(below["y"], np.asarray([10.0]))
+    np.testing.assert_array_equal(above["y"], np.asarray([20.0]))
 
 
 def frozen_trial_factory(

--- a/tests/samplers_tests/tpe_tests/test_sampler.py
+++ b/tests/samplers_tests/tpe_tests/test_sampler.py
@@ -1013,11 +1013,13 @@ def test_constant_liar_experimental_warning() -> None:
 def test_sample_independent_with_branch_division() -> None:
     sampler = TPESampler(n_startup_trials=0)
 
+    # This objective function has different parameters to sample across trials, and TPE should
+    # ignore trials where the parameters you want to sample are not present.
     def objective(trial: Trial) -> float:
         if trial.number < 3:
             return trial.suggest_float("x", 0, 1)
         else:
-            c = trial.suggest_categorical("c", [0., 1., 2.])
+            c = trial.suggest_categorical("c", [0.0, 1.0, 2.0])
             assert isinstance(c, float)
             return c
 

--- a/tests/samplers_tests/tpe_tests/test_sampler.py
+++ b/tests/samplers_tests/tpe_tests/test_sampler.py
@@ -821,7 +821,6 @@ def test_get_observation_pairs() -> None:
 
 
 def test_split_observation_pairs() -> None:
-
     def _gamma(n: int) -> int:
         return n // 2
 

--- a/tests/samplers_tests/tpe_tests/test_sampler.py
+++ b/tests/samplers_tests/tpe_tests/test_sampler.py
@@ -1008,3 +1008,16 @@ def test_constant_liar_observation_pairs(direction: str, multivariate: bool) -> 
 def test_constant_liar_experimental_warning() -> None:
     with pytest.warns(optuna.exceptions.ExperimentalWarning):
         _ = TPESampler(constant_liar=True)
+
+
+def test_sample_independent_with_branch_division() -> None:
+    sampler = TPESampler(n_startup_trials=0)
+
+    def objective(trial: Trial) -> float:
+        if trial.number < 3:
+            return trial.suggest_float("x", 0, 1)
+        else:
+            return trial.suggest_categorical("c", [0, 1, 2])
+
+    study = optuna.create_study(sampler=sampler)
+    study.optimize(objective, n_trials=10)

--- a/tests/samplers_tests/tpe_tests/test_sampler.py
+++ b/tests/samplers_tests/tpe_tests/test_sampler.py
@@ -821,9 +821,6 @@ def test_get_observation_pairs() -> None:
 
 
 def test_split_observation_pairs() -> None:
-    def _gamma(n: int) -> int:
-        return n // 2
-
     below, above = _tpe.sampler._split_observation_pairs(
         {"x": [1.0, 2.0, 3.0, 4.0], "y": [10.0, None, 20.0, None]},
         [
@@ -832,7 +829,7 @@ def test_split_observation_pairs() -> None:
             (-3, float("inf")),  # PRUNED (with a NaN intermediate value; it's treated as infinity)
             (float("inf"), 0.0),  # PRUNED (without intermediate values)
         ],
-        _gamma,
+        2,
     )
     assert (below["x"] == np.asarray([1.0, 2.0])).all()
     assert (above["x"] == np.asarray([3.0, 4.0])).all()


### PR DESCRIPTION
## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
As @tohmae discovered in https://github.com/optuna/optuna/pull/2734#issuecomment-857649769, the current master `TPESampler` causes an error when the objective function has parameters containing branching. This is because we cast the parameter values to `float` before removing `None` in `TPESampler._split_observation_pairs`. This PR fix the error.


## Description of the changes
- Remove nan instead of None
- Make `_split_observation_pairs` a free function
- Add test

## How to reproduce the error.
Execute https://github.com/optuna/optuna-examples/blob/main/xgboost/xgboost_simple.py with the current master (https://github.com/optuna/optuna/commit/5de458987d7f027f59a140b4391d1991bcb73e42)

Error logs:
```
(venv) mamu@HideakinoMacBook-puro optuna-examples % python ./xgboost/xgboost_simple.py
[I 2021-06-09 23:50:50,364] A new study created in memory with name: no-name-8c7ec59f-9eec-4b44-a567-92ad87b034c9
[I 2021-06-09 23:50:50,380] Trial 0 finished with value: 0.8321678321678322 and parameters: {'booster': 'gblinear', 'lambda': 0.040398224953566465, 'alpha': 0.5443271290979902, 'subsample': 0.9824882214036883, 'colsample_bytree': 0.8993790284987895}. Best is trial 0 with value: 0.8321678321678322.
[I 2021-06-09 23:50:50,396] Trial 1 finished with value: 0.9370629370629371 and parameters: {'booster': 'gblinear', 'lambda': 5.1215991618968e-07, 'alpha': 2.5389780441107583e-07, 'subsample': 0.3087557340681471, 'colsample_bytree': 0.6748019528883034}. Best is trial 1 with value: 0.9370629370629371.
[I 2021-06-09 23:50:50,419] Trial 2 finished with value: 0.9230769230769231 and parameters: {'booster': 'gblinear', 'lambda': 0.009706741622334536, 'alpha': 0.05731950271820943, 'subsample': 0.2768919453042081, 'colsample_bytree': 0.29044111320457777}. Best is trial 1 with value: 0.9370629370629371.
[I 2021-06-09 23:50:50,447] Trial 3 finished with value: 0.9370629370629371 and parameters: {'booster': 'gbtree', 'lambda': 0.002801324673032621, 'alpha': 8.77678561131975e-06, 'subsample': 0.2824301743195605, 'colsample_bytree': 0.9209405766613006, 'max_depth': 7, 'min_child_weight': 6, 'eta': 0.00018224151539981037, 'gamma': 0.006771053282283436, 'grow_policy': 'lossguide'}. Best is trial 1 with value: 0.9370629370629371.
[I 2021-06-09 23:50:50,477] Trial 4 finished with value: 0.9230769230769231 and parameters: {'booster': 'dart', 'lambda': 0.8625890552039833, 'alpha': 3.702240957256518e-08, 'subsample': 0.8817257155243725, 'colsample_bytree': 0.25821315901446795, 'max_depth': 9, 'min_child_weight': 9, 'eta': 6.276758483441583e-07, 'gamma': 0.002234134294509528, 'grow_policy': 'lossguide', 'sample_type': 'uniform', 'normalize_type': 'forest', 'rate_drop': 0.0042353012141847285, 'skip_drop': 2.203775877284396e-06}. Best is trial 1 with value: 0.9370629370629371.
[I 2021-06-09 23:50:50,494] Trial 5 finished with value: 0.9020979020979021 and parameters: {'booster': 'gblinear', 'lambda': 0.04477960826403899, 'alpha': 0.26904318327505633, 'subsample': 0.6249821608759203, 'colsample_bytree': 0.29193691489242024}. Best is trial 1 with value: 0.9370629370629371.
[I 2021-06-09 23:50:50,534] Trial 6 finished with value: 0.9230769230769231 and parameters: {'booster': 'gbtree', 'lambda': 1.602889292272454e-07, 'alpha': 0.016671612106849323, 'subsample': 0.8106009566846204, 'colsample_bytree': 0.583769315682823, 'max_depth': 7, 'min_child_weight': 10, 'eta': 0.0007125974117337914, 'gamma': 4.030224436007477e-05, 'grow_policy': 'lossguide'}. Best is trial 1 with value: 0.9370629370629371.
[I 2021-06-09 23:50:50,560] Trial 7 finished with value: 0.9090909090909091 and parameters: {'booster': 'gbtree', 'lambda': 0.0002106202492135643, 'alpha': 1.1772928216750774e-07, 'subsample': 0.2603990025637316, 'colsample_bytree': 0.38094833891962826, 'max_depth': 3, 'min_child_weight': 6, 'eta': 3.8906958028388586e-08, 'gamma': 0.00021830157418713093, 'grow_policy': 'depthwise'}. Best is trial 1 with value: 0.9370629370629371.
[I 2021-06-09 23:50:50,581] Trial 8 finished with value: 0.9300699300699301 and parameters: {'booster': 'gblinear', 'lambda': 5.6590034731208574e-08, 'alpha': 0.004626874994323875, 'subsample': 0.6181073251904217, 'colsample_bytree': 0.6557153334766561}. Best is trial 1 with value: 0.9370629370629371.
[I 2021-06-09 23:50:50,609] Trial 9 finished with value: 0.972027972027972 and parameters: {'booster': 'dart', 'lambda': 0.12198765442066387, 'alpha': 0.00016278380419690108, 'subsample': 0.604445508805894, 'colsample_bytree': 0.30814867066506546, 'max_depth': 5, 'min_child_weight': 7, 'eta': 8.213226691474149e-08, 'gamma': 0.005631033075392603, 'grow_policy': 'lossguide', 'sample_type': 'weighted', 'normalize_type': 'tree', 'rate_drop': 0.00018656823367699428, 'skip_drop': 5.282717829309669e-08}. Best is trial 9 with value: 0.972027972027972.
[W 2021-06-09 23:50:50,659] Trial 10 failed because of the following error: IndexError('index -9223372036854775808 is out of bounds for axis 1 with size 2')
Traceback (most recent call last):
  File "/Users/mamu/Dev/pfn/optuna/optuna/_optimize.py", line 216, in _run_trial
    value_or_values = func(trial)
  File "/Users/mamu/Dev/pfn/optuna-examples/./xgboost/xgboost_simple.py", line 51, in objective
    param["grow_policy"] = trial.suggest_categorical("grow_policy", ["depthwise", "lossguide"])
  File "/Users/mamu/Dev/pfn/optuna/optuna/trial/_trial.py", line 505, in suggest_categorical
    return self._suggest(name, CategoricalDistribution(choices=choices))
  File "/Users/mamu/Dev/pfn/optuna/optuna/trial/_trial.py", line 716, in _suggest
    param_value = self.study.sampler.sample_independent(
  File "/Users/mamu/Dev/pfn/optuna/optuna/samplers/_tpe/sampler.py", line 402, in sample_independent
    mpe_above = _ParzenEstimator(
  File "/Users/mamu/Dev/pfn/optuna/optuna/samplers/_tpe/parzen_estimator.py", line 83, in __init__
    categorical_weights = self._calculate_categorical_params(
  File "/Users/mamu/Dev/pfn/optuna/optuna/samplers/_tpe/parzen_estimator.py", line 348, in _calculate_categorical_params
    weights[np.arange(n_observations), observations] += 1
IndexError: index -9223372036854775808 is out of bounds for axis 1 with size 2
Traceback (most recent call last):
  File "/Users/mamu/Dev/pfn/optuna-examples/./xgboost/xgboost_simple.py", line 68, in <module>
    study.optimize(objective, n_trials=100, timeout=600)
  File "/Users/mamu/Dev/pfn/optuna/optuna/study.py", line 401, in optimize
    _optimize(
  File "/Users/mamu/Dev/pfn/optuna/optuna/_optimize.py", line 65, in _optimize
    _optimize_sequential(
  File "/Users/mamu/Dev/pfn/optuna/optuna/_optimize.py", line 162, in _optimize_sequential
    trial = _run_trial(study, func, catch)
  File "/Users/mamu/Dev/pfn/optuna/optuna/_optimize.py", line 267, in _run_trial
    raise func_err
  File "/Users/mamu/Dev/pfn/optuna/optuna/_optimize.py", line 216, in _run_trial
    value_or_values = func(trial)
  File "/Users/mamu/Dev/pfn/optuna-examples/./xgboost/xgboost_simple.py", line 51, in objective
    param["grow_policy"] = trial.suggest_categorical("grow_policy", ["depthwise", "lossguide"])
  File "/Users/mamu/Dev/pfn/optuna/optuna/trial/_trial.py", line 505, in suggest_categorical
    return self._suggest(name, CategoricalDistribution(choices=choices))
  File "/Users/mamu/Dev/pfn/optuna/optuna/trial/_trial.py", line 716, in _suggest
    param_value = self.study.sampler.sample_independent(
  File "/Users/mamu/Dev/pfn/optuna/optuna/samplers/_tpe/sampler.py", line 402, in sample_independent
    mpe_above = _ParzenEstimator(
  File "/Users/mamu/Dev/pfn/optuna/optuna/samplers/_tpe/parzen_estimator.py", line 83, in __init__
    categorical_weights = self._calculate_categorical_params(
  File "/Users/mamu/Dev/pfn/optuna/optuna/samplers/_tpe/parzen_estimator.py", line 348, in _calculate_categorical_params
    weights[np.arange(n_observations), observations] += 1
IndexError: index -9223372036854775808 is out of bounds for axis 1 with size 2
```

## How to confirm that the error is fixed.
Succeeded to execute the above example `xgboost_simple.py`.
