### PR TITLE
Raise errors if `optuna ask` CLI receives `--sampler-kwargs` without `--sampler`.

### DIFF
--- a/optuna/cli.py
+++ b/optuna/cli.py
@@ -818,7 +818,8 @@ class _Ask(_BaseCommand):
         else:
             if parsed_args.sampler_kwargs is not None:
                 raise ValueError(
-                    "`--sampler_kwargs` is set without `--sampler`. Please specify `--sampler` as well."
+                    "`--sampler_kwargs` is set without `--sampler`. Please specify `--sampler` as"
+                    " well or omit `--sampler-kwargs`."
                 )
 
         if parsed_args.search_space is not None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1267,7 +1267,7 @@ def test_ask_sampler_kwargs_without_sampler() -> None:
 
         result = subprocess.run(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         error_message = result.stderr.decode()
-        assert "`sampler_kwargs` is set without `sampler`." in error_message
+        assert "`--sampler_kwargs` is set without `--sampler`." in error_message
 
 
 def test_tell() -> None:


### PR DESCRIPTION
## Motivation

Currently, `--sampler-kwargs` is silently ignored if `--sampler` is not specified.
Users cannot notice that the argument is ignored.

## Description of the changes

- Raise `ValueError` if `--sampler-kwargs` is set without `--sampler`