### PR TITLE
Handle `single` distributions in `fANOVA` evaluator

### DIFF
--- a/optuna/importance/_fanova/_evaluator.py
+++ b/optuna/importance/_fanova/_evaluator.py
@@ -88,6 +88,9 @@ class FanovaImportanceEvaluator(BaseImportanceEvaluator):
         if len(distributions) == 0:
             return OrderedDict()
 
+        zero_importances = {name: 0.0 for name, dist in distributions.items() if dist.single()}
+        distributions = {name: dist for name, dist in distributions.items() if not dist.single()}
+
         trials = []
         for trial in study.trials:
             if trial.state != TrialState.COMPLETE:
@@ -131,6 +134,7 @@ class FanovaImportanceEvaluator(BaseImportanceEvaluator):
             importance, _ = evaluator.get_importance((i,))
             importances[name] = importance
 
+        importances = {**importances, **zero_importances}
         total_importance = sum(importances.values())
         for name in importances:
             importances[name] /= total_importance

--- a/optuna/importance/_fanova/_evaluator.py
+++ b/optuna/importance/_fanova/_evaluator.py
@@ -88,6 +88,9 @@ class FanovaImportanceEvaluator(BaseImportanceEvaluator):
         if len(distributions) == 0:
             return OrderedDict()
 
+        # fANOVA does not support parameter distributions with a single value.
+        # However, there is no reason to calculate parameter importance in such case anyway,
+        # since it will always be 0 as the parameter is constant in the objective function.
         zero_importances = {name: 0.0 for name, dist in distributions.items() if dist.single()}
         distributions = {name: dist for name, dist in distributions.items() if not dist.single()}
 

--- a/tests/importance_tests/test_fanova.py
+++ b/tests/importance_tests/test_fanova.py
@@ -71,3 +71,19 @@ def test_fanova_importance_evaluator_with_target() -> None:
     )
 
     assert param_importance != param_importance_with_target
+
+
+def test_fanova_importance_evaluator_single_distribution() -> None:
+    def _objective(trial: Trial) -> float:
+        x = trial.suggest_float("x", 0, 5)
+        y = trial.suggest_float("y", 1, 1)
+        v0 = 4 * x ** 2 + 4 * y ** 2
+        return v0
+
+    study = create_study()
+    study.optimize(_objective, n_trials=3)
+
+    evaluator = FanovaImportanceEvaluator()
+    importances = evaluator.evaluate(study)
+
+    assert importances["y"] == 0.0

--- a/tests/importance_tests/test_fanova.py
+++ b/tests/importance_tests/test_fanova.py
@@ -86,4 +86,6 @@ def test_fanova_importance_evaluator_single_distribution() -> None:
     evaluator = FanovaImportanceEvaluator()
     importances = evaluator.evaluate(study)
 
+    assert all([param in importances for param in ["x", "y"]])
+    assert importances["x"] == 1.0
     assert importances["y"] == 0.0


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
This PR fixes #2542 by making `FanovaImportanceEvaluator` correctly handle param distributions with equal lower and upper bounds. This is an alternative implementation, as discussed in #3074 (thanks @hvy!).

## Description of the changes
<!-- Describe the changes in this PR. -->
* Handle `single` distributions in `FanovaImportanceEvaluator.evaluate`
* Write tests