### PR TITLE
Pin `tensorflow` and `tensorflow-estimator` versions to `<2.7.0`.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -101,7 +101,7 @@ def get_extras_require() -> Dict[str, List[str]]:
             "scikit-learn>=0.24.2",
             "scikit-optimize",
             "xgboost",
-            # TODO(toshihikoyanase): Remove the version constraints after tensorflow==2.7.0 is released.
+            # TODO(toshihikoyanase): Remove the constraints when tensorflow==2.7.0 is released.
             "tensorflow-estimator<2.7.0",
             "tensorflow<2.7.0",
             "tensorflow-datasets",
@@ -145,7 +145,7 @@ def get_extras_require() -> Dict[str, List[str]]:
             "scikit-learn>=0.24.2",
             "scikit-optimize",
             "xgboost",
-            # TODO(toshihikoyanase): Remove the version constraints after tensorflow==2.7.0 is released.
+            # TODO(toshihikoyanase): Remove the constraints when tensorflow==2.7.0 is released.
             "tensorflow-estimator<2.7.0",
             "tensorflow<2.7.0",
             "tensorflow-datasets",

--- a/setup.py
+++ b/setup.py
@@ -101,7 +101,9 @@ def get_extras_require() -> Dict[str, List[str]]:
             "scikit-learn>=0.24.2",
             "scikit-optimize",
             "xgboost",
-            "tensorflow",
+            # TODO(toshihikoyanase): Remove the version constraints after tensorflow==2.7.0 is released.
+            "tensorflow-estimator<2.7.0",
+            "tensorflow<2.7.0",
             "tensorflow-datasets",
             "pytorch-ignite",
             "pytorch-lightning>=1.0.2",
@@ -143,7 +145,9 @@ def get_extras_require() -> Dict[str, List[str]]:
             "scikit-learn>=0.24.2",
             "scikit-optimize",
             "xgboost",
-            "tensorflow",
+            # TODO(toshihikoyanase): Remove the version constraints after tensorflow==2.7.0 is released.
+            "tensorflow-estimator<2.7.0",
+            "tensorflow<2.7.0",
             "tensorflow-datasets",
             "pytorch-ignite",
             "pytorch-lightning>=1.0.2",


### PR DESCRIPTION
## Motivation

As can be seen in the [CI log](https://github.com/optuna/optuna/runs/4058023388?check_suite_focus=true#step:7:19), `tests/integration_tests/test_tensorflow.py` failed due to the import error.

```
ImportError while importing test module '/home/runner/work/optuna/optuna/tests/integration_tests/test_tensorflow.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/importlib/__init__.py:127: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
tests/integration_tests/test_tensorflow.py:10: in <module>
    from optuna.integration import TensorFlowPruningHook
E   ImportError: cannot import name 'TensorFlowPruningHook' from 'optuna.integration' (unknown location)
```

This may be related to the [release](https://github.com/tensorflow/estimator/releases/tag/v2.7.0) of `tensorflow-estimator==2.7.0`. I think It requires `tensorflow==2.7.0`, but it has not been released yet. These inconsistent versions seem to be the cause of the error.

CC @hvy @himkt 

## Description of the changes
This PR adds the version restriction to `tensorflow` and `tensorflow-estimator`.