### PR TITLE
Fix documentation for the package installation procedure on different OS

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -139,7 +139,7 @@ Please install some required packages at first.
 pip install ".[tests]"
 
 # Install required packages to test all modules including visualization and integration modules.
-pip install ".[testing]"
+pip install ".[testing]" -f https://download.pytorch.org/whl/torch_stable.html
 ```
 
 You can run your tests as follows:


### PR DESCRIPTION
## Motivation
On Ubuntu 20.04, the command
```
sudo pip install ".[testing]"
```
causes trailing error.
```
ERROR: Could not find a version that satisfies the requirement torchvision==0.9.0+cpu; sys_platform != "darwin" and extra == "testing" (from optuna==3.0.0a1.dev0) (from versions: 0.1.6, 0.1.7, 0.1.8, 0.1.9, 0.2.0, 0.2.1, 0.2.2, 0.2.2.post2, 0.2.2.post3, 0.5.0, 0.6.0, 0.6.1, 0.7.0, 0.8.0, 0.8.1, 0.8.2, 0.9.0, 0.9.1, 0.10.0, 0.10.1, 0.11.0, 0.11.1)
ERROR: No matching distribution found for torchvision==0.9.0+cpu; sys_platform != "darwin" and extra == "testing" (from optuna==3.0.0a1.dev0)
```

By official document of pytorch <https://pytorch.org/get-started/previous-versions> the ```-f``` option is not required for mac, but it can be installed even if the option is enabled, so we well enable it for all platforms.

Signed-off-by: Masashi Honma <masashi.honma@gmail.com>

## Description of the changes
This PR fix the document.