### PR TITLE
Add a note logging_callback only works in single process situation

### DIFF
--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -373,7 +373,7 @@ Here's an example:
     study = optuna.create_study()
     study.optimize(objective, n_trials=100, callbacks=[logging_callback])
 
-Note that this callback may show incorrect values when you try to optimize an objective function with `n_jobs!=1`
+Note that this callback may show incorrect values when you try to optimize an objective function with ``n_jobs!=1``
 (or other forms of distributed optimization) due to its reads and writes to storage that are prone to race conditions.
 
 How do I suggest variables which represent the proportion, that is, are in accordance with Dirichlet distribution?

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -373,6 +373,8 @@ Here's an example:
     study = optuna.create_study()
     study.optimize(objective, n_trials=100, callbacks=[logging_callback])
 
+Note that this callback would not work as expected when you try to optimize a objective function with `n_jobs>1`.
+
 How do I suggest variables which represent the proportion, that is, are in accordance with Dirichlet distribution?
 ------------------------------------------------------------------------------------------------------------------
 

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -373,7 +373,8 @@ Here's an example:
     study = optuna.create_study()
     study.optimize(objective, n_trials=100, callbacks=[logging_callback])
 
-Note that this callback would not work as expected when you try to optimize a objective function with `n_jobs>1`.
+Note that this callback may show incorrect values when you try to optimize an objective function with `n_jobs!=1`
+(or other forms of distributed optimization) due to its reads and writes to storage that are prone to race conditions.
 
 How do I suggest variables which represent the proportion, that is, are in accordance with Dirichlet distribution?
 ------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
🔗 https://github.com/optuna/optuna/issues/3134

## Motivation
This PR adds a note to FAQ that `logging_callback` doesn't work as expected with `n_jobs>1`.
