### PR TITLE
Avoid keras 2.6.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -101,7 +101,9 @@ def get_extras_require() -> Dict[str, List[str]]:
             "scikit-learn>=0.24.2",
             "scikit-optimize",
             "xgboost",
-            "keras",
+            # TODO(nzw0301): Remove the version constraint after resolving the CI error
+            # by keras 2.6.0
+            "keras<2.6.0",
             # TODO(HideakiImamura): Remove the version constraint after resolving the issue
             # https://github.com/keras-team/keras/issues/14632
             "tensorflow<2.5.0 ; python_version<'3.9'",
@@ -146,7 +148,9 @@ def get_extras_require() -> Dict[str, List[str]]:
             "scikit-learn>=0.24.2",
             "scikit-optimize",
             "xgboost",
-            "keras ; python_version<'3.9'",
+            # TODO(nzw0301): Remove the version constraint after resolving the CI error
+            # by keras 2.6.0
+            "keras<2.6.0 ; python_version<'3.9'",
             # TODO(HideakiImamura): Remove the version constraint after resolving the issue
             # https://github.com/keras-team/keras/issues/14632
             "tensorflow<2.5.0 ; python_version<'3.9'",


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

The current master branch fails in CI because of the latest release of keras 2.6.0. This PR is a hotfix.

Failed CI example: https://github.com/optuna/optuna/pull/2847/checks?check_run_id=3286012452


## Description of the changes
<!-- Describe the changes in this PR. -->

Introduce the version constraint of keras: `keras<2.6.0`.
