### PR TITLE
Add feature to get sampler attributes

### DIFF
--- a/optuna/integration/botorch.py
+++ b/optuna/integration/botorch.py
@@ -2,6 +2,7 @@ from collections import OrderedDict
 from typing import Any
 from typing import Callable
 from typing import Dict
+from typing import List
 from typing import Optional
 from typing import Sequence
 from typing import Union
@@ -533,8 +534,8 @@ class BoTorchSampler(BaseSampler):
             study, trial, param_name, param_distribution
         )
 
-    def reseed_rng(self) -> None:
-        self._independent_sampler.reseed_rng()
+    def get_child_samplers(self) -> List[BaseSampler]:
+        return [self._independent_sampler]
 
     def after_trial(
         self,
@@ -563,4 +564,5 @@ class BoTorchSampler(BaseSampler):
                     "botorch:constraints",
                     constraints,
                 )
-        self._independent_sampler.after_trial(study, trial, state, values)
+
+        super().after_trial(study, trial, state, values)

--- a/optuna/integration/cma.py
+++ b/optuna/integration/cma.py
@@ -4,7 +4,6 @@ from typing import Any
 from typing import Dict
 from typing import List
 from typing import Optional
-from typing import Sequence
 from typing import Set
 
 import numpy
@@ -155,7 +154,7 @@ class PyCmaSampler(BaseSampler):
     def reseed_rng(self) -> None:
 
         self._cma_opts["seed"] = random.randint(1, 2 ** 32)
-        self._independent_sampler.reseed_rng()
+        super().reseed_rng()
 
     def infer_relative_search_space(
         self, study: Study, trial: FrozenTrial
@@ -291,15 +290,8 @@ class PyCmaSampler(BaseSampler):
             )
         )
 
-    def after_trial(
-        self,
-        study: Study,
-        trial: FrozenTrial,
-        state: TrialState,
-        values: Optional[Sequence[float]],
-    ) -> None:
-
-        self._independent_sampler.after_trial(study, trial, state, values)
+    def get_child_samplers(self) -> List[BaseSampler]:
+        return [self._independent_sampler]
 
 
 class _Optimizer(object):

--- a/optuna/integration/skopt.py
+++ b/optuna/integration/skopt.py
@@ -3,7 +3,6 @@ from typing import Any
 from typing import Dict
 from typing import List
 from typing import Optional
-from typing import Sequence
 from typing import Tuple
 import warnings
 
@@ -129,10 +128,6 @@ class SkoptSampler(BaseSampler):
                 ExperimentalWarning,
             )
 
-    def reseed_rng(self) -> None:
-
-        self._independent_sampler.reseed_rng()
-
     def infer_relative_search_space(
         self, study: Study, trial: FrozenTrial
     ) -> Dict[str, distributions.BaseDistribution]:
@@ -223,15 +218,8 @@ class SkoptSampler(BaseSampler):
                 complete_trials.append(copied_t)
         return complete_trials
 
-    def after_trial(
-        self,
-        study: Study,
-        trial: FrozenTrial,
-        state: TrialState,
-        values: Optional[Sequence[float]],
-    ) -> None:
-
-        self._independent_sampler.after_trial(study, trial, state, values)
+    def get_child_samplers(self) -> List[BaseSampler]:
+        return [self._independent_sampler]
 
 
 class _Optimizer(object):

--- a/optuna/samplers/_base.py
+++ b/optuna/samplers/_base.py
@@ -1,6 +1,7 @@
 import abc
 from typing import Any
 from typing import Dict
+from typing import List
 from typing import Optional
 from typing import Sequence
 
@@ -143,6 +144,15 @@ class BaseSampler(object, metaclass=abc.ABCMeta):
 
         raise NotImplementedError
 
+    def get_child_samplers(self) -> List["BaseSampler"]:
+        """Get the samplers in attribute.
+
+        This method returns sampler attributes in the sampler. Samplers that inherit `BaseSampler`
+        may have sampler attributes, e.g., a random sampler for fallback.
+        """
+
+        return []
+
     def after_trial(
         self,
         study: Study,
@@ -172,7 +182,8 @@ class BaseSampler(object, metaclass=abc.ABCMeta):
 
         """
 
-        pass
+        for sampler in self.get_child_samplers():
+            sampler.after_trial(study, trial, state, values)
 
     def reseed_rng(self) -> None:
         """Reseed sampler's random number generator.
@@ -184,7 +195,8 @@ class BaseSampler(object, metaclass=abc.ABCMeta):
         number generator.
         """
 
-        pass
+        for sampler in self.get_child_samplers():
+            sampler.reseed_rng()
 
     def _raise_error_if_multi_objective(self, study: Study) -> None:
 

--- a/optuna/samplers/_cmaes.py
+++ b/optuna/samplers/_cmaes.py
@@ -6,7 +6,6 @@ from typing import cast
 from typing import Dict
 from typing import List
 from typing import Optional
-from typing import Sequence
 from typing import Tuple
 from typing import Union
 import warnings
@@ -270,7 +269,7 @@ class CmaEsSampler(BaseSampler):
 
     def reseed_rng(self) -> None:
         # _cma_rng doesn't require reseeding because the relative sampling reseeds in each trial.
-        self._independent_sampler.reseed_rng()
+        super().reseed_rng()
 
     def infer_relative_search_space(
         self, study: "optuna.Study", trial: "optuna.trial.FrozenTrial"
@@ -544,15 +543,8 @@ class CmaEsSampler(BaseSampler):
                 complete_trials.append(copied_t)
         return complete_trials
 
-    def after_trial(
-        self,
-        study: "optuna.Study",
-        trial: "optuna.trial.FrozenTrial",
-        state: TrialState,
-        values: Optional[Sequence[float]],
-    ) -> None:
-
-        self._independent_sampler.after_trial(study, trial, state, values)
+    def get_child_samplers(self) -> List[BaseSampler]:
+        return [self._independent_sampler]
 
 
 def _split_optimizer_str(optimizer_str: str) -> Dict[str, str]:

--- a/optuna/samplers/_nsga2.py
+++ b/optuna/samplers/_nsga2.py
@@ -134,7 +134,7 @@ class NSGAIISampler(BaseSampler):
         self._constraints_func = constraints_func
 
     def reseed_rng(self) -> None:
-        self._random_sampler.reseed_rng()
+        super().reseed_rng()
         self._rng = np.random.RandomState()
 
     def infer_relative_search_space(
@@ -346,6 +346,9 @@ class NSGAIISampler(BaseSampler):
 
         return population_per_rank
 
+    def get_child_samplers(self) -> List[BaseSampler]:
+        return [self._random_sampler]
+
     def after_trial(
         self,
         study: Study,
@@ -373,7 +376,8 @@ class NSGAIISampler(BaseSampler):
                     _CONSTRAINTS_KEY,
                     constraints,
                 )
-        self._random_sampler.after_trial(study, trial, state, values)
+
+        super().after_trial(study, trial, state, values)
 
 
 def _crowding_distance_sort(population: List[FrozenTrial]) -> None:

--- a/optuna/samplers/_partial_fixed.py
+++ b/optuna/samplers/_partial_fixed.py
@@ -1,7 +1,6 @@
 from typing import Any
 from typing import Dict
-from typing import Optional
-from typing import Sequence
+from typing import List
 import warnings
 
 from optuna._experimental import experimental
@@ -9,7 +8,6 @@ from optuna.distributions import BaseDistribution
 from optuna.samplers import BaseSampler
 from optuna.study import Study
 from optuna.trial import FrozenTrial
-from optuna.trial import TrialState
 
 
 @experimental("2.4.0")
@@ -56,9 +54,6 @@ class PartialFixedSampler(BaseSampler):
     def __init__(self, fixed_params: Dict[str, Any], base_sampler: BaseSampler) -> None:
         self._fixed_params = fixed_params
         self._base_sampler = base_sampler
-
-    def reseed_rng(self) -> None:
-        self._base_sampler.reseed_rng()
 
     def infer_relative_search_space(
         self, study: Study, trial: FrozenTrial
@@ -112,12 +107,5 @@ class PartialFixedSampler(BaseSampler):
                 )
             return param_value
 
-    def after_trial(
-        self,
-        study: Study,
-        trial: FrozenTrial,
-        state: TrialState,
-        values: Optional[Sequence[float]],
-    ) -> None:
-
-        self._base_sampler.after_trial(study, trial, state, values)
+    def get_child_samplers(self) -> List[BaseSampler]:
+        return [self._base_sampler]

--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -4,7 +4,6 @@ from typing import Callable
 from typing import Dict
 from typing import List
 from typing import Optional
-from typing import Sequence
 from typing import Tuple
 from typing import Union
 import warnings
@@ -288,7 +287,7 @@ class TPESampler(BaseSampler):
     def reseed_rng(self) -> None:
 
         self._rng = np.random.RandomState()
-        self._random_sampler.reseed_rng()
+        super().reseed_rng()
 
     def infer_relative_search_space(
         self, study: Study, trial: FrozenTrial
@@ -514,15 +513,8 @@ class TPESampler(BaseSampler):
             "weights": default_weights,
         }
 
-    def after_trial(
-        self,
-        study: Study,
-        trial: FrozenTrial,
-        state: TrialState,
-        values: Optional[Sequence[float]],
-    ) -> None:
-
-        self._random_sampler.after_trial(study, trial, state, values)
+    def get_child_samplers(self) -> List[BaseSampler]:
+        return [self._random_sampler]
 
 
 def _calculate_nondomination_rank(loss_vals: np.ndarray) -> np.ndarray:


### PR DESCRIPTION
## Motivation
The current implementation of `after_trial` and `reseed_rng` has repeated code to call child samplers. This PR will add `get_child_samplers` to refactor these methods.

## Description of the changes
- Add `get_child_samplers`
