### PR TITLE
Unify `suggest` APIs for floating-point parameters

### DIFF
--- a/optuna/integration/chainermn.py
+++ b/optuna/integration/chainermn.py
@@ -9,6 +9,7 @@ from typing import Type
 import warnings
 
 from optuna import TrialPruned
+from optuna._deprecated import deprecated
 from optuna._imports import try_import
 from optuna.distributions import BaseDistribution
 from optuna.distributions import CategoricalChoiceType
@@ -21,6 +22,9 @@ from optuna.trial import Trial
 
 with try_import() as _imports:
     from chainermn.communicators.communicator_base import CommunicatorBase  # NOQA
+
+
+_suggest_deprecated_msg = "Use `suggest_float` instead."
 
 
 class _ChainerMNObjectiveFunc(object):
@@ -178,29 +182,20 @@ class ChainerMNTrial(BaseTrial):
 
         return self._call_with_mpi(func)
 
+    @deprecated("2.11.0", text=_suggest_deprecated_msg)
     def suggest_uniform(self, name: str, low: float, high: float) -> float:
-        def func() -> float:
 
-            assert self.delegate is not None
-            return self.delegate.suggest_uniform(name, low, high)
+        return self.suggest_float(name, low, high)
 
-        return self._call_with_mpi(func)
-
+    @deprecated("2.11.0", text=_suggest_deprecated_msg)
     def suggest_loguniform(self, name: str, low: float, high: float) -> float:
-        def func() -> float:
 
-            assert self.delegate is not None
-            return self.delegate.suggest_loguniform(name, low, high)
+        return self.suggest_float(name, low, high, log=True)
 
-        return self._call_with_mpi(func)
-
+    @deprecated("2.11.0", text=_suggest_deprecated_msg)
     def suggest_discrete_uniform(self, name: str, low: float, high: float, q: float) -> float:
-        def func() -> float:
 
-            assert self.delegate is not None
-            return self.delegate.suggest_discrete_uniform(name, low, high, q)
-
-        return self._call_with_mpi(func)
+        return self.suggest_float(name, low, high, step=q)
 
     def suggest_int(self, name: str, low: int, high: int, step: int = 1, log: bool = False) -> int:
         def func() -> int:

--- a/optuna/integration/pytorch_distributed.py
+++ b/optuna/integration/pytorch_distributed.py
@@ -7,6 +7,7 @@ from typing import Optional
 from typing import Sequence
 
 import optuna
+from optuna._deprecated import deprecated
 from optuna._experimental import experimental
 from optuna._imports import try_import
 from optuna.distributions import BaseDistribution
@@ -16,6 +17,9 @@ from optuna.distributions import CategoricalChoiceType
 with try_import() as _imports:
     import torch
     import torch.distributed as dist
+
+
+_suggest_deprecated_msg = "Use `suggest_float` instead."
 
 
 @experimental("2.6.0")
@@ -84,29 +88,20 @@ class TorchDistributedTrial(optuna.trial.BaseTrial):
 
         return self._call_and_communicate(func, torch.float)
 
+    @deprecated("2.11.0", text=_suggest_deprecated_msg)
     def suggest_uniform(self, name: str, low: float, high: float) -> float:
-        def func() -> float:
 
-            assert self._delegate is not None
-            return self._delegate.suggest_uniform(name, low, high)
+        return self.suggest_float(name, low, high)
 
-        return self._call_and_communicate(func, torch.float)
-
+    @deprecated("2.11.0", text=_suggest_deprecated_msg)
     def suggest_loguniform(self, name: str, low: float, high: float) -> float:
-        def func() -> float:
 
-            assert self._delegate is not None
-            return self._delegate.suggest_loguniform(name, low, high)
+        return self.suggest_float(name, low, high, log=True)
 
-        return self._call_and_communicate(func, torch.float)
-
+    @deprecated("2.11.0", text=_suggest_deprecated_msg)
     def suggest_discrete_uniform(self, name: str, low: float, high: float, q: float) -> float:
-        def func() -> float:
 
-            assert self._delegate is not None
-            return self._delegate.suggest_discrete_uniform(name, low, high, q=q)
-
-        return self._call_and_communicate(func, torch.float)
+        return self.suggest_float(name, low, high, step=q)
 
     def suggest_int(self, name: str, low: int, high: int, step: int = 1, log: bool = False) -> int:
         def func() -> float:

--- a/optuna/trial/_base.py
+++ b/optuna/trial/_base.py
@@ -5,6 +5,7 @@ from typing import Dict
 from typing import Optional
 from typing import Sequence
 
+from optuna._deprecated import deprecated
 from optuna.distributions import BaseDistribution
 from optuna.distributions import CategoricalChoiceType
 
@@ -28,16 +29,19 @@ class BaseTrial(object, metaclass=abc.ABCMeta):
 
         raise NotImplementedError
 
+    @deprecated("2.11.0")
     @abc.abstractmethod
     def suggest_uniform(self, name: str, low: float, high: float) -> float:
 
         raise NotImplementedError
 
+    @deprecated("2.11.0")
     @abc.abstractmethod
     def suggest_loguniform(self, name: str, low: float, high: float) -> float:
 
         raise NotImplementedError
 
+    @deprecated("2.11.0")
     @abc.abstractmethod
     def suggest_discrete_uniform(self, name: str, low: float, high: float, q: float) -> float:
 

--- a/optuna/trial/_fixed.py
+++ b/optuna/trial/_fixed.py
@@ -6,6 +6,7 @@ from typing import Sequence
 from typing import Union
 
 from optuna import distributions
+from optuna._deprecated import deprecated
 from optuna.distributions import BaseDistribution
 from optuna.distributions import CategoricalChoiceType
 from optuna.distributions import CategoricalDistribution
@@ -15,6 +16,9 @@ from optuna.distributions import IntUniformDistribution
 from optuna.distributions import LogUniformDistribution
 from optuna.distributions import UniformDistribution
 from optuna.trial._base import BaseTrial
+
+
+_suggest_deprecated_msg = "Use `suggest_float` instead."
 
 
 class FixedTrial(BaseTrial):
@@ -86,17 +90,20 @@ class FixedTrial(BaseTrial):
             else:
                 return self._suggest(name, UniformDistribution(low=low, high=high))
 
+    @deprecated("2.11.0", text=_suggest_deprecated_msg)
     def suggest_uniform(self, name: str, low: float, high: float) -> float:
 
-        return self._suggest(name, UniformDistribution(low=low, high=high))
+        return self.suggest_float(name, low, high)
 
+    @deprecated("2.11.0", text=_suggest_deprecated_msg)
     def suggest_loguniform(self, name: str, low: float, high: float) -> float:
 
-        return self._suggest(name, LogUniformDistribution(low=low, high=high))
+        return self.suggest_float(name, low, high, log=True)
 
+    @deprecated("2.11.0", text=_suggest_deprecated_msg)
     def suggest_discrete_uniform(self, name: str, low: float, high: float, q: float) -> float:
-        discrete = DiscreteUniformDistribution(low=low, high=high, q=q)
-        return self._suggest(name, discrete)
+
+        return self.suggest_float(name, low, high, step=q)
 
     def suggest_int(self, name: str, low: int, high: int, step: int = 1, log: bool = False) -> int:
         if step != 1:

--- a/optuna/trial/_frozen.py
+++ b/optuna/trial/_frozen.py
@@ -8,6 +8,7 @@ from typing import Union
 
 from optuna import distributions
 from optuna import logging
+from optuna._deprecated import deprecated
 from optuna._experimental import experimental
 from optuna.distributions import BaseDistribution
 from optuna.distributions import CategoricalDistribution
@@ -21,6 +22,7 @@ from optuna.trial._state import TrialState
 
 
 _logger = logging.get_logger(__name__)
+_suggest_deprecated_msg = "Use `suggest_float` instead."
 
 CategoricalChoiceType = Union[None, bool, int, float, str]
 
@@ -233,18 +235,20 @@ class FrozenTrial(BaseTrial):
             else:
                 return self._suggest(name, UniformDistribution(low=low, high=high))
 
+    @deprecated("2.11.0", text=_suggest_deprecated_msg)
     def suggest_uniform(self, name: str, low: float, high: float) -> float:
 
-        return self._suggest(name, UniformDistribution(low=low, high=high))
+        return self.suggest_float(name, low, high)
 
+    @deprecated("2.11.0", text=_suggest_deprecated_msg)
     def suggest_loguniform(self, name: str, low: float, high: float) -> float:
 
-        return self._suggest(name, LogUniformDistribution(low=low, high=high))
+        return self.suggest_float(name, low, high, log=True)
 
+    @deprecated("2.11.0", text=_suggest_deprecated_msg)
     def suggest_discrete_uniform(self, name: str, low: float, high: float, q: float) -> float:
 
-        discrete = DiscreteUniformDistribution(low=low, high=high, q=q)
-        return self._suggest(name, discrete)
+        return self.suggest_float(name, low, high, step=q)
 
     def suggest_int(self, name: str, low: int, high: int, step: int = 1, log: bool = False) -> int:
 

--- a/optuna/trial/_trial.py
+++ b/optuna/trial/_trial.py
@@ -11,6 +11,7 @@ import optuna
 from optuna import distributions
 from optuna import logging
 from optuna import pruners
+from optuna._deprecated import deprecated
 from optuna.distributions import BaseDistribution
 from optuna.distributions import CategoricalChoiceType
 from optuna.distributions import CategoricalDistribution
@@ -23,6 +24,7 @@ from optuna.trial._base import BaseTrial
 
 
 _logger = logging.get_logger(__name__)
+_suggest_deprecated_msg = "Use `suggest_float` instead."
 
 
 class Trial(BaseTrial):
@@ -182,6 +184,8 @@ class Trial(BaseTrial):
         self._check_distribution(name, distribution)
 
         return self._suggest(name, distribution)
+
+    @deprecated("2.11.0", text=_suggest_deprecated_msg)
     def suggest_uniform(self, name: str, low: float, high: float) -> float:
         """Suggest a value for the continuous parameter.
 
@@ -235,12 +239,9 @@ class Trial(BaseTrial):
             A suggested float value.
         """
 
-        distribution = UniformDistribution(low=low, high=high)
+        return self.suggest_float(name, low, high)
 
-        self._check_distribution(name, distribution)
-
-        return self._suggest(name, distribution)
-
+    @deprecated("2.11.0", text=_suggest_deprecated_msg)
     def suggest_loguniform(self, name: str, low: float, high: float) -> float:
         """Suggest a value for the continuous parameter.
 
@@ -289,12 +290,9 @@ class Trial(BaseTrial):
             A suggested float value.
         """
 
-        distribution = LogUniformDistribution(low=low, high=high)
+        return self.suggest_float(name, low, high, log=True)
 
-        self._check_distribution(name, distribution)
-
-        return self._suggest(name, distribution)
-
+    @deprecated("2.11.0", text=_suggest_deprecated_msg)
     def suggest_discrete_uniform(self, name: str, low: float, high: float, q: float) -> float:
         """Suggest a value for the discrete parameter.
 
@@ -350,11 +348,7 @@ class Trial(BaseTrial):
             A suggested float value.
         """
 
-        distribution = DiscreteUniformDistribution(low=low, high=high, q=q)
-
-        self._check_distribution(name, distribution)
-
-        return self._suggest(name, distribution)
+        return self.suggest_float(name, low, high, step=q)
 
     def suggest_int(self, name: str, low: int, high: int, step: int = 1, log: bool = False) -> int:
         """Suggest a value for the integer parameter.

--- a/optuna/trial/_trial.py
+++ b/optuna/trial/_trial.py
@@ -79,10 +79,6 @@ class Trial(BaseTrial):
     ) -> float:
         """Suggest a value for the floating point parameter.
 
-        Note that this is a wrapper method for :func:`~optuna.trial.Trial.suggest_uniform`,
-        :func:`~optuna.trial.Trial.suggest_loguniform` and
-        :func:`~optuna.trial.Trial.suggest_discrete_uniform`.
-
         .. versionadded:: 1.3.0
 
         .. seealso::

--- a/optuna/trial/_trial.py
+++ b/optuna/trial/_trial.py
@@ -170,13 +170,18 @@ class Trial(BaseTrial):
             if log:
                 raise ValueError("The parameter `step` is not supported when `log` is True.")
             else:
-                return self.suggest_discrete_uniform(name, low, high, step)
+                distribution: Union[
+                    DiscreteUniformDistribution, LogUniformDistribution, UniformDistribution
+                ] = DiscreteUniformDistribution(low=low, high=high, q=step)
         else:
             if log:
-                return self.suggest_loguniform(name, low, high)
+                distribution = LogUniformDistribution(low=low, high=high)
             else:
-                return self.suggest_uniform(name, low, high)
+                distribution = UniformDistribution(low=low, high=high)
 
+        self._check_distribution(name, distribution)
+
+        return self._suggest(name, distribution)
     def suggest_uniform(self, name: str, low: float, high: float) -> float:
         """Suggest a value for the continuous parameter.
 

--- a/tests/trial_tests/test_trial.py
+++ b/tests/trial_tests/test_trial.py
@@ -80,7 +80,8 @@ def test_check_distribution_suggest_uniform(storage_mode: str) -> None:
             trial.suggest_uniform("x", 10, 20)
             trial.suggest_uniform("x", 10, 30)
 
-        # we expect exactly one warning
+        # we expect exactly one warning (not counting ones caused by deprecation)
+        record = [r for r in record if r.category != FutureWarning]
         assert len(record) == 1
 
         with pytest.raises(ValueError):
@@ -104,7 +105,8 @@ def test_check_distribution_suggest_loguniform(storage_mode: str) -> None:
             trial.suggest_loguniform("x", 10, 20)
             trial.suggest_loguniform("x", 10, 30)
 
-        # we expect exactly one warning
+        # we expect exactly one warning (not counting ones caused by deprecation)
+        record = [r for r in record if r.category != FutureWarning]
         assert len(record) == 1
 
         with pytest.raises(ValueError):
@@ -128,7 +130,8 @@ def test_check_distribution_suggest_discrete_uniform(storage_mode: str) -> None:
             trial.suggest_discrete_uniform("x", 10, 20, 2)
             trial.suggest_discrete_uniform("x", 10, 22, 2)
 
-        # we expect exactly one warning
+        # we expect exactly one warning (not counting ones caused by deprecation)
+        record = [r for r in record if r.category != FutureWarning]
         assert len(record) == 1
 
         with pytest.raises(ValueError):


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
This PR aims to unify `suggest` API for floating-point parameters by deprecating `suggest_uniform`, `suggest_loguniform`, and `suggest_discrete_uniform` in favor of `suggest_float`. Implements changes discussed in #2939.

## Description of the changes
<!-- Describe the changes in this PR. -->
* Deprecate `suggest_uniform`, `suggest_loguniform`, and `suggest_discrete_uniform` in abstract base class and all implementations.
* Make them call `suggest_float` instead.
* Refactor `suggest_float` in `optuna/trial/_trial.py` to not call any of deprecated methods.
* Fix tests & docstrings.
