### PR TITLE
Add tests for generated plots of `matplotlib.plot_edf`

### DIFF
--- a/tests/visualization_tests/matplotlib_tests/test_edf.py
+++ b/tests/visualization_tests/matplotlib_tests/test_edf.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import Sequence
 
 import numpy as np
 import pytest
@@ -14,7 +14,7 @@ def test_target_is_none_and_study_is_multi_obj() -> None:
         plot_edf(study)
 
 
-def _validate(y_values: List[float]) -> None:
+def _validate(y_values: Sequence[float]) -> None:
     np_values = np.array(y_values)
     # This line confirms that the values are monotonically non-decreasing.
     assert np.all(np_values[1:] - np_values[:-1] >= 0)

--- a/tests/visualization_tests/matplotlib_tests/test_edf.py
+++ b/tests/visualization_tests/matplotlib_tests/test_edf.py
@@ -2,7 +2,8 @@ import pytest
 
 from optuna.study import create_study
 from optuna.visualization.matplotlib import plot_edf
-
+from typing import List
+import matplotlib.pyplot as plt
 
 def test_target_is_none_and_study_is_multi_obj() -> None:
 
@@ -10,6 +11,20 @@ def test_target_is_none_and_study_is_multi_obj() -> None:
     with pytest.raises(ValueError):
         plot_edf(study)
 
+confirm_0_1 = lambda y: 0<=y and y<=1
+
+def confirm_monotonous_increase_and_0_1(lst:List)-> bool:
+    last_value=lst[0]
+    if not confirm_0_1(last_value):
+        return False
+    for i in lst[1:]:
+        if not confirm_0_1(i):
+            return False
+        if last_value<=i:
+            last_value=i
+        else:
+            return False
+    return True
 
 @pytest.mark.parametrize("direction", ["minimize", "maximize"])
 def test_plot_optimization_history(direction: str) -> None:
@@ -28,27 +43,42 @@ def test_plot_optimization_history(direction: str) -> None:
     study0 = create_study(direction=direction)
     study0.optimize(lambda t: t.suggest_float("x", 0, 5), n_trials=10)
     figure = plot_edf(study0)
-    assert len(figure.get_lines()) == 1
+    lines  = figure.get_lines()
+    assert confirm_monotonous_increase_and_0_1(lines[0].get_ydata())
+    assert len(lines) == 1
     assert figure.xaxis.label.get_text() == "Objective Value"
 
     # Test with two studies.
     study1 = create_study(direction=direction)
     study1.optimize(lambda t: t.suggest_float("x", 0, 5), n_trials=10)
     figure = plot_edf([study0, study1])
-    assert len(figure.get_lines()) == 2
+    lines  = figure.get_lines()
+    for line in lines:
+        y = line.get_ydata()
+        assert confirm_monotonous_increase_and_0_1(y)
+    assert len(lines) == 2
+
     figure = plot_edf((study0, study1))
-    assert len(figure.get_lines()) == 2
+    lines  = figure.get_lines()
+    for line in lines:
+        y = line.get_ydata()
+        assert confirm_monotonous_increase_and_0_1(y)
+    assert len(lines) == 2
 
     # Test with a customized target value.
     study0 = create_study(direction=direction)
     study0.optimize(lambda t: t.suggest_float("x", 0, 5), n_trials=10)
     with pytest.warns(UserWarning):
         figure = plot_edf(study0, target=lambda t: t.params["x"])
-    assert len(figure.get_lines()) == 1
+    lines  = figure.get_lines()
+    assert confirm_monotonous_increase_and_0_1(lines[0].get_ydata())
+    assert len(lines) == 1
 
     # Test with a customized target name.
     study0 = create_study(direction=direction)
     study0.optimize(lambda t: t.suggest_float("x", 0, 5), n_trials=10)
     figure = plot_edf(study0, target_name="Target Name")
+    lines  = figure.get_lines()
+    assert confirm_monotonous_increase_and_0_1(lines[0].get_ydata())
     assert len(figure.get_lines()) == 1
     assert figure.xaxis.label.get_text() == "Target Name"

--- a/tests/visualization_tests/test_edf.py
+++ b/tests/visualization_tests/test_edf.py
@@ -13,7 +13,6 @@ def test_target_is_none_and_study_is_multi_obj() -> None:
 
 @pytest.mark.parametrize("direction", ["minimize", "maximize"])
 def test_plot_optimization_history(direction: str) -> None:
-    print(direction)
     # Test with no studies.
     figure = plot_edf([])
     assert len(figure.data) == 0

--- a/tests/visualization_tests/test_edf.py
+++ b/tests/visualization_tests/test_edf.py
@@ -13,6 +13,7 @@ def test_target_is_none_and_study_is_multi_obj() -> None:
 
 @pytest.mark.parametrize("direction", ["minimize", "maximize"])
 def test_plot_optimization_history(direction: str) -> None:
+    print(direction)
     # Test with no studies.
     figure = plot_edf([])
     assert len(figure.data) == 0


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
Add test in matplotlib test ``plot_edf``  of matplotlib.

## Description of the changes
<!-- Describe the changes in this PR. -->
This test confirms 
- that the values are monotonically non-decreasing and  
- that the values are in [0,1].
## Reference
- [Stabilise visualisation module #2959](https://github.com/optuna/optuna/issues/2959)  
- [Add tests for generated plots of plot_edf #3188](https://github.com/optuna/optuna/pull/3188)