### PR TITLE
Hyperparameter importance made deterministic when no evaluator is specified

### DIFF
--- a/optuna/importance/__init__.py
+++ b/optuna/importance/__init__.py
@@ -85,7 +85,7 @@ def get_param_importances(
             optimization.
     """
     if evaluator is None:
-        evaluator = FanovaImportanceEvaluator()
+        evaluator = FanovaImportanceEvaluator(seed=0)
 
     if not isinstance(evaluator, BaseImportanceEvaluator):
         raise TypeError("Evaluator must be a subclass of BaseImportanceEvaluator.")

--- a/tests/importance_tests/test_init.py
+++ b/tests/importance_tests/test_init.py
@@ -279,3 +279,16 @@ def test_get_param_importances_invalid_params_type(
 
     with pytest.raises(TypeError):
         get_param_importances(study, evaluator=evaluator_init_func(), params=[0])  # type: ignore
+
+
+def test_get_param_importances_default_evaluator_deterministic() -> None:
+    def objective(trial: Trial) -> float:
+        return sum(trial.suggest_float(f"x{i}", 0, 1) for i in range(3))
+
+    study = optuna.create_study(sampler=samplers.RandomSampler())
+    study.optimize(objective, n_trials=3)
+
+    param_importance0 = optuna.importance.get_param_importances(study)
+    param_importance1 = optuna.importance.get_param_importances(study)
+
+    assert param_importance0 == param_importance1


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation

Hyperparameter importance evaluations are non-deterministic by default (when no evaluator is specified). This may be confusing, for instance when you want to obtain the importances as a dictionary using `optuna.importance.get_param_importances(study)`, then visualize them via `optuna.visualization.plot_param_importances(study)`, just to observe that the computed importances are different.

## Description of the changes

Fixes the seed of the importance evaluator that is constructed when no evaluator is explicitly specified by the caller (default behavior).

## References

This has been raised as an issue before, e.g. https://github.com/optuna/optuna/issues/2207.