### PR TITLE
Add tests for axis scales to `matplotlib.plot_slice`

### DIFF
--- a/tests/visualization_tests/matplotlib_tests/test_slice.py
+++ b/tests/visualization_tests/matplotlib_tests/test_slice.py
@@ -81,12 +81,13 @@ def test_plot_slice_log_scale() -> None:
 
     # Plot a parameter.
     figure = plot_slice(study, params=["y_log"])
-
     assert len(figure.get_lines()) == 0
     assert figure.xaxis.label.get_text() == "y_log"
+    assert figure.xaxis.get_scale() == "log"
     figure = plot_slice(study, params=["x_linear"])
     assert len(figure.get_lines()) == 0
     assert figure.xaxis.label.get_text() == "x_linear"
+    assert figure.xaxis.get_scale() == "linear"
 
     # Plot multiple parameters.
     figure = plot_slice(study)
@@ -95,3 +96,5 @@ def test_plot_slice_log_scale() -> None:
     assert len(figure[1].get_lines()) == 0
     assert figure[0].xaxis.label.get_text() == "x_linear"
     assert figure[1].xaxis.label.get_text() == "y_log"
+    assert figure[0].xaxis.get_scale() == "linear"
+    assert figure[1].xaxis.get_scale() == "log"


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

A part of https://github.com/optuna/optuna/issues/2959.

Improve tests of `matplotlib.plot_slice` by following plotly plot, more specifically the following scale test: https://github.com/optuna/optuna/blob/c4ebc0394f3996720b8cd0829edfa8630d1b99c1/tests/visualization_tests/test_slice.py#L86

## Description of the changes
<!-- Describe the changes in this PR. -->

Add test to check log param scales.

---

### References
- https://matplotlib.org/stable/api/_as_gen/matplotlib.axes.Axes.set_yscale.html
- https://matplotlib.org/stable/api/_as_gen/matplotlib.axes.Axes.get_yscale.html