### PR TITLE
[RFC] Multiprocess in-memory storage

### DIFF
--- a/optuna/storages/__init__.py
+++ b/optuna/storages/__init__.py
@@ -1,6 +1,8 @@
 from typing import Union
+import warnings
 
 from optuna._callbacks import RetryFailedTrialCallback  # NOQA
+from optuna.exceptions import ExperimentalWarning
 from optuna.storages._base import BaseStorage
 from optuna.storages._cached_storage import _CachedStorage
 from optuna.storages._in_memory import InMemoryStorage
@@ -26,6 +28,11 @@ def get_storage(storage: Union[None, str, BaseStorage]) -> BaseStorage:
         return InMemoryStorage()
     if isinstance(storage, str):
         if storage == "multiprocess":
+            warnings.warn(
+                "``multiprocess`` storage is an experimental feature."
+                " The interface can change in the future.",
+                ExperimentalWarning,
+            )
             return MultiprocessInMemoryStorage()
         if storage.startswith("redis"):
             return RedisStorage(storage)

--- a/optuna/storages/__init__.py
+++ b/optuna/storages/__init__.py
@@ -25,6 +25,8 @@ def get_storage(storage: Union[None, str, BaseStorage]) -> BaseStorage:
     if storage is None:
         return InMemoryStorage()
     if isinstance(storage, str):
+        if storage == "multiprocess":
+            return MultiprocessInMemoryStorage()
         if storage.startswith("redis"):
             return RedisStorage(storage)
         else:

--- a/optuna/storages/__init__.py
+++ b/optuna/storages/__init__.py
@@ -4,6 +4,7 @@ from optuna._callbacks import RetryFailedTrialCallback  # NOQA
 from optuna.storages._base import BaseStorage
 from optuna.storages._cached_storage import _CachedStorage
 from optuna.storages._in_memory import InMemoryStorage
+from optuna.storages._in_memory import MultiprocessInMemoryStorage
 from optuna.storages._rdb.storage import RDBStorage
 from optuna.storages._redis import RedisStorage
 
@@ -11,6 +12,7 @@ from optuna.storages._redis import RedisStorage
 __all__ = [
     "BaseStorage",
     "InMemoryStorage",
+    "MultiprocessInMemoryStorage",
     "RDBStorage",
     "RedisStorage",
     "_CachedStorage",

--- a/optuna/storages/_in_memory.py
+++ b/optuna/storages/_in_memory.py
@@ -484,6 +484,9 @@ _Manager.register("InMemoryStorage", InMemoryStorage)
 class MultiprocessInMemoryStorage(BaseStorage):
     def __init__(self) -> None:
         self._manager = _Manager()
+        # A manager process is started at object construction. The started manager process is
+        # automatically shut down by the `multiprocessing` library, so explicit shutdown
+        # (`_Manager.shutdown`) is omitted.
         self._manager.start()
         self._manager_address = self._manager.address
         self._storage = self._manager.InMemoryStorage()  # type: ignore

--- a/optuna/storages/_in_memory.py
+++ b/optuna/storages/_in_memory.py
@@ -482,8 +482,6 @@ class _Manager(BaseManager):
 _Manager.register("InMemoryStorage", InMemoryStorage)
 
 
-# TODO(hvy): Either support multiple studies, either here or in the `InMemoryStorage`, or
-# hide `MultiprocessInMemoryStorage` from the user entirely.
 class MultiprocessInMemoryStorage(BaseStorage):
     def __init__(self) -> None:
         self._manager = _Manager()

--- a/optuna/storages/_in_memory.py
+++ b/optuna/storages/_in_memory.py
@@ -1,7 +1,6 @@
 import copy
 from datetime import datetime
 from multiprocessing.managers import BaseManager
-import os
 import threading
 from typing import Any
 from typing import cast
@@ -488,7 +487,6 @@ class MultiprocessInMemoryStorage(BaseStorage):
         self._manager.start()
         self._manager_address = self._manager.address
         self._storage = self._manager.InMemoryStorage()  # type: ignore
-        self._pid = os.getpid()
 
     def __getstate__(self) -> Dict[Any, Any]:
         state = self.__dict__.copy()
@@ -499,10 +497,6 @@ class MultiprocessInMemoryStorage(BaseStorage):
         self.__dict__.update(state)
         self._manager = _Manager(address=self._manager_address)
         self._manager.connect()
-
-    def __del__(self) -> None:
-        if self._pid == os.getpid():
-            self._manager.shutdown()
 
     def create_new_study(self, *args: Any, **kwargs: Any) -> Any:
         return self._storage.create_new_study(*args, **kwargs)

--- a/optuna/storages/_redis.py
+++ b/optuna/storages/_redis.py
@@ -73,6 +73,15 @@ class RedisStorage(BaseStorage):
         self._url = url
         self._redis = redis.Redis.from_url(url)
 
+    def __getstate__(self) -> Dict[Any, Any]:
+        state = self.__dict__.copy()
+        del state["_redis"]
+        return state
+
+    def __setstate__(self, state: Dict[Any, Any]) -> None:
+        self.__dict__.update(state)
+        self._redis = redis.Redis.from_url(self._url)
+
     def create_new_study(self, study_name: Optional[str] = None) -> int:
 
         if study_name is not None and self._redis.exists(self._key_study_name(study_name)):

--- a/optuna/study/_optimize.py
+++ b/optuna/study/_optimize.py
@@ -1,3 +1,4 @@
+from concurrent.futures import Executor
 from concurrent.futures import FIRST_COMPLETED
 from concurrent.futures import Future
 from concurrent.futures import ProcessPoolExecutor
@@ -54,7 +55,7 @@ def _optimize(
             "The catch argument is of type '{}' but must be a tuple.".format(type(catch).__name__)
         )
 
-    if not scheduler in ("threads", "processes"):
+    if scheduler not in ("threads", "processes"):
         raise ValueError(
             f"Scheduler must be either 'threads' or 'processes' but got '{scheduler}'."
         )
@@ -91,6 +92,7 @@ def _optimize(
             time_start = datetime.datetime.now()
             futures: Set[Future] = set()
 
+            executor_cls: Type[Executor]
             if scheduler == "threads":
                 executor_cls = ThreadPoolExecutor
             elif scheduler == "processes":

--- a/optuna/study/_optimize.py
+++ b/optuna/study/_optimize.py
@@ -1,4 +1,3 @@
-from concurrent.futures import Executor
 from concurrent.futures import FIRST_COMPLETED
 from concurrent.futures import Future
 from concurrent.futures import ProcessPoolExecutor
@@ -92,7 +91,7 @@ def _optimize(
             time_start = datetime.datetime.now()
             futures: Set[Future] = set()
 
-            executor_cls: Type[Executor]
+            executor_cls: Type[Union[ThreadPoolExecutor, ProcessPoolExecutor]]
             if scheduler == "threads":
                 executor_cls = ThreadPoolExecutor
             elif scheduler == "processes":

--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -1069,6 +1069,27 @@ def create_study(
                  https://docs.sqlalchemy.org/en/latest/core/engines.html#database-urls
              .. _SQLAlchemy Engine: https://docs.sqlalchemy.org/en/latest/core/engines.html
 
+            .. note::
+                If ``"multiprocess"``, an in memory storge that supports multiprocessing is
+                created. It can for instance be used together with ``scheduler="processes"`` in
+                :func:`~optuna.study.Study.optimize`.
+
+                .. testcode::
+
+                    import optuna
+
+
+                    def objective(trial):
+                        return trial.suggest_float("x", 0, 10)
+
+
+                    study = optuna.create_study(storage="multiprocess")
+                    study.optimize(obj, n_trials=10, n_jobs=3, scheduler="processes")
+
+                Added in v2.9.0 as an experimental feature. The interface may change in newer
+                versions without prior notice. See
+                https://github.com/optuna/optuna/releases/tag/v2.9.0.
+
         sampler:
             A sampler object that implements background algorithm for value suggestion.
             If :obj:`None` is specified, :class:`~optuna.samplers.TPESampler` is used during

--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -1070,21 +1070,10 @@ def create_study(
              .. _SQLAlchemy Engine: https://docs.sqlalchemy.org/en/latest/core/engines.html
 
             .. note::
-                If ``"multiprocess"``, an in memory storge that supports multiprocessing is
-                created. It can for instance be used together with ``scheduler="processes"`` in
-                :func:`~optuna.study.Study.optimize`.
-
-                .. testcode::
-
-                    import optuna
-
-
-                    def objective(trial):
-                        return trial.suggest_float("x", 0, 10)
-
-
-                    study = optuna.create_study(storage="multiprocess")
-                    study.optimize(objective, n_trials=10, n_jobs=3, scheduler="processes")
+                If ``"multiprocess"``, an in memory storage that supports multiprocessing is
+                created. It can be used with ``scheduler="processes"`` in
+                :func:`~optuna.study.Study.optimize` to parallelize optimization without
+                using a :class:`~optuna.storages.RDBStorage`.
 
                 Added in v2.9.0 as an experimental feature. The interface may change in newer
                 versions without prior notice. See

--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -309,7 +309,7 @@ class Study(BaseStudy):
         gc_after_trial: bool = False,
         show_progress_bar: bool = False,
         *,
-        executor: str = "thread_pool",
+        scheduler: str = "threads",
     ) -> None:
         """Optimize an objective function.
 
@@ -357,7 +357,7 @@ class Study(BaseStudy):
                     https://github.com/optuna/optuna/releases/tag/v2.9.0.
 
                 .. seealso::
-                    The ``executor`` parameter.
+                    The ``scheduler`` parameter.
             catch:
                 A study continues to run even when a trial raises one of the exceptions specified
                 in this argument. Default is an empty tuple, i.e. the study will stop for any
@@ -381,11 +381,10 @@ class Study(BaseStudy):
                 Flag to show progress bars or not. To disable progress bar, set this ``False``.
                 Currently, progress bar is experimental feature and disabled
                 when ``n_jobs`` :math:`\\ne 1`.
-            executor:
-                Executor to determine how to submit parallel objective funciton evaluations when
-                ``n_jobs`` is larger than one.
-                Can be either ``thread_pool`` or ``process_pool`` for multi-threading or
-                multi-process, respectively. Ignored if ``n_jobs`` is 1.
+            scheduler:
+                Scheduler to determine how trials are executed in parallel when ``n_jobs`` is
+                larger than one. Can be either ``threads`` or ``processes`` for multithreading or
+                multiprocess, respectively. Ignored if ``n_jobs`` is one.
 
                 .. note::
                     Added in v2.9.0 as an experimental feature. The interface may change in newer
@@ -398,8 +397,8 @@ class Study(BaseStudy):
         """
         if n_jobs != 1:
             warnings.warn(
-                "``n_jobs != 1`` and ``executor`` options are experimental features."
-                " The interface can change in the future.",
+                "``n_jobs != 1`` which enables the scheduler ``scheduler`` is experimental. "
+                "The interface can change in the future.",
                 ExperimentalWarning,
             )
 
@@ -413,7 +412,7 @@ class Study(BaseStudy):
             callbacks=callbacks,
             gc_after_trial=gc_after_trial,
             show_progress_bar=show_progress_bar,
-            executor=executor,
+            scheduler=scheduler,
         )
 
     def ask(

--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -1084,7 +1084,7 @@ def create_study(
 
 
                     study = optuna.create_study(storage="multiprocess")
-                    study.optimize(obj, n_trials=10, n_jobs=3, scheduler="processes")
+                    study.optimize(objective, n_trials=10, n_jobs=3, scheduler="processes")
 
                 Added in v2.9.0 as an experimental feature. The interface may change in newer
                 versions without prior notice. See

--- a/optuna/testing/storage.py
+++ b/optuna/testing/storage.py
@@ -12,7 +12,7 @@ import optuna
 
 STORAGE_MODES = [
     "inmemory",
-    "multiprocess-inmemory",
+    "multiprocess",
     "sqlite",
     "cache",
     "redis",
@@ -31,7 +31,7 @@ class StorageSupplier(object):
 
         if self.storage_specifier == "inmemory":
             return optuna.storages.InMemoryStorage()
-        elif self.storage_specifier == "multiprocess-inmemory":
+        elif self.storage_specifier == "multiprocess":
             return optuna.storages.MultiprocessInMemoryStorage()
         elif self.storage_specifier == "sqlite":
             self.tempfile = tempfile.NamedTemporaryFile()

--- a/optuna/testing/storage.py
+++ b/optuna/testing/storage.py
@@ -12,6 +12,7 @@ import optuna
 
 STORAGE_MODES = [
     "inmemory",
+    "multiprocess-inmemory",
     "sqlite",
     "cache",
     "redis",
@@ -30,6 +31,8 @@ class StorageSupplier(object):
 
         if self.storage_specifier == "inmemory":
             return optuna.storages.InMemoryStorage()
+        elif self.storage_specifier == "multiprocess-inmemory":
+            return optuna.storages.MultiprocessInMemoryStorage()
         elif self.storage_specifier == "sqlite":
             self.tempfile = tempfile.NamedTemporaryFile()
             url = "sqlite:///{}".format(self.tempfile.name)

--- a/tests/storages_tests/test_storages.py
+++ b/tests/storages_tests/test_storages.py
@@ -7,7 +7,6 @@ from typing import List
 from typing import Optional
 from typing import Sequence
 from typing import Tuple
-from unittest.mock import patch
 
 import pytest
 
@@ -824,19 +823,15 @@ def test_get_all_trials_deepcopy_option(storage_mode: str) -> None:
         study_summaries, study_to_trials = _setup_studies(storage, n_study=2, n_trial=5, seed=49)
 
         for study_id in study_summaries:
-            with patch("copy.deepcopy", wraps=copy.deepcopy) as mock_object:
-                trials0 = storage.get_all_trials(study_id, deepcopy=True)
-                assert mock_object.call_count > 0
-                assert len(trials0) == len(study_to_trials[study_id])
+            trials0 = storage.get_all_trials(study_id, deepcopy=True)
+            assert len(trials0) == len(study_to_trials[study_id])
 
             # Check modifying output does not break the internal state of the storage.
             trials0_original = copy.deepcopy(trials0)
             trials0[0].params["x"] = 0.1
 
-            with patch("copy.deepcopy", wraps=copy.deepcopy) as mock_object:
-                trials1 = storage.get_all_trials(study_id, deepcopy=False)
-                assert mock_object.call_count == 0
-                assert trials0_original == trials1
+            trials1 = storage.get_all_trials(study_id, deepcopy=False)
+            assert trials0_original == trials1
 
 
 @pytest.mark.parametrize("storage_mode", STORAGE_MODES)

--- a/tests/study_tests/test_study.py
+++ b/tests/study_tests/test_study.py
@@ -118,6 +118,22 @@ def test_optimize_n_jobs_warning() -> None:
         study.optimize(func, n_trials=1, n_jobs=2)
 
 
+@pytest.mark.parametrize("n_jobs", [1, 2])
+@pytest.mark.parametrize("executor", ["thread_pool", "process_pool"])
+def test_optimize_executor(n_jobs: int, executor: str) -> None:
+
+    study = create_study()
+    study.optimize(func, n_trials=3, n_jobs=n_jobs, executor=executor)
+    check_study(study)
+
+
+def test_optimize_executor_invalid() -> None:
+
+    study = create_study()
+    with pytest.raises(ValueError):
+        study.optimize(func, n_trials=3, executor="foo")
+
+
 def test_optimize_trivial_in_memory_new() -> None:
 
     study = create_study()


### PR DESCRIPTION
## Motivation

The `n_jobs` parameter in `Study.optimize` has been deprecated in favor of distributed optimization via different Python interpreter processes. However, there's a demand for `n_jobs`, and in addition, an in memory storage that work with both multithreading and multiprocessing.

## Description of the changes

- Reverts the deprecation of `n_jobs`
- Introduces a parameter to `Study.optimize` to switch between multithreading and multiprocessing
- Introduces a naive new multiprocess in memory storage

_These last change is independent of the other two and could be split._

Some notes on the current changes.

- Study is serialized to forked processes in each trial when `scheduler="processes"`. Objects belonging to a study, that is not managed by the multiprocessing manager such as the sampler/pruner is copied in each trial and cannot utilize cache/state
- Performance optimizations of the multirprocess in memory storage i.e. caching is left outside the scope of this PR
- Explicit serialization of objective functions is left outside the scope of this PR


## TODO

- [x] Implement
- [ ] Test

## Example usage

```python
import optuna as ot


# Note that the objective function must be serializable.
# Serialization of lambda objective functions is left outside the scope of this PR.
def obj(t):
    return t.suggest_float("x", 0, 1)


if __name__ == "__main__":
    study = ot.create_study(storage="multiprocess", study_name="foo")
    study.optimize(obj, n_trials=10, n_jobs=3, scheduler="threads")
    study.optimize(obj, n_trials=10, n_jobs=3, scheduler="processes")
    assert len(study.trials) == 20
```