### PR TITLE
[WIP] Unify plot pareto front

### DIFF
--- a/optuna/study/_multi_objective.py
+++ b/optuna/study/_multi_objective.py
@@ -8,8 +8,10 @@ from optuna.trial import FrozenTrial
 from optuna.trial import TrialState
 
 
-def _get_pareto_front_trials_2d(study: "optuna.study.Study") -> List[FrozenTrial]:
-    trials = [trial for trial in study.trials if trial.state == TrialState.COMPLETE]
+def _get_pareto_front_trials_2d(
+    orig_trials: List[FrozenTrial], directions: List[StudyDirection]
+) -> List[FrozenTrial]:
+    trials = [trial for trial in orig_trials if trial.state == TrialState.COMPLETE]
 
     n_trials = len(trials)
     if n_trials == 0:
@@ -17,8 +19,8 @@ def _get_pareto_front_trials_2d(study: "optuna.study.Study") -> List[FrozenTrial
 
     trials.sort(
         key=lambda trial: (
-            _normalize_value(trial.values[0], study.directions[0]),
-            _normalize_value(trial.values[1], study.directions[1]),
+            _normalize_value(trial.values[0], directions[0]),
+            _normalize_value(trial.values[1], directions[1]),
         ),
     )
 
@@ -26,7 +28,7 @@ def _get_pareto_front_trials_2d(study: "optuna.study.Study") -> List[FrozenTrial
     pareto_front = [last_nondominated_trial]
     for i in range(1, n_trials):
         trial = trials[i]
-        if _dominates(last_nondominated_trial, trial, study.directions):
+        if _dominates(last_nondominated_trial, trial, directions):
             continue
         pareto_front.append(trial)
         last_nondominated_trial = trial
@@ -35,15 +37,17 @@ def _get_pareto_front_trials_2d(study: "optuna.study.Study") -> List[FrozenTrial
     return pareto_front
 
 
-def _get_pareto_front_trials_nd(study: "optuna.study.Study") -> List[FrozenTrial]:
+def _get_pareto_front_trials_nd(
+    orig_trials: List[FrozenTrial], directions: List[StudyDirection]
+) -> List[FrozenTrial]:
     pareto_front = []
-    trials = [t for t in study.trials if t.state == TrialState.COMPLETE]
+    trials = [t for t in orig_trials if t.state == TrialState.COMPLETE]
 
     # TODO(vincent): Optimize (use the fast non dominated sort defined in the NSGA-II paper).
     for trial in trials:
         dominated = False
         for other in trials:
-            if _dominates(other, trial, study.directions):
+            if _dominates(other, trial, directions):
                 dominated = True
                 break
 
@@ -53,10 +57,16 @@ def _get_pareto_front_trials_nd(study: "optuna.study.Study") -> List[FrozenTrial
     return pareto_front
 
 
+def _get_pareto_front_trials_by_trials(
+    trials: List[FrozenTrial], directions: List[StudyDirection]
+) -> List[FrozenTrial]:
+    if len(directions) == 2:
+        return _get_pareto_front_trials_2d(trials, directions)  # Log-linear in number of trials.
+    return _get_pareto_front_trials_nd(trials, directions)  # Quadratic in number of trials.
+
+
 def _get_pareto_front_trials(study: "optuna.study.Study") -> List[FrozenTrial]:
-    if len(study.directions) == 2:
-        return _get_pareto_front_trials_2d(study)  # Log-linear in number of trials.
-    return _get_pareto_front_trials_nd(study)  # Quadratic in number of trials.
+    return _get_pareto_front_trials_by_trials(study.trials, study.directions)
 
 
 def _dominates(

--- a/tests/test_multi_objective.py
+++ b/tests/test_multi_objective.py
@@ -13,60 +13,88 @@ def _trial_to_values(t: FrozenTrial) -> Tuple[float, ...]:
 
 def test_get_pareto_front_trials_2d() -> None:
     study = create_study(directions=["minimize", "maximize"])
-    assert {_trial_to_values(t) for t in _get_pareto_front_trials_2d(study)} == set()
+    assert {
+        _trial_to_values(t) for t in _get_pareto_front_trials_2d(study.trials, study.directions)
+    } == set()
 
     study.optimize(lambda t: [2, 2], n_trials=1)
-    assert {_trial_to_values(t) for t in _get_pareto_front_trials_2d(study)} == {(2, 2)}
+    assert {
+        _trial_to_values(t) for t in _get_pareto_front_trials_2d(study.trials, study.directions)
+    } == {(2, 2)}
 
     study.optimize(lambda t: [1, 1], n_trials=1)
-    assert {_trial_to_values(t) for t in _get_pareto_front_trials_2d(study)} == {(1, 1), (2, 2)}
+    assert {
+        _trial_to_values(t) for t in _get_pareto_front_trials_2d(study.trials, study.directions)
+    } == {(1, 1), (2, 2)}
 
     study.optimize(lambda t: [3, 1], n_trials=1)
-    assert {_trial_to_values(t) for t in _get_pareto_front_trials_2d(study)} == {(1, 1), (2, 2)}
+    assert {
+        _trial_to_values(t) for t in _get_pareto_front_trials_2d(study.trials, study.directions)
+    } == {(1, 1), (2, 2)}
 
     study.optimize(lambda t: [3, 2], n_trials=1)
-    assert {_trial_to_values(t) for t in _get_pareto_front_trials_2d(study)} == {(1, 1), (2, 2)}
+    assert {
+        _trial_to_values(t) for t in _get_pareto_front_trials_2d(study.trials, study.directions)
+    } == {(1, 1), (2, 2)}
 
     study.optimize(lambda t: [1, 3], n_trials=1)
-    assert {_trial_to_values(t) for t in _get_pareto_front_trials_2d(study)} == {(1, 3)}
-    assert len(_get_pareto_front_trials_2d(study)) == 1
+    assert {
+        _trial_to_values(t) for t in _get_pareto_front_trials_2d(study.trials, study.directions)
+    } == {(1, 3)}
+    assert len(_get_pareto_front_trials_2d(study.trials, study.directions)) == 1
 
     study.optimize(lambda t: [1, 3], n_trials=1)  # The trial result is the same as the above one.
-    assert {_trial_to_values(t) for t in _get_pareto_front_trials_2d(study)} == {(1, 3)}
-    assert len(_get_pareto_front_trials_2d(study)) == 2
+    assert {
+        _trial_to_values(t) for t in _get_pareto_front_trials_2d(study.trials, study.directions)
+    } == {(1, 3)}
+    assert len(_get_pareto_front_trials_2d(study.trials, study.directions)) == 2
 
 
 def test_get_pareto_front_trials_nd() -> None:
     study = create_study(directions=["minimize", "maximize", "minimize"])
-    assert {_trial_to_values(t) for t in _get_pareto_front_trials_nd(study)} == set()
+    assert {
+        _trial_to_values(t) for t in _get_pareto_front_trials_nd(study.trials, study.directions)
+    } == set()
 
     study.optimize(lambda t: [2, 2, 2], n_trials=1)
-    assert {_trial_to_values(t) for t in _get_pareto_front_trials_nd(study)} == {(2, 2, 2)}
+    assert {
+        _trial_to_values(t) for t in _get_pareto_front_trials_nd(study.trials, study.directions)
+    } == {(2, 2, 2)}
 
     study.optimize(lambda t: [1, 1, 1], n_trials=1)
-    assert {_trial_to_values(t) for t in _get_pareto_front_trials_nd(study)} == {
+    assert {
+        _trial_to_values(t) for t in _get_pareto_front_trials_nd(study.trials, study.directions)
+    } == {
         (1, 1, 1),
         (2, 2, 2),
     }
 
     study.optimize(lambda t: [3, 1, 3], n_trials=1)
-    assert {_trial_to_values(t) for t in _get_pareto_front_trials_nd(study)} == {
+    assert {
+        _trial_to_values(t) for t in _get_pareto_front_trials_nd(study.trials, study.directions)
+    } == {
         (1, 1, 1),
         (2, 2, 2),
     }
 
     study.optimize(lambda t: [3, 2, 3], n_trials=1)
-    assert {_trial_to_values(t) for t in _get_pareto_front_trials_nd(study)} == {
+    assert {
+        _trial_to_values(t) for t in _get_pareto_front_trials_nd(study.trials, study.directions)
+    } == {
         (1, 1, 1),
         (2, 2, 2),
     }
 
     study.optimize(lambda t: [1, 3, 1], n_trials=1)
-    assert {_trial_to_values(t) for t in _get_pareto_front_trials_nd(study)} == {(1, 3, 1)}
-    assert len(_get_pareto_front_trials_nd(study)) == 1
+    assert {
+        _trial_to_values(t) for t in _get_pareto_front_trials_nd(study.trials, study.directions)
+    } == {(1, 3, 1)}
+    assert len(_get_pareto_front_trials_nd(study.trials, study.directions)) == 1
 
     study.optimize(
         lambda t: [1, 3, 1], n_trials=1
     )  # The trial result is the same as the above one.
-    assert {_trial_to_values(t) for t in _get_pareto_front_trials_nd(study)} == {(1, 3, 1)}
-    assert len(_get_pareto_front_trials_nd(study)) == 2
+    assert {
+        _trial_to_values(t) for t in _get_pareto_front_trials_nd(study.trials, study.directions)
+    } == {(1, 3, 1)}
+    assert len(_get_pareto_front_trials_nd(study.trials, study.directions)) == 2

--- a/tests/visualization_tests/test_pareto_front.py
+++ b/tests/visualization_tests/test_pareto_front.py
@@ -34,11 +34,12 @@ def test_plot_pareto_front_2d(
     assert (figure.data[1]["x"] + figure.data[0]["x"]) == ()
     assert (figure.data[1]["y"] + figure.data[0]["y"]) == ()
 
-    # Test with three trials.
+    # Test with four trials.
+    study.enqueue_trial({"x": 1, "y": 2})
     study.enqueue_trial({"x": 1, "y": 1})
+    study.enqueue_trial({"x": 0, "y": 2})
     study.enqueue_trial({"x": 1, "y": 0})
-    study.enqueue_trial({"x": 0, "y": 1})
-    study.optimize(lambda t: [t.suggest_int("x", 0, 1), t.suggest_int("y", 0, 1)], n_trials=3)
+    study.optimize(lambda t: [t.suggest_int("x", 0, 2), t.suggest_int("y", 0, 2)], n_trials=4)
 
     constraints_func: Optional[Callable[[FrozenTrial], Sequence[float]]]
     if use_constraints_func:
@@ -62,7 +63,7 @@ def test_plot_pareto_front_2d(
         assert len(figure.data) == 3
         if include_dominated_trials:
             # The enqueue order of trial is: infeasible, feasible non-best, then feasible best.
-            data = [(0, 1, 1), (1, 1, 0)]  # type: ignore
+            data = [(1, 0, 1, 1), (1, 2, 2, 0)]  # type: ignore
             if axis_order is None:
                 assert (figure.data[2]["x"] + figure.data[1]["x"] + figure.data[0]["x"]) == data[0]
                 assert (figure.data[2]["y"] + figure.data[1]["y"] + figure.data[0]["y"]) == data[1]
@@ -75,7 +76,7 @@ def test_plot_pareto_front_2d(
                 ]
         else:
             # The enqueue order of trial is: infeasible, feasible.
-            data = [(0, 1), (1, 0)]  # type: ignore
+            data = [(1, 0, 1), (1, 2, 0)]  # type: ignore
             if axis_order is None:
                 assert (figure.data[2]["x"] + figure.data[1]["x"] + figure.data[0]["x"]) == data[0]
                 assert (figure.data[2]["y"] + figure.data[1]["y"] + figure.data[0]["y"]) == data[1]
@@ -90,7 +91,7 @@ def test_plot_pareto_front_2d(
         assert len(figure.data) == 2
         if include_dominated_trials:
             # The last elements come from dominated trial that is enqueued firstly.
-            data = [(1, 0, 1), (0, 1, 1)]  # type: ignore
+            data = [(0, 1, 1, 1), (2, 0, 2, 1)]  # type: ignore
             if axis_order is None:
                 assert (figure.data[1]["x"] + figure.data[0]["x"]) == data[0]
                 assert (figure.data[1]["y"] + figure.data[0]["y"]) == data[1]
@@ -98,7 +99,7 @@ def test_plot_pareto_front_2d(
                 assert (figure.data[1]["x"] + figure.data[0]["x"]) == data[axis_order[0]]
                 assert (figure.data[1]["y"] + figure.data[0]["y"]) == data[axis_order[1]]
         else:
-            data = [(1, 0), (0, 1)]  # type: ignore
+            data = [(0, 1), (2, 0)]  # type: ignore
             if axis_order is None:
                 assert (figure.data[1]["x"] + figure.data[0]["x"]) == data[0]
                 assert (figure.data[1]["y"] + figure.data[0]["y"]) == data[1]
@@ -170,19 +171,20 @@ def test_plot_pareto_front_3d(
     assert (figure.data[1]["z"] + figure.data[0]["z"]) == ()
 
     # Test with three trials.
+    study.enqueue_trial({"x": 1, "y": 1, "z": 2})
     study.enqueue_trial({"x": 1, "y": 1, "z": 1})
-    study.enqueue_trial({"x": 1, "y": 0, "z": 1})
+    study.enqueue_trial({"x": 1, "y": 0, "z": 2})
     study.enqueue_trial({"x": 1, "y": 1, "z": 0})
     study.optimize(
-        lambda t: [t.suggest_int("x", 0, 1), t.suggest_int("y", 0, 1), t.suggest_int("z", 0, 1)],
-        n_trials=3,
+        lambda t: [t.suggest_int("x", 0, 1), t.suggest_int("y", 0, 2), t.suggest_int("z", 0, 2)],
+        n_trials=4,
     )
 
     constraints_func: Optional[Callable[[FrozenTrial], Sequence[float]]]
     if use_constraints_func:
         # (x, y, z) = (1, 0, 1) is infeasible; others are feasible.
         def constraints_func(t: FrozenTrial) -> Sequence[float]:
-            if t.params["x"] == 1 and t.params["y"] == 0 and t.params["z"] == 1:
+            if t.params["x"] == 1 and t.params["y"] == 1 and t.params["z"] == 0:
                 return [1.0]
             else:
                 return [-1.0]
@@ -200,7 +202,7 @@ def test_plot_pareto_front_3d(
         assert len(figure.data) == 3
         if include_dominated_trials:
             # The enqueue order of trial is: infeasible, feasible non-best, then feasible best.
-            data = [(1, 1, 1), (1, 1, 0), (0, 1, 1)]  # type: ignore
+            data = [(1, 1, 1, 1), (1, 0, 1, 1), (1, 2, 2, 0)]  # type: ignore
             if axis_order is None:
                 assert (figure.data[2]["x"] + figure.data[1]["x"] + figure.data[0]["x"]) == data[0]
                 assert (figure.data[2]["y"] + figure.data[1]["y"] + figure.data[0]["y"]) == data[1]
@@ -217,7 +219,7 @@ def test_plot_pareto_front_3d(
                 ]
         else:
             # The enqueue order of trial is: infeasible, feasible.
-            data = [(1, 1), (1, 0), (0, 1)]  # type: ignore
+            data = [(1, 1, 1), (1, 0, 1), (1, 2, 0)]  # type: ignore
             if axis_order is None:
                 assert (figure.data[2]["x"] + figure.data[1]["x"] + figure.data[0]["x"]) == data[0]
                 assert (figure.data[2]["y"] + figure.data[1]["y"] + figure.data[0]["y"]) == data[1]
@@ -236,7 +238,7 @@ def test_plot_pareto_front_3d(
         assert len(figure.data) == 2
         if include_dominated_trials:
             # The last elements come from dominated trial that is enqueued firstly.
-            data = [(1, 1, 1), (0, 1, 1), (1, 0, 1)]  # type: ignore
+            data = [(1, 1, 1, 1), (0, 1, 1, 1), (2, 0, 2, 1)]  # type: ignore
             if axis_order is None:
                 assert (figure.data[1]["x"] + figure.data[0]["x"]) == data[0]
                 assert (figure.data[1]["y"] + figure.data[0]["y"]) == data[1]
@@ -246,7 +248,7 @@ def test_plot_pareto_front_3d(
                 assert (figure.data[1]["y"] + figure.data[0]["y"]) == data[axis_order[1]]
                 assert (figure.data[1]["z"] + figure.data[0]["z"]) == data[axis_order[2]]
         else:
-            data = [(1, 1), (0, 1), (1, 0)]  # type: ignore
+            data = [(1, 1), (0, 1), (2, 0)]  # type: ignore
             if axis_order is None:
                 assert (figure.data[1]["x"] + figure.data[0]["x"]) == data[0]
                 assert (figure.data[1]["y"] + figure.data[0]["y"]) == data[1]


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

NOTE: #3128 should be merged before this PR. Once #3128 is merged, I will rebase this feature branch upon `master`

## Motivation
It is desirable to support `constraints_func` in `matplotlib.plot_pareto_front` as in #3128. To avoid repetition of pareto-front computation codes, we would like to factor out the preprocessing in `plot_pareto_front`s for pyplot and matplotlib.

## Description of the changes
Preprocessing of `plot_pareto_front` (for pyplot) is factored out so that it can be used by `matplotlib.plot_pareto_front` as well. At the same time, both 2D and 3D plots are done in a single function as in #3128.