### PR TITLE
Add `seealso` link of `002_configurations.py`

### DIFF
--- a/optuna/trial/_trial.py
+++ b/optuna/trial/_trial.py
@@ -398,8 +398,8 @@ class Trial(BaseTrial):
             A suggested value.
         
         .. seealso::
-            See an `tutorial <https://optuna.readthedocs.io/en/latest/
-            tutorial/10_key_features/002_configurations.html>`_how to use the trial.
+            See an `tutorial <https://optuna.readthedocs.io/en/latest/tutorial/
+            10_key_features/002_configurations.html>`_how to use the trial.
         
         """
         # There is no need to call self._check_distribution because

--- a/optuna/trial/_trial.py
+++ b/optuna/trial/_trial.py
@@ -398,10 +398,9 @@ class Trial(BaseTrial):
             A suggested value.
         
         .. seealso::
-            Please refer to `PythonicSearchSpace` tutorial
+            See an `tutorial <https://optuna.readthedocs.io/en/latest/
+            tutorial/10_key_features/002_configurations.html>`_how to use the trial.
         
-        .. _PythonicSearchSpace: https://optuna.readthedocs.io/en/latest/tutorial/10_key_features/002_configurations.html
-
         """
         # There is no need to call self._check_distribution because
         # CategoricalDistribution does not support dynamic value space.

--- a/optuna/trial/_trial.py
+++ b/optuna/trial/_trial.py
@@ -158,7 +158,7 @@ class Trial(BaseTrial):
 
         See also:
             Please refer to [this tutorial](https://optuna.readthedocs.io/en/latest/tutorial/10_key_features/002_configurations.html)
-            
+
         """
 
         if step is not None:
@@ -405,8 +405,11 @@ class Trial(BaseTrial):
         Returns:
             A suggested value.
         
-        See also:
-            Please refer to [this tutorial](https://optuna.readthedocs.io/en/latest/tutorial/10_key_features/002_configurations.html)
+        .. seealso::
+            Please refer to `PythonicSearchSpace` tutorial
+        
+        .. _PythonicSearchSpace: https://optuna.readthedocs.io/en/latest/tutorial/10_key_features/002_configurations.html
+
 
         """
         # There is no need to call self._check_distribution because

--- a/optuna/trial/_trial.py
+++ b/optuna/trial/_trial.py
@@ -156,8 +156,9 @@ class Trial(BaseTrial):
         Returns:
             A suggested float value.
 
-        .. seealso::
+        See also:
             Please refer to [this tutorial](https://optuna.readthedocs.io/en/latest/tutorial/10_key_features/002_configurations.html)
+            
         """
 
         if step is not None:
@@ -331,8 +332,9 @@ class Trial(BaseTrial):
             :exc:`ValueError`:
                 If ``step != 1`` and ``log = True`` are specified.
         
-        .. seealso::
+        See also:
             Please refer to [this tutorial](https://optuna.readthedocs.io/en/latest/tutorial/10_key_features/002_configurations.html)
+
         """
 
         if step != 1:
@@ -403,8 +405,9 @@ class Trial(BaseTrial):
         Returns:
             A suggested value.
         
-        .. seealso::
+        See also:
             Please refer to [this tutorial](https://optuna.readthedocs.io/en/latest/tutorial/10_key_features/002_configurations.html)
+
         """
         # There is no need to call self._check_distribution because
         # CategoricalDistribution does not support dynamic value space.

--- a/optuna/trial/_trial.py
+++ b/optuna/trial/_trial.py
@@ -330,6 +330,9 @@ class Trial(BaseTrial):
         Raises:
             :exc:`ValueError`:
                 If ``step != 1`` and ``log = True`` are specified.
+        
+        .. seealso::
+            Please refer to [this tutorial](https://optuna.readthedocs.io/en/latest/tutorial/10_key_features/002_configurations.html)
         """
 
         if step != 1:

--- a/optuna/trial/_trial.py
+++ b/optuna/trial/_trial.py
@@ -155,10 +155,6 @@ class Trial(BaseTrial):
 
         Returns:
             A suggested float value.
-
-        See also:
-            Please refer to [this tutorial](https://optuna.readthedocs.io/en/latest/tutorial/10_key_features/002_configurations.html)
-
         """
 
         if step is not None:
@@ -331,10 +327,6 @@ class Trial(BaseTrial):
         Raises:
             :exc:`ValueError`:
                 If ``step != 1`` and ``log = True`` are specified.
-        
-        See also:
-            Please refer to [this tutorial](https://optuna.readthedocs.io/en/latest/tutorial/10_key_features/002_configurations.html)
-
         """
 
         if step != 1:
@@ -409,7 +401,6 @@ class Trial(BaseTrial):
             Please refer to `PythonicSearchSpace` tutorial
         
         .. _PythonicSearchSpace: https://optuna.readthedocs.io/en/latest/tutorial/10_key_features/002_configurations.html
-
 
         """
         # There is no need to call self._check_distribution because

--- a/optuna/trial/_trial.py
+++ b/optuna/trial/_trial.py
@@ -398,8 +398,7 @@ class Trial(BaseTrial):
             A suggested value.
         
         .. seealso::
-            See an `tutorial <https://optuna.readthedocs.io/en/latest/tutorial/
-            10_key_features/002_configurations.html>`_how to use the trial.
+            :ref:`configurations` tutorial describes more details and flexible usages.
         
         """
         # There is no need to call self._check_distribution because

--- a/optuna/trial/_trial.py
+++ b/optuna/trial/_trial.py
@@ -155,6 +155,8 @@ class Trial(BaseTrial):
 
         Returns:
             A suggested float value.
+        .. seealso::
+            :ref:`configurations` tutorial describes more details and flexible usages.
         """
 
         if step is not None:

--- a/optuna/trial/_trial.py
+++ b/optuna/trial/_trial.py
@@ -396,10 +396,8 @@ class Trial(BaseTrial):
 
         Returns:
             A suggested value.
-        
         .. seealso::
             :ref:`configurations` tutorial describes more details and flexible usages.
-        
         """
         # There is no need to call self._check_distribution because
         # CategoricalDistribution does not support dynamic value space.

--- a/optuna/trial/_trial.py
+++ b/optuna/trial/_trial.py
@@ -402,6 +402,9 @@ class Trial(BaseTrial):
 
         Returns:
             A suggested value.
+        
+        .. seealso::
+            Please refer to [this tutorial](https://optuna.readthedocs.io/en/latest/tutorial/10_key_features/002_configurations.html)
         """
         # There is no need to call self._check_distribution because
         # CategoricalDistribution does not support dynamic value space.

--- a/optuna/trial/_trial.py
+++ b/optuna/trial/_trial.py
@@ -327,6 +327,8 @@ class Trial(BaseTrial):
         Raises:
             :exc:`ValueError`:
                 If ``step != 1`` and ``log = True`` are specified.
+        .. seealso::
+            :ref:`configurations` tutorial describes more details and flexible usages.
         """
 
         if step != 1:

--- a/optuna/trial/_trial.py
+++ b/optuna/trial/_trial.py
@@ -155,6 +155,9 @@ class Trial(BaseTrial):
 
         Returns:
             A suggested float value.
+
+        .. seealso::
+            Please refer to [this tutorial](https://optuna.readthedocs.io/en/latest/tutorial/10_key_features/002_configurations.html)
         """
 
         if step is not None:

--- a/optuna/trial/_trial.py
+++ b/optuna/trial/_trial.py
@@ -155,6 +155,7 @@ class Trial(BaseTrial):
 
         Returns:
             A suggested float value.
+
         .. seealso::
             :ref:`configurations` tutorial describes more details and flexible usages.
         """
@@ -329,6 +330,7 @@ class Trial(BaseTrial):
         Raises:
             :exc:`ValueError`:
                 If ``step != 1`` and ``log = True`` are specified.
+
         .. seealso::
             :ref:`configurations` tutorial describes more details and flexible usages.
         """
@@ -400,6 +402,7 @@ class Trial(BaseTrial):
 
         Returns:
             A suggested value.
+
         .. seealso::
             :ref:`configurations` tutorial describes more details and flexible usages.
         """

--- a/tutorial/10_key_features/002_configurations.py
+++ b/tutorial/10_key_features/002_configurations.py
@@ -12,6 +12,9 @@ For hyperparameter sampling, Optuna provides the following features:
 
 With optional arguments of ``step`` and ``log``, we can discretize or take the logarithm of
 integer and floating point parameters.
+
+.. seealso::
+    Please refer to :class:`~optuna.trial.Trial`.
 """
 
 

--- a/tutorial/10_key_features/002_configurations.py
+++ b/tutorial/10_key_features/002_configurations.py
@@ -12,9 +12,6 @@ For hyperparameter sampling, Optuna provides the following features:
 
 With optional arguments of ``step`` and ``log``, we can discretize or take the logarithm of
 integer and floating point parameters.
-
-.. seealso::
-    Please refer to :class:`~optuna.trial.Trial`.
 """
 
 


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
Partially fixed https://github.com/optuna/optuna/issues/2940 .

## Description of the changes
<!-- Describe the changes in this PR. -->
To 3 corresponded methods in `optuna/trial/_trial.py`, `seealso` link which leads to [optuna tutorial link](https://optuna.readthedocs.io/en/stable/tutorial/10_key_features/002_configurations.html) is added respectively. I think these changes completes the `Pythonic Search Space` items.
