### PR TITLE
Fixed relational operator not including `1`

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -672,7 +672,7 @@ def test_ask(
 
         assert output["trial"]["number"] == 0
         assert len(output["trial"]["params"]) == 2
-        assert 0 <= output["trial"]["params"]["x"] < 1
+        assert 0 <= output["trial"]["params"]["x"] <= 1
         assert output["trial"]["params"]["y"] == "foo"
 
 


### PR DESCRIPTION
## Motivation
Since the range of `UniformDistribution` is a closed interval, `output["trial"]["params"]["x"]` can be `1`, but assert statement does not include `1`.

## Description of the changes
Changed relational operator from `<` to `<=`.