### PR TITLE
Check if texts in legend by order agnostic way

### DIFF
--- a/tests/visualization_tests/matplotlib_tests/test_optimization_history.py
+++ b/tests/visualization_tests/matplotlib_tests/test_optimization_history.py
@@ -83,11 +83,17 @@ def test_plot_optimization_history_with_multiple_studies(direction: str) -> None
     figure = plot_optimization_history(studies)
     assert len(figure.get_lines()) == n_studies
 
+    legend_texts = []
+    expected_legend_texts = []
     for i, legend in enumerate(figure.legend().get_texts()):
+        legend_texts.append(legend.get_text())
+
         if i < n_studies:
-            assert legend.get_text() == f"Best Values of {studies[i].study_name}"
+            expected_legend_texts.append(f"Best Values of {studies[i].study_name}")
         else:
-            assert legend.get_text() == f"Objective Value of {studies[i-n_studies].study_name}"
+            expected_legend_texts.append(f"Objective Value of {studies[i-n_studies].study_name}")
+
+    assert sorted(legend_texts) == sorted(expected_legend_texts)
 
     # Test customized target.
     with pytest.warns(UserWarning):
@@ -96,12 +102,21 @@ def test_plot_optimization_history_with_multiple_studies(direction: str) -> None
     assert len(figure.get_legend().get_texts()) == n_studies
 
     # Test customized target name.
-    figure = plot_optimization_history(studies, target_name="Target Name")
-    assert (
-        figure.legend().get_texts()[n_studies].get_text()
-        == f"Target Name of {studies[0].study_name}"
-    )
-    assert figure.get_ylabel() == "Target Name"
+    custom_target_name = "Target Name"
+    figure = plot_optimization_history(studies, target_name=custom_target_name)
+
+    legend_texts = []
+    expected_legend_texts = []
+    for i, legend in enumerate(figure.legend().get_texts()):
+        legend_texts.append(legend.get_text())
+
+        if i < n_studies:
+            expected_legend_texts.append(f"Best Values of {studies[i].study_name}")
+        else:
+            expected_legend_texts.append(f"{custom_target_name} of {studies[i-n_studies].study_name}")
+
+    assert sorted(legend_texts) == sorted(expected_legend_texts)
+    assert figure.get_ylabel() == custom_target_name
 
     # Ignore failed trials.
     def fail_objective(_: Trial) -> float:

--- a/tests/visualization_tests/matplotlib_tests/test_optimization_history.py
+++ b/tests/visualization_tests/matplotlib_tests/test_optimization_history.py
@@ -113,7 +113,9 @@ def test_plot_optimization_history_with_multiple_studies(direction: str) -> None
         if i < n_studies:
             expected_legend_texts.append(f"Best Values of {studies[i].study_name}")
         else:
-            expected_legend_texts.append(f"{custom_target_name} of {studies[i-n_studies].study_name}")
+            expected_legend_texts.append(
+                f"{custom_target_name} of {studies[i-n_studies].study_name}"
+            )
 
     assert sorted(legend_texts) == sorted(expected_legend_texts)
     assert figure.get_ylabel() == custom_target_name

--- a/tests/visualization_tests/matplotlib_tests/test_optimization_history.py
+++ b/tests/visualization_tests/matplotlib_tests/test_optimization_history.py
@@ -83,16 +83,11 @@ def test_plot_optimization_history_with_multiple_studies(direction: str) -> None
     figure = plot_optimization_history(studies)
     assert len(figure.get_lines()) == n_studies
 
-    legend_texts = []
     expected_legend_texts = []
-    for i, legend in enumerate(figure.legend().get_texts()):
-        legend_texts.append(legend.get_text())
-
-        if i < n_studies:
-            expected_legend_texts.append(f"Best Values of {studies[i].study_name}")
-        else:
-            expected_legend_texts.append(f"Objective Value of {studies[i-n_studies].study_name}")
-
+    for i in range(n_studies):
+        expected_legend_texts.append(f"Best Values of {studies[i].study_name}")
+        expected_legend_texts.append(f"Objective Value of {studies[i].study_name}")
+    legend_texts = [legend.get_text() for legend in figure.legend().get_texts()]
     assert sorted(legend_texts) == sorted(expected_legend_texts)
 
     # Test customized target.
@@ -105,18 +100,11 @@ def test_plot_optimization_history_with_multiple_studies(direction: str) -> None
     custom_target_name = "Target Name"
     figure = plot_optimization_history(studies, target_name=custom_target_name)
 
-    legend_texts = []
     expected_legend_texts = []
-    for i, legend in enumerate(figure.legend().get_texts()):
-        legend_texts.append(legend.get_text())
-
-        if i < n_studies:
-            expected_legend_texts.append(f"Best Values of {studies[i].study_name}")
-        else:
-            expected_legend_texts.append(
-                f"{custom_target_name} of {studies[i-n_studies].study_name}"
-            )
-
+    for i in range(n_studies):
+        expected_legend_texts.append(f"Best Values of {studies[i].study_name}")
+        expected_legend_texts.append(f"{custom_target_name} of {studies[i].study_name}")
+    legend_texts = [legend.get_text() for legend in figure.legend().get_texts()]
     assert sorted(legend_texts) == sorted(expected_legend_texts)
     assert figure.get_ylabel() == custom_target_name
 


### PR DESCRIPTION
CI failed after matplotlib v3.5.0 is available.
https://github.com/optuna/optuna/runs/4224429852?check_suite_focus=true

This is because the order of texts in legend has changed in the latest matplotlib.

3.4.3 | 3.5.0
-- | --
![3 4 3](https://user-images.githubusercontent.com/5164000/142004524-8149435e-3f5f-44a8-8a28-afa52690f065.png) | ![3 5 0](https://user-images.githubusercontent.com/5164000/142004584-bbd26f08-759f-439b-9756-3b3aa2de6f17.png)

The order of texts is potentially undefined so we shouldn't test them based on it.
I updated the test to remove order specific checks.