### PR TITLE
Fix deprecation version of `suggest` APIs

### DIFF
--- a/optuna/integration/chainermn.py
+++ b/optuna/integration/chainermn.py
@@ -182,17 +182,17 @@ class ChainerMNTrial(BaseTrial):
 
         return self._call_with_mpi(func)
 
-    @deprecated("2.11.0", "6.0.0", text=_suggest_deprecated_msg)
+    @deprecated("3.0.0a1", "6.0.0", text=_suggest_deprecated_msg)
     def suggest_uniform(self, name: str, low: float, high: float) -> float:
 
         return self.suggest_float(name, low, high)
 
-    @deprecated("2.11.0", "6.0.0", text=_suggest_deprecated_msg)
+    @deprecated("3.0.0a1", "6.0.0", text=_suggest_deprecated_msg)
     def suggest_loguniform(self, name: str, low: float, high: float) -> float:
 
         return self.suggest_float(name, low, high, log=True)
 
-    @deprecated("2.11.0", "6.0.0", text=_suggest_deprecated_msg)
+    @deprecated("3.0.0a1", "6.0.0", text=_suggest_deprecated_msg)
     def suggest_discrete_uniform(self, name: str, low: float, high: float, q: float) -> float:
 
         return self.suggest_float(name, low, high, step=q)

--- a/optuna/integration/chainermn.py
+++ b/optuna/integration/chainermn.py
@@ -182,17 +182,17 @@ class ChainerMNTrial(BaseTrial):
 
         return self._call_with_mpi(func)
 
-    @deprecated("3.0.0a1", "6.0.0", text=_suggest_deprecated_msg)
+    @deprecated("3.0.0", "6.0.0", text=_suggest_deprecated_msg)
     def suggest_uniform(self, name: str, low: float, high: float) -> float:
 
         return self.suggest_float(name, low, high)
 
-    @deprecated("3.0.0a1", "6.0.0", text=_suggest_deprecated_msg)
+    @deprecated("3.0.0", "6.0.0", text=_suggest_deprecated_msg)
     def suggest_loguniform(self, name: str, low: float, high: float) -> float:
 
         return self.suggest_float(name, low, high, log=True)
 
-    @deprecated("3.0.0a1", "6.0.0", text=_suggest_deprecated_msg)
+    @deprecated("3.0.0", "6.0.0", text=_suggest_deprecated_msg)
     def suggest_discrete_uniform(self, name: str, low: float, high: float, q: float) -> float:
 
         return self.suggest_float(name, low, high, step=q)

--- a/optuna/integration/mlflow.py
+++ b/optuna/integration/mlflow.py
@@ -142,7 +142,7 @@ class MLflowCallback(object):
             in case of a collison.
 
     .. note::
-        ``nest_trials`` argument added in v2.3.0 is a part of ``mlflow_kwargs`` since v3.0.0a1.
+        ``nest_trials`` argument added in v2.3.0 is a part of ``mlflow_kwargs`` since v3.0.0.
         Anyone using ``nest_trials=True`` should migrate to ``mlflow_kwargs={"nested": True}``
         to avoid raising :exc:`TypeError`.
 

--- a/optuna/integration/pytorch_distributed.py
+++ b/optuna/integration/pytorch_distributed.py
@@ -90,17 +90,17 @@ class TorchDistributedTrial(optuna.trial.BaseTrial):
 
         return self._call_and_communicate(func, torch.float)
 
-    @deprecated("3.0.0a1", "6.0.0", text=_suggest_deprecated_msg)
+    @deprecated("3.0.0", "6.0.0", text=_suggest_deprecated_msg)
     def suggest_uniform(self, name: str, low: float, high: float) -> float:
 
         return self.suggest_float(name, low, high)
 
-    @deprecated("3.0.0a1", "6.0.0", text=_suggest_deprecated_msg)
+    @deprecated("3.0.0", "6.0.0", text=_suggest_deprecated_msg)
     def suggest_loguniform(self, name: str, low: float, high: float) -> float:
 
         return self.suggest_float(name, low, high, log=True)
 
-    @deprecated("3.0.0a1", "6.0.0", text=_suggest_deprecated_msg)
+    @deprecated("3.0.0", "6.0.0", text=_suggest_deprecated_msg)
     def suggest_discrete_uniform(self, name: str, low: float, high: float, q: float) -> float:
 
         return self.suggest_float(name, low, high, step=q)

--- a/optuna/integration/pytorch_distributed.py
+++ b/optuna/integration/pytorch_distributed.py
@@ -90,17 +90,17 @@ class TorchDistributedTrial(optuna.trial.BaseTrial):
 
         return self._call_and_communicate(func, torch.float)
 
-    @deprecated("2.11.0", "6.0.0", text=_suggest_deprecated_msg)
+    @deprecated("3.0.0a1", "6.0.0", text=_suggest_deprecated_msg)
     def suggest_uniform(self, name: str, low: float, high: float) -> float:
 
         return self.suggest_float(name, low, high)
 
-    @deprecated("2.11.0", "6.0.0", text=_suggest_deprecated_msg)
+    @deprecated("3.0.0a1", "6.0.0", text=_suggest_deprecated_msg)
     def suggest_loguniform(self, name: str, low: float, high: float) -> float:
 
         return self.suggest_float(name, low, high, log=True)
 
-    @deprecated("2.11.0", "6.0.0", text=_suggest_deprecated_msg)
+    @deprecated("3.0.0a1", "6.0.0", text=_suggest_deprecated_msg)
     def suggest_discrete_uniform(self, name: str, low: float, high: float, q: float) -> float:
 
         return self.suggest_float(name, low, high, step=q)

--- a/optuna/trial/_base.py
+++ b/optuna/trial/_base.py
@@ -29,19 +29,19 @@ class BaseTrial(object, metaclass=abc.ABCMeta):
 
         raise NotImplementedError
 
-    @deprecated("3.0.0a1", "6.0.0")
+    @deprecated("3.0.0", "6.0.0")
     @abc.abstractmethod
     def suggest_uniform(self, name: str, low: float, high: float) -> float:
 
         raise NotImplementedError
 
-    @deprecated("3.0.0a1", "6.0.0")
+    @deprecated("3.0.0", "6.0.0")
     @abc.abstractmethod
     def suggest_loguniform(self, name: str, low: float, high: float) -> float:
 
         raise NotImplementedError
 
-    @deprecated("3.0.0a1", "6.0.0")
+    @deprecated("3.0.0", "6.0.0")
     @abc.abstractmethod
     def suggest_discrete_uniform(self, name: str, low: float, high: float, q: float) -> float:
 

--- a/optuna/trial/_base.py
+++ b/optuna/trial/_base.py
@@ -29,19 +29,19 @@ class BaseTrial(object, metaclass=abc.ABCMeta):
 
         raise NotImplementedError
 
-    @deprecated("2.11.0", "6.0.0")
+    @deprecated("3.0.0a1", "6.0.0")
     @abc.abstractmethod
     def suggest_uniform(self, name: str, low: float, high: float) -> float:
 
         raise NotImplementedError
 
-    @deprecated("2.11.0", "6.0.0")
+    @deprecated("3.0.0a1", "6.0.0")
     @abc.abstractmethod
     def suggest_loguniform(self, name: str, low: float, high: float) -> float:
 
         raise NotImplementedError
 
-    @deprecated("2.11.0", "6.0.0")
+    @deprecated("3.0.0a1", "6.0.0")
     @abc.abstractmethod
     def suggest_discrete_uniform(self, name: str, low: float, high: float, q: float) -> float:
 

--- a/optuna/trial/_fixed.py
+++ b/optuna/trial/_fixed.py
@@ -91,17 +91,17 @@ class FixedTrial(BaseTrial):
             else:
                 return self._suggest(name, UniformDistribution(low=low, high=high))
 
-    @deprecated("2.11.0", "6.0.0", text=_suggest_deprecated_msg)
+    @deprecated("3.0.0a1", "6.0.0", text=_suggest_deprecated_msg)
     def suggest_uniform(self, name: str, low: float, high: float) -> float:
 
         return self.suggest_float(name, low, high)
 
-    @deprecated("2.11.0", "6.0.0", text=_suggest_deprecated_msg)
+    @deprecated("3.0.0a1", "6.0.0", text=_suggest_deprecated_msg)
     def suggest_loguniform(self, name: str, low: float, high: float) -> float:
 
         return self.suggest_float(name, low, high, log=True)
 
-    @deprecated("2.11.0", "6.0.0", text=_suggest_deprecated_msg)
+    @deprecated("3.0.0a1", "6.0.0", text=_suggest_deprecated_msg)
     def suggest_discrete_uniform(self, name: str, low: float, high: float, q: float) -> float:
 
         return self.suggest_float(name, low, high, step=q)

--- a/optuna/trial/_fixed.py
+++ b/optuna/trial/_fixed.py
@@ -91,17 +91,17 @@ class FixedTrial(BaseTrial):
             else:
                 return self._suggest(name, UniformDistribution(low=low, high=high))
 
-    @deprecated("3.0.0a1", "6.0.0", text=_suggest_deprecated_msg)
+    @deprecated("3.0.0", "6.0.0", text=_suggest_deprecated_msg)
     def suggest_uniform(self, name: str, low: float, high: float) -> float:
 
         return self.suggest_float(name, low, high)
 
-    @deprecated("3.0.0a1", "6.0.0", text=_suggest_deprecated_msg)
+    @deprecated("3.0.0", "6.0.0", text=_suggest_deprecated_msg)
     def suggest_loguniform(self, name: str, low: float, high: float) -> float:
 
         return self.suggest_float(name, low, high, log=True)
 
-    @deprecated("3.0.0a1", "6.0.0", text=_suggest_deprecated_msg)
+    @deprecated("3.0.0", "6.0.0", text=_suggest_deprecated_msg)
     def suggest_discrete_uniform(self, name: str, low: float, high: float, q: float) -> float:
 
         return self.suggest_float(name, low, high, step=q)

--- a/optuna/trial/_frozen.py
+++ b/optuna/trial/_frozen.py
@@ -236,17 +236,17 @@ class FrozenTrial(BaseTrial):
             else:
                 return self._suggest(name, UniformDistribution(low=low, high=high))
 
-    @deprecated("3.0.0a1", "6.0.0", text=_suggest_deprecated_msg)
+    @deprecated("3.0.0", "6.0.0", text=_suggest_deprecated_msg)
     def suggest_uniform(self, name: str, low: float, high: float) -> float:
 
         return self.suggest_float(name, low, high)
 
-    @deprecated("3.0.0a1", "6.0.0", text=_suggest_deprecated_msg)
+    @deprecated("3.0.0", "6.0.0", text=_suggest_deprecated_msg)
     def suggest_loguniform(self, name: str, low: float, high: float) -> float:
 
         return self.suggest_float(name, low, high, log=True)
 
-    @deprecated("3.0.0a1", "6.0.0", text=_suggest_deprecated_msg)
+    @deprecated("3.0.0", "6.0.0", text=_suggest_deprecated_msg)
     def suggest_discrete_uniform(self, name: str, low: float, high: float, q: float) -> float:
 
         return self.suggest_float(name, low, high, step=q)

--- a/optuna/trial/_frozen.py
+++ b/optuna/trial/_frozen.py
@@ -236,17 +236,17 @@ class FrozenTrial(BaseTrial):
             else:
                 return self._suggest(name, UniformDistribution(low=low, high=high))
 
-    @deprecated("2.11.0", "6.0.0", text=_suggest_deprecated_msg)
+    @deprecated("3.0.0a1", "6.0.0", text=_suggest_deprecated_msg)
     def suggest_uniform(self, name: str, low: float, high: float) -> float:
 
         return self.suggest_float(name, low, high)
 
-    @deprecated("2.11.0", "6.0.0", text=_suggest_deprecated_msg)
+    @deprecated("3.0.0a1", "6.0.0", text=_suggest_deprecated_msg)
     def suggest_loguniform(self, name: str, low: float, high: float) -> float:
 
         return self.suggest_float(name, low, high, log=True)
 
-    @deprecated("2.11.0", "6.0.0", text=_suggest_deprecated_msg)
+    @deprecated("3.0.0a1", "6.0.0", text=_suggest_deprecated_msg)
     def suggest_discrete_uniform(self, name: str, low: float, high: float, q: float) -> float:
 
         return self.suggest_float(name, low, high, step=q)

--- a/optuna/trial/_trial.py
+++ b/optuna/trial/_trial.py
@@ -174,7 +174,7 @@ class Trial(BaseTrial):
 
         return self._suggest(name, distribution)
 
-    @deprecated("2.11.0", "6.0.0", text=_suggest_deprecated_msg)
+    @deprecated("3.0.0a1", "6.0.0", text=_suggest_deprecated_msg)
     def suggest_uniform(self, name: str, low: float, high: float) -> float:
         """Suggest a value for the continuous parameter.
 
@@ -197,7 +197,7 @@ class Trial(BaseTrial):
 
         return self.suggest_float(name, low, high)
 
-    @deprecated("2.11.0", "6.0.0", text=_suggest_deprecated_msg)
+    @deprecated("3.0.0a1", "6.0.0", text=_suggest_deprecated_msg)
     def suggest_loguniform(self, name: str, low: float, high: float) -> float:
         """Suggest a value for the continuous parameter.
 
@@ -220,7 +220,7 @@ class Trial(BaseTrial):
 
         return self.suggest_float(name, low, high, log=True)
 
-    @deprecated("2.11.0", "6.0.0", text=_suggest_deprecated_msg)
+    @deprecated("3.0.0a1", "6.0.0", text=_suggest_deprecated_msg)
     def suggest_discrete_uniform(self, name: str, low: float, high: float, q: float) -> float:
         """Suggest a value for the discrete parameter.
 

--- a/optuna/trial/_trial.py
+++ b/optuna/trial/_trial.py
@@ -174,7 +174,7 @@ class Trial(BaseTrial):
 
         return self._suggest(name, distribution)
 
-    @deprecated("3.0.0a1", "6.0.0", text=_suggest_deprecated_msg)
+    @deprecated("3.0.0", "6.0.0", text=_suggest_deprecated_msg)
     def suggest_uniform(self, name: str, low: float, high: float) -> float:
         """Suggest a value for the continuous parameter.
 
@@ -197,7 +197,7 @@ class Trial(BaseTrial):
 
         return self.suggest_float(name, low, high)
 
-    @deprecated("3.0.0a1", "6.0.0", text=_suggest_deprecated_msg)
+    @deprecated("3.0.0", "6.0.0", text=_suggest_deprecated_msg)
     def suggest_loguniform(self, name: str, low: float, high: float) -> float:
         """Suggest a value for the continuous parameter.
 
@@ -220,7 +220,7 @@ class Trial(BaseTrial):
 
         return self.suggest_float(name, low, high, log=True)
 
-    @deprecated("3.0.0a1", "6.0.0", text=_suggest_deprecated_msg)
+    @deprecated("3.0.0", "6.0.0", text=_suggest_deprecated_msg)
     def suggest_discrete_uniform(self, name: str, low: float, high: float, q: float) -> float:
         """Suggest a value for the discrete parameter.
 


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
Next release version introduced in #3006 was not reflected in #2990. Let me fix that.

## Description of the changes
<!-- Describe the changes in this PR. -->
* Bump `deprecated_version` of `suggest` APIs to `3.0.0a1`