### PR TITLE
Add note of the behavior when calling multiple `trial.report`

### DIFF
--- a/optuna/trial/_trial.py
+++ b/optuna/trial/_trial.py
@@ -518,6 +518,11 @@ class Trial(BaseTrial):
             function internally. Thus, it accepts all float-like types (e.g., ``numpy.float32``).
             If the conversion fails, a ``TypeError`` is raised.
 
+        .. note::
+            If this method is called multiple times at the same ``step`` in a trial,
+            reported ``value`` only the first time is stored and the reported values
+            from the second time are ignored.
+
         Example:
 
             Report intermediate scores of `SGDClassifier <https://scikit-learn.org/stable/modules/


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

Resolve https://github.com/optuna/optuna/issues/2933

When we call `trial.report` at the same `step` in a trial, optuna shows a warming message. However, this behaviour has not been described in the documentation.

## Description of the changes
<!-- Describe the changes in this PR. -->

Add a note section to describe the behaviour.
