### PR TITLE
Extend `MLflowCallback` interface

### DIFF
--- a/optuna/integration/mlflow.py
+++ b/optuna/integration/mlflow.py
@@ -248,7 +248,16 @@ class MLflowCallback(object):
         tags["direction"] = directions if len(directions) != 1 else directions[0]
 
         distributions = {(k + "_distribution"): str(v) for (k, v) in trial.distributions.items()}
-        tags.update({**distributions, **trial.user_attrs, **study.user_attrs})
+        study_attrs = study.user_attrs
+        trial_attrs = trial.user_attrs
+        collisions = study_attrs.keys() & trial_attrs.keys()
+
+        for key in collisions:
+            # make colliding trial and study user attributes unique
+            study_attrs["study_{}".format(key)] = study_attrs.pop(key)
+            trial_attrs["trial_{}".format(key)] = trial_attrs.pop(key)
+
+        tags.update({**distributions, **trial_attrs, **study_attrs})
 
         # This is a temporary fix on Optuna side. It avoids an error with user
         # attributes that are too long. It should be fixed on MLflow side later.

--- a/optuna/integration/mlflow.py
+++ b/optuna/integration/mlflow.py
@@ -133,7 +133,6 @@ class MLflowCallback(object):
         tracking_uri: Optional[str] = None,
         metric_name: Union[str, Sequence[str]] = "value",
         nest_trials: bool = False,
-        tag_study_user_attrs: bool = False,
     ) -> None:
 
         _imports.check()
@@ -148,7 +147,6 @@ class MLflowCallback(object):
         self._tracking_uri = tracking_uri
         self._metric_name = metric_name
         self._nest_trials = nest_trials
-        self._tag_study_user_attrs = tag_study_user_attrs
 
     def __call__(self, study: optuna.study.Study, trial: optuna.trial.FrozenTrial) -> None:
 
@@ -234,12 +232,8 @@ class MLflowCallback(object):
         directions = [d.name for d in study.directions]
         tags["direction"] = directions if len(directions) != 1 else directions[0]
 
-        tags.update(trial.user_attrs)
         distributions = {(k + "_distribution"): str(v) for (k, v) in trial.distributions.items()}
-        tags.update(distributions)
-
-        if self._tag_study_user_attrs:
-            tags.update(study.user_attrs)
+        tags.update({**distributions, **trial.user_attrs, **study.user_attrs})
 
         # This is a temporary fix on Optuna side. It avoids an error with user
         # attributes that are too long. It should be fixed on MLflow side later.

--- a/optuna/integration/mlflow.py
+++ b/optuna/integration/mlflow.py
@@ -137,8 +137,8 @@ class MLflowCallback(object):
             will supersede existing tags.
 
     .. note::
-        ``nest_trials`` argument is now a part of ``mlflow_kwargs``. Anyone using
-        ``nest_trials=True`` should migrate to ``mlflow_kwargs={"nested": True}``
+        ``nest_trials`` argument added in v2.3.0 is a part of ``mlflow_kwargs`` since v2.11.0.
+        Anyone using ``nest_trials=True`` should migrate to ``mlflow_kwargs={"nested": True}``
         to avoid raising :exc:`TypeError`.
 
     Raises:

--- a/optuna/integration/mlflow.py
+++ b/optuna/integration/mlflow.py
@@ -117,13 +117,13 @@ class MLflowCallback(object):
             returned by objective function e.g. two objectives and default metric name
             will be logged as ``value_0`` and ``value_1``.
         create_experiment:
-            When ``True``, new MLflow experiment will be created for each optimization run,
-            named after the Optuna study. Setting this argument to ``False`` lets user run
+            When :obj:`True`, new MLflow experiment will be created for each optimization run,
+            named after the Optuna study. Setting this argument to :obj:`False` lets user run
             optimization under existing experiment, set via `mlflow.set_experiment
             <https://www.mlflow.org/docs/latest/python_api/mlflow.html#mlflow.get_tracking_uri>`_,
             by passing ``experiment_id`` as one of ``mlflow_kwargs`` or under default MLflow
             experiment, when no additional arguments are passed. Note that this argument
-            must be set to ``False`` when using Optuna with this callback within
+            must be set to :obj:`False` when using Optuna with this callback within
             Databricks Notebook.
         mlflow_kwargs:
             Set of arguments passed when initializing MLflow run.

--- a/optuna/integration/mlflow.py
+++ b/optuna/integration/mlflow.py
@@ -132,6 +132,7 @@ class MLflowCallback(object):
         self,
         tracking_uri: Optional[str] = None,
         metric_name: Union[str, Sequence[str]] = "value",
+        create_experiment: bool = True,
         mlflow_kwargs: Optional[Dict[str, Any]] = None,
     ) -> None:
 
@@ -146,6 +147,7 @@ class MLflowCallback(object):
 
         self._tracking_uri = tracking_uri
         self._metric_name = metric_name
+        self._create_experiment = create_experiment
         self._mlflow_kwargs = mlflow_kwargs or {}
 
     def __call__(self, study: optuna.study.Study, trial: optuna.trial.FrozenTrial) -> None:
@@ -210,8 +212,8 @@ class MLflowCallback(object):
         if self._tracking_uri is not None:
             mlflow.set_tracking_uri(self._tracking_uri)
 
-        # This sets the experiment of MLflow.
-        mlflow.set_experiment(study.study_name)
+        if self._create_experiment:
+            mlflow.set_experiment(study.study_name)
 
     def _set_tags(self, trial: optuna.trial.FrozenTrial, study: optuna.study.Study) -> None:
         """Sets the Optuna tags for the current MLflow run.

--- a/optuna/integration/mlflow.py
+++ b/optuna/integration/mlflow.py
@@ -136,6 +136,11 @@ class MLflowCallback(object):
             set, key value pairs in :attr:`~optuna.study.Study.user_attrs`
             will supersede existing tags.
 
+    .. note::
+        ``nest_trials`` argument is now a part of ``mlflow_kwargs``. Anyone using
+        ``nest_trials=True`` should migrate to ``mlflow_kwargs={"nested": True}``
+        to avoid raising :exc:`TypeError`.
+
     Raises:
         :exc:`ValueError`:
             If there are missing or extra metric names in multi-objective optimization.

--- a/optuna/integration/mlflow.py
+++ b/optuna/integration/mlflow.py
@@ -23,8 +23,7 @@ class MLflowCallback(object):
     """Callback to track Optuna trials with MLflow.
 
     This callback adds relevant information that is
-    tracked by Optuna to MLflow. The MLflow experiment
-    will be named after the Optuna study name.
+    tracked by Optuna to MLflow.
 
     Example:
 
@@ -117,15 +116,26 @@ class MLflowCallback(object):
             it will be broadcasted to each objective with a number suffix in order
             returned by objective function e.g. two objectives and default metric name
             will be logged as ``value_0`` and ``value_1``.
-        nest_trials:
-            Flag indicating whether or not trials should be logged as
-            nested runs. This is often helpful for aggregating trials
-            to a particular study, under a given experiment.
-        tag_study_user_attrs:
-            Flag indicating whether or not to add the study's user attrs
-            to the mlflow trial as tags. Please note that when this flag is
-            set, key value pairs in :attr:`~optuna.study.Study.user_attrs`
-            will supersede existing tags.
+        create_experiment:
+            When ``True``, new MLflow experiment will be created for each optimization run,
+            named after the Optuna study. Setting this argument to ``False`` lets user run
+            optimization under existing experiment, set via `mlflow.set_experiment
+            <https://www.mlflow.org/docs/latest/python_api/mlflow.html#mlflow.get_tracking_uri>`_,
+            by passing ``experiment_id`` as one of ``mlflow_kwargs`` or under default MLflow
+            experiment, when no additional arguments are passed. Note that this argument
+            must be set to ``False`` when using Optuna with this callback within
+            Databricks Notebook.
+        mlflow_kwargs:
+            Set of arguments passed when initializing MLflow run.
+            Please refer to `MLflow API documentation
+            <https://www.mlflow.org/docs/latest/python_api/mlflow.html#mlflow.start_run>`_
+            for more details.
+
+    Raises:
+        :exc:`ValueError`:
+            If there are missing or extra metric names in multi-objective optimization.
+        :exc:`TypeError`:
+            When metric names are not passed as sequence.
     """
 
     def __init__(

--- a/tests/integration_tests/test_mlflow.py
+++ b/tests/integration_tests/test_mlflow.py
@@ -101,12 +101,17 @@ def test_use_existing_or_default_experiment(
     tmpdir: py.path.local, name: Optional[str], expected: str
 ) -> None:
 
-    tracking_file_name = "file:{}".format(tmpdir)
-    mlflow.set_tracking_uri(tracking_file_name)
+    if name is not None:
+        tracking_file_name = "file:{}".format(tmpdir)
+        mlflow.set_tracking_uri(tracking_file_name)
+        mlflow.set_experiment(name)
 
-    # TODO(xadrianzetx) Investigate why `Default` cannot be created
-    # automatically, when tmpdir is used.
-    mlflow.set_experiment(name if name is not None else "Default")
+    else:
+        # Target directory can't exist when initializing first
+        # run with default experiment at non-default uri.
+        tracking_file_name = "file:{}/foo".format(tmpdir)
+        mlflow.set_tracking_uri(tracking_file_name)
+
     mlflc = MLflowCallback(tracking_uri=tracking_file_name, create_experiment=False)
     study = optuna.create_study()
 

--- a/tests/integration_tests/test_mlflow.py
+++ b/tests/integration_tests/test_mlflow.py
@@ -194,7 +194,7 @@ def test_nest_trials(tmpdir: py.path.local) -> None:
     mlflow.set_tracking_uri(tmp_tracking_uri)
     mlflow.set_experiment(study_name)
 
-    mlflc = MLflowCallback(tracking_uri=tmp_tracking_uri, nest_trials=True)
+    mlflc = MLflowCallback(tracking_uri=tmp_tracking_uri, mlflow_kwargs={"nested": True})
     study = optuna.create_study(study_name=study_name)
 
     n_trials = 3
@@ -224,7 +224,7 @@ def test_mlflow_callback_fails_when_nest_trials_is_false_and_active_run_exists(
     mlflow.set_tracking_uri(tmp_tracking_uri)
     mlflow.set_experiment(study_name)
 
-    mlflc = MLflowCallback(tracking_uri=tmp_tracking_uri, nest_trials=False)
+    mlflc = MLflowCallback(tracking_uri=tmp_tracking_uri)
     study = optuna.create_study(study_name=study_name)
 
     with mlflow.start_run():


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
Previously users had limited control over mlflow experiment and run initialization, while using `MLflowCallback`. This PR extends its functionality by allowing all `mlflow.start_run` arguments via `mlflow_kwargs` argument (similar to [#2781](https://github.com/optuna/optuna/pull/2781#discussion_r664086151)) and by allowing to decouple experiment name from study name (default behavior is not changed).

This is last task mentioned in #2788.

## Description of the changes
<!-- Describe the changes in this PR. -->
* [x] Add `mlflow_kwargs`argument 
* [x] Decouple experiment name from study name (conditionally)
* [x] ~~Remove `tag_study_user_attrs` argument~~ This has been moved outside of the scope of this PR.
* [x] Write tests
* [x] Update docstrings