### PR TITLE
Add note to `OptunaSearchCV` about direction

### DIFF
--- a/optuna/integration/sklearn.py
+++ b/optuna/integration/sklearn.py
@@ -503,6 +503,11 @@ class OptunaSearchCV(BaseEstimator):
             X, y = load_iris(return_X_y=True)
             optuna_search.fit(X, y)
             y_pred = optuna_search.predict(X)
+
+    .. note::
+        By following the scikit-learn convention for scorers, the direction of optimization is
+        ``maximize``. See https://scikit-learn.org/stable/modules/model_evaluation.html.
+        For the minimization problem, please multiply ``-1``.
     """
 
     _required_parameters = ["estimator", "param_distributions"]


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

Resolve https://github.com/optuna/optuna/issues/2948.

In `OptunaSearchCV`, `direction` is always `maximize` by following scikit-learn's scorer convention. However, the optuna's default direction is `minimize`, so some users might confuse this behaviour. 

## Description of the changes
<!-- Describe the changes in this PR. -->

Add `note` section to explain that.