### PR TITLE
Be aware of trial preparation when checking heartbeat interval

### DIFF
--- a/tests/storages_tests/rdb_tests/test_storage.py
+++ b/tests/storages_tests/rdb_tests/test_storage.py
@@ -423,5 +423,11 @@ def test_record_heartbeat() -> None:
                 trial_heartbeats.append(heartbeat_model.heartbeat)
 
         assert len(trial_heartbeats) == n_trials
+        trials = study.trials
         for i in range(n_trials - 1):
-            assert (trial_heartbeats[i + 1] - trial_heartbeats[i]).seconds - sleep_sec <= 1
+            datetime_start = trials[i + 1].datetime_start
+            prev_datetime_complete = trials[i].datetime_complete
+            assert datetime_start is not None and prev_datetime_complete is not None
+            trial_prep = (datetime_start - prev_datetime_complete).seconds
+            heartbeats_interval = (trial_heartbeats[i + 1] - trial_heartbeats[i]).seconds
+            assert heartbeats_interval - sleep_sec - trial_prep <= 1


### PR DESCRIPTION
## Motivation

Fix https://github.com/optuna/optuna/runs/3787941538.

The following assertion checks the difference between heartbeat timestamps of two consequent trials is nearly equal to the calculation time of the objective value (i.e., `sleep_sec`). 
https://github.com/optuna/optuna/blob/f92457afffa8aaa9814c31649b78ff15910fa269/tests/storages_tests/rdb_tests/test_storage.py#L426-L427

However, the difference between heartbeat timestamps also includes trial preparation time. This seems to be a cause of the CI failure.

<details>
<summary>Error log</summary>

```console
    def test_record_heartbeat() -> None:
    
        heartbeat_interval = 1
        n_trials = 2
        sleep_sec = 2
    
        def objective(trial: Trial) -> float:
            time.sleep(sleep_sec)
            return 1.0
    
        with StorageSupplier("sqlite") as storage:
            assert isinstance(storage, RDBStorage)
            storage.heartbeat_interval = heartbeat_interval
            study = create_study(storage=storage)
            # Exceptions raised in spawned threads are caught by `_TestableThread`.
            with patch("optuna.study._optimize.Thread", _TestableThread):
                study.optimize(objective, n_trials=n_trials)
    
            trial_heartbeats = []
    
            with _create_scoped_session(storage.scoped_session) as session:
                trial_ids = [trial._trial_id for trial in study.trials]
                for trial_id in trial_ids:
                    heartbeat_model = TrialHeartbeatModel.where_trial_id(trial_id, session)
                    assert heartbeat_model is not None
                    trial_heartbeats.append(heartbeat_model.heartbeat)
    
            assert len(trial_heartbeats) == n_trials
            for i in range(n_trials - 1):
>               assert (trial_heartbeats[i + 1] - trial_heartbeats[i]).seconds - sleep_sec <= 1
E               assert (4 - 2) <= 1
E                +  where 4 = (datetime.datetime(2021, 10, 4, 7, 55, 59) - datetime.datetime(2021, 10, 4, 7, 55, 55)).seconds

tests/storages_tests/rdb_tests/test_storage.py:427: AssertionError
```

</details>

## Description of the changes

- This PR calculates the trial preparation time and subtracts it from the heartbeat timestamp differences. The updated assertion pass even if I add a callback that waits for `sleep_sec` to `study.optimize(objective, n_trials=n_trials)`.

