### PR TITLE
Relax metric name type hinting in `WeightsAndBiasesCallback`

### DIFF
--- a/optuna/integration/wandb.py
+++ b/optuna/integration/wandb.py
@@ -76,6 +76,8 @@ class WeightsAndBiasesCallback(object):
     Raises:
         :exc:`ValueError`:
             If there are missing or extra metric names in multi-objective optimization.
+        :exc:`TypeError`:
+            When metric names are not passed as sequence.
     """
 
     def __init__(

--- a/optuna/integration/wandb.py
+++ b/optuna/integration/wandb.py
@@ -74,7 +74,7 @@ class WeightsAndBiasesCallback(object):
             <https://docs.wandb.ai/ref/python/init>`_ for more details.
 
     Raises:
-        :exc:`RuntimeError`:
+        :exc:`ValueError`:
             If there are missing or extra metric names in multi-objective optimization.
     """
 
@@ -95,7 +95,7 @@ class WeightsAndBiasesCallback(object):
 
         if isinstance(self._metric_name, list):
             if len(self._metric_name) != len(trial.values):
-                raise RuntimeError(
+                raise ValueError(
                     "Running multi-objective optimization "
                     "with {} objective values, but {} names specified. "
                     "Match objective values and names, or use default broadcasting.".format(

--- a/optuna/integration/wandb.py
+++ b/optuna/integration/wandb.py
@@ -1,7 +1,7 @@
 from typing import Any
 from typing import Dict
-from typing import List
 from typing import Optional
+from typing import Sequence
 from typing import Union
 
 import optuna
@@ -80,11 +80,18 @@ class WeightsAndBiasesCallback(object):
 
     def __init__(
         self,
-        metric_name: Union[str, List[str]] = "value",
+        metric_name: Union[str, Sequence[str]] = "value",
         wandb_kwargs: Optional[Dict[str, Any]] = None,
     ) -> None:
 
         _imports.check()
+
+        if not isinstance(metric_name, Sequence):
+            raise TypeError(
+                "Expected metric_name to be string or sequence of strings, got {}.".format(
+                    type(metric_name)
+                )
+            )
 
         self._metric_name = metric_name
         self._wandb_kwargs = wandb_kwargs or {}
@@ -93,7 +100,15 @@ class WeightsAndBiasesCallback(object):
 
     def __call__(self, study: optuna.study.Study, trial: optuna.trial.FrozenTrial) -> None:
 
-        if isinstance(self._metric_name, list):
+        if isinstance(self._metric_name, str):
+            if len(trial.values) > 1:
+                # Broadcast default name for multi-objective optimization.
+                names = ["{}_{}".format(self._metric_name, i) for i in range(len(trial.values))]
+
+            else:
+                names = [self._metric_name]
+
+        else:
             if len(self._metric_name) != len(trial.values):
                 raise ValueError(
                     "Running multi-objective optimization "
@@ -104,15 +119,7 @@ class WeightsAndBiasesCallback(object):
                 )
 
             else:
-                names = self._metric_name
-
-        if isinstance(self._metric_name, str):
-            if len(trial.values) > 1:
-                # broadcast default name for multi-objective optimization
-                names = ["{}_{}".format(self._metric_name, i) for i in range(len(trial.values))]
-
-            else:
-                names = [self._metric_name]
+                names = [*self._metric_name]
 
         metrics = {name: value for name, value in zip(names, trial.values)}
         attributes = {"direction": [d.name for d in study.directions]}

--- a/tests/integration_tests/test_wandb.py
+++ b/tests/integration_tests/test_wandb.py
@@ -11,15 +11,15 @@ from optuna.integration import WeightsAndBiasesCallback
 
 def _objective_func(trial: optuna.trial.Trial) -> float:
 
-    x = trial.suggest_uniform("x", low=-10, high=10)
-    y = trial.suggest_loguniform("y", low=1, high=10)
+    x = trial.suggest_float("x", low=-10, high=10)
+    y = trial.suggest_float("y", low=1, high=10, log=True)
     return (x - 2) ** 2 + (y - 25) ** 2
 
 
 def _multiobjective_func(trial: optuna.trial.Trial) -> Tuple[float, float]:
 
-    x = trial.suggest_uniform("x", low=-10, high=10)
-    y = trial.suggest_loguniform("y", low=1, high=10)
+    x = trial.suggest_float("x", low=-10, high=10)
+    y = trial.suggest_float("y", low=1, high=10, log=True)
     first_objective = (x - 2) ** 2 + (y - 25) ** 2
     second_objective = (x - 2) ** 3 + (y - 25) ** 3
 

--- a/tests/integration_tests/test_wandb.py
+++ b/tests/integration_tests/test_wandb.py
@@ -1,4 +1,6 @@
+from typing import Any
 from typing import List
+from typing import Sequence
 from typing import Tuple
 from typing import Union
 from unittest import mock
@@ -106,11 +108,15 @@ def test_values_registered_on_epoch(wandb: mock.Mock, metric: str, expected: Lis
 
 @pytest.mark.parametrize(
     "metrics,expected",
-    [("value", ["x", "y", "value_0", "value_1"]), (["foo", "bar"], ["x", "y", "foo", "bar"])],
+    [
+        ("value", ["x", "y", "value_0", "value_1"]),
+        (["foo", "bar"], ["x", "y", "foo", "bar"]),
+        (("foo", "bar"), ["x", "y", "foo", "bar"]),
+    ],
 )
 @mock.patch("optuna.integration.wandb.wandb")
 def test_multiobjective_values_registered_on_epoch(
-    wandb: mock.Mock, metrics: Union[str, List[str]], expected: List[str]
+    wandb: mock.Mock, metrics: Union[str, Sequence[str]], expected: List[str]
 ) -> None:
 
     wandb.log = mock.MagicMock()
@@ -133,3 +139,10 @@ def test_multiobjective_raises_on_name_mismatch(wandb: mock.MagicMock, metrics: 
 
     with pytest.raises(ValueError):
         study.optimize(_multiobjective_func, n_trials=1, callbacks=[wandbc])
+
+
+@pytest.mark.parametrize("metrics", [{0: "foo", 1: "bar"}])
+def test_multiobjective_raises_on_type_mismatch(metrics: Any) -> None:
+
+    with pytest.raises(TypeError):
+        WeightsAndBiasesCallback(metric_name=metrics)

--- a/tests/integration_tests/test_wandb.py
+++ b/tests/integration_tests/test_wandb.py
@@ -131,5 +131,5 @@ def test_multiobjective_raises_on_name_mismatch(wandb: mock.MagicMock, metrics: 
     wandbc = WeightsAndBiasesCallback(metric_name=metrics)
     study = optuna.create_study(directions=["minimize", "maximize"])
 
-    with pytest.raises(RuntimeError):
+    with pytest.raises(ValueError):
         study.optimize(_multiobjective_func, n_trials=1, callbacks=[wandbc])


### PR DESCRIPTION
## Motivation

This PR introduces recent changes implemented in `MLflowCallback` to `WeightsAndBiasesCallback`, since both APIs are similar.

## Description of the changes

* `metric_name` type hinting is relaxed as suggested in [#2863 (review)](https://github.com/optuna/optuna/pull/2863#discussion_r694519044).
* More specific exception is raised when user passes incorrect number of metric names when optimizing multi-objective function.
* New test cases added.
* Test objective functions now follow [Optuna wiki](https://github.com/optuna/optuna/wiki/Coding-Style-Conventions#consistently-use-suggest_float).
