### PR TITLE
Speed-up sampler tests by using random sampling of skopt

### DIFF
--- a/tests/samplers_tests/test_samplers.py
+++ b/tests/samplers_tests/test_samplers.py
@@ -34,7 +34,9 @@ parametrize_sampler = pytest.mark.parametrize(
         lambda: optuna.samplers.TPESampler(n_startup_trials=0),
         lambda: optuna.samplers.TPESampler(n_startup_trials=0, multivariate=True),
         lambda: optuna.samplers.CmaEsSampler(n_startup_trials=0),
-        lambda: optuna.integration.SkoptSampler(skopt_kwargs={"n_initial_points": 1}),
+        lambda: optuna.integration.SkoptSampler(
+            skopt_kwargs={"base_estimator": "dummy", "n_initial_points": 1}
+        ),
         lambda: optuna.integration.PyCmaSampler(n_startup_trials=0),
         optuna.samplers.NSGAIISampler,
     ],
@@ -52,7 +54,9 @@ parametrize_multi_objective_sampler = pytest.mark.parametrize(
     "sampler_class",
     [
         lambda: optuna.samplers.CmaEsSampler(n_startup_trials=0),
-        lambda: optuna.integration.SkoptSampler(skopt_kwargs={"n_initial_points": 1}),
+        lambda: optuna.integration.SkoptSampler(
+            skopt_kwargs={"base_estimator": "dummy", "n_initial_points": 1}
+        ),
         lambda: optuna.integration.PyCmaSampler(n_startup_trials=0),
     ],
 )


### PR DESCRIPTION
## Motivation

Applies @not522 's suggestion in https://github.com/optuna/optuna/pull/2869#discussion_r702550677.

They found that `scikit-optimize` took a large portion of test time of `tests/sampler_tests/tests_samplers.py`, and we can reduce the test time by using the random sampling instead of Gaussian Process.

skopt-specific behavior is tested in `tests/integration_tests/test_skopt.py`, and I think it is reasonable to use the random sampling in `tests/integration_tests/test_skopt.py`.

## Description of the changes

- Set `"base_estimator": "dummy"` to `skopt_kwargs` of `SkoptSampler`. It reduced the test time from 12 sec to 8 sec (about 1.5 times faster).
