### PR TITLE
Add single distribution support to `BoTorchSampler`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -66,6 +66,7 @@ jobs:
         # TODO(hvy): Fix samplers_tests/test_samplers.py to not require optional dependencies and remove these installs.
         pip install scikit-optimize
         pip install cma
+        pip install botorch torch==1.8.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
 
     - name: Tests
       run: |

--- a/tests/samplers_tests/test_samplers.py
+++ b/tests/samplers_tests/test_samplers.py
@@ -51,7 +51,7 @@ parametrize_multi_objective_sampler = pytest.mark.parametrize(
     "multi_objective_sampler_class",
     [
         optuna.samplers.NSGAIISampler,
-        optuna.samplers.MOTPESampler,
+        lambda: optuna.samplers.MOTPESampler(n_startup_trials=0),
     ]
     + []
     if sys.version_info < (3, 7, 0)

--- a/tests/samplers_tests/test_samplers.py
+++ b/tests/samplers_tests/test_samplers.py
@@ -1,4 +1,5 @@
 import pickle
+import sys
 from typing import Any
 from typing import Callable
 from typing import cast
@@ -40,17 +41,21 @@ parametrize_sampler = pytest.mark.parametrize(
             skopt_kwargs={"base_estimator": "dummy", "n_initial_points": 1}
         ),
         lambda: optuna.integration.PyCmaSampler(n_startup_trials=0),
-        lambda: optuna.integration.BoTorchSampler(n_startup_trials=0),
         optuna.samplers.NSGAIISampler,
-    ],
+    ]
+    + []
+    if sys.version_info < (3, 7, 0)
+    else [lambda: optuna.integration.BoTorchSampler(n_startup_trials=0)],
 )
 parametrize_multi_objective_sampler = pytest.mark.parametrize(
     "multi_objective_sampler_class",
     [
         optuna.samplers.NSGAIISampler,
         optuna.samplers.MOTPESampler,
-        lambda: optuna.integration.BoTorchSampler(n_startup_trials=0),
-    ],
+    ]
+    + []
+    if sys.version_info < (3, 7, 0)
+    else [lambda: optuna.integration.BoTorchSampler(n_startup_trials=0)],
 )
 
 

--- a/tests/samplers_tests/test_samplers.py
+++ b/tests/samplers_tests/test_samplers.py
@@ -49,6 +49,7 @@ parametrize_multi_objective_sampler = pytest.mark.parametrize(
     [
         optuna.samplers.NSGAIISampler,
         optuna.samplers.MOTPESampler,
+        lambda: optuna.integration.BoTorchSampler(n_startup_trials=0),
     ],
 )
 

--- a/tests/samplers_tests/test_samplers.py
+++ b/tests/samplers_tests/test_samplers.py
@@ -40,6 +40,7 @@ parametrize_sampler = pytest.mark.parametrize(
             skopt_kwargs={"base_estimator": "dummy", "n_initial_points": 1}
         ),
         lambda: optuna.integration.PyCmaSampler(n_startup_trials=0),
+        lambda: optuna.integration.BoTorchSampler(n_startup_trials=0),
         optuna.samplers.NSGAIISampler,
     ],
 )


### PR DESCRIPTION
## Motivation

This PR addresses an issue reported in https://github.com/optuna/optuna/pull/2897#issuecomment-913821261.
The current `BoTorchSampler` raises `InputDataError` when users input distributions with a single value (i.e., a uniform distribution whose `low` and `high` are the same value).

```console
Z = tensor([[   nan,    nan, 0.5000, 0.5000, 0.6309, 1.0000]], dtype=torch.float64)

    def check_no_nans(Z: Tensor) -> None:
        r"""Check that tensor does not contain NaN values.
    
        Raises an InputDataError if `Z` contains NaN values.
    
        Args:
            Z: The input tensor.
        """
        if torch.any(torch.isnan(Z)).item():
>           raise InputDataError("Input data contains NaN values.")
E           botorch.exceptions.errors.InputDataError: Input data contains NaN values.

.venv/lib/python3.8/site-packages/botorch/models/utils.py:131: InputDataError
```

More specifically, input values `train_x` of `botorch.models.SingleTaskGP` will be `nan` after the normalization using `botorch.utils.transforms.normalize`.
https://github.com/optuna/optuna/blob/58b6889b8258f9e58ed995c2f58b1541f17be4c3/optuna/integration/botorch.py#L120-L122

## Description of the changes

- Exclude such distributions in `infer_relative_search_space` similarly to `optuna.samplers.CmaEsSampler`.
- Tests `BoTorchSampler` in `tests/sampler_tests/test_samplers.py` that has the `test_sample_single_distribution` test case.