### PR TITLE
Use `:obj:` for `True`, `False`, and `None` instead of inline code

### DIFF
--- a/optuna/integration/allennlp/_pruner.py
+++ b/optuna/integration/allennlp/_pruner.py
@@ -122,7 +122,7 @@ class AllenNLPPruningCallback(TrainerCallback):
 
         On the other hand, when :class:`~optuna.integration.AllenNLPPruningCallback` is used with
         :class:`~optuna.integration.AllenNLPExecutor`, ``trial`` and ``monitor``
-        would be ``None``. :class:`~optuna.integration.AllenNLPExecutor` sets
+        would be :obj:`None`. :class:`~optuna.integration.AllenNLPExecutor` sets
         environment variables for a study name, trial id, monitor, and storage.
         Then :class:`~optuna.integration.AllenNLPPruningCallback`
         loads them to restore ``trial`` and ``monitor``.

--- a/optuna/progress_bar.py
+++ b/optuna/progress_bar.py
@@ -25,11 +25,11 @@ class _TqdmLoggingHandler(logging.StreamHandler):
 
 
 class _ProgressBar(object):
-    """Progress Bar implementation for `Study.optimize` on the top of `tqdm`.
+    """Progress Bar implementation for :func:`~optuna.study.Study.optimize` on the top of `tqdm`.
 
     Args:
         is_valid:
-            Whether to show progress bars in `Study.optimize`.
+            Whether to show progress bars in :func:`~optuna.study.Study.optimize`.
         n_trials:
             The number of trials.
         timeout:
@@ -60,11 +60,11 @@ class _ProgressBar(object):
         optuna_logging._get_library_root_logger().addHandler(_tqdm_handler)
 
     def update(self, elapsed_seconds: Optional[float]) -> None:
-        """Update the progress bars if ``is_valid`` is ``True``.
+        """Update the progress bars if ``is_valid`` is :obj:`True`.
 
         Args:
             elapsed_seconds:
-                The time past since `Study.optimize` started.
+                The time past since :func:`~optuna.study.Study.optimize` started.
         """
         if self._is_valid:
             self._progress_bar.update(1)

--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -381,7 +381,7 @@ class Study(BaseStudy):
                     :ref:`out-of-memory-gc-collect`
 
             show_progress_bar:
-                Flag to show progress bars or not. To disable progress bar, set this ``False``.
+                Flag to show progress bars or not. To disable progress bar, set this :obj:`False`.
                 Currently, progress bar is experimental feature and disabled
                 when ``n_jobs`` :math:`\\ne 1`.
 

--- a/optuna/testing/visualization.py
+++ b/optuna/testing/visualization.py
@@ -15,14 +15,14 @@ def prepare_study_with_trials(
     """Prepare a study for tests.
 
     Args:
-        no_trials: If ``False``, create a study with no trials.
-        less_than_two: If ``True``, create a study with two/four hyperparameters where
+        no_trials: If :obj:`False`, create a study with no trials.
+        less_than_two: If :obj:`True`, create a study with two/four hyperparameters where
             'param_a' (and 'param_c') appear(s) only once while 'param_b' (and 'param_d')
             appear(s) twice in `study.trials`.
-        more_than_three: If ``True``, create a study with two/four hyperparameters where
+        more_than_three: If :obj:`True`, create a study with two/four hyperparameters where
             'param_a' (and 'param_c') appear(s) only three times while 'param_b' (and 'param_d')
             appear(s) four times in `study.trials`.
-        with_c_d: If ``True``, the study has four hyperparameters named 'param_a',
+        with_c_d: If :obj:`True`, the study has four hyperparameters named 'param_a',
             'param_b', 'param_c', and 'param_d'. Otherwise, there are only two
             hyperparameters ('param_a' and 'param_b').
         n_objectives: Number of objective values.

--- a/optuna/trial/_trial.py
+++ b/optuna/trial/_trial.py
@@ -146,7 +146,8 @@ class Trial(BaseTrial):
 
                 .. note::
                     The ``step`` and ``log`` arguments cannot be used at the same time. To set
-                    the ``step`` argument to a float number, set the ``log`` argument to ``False``.
+                    the ``step`` argument to a float number, set the ``log`` argument to
+                    :obj:`False`.
             log:
                 A flag to sample the value from the log domain or not.
                 If ``log`` is true, the value is sampled from the range in the log domain.
@@ -155,7 +156,7 @@ class Trial(BaseTrial):
 
                 .. note::
                     The ``step`` and ``log`` arguments cannot be used at the same time. To set
-                    the ``log`` argument to ``True``, set the ``step`` argument to ``None``.
+                    the ``log`` argument to :obj:`True`, set the ``step`` argument to :obj:`None`.
 
         Raises:
             :exc:`ValueError`:
@@ -407,7 +408,7 @@ class Trial(BaseTrial):
                 .. note::
                     The ``step != 1`` and ``log`` arguments cannot be used at the same time.
                     To set the ``step`` argument :math:`\\mathsf{step} \\ge 2`, set the
-                    ``log`` argument to ``False``.
+                    ``log`` argument to :obj:`False`.
             log:
                 A flag to sample the value from the log domain or not.
 
@@ -423,7 +424,7 @@ class Trial(BaseTrial):
 
                 .. note::
                     The ``step != 1`` and ``log`` arguments cannot be used at the same time.
-                    To set the ``log`` argument to ``True``, set the ``step`` argument to 1.
+                    To set the ``log`` argument to :obj:`True`, set the ``step`` argument to 1.
 
         Raises:
             :exc:`ValueError`:


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->


By chance, I found that a few `True`, `False`, and `None` are not used with `:obj:` in the docstring.

## Description of the changes
<!-- Describe the changes in this PR. -->

Use `:obj:` prefix instead of inline code syntax. 

~Note that the following codes do not use the prefix as well, but they are not shown in Optuna's document. If I should replace them as well, I'm happy to update this pull request!~

I locally confirmed no more such inline code in the Optuna codebase as follows.

### `True`
```bash
grep -i "\`\`True\`\`" -r optuna/
```

### `False`

```bash
grep -i "\`\`False\`\`" -r optuna/
```

### `None`
```bash
 grep -i "\`\`None\`\`" -r optuna/
```