### PR TITLE
Simplify documentation of `FrozenTrial`

### DIFF
--- a/optuna/trial/_frozen.py
+++ b/optuna/trial/_frozen.py
@@ -53,6 +53,11 @@ class FrozenTrial(BaseTrial):
             assert objective(study.best_trial) == study.best_value
 
     .. note::
+        Instances are mutable, despite the name.
+        For instance, :func:`~optuna.trial.FrozenTrial.set_user_attr` will update user attributes
+        of objects in-place.
+
+    .. note::
         Please refer to :class:`~optuna.trial.Trial` for details of methods and properties.
 
 

--- a/optuna/trial/_frozen.py
+++ b/optuna/trial/_frozen.py
@@ -53,46 +53,6 @@ class FrozenTrial(BaseTrial):
             assert objective(study.best_trial) == study.best_value
 
     .. note::
-        Attributes are set in :func:`optuna.Study.optimize`,
-        but several attributes can be updated after the optimization.
-        That means such attributes are overwritten by the re-evaluation
-        if your objective updates attributes of :class:`~optuna.trial.Trial`.
-
-
-        Example:
-
-            Overwritten attributes.
-
-            .. testcode::
-
-                import copy
-                import datetime
-
-                import optuna
-
-
-                def objective(trial):
-                    x = trial.suggest_uniform("x", -1, 1)
-
-                    # this user attribute always differs
-                    trial.set_user_attr("evaluation time", datetime.datetime.now())
-
-                    return x ** 2
-
-
-                study = optuna.create_study()
-                study.optimize(objective, n_trials=3)
-
-                best_trial = study.best_trial
-                best_trial_copy = copy.deepcopy(best_trial)
-
-                # re-evaluate
-                objective(best_trial)
-
-                # the user attribute is overwritten by re-evaluation
-                assert best_trial.user_attrs != best_trial_copy.user_attrs
-
-    .. note::
         Please refer to :class:`~optuna.trial.Trial` for details of methods and properties.
 
 

--- a/optuna/trial/_frozen.py
+++ b/optuna/trial/_frozen.py
@@ -57,6 +57,40 @@ class FrozenTrial(BaseTrial):
         For instance, :func:`~optuna.trial.FrozenTrial.set_user_attr` will update user attributes
         of objects in-place.
 
+
+        Example:
+
+            Overwritten attributes.
+
+            .. testcode::
+
+                import copy
+                import datetime
+
+                import optuna
+
+
+                def objective(trial):
+                    x = trial.suggest_uniform("x", -1, 1)
+
+                    # this user attribute always differs
+                    trial.set_user_attr("evaluation time", datetime.datetime.now())
+
+                    return x ** 2
+
+
+                study = optuna.create_study()
+                study.optimize(objective, n_trials=3)
+
+                best_trial = study.best_trial
+                best_trial_copy = copy.deepcopy(best_trial)
+
+                # re-evaluate
+                objective(best_trial)
+
+                # the user attribute is overwritten by re-evaluation
+                assert best_trial.user_attrs != best_trial_copy.user_attrs
+
     .. note::
         Please refer to :class:`~optuna.trial.Trial` for details of methods and properties.
 


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation

There was a report about a note in the documentation of `FrozenTrial` being a bit confusing. 
The note addressed the fact that the class is actually not "frozen" and can be mutated.
However, I expect it to be intuitive to most users given the dynamic nature of Python.


## Description of the changes

Removes the note from the docs of `FrozenTrial` that lead to the above report.
