### PR TITLE
Show progress bar based on `timeout`

### DIFF
--- a/optuna/progress_bar.py
+++ b/optuna/progress_bar.py
@@ -87,7 +87,7 @@ class _ProgressBar(object):
         if self._is_valid:
             if self._n_trials is not None:
                 self._progress_bar.update(1)
-                if self._timeout is not None and elapsed_seconds is not None:
+                if self._timeout is not None:
                     self._progress_bar.set_postfix_str(
                         "{:.02f}/{} seconds".format(elapsed_seconds, self._timeout)
                     )

--- a/optuna/progress_bar.py
+++ b/optuna/progress_bar.py
@@ -1,5 +1,4 @@
 import logging
-import time
 from typing import Any
 from typing import Optional
 
@@ -65,7 +64,7 @@ class _ProgressBar(object):
             # to display formatted timeout, since postfix carries
             # extra comma space auto-format.
             # https://github.com/tqdm/tqdm/issues/712
-            total = time.strftime("%M:%S", time.gmtime(self._timeout))
+            total = tqdm.format_interval(self._timeout)
             self._progress_bar.set_description_str(total)
 
         global _tqdm_handler

--- a/optuna/progress_bar.py
+++ b/optuna/progress_bar.py
@@ -1,4 +1,5 @@
 import logging
+import time
 from typing import Any
 from typing import Optional
 
@@ -39,9 +40,11 @@ class _ProgressBar(object):
     def __init__(
         self, is_valid: bool, n_trials: Optional[int] = None, timeout: Optional[float] = None
     ) -> None:
-        self._is_valid = is_valid
+
+        self._is_valid = is_valid and (n_trials or timeout) is not None
         self._n_trials = n_trials
         self._timeout = timeout
+        self._last_elapsed_seconds = 0.0
 
         if self._is_valid:
             self._init_valid()
@@ -50,7 +53,21 @@ class _ProgressBar(object):
     # longer experimental.
     @experimental("1.2.0", name="Progress bar")
     def _init_valid(self) -> None:
-        self._progress_bar = tqdm(range(self._n_trials) if self._n_trials is not None else None)
+
+        if self._n_trials is not None:
+            self._progress_bar = tqdm(total=self._n_trials)
+
+        else:
+            fmt = "{percentage:3.0f}%|{bar}| {elapsed}/{desc}"
+            self._progress_bar = tqdm(total=self._timeout, bar_format=fmt)
+
+            # Using description string instead postfix string
+            # to display formatted timeout, since postfix carries
+            # extra comma space auto-format.
+            # https://github.com/tqdm/tqdm/issues/712
+            total = time.strftime("%M:%S", time.gmtime(self._timeout))
+            self._progress_bar.set_description_str(total)
+
         global _tqdm_handler
 
         _tqdm_handler = _TqdmLoggingHandler()
@@ -59,22 +76,35 @@ class _ProgressBar(object):
         optuna_logging.disable_default_handler()
         optuna_logging._get_library_root_logger().addHandler(_tqdm_handler)
 
-    def update(self, elapsed_seconds: Optional[float]) -> None:
+    def update(self, elapsed_seconds: float) -> None:
         """Update the progress bars if ``is_valid`` is :obj:`True`.
 
         Args:
             elapsed_seconds:
                 The time past since :func:`~optuna.study.Study.optimize` started.
         """
+
         if self._is_valid:
-            self._progress_bar.update(1)
-            if self._timeout is not None and elapsed_seconds is not None:
-                self._progress_bar.set_postfix_str(
-                    "{:.02f}/{} seconds".format(elapsed_seconds, self._timeout)
-                )
+            if self._n_trials is not None:
+                self._progress_bar.update(1)
+                if self._timeout is not None and elapsed_seconds is not None:
+                    self._progress_bar.set_postfix_str(
+                        "{:.02f}/{} seconds".format(elapsed_seconds, self._timeout)
+                    )
+
+            else:
+                assert self._timeout is not None
+                time_diff = elapsed_seconds - self._last_elapsed_seconds
+                if elapsed_seconds > self._timeout:
+                    # Clip elapsed time to avoid tqdm warnings.
+                    time_diff -= elapsed_seconds - self._timeout
+
+                self._progress_bar.update(time_diff)
+                self._last_elapsed_seconds = elapsed_seconds
 
     def close(self) -> None:
         """Close progress bars."""
+
         if self._is_valid:
             self._progress_bar.close()
             assert _tqdm_handler is not None

--- a/optuna/progress_bar.py
+++ b/optuna/progress_bar.py
@@ -92,8 +92,7 @@ class _ProgressBar(object):
                         "{:.02f}/{} seconds".format(elapsed_seconds, self._timeout)
                     )
 
-            else:
-                assert self._timeout is not None
+            elif self._timeout is not None:
                 time_diff = elapsed_seconds - self._last_elapsed_seconds
                 if elapsed_seconds > self._timeout:
                     # Clip elapsed time to avoid tqdm warnings.
@@ -101,6 +100,9 @@ class _ProgressBar(object):
 
                 self._progress_bar.update(time_diff)
                 self._last_elapsed_seconds = elapsed_seconds
+
+            else:
+                assert False
 
     def close(self) -> None:
         """Close progress bars."""

--- a/tests/study_tests/test_study.py
+++ b/tests/study_tests/test_study.py
@@ -725,6 +725,7 @@ def test_optimize_with_progbar_timeout(capsys: _pytest.capture.CaptureFixture) -
         (60.0, "/01:00"),
         (60.0 * 60, "/1:00:00"),
         (60.0 * 60 * 24, "/24:00:00"),
+        (60.0 * 60 * 24 * 10, "/240:00:00"),
     ],
 )
 def test_optimize_with_progbar_timeout_formats(

--- a/tests/study_tests/test_study.py
+++ b/tests/study_tests/test_study.py
@@ -718,6 +718,29 @@ def test_optimize_with_progbar_timeout(capsys: _pytest.capture.CaptureFixture) -
     assert "100%" in err
 
 
+@pytest.mark.parametrize(
+    "timeout,expected",
+    [
+        (59.0, "/00:59"),
+        (60.0, "/01:00"),
+        (60.0 * 60, "/1:00:00"),
+        (60.0 * 60 * 24, "/24:00:00"),
+    ],
+)
+def test_optimize_with_progbar_timeout_formats(
+    timeout: float, expected: str, capsys: _pytest.capture.CaptureFixture
+) -> None:
+    def _objective(trial: Trial) -> float:
+        if trial.number == 5:
+            trial.study.stop()
+        return 1.0
+
+    study = create_study()
+    study.optimize(_objective, timeout=timeout, show_progress_bar=True)
+    _, err = capsys.readouterr()
+    assert expected in err
+
+
 def test_optimize_without_progbar_timeout(capsys: _pytest.capture.CaptureFixture) -> None:
 
     study = create_study()

--- a/tests/study_tests/test_study.py
+++ b/tests/study_tests/test_study.py
@@ -708,6 +708,54 @@ def test_optimize_without_progbar(capsys: _pytest.capture.CaptureFixture) -> Non
     assert "100%" not in err
 
 
+def test_optimize_with_progbar_timeout(capsys: _pytest.capture.CaptureFixture) -> None:
+
+    study = create_study()
+    study.optimize(lambda _: 1.0, timeout=2.0, show_progress_bar=True)
+    _, err = capsys.readouterr()
+
+    assert "00:02/00:02" in err
+    assert "100%" in err
+
+
+def test_optimize_without_progbar_timeout(capsys: _pytest.capture.CaptureFixture) -> None:
+
+    study = create_study()
+    study.optimize(lambda _: 1.0, timeout=2.0)
+    _, err = capsys.readouterr()
+
+    assert "00:02/00:02" not in err
+    assert "100%" not in err
+
+
+def test_optimize_progbar_n_trials_prioritized(capsys: _pytest.capture.CaptureFixture) -> None:
+
+    study = create_study()
+    study.optimize(lambda _: 1.0, n_trials=10, timeout=10.0, show_progress_bar=True)
+    _, err = capsys.readouterr()
+
+    assert "10/10" in err
+    assert "100%" in err
+    assert "it" in err
+
+
+def test_optimize_progbar_no_constraints(capsys: _pytest.capture.CaptureFixture) -> None:
+
+    def _objective(trial: Trial) -> float:
+        if trial.number == 5:
+            trial.study.stop()
+        return 1.0
+
+    study = create_study()
+    study.optimize(_objective, show_progress_bar=True)
+    _, err = capsys.readouterr()
+
+    # We can't simply test if stderr is empty, since we're not sure
+    # what else could write to it. Instead, we are testing for a character
+    # that forms progress bar borders.
+    assert "|" not in err
+
+
 def test_optimize_with_progbar_parallel(capsys: _pytest.capture.CaptureFixture) -> None:
 
     study = create_study()

--- a/tests/study_tests/test_study.py
+++ b/tests/study_tests/test_study.py
@@ -740,7 +740,6 @@ def test_optimize_progbar_n_trials_prioritized(capsys: _pytest.capture.CaptureFi
 
 
 def test_optimize_progbar_no_constraints(capsys: _pytest.capture.CaptureFixture) -> None:
-
     def _objective(trial: Trial) -> float:
         if trial.number == 5:
             trial.study.stop()


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
This PR makes progress bar functional when optimization is being limited by `timeout` rather than `n_trials`.  In this case, bar represents percentage of allocated time already spend on optimization. Formatted elapsed time and timeout are also displayed. This implementation will prioritize `n_trials` when both `n_trials` and `timeout` are specified. Closes #2958

## Description of the changes
<!-- Describe the changes in this PR. -->
* Show progress bar based on `timeout`
* Write tests

## Examples

### `timeout` specified

![Peek 2021-11-28 11-55](https://user-images.githubusercontent.com/37713008/143765183-fea4aa09-8773-4822-85b1-f52e1050be49.gif)

### `n_trials` specified (same as current master)

![Peek 2021-11-28 11-58](https://user-images.githubusercontent.com/37713008/143765211-826a95f2-5442-4101-baf1-84d5a6df6034.gif)

### Both `n_trials` and `timeout` specified (`n_trials` takes priority)

![Peek 2021-11-28 12-00](https://user-images.githubusercontent.com/37713008/143765256-a06eb031-cb79-41ce-a903-e8697a4e2294.gif)

### Neither `n_trials` nor `timeout` specified (progress bar automatically disabled)

![Peek 2021-11-28 12-02](https://user-images.githubusercontent.com/37713008/143765284-0729f2af-ec73-4fef-bc10-28754c261ff9.gif)