### PR TITLE
Add upper version constraint of PyTorchLightning

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -103,7 +103,9 @@ def get_extras_require() -> Dict[str, List[str]]:
             "tensorflow<2.7.0",
             "tensorflow-datasets",
             "pytorch-ignite",
-            "pytorch-lightning>=1.0.2",
+            # TODO(nzw0301): remove the upper version constraint when the callback supports
+            # pytorch-lightning==1.5.0.
+            "pytorch-lightning>=1.0.2,<1.5.0",
             "skorch",
             "catalyst>=21.3",
             "torch==1.8.0 ; sys_platform=='darwin'",
@@ -144,7 +146,9 @@ def get_extras_require() -> Dict[str, List[str]]:
             "tensorflow<2.7.0",
             "tensorflow-datasets",
             "pytorch-ignite",
-            "pytorch-lightning>=1.0.2",
+            # TODO(nzw0301): remove the upper version constraint when the callback supports
+            # pytorch-lightning==1.5.0.
+            "pytorch-lightning>=1.0.2,<1.5.0",
             "skorch",
             "catalyst>=21.3",
             "torch==1.8.0 ; sys_platform=='darwin'",


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
Pytorch-Lightning 1.5.0 has been released, but this release contains backwards-incompatible changes as in https://github.com/PyTorchLightning/pytorch-lightning/releases/tag/1.5.0#bc-changes. Due to this change, integration CI is falling now.

## Description of the changes
<!-- Describe the changes in this PR. -->

Add the version constraint of PyTorchLightning not to use `1.5.0` or higher version.