### PR TITLE
snowflake connections

### DIFF
--- a/optuna/storages/_rdb/models.py
+++ b/optuna/storages/_rdb/models.py
@@ -13,6 +13,7 @@ from sqlalchemy import ForeignKey
 from sqlalchemy import func
 from sqlalchemy import Integer
 from sqlalchemy import orm
+from sqlalchemy import Sequence as sa_sequence
 from sqlalchemy import String
 from sqlalchemy import Text
 from sqlalchemy import UniqueConstraint
@@ -37,8 +38,10 @@ BaseModel: Any = declarative_base()
 
 class StudyModel(BaseModel):
     __tablename__ = "studies"
-    study_id = Column(Integer, primary_key=True)
-    study_name = Column(String(MAX_INDEXED_STRING_LENGTH), index=True, unique=True, nullable=False)
+    # study_id = Column(Integer, primary_key=True)
+    study_id = Column("study_id", Integer, sa_sequence("study_id_seq"),  primary_key=True)
+    # study_name = Column(String(MAX_INDEXED_STRING_LENGTH), index=True, unique=True, nullable=False)
+    study_name = Column(String(MAX_INDEXED_STRING_LENGTH), index=False, unique=True, nullable=False)
 
     @classmethod
     def find_or_raise_by_id(
@@ -76,7 +79,8 @@ class StudyModel(BaseModel):
 class StudyDirectionModel(BaseModel):
     __tablename__ = "study_directions"
     __table_args__: Any = (UniqueConstraint("study_id", "objective"),)
-    study_direction_id = Column(Integer, primary_key=True)
+    # study_direction_id = Column(Integer, primary_key=True)
+    study_direction_id = Column("study_direction_id", Integer, sa_sequence("study_direction_id_seq"), primary_key=True)
     direction = Column(Enum(StudyDirection), nullable=False)
     study_id = Column(Integer, ForeignKey("studies.study_id"), nullable=False)
     objective = Column(Integer, nullable=False)
@@ -107,7 +111,8 @@ class StudyDirectionModel(BaseModel):
 class StudyUserAttributeModel(BaseModel):
     __tablename__ = "study_user_attributes"
     __table_args__: Any = (UniqueConstraint("study_id", "key"),)
-    study_user_attribute_id = Column(Integer, primary_key=True)
+    # study_user_attribute_id = Column(Integer, primary_key=True)
+    study_user_attribute_id = Column("study_user_attribute_id", Integer, sa_sequence("study_user_attribute_id_seq"), primary_key=True)
     study_id = Column(Integer, ForeignKey("studies.study_id"))
     key = Column(String(MAX_INDEXED_STRING_LENGTH))
     value_json = Column(Text())
@@ -141,7 +146,8 @@ class StudyUserAttributeModel(BaseModel):
 class StudySystemAttributeModel(BaseModel):
     __tablename__ = "study_system_attributes"
     __table_args__: Any = (UniqueConstraint("study_id", "key"),)
-    study_system_attribute_id = Column(Integer, primary_key=True)
+    # study_system_attribute_id = Column(Integer, primary_key=True)
+    study_user_attribute_id = Column("study_system_attribute_id", Integer, sa_sequence("study_system_attribute_id_seq"), primary_key=True)
     study_id = Column(Integer, ForeignKey("studies.study_id"))
     key = Column(String(MAX_INDEXED_STRING_LENGTH))
     value_json = Column(Text())
@@ -174,7 +180,8 @@ class StudySystemAttributeModel(BaseModel):
 
 class TrialModel(BaseModel):
     __tablename__ = "trials"
-    trial_id = Column(Integer, primary_key=True)
+    # trial_id = Column(Integer, primary_key=True)
+    trial_id = Column("trial_id", Integer, sa_sequence("trial_id_seq"), primary_key=True)
     # No `UniqueConstraint` is put on the `number` columns although it in practice is constrained
     # to be unique. This is to reduce code complexity as table-level locking would be required
     # otherwise. See https://github.com/optuna/optuna/pull/939#discussion_r387447632.
@@ -271,7 +278,8 @@ class TrialModel(BaseModel):
 class TrialUserAttributeModel(BaseModel):
     __tablename__ = "trial_user_attributes"
     __table_args__: Any = (UniqueConstraint("trial_id", "key"),)
-    trial_user_attribute_id = Column(Integer, primary_key=True)
+    # trial_user_attribute_id = Column(Integer, primary_key=True)
+    trial_user_attribute_id = Column("trial_user_attribute_id", Integer, sa_sequence("trial_user_attribute_id_seq"), primary_key=True)
     trial_id = Column(Integer, ForeignKey("trials.trial_id"))
     key = Column(String(MAX_INDEXED_STRING_LENGTH))
     value_json = Column(Text())
@@ -305,7 +313,8 @@ class TrialUserAttributeModel(BaseModel):
 class TrialSystemAttributeModel(BaseModel):
     __tablename__ = "trial_system_attributes"
     __table_args__: Any = (UniqueConstraint("trial_id", "key"),)
-    trial_system_attribute_id = Column(Integer, primary_key=True)
+    # trial_system_attribute_id = Column(Integer, primary_key=True)
+    trial_system_attribute_id = Column("trial_system_attribute_id", Integer, sa_sequence("trial_system_attribute_id_seq"), primary_key=True)
     trial_id = Column(Integer, ForeignKey("trials.trial_id"))
     key = Column(String(MAX_INDEXED_STRING_LENGTH))
     value_json = Column(Text())
@@ -339,7 +348,8 @@ class TrialSystemAttributeModel(BaseModel):
 class TrialParamModel(BaseModel):
     __tablename__ = "trial_params"
     __table_args__: Any = (UniqueConstraint("trial_id", "param_name"),)
-    param_id = Column(Integer, primary_key=True)
+    # param_id = Column(Integer, primary_key=True)
+    param_id = Column("param_id", Integer, sa_sequence("param_id_seq"), primary_key=True)
     trial_id = Column(Integer, ForeignKey("trials.trial_id"))
     param_name = Column(String(MAX_INDEXED_STRING_LENGTH))
     param_value = Column(Float)
@@ -410,7 +420,8 @@ class TrialParamModel(BaseModel):
 class TrialValueModel(BaseModel):
     __tablename__ = "trial_values"
     __table_args__: Any = (UniqueConstraint("trial_id", "objective"),)
-    trial_value_id = Column(Integer, primary_key=True)
+    # trial_value_id = Column(Integer, primary_key=True)
+    trial_value_id = Column("trial_value_id", Integer, sa_sequence("trial_value_id_seq"), primary_key=True)
     trial_id = Column(Integer, ForeignKey("trials.trial_id"), nullable=False)
     objective = Column(Integer, nullable=False)
     value = Column(Float, nullable=False)
@@ -446,7 +457,8 @@ class TrialValueModel(BaseModel):
 class TrialIntermediateValueModel(BaseModel):
     __tablename__ = "trial_intermediate_values"
     __table_args__: Any = (UniqueConstraint("trial_id", "step"),)
-    trial_intermediate_value_id = Column(Integer, primary_key=True)
+    # trial_intermediate_value_id = Column(Integer, primary_key=True)
+    trial_intermediate_value_id = Column("trial_intermediate_value_id", Integer, sa_sequence("trial_intermediate_value_id_seq"), primary_key=True)
     trial_id = Column(Integer, ForeignKey("trials.trial_id"), nullable=False)
     step = Column(Integer, nullable=False)
     intermediate_value = Column(Float, nullable=False)
@@ -482,7 +494,8 @@ class TrialIntermediateValueModel(BaseModel):
 class TrialHeartbeatModel(BaseModel):
     __tablename__ = "trial_heartbeats"
     __table_args__: Any = (UniqueConstraint("trial_id"),)
-    trial_heartbeat_id = Column(Integer, primary_key=True)
+    # trial_heartbeat_id = Column(Integer, primary_key=True)
+    trial_heartbeat_id = Column("trial_heartbeat_id", Integer, sa_sequence("trial_heartbeat_id_seq"), primary_key=True)
     trial_id = Column(Integer, ForeignKey("trials.trial_id"), nullable=False)
     heartbeat = Column(DateTime, nullable=False, default=func.current_timestamp())
 
@@ -500,7 +513,7 @@ class TrialHeartbeatModel(BaseModel):
 class VersionInfoModel(BaseModel):
     __tablename__ = "version_info"
     # setting check constraint to ensure the number of rows is at most 1
-    __table_args__: Any = (CheckConstraint("version_info_id=1"),)
+    # __table_args__: Any = (CheckConstraint("version_info_id=1"),)
     version_info_id = Column(Integer, primary_key=True, autoincrement=False, default=1)
     schema_version = Column(Integer)
     library_version = Column(String(MAX_VERSION_LENGTH))

--- a/optuna/storages/_rdb/storage.py
+++ b/optuna/storages/_rdb/storage.py
@@ -1277,6 +1277,16 @@ class _VersionManager(object):
 
         logging.getLogger("alembic").setLevel(logging.WARN)
 
+        # as per https://docs.snowflake.com/en/user-guide/sqlalchemy.html#alembic-support
+        # If here, assume that sqlalchemy-snowflake exists and add it to the
+        # alembic _impls dictionary. self.engine.dialect.driver will return
+        # the sqlalchemy driver name that the engine creates.
+        if self.engine.dialect.driver == "snowflake":
+            from alembic.ddl.impl import DefaultImpl
+
+            class SnowflakeImpl(DefaultImpl):
+                __dialect__ = 'snowflake'
+
         context = alembic.migration.MigrationContext.configure(self.engine.connect())
         is_initialized = context.get_current_revision() is not None
 


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

 **DO NOT APPROVE THIS PR** 

As per the discussion on how to build support for snowflake, these are the minimal changes I made to optuna to get it to work in my environment. I am looking at ways to get this to work within SQLAlchemy to keep a single model file and add bits that are available to specific platforms. More on that tomorrow. 

## Motivation
I needed snowflake support to start multiple processing jobs in AWS and our company demanded snowflake support. 

## Description of the changes
This breaks models. It will remove code that is not supported by snowflake to get snowflake to run. It also adds a class declaration if the snowflake engine is snowflake. That is there to avoid a key error within alembic since optuna uses the python alembic bindings rather than relying on the env.py. 
