### PR TITLE
Avoid latest numpy 1.21

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ def get_install_requires() -> List[str]:
         "cliff",
         "cmaes>=0.8.2",
         "colorlog",
-        "numpy",
+        "numpy<1.21",
         "packaging>=20.0",
         "scipy!=1.4.0",
         "sqlalchemy>=1.1.0",


### PR DESCRIPTION
## Motivation

Temporarily fix broken mypy checks workflow CI.

```
2021-06-27T12:01:58.5390687Z optuna/samplers/_tpe/parzen_estimator.py:284: error: No overload variant of "__truediv__" of "ndarray" matches argument type "None"
2021-06-27T12:01:58.5392368Z optuna/samplers/_tpe/parzen_estimator.py:284: note: Possible overload variants:
2021-06-27T12:01:58.5395006Z optuna/samplers/_tpe/parzen_estimator.py:284: note:     def __truediv__(self, other: Union[str, bytes, Sequence[Union[str, bytes]], Sequence[Sequence[Union[str, bytes]]], Sequence[Sequence[Sequence[Union[str, bytes]]]], Sequence[Sequence[Sequence[Sequence[Union[str, bytes]]]]]]) -> NoReturn
2021-06-27T12:01:58.5398813Z optuna/samplers/_tpe/parzen_estimator.py:284: note:     def __truediv__(self, other: Union[<union: 5 items>, Union[bool, int, float, Sequence[Union[bool, int, float]], Sequence[Sequence[Union[bool, int, float]]], Sequence[Sequence[Sequence[Union[bool, int, float]]]], Sequence[Sequence[Sequence[Sequence[Union[bool, int, float]]]]]]]) -> ndarray[Any, dtype[floating[Any]]]
2021-06-27T12:01:58.5401243Z optuna/samplers/_tpe/parzen_estimator.py:284: note:     <3 more similar overloads not shown, out of 5 total overloads>
2021-06-27T12:01:58.5402568Z optuna/samplers/_tpe/parzen_estimator.py:284: note: Right operand is of type "Optional[float]"
2021-06-27T12:01:58.5407388Z optuna/visualization/_optimization_history.py:97: error: Argument 1 to "accumulate" of "_UFunc_Nin2_Nout1" has incompatible type "List[Optional[float]]"; expected "Union[Sequence[Sequence[Sequence[Sequence[Sequence[Any]]]]], <union: 2 items>]"
2021-06-27T12:01:58.5411169Z optuna/visualization/_optimization_history.py:99: error: Argument 1 to "accumulate" of "_UFunc_Nin2_Nout1" has incompatible type "List[Optional[float]]"; expected "Union[Sequence[Sequence[Sequence[Sequence[Sequence[Any]]]]], <union: 2 items>]"
2021-06-27T12:01:58.5415267Z optuna/visualization/matplotlib/_optimization_history.py:105: error: Argument 1 to "accumulate" of "_UFunc_Nin2_Nout1" has incompatible type "List[Optional[float]]"; expected "Union[Sequence[Sequence[Sequence[Sequence[Sequence[Any]]]]], <union: 2 items>]"
2021-06-27T12:01:58.5417289Z optuna/visualization/matplotlib/_optimization_history.py:107: error: Argument 1 to "accumulate" of "_UFunc_Nin2_Nout1" has incompatible type "List[Optional[float]]"; expected "Union[Sequence[Sequence[Sequence[Sequence[Sequence[Any]]]]], <union: 2 items>]"
2021-06-27T12:01:58.5419225Z optuna/samplers/_nsga2.py:290: error: Argument 1 to "choice" of "RandomState" has incompatible type "List[FrozenTrial]"; expected "Union[Sequence[Sequence[Sequence[Sequence[Sequence[Any]]]]], <union: 2 items>]"
2021-06-27T12:01:58.5421959Z optuna/samplers/_nsga2.py:291: error: Argument 1 to "choice" of "RandomState" has incompatible type "List[FrozenTrial]"; expected "Union[Sequence[Sequence[Sequence[Sequence[Sequence[Any]]]]], <union: 2 items>]"
2021-06-27T12:01:58.5423904Z optuna/multi_objective/samplers/_nsga2.py:265: error: Argument 1 to "choice" of "RandomState" has incompatible type "List[FrozenMultiObjectiveTrial]"; expected "Union[Sequence[Sequence[Sequence[Sequence[Sequence[Any]]]]], <union: 2 items>]"
2021-06-27T12:01:58.5426255Z optuna/multi_objective/samplers/_nsga2.py:266: error: Argument 1 to "choice" of "RandomState" has incompatible type "List[FrozenMultiObjectiveTrial]"; expected "Union[Sequence[Sequence[Sequence[Sequence[Sequence[Any]]]]], <union: 2 items>]"
2021-06-27T12:01:58.5428491Z optuna/dashboard.py:77: error: Argument 1 to "accumulate" of "_UFunc_Nin2_Nout1" has incompatible type "List[Optional[float]]"; expected "Union[Sequence[Sequence[Sequence[Sequence[Sequence[Any]]]]], <union: 2 items>]"
2021-06-27T12:01:58.5430361Z optuna/dashboard.py:79: error: Argument 1 to "accumulate" of "_UFunc_Nin2_Nout1" has incompatible type "List[Optional[float]]"; expected "Union[Sequence[Sequence[Sequence[Sequence[Sequence[Any]]]]], <union: 2 items>]"
2021-06-27T12:02:01.0453722Z tests/integration_tests/test_chainer.py:29: error: Incompatible return value type (got "Tuple[ndarray[Any, Any], signedinteger[Any]]", expected "Tuple[ndarray[Any, Any], int]")
```

## Description of the changes

- [x] Avoid latests numpy 1.21
- [x] Verify CI
