### PR TITLE
Do not call `trial.report` during sanity check

### DIFF
--- a/optuna/integration/pytorch_lightning.py
+++ b/optuna/integration/pytorch_lightning.py
@@ -67,6 +67,14 @@ class PyTorchLightningPruningCallback(Callback):
                 )
 
     def on_validation_end(self, trainer: Trainer, pl_module: LightningModule) -> None:
+
+        # When the trainer calls `on_validation_end` for sanity check,
+        # do not call `trial.report` to avoid calling `trial.report` multiple times
+        # at epoch 0. The related page is
+        # https://github.com/PyTorchLightning/pytorch-lightning/issues/1391.
+        if trainer.sanity_checking:
+            return
+
         epoch = pl_module.current_epoch
 
         current_score = trainer.callback_metrics.get(self.monitor)


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

**[Updated]** non-ddp training has the same issue. For example, https://github.com/optuna/optuna-examples/blob/main/pytorch/pytorch_lightning_simple.py shows the same warning message.

When using `PyTorchLightningPruningCallback` with ddp backend,  the current implementation shows a warning message, `UserWarning: The reported value is ignored because this step 0 is already reported.`, at the first step.

We can reproduce it by running the example code in https://github.com/optuna/optuna-examples/pull/43.

The root reason is that PyTorch-lightning calls `validation_end` before training as a sanity check for debugging by default.
Ref: https://pytorch-lightning.readthedocs.io/en/latest/common/trainer.html#num-sanity-val-steps


## Description of the changes
<!-- Describe the changes in this PR. -->

Do not call `trial.report` during sanity checking. To do so, we can use `Trainer.sanity_checking` that is a flag to know the current `validation_end` is called a sanity check or not.

Note that I could not find the documentation of `sanity_checking`, so I refer to https://github.com/PyTorchLightning/pytorch-lightning/issues/1391 in the comment. In addition, `running_sanity_check` will be removed lightning 1.5.0 according to [`CHANGELOG.md`](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md). This is why I use `sanity_checking`.