### PR TITLE
[RFC] Speed up `TPESampler`

### DIFF
--- a/optuna/samplers/_tpe/parzen_estimator.py
+++ b/optuna/samplers/_tpe/parzen_estimator.py
@@ -145,6 +145,16 @@ class _ParzenEstimator:
         n_samples = next(iter(samples_dict.values())).size
         if n_samples == 0:
             return np.asarray([], dtype=float)
+
+        if len(self._search_space.items()) == 1:
+            param_name, dist = list(self._search_space.items())[0]
+            if isinstance(dist, distributions.CategoricalDistribution):
+                samples = samples_dict[param_name]
+                categorical_weights = self._categorical_weights[param_name]
+                assert categorical_weights is not None
+                ret = np.log(np.inner(categorical_weights.T, self._weights))[samples]
+                return ret
+
         # We compute log pdf (component_log_pdf)
         # for each sample in samples_dict (of size n_samples)
         # for each component of `_MultivariateParzenEstimator` (of size n_observations).

--- a/optuna/samplers/_tpe/parzen_estimator.py
+++ b/optuna/samplers/_tpe/parzen_estimator.py
@@ -146,6 +146,8 @@ class _ParzenEstimator:
         if n_samples == 0:
             return np.asarray([], dtype=float)
 
+        # When the search space is one CategoricalDistribution, we use the faster processing,
+        # whose computation result is equivalent to the general one.
         if len(self._search_space.items()) == 1:
             param_name, dist = list(self._search_space.items())[0]
             if isinstance(dist, distributions.CategoricalDistribution):

--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -764,7 +764,7 @@ def _solve_hssp(
 
 
 def _calculate_weights_below_for_multi_objective(
-    config_vals: Dict[str, np.ndarray],
+    config_values: Dict[str, np.ndarray],
     loss_vals: List[Tuple[float, List[float]]],
     indices: np.ndarray,
 ) -> np.ndarray:
@@ -774,7 +774,7 @@ def _calculate_weights_below_for_multi_objective(
     # misses the one trial, then the other parameter must miss the trial, in this call of
     # `sample_relative`.
     # In the call of `sample_independent`, we only have one parameter so the logic makes sense.
-    cvals = list(config_vals.values())[0][indices]
+    cvals = list(config_values.values())[0][indices]
 
     # Multi-objective TPE does not support pruning, so it ignores the ``step``.
     lvals = np.asarray([v for _, v in loss_vals])[indices]

--- a/tests/samplers_tests/tpe_tests/test_multi_objective_sampler.py
+++ b/tests/samplers_tests/tpe_tests/test_multi_objective_sampler.py
@@ -560,7 +560,9 @@ def test_calculate_nondomination_rank() -> None:
 def test_calculate_weights_below_for_multi_objective() -> None:
     # Two samples.
     weights_below = _tpe.sampler._calculate_weights_below_for_multi_objective(
-        {"x": [1.0, 2.0, 3.0]}, [(0, [0.2, 0.5]), (0, [0.9, 0.4]), (0, [1, 1])], np.array([0, 1])
+        {"x": np.array([1.0, 2.0, 3.0], dtype=float)},
+        [(0, [0.2, 0.5]), (0, [0.9, 0.4]), (0, [1, 1])],
+        np.array([0, 1]),
     )
     assert len(weights_below) == 2
     assert weights_below[0] > weights_below[1]
@@ -568,7 +570,9 @@ def test_calculate_weights_below_for_multi_objective() -> None:
 
     # Two equally contributed samples.
     weights_below = _tpe.sampler._calculate_weights_below_for_multi_objective(
-        {"x": [1.0, 2.0, 3.0]}, [(0, [0.2, 0.8]), (0, [0.8, 0.2]), (0, [1, 1])], np.array([0, 1])
+        {"x": np.array([1.0, 2.0, 3.0], dtype=float)},
+        [(0, [0.2, 0.8]), (0, [0.8, 0.2]), (0, [1, 1])],
+        np.array([0, 1]),
     )
     assert len(weights_below) == 2
     assert weights_below[0] == weights_below[1]
@@ -576,7 +580,9 @@ def test_calculate_weights_below_for_multi_objective() -> None:
 
     # Duplicated samples.
     weights_below = _tpe.sampler._calculate_weights_below_for_multi_objective(
-        {"x": [1.0, 2.0, 3.0]}, [(0, [0.2, 0.8]), (0, [0.2, 0.8]), (0, [1, 1])], np.array([0, 1])
+        {"x": np.array([1.0, 2.0, 3.0], dtype=float)},
+        [(0, [0.2, 0.8]), (0, [0.2, 0.8]), (0, [1, 1])],
+        np.array([0, 1]),
     )
     assert len(weights_below) == 2
     assert weights_below[0] == weights_below[1]
@@ -584,7 +590,7 @@ def test_calculate_weights_below_for_multi_objective() -> None:
 
     # Three samples.
     weights_below = _tpe.sampler._calculate_weights_below_for_multi_objective(
-        {"x": [1.0, 2.0, 3.0, 4.0]},
+        {"x": np.array([1.0, 2.0, 3.0, 4.0], dtype=float)},
         [(0, [0.3, 0.3]), (0, [0.2, 0.8]), (0, [0.8, 0.2]), (0, [1, 1])],
         np.array([0, 1, 2]),
     )

--- a/tests/samplers_tests/tpe_tests/test_sampler.py
+++ b/tests/samplers_tests/tpe_tests/test_sampler.py
@@ -845,7 +845,11 @@ def test_split_observation_pairs() -> None:
 
 def test_build_observation_dict() -> None:
     observation_dict = _tpe.sampler._build_observation_dict(
-        {"x": [1.0, 2.0, 3.0, 4.0], "y": [10.0, None, 20.0, None]}, np.asarray([0, 3])
+        {
+            "x": np.asarray([1.0, 2.0, 3.0, 4.0], dtype=float),
+            "y": np.asarray([10.0, None, 20.0, None], dtype=float),
+        },
+        np.asarray([0, 3]),
     )
 
     np.testing.assert_array_equal(observation_dict["x"], np.asarray([1.0, 4.0]))


### PR DESCRIPTION
## Motivation
By unifying the univariate and multivariate TPE, the execution speed of the univariate `TPESampler` was decreased especially for `suggest_categorical` ([review comment](https://github.com/optuna/optuna/pull/2618#issuecomment-845692659)). This PR will speed up the sampler and partially relax degradation. This change will complicate the code, so I'd like to discuss if it's really necessary.

## Description of the changes
- Accelerate when using `suggest_categorical` with univariate `TPESampler`
- Make `config_values` outside of `_build_observation_dict` to prevent duplicated calculation

## Benchmark Results

<details>
<summary>suggest_categorical</summary>

- master

| #params | #trials | time(sec) | time/trial(ms) | time/trial/param(ms) |
| ------- | ------- | --------- | -------------- | -------------------- |
| 1 | 1 | 0.00 | 0.36 | 0.36 |
| 1 | 10 | 0.00 | 0.14 | 0.14 |
| 1 | 100 | 0.06 | 0.58 | 0.58 |
| 1 | 1000 | 2.22 | 2.22 | 2.22 |
| 2 | 1 | 0.00 | 0.32 | 0.16 |
| 2 | 10 | 0.00 | 0.20 | 0.10 |
| 2 | 100 | 0.10 | 1.03 | 0.52 |
| 2 | 1000 | 3.90 | 3.90 | 1.95 |
| 4 | 1 | 0.00 | 0.57 | 0.14 |
| 4 | 10 | 0.00 | 0.29 | 0.07 |
| 4 | 100 | 0.19 | 1.89 | 0.47 |
| 4 | 1000 | 7.93 | 7.93 | 1.98 |
| 8 | 1 | 0.00 | 0.61 | 0.08 |
| 8 | 10 | 0.01 | 0.60 | 0.07 |
| 8 | 100 | 0.40 | 4.01 | 0.50 |
| 8 | 1000 | 15.61 | 15.61 | 1.95 |
| 16 | 1 | 0.00 | 0.99 | 0.06 |
| 16 | 10 | 0.01 | 1.05 | 0.07 |
| 16 | 100 | 0.72 | 7.25 | 0.45 |
| 16 | 1000 | 31.74 | 31.74 | 1.98 |
| 32 | 1 | 0.00 | 1.99 | 0.06 |
| 32 | 10 | 0.02 | 2.19 | 0.07 |
| 32 | 100 | 1.47 | 14.66 | 0.46 |
| 32 | 1000 | 65.30 | 65.30 | 2.04 |

- v2.8.0

| #params | #trials | time(sec) | time/trial(ms) | time/trial/param(ms) |
| ------- | ------- | --------- | -------------- | -------------------- |
| 1 | 1 | 0.00 | 0.36 | 0.36 |
| 1 | 10 | 0.00 | 0.14 | 0.14 |
| 1 | 100 | 0.03 | 0.34 | 0.34 |
| 1 | 1000 | 1.52 | 1.52 | 1.52 |
| 2 | 1 | 0.00 | 0.24 | 0.12 |
| 2 | 10 | 0.00 | 0.20 | 0.10 |
| 2 | 100 | 0.06 | 0.60 | 0.30 |
| 2 | 1000 | 2.77 | 2.77 | 1.39 |
| 4 | 1 | 0.00 | 0.37 | 0.09 |
| 4 | 10 | 0.00 | 0.34 | 0.09 |
| 4 | 100 | 0.11 | 1.14 | 0.28 |
| 4 | 1000 | 5.55 | 5.55 | 1.39 |
| 8 | 1 | 0.00 | 0.60 | 0.07 |
| 8 | 10 | 0.01 | 0.64 | 0.08 |
| 8 | 100 | 0.22 | 2.16 | 0.27 |
| 8 | 1000 | 11.11 | 11.11 | 1.39 |
| 16 | 1 | 0.00 | 1.06 | 0.07 |
| 16 | 10 | 0.01 | 1.12 | 0.07 |
| 16 | 100 | 0.40 | 3.99 | 0.25 |
| 16 | 1000 | 22.17 | 22.17 | 1.39 |
| 32 | 1 | 0.00 | 2.06 | 0.06 |
| 32 | 10 | 0.02 | 2.18 | 0.07 |
| 32 | 100 | 0.82 | 8.20 | 0.26 |
| 32 | 1000 | 45.73 | 45.73 | 1.43 |

- PR

| #params | #trials | time(sec) | time/trial(ms) | time/trial/param(ms) |
| ------- | ------- | --------- | -------------- | -------------------- |
| 1 | 1 | 0.00 | 0.34 | 0.34 |
| 1 | 10 | 0.00 | 0.14 | 0.14 |
| 1 | 100 | 0.05 | 0.46 | 0.46 |
| 1 | 1000 | 1.74 | 1.74 | 1.74 |
| 2 | 1 | 0.00 | 0.25 | 0.13 |
| 2 | 10 | 0.00 | 0.19 | 0.10 |
| 2 | 100 | 0.08 | 0.80 | 0.40 |
| 2 | 1000 | 3.37 | 3.37 | 1.69 |
| 4 | 1 | 0.00 | 0.36 | 0.09 |
| 4 | 10 | 0.00 | 0.32 | 0.08 |
| 4 | 100 | 0.15 | 1.55 | 0.39 |
| 4 | 1000 | 6.78 | 6.78 | 1.69 |
| 8 | 1 | 0.00 | 0.57 | 0.07 |
| 8 | 10 | 0.01 | 0.59 | 0.07 |
| 8 | 100 | 0.30 | 2.96 | 0.37 |
| 8 | 1000 | 13.56 | 13.56 | 1.69 |
| 16 | 1 | 0.00 | 1.04 | 0.07 |
| 16 | 10 | 0.01 | 1.15 | 0.07 |
| 16 | 100 | 0.58 | 5.79 | 0.36 |
| 16 | 1000 | 27.95 | 27.95 | 1.75 |
| 32 | 1 | 0.00 | 1.94 | 0.06 |
| 32 | 10 | 0.02 | 2.24 | 0.07 |
| 32 | 100 | 1.19 | 11.92 | 0.37 |
| 32 | 1000 | 57.11 | 57.11 | 1.78 |

</details>

<details>
<summary>suggest_float</summary>

- master

| #params | #trials | time(sec) | time/trial(ms) | time/trial/param(ms) |
| ------- | ------- | --------- | -------------- | -------------------- |
| 1 | 1 | 0.00 | 0.50 | 0.50 |
| 1 | 10 | 0.00 | 0.16 | 0.16 |
| 1 | 100 | 0.22 | 2.23 | 2.23 |
| 1 | 1000 | 3.94 | 3.94 | 3.94 |
| 2 | 1 | 0.00 | 0.29 | 0.15 |
| 2 | 10 | 0.00 | 0.22 | 0.11 |
| 2 | 100 | 0.42 | 4.24 | 2.12 |
| 2 | 1000 | 7.73 | 7.73 | 3.87 |
| 4 | 1 | 0.00 | 0.52 | 0.13 |
| 4 | 10 | 0.00 | 0.41 | 0.10 |
| 4 | 100 | 0.85 | 8.49 | 2.12 |
| 4 | 1000 | 15.16 | 15.16 | 3.79 |
| 8 | 1 | 0.00 | 0.63 | 0.08 |
| 8 | 10 | 0.01 | 0.62 | 0.08 |
| 8 | 100 | 1.62 | 16.18 | 2.02 |
| 8 | 1000 | 30.06 | 30.06 | 3.76 |
| 16 | 1 | 0.00 | 1.22 | 0.08 |
| 16 | 10 | 0.01 | 1.30 | 0.08 |
| 16 | 100 | 3.28 | 32.82 | 2.05 |
| 16 | 1000 | 60.08 | 60.08 | 3.76 |
| 32 | 1 | 0.00 | 2.52 | 0.08 |
| 32 | 10 | 0.03 | 2.54 | 0.08 |
| 32 | 100 | 6.59 | 65.86 | 2.06 |
| 32 | 1000 | 122.97 | 122.97 | 3.84 |

- v2.8.0

| #params | #trials | time(sec) | time/trial(ms) | time/trial/param(ms) |
| ------- | ------- | --------- | -------------- | -------------------- |
| 1 | 1 | 0.00 | 0.39 | 0.39 |
| 1 | 10 | 0.00 | 0.16 | 0.16 |
| 1 | 100 | 0.21 | 2.10 | 2.10 |
| 1 | 1000 | 3.74 | 3.74 | 3.74 |
| 2 | 1 | 0.00 | 0.27 | 0.13 |
| 2 | 10 | 0.00 | 0.21 | 0.11 |
| 2 | 100 | 0.40 | 4.05 | 2.02 |
| 2 | 1000 | 6.96 | 6.96 | 3.48 |
| 4 | 1 | 0.00 | 0.41 | 0.10 |
| 4 | 10 | 0.00 | 0.36 | 0.09 |
| 4 | 100 | 0.82 | 8.21 | 2.05 |
| 4 | 1000 | 13.75 | 13.75 | 3.44 |
| 8 | 1 | 0.00 | 0.67 | 0.08 |
| 8 | 10 | 0.01 | 0.65 | 0.08 |
| 8 | 100 | 1.53 | 15.30 | 1.91 |
| 8 | 1000 | 26.81 | 26.81 | 3.35 |
| 16 | 1 | 0.00 | 1.12 | 0.07 |
| 16 | 10 | 0.01 | 1.13 | 0.07 |
| 16 | 100 | 3.20 | 32.01 | 2.00 |
| 16 | 1000 | 54.25 | 54.25 | 3.39 |
| 32 | 1 | 0.00 | 2.29 | 0.07 |
| 32 | 10 | 0.02 | 2.43 | 0.08 |
| 32 | 100 | 6.39 | 63.88 | 2.00 |
| 32 | 1000 | 119.51 | 119.51 | 3.73 |

- PR

| #params | #trials | time(sec) | time/trial(ms) | time/trial/param(ms) |
| ------- | ------- | --------- | -------------- | -------------------- |
| 1 | 1 | 0.00 | 0.42 | 0.42 |
| 1 | 10 | 0.00 | 0.20 | 0.20 |
| 1 | 100 | 0.22 | 2.25 | 2.25 |
| 1 | 1000 | 3.95 | 3.95 | 3.95 |
| 2 | 1 | 0.00 | 0.27 | 0.13 |
| 2 | 10 | 0.00 | 0.21 | 0.11 |
| 2 | 100 | 0.42 | 4.19 | 2.10 |
| 2 | 1000 | 7.82 | 7.82 | 3.91 |
| 4 | 1 | 0.00 | 0.41 | 0.10 |
| 4 | 10 | 0.00 | 0.35 | 0.09 |
| 4 | 100 | 0.85 | 8.52 | 2.13 |
| 4 | 1000 | 15.28 | 15.28 | 3.82 |
| 8 | 1 | 0.00 | 0.65 | 0.08 |
| 8 | 10 | 0.01 | 0.64 | 0.08 |
| 8 | 100 | 1.73 | 17.32 | 2.16 |
| 8 | 1000 | 29.95 | 29.95 | 3.74 |
| 16 | 1 | 0.00 | 1.17 | 0.07 |
| 16 | 10 | 0.01 | 1.11 | 0.07 |
| 16 | 100 | 3.48 | 34.76 | 2.17 |
| 16 | 1000 | 61.64 | 61.64 | 3.85 |
| 32 | 1 | 0.00 | 2.15 | 0.07 |
| 32 | 10 | 0.02 | 2.38 | 0.07 |
| 32 | 100 | 6.67 | 66.73 | 2.09 |
| 32 | 1000 | 126.51 | 126.51 | 3.95 |

</details>

<details>
<summary>Code</summary>

```python
import math
import time

import optuna


class Profile:
    def __enter__(self):
        self.start = time.time()
        return self

    def __exit__(self, exc_type, exc_val, exc_tb):
        self.end = time.time()

    def get(self):
        return self.end - self.start


def build_objective_func(n_param):
    def objective(trial):
        return sum(
            [
                math.sin(trial.suggest_float("param-{}".format(i), 0, 1))
                # int(trial.suggest_categorical("param-{}".format(i), [1, 2, 3]))
                for i in range(n_param)
            ]
        )

    return objective


n_params = [1, 2, 4, 8, 16, 32]
n_trials = [1, 10, 100, 1000]

optuna.logging.set_verbosity(optuna.logging.CRITICAL)

print("| #params | #trials | time(sec) | time/trial(ms) | time/trial/param(ms) |")
print("| ------- | ------- | --------- | -------------- | -------------------- |")

for n_param in n_params:
    for n_trial in n_trials:
        sampler = optuna.samplers.TPESampler()
        study = optuna.create_study(sampler=sampler)

        with Profile() as prof:
            study.optimize(
                build_objective_func(n_param),
                n_trials=n_trial,
                gc_after_trial=False,
            )

        print(
            f"| {n_param} | {n_trial} | {prof.get():.2f} "
            f"| {prof.get() / n_trial * 1e3:.2f} "
            f"| {prof.get() / n_trial / n_param * 1e3:.2f} "
            "|"
        )
```
</details>