### PR TITLE
Add tests of `sample_relative` and fix type of return values of `SkoptSampler` and `PyCmaSampler`

### DIFF
--- a/optuna/integration/cma.py
+++ b/optuna/integration/cma.py
@@ -463,7 +463,7 @@ class _Optimizer(object):
             # Type of cma_param_value is np.floating, so cast it to Python's built-in float.
             return float(cma_param_value)
         if isinstance(dist, LogUniformDistribution):
-            return float(math.exp(cma_param_value))
+            return math.exp(cma_param_value)
         if isinstance(dist, DiscreteUniformDistribution):
             v = numpy.round(cma_param_value / dist.q) * dist.q + dist.low
             # v may slightly exceed range due to round-off errors.

--- a/optuna/integration/cma.py
+++ b/optuna/integration/cma.py
@@ -459,8 +459,11 @@ class _Optimizer(object):
     ) -> Any:
 
         dist = search_space[param_name]
+        if isinstance(dist, UniformDistribution):
+            # Type of cma_param_value is np.floating, so cast it to Python's built-in float.
+            return float(cma_param_value)
         if isinstance(dist, LogUniformDistribution):
-            return math.exp(cma_param_value)
+            return float(math.exp(cma_param_value))
         if isinstance(dist, DiscreteUniformDistribution):
             v = numpy.round(cma_param_value / dist.q) * dist.q + dist.low
             # v may slightly exceed range due to round-off errors.

--- a/optuna/integration/skopt.py
+++ b/optuna/integration/skopt.py
@@ -292,6 +292,16 @@ class _Optimizer(object):
         params = {}
         param_values = self._optimizer.ask()
         for (name, distribution), value in zip(sorted(self._search_space.items()), param_values):
+            if isinstance(
+                distribution,
+                (
+                    distributions.UniformDistribution,
+                    distributions.LogUniformDistribution,
+                    distributions.DiscreteUniformDistribution,
+                ),
+            ):
+                # Type of value is np.floating, so cast it to Python's built-in float.
+                value = float(value)
             if isinstance(distribution, distributions.DiscreteUniformDistribution):
                 value = value * distribution.q + distribution.low
             if isinstance(distribution, distributions.IntUniformDistribution):

--- a/optuna/integration/skopt.py
+++ b/optuna/integration/skopt.py
@@ -305,7 +305,7 @@ class _Optimizer(object):
             if isinstance(distribution, distributions.DiscreteUniformDistribution):
                 value = value * distribution.q + distribution.low
             if isinstance(distribution, distributions.IntUniformDistribution):
-                value = value * distribution.step + distribution.low
+                value = int(value * distribution.step + distribution.low)
             if isinstance(distribution, distributions.IntLogUniformDistribution):
                 value = int(np.round(value))
                 value = min(max(value, distribution.low), distribution.high)

--- a/tests/samplers_tests/test_samplers.py
+++ b/tests/samplers_tests/test_samplers.py
@@ -6,6 +6,7 @@ from typing import Dict
 from typing import List
 from typing import Optional
 from typing import Sequence
+from typing import Union
 import warnings
 
 import numpy as np

--- a/tests/samplers_tests/test_samplers.py
+++ b/tests/samplers_tests/test_samplers.py
@@ -48,7 +48,9 @@ parametrize_relative_sampler = pytest.mark.parametrize(
     [
         lambda: optuna.samplers.TPESampler(n_startup_trials=0, multivariate=True),
         lambda: optuna.samplers.CmaEsSampler(n_startup_trials=0),
-        lambda: optuna.integration.SkoptSampler(skopt_kwargs={"n_initial_points": 1}),
+        lambda: optuna.integration.SkoptSampler(
+            skopt_kwargs={"base_estimator": "dummy", "n_initial_points": 1}
+        ),
         lambda: optuna.integration.PyCmaSampler(n_startup_trials=0),
     ],
 )
@@ -276,7 +278,7 @@ def test_sample_relative_numerical(
         params = study.sampler.sample_relative(study, _create_new_trial(study), search_space)
         return [params[name] for name in search_space]
 
-    points = np.array([sample() for _ in range(2)])
+    points = np.array([sample() for _ in range(10)])
     for i, distribution in enumerate(search_space.values()):
         assert isinstance(
             distribution,
@@ -308,7 +310,7 @@ def test_sample_relative_categorical(relative_sampler_class: Callable[[], BaseSa
         params = study.sampler.sample_relative(study, _create_new_trial(study), search_space)
         return [params[name] for name in search_space]
 
-    points = np.array([sample() for _ in range(2)])
+    points = np.array([sample() for _ in range(10)])
     for i, distribution in enumerate(search_space.values()):
         assert isinstance(distribution, CategoricalDistribution)
         assert np.all([v in distribution.choices for v in points[:, i]])
@@ -342,7 +344,7 @@ def test_sample_relative_mixed(
         params = study.sampler.sample_relative(study, _create_new_trial(study), search_space)
         return [params[name] for name in search_space]
 
-    points = np.array([sample() for _ in range(2)])
+    points = np.array([sample() for _ in range(10)])
     assert isinstance(
         search_space["x"],
         (

--- a/tests/samplers_tests/test_samplers.py
+++ b/tests/samplers_tests/test_samplers.py
@@ -274,7 +274,7 @@ def test_sample_relative_numerical(
     trial = study.ask(search_space)
     study.tell(trial, sum(trial.params.values()))
 
-    def sample() -> List[float]:
+    def sample() -> List[Union[int, float]]:
         params = study.sampler.sample_relative(study, _create_new_trial(study), search_space)
         return [params[name] for name in search_space]
 

--- a/tests/samplers_tests/test_samplers.py
+++ b/tests/samplers_tests/test_samplers.py
@@ -292,8 +292,13 @@ def test_sample_relative_numerical(
         )
         assert np.all(points[:, i] >= distribution.low)
         assert np.all(points[:, i] <= distribution.high)
-    for param_value in sample():
+    for param_value, distribution in zip(sample(), search_space.values()):
         assert not isinstance(param_value, np.floating)
+        assert not isinstance(param_value, np.integer)
+        if isinstance(distribution, (IntUniformDistribution, IntLogUniformDistribution)):
+            assert isinstance(param_value, int)
+        else:
+            assert isinstance(param_value, float)
 
 
 @parametrize_relative_sampler
@@ -316,6 +321,8 @@ def test_sample_relative_categorical(relative_sampler_class: Callable[[], BaseSa
         assert np.all([v in distribution.choices for v in points[:, i]])
     for param_value in sample():
         assert not isinstance(param_value, np.floating)
+        assert not isinstance(param_value, np.integer)
+        assert isinstance(param_value, int)
 
 
 @parametrize_relative_sampler
@@ -359,8 +366,16 @@ def test_sample_relative_mixed(
     assert np.all(points[:, 0] <= search_space["x"].high)
     assert isinstance(search_space["y"], CategoricalDistribution)
     assert np.all([v in search_space["y"].choices for v in points[:, 1]])
-    for param_value in sample():
+    for param_value, distribution in zip(sample(), search_space.values()):
         assert not isinstance(param_value, np.floating)
+        assert not isinstance(param_value, np.integer)
+        if isinstance(
+            distribution,
+            (IntUniformDistribution, IntLogUniformDistribution, CategoricalDistribution),
+        ):
+            assert isinstance(param_value, int)
+        else:
+            assert isinstance(param_value, float)
 
 
 def _create_new_trial(study: Study) -> FrozenTrial:


### PR DESCRIPTION
## Motivation

Currently, tests of the `sample_relative` methods are missing in `tests/sampler_tests/test_sampler.py` while the `sample_independent` methods are tested in it. I think this is because only a few samplers implemented `sample_relative` when we introduced `sample_relative` and each sampler with `sample_relative` tested it in the individual test file (i.e., `tests/sampler_tests/test_cmaes.py`).

Now that multiple samplers implement `sample_relative`, I think we can introduce the test cases for `sample_relative` to `tests/sampler_tests/test_sampler.py`.


## Description of the changes

- Add test cases of `sample_relative` for `TPESampler(multivariate=True)`, `CmaEsSampler`, `SkoptSampler` and `PyCmaSampler`.
- Fix type of return values of `SkoptSampler` and `PyCmaSampler`.
  - This type checking can be seen in the test cases of `sample_independent`.
