### PR TITLE
Fix recent `alembic` 1.7.0 type hint error

### DIFF
--- a/optuna/storages/_rdb/storage.py
+++ b/optuna/storages/_rdb/storage.py
@@ -1346,7 +1346,9 @@ class _VersionManager(object):
     def _get_base_version(self) -> str:
 
         script = self._create_alembic_script()
-        return script.get_base()
+        base = script.get_base()
+        assert base is not None, "There should be exactly one base, i.e. v0.9.0.a."
+        return base
 
     def get_all_versions(self) -> List[str]:
 


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation

Fixes the error described in https://github.com/optuna/optuna/pull/2885.

I think this fix is acceptable according to the description of https://alembic.sqlalchemy.org/en/latest/api/script.html#alembic.script.ScriptDirectory.get_base and that we always have 
precisely one version that doesn't have a `down_revision` in https://github.com/optuna/optuna/tree/master/optuna/storages/_rdb/alembic/versions.

## Description of the changes

Suppresses `None` return values from `ScriptDirectory.get_base`.
