### PR TITLE
Add Plotly-like interpolation algorithm to `optuna.visualization.matplotlib.plot_contour`

### DIFF
--- a/optuna/visualization/matplotlib/_contour.py
+++ b/optuna/visualization/matplotlib/_contour.py
@@ -148,7 +148,7 @@ def _get_contour_plot(
         fig, axs = plt.subplots()
         axs.set_title("Contour Plot")
         cmap = _set_cmap(study, target)
-        contour_point_num = 1000
+        contour_point_num = 100
 
         # Prepare data and draw contour plots.
         if params:
@@ -318,21 +318,21 @@ def _calculate_griddata(
     if x_param != y_param:
         if _is_log_scale(trials, x_param):
             xi = np.logspace(np.log10(x_values_min), np.log10(x_values_max), contour_point_num)
+            tmp_x = np.log10(x_values)
         else:
             xi = np.linspace(x_values_min, x_values_max, contour_point_num)
+            tmp_x = x_values
         if _is_log_scale(trials, y_param):
             yi = np.logspace(np.log10(y_values_min), np.log10(y_values_max), contour_point_num)
+            tmp_y = np.log10(y_values)
         else:
             yi = np.linspace(y_values_min, y_values_max, contour_point_num)
+            tmp_y = y_values
 
-        # Interpolate z-axis data on a grid with linear interpolator.
-        # TODO(ytknzw): Implement Plotly-like interpolation algorithm.
-        zi = griddata(
-            np.column_stack((x_values, y_values)),
-            z_values,
-            (xi[None, :], yi[:, None]),
-            method="linear",
-        )
+        # create irregularly spaced matrix of trial values
+        # and interpolate it with Plotly algorithm
+        zmatrix = _create_zmatrix(tmp_x, tmp_y, z_values, xi, yi)
+        zi = _interpolate_zmatrix(zmatrix)
 
     return (
         xi,

--- a/optuna/visualization/matplotlib/_contour.py
+++ b/optuna/visualization/matplotlib/_contour.py
@@ -317,30 +317,30 @@ def _calculate_griddata(
             x_values_min = np.power(np.log10(x_values_min) - padding_x, 10)
             x_values_max = np.power(np.log10(x_values_max) + padding_x, 10)
             xi = np.logspace(np.log10(x_values_min), np.log10(x_values_max), contour_point_num)
-            tmp_x = np.log10(x_values)
+            x_array = np.log10(x_values)
         else:
             padding_x = (x_values_max - x_values_min) * AXES_PADDING_RATIO
             x_values_min -= padding_x
             x_values_max += padding_x
             xi = np.linspace(x_values_min, x_values_max, contour_point_num)
-            tmp_x = np.array(x_values)
+            x_array = np.array(x_values)
 
         if _is_log_scale(trials, y_param):
             padding_y = (np.log10(y_values_max) - np.log10(y_values_min)) * AXES_PADDING_RATIO
             y_values_min = np.power(np.log10(y_values_min) - padding_y, 10)
             y_values_max = np.power(np.log10(y_values_max) + padding_y, 10)
             yi = np.logspace(np.log10(y_values_min), np.log10(y_values_max), contour_point_num)
-            tmp_y = np.log10(y_values)
+            y_array = np.log10(y_values)
         else:
             padding_y = (y_values_max - y_values_min) * AXES_PADDING_RATIO
             y_values_min -= padding_y
             y_values_max += padding_y
             yi = np.linspace(y_values_min, y_values_max, contour_point_num)
-            tmp_y = np.array(y_values)
+            y_array = np.array(y_values)
 
         # create irregularly spaced map of trial values
         # and interpolate it with Plotly algorithm
-        zmap = _create_zmap(tmp_x, tmp_y, z_values, xi, yi)
+        zmap = _create_zmap(x_array, y_array, z_values, xi, yi)
         zmap = _interpolate_zmap(zmap, contour_point_num)
         zi = _create_zmatrix_from_zmap(zmap, contour_point_num)
 

--- a/optuna/visualization/matplotlib/_contour.py
+++ b/optuna/visualization/matplotlib/_contour.py
@@ -417,3 +417,26 @@ def _generate_contour_subplot(
         ax.set_yticklabels(y_cat_param_label)
     ax.label_outer()
     return cs
+
+
+def _create_zmatrix(
+    x_values: List[Union[int, float]],
+    y_values: List[Union[int, float]],
+    z_values: List[Union[int, float]],
+    xi: np.ndarray,
+    yi: np.ndarray,
+) -> np.ndarray:
+
+    # creates z-matrix from trial values and params.
+    # since params were upsampled either with linspace or logspace
+    # original params might not be on the xi and yi axes anymore
+    # so we are going with close approximations of z-value positions
+    shape = (*yi.shape, *xi.shape)
+    zmatrix = np.full(shape, fill_value=np.nan)
+
+    for x, y, z in zip(x_values, y_values, z_values):
+        xaxis = np.argmin(np.abs(xi - x))
+        yaxis = np.argmin(np.abs(yi - y))
+        zmatrix[yaxis, xaxis] = z
+
+    return zmatrix

--- a/optuna/visualization/matplotlib/_contour.py
+++ b/optuna/visualization/matplotlib/_contour.py
@@ -33,6 +33,7 @@ _logger = get_logger(__name__)
 
 NUM_OPTIMIZATION_ITERATIONS = 100
 FRACTIONAL_DELTA_THRESHOLD = 1e-2
+AXES_PADDING_RATIO = 5e-2
 
 
 @experimental("2.2.0")
@@ -312,15 +313,28 @@ def _calculate_griddata(
     zi = np.array([])
     if x_param != y_param:
         if _is_log_scale(trials, x_param):
+            padding_x = (np.log10(x_values_max) - np.log10(x_values_min)) * AXES_PADDING_RATIO
+            x_values_min = np.power(np.log10(x_values_min) - padding_x, 10)
+            x_values_max = np.power(np.log10(x_values_max) + padding_x, 10)
             xi = np.logspace(np.log10(x_values_min), np.log10(x_values_max), contour_point_num)
             tmp_x = np.log10(x_values)
         else:
+            padding_x = (x_values_max - x_values_min) * AXES_PADDING_RATIO
+            x_values_min -= padding_x
+            x_values_max += padding_x
             xi = np.linspace(x_values_min, x_values_max, contour_point_num)
             tmp_x = np.array(x_values)
+
         if _is_log_scale(trials, y_param):
+            padding_y = (np.log10(y_values_max) - np.log10(y_values_min)) * AXES_PADDING_RATIO
+            y_values_min = np.power(np.log10(y_values_min) - padding_y, 10)
+            y_values_max = np.power(np.log10(y_values_max) + padding_y, 10)
             yi = np.logspace(np.log10(y_values_min), np.log10(y_values_max), contour_point_num)
             tmp_y = np.log10(y_values)
         else:
+            padding_y = (y_values_max - y_values_min) * AXES_PADDING_RATIO
+            y_values_min -= padding_y
+            y_values_max += padding_y
             yi = np.linspace(y_values_min, y_values_max, contour_point_num)
             tmp_y = np.array(y_values)
 

--- a/optuna/visualization/matplotlib/_contour.py
+++ b/optuna/visualization/matplotlib/_contour.py
@@ -316,13 +316,13 @@ def _calculate_griddata(
             tmp_x = np.log10(x_values)
         else:
             xi = np.linspace(x_values_min, x_values_max, contour_point_num)
-            tmp_x = x_values
+            tmp_x = np.array(x_values)
         if _is_log_scale(trials, y_param):
             yi = np.logspace(np.log10(y_values_min), np.log10(y_values_max), contour_point_num)
             tmp_y = np.log10(y_values)
         else:
             yi = np.linspace(y_values_min, y_values_max, contour_point_num)
-            tmp_y = y_values
+            tmp_y = np.array(y_values)
 
         # create irregularly spaced matrix of trial values
         # and interpolate it with Plotly algorithm
@@ -425,8 +425,8 @@ def _generate_contour_subplot(
 
 
 def _create_zmatrix(
-    x_values: List[Union[int, float]],
-    y_values: List[Union[int, float]],
+    x_values: np.ndarray,
+    y_values: np.ndarray,
     z_values: List[Union[int, float]],
     xi: np.ndarray,
     yi: np.ndarray,

--- a/optuna/visualization/matplotlib/_contour.py
+++ b/optuna/visualization/matplotlib/_contour.py
@@ -6,11 +6,11 @@ from typing import Optional
 from typing import Tuple
 from typing import Union
 
+from numba import jit
 import numpy as np
 from scipy.ndimage import generic_filter
 
 from optuna._experimental import experimental
-from optuna._imports import try_import
 from optuna.logging import get_logger
 from optuna.study import Study
 from optuna.study import StudyDirection
@@ -28,11 +28,6 @@ if _imports.is_successful():
     from optuna.visualization.matplotlib._matplotlib_imports import ContourSet
     from optuna.visualization.matplotlib._matplotlib_imports import plt
 
-
-with try_import() as _imports_numba:
-    from numba import jit
-
-_imports_numba.check()
 _logger = get_logger(__name__)
 
 

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,6 @@ def get_install_requires() -> List[str]:
         "cliff",
         "cmaes>=0.8.2",
         "colorlog",
-        "numba",
         "numpy",
         "packaging>=20.0",
         "scipy!=1.4.0",

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ def get_install_requires() -> List[str]:
         "cliff",
         "cmaes>=0.8.2",
         "colorlog",
+        "numba",
         "numpy",
         "packaging>=20.0",
         "scipy!=1.4.0",
@@ -125,7 +126,6 @@ def get_extras_require() -> Dict[str, List[str]]:
         "optional": [
             "bokeh<2.0.0",  # optuna/cli.py, optuna/dashboard.py.
             "matplotlib>=3.0.0",  # optuna/visualization/matplotlib
-            "numba",  # optuna/visualization/matplotlib
             "pandas",  # optuna/study.py
             "plotly>=4.0.0",  # optuna/visualization.
             "redis",  # optuna/storages/redis.py.

--- a/setup.py
+++ b/setup.py
@@ -125,6 +125,7 @@ def get_extras_require() -> Dict[str, List[str]]:
         "optional": [
             "bokeh<2.0.0",  # optuna/cli.py, optuna/dashboard.py.
             "matplotlib>=3.0.0",  # optuna/visualization/matplotlib
+            "numba",  # optuna/visualization/matplotlib
             "pandas",  # optuna/study.py
             "plotly>=4.0.0",  # optuna/visualization.
             "redis",  # optuna/storages/redis.py.

--- a/tests/visualization_tests/matplotlib_tests/test_contour.py
+++ b/tests/visualization_tests/matplotlib_tests/test_contour.py
@@ -19,7 +19,7 @@ def test_create_zmap() -> None:
 
     x_values = np.arange(10)
     y_values = np.arange(10)
-    z_values = list(np.random.randn(10))
+    z_values = list(np.random.rand(10))
 
     # we are testing for exact placement of z_values
     # so also passing x_values and y_values as xi and yi
@@ -38,9 +38,9 @@ def test_create_zmap() -> None:
 def test_create_zmatrix_from_zmap() -> None:
 
     contour_point_num = 2
-    zmap = {0 + 0j: 1, 1 + 0j: 2, 0 + 1j: 3, 1 + 1j: 4}
-    expected = np.array([[1, 2], [3, 4]])
-    zmatrix = _create_zmatrix_from_zmap(zmap, contour_point_num)  # type: ignore
+    zmap = {0 + 0j: 1.0, 1 + 0j: 2.0, 0 + 1j: 3.0, 1 + 1j: 4.0}
+    expected = np.array([[1.0, 2.0], [3.0, 4.0]])
+    zmatrix = _create_zmatrix_from_zmap(zmap, contour_point_num)
 
     assert zmatrix.shape == (contour_point_num, contour_point_num)
     assert np.array_equal(zmatrix, expected)
@@ -49,9 +49,9 @@ def test_create_zmatrix_from_zmap() -> None:
 def test_find_coordinates_where_empty() -> None:
 
     contour_point_num = 2
-    zmap = {0 + 0j: 1, 1 + 1j: 4}
+    zmap = {0 + 0j: 1.0, 1 + 1j: 4.0}
     n_missing = (contour_point_num ** 2) - len(zmap)
-    empties = _find_coordinates_where_empty(zmap, contour_point_num)  # type: ignore
+    empties = _find_coordinates_where_empty(zmap, contour_point_num)
 
     # test if all missing are found
     assert len(empties) == n_missing
@@ -63,11 +63,11 @@ def test_find_coordinates_where_empty() -> None:
 
 def test_interpolation_first_iteration() -> None:
 
-    zmap = {0 + 0j: 1, 1 + 1j: 4}
+    zmap = {0 + 0j: 1.0, 1 + 1j: 4.0}
     empties = [1 + 0j, 0 + 1j]
     initial_zmap_len = len(zmap)
 
-    zmap, max_fractional_change = _run_iteration(zmap, empties)  # type: ignore
+    max_fractional_change = _run_iteration(zmap, empties)
 
     # test loss after first iter
     assert max_fractional_change == 1.0
@@ -79,10 +79,10 @@ def test_interpolation_first_iteration() -> None:
 def test_interpolate_zmap() -> None:
 
     contour_point_num = 2
-    zmap = {0 + 0j: 1, 1 + 1j: 4}
-    interpolated = {1 + 0j: 2.5, 1 + 1j: 4, 0 + 0j: 1, 0 + 1j: 2.5}
+    zmap = {0 + 0j: 1.0, 1 + 1j: 4.0}
+    interpolated = {1 + 0j: 2.5, 1 + 1j: 4.0, 0 + 0j: 1.0, 0 + 1j: 2.5}
 
-    zmap = _interpolate_zmap(zmap, contour_point_num)  # type: ignore
+    _interpolate_zmap(zmap, contour_point_num)
 
     for coord, value in zmap.items():
         expected_at_coord = interpolated.get(coord)

--- a/tests/visualization_tests/matplotlib_tests/test_contour.py
+++ b/tests/visualization_tests/matplotlib_tests/test_contour.py
@@ -1,12 +1,92 @@
 from typing import List
 from typing import Optional
 
+import numpy as np
 import pytest
 
 from optuna.study import create_study
 from optuna.testing.visualization import prepare_study_with_trials
 from optuna.trial import Trial
 from optuna.visualization.matplotlib import plot_contour
+from optuna.visualization.matplotlib._contour import _create_zmap
+from optuna.visualization.matplotlib._contour import _create_zmatrix_from_zmap
+from optuna.visualization.matplotlib._contour import _find_coordinates_where_empty
+from optuna.visualization.matplotlib._contour import _interpolate_zmap
+from optuna.visualization.matplotlib._contour import _run_iteration
+
+
+def test_create_zmap() -> None:
+
+    x_values = np.arange(10)
+    y_values = np.arange(10)
+    z_values = list(np.random.randn(10))
+
+    # we are testing for exact placement of z_values
+    # so also passing x_values and y_values as xi and yi
+    zmap = _create_zmap(x_values, y_values, z_values, x_values, y_values)
+
+    assert len(zmap) == len(z_values)
+    for coord, value in zmap.items():
+        # test if value under coordinate
+        # still refers to original trial value
+        xidx = int(coord.real)
+        yidx = int(coord.imag)
+        assert xidx == yidx
+        assert z_values[xidx] == value
+
+
+def test_create_zmatrix_from_zmap() -> None:
+
+    contour_point_num = 2
+    zmap = {0 + 0j: 1, 1 + 0j: 2, 0 + 1j: 3, 1 + 1j: 4}
+    expected = np.array([[1, 2], [3, 4]])
+    zmatrix = _create_zmatrix_from_zmap(zmap, contour_point_num)  # type: ignore
+
+    assert zmatrix.shape == (contour_point_num, contour_point_num)
+    assert np.array_equal(zmatrix, expected)
+
+
+def test_find_coordinates_where_empty() -> None:
+
+    contour_point_num = 2
+    zmap = {0 + 0j: 1, 1 + 1j: 4}
+    n_missing = (contour_point_num ** 2) - len(zmap)
+    empties = _find_coordinates_where_empty(zmap, contour_point_num)  # type: ignore
+
+    # test if all missing are found
+    assert len(empties) == n_missing
+
+    # test if iter queue follows C style iteration
+    assert empties[0] == 1 + 0j
+    assert empties[1] == 0 + 1j
+
+
+def test_interpolation_first_iteration() -> None:
+
+    zmap = {0 + 0j: 1, 1 + 1j: 4}
+    empties = [1 + 0j, 0 + 1j]
+    initial_zmap_len = len(zmap)
+
+    zmap, max_fractional_change = _run_iteration(zmap, empties)  # type: ignore
+
+    # test loss after first iter
+    assert max_fractional_change == 1.0
+
+    # test if initial pass filled all values
+    assert len(zmap) == initial_zmap_len + len(empties)
+
+
+def test_interpolate_zmap() -> None:
+
+    contour_point_num = 2
+    zmap = {0 + 0j: 1, 1 + 1j: 4}
+    interpolated = {1 + 0j: 2.5, 1 + 1j: 4, 0 + 0j: 1, 0 + 1j: 2.5}
+
+    zmap = _interpolate_zmap(zmap, contour_point_num)  # type: ignore
+
+    for coord, value in zmap.items():
+        expected_at_coord = interpolated.get(coord)
+        assert value == expected_at_coord
 
 
 def test_target_is_none_and_study_is_multi_obj() -> None:


### PR DESCRIPTION
This PR introduces new interpolation algorithm to be used when creating contour plots with `optuna.visualization.matplotlib.plot_contour()`, improving on linear interpolation offered by `scipy.griddata()`. 

The algorithm is a port of [Plotly.js](https://github.com/plotly/plotly.js/blob/master/src/traces/heatmap/interp2d.js#L30) version.

This addresses known issues in current implementation:

* contour lines which are not smooth
* blank areas on edges of the plot

Additionally, tweaks to `xrange` and `yrange`  are introduced in order to correctly visualize trial values at the edges of param grid.

## Motivation
This PR resolves #2738 and addresses [#2712 (review)](https://github.com/optuna/optuna/pull/2712#pullrequestreview-679629017).

## Description of the changes
- [x] Implement interpolation algorithm and helpers.
- [x] Switch to new algorithm in `optuna.visualization.matplotlib.plot_contour()`
- [x] Address `xrange` and `yrange` padding
- [x] Write tests

## Examples
All plots were generated using example from #2595 

Current algorithm
![image](https://user-images.githubusercontent.com/37713008/125852613-3ff953ee-9bfe-4364-9d0a-89b9614cd217.png)

New algorithm
![image](https://user-images.githubusercontent.com/37713008/126040517-c60003b9-77cf-47b0-b4d0-f1af3dea30ff.png)

Plotly
![image](https://user-images.githubusercontent.com/37713008/125852934-e73ea236-eab6-4149-9621-ac06a86cd43d.png)

And a very cool gif showing how this algorithm converges :^)
![plot_iter2](https://user-images.githubusercontent.com/37713008/125853357-9f9d9e3b-78d3-4afe-ac8b-14302ad7bb52.gif)
