### PR TITLE
Preinstall RDB binding Python libraries in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,4 +26,7 @@ RUN if [ "${BUILD_TYPE}" = "dev" ]; then \
     fi \
     && pip install ${PIP_OPTIONS} jupyter notebook
 
+# Install RDB bindings.
+RUN pip install ${PIP_OPTIONS} PyMySQL cryptography psycopg2-binary
+
 ENV PIP_OPTIONS ""


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation

As seen here https://github.com/optuna/optuna/blob/v2.8.0/.github/workflows/tests-rdbstorage.yml#L89, several Python libraries are necessary in order to utilize the `RDBStorage` in Optuna (with MySQL). It would be good to have these libraries pre-installed in our Docker images.

Motivation is related to https://github.com/optuna/optuna/pull/2817. Being able to just grab an image and with a single command obtain parameters is useful.

## Description of the changes

Pre-installs/includes Python libraries required for the `RDBStorage` and especially with MySQL.