### PR TITLE
Align CLI output format

### DIFF
--- a/optuna/cli.py
+++ b/optuna/cli.py
@@ -356,7 +356,12 @@ class _Studies(_BaseCommand):
             default="table",
             help="Output format.",
         )
-        parser.add_argument("--flatten", default=False, action="store_true", help="Output format.")
+        parser.add_argument(
+            "--flatten",
+            default=False,
+            action="store_true",
+            help="Flatten nested columns such as directions.",
+        )
         return parser
 
     def take_action(self, parsed_args: Namespace) -> None:
@@ -405,7 +410,12 @@ class _Trials(_BaseCommand):
             default="table",
             help="Output format.",
         )
-        parser.add_argument("--flatten", default=False, action="store_true", help="Output format.")
+        parser.add_argument(
+            "--flatten",
+            default=False,
+            action="store_true",
+            help="Flatten nested columns such as params and user_attrs.",
+        )
         return parser
 
     def take_action(self, parsed_args: Namespace) -> None:
@@ -452,7 +462,12 @@ class _BestTrial(_BaseCommand):
             default="table",
             help="Output format.",
         )
-        parser.add_argument("--flatten", default=False, action="store_true", help="Output format.")
+        parser.add_argument(
+            "--flatten",
+            default=False,
+            action="store_true",
+            help="Flatten nested columns such as params and user_attrs.",
+        )
         return parser
 
     def take_action(self, parsed_args: Namespace) -> None:
@@ -503,7 +518,12 @@ class _BestTrials(_BaseCommand):
             default="table",
             help="Output format.",
         )
-        parser.add_argument("--flatten", default=False, action="store_true", help="Output format.")
+        parser.add_argument(
+            "--flatten",
+            default=False,
+            action="store_true",
+            help="Flatten nested columns such as params and user_attrs.",
+        )
         return parser
 
     def take_action(self, parsed_args: Namespace) -> None:
@@ -761,7 +781,12 @@ class _Ask(_BaseCommand):
             default="json",
             help="Output format.",
         )
-        parser.add_argument("--flatten", default=False, action="store_true", help="Output format.")
+        parser.add_argument(
+            "--flatten",
+            default=False,
+            action="store_true",
+            help="Flatten nested columns such as params.",
+        )
         return parser
 
     def take_action(self, parsed_args: Namespace) -> None:

--- a/optuna/cli.py
+++ b/optuna/cli.py
@@ -104,7 +104,12 @@ def _convert_to_dict(
             for column in columns:
                 if column in record:
                     value = _format_value(record[column])
-                    if column[1] != "":
+                    if isinstance(column[1], int):
+                        if attrs[column[0]] == {}:
+                            attrs[column[0]] = []
+                        attrs[column[0]] += [None] * max(column[1] + 1 - len(attrs[column[0]]), 0)
+                        attrs[column[0]][column[1]] = value
+                    elif column[1] != "":
                         attrs[column[0]][column[1]] = value
                     else:
                         attrs[column[0]] = value

--- a/optuna/cli.py
+++ b/optuna/cli.py
@@ -751,7 +751,7 @@ class _Ask(_BaseCommand):
             "--format",
             type=str,
             choices=("json", "table", "yaml"),
-            default="table",
+            default="json",
             help="Output format.",
         )
         parser.add_argument("--flatten", default=False, action="store_true", help="Output format.")

--- a/optuna/cli.py
+++ b/optuna/cli.py
@@ -49,7 +49,7 @@ def _check_storage_url(storage_url: Optional[str]) -> str:
 
 
 def _format_value(value: Any) -> Any:
-    #  Format value that can be serialized to JSON or YAML
+    #  Format value that can be serialized to JSON or YAML.
     if value is None or isinstance(value, (int, float)):
         return value
     elif isinstance(value, datetime.datetime):
@@ -85,15 +85,16 @@ def _convert_to_dict(
         for record in records:
             row = {}
             for column in columns:
-                if column in record:
-                    value = _format_value(record[column])
-                    if column[1] != "":
-                        row[f"{column[0]}_{column[1]}"] = value
-                    elif any(isinstance(record.get(column), (list, tuple)) for record in records):
-                        for i, v in enumerate(value):
-                            row[f"{column[0]}_{i}"] = v
-                    else:
-                        row[f"{column[0]}"] = value
+                if column not in record:
+                    continue
+                value = _format_value(record[column])
+                if column[1] != "":
+                    row[f"{column[0]}_{column[1]}"] = value
+                elif any(isinstance(record.get(column), (list, tuple)) for record in records):
+                    for i, v in enumerate(value):
+                        row[f"{column[0]}_{i}"] = v
+                else:
+                    row[f"{column[0]}"] = value
             ret.append(row)
     else:
         for column in columns:
@@ -102,17 +103,18 @@ def _convert_to_dict(
         for record in records:
             attrs: Dict[str, Any] = {column_name: {} for column_name in header}
             for column in columns:
-                if column in record:
-                    value = _format_value(record[column])
-                    if isinstance(column[1], int):
-                        if attrs[column[0]] == {}:
-                            attrs[column[0]] = []
-                        attrs[column[0]] += [None] * max(column[1] + 1 - len(attrs[column[0]]), 0)
-                        attrs[column[0]][column[1]] = value
-                    elif column[1] != "":
-                        attrs[column[0]][column[1]] = value
-                    else:
-                        attrs[column[0]] = value
+                if column not in record:
+                    continue
+                value = _format_value(record[column])
+                if isinstance(column[1], int):
+                    if attrs[column[0]] == {}:
+                        attrs[column[0]] = []
+                    attrs[column[0]] += [None] * max(column[1] + 1 - len(attrs[column[0]]), 0)
+                    attrs[column[0]][column[1]] = value
+                elif column[1] != "":
+                    attrs[column[0]][column[1]] = value
+                else:
+                    attrs[column[0]] = value
             ret.append(attrs)
 
     return ret, header
@@ -163,7 +165,7 @@ def _dump_table(records: List[Dict[str, Any]], header: List[str]) -> str:
 
     separator = "+"
     header_string = "|"
-    rows_string = ["|" for _ in range(len(rows))]
+    rows_string = ["|" for _ in rows]
     for column in range(len(header)):
         value_types = [row[column].value_type for row in rows]
         value_type = ValueType.NUMERIC

--- a/optuna/cli.py
+++ b/optuna/cli.py
@@ -10,6 +10,7 @@ c.f. https://docs.openstack.org/cliff/latest/user/demoapp.html#setup-py
 from argparse import ArgumentParser  # NOQA
 from argparse import Namespace  # NOQA
 import datetime
+from enum import Enum
 from importlib.machinery import SourceFileLoader
 import json
 import logging
@@ -26,9 +27,6 @@ import warnings
 from cliff.app import App
 from cliff.command import Command
 from cliff.commandmanager import CommandManager
-from cliff.lister import Lister
-from cliff.show import ShowOne
-import numpy as np
 import yaml
 
 import optuna
@@ -48,6 +46,169 @@ def _check_storage_url(storage_url: Optional[str]) -> str:
     if storage_url is None:
         raise CLIUsageError("Storage URL is not specified.")
     return storage_url
+
+
+def _format_value(value: Any) -> Any:
+    #  Format value that can be serialized to JSON or YAML
+    if value is None or isinstance(value, (int, float)):
+        return value
+    elif isinstance(value, datetime.datetime):
+        return value.strftime(_DATETIME_FORMAT)
+    elif isinstance(value, list):
+        return list(_format_value(v) for v in value)
+    elif isinstance(value, tuple):
+        return tuple(_format_value(v) for v in value)
+    elif isinstance(value, dict):
+        return {_format_value(k): _format_value(v) for k, v in value.items()}
+    else:
+        return str(value)
+
+
+def _convert_to_dict(
+    records: List[Dict[Tuple[str, str], Any]], columns: List[Tuple[str, str]], flatten: bool
+) -> Tuple[List[Dict[str, Any]], List[str]]:
+    header = []
+    ret = []
+    if flatten:
+        for column in columns:
+            if column[1] != "":
+                header.append(f"{column[0]}_{column[1]}")
+            elif any(isinstance(record.get(column), (list, tuple)) for record in records):
+                max_length = 0
+                for record in records:
+                    if column in record:
+                        max_length = max(max_length, len(record[column]))
+                for i in range(max_length):
+                    header.append(f"{column[0]}_{i}")
+            else:
+                header.append(column[0])
+        for record in records:
+            row = {}
+            for column in columns:
+                if column in record:
+                    value = _format_value(record[column])
+                    if column[1] != "":
+                        row[f"{column[0]}_{column[1]}"] = value
+                    elif any(isinstance(record.get(column), (list, tuple)) for record in records):
+                        for i, v in enumerate(value):
+                            row[f"{column[0]}_{i}"] = v
+                    else:
+                        row[f"{column[0]}"] = value
+            ret.append(row)
+    else:
+        for column in columns:
+            if column[0] not in header:
+                header.append(column[0])
+        for record in records:
+            attrs: Dict[str, Any] = {column_name: {} for column_name in header}
+            for column in columns:
+                if column in record:
+                    value = _format_value(record[column])
+                    if column[1] != "":
+                        attrs[column[0]][column[1]] = value
+                    else:
+                        attrs[column[0]] = value
+            ret.append(attrs)
+
+    return ret, header
+
+
+class ValueType(Enum):
+    NONE = 0
+    NUMERIC = 1
+    STRING = 2
+
+
+class CellValue:
+    def __init__(self, value: Any) -> None:
+        self.value = value
+        if value is None:
+            self.value_type = ValueType.NONE
+        elif isinstance(value, (int, float)):
+            self.value_type = ValueType.NUMERIC
+        else:
+            self.value_type = ValueType.STRING
+
+    def __str__(self) -> str:
+        if isinstance(self.value, datetime.datetime):
+            return self.value.strftime(_DATETIME_FORMAT)
+        else:
+            return str(self.value)
+
+    def width(self) -> int:
+        return len(str(self.value))
+
+    def get_string(self, value_type: ValueType, width: int) -> str:
+        value = str(self.value)
+        if self.value is None:
+            return " " * width
+        elif value_type == ValueType.NUMERIC:
+            return f"{value:>{width}}"
+        else:
+            return f"{value:<{width}}"
+
+
+def _dump_table(records: List[Dict[str, Any]], header: List[str]) -> str:
+    rows = []
+    for record in records:
+        row = []
+        for column_name in header:
+            row.append(CellValue(record.get(column_name)))
+        rows.append(row)
+
+    separator = "+"
+    header_string = "|"
+    rows_string = ["|" for _ in range(len(rows))]
+    for column in range(len(header)):
+        value_types = [row[column].value_type for row in rows]
+        value_type = ValueType.NUMERIC
+        for t in value_types:
+            if t == ValueType.STRING:
+                value_type = ValueType.STRING
+        max_width = max(len(header[column]), max(row[column].width() for row in rows))
+        separator += "-" * (max_width + 2) + "+"
+        if value_type == ValueType.NUMERIC:
+            header_string += f" {header[column]:>{max_width}} |"
+        else:
+            header_string += f" {header[column]:<{max_width}} |"
+        for i, row in enumerate(rows):
+            rows_string[i] += " " + row[column].get_string(value_type, max_width) + " |"
+
+    ret = ""
+    ret += separator + "\n"
+    ret += header_string + "\n"
+    ret += separator + "\n"
+    ret += "\n".join(rows_string) + "\n"
+    ret += separator + "\n"
+
+    return ret
+
+
+def _format_output(
+    records: Union[List[Dict[Tuple[str, str], Any]], Dict[Tuple[str, str], Any]],
+    columns: List[Tuple[str, str]],
+    output_format: str,
+    flatten: bool,
+) -> str:
+    if isinstance(records, list):
+        values, header = _convert_to_dict(records, columns, flatten)
+    else:
+        values, header = _convert_to_dict([records], columns, flatten)
+
+    if output_format == "table":
+        return _dump_table(values, header).strip()
+    elif output_format == "json":
+        if isinstance(records, list):
+            return json.dumps(values).strip()
+        else:
+            return json.dumps(values[0]).strip()
+    elif output_format == "yaml":
+        if isinstance(records, list):
+            return yaml.dump(values).strip()
+        else:
+            return yaml.dump(values[0]).strip()
+    else:
+        raise CLIUsageError(f"Optuna CLI does not supported the {output_format} format.")
 
 
 class _BaseCommand(Command):
@@ -167,50 +328,57 @@ class _StudySetUserAttribute(_BaseCommand):
         self.logger.info("Attribute successfully written.")
 
 
-class _Studies(Lister):
+class _Studies(_BaseCommand):
     """Show a list of studies."""
 
-    _study_list_header = ("NAME", "DIRECTION", "N_TRIALS", "DATETIME_START")
+    _study_list_header = [
+        ("name", ""),
+        ("direction", ""),
+        ("n_trials", ""),
+        ("datetime_start", ""),
+    ]
 
     def get_parser(self, prog_name: str) -> ArgumentParser:
 
         parser = super(_Studies, self).get_parser(prog_name)
+        parser.add_argument(
+            "-f",
+            "--format",
+            type=str,
+            choices=("json", "table", "yaml"),
+            default="table",
+            help="Output format.",
+        )
+        parser.add_argument("--flatten", default=False, action="store_true", help="Output format.")
         return parser
 
-    def take_action(self, parsed_args: Namespace) -> Tuple[Tuple, Tuple[Tuple, ...]]:
+    def take_action(self, parsed_args: Namespace) -> None:
 
         storage_url = _check_storage_url(self.app_args.storage)
         summaries = optuna.get_all_study_summaries(storage=storage_url)
 
-        rows = []
+        records = []
         for s in summaries:
             start = (
                 s.datetime_start.strftime(_DATETIME_FORMAT)
                 if s.datetime_start is not None
                 else None
             )
-            row = (s.study_name, tuple(d.name for d in s.directions), s.n_trials, start)
-            rows.append(row)
+            record: Dict[Tuple[str, str], Any] = {}
+            record[("name", "")] = s.study_name
+            record[("direction", "")] = tuple(d.name for d in s.directions)
+            record[("n_trials", "")] = s.n_trials
+            record[("datetime_start", "")] = start
+            records.append(record)
 
-        return self._study_list_header, tuple(rows)
-
-
-def _format_trial_values(
-    record: Dict[Tuple[str, str], Any], columns: List[Tuple[str, str]]
-) -> List[Union[int, float, str]]:
-    row: List[Union[int, float, str]] = []
-    for column in columns:
-        value = record.get(column, np.nan)
-        if isinstance(value, (int, float)):
-            row.append(value)
-        elif isinstance(value, datetime.datetime):
-            row.append(value.strftime(_DATETIME_FORMAT))
-        else:
-            row.append(str(value))
-    return row
+        print(
+            _format_output(
+                records, self._study_list_header, parsed_args.format, parsed_args.flatten
+            )
+        )
 
 
-class _Trials(Lister):
+class _Trials(_BaseCommand):
     """Show a list of trials."""
 
     def get_parser(self, prog_name: str) -> ArgumentParser:
@@ -222,11 +390,18 @@ class _Trials(Lister):
             required=True,
             help="The name of the study which includes trials.",
         )
+        parser.add_argument(
+            "-f",
+            "--format",
+            type=str,
+            choices=("json", "table", "yaml"),
+            default="table",
+            help="Output format.",
+        )
+        parser.add_argument("--flatten", default=False, action="store_true", help="Output format.")
         return parser
 
-    def take_action(
-        self, parsed_args: Namespace
-    ) -> Tuple[List[str], List[List[Union[int, float, str]]]]:
+    def take_action(self, parsed_args: Namespace) -> None:
 
         warnings.warn(
             "'trials' is an experimental CLI command. The interface can change in the future.",
@@ -247,11 +422,10 @@ class _Trials(Lister):
         )
 
         records, columns = _dataframe._create_records_and_aggregate_column(study, attrs)
-        list_of_trial_values = [_format_trial_values(record, columns) for record in records]
-        return _dataframe._flatten_columns(columns), list_of_trial_values
+        print(_format_output(records, columns, parsed_args.format, parsed_args.flatten))
 
 
-class _BestTrial(ShowOne):
+class _BestTrial(_BaseCommand):
     """Show the best trial."""
 
     def get_parser(self, prog_name: str) -> ArgumentParser:
@@ -263,11 +437,18 @@ class _BestTrial(ShowOne):
             required=True,
             help="The name of the study to get the best trial.",
         )
+        parser.add_argument(
+            "-f",
+            "--format",
+            type=str,
+            choices=("json", "table", "yaml"),
+            default="table",
+            help="Output format.",
+        )
+        parser.add_argument("--flatten", default=False, action="store_true", help="Output format.")
         return parser
 
-    def take_action(
-        self, parsed_args: Namespace
-    ) -> Tuple[List[str], List[Union[int, float, str]]]:
+    def take_action(self, parsed_args: Namespace) -> None:
 
         warnings.warn(
             "'best-trial' is an experimental CLI command. The interface can change in the future.",
@@ -288,11 +469,14 @@ class _BestTrial(ShowOne):
         )
 
         records, columns = _dataframe._create_records_and_aggregate_column(study, attrs)
-        trial_values = _format_trial_values(records[study.best_trial.number], columns)
-        return _dataframe._flatten_columns(columns), trial_values
+        print(
+            _format_output(
+                records[study.best_trial.number], columns, parsed_args.format, parsed_args.flatten
+            )
+        )
 
 
-class _BestTrials(Lister):
+class _BestTrials(_BaseCommand):
     """Show a list of trials located at the Pareto front."""
 
     def get_parser(self, prog_name: str) -> ArgumentParser:
@@ -304,11 +488,18 @@ class _BestTrials(Lister):
             required=True,
             help="The name of the study to get the best trials (trials at the Pareto front).",
         )
+        parser.add_argument(
+            "-f",
+            "--format",
+            type=str,
+            choices=("json", "table", "yaml"),
+            default="table",
+            help="Output format.",
+        )
+        parser.add_argument("--flatten", default=False, action="store_true", help="Output format.")
         return parser
 
-    def take_action(
-        self, parsed_args: Namespace
-    ) -> Tuple[List[str], List[List[Union[int, float, str]]]]:
+    def take_action(self, parsed_args: Namespace) -> None:
 
         warnings.warn(
             "'best-trials' is an experimental CLI command. The interface can change in the "
@@ -331,9 +522,8 @@ class _BestTrials(Lister):
         )
 
         records, columns = _dataframe._create_records_and_aggregate_column(study, attrs)
-        best_records = filter(lambda record: record[("number", "")] in best_trials, records)
-        list_of_trial_values = [_format_trial_values(record, columns) for record in best_records]
-        return _dataframe._flatten_columns(columns), list_of_trial_values
+        best_records = list(filter(lambda record: record[("number", "")] in best_trials, records))
+        print(_format_output(best_records, columns, parsed_args.format, parsed_args.flatten))
 
 
 class _Dashboard(_BaseCommand):
@@ -557,11 +747,17 @@ class _Ask(_BaseCommand):
             ),
         )
         parser.add_argument(
-            "--out", type=str, choices=("json", "yaml"), default="json", help="Output format."
+            "-f",
+            "--format",
+            type=str,
+            choices=("json", "table", "yaml"),
+            default="table",
+            help="Output format.",
         )
+        parser.add_argument("--flatten", default=False, action="store_true", help="Output format.")
         return parser
 
-    def take_action(self, parsed_args: Namespace) -> int:
+    def take_action(self, parsed_args: Namespace) -> None:
 
         warnings.warn(
             "'ask' is an experimental CLI command. The interface can change in the future.",
@@ -599,23 +795,21 @@ class _Ask(_BaseCommand):
 
         study = optuna.create_study(**create_study_kwargs)
         trial = study.ask(fixed_distributions=search_space)
-        out = {
-            "trial": {
-                "number": trial.number,
-                "params": trial.params,
-            }
-        }
 
         self.logger.info(f"Asked trial {trial.number} with parameters {trial.params}.")
 
-        if parsed_args.out == "json":
-            print(json.dumps(out))
-        elif parsed_args.out == "yaml":
-            print(yaml.dump(out))
-        else:
-            assert False
+        record: Dict[Tuple[str, str], Any] = {("number", ""): trial.number}
+        columns = [("number", "")]
 
-        return 0
+        if len(trial.params) == 0:
+            record[("params", "")] = {}
+            columns.append(("params", ""))
+        else:
+            for param_name, param_value in trial.params.items():
+                record[("params", param_name)] = param_value
+                columns.append(("params", param_name))
+
+        print(_format_output(record, columns, parsed_args.format, parsed_args.flatten))
 
 
 class _Tell(_BaseCommand):

--- a/optuna/cli.py
+++ b/optuna/cli.py
@@ -204,9 +204,9 @@ def _format_output(
             return json.dumps(values[0]).strip()
     elif output_format == "yaml":
         if isinstance(records, list):
-            return yaml.dump(values).strip()
+            return yaml.safe_dump(values).strip()
         else:
-            return yaml.dump(values[0]).strip()
+            return yaml.safe_dump(values[0]).strip()
     else:
         raise CLIUsageError(f"Optuna CLI does not supported the {output_format} format.")
 

--- a/optuna/cli.py
+++ b/optuna/cli.py
@@ -801,7 +801,7 @@ class _Ask(_BaseCommand):
         record: Dict[Tuple[str, str], Any] = {("number", ""): trial.number}
         columns = [("number", "")]
 
-        if len(trial.params) == 0:
+        if len(trial.params) == 0 and not parsed_args.flatten:
             record[("params", "")] = {}
             columns.append(("params", ""))
         else:

--- a/optuna/cli.py
+++ b/optuna/cli.py
@@ -107,6 +107,8 @@ def _convert_to_dict(
                     continue
                 value = _format_value(record[column])
                 if isinstance(column[1], int):
+                    # Reconstruct list of values. `_dataframe._create_records_and_aggregate_column`
+                    # returns indices of list as the second key of column.
                     if attrs[column[0]] == {}:
                         attrs[column[0]] = []
                     attrs[column[0]] += [None] * max(column[1] + 1 - len(attrs[column[0]]), 0)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -71,7 +71,7 @@ def _parse_output(output: str, output_format: Optional[str]) -> Any:
     elif output_format == "json":
         return json.loads(output)
     elif output_format == "yaml":
-        return yaml.load(output)
+        return yaml.safe_load(output)
     else:
         assert False
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -823,15 +823,9 @@ def test_best_trials_command_flatten(output_format: Optional[str]) -> None:
 
         for trial in trials:
             assert set(trial.keys()) <= set(df.columns)
-            if output_format is None or output_format == "table":
-                assert int(trial["number"]) in best_trials
-            else:
-                assert trial["number"] in best_trials
+            number = int(trial["number"]) if output_format in (None, "table") else trial["number"]
             for key in df.columns:
-                if output_format is None or output_format == "table":
-                    expected_value = df.loc[int(trial["number"])][key]
-                else:
-                    expected_value = df.loc[trial["number"]][key]
+                expected_value = df.loc[number][key]
                 if (
                     key.startswith("params_")
                     and isinstance(expected_value, float)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -429,6 +429,8 @@ def test_trials_command(objective: Callable[[Trial], float], output_format: Opti
         for i, trial in enumerate(trials):
             for key in df.columns:
                 expected_value = df.loc[i][key]
+
+                # The param may be NaN when the objective function has branched search space.
                 if (
                     key[0] == "params"
                     and isinstance(expected_value, float)
@@ -511,6 +513,8 @@ def test_trials_command_flatten(
             assert set(trial.keys()) <= set(df.columns)
             for key in df.columns:
                 expected_value = df.loc[i][key]
+
+                # The param may be NaN when the objective function has branched search space.
                 if (
                     key.startswith("params_")
                     and isinstance(expected_value, float)
@@ -586,6 +590,8 @@ def test_best_trial_command(
 
         for key in df.columns:
             expected_value = df.loc[study.best_trial.number][key]
+
+            # The param may be NaN when the objective function has branched search space.
             if (
                 key[0] == "params"
                 and isinstance(expected_value, float)
@@ -669,6 +675,8 @@ def test_best_trial_command_flatten(
         assert set(best_trial.keys()) <= set(df.columns)
         for key in df.columns:
             expected_value = df.loc[study.best_trial.number][key]
+
+            # The param may be NaN when the objective function has branched search space.
             if (
                 key.startswith("params_")
                 and isinstance(expected_value, float)
@@ -679,6 +687,7 @@ def test_best_trial_command_flatten(
                 else:
                     assert key not in best_trial
                 continue
+
             value = best_trial[key]
             if isinstance(value, (int, float)):
                 if np.isnan(expected_value):
@@ -743,6 +752,8 @@ def test_best_trials_command(output_format: Optional[str]) -> None:
             assert number in best_trials
             for key in df.columns:
                 expected_value = df.loc[number][key]
+
+                # The param may be NaN when the objective function has branched search space.
                 if (
                     key[0] == "params"
                     and isinstance(expected_value, float)
@@ -826,6 +837,8 @@ def test_best_trials_command_flatten(output_format: Optional[str]) -> None:
             number = int(trial["number"]) if output_format in (None, "table") else trial["number"]
             for key in df.columns:
                 expected_value = df.loc[number][key]
+
+                # The param may be NaN when the objective function has branched search space.
                 if (
                     key.startswith("params_")
                     and isinstance(expected_value, float)
@@ -836,6 +849,7 @@ def test_best_trials_command_flatten(output_format: Optional[str]) -> None:
                     else:
                         assert key not in trial
                     continue
+
                 value = trial[key]
                 if isinstance(value, (int, float)):
                     if np.isnan(expected_value):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -58,6 +58,7 @@ def _parse_output(output: str, output_format: str) -> Any:
     if output_format == "table":
         rows = output.split("\n")
         assert all(len(rows[0]) == len(row) for row in rows)
+        # Check ruled lines.
         assert rows[0] == rows[2] == rows[-1]
 
         keys = [r.strip() for r in rows[1].split("|")[1:-1]]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -54,6 +54,18 @@ def objective_func_multi_objective(trial: Trial) -> Tuple[float, float]:
 
 
 def _parse_output(output: str, output_format: str) -> Any:
+    """Parse CLI output.
+
+    Args:
+        output:
+            The output of command.
+        output_format:
+            The format of output specified by command.
+
+    Returns:
+        For table format, a list of dict formatted rows.
+        For JSON or YAML format, a list or a dict corresponding to ``output``.
+    """
 
     if output_format == "table":
         rows = output.split("\n")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -328,14 +328,7 @@ def test_studies_command_flatten(output_format: Optional[str]) -> None:
         studies = _parse_output(output, output_format or "table")
 
         if output_format is None or output_format == "table":
-            expected_keys_1 = [
-                "name",
-                "direction_0",
-                "direction_1",
-                "n_trials",
-                "datetime_start",
-            ]
-            expected_keys_2 = [
+            expected_keys_1 = expected_keys_2 = [
                 "name",
                 "direction_0",
                 "direction_1",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -728,8 +728,6 @@ def test_best_trials_command(output_format: Optional[str]) -> None:
         trials = _parse_output(output, output_format or "table")
         best_trials = [trial.number for trial in study.best_trials]
 
-        print(output)
-
         assert len(trials) == len(best_trials)
 
         df = study.trials_dataframe(attrs, multi_index=True)
@@ -817,8 +815,6 @@ def test_best_trials_command_flatten(output_format: Optional[str]) -> None:
         output = str(subprocess.check_output(command).decode().strip())
         trials = _parse_output(output, output_format or "table")
         best_trials = [trial.number for trial in study.best_trials]
-
-        print(output)
 
         assert len(trials) == len(best_trials)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -739,15 +739,10 @@ def test_best_trials_command(output_format: Optional[str]) -> None:
         df = study.trials_dataframe(attrs, multi_index=True)
 
         for trial in trials:
-            if output_format is None or output_format == "table":
-                assert int(trial["number"]) in best_trials
-            else:
-                assert trial["number"] in best_trials
+            number = int(trial["number"]) if output_format in (None, "table") else trial["number"]
+            assert number in best_trials
             for key in df.columns:
-                if output_format is None or output_format == "table":
-                    expected_value = df.loc[int(trial["number"])][key]
-                else:
-                    expected_value = df.loc[trial["number"]][key]
+                expected_value = df.loc[number][key]
                 if (
                     key[0] == "params"
                     and isinstance(expected_value, float)


### PR DESCRIPTION
## Motivation
This PR aligns the output format of CLI.

This is related to #2628.

## Description of the changes
- Align the output format of CLI.
- Add tests.

## Breaking Changes
- Disable some features by cliff
- Lowercase header of `studies`
- Make the default output of `trials`, `best_trial`, and `best_trials` nested
- Make the default output of `ask` tabular
- Add `--format` option for `ask` instead of `--out`
- Change the output structure of `ask`

## `optuna studies`

- master

```
$ optuna studies --storage sqlite:///example.db 
+------------+--------------------------+----------+---------------------+
| NAME       | DIRECTION                | N_TRIALS | DATETIME_START      |
+------------+--------------------------+----------+---------------------+
| example    | ('MINIMIZE',)            |        5 | 2021-08-30 12:03:57 |
| example-mo | ('MINIMIZE', 'MINIMIZE') |        5 | 2021-08-30 12:03:58 |
+------------+--------------------------+----------+---------------------+
```

- This PR

```
$ optuna studies --storage sqlite:///example.db 
+------------+--------------------------+----------+---------------------+
| name       | direction                | n_trials | datetime_start      |
+------------+--------------------------+----------+---------------------+
| example    | ('MINIMIZE',)            |        5 | 2021-08-30 12:03:57 |
| example-mo | ('MINIMIZE', 'MINIMIZE') |        5 | 2021-08-30 12:03:58 |
+------------+--------------------------+----------+---------------------+
```

## `optuna trials`

- master

```
$ optuna trials --storage sqlite:///example.db --study-name example
+--------+---------------------+---------------------+---------------------+----------------+----------+--------------------+---------------------+----------+
| number |               value | datetime_start      | datetime_complete   | duration       | params_c |           params_x |            params_y | state    |
+--------+---------------------+---------------------+---------------------+----------------+----------+--------------------+---------------------+----------+
|      0 | -2.7151068109937633 | 2021-08-30 12:03:57 | 2021-08-30 12:03:57 | 0:00:00.028117 | B        |                nan | -2.7151068109937633 | COMPLETE |
|      1 |   3.342616455087768 | 2021-08-30 12:03:57 | 2021-08-30 12:03:57 | 0:00:00.020461 | B        |                nan |   3.342616455087768 | COMPLETE |
|      2 |  -6.373279474087967 | 2021-08-30 12:03:57 | 2021-08-30 12:03:57 | 0:00:00.028855 | A        | -6.373279474087967 |                 nan | COMPLETE |
|      3 |  -8.407466060642065 | 2021-08-30 12:03:58 | 2021-08-30 12:03:58 | 0:00:00.027137 | B        |                nan |  -8.407466060642065 | COMPLETE |
|      4 |    9.28544492983972 | 2021-08-30 12:03:58 | 2021-08-30 12:03:58 | 0:00:00.547470 | A        |   9.28544492983972 |                 nan | COMPLETE |
+--------+---------------------+---------------------+---------------------+----------------+----------+--------------------+---------------------+----------+
```

- This PR

```
$ optuna trials --storage sqlite:///example.db --study-name example
+--------+---------------------+---------------------+---------------------+----------------+--------------------------------------+----------+
| number |               value | datetime_start      | datetime_complete   | duration       | params                               | state    |
+--------+---------------------+---------------------+---------------------+----------------+--------------------------------------+----------+
|      0 | -2.7151068109937633 | 2021-08-30 12:03:57 | 2021-08-30 12:03:57 | 0:00:00.028117 | {'c': 'B', 'y': -2.7151068109937633} | COMPLETE |
|      1 |   3.342616455087768 | 2021-08-30 12:03:57 | 2021-08-30 12:03:57 | 0:00:00.020461 | {'c': 'B', 'y': 3.342616455087768}   | COMPLETE |
|      2 |  -6.373279474087967 | 2021-08-30 12:03:57 | 2021-08-30 12:03:57 | 0:00:00.028855 | {'c': 'A', 'x': -6.373279474087967}  | COMPLETE |
|      3 |  -8.407466060642065 | 2021-08-30 12:03:58 | 2021-08-30 12:03:58 | 0:00:00.027137 | {'c': 'B', 'y': -8.407466060642065}  | COMPLETE |
|      4 |    9.28544492983972 | 2021-08-30 12:03:58 | 2021-08-30 12:03:58 | 0:00:00.547470 | {'c': 'A', 'x': 9.28544492983972}    | COMPLETE |
+--------+---------------------+---------------------+---------------------+----------------+--------------------------------------+----------+
```

- This PR with `--flatten`

```
$ optuna trials --storage sqlite:///example.db --study-name example --flatten
+--------+---------------------+---------------------+---------------------+----------------+----------+--------------------+---------------------+----------+
| number |               value | datetime_start      | datetime_complete   | duration       | params_c |           params_x |            params_y | state    |
+--------+---------------------+---------------------+---------------------+----------------+----------+--------------------+---------------------+----------+
|      0 | -2.7151068109937633 | 2021-08-30 12:03:57 | 2021-08-30 12:03:57 | 0:00:00.028117 | B        |                    | -2.7151068109937633 | COMPLETE |
|      1 |   3.342616455087768 | 2021-08-30 12:03:57 | 2021-08-30 12:03:57 | 0:00:00.020461 | B        |                    |   3.342616455087768 | COMPLETE |
|      2 |  -6.373279474087967 | 2021-08-30 12:03:57 | 2021-08-30 12:03:57 | 0:00:00.028855 | A        | -6.373279474087967 |                     | COMPLETE |
|      3 |  -8.407466060642065 | 2021-08-30 12:03:58 | 2021-08-30 12:03:58 | 0:00:00.027137 | B        |                    |  -8.407466060642065 | COMPLETE |
|      4 |    9.28544492983972 | 2021-08-30 12:03:58 | 2021-08-30 12:03:58 | 0:00:00.547470 | A        |   9.28544492983972 |                     | COMPLETE |
+--------+---------------------+---------------------+---------------------+----------------+----------+--------------------+---------------------+----------+
```

## `optuna ask`

- master

```
$ optuna ask --storage sqlite:///example.db --study-name example --search-space '{"x": {"name": "UniformDistribution", "attributes": {"low": -10, "high": 10}}, "c": {"name": "CategoricalDistribution", "attributes": {"choices": ["A", "B"]}}}'
{"trial": {"number": 5, "params": {"x": -4.8769193781425235, "c": "A"}}}
```

- This PR

```
$ optuna ask --storage sqlite:///example.db --study-name example --search-space '{"x": {"name": "UniformDistribution", "attributes": {"low": -10, "high": 10}}, "c": {"name": "CategoricalDistribution", "attributes": {"choices": ["A", "B"]}}}'
{"number": 5, "params": {"x": -4.8769193781425235, "c": "A"}}
```