### PR TITLE
Add test case of samplers for conditional objective function

### DIFF
--- a/tests/samplers_tests/test_samplers.py
+++ b/tests/samplers_tests/test_samplers.py
@@ -408,6 +408,8 @@ def test_sample_relative_mixed(
 
 @parametrize_sampler
 def test_conditional_sample_independent(sampler_class: Callable[[], BaseSampler]) -> None:
+    # This test case reproduces the error reported in #2734.
+    # See https://github.com/optuna/optuna/pull/2734#issuecomment-857649769.
 
     study = optuna.study.create_study(sampler=sampler_class())
     categorical_distribution = CategoricalDistribution(choices=["x", "y"])


### PR DESCRIPTION
## Motivation

This PR addresses a part of #2741. It reproduced the error reported in https://github.com/optuna/optuna/pull/2734#issuecomment-857649769.

## Description of the changes

- Add a test case of conditional parameter suggestion.

I confirmed that the test case reproduced the error as follows:

```console

================================================================================================= FAILURES =================================================================================================______________________________________________________________________________ test_conditional_sample_independent[<lambda>0] ______________________________________________________________________________
sampler_class = <function <lambda> at 0x7f19b7258a60>

    @parametrize_sampler
    def test_conditional_sample_independent(sampler_class: Callable[[], BaseSampler]) -> None:

        study = optuna.study.create_study(sampler=sampler_class())
        categorical_distribution = CategoricalDistribution(choices=["x", "y"])
        dependent_distribution = CategoricalDistribution(choices=["a", "b"])                                                                                                                                
        study.add_trial(
            optuna.create_trial(
                params={"category": "x", "x": "a"},
                distributions={"category": categorical_distribution, "x": dependent_distribution},
                value=0.1,
            )
        )

        study.add_trial(                                                                                                                                                                                                optuna.create_trial(
                params={"category": "y", "y": "b"},
                distributions={"category": categorical_distribution, "y": dependent_distribution},
                value=0.1,
            )
        )

        _trial = _create_new_trial(study)
        category = study.sampler.sample_independent(
            study, _trial, "category", categorical_distribution                                                                                                                                                     )
        assert category in ["x", "y"]
>       value = study.sampler.sample_independent(study, _trial, category, dependent_distribution)
                                                                                                                                                                                                            test9.py:80:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ optuna/samplers/_tpe/sampler.py:401: in sample_independent
    mpe_above = _ParzenEstimator(                                                                                                                                                                           optuna/samplers/_tpe/parzen_estimator.py:83: in __init__                                                                                                                                                        categorical_weights = self._calculate_categorical_params(
```


