### PR TITLE
Support error bar for matplotlib

### DIFF
--- a/optuna/visualization/matplotlib/_optimization_history.py
+++ b/optuna/visualization/matplotlib/_optimization_history.py
@@ -134,7 +134,8 @@ def _get_optimization_history_plot(
         ax = _get_optimization_histories_with_error_bar(studies, target, target_name, ax)
     else:
         ax = _get_optimization_histories(studies, target, target_name, ax)
-        plt.legend(bbox_to_anchor=(1.05, 1.0), loc="upper left")
+
+    plt.legend(bbox_to_anchor=(1.05, 1.0), loc="upper left")
     return ax
 
 

--- a/optuna/visualization/matplotlib/_optimization_history.py
+++ b/optuna/visualization/matplotlib/_optimization_history.py
@@ -172,9 +172,9 @@ def _get_optimization_histories_with_error_bar(
         for t in trials:
             target_values[t.number].append(_target(t))
 
-    mean_of_target_values = [np.mean(v) if len(v) > 0 else None for v in target_values]
-    std_of_target_values = [np.std(v) if len(v) > 0 else None for v in target_values]
-    trial_numbers = np.arange(max_trial_number + 2)[[v is not None for v in mean_of_target_values]]
+    mean_of_target_values = [np.mean(v) if len(v) > 0 else np.nan for v in target_values]
+    std_of_target_values = [np.std(v) if len(v) > 0 else np.nan for v in target_values]
+    trial_numbers = np.arange(max_trial_number + 2)[[v is not np.nan for v in mean_of_target_values]]
     means = np.asarray(mean_of_target_values)[trial_numbers]
     stds = np.asarray(std_of_target_values)[trial_numbers]
 
@@ -200,16 +200,16 @@ def _get_optimization_histories_with_error_bar(
             for i, t in enumerate(trials):
                 best_values[t.number].append(best_vs[i])
 
-        mean_of_best_values = [np.mean(v) if len(v) > 0 else None for v in best_values]
-        std_of_best_values = [np.std(v) if len(v) > 0 else None for v in best_values]
+        mean_of_best_values = [np.mean(v) if len(v) > 0 else np.nan for v in best_values]
+        std_of_best_values = [np.std(v) if len(v) > 0 else np.nan for v in best_values]
         means = np.asarray(mean_of_best_values)[trial_numbers]
         stds = np.asarray(std_of_best_values)[trial_numbers]
 
         ax.plot(trial_numbers, means, color="tab:red", label="Best Value")
         ax.fill_between(
             x=trial_numbers,
-            y1=np.array(means - stds, float),
-            y2=np.array(means + stds, float),
+            y1=means - stds,
+            y2=means + stds,
             color="tab:red",
             alpha=0.4,
         )

--- a/optuna/visualization/matplotlib/_optimization_history.py
+++ b/optuna/visualization/matplotlib/_optimization_history.py
@@ -174,7 +174,9 @@ def _get_optimization_histories_with_error_bar(
 
     mean_of_target_values = [np.mean(v) if len(v) > 0 else np.nan for v in target_values]
     std_of_target_values = [np.std(v) if len(v) > 0 else np.nan for v in target_values]
-    trial_numbers = np.arange(max_trial_number + 2)[[v is not np.nan for v in mean_of_target_values]]
+    trial_numbers = np.arange(max_trial_number + 2)[
+        [v is not np.nan for v in mean_of_target_values]
+    ]
     means = np.asarray(mean_of_target_values)[trial_numbers]
     stds = np.asarray(std_of_target_values)[trial_numbers]
 

--- a/optuna/visualization/matplotlib/_optimization_history.py
+++ b/optuna/visualization/matplotlib/_optimization_history.py
@@ -198,7 +198,7 @@ def _get_optimization_histories_with_error_bar(
             if study.direction == StudyDirection.MINIMIZE:
                 best_vs = np.minimum.accumulate([cast(float, t.values) for t in trials])
             else:
-                best_vs = np.miximum.accumulate([cast(float, t.values) for t in trials])
+                best_vs = np.maximum.accumulate([cast(float, t.values) for t in trials])
 
             for i, t in enumerate(trials):
                 best_values[t.number].append(best_vs[i])

--- a/optuna/visualization/matplotlib/_optimization_history.py
+++ b/optuna/visualization/matplotlib/_optimization_history.py
@@ -77,6 +77,9 @@ def plot_optimization_history(
         target_name:
             Target's name to display on the axis label and the legend.
 
+        error_bar:
+            A flag to show the error bar.
+
     Returns:
         A :class:`matplotlib.axes.Axes` object.
 
@@ -154,7 +157,7 @@ def _get_optimization_histories_with_error_bar(
         ]
     )
 
-    _target: Callable[[FrozenTrial,], float]
+    _target: Callable[[FrozenTrial], float]
     if target is None:
 
         def _target(t: FrozenTrial) -> float:
@@ -184,7 +187,6 @@ def _get_optimization_histories_with_error_bar(
         color="tab:blue",
     )
     ax.scatter(trial_numbers, means, color="tab:blue", label=target_name)
-
 
     if target is None:
         best_values: List[List[float]] = [[] for _ in range(max_trial_number + 2)]

--- a/optuna/visualization/matplotlib/_optimization_history.py
+++ b/optuna/visualization/matplotlib/_optimization_history.py
@@ -154,12 +154,7 @@ def _get_optimization_histories_with_error_bar(
         ]
     )
 
-    _target: Callable[
-        [
-            FrozenTrial,
-        ],
-        float,
-    ]
+    _target: Callable[[FrozenTrial,], float]
     if target is None:
 
         def _target(t: FrozenTrial) -> float:
@@ -190,9 +185,9 @@ def _get_optimization_histories_with_error_bar(
     )
     ax.scatter(trial_numbers, means, color="tab:blue", label=target_name)
 
-    best_values: List[List[float]] = [[] for _ in range(max_trial_number + 2)]
 
     if target is None:
+        best_values: List[List[float]] = [[] for _ in range(max_trial_number + 2)]
         for study in studies:
             trials = study.get_trials(states=(TrialState.COMPLETE,))
             if study.direction == StudyDirection.MINIMIZE:

--- a/optuna/visualization/matplotlib/_optimization_history.py
+++ b/optuna/visualization/matplotlib/_optimization_history.py
@@ -188,11 +188,11 @@ def _get_optimization_histories_with_error_bar(
         fmt="o",
         color="tab:blue",
     )
-    plt.scatter(trial_numbers, means, color="tab:blue", label="Object Value")
+    ax.scatter(trial_numbers, means, color="tab:blue", label=target_name)
+
+    best_values: List[List[float]] = [[] for _ in range(max_trial_number + 2)]
 
     if target is None:
-        best_values: List[List[float]] = [[] for _ in range(max_trial_number + 2)]
-
         for study in studies:
             trials = study.get_trials(states=(TrialState.COMPLETE,))
             if study.direction == StudyDirection.MINIMIZE:

--- a/tests/visualization_tests/matplotlib_tests/test_optimization_history.py
+++ b/tests/visualization_tests/matplotlib_tests/test_optimization_history.py
@@ -147,7 +147,7 @@ def test_plot_optimization_history_with_error_bar(direction: str) -> None:
     assert len(figure.get_lines()) == 4
 
     legend_texts = [legend.get_text() for legend in figure.legend().get_texts()]
-    assert sorted(legend_texts) == sorted(["Best Value", "Objective Value"])
+    assert sorted(legend_texts) == ["Best Value", "Objective Value"]
 
     # Test customized target.
     with pytest.warns(UserWarning):
@@ -157,7 +157,7 @@ def test_plot_optimization_history_with_error_bar(direction: str) -> None:
     # Test customized target name.
     figure = plot_optimization_history(studies, target_name="Target Name", error_bar=True)
     legend_texts = [legend.get_text() for legend in figure.legend().get_texts()]
-    assert sorted(legend_texts) == sorted(["Best Value", "Target Name"])
+    assert sorted(legend_texts) == ["Best Value", "Target Name"]
 
     # Ignore failed trials.
     def fail_objective(_: Trial) -> float:

--- a/tests/visualization_tests/matplotlib_tests/test_optimization_history.py
+++ b/tests/visualization_tests/matplotlib_tests/test_optimization_history.py
@@ -145,7 +145,7 @@ def test_plot_optimization_history_with_error_bar(direction: str) -> None:
         study.optimize(objective, n_trials=3)
     figure = plot_optimization_history(studies, error_bar=True)
     assert len(figure.get_lines()) == 4
-    
+
     legend_texts = [legend.get_text() for legend in figure.legend().get_texts()]
     assert legend_texts[0] == "Best Value"
     assert legend_texts[1] == "Objective Value"

--- a/tests/visualization_tests/matplotlib_tests/test_optimization_history.py
+++ b/tests/visualization_tests/matplotlib_tests/test_optimization_history.py
@@ -118,3 +118,56 @@ def test_plot_optimization_history_with_multiple_studies(direction: str) -> None
 
     figure = plot_optimization_history(studies)
     assert len(figure.get_lines()) == 0
+
+
+@pytest.mark.parametrize("direction", ["minimize", "maximize"])
+def test_plot_optimization_history_with_error_bar(direction: str) -> None:
+    n_studies = 10
+
+    # Test with no trial.
+    studies = [create_study(direction=direction) for _ in range(n_studies)]
+    figure = plot_optimization_history(studies, error_bar=True)
+    assert len(figure.get_lines()) == 0
+
+    def objective(trial: Trial) -> float:
+
+        if trial.number == 0:
+            return 1.0
+        elif trial.number == 1:
+            return 2.0
+        elif trial.number == 2:
+            return 0.0
+        return 0.0
+
+    # Test with trials.
+    studies = [create_study(direction=direction) for _ in range(n_studies)]
+    for study in studies:
+        study.optimize(objective, n_trials=3)
+    figure = plot_optimization_history(studies, error_bar=True)
+    assert len(figure.get_lines()) == 4
+    
+    legend_texts = [legend.get_text() for legend in figure.legend().get_texts()]
+    assert legend_texts[0] == "Best Value"
+    assert legend_texts[1] == "Objective Value"
+
+    # Test customized target.
+    with pytest.warns(UserWarning):
+        figure = plot_optimization_history(studies, target=lambda t: t.number, error_bar=True)
+    assert len(figure.get_lines()) == 3
+
+    # Test customized target name.
+    figure = plot_optimization_history(studies, target_name="Target Name", error_bar=True)
+    legend_texts = [legend.get_text() for legend in figure.legend().get_texts()]
+    assert legend_texts[0] == "Best Value"
+    assert legend_texts[1] == "Target Name"
+
+    # Ignore failed trials.
+    def fail_objective(_: Trial) -> float:
+        raise ValueError
+
+    studies = [create_study(direction=direction) for _ in range(n_studies)]
+    for study in studies:
+        study.optimize(fail_objective, n_trials=1, catch=(ValueError,))
+
+    figure = plot_optimization_history(studies, error_bar=True)
+    assert len(figure.get_lines()) == 0

--- a/tests/visualization_tests/matplotlib_tests/test_optimization_history.py
+++ b/tests/visualization_tests/matplotlib_tests/test_optimization_history.py
@@ -147,8 +147,7 @@ def test_plot_optimization_history_with_error_bar(direction: str) -> None:
     assert len(figure.get_lines()) == 4
 
     legend_texts = [legend.get_text() for legend in figure.legend().get_texts()]
-    assert legend_texts[0] == "Best Value"
-    assert legend_texts[1] == "Objective Value"
+    assert sorted(legend_texts) == sorted(["Best Value", "Objective Value"])
 
     # Test customized target.
     with pytest.warns(UserWarning):
@@ -158,8 +157,7 @@ def test_plot_optimization_history_with_error_bar(direction: str) -> None:
     # Test customized target name.
     figure = plot_optimization_history(studies, target_name="Target Name", error_bar=True)
     legend_texts = [legend.get_text() for legend in figure.legend().get_texts()]
-    assert legend_texts[0] == "Best Value"
-    assert legend_texts[1] == "Target Name"
+    assert sorted(legend_texts) == sorted(["Best Value", "Target Name"])
 
     # Ignore failed trials.
     def fail_objective(_: Trial) -> float:


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
For consistency,  We want to use error bars with matplotlib. Please check also https://github.com/optuna/optuna/issues/3020.

## Description of the changes
<!-- Describe the changes in this PR. -->
Implement 
I have modified the logic introduced by #2807 that can be used for matplotlib.

## Examples
```python
import matplotlib.pyplot as plt
import optuna


def objective(trial):
    return trial.suggest_float("x", 0, 1) ** 2


n_studies = 5
studies = [optuna.create_study() for _ in range(n_studies)]
for study in studies:
    study.optimize(objective, n_trials=20)

plt.figure()
fig = optuna.visualization.matplotlib.plot_optimization_history(studies, error_bar=True)
plt.savefig("./error_bar.png", bbox_layout='tight')

```

![download](https://user-images.githubusercontent.com/49433901/143730661-16d17cc5-3583-4acf-9a7d-0e6ae2e26cea.png)

