### PR TITLE
Fix verbosity for `tests/integration_tests/lightgbm_tuner_tests/test_optimize.py`

### DIFF
--- a/tests/integration_tests/lightgbm_tuner_tests/test_optimize.py
+++ b/tests/integration_tests/lightgbm_tuner_tests/test_optimize.py
@@ -449,10 +449,7 @@ class TestLightGBMTuner(object):
 
     def test_tune_num_leaves_negative_max_depth(self) -> None:
 
-        params: Dict[str, Any] = {
-            "metric": "binary_logloss",
-            "max_depth": -1,
-        }
+        params: Dict[str, Any] = {"metric": "binary_logloss", "max_depth": -1, "verbose": -1}
         X_trn = np.random.uniform(10, size=(10, 5))
         y_trn = np.random.randint(2, size=10)
         train_dataset = lgb.Dataset(X_trn, label=y_trn)
@@ -464,6 +461,7 @@ class TestLightGBMTuner(object):
             num_boost_round=3,
             early_stopping_rounds=2,
             valid_sets=valid_dataset,
+            verbose_eval=False,
         )
         runner.tune_num_leaves()
         assert len(runner.study.trials) == 20
@@ -550,7 +548,7 @@ class TestLightGBMTuner(object):
         dataset = lgb.Dataset(np.zeros((10, 10)))
 
         study = optuna.create_study()
-        tuner = LightGBMTuner(params, dataset, valid_sets=dataset, study=study)
+        tuner = LightGBMTuner(params, dataset, valid_sets=dataset, study=study, verbose_eval=False)
 
         with mock.patch.object(_BaseTuner, "_get_booster_best_score", return_value=1.0):
             tuner.tune_regularization_factors()
@@ -591,6 +589,7 @@ class TestLightGBMTuner(object):
                 valid_sets=dataset,
                 study=study,
                 verbosity=verbosity,
+                verbose_eval=False,
                 time_budget=1,
             )
 
@@ -611,6 +610,7 @@ class TestLightGBMTuner(object):
             dataset,
             valid_sets=dataset,
             study=study,
+            verbose_eval=False,
             time_budget=1,
             show_progress_bar=show_progress_bar,
         )
@@ -629,7 +629,7 @@ class TestLightGBMTuner(object):
         dataset = lgb.Dataset(np.zeros((10, 10)))
 
         study = optuna.create_study()
-        tuner = LightGBMTuner(params, dataset, valid_sets=dataset, study=study)
+        tuner = LightGBMTuner(params, dataset, valid_sets=dataset, study=study, verbose_eval=False)
 
         with pytest.raises(ValueError):
             tuner.get_best_booster()
@@ -663,7 +663,12 @@ class TestLightGBMTuner(object):
         study = optuna.create_study()
         with TemporaryDirectory() as tmpdir:
             tuner = LightGBMTuner(
-                params, dataset, valid_sets=dataset, study=study, model_dir=tmpdir
+                params,
+                dataset,
+                valid_sets=dataset,
+                study=study,
+                model_dir=tmpdir,
+                verbose_eval=False,
             )
 
             with mock.patch.object(_BaseTuner, "_get_booster_best_score", return_value=0.0):
@@ -723,7 +728,12 @@ class TestLightGBMTuner(object):
 
         study = optuna.create_study()
         tuner = LightGBMTuner(
-            params, dataset, valid_sets=dataset, study=study, optuna_callbacks=[callback_mock]
+            params,
+            dataset,
+            valid_sets=dataset,
+            study=study,
+            optuna_callbacks=[callback_mock],
+            verbose_eval=False,
         )
 
         with mock.patch.object(_BaseTuner, "_get_booster_best_score", return_value=1.0):
@@ -754,6 +764,7 @@ class TestLightGBMTuner(object):
             valid_sets=valid,
             early_stopping_rounds=3,
             optuna_seed=10,
+            verbose_eval=False,
         )
         tuner_first_try.run()
         best_score_first_try = tuner_first_try.best_score
@@ -764,6 +775,7 @@ class TestLightGBMTuner(object):
             valid_sets=valid,
             early_stopping_rounds=3,
             optuna_seed=10,
+            verbose_eval=False,
         )
         tuner_second_try.run()
         best_score_second_try = tuner_second_try.best_score

--- a/tests/integration_tests/lightgbm_tuner_tests/test_optimize.py
+++ b/tests/integration_tests/lightgbm_tuner_tests/test_optimize.py
@@ -10,6 +10,7 @@ from typing import Union
 from unittest import mock
 import warnings
 
+from lightgbm import log_evaluation
 import numpy as np
 import pytest
 import sklearn.datasets
@@ -461,7 +462,7 @@ class TestLightGBMTuner(object):
             num_boost_round=3,
             early_stopping_rounds=2,
             valid_sets=valid_dataset,
-            verbose_eval=False,
+            callbacks=[log_evaluation(-1)],
         )
         runner.tune_num_leaves()
         assert len(runner.study.trials) == 20
@@ -548,7 +549,9 @@ class TestLightGBMTuner(object):
         dataset = lgb.Dataset(np.zeros((10, 10)))
 
         study = optuna.create_study()
-        tuner = LightGBMTuner(params, dataset, valid_sets=dataset, study=study, verbose_eval=False)
+        tuner = LightGBMTuner(
+            params, dataset, valid_sets=dataset, study=study, callbacks=[log_evaluation(-1)]
+        )
 
         with mock.patch.object(_BaseTuner, "_get_booster_best_score", return_value=1.0):
             tuner.tune_regularization_factors()
@@ -589,7 +592,7 @@ class TestLightGBMTuner(object):
                 valid_sets=dataset,
                 study=study,
                 verbosity=verbosity,
-                verbose_eval=False,
+                callbacks=[log_evaluation(-1)],
                 time_budget=1,
             )
 
@@ -610,7 +613,7 @@ class TestLightGBMTuner(object):
             dataset,
             valid_sets=dataset,
             study=study,
-            verbose_eval=False,
+            callbacks=[log_evaluation(-1)],
             time_budget=1,
             show_progress_bar=show_progress_bar,
         )
@@ -629,7 +632,9 @@ class TestLightGBMTuner(object):
         dataset = lgb.Dataset(np.zeros((10, 10)))
 
         study = optuna.create_study()
-        tuner = LightGBMTuner(params, dataset, valid_sets=dataset, study=study, verbose_eval=False)
+        tuner = LightGBMTuner(
+            params, dataset, valid_sets=dataset, study=study, callbacks=[log_evaluation(-1)]
+        )
 
         with pytest.raises(ValueError):
             tuner.get_best_booster()
@@ -668,7 +673,7 @@ class TestLightGBMTuner(object):
                 valid_sets=dataset,
                 study=study,
                 model_dir=tmpdir,
-                verbose_eval=False,
+                callbacks=[log_evaluation(-1)],
             )
 
             with mock.patch.object(_BaseTuner, "_get_booster_best_score", return_value=0.0):
@@ -732,8 +737,8 @@ class TestLightGBMTuner(object):
             dataset,
             valid_sets=dataset,
             study=study,
+            callbacks=[log_evaluation(-1)],
             optuna_callbacks=[callback_mock],
-            verbose_eval=False,
         )
 
         with mock.patch.object(_BaseTuner, "_get_booster_best_score", return_value=1.0):
@@ -764,7 +769,7 @@ class TestLightGBMTuner(object):
             valid_sets=valid,
             early_stopping_rounds=3,
             optuna_seed=10,
-            verbose_eval=False,
+            callbacks=[log_evaluation(-1)],
         )
         tuner_first_try.run()
         best_score_first_try = tuner_first_try.best_score
@@ -775,7 +780,7 @@ class TestLightGBMTuner(object):
             valid_sets=valid,
             early_stopping_rounds=3,
             optuna_seed=10,
-            verbose_eval=False,
+            callbacks=[log_evaluation(-1)],
         )
         tuner_second_try.run()
         best_score_second_try = tuner_second_try.best_score


### PR DESCRIPTION
## Motivation
To address the issue #3079. 

## Description of the changes
Specified `verbose_eval = False` to suppress the log of intermediate values.
Specified `verbose = -1` for `test_tune_num_leaves_negative_max_depth()` to suppress warning and info like below from LightGBM library:


```
Warning: m...[LightGBM] [Warning] Auto-choosing row-wise multi-threading, the overhead of testing was 0.000017 seconds.
You can set `force_row_wise=true` to remove the overhead.
And if memory is not enough, you can set `force_col_wise=true`.
[LightGBM] [Info] Total Bins 25
[LightGBM] [Info] Number of data points in the train set: 10, number of used features: 5
[LightGBM] [Info] Start training from score 0.700000
Warning: ] [Warning] No further splits with positive gain, best gain: -inf
Warning: ] [Warning] Stopped training because there are no more leaves that meet the split requirements
```