### PR TITLE
Function for failing zombie trials and invoke their callbacks

### DIFF
--- a/docs/source/reference/storages.rst
+++ b/docs/source/reference/storages.rst
@@ -12,3 +12,4 @@ The :mod:`~optuna.storages` module defines a :class:`~optuna.storages.BaseStorag
    optuna.storages.RDBStorage
    optuna.storages.RedisStorage
    optuna.storages.RetryFailedTrialCallback
+   optuna.storages.fail_stale_trials

--- a/docs/source/reference/storages.rst
+++ b/docs/source/reference/storages.rst
@@ -12,4 +12,4 @@ The :mod:`~optuna.storages` module defines a :class:`~optuna.storages.BaseStorag
    optuna.storages.RDBStorage
    optuna.storages.RedisStorage
    optuna.storages.RetryFailedTrialCallback
-   optuna.storages.fail_stale_trials_with_callback
+   optuna.storages.fail_stale_trials

--- a/docs/source/reference/storages.rst
+++ b/docs/source/reference/storages.rst
@@ -12,4 +12,4 @@ The :mod:`~optuna.storages` module defines a :class:`~optuna.storages.BaseStorag
    optuna.storages.RDBStorage
    optuna.storages.RedisStorage
    optuna.storages.RetryFailedTrialCallback
-   optuna.storages.fail_stale_trials
+   optuna.storages.fail_stale_trials_with_callback

--- a/optuna/storages/__init__.py
+++ b/optuna/storages/__init__.py
@@ -1,11 +1,9 @@
-import copy
 from typing import Union
 
-import optuna
 from optuna._callbacks import RetryFailedTrialCallback  # NOQA
-from optuna._experimental import experimental
 from optuna.storages._base import BaseStorage
 from optuna.storages._cached_storage import _CachedStorage
+from optuna.storages._heartbeat import fail_stale_trials_with_callback
 from optuna.storages._in_memory import InMemoryStorage
 from optuna.storages._rdb.storage import RDBStorage
 from optuna.storages._redis import RedisStorage
@@ -17,7 +15,7 @@ __all__ = [
     "RDBStorage",
     "RedisStorage",
     "_CachedStorage",
-    "fail_stale_trials",
+    "fail_stale_trials_with_callback",
 ]
 
 
@@ -35,31 +33,3 @@ def get_storage(storage: Union[None, str, BaseStorage]) -> BaseStorage:
         return _CachedStorage(storage)
     else:
         return storage
-
-
-@experimental("2.9.0")
-def fail_stale_trials(study: "optuna.Study") -> None:
-    """Fail stale trials and run their failure callbacks.
-
-    The running trials whose heartbeat has not been updated for a long time will be failed,
-    that is, those states will be changed to :obj:`~optuna.trial.TrialState.FAIL`.
-
-    .. seealso::
-
-       See :class:`~optuna.storages.RDBStorage`.
-
-    Args:
-        study:
-            Study holding the trials to check.
-    """
-    storage = study._storage
-
-    if not storage.is_heartbeat_enabled():
-        return
-
-    failed_trial_ids = storage.fail_stale_trials(study._study_id)
-    failed_trial_callback = storage.get_failed_trial_callback()
-    if failed_trial_callback is not None:
-        for trial_id in failed_trial_ids:
-            failed_trial = copy.deepcopy(storage.get_trial(trial_id))
-            failed_trial_callback(study, failed_trial)

--- a/optuna/storages/__init__.py
+++ b/optuna/storages/__init__.py
@@ -3,7 +3,7 @@ from typing import Union
 from optuna._callbacks import RetryFailedTrialCallback  # NOQA
 from optuna.storages._base import BaseStorage
 from optuna.storages._cached_storage import _CachedStorage
-from optuna.storages._heartbeat import fail_stale_trials_with_callback
+from optuna.storages._heartbeat import fail_stale_trials
 from optuna.storages._in_memory import InMemoryStorage
 from optuna.storages._rdb.storage import RDBStorage
 from optuna.storages._redis import RedisStorage
@@ -15,7 +15,7 @@ __all__ = [
     "RDBStorage",
     "RedisStorage",
     "_CachedStorage",
-    "fail_stale_trials_with_callback",
+    "fail_stale_trials",
 ]
 
 

--- a/optuna/storages/__init__.py
+++ b/optuna/storages/__init__.py
@@ -1,6 +1,9 @@
+import copy
 from typing import Union
 
+import optuna
 from optuna._callbacks import RetryFailedTrialCallback  # NOQA
+from optuna._experimental import experimental
 from optuna.storages._base import BaseStorage
 from optuna.storages._cached_storage import _CachedStorage
 from optuna.storages._in_memory import InMemoryStorage
@@ -14,6 +17,7 @@ __all__ = [
     "RDBStorage",
     "RedisStorage",
     "_CachedStorage",
+    "fail_stale_trials",
 ]
 
 
@@ -31,3 +35,31 @@ def get_storage(storage: Union[None, str, BaseStorage]) -> BaseStorage:
         return _CachedStorage(storage)
     else:
         return storage
+
+
+@experimental("2.9.0")
+def fail_stale_trials(study: "optuna.Study") -> None:
+    """Fail stale trials and run their failure callbacks.
+
+    The running trials whose heartbeat has not been updated for a long time will be failed,
+    that is, those states will be changed to :obj:`~optuna.trial.TrialState.FAIL`.
+
+    .. seealso::
+
+       See :class:`~optuna.storages.RDBStorage`.
+
+    Args:
+        study:
+            Study holding the trials to check.
+    """
+    storage = study._storage
+
+    if not storage.is_heartbeat_enabled():
+        return
+
+    failed_trial_ids = storage.fail_stale_trials(study._study_id)
+    failed_trial_callback = storage.get_failed_trial_callback()
+    if failed_trial_callback is not None:
+        for trial_id in failed_trial_ids:
+            failed_trial = copy.deepcopy(storage.get_trial(trial_id))
+            failed_trial_callback(study, failed_trial)

--- a/optuna/storages/_heartbeat.py
+++ b/optuna/storages/_heartbeat.py
@@ -5,7 +5,7 @@ from optuna._experimental import experimental
 
 
 @experimental("2.9.0")
-def fail_stale_trials_with_callback(study: "optuna.Study") -> None:
+def fail_stale_trials(study: "optuna.Study") -> None:
     """Fail stale trials and run their failure callbacks.
 
     The running trials whose heartbeat has not been updated for a long time will be failed,

--- a/optuna/storages/_heartbeat.py
+++ b/optuna/storages/_heartbeat.py
@@ -13,7 +13,7 @@ def fail_stale_trials_with_callback(study: "optuna.Study") -> None:
 
     .. seealso::
 
-       See :class:`~optuna.storages.RDBStorage`.
+        See :class:`~optuna.storages.RDBStorage`.
 
     Args:
         study:

--- a/optuna/storages/_heartbeat.py
+++ b/optuna/storages/_heartbeat.py
@@ -1,0 +1,32 @@
+import copy
+
+import optuna
+from optuna._experimental import experimental
+
+
+@experimental("2.9.0")
+def fail_stale_trials_with_callback(study: "optuna.Study") -> None:
+    """Fail stale trials and run their failure callbacks.
+
+    The running trials whose heartbeat has not been updated for a long time will be failed,
+    that is, those states will be changed to :obj:`~optuna.trial.TrialState.FAIL`.
+
+    .. seealso::
+
+       See :class:`~optuna.storages.RDBStorage`.
+
+    Args:
+        study:
+            Study holding the trials to check.
+    """
+    storage = study._storage
+
+    if not storage.is_heartbeat_enabled():
+        return
+
+    failed_trial_ids = storage.fail_stale_trials(study._study_id)
+    failed_trial_callback = storage.get_failed_trial_callback()
+    if failed_trial_callback is not None:
+        for trial_id in failed_trial_ids:
+            failed_trial = copy.deepcopy(storage.get_trial(trial_id))
+            failed_trial_callback(study, failed_trial)

--- a/optuna/study/_optimize.py
+++ b/optuna/study/_optimize.py
@@ -186,13 +186,7 @@ def _run_trial(
     func: "optuna.study.study.ObjectiveFuncType",
     catch: Tuple[Type[Exception], ...],
 ) -> trial_module.Trial:
-    if study._storage.is_heartbeat_enabled():
-        failed_trial_ids = study._storage.fail_stale_trials(study._study_id)
-        failed_trial_callback = study._storage.get_failed_trial_callback()
-        if failed_trial_callback is not None:
-            for trial_id in failed_trial_ids:
-                failed_trial = copy.deepcopy(study._storage.get_trial(trial_id))
-                failed_trial_callback(study, failed_trial)
+    optuna.storages.fail_stale_trials(study)
 
     trial = study.ask()
 

--- a/optuna/study/_optimize.py
+++ b/optuna/study/_optimize.py
@@ -189,7 +189,7 @@ def _run_trial(
 ) -> trial_module.Trial:
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", ExperimentalWarning)
-        optuna.storages.fail_stale_trials_with_callback(study)
+        optuna.storages.fail_stale_trials(study)
 
     trial = study.ask()
 

--- a/optuna/study/_optimize.py
+++ b/optuna/study/_optimize.py
@@ -29,6 +29,7 @@ from optuna import logging
 from optuna import progress_bar as pbar_module
 from optuna import storages
 from optuna import trial as trial_module
+from optuna.exceptions import ExperimentalWarning
 from optuna.trial import FrozenTrial
 from optuna.trial import TrialState
 
@@ -186,7 +187,9 @@ def _run_trial(
     func: "optuna.study.study.ObjectiveFuncType",
     catch: Tuple[Type[Exception], ...],
 ) -> trial_module.Trial:
-    optuna.storages.fail_stale_trials(study)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", ExperimentalWarning)
+        optuna.storages.fail_stale_trials(study)
 
     trial = study.ask()
 

--- a/optuna/study/_optimize.py
+++ b/optuna/study/_optimize.py
@@ -189,7 +189,7 @@ def _run_trial(
 ) -> trial_module.Trial:
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", ExperimentalWarning)
-        optuna.storages.fail_stale_trials(study)
+        optuna.storages.fail_stale_trials_with_callback(study)
 
     trial = study.ask()
 

--- a/tests/storages_tests/test_storages.py
+++ b/tests/storages_tests/test_storages.py
@@ -1090,7 +1090,7 @@ def test_get_trial_id_from_study_id_trial_number(storage_mode: str) -> None:
         )
 
 
-def test_fail_stail_trials_with_callback() -> None:
+def test_fail_stale_trials_with_callback() -> None:
     heartbeat_interval = 1
     grace_period = 2
 

--- a/tests/storages_tests/test_storages.py
+++ b/tests/storages_tests/test_storages.py
@@ -1090,7 +1090,7 @@ def test_get_trial_id_from_study_id_trial_number(storage_mode: str) -> None:
         )
 
 
-def test_fail_stail_trials() -> None:
+def test_fail_stail_trials_with_callback() -> None:
     heartbeat_interval = 1
     grace_period = 2
 
@@ -1113,6 +1113,6 @@ def test_fail_stail_trials() -> None:
 
         assert study.trials[0].state is TrialState.RUNNING
 
-        optuna.storages.fail_stale_trials(study)
+        optuna.storages.fail_stale_trials_with_callback(study)
 
         assert study.trials[0].state is TrialState.FAIL

--- a/tests/storages_tests/test_storages.py
+++ b/tests/storages_tests/test_storages.py
@@ -1097,7 +1097,7 @@ def test_get_trial_id_from_study_id_trial_number(storage_mode: str) -> None:
 
 
 @pytest.mark.parametrize("storage_mode", STORAGE_MODES_HEARTBEAT)
-def test_fail_stale_trials(storage_mode: str) -> None:
+def test_fail_stale_trials_with_optimize(storage_mode: str) -> None:
 
     heartbeat_interval = 1
     grace_period = 2
@@ -1206,7 +1206,7 @@ def test_retry_failed_trial_callback(storage_mode: str, max_retry: Optional[int]
         )
 
 
-def test_fail_stale_trials_with_callback() -> None:
+def test_fail_stale_trials() -> None:
     heartbeat_interval = 1
     grace_period = 2
 
@@ -1229,6 +1229,6 @@ def test_fail_stale_trials_with_callback() -> None:
 
         assert study.trials[0].state is TrialState.RUNNING
 
-        optuna.storages.fail_stale_trials_with_callback(study)
+        optuna.storages.fail_stale_trials(study)
 
         assert study.trials[0].state is TrialState.FAIL


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation

Currently, zombie trials are checked for and automatically failed in the beginning of each trial when running `Study.optimize` (https://github.com/optuna/optuna/blob/master/optuna/study/_optimize.py#L189-L195). However, users would like to fail these zombie trials without having to invoke `Study.optimize`.

_Zombie trials are trials that have been abnormally terminated and are stuck in the RUNNING state._

## Description of the changes

This PR introduces a function that allows users to sweep and fail zombie trials at any time.

## Note

The function is marked experimental since the Storage/heartbeat APIs in general are somewhat controversial and open for discussion affecting the design of this API. Note that we could make this a method of the `Study` but I'm not sure we should expose it to that degree, yet.