### PR TITLE
Fix a BoTorch deprecation warning

### DIFF
--- a/optuna/integration/botorch.py
+++ b/optuna/integration/botorch.py
@@ -34,7 +34,7 @@ with try_import() as _imports:
     from botorch.models.transforms.outcome import Standardize
     from botorch.optim import optimize_acqf
     from botorch.sampling.samplers import SobolQMCNormalSampler
-    from botorch.utils.multi_objective.box_decomposition import NondominatedPartitioning
+    from botorch.utils.multi_objective.box_decompositions import NondominatedPartitioning
     from botorch.utils.multi_objective.scalarization import get_chebyshev_scalarization
     from botorch.utils.sampling import sample_simplex
     from botorch.utils.transforms import normalize


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation

Deprecation warnings should in general be addressed. 

## Description of the changes

Fixes a deprecation warning from BoTorch.

> site-packages/botorch/utils/multi_objective/box_decomposition.py:24: DeprecationWarning: The botorch.utils.multi_objective.box_decomposition module has been renamed to botorch.utils.multi_objective.box_decompositions. botorch.utils.multi_objective.box_decomposition will be removed in the next release.
    DeprecationWarning,
