### PR TITLE
Fix `datetime_complete` in `_CachedStorage`

### DIFF
--- a/optuna/storages/_cached_storage.py
+++ b/optuna/storages/_cached_storage.py
@@ -209,8 +209,9 @@ class _CachedStorage(BaseStorage):
                 updates.state = state
 
                 if cached_trial.state.is_finished():
-                    updates.datetime_complete = datetime.datetime.now()
-                    cached_trial.datetime_complete = datetime.datetime.now()
+                    now = datetime.datetime.now()
+                    updates.datetime_complete = now
+                    cached_trial.datetime_complete = now
                 return self._flush_trial(trial_id)
 
         ret = self._backend.set_trial_state(trial_id, state)

--- a/tests/storages_tests/test_cached_storage.py
+++ b/tests/storages_tests/test_cached_storage.py
@@ -36,7 +36,7 @@ def test_set_trial_state() -> None:
     storage.set_trial_state(trial_id, TrialState.COMPLETE)
 
     cached_trial = storage.get_trial(trial_id)
-    base_trial = storage._backend.get_trial(trial_id)
+    base_trial = base_storage.get_trial(trial_id)
 
     assert cached_trial == base_trial
 

--- a/tests/storages_tests/test_cached_storage.py
+++ b/tests/storages_tests/test_cached_storage.py
@@ -28,6 +28,19 @@ def test_create_trial() -> None:
     storage.create_new_trial(study_id)
 
 
+def test_set_trial_state() -> None:
+    base_storage = RDBStorage("sqlite:///:memory:")
+    storage = _CachedStorage(base_storage)
+    study_id = storage.create_new_study("test-study")
+    trial_id = storage.create_new_trial(study_id)
+    storage.set_trial_state(trial_id, TrialState.COMPLETE)
+
+    cached_trial = storage.get_trial(trial_id)
+    base_trial = storage._backend.get_trial(trial_id)
+
+    assert cached_trial == base_trial
+
+
 def test_cached_set() -> None:
 
     """Test CachedStorage does not flush to persistent storages.


### PR DESCRIPTION
## Motivation
The cached `datetime_complete` is inconsistent with the one in the RDB. This PR fixes the bug.

## Description of the changes
- Fix `datetime_complete` in `_CachedStorage`
- Add test