### PR TITLE
Drop tensorflow constraints

### DIFF
--- a/.github/workflows/tests-integration.yml
+++ b/.github/workflows/tests-integration.yml
@@ -60,12 +60,6 @@ jobs:
         if [ ${{ matrix.python-version }} = 3.6 ]; then
           pytest tests/integration_tests \
             --ignore tests/integration_tests/test_botorch.py
-        elif  [ ${{ matrix.python-version }} = 3.9 ]; then
-          pytest tests/integration_tests \
-            --ignore tests/integration_tests/test_keras.py \
-            --ignore tests/integration_tests/test_tensorflow.py \
-            --ignore tests/integration_tests/test_tfkeras.py \
-            --ignore tests/integration_tests/test_tensorboard.py
         else
           pytest -s tests/integration_tests
         fi

--- a/setup.py
+++ b/setup.py
@@ -101,12 +101,7 @@ def get_extras_require() -> Dict[str, List[str]]:
             "scikit-learn>=0.24.2",
             "scikit-optimize",
             "xgboost",
-            # TODO(nzw0301): Remove the version constraint after resolving the CI error
-            # by keras 2.6.0
-            "keras<2.6.0",
-            # TODO(HideakiImamura): Remove the version constraint after resolving the issue
-            # https://github.com/keras-team/keras/issues/14632
-            "tensorflow<2.5.0 ; python_version<'3.9'",
+            "tensorflow",
             "tensorflow-datasets",
             "pytorch-ignite",
             "pytorch-lightning>=1.0.2",
@@ -148,13 +143,8 @@ def get_extras_require() -> Dict[str, List[str]]:
             "scikit-learn>=0.24.2",
             "scikit-optimize",
             "xgboost",
-            # TODO(nzw0301): Remove the version constraint after resolving the CI error
-            # by keras 2.6.0
-            "keras<2.6.0 ; python_version<'3.9'",
-            # TODO(HideakiImamura): Remove the version constraint after resolving the issue
-            # https://github.com/keras-team/keras/issues/14632
-            "tensorflow<2.5.0 ; python_version<'3.9'",
-            "tensorflow-datasets ; python_version<'3.9'",
+            "tensorflow",
+            "tensorflow-datasets",
             "pytorch-ignite",
             "pytorch-lightning>=1.0.2",
             "skorch",


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

TensorFlow and Keras 2.6.0 have been released. Since this release, `tf.keras` uses [`keras-team/keras`](https://github.com/keras-team/keras) instead of the keras under the TensorFlow repo. 


## Description of the changes
<!-- Describe the changes in this PR. -->

Remove the constraints introduced by 

- https://github.com/optuna/optuna/pull/2851
- https://github.com/optuna/optuna/pull/2674
- https://github.com/optuna/optuna/pull/2530