### PR TITLE
Improve the docstring of `MLflowCallback` 

### DIFF
--- a/optuna/integration/mlflow.py
+++ b/optuna/integration/mlflow.py
@@ -124,7 +124,8 @@ class MLflowCallback(object):
         tag_study_user_attrs:
             Flag indicating whether or not to add the study's user attrs
             to the mlflow trial as tags. Please note that when this flag is
-            set, key value pairs in study.user_attrs will supersede existing tags.
+            set, key value pairs in :attr:`~optuna.study.Study.user_attrs`
+            will supersede existing tags.
     """
 
     def __init__(


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

I found a minor thing that `study.user_attrs` in the docstring can be linked to Optuna's documentation element.

## Description of the changes
<!-- Describe the changes in this PR. -->

Use sphinx's syntax to link to the corresponding part: [`study.user_attrs`](https://optuna.readthedocs.io/en/stable/reference/generated/optuna.study.Study.html#optuna.study.Study.user_attrs).

I think this PR is straightforward, so one approval is enough to be merged into the master branch.