### PR TITLE
Use `optuna.load_study` in `optuna ask` CLI to omit `direction`/`directions` option

### DIFF
--- a/optuna/cli.py
+++ b/optuna/cli.py
@@ -833,7 +833,14 @@ class _Ask(_BaseCommand):
         else:
             search_space = {}
 
-        study = optuna.create_study(**create_study_kwargs)
+        try:
+            study = optuna.load_study(
+                create_study_kwargs["study_name"],
+                create_study_kwargs["storage"],
+                create_study_kwargs.get("sampler"),
+            )
+        except KeyError:
+            study = optuna.create_study(**create_study_kwargs)
         trial = study.ask(fixed_distributions=search_space)
 
         self.logger.info(f"Asked trial {trial.number} with parameters {trial.params}.")

--- a/optuna/cli.py
+++ b/optuna/cli.py
@@ -855,7 +855,10 @@ class _Ask(_BaseCommand):
                 create_study_kwargs.get("sampler"),
             )
             directions = None
-            if create_study_kwargs["direction"] is not None and create_study_kwargs["directions"] is not None:
+            if (
+                create_study_kwargs["direction"] is not None
+                and create_study_kwargs["directions"] is not None
+            ):
                 raise ValueError("Specify only one of `direction` and `directions`.")
             if create_study_kwargs["direction"] is not None:
                 directions = [

--- a/optuna/cli.py
+++ b/optuna/cli.py
@@ -855,6 +855,8 @@ class _Ask(_BaseCommand):
                 create_study_kwargs.get("sampler"),
             )
             directions = None
+            if create_study_kwargs["direction"] is not None and create_study_kwargs["directions"] is not None:
+                raise ValueError("Specify only one of `direction` and `directions`.")
             if create_study_kwargs["direction"] is not None:
                 directions = [
                     optuna.study.StudyDirection[create_study_kwargs["direction"].upper()]

--- a/optuna/cli.py
+++ b/optuna/cli.py
@@ -816,8 +816,9 @@ class _Ask(_BaseCommand):
 
         if parsed_args.direction is not None or parsed_args.directions is not None:
             message = (
-                "The `direction` and `directions` arguments of the `study ask` command is"
-                " deprecated. Please create a study in advance."
+                "The `direction` and `directions` arguments of the `study ask` command are"
+                " deprecated because the command will no longer create a study when you specify"
+                " the arguments. Please create a study in advance."
             )
             warnings.warn(message, FutureWarning)
 

--- a/optuna/cli.py
+++ b/optuna/cli.py
@@ -752,14 +752,20 @@ class _Ask(_BaseCommand):
             "--direction",
             type=str,
             choices=("minimize", "maximize"),
-            help="Direction of optimization.",
+            help=(
+                "Direction of optimization. This argument is deprecated."
+                " Please create a study in advance.",
+            ),
         )
         parser.add_argument(
             "--directions",
             type=str,
             nargs="+",
             choices=("minimize", "maximize"),
-            help="Directions of optimization, if there are multiple objectives.",
+            help=(
+                "Directions of optimization, if there are multiple objectives."
+                " This argument is deprecated. Please create a study in advance.",
+            ),
         )
         parser.add_argument("--sampler", type=str, help="Class name of sampler object to create.")
         parser.add_argument(
@@ -807,6 +813,14 @@ class _Ask(_BaseCommand):
             "directions": parsed_args.directions,
             "load_if_exists": True,
         }
+
+        if parsed_args.direction is not None or parsed_args.directions is not None:
+            message = (
+                "The `direction` and `directions` arguments of the `study ask` command is"
+                " deprecated. Please create a study in advance."
+            )
+            warnings.warn(message, FutureWarning)
+
         if parsed_args.sampler is not None:
             if parsed_args.sampler_kwargs is not None:
                 sampler_kwargs = json.loads(parsed_args.sampler_kwargs)
@@ -839,6 +853,18 @@ class _Ask(_BaseCommand):
                 create_study_kwargs["storage"],
                 create_study_kwargs.get("sampler"),
             )
+            if create_study_kwargs["direction"] is not None:
+                message = (
+                    "The direction argument of the optuna ask command was ignored when the"
+                    " existing study was loaded."
+                )
+                warnings.warn(message)
+            if create_study_kwargs["directions"] is not None:
+                message = (
+                    "The directions argument of the optuna ask command was ignored when the"
+                    " existing study was loaded."
+                )
+                warnings.warn(message)
         except KeyError:
             study = optuna.create_study(**create_study_kwargs)
         trial = study.ask(fixed_distributions=search_space)

--- a/optuna/cli.py
+++ b/optuna/cli.py
@@ -754,7 +754,7 @@ class _Ask(_BaseCommand):
             choices=("minimize", "maximize"),
             help=(
                 "Direction of optimization. This argument is deprecated."
-                " Please create a study in advance.",
+                " Please create a study in advance."
             ),
         )
         parser.add_argument(
@@ -764,7 +764,7 @@ class _Ask(_BaseCommand):
             choices=("minimize", "maximize"),
             help=(
                 "Directions of optimization, if there are multiple objectives."
-                " This argument is deprecated. Please create a study in advance.",
+                " This argument is deprecated. Please create a study in advance."
             ),
         )
         parser.add_argument("--sampler", type=str, help="Class name of sampler object to create.")

--- a/optuna/cli.py
+++ b/optuna/cli.py
@@ -853,18 +853,21 @@ class _Ask(_BaseCommand):
                 create_study_kwargs["storage"],
                 create_study_kwargs.get("sampler"),
             )
+            directions = None
             if create_study_kwargs["direction"] is not None:
-                message = (
-                    "The direction argument of the optuna ask command was ignored when the"
-                    " existing study was loaded."
-                )
-                warnings.warn(message)
+                directions = [
+                    optuna.study.StudyDirection[create_study_kwargs["direction"].upper()]
+                ]
             if create_study_kwargs["directions"] is not None:
-                message = (
-                    "The directions argument of the optuna ask command was ignored when the"
-                    " existing study was loaded."
+                directions = [
+                    optuna.study.StudyDirection[d.upper()]
+                    for d in create_study_kwargs["directions"]
+                ]
+            if directions is not None and study.directions != directions:
+                raise ValueError(
+                    f"Cannot overwrite study direction from {study.directions} to {directions}."
                 )
-                warnings.warn(message)
+
         except KeyError:
             study = optuna.create_study(**create_study_kwargs)
         trial = study.ask(fixed_distributions=search_space)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1092,7 +1092,8 @@ def test_ask(
         if output_format is not None:
             args += ["--format", output_format]
 
-        output = str(subprocess.check_output(args).decode().strip())
+        result = subprocess.run(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        output = str(result.stdout.decode().strip())
         trial = _parse_output(output, output_format or "json")
 
         if output_format == "table":
@@ -1108,6 +1109,9 @@ def test_ask(
             assert 0 <= trial["params"]["x"] <= 1
             assert trial["params"]["y"] == "foo"
 
+        if direction is not None or directions is not None:
+            warning_message = result.stderr.decode()
+            assert "FutureWarning" in warning_message
 
 @pytest.mark.parametrize(
     "direction,directions,sampler,sampler_kwargs,output_format",
@@ -1161,7 +1165,8 @@ def test_ask_flatten(
         if output_format is not None:
             args += ["--format", output_format]
 
-        output = str(subprocess.check_output(args).decode().strip())
+        result = subprocess.run(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        output = str(result.stdout.decode().strip())
         trial = _parse_output(output, output_format or "json")
 
         if output_format == "table":
@@ -1175,6 +1180,9 @@ def test_ask_flatten(
             assert 0 <= trial["params_x"] <= 1
             assert trial["params_y"] == "foo"
 
+        if direction is not None or directions is not None:
+            warning_message = result.stderr.decode()
+            assert "FutureWarning" in warning_message
 
 @pytest.mark.parametrize("output_format", (None, "table", "json", "yaml"))
 def test_ask_empty_search_space(output_format: str) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1113,6 +1113,7 @@ def test_ask(
             warning_message = result.stderr.decode()
             assert "FutureWarning" in warning_message
 
+
 @pytest.mark.parametrize(
     "direction,directions,sampler,sampler_kwargs,output_format",
     [
@@ -1183,6 +1184,7 @@ def test_ask_flatten(
         if direction is not None or directions is not None:
             warning_message = result.stderr.decode()
             assert "FutureWarning" in warning_message
+
 
 @pytest.mark.parametrize("output_format", (None, "table", "json", "yaml"))
 def test_ask_empty_search_space(output_format: str) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1278,8 +1278,6 @@ def test_ask_sampler_kwargs_without_sampler() -> None:
         (None, "minimize maximize", None, None),
         (None, None, "RandomSampler", None),
         (None, None, "TPESampler", '{"multivariate": true}'),
-        (None, None, None, None),
-        (None, None, None, None),
     ],
 )
 def test_create_study_and_ask(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1406,6 +1406,47 @@ def test_create_study_and_ask_with_inconsistent_directions(
         assert "Cannot overwrite study direction" in error_message
 
 
+def test_ask_with_both_direction_and_directions() -> None:
+
+    study_name = "test_study"
+    search_space = (
+        '{"x": {"name": "UniformDistribution", "attributes": {"low": 0.0, "high": 1.0}}, '
+        '"y": {"name": "CategoricalDistribution", "attributes": {"choices": ["foo"]}}}'
+    )
+
+    with tempfile.NamedTemporaryFile() as tf:
+        db_url = "sqlite:///{}".format(tf.name)
+
+        create_study_args = [
+            "optuna",
+            "create-study",
+            "--storage",
+            db_url,
+            "--study-name",
+            study_name,
+        ]
+        subprocess.check_call(create_study_args)
+
+        args = [
+            "optuna",
+            "ask",
+            "--storage",
+            db_url,
+            "--study-name",
+            study_name,
+            "--search-space",
+            search_space,
+            "--direction",
+            "minimize",
+            "--directions",
+            "minimize",
+        ]
+
+        result = subprocess.run(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        error_message = result.stderr.decode()
+        assert "Specify only one of `direction` and `directions`." in error_message
+
+
 def test_tell() -> None:
     study_name = "test_study"
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1403,7 +1403,6 @@ def test_create_study_and_ask_with_inconsistent_directions(
 
         result = subprocess.run(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         error_message = result.stderr.decode()
-        print(error_message)
         assert "Cannot overwrite study direction" in error_message
 
 


### PR DESCRIPTION
## Motivation
`direction`/`directions` option is usually required to ask parameters via CLI.
If the study's direction is `maximize`, the following error occurs if I omit the direction:

```console
$ optuna create-study --storage sqlite:///hoge.db --directions maximize --study-name maximize
[I 2021-10-06 17:26:26,350] A new study created in RDB with name: maximize
maximize
$ optuna ask --storage sqlite:///hoge.db --study-name maximize \
    --search-space '{"x": {"name": "UniformDistribution", "attributes": {"low": 1.0, "high": 10.0}}}'
[I 2021-10-06 17:26:35,236] Using an existing study with name 'maximize' instead of creating a new one.
[E 2021-10-06 17:26:35,240] Cannot overwrite study direction from [<StudyDirection.MAXIMIZE: 2>] to [<StudyDirection.MINIMIZE: 1>].
```

This is because `optuna.create_study` is called in the ask CLI to load the existing studies and `optuna.create_study` set `direction="minimize"` if the argument is omitted.

## Description of the changes

- Call `optuna.load_study` to load existing studies first, then call `optuna.create_study` to create new studies.
- Add tests to load existing studies without `direction` or `directions`.
- (Updated on October 8) Add deprecated warning to `direction` and `directions` arguments. 