### PR TITLE
Refactor pareto front and support `constraints_func` in `plot_pareto_front`

### DIFF
--- a/optuna/study/_multi_objective.py
+++ b/optuna/study/_multi_objective.py
@@ -9,9 +9,9 @@ from optuna.trial import TrialState
 
 
 def _get_pareto_front_trials_2d(
-    orig_trials: List[FrozenTrial], directions: List[StudyDirection]
+    trials: List[FrozenTrial], directions: List[StudyDirection]
 ) -> List[FrozenTrial]:
-    trials = [trial for trial in orig_trials if trial.state == TrialState.COMPLETE]
+    trials = [trial for trial in trials if trial.state == TrialState.COMPLETE]
 
     n_trials = len(trials)
     if n_trials == 0:
@@ -38,10 +38,10 @@ def _get_pareto_front_trials_2d(
 
 
 def _get_pareto_front_trials_nd(
-    orig_trials: List[FrozenTrial], directions: List[StudyDirection]
+    trials: List[FrozenTrial], directions: List[StudyDirection]
 ) -> List[FrozenTrial]:
     pareto_front = []
-    trials = [t for t in orig_trials if t.state == TrialState.COMPLETE]
+    trials = [t for t in trials if t.state == TrialState.COMPLETE]
 
     # TODO(vincent): Optimize (use the fast non dominated sort defined in the NSGA-II paper).
     for trial in trials:

--- a/optuna/study/_multi_objective.py
+++ b/optuna/study/_multi_objective.py
@@ -9,7 +9,7 @@ from optuna.trial import TrialState
 
 
 def _get_pareto_front_trials_2d(
-    trials: List[FrozenTrial], directions: List[StudyDirection]
+    trials: Sequence[FrozenTrial], directions: Sequence[StudyDirection]
 ) -> List[FrozenTrial]:
     trials = [trial for trial in trials if trial.state == TrialState.COMPLETE]
 
@@ -38,7 +38,7 @@ def _get_pareto_front_trials_2d(
 
 
 def _get_pareto_front_trials_nd(
-    trials: List[FrozenTrial], directions: List[StudyDirection]
+    trials: Sequence[FrozenTrial], directions: Sequence[StudyDirection]
 ) -> List[FrozenTrial]:
     pareto_front = []
     trials = [t for t in trials if t.state == TrialState.COMPLETE]
@@ -58,7 +58,7 @@ def _get_pareto_front_trials_nd(
 
 
 def _get_pareto_front_trials_by_trials(
-    trials: List[FrozenTrial], directions: List[StudyDirection]
+    trials: Sequence[FrozenTrial], directions: Sequence[StudyDirection]
 ) -> List[FrozenTrial]:
     if len(directions) == 2:
         return _get_pareto_front_trials_2d(trials, directions)  # Log-linear in number of trials.

--- a/optuna/study/_multi_objective.py
+++ b/optuna/study/_multi_objective.py
@@ -8,8 +8,10 @@ from optuna.trial import FrozenTrial
 from optuna.trial import TrialState
 
 
-def _get_pareto_front_trials_2d(study: "optuna.study.Study") -> List[FrozenTrial]:
-    trials = [trial for trial in study.trials if trial.state == TrialState.COMPLETE]
+def _get_pareto_front_trials_2d(
+    orig_trials: List[FrozenTrial], directions: List[StudyDirection]
+) -> List[FrozenTrial]:
+    trials = [trial for trial in orig_trials if trial.state == TrialState.COMPLETE]
 
     n_trials = len(trials)
     if n_trials == 0:
@@ -17,8 +19,8 @@ def _get_pareto_front_trials_2d(study: "optuna.study.Study") -> List[FrozenTrial
 
     trials.sort(
         key=lambda trial: (
-            _normalize_value(trial.values[0], study.directions[0]),
-            _normalize_value(trial.values[1], study.directions[1]),
+            _normalize_value(trial.values[0], directions[0]),
+            _normalize_value(trial.values[1], directions[1]),
         ),
     )
 
@@ -26,7 +28,7 @@ def _get_pareto_front_trials_2d(study: "optuna.study.Study") -> List[FrozenTrial
     pareto_front = [last_nondominated_trial]
     for i in range(1, n_trials):
         trial = trials[i]
-        if _dominates(last_nondominated_trial, trial, study.directions):
+        if _dominates(last_nondominated_trial, trial, directions):
             continue
         pareto_front.append(trial)
         last_nondominated_trial = trial
@@ -35,15 +37,17 @@ def _get_pareto_front_trials_2d(study: "optuna.study.Study") -> List[FrozenTrial
     return pareto_front
 
 
-def _get_pareto_front_trials_nd(study: "optuna.study.Study") -> List[FrozenTrial]:
+def _get_pareto_front_trials_nd(
+    orig_trials: List[FrozenTrial], directions: List[StudyDirection]
+) -> List[FrozenTrial]:
     pareto_front = []
-    trials = [t for t in study.trials if t.state == TrialState.COMPLETE]
+    trials = [t for t in orig_trials if t.state == TrialState.COMPLETE]
 
     # TODO(vincent): Optimize (use the fast non dominated sort defined in the NSGA-II paper).
     for trial in trials:
         dominated = False
         for other in trials:
-            if _dominates(other, trial, study.directions):
+            if _dominates(other, trial, directions):
                 dominated = True
                 break
 
@@ -53,10 +57,16 @@ def _get_pareto_front_trials_nd(study: "optuna.study.Study") -> List[FrozenTrial
     return pareto_front
 
 
+def _get_pareto_front_trials_by_trials(
+    trials: List[FrozenTrial], directions: List[StudyDirection]
+) -> List[FrozenTrial]:
+    if len(directions) == 2:
+        return _get_pareto_front_trials_2d(trials, directions)  # Log-linear in number of trials.
+    return _get_pareto_front_trials_nd(trials, directions)  # Quadratic in number of trials.
+
+
 def _get_pareto_front_trials(study: "optuna.study.Study") -> List[FrozenTrial]:
-    if len(study.directions) == 2:
-        return _get_pareto_front_trials_2d(study)  # Log-linear in number of trials.
-    return _get_pareto_front_trials_nd(study)  # Quadratic in number of trials.
+    return _get_pareto_front_trials_by_trials(study.trials, study.directions)
 
 
 def _dominates(

--- a/optuna/visualization/_pareto_front.py
+++ b/optuna/visualization/_pareto_front.py
@@ -75,7 +75,7 @@ def plot_pareto_front(
             be a sequence of :obj:`float` s. A value strictly larger than 0 means that a
             constraint is violated. A value equal to or smaller than 0 is considered feasible.
             This specification is the same as in, for example,
-            :class:`~optuna.integration.BoTorchSampler`.
+            :class:`~optuna.integration.NSGAIISampler`.
 
             If given, trials are classified into three categories: feasible and best, feasible but
             non-best, and infeasible. Categories are shown in different colors. Here, whether a
@@ -103,12 +103,8 @@ def plot_pareto_front(
     if constraints_func is not None:
         feasible_trials = []
         infeasible_trials = []
-        for trial in study.trials:
-            if trial.state != TrialState.COMPLETE:
-                continue
-            constraint_score = constraints_func(trial)
-            is_feasible = all(map(lambda x: x <= 0.0, constraint_score))
-            if is_feasible:
+        for trial in study.get_trials(states=(TrialState.COMPLETE,)):
+            if all(map(lambda x: x <= 0.0, constraints_func(trial))):
                 feasible_trials.append(trial)
             else:
                 infeasible_trials.append(trial)

--- a/optuna/visualization/_pareto_front.py
+++ b/optuna/visualization/_pareto_front.py
@@ -152,7 +152,7 @@ def plot_pareto_front(
         hovertemplate: str,
         name: Optional[str] = None,
         color: Optional[str] = None,
-        dominated_samples: bool = False,
+        dominated_trials: bool = False,
     ) -> Union["go.Scatter", "go.Scatter3d"]:
         return _make_scatter_object_base(
             n_dim,
@@ -162,7 +162,7 @@ def plot_pareto_front(
             hovertemplate=hovertemplate,
             name=name,
             color=color,
-            dominated_samples=dominated_samples,
+            dominated_trials=dominated_trials,
         )
 
     if constraints_func is None:
@@ -170,12 +170,12 @@ def plot_pareto_front(
             _make_scatter_object(
                 non_best_trials,
                 hovertemplate="%{text}<extra>Trial</extra>",
-                dominated_samples=True,
+                dominated_trials=True,
             ),
             _make_scatter_object(
                 best_trials,
                 hovertemplate="%{text}<extra>Best Trial</extra>",
-                dominated_samples=False,
+                dominated_trials=False,
             ),
         ]
     else:
@@ -183,19 +183,19 @@ def plot_pareto_front(
             _make_scatter_object(
                 infeasible_trials,
                 hovertemplate="%{text}<extra>Infeasible</extra>",
-                name="infeasible",
+                name="Infeasible",
                 color="grey",
             ),
             _make_scatter_object(
                 non_best_trials,
                 hovertemplate="%{text}<extra>Non-best feasible</extra>",
-                name="non-best feasible",
+                name="Non-best feasible",
                 color="blue",
             ),
             _make_scatter_object(
                 best_trials,
                 hovertemplate="%{text}<extra>Best feasible</extra>",
-                name="best feasible",
+                name="Best feasible",
                 color="red",
             ),
         ]
@@ -246,14 +246,14 @@ def _make_scatter_object_base(
     hovertemplate: str,
     name: Optional[str] = None,
     color: Optional[str] = None,
-    dominated_samples: bool = False,
+    dominated_trials: bool = False,
 ) -> Union["go.Scatter", "go.Scatter3d"]:
     assert n_dim in (2, 3)
     marker = _make_marker(
         trials,
         include_dominated_trials,
         use_constraints_func=name is not None,
-        dominated_samples=dominated_samples,
+        dominated_trials=dominated_trials,
         color=color,
     )
     if n_dim == 2:
@@ -301,14 +301,20 @@ def _make_marker(
     trials: List[FrozenTrial],
     include_dominated_trials: bool,
     use_constraints_func: bool,
-    dominated_samples: bool = False,
+    dominated_trials: bool = False,
     color: Optional[str] = None,
 ) -> Dict[str, Any]:
-    if dominated_samples and not include_dominated_trials:
+    if dominated_trials and not include_dominated_trials:
         assert len(trials) == 0
 
-    if not use_constraints_func:
-        if dominated_samples:
+    if use_constraints_func:
+        assert color is not None
+        return {
+            "line": {"width": 0.5, "color": "Grey"},
+            "color": color,
+        }
+    else:
+        if dominated_trials:
             return {
                 "line": {"width": 0.5, "color": "Grey"},
                 "color": [t.number for t in trials],
@@ -328,9 +334,3 @@ def _make_marker(
                     "xpad": 40,
                 },
             }
-    else:
-        assert color is not None
-        return {
-            "line": {"width": 0.5, "color": "Grey"},
-            "color": color,
-        }

--- a/optuna/visualization/_pareto_front.py
+++ b/optuna/visualization/_pareto_front.py
@@ -79,7 +79,7 @@ def plot_pareto_front(
 
             If given, trials are classified into three categories: feasible and best, feasible but
             non-best, and infeasible. Categories are shown in different colors. Here, whether a
-            trial is best (on pareto front) or not is determined ignoring all infeasible trials.
+            trial is best (on Pareto front) or not is determined ignoring all infeasible trials.
 
     Returns:
         A :class:`plotly.graph_objs.Figure` object.
@@ -122,7 +122,9 @@ def plot_pareto_front(
             _logger.warning("Your study does not have any completed trials.")
 
         if include_dominated_trials:
-            non_best_trials = _get_non_pareto_front_trials(study.get_trials(), best_trials)
+            non_best_trials = _get_non_pareto_front_trials(
+                study.get_trials(deepcopy=False), best_trials
+            )
         else:
             non_best_trials = []
         infeasible_trials = []
@@ -148,7 +150,7 @@ def plot_pareto_front(
             )
 
     def _make_scatter_object(
-        trials: List[FrozenTrial],
+        trials: Sequence[FrozenTrial],
         hovertemplate: str,
         name: Optional[str] = None,
         color: Optional[str] = None,
@@ -182,20 +184,20 @@ def plot_pareto_front(
         data = [
             _make_scatter_object(
                 infeasible_trials,
-                hovertemplate="%{text}<extra>Infeasible</extra>",
-                name="Infeasible",
+                hovertemplate="%{text}<extra>Infeasible Trial</extra>",
+                name="Infeasible Trial",
                 color="grey",
             ),
             _make_scatter_object(
                 non_best_trials,
-                hovertemplate="%{text}<extra>Non-best feasible</extra>",
-                name="Non-best feasible",
+                hovertemplate="%{text}<extra>Feasible Trial</extra>",
+                name="Feasible Trial",
                 color="blue",
             ),
             _make_scatter_object(
                 best_trials,
-                hovertemplate="%{text}<extra>Best feasible</extra>",
-                name="Best feasible",
+                hovertemplate="%{text}<extra>Best Trial</extra>",
+                name="Best Trial",
                 color="red",
             ),
         ]
@@ -240,7 +242,7 @@ def _make_json_compatible(value: Any) -> Any:
 
 def _make_scatter_object_base(
     n_dim: int,
-    trials: List[FrozenTrial],
+    trials: Sequence[FrozenTrial],
     axis_order: List[int],
     include_dominated_trials: bool,
     hovertemplate: str,
@@ -298,7 +300,7 @@ def _make_hovertext(trial: FrozenTrial) -> str:
 
 
 def _make_marker(
-    trials: List[FrozenTrial],
+    trials: Sequence[FrozenTrial],
     include_dominated_trials: bool,
     use_constraints_func: bool,
     dominated_trials: bool = False,

--- a/tests/test_multi_objective.py
+++ b/tests/test_multi_objective.py
@@ -13,60 +13,88 @@ def _trial_to_values(t: FrozenTrial) -> Tuple[float, ...]:
 
 def test_get_pareto_front_trials_2d() -> None:
     study = create_study(directions=["minimize", "maximize"])
-    assert {_trial_to_values(t) for t in _get_pareto_front_trials_2d(study)} == set()
+    assert {
+        _trial_to_values(t) for t in _get_pareto_front_trials_2d(study.trials, study.directions)
+    } == set()
 
     study.optimize(lambda t: [2, 2], n_trials=1)
-    assert {_trial_to_values(t) for t in _get_pareto_front_trials_2d(study)} == {(2, 2)}
+    assert {
+        _trial_to_values(t) for t in _get_pareto_front_trials_2d(study.trials, study.directions)
+    } == {(2, 2)}
 
     study.optimize(lambda t: [1, 1], n_trials=1)
-    assert {_trial_to_values(t) for t in _get_pareto_front_trials_2d(study)} == {(1, 1), (2, 2)}
+    assert {
+        _trial_to_values(t) for t in _get_pareto_front_trials_2d(study.trials, study.directions)
+    } == {(1, 1), (2, 2)}
 
     study.optimize(lambda t: [3, 1], n_trials=1)
-    assert {_trial_to_values(t) for t in _get_pareto_front_trials_2d(study)} == {(1, 1), (2, 2)}
+    assert {
+        _trial_to_values(t) for t in _get_pareto_front_trials_2d(study.trials, study.directions)
+    } == {(1, 1), (2, 2)}
 
     study.optimize(lambda t: [3, 2], n_trials=1)
-    assert {_trial_to_values(t) for t in _get_pareto_front_trials_2d(study)} == {(1, 1), (2, 2)}
+    assert {
+        _trial_to_values(t) for t in _get_pareto_front_trials_2d(study.trials, study.directions)
+    } == {(1, 1), (2, 2)}
 
     study.optimize(lambda t: [1, 3], n_trials=1)
-    assert {_trial_to_values(t) for t in _get_pareto_front_trials_2d(study)} == {(1, 3)}
-    assert len(_get_pareto_front_trials_2d(study)) == 1
+    assert {
+        _trial_to_values(t) for t in _get_pareto_front_trials_2d(study.trials, study.directions)
+    } == {(1, 3)}
+    assert len(_get_pareto_front_trials_2d(study.trials, study.directions)) == 1
 
     study.optimize(lambda t: [1, 3], n_trials=1)  # The trial result is the same as the above one.
-    assert {_trial_to_values(t) for t in _get_pareto_front_trials_2d(study)} == {(1, 3)}
-    assert len(_get_pareto_front_trials_2d(study)) == 2
+    assert {
+        _trial_to_values(t) for t in _get_pareto_front_trials_2d(study.trials, study.directions)
+    } == {(1, 3)}
+    assert len(_get_pareto_front_trials_2d(study.trials, study.directions)) == 2
 
 
 def test_get_pareto_front_trials_nd() -> None:
     study = create_study(directions=["minimize", "maximize", "minimize"])
-    assert {_trial_to_values(t) for t in _get_pareto_front_trials_nd(study)} == set()
+    assert {
+        _trial_to_values(t) for t in _get_pareto_front_trials_nd(study.trials, study.directions)
+    } == set()
 
     study.optimize(lambda t: [2, 2, 2], n_trials=1)
-    assert {_trial_to_values(t) for t in _get_pareto_front_trials_nd(study)} == {(2, 2, 2)}
+    assert {
+        _trial_to_values(t) for t in _get_pareto_front_trials_nd(study.trials, study.directions)
+    } == {(2, 2, 2)}
 
     study.optimize(lambda t: [1, 1, 1], n_trials=1)
-    assert {_trial_to_values(t) for t in _get_pareto_front_trials_nd(study)} == {
+    assert {
+        _trial_to_values(t) for t in _get_pareto_front_trials_nd(study.trials, study.directions)
+    } == {
         (1, 1, 1),
         (2, 2, 2),
     }
 
     study.optimize(lambda t: [3, 1, 3], n_trials=1)
-    assert {_trial_to_values(t) for t in _get_pareto_front_trials_nd(study)} == {
+    assert {
+        _trial_to_values(t) for t in _get_pareto_front_trials_nd(study.trials, study.directions)
+    } == {
         (1, 1, 1),
         (2, 2, 2),
     }
 
     study.optimize(lambda t: [3, 2, 3], n_trials=1)
-    assert {_trial_to_values(t) for t in _get_pareto_front_trials_nd(study)} == {
+    assert {
+        _trial_to_values(t) for t in _get_pareto_front_trials_nd(study.trials, study.directions)
+    } == {
         (1, 1, 1),
         (2, 2, 2),
     }
 
     study.optimize(lambda t: [1, 3, 1], n_trials=1)
-    assert {_trial_to_values(t) for t in _get_pareto_front_trials_nd(study)} == {(1, 3, 1)}
-    assert len(_get_pareto_front_trials_nd(study)) == 1
+    assert {
+        _trial_to_values(t) for t in _get_pareto_front_trials_nd(study.trials, study.directions)
+    } == {(1, 3, 1)}
+    assert len(_get_pareto_front_trials_nd(study.trials, study.directions)) == 1
 
     study.optimize(
         lambda t: [1, 3, 1], n_trials=1
     )  # The trial result is the same as the above one.
-    assert {_trial_to_values(t) for t in _get_pareto_front_trials_nd(study)} == {(1, 3, 1)}
-    assert len(_get_pareto_front_trials_nd(study)) == 2
+    assert {
+        _trial_to_values(t) for t in _get_pareto_front_trials_nd(study.trials, study.directions)
+    } == {(1, 3, 1)}
+    assert len(_get_pareto_front_trials_nd(study.trials, study.directions)) == 2

--- a/tests/visualization_tests/test_pareto_front.py
+++ b/tests/visualization_tests/test_pareto_front.py
@@ -25,9 +25,9 @@ def _check_data(figure: "go.Figure", axis: str, expected: Sequence[int]) -> None
     the `expected` result.
 
     Args:
-        figure (:class:`go.Figure`): A figure.
-        axis (str): The axis to be checked.
-        expected (Sequence[int]): The expected result.
+        figure: A figure.
+        axis: The axis to be checked.
+        expected: The expected result.
     """
 
     n_data = len(figure.data)

--- a/tests/visualization_tests/test_pareto_front.py
+++ b/tests/visualization_tests/test_pareto_front.py
@@ -167,7 +167,7 @@ def test_plot_pareto_front_3d(
         def constraints_func(t: FrozenTrial) -> Sequence[float]:
             return (
                 [1.0]
-                if t.params["x"] == 1 and t.params["x"] == 1 and t.params["y"] == 0
+                if t.params["x"] == 1 and t.params["y"] == 1 and t.params["z"] == 0
                 else [-1.0]
             )
 
@@ -180,7 +180,7 @@ def test_plot_pareto_front_3d(
         axis_order=axis_order,
         constraints_func=constraints_func,
     )
-    actual_axis_order = axis_order or [0, 1]
+    actual_axis_order = axis_order or [0, 1, 2]
     if use_constraints_func:
         assert len(figure.data) == 3
         if include_dominated_trials:

--- a/tests/visualization_tests/test_pareto_front.py
+++ b/tests/visualization_tests/test_pareto_front.py
@@ -34,11 +34,12 @@ def test_plot_pareto_front_2d(
     assert (figure.data[1]["x"] + figure.data[0]["x"]) == ()
     assert (figure.data[1]["y"] + figure.data[0]["y"]) == ()
 
-    # Test with three trials.
+    # Test with four trials.
+    study.enqueue_trial({"x": 1, "y": 2})
     study.enqueue_trial({"x": 1, "y": 1})
+    study.enqueue_trial({"x": 0, "y": 2})
     study.enqueue_trial({"x": 1, "y": 0})
-    study.enqueue_trial({"x": 0, "y": 1})
-    study.optimize(lambda t: [t.suggest_int("x", 0, 1), t.suggest_int("y", 0, 1)], n_trials=3)
+    study.optimize(lambda t: [t.suggest_int("x", 0, 2), t.suggest_int("y", 0, 2)], n_trials=4)
 
     constraints_func: Optional[Callable[[FrozenTrial], Sequence[float]]]
     if use_constraints_func:
@@ -62,7 +63,7 @@ def test_plot_pareto_front_2d(
         assert len(figure.data) == 3
         if include_dominated_trials:
             # The enqueue order of trial is: infeasible, feasible non-best, then feasible best.
-            data = [(0, 1, 1), (1, 1, 0)]  # type: ignore
+            data = [(1, 0, 1, 1), (1, 2, 2, 0)]  # type: ignore
             if axis_order is None:
                 assert (figure.data[2]["x"] + figure.data[1]["x"] + figure.data[0]["x"]) == data[0]
                 assert (figure.data[2]["y"] + figure.data[1]["y"] + figure.data[0]["y"]) == data[1]
@@ -75,7 +76,7 @@ def test_plot_pareto_front_2d(
                 ]
         else:
             # The enqueue order of trial is: infeasible, feasible.
-            data = [(0, 1), (1, 0)]  # type: ignore
+            data = [(1, 0, 1), (1, 2, 0)]  # type: ignore
             if axis_order is None:
                 assert (figure.data[2]["x"] + figure.data[1]["x"] + figure.data[0]["x"]) == data[0]
                 assert (figure.data[2]["y"] + figure.data[1]["y"] + figure.data[0]["y"]) == data[1]
@@ -90,7 +91,7 @@ def test_plot_pareto_front_2d(
         assert len(figure.data) == 2
         if include_dominated_trials:
             # The last elements come from dominated trial that is enqueued firstly.
-            data = [(1, 0, 1), (0, 1, 1)]  # type: ignore
+            data = [(0, 1, 1, 1), (2, 0, 2, 1)]  # type: ignore
             if axis_order is None:
                 assert (figure.data[1]["x"] + figure.data[0]["x"]) == data[0]
                 assert (figure.data[1]["y"] + figure.data[0]["y"]) == data[1]
@@ -98,7 +99,7 @@ def test_plot_pareto_front_2d(
                 assert (figure.data[1]["x"] + figure.data[0]["x"]) == data[axis_order[0]]
                 assert (figure.data[1]["y"] + figure.data[0]["y"]) == data[axis_order[1]]
         else:
-            data = [(1, 0), (0, 1)]  # type: ignore
+            data = [(0, 1), (2, 0)]  # type: ignore
             if axis_order is None:
                 assert (figure.data[1]["x"] + figure.data[0]["x"]) == data[0]
                 assert (figure.data[1]["y"] + figure.data[0]["y"]) == data[1]
@@ -170,19 +171,20 @@ def test_plot_pareto_front_3d(
     assert (figure.data[1]["z"] + figure.data[0]["z"]) == ()
 
     # Test with three trials.
+    study.enqueue_trial({"x": 1, "y": 1, "z": 2})
     study.enqueue_trial({"x": 1, "y": 1, "z": 1})
-    study.enqueue_trial({"x": 1, "y": 0, "z": 1})
+    study.enqueue_trial({"x": 1, "y": 0, "z": 2})
     study.enqueue_trial({"x": 1, "y": 1, "z": 0})
     study.optimize(
-        lambda t: [t.suggest_int("x", 0, 1), t.suggest_int("y", 0, 1), t.suggest_int("z", 0, 1)],
-        n_trials=3,
+        lambda t: [t.suggest_int("x", 0, 1), t.suggest_int("y", 0, 2), t.suggest_int("z", 0, 2)],
+        n_trials=4,
     )
 
     constraints_func: Optional[Callable[[FrozenTrial], Sequence[float]]]
     if use_constraints_func:
         # (x, y, z) = (1, 0, 1) is infeasible; others are feasible.
         def constraints_func(t: FrozenTrial) -> Sequence[float]:
-            if t.params["x"] == 1 and t.params["y"] == 0 and t.params["z"] == 1:
+            if t.params["x"] == 1 and t.params["y"] == 1 and t.params["z"] == 0:
                 return [1.0]
             else:
                 return [-1.0]
@@ -200,7 +202,7 @@ def test_plot_pareto_front_3d(
         assert len(figure.data) == 3
         if include_dominated_trials:
             # The enqueue order of trial is: infeasible, feasible non-best, then feasible best.
-            data = [(1, 1, 1), (1, 1, 0), (0, 1, 1)]  # type: ignore
+            data = [(1, 1, 1, 1), (1, 0, 1, 1), (1, 2, 2, 0)]  # type: ignore
             if axis_order is None:
                 assert (figure.data[2]["x"] + figure.data[1]["x"] + figure.data[0]["x"]) == data[0]
                 assert (figure.data[2]["y"] + figure.data[1]["y"] + figure.data[0]["y"]) == data[1]
@@ -217,7 +219,7 @@ def test_plot_pareto_front_3d(
                 ]
         else:
             # The enqueue order of trial is: infeasible, feasible.
-            data = [(1, 1), (1, 0), (0, 1)]  # type: ignore
+            data = [(1, 1, 1), (1, 0, 1), (1, 2, 0)]  # type: ignore
             if axis_order is None:
                 assert (figure.data[2]["x"] + figure.data[1]["x"] + figure.data[0]["x"]) == data[0]
                 assert (figure.data[2]["y"] + figure.data[1]["y"] + figure.data[0]["y"]) == data[1]
@@ -236,7 +238,7 @@ def test_plot_pareto_front_3d(
         assert len(figure.data) == 2
         if include_dominated_trials:
             # The last elements come from dominated trial that is enqueued firstly.
-            data = [(1, 1, 1), (0, 1, 1), (1, 0, 1)]  # type: ignore
+            data = [(1, 1, 1, 1), (0, 1, 1, 1), (2, 0, 2, 1)]  # type: ignore
             if axis_order is None:
                 assert (figure.data[1]["x"] + figure.data[0]["x"]) == data[0]
                 assert (figure.data[1]["y"] + figure.data[0]["y"]) == data[1]
@@ -246,7 +248,7 @@ def test_plot_pareto_front_3d(
                 assert (figure.data[1]["y"] + figure.data[0]["y"]) == data[axis_order[1]]
                 assert (figure.data[1]["z"] + figure.data[0]["z"]) == data[axis_order[2]]
         else:
-            data = [(1, 1), (0, 1), (1, 0)]  # type: ignore
+            data = [(1, 1), (0, 1), (2, 0)]  # type: ignore
             if axis_order is None:
                 assert (figure.data[1]["x"] + figure.data[0]["x"]) == data[0]
                 assert (figure.data[1]["y"] + figure.data[0]["y"]) == data[1]

--- a/tests/visualization_tests/test_pareto_front.py
+++ b/tests/visualization_tests/test_pareto_front.py
@@ -65,10 +65,7 @@ def test_plot_pareto_front_2d(
     if use_constraints_func:
         # (x, y) = (1, 0) is infeasible; others are feasible.
         def constraints_func(t: FrozenTrial) -> Sequence[float]:
-            if t.params["x"] == 1 and t.params["y"] == 0:
-                return [1.0]
-            else:
-                return [-1.0]
+            return [1.0] if t.params["x"] == 1 and t.params["y"] == 0 else [-1.0]
 
     else:
         constraints_func = None
@@ -166,12 +163,13 @@ def test_plot_pareto_front_3d(
 
     constraints_func: Optional[Callable[[FrozenTrial], Sequence[float]]]
     if use_constraints_func:
-        # (x, y, z) = (1, 0, 1) is infeasible; others are feasible.
+        # (x, y, z) = (1, 1, 0) is infeasible; others are feasible.
         def constraints_func(t: FrozenTrial) -> Sequence[float]:
-            if t.params["x"] == 1 and t.params["y"] == 1 and t.params["z"] == 0:
-                return [1.0]
-            else:
-                return [-1.0]
+            return (
+                [1.0]
+                if t.params["x"] == 1 and t.params["x"] == 1 and t.params["y"] == 0
+                else [-1.0]
+            )
 
     else:
         constraints_func = None
@@ -201,7 +199,7 @@ def test_plot_pareto_front_3d(
 
     _check_data(figure, "x", data[actual_axis_order[0]])
     _check_data(figure, "y", data[actual_axis_order[1]])
-    _check_data(figure, "z", data[actual_axis_order[1]])
+    _check_data(figure, "z", data[actual_axis_order[2]])
 
     titles = ["Objective {}".format(i) for i in range(3)]
     assert figure.layout.scene.xaxis.title.text == titles[actual_axis_order[0]]


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
Implementation in #3125 is repetitious (10 times of `go.Scatter` and `go.Scatter3d` in total), so it will be desirable to be refactored. This refactoring is strongly tied with the enhancement of `plot_pareto_front`, so I did both in this PR.

## Description of the changes

- Fused `_get_pareto_front_2d` and `_get_pareto_front_3d`.
- Added helper function `_make_scatter_object_base` and used it in `plot_pareto_front` because each invocation of `go.Scatter` and `go.Scatter3d` shares several parameters in common.
- I added `constraints_func` property to plot_parent_front so that infeasible trials can be explicitly marked in case of training with objective constraints. Infeasible trials are excluded from the computation of pareto front.
  - I added `_get_pareto_front_trials_by_trials` to `_multi_objective.py` so that we don't have to create another `Study` in order to compute the pareto front of a part of trials in a `Study`.