### PR TITLE
Pin `keras` version to `<2.7.0`.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -99,6 +99,7 @@ def get_extras_require() -> Dict[str, List[str]]:
             "scikit-optimize",
             "xgboost",
             # TODO(toshihikoyanase): Remove the constraints when tensorflow==2.7.0 is released.
+            "keras<2.7.0",
             "tensorflow-estimator<2.7.0",
             "tensorflow<2.7.0",
             "tensorflow-datasets",
@@ -142,6 +143,7 @@ def get_extras_require() -> Dict[str, List[str]]:
             "scikit-optimize",
             "xgboost",
             # TODO(toshihikoyanase): Remove the constraints when tensorflow==2.7.0 is released.
+            "keras<2.7.0",
             "tensorflow-estimator<2.7.0",
             "tensorflow<2.7.0",
             "tensorflow-datasets",


### PR DESCRIPTION
## Motivation

[CI jobs](https://github.com/optuna/optuna/runs/4100003344?check_suite_focus=true) failed due to the import error of `keras`. `keras==2.7.0` was released today, but the corresponding version of `tensorflow` has not been released yet. I guess the version inconsistency caused the issue similarly to #3059.

### Reproducible code

```
% docker run -it python:3.7 bash
# pip install 'tensorflow<2.7.0' 'tensorflow-estimator<2.7.0' 'tensorflow-datasets'
# pip freeze | grep keras
keras==2.7.0
# python
>>> import keras
  ...
  File "/usr/local/lib/python3.7/site-packages/tensorflow/python/eager/monitoring.py", line 135, in __init__
    self._metric = self._metric_methods[self._label_length].create(*args)
tensorflow.python.framework.errors_impl.AlreadyExistsError: Another metric with the same name already exists.
```

If I installed the release candidate of `tensorflow`, the keras can be imported successfully. So, I think we can simply remove the version constraint after `tensorflow==2.7.0` is released.

```
% docker run -it python:3.7 bash
# pip install --pre tensorflow
# python
>>> import keras
>>>
```


## Description of the changes

- Add version constraint of `keras`.