### PR TITLE
Switch to `FloatDistribution`

### DIFF
--- a/optuna/distributions.py
+++ b/optuna/distributions.py
@@ -655,7 +655,7 @@ def json_to_distribution(json_str: str) -> BaseDistribution:
             low = json_dict["low"]
             high = json_dict["high"]
             step = json_dict.get("step")
-            log = json_dict.get("log")
+            log = json_dict.get("log", False)
 
             if json_dict["type"] == "float":
                 return FloatDistribution(low, high, log=log, step=step)

--- a/optuna/distributions.py
+++ b/optuna/distributions.py
@@ -664,12 +664,12 @@ def json_to_distribution(json_str: str) -> BaseDistribution:
                             "The parameter `step` is not supported when `log` is true."
                         )
                     else:
-                        return LogUniformDistribution(low, high)
+                        return FloatDistribution(low, high, log=True)
                 else:
                     if step is not None:
-                        return DiscreteUniformDistribution(low, high, step)
+                        return FloatDistribution(low, high, step=step)
                     else:
-                        return UniformDistribution(low, high)
+                        return FloatDistribution(low, high)
             else:
                 if log:
                     if step is not None:

--- a/optuna/distributions.py
+++ b/optuna/distributions.py
@@ -658,18 +658,8 @@ def json_to_distribution(json_str: str) -> BaseDistribution:
             log = json_dict.get("log")
 
             if json_dict["type"] == "float":
-                if log:
-                    if step is not None:
-                        raise ValueError(
-                            "The parameter `step` is not supported when `log` is true."
-                        )
-                    else:
-                        return FloatDistribution(low, high, log=True)
-                else:
-                    if step is not None:
-                        return FloatDistribution(low, high, step=step)
-                    else:
-                        return FloatDistribution(low, high)
+                return FloatDistribution(low, high, log=log, step=step)
+
             else:
                 if log:
                     if step is not None:

--- a/optuna/testing/visualization.py
+++ b/optuna/testing/visualization.py
@@ -1,5 +1,5 @@
 from optuna import Study
-from optuna.distributions import UniformDistribution
+from optuna.distributions import FloatDistribution
 from optuna.study import create_study
 from optuna.trial import create_trial
 
@@ -42,15 +42,15 @@ def prepare_study_with_trials(
             if with_c_d
             else {"param_a": 1.0, "param_b": 2.0},
             distributions={
-                "param_a": UniformDistribution(0.0, 3.0),
-                "param_b": UniformDistribution(0.0, 3.0),
-                "param_c": UniformDistribution(2.0, 5.0),
-                "param_d": UniformDistribution(2.0, 5.0),
+                "param_a": FloatDistribution(0.0, 3.0),
+                "param_b": FloatDistribution(0.0, 3.0),
+                "param_c": FloatDistribution(2.0, 5.0),
+                "param_d": FloatDistribution(2.0, 5.0),
             }
             if with_c_d
             else {
-                "param_a": UniformDistribution(0.0, 3.0),
-                "param_b": UniformDistribution(0.0, 3.0),
+                "param_a": FloatDistribution(0.0, 3.0),
+                "param_b": FloatDistribution(0.0, 3.0),
             },
         )
     )
@@ -59,11 +59,11 @@ def prepare_study_with_trials(
             values=[2.0] * n_objectives,
             params={"param_b": 0.0, "param_d": 4.0} if with_c_d else {"param_b": 0.0},
             distributions={
-                "param_b": UniformDistribution(0.0, 3.0),
-                "param_d": UniformDistribution(2.0, 5.0),
+                "param_b": FloatDistribution(0.0, 3.0),
+                "param_d": FloatDistribution(2.0, 5.0),
             }
             if with_c_d
-            else {"param_b": UniformDistribution(0.0, 3.0)},
+            else {"param_b": FloatDistribution(0.0, 3.0)},
         )
     )
     if less_than_two:
@@ -76,15 +76,15 @@ def prepare_study_with_trials(
             if with_c_d
             else {"param_a": 2.5, "param_b": 1.0},
             distributions={
-                "param_a": UniformDistribution(0.0, 3.0),
-                "param_b": UniformDistribution(0.0, 3.0),
-                "param_c": UniformDistribution(2.0, 5.0),
-                "param_d": UniformDistribution(2.0, 5.0),
+                "param_a": FloatDistribution(0.0, 3.0),
+                "param_b": FloatDistribution(0.0, 3.0),
+                "param_c": FloatDistribution(2.0, 5.0),
+                "param_d": FloatDistribution(2.0, 5.0),
             }
             if with_c_d
             else {
-                "param_a": UniformDistribution(0.0, 3.0),
-                "param_b": UniformDistribution(0.0, 3.0),
+                "param_a": FloatDistribution(0.0, 3.0),
+                "param_b": FloatDistribution(0.0, 3.0),
             },
         )
     )
@@ -97,15 +97,15 @@ def prepare_study_with_trials(
                 if with_c_d
                 else {"param_a": 0.5, "param_b": 1.5},
                 distributions={
-                    "param_a": UniformDistribution(0.0, 3.0),
-                    "param_b": UniformDistribution(0.0, 3.0),
-                    "param_c": UniformDistribution(2.0, 5.0),
-                    "param_d": UniformDistribution(2.0, 5.0),
+                    "param_a": FloatDistribution(0.0, 3.0),
+                    "param_b": FloatDistribution(0.0, 3.0),
+                    "param_c": FloatDistribution(2.0, 5.0),
+                    "param_d": FloatDistribution(2.0, 5.0),
                 }
                 if with_c_d
                 else {
-                    "param_a": UniformDistribution(0.0, 3.0),
-                    "param_b": UniformDistribution(0.0, 3.0),
+                    "param_a": FloatDistribution(0.0, 3.0),
+                    "param_b": FloatDistribution(0.0, 3.0),
                 },
             )
         )

--- a/optuna/trial/_fixed.py
+++ b/optuna/trial/_fixed.py
@@ -78,16 +78,7 @@ class FixedTrial(BaseTrial):
         log: bool = False,
     ) -> float:
 
-        if step is not None:
-            if log:
-                raise ValueError("The parameter `step` is not supported when `log` is True.")
-            else:
-                return self._suggest(name, FloatDistribution(low=low, high=high, step=step))
-        else:
-            if log:
-                return self._suggest(name, FloatDistribution(low=low, high=high, log=True))
-            else:
-                return self._suggest(name, FloatDistribution(low=low, high=high))
+        return self._suggest(name, FloatDistribution(low, high, log=log, step=step))
 
     @deprecated("3.0.0", "6.0.0", text=_suggest_deprecated_msg)
     def suggest_uniform(self, name: str, low: float, high: float) -> float:

--- a/optuna/trial/_fixed.py
+++ b/optuna/trial/_fixed.py
@@ -11,11 +11,9 @@ from optuna._deprecated import deprecated
 from optuna.distributions import BaseDistribution
 from optuna.distributions import CategoricalChoiceType
 from optuna.distributions import CategoricalDistribution
-from optuna.distributions import DiscreteUniformDistribution
+from optuna.distributions import FloatDistribution
 from optuna.distributions import IntLogUniformDistribution
 from optuna.distributions import IntUniformDistribution
-from optuna.distributions import LogUniformDistribution
-from optuna.distributions import UniformDistribution
 from optuna.trial._base import BaseTrial
 
 
@@ -84,12 +82,12 @@ class FixedTrial(BaseTrial):
             if log:
                 raise ValueError("The parameter `step` is not supported when `log` is True.")
             else:
-                return self._suggest(name, DiscreteUniformDistribution(low=low, high=high, q=step))
+                return self._suggest(name, FloatDistribution(low=low, high=high, step=step))
         else:
             if log:
-                return self._suggest(name, LogUniformDistribution(low=low, high=high))
+                return self._suggest(name, FloatDistribution(low=low, high=high, log=True))
             else:
-                return self._suggest(name, UniformDistribution(low=low, high=high))
+                return self._suggest(name, FloatDistribution(low=low, high=high))
 
     @deprecated("3.0.0", "6.0.0", text=_suggest_deprecated_msg)
     def suggest_uniform(self, name: str, low: float, high: float) -> float:

--- a/optuna/trial/_frozen.py
+++ b/optuna/trial/_frozen.py
@@ -223,16 +223,7 @@ class FrozenTrial(BaseTrial):
         log: bool = False,
     ) -> float:
 
-        if step is not None:
-            if log:
-                raise ValueError("The parameter `step` is not supported when `log` is True.")
-            else:
-                return self._suggest(name, FloatDistribution(low=low, high=high, step=step))
-        else:
-            if log:
-                return self._suggest(name, FloatDistribution(low=low, high=high, log=True))
-            else:
-                return self._suggest(name, FloatDistribution(low=low, high=high))
+        return self._suggest(name, FloatDistribution(low, high, log=log, step=step))
 
     @deprecated("3.0.0", "6.0.0", text=_suggest_deprecated_msg)
     def suggest_uniform(self, name: str, low: float, high: float) -> float:

--- a/optuna/trial/_frozen.py
+++ b/optuna/trial/_frozen.py
@@ -13,11 +13,9 @@ from optuna._deprecated import deprecated
 from optuna._experimental import experimental
 from optuna.distributions import BaseDistribution
 from optuna.distributions import CategoricalDistribution
-from optuna.distributions import DiscreteUniformDistribution
+from optuna.distributions import FloatDistribution
 from optuna.distributions import IntLogUniformDistribution
 from optuna.distributions import IntUniformDistribution
-from optuna.distributions import LogUniformDistribution
-from optuna.distributions import UniformDistribution
 from optuna.trial._base import BaseTrial
 from optuna.trial._state import TrialState
 
@@ -229,12 +227,12 @@ class FrozenTrial(BaseTrial):
             if log:
                 raise ValueError("The parameter `step` is not supported when `log` is True.")
             else:
-                return self._suggest(name, DiscreteUniformDistribution(low=low, high=high, q=step))
+                return self._suggest(name, FloatDistribution(low=low, high=high, step=step))
         else:
             if log:
-                return self._suggest(name, LogUniformDistribution(low=low, high=high))
+                return self._suggest(name, FloatDistribution(low=low, high=high, log=True))
             else:
-                return self._suggest(name, UniformDistribution(low=low, high=high))
+                return self._suggest(name, FloatDistribution(low=low, high=high))
 
     @deprecated("3.0.0", "6.0.0", text=_suggest_deprecated_msg)
     def suggest_uniform(self, name: str, low: float, high: float) -> float:

--- a/optuna/trial/_trial.py
+++ b/optuna/trial/_trial.py
@@ -15,11 +15,9 @@ from optuna._deprecated import deprecated
 from optuna.distributions import BaseDistribution
 from optuna.distributions import CategoricalChoiceType
 from optuna.distributions import CategoricalDistribution
-from optuna.distributions import DiscreteUniformDistribution
+from optuna.distributions import FloatDistribution
 from optuna.distributions import IntLogUniformDistribution
 from optuna.distributions import IntUniformDistribution
-from optuna.distributions import LogUniformDistribution
-from optuna.distributions import UniformDistribution
 from optuna.trial._base import BaseTrial
 
 
@@ -159,14 +157,12 @@ class Trial(BaseTrial):
             if log:
                 raise ValueError("The parameter `step` is not supported when `log` is True.")
             else:
-                distribution: Union[
-                    DiscreteUniformDistribution, LogUniformDistribution, UniformDistribution
-                ] = DiscreteUniformDistribution(low=low, high=high, q=step)
+                distribution = FloatDistribution(low=low, high=high, step=step)
         else:
             if log:
-                distribution = LogUniformDistribution(low=low, high=high)
+                distribution = FloatDistribution(low=low, high=high, log=True)
             else:
-                distribution = UniformDistribution(low=low, high=high)
+                distribution = FloatDistribution(low=low, high=high)
 
         self._check_distribution(name, distribution)
 

--- a/optuna/trial/_trial.py
+++ b/optuna/trial/_trial.py
@@ -153,17 +153,7 @@ class Trial(BaseTrial):
             :ref:`configurations` tutorial describes more details and flexible usages.
         """
 
-        if step is not None:
-            if log:
-                raise ValueError("The parameter `step` is not supported when `log` is True.")
-            else:
-                distribution = FloatDistribution(low=low, high=high, step=step)
-        else:
-            if log:
-                distribution = FloatDistribution(low=low, high=high, log=True)
-            else:
-                distribution = FloatDistribution(low=low, high=high)
-
+        distribution = FloatDistribution(low, high, log=log, step=step)
         self._check_distribution(name, distribution)
 
         return self._suggest(name, distribution)

--- a/tests/integration_tests/test_chainermn.py
+++ b/tests/integration_tests/test_chainermn.py
@@ -223,8 +223,8 @@ class TestChainerMNStudy(object):
     def test_relative_sampling(storage_mode: str, comm: CommunicatorBase) -> None:
 
         relative_search_space = {
-            "x": distributions.UniformDistribution(low=-10, high=10),
-            "y": distributions.LogUniformDistribution(low=20, high=30),
+            "x": distributions.FloatDistribution(low=-10, high=10),
+            "y": distributions.FloatDistribution(low=20, high=30, log=True),
             "z": distributions.CategoricalDistribution(choices=(-1.0, 1.0)),
         }
         relative_params = {"x": 1.0, "y": 25.0, "z": -1.0}
@@ -298,8 +298,8 @@ class TestChainerMNTrial(object):
 
                 assert x1 == x2
 
-                with pytest.raises(ValueError):
-                    mn_trial.suggest_loguniform("x1", low1, high1)
+                # Adding a parameter should not cause any errors.
+                mn_trial.suggest_float("x1", low1, high1, log=True)
 
             low2 = 1e-7
             high2 = 1e-2
@@ -309,52 +309,11 @@ class TestChainerMNTrial(object):
                 x3 = mn_trial.suggest_float("x2", low2, high2, log=True)
                 assert low2 <= x3 <= high2
 
-                x4 = mn_trial.suggest_loguniform("x2", low2, high2)
-
+                x4 = mn_trial.suggest_float("x2", low2, high2, log=True)
                 assert x3 == x4
 
-                with pytest.raises(ValueError):
-                    mn_trial.suggest_float("x2", low2, high2)
-
-    @staticmethod
-    @pytest.mark.parametrize("storage_mode", STORAGE_MODES)
-    def test_suggest_uniform(storage_mode: str, comm: CommunicatorBase) -> None:
-
-        with MultiNodeStorageSupplier(storage_mode, comm) as storage:
-            study = TestChainerMNStudy._create_shared_study(storage, comm)
-            low = 0.5
-            high = 1.0
-            for _ in range(10):
-                mn_trial = _create_new_chainermn_trial(study, comm)
-
-                x1 = mn_trial.suggest_float("x", low, high)
-                assert low <= x1 <= high
-
-                x2 = mn_trial.suggest_float("x", low, high)
-                assert x1 == x2
-
-                with pytest.raises(ValueError):
-                    mn_trial.suggest_loguniform("x", low, high)
-
-    @staticmethod
-    @pytest.mark.parametrize("storage_mode", STORAGE_MODES)
-    def test_suggest_loguniform(storage_mode: str, comm: CommunicatorBase) -> None:
-
-        with MultiNodeStorageSupplier(storage_mode, comm) as storage:
-            study = TestChainerMNStudy._create_shared_study(storage, comm)
-            low = 1e-7
-            high = 1e-2
-            for _ in range(10):
-                mn_trial = _create_new_chainermn_trial(study, comm)
-
-                x1 = mn_trial.suggest_loguniform("x", low, high)
-                assert low <= x1 <= high
-
-                x2 = mn_trial.suggest_loguniform("x", low, high)
-                assert x1 == x2
-
-                with pytest.raises(ValueError):
-                    mn_trial.suggest_float("x", low, high)
+                # Neither should changing.
+                mn_trial.suggest_float("x2", low2, high2)
 
     @staticmethod
     @pytest.mark.parametrize("storage_mode", STORAGE_MODES)
@@ -364,18 +323,17 @@ class TestChainerMNTrial(object):
             study = TestChainerMNStudy._create_shared_study(storage, comm)
             low = 0.0
             high = 10.0
-            q = 1.0
+            step = 1.0
             for _ in range(10):
                 mn_trial = _create_new_chainermn_trial(study, comm)
 
-                x1 = mn_trial.suggest_discrete_uniform("x", low, high, q)
+                x1 = mn_trial.suggest_float("x", low, high, step=step)
                 assert low <= x1 <= high
 
-                x2 = mn_trial.suggest_discrete_uniform("x", low, high, q)
+                x2 = mn_trial.suggest_float("x", low, high, step=step)
                 assert x1 == x2
 
-                with pytest.raises(ValueError):
-                    mn_trial.suggest_float("x", low, high)
+                mn_trial.suggest_float("x", low, high)
 
     @staticmethod
     @pytest.mark.parametrize("storage_mode", STORAGE_MODES)

--- a/tests/integration_tests/test_mlflow.py
+++ b/tests/integration_tests/test_mlflow.py
@@ -82,11 +82,11 @@ def test_study_name(tmpdir: py.path.local) -> None:
     assert first_run_dict["data"]["tags"]["state"] == "COMPLETE"
     assert (
         first_run_dict["data"]["tags"]["x_distribution"]
-        == "UniformDistribution(high=1.0, low=-1.0)"
+        == "FloatDistribution(high=1.0, log=False, low=-1.0, step=None)"
     )
     assert (
         first_run_dict["data"]["tags"]["y_distribution"]
-        == "LogUniformDistribution(high=30.0, low=20.0)"
+        == "FloatDistribution(high=30.0, log=True, low=20.0, step=None)"
     )
     assert (
         first_run_dict["data"]["tags"]["z_distribution"]
@@ -522,7 +522,7 @@ def test_log_params(tmpdir: py.path.local) -> None:
             params=params,
             distributions={
                 param1_name: optuna.distributions.CategoricalDistribution(["a", "b"]),
-                param2_name: optuna.distributions.UniformDistribution(0, 10),
+                param2_name: optuna.distributions.FloatDistribution(0, 10),
             },
             value=5.0,
         )

--- a/tests/integration_tests/test_pytorch_distributed.py
+++ b/tests/integration_tests/test_pytorch_distributed.py
@@ -328,9 +328,9 @@ def test_distributions(storage_mode: str) -> None:
         trial.suggest_categorical("c", ("a", "b", "c"))
 
         distributions = trial.distributions
-        assert distributions["u"] == optuna.distributions.UniformDistribution(0, 1)
-        assert distributions["lu"] == optuna.distributions.LogUniformDistribution(1e-7, 1)
-        assert distributions["du"] == optuna.distributions.DiscreteUniformDistribution(0, 1, 0.5)
+        assert distributions["u"] == optuna.distributions.FloatDistribution(0, 1)
+        assert distributions["lu"] == optuna.distributions.FloatDistribution(1e-7, 1, log=True)
+        assert distributions["du"] == optuna.distributions.FloatDistribution(0, 1, step=0.5)
         assert distributions["i"] == optuna.distributions.IntUniformDistribution(0, 1)
         assert distributions["il"] == optuna.distributions.IntLogUniformDistribution(1, 128)
         assert distributions["c"] == optuna.distributions.CategoricalDistribution(("a", "b", "c"))

--- a/tests/integration_tests/test_sklearn.py
+++ b/tests/integration_tests/test_sklearn.py
@@ -47,7 +47,7 @@ def test_optuna_search(enable_pruning: bool, fit_params: str) -> None:
 
     X, y = make_blobs(n_samples=10)
     est = SGDClassifier(max_iter=5, tol=1e-03)
-    param_dist = {"alpha": distributions.LogUniformDistribution(1e-04, 1e03)}
+    param_dist = {"alpha": distributions.FloatDistribution(1e-04, 1e03, log=True)}
     optuna_search = integration.OptunaSearchCV(
         est,
         param_dist,
@@ -78,7 +78,7 @@ def test_optuna_search_properties() -> None:
 
     X, y = make_blobs(n_samples=10)
     est = LogisticRegression(tol=1e-03)
-    param_dist = {"C": distributions.LogUniformDistribution(1e-04, 1e03)}
+    param_dist = {"C": distributions.FloatDistribution(1e-04, 1e03, log=True)}
 
     optuna_search = integration.OptunaSearchCV(
         est, param_dist, cv=3, error_score="raise", random_state=0, return_train_score=True

--- a/tests/integration_tests/test_skopt.py
+++ b/tests/integration_tests/test_skopt.py
@@ -87,19 +87,19 @@ def test_is_compatible() -> None:
 
     study.optimize(lambda t: t.suggest_float("p0", 0, 10), n_trials=1)
     search_space = optuna.samplers.intersection_search_space(study)
-    assert search_space == {"p0": distributions.UniformDistribution(low=0, high=10)}
+    assert search_space == {"p0": distributions.FloatDistribution(low=0, high=10)}
 
     optimizer = optuna.integration.skopt._Optimizer(search_space, {})
 
     # Compatible.
     trial = _create_frozen_trial(
-        {"p0": 5}, {"p0": distributions.UniformDistribution(low=0, high=10)}
+        {"p0": 5}, {"p0": distributions.FloatDistribution(low=0, high=10)}
     )
     assert optimizer._is_compatible(trial)
 
     # Compatible.
     trial = _create_frozen_trial(
-        {"p0": 5}, {"p0": distributions.UniformDistribution(low=0, high=100)}
+        {"p0": 5}, {"p0": distributions.FloatDistribution(low=0, high=100)}
     )
     assert optimizer._is_compatible(trial)
 
@@ -107,21 +107,21 @@ def test_is_compatible() -> None:
     trial = _create_frozen_trial(
         {"p0": 5, "p1": 7},
         {
-            "p0": distributions.UniformDistribution(low=0, high=10),
-            "p1": distributions.UniformDistribution(low=0, high=10),
+            "p0": distributions.FloatDistribution(low=0, high=10),
+            "p1": distributions.FloatDistribution(low=0, high=10),
         },
     )
     assert optimizer._is_compatible(trial)
 
     # Incompatible ('p0' doesn't exist).
     trial = _create_frozen_trial(
-        {"p1": 5}, {"p1": distributions.UniformDistribution(low=0, high=10)}
+        {"p1": 5}, {"p1": distributions.FloatDistribution(low=0, high=10)}
     )
     assert not optimizer._is_compatible(trial)
 
     # Incompatible (the value of 'p0' is out of range).
     trial = _create_frozen_trial(
-        {"p0": 20}, {"p0": distributions.UniformDistribution(low=0, high=100)}
+        {"p0": 20}, {"p0": distributions.FloatDistribution(low=0, high=100)}
     )
     assert not optimizer._is_compatible(trial)
 

--- a/tests/multi_objective_tests/test_trial.py
+++ b/tests/multi_objective_tests/test_trial.py
@@ -118,7 +118,7 @@ def test_params_and_distributions() -> None:
 
         assert set(trial.params.keys()) == {"x"}
         assert set(trial.distributions.keys()) == {"x"}
-        assert isinstance(trial.distributions["x"], optuna.distributions.UniformDistribution)
+        assert isinstance(trial.distributions["x"], optuna.distributions.FloatDistribution)
 
         return [x, x, x]
 
@@ -127,7 +127,7 @@ def test_params_and_distributions() -> None:
     trial = study.trials[0]
     assert set(trial.params.keys()) == {"x"}
     assert set(trial.distributions.keys()) == {"x"}
-    assert isinstance(trial.distributions["x"], optuna.distributions.UniformDistribution)
+    assert isinstance(trial.distributions["x"], optuna.distributions.FloatDistribution)
 
 
 def test_datetime() -> None:

--- a/tests/samplers_tests/search_space_tests/test_group_decomposed.py
+++ b/tests/samplers_tests/search_space_tests/test_group_decomposed.py
@@ -3,10 +3,9 @@ import pytest
 from optuna import create_study
 from optuna import TrialPruned
 from optuna.distributions import CategoricalDistribution
+from optuna.distributions import FloatDistribution
 from optuna.distributions import IntLogUniformDistribution
 from optuna.distributions import IntUniformDistribution
-from optuna.distributions import LogUniformDistribution
-from optuna.distributions import UniformDistribution
 from optuna.samplers._search_space import _GroupDecomposedSearchSpace
 from optuna.samplers._search_space.group_decomposed import _SearchSpaceGroup
 from optuna.testing.storage import StorageSupplier
@@ -35,14 +34,14 @@ def test_search_space_group() -> None:
     search_space_group.add_distributions(
         {
             "y": IntUniformDistribution(low=0, high=10),
-            "z": UniformDistribution(low=-3, high=3),
+            "z": FloatDistribution(low=-3, high=3),
         }
     )
     assert search_space_group.search_spaces == [
         {"x": IntUniformDistribution(low=0, high=10)},
         {
             "y": IntUniformDistribution(low=0, high=10),
-            "z": UniformDistribution(low=-3, high=3),
+            "z": FloatDistribution(low=-3, high=3),
         },
     ]
 
@@ -50,8 +49,8 @@ def test_search_space_group() -> None:
     search_space_group.add_distributions(
         {
             "y": IntUniformDistribution(low=0, high=10),
-            "z": UniformDistribution(low=-3, high=3),
-            "u": LogUniformDistribution(low=1e-2, high=1e2),
+            "z": FloatDistribution(low=-3, high=3),
+            "u": FloatDistribution(low=1e-2, high=1e2, log=True),
             "v": CategoricalDistribution(choices=["A", "B", "C"]),
         }
     )
@@ -59,23 +58,23 @@ def test_search_space_group() -> None:
         {"x": IntUniformDistribution(low=0, high=10)},
         {
             "y": IntUniformDistribution(low=0, high=10),
-            "z": UniformDistribution(low=-3, high=3),
+            "z": FloatDistribution(low=-3, high=3),
         },
         {
-            "u": LogUniformDistribution(low=1e-2, high=1e2),
+            "u": FloatDistribution(low=1e-2, high=1e2, log=True),
             "v": CategoricalDistribution(choices=["A", "B", "C"]),
         },
     ]
 
     # Add a distribution, which is included by one of search spaces in the group.
-    search_space_group.add_distributions({"u": LogUniformDistribution(low=1e-2, high=1e2)})
+    search_space_group.add_distributions({"u": FloatDistribution(low=1e-2, high=1e2, log=True)})
     assert search_space_group.search_spaces == [
         {"x": IntUniformDistribution(low=0, high=10)},
         {
             "y": IntUniformDistribution(low=0, high=10),
-            "z": UniformDistribution(low=-3, high=3),
+            "z": FloatDistribution(low=-3, high=3),
         },
-        {"u": LogUniformDistribution(low=1e-2, high=1e2)},
+        {"u": FloatDistribution(low=1e-2, high=1e2, log=True)},
         {"v": CategoricalDistribution(choices=["A", "B", "C"])},
     ]
 
@@ -89,8 +88,8 @@ def test_search_space_group() -> None:
     assert search_space_group.search_spaces == [
         {"x": IntUniformDistribution(low=0, high=10)},
         {"y": IntUniformDistribution(low=0, high=10)},
-        {"z": UniformDistribution(low=-3, high=3)},
-        {"u": LogUniformDistribution(low=1e-2, high=1e2)},
+        {"z": FloatDistribution(low=-3, high=3)},
+        {"u": FloatDistribution(low=1e-2, high=1e2, log=True)},
         {"v": CategoricalDistribution(choices=["A", "B", "C"])},
         {"w": IntLogUniformDistribution(low=2, high=8)},
     ]
@@ -100,17 +99,17 @@ def test_search_space_group() -> None:
         {
             "y": IntUniformDistribution(low=0, high=10),
             "w": IntLogUniformDistribution(low=2, high=8),
-            "t": UniformDistribution(low=10, high=100),
+            "t": FloatDistribution(low=10, high=100),
         }
     )
     assert search_space_group.search_spaces == [
         {"x": IntUniformDistribution(low=0, high=10)},
         {"y": IntUniformDistribution(low=0, high=10)},
-        {"z": UniformDistribution(low=-3, high=3)},
-        {"u": LogUniformDistribution(low=1e-2, high=1e2)},
+        {"z": FloatDistribution(low=-3, high=3)},
+        {"u": FloatDistribution(low=1e-2, high=1e2, log=True)},
         {"v": CategoricalDistribution(choices=["A", "B", "C"])},
         {"w": IntLogUniformDistribution(low=2, high=8)},
-        {"t": UniformDistribution(low=10, high=100)},
+        {"t": FloatDistribution(low=10, high=100)},
     ]
 
 
@@ -133,7 +132,7 @@ def test_group_decomposed_search_space() -> None:
         {"x": IntUniformDistribution(low=0, high=10)},
         {
             "y": IntUniformDistribution(low=0, high=10),
-            "z": UniformDistribution(low=-3, high=3),
+            "z": FloatDistribution(low=-3, high=3),
         },
     ]
 
@@ -148,11 +147,11 @@ def test_group_decomposed_search_space() -> None:
     assert search_space.calculate(study).search_spaces == [
         {"x": IntUniformDistribution(low=0, high=10)},
         {
-            "z": UniformDistribution(low=-3, high=3),
+            "z": FloatDistribution(low=-3, high=3),
             "y": IntUniformDistribution(low=0, high=10),
         },
         {
-            "u": LogUniformDistribution(low=1e-2, high=1e2),
+            "u": FloatDistribution(low=1e-2, high=1e2, log=True),
             "v": CategoricalDistribution(choices=["A", "B", "C"]),
         },
     ]
@@ -163,9 +162,9 @@ def test_group_decomposed_search_space() -> None:
         {"x": IntUniformDistribution(low=0, high=10)},
         {
             "y": IntUniformDistribution(low=0, high=10),
-            "z": UniformDistribution(low=-3, high=3),
+            "z": FloatDistribution(low=-3, high=3),
         },
-        {"u": LogUniformDistribution(low=1e-2, high=1e2)},
+        {"u": FloatDistribution(low=1e-2, high=1e2, log=True)},
         {"v": CategoricalDistribution(choices=["A", "B", "C"])},
     ]
 
@@ -176,8 +175,8 @@ def test_group_decomposed_search_space() -> None:
     assert search_space.calculate(study).search_spaces == [
         {"x": IntUniformDistribution(low=0, high=10)},
         {"y": IntUniformDistribution(low=0, high=10)},
-        {"z": UniformDistribution(low=-3, high=3)},
-        {"u": LogUniformDistribution(low=1e-2, high=1e2)},
+        {"z": FloatDistribution(low=-3, high=3)},
+        {"u": FloatDistribution(low=1e-2, high=1e2, log=True)},
         {"v": CategoricalDistribution(choices=["A", "B", "C"])},
         {"w": IntLogUniformDistribution(low=2, high=8)},
     ]
@@ -201,7 +200,7 @@ def test_group_decomposed_search_space() -> None:
     study.optimize(lambda t: t.suggest_float("a", -1, 1), n_trials=1)
     study.optimize(lambda t: t.suggest_float("a", 0, 1), n_trials=1)
     assert search_space.calculate(study).search_spaces == [
-        {"a": UniformDistribution(low=-1, high=1)}
+        {"a": FloatDistribution(low=-1, high=1)}
     ]
 
 

--- a/tests/samplers_tests/search_space_tests/test_intersection.py
+++ b/tests/samplers_tests/search_space_tests/test_intersection.py
@@ -4,8 +4,8 @@ import pytest
 
 from optuna import create_study
 from optuna import TrialPruned
+from optuna.distributions import FloatDistribution
 from optuna.distributions import IntUniformDistribution
-from optuna.distributions import UniformDistribution
 from optuna.samplers import intersection_search_space
 from optuna.samplers import IntersectionSearchSpace
 from optuna.testing.storage import StorageSupplier
@@ -24,7 +24,7 @@ def test_intersection_search_space() -> None:
     study.optimize(lambda t: t.suggest_float("y", -3, 3) + t.suggest_int("x", 0, 10), n_trials=1)
     assert search_space.calculate(study) == {
         "x": IntUniformDistribution(low=0, high=10),
-        "y": UniformDistribution(low=-3, high=3),
+        "y": FloatDistribution(low=-3, high=3),
     }
     assert search_space.calculate(study) == intersection_search_space(study)
 
@@ -32,7 +32,7 @@ def test_intersection_search_space() -> None:
     assert search_space.calculate(study, ordered_dict=True) == OrderedDict(
         [
             ("x", IntUniformDistribution(low=0, high=10)),
-            ("y", UniformDistribution(low=-3, high=3)),
+            ("y", FloatDistribution(low=-3, high=3)),
         ]
     )
     assert search_space.calculate(study, ordered_dict=True) == intersection_search_space(
@@ -41,7 +41,7 @@ def test_intersection_search_space() -> None:
 
     # Second trial (only 'y' parameter is suggested in this trial).
     study.optimize(lambda t: t.suggest_float("y", -3, 3), n_trials=1)
-    assert search_space.calculate(study) == {"y": UniformDistribution(low=-3, high=3)}
+    assert search_space.calculate(study) == {"y": FloatDistribution(low=-3, high=3)}
     assert search_space.calculate(study) == intersection_search_space(study)
 
     # Failed or pruned trials are not considered in the calculation of
@@ -53,7 +53,7 @@ def test_intersection_search_space() -> None:
 
     study.optimize(lambda t: objective(t, RuntimeError()), n_trials=1, catch=(RuntimeError,))
     study.optimize(lambda t: objective(t, TrialPruned()), n_trials=1)
-    assert search_space.calculate(study) == {"y": UniformDistribution(low=-3, high=3)}
+    assert search_space.calculate(study) == {"y": FloatDistribution(low=-3, high=3)}
     assert search_space.calculate(study) == intersection_search_space(study)
 
     # If two parameters have the same name but different distributions,

--- a/tests/samplers_tests/test_cmaes.py
+++ b/tests/samplers_tests/test_cmaes.py
@@ -387,7 +387,7 @@ def test_call_after_trial_of_base_sampler() -> None:
 def test_is_compatible_search_space() -> None:
     transform = _SearchSpaceTransform(
         {
-            "x0": optuna.distributions.UniformDistribution(2, 3),
+            "x0": optuna.distributions.FloatDistribution(2, 3),
             "x1": optuna.distributions.CategoricalDistribution(["foo", "bar", "baz", "qux"]),
         }
     )
@@ -396,7 +396,7 @@ def test_is_compatible_search_space() -> None:
         transform,
         {
             "x1": optuna.distributions.CategoricalDistribution(["foo", "bar", "baz", "qux"]),
-            "x0": optuna.distributions.UniformDistribution(2, 3),
+            "x0": optuna.distributions.FloatDistribution(2, 3),
         },
     )
 
@@ -404,7 +404,7 @@ def test_is_compatible_search_space() -> None:
     assert not optuna.samplers._cmaes._is_compatible_search_space(
         transform,
         {
-            "x0": optuna.distributions.UniformDistribution(2, 3),
+            "x0": optuna.distributions.FloatDistribution(2, 3),
             "foo": optuna.distributions.CategoricalDistribution(["foo", "bar", "baz", "qux"]),
         },
     )
@@ -413,9 +413,9 @@ def test_is_compatible_search_space() -> None:
     assert not optuna.samplers._cmaes._is_compatible_search_space(
         transform,
         {
-            "x0": optuna.distributions.UniformDistribution(2, 3),
+            "x0": optuna.distributions.FloatDistribution(2, 3),
             "x1": optuna.distributions.CategoricalDistribution(["foo", "bar", "baz", "qux"]),
-            "x2": optuna.distributions.DiscreteUniformDistribution(2, 3, q=0.1),
+            "x2": optuna.distributions.FloatDistribution(2, 3, step=0.1),
         },
     )
 

--- a/tests/samplers_tests/test_samplers.py
+++ b/tests/samplers_tests/test_samplers.py
@@ -108,7 +108,7 @@ def test_raise_error_for_samplers_during_multi_objectives(
 
     study = optuna.study.create_study(directions=["maximize", "maximize"], sampler=sampler_class())
 
-    distribution = UniformDistribution(0.0, 1.0)
+    distribution = FloatDistribution(0.0, 1.0)
     with pytest.raises(ValueError):
         study.sampler.sample_independent(study, _create_new_trial(study), "x", distribution)
 

--- a/tests/samplers_tests/test_samplers.py
+++ b/tests/samplers_tests/test_samplers.py
@@ -512,7 +512,7 @@ class FixedSampler(BaseSampler):
 def test_sample_relative() -> None:
 
     relative_search_space: Dict[str, BaseDistribution] = {
-        "a": UniformDistribution(low=0, high=5),
+        "a": FloatDistribution(low=0, high=5),
         "b": CategoricalDistribution(choices=("foo", "bar", "baz")),
         "c": IntUniformDistribution(low=20, high=50),  # Not exist in `relative_params`.
     }

--- a/tests/samplers_tests/tpe_tests/test_multi_objective_sampler.py
+++ b/tests/samplers_tests/tpe_tests/test_multi_objective_sampler.py
@@ -27,7 +27,7 @@ class MockSystemAttr:
 
 def test_multi_objective_sample_independent_seed_fix() -> None:
     study = optuna.create_study(directions=["minimize", "maximize"])
-    dist = optuna.distributions.UniformDistribution(1.0, 100.0)
+    dist = optuna.distributions.FloatDistribution(1.0, 100.0)
 
     random.seed(128)
     past_trials = [frozen_trial_factory(i, [random.random(), random.random()]) for i in range(16)]
@@ -78,7 +78,7 @@ def test_multi_objective_sample_independent_seed_fix() -> None:
 
 def test_multi_objective_sample_independent_prior() -> None:
     study = optuna.create_study(directions=["minimize", "maximize"])
-    dist = optuna.distributions.UniformDistribution(1.0, 100.0)
+    dist = optuna.distributions.FloatDistribution(1.0, 100.0)
 
     random.seed(128)
     past_trials = [frozen_trial_factory(i, [random.random(), random.random()]) for i in range(16)]
@@ -130,7 +130,7 @@ def test_multi_objective_sample_independent_prior() -> None:
 
 def test_multi_objective_sample_independent_n_startup_trial() -> None:
     study = optuna.create_study(directions=["minimize", "maximize"])
-    dist = optuna.distributions.UniformDistribution(1.0, 100.0)
+    dist = optuna.distributions.FloatDistribution(1.0, 100.0)
     random.seed(128)
     past_trials = [frozen_trial_factory(i, [random.random(), random.random()]) for i in range(16)]
 
@@ -180,7 +180,7 @@ def test_multi_objective_sample_independent_n_startup_trial() -> None:
 
 def test_multi_objective_sample_independent_misc_arguments() -> None:
     study = optuna.create_study(directions=["minimize", "maximize"])
-    dist = optuna.distributions.UniformDistribution(1.0, 100.0)
+    dist = optuna.distributions.FloatDistribution(1.0, 100.0)
     random.seed(128)
     past_trials = [frozen_trial_factory(i, [random.random(), random.random()]) for i in range(32)]
 
@@ -250,7 +250,7 @@ def test_multi_objective_sample_independent_uniform_distributions() -> None:
     random.seed(128)
     past_trials = [frozen_trial_factory(i, [random.random(), random.random()]) for i in range(16)]
 
-    uni_dist = optuna.distributions.UniformDistribution(1.0, 100.0)
+    uni_dist = optuna.distributions.FloatDistribution(1.0, 100.0)
     trial = frozen_trial_factory(16, [0, 0])
     sampler = TPESampler(seed=0)
     attrs = MockSystemAttr()
@@ -274,7 +274,7 @@ def test_multi_objective_sample_independent_log_uniform_distributions() -> None:
     study = optuna.create_study(directions=["minimize", "maximize"])
     random.seed(128)
 
-    uni_dist = optuna.distributions.UniformDistribution(1.0, 100.0)
+    uni_dist = optuna.distributions.FloatDistribution(1.0, 100.0)
     past_trials = [frozen_trial_factory(i, [random.random(), random.random()]) for i in range(16)]
     trial = frozen_trial_factory(16, [0, 0])
     sampler = TPESampler(seed=0)
@@ -292,7 +292,7 @@ def test_multi_objective_sample_independent_log_uniform_distributions() -> None:
         uniform_suggestion = sampler.sample_independent(study, trial, "param-a", uni_dist)
 
     # Test sample from log-uniform is different from uniform.
-    log_dist = optuna.distributions.LogUniformDistribution(1.0, 100.0)
+    log_dist = optuna.distributions.FloatDistribution(1.0, 100.0, log=True)
     past_trials = [
         frozen_trial_factory(i, [random.random(), random.random()], log_dist) for i in range(16)
     ]
@@ -320,7 +320,7 @@ def test_multi_objective_sample_independent_disrete_uniform_distributions() -> N
     study = optuna.create_study(directions=["minimize", "maximize"])
     random.seed(128)
 
-    disc_dist = optuna.distributions.DiscreteUniformDistribution(1.0, 100.0, 0.1)
+    disc_dist = optuna.distributions.FloatDistribution(1.0, 100.0, step=0.1)
 
     def value_fn(idx: int) -> float:
         return int(random.random() * 1000) * 0.1
@@ -436,7 +436,7 @@ def test_multi_objective_sample_independent_handle_unsuccessful_states(
     state: optuna.trial.TrialState,
 ) -> None:
     study = optuna.create_study(directions=["minimize", "maximize"])
-    dist = optuna.distributions.UniformDistribution(1.0, 100.0)
+    dist = optuna.distributions.FloatDistribution(1.0, 100.0)
     random.seed(128)
 
     # Prepare sampling result for later tests.
@@ -484,7 +484,7 @@ def test_multi_objective_sample_independent_handle_unsuccessful_states(
 def test_multi_objective_sample_independent_ignored_states() -> None:
     """Tests FAIL, RUNNING, and WAITING states are equally."""
     study = optuna.create_study(directions=["minimize", "maximize"])
-    dist = optuna.distributions.UniformDistribution(1.0, 100.0)
+    dist = optuna.distributions.FloatDistribution(1.0, 100.0)
 
     suggestions = []
     for state in [
@@ -634,7 +634,7 @@ def test_solve_hssp() -> None:
 def frozen_trial_factory(
     number: int,
     values: List[float],
-    dist: optuna.distributions.BaseDistribution = optuna.distributions.UniformDistribution(
+    dist: optuna.distributions.BaseDistribution = optuna.distributions.FloatDistribution(
         1.0, 100.0
     ),
     value_fn: Optional[Callable[[int], Union[int, float]]] = None,

--- a/tests/samplers_tests/tpe_tests/test_parzen_estimator.py
+++ b/tests/samplers_tests/tpe_tests/test_parzen_estimator.py
@@ -12,9 +12,9 @@ from optuna.samplers._tpe.sampler import default_weights
 
 
 SEARCH_SPACE = {
-    "a": distributions.UniformDistribution(1.0, 100.0),
-    "b": distributions.LogUniformDistribution(1.0, 100.0),
-    "c": distributions.DiscreteUniformDistribution(1.0, 100.0, 3.0),
+    "a": distributions.FloatDistribution(1.0, 100.0),
+    "b": distributions.FloatDistribution(1.0, 100.0, log=True),
+    "c": distributions.FloatDistribution(1.0, 100.0, step=3.0),
     "d": distributions.IntUniformDistribution(1, 100),
     "e": distributions.IntLogUniformDistribution(1, 100),
     "f": distributions.CategoricalDistribution(["x", "y", "z"]),
@@ -170,7 +170,7 @@ def test_suggest_with_step_parzen_estimator(multivariate: bool) -> None:
 
     # Define search space for distribution with step argument and true ranges
     search_space = {
-        "c": distributions.DiscreteUniformDistribution(low=1.0, high=7.0, q=3.0),
+        "c": distributions.FloatDistribution(low=1.0, high=7.0, step=3.0),
         "d": distributions.IntUniformDistribution(low=1, high=5, step=2),
     }
     multivariate_samples = {"c": np.array([4]), "d": np.array([3])}
@@ -226,7 +226,7 @@ def test_calculate_shape_check(
         multivariate=False,
     )
     mpe = _ParzenEstimator(
-        {"a": mus}, {"a": distributions.UniformDistribution(-1.0, 1.0)}, parameters
+        {"a": mus}, {"a": distributions.FloatDistribution(-1.0, 1.0)}, parameters
     )
     s_weights, s_mus, s_sigmas = mpe._weights, mpe._mus["a"], mpe._sigmas["a"]
 
@@ -311,7 +311,7 @@ def test_calculate(
         multivariate=False,
     )
     mpe = _ParzenEstimator(
-        {"a": mus}, {"a": distributions.UniformDistribution(-1.0, 1.0)}, parameters
+        {"a": mus}, {"a": distributions.FloatDistribution(-1.0, 1.0)}, parameters
     )
     s_weights, s_mus, s_sigmas = mpe._weights, mpe._mus["a"], mpe._sigmas["a"]
 

--- a/tests/samplers_tests/tpe_tests/test_sampler.py
+++ b/tests/samplers_tests/tpe_tests/test_sampler.py
@@ -81,9 +81,9 @@ def test_warn_independent_sampling_group(capsys: _pytest.capture.CaptureFixture)
 def test_infer_relative_search_space() -> None:
     sampler = TPESampler()
     search_space = {
-        "a": distributions.UniformDistribution(1.0, 100.0),
-        "b": distributions.LogUniformDistribution(1.0, 100.0),
-        "c": distributions.DiscreteUniformDistribution(1.0, 100.0, 3.0),
+        "a": distributions.FloatDistribution(1.0, 100.0),
+        "b": distributions.FloatDistribution(1.0, 100.0, log=True),
+        "c": distributions.FloatDistribution(1.0, 100.0, step=3.0),
         "d": distributions.IntUniformDistribution(1, 100),
         "e": distributions.IntUniformDistribution(0, 100, step=2),
         "f": distributions.IntLogUniformDistribution(1, 100),
@@ -130,7 +130,7 @@ def test_sample_relative_empty_input(multivariate: bool) -> None:
 
 def test_sample_relative_seed_fix() -> None:
     study = optuna.create_study()
-    dist = optuna.distributions.UniformDistribution(1.0, 100.0)
+    dist = optuna.distributions.FloatDistribution(1.0, 100.0)
     past_trials = [frozen_trial_factory(i, dist=dist) for i in range(1, 8)]
 
     # Prepare a trial and a sample for later checks.
@@ -156,7 +156,7 @@ def test_sample_relative_seed_fix() -> None:
 
 def test_sample_relative_prior() -> None:
     study = optuna.create_study()
-    dist = optuna.distributions.UniformDistribution(1.0, 100.0)
+    dist = optuna.distributions.FloatDistribution(1.0, 100.0)
     past_trials = [frozen_trial_factory(i, dist=dist) for i in range(1, 8)]
 
     # Prepare a trial and a sample for later checks.
@@ -182,7 +182,7 @@ def test_sample_relative_prior() -> None:
 
 def test_sample_relative_n_startup_trial() -> None:
     study = optuna.create_study()
-    dist = optuna.distributions.UniformDistribution(1.0, 100.0)
+    dist = optuna.distributions.FloatDistribution(1.0, 100.0)
     past_trials = [frozen_trial_factory(i, dist=dist) for i in range(1, 8)]
 
     trial = frozen_trial_factory(8)
@@ -199,7 +199,7 @@ def test_sample_relative_n_startup_trial() -> None:
 
 def test_sample_relative_misc_arguments() -> None:
     study = optuna.create_study()
-    dist = optuna.distributions.UniformDistribution(1.0, 100.0)
+    dist = optuna.distributions.FloatDistribution(1.0, 100.0)
     past_trials = [frozen_trial_factory(i, dist=dist) for i in range(1, 40)]
 
     # Prepare a trial and a sample for later checks.
@@ -239,7 +239,7 @@ def test_sample_relative_uniform_distributions() -> None:
     study = optuna.create_study()
 
     # Prepare sample from uniform distribution for cheking other distributions.
-    uni_dist = optuna.distributions.UniformDistribution(1.0, 100.0)
+    uni_dist = optuna.distributions.FloatDistribution(1.0, 100.0)
     past_trials = [frozen_trial_factory(i, dist=uni_dist) for i in range(1, 8)]
     trial = frozen_trial_factory(8)
     with warnings.catch_warnings():
@@ -255,7 +255,7 @@ def test_sample_relative_log_uniform_distributions() -> None:
 
     study = optuna.create_study()
 
-    uni_dist = optuna.distributions.UniformDistribution(1.0, 100.0)
+    uni_dist = optuna.distributions.FloatDistribution(1.0, 100.0)
     past_trials = [frozen_trial_factory(i, dist=uni_dist) for i in range(1, 8)]
     trial = frozen_trial_factory(8)
     with warnings.catch_warnings():
@@ -265,7 +265,7 @@ def test_sample_relative_log_uniform_distributions() -> None:
         uniform_suggestion = sampler.sample_relative(study, trial, {"param-a": uni_dist})
 
     # Test sample from log-uniform is different from uniform.
-    log_dist = optuna.distributions.LogUniformDistribution(1.0, 100.0)
+    log_dist = optuna.distributions.FloatDistribution(1.0, 100.0, log=True)
     past_trials = [frozen_trial_factory(i, dist=log_dist) for i in range(1, 8)]
     trial = frozen_trial_factory(8)
     with warnings.catch_warnings():
@@ -281,7 +281,7 @@ def test_sample_relative_disrete_uniform_distributions() -> None:
     """Test samples from discrete have expected intervals."""
 
     study = optuna.create_study()
-    disc_dist = optuna.distributions.DiscreteUniformDistribution(1.0, 100.0, 0.1)
+    disc_dist = optuna.distributions.FloatDistribution(1.0, 100.0, step=0.1)
 
     def value_fn(idx: int) -> float:
         random.seed(idx)
@@ -384,7 +384,7 @@ def test_sample_relative_int_loguniform_distributions() -> None:
 def test_sample_relative_handle_unsuccessful_states(
     state: optuna.trial.TrialState,
 ) -> None:
-    dist = optuna.distributions.UniformDistribution(1.0, 100.0)
+    dist = optuna.distributions.FloatDistribution(1.0, 100.0)
 
     # Prepare sampling result for later tests.
     study = optuna.create_study()
@@ -415,7 +415,7 @@ def test_sample_relative_handle_unsuccessful_states(
 def test_sample_relative_ignored_states() -> None:
     """Tests FAIL, RUNNING, and WAITING states are equally."""
 
-    dist = optuna.distributions.UniformDistribution(1.0, 100.0)
+    dist = optuna.distributions.FloatDistribution(1.0, 100.0)
 
     suggestions = []
     for state in [
@@ -439,7 +439,7 @@ def test_sample_relative_ignored_states() -> None:
 def test_sample_relative_pruned_state() -> None:
     """Tests PRUNED state is treated differently from both FAIL and COMPLETE."""
 
-    dist = optuna.distributions.UniformDistribution(1.0, 100.0)
+    dist = optuna.distributions.FloatDistribution(1.0, 100.0)
 
     suggestions = []
     for state in [
@@ -463,7 +463,7 @@ def test_sample_relative_pruned_state() -> None:
 
 def test_sample_independent_seed_fix() -> None:
     study = optuna.create_study()
-    dist = optuna.distributions.UniformDistribution(1.0, 100.0)
+    dist = optuna.distributions.FloatDistribution(1.0, 100.0)
     past_trials = [frozen_trial_factory(i, dist=dist) for i in range(1, 8)]
 
     # Prepare a trial and a sample for later checks.
@@ -483,7 +483,7 @@ def test_sample_independent_seed_fix() -> None:
 
 def test_sample_independent_prior() -> None:
     study = optuna.create_study()
-    dist = optuna.distributions.UniformDistribution(1.0, 100.0)
+    dist = optuna.distributions.FloatDistribution(1.0, 100.0)
     past_trials = [frozen_trial_factory(i, dist=dist) for i in range(1, 8)]
 
     # Prepare a trial and a sample for later checks.
@@ -503,7 +503,7 @@ def test_sample_independent_prior() -> None:
 
 def test_sample_independent_n_startup_trial() -> None:
     study = optuna.create_study()
-    dist = optuna.distributions.UniformDistribution(1.0, 100.0)
+    dist = optuna.distributions.FloatDistribution(1.0, 100.0)
     past_trials = [frozen_trial_factory(i, dist=dist) for i in range(1, 8)]
 
     trial = frozen_trial_factory(8)
@@ -525,7 +525,7 @@ def test_sample_independent_n_startup_trial() -> None:
 
 def test_sample_independent_misc_arguments() -> None:
     study = optuna.create_study()
-    dist = optuna.distributions.UniformDistribution(1.0, 100.0)
+    dist = optuna.distributions.FloatDistribution(1.0, 100.0)
     past_trials = [frozen_trial_factory(i, dist=dist) for i in range(1, 8)]
 
     # Prepare a trial and a sample for later checks.
@@ -554,7 +554,7 @@ def test_sample_independent_uniform_distributions() -> None:
     study = optuna.create_study()
 
     # Prepare sample from uniform distribution for cheking other distributions.
-    uni_dist = optuna.distributions.UniformDistribution(1.0, 100.0)
+    uni_dist = optuna.distributions.FloatDistribution(1.0, 100.0)
     past_trials = [frozen_trial_factory(i, dist=uni_dist) for i in range(1, 8)]
     trial = frozen_trial_factory(8)
     sampler = TPESampler(n_startup_trials=5, seed=0)
@@ -568,7 +568,7 @@ def test_sample_independent_log_uniform_distributions() -> None:
 
     study = optuna.create_study()
 
-    uni_dist = optuna.distributions.UniformDistribution(1.0, 100.0)
+    uni_dist = optuna.distributions.FloatDistribution(1.0, 100.0)
     past_trials = [frozen_trial_factory(i, dist=uni_dist) for i in range(1, 8)]
     trial = frozen_trial_factory(8)
     sampler = TPESampler(n_startup_trials=5, seed=0)
@@ -576,7 +576,7 @@ def test_sample_independent_log_uniform_distributions() -> None:
         uniform_suggestion = sampler.sample_independent(study, trial, "param-a", uni_dist)
 
     # Test sample from log-uniform is different from uniform.
-    log_dist = optuna.distributions.LogUniformDistribution(1.0, 100.0)
+    log_dist = optuna.distributions.FloatDistribution(1.0, 100.0, log=True)
     past_trials = [frozen_trial_factory(i, dist=log_dist) for i in range(1, 8)]
     trial = frozen_trial_factory(8)
     sampler = TPESampler(n_startup_trials=5, seed=0)
@@ -590,7 +590,7 @@ def test_sample_independent_disrete_uniform_distributions() -> None:
     """Test samples from discrete have expected intervals."""
 
     study = optuna.create_study()
-    disc_dist = optuna.distributions.DiscreteUniformDistribution(1.0, 100.0, 0.1)
+    disc_dist = optuna.distributions.FloatDistribution(1.0, 100.0, step=0.1)
 
     def value_fn(idx: int) -> float:
         random.seed(idx)
@@ -680,7 +680,7 @@ def test_sample_independent_int_loguniform_distributions() -> None:
     ],
 )
 def test_sample_independent_handle_unsuccessful_states(state: optuna.trial.TrialState) -> None:
-    dist = optuna.distributions.UniformDistribution(1.0, 100.0)
+    dist = optuna.distributions.FloatDistribution(1.0, 100.0)
 
     # Prepare sampling result for later tests.
     study = optuna.create_study()
@@ -707,7 +707,7 @@ def test_sample_independent_handle_unsuccessful_states(state: optuna.trial.Trial
 def test_sample_independent_ignored_states() -> None:
     """Tests FAIL, RUNNING, and WAITING states are equally."""
 
-    dist = optuna.distributions.UniformDistribution(1.0, 100.0)
+    dist = optuna.distributions.FloatDistribution(1.0, 100.0)
 
     suggestions = []
     for state in [
@@ -730,7 +730,7 @@ def test_sample_independent_ignored_states() -> None:
 def test_sample_independent_pruned_state() -> None:
     """Tests PRUNED state is treated differently from both FAIL and COMPLETE."""
 
-    dist = optuna.distributions.UniformDistribution(1.0, 100.0)
+    dist = optuna.distributions.FloatDistribution(1.0, 100.0)
 
     suggestions = []
     for state in [
@@ -903,7 +903,7 @@ def test_build_observation_dict() -> None:
 
 def frozen_trial_factory(
     idx: int,
-    dist: optuna.distributions.BaseDistribution = optuna.distributions.UniformDistribution(
+    dist: optuna.distributions.BaseDistribution = optuna.distributions.FloatDistribution(
         1.0, 100.0
     ),
     state_fn: Callable[
@@ -1000,7 +1000,7 @@ def test_group() -> None:
         assert mock.call_count == 1
     assert study.trials[-1].distributions == {
         "y": distributions.IntUniformDistribution(low=0, high=10),
-        "z": distributions.UniformDistribution(low=-3, high=3),
+        "z": distributions.FloatDistribution(low=-3, high=3),
     }
 
     with patch.object(sampler, "_sample_relative", wraps=sampler._sample_relative) as mock:
@@ -1013,17 +1013,17 @@ def test_group() -> None:
         )
         assert mock.call_count == 2
     assert study.trials[-1].distributions == {
-        "u": distributions.LogUniformDistribution(low=1e-2, high=1e2),
+        "u": distributions.FloatDistribution(low=1e-2, high=1e2, log=True),
         "v": distributions.CategoricalDistribution(choices=["A", "B", "C"]),
         "y": distributions.IntUniformDistribution(low=0, high=10),
-        "z": distributions.UniformDistribution(low=-3, high=3),
+        "z": distributions.FloatDistribution(low=-3, high=3),
     }
 
     with patch.object(sampler, "_sample_relative", wraps=sampler._sample_relative) as mock:
         study.optimize(lambda t: t.suggest_float("u", 1e-2, 1e2, log=True), n_trials=1)
         assert mock.call_count == 3
     assert study.trials[-1].distributions == {
-        "u": distributions.LogUniformDistribution(low=1e-2, high=1e2)
+        "u": distributions.FloatDistribution(low=1e-2, high=1e2, log=True)
     }
 
     with patch.object(sampler, "_sample_relative", wraps=sampler._sample_relative) as mock:

--- a/tests/storages_tests/test_cached_storage.py
+++ b/tests/storages_tests/test_cached_storage.py
@@ -63,14 +63,14 @@ def test_uncached_set() -> None:
         base_storage, "_check_and_set_param_distribution", return_value=True
     ) as set_mock:
         storage.set_trial_param(
-            trial_id, "paramA", 1.2, optuna.distributions.UniformDistribution(-0.2, 2.3)
+            trial_id, "paramA", 1.2, optuna.distributions.FloatDistribution(-0.2, 2.3)
         )
         assert set_mock.call_count == 1
 
     trial_id = storage.create_new_trial(study_id)
     with patch.object(base_storage, "set_trial_param", return_value=True) as set_mock:
         storage.set_trial_param(
-            trial_id, "paramA", 1.2, optuna.distributions.UniformDistribution(-0.2, 2.3)
+            trial_id, "paramA", 1.2, optuna.distributions.FloatDistribution(-0.2, 2.3)
         )
         assert set_mock.call_count == 1
 

--- a/tests/storages_tests/test_storages.py
+++ b/tests/storages_tests/test_storages.py
@@ -18,8 +18,7 @@ import optuna
 from optuna import Study
 from optuna._callbacks import RetryFailedTrialCallback
 from optuna.distributions import CategoricalDistribution
-from optuna.distributions import LogUniformDistribution
-from optuna.distributions import UniformDistribution
+from optuna.distributions import FloatDistribution
 from optuna.storages import _CachedStorage
 from optuna.storages import BaseStorage
 from optuna.storages import InMemoryStorage
@@ -383,7 +382,7 @@ def test_create_new_trial_with_template_trial(storage_mode: str) -> None:
         datetime_start=start_time,
         datetime_complete=complete_time,
         params={"x": 0.5},
-        distributions={"x": UniformDistribution(0, 1)},
+        distributions={"x": FloatDistribution(0, 1)},
         user_attrs={"foo": "bar"},
         system_attrs={"baz": 123},
         intermediate_values={1: 10, 2: 100, 3: 1000},
@@ -522,10 +521,10 @@ def test_set_trial_param(storage_mode: str) -> None:
         trial_id_3 = storage.create_new_trial(storage.create_new_study())
 
         # Setup distributions.
-        distribution_x = UniformDistribution(low=1.0, high=2.0)
+        distribution_x = FloatDistribution(low=1.0, high=2.0)
         distribution_y_1 = CategoricalDistribution(choices=("Shibuya", "Ebisu", "Meguro"))
         distribution_y_2 = CategoricalDistribution(choices=("Shibuya", "Shinsen"))
-        distribution_z = LogUniformDistribution(low=1.0, high=100.0)
+        distribution_z = FloatDistribution(low=1.0, high=100.0, log=True)
 
         # Set new params.
         storage.set_trial_param(trial_id_1, "x", 0.5, distribution_x)
@@ -550,8 +549,6 @@ def test_set_trial_param(storage_mode: str) -> None:
         assert storage.get_trial_params(trial_id_2) == {"x": 0.3, "z": 0.1}
 
         # Set params with distributions that do not match previous ones.
-        with pytest.raises(ValueError):
-            storage.set_trial_param(trial_id_2, "x", 0.5, distribution_z)
         with pytest.raises(ValueError):
             storage.set_trial_param(trial_id_2, "y", 0.5, distribution_z)
         # Choices in CategoricalDistribution should match including its order.
@@ -1002,13 +999,13 @@ def _setup_studies(
 
 def _generate_trial(generator: random.Random) -> FrozenTrial:
     example_params = {
-        "paramA": (generator.uniform(0, 1), UniformDistribution(0, 1)),
-        "paramB": (generator.uniform(1, 2), LogUniformDistribution(1, 2)),
+        "paramA": (generator.uniform(0, 1), FloatDistribution(0, 1)),
+        "paramB": (generator.uniform(1, 2), FloatDistribution(1, 2, log=True)),
         "paramC": (
             generator.choice(["CatA", "CatB", "CatC"]),
             CategoricalDistribution(("CatA", "CatB", "CatC")),
         ),
-        "paramD": (generator.uniform(-3, 0), UniformDistribution(-3, 0)),
+        "paramD": (generator.uniform(-3, 0), FloatDistribution(-3, 0)),
         "paramE": (generator.choice([0.1, 0.2]), CategoricalDistribution((0.1, 0.2))),
     }
     example_attrs = {

--- a/tests/study_tests/test_study.py
+++ b/tests/study_tests/test_study.py
@@ -981,7 +981,7 @@ def test_ask_enqueue_trial() -> None:
 
 def test_ask_fixed_search_space() -> None:
     fixed_distributions = {
-        "x": distributions.UniformDistribution(0, 1),
+        "x": distributions.FloatDistribution(0, 1),
         "y": distributions.CategoricalDistribution(["bacon", "spam"]),
     }
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1030,7 +1030,7 @@ def test_ask(
 
     study_name = "test_study"
     search_space = (
-        '{"x": {"name": "UniformDistribution", "attributes": {"low": 0.0, "high": 1.0}}, '
+        '{"x": {"name": "FloatDistribution", "attributes": {"low": 0.0, "high": 1.0}}, '
         '"y": {"name": "CategoricalDistribution", "attributes": {"choices": ["foo"]}}}'
     )
 
@@ -1104,7 +1104,7 @@ def test_ask_flatten(
 
     study_name = "test_study"
     search_space = (
-        '{"x": {"name": "UniformDistribution", "attributes": {"low": 0.0, "high": 1.0}}, '
+        '{"x": {"name": "FloatDistribution", "attributes": {"low": 0.0, "high": 1.0}}, '
         '"y": {"name": "CategoricalDistribution", "attributes": {"choices": ["foo"]}}}'
     )
 
@@ -1226,7 +1226,7 @@ def test_ask_sampler_kwargs_without_sampler() -> None:
 
     study_name = "test_study"
     search_space = (
-        '{"x": {"name": "UniformDistribution", "attributes": {"low": 0.0, "high": 1.0}}, '
+        '{"x": {"name": "FloatDistribution", "attributes": {"low": 0.0, "high": 1.0}}, '
         '"y": {"name": "CategoricalDistribution", "attributes": {"choices": ["foo"]}}}'
     )
 
@@ -1271,7 +1271,7 @@ def test_create_study_and_ask(
 
     study_name = "test_study"
     search_space = (
-        '{"x": {"name": "UniformDistribution", "attributes": {"low": 0.0, "high": 1.0}}, '
+        '{"x": {"name": "FloatDistribution", "attributes": {"low": 0.0, "high": 1.0}}, '
         '"y": {"name": "CategoricalDistribution", "attributes": {"choices": ["foo"]}}}'
     )
 
@@ -1337,7 +1337,7 @@ def test_create_study_and_ask_with_inconsistent_directions(
 
     study_name = "test_study"
     search_space = (
-        '{"x": {"name": "UniformDistribution", "attributes": {"low": 0.0, "high": 1.0}}, '
+        '{"x": {"name": "FloatDistribution", "attributes": {"low": 0.0, "high": 1.0}}, '
         '"y": {"name": "CategoricalDistribution", "attributes": {"choices": ["foo"]}}}'
     )
 
@@ -1384,7 +1384,7 @@ def test_ask_with_both_direction_and_directions() -> None:
 
     study_name = "test_study"
     search_space = (
-        '{"x": {"name": "UniformDistribution", "attributes": {"low": 0.0, "high": 1.0}}, '
+        '{"x": {"name": "FloatDistribution", "attributes": {"low": 0.0, "high": 1.0}}, '
         '"y": {"name": "CategoricalDistribution", "attributes": {"choices": ["foo"]}}}'
     )
 

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -18,9 +18,6 @@ EXAMPLE_DISTRIBUTIONS: Dict[str, Any] = {
     "f": distributions.FloatDistribution(low=1.0, high=2.0, log=False),
     "fl": distributions.FloatDistribution(low=0.001, high=100.0, log=True),
     "fd": distributions.FloatDistribution(low=1.0, high=9.0, log=False, step=2.0),
-    "u": distributions.UniformDistribution(low=1.0, high=2.0),
-    "l": distributions.LogUniformDistribution(low=0.001, high=100),
-    "du": distributions.DiscreteUniformDistribution(low=1.0, high=9.0, q=2.0),
     "iu": distributions.IntUniformDistribution(low=1, high=9),
     "iuq": distributions.IntUniformDistribution(low=1, high=9, step=2),
     "c1": distributions.CategoricalDistribution(choices=(2.71, -float("inf"))),
@@ -43,10 +40,6 @@ EXAMPLE_JSONS = {
     '"attributes": {"low": 0.001, "high": 100.0, "log": true, "step": null}}',
     "fd": '{"name": "FloatDistribution", '
     '"attributes": {"low": 1.0, "high": 9.0, "step": 2.0, "log": false}}',
-    "u": '{"name": "UniformDistribution", "attributes": {"low": 1.0, "high": 2.0}}',
-    "l": '{"name": "LogUniformDistribution", "attributes": {"low": 0.001, "high": 100}}',
-    "du": '{"name": "DiscreteUniformDistribution",'
-    '"attributes": {"low": 1.0, "high": 9.0, "q": 2.0}}',
     "iu": '{"name": "IntUniformDistribution", "attributes": {"low": 1, "high": 9}}',
     "iuq": '{"name": "IntUniformDistribution", "attributes": {"low": 1, "high": 9, "step": 2}}',
     "c1": '{"name": "CategoricalDistribution", "attributes": {"choices": [2.71, -Infinity]}}',
@@ -58,9 +51,9 @@ EXAMPLE_JSONS = {
 }
 
 EXAMPLE_ABBREVIATED_JSONS = {
-    "u": '{"type": "float", "low": 1.0, "high": 2.0}',
-    "l": '{"type": "float", "low": 0.001, "high": 100, "log": true}',
-    "du": '{"type": "float", "low": 1.0, "high": 9.0, "step": 2.0}',
+    "f": '{"type": "float", "low": 1.0, "high": 2.0, "log": false, "step": null}',
+    "fl": '{"type": "float", "low": 0.001, "high": 100, "log": true, "step": null}',
+    "fd": '{"type": "float", "low": 1.0, "high": 9.0, "log": false, "step": 2.0}',
     "iu": '{"type": "int", "low": 1, "high": 9}',
     "iuq": '{"type": "int", "low": 1, "high": 9, "step": 2}',
     "c1": '{"type": "categorical", "choices": [2.71, -Infinity]}',
@@ -144,13 +137,6 @@ def test_check_distribution_compatibility() -> None:
         ),
     )
 
-    pytest.raises(
-        ValueError,
-        lambda: distributions.check_distribution_compatibility(
-            EXAMPLE_DISTRIBUTIONS["u"], EXAMPLE_DISTRIBUTIONS["l"]
-        ),
-    )
-
     # test compatibility between IntDistributions.
     distributions.check_distribution_compatibility(
         EXAMPLE_DISTRIBUTIONS["i"], EXAMPLE_DISTRIBUTIONS["il"]
@@ -200,16 +186,6 @@ def test_check_distribution_compatibility() -> None:
     )
     distributions.check_distribution_compatibility(
         EXAMPLE_DISTRIBUTIONS["fd"], distributions.FloatDistribution(low=-1.0, high=11.0, step=0.5)
-    )
-    distributions.check_distribution_compatibility(
-        EXAMPLE_DISTRIBUTIONS["u"], distributions.UniformDistribution(low=-3.0, high=-2.0)
-    )
-    distributions.check_distribution_compatibility(
-        EXAMPLE_DISTRIBUTIONS["l"], distributions.LogUniformDistribution(low=0.1, high=1.0)
-    )
-    distributions.check_distribution_compatibility(
-        EXAMPLE_DISTRIBUTIONS["du"],
-        distributions.DiscreteUniformDistribution(low=-1.0, high=11.0, q=3.0),
     )
     distributions.check_distribution_compatibility(
         EXAMPLE_DISTRIBUTIONS["iu"], distributions.IntUniformDistribution(low=-1, high=1)
@@ -270,33 +246,6 @@ def test_float_contains(expected: bool, value: float, step: Optional[float]) -> 
 
 
 def test_contains() -> None:
-
-    u = distributions.UniformDistribution(low=1.0, high=2.0)
-    assert not u._contains(0.9)
-    assert u._contains(1)
-    assert u._contains(1.5)
-    assert u._contains(2)
-    assert not u._contains(2.1)
-
-    lu = distributions.LogUniformDistribution(low=0.001, high=100)
-    assert not lu._contains(0.0)
-    assert lu._contains(0.001)
-    assert lu._contains(12.3)
-    assert lu._contains(100)
-    assert not lu._contains(1000)
-
-    with warnings.catch_warnings():
-        # UserWarning will be raised since the range is not divisible by 2.
-        # The range will be replaced with [1.0, 9.0].
-        warnings.simplefilter("ignore", category=UserWarning)
-        du = distributions.DiscreteUniformDistribution(low=1.0, high=10.0, q=2.0)
-    assert not du._contains(0.9)
-    assert du._contains(1.0)
-    assert not du._contains(3.5)
-    assert not du._contains(6)
-    assert du._contains(9)
-    assert not du._contains(9.1)
-    assert not du._contains(10)
 
     iu = distributions.IntUniformDistribution(low=1, high=10)
     assert not iu._contains(0.9)
@@ -366,21 +315,6 @@ def test_empty_range_contains() -> None:
     assert fd._contains(1.0)
     assert not fd._contains(1.1)
 
-    u = distributions.UniformDistribution(low=1.0, high=1.0)
-    assert not u._contains(0.9)
-    assert u._contains(1.0)
-    assert not u._contains(1.1)
-
-    lu = distributions.LogUniformDistribution(low=1.0, high=1.0)
-    assert not lu._contains(0.9)
-    assert lu._contains(1.0)
-    assert not lu._contains(1.1)
-
-    du = distributions.DiscreteUniformDistribution(low=1.0, high=1.0, q=2.0)
-    assert not du._contains(0.9)
-    assert du._contains(1.0)
-    assert not du._contains(1.1)
-
     iu = distributions.IntUniformDistribution(low=1, high=1)
     assert not iu._contains(0)
     assert iu._contains(1)
@@ -447,10 +381,10 @@ def test_single() -> None:
         # UserWarning will be raised since the range is not divisible by step.
         warnings.simplefilter("ignore", category=UserWarning)
         single_distributions: List[distributions.BaseDistribution] = [
-            distributions.UniformDistribution(low=1.0, high=1.0),
-            distributions.LogUniformDistribution(low=7.3, high=7.3),
-            distributions.DiscreteUniformDistribution(low=2.22, high=2.22, q=0.1),
-            distributions.DiscreteUniformDistribution(low=2.22, high=2.24, q=0.3),
+            distributions.FloatDistribution(low=1.0, high=1.0),
+            distributions.FloatDistribution(low=7.3, high=7.3, log=True),
+            distributions.FloatDistribution(low=2.22, high=2.22, step=0.1),
+            distributions.FloatDistribution(low=2.22, high=2.24, step=0.3),
             distributions.IntUniformDistribution(low=-123, high=-123),
             distributions.IntUniformDistribution(low=-123, high=-120, step=4),
             distributions.CategoricalDistribution(choices=("foo",)),
@@ -460,13 +394,13 @@ def test_single() -> None:
         assert distribution.single()
 
     nonsingle_distributions: List[distributions.BaseDistribution] = [
-        distributions.UniformDistribution(low=1.0, high=1.001),
-        distributions.LogUniformDistribution(low=7.3, high=10),
-        distributions.DiscreteUniformDistribution(low=-30, high=-20, q=2),
-        distributions.DiscreteUniformDistribution(low=-30, high=-20, q=10),
+        distributions.FloatDistribution(low=1.0, high=1.001),
+        distributions.FloatDistribution(low=7.3, high=10, log=True),
+        distributions.FloatDistribution(low=-30, high=-20, step=2),
+        distributions.FloatDistribution(low=-30, high=-20, step=10),
         # In Python, "0.3 - 0.2 != 0.1" is True.
-        distributions.DiscreteUniformDistribution(low=0.2, high=0.3, q=0.1),
-        distributions.DiscreteUniformDistribution(low=0.7, high=0.8, q=0.1),
+        distributions.FloatDistribution(low=0.2, high=0.3, step=0.1),
+        distributions.FloatDistribution(low=0.7, high=0.8, step=0.1),
         distributions.IntUniformDistribution(low=-123, high=0),
         distributions.IntUniformDistribution(low=-123, high=0, step=123),
         distributions.CategoricalDistribution(choices=("foo", "bar")),
@@ -480,13 +414,13 @@ def test_empty_distribution() -> None:
 
     # Empty distributions cannot be instantiated.
     with pytest.raises(ValueError):
-        distributions.UniformDistribution(low=0.0, high=-100.0)
+        distributions.FloatDistribution(low=0.0, high=-100.0)
 
     with pytest.raises(ValueError):
-        distributions.LogUniformDistribution(low=7.3, high=7.2)
+        distributions.FloatDistribution(low=7.3, high=7.2, log=True)
 
     with pytest.raises(ValueError):
-        distributions.DiscreteUniformDistribution(low=-30, high=-40, q=3)
+        distributions.FloatDistribution(low=-30, high=-40, step=3)
 
     with pytest.raises(ValueError):
         distributions.IntUniformDistribution(low=123, high=100)
@@ -523,15 +457,6 @@ def test_eq_ne_hash() -> None:
     # Different distribution classes.
     di2 = distributions.IntDistribution(low=1, high=2)
     assert di0 != di2
-
-    # Different field values.
-    d0 = distributions.UniformDistribution(low=1, high=2)
-    d1 = distributions.UniformDistribution(low=1, high=3)
-    assert d0 != d1
-
-    # Different distribution classes.
-    d2 = distributions.IntUniformDistribution(low=1, high=2)
-    assert d0 != d2
 
 
 def test_repr() -> None:
@@ -570,21 +495,6 @@ def test_float_distribution_asdict(
 ) -> None:
     expected_dict = {"low": low, "high": high, "log": log, "step": step}
     assert EXAMPLE_DISTRIBUTIONS[key]._asdict() == expected_dict
-
-
-def test_uniform_distribution_asdict() -> None:
-
-    assert EXAMPLE_DISTRIBUTIONS["u"]._asdict() == {"low": 1.0, "high": 2.0}
-
-
-def test_log_uniform_distribution_asdict() -> None:
-
-    assert EXAMPLE_DISTRIBUTIONS["l"]._asdict() == {"low": 0.001, "high": 100}
-
-
-def test_discrete_uniform_distribution_asdict() -> None:
-
-    assert EXAMPLE_DISTRIBUTIONS["du"]._asdict() == {"low": 1.0, "high": 9.0, "q": 2.0}
 
 
 def test_int_uniform_distribution_asdict() -> None:
@@ -645,15 +555,6 @@ def test_float_init_error() -> None:
 
     with pytest.raises(ValueError):
         distributions.FloatDistribution(low=1.0, high=100.0, step=-1)
-
-
-def test_discrete_uniform_distribution_invalid_q() -> None:
-
-    with pytest.raises(ValueError):
-        distributions.DiscreteUniformDistribution(low=1, high=100, q=0)
-
-    with pytest.raises(ValueError):
-        distributions.DiscreteUniformDistribution(low=1, high=100, q=-1)
 
 
 def test_int_uniform_distribution_invalid_step() -> None:

--- a/tests/trial_tests/test_frozen.py
+++ b/tests/trial_tests/test_frozen.py
@@ -11,11 +11,9 @@ import pytest
 from optuna import create_study
 from optuna.distributions import BaseDistribution
 from optuna.distributions import CategoricalDistribution
-from optuna.distributions import DiscreteUniformDistribution
+from optuna.distributions import FloatDistribution
 from optuna.distributions import IntLogUniformDistribution
 from optuna.distributions import IntUniformDistribution
-from optuna.distributions import LogUniformDistribution
-from optuna.distributions import UniformDistribution
 from optuna.testing.storage import STORAGE_MODES
 from optuna.testing.storage import StorageSupplier
 from optuna.trial import BaseTrial
@@ -72,7 +70,7 @@ def _create_frozen_trial() -> FrozenTrial:
         datetime_start=datetime.datetime.now(),
         datetime_complete=datetime.datetime.now(),
         params={"x": 10},
-        distributions={"x": UniformDistribution(5, 12)},
+        distributions={"x": FloatDistribution(5, 12)},
         user_attrs={},
         system_attrs={},
         intermediate_values={},
@@ -89,7 +87,7 @@ def test_repr() -> None:
         datetime_start=datetime.datetime.now(),
         datetime_complete=datetime.datetime.now(),
         params={"x": 10},
-        distributions={"x": UniformDistribution(5, 12)},
+        distributions={"x": FloatDistribution(5, 12)},
         user_attrs={},
         system_attrs={},
         intermediate_values={},
@@ -134,7 +132,7 @@ def test_suggest_float() -> None:
         datetime_start=datetime.datetime.now(),
         datetime_complete=datetime.datetime.now(),
         params={"x": 0.2},
-        distributions={"x": UniformDistribution(0.0, 1.0)},
+        distributions={"x": FloatDistribution(0.0, 1.0)},
         user_attrs={},
         system_attrs={},
         intermediate_values={},
@@ -159,7 +157,7 @@ def test_suggest_uniform() -> None:
         datetime_start=datetime.datetime.now(),
         datetime_complete=datetime.datetime.now(),
         params={"x": 0.2},
-        distributions={"x": UniformDistribution(0.0, 1.0)},
+        distributions={"x": FloatDistribution(0.0, 1.0)},
         user_attrs={},
         system_attrs={},
         intermediate_values={},
@@ -181,7 +179,7 @@ def test_suggest_loguniform() -> None:
         datetime_start=datetime.datetime.now(),
         datetime_complete=datetime.datetime.now(),
         params={"x": 0.99},
-        distributions={"x": LogUniformDistribution(0.1, 1.0)},
+        distributions={"x": FloatDistribution(0.1, 1.0, log=True)},
         user_attrs={},
         system_attrs={},
         intermediate_values={},
@@ -202,7 +200,7 @@ def test_suggest_discrete_uniform() -> None:
         datetime_start=datetime.datetime.now(),
         datetime_complete=datetime.datetime.now(),
         params={"x": 0.9},
-        distributions={"x": DiscreteUniformDistribution(0.0, 1.0, q=0.1)},
+        distributions={"x": FloatDistribution(0.0, 1.0, step=0.1)},
         user_attrs={},
         system_attrs={},
         intermediate_values={},
@@ -315,7 +313,7 @@ def test_not_contained_param() -> None:
     trial = create_trial(
         value=0.2,
         params={"x": 1.0},
-        distributions={"x": UniformDistribution(1.0, 10.0)},
+        distributions={"x": FloatDistribution(1.0, 10.0)},
     )
     with pytest.warns(UserWarning):
         assert trial.suggest_float("x", 10.0, 100.0) == 1.0
@@ -323,7 +321,7 @@ def test_not_contained_param() -> None:
     trial = create_trial(
         value=0.2,
         params={"x": 1.0},
-        distributions={"x": LogUniformDistribution(1.0, 10.0)},
+        distributions={"x": FloatDistribution(1.0, 10.0, log=True)},
     )
     with pytest.warns(UserWarning):
         assert trial.suggest_float("x", 10.0, 100.0, log=True) == 1.0
@@ -331,7 +329,7 @@ def test_not_contained_param() -> None:
     trial = create_trial(
         value=0.2,
         params={"x": 1.0},
-        distributions={"x": DiscreteUniformDistribution(1.0, 10.0, 1.0)},
+        distributions={"x": FloatDistribution(1.0, 10.0, step=1.0)},
     )
     with pytest.warns(UserWarning):
         assert trial.suggest_float("x", 10.0, 100.0, step=1.0) == 1.0
@@ -449,11 +447,11 @@ def test_validate() -> None:
     # Invalid: Inconsistent `params` and `distributions`
     inconsistent_pairs: List[Tuple[Dict[str, Any], Dict[str, BaseDistribution]]] = [
         # `params` has an extra element.
-        ({"x": 0.1, "y": 0.5}, {"x": UniformDistribution(0, 1)}),
+        ({"x": 0.1, "y": 0.5}, {"x": FloatDistribution(0, 1)}),
         # `distributions` has an extra element.
-        ({"x": 0.1}, {"x": UniformDistribution(0, 1), "y": LogUniformDistribution(0.1, 1.0)}),
+        ({"x": 0.1}, {"x": FloatDistribution(0, 1), "y": FloatDistribution(0.1, 1.0, log=True)}),
         # The value of `x` isn't contained in the distribution.
-        ({"x": -0.5}, {"x": UniformDistribution(0, 1)}),
+        ({"x": -0.5}, {"x": FloatDistribution(0, 1)}),
     ]
 
     for params, distributions in inconsistent_pairs:
@@ -493,7 +491,7 @@ def test_params() -> None:
         datetime_start=datetime.datetime.now(),
         datetime_complete=datetime.datetime.now(),
         params=params,
-        distributions={"x": UniformDistribution(0, 10)},
+        distributions={"x": FloatDistribution(0, 10)},
         user_attrs={},
         system_attrs={},
         intermediate_values={},
@@ -510,7 +508,7 @@ def test_params() -> None:
 
 def test_distributions() -> None:
 
-    distributions = {"x": UniformDistribution(0, 10)}
+    distributions = {"x": FloatDistribution(0, 10)}
     trial = FrozenTrial(
         number=0,
         trial_id=0,
@@ -526,7 +524,7 @@ def test_distributions() -> None:
     )
     assert trial.distributions == distributions
 
-    distributions = {"x": UniformDistribution(1, 9)}
+    distributions = {"x": FloatDistribution(1, 9)}
     trial.distributions = dict(distributions)
     assert trial.distributions == distributions
 
@@ -556,7 +554,7 @@ def test_called_single_methods_when_multi() -> None:
     state = TrialState.COMPLETE
     values = (0.2, 0.3)
     params = {"x": 10}
-    distributions = {"x": UniformDistribution(5, 12)}
+    distributions = {"x": FloatDistribution(5, 12)}
     user_attrs = {"foo": "bar"}
     system_attrs = {"baz": "qux"}
     intermediate_values = {0: 0.0, 1: 0.1, 2: 0.1}
@@ -593,7 +591,7 @@ def test_init() -> None:
             datetime_start=datetime.datetime.now(),
             datetime_complete=datetime.datetime.now(),
             params={},
-            distributions={"x": UniformDistribution(0, 10)},
+            distributions={"x": FloatDistribution(0, 10)},
             user_attrs={},
             system_attrs={},
             intermediate_values={},

--- a/tests/trial_tests/test_frozen.py
+++ b/tests/trial_tests/test_frozen.py
@@ -554,7 +554,7 @@ def test_called_single_methods_when_multi() -> None:
     state = TrialState.COMPLETE
     values = (0.2, 0.3)
     params = {"x": 10}
-    distributions = {"x": FloatDistribution(5, 12)}
+    distributions: Dict[str, BaseDistribution] = {"x": FloatDistribution(5, 12)}
     user_attrs = {"foo": "bar"}
     system_attrs = {"baz": "qux"}
     intermediate_values = {0: 0.0, 1: 0.1, 2: 0.1}

--- a/tests/trial_tests/test_trial.py
+++ b/tests/trial_tests/test_trial.py
@@ -649,7 +649,7 @@ def test_study_id() -> None:
 def test_create_trial(state: TrialState) -> None:
     value = 0.2
     params = {"x": 10}
-    distributions = {"x": FloatDistribution(5, 12)}
+    distributions: Dict[str, BaseDistribution] = {"x": FloatDistribution(5, 12)}
     user_attrs = {"foo": "bar"}
     system_attrs = {"baz": "qux"}
     intermediate_values = {0: 0.0, 1: 0.1, 2: 0.1}

--- a/tests/visualization_tests/matplotlib_tests/test_parallel_coordinate.py
+++ b/tests/visualization_tests/matplotlib_tests/test_parallel_coordinate.py
@@ -1,7 +1,7 @@
 import pytest
 
 from optuna.distributions import CategoricalDistribution
-from optuna.distributions import LogUniformDistribution
+from optuna.distributions import FloatDistribution
 from optuna.study import create_study
 from optuna.testing.visualization import prepare_study_with_trials
 from optuna.trial import create_trial
@@ -133,8 +133,8 @@ def test_plot_parallel_coordinate_log_params() -> None:
             value=0.0,
             params={"param_a": 1e-6, "param_b": 10},
             distributions={
-                "param_a": LogUniformDistribution(1e-7, 1e-2),
-                "param_b": LogUniformDistribution(1, 1000),
+                "param_a": FloatDistribution(1e-7, 1e-2, log=True),
+                "param_b": FloatDistribution(1, 1000, log=True),
             },
         )
     )
@@ -143,8 +143,8 @@ def test_plot_parallel_coordinate_log_params() -> None:
             value=1.0,
             params={"param_a": 2e-5, "param_b": 200},
             distributions={
-                "param_a": LogUniformDistribution(1e-7, 1e-2),
-                "param_b": LogUniformDistribution(1, 1000),
+                "param_a": FloatDistribution(1e-7, 1e-2, log=True),
+                "param_b": FloatDistribution(1, 1000, log=True),
             },
         )
     )
@@ -153,8 +153,8 @@ def test_plot_parallel_coordinate_log_params() -> None:
             value=0.1,
             params={"param_a": 1e-4, "param_b": 30},
             distributions={
-                "param_a": LogUniformDistribution(1e-7, 1e-2),
-                "param_b": LogUniformDistribution(1, 1000),
+                "param_a": FloatDistribution(1e-7, 1e-2, log=True),
+                "param_b": FloatDistribution(1, 1000, log=True),
             },
         )
     )
@@ -172,7 +172,7 @@ def test_plot_parallel_coordinate_unique_hyper_param() -> None:
             params={"category_a": "preferred", "param_b": 30},
             distributions={
                 "category_a": CategoricalDistribution(("preferred", "opt")),
-                "param_b": LogUniformDistribution(1, 1000),
+                "param_b": FloatDistribution(1, 1000, log=True),
             },
         )
     )
@@ -187,7 +187,7 @@ def test_plot_parallel_coordinate_unique_hyper_param() -> None:
             params={"category_a": "preferred", "param_b": 20},
             distributions={
                 "category_a": CategoricalDistribution(("preferred", "opt")),
-                "param_b": LogUniformDistribution(1, 1000),
+                "param_b": FloatDistribution(1, 1000, log=True),
             },
         )
     )

--- a/tests/visualization_tests/matplotlib_tests/test_slice.py
+++ b/tests/visualization_tests/matplotlib_tests/test_slice.py
@@ -1,7 +1,6 @@
 import pytest
 
-from optuna.distributions import LogUniformDistribution
-from optuna.distributions import UniformDistribution
+from optuna.distributions import FloatDistribution
 from optuna.study import create_study
 from optuna.testing.visualization import prepare_study_with_trials
 from optuna.trial import create_trial
@@ -73,8 +72,8 @@ def test_plot_slice_log_scale() -> None:
             value=0.0,
             params={"x_linear": 1.0, "y_log": 1e-3},
             distributions={
-                "x_linear": UniformDistribution(0.0, 3.0),
-                "y_log": LogUniformDistribution(1e-5, 1.0),
+                "x_linear": FloatDistribution(0.0, 3.0),
+                "y_log": FloatDistribution(1e-5, 1.0, log=True),
             },
         )
     )

--- a/tests/visualization_tests/test_contour.py
+++ b/tests/visualization_tests/test_contour.py
@@ -9,7 +9,7 @@ import plotly
 import pytest
 
 from optuna.distributions import CategoricalDistribution
-from optuna.distributions import LogUniformDistribution
+from optuna.distributions import FloatDistribution
 from optuna.study import create_study
 from optuna.study import StudyDirection
 from optuna.testing.visualization import prepare_study_with_trials
@@ -162,7 +162,7 @@ def test_plot_contour_log_scale_and_str_category() -> None:
             value=0.0,
             params={"param_a": 1e-6, "param_b": "100"},
             distributions={
-                "param_a": LogUniformDistribution(1e-7, 1e-2),
+                "param_a": FloatDistribution(1e-7, 1e-2, log=True),
                 "param_b": CategoricalDistribution(["100", "101"]),
             },
         )
@@ -172,7 +172,7 @@ def test_plot_contour_log_scale_and_str_category() -> None:
             value=1.0,
             params={"param_a": 1e-5, "param_b": "101"},
             distributions={
-                "param_a": LogUniformDistribution(1e-7, 1e-2),
+                "param_a": FloatDistribution(1e-7, 1e-2, log=True),
                 "param_b": CategoricalDistribution(["100", "101"]),
             },
         )
@@ -194,7 +194,7 @@ def test_plot_contour_log_scale_and_str_category() -> None:
             value=0.0,
             params={"param_a": 1e-6, "param_b": "100", "param_c": "one"},
             distributions={
-                "param_a": LogUniformDistribution(1e-7, 1e-2),
+                "param_a": FloatDistribution(1e-7, 1e-2, log=True),
                 "param_b": CategoricalDistribution(["100", "101"]),
                 "param_c": CategoricalDistribution(["one", "two"]),
             },
@@ -205,7 +205,7 @@ def test_plot_contour_log_scale_and_str_category() -> None:
             value=1.0,
             params={"param_a": 1e-5, "param_b": "101", "param_c": "two"},
             distributions={
-                "param_a": LogUniformDistribution(1e-7, 1e-2),
+                "param_a": FloatDistribution(1e-7, 1e-2, log=True),
                 "param_b": CategoricalDistribution(["100", "101"]),
                 "param_c": CategoricalDistribution(["one", "two"]),
             },

--- a/tests/visualization_tests/test_parallel_coordinate.py
+++ b/tests/visualization_tests/test_parallel_coordinate.py
@@ -3,7 +3,7 @@ import math
 import pytest
 
 from optuna.distributions import CategoricalDistribution
-from optuna.distributions import LogUniformDistribution
+from optuna.distributions import FloatDistribution
 from optuna.study import create_study
 from optuna.testing.visualization import prepare_study_with_trials
 from optuna.trial import create_trial
@@ -137,8 +137,8 @@ def test_plot_parallel_coordinate_log_params() -> None:
             value=0.0,
             params={"param_a": 1e-6, "param_b": 10},
             distributions={
-                "param_a": LogUniformDistribution(1e-7, 1e-2),
-                "param_b": LogUniformDistribution(1, 1000),
+                "param_a": FloatDistribution(1e-7, 1e-2, log=True),
+                "param_b": FloatDistribution(1, 1000, log=True),
             },
         )
     )
@@ -147,8 +147,8 @@ def test_plot_parallel_coordinate_log_params() -> None:
             value=1.0,
             params={"param_a": 2e-5, "param_b": 200},
             distributions={
-                "param_a": LogUniformDistribution(1e-7, 1e-2),
-                "param_b": LogUniformDistribution(1, 1000),
+                "param_a": FloatDistribution(1e-7, 1e-2, log=True),
+                "param_b": FloatDistribution(1, 1000, log=True),
             },
         )
     )
@@ -157,8 +157,8 @@ def test_plot_parallel_coordinate_log_params() -> None:
             value=0.1,
             params={"param_a": 1e-4, "param_b": 30},
             distributions={
-                "param_a": LogUniformDistribution(1e-7, 1e-2),
-                "param_b": LogUniformDistribution(1, 1000),
+                "param_a": FloatDistribution(1e-7, 1e-2, log=True),
+                "param_b": FloatDistribution(1, 1000, log=True),
             },
         )
     )
@@ -190,7 +190,7 @@ def test_plot_parallel_coordinate_with_categorical_numeric_params() -> None:
             distributions={
                 "param_a": CategoricalDistribution(("preferred", "opt")),
                 "param_b": CategoricalDistribution((1, 2, 10)),
-                "param_c": LogUniformDistribution(1, 1000),
+                "param_c": FloatDistribution(1, 1000, log=True),
                 "param_d": CategoricalDistribution((1, -1, 2)),
             },
         )
@@ -203,7 +203,7 @@ def test_plot_parallel_coordinate_with_categorical_numeric_params() -> None:
             distributions={
                 "param_a": CategoricalDistribution(("preferred", "opt")),
                 "param_b": CategoricalDistribution((1, 2, 10)),
-                "param_c": LogUniformDistribution(1, 1000),
+                "param_c": FloatDistribution(1, 1000, log=True),
                 "param_d": CategoricalDistribution((1, -1, 2)),
             },
         )
@@ -216,7 +216,7 @@ def test_plot_parallel_coordinate_with_categorical_numeric_params() -> None:
             distributions={
                 "param_a": CategoricalDistribution(("preferred", "opt")),
                 "param_b": CategoricalDistribution((1, 2, 10)),
-                "param_c": LogUniformDistribution(1, 1000),
+                "param_c": FloatDistribution(1, 1000, log=True),
                 "param_d": CategoricalDistribution((1, -1, 2)),
             },
         )
@@ -229,7 +229,7 @@ def test_plot_parallel_coordinate_with_categorical_numeric_params() -> None:
             distributions={
                 "param_a": CategoricalDistribution(("preferred", "opt")),
                 "param_b": CategoricalDistribution((1, 2, 10)),
-                "param_c": LogUniformDistribution(1, 1000),
+                "param_c": FloatDistribution(1, 1000, log=True),
                 "param_d": CategoricalDistribution((-1, 1, 2)),
             },
         )

--- a/tests/visualization_tests/test_pareto_front.py
+++ b/tests/visualization_tests/test_pareto_front.py
@@ -8,7 +8,7 @@ import numpy as np
 import pytest
 
 import optuna
-from optuna.distributions import UniformDistribution
+from optuna.distributions import FloatDistribution
 from optuna.trial import FrozenTrial
 from optuna.trial import TrialState
 from optuna.visualization import plot_pareto_front
@@ -295,7 +295,7 @@ def test_make_hovertext() -> None:
         datetime_start=datetime.datetime.now(),
         datetime_complete=datetime.datetime.now(),
         params={"x": 10},
-        distributions={"x": UniformDistribution(5, 12)},
+        distributions={"x": FloatDistribution(5, 12)},
         user_attrs={},
         system_attrs={},
         intermediate_values={},
@@ -327,7 +327,7 @@ def test_make_hovertext() -> None:
         datetime_start=datetime.datetime.now(),
         datetime_complete=datetime.datetime.now(),
         params={"x": 10},
-        distributions={"x": UniformDistribution(5, 12)},
+        distributions={"x": FloatDistribution(5, 12)},
         user_attrs={"a": 42, "b": 3.14},
         system_attrs={},
         intermediate_values={},
@@ -363,7 +363,7 @@ def test_make_hovertext() -> None:
         datetime_start=datetime.datetime.now(),
         datetime_complete=datetime.datetime.now(),
         params={"x": 10},
-        distributions={"x": UniformDistribution(5, 12)},
+        distributions={"x": FloatDistribution(5, 12)},
         user_attrs={"a": 42, "b": 3.14, "c": np.zeros(1), "d": np.nan},
         system_attrs={},
         intermediate_values={},

--- a/tests/visualization_tests/test_slice.py
+++ b/tests/visualization_tests/test_slice.py
@@ -1,7 +1,6 @@
 import pytest
 
-from optuna.distributions import LogUniformDistribution
-from optuna.distributions import UniformDistribution
+from optuna.distributions import FloatDistribution
 from optuna.study import create_study
 from optuna.testing.visualization import prepare_study_with_trials
 from optuna.trial import create_trial
@@ -75,8 +74,8 @@ def test_plot_slice_log_scale() -> None:
             value=0.0,
             params={"x_linear": 1.0, "y_log": 1e-3},
             distributions={
-                "x_linear": UniformDistribution(0.0, 3.0),
-                "y_log": LogUniformDistribution(1e-5, 1.0),
+                "x_linear": FloatDistribution(0.0, 3.0),
+                "y_log": FloatDistribution(1e-5, 1.0, log=True),
             },
         )
     )

--- a/tests/visualization_tests/test_utils.py
+++ b/tests/visualization_tests/test_utils.py
@@ -2,8 +2,7 @@ from typing import cast
 
 import pytest
 
-from optuna.distributions import LogUniformDistribution
-from optuna.distributions import UniformDistribution
+from optuna.distributions import FloatDistribution
 from optuna.study import create_study
 from optuna.trial import create_trial
 from optuna.visualization import is_available
@@ -18,7 +17,7 @@ def test_is_log_scale() -> None:
         create_trial(
             value=0.0,
             params={"param_linear": 1.0},
-            distributions={"param_linear": UniformDistribution(0.0, 3.0)},
+            distributions={"param_linear": FloatDistribution(0.0, 3.0)},
         )
     )
     study.add_trial(
@@ -26,8 +25,8 @@ def test_is_log_scale() -> None:
             value=2.0,
             params={"param_linear": 2.0, "param_log": 1e-3},
             distributions={
-                "param_linear": UniformDistribution(0.0, 3.0),
-                "param_log": LogUniformDistribution(1e-5, 1.0),
+                "param_linear": FloatDistribution(0.0, 3.0),
+                "param_log": FloatDistribution(1e-5, 1.0, log=True),
             },
         )
     )

--- a/tutorial/20_recipes/005_user_defined_sampler.py
+++ b/tutorial/20_recipes/005_user_defined_sampler.py
@@ -74,7 +74,7 @@ class SimulatedAnnealingSampler(optuna.samplers.BaseSampler):
         # the objective function passed to the study.
         params = {}
         for param_name, param_distribution in search_space.items():
-            if not isinstance(param_distribution, optuna.distributions.UniformDistribution):
+            if not isinstance(param_distribution, optuna.distributions.FloatDistribution):
                 raise NotImplementedError("Only suggest_float() is supported")
 
             current_value = self._current_trial.params[param_name]

--- a/tutorial/20_recipes/008_specify_params.py
+++ b/tutorial/20_recipes/008_specify_params.py
@@ -119,7 +119,7 @@ study.add_trial(
             "min_child_samples": 20,
         },
         distributions={
-            "bagging_fraction": optuna.distributions.UniformDistribution(0.4, 1.0 + 1e-12),
+            "bagging_fraction": optuna.distributions.FloatDistribution(0.4, 1.0 + 1e-12),
             "bagging_freq": optuna.distributions.IntUniformDistribution(0, 7),
             "min_child_samples": optuna.distributions.IntUniformDistribution(5, 100),
         },
@@ -134,7 +134,7 @@ study.add_trial(
             "min_child_samples": 20,
         },
         distributions={
-            "bagging_fraction": optuna.distributions.UniformDistribution(0.4, 1.0 + 1e-12),
+            "bagging_fraction": optuna.distributions.FloatDistribution(0.4, 1.0 + 1e-12),
             "bagging_freq": optuna.distributions.IntUniformDistribution(0, 7),
             "min_child_samples": optuna.distributions.IntUniformDistribution(5, 100),
         },

--- a/tutorial/20_recipes/009_ask_and_tell.py
+++ b/tutorial/20_recipes/009_ask_and_tell.py
@@ -162,7 +162,7 @@ for _ in range(n_trials):
 # For example,
 
 distributions = {
-    "C": optuna.distributions.LogUniformDistribution(1e-7, 10.0),
+    "C": optuna.distributions.FloatDistribution(1e-7, 10.0, log=True),
     "solver": optuna.distributions.CategoricalDistribution(("lbfgs", "saga")),
 }
 


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
This PR makes the switch from old `UniformDistribution` classes to unified  `FloatDistribution` by instantiating it in `suggest` APIs and few other minor places in codebase. Additionally, all instances of old distributions in test suite are replaced with new one, and parametrization over deprecated classes is removed following https://github.com/optuna/optuna/pull/3111#pullrequestreview-825894668. Part of #2941. This also solves last part of #2939 - parameters within new distribution can be changed freely.

## Description of the changes
<!-- Describe the changes in this PR. -->
* [x] Use `FloatDistribution` in `suggest` APIs and other minor places
* [x] Use instances of `FloatDistribution` in test suite
* [x] Remove *some* test parametrization for old distributions (w/o `pytest.parametrize` cases)
* [x] Fix tutorials