### PR TITLE
Fix `create_trial` document

### DIFF
--- a/optuna/trial/_frozen.py
+++ b/optuna/trial/_frozen.py
@@ -548,8 +548,9 @@ def create_trial(
         functions are created inside :func:`~optuna.study.Study.optimize`.
 
     .. note::
-        When ``state`` is ``TrialState.COMPLETE``, the following parameters are
+        When ``state`` is :class:`TrialState.COMPLETE`, the following parameters are
         required:
+
         * ``params``
         * ``distributions``
         * ``value`` or ``values``
@@ -558,12 +559,11 @@ def create_trial(
         state:
             Trial state.
         value:
-            Trial objective value. Must be specified if ``state`` is ``None``
-            or :class:`TrialState.COMPLETE`.
+            Trial objective value. Must be specified if ``state`` is :class:`TrialState.COMPLETE`.
         values:
             Sequence of the trial objective values. The length is greater than 1 if the problem is
             multi-objective optimization.
-            Must be specified if ``state`` is ``None`` or :class:`TrialState.COMPLETE`.
+            Must be specified if ``state`` is :class:`TrialState.COMPLETE`.
         params:
             Dictionary with suggested parameters of the trial.
         distributions:


### PR DESCRIPTION
## Motivation
This PR fixes stale descriptions and broken formats in the document of `create_trial`.

Note: The default value of `state` of `create_trial` was changed to `COMPLETE` by #2429.

## Description of the changes
- Fix stale descriptions
- Fix broken document formats