### PR TITLE
Add `skip_if_finished` flag to `Study.tell`

### DIFF
--- a/optuna/cli.py
+++ b/optuna/cli.py
@@ -865,22 +865,12 @@ class _Tell(_BaseCommand):
         trial_number = parsed_args.trial_number
         values = parsed_args.values
 
-        # TODO(hvy): Consider introducing `skip_if_finished` to `Study.tell` and let the method
-        # do all error handling, such as invalid trial numbers.
-        if parsed_args.skip_if_finished:
-            trials = study.get_trials(deepcopy=False)
-            trial = trials[trial_number]
-            assert trial.number == trial_number
-
-            if trial.state.is_finished():
-                self.logger.info(
-                    f"Skipped telling trial {trial_number} with values "
-                    f"{values} and state {state} since trial was already finished. "
-                    f"Finished trial has values {trial.values} and state {trial.state}."
-                )
-                return 0
-
-        study.tell(trial=trial_number, values=values, state=state)
+        study.tell(
+            trial=trial_number,
+            values=values,
+            state=state,
+            skip_if_finished=parsed_args.skip_if_finished,
+        )
 
         self.logger.info(f"Told trial {trial_number} with values {values} and state " f"{state}.")
 

--- a/tests/study_tests/test_study.py
+++ b/tests/study_tests/test_study.py
@@ -1040,8 +1040,11 @@ def test_tell_duplicate_tell() -> None:
     trial = study.ask()
     study.tell(trial, 1.0)
 
+    # Should not panic when passthrough is enabled.
+    study.tell(trial, 1.0, skip_if_finished=True)
+
     with pytest.raises(RuntimeError):
-        study.tell(trial, 1.0)
+        study.tell(trial, 1.0, skip_if_finished=False)
 
 
 def test_tell_values() -> None:


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
This PR introduces new flag to `Study.tell`, allowing to skip tell without an error when trial is already finished. Closes #3146.

## Description of the changes
<!-- Describe the changes in this PR. -->
* Implemented `skip_if_finished` flag in `Study.tell`
* Not handling above logic in  `optuna tell` CLI command anymore
* Tests