### PR TITLE
Avoid installing the latest MLfow to prevent doctests from failing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ def get_extras_require() -> Dict[str, List[str]]:
             "plotly>=4.0.0",
             "scikit-learn>=0.24.2",
             "scikit-optimize",
-            "mlflow",
+            "mlflow==1.22.0",
         ],
         "document": [
             # TODO(nzw): Remove the version constraint after resolving the issue
@@ -89,7 +89,7 @@ def get_extras_require() -> Dict[str, List[str]]:
             "fakeredis",
             "lightgbm",
             "matplotlib>=3.0.0",
-            "mlflow",
+            "mlflow==1.22.0",
             "mpi4py",
             "mxnet",
             "pandas",
@@ -131,7 +131,7 @@ def get_extras_require() -> Dict[str, List[str]]:
             "chainer>=5.0.0",
             "cma",
             "lightgbm",
-            "mlflow",
+            "mlflow==1.22.0",
             "wandb",
             "mpi4py",
             "mxnet",

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ def get_extras_require() -> Dict[str, List[str]]:
             "plotly>=4.0.0",
             "scikit-learn>=0.24.2",
             "scikit-optimize",
-            "mlflow==1.22.0",
+            "mlflow<1.22.0",
         ],
         "document": [
             # TODO(nzw): Remove the version constraint after resolving the issue
@@ -89,7 +89,7 @@ def get_extras_require() -> Dict[str, List[str]]:
             "fakeredis",
             "lightgbm",
             "matplotlib>=3.0.0",
-            "mlflow==1.22.0",
+            "mlflow<1.22.0",
             "mpi4py",
             "mxnet",
             "pandas",
@@ -131,7 +131,7 @@ def get_extras_require() -> Dict[str, List[str]]:
             "chainer>=5.0.0",
             "cma",
             "lightgbm",
-            "mlflow==1.22.0",
+            "mlflow<1.22.0",
             "wandb",
             "mpi4py",
             "mxnet",


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
Although I haven't investigated the cause yet, the doctest was failing with the latest MLflow.
https://github.com/optuna/optuna/runs/4368455449?check_suite_focus=true

I confirmed the problem doesn't occur with MLflow v1.21.0.
https://github.com/optuna/optuna/runs/4368582442?check_suite_focus=true
So, as a tentative patch, I introduce the version constraint.

## Description of the changes
<!-- Describe the changes in this PR. -->
