### PR TITLE
Use `json.loads` to decode pruner configuration loaded from environment variables

### DIFF
--- a/optuna/integration/allennlp/_executor.py
+++ b/optuna/integration/allennlp/_executor.py
@@ -171,8 +171,7 @@ class AllenNLPExecutor(object):
 
         if trial.study.pruner is not None:
             variable_manager.set_value("pruner_class", type(trial.study.pruner).__name__)
-            variable_manager.set_value("pruner_keys", list(pruner_params.keys()))
-            variable_manager.set_value("pruner_values", list(pruner_params.values()))
+            variable_manager.set_value("pruner_params", pruner_params)
 
     def _build_params(self) -> Dict[str, Any]:
         """Create a dict of params for AllenNLP.

--- a/optuna/integration/allennlp/_executor.py
+++ b/optuna/integration/allennlp/_executor.py
@@ -163,7 +163,7 @@ class AllenNLPExecutor(object):
         target_pid = psutil.Process().ppid()
         variable_manager = _VariableManager(target_pid)
 
-        pruner_params = _fetch_pruner_config(trial)
+        pruner_kwargs = _fetch_pruner_config(trial)
         variable_manager.set_value("study_name", trial.study.study_name)
         variable_manager.set_value("trial_id", trial._trial_id)
         variable_manager.set_value("storage_name", url)
@@ -171,7 +171,7 @@ class AllenNLPExecutor(object):
 
         if trial.study.pruner is not None:
             variable_manager.set_value("pruner_class", type(trial.study.pruner).__name__)
-            variable_manager.set_value("pruner_params", pruner_params)
+            variable_manager.set_value("pruner_kwargs", pruner_kwargs)
 
     def _build_params(self) -> Dict[str, Any]:
         """Create a dict of params for AllenNLP.

--- a/optuna/integration/allennlp/_executor.py
+++ b/optuna/integration/allennlp/_executor.py
@@ -14,7 +14,6 @@ from optuna._imports import try_import
 from optuna.integration.allennlp._environment import _environment_variables
 from optuna.integration.allennlp._variables import _VariableManager
 from optuna.integration.allennlp._variables import OPTUNA_ALLENNLP_DISTRIBUTED_FLAG
-from optuna.integration.allennlp._variables import SPECIAL_DELIMITER as DELIMITER
 
 
 with try_import() as _imports:
@@ -165,17 +164,15 @@ class AllenNLPExecutor(object):
         variable_manager = _VariableManager(target_pid)
 
         pruner_params = _fetch_pruner_config(trial)
-        pruner_params = {key: repr(value) for key, value in pruner_params.items()}
-
         variable_manager.set_value("study_name", trial.study.study_name)
-        variable_manager.set_value("trial_id", str(trial._trial_id))
+        variable_manager.set_value("trial_id", trial._trial_id)
         variable_manager.set_value("storage_name", url)
         variable_manager.set_value("monitor", metrics)
 
         if trial.study.pruner is not None:
             variable_manager.set_value("pruner_class", type(trial.study.pruner).__name__)
-            variable_manager.set_value("pruner_keys", DELIMITER.join(pruner_params.keys()))
-            variable_manager.set_value("pruner_values", DELIMITER.join(pruner_params.values()))
+            variable_manager.set_value("pruner_keys", list(pruner_params.keys()))
+            variable_manager.set_value("pruner_values", list(pruner_params.values()))
 
     def _build_params(self) -> Dict[str, Any]:
         """Create a dict of params for AllenNLP.

--- a/optuna/integration/allennlp/_pruner.py
+++ b/optuna/integration/allennlp/_pruner.py
@@ -52,7 +52,7 @@ else:
 
 def _create_pruner(
     pruner_class: str,
-    pruner_params: Dict[str, Any],
+    pruner_kwargs: Dict[str, Any],
 ) -> Optional[pruners.BasePruner]:
 
     """Restore a pruner which is defined in `create_study`.
@@ -66,7 +66,7 @@ def _create_pruner(
 
     """
     pruner = getattr(pruners, pruner_class, None)
-    return pruner(**pruner_params)
+    return pruner(**pruner_kwargs)
 
 
 @experimental("2.0.0")
@@ -171,7 +171,7 @@ class AllenNLPPruningCallback(TrainerCallback):
 
                 pruner = _create_pruner(
                     variable_manager.get_value("pruner_class"),
-                    variable_manager.get_value("pruner_params"),
+                    variable_manager.get_value("pruner_kwargs"),
                 )
 
                 study = load_study(

--- a/optuna/integration/allennlp/_pruner.py
+++ b/optuna/integration/allennlp/_pruner.py
@@ -66,6 +66,9 @@ def _create_pruner(
 
     """
     pruner = getattr(pruners, pruner_class, None)
+    if pruner is None:
+        return None
+
     return pruner(**pruner_kwargs)
 
 

--- a/optuna/integration/allennlp/_pruner.py
+++ b/optuna/integration/allennlp/_pruner.py
@@ -2,7 +2,6 @@ import os
 from typing import Any
 from typing import Callable
 from typing import Dict
-from typing import List
 from typing import Optional
 
 from packaging import version
@@ -53,8 +52,7 @@ else:
 
 def _create_pruner(
     pruner_class: str,
-    pruner_keys: List[str],
-    pruner_values: List[Any],
+    pruner_params: Dict[str, Any],
 ) -> Optional[pruners.BasePruner]:
 
     """Restore a pruner which is defined in `create_study`.
@@ -67,7 +65,6 @@ def _create_pruner(
     re-create the same pruner in `AllenNLPPruningCallback`.
 
     """
-    pruner_params = {k: v for k, v in zip(pruner_keys, pruner_values)}
     pruner = getattr(pruners, pruner_class, None)
     return pruner(**pruner_params)
 
@@ -174,8 +171,7 @@ class AllenNLPPruningCallback(TrainerCallback):
 
                 pruner = _create_pruner(
                     variable_manager.get_value("pruner_class"),
-                    variable_manager.get_value("pruner_keys"),
-                    variable_manager.get_value("pruner_values"),
+                    variable_manager.get_value("pruner_params"),
                 )
 
                 study = load_study(

--- a/optuna/integration/allennlp/_variables.py
+++ b/optuna/integration/allennlp/_variables.py
@@ -68,6 +68,6 @@ class _VariableManager:
         """
         key = self._get_key(name).format(self.target_pid)
         value = os.environ.get(key)
-        assert value is not None, f"{key} is not found in environment variables."
-
-        return value
+        if value is None:
+            raise KeyError(f"{key} is not found in environment variables.")
+        return json.loads(value)

--- a/optuna/integration/allennlp/_variables.py
+++ b/optuna/integration/allennlp/_variables.py
@@ -30,7 +30,7 @@ class _VariableManager:
     NAME_OF_KEY = {
         "monitor": "{}_MONITOR",
         "pruner_class": "{}_PRUNER_CLASS",
-        "pruner_params": "{}_PRUNER_PARAMS",
+        "pruner_kwargs": "{}_PRUNER_PARAMS",
         "storage_name": "{}_STORAGE_NAME",
         "study_name": "{}_STUDY_NAME",
         "trial_id": "{}_TRIAL_ID",

--- a/optuna/integration/allennlp/_variables.py
+++ b/optuna/integration/allennlp/_variables.py
@@ -1,8 +1,8 @@
+import json
 import os
-from typing import Optional
+from typing import Any
 
 
-SPECIAL_DELIMITER = "[OPTUNA_ALLENNLP_INTEGRATION_DELIMITER]"
 OPTUNA_ALLENNLP_DISTRIBUTED_FLAG = "OPTUNA_ALLENNLP_USE_DISTRIBUTED"
 
 
@@ -51,16 +51,16 @@ class _VariableManager:
             raise KeyError(f"{name} is not found in `{self.NAME_OF_PATH}`.")
         return key
 
-    def set_value(self, name: str, value: str) -> None:
+    def set_value(self, name: str, value: Any) -> None:
         """Set values to environment variables.
 
         `set_value` is only invoked in `optuna.integration.allennlp.AllenNLPExecutor`.
 
         """
         key = self._get_key(name).format(self.target_pid)
-        os.environ[key] = value
+        os.environ[key] = json.dumps(value)
 
-    def get_value(self, name: str) -> Optional[str]:
+    def get_value(self, name: str) -> Any:
         """Fetch parameters from environment variables.
 
         `get_value` is only called in `optuna.integration.allennlp.AllenNLPPruningCallback`.

--- a/optuna/integration/allennlp/_variables.py
+++ b/optuna/integration/allennlp/_variables.py
@@ -30,8 +30,7 @@ class _VariableManager:
     NAME_OF_KEY = {
         "monitor": "{}_MONITOR",
         "pruner_class": "{}_PRUNER_CLASS",
-        "pruner_keys": "{}_PRUNER_KEYS",
-        "pruner_values": "{}_PRUNER_VALUES",
+        "pruner_params": "{}_PRUNER_PARAMS",
         "storage_name": "{}_STORAGE_NAME",
         "study_name": "{}_STUDY_NAME",
         "trial_id": "{}_TRIAL_ID",

--- a/tests/integration_tests/allennlp_tests/test_allennlp.py
+++ b/tests/integration_tests/allennlp_tests/test_allennlp.py
@@ -393,7 +393,7 @@ def test_allennlp_pruning_callback_with_executor(
         manager = _VariableManager(process.ppid())
         ret_pruner = _create_pruner(
             manager.get_value("pruner_class"),
-            manager.get_value("pruner_params"),
+            manager.get_value("pruner_kwargs"),
         )
 
         assert isinstance(ret_pruner, pruner_class)

--- a/tests/integration_tests/allennlp_tests/test_allennlp.py
+++ b/tests/integration_tests/allennlp_tests/test_allennlp.py
@@ -393,8 +393,7 @@ def test_allennlp_pruning_callback_with_executor(
         manager = _VariableManager(process.ppid())
         ret_pruner = _create_pruner(
             manager.get_value("pruner_class"),
-            manager.get_value("pruner_keys"),
-            manager.get_value("pruner_values"),
+            manager.get_value("pruner_params"),
         )
 
         assert isinstance(ret_pruner, pruner_class)


### PR DESCRIPTION
This PR changes the way to set/fetch pruner configuration to/from environment variables.

The current implementation of AllenNLP integration utilize `repr()` and `eval()` for storing and fetching parameters but it would be safer to avoid `eval()` invocation. For this purpose, I found JSON to be useful since all parameters to be stored are JSON decodable.

## Motivation
- Remove `eval()` usage from source code

## Description of the changes
- 200d1d changes the exception when a key is not found on environment variables (follow-up of https://github.com/optuna/optuna/pull/2977#discussion_r756009719)
- eb185c changes the way to store/fetch a pruner configuration