### PR TITLE
Add regex filtering support to `get_all_study_summaries()`

### DIFF
--- a/optuna/storages/_base.py
+++ b/optuna/storages/_base.py
@@ -294,8 +294,12 @@ class BaseStorage(object, metaclass=abc.ABCMeta):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def get_all_study_summaries(self) -> List[StudySummary]:
+    def get_all_study_summaries(self, regex: str = None) -> List[StudySummary]:
         """Read a list of :class:`~optuna.study.StudySummary` objects.
+
+        Args:
+            regex:
+                A regular expression that is used to filter the studies by name.
 
         Returns:
             A list of :class:`~optuna.study.StudySummary` objects.

--- a/optuna/storages/_cached_storage.py
+++ b/optuna/storages/_cached_storage.py
@@ -169,9 +169,9 @@ class _CachedStorage(BaseStorage):
 
         return self._backend.get_study_system_attrs(study_id)
 
-    def get_all_study_summaries(self) -> List[StudySummary]:
+    def get_all_study_summaries(self, regex: str = None) -> List[StudySummary]:
 
-        return self._backend.get_all_study_summaries()
+        return self._backend.get_all_study_summaries(regex=regex)
 
     def create_new_trial(self, study_id: int, template_trial: Optional[FrozenTrial] = None) -> int:
 

--- a/optuna/storages/_in_memory.py
+++ b/optuna/storages/_in_memory.py
@@ -1,5 +1,6 @@
 import copy
 from datetime import datetime
+import re
 import threading
 from typing import Any
 from typing import cast
@@ -150,10 +151,19 @@ class InMemoryStorage(BaseStorage):
             self._check_study_id(study_id)
             return self._studies[study_id].system_attrs
 
-    def get_all_study_summaries(self) -> List[StudySummary]:
+    def get_all_study_summaries(self, regex: str = None) -> List[StudySummary]:
 
         with self._lock:
-            return [self._build_study_summary(study_id) for study_id in self._studies]
+            if regex is not None:
+                pattern = re.compile(regex)
+                studies = [
+                    study_id
+                    for study_id, study in self._studies.items()
+                    if pattern.match(study.name)
+                ]
+            else:
+                studies = list(self._studies.keys())
+            return [self._build_study_summary(study_id) for study_id in studies]
 
     def _build_study_summary(self, study_id: int) -> StudySummary:
         study = self._studies[study_id]


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
Querying all study summaries just to select a subset of them from a large RDB database is awfully slow.

## Description of the changes
With this option, one can filter the results by a regex beforehand for all storage backends. This increased the query speed for a large remote database of mine from ~770 seconds to ~16 seconds by reducing the number of studies from ~3500 to ~50. I did not test for performance on the other storage backends, but I would expect performance increases there, too.

Note that I only execute the regex statements on the client side. The main reason for this is portability: While some SQL databases have a regex operator, the support varies between them. Also, Redis does not have such an operator.
