### PR TITLE
Reformat labels for small importance scores in `plotly.plot_param_importances`

### DIFF
--- a/optuna/visualization/_param_importances.py
+++ b/optuna/visualization/_param_importances.py
@@ -116,14 +116,14 @@ def plot_param_importances(
     importances = OrderedDict(reversed(list(importances.items())))
     importance_values = list(importances.values())
     param_names = list(importances.keys())
+    importance_labels = [f"{val:.2f}" if val >= 0.01 else "<0.01" for val in importance_values]
 
     fig = go.Figure(
         data=[
             go.Bar(
                 x=importance_values,
                 y=param_names,
-                text=importance_values,
-                texttemplate="%{text:.2f}",
+                text=importance_labels,
                 textposition="outside",
                 cliponaxis=False,  # Ensure text is not clipped.
                 hovertemplate=[

--- a/tests/visualization_tests/test_param_importances.py
+++ b/tests/visualization_tests/test_param_importances.py
@@ -76,3 +76,21 @@ def test_plot_param_importances() -> None:
     study.optimize(fail_objective, n_trials=1, catch=(ValueError,))
     figure = plot_param_importances(study)
     assert len(figure.data) == 0
+
+
+def test_switch_label_when_param_insignificant() -> None:
+    def _objective(trial: Trial) -> int:
+        x = trial.suggest_int("x", 0, 2)
+        _ = trial.suggest_int("y", -1, 1)
+        return x ** 2
+
+    study = create_study()
+    for x in range(1, 3):
+        study.enqueue_trial({"x": x, "y": 0})
+
+    study.optimize(_objective, n_trials=2)
+    figure = plot_param_importances(study)
+
+    # Test if label for `y` param has been switched to `<0.01`.
+    labels = figure.data[0].text
+    assert labels == ("<0.01", "1.00")


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
This PR aims to close visual differences between plotly and matplotlib impolementations of `plot_param_importances` by introducing custom label formatting to `plotly` version of the plot. Labels for importance scores < 0.01 are reformatted as `<0.01`. Discussed in #2893.

## Description of the changes
<!-- Describe the changes in this PR. -->
* Add custom formatting for bar labels
* Write tests

## Example

Current master
![image](https://user-images.githubusercontent.com/37713008/139656164-84781511-ca3f-4ab2-a3b2-bcba00587403.png)

This PR

![Screenshot from 2021-11-01 11-20-50](https://user-images.githubusercontent.com/37713008/139657190-4e3f8649-dafa-4697-bc6d-7b9f8754b602.png)

