### PR TITLE
Use `pytorch-lightning>=1.5.0`

### DIFF
--- a/optuna/integration/pytorch_lightning.py
+++ b/optuna/integration/pytorch_lightning.py
@@ -43,7 +43,7 @@ class PyTorchLightningPruningCallback(Callback):
 
     .. note::
         For the distributed data parallel training, the version of PyTorchLightning needs to be
-        higher than or equal to v1.4.0. In addition, :class:`~optuna.study.Study` should be
+        higher than or equal to v1.5.0. In addition, :class:`~optuna.study.Study` should be
         instantiated with RDB storage.
     """
 
@@ -56,10 +56,10 @@ class PyTorchLightningPruningCallback(Callback):
         self.is_ddp_backend = False
 
     def on_init_start(self, trainer: Trainer) -> None:
-        self.is_ddp_backend = trainer.accelerator_connector.distributed_backend is not None
+        self.is_ddp_backend = trainer._accelerator_connector.distributed_backend is not None
         if self.is_ddp_backend:
-            if version.parse(pl.__version__) < version.parse("1.4.0"):
-                raise ValueError("PyTorch Lightning>=1.4.0 is required in DDP.")
+            if version.parse(pl.__version__) < version.parse("1.5.0"):
+                raise ValueError("PyTorch Lightning>=1.5.0 is required in DDP.")
             if not isinstance(self._trial.study._storage, _CachedStorage):
                 raise ValueError(
                     "optuna.integration.PyTorchLightningPruningCallback"

--- a/setup.py
+++ b/setup.py
@@ -108,9 +108,7 @@ def get_extras_require() -> Dict[str, List[str]]:
             "tensorflow",
             "tensorflow-datasets",
             "pytorch-ignite",
-            # TODO(nzw0301): remove the upper version constraint when the callback supports
-            # pytorch-lightning==1.5.0.
-            "pytorch-lightning>=1.0.2,<1.5.0",
+            "pytorch-lightning>=1.5.0",
             "skorch",
             "catalyst>=21.3",
             "torch==1.8.0 ; sys_platform=='darwin'",
@@ -149,9 +147,7 @@ def get_extras_require() -> Dict[str, List[str]]:
             "tensorflow",
             "tensorflow-datasets",
             "pytorch-ignite",
-            # TODO(nzw0301): remove the upper version constraint when the callback supports
-            # pytorch-lightning==1.5.0.
-            "pytorch-lightning>=1.0.2,<1.5.0",
+            "pytorch-lightning>=1.5.0",
             "skorch",
             "catalyst>=21.3",
             "torch==1.8.0 ; sys_platform=='darwin'",

--- a/tests/integration_tests/test_pytorch_lightning.py
+++ b/tests/integration_tests/test_pytorch_lightning.py
@@ -98,7 +98,7 @@ def test_pytorch_lightning_pruning_callback() -> None:
 
         trainer = pl.Trainer(
             max_epochs=2,
-            checkpoint_callback=False,
+            enable_checkpointing=False,
             callbacks=[PyTorchLightningPruningCallback(trial, monitor="accuracy")],
         )
 
@@ -125,7 +125,7 @@ def test_pytorch_lightning_pruning_callback_monitor_is_invalid() -> None:
 
     trainer = pl.Trainer(
         max_epochs=1,
-        checkpoint_callback=False,
+        enable_checkpointing=False,
         callbacks=[callback],
     )
     model = Model()
@@ -144,7 +144,7 @@ def test_pytorch_lightning_pruning_callback_ddp_monitor(
             max_epochs=2,
             accelerator="ddp_cpu",
             num_processes=2,
-            checkpoint_callback=False,
+            enable_checkpointing=False,
             callbacks=[PyTorchLightningPruningCallback(trial, monitor="accuracy")],
         )
 
@@ -179,7 +179,7 @@ def test_pytorch_lightning_pruning_callback_ddp_unsupported_storage(
             max_epochs=1,
             accelerator="ddp_cpu",
             num_processes=2,
-            checkpoint_callback=False,
+            enable_checkpointing=False,
             callbacks=[PyTorchLightningPruningCallback(trial, monitor="accuracy")],
         )
 


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

Use recent PyTorch-lightning, `1.5.*` to resolve https://github.com/optuna/optuna/pull/3077.

## Description of the changes
<!-- Describe the changes in this PR. -->

- Fix the error by following https://github.com/optuna/optuna/pull/3077#pullrequestreview-796783965
- Update the PyTorch-lightning version in `setup.py` because the callback implementation does not work with `pytorch-lightning<1.5` anymore.
- Fix warning in the test: replace `checkpoint_callback` with `enable_checkpointing`