### PR TITLE
Fixes 'UnicodeDecodeError: ...' issue on Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ def get_version() -> str:
 def get_long_description() -> str:
 
     readme_filepath = os.path.join(os.path.dirname(__file__), "README.md")
-    with open(readme_filepath) as f:
+    with open(readme_filepath, encoding="utf8") as f:
         return f.read()
 
 


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
pip install from source (`pip install -e .`) throws `UnicodeDecodeError: 'charmap' codec can't decode byte` on Windows systems that use character encoding different than cp1252 ( in my case Turkish cp-1254).

## Description of the changes
 Encoding readme file with utf-8 fixes this issue.

 setup.py:
```python
 readme_filepath = os.path.join(os.path.dirname(__file__), "README.md")
    with open(readme_filepath, encoding="utf8") as f:
```
