### PR TITLE
Fix deprecated version of `MOTPESampler`

### DIFF
--- a/optuna/samplers/_tpe/multi_objective_sampler.py
+++ b/optuna/samplers/_tpe/multi_objective_sampler.py
@@ -18,7 +18,7 @@ def _default_weights_above(x: int) -> np.ndarray:
     return np.ones(x)
 
 
-@deprecated("2.8.0")
+@deprecated("2.9.0")
 class MOTPESampler(TPESampler):
     """Multi-objective sampler using the MOTPE algorithm.
 


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
The `MOTPESampler` will be deprecated in v2.9.0, but it is v2.8.0 in the codes. This PR fixes it.

## Description of the changes
<!-- Describe the changes in this PR. -->
- deprecated("2.8.0") -> deprecated("2.9.0")
