### PR TITLE
Introduce Weights & Biases integration

### DIFF
--- a/docs/source/reference/integration.rst
+++ b/docs/source/reference/integration.rst
@@ -96,6 +96,15 @@ MLflow
 
    optuna.integration.MLflowCallback
 
+Weights & Biases
+----------------
+
+.. autosummary::
+   :toctree: generated/
+   :nosignatures:
+
+   optuna.integration.WeightsAndBiasesCallback
+
 MXNet
 -----
 

--- a/optuna/integration/__init__.py
+++ b/optuna/integration/__init__.py
@@ -52,7 +52,6 @@ if TYPE_CHECKING:
     from optuna.integration.lightgbm import LightGBMTuner  # NOQA
     from optuna.integration.lightgbm import LightGBMTunerCV  # NOQA
     from optuna.integration.mlflow import MLflowCallback  # NOQA
-    from optuna.integration.wandb import WeightsAndBiasesCallback  # NOQA
     from optuna.integration.mxnet import MXNetPruningCallback  # NOQA
     from optuna.integration.pytorch_distributed import TorchDistributedTrial  # NOQA
     from optuna.integration.pytorch_ignite import PyTorchIgnitePruningHandler  # NOQA
@@ -63,6 +62,7 @@ if TYPE_CHECKING:
     from optuna.integration.tensorboard import TensorBoardCallback  # NOQA
     from optuna.integration.tensorflow import TensorFlowPruningHook  # NOQA
     from optuna.integration.tfkeras import TFKerasPruningCallback  # NOQA
+    from optuna.integration.wandb import WeightsAndBiasesCallback  # NOQA
     from optuna.integration.xgboost import XGBoostPruningCallback  # NOQA
 else:
 

--- a/optuna/integration/__init__.py
+++ b/optuna/integration/__init__.py
@@ -13,6 +13,7 @@ _import_structure = {
     "chainermn": ["ChainerMNStudy"],
     "cma": ["CmaEsSampler", "PyCmaSampler"],
     "mlflow": ["MLflowCallback"],
+    "wandb": ["WeightsAndBiasesCallback"],
     "keras": ["KerasPruningCallback"],
     "lightgbm": ["LightGBMPruningCallback", "LightGBMTuner", "LightGBMTunerCV"],
     "pytorch_distributed": ["TorchDistributedTrial"],
@@ -51,6 +52,7 @@ if TYPE_CHECKING:
     from optuna.integration.lightgbm import LightGBMTuner  # NOQA
     from optuna.integration.lightgbm import LightGBMTunerCV  # NOQA
     from optuna.integration.mlflow import MLflowCallback  # NOQA
+    from optuna.integration.wandb import WeightsAndBiasesCallback  # NOQA
     from optuna.integration.mxnet import MXNetPruningCallback  # NOQA
     from optuna.integration.pytorch_distributed import TorchDistributedTrial  # NOQA
     from optuna.integration.pytorch_ignite import PyTorchIgnitePruningHandler  # NOQA

--- a/optuna/integration/wandb.py
+++ b/optuna/integration/wandb.py
@@ -1,0 +1,142 @@
+from typing import Optional
+from typing import Union
+
+import optuna
+from optuna._imports import try_import
+
+
+with try_import() as _imports:
+    import wandb
+
+
+class WeightsAndBiasesCallback(object):
+    """Callback to track Optuna trials with Weights & Biases.
+
+    This callback enables tracking of Optuna study in
+    Weights & Biases. The study is tracked as a single experiment
+    run, where all suggested hyperparameters and optimized metric
+    are logged and plotted as a function of optimizer steps.
+
+    .. note::
+        User needs to be logged in to Weights & Biases before
+        using this callback. For more information, please
+        refer to `wandb setup <https://docs.wandb.ai/quickstart#1-set-up-wandb>`_.
+
+    Example:
+
+        Add Weights & Biases callback to Optuna optimization.
+
+        .. code::
+
+            import optuna
+            from optuna.integration.wandb import WeightsAndBiasesCallback
+
+
+            def objective(trial):
+                x = trial.suggest_float("x", -10, 10)
+                return (x - 2) ** 2
+
+
+            n_trials = 10
+            wandbc = WeightsAndBiasesCallback(
+                n_trials=n_trials,
+                project_name="my-project-name",
+                group_name="my-group-name",
+                job_type="my-job-type",
+            )
+
+
+            study = optuna.create_study(study_name="my_study")
+            study.optimize(objective, n_trials=n_trials, callbacks=[wandbc])
+
+    Args:
+        n_trials:
+            The number of optimizer trials.
+        metric_name:
+            Name of the optimized metric. Since the metric itself is just a number,
+            `metric_name` can be used to give it a name. So you know later
+            if it was roc-auc or accuracy.
+        project_name:
+            Name of the project under which run should be categorized.
+            If the project is not specified, the run is put in an "Uncategorized" project.
+        group_name:
+            Specifies a group under project into which run should be categorized.
+            Please refer to `Group Runs
+            <https://docs.wandb.ai/guides/track/advanced/grouping>`_ for more details.
+        entity_name:
+            Username or team name under which run should be logged. When set to `None`,
+            the run is logged under the current user.
+        run_name:
+            Specifies the display name in Weights & Biases UI for this run.
+            When set to `None`, random two word name is generated instead.
+        job_type:
+            Specifies type of the run, and is used as additional grouping
+            for the runs.
+    """
+
+    def __init__(
+        self,
+        n_trials: int,
+        metric_name: Union[str] = "value",
+        project_name: Optional[str] = None,
+        group_name: Optional[str] = None,
+        entity_name: Optional[str] = None,
+        run_name: Optional[str] = None,
+        job_type: Optional[str] = None,
+    ) -> None:
+
+        _imports.check()
+
+        self._n_trials = n_trials
+        self._metric_name = metric_name
+        self._project_name = project_name
+        self._group_name = group_name
+        self._entity_name = entity_name
+        self._run_name = run_name
+        self._job_type = job_type
+
+    def __call__(self, study: optuna.study.Study, trial: optuna.trial.FrozenTrial) -> None:
+
+        if trial.number == 0:
+            self._initialize_run(study, trial)
+
+        for key, value in trial.params.items():
+            wandb.log({key: value}, step=trial.number)
+
+        wandb.log({self._metric_name: trial.value}, step=trial.number)
+
+        # We need to know when study ends to allow
+        # Weights & Biases to finish run and sync up.
+        # This means that this callback can't be currently used
+        # for time-constrained or non-constrained studies.
+        if trial.number + 1 == self._n_trials:
+            datetime_complete = str(trial.datetime_complete)
+            wandb.config.update({"datetime_complete": datetime_complete})
+            wandb.finish()
+
+    def _initialize_run(self, study: optuna.study.Study, trial: optuna.trial.FrozenTrial) -> None:
+        """Initializes Weights & Biases run.
+
+        Args:
+            trial:
+                First trial in the study.
+            study:
+                Tracked study.
+        """
+
+        study_direction = str(study.direction).split(".")[-1]
+        config = {
+            "direction": study_direction,
+            "n_trials": self._n_trials,
+            "datetime_start": str(trial.datetime_start),
+        }
+
+        wandb.init(
+            project=self._project_name,
+            group=self._group_name,
+            entity=self._entity_name,
+            name=self._run_name,
+            job_type=self._job_type,
+            config=config,
+            reinit=True,
+        )

--- a/optuna/integration/wandb.py
+++ b/optuna/integration/wandb.py
@@ -1,3 +1,5 @@
+from typing import Any
+from typing import Dict
 from typing import Optional
 from typing import Union
 
@@ -39,11 +41,8 @@ class WeightsAndBiasesCallback(object):
                 return (x - 2) ** 2
 
 
-            wandbc = WeightsAndBiasesCallback(
-                project_name="my-project-name",
-                group_name="my-group-name",
-                job_type="my-job-type",
-            )
+            wandb_kwargs = {"project": "my-project"}
+            wandbc = WeightsAndBiasesCallback(wandb_kwargs=wandb_kwargs)
 
 
             study = optuna.create_study(study_name="my_study")
@@ -54,47 +53,20 @@ class WeightsAndBiasesCallback(object):
             Name of the optimized metric. Since the metric itself is just a number,
             ``metric_name`` can be used to give it a name. So you know later
             if it was roc-auc or accuracy.
-        project_name:
-            Name of the project under which run should be categorized.
-            If the project is not specified, the run is put in an "Uncategorized" project.
-        group_name:
-            Specifies a group under project into which run should be categorized.
-            Please refer to `Group Runs
-            <https://docs.wandb.ai/guides/track/advanced/grouping>`_ for more details.
-        entity_name:
-            Username or team name under which run should be logged. When set to :obj:`None`,
-            the run is logged under the current user.
-        run_name:
-            Specifies the display name in Weights & Biases UI for this run.
-            When set to :obj:`None`, random two word name is generated instead.
-        job_type:
-            Specifies type of the run, and is used as additional grouping
-            for the runs.
-        mode:
-            Specifies execution mode for Weights & Biases. One of
-            ``online``, ``offline`` or ``disabled``. Defaults to online.
+        wandb_kwargs:
+            Set of arguments passed when initializing Weights & Biases run.
+            Please refer to `Weights & Biases API documentation
+            <https://docs.wandb.ai/ref/python/init>`_ for more details.
     """
 
     def __init__(
-        self,
-        metric_name: Union[str] = "value",
-        project_name: Optional[str] = None,
-        group_name: Optional[str] = None,
-        entity_name: Optional[str] = None,
-        run_name: Optional[str] = None,
-        job_type: Optional[str] = None,
-        mode: Union[str] = "online",
+        self, metric_name: Union[str] = "value", wandb_kwargs: Optional[Dict[str, Any]] = None
     ) -> None:
 
         _imports.check()
 
         self._metric_name = metric_name
-        self._project_name = project_name
-        self._group_name = group_name
-        self._entity_name = entity_name
-        self._run_name = run_name
-        self._job_type = job_type
-        self._mode = mode
+        self._wandb_kwargs = wandb_kwargs or {}
 
         self._initialize_run()
 
@@ -116,12 +88,4 @@ class WeightsAndBiasesCallback(object):
     def _initialize_run(self) -> None:
         """Initializes Weights & Biases run."""
 
-        wandb.init(
-            project=self._project_name,
-            group=self._group_name,
-            entity=self._entity_name,
-            name=self._run_name,
-            job_type=self._job_type,
-            mode=self._mode,
-            reinit=True,
-        )
+        wandb.init(**self._wandb_kwargs)

--- a/optuna/integration/wandb.py
+++ b/optuna/integration/wandb.py
@@ -26,6 +26,17 @@ class WeightsAndBiasesCallback(object):
         using this callback in online mode. For more information, please
         refer to `wandb setup <https://docs.wandb.ai/quickstart#1-set-up-wandb>`_.
 
+    .. note::
+        Users who want to run multiple Optuna studies within the same process
+        should call ``wandb.finish()`` between subsequent calls to
+        ``study.optimize()``. Calling ``wandb.finish()`` is not necessary
+        if you are running one Optuna study per process.
+
+    .. note::
+        To ensure correct trial order in Weights & Biases, this callback
+        should only be used with ``study.optimize(n_jobs=1)``.
+
+
     Example:
 
         Add Weights & Biases callback to Optuna optimization.

--- a/optuna/integration/wandb.py
+++ b/optuna/integration/wandb.py
@@ -2,6 +2,7 @@ from typing import Optional
 from typing import Union
 
 import optuna
+from optuna._experimental import experimental
 from optuna._imports import try_import
 
 
@@ -9,6 +10,7 @@ with try_import() as _imports:
     import wandb
 
 
+@experimental("2.9.0")
 class WeightsAndBiasesCallback(object):
     """Callback to track Optuna trials with Weights & Biases.
 

--- a/optuna/integration/wandb.py
+++ b/optuna/integration/wandb.py
@@ -21,7 +21,7 @@ class WeightsAndBiasesCallback(object):
 
     .. note::
         User needs to be logged in to Weights & Biases before
-        using this callback. For more information, please
+        using this callback in online mode. For more information, please
         refer to `wandb setup <https://docs.wandb.ai/quickstart#1-set-up-wandb>`_.
 
     Example:
@@ -70,6 +70,9 @@ class WeightsAndBiasesCallback(object):
         job_type:
             Specifies type of the run, and is used as additional grouping
             for the runs.
+        mode:
+            Specifies execution mode for Weights & Biases. One of
+            ``online``, ``offline`` or ``disabled``. Defaults to online.
     """
 
     def __init__(
@@ -80,6 +83,7 @@ class WeightsAndBiasesCallback(object):
         entity_name: Optional[str] = None,
         run_name: Optional[str] = None,
         job_type: Optional[str] = None,
+        mode: Union[str] = "online",
     ) -> None:
 
         _imports.check()
@@ -90,6 +94,7 @@ class WeightsAndBiasesCallback(object):
         self._entity_name = entity_name
         self._run_name = run_name
         self._job_type = job_type
+        self._mode = mode
 
         self._initialize_run()
 
@@ -117,5 +122,6 @@ class WeightsAndBiasesCallback(object):
             entity=self._entity_name,
             name=self._run_name,
             job_type=self._job_type,
+            mode=self._mode,
             reinit=True,
         )

--- a/optuna/integration/wandb.py
+++ b/optuna/integration/wandb.py
@@ -95,10 +95,18 @@ class WeightsAndBiasesCallback(object):
 
     def __call__(self, study: optuna.study.Study, trial: optuna.trial.FrozenTrial) -> None:
 
-        for key, value in trial.params.items():
-            wandb.log({key: value}, step=trial.number)
+        trial_state = str(trial.state).split(".")[-1]
+        direction = str(study.direction).split(".")[-1]
 
-        wandb.log({self._metric_name: trial.value}, step=trial.number)
+        attributes = {
+            "direction": direction,
+            "trial_state": trial_state,
+            "distributions": trial.distributions,
+            **study.user_attrs,
+        }
+
+        wandb.config.update(attributes)
+        wandb.log({**trial.params, self._metric_name: trial.value}, step=trial.number)
 
     def _initialize_run(self) -> None:
         """Initializes Weights & Biases run."""

--- a/optuna/integration/wandb.py
+++ b/optuna/integration/wandb.py
@@ -52,7 +52,7 @@ class WeightsAndBiasesCallback(object):
     Args:
         metric_name:
             Name of the optimized metric. Since the metric itself is just a number,
-            `metric_name` can be used to give it a name. So you know later
+            ``metric_name`` can be used to give it a name. So you know later
             if it was roc-auc or accuracy.
         project_name:
             Name of the project under which run should be categorized.
@@ -62,11 +62,11 @@ class WeightsAndBiasesCallback(object):
             Please refer to `Group Runs
             <https://docs.wandb.ai/guides/track/advanced/grouping>`_ for more details.
         entity_name:
-            Username or team name under which run should be logged. When set to `None`,
+            Username or team name under which run should be logged. When set to :obj:`None`,
             the run is logged under the current user.
         run_name:
             Specifies the display name in Weights & Biases UI for this run.
-            When set to `None`, random two word name is generated instead.
+            When set to :obj:`None`, random two word name is generated instead.
         job_type:
             Specifies type of the run, and is used as additional grouping
             for the runs.

--- a/optuna/integration/wandb.py
+++ b/optuna/integration/wandb.py
@@ -72,15 +72,8 @@ class WeightsAndBiasesCallback(object):
 
     def __call__(self, study: optuna.study.Study, trial: optuna.trial.FrozenTrial) -> None:
 
-        trial_state = str(trial.state).split(".")[-1]
         direction = str(study.direction).split(".")[-1]
-
-        attributes = {
-            "direction": direction,
-            "trial_state": trial_state,
-            "distributions": trial.distributions,
-            **study.user_attrs,
-        }
+        attributes = {"direction": direction}
 
         wandb.config.update(attributes)
         wandb.log({**trial.params, self._metric_name: trial.value}, step=trial.number)

--- a/optuna/integration/wandb.py
+++ b/optuna/integration/wandb.py
@@ -1,7 +1,6 @@
 from typing import Any
 from typing import Dict
 from typing import Optional
-from typing import Union
 
 import optuna
 from optuna._experimental import experimental
@@ -36,6 +35,8 @@ class WeightsAndBiasesCallback(object):
         To ensure correct trial order in Weights & Biases, this callback
         should only be used with ``study.optimize(n_jobs=1)``.
 
+    .. note::
+        This callback currently supports only single-objective optimization.
 
     Example:
 
@@ -71,7 +72,7 @@ class WeightsAndBiasesCallback(object):
     """
 
     def __init__(
-        self, metric_name: Union[str] = "value", wandb_kwargs: Optional[Dict[str, Any]] = None
+        self, metric_name: str = "value", wandb_kwargs: Optional[Dict[str, Any]] = None
     ) -> None:
 
         _imports.check()
@@ -83,7 +84,7 @@ class WeightsAndBiasesCallback(object):
 
     def __call__(self, study: optuna.study.Study, trial: optuna.trial.FrozenTrial) -> None:
 
-        direction = str(study.direction).split(".")[-1]
+        direction = study.direction.name
         attributes = {"direction": direction}
 
         wandb.config.update(attributes)

--- a/setup.py
+++ b/setup.py
@@ -138,6 +138,7 @@ def get_extras_require() -> Dict[str, List[str]]:
             "cma",
             "lightgbm",
             "mlflow",
+            "wandb",
             "mpi4py",
             "mxnet",
             "pandas",

--- a/tests/integration_tests/test_wandb.py
+++ b/tests/integration_tests/test_wandb.py
@@ -17,22 +17,23 @@ def _objective_func(trial: optuna.trial.Trial) -> float:
 def test_run_initialized(wandb: mock.MagicMock) -> None:
 
     wandb.run = None
+    wandb_kwargs = {
+        "project": "optuna",
+        "group": "summary",
+        "job_type": "logging",
+        "mode": "offline",
+    }
+
     WeightsAndBiasesCallback(
         metric_name="mse",
-        project_name="optuna",
-        group_name="summary",
-        job_type="logging",
-        mode="offline",
+        wandb_kwargs=wandb_kwargs,
     )
 
     wandb.init.assert_called_once_with(
         project="optuna",
         group="summary",
-        entity=None,
-        name=None,
         job_type="logging",
         mode="offline",
-        reinit=True,
     )
 
 

--- a/tests/integration_tests/test_wandb.py
+++ b/tests/integration_tests/test_wandb.py
@@ -1,0 +1,112 @@
+from unittest import mock
+
+import optuna
+from optuna.distributions import LogUniformDistribution
+from optuna.distributions import UniformDistribution
+from optuna.integration import WeightsAndBiasesCallback
+
+
+def _objective_func(trial: optuna.trial.Trial) -> float:
+
+    x = trial.suggest_uniform("x", low=-10, high=10)
+    y = trial.suggest_loguniform("y", low=1, high=10)
+    return (x - 2) ** 2 + (y - 25) ** 2
+
+
+@mock.patch("optuna.integration.wandb.wandb")
+def test_run_initialized(wandb: mock.MagicMock) -> None:
+
+    wandb.run = None
+    WeightsAndBiasesCallback(
+        metric_name="mse",
+        project_name="optuna",
+        group_name="summary",
+        job_type="logging",
+        mode="offline",
+    )
+
+    wandb.init.assert_called_once_with(
+        project="optuna",
+        group="summary",
+        entity=None,
+        name=None,
+        job_type="logging",
+        mode="offline",
+        reinit=True,
+    )
+
+
+@mock.patch("optuna.integration.wandb.wandb")
+def test_attributes_set_on_epoch(wandb: mock.MagicMock) -> None:
+
+    wandb.run = None
+    wandb.config.update = mock.MagicMock()
+
+    wandbc = WeightsAndBiasesCallback()
+    study = optuna.create_study(direction="minimize")
+    study.optimize(_objective_func, n_trials=1, callbacks=[wandbc])
+
+    expected = {
+        "direction": "MINIMIZE",
+        "trial_state": "COMPLETE",
+        "distributions": {
+            "x": UniformDistribution(high=10.0, low=-10.0),
+            "y": LogUniformDistribution(high=10.0, low=1.0),
+        },
+    }
+
+    wandb.config.update.assert_called_once_with(expected)
+
+
+@mock.patch("optuna.integration.wandb.wandb")
+def test_user_attributes_set_on_epoch(wandb: mock.MagicMock) -> None:
+
+    wandb.run = None
+    wandb.config.update = mock.MagicMock()
+
+    wandbc = WeightsAndBiasesCallback()
+    study = optuna.create_study(direction="minimize")
+    study.set_user_attr("contributors", ["Akiba", "Sano"])
+    study.set_user_attr("dataset", "MNIST")
+    study.optimize(_objective_func, n_trials=1, callbacks=[wandbc])
+
+    expected = {
+        "direction": "MINIMIZE",
+        "trial_state": "COMPLETE",
+        "distributions": {
+            "x": UniformDistribution(high=10.0, low=-10.0),
+            "y": LogUniformDistribution(high=10.0, low=1.0),
+        },
+        "contributors": ["Akiba", "Sano"],
+        "dataset": "MNIST",
+    }
+
+    wandb.config.update.assert_called_once_with(expected)
+
+
+@mock.patch("optuna.integration.wandb.wandb")
+def test_log_api_call_count(wandb: mock.Mock) -> None:
+
+    wandb.run = None
+    wandb.log = mock.MagicMock()
+
+    wandbc = WeightsAndBiasesCallback()
+    target_n_trials = 10
+    study = optuna.create_study()
+    study.optimize(_objective_func, n_trials=target_n_trials, callbacks=[wandbc])
+    assert wandb.log.call_count == target_n_trials
+
+
+@mock.patch("optuna.integration.wandb.wandb")
+def test_values_registered_on_epoch(wandb: mock.Mock) -> None:
+
+    wandb.run = None
+    wandb.log = mock.MagicMock()
+
+    wandbc = WeightsAndBiasesCallback()
+    study = optuna.create_study()
+    study.optimize(_objective_func, n_trials=1, callbacks=[wandbc])
+
+    kall = wandb.log.call_args
+    assert list(kall[0][0].keys()) == ["x", "y", "value"]
+    assert kall[1] == {"step": 0}

--- a/tests/integration_tests/test_wandb.py
+++ b/tests/integration_tests/test_wandb.py
@@ -1,8 +1,6 @@
 from unittest import mock
 
 import optuna
-from optuna.distributions import LogUniformDistribution
-from optuna.distributions import UniformDistribution
 from optuna.integration import WeightsAndBiasesCallback
 
 
@@ -47,41 +45,7 @@ def test_attributes_set_on_epoch(wandb: mock.MagicMock) -> None:
     study = optuna.create_study(direction="minimize")
     study.optimize(_objective_func, n_trials=1, callbacks=[wandbc])
 
-    expected = {
-        "direction": "MINIMIZE",
-        "trial_state": "COMPLETE",
-        "distributions": {
-            "x": UniformDistribution(high=10.0, low=-10.0),
-            "y": LogUniformDistribution(high=10.0, low=1.0),
-        },
-    }
-
-    wandb.config.update.assert_called_once_with(expected)
-
-
-@mock.patch("optuna.integration.wandb.wandb")
-def test_user_attributes_set_on_epoch(wandb: mock.MagicMock) -> None:
-
-    wandb.run = None
-    wandb.config.update = mock.MagicMock()
-
-    wandbc = WeightsAndBiasesCallback()
-    study = optuna.create_study(direction="minimize")
-    study.set_user_attr("contributors", ["Akiba", "Sano"])
-    study.set_user_attr("dataset", "MNIST")
-    study.optimize(_objective_func, n_trials=1, callbacks=[wandbc])
-
-    expected = {
-        "direction": "MINIMIZE",
-        "trial_state": "COMPLETE",
-        "distributions": {
-            "x": UniformDistribution(high=10.0, low=-10.0),
-            "y": LogUniformDistribution(high=10.0, low=1.0),
-        },
-        "contributors": ["Akiba", "Sano"],
-        "dataset": "MNIST",
-    }
-
+    expected = {"direction": "MINIMIZE"}
     wandb.config.update.assert_called_once_with(expected)
 
 

--- a/tests/integration_tests/test_wandb.py
+++ b/tests/integration_tests/test_wandb.py
@@ -14,7 +14,6 @@ def _objective_func(trial: optuna.trial.Trial) -> float:
 @mock.patch("optuna.integration.wandb.wandb")
 def test_run_initialized(wandb: mock.MagicMock) -> None:
 
-    wandb.run = None
     wandb_kwargs = {
         "project": "optuna",
         "group": "summary",
@@ -38,7 +37,6 @@ def test_run_initialized(wandb: mock.MagicMock) -> None:
 @mock.patch("optuna.integration.wandb.wandb")
 def test_attributes_set_on_epoch(wandb: mock.MagicMock) -> None:
 
-    wandb.run = None
     wandb.config.update = mock.MagicMock()
 
     wandbc = WeightsAndBiasesCallback()
@@ -52,7 +50,6 @@ def test_attributes_set_on_epoch(wandb: mock.MagicMock) -> None:
 @mock.patch("optuna.integration.wandb.wandb")
 def test_log_api_call_count(wandb: mock.Mock) -> None:
 
-    wandb.run = None
     wandb.log = mock.MagicMock()
 
     wandbc = WeightsAndBiasesCallback()
@@ -65,7 +62,6 @@ def test_log_api_call_count(wandb: mock.Mock) -> None:
 @mock.patch("optuna.integration.wandb.wandb")
 def test_values_registered_on_epoch(wandb: mock.Mock) -> None:
 
-    wandb.run = None
     wandb.log = mock.MagicMock()
 
     wandbc = WeightsAndBiasesCallback()


### PR DESCRIPTION
This PR introduces basic integration to Weights & Biases UI in a form of callback passed to `study.optimize()`.

This callback enables tracking of Optuna study in Weights & Biases. The study is tracked as a single experiment run, where all suggested hyperparameters and optimized metric are logged and plotted as a function of optimizer steps.

## Motivation
This PR resolves #2553, where proposition was initially raised.

## Description of the changes
* Implemented `WeightsAndBiasesCallback`.
* Add documentation and example for new callback.

## Example

Experiment from blog post mentioned in #2553 is now reduced to the following

```python
# [...]

black_box = Objective(seed=4444)
sampler = optuna.samplers.TPESampler(seed=4444)

wandb_kwargs = {
    "project": "optuna",
    "group": "summary",
    "job_type": "logging",
}

wandbc = WeightsAndBiasesCallback(
    metric_name="mse",
    wandb_kwargs=wandb_kwargs
)

study = optuna.create_study(direction="minimize", sampler=sampler)
study.optimize(black_box, n_trials=100, callbacks=[wandbc])

# [...]
```

and results in following visuals in Weights & Biases UI

![image](https://user-images.githubusercontent.com/37713008/124358587-47b4e100-dc21-11eb-803e-9055f2ea7ca1.png)

![image](https://user-images.githubusercontent.com/37713008/124358613-674c0980-dc21-11eb-9a07-886f4e583724.png)
