### PR TITLE
Wrap data with np.asarray in lightgbm test

### DIFF
--- a/tests/integration_tests/test_lightgbm.py
+++ b/tests/integration_tests/test_lightgbm.py
@@ -1,6 +1,7 @@
 from functools import partial
 
 import lightgbm as lgb
+import numpy as np
 import pytest
 
 import optuna
@@ -116,8 +117,8 @@ def objective(
     cv: bool = False,
 ) -> float:
 
-    dtrain = lgb.Dataset([[1.0], [2.0], [3.0]], label=[1.0, 0.0, 1.0])
-    dtest = lgb.Dataset([[1.0]], label=[1.0])
+    dtrain = lgb.Dataset(np.asarray([[1.0], [2.0], [3.0]]), label=[1.0, 0.0, 1.0])
+    dtest = lgb.Dataset(np.asarray([[1.0]]), label=[1.0])
 
     if force_default_valid_names:
         valid_names = None


### PR DESCRIPTION
Resolve https://github.com/optuna/optuna/issues/2995.

This PR wraps data that is fed into `lightgbm.Dataset` with `np.asarray`, which solves the type error in lightgbm 3.3.0.
According to the soruce code, LightGBM requires data to be a list of `numpy.ndarray` or 'lightgbm.basic.Sequence' when data is a list.

https://github.com/microsoft/LightGBM/blob/f3987f37249ea4cc7b30b11cb83129ab73f5d588/python-package/lightgbm/basic.py#L1526-L1545

This patch was made based on the suggestion by @nzw0301 (thank you).