### PR TITLE
Support multiple input of studies when plot with matplotlib.

### DIFF
--- a/optuna/visualization/matplotlib/_optimization_history.py
+++ b/optuna/visualization/matplotlib/_optimization_history.py
@@ -143,7 +143,7 @@ def _get_optimization_histories(
             ax.scatter(
                 x=[t.number for t in trials],
                 y=[t.value for t in trials],
-                color=cmap(3) if len(studies) == 1 else cmap(2 * i),
+                color=cmap(0) if len(studies) == 1 else cmap(2 * i),
                 alpha=1,
                 label=target_name if len(studies) == 1 else f"{target_name} of {study.study_name}",
             )
@@ -151,7 +151,7 @@ def _get_optimization_histories(
                 [t.number for t in trials],
                 best_values,
                 marker="o",
-                color=cmap(0) if len(studies) == 1 else cmap(2 * i + 1),
+                color=cmap(3) if len(studies) == 1 else cmap(2 * i + 1),
                 alpha=0.5,
                 label="Best Value" if len(studies) == 1 else f"Best Values of {study.study_name}",
             )

--- a/optuna/visualization/matplotlib/_optimization_history.py
+++ b/optuna/visualization/matplotlib/_optimization_history.py
@@ -61,6 +61,8 @@ def plot_optimization_history(
     Args:
         study:
             A :class:`~optuna.study.Study` object whose trials are plotted for their target values.
+            You can pass multiple studies if you want to compare those optimization histories.
+
         target:
             A function to specify the value to display. If it is :obj:`None` and ``study`` is being
             used for single-objective optimization, the objective values are plotted.
@@ -117,6 +119,7 @@ def _get_optimization_history_plot(
 
     if len(all_trials) == 0:
         _logger.warning("Study instance does not contain trials.")
+        ax.plot()
         return ax
 
     ax = _get_optimization_histories(studies, target, target_name, ax)

--- a/optuna/visualization/matplotlib/_optimization_history.py
+++ b/optuna/visualization/matplotlib/_optimization_history.py
@@ -20,7 +20,6 @@ from optuna.visualization.matplotlib._matplotlib_imports import _imports
 
 if _imports.is_successful():
     from optuna.visualization.matplotlib._matplotlib_imports import Axes
-    from optuna.visualization.matplotlib._matplotlib_imports import Colormap
     from optuna.visualization.matplotlib._matplotlib_imports import plt
 
 _logger = get_logger(__name__)

--- a/optuna/visualization/matplotlib/_optimization_history.py
+++ b/optuna/visualization/matplotlib/_optimization_history.py
@@ -4,7 +4,7 @@ from typing import cast
 from typing import List
 from typing import Optional
 from typing import Sequence
-from typing import Union 
+from typing import Union
 
 import numpy as np
 
@@ -143,7 +143,9 @@ def _get_optimization_histories(
                 y=[t.value for t in trials],
                 color=cmap(0),
                 alpha=1,
-                label=target_name,
+                label=target_name
+                if len(studies) == 1
+                else f"{target_name} of {study.study_name}",
             )
             ax.plot(
                 [t.number for t in trials],
@@ -151,7 +153,9 @@ def _get_optimization_histories(
                 marker="o",
                 color=cmap(3),
                 alpha=0.5,
-                label="Best Value",
+                label="Best Value"
+                if len(studies) == 1
+                else f"Best Values of {study.study_name}",
             )
 
             ax.legend()
@@ -161,7 +165,9 @@ def _get_optimization_histories(
                 y=[target(t) for t in trials],
                 color=cmap(0),
                 alpha=1,
-                label=target_name,
+                label=target_name
+                if len(studies) == 1
+                else f"{target_name} of {study.study_name}",
             )
 
     return ax

--- a/optuna/visualization/matplotlib/_optimization_history.py
+++ b/optuna/visualization/matplotlib/_optimization_history.py
@@ -143,7 +143,7 @@ def _get_optimization_histories(
             ax.scatter(
                 x=[t.number for t in trials],
                 y=[t.value for t in trials],
-                color=cmap(2 * i),
+                color=cmap(3) if len(studies) == 1 else cmap(2 * i),
                 alpha=1,
                 label=target_name if len(studies) == 1 else f"{target_name} of {study.study_name}",
             )
@@ -151,7 +151,7 @@ def _get_optimization_histories(
                 [t.number for t in trials],
                 best_values,
                 marker="o",
-                color=cmap(2 * i + 1),
+                color=cmap(0) if len(studies) == 1 else cmap(2 * i + 1),
                 alpha=0.5,
                 label="Best Value" if len(studies) == 1 else f"Best Values of {study.study_name}",
             )
@@ -161,7 +161,7 @@ def _get_optimization_histories(
             ax.scatter(
                 x=[t.number for t in trials],
                 y=[target(t) for t in trials],
-                color=cmap(2 * i),
+                color=cmap(0) if len(studies) == 0 else cmap(2 * i),
                 alpha=1,
                 label=target_name if len(studies) == 1 else f"{target_name} of {study.study_name}",
             )

--- a/optuna/visualization/matplotlib/_optimization_history.py
+++ b/optuna/visualization/matplotlib/_optimization_history.py
@@ -60,7 +60,8 @@ def plot_optimization_history(
             optuna.visualization.matplotlib.plot_optimization_history(study)
 
         .. note::
-            You need  to adjust the size of the plot by yourself using `plt.tight_layout()` or `plt.savefig(IMAGE_NAME, bbox_inches='tight')`.
+            You need  to adjust the size of the plot by yourself using ``plt.tight_layout()`` or
+            ``plt.savefig(IMAGE_NAME, bbox_inches='tight')``.
     Args:
         study:
             A :class:`~optuna.study.Study` object whose trials are plotted for their target values.

--- a/optuna/visualization/matplotlib/_optimization_history.py
+++ b/optuna/visualization/matplotlib/_optimization_history.py
@@ -105,6 +105,9 @@ def _get_optimization_history_plot(
     ax.set_xlabel("#Trials")
     ax.set_ylabel(target_name)
 
+    if len(studies) == 0:
+        _logger.warning("There are no studies.")
+        return ax
     # Prepare data for plotting.
     all_trials = list(
         itertools.chain.from_iterable(
@@ -119,7 +122,6 @@ def _get_optimization_history_plot(
 
     if len(all_trials) == 0:
         _logger.warning("Study instance does not contain trials.")
-        ax.plot()
         return ax
 
     ax = _get_optimization_histories(studies, target, target_name, ax)

--- a/optuna/visualization/matplotlib/_optimization_history.py
+++ b/optuna/visualization/matplotlib/_optimization_history.py
@@ -102,7 +102,6 @@ def _get_optimization_history_plot(
     ax.set_title("Optimization History Plot")
     ax.set_xlabel("#Trials")
     ax.set_ylabel(target_name)
-    cmap = plt.get_cmap("tab10")  # Use tab10 colormap for similar outputs to plotly.
 
     # Prepare data for plotting.
     all_trials = list(
@@ -120,7 +119,7 @@ def _get_optimization_history_plot(
         _logger.warning("Study instance does not contain trials.")
         return ax
 
-    ax = _get_optimization_histories(studies, target, target_name, ax, cmap)
+    ax = _get_optimization_histories(studies, target, target_name, ax)
     plt.legend(bbox_to_anchor=(1.05, 1.0), loc="upper left")
     return ax
 
@@ -130,8 +129,8 @@ def _get_optimization_histories(
     target: Optional[Callable[[FrozenTrial], float]],
     target_name: str,
     ax: "Axes",
-    cmap: "Colormap",
 ) -> "Axes":
+    cmap = plt.get_cmap("tab10")  # Use tab10 colormap for similar outputs to plotly.
 
     # Draw a scatter plot and a line plot.
     for i, study in enumerate(studies):

--- a/optuna/visualization/matplotlib/_optimization_history.py
+++ b/optuna/visualization/matplotlib/_optimization_history.py
@@ -20,8 +20,8 @@ from optuna.visualization.matplotlib._matplotlib_imports import _imports
 
 if _imports.is_successful():
     from optuna.visualization.matplotlib._matplotlib_imports import Axes
-    from optuna.visualization.matplotlib._matplotlib_imports import plt
     from optuna.visualization.matplotlib._matplotlib_imports import Colormap
+    from optuna.visualization.matplotlib._matplotlib_imports import plt
 
 _logger = get_logger(__name__)
 
@@ -97,6 +97,7 @@ def _get_optimization_history_plot(
 
     # Set up the graph style.
     plt.style.use("ggplot")  # Use ggplot style sheet for similar outputs to plotly.
+
     _, ax = plt.subplots()
     ax.set_title("Optimization History Plot")
     ax.set_xlabel("#Trials")
@@ -104,7 +105,6 @@ def _get_optimization_history_plot(
     cmap = plt.get_cmap("tab10")  # Use tab10 colormap for similar outputs to plotly.
 
     # Prepare data for plotting.
-    # trials = [t for t in study.trials if t.state == TrialState.COMPLETE]
     all_trials = list(
         itertools.chain.from_iterable(
             (
@@ -120,18 +120,21 @@ def _get_optimization_history_plot(
         _logger.warning("Study instance does not contain trials.")
         return ax
 
-    return _get_optimization_histories(studies, target, target_name, ax, cmap)
-    
+    ax = _get_optimization_histories(studies, target, target_name, ax, cmap)
+    plt.legend(bbox_to_anchor=(1.05, 1.0), loc="upper left")
+    return ax
+
+
 def _get_optimization_histories(
     studies: List[Study],
     target: Optional[Callable[[FrozenTrial], float]],
     target_name: str,
     ax: "Axes",
-    cmap: "Colormap" 
+    cmap: "Colormap",
 ) -> "Axes":
 
     # Draw a scatter plot and a line plot.
-    for study in studies:
+    for i, study in enumerate(studies):
         trials = study.get_trials(states=(TrialState.COMPLETE,))
         if target is None:
             if study.direction == StudyDirection.MINIMIZE:
@@ -141,21 +144,17 @@ def _get_optimization_histories(
             ax.scatter(
                 x=[t.number for t in trials],
                 y=[t.value for t in trials],
-                color=cmap(0),
+                color=cmap(2 * i),
                 alpha=1,
-                label=target_name
-                if len(studies) == 1
-                else f"{target_name} of {study.study_name}",
+                label=target_name if len(studies) == 1 else f"{target_name} of {study.study_name}",
             )
             ax.plot(
                 [t.number for t in trials],
                 best_values,
                 marker="o",
-                color=cmap(3),
+                color=cmap(2 * i + 1),
                 alpha=0.5,
-                label="Best Value"
-                if len(studies) == 1
-                else f"Best Values of {study.study_name}",
+                label="Best Value" if len(studies) == 1 else f"Best Values of {study.study_name}",
             )
 
             ax.legend()
@@ -163,12 +162,9 @@ def _get_optimization_histories(
             ax.scatter(
                 x=[t.number for t in trials],
                 y=[target(t) for t in trials],
-                color=cmap(0),
+                color=cmap(2 * i),
                 alpha=1,
-                label=target_name
-                if len(studies) == 1
-                else f"{target_name} of {study.study_name}",
+                label=target_name if len(studies) == 1 else f"{target_name} of {study.study_name}",
             )
 
     return ax
-

--- a/optuna/visualization/matplotlib/_optimization_history.py
+++ b/optuna/visualization/matplotlib/_optimization_history.py
@@ -60,7 +60,7 @@ def plot_optimization_history(
             optuna.visualization.matplotlib.plot_optimization_history(study)
 
         .. note::
-            You need  to adjust the size of the plot by yourself using ``plt.tight_layout()`` or
+            You need to adjust the size of the plot by yourself using ``plt.tight_layout()`` or
             ``plt.savefig(IMAGE_NAME, bbox_inches='tight')``.
     Args:
         study:

--- a/optuna/visualization/matplotlib/_optimization_history.py
+++ b/optuna/visualization/matplotlib/_optimization_history.py
@@ -56,8 +56,8 @@ def plot_optimization_history(
             study = optuna.create_study(sampler=sampler)
             study.optimize(objective, n_trials=10)
 
-            plt.tight_layout()
             optuna.visualization.matplotlib.plot_optimization_history(study)
+            plt.tight_layout()
 
         .. note::
             You need to adjust the size of the plot by yourself using ``plt.tight_layout()`` or

--- a/optuna/visualization/matplotlib/_optimization_history.py
+++ b/optuna/visualization/matplotlib/_optimization_history.py
@@ -44,6 +44,7 @@ def plot_optimization_history(
         .. plot::
 
             import optuna
+            import matplotlib.pyplot as plt
 
 
             def objective(trial):
@@ -55,8 +56,11 @@ def plot_optimization_history(
             study = optuna.create_study(sampler=sampler)
             study.optimize(objective, n_trials=10)
 
+            plt.tight_layout()
             optuna.visualization.matplotlib.plot_optimization_history(study)
 
+        .. note::
+            You need  to adjust the size of the plot by yourself using `plt.tight_layout()` or `plt.savefig(IMAGE_NAME, bbox_inches='tight')`.
     Args:
         study:
             A :class:`~optuna.study.Study` object whose trials are plotted for their target values.

--- a/tests/visualization_tests/matplotlib_tests/test_optimization_history.py
+++ b/tests/visualization_tests/matplotlib_tests/test_optimization_history.py
@@ -56,6 +56,7 @@ def test_plot_optimization_history(direction: str) -> None:
     figure = plot_optimization_history(study)
     assert len(figure.get_lines()) == 0
 
+
 @pytest.mark.parametrize("direction", ["minimize", "maximize"])
 def test_plot_optimization_history_with_multiple_studies(direction: str) -> None:
     n_studies = 10
@@ -80,14 +81,13 @@ def test_plot_optimization_history_with_multiple_studies(direction: str) -> None
     for study in studies:
         study.optimize(objective, n_trials=3)
     figure = plot_optimization_history(studies)
-    assert len(figure.get_lines()) ==  n_studies
-    
+    assert len(figure.get_lines()) == n_studies
+
     for i, legend in enumerate(figure.legend().get_texts()):
         if i < n_studies:
-            assert legend.get_text() == f'Best Values of {studies[i].study_name}'
+            assert legend.get_text() == f"Best Values of {studies[i].study_name}"
         else:
-            assert legend.get_text() == f'Objective Value of {studies[i-n_studies].study_name}'
-
+            assert legend.get_text() == f"Objective Value of {studies[i-n_studies].study_name}"
 
     # Test customized target.
     with pytest.warns(UserWarning):
@@ -95,9 +95,12 @@ def test_plot_optimization_history_with_multiple_studies(direction: str) -> None
     assert len(figure.get_lines()) == 0
     assert len(figure.get_legend().get_texts()) == n_studies
 
-    # # Test customized target name.
+    # Test customized target name.
     figure = plot_optimization_history(studies, target_name="Target Name")
-    assert figure.legend().get_texts()[n_studies].get_text() == f"Target Name of {studies[0].study_name}"
+    assert (
+        figure.legend().get_texts()[n_studies].get_text()
+        == f"Target Name of {studies[0].study_name}"
+    )
     assert figure.get_ylabel() == "Target Name"
 
     # Ignore failed trials.
@@ -110,4 +113,3 @@ def test_plot_optimization_history_with_multiple_studies(direction: str) -> None
 
     figure = plot_optimization_history(studies)
     assert len(figure.get_lines()) == 0
-

--- a/tests/visualization_tests/matplotlib_tests/test_optimization_history.py
+++ b/tests/visualization_tests/matplotlib_tests/test_optimization_history.py
@@ -81,6 +81,12 @@ def test_plot_optimization_history_with_multiple_studies(direction: str) -> None
         study.optimize(objective, n_trials=3)
     figure = plot_optimization_history(studies)
     assert len(figure.get_lines()) ==  n_studies
+    
+    for i, legend in enumerate(figure.legend().get_texts()):
+        if i < n_studies:
+            assert legend.get_text() == f'Best Values of {studies[i].study_name}'
+        else:
+            assert legend.get_text() == f'Objective Value of {studies[i-n_studies].study_name}'
 
     # Ignore failed trials.
     def fail_objective(_: Trial) -> float:

--- a/tests/visualization_tests/matplotlib_tests/test_optimization_history.py
+++ b/tests/visualization_tests/matplotlib_tests/test_optimization_history.py
@@ -55,3 +55,41 @@ def test_plot_optimization_history(direction: str) -> None:
 
     figure = plot_optimization_history(study)
     assert len(figure.get_lines()) == 0
+
+@pytest.mark.parametrize("direction", ["minimize", "maximize"])
+def test_plot_optimization_history_with_multiple_studies(direction: str) -> None:
+    n_studies = 10
+
+    # Test with no trial.
+    studies = [create_study(direction=direction) for _ in range(n_studies)]
+    figure = plot_optimization_history(studies)
+    assert len(figure.get_lines()) == 0
+
+    def objective(trial: Trial) -> float:
+
+        if trial.number == 0:
+            return 1.0
+        elif trial.number == 1:
+            return 2.0
+        elif trial.number == 2:
+            return 0.0
+        return 0.0
+
+    # Test with trials.
+    studies = [create_study(direction=direction) for _ in range(n_studies)]
+    for study in studies:
+        study.optimize(objective, n_trials=3)
+    figure = plot_optimization_history(studies)
+    assert len(figure.get_lines()) ==  n_studies
+
+    # Ignore failed trials.
+    def fail_objective(_: Trial) -> float:
+        raise ValueError
+
+    studies = [create_study(direction=direction) for _ in range(n_studies)]
+    for study in studies:
+        study.optimize(fail_objective, n_trials=1, catch=(ValueError,))
+
+    figure = plot_optimization_history(studies)
+    assert len(figure.get_lines()) == 0
+

--- a/tests/visualization_tests/matplotlib_tests/test_optimization_history.py
+++ b/tests/visualization_tests/matplotlib_tests/test_optimization_history.py
@@ -88,6 +88,18 @@ def test_plot_optimization_history_with_multiple_studies(direction: str) -> None
         else:
             assert legend.get_text() == f'Objective Value of {studies[i-n_studies].study_name}'
 
+
+    # Test customized target.
+    with pytest.warns(UserWarning):
+        figure = plot_optimization_history(studies, target=lambda t: t.number)
+    assert len(figure.get_lines()) == 0
+    assert len(figure.get_legend().get_texts()) == n_studies
+
+    # # Test customized target name.
+    figure = plot_optimization_history(studies, target_name="Target Name")
+    assert figure.legend().get_texts()[n_studies].get_text() == f"Target Name of {studies[0].study_name}"
+    assert figure.get_ylabel() == "Target Name"
+
     # Ignore failed trials.
     def fail_objective(_: Trial) -> float:
         raise ValueError


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
As a part of https://github.com/optuna/optuna/issues/3020, We wants to support a input of studies at the matplotlib.

## Description of the changes
<!-- Describe the changes in this PR. -->
implement the same logic of https://github.com/optuna/optuna/issues/2807

## Examples
```python
import optuna


def objective(trial):
    return trial.suggest_float("x", 0, 1) ** 2


plt.figure()
n_studies = 5
studies = [optuna.create_study() for _ in range(n_studies)]
for study in studies:
    study.optimize(objective, n_trials=20)

fig = optuna.visualization.matplotlib.plot_optimization_history(studies)
```
![2021-10-31-144336_3286x1200_scrot](https://user-images.githubusercontent.com/49433901/139574953-053a9382-6a7a-41cb-8aec-78e8486d715c.png)

