### PR TITLE
Avoid segmentation fault of `test_lightgbm.py` on macOS

### DIFF
--- a/.github/workflows/mac-tests.yml
+++ b/.github/workflows/mac-tests.yml
@@ -7,6 +7,9 @@ on:
   push:
     branches:
       - master
+  pull_request:
+    paths:
+      - '.github/workflows/mac-tests.yml'
 
 jobs:
   tests-mac:

--- a/.github/workflows/mac-tests.yml
+++ b/.github/workflows/mac-tests.yml
@@ -97,8 +97,14 @@ jobs:
 
     - name: Tests
       run: |
-        # pytest cannot collect allennlp tests with allennlp==1.0.0.
-        pytest -s tests/integration_tests
+        # 'pytest tests/integration_tests' causes segmentation fault at the end of
+        # tests/integration_tests/test_lightgbm.py as shown in
+        # https://github.com/optuna/optuna/issues/2695. It can be completed if we
+        # execute tests individually.
+        for file in `find tests/integration_tests -name 'test_*.py' -print`;
+        do
+          pytest $file;
+        done
 
     - name: Tests MPI
       run: |

--- a/.github/workflows/mac-tests.yml
+++ b/.github/workflows/mac-tests.yml
@@ -108,6 +108,8 @@ jobs:
         do
           pytest $file;
         done
+      env:
+        OMP_NUM_THREADS: 1
 
     - name: Tests MPI
       run: |


### PR DESCRIPTION
## Motivation

This is a workaround for  #2695. @nzw0301 found that the segmentation fault did not occur when each test file was executed separately.

## Description of the changes

- Lists test files by the `find` command and executes each file.
- Not related to the title, I guess the comment on allennlp is stale since the current allennlp version is 2.7.0, and I remove it.
- Kick CI when the GitHub Actions workflow file is modified.
- Set `OMP_NUM_THREADS=1` for the reproducibility of LightGBM. The corresponding test case is `tests/integration_tests/lightgbm_tuner_tests/test_optimize.py::TestLightGBMTuner::test_tune_best_score_reproducibility`.
## Notes
- I'm not sure why `mac-tests.xml` only executes `test/integration_tests` and does not execute others.