### PR TITLE
Remove _get_removed_version_from_deprecated_version function

### DIFF
--- a/optuna/_deprecated.py
+++ b/optuna/_deprecated.py
@@ -43,7 +43,7 @@ def _format_text(text: str) -> str:
 
 def deprecated(
     deprecated_version: str,
-    removed_version: Optional[str] = None,
+    removed_version: str = None,
     name: Optional[str] = None,
     text: Optional[str] = None,
 ) -> Any:

--- a/optuna/_deprecated.py
+++ b/optuna/_deprecated.py
@@ -43,7 +43,7 @@ def _format_text(text: str) -> str:
 
 def deprecated(
     deprecated_version: str,
-    removed_version: str = None,
+    removed_version: str,
     name: Optional[str] = None,
     text: Optional[str] = None,
 ) -> Any:
@@ -53,10 +53,7 @@ def deprecated(
         deprecated_version:
             The version in which the target feature is deprecated.
         removed_version:
-            The version in which the target feature will be removed. If :obj:`None`, determined
-            based on the deprecated version. In this case, it will become the next next major
-            version after the deprecated version. E.g. if ``deprecated_version`` is ``1.5.0``,
-            this version becomes ``3.0.0``.
+            The version in which the target feature will be removed.
         name:
             The name of the feature. Defaults to the function or class name. Optional.
         text:

--- a/optuna/_deprecated.py
+++ b/optuna/_deprecated.py
@@ -41,12 +41,6 @@ def _format_text(text: str) -> str:
     return "\n\n" + textwrap.indent(text.strip(), "    ") + "\n"
 
 
-def _get_removed_version_from_deprecated_version(deprecated_version: str) -> str:
-    parsed_deprecated_version = version.parse(deprecated_version)
-    assert isinstance(parsed_deprecated_version, version.Version)  # Required for mypy.
-    return "{}.0.0".format(parsed_deprecated_version.major + 2)
-
-
 def deprecated(
     deprecated_version: str,
     removed_version: Optional[str] = None,
@@ -81,8 +75,6 @@ def deprecated(
     """
 
     _validate_version(deprecated_version)
-    if removed_version is None:
-        removed_version = _get_removed_version_from_deprecated_version(deprecated_version)
     _validate_version(removed_version)
     _validate_two_version(deprecated_version, removed_version)
 

--- a/tests/test_deprecated.py
+++ b/tests/test_deprecated.py
@@ -196,8 +196,3 @@ def test_deprecation_decorator_default_removed_version() -> None:
 
     with pytest.warns(FutureWarning):
         decorated_func()
-
-
-def test_get_removed_version_from_deprecated_version() -> None:
-    assert _deprecated._get_removed_version_from_deprecated_version("1.0.0") == "3.0.0"
-    assert _deprecated._get_removed_version_from_deprecated_version("1.5.0") == "3.0.0"

--- a/tests/test_deprecated.py
+++ b/tests/test_deprecated.py
@@ -181,7 +181,8 @@ def test_deprecation_class_text_specified(text: Optional[str]) -> None:
 
 def test_deprecation_decorator_default_removed_version() -> None:
     deprecated_version = "1.1.0"
-    decorator_deprecation = _deprecated.deprecated(deprecated_version)
+    removed_version = "3.0.0"
+    decorator_deprecation = _deprecated.deprecated(deprecated_version, removed_version)
     assert callable(decorator_deprecation)
 
     def _func() -> int:
@@ -191,7 +192,7 @@ def test_deprecation_decorator_default_removed_version() -> None:
     decorated_func = decorator_deprecation(_func)
     assert decorated_func.__name__ == _func.__name__
     assert decorated_func.__doc__ == _deprecated._DEPRECATION_NOTE_TEMPLATE.format(
-        d_ver=deprecated_version, r_ver="3.0.0"
+        d_ver=deprecated_version, r_ver=removed_version
     )
 
     with pytest.warns(FutureWarning):


### PR DESCRIPTION
## Motivation

See #2902

## Description of the changes

Remove `_get_removed_version_from_deprecated_version` function.

NOTE: This PR must be rebased after merging #3064 