### PR TITLE
Redis Heartbeat

### DIFF
--- a/optuna/storages/_redis.py
+++ b/optuna/storages/_redis.py
@@ -68,7 +68,7 @@ class RedisStorage(BaseStorage):
         failed_trial_callback:
             A callback function that is invoked after failing each stale trial.
             The function must accept two parameters with the following types in this order:
-            :class:`~optuna.study.Study` and :class:`~optuna.FrozenTrial`.
+            :class:`~optuna.study.Study` and :class:`~optuna.trial.FrozenTrial`.
 
             .. note::
                 The procedure to fail existing stale trials is called just before asking the
@@ -87,6 +87,7 @@ class RedisStorage(BaseStorage):
     def __init__(
         self,
         url: str,
+        *,
         heartbeat_interval: Optional[int] = None,
         grace_period: Optional[int] = None,
         failed_trial_callback: Optional[Callable[["optuna.Study", FrozenTrial], None]] = None,

--- a/optuna/storages/_redis.py
+++ b/optuna/storages/_redis.py
@@ -399,6 +399,8 @@ class RedisStorage(BaseStorage):
             self._redis.set(self._key_trial(trial_id), pickle.dumps(trial))
             self._update_cache(trial_id)
 
+            # To ensure that there are no failed trials with heartbeats in the DB
+            # under any circumstances
             study_id = self.get_study_id_from_trial_id(trial_id)
             self._redis.hdel(self._key_study_heartbeats(study_id), str(trial_id))
         else:

--- a/optuna/testing/storage.py
+++ b/optuna/testing/storage.py
@@ -1,6 +1,6 @@
 import tempfile
 from types import TracebackType
-from typing import Any, Dict
+from typing import Any
 from typing import IO
 from typing import Optional
 from typing import Type

--- a/optuna/testing/storage.py
+++ b/optuna/testing/storage.py
@@ -1,6 +1,6 @@
 import tempfile
 from types import TracebackType
-from typing import Any
+from typing import Any, Dict
 from typing import IO
 from typing import Optional
 from typing import Type
@@ -17,35 +17,48 @@ STORAGE_MODES = [
     "redis",
 ]
 
+STORAGE_MODES_HEARTBEAT = [
+    "sqlite",
+    "cache",
+    "redis",
+]
+
 SQLITE3_TIMEOUT = 300
 
 
 class StorageSupplier(object):
-    def __init__(self, storage_specifier: str) -> None:
+    def __init__(self, storage_specifier: str, **kwargs: Any) -> None:
 
         self.storage_specifier = storage_specifier
         self.tempfile: Optional[IO[Any]] = None
+        self.extra_args = kwargs
 
     def __enter__(self) -> optuna.storages.BaseStorage:
 
         if self.storage_specifier == "inmemory":
+            if len(self.extra_args) > 0:
+                raise ValueError("InMemoryStorage does not accept any arguments!")
             return optuna.storages.InMemoryStorage()
         elif self.storage_specifier == "sqlite":
             self.tempfile = tempfile.NamedTemporaryFile()
             url = "sqlite:///{}".format(self.tempfile.name)
             return optuna.storages.RDBStorage(
-                url, engine_kwargs={"connect_args": {"timeout": SQLITE3_TIMEOUT}}
+                url,
+                engine_kwargs={"connect_args": {"timeout": SQLITE3_TIMEOUT}},
+                **self.extra_args,
             )
         elif self.storage_specifier == "cache":
             self.tempfile = tempfile.NamedTemporaryFile()
             url = "sqlite:///{}".format(self.tempfile.name)
             return optuna.storages._CachedStorage(
                 optuna.storages.RDBStorage(
-                    url, engine_kwargs={"connect_args": {"timeout": SQLITE3_TIMEOUT}}
+                    url,
+                    engine_kwargs={"connect_args": {"timeout": SQLITE3_TIMEOUT}},
+                    **self.extra_args,
                 )
             )
         elif self.storage_specifier == "redis":
-            storage = optuna.storages.RedisStorage("redis://localhost")
+            storage = optuna.storages.RedisStorage("redis://localhost", **self.extra_args)
             storage._redis = fakeredis.FakeStrictRedis()
             return storage
         else:

--- a/tests/storages_tests/rdb_tests/test_storage.py
+++ b/tests/storages_tests/rdb_tests/test_storage.py
@@ -12,12 +12,10 @@ import pytest
 from sqlalchemy.exc import IntegrityError
 
 from optuna import create_study
-from optuna import Study
 from optuna import version
 from optuna.distributions import CategoricalDistribution
 from optuna.distributions import UniformDistribution
 from optuna.storages import RDBStorage
-from optuna.storages import RetryFailedTrialCallback
 from optuna.storages._rdb.models import SCHEMA_VERSION
 from optuna.storages._rdb.models import TrialHeartbeatModel
 from optuna.storages._rdb.models import VersionInfoModel
@@ -332,101 +330,3 @@ def test_record_heartbeat() -> None:
         assert len(trial_heartbeats) == n_trials
         for i in range(n_trials - 1):
             assert (trial_heartbeats[i + 1] - trial_heartbeats[i]).seconds - sleep_sec <= 1
-
-
-def test_fail_stale_trials() -> None:
-
-    heartbeat_interval = 1
-    grace_period = 2
-
-    with StorageSupplier("sqlite") as storage:
-        assert isinstance(storage, RDBStorage)
-        storage.heartbeat_interval = heartbeat_interval
-        storage.grace_period = grace_period
-        study1 = create_study(storage=storage)
-        study2 = create_study(storage=storage)
-
-        trial1 = study1.ask()
-        trial2 = study2.ask()
-        storage.record_heartbeat(trial1._trial_id)
-        storage.record_heartbeat(trial2._trial_id)
-        time.sleep(grace_period + 1)
-
-        assert study1.trials[0].state is TrialState.RUNNING
-        assert study2.trials[0].state is TrialState.RUNNING
-
-        assert storage._get_stale_trial_ids(study1._study_id) == [study1.trials[0]._trial_id]
-
-        # Exceptions raised in spawned threads are caught by `_TestableThread`.
-        with patch("optuna.study._optimize.Thread", _TestableThread):
-            study1.optimize(lambda _: 1.0, n_trials=1)
-
-        assert study1.trials[0].state is TrialState.FAIL
-        assert study2.trials[0].state is TrialState.RUNNING
-
-
-def test_invalid_heartbeat_interval_and_grace_period() -> None:
-
-    with pytest.raises(ValueError):
-        _ = RDBStorage("sqlite:///:memory:", heartbeat_interval=-1)
-
-    with pytest.raises(ValueError):
-        _ = RDBStorage("sqlite:///:memory:", grace_period=-1)
-
-
-def test_failed_trial_callback() -> None:
-    heartbeat_interval = 1
-    grace_period = 2
-
-    def failed_trial_callback(study: Study, trial: FrozenTrial) -> None:
-        assert study.system_attrs["test"] == "A"
-        assert trial.system_attrs["test"] == "B"
-
-    with StorageSupplier("sqlite") as storage:
-        assert isinstance(storage, RDBStorage)
-        storage.heartbeat_interval = heartbeat_interval
-        storage.grace_period = grace_period
-        storage.failed_trial_callback = failed_trial_callback
-        study = create_study(storage=storage)
-        study.set_system_attr("test", "A")
-
-        trial = study.ask()
-        trial.set_system_attr("test", "B")
-        storage.record_heartbeat(trial._trial_id)
-        time.sleep(grace_period + 1)
-
-        # Exceptions raised in spawned threads are caught by `_TestableThread`.
-        with patch("optuna.study._optimize.Thread", _TestableThread):
-            with patch.object(storage, "failed_trial_callback", wraps=failed_trial_callback) as m:
-                study.optimize(lambda _: 1.0, n_trials=1)
-                m.assert_called_once()
-
-
-@pytest.mark.parametrize("max_retry", [None, 0, 1])
-def test_retry_failed_trial_callback(max_retry: Optional[int]) -> None:
-    heartbeat_interval = 1
-    grace_period = 2
-
-    with StorageSupplier("sqlite") as storage:
-        assert isinstance(storage, RDBStorage)
-        storage.heartbeat_interval = heartbeat_interval
-        storage.grace_period = grace_period
-
-        storage.failed_trial_callback = RetryFailedTrialCallback(max_retry=max_retry)
-        study = create_study(storage=storage)
-
-        trial = study.ask()
-        storage.record_heartbeat(trial._trial_id)
-        time.sleep(grace_period + 1)
-
-        # Exceptions raised in spawned threads are caught by `_TestableThread`.
-        with patch("optuna.study._optimize.Thread", _TestableThread):
-            study.optimize(lambda _: 1.0, n_trials=1)
-
-        # Test the last trial to see if it was a retry of the first trial or not.
-        # Test max_rety=None to see if trial is retried.
-        # Test max_rety=0 to see if no trials are retried.
-        # Test max_rety=1 to see if trial is retried.
-        assert RetryFailedTrialCallback.retried_trial_number(study.trials[1]) == (
-            None if max_retry == 0 else 0
-        )

--- a/tests/storages_tests/test_storages.py
+++ b/tests/storages_tests/test_storages.py
@@ -1,6 +1,8 @@
 import copy
 from datetime import datetime
+import itertools
 import random
+import time
 from typing import Any
 from typing import Dict
 from typing import List
@@ -12,6 +14,8 @@ from unittest.mock import patch
 import pytest
 
 import optuna
+from optuna import Study
+from optuna._callbacks import RetryFailedTrialCallback
 from optuna.distributions import CategoricalDistribution
 from optuna.distributions import LogUniformDistribution
 from optuna.distributions import UniformDistribution
@@ -24,7 +28,9 @@ from optuna.storages._base import DEFAULT_STUDY_NAME_PREFIX
 from optuna.study._study_direction import StudyDirection
 from optuna.study._study_summary import StudySummary
 from optuna.testing.storage import STORAGE_MODES
+from optuna.testing.storage import STORAGE_MODES_HEARTBEAT
 from optuna.testing.storage import StorageSupplier
+from optuna.testing.threading import _TestableThread
 from optuna.trial import FrozenTrial
 from optuna.trial import TrialState
 
@@ -1086,4 +1092,119 @@ def test_get_trial_id_from_study_id_trial_number(storage_mode: str) -> None:
 
         assert trial_id == storage.get_trial_id_from_study_id_trial_number(
             study_id, trial_number=0
+        )
+
+
+@pytest.mark.parametrize("storage_mode", STORAGE_MODES_HEARTBEAT)
+def test_fail_stale_trials(storage_mode: str) -> None:
+
+    heartbeat_interval = 1
+    grace_period = 2
+
+    with StorageSupplier(
+        storage_mode, heartbeat_interval=heartbeat_interval, grace_period=grace_period
+    ) as storage:
+        assert storage.is_heartbeat_enabled()
+
+        study1 = optuna.create_study(storage=storage)
+        study2 = optuna.create_study(storage=storage)
+
+        trial1 = study1.ask()
+        trial2 = study2.ask()
+        storage.record_heartbeat(trial1._trial_id)
+        storage.record_heartbeat(trial2._trial_id)
+        time.sleep(grace_period + 1)
+
+        assert study1.trials[0].state is TrialState.RUNNING
+        assert study2.trials[0].state is TrialState.RUNNING
+
+        # Exceptions raised in spawned threads are caught by `_TestableThread`.
+        with patch("optuna.study._optimize.Thread", _TestableThread):
+            study1.optimize(lambda _: 1.0, n_trials=1)
+
+        assert study1.trials[0].state is TrialState.FAIL
+        assert study2.trials[0].state is TrialState.RUNNING
+
+
+@pytest.mark.parametrize("storage_mode", STORAGE_MODES_HEARTBEAT)
+def test_invalid_heartbeat_interval_and_grace_period(storage_mode: str) -> None:
+
+    with pytest.raises(ValueError):
+        with StorageSupplier(storage_mode, heartbeat_interval=-1):
+            pass
+
+    with pytest.raises(ValueError):
+        with StorageSupplier(storage_mode, grace_period=-1):
+            pass
+
+
+@pytest.mark.parametrize("storage_mode", STORAGE_MODES_HEARTBEAT)
+def test_failed_trial_callback(storage_mode: str) -> None:
+    heartbeat_interval = 1
+    grace_period = 2
+
+    class FailedTrialCallback:
+        def __init__(self) -> None:
+            self.called_once: bool = False
+
+        def __call__(self, study: Study, trial: FrozenTrial) -> None:
+            assert study.system_attrs["test"] == "A"
+            assert trial.system_attrs["test"] == "B"
+            self.called_once = True
+
+    failed_trial_callback = FailedTrialCallback()
+
+    with StorageSupplier(
+        storage_mode,
+        heartbeat_interval=heartbeat_interval,
+        grace_period=grace_period,
+        failed_trial_callback=failed_trial_callback,
+    ) as storage:
+        assert storage.is_heartbeat_enabled()
+
+        study = optuna.create_study(storage=storage)
+        study.set_system_attr("test", "A")
+
+        trial = study.ask()
+        trial.set_system_attr("test", "B")
+        storage.record_heartbeat(trial._trial_id)
+        time.sleep(grace_period + 1)
+
+        # Exceptions raised in spawned threads are caught by `_TestableThread`.
+        with patch("optuna.study._optimize.Thread", _TestableThread):
+            study.optimize(lambda _: 1.0, n_trials=1)
+            assert failed_trial_callback.called_once
+
+
+@pytest.mark.parametrize(
+    "storage_mode,max_retry", itertools.product(STORAGE_MODES_HEARTBEAT, [None, 0, 1])
+)
+def test_retry_failed_trial_callback(storage_mode: str, max_retry: Optional[int]) -> None:
+    heartbeat_interval = 1
+    grace_period = 2
+
+    with StorageSupplier(
+        storage_mode,
+        heartbeat_interval=heartbeat_interval,
+        grace_period=grace_period,
+        failed_trial_callback=RetryFailedTrialCallback(max_retry=max_retry),
+    ) as storage:
+        assert storage.is_heartbeat_enabled()
+
+        study = optuna.create_study(storage=storage)
+
+        trial = study.ask()
+        storage.record_heartbeat(trial._trial_id)
+        time.sleep(grace_period + 1)
+
+        # Exceptions raised in spawned threads are caught by `_TestableThread`.
+        with patch("optuna.study._optimize.Thread", _TestableThread):
+            study.optimize(lambda _: 1.0, n_trials=1)
+
+        # Test the last trial to see if it was a retry of the first trial or not.
+        # Test max_retry=None to see if trial is retried.
+        # Test max_retry=0 to see if no trials are retried.
+        # Test max_retry=1 to see if trial is retried.
+        assert RetryFailedTrialCallback.retried_trial_number(study.trials[1]) == (
+            None if max_retry == 0 else 0
         )


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
Fix #2773. Sorry for not waiting for your replies there, but I could not wait to start coding :smile: 

## Description of the changes
This PR adds heartbeat support to the Redis storage backend and unifies some of the heartbeat related tests for RDB and Redis backends. Detailed list of changes:

- Heartbeats are saved in a hash (i.e. dict) per study and not per trial. While this requires an additional lookup of the study ID in `set_trial_state()` and `record_heartbeat()`, it significantly improves the performance of `fail_stale_trials()` for studies with many non-running trials.
- Heartbeats are removed when a trial's state is updated on completion. As empty hashes are deleted in Redis automatically, there should be no permanent storage usage after finishing all running trials. However, a user can call `record_heartbeat` out of order, but as he/she is not supposed to call backend methods anyway and the RDB storage has the same problem, I ignored this. After all, looking up the trial state in `record_heartbeat()` would cause a performance cost.
- I moved the tests from the RDB storage tests to the general storage tests and added a new list `STORAGE_MODES_HEARTBEAT`. Additionally, `StorageSupplier` now supports passing `kwargs` to the backends to unify the setting of `heartbeat_interval`, `grace_period` and `failed_trial_callback`. In this process, I lost one single test which is redundant in my opinion, i.e. checking the return value of `_get_stale_trials()` in `test_fail_stale_trials()`.
