### PR TITLE
Validate `FrozenTrial.values`

### DIFF
--- a/optuna/trial/_frozen.py
+++ b/optuna/trial/_frozen.py
@@ -350,6 +350,22 @@ class FrozenTrial(BaseTrial):
                     "{}.".format(param_value, param_name, distribution)
                 )
 
+        if self.values is not None:
+            for i, v in enumerate(self.values):
+                # `value` can be None.
+                if v is None:
+                    continue
+                try:
+                    # Check if `values` element is float. This check accepts float-castable values
+                    # including numpy.floating and numpy.integer, which are sometimes returned
+                    # by objective functions.
+                    _ = v + 1
+                except TypeError:
+                    raise ValueError(
+                        "{}-th element of `values` is {}. All elements are supposed to be float "
+                        "or None.".format(i, type(v).__name__)
+                    ) from None
+
     def _suggest(self, name: str, distribution: BaseDistribution) -> Any:
 
         if name not in self._params:

--- a/optuna/trial/_frozen.py
+++ b/optuna/trial/_frozen.py
@@ -1,4 +1,5 @@
 import datetime
+import numbers
 from typing import Any
 from typing import Dict
 from typing import List
@@ -355,16 +356,14 @@ class FrozenTrial(BaseTrial):
                 # `value` can be None.
                 if v is None:
                     continue
-                try:
-                    # Check if `values` element is float. This check accepts float-castable values
-                    # including numpy.floating and numpy.integer, which are sometimes returned
-                    # by objective functions.
-                    _ = v + 1
-                except TypeError:
+                # Check if `values` element is a real number. This check accepts float-castable
+                # values including numpy.floating and numpy.integer, which are sometimes returned
+                # by objective functions.
+                if not isinstance(v, numbers.Real):
                     raise ValueError(
                         "{}-th element of `values` is {}. All elements are supposed to be float "
                         "or None.".format(i, type(v).__name__)
-                    ) from None
+                    )
 
     def _suggest(self, name: str, distribution: BaseDistribution) -> Any:
 

--- a/tests/trial_tests/test_frozen.py
+++ b/tests/trial_tests/test_frozen.py
@@ -422,7 +422,7 @@ def test_validate() -> None:
 
     # Invalid: `value` has invalid type value.
     invalid_trial = copy.copy(valid_trial)
-    for value in ["1", "a", [1], {2}, [3, 4], {"k", "v"}]:
+    for value in ["1", "a", [1], {2}, [3, 4], {"k", "v"}, 1j]:
         invalid_trial.value = value  # type: ignore
         with pytest.raises(ValueError):
             invalid_trial._validate()

--- a/tests/trial_tests/test_frozen.py
+++ b/tests/trial_tests/test_frozen.py
@@ -427,6 +427,7 @@ def test_validate() -> None:
         with pytest.raises(ValueError):
             invalid_trial._validate()
 
+
 def test_number() -> None:
 
     trial = _create_frozen_trial()

--- a/tests/trial_tests/test_frozen.py
+++ b/tests/trial_tests/test_frozen.py
@@ -423,7 +423,7 @@ def test_validate() -> None:
     # Invalid: `value` has invalid type value.
     invalid_trial = copy.copy(valid_trial)
     for value in ["1", "a", [1], {2}, [3, 4], {"k", "v"}]:
-        invalid_trial.value = value
+        invalid_trial.value = value  # type: ignore
         with pytest.raises(ValueError):
             invalid_trial._validate()
 

--- a/tests/trial_tests/test_frozen.py
+++ b/tests/trial_tests/test_frozen.py
@@ -6,6 +6,7 @@ from typing import List
 from typing import Optional
 from typing import Tuple
 
+import numpy as np
 import pytest
 
 from optuna import create_study
@@ -413,6 +414,18 @@ def test_validate() -> None:
         with pytest.raises(ValueError):
             invalid_trial._validate()
 
+    # Valid: `value` accepts float-castable values.
+    _trial = copy.copy(valid_trial)
+    for value in [1.0, 1, np.float32(1.0), np.int_(1)]:
+        _trial.value = value
+        _trial._validate()
+
+    # Invalid: `value` has invalid type value.
+    invalid_trial = copy.copy(valid_trial)
+    for value in ["1", "a", [1], {2}, [3, 4], {"k", "v"}]:
+        invalid_trial.value = value
+        with pytest.raises(ValueError):
+            invalid_trial._validate()
 
 def test_number() -> None:
 

--- a/tests/trial_tests/test_frozen.py
+++ b/tests/trial_tests/test_frozen.py
@@ -417,7 +417,7 @@ def test_validate() -> None:
     # Valid: `value` accepts float-castable values.
     _trial = copy.copy(valid_trial)
     for value in [1.0, 1, np.float32(1.0), np.int_(1)]:
-        _trial.value = value  #type: ignore
+        _trial.value = value  # type: ignore
         _trial._validate()
 
     # Invalid: `value` has invalid type value.

--- a/tests/trial_tests/test_frozen.py
+++ b/tests/trial_tests/test_frozen.py
@@ -417,7 +417,7 @@ def test_validate() -> None:
     # Valid: `value` accepts float-castable values.
     _trial = copy.copy(valid_trial)
     for value in [1.0, 1, np.float32(1.0), np.int_(1)]:
-        _trial.value = value
+        _trial.value = value  #type: ignore
         _trial._validate()
 
     # Invalid: `value` has invalid type value.


### PR DESCRIPTION
## Motivation

This PR Addresses #2929.

## Description of the changes

Users use `optuna.create_trial` to create `FrozenTrial` instances and it calls `FrozenTrial._validate`. So, I added the value checking to `FrozenTrial._validate` instead of the setter of `FrozenTrial.values`.

- Check `FrozenTrial.values` in `FrozenTrial._validate`.
- Add test cases for `FrozenTrial.values`.

Alternatively, we can check then in . I think 