### PR TITLE
Add tests in visualization_tests/matplotlib_tests/test_slice.py

### DIFF
--- a/tests/visualization_tests/matplotlib_tests/test_slice.py
+++ b/tests/visualization_tests/matplotlib_tests/test_slice.py
@@ -60,8 +60,6 @@ def test_plot_slice() -> None:
     # Test with a customized target name.
     figure = plot_slice(study, target_name="Target Name")
     assert len(figure) == 2
-    assert len(figure[0].get_lines()) == 0
-    assert len(figure[1].get_lines()) == 0
     assert len(figure[0].findobj(PathCollection)) == 1
     assert len(figure[1].findobj(PathCollection)) == 1
     assert figure[0].yaxis.label.get_text() == "Target Name"

--- a/tests/visualization_tests/matplotlib_tests/test_slice.py
+++ b/tests/visualization_tests/matplotlib_tests/test_slice.py
@@ -23,43 +23,47 @@ def test_plot_slice() -> None:
     # Test with no trial.
     study = prepare_study_with_trials(no_trials=True)
     figure = plot_slice(study)
-    assert len(figure.get_lines()) == 0
+    assert len(figure.findobj(PathCollection)) == 0
 
     study = prepare_study_with_trials(with_c_d=False)
 
     # Test with a trial.
     figure = plot_slice(study)
     assert len(figure) == 2
-    assert len(figure[0].get_lines()) == 0
-    assert len(figure[1].get_lines()) == 0
     assert len(figure[0].findobj(PathCollection)) == 1
     assert len(figure[1].findobj(PathCollection)) == 1
+    assert figure[0].yaxis.label.get_text() == "Objective Value"
 
+    # Scatter plot data is available as PathCollection
     data0 = figure[0].findobj(PathCollection)[0].get_offsets().data
     data1 = figure[1].findobj(PathCollection)[0].get_offsets().data
-    assert np.allclose(data0, [[1.0, 0.0],
-                               [2.5, 1.0]])
-    assert np.allclose(data1, [[2.0, 0.0],
-                               [0.0, 2.0],
-                               [1.0, 1.0]])
-    assert figure[0].yaxis.label.get_text() == "Objective Value"
+    assert np.allclose(data0, [[1.0, 0.0], [2.5, 1.0]])
+    assert np.allclose(data1, [[2.0, 0.0], [0.0, 2.0], [1.0, 1.0]])
 
     # Test with a trial to select parameter.
     figure = plot_slice(study, params=["param_a"])
-    assert len(figure.get_lines()) == 0
+    assert len(figure.findobj(PathCollection)) == 1
     assert figure.yaxis.label.get_text() == "Objective Value"
+
+    data0 = figure.findobj(PathCollection)[0].get_offsets().data
+    np.allclose(data0, [[1.0, 2.0], [2.5, 1.0]])
 
     # Test with a customized target value.
     with pytest.warns(UserWarning):
         figure = plot_slice(study, params=["param_a"], target=lambda t: t.params["param_b"])
-    assert len(figure.get_lines()) == 0
+    assert len(figure.findobj(PathCollection)) == 1
     assert figure.yaxis.label.get_text() == "Objective Value"
+
+    data0 = figure.findobj(PathCollection)[0].get_offsets().data
+    np.allclose(data0, [[1.0, 2.0], [2.5, 1.0]])
 
     # Test with a customized target name.
     figure = plot_slice(study, target_name="Target Name")
     assert len(figure) == 2
     assert len(figure[0].get_lines()) == 0
     assert len(figure[1].get_lines()) == 0
+    assert len(figure[0].findobj(PathCollection)) == 1
+    assert len(figure[1].findobj(PathCollection)) == 1
     assert figure[0].yaxis.label.get_text() == "Target Name"
 
     # Test with wrong parameters.
@@ -75,6 +79,7 @@ def test_plot_slice() -> None:
     study.optimize(fail_objective, n_trials=1, catch=(ValueError,))
     figure = plot_slice(study)
     assert len(figure.get_lines()) == 0
+    assert len(figure.findobj(PathCollection)) == 0
 
 
 def test_plot_slice_log_scale() -> None:
@@ -93,19 +98,19 @@ def test_plot_slice_log_scale() -> None:
 
     # Plot a parameter.
     figure = plot_slice(study, params=["y_log"])
-    assert len(figure.get_lines()) == 0
+    assert len(figure.findobj(PathCollection)) == 1
     assert figure.xaxis.label.get_text() == "y_log"
     assert figure.xaxis.get_scale() == "log"
     figure = plot_slice(study, params=["x_linear"])
-    assert len(figure.get_lines()) == 0
+    assert len(figure.findobj(PathCollection)) == 1
     assert figure.xaxis.label.get_text() == "x_linear"
     assert figure.xaxis.get_scale() == "linear"
 
     # Plot multiple parameters.
     figure = plot_slice(study)
     assert len(figure) == 2
-    assert len(figure[0].get_lines()) == 0
-    assert len(figure[1].get_lines()) == 0
+    assert len(figure[0].findobj(PathCollection)) == 1
+    assert len(figure[1].findobj(PathCollection)) == 1
     assert figure[0].xaxis.label.get_text() == "x_linear"
     assert figure[1].xaxis.label.get_text() == "y_log"
     assert figure[0].xaxis.get_scale() == "linear"

--- a/tests/visualization_tests/matplotlib_tests/test_slice.py
+++ b/tests/visualization_tests/matplotlib_tests/test_slice.py
@@ -1,4 +1,6 @@
 import pytest
+import numpy as np
+from matplotlib.collections import PathCollection
 
 from optuna.distributions import LogUniformDistribution
 from optuna.distributions import UniformDistribution
@@ -30,6 +32,16 @@ def test_plot_slice() -> None:
     assert len(figure) == 2
     assert len(figure[0].get_lines()) == 0
     assert len(figure[1].get_lines()) == 0
+    assert len(figure[0].findobj(PathCollection)) == 1
+    assert len(figure[1].findobj(PathCollection)) == 1
+
+    data0 = figure[0].findobj(PathCollection)[0].get_offsets().data
+    data1 = figure[1].findobj(PathCollection)[0].get_offsets().data
+    assert np.allclose(data0, [[1.0, 0.0],
+                               [2.5, 1.0]])
+    assert np.allclose(data1, [[2.0, 0.0],
+                               [0.0, 2.0],
+                               [1.0, 1.0]])
     assert figure[0].yaxis.label.get_text() == "Objective Value"
 
     # Test with a trial to select parameter.

--- a/tests/visualization_tests/matplotlib_tests/test_slice.py
+++ b/tests/visualization_tests/matplotlib_tests/test_slice.py
@@ -1,6 +1,6 @@
-import pytest
-import numpy as np
 from matplotlib.collections import PathCollection
+import numpy as np
+import pytest
 
 from optuna.distributions import LogUniformDistribution
 from optuna.distributions import UniformDistribution

--- a/tests/visualization_tests/matplotlib_tests/test_slice.py
+++ b/tests/visualization_tests/matplotlib_tests/test_slice.py
@@ -46,7 +46,7 @@ def test_plot_slice() -> None:
     assert figure.yaxis.label.get_text() == "Objective Value"
 
     data0 = figure.findobj(PathCollection)[0].get_offsets().data
-    np.allclose(data0, [[1.0, 2.0], [2.5, 1.0]])
+    assert np.allclose(data0, [[1.0, 0.0], [2.5, 1.0]])
 
     # Test with a customized target value.
     with pytest.warns(UserWarning):
@@ -55,7 +55,7 @@ def test_plot_slice() -> None:
     assert figure.yaxis.label.get_text() == "Objective Value"
 
     data0 = figure.findobj(PathCollection)[0].get_offsets().data
-    np.allclose(data0, [[1.0, 2.0], [2.5, 1.0]])
+    assert np.allclose(data0, [[1.0, 2.0], [2.5, 1.0]])
 
     # Test with a customized target name.
     figure = plot_slice(study, target_name="Target Name")


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
This is a part of my Optuna hackathon(2021-12-19) outcomes. I'm working on #2959 `test_slice` part.


## Description of the changes
<!-- Describe the changes in this PR. -->
This PR adds more tests in `tests/visualization_tests/matplotlib_tests/test_slice.py` since Matplotlib tests have fewer tests than it's Plotly counterpart.

NOTE:
 * Currently it checks `len(figures.get_line()) == 0`, but it 's rather meaningless. In scatter plot, the plotted data is stored as PathCollection, which is available through `figure.findobj(PathCollection)` (actually `figure` is `Axes` object and maybe confusing). Although  `len(figures.get_line()) == 0` is harmless, I deleted them. Please let me know if I should put them back.

 * [x] test_plot_slice
 * [x] test_plot_slice_log_scale