### PR TITLE
[RFC] Add multithread and multiprocess tests for optimize

### DIFF
--- a/optuna/testing/threading.py
+++ b/optuna/testing/threading.py
@@ -1,22 +1,20 @@
 import threading
 from typing import Any
-from typing import Callable
 from typing import Optional
-from typing import Tuple
 
 
 class _TestableThread(threading.Thread):
-    def __init__(self, target: Callable[..., Any], args: Tuple):
-        threading.Thread.__init__(self, target=target, args=args)
+    def __init__(self, *args: Any, **kwargs: Any):
+        super().__init__(*args, **kwargs)
         self.exc: Optional[BaseException] = None
 
     def run(self) -> None:
         try:
-            threading.Thread.run(self)
+            super().run()
         except BaseException as e:
             self.exc = e
 
     def join(self, timeout: Optional[float] = None) -> None:
-        super(_TestableThread, self).join(timeout)
+        super().join(timeout)
         if self.exc:
             raise self.exc


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation

Discuss whether `Study`, and in particular `Study.optimize`, should supports multithreading and/or multiprocessing. 

- Multithreading 
  - Currently not supported due to the Study optimization lock check
  - "Supported" otherwise (verified by `n_jobs`)
- Multiprocessing
  - "Supported" by Study
  - Not supported by `InMemoryStorage`
  - Currently not supported by `RedisStorage` (have to reestablish a connection to the server on {get,set}state.)

## Description of the changes

Adds tests for `Study.optimize` 