### PR TITLE
[not for merge] Run Python 3.10 tests on CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
 
     services:
       redis:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -70,7 +70,6 @@ jobs:
         # TODO(hvy): Fix samplers_tests/test_samplers.py to not require optional dependencies and remove these installs.
         pip install scikit-optimize
         pip install cma
-        pip install botorch torch==1.10.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
 
     - name: Tests
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
 
     services:
       redis:

--- a/setup.py
+++ b/setup.py
@@ -230,6 +230,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3 :: Only",
         "Topic :: Scientific/Engineering",
         "Topic :: Scientific/Engineering :: Mathematics",

--- a/setup.py
+++ b/setup.py
@@ -111,7 +111,6 @@ def get_extras_require() -> Dict[str, List[str]]:
             # pytorch-lightning==1.5.0.
             "skorch",
             "catalyst>=21.3",
-            "allennlp>=2.2.0 ; python_version>'3.6'",
             "fastai",
         ],
         "tests": [

--- a/setup.py
+++ b/setup.py
@@ -110,16 +110,9 @@ def get_extras_require() -> Dict[str, List[str]]:
             "pytorch-ignite",
             # TODO(nzw0301): remove the upper version constraint when the callback supports
             # pytorch-lightning==1.5.0.
-            "pytorch-lightning>=1.0.2,<1.5.0",
             "skorch",
             "catalyst>=21.3",
-            "torch==1.10.0 ; sys_platform=='darwin'",
-            "torch==1.10.0+cpu ; sys_platform!='darwin'",
-            "torchvision==0.11.1 ; sys_platform=='darwin'",
-            "torchvision==0.11.1+cpu ; sys_platform!='darwin'",
-            "torchaudio==0.10.0",
             "allennlp>=2.2.0 ; python_version>'3.6'",
-            "botorch>=0.4.0 ; python_version>'3.6'",
             "fastai",
         ],
         "tests": [

--- a/setup.py
+++ b/setup.py
@@ -107,7 +107,6 @@ def get_extras_require() -> Dict[str, List[str]]:
             "xgboost",
             "tensorflow",
             "tensorflow-datasets",
-            "pytorch-ignite",
             # TODO(nzw0301): remove the upper version constraint when the callback supports
             # pytorch-lightning==1.5.0.
             "skorch",


### PR DESCRIPTION
## Motivation
We would like to support Python 3.10.

## Description of the changes
This branch is to examine how current tests work on CI with Python 3.10.