### PR TITLE
Changed y-axis and x-axis access according to matplotlib docs.

### DIFF
--- a/optuna/visualization/matplotlib/_parallel_coordinate.py
+++ b/optuna/visualization/matplotlib/_parallel_coordinate.py
@@ -188,7 +188,7 @@ def _get_parallel_coordinate_plot(
             ax2.set_yscale("log")
         ax2.spines["top"].set_visible(False)
         ax2.spines["bottom"].set_visible(False)
-        ax2.get_xaxis().set_visible(False)
+        ax2.xaxis.set_visible(False)
         ax2.plot([1] * len(param_values[i]), param_values[i], visible=False)
         ax2.spines["right"].set_position(("axes", (i + 1) / len(sorted_params)))
         if p_name in cat_param_names:

--- a/tests/visualization_tests/matplotlib_tests/test_contour.py
+++ b/tests/visualization_tests/matplotlib_tests/test_contour.py
@@ -154,11 +154,11 @@ def test_plot_contour(params: Optional[List[str]]) -> None:
     elif params is None:
         assert figure.shape == (len(study.best_params), len(study.best_params))
         for i in range(len(study.best_params)):
-            assert figure[i][0].get_yaxis().label.get_text() == list(study.best_params)[i]
+            assert figure[i][0].yaxis.label.get_text() == list(study.best_params)[i]
     else:
         assert figure.shape == (len(params), len(params))
         for i in range(len(params)):
-            assert figure[i][0].get_yaxis().label.get_text() == list(params)[i]
+            assert figure[i][0].yaxis.label.get_text() == list(params)[i]
 
 
 @pytest.mark.parametrize(
@@ -178,7 +178,7 @@ def test_plot_contour_customized_target(params: List[str]) -> None:
     else:
         assert figure.shape == (len(params), len(params))
         for i in range(len(params)):
-            assert figure[i][0].get_yaxis().label.get_text() == list(params)[i]
+            assert figure[i][0].yaxis.label.get_text() == list(params)[i]
 
 
 @pytest.mark.parametrize(
@@ -197,4 +197,4 @@ def test_plot_contour_customized_target_name(params: List[str]) -> None:
     else:
         assert figure.shape == (len(params), len(params))
         for i in range(len(params)):
-            assert figure[i][0].get_yaxis().label.get_text() == list(params)[i]
+            assert figure[i][0].yaxis.label.get_text() == list(params)[i]

--- a/tests/visualization_tests/matplotlib_tests/test_edf.py
+++ b/tests/visualization_tests/matplotlib_tests/test_edf.py
@@ -29,7 +29,7 @@ def test_plot_optimization_history(direction: str) -> None:
     study0.optimize(lambda t: t.suggest_float("x", 0, 5), n_trials=10)
     figure = plot_edf(study0)
     assert len(figure.get_lines()) == 1
-    assert figure.get_xaxis().label.get_text() == "Objective Value"
+    assert figure.xaxis.label.get_text() == "Objective Value"
 
     # Test with two studies.
     study1 = create_study(direction=direction)
@@ -51,4 +51,4 @@ def test_plot_optimization_history(direction: str) -> None:
     study0.optimize(lambda t: t.suggest_float("x", 0, 5), n_trials=10)
     figure = plot_edf(study0, target_name="Target Name")
     assert len(figure.get_lines()) == 1
-    assert figure.get_xaxis().label.get_text() == "Target Name"
+    assert figure.xaxis.label.get_text() == "Target Name"

--- a/tests/visualization_tests/matplotlib_tests/test_optimization_history.py
+++ b/tests/visualization_tests/matplotlib_tests/test_optimization_history.py
@@ -44,7 +44,7 @@ def test_plot_optimization_history(direction: str) -> None:
     # Test customized target name.
     figure = plot_optimization_history(study, target_name="Target Name")
     assert len(figure.get_lines()) == 1
-    assert figure.get_yaxis().label.get_text() == "Target Name"
+    assert figure.yaxis.label.get_text() == "Target Name"
 
     # Ignore failed trials.
     def fail_objective(_: Trial) -> float:

--- a/tests/visualization_tests/matplotlib_tests/test_param_importances.py
+++ b/tests/visualization_tests/matplotlib_tests/test_param_importances.py
@@ -26,17 +26,17 @@ def test_plot_param_importances() -> None:
     # Test with a trial.
     figure = plot_param_importances(study)
     assert len(figure.get_lines()) == 0
-    assert figure.get_xaxis().label.get_text() == "Importance for Objective Value"
+    assert figure.xaxis.label.get_text() == "Importance for Objective Value"
 
     # Test with an evaluator.
     plot_param_importances(study, evaluator=MeanDecreaseImpurityImportanceEvaluator())
     assert len(figure.get_lines()) == 0
-    assert figure.get_xaxis().label.get_text() == "Importance for Objective Value"
+    assert figure.xaxis.label.get_text() == "Importance for Objective Value"
 
     # Test with a trial to select parameter.
     figure = plot_param_importances(study, params=["param_b"])
     assert len(figure.get_lines()) == 0
-    assert figure.get_xaxis().label.get_text() == "Importance for Objective Value"
+    assert figure.xaxis.label.get_text() == "Importance for Objective Value"
 
     # Test with a customized target value.
     with pytest.warns(UserWarning):
@@ -48,7 +48,7 @@ def test_plot_param_importances() -> None:
     # Test with a customized target name.
     figure = plot_param_importances(study, target_name="Target Name")
     assert len(figure.get_lines()) == 0
-    assert figure.get_xaxis().label.get_text() == "Importance for Target Name"
+    assert figure.xaxis.label.get_text() == "Importance for Target Name"
 
     # Test with wrong parameters.
     with pytest.raises(ValueError):

--- a/tests/visualization_tests/matplotlib_tests/test_slice.py
+++ b/tests/visualization_tests/matplotlib_tests/test_slice.py
@@ -30,25 +30,25 @@ def test_plot_slice() -> None:
     assert len(figure) == 2
     assert len(figure[0].get_lines()) == 0
     assert len(figure[1].get_lines()) == 0
-    assert figure[0].get_yaxis().label.get_text() == "Objective Value"
+    assert figure[0].yaxis.label.get_text() == "Objective Value"
 
     # Test with a trial to select parameter.
     figure = plot_slice(study, params=["param_a"])
     assert len(figure.get_lines()) == 0
-    assert figure.get_yaxis().label.get_text() == "Objective Value"
+    assert figure.yaxis.label.get_text() == "Objective Value"
 
     # Test with a customized target value.
     with pytest.warns(UserWarning):
         figure = plot_slice(study, params=["param_a"], target=lambda t: t.params["param_b"])
     assert len(figure.get_lines()) == 0
-    assert figure.get_yaxis().label.get_text() == "Objective Value"
+    assert figure.yaxis.label.get_text() == "Objective Value"
 
     # Test with a customized target name.
     figure = plot_slice(study, target_name="Target Name")
     assert len(figure) == 2
     assert len(figure[0].get_lines()) == 0
     assert len(figure[1].get_lines()) == 0
-    assert figure[0].get_yaxis().label.get_text() == "Target Name"
+    assert figure[0].yaxis.label.get_text() == "Target Name"
 
     # Test with wrong parameters.
     with pytest.raises(ValueError):
@@ -83,15 +83,15 @@ def test_plot_slice_log_scale() -> None:
     figure = plot_slice(study, params=["y_log"])
 
     assert len(figure.get_lines()) == 0
-    assert figure.get_xaxis().label.get_text() == "y_log"
+    assert figure.xaxis.label.get_text() == "y_log"
     figure = plot_slice(study, params=["x_linear"])
     assert len(figure.get_lines()) == 0
-    assert figure.get_xaxis().label.get_text() == "x_linear"
+    assert figure.xaxis.label.get_text() == "x_linear"
 
     # Plot multiple parameters.
     figure = plot_slice(study)
     assert len(figure) == 2
     assert len(figure[0].get_lines()) == 0
     assert len(figure[1].get_lines()) == 0
-    assert figure[0].get_xaxis().label.get_text() == "x_linear"
-    assert figure[1].get_xaxis().label.get_text() == "y_log"
+    assert figure[0].xaxis.label.get_text() == "x_linear"
+    assert figure[1].xaxis.label.get_text() == "y_log"


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
As discussed [here](https://github.com/optuna/optuna/issues/2643#issuecomment-880877269), the matplotlib suggest that accessing the axis  using `get_xaxis` and `get_yaxis` is 'discouraged'. The maplotlib docs [link](https://matplotlib.org/stable/api/_as_gen/matplotlib.axes.Axes.get_yaxis.html).
## Description of the changes
<!-- Describe the changes in this PR. -->
- Changed access method to an attribute for x-axis and y-axis
