### PR TITLE
Run `mac-tests` CI at a scheduled time.

### DIFF
--- a/.github/workflows/mac-tests.yml
+++ b/.github/workflows/mac-tests.yml
@@ -10,6 +10,8 @@ on:
   pull_request:
     paths:
       - '.github/workflows/mac-tests.yml'
+  schedule:
+    - cron: '0 23 * * SUN-THU'
 
 jobs:
   tests-mac:


### PR DESCRIPTION
## Motivation

Currently, the CI jobs on macOS are executed when the changes are committed into the master branch. We may not notice errors due to updates of external libraries (e.g., #3024). 

## Description of the changes

- Add a schedule trigger