### PR TITLE
Fix `bounds`' shape in the document

### DIFF
--- a/optuna/integration/botorch.py
+++ b/optuna/integration/botorch.py
@@ -76,8 +76,8 @@ def qei_candidates_func(
             constraints. A constraint is violated if strictly larger than 0. If no constraints are
             involved in the optimization, this argument will be :obj:`None`.
         bounds:
-            Search space bounds. A ``torch.Tensor`` of shape ``(n_params, 2)``. ``n_params`` is
-            identical to that of ``train_x``. The first and the second column correspond to the
+            Search space bounds. A ``torch.Tensor`` of shape ``(2, n_params)``. ``n_params`` is
+            identical to that of ``train_x``. The first and the second rows correspond to the
             lower and upper bounds for each parameter respectively.
 
     Returns:


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

I think that the current  `bounds`' shape is swapped.

After `bounds` is initialised by [here](https://github.com/optuna/optuna/blob/8ee931a77343f64e7ba270f0d37d7bb611dbe221/optuna/_transform.py#L172), it is [transposed](https://github.com/optuna/optuna/blob/8ee931a77343f64e7ba270f0d37d7bb611dbe221/optuna/integration/botorch.py#L498) in `sample_relative` in botorch sampler. Thus `bounds`' shape is `(2, n_params)` that is passed to `qei_candidates_func`. Indeed, according to the [botorch documentation](https://botorch.org/api/optim.html#module-botorch.optim.optimize), `bounds`' shape is supposed to be `(2, n_param)`.

## Description of the changes
<!-- Describe the changes in this PR. -->

Fix the shape and update the document.
