### PR TITLE
Support multi-objective optimization in `WeightsAndBiasesCallback`

### DIFF
--- a/optuna/integration/wandb.py
+++ b/optuna/integration/wandb.py
@@ -64,6 +64,10 @@ class WeightsAndBiasesCallback(object):
             Name assigned to optimized metric. In case of multi-objective optimization,
             list of names can be passed. Those names will be assigned
             to metrics in the order returned by objective function.
+            If single name is provided, or this argument is left to default value,
+            it will be broadcasted to each objective with a number suffix in order
+            returned by objective function e.g. two objectives and default metric name
+            will be logged as ``value_0`` and ``value_1``.
         wandb_kwargs:
             Set of arguments passed when initializing Weights & Biases run.
             Please refer to `Weights & Biases API documentation

--- a/optuna/integration/wandb.py
+++ b/optuna/integration/wandb.py
@@ -19,7 +19,7 @@ class WeightsAndBiasesCallback(object):
 
     This callback enables tracking of Optuna study in
     Weights & Biases. The study is tracked as a single experiment
-    run, where all suggested hyperparameters and optimized metric
+    run, where all suggested hyperparameters and optimized metrics
     are logged and plotted as a function of optimizer steps.
 
     .. note::
@@ -36,9 +36,6 @@ class WeightsAndBiasesCallback(object):
     .. note::
         To ensure correct trial order in Weights & Biases, this callback
         should only be used with ``study.optimize(n_jobs=1)``.
-
-    .. note::
-        This callback currently supports only single-objective optimization.
 
     Example:
 
@@ -64,13 +61,17 @@ class WeightsAndBiasesCallback(object):
 
     Args:
         metric_name:
-            Name of the optimized metric. Since the metric itself is just a number,
-            ``metric_name`` can be used to give it a name. So you know later
-            if it was roc-auc or accuracy.
+            Name assigned to optimized metric. In case of multi-objective optimization,
+            list of names can be passed. Those names will be assigned
+            to metrics in the order returned by objective function.
         wandb_kwargs:
             Set of arguments passed when initializing Weights & Biases run.
             Please refer to `Weights & Biases API documentation
             <https://docs.wandb.ai/ref/python/init>`_ for more details.
+
+    Raises:
+        :exc:`RuntimeError`:
+            If there are missing or extra metric names in multi-objective optimization.
     """
 
     def __init__(

--- a/tests/integration_tests/test_wandb.py
+++ b/tests/integration_tests/test_wandb.py
@@ -124,7 +124,7 @@ def test_multiobjective_values_registered_on_epoch(
     assert kall[1] == {"step": 0}
 
 
-@pytest.mark.parametrize("metrics", [(["foo"]), (["foo", "bar", "baz"])])
+@pytest.mark.parametrize("metrics", [["foo"], ["foo", "bar", "baz"]])
 @mock.patch("optuna.integration.wandb.wandb")
 def test_multiobjective_raises_on_name_mismatch(wandb: mock.MagicMock, metrics: List[str]) -> None:
 


### PR DESCRIPTION
This PR introduces support for tracking multi-objective optimization in Weights & Biases UI by extending functionality of `WeightsAndBiasesCallback`

Now, arbitrary number of trial values can be tracked with distinctive names, and optimization directions.

## Motivation
Follow up to [#2781 review](https://github.com/optuna/optuna/pull/2781#pullrequestreview-701578675)

## Description of the changes

*  Modify `WeightsAndBiasesCallback` to support multi-objective optimization
*  Modify and parametrize some of existing tests to facilitate the change
*  Add new test cases

## Example

### Objective function
Using modified version of objective function from #2553 with two objectives.

```python
# [...]

def objective(self, trial):
    # Parameters.
    trial_alpha = trial.suggest_uniform("alpha", low=-10, high=10)
    trial_beta = trial.suggest_uniform("beta", low=-10, high=10)

    # Prediction and loss.
    y_hat = self.X1 * trial_alpha + self.X2 * trial_beta
    mse = ((self.y - y_hat) ** 2).mean()
    mae = (np.abs(self.y - y_hat)).mean()

    return mse,  mae

# [...]
```
### Optimization

```python
black_box = Objective(seed=4444)
sampler = optuna.samplers.TPESampler(seed=4444)

wandb_kwargs = {"project": "optuna"}

wandbc = WeightsAndBiasesCallback(
    metric_name=["mse", "mae"],
    wandb_kwargs=wandb_kwargs
)

study = optuna.create_study(directions=["minimize", "minimize"], sampler=sampler)
study.optimize(black_box, n_trials=100, callbacks=[wandbc])
```
### W&B UI results

![image](https://user-images.githubusercontent.com/37713008/127893994-a4cdf6ca-4987-4e6d-b28d-81800b59a0e3.png)

![image](https://user-images.githubusercontent.com/37713008/127894245-930caa0a-bc52-4c79-a915-32e39828338d.png)
