### PR TITLE
Fix range description in `suggest_float` docstring

### DIFF
--- a/optuna/trial/_trial.py
+++ b/optuna/trial/_trial.py
@@ -127,12 +127,7 @@ class Trial(BaseTrial):
             low:
                 Lower endpoint of the range of suggested values. ``low`` is included in the range.
             high:
-                Upper endpoint of the range of suggested values. ``high`` is excluded from the
-                range.
-
-                .. note::
-                    If ``step`` is specified, ``high`` is included as well as ``low``.
-
+                Upper endpoint of the range of suggested values. ``high`` is included in the range.
             step:
                 A step of discretization.
 
@@ -191,8 +186,7 @@ class Trial(BaseTrial):
             low:
                 Lower endpoint of the range of suggested values. ``low`` is included in the range.
             high:
-                Upper endpoint of the range of suggested values. ``high`` is excluded from the
-                range.
+                Upper endpoint of the range of suggested values. ``high`` is included in the range.
 
         Returns:
             A suggested float value.
@@ -214,8 +208,7 @@ class Trial(BaseTrial):
             low:
                 Lower endpoint of the range of suggested values. ``low`` is included in the range.
             high:
-                Upper endpoint of the range of suggested values. ``high`` is excluded from the
-                range.
+                Upper endpoint of the range of suggested values. ``high`` is included in the range.
 
         Returns:
             A suggested float value.


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
Previously documentation stated that `high` distribution bound is not included in the range from which floating point value is suggested. This PR address that as per second point described in #2939.

## Description of the changes
<!-- Describe the changes in this PR. -->
* Fix docstring in `suggest_float` and methods calling `suggest_float`.