### PR TITLE
add the warning if intermediate values is already reported

### DIFF
--- a/optuna/trial/_trial.py
+++ b/optuna/trial/_trial.py
@@ -587,7 +587,7 @@ class Trial(BaseTrial):
 
         if step in intermediate_values:
             # Do nothing if already reported.
-            warnings.warn("this `step` {} is already repoted.".format(step))
+            warnings.warn("The reported value is ignored because this `step` {} is already reported.".format(step))
             return
 
         self.storage.set_trial_intermediate_value(self._trial_id, step, value)

--- a/optuna/trial/_trial.py
+++ b/optuna/trial/_trial.py
@@ -587,9 +587,7 @@ class Trial(BaseTrial):
 
         if step in intermediate_values:
             # Do nothing if already reported.
-            # TODO(hvy): Consider raising a warning or an error.
-            # See https://github.com/optuna/optuna/issues/852.
-            warnings.warn("this 'step' {} is already repoted.".format(step))
+            warnings.warn("this `step` {} is already repoted.".format(step))
             return
 
         self.storage.set_trial_intermediate_value(self._trial_id, step, value)

--- a/optuna/trial/_trial.py
+++ b/optuna/trial/_trial.py
@@ -588,8 +588,8 @@ class Trial(BaseTrial):
         if step in intermediate_values:
             # Do nothing if already reported.
             warnings.warn(
-                    "The reported value is ignored because this `step` {} is already reported.".format(
-                        step
+                "The reported value is ignored because this `step` {} is already reported.".format(
+                    step
                 )
             )
             return

--- a/optuna/trial/_trial.py
+++ b/optuna/trial/_trial.py
@@ -587,7 +587,11 @@ class Trial(BaseTrial):
 
         if step in intermediate_values:
             # Do nothing if already reported.
-            warnings.warn("The reported value is ignored because this `step` {} is already reported.".format(step))
+            warnings.warn(
+                    "The reported value is ignored because this `step` {} is already reported.".format(
+                        step
+                )
+            )
             return
 
         self.storage.set_trial_intermediate_value(self._trial_id, step, value)

--- a/optuna/trial/_trial.py
+++ b/optuna/trial/_trial.py
@@ -589,6 +589,7 @@ class Trial(BaseTrial):
             # Do nothing if already reported.
             # TODO(hvy): Consider raising a warning or an error.
             # See https://github.com/optuna/optuna/issues/852.
+            warnings.warn("this 'step' {} is already repoted.".format(step))
             return
 
         self.storage.set_trial_intermediate_value(self._trial_id, step, value)

--- a/tests/trial_tests/test_trial.py
+++ b/tests/trial_tests/test_trial.py
@@ -600,6 +600,18 @@ def test_report() -> None:
         trial.report(1.23, -1)
 
 
+def test_report_warning() -> None:
+
+    study = create_study()
+    trial = study.ask()
+
+    trial.report(1.23, 1)
+
+    # Warn if multipe times call  report method at the same step
+    with pytest.warns(UserWarning):
+        trial.report(1, 1)
+
+
 def test_study_id() -> None:
 
     study = create_study()

--- a/tests/trial_tests/test_trial.py
+++ b/tests/trial_tests/test_trial.py
@@ -607,7 +607,7 @@ def test_report_warning() -> None:
 
     trial.report(1.23, 1)
 
-    # Warn if multipe times call  report method at the same step
+    # Warn if multiple times call report method at the same step
     with pytest.warns(UserWarning):
         trial.report(1, 1)
 


### PR DESCRIPTION
## Motivation
resolve the issue of https://github.com/optuna/optuna/issues/852.

## Description of the changes
add the warning if the step is already reported.