### PR TITLE
[WIP] Add reference to tutorial page in study.enqueue_trial

### DIFF
--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -863,6 +863,10 @@ class Study:
         Args:
             params:
                 Parameter values to pass your objective function.
+
+        .. seealso::
+            Please refer to :ref:`specify_params` for the tutorial of specifying hyperparameters
+            manually.
         """
 
         self.add_trial(


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
Fixed
> the first section can be linked from Study.enqueue_trial

of #2940

## Description of the changes
I added a link from `study.enqueue_trial` to [Specify Hyperparameters Manually](https://optuna.readthedocs.io/en/stable/tutorial/20_recipes/008_specify_params.html).
