### PR TITLE
[RFC] Add abbreviated JSON formats of distributions

### DIFF
--- a/optuna/distributions.py
+++ b/optuna/distributions.py
@@ -477,14 +477,52 @@ def json_to_distribution(json_str: str) -> BaseDistribution:
 
     json_dict = json.loads(json_str)
 
-    if json_dict["name"] == CategoricalDistribution.__name__:
-        json_dict["attributes"]["choices"] = tuple(json_dict["attributes"]["choices"])
+    if "name" in json_dict:
+        if json_dict["name"] == CategoricalDistribution.__name__:
+            json_dict["attributes"]["choices"] = tuple(json_dict["attributes"]["choices"])
 
-    for cls in DISTRIBUTION_CLASSES:
-        if json_dict["name"] == cls.__name__:
-            return cls(**json_dict["attributes"])
+        for cls in DISTRIBUTION_CLASSES:
+            if json_dict["name"] == cls.__name__:
+                return cls(**json_dict["attributes"])
 
-    raise ValueError("Unknown distribution class: {}".format(json_dict["name"]))
+        raise ValueError("Unknown distribution class: {}".format(json_dict["name"]))
+
+    else:
+        # Deserialize a distribution from an abbreviated format.
+        if json_dict["type"] == "categorical":
+            return CategoricalDistribution(json_dict["choices"])
+        elif json_dict["type"] in ("float", "int"):
+            low = json_dict["low"]
+            high = json_dict["high"]
+            step = json_dict.get("step")
+            log = json_dict.get("log")
+
+            if json_dict["type"] == "float":
+                if log:
+                    if step:
+                        raise ValueError(
+                            "The parameter `step` is not supported when `log` is true."
+                        )
+                    else:
+                        return LogUniformDistribution(low, high)
+                else:
+                    if step:
+                        return DiscreteUniformDistribution(low, high, step)
+                    else:
+                        return UniformDistribution(low, high)
+            else:
+                if log:
+                    if step:
+                        return IntLogUniformDistribution(low, high, step)
+                    else:
+                        return IntLogUniformDistribution(low, high)
+                else:
+                    if step:
+                        return IntUniformDistribution(low, high, step)
+                    else:
+                        return IntUniformDistribution(low, high)
+
+        raise ValueError("Unknown distribution class: {}".format(json_dict["type"]))
 
 
 def distribution_to_json(dist: BaseDistribution) -> str:

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -34,10 +34,31 @@ EXAMPLE_JSONS = {
     '"attributes": {"low": 2, "high": 12, "step": 2}}',
 }
 
+EXAMPLE_ABBREVIATED_JSONS = {
+    "u": '{"type": "float", "low": 1.0, "high": 2.0}',
+    "l": '{"type": "float", "low": 0.001, "high": 100, "log": true}',
+    "du": '{"type": "float", "low": 1.0, "high": 9.0, "step": 2.0}',
+    "iu": '{"type": "int", "low": 1, "high": 9, "step": 2}',
+    "c1": '{"type": "categorical", "choices": [2.71, -Infinity]}',
+    "c2": '{"type": "categorical", "choices": ["Roppongi", "Azabu"]}',
+    "c3": '{"type": "categorical", "choices": ["Roppongi", "Azabu"]}',
+    "ilu": '{"type": "int", "low": 2, "high": 12, "step": 2, "log": true}',
+}
+
 
 def test_json_to_distribution() -> None:
 
     for key in EXAMPLE_JSONS:
+        distribution_actual = distributions.json_to_distribution(EXAMPLE_JSONS[key])
+        assert distribution_actual == EXAMPLE_DISTRIBUTIONS[key]
+
+    unknown_json = '{"name": "UnknownDistribution", "attributes": {"low": 1.0, "high": 2.0}}'
+    pytest.raises(ValueError, lambda: distributions.json_to_distribution(unknown_json))
+
+
+def test_abbreviated_json_to_distribution() -> None:
+
+    for key in EXAMPLE_ABBREVIATED_JSONS:
         distribution_actual = distributions.json_to_distribution(EXAMPLE_JSONS[key])
         assert distribution_actual == EXAMPLE_DISTRIBUTIONS[key]
 


### PR DESCRIPTION
## Motivation
In the ask CLI, users write JSON formatted distributions. But, the format is complicated to code by hand. The purpose of this PR is to introduce JSON formats of distributions that are more human-readable. 
I think there are other possible formats. Please give me your opinion freely.

- master
```
$ optuna ask --storage sqlite:///mystorage.db --study-name mystudy \
    --search-space '{"x": {"name": "UniformDistribution", "attributes": {"low": 0.0, "high": 1.0}}, "y": {"name": "CategoricalDistribution", "attributes": {"choices": ["foo", "bar"]}}}'
```

- This PR (The master's format also works)
```
$ optuna ask --storage sqlite:///mystorage.db --study-name mystudy \
    --search-space '{"x": {"type": "float", "low": 0.0, "high": 1.0}, "y": {"type": "categorical", "choices": ["foo", "bar"]}}'
```
## Description of the changes
- Deserialize a distribution from an abbreviated format
- Add tests for abbreviated format
