### PR TITLE
Avoid applying `constraint_fn` to non-`COMPLETE` trials in NSGAII-sampler.

### DIFF
--- a/optuna/samplers/_nsga2.py
+++ b/optuna/samplers/_nsga2.py
@@ -71,6 +71,10 @@ class NSGAIISampler(BaseSampler):
             If constraints_func returns more than one value for a trial, that trial is considered
             feasible if and only if all values are equal to 0 or smaller.
 
+            The constraint_func will be evaluated after each successful trial.
+            The function won't be called when trials fail or they are pruned, but this behavior is
+            subject to change in the future releases.
+
             The constraints are handled by the constrained domination. A trial x is said to
             constrained-dominate a trial y, if any of the following conditions is true:
 

--- a/optuna/samplers/_nsga2.py
+++ b/optuna/samplers/_nsga2.py
@@ -213,6 +213,7 @@ class NSGAIISampler(BaseSampler):
                     generation_to_runnings[generation].append(trial)
                 continue
 
+            # Do not use trials whose states are not COMPLETE, or `constraint` will be unavailable.
             generation_to_population[generation].append(trial)
 
         hasher = hashlib.sha256()
@@ -347,7 +348,8 @@ class NSGAIISampler(BaseSampler):
         state: TrialState,
         values: Optional[Sequence[float]],
     ) -> None:
-        if self._constraints_func is not None:
+        assert state in [TrialState.COMPLETE, TrialState.FAIL, TrialState.PRUNED]
+        if state == TrialState.COMPLETE and self._constraints_func is not None:
             constraints = None
             try:
                 con = self._constraints_func(trial)


### PR DESCRIPTION
## Motivation

This PR resolves #2790.

## Description of the changes

Stop evaluating `constraint_func` when trials' status are not `TrialState.COMPLETE`.