### PR TITLE
Sort values when the categorical values is numerical in `plot_parallel_coordinate`

### DIFF
--- a/optuna/visualization/_parallel_coordinate.py
+++ b/optuna/visualization/_parallel_coordinate.py
@@ -183,13 +183,7 @@ def _get_parallel_coordinate_plot(
         dims.append(dim)
 
     if len(numeric_cat_params.keys()) != 0:
-        sorted_categorical_vals = (
-            pd.DataFrame()
-            .from_dict(numeric_cat_params)
-            .sort_values(by=list(numeric_cat_params.keys()))
-        )
-        idx = sorted_categorical_vals.index
-
+        idx = list(np.lexsort(list(numeric_cat_params.values()))[::-1])
         for dim in dims:
             dim.update({"values": tuple(np.array(dim["values"])[idx])})
 

--- a/optuna/visualization/_parallel_coordinate.py
+++ b/optuna/visualization/_parallel_coordinate.py
@@ -9,7 +9,6 @@ from typing import List
 from typing import Optional
 
 import numpy as np
-import pandas as pd
 
 from optuna.logging import get_logger
 from optuna.study import Study

--- a/optuna/visualization/_parallel_coordinate.py
+++ b/optuna/visualization/_parallel_coordinate.py
@@ -182,7 +182,7 @@ def _get_parallel_coordinate_plot(
         dims.append(dim)
 
     if len(numeric_cat_params.keys()) != 0:
-        idx = list(np.lexsort(list(numeric_cat_params.values()))[::-1])
+        idx = np.lexsort(list(numeric_cat_params.values())[::-1])
         for dim in dims:
             dim.update({"values": tuple(np.array(dim["values"])[idx])})
 

--- a/optuna/visualization/_parallel_coordinate.py
+++ b/optuna/visualization/_parallel_coordinate.py
@@ -20,6 +20,7 @@ from optuna.visualization._plotly_imports import _imports
 from optuna.visualization._utils import _check_plot_args
 from optuna.visualization._utils import _is_categorical
 from optuna.visualization._utils import _is_log_scale
+from optuna.visualization._utils import _is_numerical
 
 
 if _imports.is_successful():
@@ -156,7 +157,7 @@ def _get_parallel_coordinate_plot(
         elif _is_categorical(trials, p_name):
             vocab: DefaultDict[str, int] = defaultdict(lambda: len(vocab))
 
-            if all([isinstance(v, (int, float)) for v in values]):
+            if _is_numerical(trials, p_name):
                 _ = [vocab[v] for v in sorted(values)]
                 values = [vocab[v] for v in values]
                 numeric_cat_params[p_name] = values

--- a/optuna/visualization/_parallel_coordinate.py
+++ b/optuna/visualization/_parallel_coordinate.py
@@ -7,9 +7,11 @@ from typing import DefaultDict
 from typing import Dict
 from typing import List
 from typing import Optional
+from typing import Sequence
 
 import numpy as np
 
+from optuna.distributions import CategoricalChoiceType
 from optuna.logging import get_logger
 from optuna.study import Study
 from optuna.study._study_direction import StudyDirection
@@ -130,7 +132,7 @@ def _get_parallel_coordinate_plot(
         }
     ]
 
-    numeric_cat_params: Dict[str, List[Any]] = {}
+    numeric_cat_params: Dict[str, Sequence[CategoricalChoiceType]] = {}
     for p_name in sorted_params:
         values = []
         for t in trials:
@@ -181,9 +183,13 @@ def _get_parallel_coordinate_plot(
 
         dims.append(dim)
 
-    if len(numeric_cat_params.keys()) != 0:
+    if numeric_cat_params:
+        # np.lexsort consumes the sort keys the order from back to front.
+        # So the values of parameters have to be reversed the order.
         idx = np.lexsort(list(numeric_cat_params.values())[::-1])
         for dim in dims:
+            # Since the values are mapped to other categories by the index,
+            # the index will be swapped according to the sorted index of numeric params.
             dim.update({"values": tuple(np.array(dim["values"])[idx])})
 
     traces = [

--- a/optuna/visualization/matplotlib/_parallel_coordinate.py
+++ b/optuna/visualization/matplotlib/_parallel_coordinate.py
@@ -21,6 +21,7 @@ from optuna.visualization._utils import _check_plot_args
 from optuna.visualization.matplotlib._matplotlib_imports import _imports
 from optuna.visualization.matplotlib._utils import _is_categorical
 from optuna.visualization.matplotlib._utils import _is_log_scale
+from optuna.visualization.matplotlib._utils import _is_numerical
 
 
 if _imports.is_successful():
@@ -154,7 +155,7 @@ def _get_parallel_coordinate_plot(
         elif _is_categorical(trials, p_name):
             vocab = defaultdict(lambda: len(vocab))  # type: DefaultDict[str, int]
 
-            if all([isinstance(v, (int, float)) for v in values]):
+            if _is_numerical(trials, p_name):
                 _ = [vocab[v] for v in sorted(values)]
                 values = [vocab[v] for v in values]
                 numeric_cat_params[p_name] = values

--- a/optuna/visualization/matplotlib/_parallel_coordinate.py
+++ b/optuna/visualization/matplotlib/_parallel_coordinate.py
@@ -182,8 +182,8 @@ def _get_parallel_coordinate_plot(
         param_values.append(values)
 
     if len(numeric_cat_params.keys()) != 0:
-        idx = list(np.lexsort(list(numeric_cat_params.values()))[::-1])
-        param_values = [tuple(np.array(v)[idx]) for v in param_values]
+        sorted_idx = list(np.lexsort(list(numeric_cat_params.values()))[::-1])
+        param_values = [list(np.array(v)[sorted_idx]) for v in param_values]
 
     # Draw multiple line plots and axes.
     # Ref: https://stackoverflow.com/a/50029441
@@ -208,7 +208,7 @@ def _get_parallel_coordinate_plot(
         ax2.plot([1] * len(param_values[i]), param_values[i], visible=False)
         ax2.spines["right"].set_position(("axes", (i + 1) / len(sorted_params)))
         if p_name in cat_param_names:
-            idx = cat_param_names.index(p_name)
+            idx: int = cat_param_names.index(p_name)
             tick_pos = cat_param_ticks[idx]
             tick_labels = cat_param_values[idx]
             ax2.set_yticks(tick_pos)

--- a/optuna/visualization/matplotlib/_parallel_coordinate.py
+++ b/optuna/visualization/matplotlib/_parallel_coordinate.py
@@ -1,16 +1,17 @@
 from collections import defaultdict
 import math
-from typing import Any
 from typing import Callable
 from typing import cast
 from typing import DefaultDict
 from typing import Dict
 from typing import List
 from typing import Optional
+from typing import Sequence
 
 import numpy as np
 
 from optuna._experimental import experimental
+from optuna.distributions import CategoricalChoiceType
 from optuna.logging import get_logger
 from optuna.study import Study
 from optuna.study._study_direction import StudyDirection
@@ -143,7 +144,7 @@ def _get_parallel_coordinate_plot(
     log_param_names = []
     param_values = []
     var_names = [target_name]
-    numeric_cat_params: Dict[str, List[Any]] = {}
+    numeric_cat_params: Dict[str, Sequence[CategoricalChoiceType]] = {}
 
     for p_name in sorted_params:
         values = [t.params[p_name] if p_name in t.params else np.nan for t in trials]
@@ -181,8 +182,12 @@ def _get_parallel_coordinate_plot(
         var_names.append(p_name if len(p_name) < 20 else "{}...".format(p_name[:17]))
         param_values.append(values)
 
-    if len(numeric_cat_params.keys()) != 0:
+    if numeric_cat_params:
+        # np.lexsort consumes the sort keys the order from back to front.
+        # So the values of parameters have to be reversed the order.
         sorted_idx = np.lexsort(list(numeric_cat_params.values())[::-1])
+        # Since the values are mapped to other categories by the index,
+        # the index will be swapped according to the sorted index of numeric params.
         param_values = [list(np.array(v)[sorted_idx]) for v in param_values]
 
     # Draw multiple line plots and axes.

--- a/optuna/visualization/matplotlib/_parallel_coordinate.py
+++ b/optuna/visualization/matplotlib/_parallel_coordinate.py
@@ -182,7 +182,7 @@ def _get_parallel_coordinate_plot(
         param_values.append(values)
 
     if len(numeric_cat_params.keys()) != 0:
-        sorted_idx = list(np.lexsort(list(numeric_cat_params.values()))[::-1])
+        sorted_idx = np.lexsort(list(numeric_cat_params.values())[::-1])
         param_values = [list(np.array(v)[sorted_idx]) for v in param_values]
 
     # Draw multiple line plots and axes.
@@ -208,7 +208,7 @@ def _get_parallel_coordinate_plot(
         ax2.plot([1] * len(param_values[i]), param_values[i], visible=False)
         ax2.spines["right"].set_position(("axes", (i + 1) / len(sorted_params)))
         if p_name in cat_param_names:
-            idx: int = cat_param_names.index(p_name)
+            idx = cat_param_names.index(p_name)
             tick_pos = cat_param_ticks[idx]
             tick_labels = cat_param_values[idx]
             ax2.set_yticks(tick_pos)

--- a/optuna/visualization/matplotlib/_parallel_coordinate.py
+++ b/optuna/visualization/matplotlib/_parallel_coordinate.py
@@ -9,7 +9,6 @@ from typing import List
 from typing import Optional
 
 import numpy as np
-import pandas as pd
 
 from optuna._experimental import experimental
 from optuna.logging import get_logger

--- a/optuna/visualization/matplotlib/_parallel_coordinate.py
+++ b/optuna/visualization/matplotlib/_parallel_coordinate.py
@@ -183,13 +183,7 @@ def _get_parallel_coordinate_plot(
         param_values.append(values)
 
     if len(numeric_cat_params.keys()) != 0:
-        sorted_categorical_vals = (
-            pd.DataFrame()
-            .from_dict(numeric_cat_params)
-            .sort_values(by=list(numeric_cat_params.keys()))
-        )
-        idx = sorted_categorical_vals.index
-
+        idx = list(np.lexsort(list(numeric_cat_params.values()))[::-1])
         param_values = [tuple(np.array(v)[idx]) for v in param_values]
 
     # Draw multiple line plots and axes.

--- a/tests/visualization_tests/matplotlib_tests/test_parallel_coordinate.py
+++ b/tests/visualization_tests/matplotlib_tests/test_parallel_coordinate.py
@@ -87,7 +87,7 @@ def test_plot_parallel_coordinate_categorical_params() -> None:
 
 
 def test_plot_parallel_coordinate_categorical_numeric_params() -> None:
-    # Test with categorical params that can be interpeted numeric.
+    # Test with categorical params that can be interpreted as numeric params.
     study_categorical_params = create_study()
     study_categorical_params.add_trial(
         create_trial(

--- a/tests/visualization_tests/matplotlib_tests/test_parallel_coordinate.py
+++ b/tests/visualization_tests/matplotlib_tests/test_parallel_coordinate.py
@@ -86,6 +86,45 @@ def test_plot_parallel_coordinate_categorical_params() -> None:
     assert len(figure.get_lines()) == 0
 
 
+def test_plot_parallel_coordinate_categorical_numeric_params() -> None:
+    # Test with categorical params that can be interpeted numeric.
+    study_categorical_params = create_study()
+    study_categorical_params.add_trial(
+        create_trial(
+            value=0.0,
+            params={"category_a": 2, "category_b": 20},
+            distributions={
+                "category_a": CategoricalDistribution((1, 2)),
+                "category_b": CategoricalDistribution((10, 20, 30)),
+            },
+        )
+    )
+
+    study_categorical_params.add_trial(
+        create_trial(
+            value=1.0,
+            params={"category_a": 1, "category_b": 30},
+            distributions={
+                "category_a": CategoricalDistribution((1, 2)),
+                "category_b": CategoricalDistribution((10, 20, 30)),
+            },
+        )
+    )
+
+    study_categorical_params.add_trial(
+        create_trial(
+            value=2.0,
+            params={"category_a": 2, "category_b": 10},
+            distributions={
+                "category_a": CategoricalDistribution((1, 2)),
+                "category_b": CategoricalDistribution((10, 20, 30)),
+            },
+        )
+    )
+    figure = plot_parallel_coordinate(study_categorical_params)
+    assert len(figure.get_lines()) == 0
+
+
 def test_plot_parallel_coordinate_log_params() -> None:
     # Test with log params
     study_log_params = create_study()

--- a/tests/visualization_tests/test_parallel_coordinate.py
+++ b/tests/visualization_tests/test_parallel_coordinate.py
@@ -129,67 +129,6 @@ def test_plot_parallel_coordinate_categorical_params() -> None:
     assert figure.data[0]["dimensions"][2]["ticktext"] == ("net", "una")
 
 
-def test_plot_parallel_coordinate_categorical_numeric_params() -> None:
-    # Test with categorical params that can be interpreted as numeric params.
-    study_categorical_params = create_study()
-    study_categorical_params.add_trial(
-        create_trial(
-            value=0.0,
-            params={"category_a": 2, "category_b": 2},
-            distributions={
-                "category_a": CategoricalDistribution((1, 2, 10)),
-                "category_b": CategoricalDistribution((-1, 1, 2)),
-            },
-        )
-    )
-
-    study_categorical_params.add_trial(
-        create_trial(
-            value=1.0,
-            params={"category_a": 1, "category_b": 2},
-            distributions={
-                "category_a": CategoricalDistribution((1, 2, 10)),
-                "category_b": CategoricalDistribution((-1, 1, 2)),
-            },
-        )
-    )
-
-    study_categorical_params.add_trial(
-        create_trial(
-            value=3.0,
-            params={"category_a": 10, "category_b": 1},
-            distributions={
-                "category_a": CategoricalDistribution((1, 2, 10)),
-                "category_b": CategoricalDistribution((-1, 1, 2)),
-            },
-        )
-    )
-
-    study_categorical_params.add_trial(
-        create_trial(
-            value=2.0,
-            params={"category_a": 2, "category_b": -1},
-            distributions={
-                "category_a": CategoricalDistribution((1, 2, 10)),
-                "category_b": CategoricalDistribution((-1, 1, 2)),
-            },
-        )
-    )
-    figure = plot_parallel_coordinate(study_categorical_params)
-    assert len(figure.data[0]["dimensions"]) == 3
-    assert figure.data[0]["dimensions"][0]["label"] == "Objective Value"
-    assert figure.data[0]["dimensions"][0]["range"] == (0.0, 3.0)
-    assert figure.data[0]["dimensions"][0]["values"] == (1.0, 2.0, 0.0, 3.0)
-    assert figure.data[0]["dimensions"][1]["label"] == "category_a"
-    assert figure.data[0]["dimensions"][1]["range"] == (0, 2)
-    assert figure.data[0]["dimensions"][1]["values"] == (0, 1, 1, 2)
-    assert figure.data[0]["dimensions"][1]["ticktext"] == (1, 2, 10)
-    assert figure.data[0]["dimensions"][2]["label"] == "category_b"
-    assert figure.data[0]["dimensions"][2]["range"] == (0, 2)
-    assert figure.data[0]["dimensions"][2]["values"] == (2, 0, 2, 1)
-    assert figure.data[0]["dimensions"][2]["ticktext"] == (-1, 1, 2)
-
-
 def test_plot_parallel_coordinate_log_params() -> None:
     # Test with log params.
     study_log_params = create_study()
@@ -240,31 +179,32 @@ def test_plot_parallel_coordinate_log_params() -> None:
     assert figure.data[0]["dimensions"][2]["tickvals"] == (1.0, 2.0, math.log10(200))
 
 
-def test_plot_parallel_coordinate_sample_from_multiple_distribution() -> None:
+def test_plot_parallel_coordinate_with_categorical_numeric_params() -> None:
     # Test with sample from mulitiple distributions including categorical params
     # that can be interpreted as numeric params.
-
     study_multi_distro_params = create_study()
     study_multi_distro_params.add_trial(
         create_trial(
             value=0.0,
-            params={"param_a": "preferred", "param_b": 30, "param_c": 2},
+            params={"param_a": "preferred", "param_b": 2, "param_c": 30, "param_d": 2},
             distributions={
                 "param_a": CategoricalDistribution(("preferred", "opt")),
-                "param_b": LogUniformDistribution(1, 1000),
-                "param_c": CategoricalDistribution((1, 2, 10)),
+                "param_b": CategoricalDistribution((1, 2, 10)),
+                "param_c": LogUniformDistribution(1, 1000),
+                "param_d": CategoricalDistribution((1, -1, 2)),
             },
         )
     )
 
     study_multi_distro_params.add_trial(
         create_trial(
-            value=3.0,
-            params={"param_a": "opt", "param_b": 200, "param_c": 1},
+            value=1.0,
+            params={"param_a": "opt", "param_b": 1, "param_c": 200, "param_d": 2},
             distributions={
                 "param_a": CategoricalDistribution(("preferred", "opt")),
-                "param_b": LogUniformDistribution(1, 1000),
-                "param_c": CategoricalDistribution((1, 2, 10)),
+                "param_b": CategoricalDistribution((1, 2, 10)),
+                "param_c": LogUniformDistribution(1, 1000),
+                "param_d": CategoricalDistribution((1, -1, 2)),
             },
         )
     )
@@ -272,29 +212,47 @@ def test_plot_parallel_coordinate_sample_from_multiple_distribution() -> None:
     study_multi_distro_params.add_trial(
         create_trial(
             value=2.0,
-            params={"param_a": "preferred", "param_b": 10, "param_c": 10},
+            params={"param_a": "preferred", "param_b": 10, "param_c": 10, "param_d": 1},
             distributions={
                 "param_a": CategoricalDistribution(("preferred", "opt")),
-                "param_b": LogUniformDistribution(1, 1000),
-                "param_c": CategoricalDistribution((1, 2, 10)),
+                "param_b": CategoricalDistribution((1, 2, 10)),
+                "param_c": LogUniformDistribution(1, 1000),
+                "param_d": CategoricalDistribution((1, -1, 2)),
+            },
+        )
+    )
+
+    study_multi_distro_params.add_trial(
+        create_trial(
+            value=3.0,
+            params={"param_a": "opt", "param_b": 2, "param_c": 10, "param_d": -1},
+            distributions={
+                "param_a": CategoricalDistribution(("preferred", "opt")),
+                "param_b": CategoricalDistribution((1, 2, 10)),
+                "param_c": LogUniformDistribution(1, 1000),
+                "param_d": CategoricalDistribution((-1, 1, 2)),
             },
         )
     )
     figure = plot_parallel_coordinate(study_multi_distro_params)
-    assert len(figure.data[0]["dimensions"]) == 4
+    assert len(figure.data[0]["dimensions"]) == 5
     assert figure.data[0]["dimensions"][0]["label"] == "Objective Value"
     assert figure.data[0]["dimensions"][0]["range"] == (0.0, 3.0)
-    assert figure.data[0]["dimensions"][0]["values"] == (3.0, 0.0, 2.0)
+    assert figure.data[0]["dimensions"][0]["values"] == (1.0, 3.0, 0.0, 2.0)
     assert figure.data[0]["dimensions"][1]["label"] == "param_a"
     assert figure.data[0]["dimensions"][1]["range"] == (0, 1)
-    assert figure.data[0]["dimensions"][1]["values"] == (1, 0, 0)
+    assert figure.data[0]["dimensions"][1]["values"] == (1, 1, 0, 0)
     assert figure.data[0]["dimensions"][1]["ticktext"] == ("preferred", "opt")
     assert figure.data[0]["dimensions"][2]["label"] == "param_b"
-    assert figure.data[0]["dimensions"][2]["range"] == (1.0, math.log10(200))
-    assert figure.data[0]["dimensions"][2]["values"] == (math.log10(200), math.log10(30), 1.0)
-    assert figure.data[0]["dimensions"][2]["ticktext"] == ("10", "100", "200")
-    assert figure.data[0]["dimensions"][2]["tickvals"] == (1.0, 2.0, math.log10(200))
+    assert figure.data[0]["dimensions"][2]["range"] == (0, 2)
+    assert figure.data[0]["dimensions"][2]["values"] == (0, 1, 1, 2)
+    assert figure.data[0]["dimensions"][2]["ticktext"] == (1, 2, 10)
     assert figure.data[0]["dimensions"][3]["label"] == "param_c"
-    assert figure.data[0]["dimensions"][3]["range"] == (0, 2)
-    assert figure.data[0]["dimensions"][3]["values"] == (0, 1, 2)
-    assert figure.data[0]["dimensions"][3]["ticktext"] == (1, 2, 10)
+    assert figure.data[0]["dimensions"][3]["range"] == (1.0, math.log10(200))
+    assert figure.data[0]["dimensions"][3]["values"] == (math.log10(200), 1.0, math.log10(30), 1.0)
+    assert figure.data[0]["dimensions"][3]["ticktext"] == ("10", "100", "200")
+    assert figure.data[0]["dimensions"][3]["tickvals"] == (1.0, 2.0, math.log10(200))
+    assert figure.data[0]["dimensions"][4]["label"] == "param_d"
+    assert figure.data[0]["dimensions"][4]["range"] == (0, 2)
+    assert figure.data[0]["dimensions"][4]["values"] == (2, 0, 2, 1)
+    assert figure.data[0]["dimensions"][4]["ticktext"] == (-1, 1, 2)

--- a/tests/visualization_tests/test_parallel_coordinate.py
+++ b/tests/visualization_tests/test_parallel_coordinate.py
@@ -238,3 +238,63 @@ def test_plot_parallel_coordinate_log_params() -> None:
     assert figure.data[0]["dimensions"][2]["values"] == (1.0, math.log10(200), math.log10(30))
     assert figure.data[0]["dimensions"][2]["ticktext"] == ("10", "100", "200")
     assert figure.data[0]["dimensions"][2]["tickvals"] == (1.0, 2.0, math.log10(200))
+
+
+def test_plot_parallel_coordinate_sample_from_multiple_distribution() -> None:
+    # Test with sample from mulitiple distributions  including categorical params
+    # that can be interpreted as numeric params.
+
+    study_multi_distro_params = create_study()
+    study_multi_distro_params.add_trial(
+        create_trial(
+            value=0.0,
+            params={"param_a": "preferred", "param_b": 30, "param_c": 2},
+            distributions={
+                "param_a": CategoricalDistribution(("preferred", "opt")),
+                "param_b": LogUniformDistribution(1, 1000),
+                "param_c": CategoricalDistribution((1, 2, 10)),
+            },
+        )
+    )
+
+    study_multi_distro_params.add_trial(
+        create_trial(
+            value=3.0,
+            params={"param_a": "opt", "param_b": 200, "param_c": 1},
+            distributions={
+                "param_a": CategoricalDistribution(("preferred", "opt")),
+                "param_b": LogUniformDistribution(1, 1000),
+                "param_c": CategoricalDistribution((1, 2, 10)),
+            },
+        )
+    )
+
+    study_multi_distro_params.add_trial(
+        create_trial(
+            value=2.0,
+            params={"param_a": "preferred", "param_b": 10, "param_c": 10},
+            distributions={
+                "param_a": CategoricalDistribution(("preferred", "opt")),
+                "param_b": LogUniformDistribution(1, 1000),
+                "param_c": CategoricalDistribution((1, 2, 10)),
+            },
+        )
+    )
+    figure = plot_parallel_coordinate(study_multi_distro_params)
+    assert len(figure.data[0]["dimensions"]) == 4
+    assert figure.data[0]["dimensions"][0]["label"] == "Objective Value"
+    assert figure.data[0]["dimensions"][0]["range"] == (0.0, 3.0)
+    assert figure.data[0]["dimensions"][0]["values"] == (3.0, 0.0, 2.0)
+    assert figure.data[0]["dimensions"][1]["label"] == "param_a"
+    assert figure.data[0]["dimensions"][1]["range"] == (0, 1)
+    assert figure.data[0]["dimensions"][1]["values"] == (1, 0, 0)
+    assert figure.data[0]["dimensions"][1]["ticktext"] == ("preferred", "opt")
+    assert figure.data[0]["dimensions"][2]["label"] == "param_b"
+    assert figure.data[0]["dimensions"][2]["range"] == (1.0, math.log10(200))
+    assert figure.data[0]["dimensions"][2]["values"] == (math.log10(200), math.log10(30), 1.0)
+    assert figure.data[0]["dimensions"][2]["ticktext"] == ("10", "100", "200")
+    assert figure.data[0]["dimensions"][2]["tickvals"] == (1.0, 2.0, math.log10(200))
+    assert figure.data[0]["dimensions"][3]["label"] == "param_c"
+    assert figure.data[0]["dimensions"][3]["range"] == (0, 2)
+    assert figure.data[0]["dimensions"][3]["values"] == (0, 1, 2)
+    assert figure.data[0]["dimensions"][3]["ticktext"] == (1, 2, 10)

--- a/tests/visualization_tests/test_parallel_coordinate.py
+++ b/tests/visualization_tests/test_parallel_coordinate.py
@@ -241,7 +241,7 @@ def test_plot_parallel_coordinate_log_params() -> None:
 
 
 def test_plot_parallel_coordinate_sample_from_multiple_distribution() -> None:
-    # Test with sample from mulitiple distributions  including categorical params
+    # Test with sample from mulitiple distributions including categorical params
     # that can be interpreted as numeric params.
 
     study_multi_distro_params = create_study()

--- a/tests/visualization_tests/test_parallel_coordinate.py
+++ b/tests/visualization_tests/test_parallel_coordinate.py
@@ -130,15 +130,15 @@ def test_plot_parallel_coordinate_categorical_params() -> None:
 
 
 def test_plot_parallel_coordinate_categorical_numeric_params() -> None:
-    # Test with categorical params that can be interpeted numeric.
+    # Test with categorical params that can be interpreted as numeric params.
     study_categorical_params = create_study()
     study_categorical_params.add_trial(
         create_trial(
             value=0.0,
-            params={"category_a": 2, "category_b": 20},
+            params={"category_a": 2, "category_b": 2},
             distributions={
-                "category_a": CategoricalDistribution((1, 2)),
-                "category_b": CategoricalDistribution((10, 20, 30)),
+                "category_a": CategoricalDistribution((1, 2, 10)),
+                "category_b": CategoricalDistribution((-1, 1, 2)),
             },
         )
     )
@@ -146,10 +146,21 @@ def test_plot_parallel_coordinate_categorical_numeric_params() -> None:
     study_categorical_params.add_trial(
         create_trial(
             value=1.0,
-            params={"category_a": 1, "category_b": 30},
+            params={"category_a": 1, "category_b": 2},
             distributions={
-                "category_a": CategoricalDistribution((1, 2)),
-                "category_b": CategoricalDistribution((10, 20, 30)),
+                "category_a": CategoricalDistribution((1, 2, 10)),
+                "category_b": CategoricalDistribution((-1, 1, 2)),
+            },
+        )
+    )
+
+    study_categorical_params.add_trial(
+        create_trial(
+            value=3.0,
+            params={"category_a": 10, "category_b": 1},
+            distributions={
+                "category_a": CategoricalDistribution((1, 2, 10)),
+                "category_b": CategoricalDistribution((-1, 1, 2)),
             },
         )
     )
@@ -157,26 +168,26 @@ def test_plot_parallel_coordinate_categorical_numeric_params() -> None:
     study_categorical_params.add_trial(
         create_trial(
             value=2.0,
-            params={"category_a": 2, "category_b": 10},
+            params={"category_a": 2, "category_b": -1},
             distributions={
-                "category_a": CategoricalDistribution((1, 2)),
-                "category_b": CategoricalDistribution((10, 20, 30)),
+                "category_a": CategoricalDistribution((1, 2, 10)),
+                "category_b": CategoricalDistribution((-1, 1, 2)),
             },
         )
     )
     figure = plot_parallel_coordinate(study_categorical_params)
     assert len(figure.data[0]["dimensions"]) == 3
     assert figure.data[0]["dimensions"][0]["label"] == "Objective Value"
-    assert figure.data[0]["dimensions"][0]["range"] == (0.0, 2.0)
-    assert figure.data[0]["dimensions"][0]["values"] == (1.0, 2.0, 0.0)
+    assert figure.data[0]["dimensions"][0]["range"] == (0.0, 3.0)
+    assert figure.data[0]["dimensions"][0]["values"] == (1.0, 2.0, 0.0, 3.0)
     assert figure.data[0]["dimensions"][1]["label"] == "category_a"
-    assert figure.data[0]["dimensions"][1]["range"] == (0, 1)
-    assert figure.data[0]["dimensions"][1]["values"] == (0, 1, 1)
-    assert figure.data[0]["dimensions"][1]["ticktext"] == (1, 2)
+    assert figure.data[0]["dimensions"][1]["range"] == (0, 2)
+    assert figure.data[0]["dimensions"][1]["values"] == (0, 1, 1, 2)
+    assert figure.data[0]["dimensions"][1]["ticktext"] == (1, 2, 10)
     assert figure.data[0]["dimensions"][2]["label"] == "category_b"
     assert figure.data[0]["dimensions"][2]["range"] == (0, 2)
-    assert figure.data[0]["dimensions"][2]["values"] == (2, 0, 1)
-    assert figure.data[0]["dimensions"][2]["ticktext"] == (10, 20, 30)
+    assert figure.data[0]["dimensions"][2]["values"] == (2, 0, 2, 1)
+    assert figure.data[0]["dimensions"][2]["ticktext"] == (-1, 1, 2)
 
 
 def test_plot_parallel_coordinate_log_params() -> None:

--- a/tests/visualization_tests/test_parallel_coordinate.py
+++ b/tests/visualization_tests/test_parallel_coordinate.py
@@ -129,6 +129,56 @@ def test_plot_parallel_coordinate_categorical_params() -> None:
     assert figure.data[0]["dimensions"][2]["ticktext"] == ("net", "una")
 
 
+def test_plot_parallel_coordinate_categorical_numeric_params() -> None:
+    # Test with categorical params that can be interpeted numeric.
+    study_categorical_params = create_study()
+    study_categorical_params.add_trial(
+        create_trial(
+            value=0.0,
+            params={"category_a": 2, "category_b": 20},
+            distributions={
+                "category_a": CategoricalDistribution((1, 2)),
+                "category_b": CategoricalDistribution((10, 20, 30)),
+            },
+        )
+    )
+
+    study_categorical_params.add_trial(
+        create_trial(
+            value=1.0,
+            params={"category_a": 1, "category_b": 30},
+            distributions={
+                "category_a": CategoricalDistribution((1, 2)),
+                "category_b": CategoricalDistribution((10, 20, 30)),
+            },
+        )
+    )
+
+    study_categorical_params.add_trial(
+        create_trial(
+            value=2.0,
+            params={"category_a": 2, "category_b": 10},
+            distributions={
+                "category_a": CategoricalDistribution((1, 2)),
+                "category_b": CategoricalDistribution((10, 20, 30)),
+            },
+        )
+    )
+    figure = plot_parallel_coordinate(study_categorical_params)
+    assert len(figure.data[0]["dimensions"]) == 3
+    assert figure.data[0]["dimensions"][0]["label"] == "Objective Value"
+    assert figure.data[0]["dimensions"][0]["range"] == (0.0, 2.0)
+    assert figure.data[0]["dimensions"][0]["values"] == (1.0, 2.0, 0.0)
+    assert figure.data[0]["dimensions"][1]["label"] == "category_a"
+    assert figure.data[0]["dimensions"][1]["range"] == (0, 1)
+    assert figure.data[0]["dimensions"][1]["values"] == (0, 1, 1)
+    assert figure.data[0]["dimensions"][1]["ticktext"] == (1, 2)
+    assert figure.data[0]["dimensions"][2]["label"] == "category_b"
+    assert figure.data[0]["dimensions"][2]["range"] == (0, 2)
+    assert figure.data[0]["dimensions"][2]["values"] == (2, 0, 1)
+    assert figure.data[0]["dimensions"][2]["ticktext"] == (10, 20, 30)
+
+
 def test_plot_parallel_coordinate_log_params() -> None:
     # Test with log params.
     study_log_params = create_study()


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->
## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
For clarity, when every values of axis in `plot_parallel_coordinate` are numeric, it's better to have sorted.
And see also https://github.com/optuna/optuna/issues/2455.

## Description of the changes
<!-- Describe the changes in this PR. -->
When called 
When the method is called with categorical values of numeric, values for plotting is sorted.
After all the values for the plot are determined, change the order of the values according to the order of categorical values. 

## TODO
- [x] Implement logic.
- [x] Implement tests.