### PR TITLE
Fix `warn_independent_sampling` in `TPESampler`

### DIFF
--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -11,7 +11,6 @@ import warnings
 
 import numpy as np
 
-from optuna import distributions
 from optuna._hypervolume import WFG
 from optuna.distributions import BaseDistribution
 from optuna.exceptions import ExperimentalWarning
@@ -30,14 +29,6 @@ from optuna.trial import TrialState
 
 
 EPS = 1e-12
-_DISTRIBUTION_CLASSES = (
-    distributions.UniformDistribution,
-    distributions.LogUniformDistribution,
-    distributions.DiscreteUniformDistribution,
-    distributions.IntUniformDistribution,
-    distributions.IntLogUniformDistribution,
-    distributions.CategoricalDistribution,
-)
 _logger = get_logger(__name__)
 
 
@@ -297,7 +288,6 @@ class TPESampler(BaseSampler):
         if not self._multivariate:
             return {}
 
-        n_complete_trials = len(study.get_trials(deepcopy=False))
         search_space: Dict[str, BaseDistribution] = {}
 
         if self._group:
@@ -305,18 +295,12 @@ class TPESampler(BaseSampler):
             self._search_space_group = self._group_decomposed_search_space.calculate(study)
             for sub_space in self._search_space_group.search_spaces:
                 for name, distribution in sub_space.items():
-                    if not isinstance(distribution, _DISTRIBUTION_CLASSES):
-                        self._log_independent_sampling(n_complete_trials, trial, name)
-                        continue
                     if distribution.single():
                         continue
                     search_space[name] = distribution
             return search_space
 
         for name, distribution in self._search_space.calculate(study).items():
-            if not isinstance(distribution, _DISTRIBUTION_CLASSES):
-                self._log_independent_sampling(n_complete_trials, trial, name)
-                continue
             if distribution.single():
                 continue
             search_space[name] = distribution
@@ -326,8 +310,8 @@ class TPESampler(BaseSampler):
     def _log_independent_sampling(
         self, n_complete_trials: int, trial: FrozenTrial, param_name: str
     ) -> None:
-        if self._warn_independent_sampling:
-            if n_complete_trials >= self._n_startup_trials:
+        if self._warn_independent_sampling and self._multivariate:
+            if n_complete_trials >= max(self._n_startup_trials, 1):
                 _logger.warning(
                     f"The parameter '{param_name}' in trial#{trial.number} is sampled "
                     "independently instead of being sampled by multivariate TPE sampler. "
@@ -347,10 +331,7 @@ class TPESampler(BaseSampler):
             for sub_space in self._search_space_group.search_spaces:
                 search_space = {}
                 for name, distribution in sub_space.items():
-                    if (
-                        isinstance(distribution, _DISTRIBUTION_CLASSES)
-                        and not distribution.single()
-                    ):
+                    if not distribution.single():
                         search_space[name] = distribution
                 params.update(self._sample_relative(study, trial, search_space))
             return params
@@ -413,6 +394,8 @@ class TPESampler(BaseSampler):
         )
 
         n = len(scores)
+
+        self._log_independent_sampling(n, trial, param_name)
 
         if n < self._n_startup_trials:
             return self._random_sampler.sample_independent(

--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -311,6 +311,7 @@ class TPESampler(BaseSampler):
         self, n_complete_trials: int, trial: FrozenTrial, param_name: str
     ) -> None:
         if self._warn_independent_sampling and self._multivariate:
+            # The first trial samples independently.
             if n_complete_trials >= max(self._n_startup_trials, 1):
                 _logger.warning(
                     f"The parameter '{param_name}' in trial#{trial.number} is sampled "


### PR DESCRIPTION
## Motivation
The current implementation of `warn_independent_sampling` in `TPESampler` is not working. This PR fixes this bug and adds tests.
## Description of the changes
- Fix `warn_independent_sampling` in `TPESampler`
- Add tests
