### PR TITLE
Use libomp 11.1.0 for Mac

### DIFF
--- a/.github/workflows/mac-tests.yml
+++ b/.github/workflows/mac-tests.yml
@@ -82,6 +82,9 @@ jobs:
 
     - name: Setup mac environment
       run: |
+        # TODO(nzw0301): remove libomp version constraint if xgboost can work with libomp>11.1.0
+        # https://github.com/dmlc/xgboost/blob/c42e3fbcf3901eec73fcdbf02526f611ef3ed05f/.github/workflows/main.yml#L24-L25
+        wget https://raw.githubusercontent.com/Homebrew/homebrew-core/679923b4eb48a8dc7ecc1f05d06063cd79b3fc00/Formula/libomp.rb -O $(find $(brew --repository) -name libomp.rb)
         brew install libomp
         brew install open-mpi
         brew install openblas


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

The Mac's CI is failing on the master branch. 
https://github.com/optuna/optuna/runs/3935332877


## Description of the changes
<!-- Describe the changes in this PR. -->

Following xgboost's version constraint for `libomp`: https://github.com/dmlc/xgboost/blob/c42e3fbcf3901eec73fcdbf02526f611ef3ed05f/.github/workflows/main.yml#L24-L25.

Since this PR's CI won't perform Mac CI, so the following passed CI on my fork might be relevant for the review.
https://github.com/nzw0301/optuna/runs/3937019712?check_suite_focus=true

Many thanks, @not522 for sharing the solution to fix the CI.

## Additional info
- https://github.com/dmlc/xgboost/issues/7039
- https://github.com/scikit-learn/scikit-learn/pull/21227#issuecomment-933001394 # not for xgboost, but the situation is very similar