### PR TITLE
Add trial.user_attrs to pareto_front hover text

### DIFF
--- a/optuna/visualization/_pareto_front.py
+++ b/optuna/visualization/_pareto_front.py
@@ -1,4 +1,5 @@
 import json
+from typing import Any
 from typing import List
 from typing import Optional
 

--- a/optuna/visualization/_pareto_front.py
+++ b/optuna/visualization/_pareto_front.py
@@ -271,7 +271,7 @@ def _make_json_compatible(value: Any) -> Any:
         json.dumps(value)
         return value
     except TypeError:
-        # looks like the value can't be converted to JSON directly, so return a string representation
+        # the value can't be converted to JSON directly, so return a string representation
         return str(value)
 
 

--- a/optuna/visualization/_pareto_front.py
+++ b/optuna/visualization/_pareto_front.py
@@ -269,6 +269,12 @@ def _make_hovertext(trial: FrozenTrial) -> str:
     user_attrs = trial.user_attrs
     user_attrs_dict = {"user_attrs": user_attrs} if user_attrs else {}
     text = json.dumps(
-        {"number": trial.number, "values": trial.values, "params": trial.params, **user_attrs_dict}, indent=2
+        {
+            "number": trial.number,
+            "values": trial.values,
+            "params": trial.params,
+            **user_attrs_dict
+        },
+        indent=2
     )
     return text.replace("\n", "<br>")

--- a/optuna/visualization/_pareto_front.py
+++ b/optuna/visualization/_pareto_front.py
@@ -266,7 +266,9 @@ def _get_pareto_front_3d(
 
 
 def _make_hovertext(trial: FrozenTrial) -> str:
+    user_attrs = trial.user_attrs
+    user_attrs_dict = {"user_attrs": user_attrs} if user_attrs else {}
     text = json.dumps(
-        {"number": trial.number, "values": trial.values, "params": trial.params}, indent=2
+        {"number": trial.number, "values": trial.values, "params": trial.params, **user_attrs_dict}, indent=2
     )
     return text.replace("\n", "<br>")

--- a/optuna/visualization/_pareto_front.py
+++ b/optuna/visualization/_pareto_front.py
@@ -273,8 +273,8 @@ def _make_hovertext(trial: FrozenTrial) -> str:
             "number": trial.number,
             "values": trial.values,
             "params": trial.params,
-            **user_attrs_dict
+            **user_attrs_dict,
         },
-        indent=2
+        indent=2,
     )
     return text.replace("\n", "<br>")

--- a/optuna/visualization/_pareto_front.py
+++ b/optuna/visualization/_pareto_front.py
@@ -265,8 +265,17 @@ def _get_pareto_front_3d(
     return go.Figure(data=data, layout=layout)
 
 
+def _make_json_compatible(value: Any) -> Any:
+    try:
+        json.dumps(value)
+        return value
+    except TypeError:
+        # looks like the value can't be converted to JSON directly, so return a string representation
+        return str(value)
+
+
 def _make_hovertext(trial: FrozenTrial) -> str:
-    user_attrs = trial.user_attrs
+    user_attrs = {key: _make_json_compatible(value) for key, value in trial.user_attrs.items()}
     user_attrs_dict = {"user_attrs": user_attrs} if user_attrs else {}
     text = json.dumps(
         {

--- a/tests/visualization_tests/test_pareto_front.py
+++ b/tests/visualization_tests/test_pareto_front.py
@@ -11,7 +11,8 @@ from optuna.visualization._pareto_front import _make_hovertext
 from optuna.distributions import UniformDistribution
 
 import optuna
-from optuna.trial import FrozenTrial, TrialState
+from optuna.trial import FrozenTrial
+from optuna.trial import TrialState
 from optuna.visualization import plot_pareto_front
 
 

--- a/tests/visualization_tests/test_pareto_front.py
+++ b/tests/visualization_tests/test_pareto_front.py
@@ -294,8 +294,10 @@ def test_make_hovertext() -> None:
         system_attrs={},
         intermediate_values={},
     )
-    assert _make_hovertext(trial_no_user_attrs) == dedent(
-        """
+    assert (
+        _make_hovertext(trial_no_user_attrs)
+        == dedent(
+            """
         {
           "number": 0,
           "values": [
@@ -305,7 +307,11 @@ def test_make_hovertext() -> None:
             "x": 10
           }
         }
-    """).strip().replace("\n", "<br>")
+        """
+        )
+        .strip()
+        .replace("\n", "<br>")
+    )
 
     trial_user_attrs_valid_json = FrozenTrial(
         number=0,
@@ -320,8 +326,10 @@ def test_make_hovertext() -> None:
         system_attrs={},
         intermediate_values={},
     )
-    assert _make_hovertext(trial_user_attrs_valid_json) == dedent(
-        """
+    assert (
+        _make_hovertext(trial_user_attrs_valid_json)
+        == dedent(
+            """
         {
           "number": 0,
           "values": [
@@ -335,7 +343,11 @@ def test_make_hovertext() -> None:
             "b": 3.14
           }
         }
-    """).strip().replace("\n", "<br>")
+        """
+        )
+        .strip()
+        .replace("\n", "<br>")
+    )
 
     trial_user_attrs_invalid_json = FrozenTrial(
         number=0,
@@ -350,8 +362,10 @@ def test_make_hovertext() -> None:
         system_attrs={},
         intermediate_values={},
     )
-    assert _make_hovertext(trial_user_attrs_invalid_json) == dedent(
-        """
+    assert (
+        _make_hovertext(trial_user_attrs_invalid_json)
+        == dedent(
+            """
         {
           "number": 0,
           "values": [
@@ -367,4 +381,8 @@ def test_make_hovertext() -> None:
             "d": NaN
           }
         }
-    """).strip().replace("\n", "<br>")
+        """
+        )
+        .strip()
+        .replace("\n", "<br>")
+    )

--- a/tests/visualization_tests/test_pareto_front.py
+++ b/tests/visualization_tests/test_pareto_front.py
@@ -328,7 +328,7 @@ def test_make_hovertext() -> None:
         datetime_complete=datetime.datetime.now(),
         params={"x": 10},
         distributions={"x": UniformDistribution(5, 12)},
-        user_attrs={'a': 42, 'b': 3.14},
+        user_attrs={"a": 42, "b": 3.14},
         system_attrs={},
         intermediate_values={},
     )
@@ -364,7 +364,7 @@ def test_make_hovertext() -> None:
         datetime_complete=datetime.datetime.now(),
         params={"x": 10},
         distributions={"x": UniformDistribution(5, 12)},
-        user_attrs={'a': 42, 'b': 3.14, 'c': np.zeros(1), "d": np.nan},
+        user_attrs={"a": 42, "b": 3.14, "c": np.zeros(1), "d": np.nan},
         system_attrs={},
         intermediate_values={},
     )

--- a/tests/visualization_tests/test_pareto_front.py
+++ b/tests/visualization_tests/test_pareto_front.py
@@ -278,3 +278,93 @@ def test_plot_pareto_front_invalid_axis_order(
             include_dominated_trials=include_dominated_trials,
             axis_order=invalid_axis_order,
         )
+
+
+def test_make_hovertext() -> None:
+    trial_no_user_attrs = FrozenTrial(
+        number=0,
+        trial_id=0,
+        state=TrialState.COMPLETE,
+        value=0.2,
+        datetime_start=datetime.datetime.now(),
+        datetime_complete=datetime.datetime.now(),
+        params={"x": 10},
+        distributions={"x": UniformDistribution(5, 12)},
+        user_attrs={},
+        system_attrs={},
+        intermediate_values={},
+    )
+    assert _make_hovertext(trial_no_user_attrs) == dedent(
+        """
+        {
+          "number": 0,
+          "values": [
+            0.2
+          ],
+          "params": {
+            "x": 10
+          }
+        }
+    """).strip().replace("\n", "<br>")
+
+    trial_user_attrs_valid_json = FrozenTrial(
+        number=0,
+        trial_id=0,
+        state=TrialState.COMPLETE,
+        value=0.2,
+        datetime_start=datetime.datetime.now(),
+        datetime_complete=datetime.datetime.now(),
+        params={"x": 10},
+        distributions={"x": UniformDistribution(5, 12)},
+        user_attrs={'a': 42, 'b': 3.14},
+        system_attrs={},
+        intermediate_values={},
+    )
+    assert _make_hovertext(trial_user_attrs_valid_json) == dedent(
+        """
+        {
+          "number": 0,
+          "values": [
+            0.2
+          ],
+          "params": {
+            "x": 10
+          },
+          "user_attrs": {
+            "a": 42,
+            "b": 3.14
+          }
+        }
+    """).strip().replace("\n", "<br>")
+
+    trial_user_attrs_invalid_json = FrozenTrial(
+        number=0,
+        trial_id=0,
+        state=TrialState.COMPLETE,
+        value=0.2,
+        datetime_start=datetime.datetime.now(),
+        datetime_complete=datetime.datetime.now(),
+        params={"x": 10},
+        distributions={"x": UniformDistribution(5, 12)},
+        user_attrs={'a': 42, 'b': 3.14, 'c': np.zeros(1), "d": np.nan},
+        system_attrs={},
+        intermediate_values={},
+    )
+    assert _make_hovertext(trial_user_attrs_invalid_json) == dedent(
+        """
+        {
+          "number": 0,
+          "values": [
+            0.2
+          ],
+          "params": {
+            "x": 10
+          },
+          "user_attrs": {
+            "a": 42,
+            "b": 3.14,
+            "c": "[0.]",
+            "d": NaN
+          }
+        }
+    """).strip().replace("\n", "<br>")

--- a/tests/visualization_tests/test_pareto_front.py
+++ b/tests/visualization_tests/test_pareto_front.py
@@ -1,11 +1,17 @@
 import itertools
+import datetime
+from textwrap import dedent
 from typing import List
 from typing import Optional
 
 import numpy as np
 import pytest
+from optuna.visualization._pareto_front import _make_hovertext
+
+from optuna.distributions import UniformDistribution
 
 import optuna
+from optuna.trial import FrozenTrial, TrialState
 from optuna.visualization import plot_pareto_front
 
 

--- a/tests/visualization_tests/test_pareto_front.py
+++ b/tests/visualization_tests/test_pareto_front.py
@@ -1,19 +1,18 @@
-import itertools
 import datetime
+import itertools
 from textwrap import dedent
 from typing import List
 from typing import Optional
 
 import numpy as np
 import pytest
-from optuna.visualization._pareto_front import _make_hovertext
-
-from optuna.distributions import UniformDistribution
 
 import optuna
+from optuna.distributions import UniformDistribution
 from optuna.trial import FrozenTrial
 from optuna.trial import TrialState
 from optuna.visualization import plot_pareto_front
+from optuna.visualization._pareto_front import _make_hovertext
 
 
 @pytest.mark.parametrize("include_dominated_trials", [False, True])


### PR DESCRIPTION
Add trial.user_attrs to pareto_front hover text if trial.user_attrs has entries.

This implements https://github.com/optuna/optuna/issues/3081.