### PR TITLE
Optuna ask and tell CLI options

### DIFF
--- a/optuna/cli.py
+++ b/optuna/cli.py
@@ -379,13 +379,37 @@ class _Ask(_BaseCommand):
     def get_parser(self, prog_name: str) -> ArgumentParser:
 
         parser = super(_Ask, self).get_parser(prog_name)
-        parser.add_argument("--study-name", type=str)
-        parser.add_argument("--direction", type=str, choices=("minimize", "maximize"))
-        parser.add_argument("--directions", type=str, nargs="+", choices=("minimize", "maximize"))
-        parser.add_argument("--sampler", type=str)
-        parser.add_argument("--sampler-kwargs", type=str)
-        parser.add_argument("--search-space", type=str)
-        parser.add_argument("--out", type=str, choices=("json", "yaml"), default="json")
+        parser.add_argument("--study-name", type=str, help="Name of study.")
+        parser.add_argument(
+            "--direction",
+            type=str,
+            choices=("minimize", "maximize"),
+            help="Direction of optimization.",
+        )
+        parser.add_argument(
+            "--directions",
+            type=str,
+            nargs="+",
+            choices=("minimize", "maximize"),
+            help="Directions of optimization, if there are multiple objectives.",
+        )
+        parser.add_argument("--sampler", type=str, help="Class name of sampler object to create.")
+        parser.add_argument(
+            "--sampler-kwargs",
+            type=str,
+            help="Sampler object initialization keyword arguments as JSON.",
+        )
+        parser.add_argument(
+            "--search-space",
+            type=str,
+            help=(
+                "Search space as JSON. Keys are names and values are outputs from "
+                ":func:`~optuna.distributions.distribution_to_json`."
+            ),
+        )
+        parser.add_argument(
+            "--out", type=str, choices=("json", "yaml"), default="json", help="Output format."
+        )
         return parser
 
     def take_action(self, parsed_args: Namespace) -> int:
@@ -454,11 +478,10 @@ class _Tell(_BaseCommand):
     def get_parser(self, prog_name: str) -> ArgumentParser:
 
         parser = super(_Tell, self).get_parser(prog_name)
-        parser.add_argument("--study-name", type=str)
-        parser.add_argument("--storage", type=str)
-        parser.add_argument("--trial-number", type=int)
-        parser.add_argument("--values", type=float, nargs="+")
-        parser.add_argument("--state", type=str, default="complete")
+        parser.add_argument("--study-name", type=str, help="Name of study.")
+        parser.add_argument("--trial-number", type=int, help="Trial number.")
+        parser.add_argument("--values", type=float, nargs="+", help="Objective values.")
+        parser.add_argument("--state", type=str, default="complete", help="Trial state.")
         return parser
 
     def take_action(self, parsed_args: Namespace) -> int:

--- a/optuna/cli.py
+++ b/optuna/cli.py
@@ -391,7 +391,7 @@ class _Ask(_BaseCommand):
     def take_action(self, parsed_args: Namespace) -> int:
 
         warnings.warn(
-            "ask is an experimental CLI command. The interface can change in the future.",
+            "'ask' is an experimental CLI command. The interface can change in the future.",
             ExperimentalWarning,
         )
 
@@ -463,7 +463,7 @@ class _Tell(_BaseCommand):
 
     def take_action(self, parsed_args: Namespace) -> int:
         warnings.warn(
-            "tell is an experimental CLI command. The interface can change in the future.",
+            "'tell' is an experimental CLI command. The interface can change in the future.",
             ExperimentalWarning,
         )
 

--- a/optuna/cli.py
+++ b/optuna/cli.py
@@ -485,6 +485,7 @@ class _Tell(_BaseCommand):
         return parser
 
     def take_action(self, parsed_args: Namespace) -> int:
+
         warnings.warn(
             "'tell' is an experimental CLI command. The interface can change in the future.",
             ExperimentalWarning,

--- a/setup.py
+++ b/setup.py
@@ -214,6 +214,8 @@ setup(
             "dashboard = optuna.cli:_Dashboard",
             "study optimize = optuna.cli:_StudyOptimize",
             "storage upgrade = optuna.cli:_StorageUpgrade",
+            "ask = optuna.cli:_Ask",
+            "tell = optuna.cli:_Tell",
         ],
     },
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ def get_install_requires() -> List[str]:
         "scipy!=1.4.0",
         "sqlalchemy>=1.1.0",
         "tqdm",
+        "PyYAML",  # Only used in `optuna/cli.py`.
     ]
     return requirements
 


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation

It is sometimes useful to be able to utilize the ask and tell APIs of Optuna via the CLI, or without having to write any Python code.

This initial design is meant to be _experimental_. The search space definition format follows the JSON-`BaseDistribution` conversions defined in https://github.com/optuna/optuna/blob/master/optuna/distributions.py which is quite verbose, but intentionally avoids introducing any new concepts or formats. Similarly, the sampler specification is highly experimental. The current design only supports JSON serializable Python arguments. It does for instance not allow configuring which secondary sampler to fall back to with the `CmaEsSampler`, nor utilize constrained optimization (`constraints_func`) with the `NSGAIISampler`.

## Description of the changes

Introduces `optuna ask` and `optuna tell` CLI commands.

## Example usage

### `optuna ask`

```console
$ optuna ask --storage sqlite:///foo.db --study-name mystudy --sampler TPESampler --sampler-kwargs '{"multivariate": true}' --search-space '{"x": {"name": "UniformDistribution", "attributes": {"low": 0.0, "high": 1.0}}, "y": {"name": "UniformDistribution", "attributes": {"low": 1.0, "high": 100.0}}}' --direction minimize --out yaml > out.yaml
```

```console
$ yq e .trial.number out.yaml
0
$ yq e .trial.params out.yaml
x: 0.9792623438714788
y: 75.24708350450462
```

### `optuna tell`

```console
$ optuna tell --storage sqlite:///foo.db --study-name mystudy --trial-number 0 --values 1.0
```

## TODO

- [x] Address existing TODOs in the code
- [x] Add tests
- [x] Mark experimental