### PR TITLE
Speed up Matplotlib backend `plot_contour` using SciPy's `spsolve`

### DIFF
--- a/optuna/visualization/matplotlib/_contour.py
+++ b/optuna/visualization/matplotlib/_contour.py
@@ -50,6 +50,11 @@ def plot_contour(
     .. seealso::
         Please refer to :func:`optuna.visualization.plot_contour` for an example.
 
+    Warnings:
+        Output figures of this Matplotlib-based
+        :func:`~optuna.visualization.matplotlib.plot_contour` function would be different from
+        those of the Plotly-based :func:`~optuna.visualization.plot_contour`.
+
     Example:
 
         The following code snippet shows how to plot the parameter relationship as contour plot.
@@ -96,6 +101,10 @@ def plot_contour(
 
     _imports.check()
     _check_plot_args(study, target, target_name)
+    _logger.warning(
+        "Output figures of this Matplotlib-based `plot_contour` function would be different from "
+        "those of the Plotly-based `plot_contour`."
+    )
     return _get_contour_plot(study, params, target, target_name)
 
 

--- a/optuna/visualization/matplotlib/_contour.py
+++ b/optuna/visualization/matplotlib/_contour.py
@@ -1,6 +1,5 @@
 from collections import defaultdict
 from typing import Callable
-from typing import cast
 from typing import DefaultDict
 from typing import Dict
 from typing import List
@@ -458,9 +457,9 @@ def _create_zmap(
     # so we are going with close approximations of trial value positions
     zmap = dict()
     for x, y, z in zip(x_values, y_values, z_values):
-        xindex = np.argmin(np.abs(xi - x))
-        yindex = np.argmin(np.abs(yi - y))
-        zmap[(cast(int, xindex), cast(int, yindex))] = z
+        xindex = int(np.argmin(np.abs(xi - x)))
+        yindex = int(np.argmin(np.abs(yi - y)))
+        zmap[(xindex, yindex)] = z
 
     return zmap
 

--- a/optuna/visualization/matplotlib/_contour.py
+++ b/optuna/visualization/matplotlib/_contour.py
@@ -485,7 +485,7 @@ def _interpolate_zmap(zmap: Dict[Tuple[int, int], float], contour_plot_num: int)
     a_data = []
     a_row = []
     a_col = []
-    b = np.zeros(contour_plot_num ** 2, dtype=np.float64)
+    b = np.zeros(contour_plot_num ** 2)
     for x in range(contour_plot_num):
         for y in range(contour_plot_num):
             grid_index = y * contour_plot_num + x

--- a/optuna/visualization/matplotlib/_contour.py
+++ b/optuna/visualization/matplotlib/_contour.py
@@ -1,5 +1,6 @@
 from collections import defaultdict
 from typing import Callable
+from typing import cast
 from typing import DefaultDict
 from typing import Dict
 from typing import List
@@ -8,6 +9,7 @@ from typing import Tuple
 from typing import Union
 
 import numpy as np
+import scipy
 
 from optuna._experimental import experimental
 from optuna.logging import get_logger
@@ -30,9 +32,6 @@ if _imports.is_successful():
 _logger = get_logger(__name__)
 
 
-NEIGHBOR_OFFSETS = [1 + 0j, -1 + 0j, 0 + 1j, 0 - 1j]
-NUM_OPTIMIZATION_ITERATIONS = 100
-FRACTIONAL_DELTA_THRESHOLD = 1e-2
 AXES_PADDING_RATIO = 5e-2
 
 
@@ -50,11 +49,6 @@ def plot_contour(
 
     .. seealso::
         Please refer to :func:`optuna.visualization.plot_contour` for an example.
-
-    Warnings:
-        Output figures of this Matplotlib-based
-        :func:`~optuna.visualization.matplotlib.plot_contour` function would be different from
-        those of the Plotly-based :func:`~optuna.visualization.plot_contour`.
 
     Example:
 
@@ -102,10 +96,6 @@ def plot_contour(
 
     _imports.check()
     _check_plot_args(study, target, target_name)
-    _logger.warning(
-        "Output figures of this Matplotlib-based `plot_contour` function would be different from "
-        "those of the Plotly-based `plot_contour`."
-    )
     return _get_contour_plot(study, params, target, target_name)
 
 
@@ -339,11 +329,10 @@ def _calculate_griddata(
         y_array = np.array(y_values)
 
     # create irregularly spaced map of trial values
-    # and interpolate it with Plotly algorithm
+    # and interpolate it with Plotly's interpolation formulation
     if x_param != y_param:
         zmap = _create_zmap(x_array, y_array, z_values, xi, yi)
-        _interpolate_zmap(zmap, contour_point_num)
-        zi = _create_zmatrix_from_zmap(zmap, contour_point_num)
+        zi = _interpolate_zmap(zmap, contour_point_num)
 
     return (
         xi,
@@ -446,13 +435,13 @@ def _create_zmap(
     z_values: List[float],
     xi: np.ndarray,
     yi: np.ndarray,
-) -> Dict[complex, float]:
+) -> Dict[Tuple[int, int], float]:
 
     # creates z-map from trial values and params.
     # z-map is represented by hashmap of coordinate and trial value pairs
     #
-    # coordinates are represented by complex numbers, where real part
-    # indicates x-axis index and imaginary part indicates y-axis index
+    # coordinates are represented by tuple of integers, where the first item
+    # indicates x-axis index and the second item indicates y-axis index
     # and refer to a position of trial value on irregular param grid
     #
     # since params were resampled either with linspace or logspace
@@ -462,24 +451,14 @@ def _create_zmap(
     for x, y, z in zip(x_values, y_values, z_values):
         xindex = np.argmin(np.abs(xi - x))
         yindex = np.argmin(np.abs(yi - y))
-        zmap[complex(xindex, yindex)] = z  # type: ignore
+        zmap[(cast(int, xindex), cast(int, yindex))] = z
 
     return zmap
 
 
-def _create_zmatrix_from_zmap(zmap: Dict[complex, float], shape: int) -> np.ndarray:
+def _interpolate_zmap(zmap: Dict[Tuple[int, int], float], contour_plot_num: int) -> np.ndarray:
 
-    # converts hashmap of coordinates to grid
-    zmatrix = np.zeros(shape=(shape, shape))
-    for coord, value in zmap.items():
-        zmatrix[int(coord.imag), int(coord.real)] += value
-
-    return zmatrix
-
-
-def _interpolate_zmap(zmap: Dict[complex, float], contour_plot_num: int) -> None:
-
-    # implements interpolation algorithm used in Plotly
+    # implements interpolation formulation used in Plotly
     # to interpolate heatmaps and contour plots
     # https://github.com/plotly/plotly.js/blob/master/src/traces/heatmap/interp2d.js#L30
     # citing their doc:
@@ -489,135 +468,34 @@ def _interpolate_zmap(zmap: Dict[complex, float], contour_plot_num: int) -> None
     # > Amazingly, this just amounts to repeatedly averaging all the existing
     # > nearest neighbors
     #
-    # our goal here is to assign value to every coordinate that is a part
-    # of 100x100 param grid (so from 0 + 0j up to 100 + 100j) that is not already
-    # occupied by actual trial value
-    max_fractional_delta = 1.0
-    empties = _find_coordinates_where_empty(zmap, contour_plot_num)
+    # Plotly's algorithm is equivalent to solve the following linear simultaneous equation.
+    # It is discretization form of the Poisson equation.
+    #
+    #     z[x, y] = zmap[(x, y)]                                  (if zmap[(x, y)] is given)
+    # 4 * z[x, y] = z[x-1, y] + z[x+1, y] + z[x, y-1] + z[x, y+1] (if zmap[(x, y)] is not given)
 
-    # one pass to fill in a starting value for all the empties
-    _run_iteration(zmap, empties)
+    a_data = []
+    a_row = []
+    a_col = []
+    b = np.zeros(contour_plot_num ** 2, dtype=np.float64)
+    for x in range(contour_plot_num):
+        for y in range(contour_plot_num):
+            grid_index = y * contour_plot_num + x
+            if (x, y) in zmap:
+                a_data.append(1)
+                a_row.append(grid_index)
+                a_col.append(grid_index)
+                b[grid_index] = zmap[(x, y)]
+            else:
+                for dx, dy in ((-1, 0), (1, 0), (0, -1), (0, 1)):
+                    if 0 <= x + dx < contour_plot_num and 0 <= y + dy < contour_plot_num:
+                        a_data.append(1)
+                        a_row.append(grid_index)
+                        a_col.append(grid_index)
+                        a_data.append(-1)
+                        a_row.append(grid_index)
+                        a_col.append(grid_index + dy * contour_plot_num + dx)
 
-    for _ in range(NUM_OPTIMIZATION_ITERATIONS):
-        if max_fractional_delta > FRACTIONAL_DELTA_THRESHOLD:
-            # correct for overshoot and run again
-            max_fractional_delta = 0.5 - 0.25 * min(1, max_fractional_delta * 0.5)
-            max_fractional_delta = _run_iteration(zmap, empties, max_fractional_delta)
+    z = scipy.sparse.linalg.spsolve(scipy.sparse.csc_matrix((a_data, (a_row, a_col))), b)
 
-        else:
-            break
-
-
-def _find_coordinates_where_empty(
-    zmap: Dict[complex, float], contour_point_num: int
-) -> List[complex]:
-
-    # this function implements missing value discovery and sorting
-    # algorithm used in Plotly to interpolate heatmaps and contour plots
-    # https://github.com/plotly/plotly.js/blob/master/src/traces/heatmap/find_empties.js
-    # it works by repeatedly iterating  over coordinate map in search for patches of
-    # missing values with existing or previously discovered neighbors
-    # when discovered, such patches are added to the iteration queue (list of coordinates)
-    # sorted by number of neighbors, marking iteration order for interpolation algorithm
-    # search ends when all missing patches have been discovered
-    # it's like playing minesweeper in reverse
-
-    iter_queue: List[complex] = []
-    zcopy = zmap.copy()
-    discovered = 0
-    n_missing = (contour_point_num ** 2) - len(zmap)
-    coordinates = [
-        complex(xaxis, yaxis)
-        for yaxis in range(contour_point_num)
-        for xaxis in range(contour_point_num)
-    ]
-
-    while discovered != n_missing:
-        # patch will contain coordinates
-        # of missing values, which happen to have neighbors
-        # at this iteration, and were not previously covered
-        patchmap: Dict[complex, int] = {}
-
-        for coord in coordinates:
-            # we will always iterate over entire grid
-            # surprisingly, this is faster than removing
-            # discovered coordinates from list after each iteration
-            value = zcopy.get(coord, None)
-
-            if value is not None:
-                # trial value or already discovered
-                continue
-
-            n_neighbors = 0
-            for offset in NEIGHBOR_OFFSETS:
-                neighbor = zcopy.get(coord + offset, None)
-                if neighbor is not None:
-                    n_neighbors += 1
-
-            if n_neighbors > 0:
-                # missing values, which still have no neighbors
-                # are left for subsequent iterations
-                patchmap[coord] = n_neighbors
-
-        # newly discovered values will form
-        # neighbors for another missing value
-        # in the next iteration
-        zcopy.update(patchmap)
-
-        # we are sorting patches independently, since neighbor counts for patch `b`
-        # are only valid after patch `a` has been discovered
-        patch = [k for k, _ in sorted(patchmap.items(), key=lambda i: i[1], reverse=True)]
-        iter_queue.extend(patch)
-        discovered += len(patch)
-
-    return iter_queue
-
-
-def _run_iteration(
-    zmap: Dict[complex, float], coordinates: List[complex], overshoot: float = 0.0
-) -> float:
-
-    max_fractional_delta = 0.0
-
-    for coord in coordinates:
-        # we will iterate the grid in order
-        # established by `find_coordinates_where_empty`
-        # this will ensure that we are not trying to interpolate
-        # value with zero neighbors
-        current_val = zmap.get(coord, None)
-        max_neighbor = -np.inf
-        min_neighbor = np.inf
-        sum_neighbors = 0.0
-        n_neighbors = 0
-
-        for offset in NEIGHBOR_OFFSETS:
-            # if we represent current value as a center
-            # of 3x3 matrix, neighbors are all other
-            # values excluding those at diagonals
-            neighbor = zmap.get(coord + offset, None)
-
-            if neighbor is None:
-                # off the edge or not filled in
-                continue
-
-            sum_neighbors += neighbor
-            n_neighbors += 1
-
-            if current_val is not None:
-                max_neighbor = max(max_neighbor, neighbor)
-                min_neighbor = min(min_neighbor, neighbor)
-
-        # fill value is just mean of its neighbors
-        new_val = sum_neighbors / n_neighbors
-
-        if current_val is None:
-            zmap[coord] = new_val
-            max_fractional_delta = 1.0
-
-        else:
-            zmap[coord] = (1 + overshoot) * new_val - overshoot * current_val
-            if max_neighbor > min_neighbor:
-                fractional_delta = abs(new_val - current_val) / (max_neighbor - min_neighbor)
-                max_fractional_delta = max(overshoot, fractional_delta)
-
-    return max_fractional_delta
+    return z.reshape((contour_plot_num, contour_plot_num))

--- a/tests/visualization_tests/matplotlib_tests/test_contour.py
+++ b/tests/visualization_tests/matplotlib_tests/test_contour.py
@@ -9,10 +9,7 @@ from optuna.testing.visualization import prepare_study_with_trials
 from optuna.trial import Trial
 from optuna.visualization.matplotlib import plot_contour
 from optuna.visualization.matplotlib._contour import _create_zmap
-from optuna.visualization.matplotlib._contour import _create_zmatrix_from_zmap
-from optuna.visualization.matplotlib._contour import _find_coordinates_where_empty
 from optuna.visualization.matplotlib._contour import _interpolate_zmap
-from optuna.visualization.matplotlib._contour import _run_iteration
 
 
 def test_create_zmap() -> None:
@@ -29,64 +26,21 @@ def test_create_zmap() -> None:
     for coord, value in zmap.items():
         # test if value under coordinate
         # still refers to original trial value
-        xidx = int(coord.real)
-        yidx = int(coord.imag)
+        xidx = coord[0]
+        yidx = coord[1]
         assert xidx == yidx
         assert z_values[xidx] == value
-
-
-def test_create_zmatrix_from_zmap() -> None:
-
-    contour_point_num = 2
-    zmap = {0 + 0j: 1.0, 1 + 0j: 2.0, 0 + 1j: 3.0, 1 + 1j: 4.0}
-    expected = np.array([[1.0, 2.0], [3.0, 4.0]])
-    zmatrix = _create_zmatrix_from_zmap(zmap, contour_point_num)
-
-    assert zmatrix.shape == (contour_point_num, contour_point_num)
-    assert np.array_equal(zmatrix, expected)
-
-
-def test_find_coordinates_where_empty() -> None:
-
-    contour_point_num = 2
-    zmap = {0 + 0j: 1.0, 1 + 1j: 4.0}
-    n_missing = (contour_point_num ** 2) - len(zmap)
-    empties = _find_coordinates_where_empty(zmap, contour_point_num)
-
-    # test if all missing are found
-    assert len(empties) == n_missing
-
-    # test if iter queue follows C style iteration
-    assert empties[0] == 1 + 0j
-    assert empties[1] == 0 + 1j
-
-
-def test_interpolation_first_iteration() -> None:
-
-    zmap = {0 + 0j: 1.0, 1 + 1j: 4.0}
-    empties = [1 + 0j, 0 + 1j]
-    initial_zmap_len = len(zmap)
-
-    max_fractional_change = _run_iteration(zmap, empties)
-
-    # test loss after first iter
-    assert max_fractional_change == 1.0
-
-    # test if initial pass filled all values
-    assert len(zmap) == initial_zmap_len + len(empties)
 
 
 def test_interpolate_zmap() -> None:
 
     contour_point_num = 2
-    zmap = {0 + 0j: 1.0, 1 + 1j: 4.0}
-    interpolated = {1 + 0j: 2.5, 1 + 1j: 4.0, 0 + 0j: 1.0, 0 + 1j: 2.5}
+    zmap = {(0, 0): 1.0, (1, 1): 4.0}
+    expected = np.array([[1.0, 2.5], [2.5, 4.0]])
 
-    _interpolate_zmap(zmap, contour_point_num)
+    actual = _interpolate_zmap(zmap, contour_point_num)
 
-    for coord, value in zmap.items():
-        expected_at_coord = interpolated.get(coord)
-        assert value == expected_at_coord
+    assert np.allclose(expected, actual)
 
 
 def test_target_is_none_and_study_is_multi_obj() -> None:


### PR DESCRIPTION
## Motivation
#2810 introduced Plotly's interpolation algorithm. But it needs a longer computation time. This PR will speed up `plot_contour` using Scipy's `spsolve`.

The output figure slightly changes because of convergence errors of algorithms.

## Description of the changes
- Speed up Matplotlib backend `plot_contour`
- Remove warning

## Examples

All plots were generated using example from #2595

- PR (0.234 sec)

![PR](https://user-images.githubusercontent.com/1255726/141080793-360136d4-192f-48f2-b99c-f59cc169d4cc.png)

- master (2.988 sec)

![master](https://user-images.githubusercontent.com/1255726/141080844-2c1bc936-902e-4de0-80fb-7909558baa3e.png)

- Plotly backend

![plotly](https://user-images.githubusercontent.com/1255726/141080891-5e0057c6-a623-48de-8059-ded0e7592409.png)

