### PR TITLE
Remove storage URI from `ask` and `tell` CLI subcommands

### DIFF
--- a/optuna/cli.py
+++ b/optuna/cli.py
@@ -457,10 +457,7 @@ class _Ask(_BaseCommand):
             }
         }
 
-        self.logger.info(
-            f"Asked trial {trial.number} with parameters {trial.params} in study "
-            f"'{study.study_name}' and storage '{storage_url}'."
-        )
+        self.logger.info(f"Asked trial {trial.number} with parameters {trial.params}.")
 
         if parsed_args.out == "json":
             print(json.dumps(out))
@@ -507,7 +504,7 @@ class _Tell(_BaseCommand):
 
         self.logger.info(
             f"Told trial {parsed_args.trial_number} with values {parsed_args.values} and state "
-            f"{state} in study '{study.study_name}' and storage '{storage_url}'."
+            f"{state}."
         )
 
         return 0


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation

Storage URI may contain sensitive information which ideally isn't logged by `optuna {ask,tell}`.

## Description of the changes

Removes the storage URI as well as the study name from the log. The study name can be kept but was removed to make the log somewhat more consistent with the optimization log and the study name is already logged when loading the study.
