### PR TITLE
Fix `infer_relative_search_space` of TPE with the single point distributions

### DIFF
--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -294,7 +294,10 @@ class TPESampler(BaseSampler):
             self._search_space_group = self._group_decomposed_search_space.calculate(study)
             for sub_space in self._search_space_group.search_spaces:
                 for name, distribution in sub_space.items():
-                    if not isinstance(distribution, _DISTRIBUTION_CLASSES) or distribution.single():
+                    if (
+                        not isinstance(distribution, _DISTRIBUTION_CLASSES)
+                        or distribution.single()
+                    ):
                         self._log_independent_sampling(n_complete_trials, trial, name)
                         continue
                     search_space[name] = distribution

--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -294,14 +294,14 @@ class TPESampler(BaseSampler):
             self._search_space_group = self._group_decomposed_search_space.calculate(study)
             for sub_space in self._search_space_group.search_spaces:
                 for name, distribution in sub_space.items():
-                    if not isinstance(distribution, _DISTRIBUTION_CLASSES):
+                    if not isinstance(distribution, _DISTRIBUTION_CLASSES) or distribution.single():
                         self._log_independent_sampling(n_complete_trials, trial, name)
                         continue
                     search_space[name] = distribution
             return search_space
 
         for name, distribution in self._search_space.calculate(study).items():
-            if not isinstance(distribution, _DISTRIBUTION_CLASSES):
+            if not isinstance(distribution, _DISTRIBUTION_CLASSES) or distribution.single():
                 self._log_independent_sampling(n_complete_trials, trial, name)
                 continue
             search_space[name] = distribution
@@ -325,7 +325,6 @@ class TPESampler(BaseSampler):
     def sample_relative(
         self, study: Study, trial: FrozenTrial, search_space: Dict[str, BaseDistribution]
     ) -> Dict[str, Any]:
-
         self._raise_error_if_multi_objective(study)
 
         if self._group:

--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -294,18 +294,19 @@ class TPESampler(BaseSampler):
             self._search_space_group = self._group_decomposed_search_space.calculate(study)
             for sub_space in self._search_space_group.search_spaces:
                 for name, distribution in sub_space.items():
-                    if (
-                        not isinstance(distribution, _DISTRIBUTION_CLASSES)
-                        or distribution.single()
-                    ):
+                    if not isinstance(distribution, _DISTRIBUTION_CLASSES):
                         self._log_independent_sampling(n_complete_trials, trial, name)
+                        continue
+                    if distribution.single():
                         continue
                     search_space[name] = distribution
             return search_space
 
         for name, distribution in self._search_space.calculate(study).items():
-            if not isinstance(distribution, _DISTRIBUTION_CLASSES) or distribution.single():
+            if not isinstance(distribution, _DISTRIBUTION_CLASSES):
                 self._log_independent_sampling(n_complete_trials, trial, name)
+                continue
+            if distribution.single():
                 continue
             search_space[name] = distribution
 
@@ -336,7 +337,10 @@ class TPESampler(BaseSampler):
             for sub_space in self._search_space_group.search_spaces:
                 search_space = {}
                 for name, distribution in sub_space.items():
-                    if isinstance(distribution, _DISTRIBUTION_CLASSES):
+                    if (
+                        isinstance(distribution, _DISTRIBUTION_CLASSES)
+                        and not distribution.single()
+                    ):
                         search_space[name] = distribution
                 params.update(self._sample_relative(study, trial, search_space))
             return params

--- a/tests/samplers_tests/test_samplers.py
+++ b/tests/samplers_tests/test_samplers.py
@@ -15,6 +15,7 @@ from optuna.distributions import CategoricalChoiceType
 from optuna.distributions import CategoricalDistribution
 from optuna.distributions import DiscreteUniformDistribution
 from optuna.distributions import IntUniformDistribution
+from optuna.distributions import IntLogUniformDistribution
 from optuna.distributions import LogUniformDistribution
 from optuna.distributions import UniformDistribution
 from optuna.samplers import BaseSampler
@@ -549,3 +550,27 @@ def test_after_trial_with_study_tell() -> None:
     study.tell(study.ask(), 1.0)
 
     assert n_calls == 1
+
+
+@parametrize_sampler
+def test_sample_single_distribution(sampler_class: Callable[[], BaseSampler]) -> None:
+
+    relative_search_space = {
+        "a": UniformDistribution(low=1.0, high=1.0),
+        "b": LogUniformDistribution(low=1.0, high=1.0),
+        "c": DiscreteUniformDistribution(low=1.0, high=1.0, q=1.0),
+        "d": IntUniformDistribution(low=1, high=1),
+        "e": IntLogUniformDistribution(low=1, high=1),
+        "f": CategoricalDistribution([1])
+    }
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", optuna.exceptions.ExperimentalWarning)
+        sampler = sampler_class()
+    study = optuna.study.create_study(sampler=sampler)
+
+    for _ in range(100):
+        trial = study.ask(fixed_distributions=relative_search_space)
+        study.tell(trial, 1.0)
+        for param_name in relative_search_space.keys():
+            np.testing.assert_almost_equal(1.0, trial.params[param_name])

--- a/tests/samplers_tests/test_samplers.py
+++ b/tests/samplers_tests/test_samplers.py
@@ -573,4 +573,4 @@ def test_sample_single_distribution(sampler_class: Callable[[], BaseSampler]) ->
         trial = study.ask(fixed_distributions=relative_search_space)
         study.tell(trial, 1.0)
         for param_name in relative_search_space.keys():
-            np.testing.assert_almost_equal(1.0, trial.params[param_name])
+            assert trial.params[param_name] == 1

--- a/tests/samplers_tests/test_samplers.py
+++ b/tests/samplers_tests/test_samplers.py
@@ -569,7 +569,7 @@ def test_sample_single_distribution(sampler_class: Callable[[], BaseSampler]) ->
         sampler = sampler_class()
     study = optuna.study.create_study(sampler=sampler)
 
-    for _ in range(100):
+    for _ in range(10):
         trial = study.ask(fixed_distributions=relative_search_space)
         study.tell(trial, 1.0)
         for param_name in relative_search_space.keys():

--- a/tests/samplers_tests/test_samplers.py
+++ b/tests/samplers_tests/test_samplers.py
@@ -14,8 +14,8 @@ from optuna.distributions import BaseDistribution
 from optuna.distributions import CategoricalChoiceType
 from optuna.distributions import CategoricalDistribution
 from optuna.distributions import DiscreteUniformDistribution
-from optuna.distributions import IntUniformDistribution
 from optuna.distributions import IntLogUniformDistribution
+from optuna.distributions import IntUniformDistribution
 from optuna.distributions import LogUniformDistribution
 from optuna.distributions import UniformDistribution
 from optuna.samplers import BaseSampler
@@ -561,7 +561,7 @@ def test_sample_single_distribution(sampler_class: Callable[[], BaseSampler]) ->
         "c": DiscreteUniformDistribution(low=1.0, high=1.0, q=1.0),
         "d": IntUniformDistribution(low=1, high=1),
         "e": IntLogUniformDistribution(low=1, high=1),
-        "f": CategoricalDistribution([1])
+        "f": CategoricalDistribution([1]),
     }
 
     with warnings.catch_warnings():

--- a/tests/samplers_tests/test_samplers.py
+++ b/tests/samplers_tests/test_samplers.py
@@ -569,6 +569,7 @@ def test_sample_single_distribution(sampler_class: Callable[[], BaseSampler]) ->
         sampler = sampler_class()
     study = optuna.study.create_study(sampler=sampler)
 
+    # We need to test the construction of the model, so we should set `n_trials >= 2`.
     for _ in range(2):
         trial = study.ask(fixed_distributions=relative_search_space)
         study.tell(trial, 1.0)

--- a/tests/samplers_tests/test_samplers.py
+++ b/tests/samplers_tests/test_samplers.py
@@ -569,7 +569,7 @@ def test_sample_single_distribution(sampler_class: Callable[[], BaseSampler]) ->
         sampler = sampler_class()
     study = optuna.study.create_study(sampler=sampler)
 
-    for _ in range(10):
+    for _ in range(2):
         trial = study.ask(fixed_distributions=relative_search_space)
         study.tell(trial, 1.0)
         for param_name in relative_search_space.keys():


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
The current TPESampler should ignore the single point distributions such as `UniformDistribution(low=1.0, high=1.0)`, but does not. This PR fixes the `infer_relative_search_space` of TPESampelr so that it ignores the single point distributions.

## Description of the changes
<!-- Describe the changes in this PR. -->
- Fix the `infer_relative_search_space` of TPESampelr so that it ignores the single point distributions.
- Add tests.