### PR TITLE
[RFC] Handle constant feature vectors in `fANOVA` tree

### DIFF
--- a/optuna/importance/_fanova/_tree.py
+++ b/optuna/importance/_fanova/_tree.py
@@ -71,7 +71,7 @@ class _FanovaTree(object):
             sample[features] = numpy.array(midpoints)
 
             value, weight = self._get_marginalized_statistics(sample)
-            weight *= float(numpy.prod(sizes))
+            weight *= float(numpy.prod(sizes)) + 1e-100  # Epsilon for numerical stability.
 
             values = numpy.append(values, value)
             weights = numpy.append(weights, weight)
@@ -299,7 +299,8 @@ class _FanovaTree(object):
 
 
 def _get_cardinality(search_spaces: numpy.ndarray) -> float:
-    return numpy.prod(search_spaces[:, 1] - search_spaces[:, 0])
+    c = numpy.prod(search_spaces[:, 1] - search_spaces[:, 0])
+    return c if c > 0 else numpy.prod(search_spaces.shape)
 
 
 def _get_subspaces(


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

This PR attempts to fix underlying issue that caused `ZeroDivisionError` in #2542. 

The error occurs in `FanovaImportanceEvaluator` when one of hyperparameters has distribution set up such that `low = high`.  This setup causes suggestion for this hyperparameter be constant across all trials (this is acceptable in Optuna) essentially creating a constant feature vector for `fANOVA` tree to fit on. Since it's just a regular decision tree, it will never split a constant feature vector. This causes range of problems when calculating importances (e.g. empty arrays, strictly positive values equal to zero) that eventually accumulate to originally reported error.

## Description of the changes
<!-- Describe the changes in this PR. -->
* [x] Fix cardinality calculation in `fANOVA` tree (same as [original implementation](https://github.com/automl/random_forest_run/blob/cc2354ed2622c270d96b88a068ae87990e1da054/include/rfr/util.hpp#L51-L62)) to avoid strictly positive weights go to 0
* [x]  Improve numerical stability when calculating marginal variance
* [ ] Write tests
