### PR TITLE
Fix `_contains` of `IntLogUniformDistribution`

### DIFF
--- a/optuna/distributions.py
+++ b/optuna/distributions.py
@@ -375,7 +375,8 @@ class IntLogUniformDistribution(BaseDistribution):
 
     def _contains(self, param_value_in_internal_repr: float) -> bool:
         value = param_value_in_internal_repr
-        return self.low <= value <= self.high and (value - self.low) % self.step == 0
+        # `step` is ignored and assumed to be 1.
+        return self.low <= value <= self.high
 
     @property
     def step(self) -> int:

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -162,7 +162,7 @@ def test_contains() -> None:
     assert c._contains(1.5)
     assert not c._contains(3)
 
-    ilu = distributions.IntUniformDistribution(low=2, high=12)
+    ilu = distributions.IntLogUniformDistribution(low=2, high=12)
     assert not ilu._contains(0.9)
     assert ilu._contains(2)
     assert ilu._contains(4)
@@ -171,12 +171,14 @@ def test_contains() -> None:
     assert not ilu._contains(12.1)
     assert not ilu._contains(13)
 
-    iluq = distributions.IntLogUniformDistribution(low=2, high=7)
+    # `step` is ignored and assumed to be 1.
+    iluq = distributions.IntLogUniformDistribution(low=2, high=7, step=2)
     assert not iluq._contains(0.9)
     assert iluq._contains(2)
     assert iluq._contains(4)
     assert iluq._contains(5)
     assert iluq._contains(6)
+    assert iluq._contains(7)
     assert not iluq._contains(7.1)
     assert not iluq._contains(8)
 
@@ -208,12 +210,12 @@ def test_empty_range_contains() -> None:
     assert iuq._contains(1)
     assert not iuq._contains(2)
 
-    ilu = distributions.IntUniformDistribution(low=1, high=1)
+    ilu = distributions.IntLogUniformDistribution(low=1, high=1)
     assert not ilu._contains(0)
     assert ilu._contains(1)
     assert not ilu._contains(2)
 
-    iluq = distributions.IntUniformDistribution(low=1, high=1, step=2)
+    iluq = distributions.IntLogUniformDistribution(low=1, high=1, step=2)
     assert not iluq._contains(0)
     assert iluq._contains(1)
     assert not iluq._contains(2)


### PR DESCRIPTION
## Motivation
The document says Optuna assumes that the `step` argument of `IntLogUniformDistribution` is always 1. This PR fixes `_contains` of `IntLogUniformDistribution` to follow the description.

## Description of the changes
- Fix `_contains` of `IntLogUniformDistribution`
- Fix `IntLogUniformDistribution` tests