### PR TITLE
Remove click constraints in yaml files

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -38,11 +38,6 @@ jobs:
         sudo apt-get update
         sudo apt-get -y install openmpi-bin libopenmpi-dev libopenblas-dev
 
-    # TODO(Crissman): Remove click after issue with allennlp import resolved
-    # https://github.com/optuna/optuna/pull/2665
-    - name: Install click 7.1.2 until allennlp import issue resolved
-      run: pip install --use-deprecated=legacy-resolver --progress-bar off click==7.1.2
-
     - name: Install
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/tests-integration.yml
+++ b/.github/workflows/tests-integration.yml
@@ -45,11 +45,6 @@ jobs:
         sudo apt-get update
         sudo apt-get -y install openmpi-bin libopenmpi-dev libopenblas-dev
 
-    # TODO(Crissman): Remove click after issue with allennlp import resolved
-    # https://github.com/optuna/optuna/pull/2665
-    - name: Install click 7.1.2 until allennlp import issue resolved
-      run: pip install --use-deprecated=legacy-resolver --progress-bar off click==7.1.2
-
     - name: Install
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

I think `click`'s version constraint introduced by https://github.com/optuna/optuna/pull/2665 is not necessary anymore. When I installed allennlp, the click's version is constrained as follows: 

```bash
pip install "allennlp>=2.2.0"
...
Requirement already satisfied: click<7.2.0,>=7.1.1 in /opt/homebrew/Caskroom/miniconda/base/envs/optuna/lib/python3.8/site-packages (from typer<0.4.0,>=0.3.0->spacy<3.1,>=2.1.0->allennlp>=2.2.0) (7.1.2)
...
```
## Description of the changes
<!-- Describe the changes in this PR. -->

Remove the `click==7.1.2` related version constraints yaml files.