### PR TITLE
Fix the document of `RetryFailedTrialCallback.retried_trial_number`

### DIFF
--- a/optuna/_callbacks.py
+++ b/optuna/_callbacks.py
@@ -132,7 +132,7 @@ class RetryFailedTrialCallback:
                 The trial object.
 
         Returns:
-            The number of the previous trial. If not retry of a previous trial,
+            The number of the first failed trial. If not retry of a previous trial,
             returns :obj:`None`.
         """
 


### PR DESCRIPTION
## Motivation
The document of `RetryFailedTrialCallback.retried_trial_number` is unclear. This PR will clarify what to return.

For example,

- `trial1` is a retry of `trial0`
- `trial2` is a retry of `trial1`

In this case, `retried_trial_number(trial2)` should return `0`, but in the current document, it looks like to return `1`.

## Description of the changes
- Fix the document