### PR TITLE
Fix method `untransform` of `_SearchSpaceTransform` with `distribution.single() == True`

### DIFF
--- a/optuna/_transform.py
+++ b/optuna/_transform.py
@@ -268,10 +268,16 @@ def _untransform_numerical_param(
     if isinstance(d, CategoricalDistribution):
         assert False, "Should not reach. Should be one-hot encoded."
     elif isinstance(d, UniformDistribution):
-        param = min(trans_param, numpy.nextafter(d.high, d.high - 1))
+        if d.single():
+            param = trans_param
+        else:
+            param = min(trans_param, numpy.nextafter(d.high, d.high - 1))
     elif isinstance(d, LogUniformDistribution):
         param = math.exp(trans_param) if transform_log else trans_param
-        param = min(param, numpy.nextafter(d.high, d.high - 1))
+        if d.single():
+            pass
+        else:
+            param = min(param, numpy.nextafter(d.high, d.high - 1))
     elif isinstance(d, DiscreteUniformDistribution):
         # Clip since result may slightly exceed range due to round-off errors.
         param = float(

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -166,6 +166,8 @@ def test_search_space_transform_untransform_params() -> None:
         "x5": LogUniformDistribution(1, 10),
         "x6": IntUniformDistribution(2, 4),
         "x7": CategoricalDistribution(["corge"]),
+        "x8": UniformDistribution(-2, -2),
+        "x9": LogUniformDistribution(1, 1),
     }
 
     params = {
@@ -177,6 +179,8 @@ def test_search_space_transform_untransform_params() -> None:
         "x5": 1.0,
         "x6": 2,
         "x7": "corge",
+        "x8": -2.0,
+        "x9": 1.0,
     }
 
     trans = _SearchSpaceTransform(search_space)


### PR DESCRIPTION
## Motivation
The current `untransform` method of `_SearchSpaceTransform` uses the higher bound offset logic, but it may return wrong values when `low==high` in `uniformDistribution` and `LogUniformDistribution`.
Details of this issue are reported in #2945 .

## Description of the changes
-  Do not apply `min()` when `d.single()==True`.
- Add some tests