### PR TITLE
Install `botorch` to CI jobs on mac.

### DIFF
--- a/.github/workflows/mac-tests.yml
+++ b/.github/workflows/mac-tests.yml
@@ -50,6 +50,7 @@ jobs:
         # TODO(hvy): Fix samplers_tests/test_samplers.py to not require optional depenendencies and remove these installs.
         pip install scikit-optimize
         pip install cma
+        pip install botorch torch==1.8.0
 
     - name: Tests
       run: |


### PR DESCRIPTION
## Motivation

Fix https://github.com/optuna/optuna/runs/3811341475.
Some test cases in `tests/samplers_tests/test_samplers.py` failed due to the missing dependencies.

```console
 E           ImportError: Tried to import ‘botorch’ but failed. Please make sure that the package is installed correctly to use this feature. Actual error: No module named ‘botorch’.
```

## Description of the changes

This PR adds `torch` and `botorch` to `tests-mac` job. Unlike https://github.com/optuna/optuna/pull/2928/files#diff-1db27d93186e46d3b441ece35801b244db8ee144ff1405ca27a163bfe878957fR69, it installs torch via PyPI because CPU version of torch for mac is not available at https://download.pytorch.org/whl/torch_stable.html.

@nzw0301 originally found the problem and the solution. Thanks a lot!