### PR TITLE
Fix `GridSampler` with `RetryFailedTrialCallback` or `enqueue_trial`

### DIFF
--- a/optuna/samplers/_grid.py
+++ b/optuna/samplers/_grid.py
@@ -125,6 +125,11 @@ class GridSampler(BaseSampler):
         # object is hard to get at the beginning of trial, while we need the access to the object
         # to validate the sampled value.
 
+        # When the trial is created by RetryFailedTrialCallback or enqueue_trial, we should not
+        # assign a new grid_id.
+        if "grid_id" in trial.system_attrs or "fixed_params" in trial.system_attrs:
+            return {}
+
         target_grids = self._get_unvisited_grid_ids(study)
 
         if len(target_grids) == 0:
@@ -157,6 +162,10 @@ class GridSampler(BaseSampler):
         param_name: str,
         param_distribution: BaseDistribution,
     ) -> Any:
+
+        if "grid_id" not in trial.system_attrs:
+            message = "You should specify all parameters in enqueue_trial when using GridSampler."
+            raise ValueError(message)
 
         if param_name not in self._search_space:
             message = "The parameter name, {}, is not found in the given grid.".format(param_name)


### PR DESCRIPTION
## Motivation
When we use `GridSampler` with `RetryFailedTrialCallback` or `enqueue_trial`, the sampler does not pick up all grids. This PR fixes this behavior by ignoring enqueued trials.

```python
import optuna

def objective(trial):
    return trial.suggest_float("x", -10, 10)

sampler = optuna.samplers.GridSampler({"x": [-1, 0, 1]})
study = optuna.create_study(sampler=sampler)
study.enqueue_trial({"x": 10})
study.optimize(objective)
```

- master

```
[I 2021-09-22 11:21:34,761] A new study created in memory with name: no-name-298969ad-d8eb-4cab-a2cf-6ec0cd2b7fde
[I 2021-09-22 11:21:34,762] Trial 0 finished with value: 10.0 and parameters: {'x': 10}. Best is trial 0 with value: 10.0.
[I 2021-09-22 11:21:34,763] Trial 1 finished with value: 1.0 and parameters: {'x': 1}. Best is trial 1 with value: 1.0.
[I 2021-09-22 11:21:34,763] Trial 2 finished with value: -1.0 and parameters: {'x': -1}. Best is trial 2 with value: -1.0.
```

- PR

```
[I 2021-09-22 11:21:22,920] A new study created in memory with name: no-name-b2e9c514-7365-467a-8b1b-4be82226a5cd
[I 2021-09-22 11:21:23,345] Trial 0 finished with value: 10.0 and parameters: {'x': 10}. Best is trial 0 with value: 10.0.
[I 2021-09-22 11:21:23,346] Trial 1 finished with value: -1.0 and parameters: {'x': -1}. Best is trial 1 with value: -1.0.
[I 2021-09-22 11:21:23,348] Trial 2 finished with value: 1.0 and parameters: {'x': 1}. Best is trial 1 with value: -1.0.
[I 2021-09-22 11:21:23,350] Trial 3 finished with value: 0.0 and parameters: {'x': 0}. Best is trial 1 with value: -1.0.
```

## Description of the changes
- Fix `GridSampler` to ignore enqueued trials
- Add tests