### PR TITLE
Generalize empty search space test case to all hyperparameter importance evaluators

### DIFF
--- a/tests/importance_tests/test_fanova.py
+++ b/tests/importance_tests/test_fanova.py
@@ -71,21 +71,3 @@ def test_fanova_importance_evaluator_with_target() -> None:
     )
 
     assert param_importance != param_importance_with_target
-
-
-def test_fanova_importance_evaluator_single_distribution() -> None:
-    def _objective(trial: Trial) -> float:
-        x = trial.suggest_float("x", 0, 5)
-        y = trial.suggest_float("y", 1, 1)
-        v0 = 4 * x ** 2 + 4 * y ** 2
-        return v0
-
-    study = create_study()
-    study.optimize(_objective, n_trials=3)
-
-    evaluator = FanovaImportanceEvaluator()
-    importances = evaluator.evaluate(study)
-
-    assert all([param in importances for param in ["x", "y"]])
-    assert importances["x"] == 1.0
-    assert importances["y"] == 0.0

--- a/tests/importance_tests/test_init.py
+++ b/tests/importance_tests/test_init.py
@@ -279,3 +279,23 @@ def test_get_param_importances_invalid_params_type(
 
     with pytest.raises(TypeError):
         get_param_importances(study, evaluator=evaluator_init_func(), params=[0])  # type: ignore
+
+
+@parametrize_evaluator
+def test_get_param_importances_empty_search_space(
+    evaluator_init_func: Callable[[], BaseImportanceEvaluator]
+) -> None:
+    def objective(trial: Trial) -> float:
+        x = trial.suggest_float("x", 0, 5)
+        y = trial.suggest_float("y", 1, 1)
+        return 4 * x ** 2 + 4 * y ** 2
+
+    study = create_study()
+    study.optimize(objective, n_trials=3)
+
+    param_importance = get_param_importances(study, evaluator=evaluator_init_func())
+
+    assert len(param_importance) == 2
+    assert all([param in param_importance for param in ["x", "y"]])
+    assert param_importance["x"] == 1.0
+    assert param_importance["y"] == 0.0


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
Currently, empty search space test case (testing evaluator behavior under circumstances described in #2542) only covers `fANOVA` evaluator. This PR generalizes this test to all existing and future evaluators. Follow up to #3085.

## Description of the changes
<!-- Describe the changes in this PR. -->
* Move empty search space test case test from `test_fanova` to `test_init`
* Parametrize over all evaluators