### PR TITLE
Prioritize grids that are not yet running in `GridSampler`

### DIFF
--- a/optuna/samplers/_grid.py
+++ b/optuna/samplers/_grid.py
@@ -208,6 +208,7 @@ class GridSampler(BaseSampler):
 
         # List up unvisited grids based on already finished ones.
         visited_grids = []
+        running_grids = []
 
         # We directly query the storage to get trials here instead of `study.get_trials`,
         # since some pruners such as `HyperbandPruner` use the study transformed
@@ -215,14 +216,19 @@ class GridSampler(BaseSampler):
         trials = study._storage.get_all_trials(study._study_id, deepcopy=False)
 
         for t in trials:
-            if (
-                t.state.is_finished()
-                and "grid_id" in t.system_attrs
-                and self._same_search_space(t.system_attrs["search_space"])
+            if "grid_id" in t.system_attrs and self._same_search_space(
+                t.system_attrs["search_space"]
             ):
-                visited_grids.append(t.system_attrs["grid_id"])
+                if t.state.is_finished():
+                    visited_grids.append(t.system_attrs["grid_id"])
+                elif t.state == TrialState.RUNNING:
+                    running_grids.append(t.system_attrs["grid_id"])
 
-        unvisited_grids = set(range(self._n_min_trials)) - set(visited_grids)
+        unvisited_grids = set(range(self._n_min_trials)) - set(visited_grids) - set(running_grids)
+
+        # If evaluations for all grids have been started, return grids that have not yet finished.
+        if len(unvisited_grids) == 0:
+            unvisited_grids = set(range(self._n_min_trials)) - set(visited_grids)
 
         return list(unvisited_grids)
 

--- a/optuna/samplers/_grid.py
+++ b/optuna/samplers/_grid.py
@@ -226,7 +226,8 @@ class GridSampler(BaseSampler):
 
         unvisited_grids = set(range(self._n_min_trials)) - set(visited_grids) - set(running_grids)
 
-        # If evaluations for all grids have been started, return grids that have not yet finished.
+        # If evaluations for all grids have been started, return grids that have not yet finished
+        # because all grids should be evaluated before stopping the optimization.
         if len(unvisited_grids) == 0:
             unvisited_grids = set(range(self._n_min_trials)) - set(visited_grids)
 


### PR DESCRIPTION
## Motivation
Addresses #2039.
To reduce duplicated suggestions in distributed optimization with `GridSampler`.

## Description of the changes
Prioritize grids that are not yet running.

## Example Code
I tested that this PR relaxes duplicated suggestions.

```python
import random
import time
import optuna

def objective(trial):
    time.sleep(5)
    x = trial.suggest_float("x", -100, 100)
    y = trial.suggest_int("y", -100, 100)
    return x ** 2 + y ** 2

random.seed(0)
search_space = {"x": [-50, 0, 50], "y": [-99, 0, 99]}
study = optuna.create_study(
    storage="sqlite:///example.db",
    sampler=optuna.samplers.GridSampler(search_space),
    study_name="grid-study",
    load_if_exists=True,
)
study.optimize(objective)
```

- master

process 1

```
[I 2021-07-05 10:37:10,278] A new study created in RDB with name: grid-study
[I 2021-07-05 10:37:15,357] Trial 0 finished with value: 12301.0 and parameters: {'x': 50, 'y': -99}. Best is trial 0 with value: 12301.0.
[I 2021-07-05 10:37:20,427] Trial 2 finished with value: 2500.0 and parameters: {'x': 50, 'y': 0}. Best is trial 2 with value: 2500.0.
[I 2021-07-05 10:37:25,498] Trial 4 finished with value: 12301.0 and parameters: {'x': -50, 'y': -99}. Best is trial 2 with value: 2500.0.
[I 2021-07-05 10:37:30,562] Trial 6 finished with value: 9801.0 and parameters: {'x': 0, 'y': -99}. Best is trial 2 with value: 2500.0.
[I 2021-07-05 10:37:35,644] Trial 8 finished with value: 12301.0 and parameters: {'x': 50, 'y': 99}. Best is trial 2 with value: 2500.0.
[I 2021-07-05 10:37:40,715] Trial 10 finished with value: 9801.0 and parameters: {'x': 0, 'y': 99}. Best is trial 2 with value: 2500.0.
[I 2021-07-05 10:37:45,789] Trial 12 finished with value: 12301.0 and parameters: {'x': -50, 'y': 99}. Best is trial 2 with value: 2500.0.
[I 2021-07-05 10:37:50,857] Trial 14 finished with value: 0.0 and parameters: {'x': 0, 'y': 0}. Best is trial 14 with value: 0.0.
[I 2021-07-05 10:37:55,935] Trial 16 finished with value: 2500.0 and parameters: {'x': -50, 'y': 0}. Best is trial 14 with value: 0.0.
```

process 2

```
[I 2021-07-05 10:37:11,766] Using an existing study with name 'grid-study' instead of creating a new one.
[I 2021-07-05 10:37:16,859] Trial 1 finished with value: 12301.0 and parameters: {'x': 50, 'y': -99}. Best is trial 0 with value: 12301.0.
[I 2021-07-05 10:37:21,924] Trial 3 finished with value: 2500.0 and parameters: {'x': 50, 'y': 0}. Best is trial 2 with value: 2500.0.
[I 2021-07-05 10:37:26,992] Trial 5 finished with value: 12301.0 and parameters: {'x': -50, 'y': -99}. Best is trial 2 with value: 2500.0.
[I 2021-07-05 10:37:32,060] Trial 7 finished with value: 9801.0 and parameters: {'x': 0, 'y': -99}. Best is trial 2 with value: 2500.0.
[I 2021-07-05 10:37:37,127] Trial 9 finished with value: 12301.0 and parameters: {'x': 50, 'y': 99}. Best is trial 2 with value: 2500.0.
[I 2021-07-05 10:37:42,196] Trial 11 finished with value: 9801.0 and parameters: {'x': 0, 'y': 99}. Best is trial 2 with value: 2500.0.
[I 2021-07-05 10:37:47,272] Trial 13 finished with value: 12301.0 and parameters: {'x': -50, 'y': 99}. Best is trial 2 with value: 2500.0.
[I 2021-07-05 10:37:52,344] Trial 15 finished with value: 0.0 and parameters: {'x': 0, 'y': 0}. Best is trial 14 with value: 0.0.
[I 2021-07-05 10:37:57,412] Trial 17 finished with value: 2500.0 and parameters: {'x': -50, 'y': 0}. Best is trial 14 with value: 0.0.
```

- This PR

process 1

```
[I 2021-07-05 10:35:37,243] A new study created in RDB with name: grid-study
[I 2021-07-05 10:35:42,332] Trial 0 finished with value: 12301.0 and parameters: {'x': 50, 'y': -99}. Best is trial 0 with value: 12301.0.
[I 2021-07-05 10:35:47,406] Trial 2 finished with value: 12301.0 and parameters: {'x': 50, 'y': 99}. Best is trial 1 with value: 2500.0.
[I 2021-07-05 10:35:52,474] Trial 4 finished with value: 0.0 and parameters: {'x': 0, 'y': 0}. Best is trial 4 with value: 0.0.
[I 2021-07-05 10:35:57,548] Trial 6 finished with value: 2500.0 and parameters: {'x': -50, 'y': 0}. Best is trial 4 with value: 0.0.
[I 2021-07-05 10:36:02,618] Trial 8 finished with value: 12301.0 and parameters: {'x': -50, 'y': 99}. Best is trial 4 with value: 0.0.
[W 2021-07-05 10:36:02,628] `GridSampler` is re-evaluating a configuration because the grid has been exhausted. This may happen due to a timing issue during distributed optimization or when re-running optimizations on already finished studies.
[I 2021-07-05 10:36:07,688] Trial 10 finished with value: 12301.0 and parameters: {'x': 50, 'y': 99}. Best is trial 4 with value: 0.0.
```

process 2

```
[I 2021-07-05 10:35:39,638] Using an existing study with name 'grid-study' instead of creating a new one.
[I 2021-07-05 10:35:45,223] Trial 1 finished with value: 2500.0 and parameters: {'x': 50, 'y': 0}. Best is trial 1 with value: 2500.0.
[I 2021-07-05 10:35:50,299] Trial 3 finished with value: 9801.0 and parameters: {'x': 0, 'y': -99}. Best is trial 1 with value: 2500.0.
[I 2021-07-05 10:35:55,352] Trial 5 finished with value: 12301.0 and parameters: {'x': -50, 'y': -99}. Best is trial 4 with value: 0.0.
[I 2021-07-05 10:36:00,422] Trial 7 finished with value: 9801.0 and parameters: {'x': 0, 'y': 99}. Best is trial 4 with value: 0.0.
[I 2021-07-05 10:36:05,491] Trial 9 finished with value: 12301.0 and parameters: {'x': -50, 'y': 99}. Best is trial 4 with value: 0.0.
```