### PR TITLE
Introduce version constraint of `alembic`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,8 @@ def get_long_description() -> str:
 def get_install_requires() -> List[str]:
 
     requirements = [
-        "alembic",
+        # TODO(nzw) remove this version constraint after fixing mypy error
+        "alembic<1.7.0",
         "cliff",
         "cmaes>=0.8.2",
         "colorlog",


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation


[`alembic` 1.7.0](https://github.com/sqlalchemy/alembic/releases/tag/rel_1_7_0) has been released. However, the CI starts to fail due to `mypy`.

See also this CI error, https://github.com/optuna/optuna/pull/2883/checks?check_run_id=3463453849, as a concrete error.

## Description of the changes
<!-- Describe the changes in this PR. -->

As a hot-fix, this PR introduces a version constraint of `alembic<1.7.0` and TODO line.
