### PR TITLE
Render importance scores next to bars in `matplotlib.plot_param_importances`

### DIFF
--- a/optuna/visualization/matplotlib/_param_importances.py
+++ b/optuna/visualization/matplotlib/_param_importances.py
@@ -152,7 +152,7 @@ def _get_param_importance_plot(
         bbox = text.get_window_extent(renderer)
         bbox = bbox.transformed(ax.transData.inverted())
         _, plot_xmax = ax.get_xlim()
-        bbox_xmax = bbox.x1
+        bbox_xmax = bbox.xmax
 
         if bbox_xmax > plot_xmax:
             ax.set_xlim(xmax=AXES_PADDING_RATIO * bbox_xmax)

--- a/optuna/visualization/matplotlib/_param_importances.py
+++ b/optuna/visualization/matplotlib/_param_importances.py
@@ -144,7 +144,7 @@ def _get_param_importance_plot(
 
     renderer = fig.canvas.get_renderer()
     for idx, val in enumerate(importance_values):
-        label = str(round(val, 2)) if val >= 0.01 else "<0.01"
+        label = f" {val:.2f}" if val >= 0.01 else " <0.01"
         text = ax.text(val, idx, label, va="center")
 
         # Sometimes horizontal axis needs to be re-scaled

--- a/optuna/visualization/matplotlib/_param_importances.py
+++ b/optuna/visualization/matplotlib/_param_importances.py
@@ -107,8 +107,8 @@ def _get_param_importance_plot(
 ) -> "Axes":
 
     # Set up the graph style.
-    _, ax = plt.subplots()
     plt.style.use("ggplot")  # Use ggplot style sheet for similar outputs to plotly.
+    _, ax = plt.subplots()
     ax.set_title("Hyperparameter Importances")
     ax.set_xlabel(f"Importance for {target_name}")
     ax.set_ylabel("Hyperparameter")

--- a/optuna/visualization/matplotlib/_param_importances.py
+++ b/optuna/visualization/matplotlib/_param_importances.py
@@ -25,6 +25,9 @@ if _imports.is_successful():
 _logger = get_logger(__name__)
 
 
+AXES_PADDING_RATIO = 1.05
+
+
 @experimental("2.2.0")
 def plot_param_importances(
     study: Study,
@@ -108,7 +111,7 @@ def _get_param_importance_plot(
 
     # Set up the graph style.
     plt.style.use("ggplot")  # Use ggplot style sheet for similar outputs to plotly.
-    _, ax = plt.subplots()
+    fig, ax = plt.subplots()
     ax.set_title("Hyperparameter Importances")
     ax.set_xlabel(f"Importance for {target_name}")
     ax.set_ylabel("Hyperparameter")
@@ -138,5 +141,20 @@ def _get_param_importance_plot(
         color=cm.get_cmap("tab20c")(0),
         tick_label=param_names,
     )
+
+    renderer = fig.canvas.get_renderer()
+    for idx, val in enumerate(importance_values):
+        label = str(round(val, 2)) if val >= 0.01 else "<0.01"
+        text = ax.text(val, idx, label, va="center")
+
+        # Sometimes horizontal axis needs to be re-scaled
+        # to avoid text going over plot area.
+        bbox = text.get_window_extent(renderer)
+        bbox = bbox.transformed(ax.transData.inverted())
+        _, plot_xmax = ax.get_xlim()
+        bbox_xmax = bbox.x1
+
+        if bbox_xmax > plot_xmax:
+            ax.set_xlim(xmax=AXES_PADDING_RATIO * bbox_xmax)
 
     return ax

--- a/tests/visualization_tests/matplotlib_tests/test_param_importances.py
+++ b/tests/visualization_tests/matplotlib_tests/test_param_importances.py
@@ -63,3 +63,30 @@ def test_plot_param_importances() -> None:
     study.optimize(fail_objective, n_trials=1, catch=(ValueError,))
     figure = plot_param_importances(study)
     assert len(figure.get_lines()) == 0
+
+
+def test_importance_scores_rendering() -> None:
+
+    study = prepare_study_with_trials()
+    ax = plot_param_importances(study)
+
+    # Test if importance scores are rendered.
+    text_objects = ax.figure.findobj(lambda obj: "Text" in str(obj))
+    importances = [patch.get_width() for patch in ax.patches]
+    labels = [obj for obj in text_objects if obj.get_position()[0] in importances]
+    assert len(labels) == 2
+
+
+def test_switch_label_when_param_insignificant() -> None:
+    def _objective(trial: Trial) -> int:
+        x = trial.suggest_int("x", 0, 2)
+        _ = trial.suggest_int("y", -1, 1)
+        return x ** 2
+
+    study = create_study()
+    study.optimize(_objective, n_trials=100)
+    ax = plot_param_importances(study)
+
+    # Test if label for `y` param has been switched to `<0.01`.
+    labels = ax.figure.findobj(lambda obj: "<0.01" in str(obj))
+    assert len(labels) == 1

--- a/tests/visualization_tests/matplotlib_tests/test_param_importances.py
+++ b/tests/visualization_tests/matplotlib_tests/test_param_importances.py
@@ -84,7 +84,10 @@ def test_switch_label_when_param_insignificant() -> None:
         return x ** 2
 
     study = create_study()
-    study.optimize(_objective, n_trials=100)
+    for x in range(1, 3):
+        study.enqueue_trial({"x": x, "y": 0})
+
+    study.optimize(_objective, n_trials=2)
     ax = plot_param_importances(study)
 
     # Test if label for `y` param has been switched to `<0.01`.


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
This PR aims to close visual differences between plotly and matplotlib impolementations of `plot_param_importances` by introducing bar labels with importance scores to matplotlib implementation, as well as fixing a bug which sometimes caused incorrect background to be used. Discussed in #2893.

## Description of the changes
<!-- Describe the changes in this PR. -->
* Make importance scores render next to bars (with special case for scores < 0.01)
* Fix bug where `ggplot` style is not used in the first call (visible in Optuna documentation and notebook environments)
* Add tests

## Example
Current master
![foo](https://user-images.githubusercontent.com/37713008/137524734-a3c70c99-f804-4957-9f99-a877ca4a79e0.png)

This PR
![Screenshot from 2021-10-18 16-53-52](https://user-images.githubusercontent.com/37713008/137757411-abdb63af-50b4-423c-bc10-49ae0fd52b15.png)

