### PR TITLE
Add specific test cases for `visualization.matplotlib.plot_intermediate_values`

### DIFF
--- a/tests/visualization_tests/matplotlib_tests/test_intermediate_plot.py
+++ b/tests/visualization_tests/matplotlib_tests/test_intermediate_plot.py
@@ -19,20 +19,22 @@ def test_plot_intermediate_values() -> None:
         return 0.0
 
     # Test with a trial with intermediate values.
-    # TODO(ytknzw): Add more specific assertion with the test case.
     study = create_study()
     study.optimize(lambda t: objective(t, True), n_trials=1)
     figure = plot_intermediate_values(study)
-    assert figure.has_data()
+    assert len(figure.get_lines()) == 1
+    assert list(figure.get_lines()[0].get_xdata()) == [0, 1]
+    assert list(figure.get_lines()[0].get_ydata()) == [1.0, 2.0]
 
     # Test a study with one trial with intermediate values and
     # one trial without intermediate values.
     # Expect the trial with no intermediate values to be ignored.
-    # TODO(ytknzw): Add more specific assertion with the test case.
     study.optimize(lambda t: objective(t, False), n_trials=1)
     assert len(study.trials) == 2
     figure = plot_intermediate_values(study)
-    assert figure.has_data()
+    assert len(figure.get_lines()) == 1
+    assert list(figure.get_lines()[0].get_xdata()) == [0, 1]
+    assert list(figure.get_lines()[0].get_ydata()) == [1.0, 2.0]
 
     # Test a study of only one trial that has no intermediate values.
     study = create_study()


### PR DESCRIPTION
## Motivation
Currently, test cases in `optuna/visualization/matplotlib/*.py` are not enough compared to `optuna/visualization/*.py`. 

## Fixes
[Issue](https://github.com/optuna/optuna/issues/2643)

## Description of the changes
In this PR, I have added some specific test cases to the file `tests/visualization_tests/matplotlib/test_intermediate_plot.py`.
I will be creating another PR to add test cases in other files of `tests/visualization_tests/matplotlib/`
