### PR TITLE
Add option to exclude best trials from study summaries

### DIFF
--- a/optuna/cli.py
+++ b/optuna/cli.py
@@ -370,7 +370,7 @@ class _Studies(_BaseCommand):
     def take_action(self, parsed_args: Namespace) -> None:
 
         storage_url = _check_storage_url(self.app_args.storage)
-        summaries = optuna.get_all_study_summaries(storage=storage_url)
+        summaries = optuna.get_all_study_summaries(storage_url, include_best_trial=False)
 
         records = []
         for s in summaries:

--- a/optuna/storages/_base.py
+++ b/optuna/storages/_base.py
@@ -294,7 +294,7 @@ class BaseStorage(object, metaclass=abc.ABCMeta):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def get_all_study_summaries(self) -> List[StudySummary]:
+    def get_all_study_summaries(self, include_best_trial: bool = True) -> List[StudySummary]:
         """Read a list of :class:`~optuna.study.StudySummary` objects.
 
         Returns:

--- a/optuna/storages/_base.py
+++ b/optuna/storages/_base.py
@@ -294,8 +294,13 @@ class BaseStorage(object, metaclass=abc.ABCMeta):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def get_all_study_summaries(self, include_best_trial: bool = True) -> List[StudySummary]:
+    def get_all_study_summaries(self, include_best_trial: bool) -> List[StudySummary]:
         """Read a list of :class:`~optuna.study.StudySummary` objects.
+
+        Args:
+            include_best_trial:
+                If :obj:`True`, :obj:`~optuna.study.StudySummary` objects have the best trials in
+                the ``best_trial`` attribute. Otherwise, ``best_trial`` is :obj:`None`.
 
         Returns:
             A list of :class:`~optuna.study.StudySummary` objects.

--- a/optuna/storages/_cached_storage.py
+++ b/optuna/storages/_cached_storage.py
@@ -156,9 +156,9 @@ class _CachedStorage(BaseStorage):
 
         return self._backend.get_study_system_attrs(study_id)
 
-    def get_all_study_summaries(self) -> List[StudySummary]:
+    def get_all_study_summaries(self, include_best_trial: bool = True) -> List[StudySummary]:
 
-        return self._backend.get_all_study_summaries()
+        return self._backend.get_all_study_summaries(include_best_trial=include_best_trial)
 
     def create_new_trial(self, study_id: int, template_trial: Optional[FrozenTrial] = None) -> int:
 

--- a/optuna/storages/_cached_storage.py
+++ b/optuna/storages/_cached_storage.py
@@ -156,7 +156,7 @@ class _CachedStorage(BaseStorage):
 
         return self._backend.get_study_system_attrs(study_id)
 
-    def get_all_study_summaries(self, include_best_trial: bool = True) -> List[StudySummary]:
+    def get_all_study_summaries(self, include_best_trial: bool) -> List[StudySummary]:
 
         return self._backend.get_all_study_summaries(include_best_trial=include_best_trial)
 

--- a/optuna/storages/_in_memory.py
+++ b/optuna/storages/_in_memory.py
@@ -150,7 +150,7 @@ class InMemoryStorage(BaseStorage):
             self._check_study_id(study_id)
             return self._studies[study_id].system_attrs
 
-    def get_all_study_summaries(self, include_best_trial: bool = True) -> List[StudySummary]:
+    def get_all_study_summaries(self, include_best_trial: bool) -> List[StudySummary]:
 
         with self._lock:
             return [

--- a/optuna/storages/_in_memory.py
+++ b/optuna/storages/_in_memory.py
@@ -150,19 +150,22 @@ class InMemoryStorage(BaseStorage):
             self._check_study_id(study_id)
             return self._studies[study_id].system_attrs
 
-    def get_all_study_summaries(self) -> List[StudySummary]:
+    def get_all_study_summaries(self, include_best_trial: bool = True) -> List[StudySummary]:
 
         with self._lock:
-            return [self._build_study_summary(study_id) for study_id in self._studies]
+            return [
+                self._build_study_summary(study_id, include_best_trial)
+                for study_id in self._studies
+            ]
 
-    def _build_study_summary(self, study_id: int) -> StudySummary:
+    def _build_study_summary(self, study_id: int, include_best_trial: bool = True) -> StudySummary:
         study = self._studies[study_id]
         return StudySummary(
             study_name=study.name,
             direction=None,
             directions=study.directions,
             best_trial=copy.deepcopy(self._get_trial(study.best_trial_id))
-            if study.best_trial_id is not None
+            if study.best_trial_id is not None and include_best_trial
             else None,
             user_attrs=copy.deepcopy(study.user_attrs),
             system_attrs=copy.deepcopy(study.system_attrs),

--- a/optuna/storages/_rdb/storage.py
+++ b/optuna/storages/_rdb/storage.py
@@ -391,7 +391,7 @@ class RDBStorage(BaseStorage):
 
         return system_attrs
 
-    def get_all_study_summaries(self, include_best_trial: bool = True) -> List[StudySummary]:
+    def get_all_study_summaries(self, include_best_trial: bool) -> List[StudySummary]:
 
         with _create_scoped_session(self.scoped_session) as session:
             summarized_trial = (

--- a/optuna/storages/_rdb/storage.py
+++ b/optuna/storages/_rdb/storage.py
@@ -391,7 +391,7 @@ class RDBStorage(BaseStorage):
 
         return system_attrs
 
-    def get_all_study_summaries(self) -> List[StudySummary]:
+    def get_all_study_summaries(self, include_best_trial: bool = True) -> List[StudySummary]:
 
         with _create_scoped_session(self.scoped_session) as session:
             summarized_trial = (
@@ -428,67 +428,71 @@ class RDBStorage(BaseStorage):
             study_summaries = []
             for study in study_summary:
                 directions = _directions[study.study_id]
-                best_trial: Optional[models.TrialModel] = None
-                try:
-                    if len(directions) > 1:
-                        raise ValueError
-                    elif directions[0] == StudyDirection.MAXIMIZE:
-                        best_trial = models.TrialModel.find_max_value_trial(
-                            study.study_id, 0, session
+                best_trial_frozen: Optional[FrozenTrial] = None
+                if include_best_trial:
+                    best_trial: Optional[models.TrialModel] = None
+                    try:
+                        if len(directions) > 1:
+                            raise ValueError
+                        elif directions[0] == StudyDirection.MAXIMIZE:
+                            best_trial = models.TrialModel.find_max_value_trial(
+                                study.study_id, 0, session
+                            )
+                        else:
+                            best_trial = models.TrialModel.find_min_value_trial(
+                                study.study_id, 0, session
+                            )
+                    except ValueError:
+                        best_trial_frozen = None
+                    if best_trial:
+                        value = models.TrialValueModel.find_by_trial_and_objective(
+                            best_trial, 0, session
                         )
-                    else:
-                        best_trial = models.TrialModel.find_min_value_trial(
-                            study.study_id, 0, session
+                        assert value
+                        params = (
+                            session.query(
+                                models.TrialParamModel.param_name,
+                                models.TrialParamModel.param_value,
+                                models.TrialParamModel.distribution_json,
+                            )
+                            .filter(models.TrialParamModel.trial_id == best_trial.trial_id)
+                            .all()
                         )
-                except ValueError:
-                    best_trial_frozen: Optional[FrozenTrial] = None
-                if best_trial:
-                    value = models.TrialValueModel.find_by_trial_and_objective(
-                        best_trial, 0, session
-                    )
-                    assert value
-                    params = (
-                        session.query(
-                            models.TrialParamModel.param_name,
-                            models.TrialParamModel.param_value,
-                            models.TrialParamModel.distribution_json,
+                        param_dict = {}
+                        param_distributions = {}
+                        for param in params:
+                            distribution = distributions.json_to_distribution(
+                                param.distribution_json
+                            )
+                            param_dict[param.param_name] = distribution.to_external_repr(
+                                param.param_value
+                            )
+                            param_distributions[param.param_name] = distribution
+                        user_attrs = models.TrialUserAttributeModel.where_trial_id(
+                            best_trial.trial_id, session
                         )
-                        .filter(models.TrialParamModel.trial_id == best_trial.trial_id)
-                        .all()
-                    )
-                    param_dict = {}
-                    param_distributions = {}
-                    for param in params:
-                        distribution = distributions.json_to_distribution(param.distribution_json)
-                        param_dict[param.param_name] = distribution.to_external_repr(
-                            param.param_value
+                        system_attrs = models.TrialSystemAttributeModel.where_trial_id(
+                            best_trial.trial_id, session
                         )
-                        param_distributions[param.param_name] = distribution
-                    user_attrs = models.TrialUserAttributeModel.where_trial_id(
-                        best_trial.trial_id, session
-                    )
-                    system_attrs = models.TrialSystemAttributeModel.where_trial_id(
-                        best_trial.trial_id, session
-                    )
-                    intermediate = models.TrialIntermediateValueModel.where_trial_id(
-                        best_trial.trial_id, session
-                    )
-                    best_trial_frozen = FrozenTrial(
-                        best_trial.number,
-                        TrialState.COMPLETE,
-                        self._lift_numerical_limit(value.value),
-                        best_trial.datetime_start,
-                        best_trial.datetime_complete,
-                        param_dict,
-                        param_distributions,
-                        {i.key: json.loads(i.value_json) for i in user_attrs},
-                        {i.key: json.loads(i.value_json) for i in system_attrs},
-                        {
-                            value.step: self._lift_numerical_limit(value.intermediate_value)
-                            for value in intermediate
-                        },
-                        best_trial.trial_id,
-                    )
+                        intermediate = models.TrialIntermediateValueModel.where_trial_id(
+                            best_trial.trial_id, session
+                        )
+                        best_trial_frozen = FrozenTrial(
+                            best_trial.number,
+                            TrialState.COMPLETE,
+                            self._lift_numerical_limit(value.value),
+                            best_trial.datetime_start,
+                            best_trial.datetime_complete,
+                            param_dict,
+                            param_distributions,
+                            {i.key: json.loads(i.value_json) for i in user_attrs},
+                            {i.key: json.loads(i.value_json) for i in system_attrs},
+                            {
+                                value.step: self._lift_numerical_limit(value.intermediate_value)
+                                for value in intermediate
+                            },
+                            best_trial.trial_id,
+                        )
                 user_attrs = _user_attrs.get(study.study_id, [])
                 system_attrs = _system_attrs.get(study.study_id, [])
                 study_summaries.append(

--- a/optuna/storages/_redis.py
+++ b/optuna/storages/_redis.py
@@ -188,11 +188,14 @@ class RedisStorage(BaseStorage):
 
         self._redis.set(self._key_study_summary(study_id), pickle.dumps(study_summary))
 
-    def _get_study_summary(self, study_id: int) -> StudySummary:
+    def _get_study_summary(self, study_id: int, include_best_trial: bool = True) -> StudySummary:
 
         summary_pkl = self._redis.get(self._key_study_summary(study_id))
         assert summary_pkl is not None
-        return pickle.loads(summary_pkl)
+        summary = pickle.loads(summary_pkl)
+        if not include_best_trial:
+            summary.best_trial = None
+        return summary
 
     def _del_study_summary(self, study_id: int) -> None:
 
@@ -310,7 +313,7 @@ class RedisStorage(BaseStorage):
             self._key_study_param_distribution(study_id), pickle.dumps(param_distribution)
         )
 
-    def get_all_study_summaries(self) -> List[StudySummary]:
+    def get_all_study_summaries(self, include_best_trial: bool = True) -> List[StudySummary]:
 
         queries = []
         study_ids = [pickle.loads(sid) for sid in self._redis.lrange("study_list", 0, -1)]
@@ -321,7 +324,10 @@ class RedisStorage(BaseStorage):
         summary_pkls = self._redis.mget(queries)
         for summary_pkl in summary_pkls:
             assert summary_pkl is not None
-            study_summaries.append(pickle.loads(summary_pkl))
+            summary = pickle.loads(summary_pkl)
+            if not include_best_trial:
+                summary.best_trial = None
+            study_summaries.append(summary)
 
         return study_summaries
 

--- a/optuna/storages/_redis.py
+++ b/optuna/storages/_redis.py
@@ -313,7 +313,7 @@ class RedisStorage(BaseStorage):
             self._key_study_param_distribution(study_id), pickle.dumps(param_distribution)
         )
 
-    def get_all_study_summaries(self, include_best_trial: bool = True) -> List[StudySummary]:
+    def get_all_study_summaries(self, include_best_trial: bool) -> List[StudySummary]:
 
         queries = []
         study_ids = [pickle.loads(sid) for sid in self._redis.lrange("study_list", 0, -1)]

--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -1406,7 +1406,9 @@ def copy_study(
     to_study.add_trials(from_study.get_trials(deepcopy=False))
 
 
-def get_all_study_summaries(storage: Union[str, storages.BaseStorage]) -> List[StudySummary]:
+def get_all_study_summaries(
+    storage: Union[str, storages.BaseStorage], include_best_trial: bool = True
+) -> List[StudySummary]:
     """Get all history of studies stored in a specified storage.
 
     Example:
@@ -1445,6 +1447,9 @@ def get_all_study_summaries(storage: Union[str, storages.BaseStorage]) -> List[S
         storage:
             Database URL such as ``sqlite:///example.db``. Please see also the documentation of
             :func:`~optuna.study.create_study` for further details.
+        include_best_trial:
+            Include the best trials if exist. It potentially increases the number of queries and
+            may take longer to fetch summaries depending on the storage.
 
     Returns:
         List of study history summarized as :class:`~optuna.study.StudySummary` objects.
@@ -1456,4 +1461,4 @@ def get_all_study_summaries(storage: Union[str, storages.BaseStorage]) -> List[S
     """
 
     storage = storages.get_storage(storage)
-    return storage.get_all_study_summaries()
+    return storage.get_all_study_summaries(include_best_trial=include_best_trial)

--- a/tests/storages_tests/test_storages.py
+++ b/tests/storages_tests/test_storages.py
@@ -61,7 +61,7 @@ def test_create_new_study(storage_mode: str) -> None:
 
         study_id = storage.create_new_study()
 
-        summaries = storage.get_all_study_summaries()
+        summaries = storage.get_all_study_summaries(include_best_trial=True)
         assert len(summaries) == 1
         assert summaries[0]._study_id == study_id
         assert summaries[0].study_name.startswith(DEFAULT_STUDY_NAME_PREFIX)
@@ -69,7 +69,7 @@ def test_create_new_study(storage_mode: str) -> None:
         study_id2 = storage.create_new_study()
         # Study id must be unique.
         assert study_id != study_id2
-        summaries = storage.get_all_study_summaries()
+        summaries = storage.get_all_study_summaries(include_best_trial=True)
         assert len(summaries) == 2
         assert {s._study_id for s in summaries} == {study_id, study_id2}
         assert all(s.study_name.startswith(DEFAULT_STUDY_NAME_PREFIX) for s in summaries)
@@ -89,7 +89,7 @@ def test_create_new_study_unique_id(storage_mode: str) -> None:
         if not isinstance(storage, (RDBStorage, _CachedStorage)):
             # TODO(ytsmiling) Fix RDBStorage so that it does not reuse study_id.
             assert len({study_id, study_id2, study_id3}) == 3
-        summaries = storage.get_all_study_summaries()
+        summaries = storage.get_all_study_summaries(include_best_trial=True)
         assert {s._study_id for s in summaries} == {study_id, study_id3}
 
 
@@ -144,7 +144,9 @@ def test_delete_study_after_create_multiple_studies(storage_mode: str) -> None:
 
         storage.delete_study(study_id2)
 
-        studies = {s._study_id: s for s in storage.get_all_study_summaries()}
+        studies = {
+            s._study_id: s for s in storage.get_all_study_summaries(include_best_trial=True)
+        }
         assert study_id1 in studies
         assert study_id2 not in studies
         assert study_id3 in studies

--- a/tests/storages_tests/test_storages.py
+++ b/tests/storages_tests/test_storages.py
@@ -759,11 +759,12 @@ def test_set_trial_system_attr(storage_mode: str) -> None:
 
 
 @pytest.mark.parametrize("storage_mode", STORAGE_MODES)
-def test_get_all_study_summaries(storage_mode: str) -> None:
+@pytest.mark.parametrize("include_best_trial", [True, False])
+def test_get_all_study_summaries(storage_mode: str, include_best_trial: bool) -> None:
 
     with StorageSupplier(storage_mode) as storage:
         expected_summaries, _ = _setup_studies(storage, n_study=10, n_trial=10, seed=46)
-        summaries = storage.get_all_study_summaries()
+        summaries = storage.get_all_study_summaries(include_best_trial=include_best_trial)
         assert len(summaries) == len(expected_summaries)
         for _, expected_summary in expected_summaries.items():
             summary: Optional[StudySummary] = None
@@ -778,9 +779,12 @@ def test_get_all_study_summaries(storage_mode: str) -> None:
             assert summary.n_trials == expected_summary.n_trials
             assert summary.user_attrs == expected_summary.user_attrs
             assert summary.system_attrs == expected_summary.system_attrs
-            if expected_summary.best_trial is not None:
-                assert summary.best_trial is not None
-                assert summary.best_trial == expected_summary.best_trial
+            if include_best_trial:
+                if expected_summary.best_trial is not None:
+                    assert summary.best_trial is not None
+                    assert summary.best_trial == expected_summary.best_trial
+            else:
+                assert summary.best_trial is None
 
 
 @pytest.mark.parametrize("storage_mode", STORAGE_MODES)

--- a/tests/study_tests/test_study.py
+++ b/tests/study_tests/test_study.py
@@ -1284,11 +1284,11 @@ def test_study_summary_datetime_start_calculation(storage_mode: str) -> None:
         study.enqueue_trial(params={"x": 1})
 
         # Study summary with only enqueued trials should have null datetime_start
-        summaries = study._storage.get_all_study_summaries()
+        summaries = study._storage.get_all_study_summaries(include_best_trial=True)
         assert summaries[0].datetime_start is None
 
         # Study summary with completed trials should have nonnull datetime_start
         study.optimize(objective, n_trials=1)
         study.enqueue_trial(params={"x": 1})
-        summaries = study._storage.get_all_study_summaries()
+        summaries = study._storage.get_all_study_summaries(include_best_trial=True)
         assert summaries[0].datetime_start is not None

--- a/tests/study_tests/test_study.py
+++ b/tests/study_tests/test_study.py
@@ -299,17 +299,22 @@ def test_trial_set_and_get_system_attrs(storage_mode: str) -> None:
 
 
 @pytest.mark.parametrize("storage_mode", STORAGE_MODES)
-def test_get_all_study_summaries(storage_mode: str) -> None:
+@pytest.mark.parametrize("include_best_trial", [True, False])
+def test_get_all_study_summaries(storage_mode: str, include_best_trial: bool) -> None:
 
     with StorageSupplier(storage_mode) as storage:
         study = create_study(storage=storage)
         study.optimize(Func(), n_trials=5)
 
-        summaries = get_all_study_summaries(study._storage)
+        summaries = get_all_study_summaries(study._storage, include_best_trial)
         summary = [s for s in summaries if s._study_id == study._study_id][0]
 
         assert summary.study_name == study.study_name
         assert summary.n_trials == 5
+        if include_best_trial:
+            assert summary.best_trial is not None
+        else:
+            assert summary.best_trial is None
 
 
 @pytest.mark.parametrize("storage_mode", STORAGE_MODES)

--- a/tests/study_tests/test_study_summary.py
+++ b/tests/study_tests/test_study_summary.py
@@ -13,7 +13,7 @@ def test_study_summary_eq_ne() -> None:
     create_study(storage=storage)
     study = create_study(storage=storage)
 
-    summaries = study._storage.get_all_study_summaries()
+    summaries = study._storage.get_all_study_summaries(include_best_trial=True)
     assert len(summaries) == 2
 
     assert summaries[0] == copy.deepcopy(summaries[0])
@@ -33,7 +33,7 @@ def test_study_summary_lt_le() -> None:
     create_study(storage=storage)
     study = create_study(storage=storage)
 
-    summaries = study._storage.get_all_study_summaries()
+    summaries = study._storage.get_all_study_summaries(include_best_trial=True)
     assert len(summaries) == 2
 
     summary_0 = summaries[0]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -224,12 +224,16 @@ def test_delete_study_command() -> None:
         # Create study.
         command = ["optuna", "create-study", "--storage", storage_url, "--study-name", study_name]
         subprocess.check_call(command)
-        assert study_name in {s.study_name: s for s in storage.get_all_study_summaries()}
+        assert study_name in {
+            s.study_name: s for s in storage.get_all_study_summaries(include_best_trial=True)
+        }
 
         # Delete study.
         command = ["optuna", "delete-study", "--storage", storage_url, "--study-name", study_name]
         subprocess.check_call(command)
-        assert study_name not in {s.study_name: s for s in storage.get_all_study_summaries()}
+        assert study_name not in {
+            s.study_name: s for s in storage.get_all_study_summaries(include_best_trial=True)
+        }
 
 
 @pytest.mark.skip_coverage


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

This PR is related to #3105 and depends on #3108.

The current master includes the best trials to study summaries. It needs O(n_studies) queries to fetch the best studies, and we can reduce the retrieval time if we skip the processing.

The `optuna studies` command does not use `StudySummary.best_trial` and #3105 suggested that some users do not use it when they fetch study summaries in their Python scripts.

This PR adds an option to exclude the best trials from study summaries.

It significantly reduces the retrieval time in my environment (100 studies in a MySQL server) as follows:

```console
# command
$ optuna studies --storage $OPTUNA_STORAGE
# master
1.56s user 1.30s system 9% cpu 31.713 total
# #3108
1.44s user 1.08s system 19% cpu 12.838 total
# this PR
1.25s user 1.30s system 51% cpu 4.963 total
```


## Description of the changes
<!-- Describe the changes in this PR. -->

- Add `include_best_trial: bool = True` option to `BaseStorage.get_all_study_summaries`
- Add `include_best_trial: bool = True` option to `optuna.get_all_study_summaries`
- Set `include_best_trial` to `False` in the `optuna studies` command
- Add test cases for the option.