### PR TITLE
Remove testoutput from doctest of mlflow integration

### DIFF
--- a/optuna/integration/mlflow.py
+++ b/optuna/integration/mlflow.py
@@ -62,12 +62,6 @@ class MLflowCallback(object):
 
             shutil.rmtree(tempdir)
 
-        .. testoutput::
-            :hide:
-            :options: +NORMALIZE_WHITESPACE
-
-            INFO: 'my_study' does not exist. Creating a new experiment
-
         Add additional logging to MLflow
 
         .. testcode::
@@ -94,12 +88,6 @@ class MLflowCallback(object):
             study = optuna.create_study(study_name="my_other_study")
             study.optimize(objective, n_trials=10, callbacks=[mlflc])
 
-
-        .. testoutput::
-            :hide:
-            :options: +NORMALIZE_WHITESPACE
-
-            INFO: 'my_other_study' does not exist. Creating a new experiment
 
     Args:
         tracking_uri:

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ def get_extras_require() -> Dict[str, List[str]]:
             "plotly>=4.0.0",
             "scikit-learn>=0.24.2",
             "scikit-optimize",
-            "mlflow<1.22.0",
+            "mlflow",
         ],
         "document": [
             # TODO(nzw): Remove the version constraint after resolving the issue
@@ -96,7 +96,7 @@ def get_extras_require() -> Dict[str, List[str]]:
             "fakeredis",
             "lightgbm",
             "matplotlib>=3.0.0",
-            "mlflow<1.22.0",
+            "mlflow",
             "mpi4py",
             "mxnet",
             "pandas",
@@ -138,7 +138,7 @@ def get_extras_require() -> Dict[str, List[str]]:
             "chainer>=5.0.0",
             "cma",
             "lightgbm",
-            "mlflow<1.22.0",
+            "mlflow",
             "wandb",
             "mpi4py",
             "mxnet",


### PR DESCRIPTION
This PR solves https://github.com/optuna/optuna/issues/3136.

## Motivation
Currently, we check stdout of mlflow integration, which causes the CI error by the change of logging format in mlflow.
I first thought we should fix the tests but now I think we don't need to check this because it is specific to mlflow internal.

This PR removes testoutput in the mlflow test and the version constraint.

## Description of the changes
- ad8849c removes version constraint
- c2755ee removes testoutput from mlflow doctest
