### PR TITLE
Add `toml` to checking requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ def get_extras_require() -> Dict[str, List[str]]:
     requirements = {
         # TODO(HideakiImamura) Unpin mypy version after fixing "Duplicate modules" error in
         # tutorials.
-        "checking": ["black", "hacking", "isort", "mypy==0.790", "blackdoc"],
+        "checking": ["black", "hacking", "isort", "mypy==0.790", "blackdoc", "toml"],
         "codecov": ["codecov", "pytest-cov"],
         "doctest": [
             "cma",

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,8 @@ def get_extras_require() -> Dict[str, List[str]]:
     requirements = {
         # TODO(HideakiImamura) Unpin mypy version after fixing "Duplicate modules" error in
         # tutorials.
+        # TODO(xadrianzetx) Remove `toml` when
+        # https://github.com/keewis/blackdoc/issues/100 is resolved
         "checking": ["black", "hacking", "isort", "mypy==0.790", "blackdoc", "toml"],
         "codecov": ["codecov", "pytest-cov"],
         "doctest": [


### PR DESCRIPTION
This PR resolves missing dependency in `Checks` CI workflow caused by latest release of Black.

## Motivation
Resolves #2813

## Description of the changes
Added `toml` to `checking` requirements
