### PR TITLE
Switch to `IntDistribution`

### DIFF
--- a/docs/source/reference/distributions.rst
+++ b/docs/source/reference/distributions.rst
@@ -3,7 +3,7 @@
 optuna.distributions
 ====================
 
-The :mod:`~optuna.distributions` module defines various classes representing probability distributions, mainly used to suggest initial hyperparameter values for an optimization trial. Distribution classes inherit from a library-internal :class:`~optuna.distributions.BaseDistribution`, and is initialized with specific parameters, such as the ``low`` and ``high`` endpoints for a :class:`~optuna.distributions.UniformDistribution`.
+The :mod:`~optuna.distributions` module defines various classes representing probability distributions, mainly used to suggest initial hyperparameter values for an optimization trial. Distribution classes inherit from a library-internal :class:`~optuna.distributions.BaseDistribution`, and is initialized with specific parameters, such as the ``low`` and ``high`` endpoints for a :class:`~optuna.distributions.IntDistribution`.
 
 Optuna users should not use distribution classes directly, but instead use utility functions provided by :class:`~optuna.trial.Trial` such as :meth:`~optuna.trial.Trial.suggest_int`.
 

--- a/optuna/_transform.py
+++ b/optuna/_transform.py
@@ -13,8 +13,6 @@ from optuna.distributions import CategoricalDistribution
 from optuna.distributions import DiscreteUniformDistribution
 from optuna.distributions import FloatDistribution
 from optuna.distributions import IntDistribution
-from optuna.distributions import IntLogUniformDistribution
-from optuna.distributions import IntUniformDistribution
 from optuna.distributions import LogUniformDistribution
 from optuna.distributions import UniformDistribution
 
@@ -191,8 +189,6 @@ def _transform_search_space(
                 UniformDistribution,
                 LogUniformDistribution,
                 DiscreteUniformDistribution,
-                IntUniformDistribution,
-                IntLogUniformDistribution,
                 FloatDistribution,
                 IntDistribution,
             ),
@@ -225,18 +221,6 @@ def _transform_search_space(
                         _transform_numerical_param(d.low, d, transform_log),
                         _transform_numerical_param(d.high, d, transform_log),
                     )
-            elif isinstance(d, IntUniformDistribution):
-                half_step = 0.5 * d.step if transform_step else 0.0
-                bds = (
-                    _transform_numerical_param(d.low, d, transform_log) - half_step,
-                    _transform_numerical_param(d.high, d, transform_log) + half_step,
-                )
-            elif isinstance(d, IntLogUniformDistribution):
-                half_step = 0.5 if transform_step else 0.0
-                bds = (
-                    _transform_numerical_param(d.low - half_step, d, transform_log),
-                    _transform_numerical_param(d.high + half_step, d, transform_log),
-                )
             elif isinstance(d, IntDistribution):
                 half_step = 0.5 * d.step if transform_step else 0.0
                 if d.log:
@@ -283,10 +267,6 @@ def _transform_numerical_param(
             trans_param = math.log(param) if transform_log else float(param)
         else:
             trans_param = float(param)
-    elif isinstance(d, IntUniformDistribution):
-        trans_param = float(param)
-    elif isinstance(d, IntLogUniformDistribution):
-        trans_param = math.log(param) if transform_log else float(param)
     elif isinstance(d, IntDistribution):
         if d.log:
             trans_param = math.log(param) if transform_log else float(param)
@@ -340,13 +320,6 @@ def _untransform_numerical_param(
                 param = trans_param
             else:
                 param = min(trans_param, numpy.nextafter(d.high, d.high - 1))
-    elif isinstance(d, IntUniformDistribution):
-        param = int(numpy.round((trans_param - d.low) / d.step) * d.step + d.low)
-    elif isinstance(d, IntLogUniformDistribution):
-        if transform_log:
-            param = int(min(max(numpy.round(math.exp(trans_param)), d.low), d.high))
-        else:
-            param = int(trans_param)
     elif isinstance(d, IntDistribution):
         if d.log:
             if transform_log:

--- a/optuna/distributions.py
+++ b/optuna/distributions.py
@@ -546,17 +546,8 @@ def json_to_distribution(json_str: str) -> BaseDistribution:
                 return FloatDistribution(low, high, log=log, step=step)
 
             else:
-                if log and step != 1:
-                    step = 1
-                    warnings.warn(
-                        "Samplers and other components in Optuna will assume that `step` is 1 "
-                        "when `log` argument is True.",
-                        FutureWarning,
-                    )
                 if step is None:
                     step = 1
-                if log is None:
-                    log = False
                 return IntDistribution(low=low, high=high, log=log, step=step)
 
         raise ValueError("Unknown distribution type: {}".format(json_dict["type"]))

--- a/optuna/distributions.py
+++ b/optuna/distributions.py
@@ -502,8 +502,6 @@ DISTRIBUTION_CLASSES = (
     UniformDistribution,
     LogUniformDistribution,
     DiscreteUniformDistribution,
-    IntUniformDistribution,
-    IntLogUniformDistribution,
     CategoricalDistribution,
 )
 
@@ -548,16 +546,18 @@ def json_to_distribution(json_str: str) -> BaseDistribution:
                 return FloatDistribution(low, high, log=log, step=step)
 
             else:
-                if log:
-                    if step is not None:
-                        return IntLogUniformDistribution(low, high, step)
-                    else:
-                        return IntLogUniformDistribution(low, high)
-                else:
-                    if step is not None:
-                        return IntUniformDistribution(low, high, step)
-                    else:
-                        return IntUniformDistribution(low, high)
+                if log and step != 1:
+                    step = 1
+                    warnings.warn(
+                        "Samplers and other components in Optuna will assume that `step` is 1 "
+                        "when `log` argument is True.",
+                        FutureWarning,
+                    )
+                if step is None:
+                    step = 1
+                if log is None:
+                    log = False
+                return IntDistribution(low=low, high=high, log=log, step=step)
 
         raise ValueError("Unknown distribution type: {}".format(json_dict["type"]))
 
@@ -653,8 +653,6 @@ def _get_single_value(distribution: BaseDistribution) -> Union[int, float, Categ
             UniformDistribution,
             LogUniformDistribution,
             DiscreteUniformDistribution,
-            IntUniformDistribution,
-            IntLogUniformDistribution,
         ),
     ):
         return distribution.low

--- a/optuna/distributions.py
+++ b/optuna/distributions.py
@@ -498,6 +498,8 @@ class CategoricalDistribution(BaseDistribution):
 
 DISTRIBUTION_CLASSES = (
     IntDistribution,
+    IntLogUniformDistribution,
+    IntUniformDistribution,
     FloatDistribution,
     UniformDistribution,
     LogUniformDistribution,

--- a/optuna/integration/cma.py
+++ b/optuna/integration/cma.py
@@ -276,10 +276,6 @@ class PyCmaSampler(BaseSampler):
                     sigma0s.append((log_high - log_low) / 6)
                 else:
                     sigma0s.append((distribution.high - distribution.low) / 6)
-            if isinstance(distribution, UniformDistribution):
-                sigma0s.append((distribution.high - distribution.low) / 6)
-            elif isinstance(distribution, DiscreteUniformDistribution):
-                sigma0s.append((distribution.high - distribution.low) / 6)
             elif isinstance(distribution, FloatDistribution):
                 if distribution.log:
                     log_high = math.log(distribution.high)

--- a/optuna/integration/skopt.py
+++ b/optuna/integration/skopt.py
@@ -243,7 +243,15 @@ class _Optimizer(object):
 
         dimensions = []
         for name, distribution in sorted(self._search_space.items()):
-            if isinstance(distribution, distributions.IntDistribution):
+            if isinstance(distribution, distributions.UniformDistribution):
+                # Convert the upper bound from exclusive (optuna) to inclusive (skopt).
+                high = np.nextafter(distribution.high, float("-inf"))
+                dimension = space.Real(distribution.low, high)
+            elif isinstance(distribution, distributions.LogUniformDistribution):
+                # Convert the upper bound from exclusive (optuna) to inclusive (skopt).
+                high = np.nextafter(distribution.high, float("-inf"))
+                dimension = space.Real(distribution.low, high, prior="log-uniform")
+            elif isinstance(distribution, distributions.IntDistribution):
                 if distribution.log:
                     low = distribution.low - 0.5
                     high = distribution.high + 0.5

--- a/optuna/integration/skopt.py
+++ b/optuna/integration/skopt.py
@@ -243,22 +243,7 @@ class _Optimizer(object):
 
         dimensions = []
         for name, distribution in sorted(self._search_space.items()):
-            if isinstance(distribution, distributions.UniformDistribution):
-                # Convert the upper bound from exclusive (optuna) to inclusive (skopt).
-                high = np.nextafter(distribution.high, float("-inf"))
-                dimension = space.Real(distribution.low, high)
-            elif isinstance(distribution, distributions.LogUniformDistribution):
-                # Convert the upper bound from exclusive (optuna) to inclusive (skopt).
-                high = np.nextafter(distribution.high, float("-inf"))
-                dimension = space.Real(distribution.low, high, prior="log-uniform")
-            elif isinstance(distribution, distributions.IntUniformDistribution):
-                count = (distribution.high - distribution.low) // distribution.step
-                dimension = space.Integer(0, count)
-            elif isinstance(distribution, distributions.IntLogUniformDistribution):
-                low = distribution.low - 0.5
-                high = distribution.high + 0.5
-                dimension = space.Real(low, high, prior="log-uniform")
-            elif isinstance(distribution, distributions.IntDistribution):
+            if isinstance(distribution, distributions.IntDistribution):
                 if distribution.log:
                     low = distribution.low - 0.5
                     high = distribution.high + 0.5
@@ -266,6 +251,14 @@ class _Optimizer(object):
                 else:
                     count = (distribution.high - distribution.low) // distribution.step
                     dimension = space.Integer(0, count)
+            elif isinstance(distribution, distributions.UniformDistribution):
+                # Convert the upper bound from exclusive (optuna) to inclusive (skopt).
+                high = np.nextafter(distribution.high, float("-inf"))
+                dimension = space.Real(distribution.low, high)
+            elif isinstance(distribution, distributions.LogUniformDistribution):
+                # Convert the upper bound from exclusive (optuna) to inclusive (skopt).
+                high = np.nextafter(distribution.high, float("-inf"))
+                dimension = space.Real(distribution.low, high, prior="log-uniform")
             elif isinstance(distribution, distributions.DiscreteUniformDistribution):
                 count = int((distribution.high - distribution.low) // distribution.q)
                 dimension = space.Integer(0, count)
@@ -323,11 +316,6 @@ class _Optimizer(object):
                 value = float(value)
             if isinstance(distribution, distributions.DiscreteUniformDistribution):
                 value = value * distribution.q + distribution.low
-            elif isinstance(distribution, distributions.IntUniformDistribution):
-                value = int(value * distribution.step + distribution.low)
-            elif isinstance(distribution, distributions.IntLogUniformDistribution):
-                value = int(np.round(value))
-                value = min(max(value, distribution.low), distribution.high)
             elif isinstance(distribution, distributions.FloatDistribution):
                 if distribution.step is not None:
                     value = value * distribution.step + distribution.low
@@ -375,8 +363,6 @@ class _Optimizer(object):
             elif isinstance(distribution, distributions.FloatDistribution):
                 if distribution.step is not None:
                     param_value = (param_value - distribution.low) // distribution.step
-            elif isinstance(distribution, distributions.IntUniformDistribution):
-                param_value = (param_value - distribution.low) // distribution.step
             elif isinstance(distribution, distributions.IntDistribution):
                 if not distribution.log:
                     param_value = (param_value - distribution.low) // distribution.step

--- a/optuna/integration/skopt.py
+++ b/optuna/integration/skopt.py
@@ -251,9 +251,6 @@ class _Optimizer(object):
                 # Convert the upper bound from exclusive (optuna) to inclusive (skopt).
                 high = np.nextafter(distribution.high, float("-inf"))
                 dimension = space.Real(distribution.low, high, prior="log-uniform")
-            elif isinstance(distribution, distributions.DiscreteUniformDistribution):
-                count = int((distribution.high - distribution.low) // distribution.q)
-                dimension = space.Integer(0, count)
             elif isinstance(distribution, distributions.IntDistribution):
                 if distribution.log:
                     low = distribution.low - 0.5
@@ -262,6 +259,11 @@ class _Optimizer(object):
                 else:
                     count = (distribution.high - distribution.low) // distribution.step
                     dimension = space.Integer(0, count)
+            elif isinstance(distribution, distributions.DiscreteUniformDistribution):
+                count = int((distribution.high - distribution.low) // distribution.q)
+                dimension = space.Integer(0, count)
+            elif isinstance(distribution, distributions.CategoricalDistribution):
+                dimension = space.Categorical(distribution.choices)
             elif isinstance(distribution, distributions.FloatDistribution):
                 if distribution.log:
                     high = np.nextafter(distribution.high, float("-inf"))
@@ -272,8 +274,6 @@ class _Optimizer(object):
                 else:
                     high = np.nextafter(distribution.high, float("-inf"))
                     dimension = space.Real(distribution.low, high)
-            elif isinstance(distribution, distributions.CategoricalDistribution):
-                dimension = space.Categorical(distribution.choices)
             else:
                 raise NotImplementedError(
                     "The distribution {} is not implemented.".format(distribution)

--- a/optuna/integration/tensorboard.py
+++ b/optuna/integration/tensorboard.py
@@ -64,8 +64,9 @@ class TensorBoardCallback(object):
         )
         supported_distributions = (
             optuna.distributions.CategoricalDistribution,
+            optuna.distributions.FloatDistribution,
             optuna.distributions.IntDistribution,
-        ) + (real_distributions,)
+        )
 
         for param_name, param_distribution in distributions.items():
             if isinstance(param_distribution, real_distributions):

--- a/optuna/integration/tensorboard.py
+++ b/optuna/integration/tensorboard.py
@@ -56,34 +56,24 @@ class TensorBoardCallback(object):
     def _add_distributions(
         self, distributions: Dict[str, optuna.distributions.BaseDistribution]
     ) -> None:
-        real_distributions = (
-            optuna.distributions.UniformDistribution,
-            optuna.distributions.LogUniformDistribution,
-            optuna.distributions.DiscreteUniformDistribution,
-            optuna.distributions.FloatDistribution,
-        )
-        int_distributions = (
-            optuna.distributions.IntUniformDistribution,
-            optuna.distributions.IntLogUniformDistribution,
-            optuna.distributions.IntDistribution,
-        )
-        categorical_distributions = (optuna.distributions.CategoricalDistribution,)
         supported_distributions = (
-            real_distributions + int_distributions + categorical_distributions
+            optuna.distributions.FloatDistribution,
+            optuna.distributions.IntDistribution,
+            optuna.distributions.CategoricalDistribution,
         )
 
         for param_name, param_distribution in distributions.items():
-            if isinstance(param_distribution, real_distributions):
+            if isinstance(param_distribution, optuna.distributions.FloatDistribution):
                 self._hp_params[param_name] = hp.HParam(
                     param_name,
                     hp.RealInterval(float(param_distribution.low), float(param_distribution.high)),
                 )
-            elif isinstance(param_distribution, int_distributions):
+            elif isinstance(param_distribution, optuna.distributions.IntDistribution):
                 self._hp_params[param_name] = hp.HParam(
                     param_name,
                     hp.IntInterval(param_distribution.low, param_distribution.high),
                 )
-            elif isinstance(param_distribution, categorical_distributions):
+            elif isinstance(param_distribution, optuna.distributions.CategoricalDistribution):
                 self._hp_params[param_name] = hp.HParam(
                     param_name,
                     hp.Discrete(param_distribution.choices),

--- a/optuna/integration/tensorboard.py
+++ b/optuna/integration/tensorboard.py
@@ -57,9 +57,9 @@ class TensorBoardCallback(object):
         self, distributions: Dict[str, optuna.distributions.BaseDistribution]
     ) -> None:
         supported_distributions = (
+            optuna.distributions.CategoricalDistribution,
             optuna.distributions.FloatDistribution,
             optuna.distributions.IntDistribution,
-            optuna.distributions.CategoricalDistribution,
         )
 
         for param_name, param_distribution in distributions.items():

--- a/optuna/integration/tensorboard.py
+++ b/optuna/integration/tensorboard.py
@@ -56,14 +56,19 @@ class TensorBoardCallback(object):
     def _add_distributions(
         self, distributions: Dict[str, optuna.distributions.BaseDistribution]
     ) -> None:
+        real_distributions = (
+            optuna.distributions.UniformDistribution,
+            optuna.distributions.LogUniformDistribution,
+            optuna.distributions.DiscreteUniformDistribution,
+            optuna.distributions.FloatDistribution,
+        )
         supported_distributions = (
             optuna.distributions.CategoricalDistribution,
-            optuna.distributions.FloatDistribution,
             optuna.distributions.IntDistribution,
-        )
+        ) + (real_distributions,)
 
         for param_name, param_distribution in distributions.items():
-            if isinstance(param_distribution, optuna.distributions.FloatDistribution):
+            if isinstance(param_distribution, real_distributions):
                 self._hp_params[param_name] = hp.HParam(
                     param_name,
                     hp.RealInterval(float(param_distribution.low), float(param_distribution.high)),

--- a/optuna/multi_objective/samplers/_motpe.py
+++ b/optuna/multi_objective/samplers/_motpe.py
@@ -37,18 +37,12 @@ class MOTPEMultiObjectiveSampler(BaseMultiObjectiveSampler):
         consider_prior:
             Enhance the stability of Parzen estimator by imposing a Gaussian prior when
             :obj:`True`. The prior is only effective if the sampling distribution is
-            either :class:`~optuna.distributions.UniformDistribution`,
-            :class:`~optuna.distributions.DiscreteUniformDistribution`,
-            :class:`~optuna.distributions.LogUniformDistribution`,
-            :class:`~optuna.distributions.IntUniformDistribution`,
-            or :class:`~optuna.distributions.IntLogUniformDistribution`.
+            either :class:`~optuna.distributions.FloatDistribution`,
+            or :class:`~optuna.distributions.IntDistribution`.
         prior_weight:
             The weight of the prior. This argument is used in
-            :class:`~optuna.distributions.UniformDistribution`,
-            :class:`~optuna.distributions.DiscreteUniformDistribution`,
-            :class:`~optuna.distributions.LogUniformDistribution`,
-            :class:`~optuna.distributions.IntUniformDistribution`,
-            :class:`~optuna.distributions.IntLogUniformDistribution`, and
+            :class:`~optuna.distributions.FloatDistribution`,
+            :class:`~optuna.distributions.IntDistribution`, and
             :class:`~optuna.distributions.CategoricalDistribution`.
         consider_magic_clip:
             Enable a heuristic to limit the smallest variances of Gaussians used in

--- a/optuna/samplers/_cmaes.py
+++ b/optuna/samplers/_cmaes.py
@@ -289,8 +289,6 @@ class CmaEsSampler(BaseSampler):
                     optuna.distributions.UniformDistribution,
                     optuna.distributions.LogUniformDistribution,
                     optuna.distributions.DiscreteUniformDistribution,
-                    optuna.distributions.IntUniformDistribution,
-                    optuna.distributions.IntLogUniformDistribution,
                     optuna.distributions.FloatDistribution,
                     optuna.distributions.IntDistribution,
                 ),

--- a/optuna/samplers/_nsga2/crossover.py
+++ b/optuna/samplers/_nsga2/crossover.py
@@ -13,8 +13,6 @@ from optuna.distributions import CategoricalDistribution
 from optuna.distributions import DiscreteUniformDistribution
 from optuna.distributions import FloatDistribution
 from optuna.distributions import IntDistribution
-from optuna.distributions import IntLogUniformDistribution
-from optuna.distributions import IntUniformDistribution
 from optuna.distributions import LogUniformDistribution
 from optuna.distributions import UniformDistribution
 from optuna.study import Study
@@ -27,8 +25,6 @@ _NUMERICAL_DISTRIBUTIONS = (
     LogUniformDistribution,
     DiscreteUniformDistribution,
     FloatDistribution,
-    IntUniformDistribution,
-    IntLogUniformDistribution,
     IntDistribution,
 )
 

--- a/optuna/samplers/_tpe/multi_objective_sampler.py
+++ b/optuna/samplers/_tpe/multi_objective_sampler.py
@@ -33,18 +33,12 @@ class MOTPESampler(TPESampler):
         consider_prior:
             Enhance the stability of Parzen estimator by imposing a Gaussian prior when
             :obj:`True`. The prior is only effective if the sampling distribution is
-            either :class:`~optuna.distributions.UniformDistribution`,
-            :class:`~optuna.distributions.DiscreteUniformDistribution`,
-            :class:`~optuna.distributions.LogUniformDistribution`,
-            :class:`~optuna.distributions.IntUniformDistribution`,
-            or :class:`~optuna.distributions.IntLogUniformDistribution`.
+            either :class:`~optuna.distributions.FloatDistribution`,
+            or :class:`~optuna.distributions.IntDistribution`.
         prior_weight:
             The weight of the prior. This argument is used in
-            :class:`~optuna.distributions.UniformDistribution`,
-            :class:`~optuna.distributions.DiscreteUniformDistribution`,
-            :class:`~optuna.distributions.LogUniformDistribution`,
-            :class:`~optuna.distributions.IntUniformDistribution`,
-            :class:`~optuna.distributions.IntLogUniformDistribution`, and
+            :class:`~optuna.distributions.FloatDistribution`,
+            :class:`~optuna.distributions.IntDistribution`, and
             :class:`~optuna.distributions.CategoricalDistribution`.
         consider_magic_clip:
             Enable a heuristic to limit the smallest variances of Gaussians used in

--- a/optuna/samplers/_tpe/parzen_estimator.py
+++ b/optuna/samplers/_tpe/parzen_estimator.py
@@ -291,7 +291,9 @@ class _ParzenEstimator:
             distribution = self._search_space[param_name]
 
             assert isinstance(distribution, _DISTRIBUTION_CLASSES)
-            if isinstance(
+            if isinstance(distribution, distributions.LogUniformDistribution):
+                samples = np.log(samples)
+            elif isinstance(
                 distribution,
                 (distributions.FloatDistribution, distributions.IntDistribution),
             ):

--- a/optuna/samplers/_tpe/parzen_estimator.py
+++ b/optuna/samplers/_tpe/parzen_estimator.py
@@ -19,8 +19,6 @@ _DISTRIBUTION_CLASSES = (
     distributions.UniformDistribution,
     distributions.LogUniformDistribution,
     distributions.DiscreteUniformDistribution,
-    distributions.IntUniformDistribution,
-    distributions.IntLogUniformDistribution,
     distributions.CategoricalDistribution,
     distributions.FloatDistribution,
     distributions.IntDistribution,
@@ -257,14 +255,6 @@ class _ParzenEstimator:
                 low = distribution.low
                 high = distribution.high
                 q = None
-        elif isinstance(distribution, distributions.IntUniformDistribution):
-            q = distribution.step
-            low = distribution.low - 0.5 * q
-            high = distribution.high + 0.5 * q
-        elif isinstance(distribution, distributions.IntLogUniformDistribution):
-            low = np.log(distribution.low - 0.5)
-            high = np.log(distribution.high + 0.5)
-            q = None
         elif isinstance(distribution, distributions.IntDistribution):
             if distribution.log:
                 low = np.log(distribution.low - 0.5)
@@ -279,8 +269,6 @@ class _ParzenEstimator:
                 distributions.UniformDistribution.__name__,
                 distributions.LogUniformDistribution.__name__,
                 distributions.DiscreteUniformDistribution.__name__,
-                distributions.IntUniformDistribution.__name__,
-                distributions.IntLogUniformDistribution.__name__,
                 distributions.CategoricalDistribution.__name__,
                 distributions.FloatDistribution.__name__,
                 distributions.IntDistribution.__name__,
@@ -304,12 +292,6 @@ class _ParzenEstimator:
 
             assert isinstance(distribution, _DISTRIBUTION_CLASSES)
             if isinstance(
-                distribution,
-                (distributions.LogUniformDistribution, distributions.IntLogUniformDistribution),
-            ):
-                samples = np.log(samples)
-
-            elif isinstance(
                 distribution,
                 (distributions.FloatDistribution, distributions.IntDistribution),
             ):
@@ -351,18 +333,6 @@ class _ParzenEstimator:
                     )
                 else:
                     transformed[param_name] = samples
-            elif isinstance(distribution, distributions.IntUniformDistribution):
-                q = self._q[param_name]
-                assert q is not None
-                samples = np.round((samples - distribution.low) / q) * q + distribution.low
-                transformed[param_name] = np.asarray(
-                    np.clip(samples, distribution.low, distribution.high)
-                )
-            elif isinstance(distribution, distributions.IntLogUniformDistribution):
-                samples = np.round(np.exp(samples))
-                transformed[param_name] = np.asarray(
-                    np.clip(samples, distribution.low, distribution.high)
-                )
             elif isinstance(distribution, distributions.IntDistribution):
                 if distribution.log:
                     samples = np.round(np.exp(samples))

--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -94,18 +94,12 @@ class TPESampler(BaseSampler):
         consider_prior:
             Enhance the stability of Parzen estimator by imposing a Gaussian prior when
             :obj:`True`. The prior is only effective if the sampling distribution is
-            either :class:`~optuna.distributions.UniformDistribution`,
-            :class:`~optuna.distributions.DiscreteUniformDistribution`,
-            :class:`~optuna.distributions.LogUniformDistribution`,
-            :class:`~optuna.distributions.IntUniformDistribution`,
-            or :class:`~optuna.distributions.IntLogUniformDistribution`.
+            either :class:`~optuna.distributions.FloatDistribution`,
+            or :class:`~optuna.distributions.IntDistribution`.
         prior_weight:
             The weight of the prior. This argument is used in
-            :class:`~optuna.distributions.UniformDistribution`,
-            :class:`~optuna.distributions.DiscreteUniformDistribution`,
-            :class:`~optuna.distributions.LogUniformDistribution`,
-            :class:`~optuna.distributions.IntUniformDistribution`,
-            :class:`~optuna.distributions.IntLogUniformDistribution`, and
+            :class:`~optuna.distributions.FloatDistribution`,
+            :class:`~optuna.distributions.IntDistribution`, and
             :class:`~optuna.distributions.CategoricalDistribution`.
         consider_magic_clip:
             Enable a heuristic to limit the smallest variances of Gaussians used in

--- a/optuna/testing/sampler.py
+++ b/optuna/testing/sampler.py
@@ -45,8 +45,6 @@ class DeterministicRelativeSampler(optuna.samplers.BaseSampler):
             param_value = param_distribution.low
         elif isinstance(param_distribution, distributions.FloatDistribution):
             param_value = param_distribution.low
-        elif isinstance(param_distribution, distributions.IntUniformDistribution):
-            param_value = param_distribution.low
         elif isinstance(param_distribution, distributions.IntDistribution):
             param_value = param_distribution.low
         elif isinstance(param_distribution, distributions.CategoricalDistribution):

--- a/optuna/trial/_fixed.py
+++ b/optuna/trial/_fixed.py
@@ -12,8 +12,7 @@ from optuna.distributions import BaseDistribution
 from optuna.distributions import CategoricalChoiceType
 from optuna.distributions import CategoricalDistribution
 from optuna.distributions import FloatDistribution
-from optuna.distributions import IntLogUniformDistribution
-from optuna.distributions import IntUniformDistribution
+from optuna.distributions import IntDistribution
 from optuna.trial._base import BaseTrial
 
 
@@ -96,22 +95,7 @@ class FixedTrial(BaseTrial):
         return self.suggest_float(name, low, high, step=q)
 
     def suggest_int(self, name: str, low: int, high: int, step: int = 1, log: bool = False) -> int:
-        if step != 1:
-            if log:
-                raise ValueError(
-                    "The parameter `step != 1` is not supported when `log` is True."
-                    "The specified `step` is {}.".format(step)
-                )
-            else:
-                distribution: Union[
-                    IntUniformDistribution, IntLogUniformDistribution
-                ] = IntUniformDistribution(low=low, high=high, step=step)
-        else:
-            if log:
-                distribution = IntLogUniformDistribution(low=low, high=high)
-            else:
-                distribution = IntUniformDistribution(low=low, high=high, step=step)
-        return int(self._suggest(name, distribution))
+        return int(self._suggest(name, IntDistribution(low, high, log=log, step=step)))
 
     def suggest_categorical(
         self, name: str, choices: Sequence[CategoricalChoiceType]

--- a/optuna/trial/_fixed.py
+++ b/optuna/trial/_fixed.py
@@ -3,7 +3,6 @@ from typing import Any
 from typing import Dict
 from typing import Optional
 from typing import Sequence
-from typing import Union
 import warnings
 
 from optuna import distributions

--- a/optuna/trial/_frozen.py
+++ b/optuna/trial/_frozen.py
@@ -13,8 +13,7 @@ from optuna._deprecated import deprecated
 from optuna.distributions import BaseDistribution
 from optuna.distributions import CategoricalDistribution
 from optuna.distributions import FloatDistribution
-from optuna.distributions import IntLogUniformDistribution
-from optuna.distributions import IntUniformDistribution
+from optuna.distributions import IntDistribution
 from optuna.trial._base import BaseTrial
 from optuna.trial._state import TrialState
 
@@ -240,23 +239,7 @@ class FrozenTrial(BaseTrial):
         return self.suggest_float(name, low, high, step=q)
 
     def suggest_int(self, name: str, low: int, high: int, step: int = 1, log: bool = False) -> int:
-
-        if step != 1:
-            if log:
-                raise ValueError(
-                    "The parameter `step != 1` is not supported when `log` is True."
-                    "The specified `step` is {}.".format(step)
-                )
-            else:
-                distribution: Union[
-                    IntUniformDistribution, IntLogUniformDistribution
-                ] = IntUniformDistribution(low=low, high=high, step=step)
-        else:
-            if log:
-                distribution = IntLogUniformDistribution(low=low, high=high)
-            else:
-                distribution = IntUniformDistribution(low=low, high=high, step=step)
-        return int(self._suggest(name, distribution))
+        return int(self._suggest(name, IntDistribution(low, high, log=log, step=step)))
 
     def suggest_categorical(
         self, name: str, choices: Sequence[CategoricalChoiceType]

--- a/optuna/trial/_trial.py
+++ b/optuna/trial/_trial.py
@@ -16,8 +16,7 @@ from optuna.distributions import BaseDistribution
 from optuna.distributions import CategoricalChoiceType
 from optuna.distributions import CategoricalDistribution
 from optuna.distributions import FloatDistribution
-from optuna.distributions import IntLogUniformDistribution
-from optuna.distributions import IntUniformDistribution
+from optuna.distributions import IntDistribution
 from optuna.trial._base import BaseTrial
 
 
@@ -314,25 +313,7 @@ class Trial(BaseTrial):
             :ref:`configurations` tutorial describes more details and flexible usages.
         """
 
-        if step != 1:
-            if log:
-                raise ValueError(
-                    "The parameter `step != 1` is not supported when `log` is True."
-                    "The specified `step` is {}.".format(step)
-                )
-            else:
-                distribution: Union[
-                    IntUniformDistribution, IntLogUniformDistribution
-                ] = IntUniformDistribution(low=low, high=high, step=step)
-        else:
-            if log:
-                distribution = IntLogUniformDistribution(low=low, high=high)
-            else:
-                distribution = IntUniformDistribution(low=low, high=high, step=step)
-
-        self._check_distribution(name, distribution)
-
-        return int(self._suggest(name, distribution))
+        return int(self._suggest(name, IntDistribution(low, high, log=log, step=step)))
 
     def suggest_categorical(
         self, name: str, choices: Sequence[CategoricalChoiceType]

--- a/optuna/trial/_trial.py
+++ b/optuna/trial/_trial.py
@@ -4,7 +4,6 @@ from typing import Any
 from typing import Dict
 from typing import Optional
 from typing import Sequence
-from typing import Union
 import warnings
 
 import optuna
@@ -305,15 +304,13 @@ class Trial(BaseTrial):
                     The ``step != 1`` and ``log`` arguments cannot be used at the same time.
                     To set the ``log`` argument to :obj:`True`, set the ``step`` argument to 1.
 
-        Raises:
-            :exc:`ValueError`:
-                If ``step != 1`` and ``log = True`` are specified.
-
         .. seealso::
             :ref:`configurations` tutorial describes more details and flexible usages.
         """
 
-        return int(self._suggest(name, IntDistribution(low, high, log=log, step=step)))
+        distribution = IntDistribution(low=low, high=high, log=log, step=step)
+        self._check_distribution(name, distribution)
+        return int(self._suggest(name, distribution))
 
     def suggest_categorical(
         self, name: str, choices: Sequence[CategoricalChoiceType]

--- a/tests/integration_tests/test_cma.py
+++ b/tests/integration_tests/test_cma.py
@@ -12,8 +12,7 @@ import optuna
 from optuna.distributions import BaseDistribution
 from optuna.distributions import CategoricalDistribution
 from optuna.distributions import FloatDistribution
-from optuna.distributions import IntLogUniformDistribution
-from optuna.distributions import IntUniformDistribution
+from optuna.distributions import IntDistribution
 from optuna.integration.cma import _Optimizer
 from optuna.study._study_direction import StudyDirection
 from optuna.testing.distribution import UnsupportedDistribution
@@ -48,8 +47,8 @@ class TestPyCmaSampler(object):
             )
             assert mock_obj.mock_calls[0] == call(
                 {
-                    "x": IntUniformDistribution(low=-1, high=1),
-                    "y": IntUniformDistribution(low=-1, high=1),
+                    "x": IntDistribution(low=-1, high=1),
+                    "y": IntDistribution(low=-1, high=1),
                 },
                 {"x": 0, "y": 0},
                 0.1,
@@ -162,9 +161,9 @@ class TestOptimizer(object):
         return {
             "c": CategoricalDistribution(("a", "b")),
             "d": FloatDistribution(-1, 9, step=2),
-            "i": IntUniformDistribution(-1, 1),
-            "ii": IntUniformDistribution(-1, 3, 2),
-            "il": IntLogUniformDistribution(2, 16),
+            "i": IntDistribution(-1, 1),
+            "ii": IntDistribution(-1, 3, step=2),
+            "il": IntDistribution(2, 16, log=True),
             "l": FloatDistribution(0.001, 0.1, log=True),
             "u": FloatDistribution(-2, 2),
         }
@@ -333,7 +332,7 @@ class TestOptimizer(object):
         assert not optimizer._is_compatible(trial)
 
         # Error (different distribution class).
-        trial = _create_frozen_trial(x0, dict(search_space, u=IntUniformDistribution(-2, 2)))
+        trial = _create_frozen_trial(x0, dict(search_space, u=IntDistribution(-2, 2)))
         with pytest.raises(ValueError):
             optimizer._is_compatible(trial)
 

--- a/tests/integration_tests/test_pytorch_distributed.py
+++ b/tests/integration_tests/test_pytorch_distributed.py
@@ -331,6 +331,6 @@ def test_distributions(storage_mode: str) -> None:
         assert distributions["u"] == optuna.distributions.FloatDistribution(0, 1)
         assert distributions["lu"] == optuna.distributions.FloatDistribution(1e-7, 1, log=True)
         assert distributions["du"] == optuna.distributions.FloatDistribution(0, 1, step=0.5)
-        assert distributions["i"] == optuna.distributions.IntUniformDistribution(0, 1)
-        assert distributions["il"] == optuna.distributions.IntLogUniformDistribution(1, 128)
+        assert distributions["i"] == optuna.distributions.IntDistribution(0, 1)
+        assert distributions["il"] == optuna.distributions.IntDistribution(1, 128, log=True)
         assert distributions["c"] == optuna.distributions.CategoricalDistribution(("a", "b", "c"))

--- a/tests/integration_tests/test_skopt.py
+++ b/tests/integration_tests/test_skopt.py
@@ -127,7 +127,7 @@ def test_is_compatible() -> None:
 
     # Error (different distribution class).
     trial = _create_frozen_trial(
-        {"p0": 5}, {"p0": distributions.IntUniformDistribution(low=0, high=10)}
+        {"p0": 5}, {"p0": distributions.IntDistribution(low=0, high=10)}
     )
     with pytest.raises(ValueError):
         optimizer._is_compatible(trial)

--- a/tests/integration_tests/test_skopt.py
+++ b/tests/integration_tests/test_skopt.py
@@ -126,9 +126,7 @@ def test_is_compatible() -> None:
     assert not optimizer._is_compatible(trial)
 
     # Error (different distribution class).
-    trial = _create_frozen_trial(
-        {"p0": 5}, {"p0": distributions.IntDistribution(low=0, high=10)}
-    )
+    trial = _create_frozen_trial({"p0": 5}, {"p0": distributions.IntDistribution(low=0, high=10)})
     with pytest.raises(ValueError):
         optimizer._is_compatible(trial)
 

--- a/tests/multi_objective_tests/samplers_tests/test_samplers.py
+++ b/tests/multi_objective_tests/samplers_tests/test_samplers.py
@@ -7,7 +7,7 @@ import optuna
 from optuna import multi_objective
 from optuna.distributions import CategoricalDistribution
 from optuna.distributions import DiscreteUniformDistribution
-from optuna.distributions import IntUniformDistribution
+from optuna.distributions import IntDistribution
 from optuna.distributions import LogUniformDistribution
 from optuna.distributions import UniformDistribution
 from optuna.multi_objective.samplers import BaseMultiObjectiveSampler
@@ -32,12 +32,12 @@ parametrize_sampler = pytest.mark.parametrize(
         LogUniformDistribution(1e-7, 1.0),
         DiscreteUniformDistribution(-10, 10, 0.1),
         DiscreteUniformDistribution(-10.2, 10.2, 0.1),
-        IntUniformDistribution(-10, 10),
-        IntUniformDistribution(0, 10),
-        IntUniformDistribution(-10, 0),
-        IntUniformDistribution(-10, 10, 2),
-        IntUniformDistribution(0, 10, 2),
-        IntUniformDistribution(-10, 0, 2),
+        IntDistribution(-10, 10),
+        IntDistribution(0, 10),
+        IntDistribution(-10, 0),
+        IntDistribution(-10, 10, step=2),
+        IntDistribution(0, 10, step=2),
+        IntDistribution(-10, 0, step=2),
         CategoricalDistribution((1, 2, 3)),
         CategoricalDistribution(("a", "b", "c")),
         CategoricalDistribution((1, "a")),

--- a/tests/samplers_tests/search_space_tests/test_group_decomposed.py
+++ b/tests/samplers_tests/search_space_tests/test_group_decomposed.py
@@ -123,9 +123,7 @@ def test_group_decomposed_search_space() -> None:
 
     # A single parameter.
     study.optimize(lambda t: t.suggest_int("x", 0, 10), n_trials=1)
-    assert search_space.calculate(study).search_spaces == [
-        {"x": IntDistribution(low=0, high=10)}
-    ]
+    assert search_space.calculate(study).search_spaces == [{"x": IntDistribution(low=0, high=10)}]
 
     # Disjoint parameters.
     study.optimize(lambda t: t.suggest_int("y", 0, 10) + t.suggest_float("z", -3, 3), n_trials=1)

--- a/tests/samplers_tests/search_space_tests/test_group_decomposed.py
+++ b/tests/samplers_tests/search_space_tests/test_group_decomposed.py
@@ -4,8 +4,7 @@ from optuna import create_study
 from optuna import TrialPruned
 from optuna.distributions import CategoricalDistribution
 from optuna.distributions import FloatDistribution
-from optuna.distributions import IntLogUniformDistribution
-from optuna.distributions import IntUniformDistribution
+from optuna.distributions import IntDistribution
 from optuna.samplers._search_space import _GroupDecomposedSearchSpace
 from optuna.samplers._search_space.group_decomposed import _SearchSpaceGroup
 from optuna.testing.storage import StorageSupplier
@@ -23,24 +22,24 @@ def test_search_space_group() -> None:
     assert search_space_group.search_spaces == []
 
     # Add a single distribution.
-    search_space_group.add_distributions({"x": IntUniformDistribution(low=0, high=10)})
-    assert search_space_group.search_spaces == [{"x": IntUniformDistribution(low=0, high=10)}]
+    search_space_group.add_distributions({"x": IntDistribution(low=0, high=10)})
+    assert search_space_group.search_spaces == [{"x": IntDistribution(low=0, high=10)}]
 
     # Add a same single distribution.
-    search_space_group.add_distributions({"x": IntUniformDistribution(low=0, high=10)})
-    assert search_space_group.search_spaces == [{"x": IntUniformDistribution(low=0, high=10)}]
+    search_space_group.add_distributions({"x": IntDistribution(low=0, high=10)})
+    assert search_space_group.search_spaces == [{"x": IntDistribution(low=0, high=10)}]
 
     # Add disjoint distributions.
     search_space_group.add_distributions(
         {
-            "y": IntUniformDistribution(low=0, high=10),
+            "y": IntDistribution(low=0, high=10),
             "z": FloatDistribution(low=-3, high=3),
         }
     )
     assert search_space_group.search_spaces == [
-        {"x": IntUniformDistribution(low=0, high=10)},
+        {"x": IntDistribution(low=0, high=10)},
         {
-            "y": IntUniformDistribution(low=0, high=10),
+            "y": IntDistribution(low=0, high=10),
             "z": FloatDistribution(low=-3, high=3),
         },
     ]
@@ -48,16 +47,16 @@ def test_search_space_group() -> None:
     # Add distributions, which include one of search spaces in the group.
     search_space_group.add_distributions(
         {
-            "y": IntUniformDistribution(low=0, high=10),
+            "y": IntDistribution(low=0, high=10),
             "z": FloatDistribution(low=-3, high=3),
             "u": FloatDistribution(low=1e-2, high=1e2, log=True),
             "v": CategoricalDistribution(choices=["A", "B", "C"]),
         }
     )
     assert search_space_group.search_spaces == [
-        {"x": IntUniformDistribution(low=0, high=10)},
+        {"x": IntDistribution(low=0, high=10)},
         {
-            "y": IntUniformDistribution(low=0, high=10),
+            "y": IntDistribution(low=0, high=10),
             "z": FloatDistribution(low=-3, high=3),
         },
         {
@@ -69,9 +68,9 @@ def test_search_space_group() -> None:
     # Add a distribution, which is included by one of search spaces in the group.
     search_space_group.add_distributions({"u": FloatDistribution(low=1e-2, high=1e2, log=True)})
     assert search_space_group.search_spaces == [
-        {"x": IntUniformDistribution(low=0, high=10)},
+        {"x": IntDistribution(low=0, high=10)},
         {
-            "y": IntUniformDistribution(low=0, high=10),
+            "y": IntDistribution(low=0, high=10),
             "z": FloatDistribution(low=-3, high=3),
         },
         {"u": FloatDistribution(low=1e-2, high=1e2, log=True)},
@@ -81,34 +80,34 @@ def test_search_space_group() -> None:
     # Add distributions whose intersection with one of search spaces in the group is not empty.
     search_space_group.add_distributions(
         {
-            "y": IntUniformDistribution(low=0, high=10),
-            "w": IntLogUniformDistribution(low=2, high=8),
+            "y": IntDistribution(low=0, high=10),
+            "w": IntDistribution(low=2, high=8, log=True),
         }
     )
     assert search_space_group.search_spaces == [
-        {"x": IntUniformDistribution(low=0, high=10)},
-        {"y": IntUniformDistribution(low=0, high=10)},
+        {"x": IntDistribution(low=0, high=10)},
+        {"y": IntDistribution(low=0, high=10)},
         {"z": FloatDistribution(low=-3, high=3)},
         {"u": FloatDistribution(low=1e-2, high=1e2, log=True)},
         {"v": CategoricalDistribution(choices=["A", "B", "C"])},
-        {"w": IntLogUniformDistribution(low=2, high=8)},
+        {"w": IntDistribution(low=2, high=8, log=True)},
     ]
 
     # Add distributions which include some of search spaces in the group.
     search_space_group.add_distributions(
         {
-            "y": IntUniformDistribution(low=0, high=10),
-            "w": IntLogUniformDistribution(low=2, high=8),
+            "y": IntDistribution(low=0, high=10, log=True),
+            "w": IntDistribution(low=2, high=8, log=True),
             "t": FloatDistribution(low=10, high=100),
         }
     )
     assert search_space_group.search_spaces == [
-        {"x": IntUniformDistribution(low=0, high=10)},
-        {"y": IntUniformDistribution(low=0, high=10)},
+        {"x": IntDistribution(low=0, high=10)},
+        {"y": IntDistribution(low=0, high=10)},
         {"z": FloatDistribution(low=-3, high=3)},
         {"u": FloatDistribution(low=1e-2, high=1e2, log=True)},
         {"v": CategoricalDistribution(choices=["A", "B", "C"])},
-        {"w": IntLogUniformDistribution(low=2, high=8)},
+        {"w": IntDistribution(low=2, high=8, log=True)},
         {"t": FloatDistribution(low=10, high=100)},
     ]
 
@@ -123,15 +122,15 @@ def test_group_decomposed_search_space() -> None:
     # A single parameter.
     study.optimize(lambda t: t.suggest_int("x", 0, 10), n_trials=1)
     assert search_space.calculate(study).search_spaces == [
-        {"x": IntUniformDistribution(low=0, high=10)}
+        {"x": IntDistribution(low=0, high=10)}
     ]
 
     # Disjoint parameters.
     study.optimize(lambda t: t.suggest_int("y", 0, 10) + t.suggest_float("z", -3, 3), n_trials=1)
     assert search_space.calculate(study).search_spaces == [
-        {"x": IntUniformDistribution(low=0, high=10)},
+        {"x": IntDistribution(low=0, high=10)},
         {
-            "y": IntUniformDistribution(low=0, high=10),
+            "y": IntDistribution(low=0, high=10),
             "z": FloatDistribution(low=-3, high=3),
         },
     ]
@@ -145,10 +144,10 @@ def test_group_decomposed_search_space() -> None:
         n_trials=1,
     )
     assert search_space.calculate(study).search_spaces == [
-        {"x": IntUniformDistribution(low=0, high=10)},
+        {"x": IntDistribution(low=0, high=10)},
         {
             "z": FloatDistribution(low=-3, high=3),
-            "y": IntUniformDistribution(low=0, high=10),
+            "y": IntDistribution(low=0, high=10),
         },
         {
             "u": FloatDistribution(low=1e-2, high=1e2, log=True),
@@ -159,9 +158,9 @@ def test_group_decomposed_search_space() -> None:
     # A parameter which is included by one of search spaces in thew group.
     study.optimize(lambda t: t.suggest_float("u", 1e-2, 1e2, log=True), n_trials=1)
     assert search_space.calculate(study).search_spaces == [
-        {"x": IntUniformDistribution(low=0, high=10)},
+        {"x": IntDistribution(low=0, high=10)},
         {
-            "y": IntUniformDistribution(low=0, high=10),
+            "y": IntDistribution(low=0, high=10),
             "z": FloatDistribution(low=-3, high=3),
         },
         {"u": FloatDistribution(low=1e-2, high=1e2, log=True)},
@@ -173,12 +172,12 @@ def test_group_decomposed_search_space() -> None:
         lambda t: t.suggest_int("y", 0, 10) + t.suggest_int("w", 2, 8, log=True), n_trials=1
     )
     assert search_space.calculate(study).search_spaces == [
-        {"x": IntUniformDistribution(low=0, high=10)},
-        {"y": IntUniformDistribution(low=0, high=10)},
+        {"x": IntDistribution(low=0, high=10)},
+        {"y": IntDistribution(low=0, high=10)},
         {"z": FloatDistribution(low=-3, high=3)},
         {"u": FloatDistribution(low=1e-2, high=1e2, log=True)},
         {"v": CategoricalDistribution(choices=["A", "B", "C"])},
-        {"w": IntLogUniformDistribution(low=2, high=8)},
+        {"w": IntDistribution(low=2, high=8, log=True)},
     ]
 
     search_space = _GroupDecomposedSearchSpace()

--- a/tests/samplers_tests/search_space_tests/test_group_decomposed.py
+++ b/tests/samplers_tests/search_space_tests/test_group_decomposed.py
@@ -5,6 +5,8 @@ from optuna import TrialPruned
 from optuna.distributions import CategoricalDistribution
 from optuna.distributions import FloatDistribution
 from optuna.distributions import IntDistribution
+from optuna.distributions import LogUniformDistribution
+from optuna.distributions import UniformDistribution
 from optuna.samplers._search_space import _GroupDecomposedSearchSpace
 from optuna.samplers._search_space.group_decomposed import _SearchSpaceGroup
 from optuna.testing.storage import StorageSupplier
@@ -96,7 +98,7 @@ def test_search_space_group() -> None:
     # Add distributions which include some of search spaces in the group.
     search_space_group.add_distributions(
         {
-            "y": IntDistribution(low=0, high=10, log=True),
+            "y": IntDistribution(low=0, high=10),
             "w": IntDistribution(low=2, high=8, log=True),
             "t": FloatDistribution(low=10, high=100),
         }

--- a/tests/samplers_tests/search_space_tests/test_group_decomposed.py
+++ b/tests/samplers_tests/search_space_tests/test_group_decomposed.py
@@ -5,8 +5,6 @@ from optuna import TrialPruned
 from optuna.distributions import CategoricalDistribution
 from optuna.distributions import FloatDistribution
 from optuna.distributions import IntDistribution
-from optuna.distributions import LogUniformDistribution
-from optuna.distributions import UniformDistribution
 from optuna.samplers._search_space import _GroupDecomposedSearchSpace
 from optuna.samplers._search_space.group_decomposed import _SearchSpaceGroup
 from optuna.testing.storage import StorageSupplier

--- a/tests/samplers_tests/search_space_tests/test_intersection.py
+++ b/tests/samplers_tests/search_space_tests/test_intersection.py
@@ -5,7 +5,7 @@ import pytest
 from optuna import create_study
 from optuna import TrialPruned
 from optuna.distributions import FloatDistribution
-from optuna.distributions import IntUniformDistribution
+from optuna.distributions import IntDistribution
 from optuna.samplers import intersection_search_space
 from optuna.samplers import IntersectionSearchSpace
 from optuna.testing.storage import StorageSupplier
@@ -23,7 +23,7 @@ def test_intersection_search_space() -> None:
     # First trial.
     study.optimize(lambda t: t.suggest_float("y", -3, 3) + t.suggest_int("x", 0, 10), n_trials=1)
     assert search_space.calculate(study) == {
-        "x": IntUniformDistribution(low=0, high=10),
+        "x": IntDistribution(low=0, high=10),
         "y": FloatDistribution(low=-3, high=3),
     }
     assert search_space.calculate(study) == intersection_search_space(study)
@@ -31,7 +31,7 @@ def test_intersection_search_space() -> None:
     # Returning sorted `OrderedDict` instead of `dict`.
     assert search_space.calculate(study, ordered_dict=True) == OrderedDict(
         [
-            ("x", IntUniformDistribution(low=0, high=10)),
+            ("x", IntDistribution(low=0, high=10)),
             ("y", FloatDistribution(low=-3, high=3)),
         ]
     )

--- a/tests/samplers_tests/test_samplers.py
+++ b/tests/samplers_tests/test_samplers.py
@@ -22,8 +22,6 @@ from optuna.distributions import CategoricalDistribution
 from optuna.distributions import DiscreteUniformDistribution
 from optuna.distributions import FloatDistribution
 from optuna.distributions import IntDistribution
-from optuna.distributions import IntLogUniformDistribution
-from optuna.distributions import IntUniformDistribution
 from optuna.distributions import LogUniformDistribution
 from optuna.distributions import UniformDistribution
 from optuna.samplers import BaseSampler
@@ -240,12 +238,6 @@ def test_discrete_uniform(
 @pytest.mark.parametrize(
     "distribution",
     [
-        IntUniformDistribution(-10, 10),
-        IntUniformDistribution(0, 10),
-        IntUniformDistribution(-10, 0),
-        IntUniformDistribution(-10, 10, 2),
-        IntUniformDistribution(0, 10, 2),
-        IntUniformDistribution(-10, 0, 2),
         IntDistribution(-10, 10),
         IntDistribution(0, 10),
         IntDistribution(-10, 0),
@@ -255,10 +247,7 @@ def test_discrete_uniform(
         IntDistribution(1, 100, log=True),
     ],
 )
-def test_int(
-    sampler_class: Callable[[], BaseSampler],
-    distribution: Union[IntDistribution, IntUniformDistribution],
-) -> None:
+def test_int(sampler_class: Callable[[], BaseSampler], distribution: IntDistribution) -> None:
 
     study = optuna.study.create_study(sampler=sampler_class())
     points = np.array(
@@ -310,8 +299,6 @@ def test_categorical(
         FloatDistribution(-1.0, 1.0),
         FloatDistribution(1e-7, 1.0, log=True),
         FloatDistribution(-10, 10, step=0.5),
-        IntUniformDistribution(1, 10),
-        IntLogUniformDistribution(1, 100),
         IntDistribution(3, 10),
         IntDistribution(1, 100, log=True),
         IntDistribution(3, 10, step=2),
@@ -326,8 +313,6 @@ def test_categorical(
         FloatDistribution(-1.0, 1.0),
         FloatDistribution(1e-7, 1.0, log=True),
         FloatDistribution(-10, 10, step=0.5),
-        IntUniformDistribution(1, 10),
-        IntLogUniformDistribution(1, 100),
         IntDistribution(3, 10),
         IntDistribution(1, 100, log=True),
         IntDistribution(3, 10, step=2),
@@ -357,8 +342,6 @@ def test_sample_relative_numerical(
                 LogUniformDistribution,
                 DiscreteUniformDistribution,
                 FloatDistribution,
-                IntUniformDistribution,
-                IntLogUniformDistribution,
                 IntDistribution,
             ),
         )
@@ -367,9 +350,7 @@ def test_sample_relative_numerical(
     for param_value, distribution in zip(sample(), search_space.values()):
         assert not isinstance(param_value, np.floating)
         assert not isinstance(param_value, np.integer)
-        if isinstance(
-            distribution, (IntUniformDistribution, IntLogUniformDistribution, IntDistribution)
-        ):
+        if isinstance(distribution, IntDistribution):
             assert isinstance(param_value, int)
         else:
             assert isinstance(param_value, float)
@@ -409,8 +390,6 @@ def test_sample_relative_categorical(relative_sampler_class: Callable[[], BaseSa
         FloatDistribution(-1.0, 1.0),
         FloatDistribution(1e-7, 1.0, log=True),
         FloatDistribution(-10, 10, step=0.5),
-        IntUniformDistribution(1, 10),
-        IntLogUniformDistribution(1, 100),
         IntDistribution(1, 10),
         IntDistribution(1, 100, log=True),
     ],
@@ -438,8 +417,6 @@ def test_sample_relative_mixed(
             LogUniformDistribution,
             DiscreteUniformDistribution,
             FloatDistribution,
-            IntUniformDistribution,
-            IntLogUniformDistribution,
             IntDistribution,
         ),
     )
@@ -453,8 +430,6 @@ def test_sample_relative_mixed(
         if isinstance(
             distribution,
             (
-                IntUniformDistribution,
-                IntLogUniformDistribution,
                 IntDistribution,
                 CategoricalDistribution,
             ),
@@ -544,7 +519,7 @@ def test_sample_relative() -> None:
     relative_search_space: Dict[str, BaseDistribution] = {
         "a": FloatDistribution(low=0, high=5),
         "b": CategoricalDistribution(choices=("foo", "bar", "baz")),
-        "c": IntUniformDistribution(low=20, high=50),  # Not exist in `relative_params`.
+        "c": IntDistribution(low=20, high=50),  # Not exist in `relative_params`.
     }
     relative_params = {
         "a": 3.2,
@@ -638,12 +613,6 @@ def test_partial_fixed_sampling(sampler_class: Callable[[], BaseSampler]) -> Non
         DiscreteUniformDistribution(-10.2, 10.2, 0.1),
         FloatDistribution(-10, 10, step=0.1),
         FloatDistribution(-10.2, 10.2, step=0.1),
-        IntUniformDistribution(-10, 10),
-        IntUniformDistribution(0, 10),
-        IntUniformDistribution(-10, 0),
-        IntUniformDistribution(-10, 10, 2),
-        IntUniformDistribution(0, 10, 2),
-        IntUniformDistribution(-10, 0, 2),
         IntDistribution(-10, 10),
         IntDistribution(0, 10),
         IntDistribution(-10, 0),
@@ -840,17 +809,12 @@ def test_after_trial_with_study_tell() -> None:
 def test_sample_single_distribution(sampler_class: Callable[[], BaseSampler]) -> None:
 
     relative_search_space = {
-        "a": UniformDistribution(low=1.0, high=1.0),
-        "b": LogUniformDistribution(low=1.0, high=1.0),
-        "c": DiscreteUniformDistribution(low=1.0, high=1.0, q=1.0),
-        "d": IntUniformDistribution(low=1, high=1),
-        "e": IntLogUniformDistribution(low=1, high=1),
-        "f": CategoricalDistribution([1]),
-        "g": FloatDistribution(low=1.0, high=1.0),
-        "h": FloatDistribution(low=1.0, high=1.0, log=True),
-        "i": FloatDistribution(low=1.0, high=1.0, step=1.0),
-        "j": IntDistribution(low=1, high=1),
-        "k": IntDistribution(low=1, high=1, log=True),
+        "a": CategoricalDistribution([1]),
+        "b": FloatDistribution(low=1.0, high=1.0),
+        "c": FloatDistribution(low=1.0, high=1.0, log=True),
+        "d": FloatDistribution(low=1.0, high=1.0, step=1.0),
+        "e": IntDistribution(low=1, high=1),
+        "f": IntDistribution(low=1, high=1, log=True),
     }
 
     with warnings.catch_warnings():

--- a/tests/samplers_tests/test_samplers.py
+++ b/tests/samplers_tests/test_samplers.py
@@ -810,11 +810,14 @@ def test_sample_single_distribution(sampler_class: Callable[[], BaseSampler]) ->
 
     relative_search_space = {
         "a": CategoricalDistribution([1]),
-        "b": FloatDistribution(low=1.0, high=1.0),
-        "c": FloatDistribution(low=1.0, high=1.0, log=True),
-        "d": FloatDistribution(low=1.0, high=1.0, step=1.0),
-        "e": IntDistribution(low=1, high=1),
-        "f": IntDistribution(low=1, high=1, log=True),
+        "b": IntDistribution(low=1, high=1),
+        "c": IntDistribution(low=1, high=1, log=True),
+        "d": FloatDistribution(low=1.0, high=1.0),
+        "e": FloatDistribution(low=1.0, high=1.0, log=True),
+        "f": FloatDistribution(low=1.0, high=1.0, step=1.0),
+        "g": UniformDistribution(low=1.0, high=1.0),
+        "h": LogUniformDistribution(low=1.0, high=1.0),
+        "i": DiscreteUniformDistribution(low=1.0, high=1.0, q=1.0),
     }
 
     with warnings.catch_warnings():

--- a/tests/samplers_tests/tpe_tests/test_multi_objective_sampler.py
+++ b/tests/samplers_tests/tpe_tests/test_multi_objective_sampler.py
@@ -397,7 +397,7 @@ def test_multi_objective_sample_int_uniform_distributions() -> None:
     def int_value_fn(idx: int) -> float:
         return random.randint(0, 100)
 
-    int_dist = optuna.distributions.IntUniformDistribution(1, 100)
+    int_dist = optuna.distributions.IntDistribution(1, 100)
     past_trials = [
         frozen_trial_factory(
             i, [random.random(), random.random()], dist=int_dist, value_fn=int_value_fn

--- a/tests/samplers_tests/tpe_tests/test_parzen_estimator.py
+++ b/tests/samplers_tests/tpe_tests/test_parzen_estimator.py
@@ -15,8 +15,8 @@ SEARCH_SPACE = {
     "a": distributions.FloatDistribution(1.0, 100.0),
     "b": distributions.FloatDistribution(1.0, 100.0, log=True),
     "c": distributions.FloatDistribution(1.0, 100.0, step=3.0),
-    "d": distributions.IntUniformDistribution(1, 100),
-    "e": distributions.IntLogUniformDistribution(1, 100),
+    "d": distributions.IntDistribution(1, 100),
+    "e": distributions.IntDistribution(1, 100, log=True),
     "f": distributions.CategoricalDistribution(["x", "y", "z"]),
 }
 
@@ -171,7 +171,7 @@ def test_suggest_with_step_parzen_estimator(multivariate: bool) -> None:
     # Define search space for distribution with step argument and true ranges
     search_space = {
         "c": distributions.FloatDistribution(low=1.0, high=7.0, step=3.0),
-        "d": distributions.IntUniformDistribution(low=1, high=5, step=2),
+        "d": distributions.IntDistribution(low=1, high=5, step=2),
     }
     multivariate_samples = {"c": np.array([4]), "d": np.array([3])}
     valid_ranges = {"c": set(np.arange(1.0, 10.0, 3.0)), "d": set(np.arange(1, 7, 2))}

--- a/tests/samplers_tests/tpe_tests/test_sampler.py
+++ b/tests/samplers_tests/tpe_tests/test_sampler.py
@@ -87,9 +87,9 @@ def test_infer_relative_search_space() -> None:
         "a": distributions.FloatDistribution(1.0, 100.0),
         "b": distributions.FloatDistribution(1.0, 100.0, log=True),
         "c": distributions.FloatDistribution(1.0, 100.0, step=3.0),
-        "d": distributions.IntUniformDistribution(1, 100),
-        "e": distributions.IntUniformDistribution(0, 100, step=2),
-        "f": distributions.IntLogUniformDistribution(1, 100),
+        "d": distributions.IntDistribution(1, 100),
+        "e": distributions.IntDistribution(0, 100, step=2),
+        "f": distributions.IntDistribution(1, 100, log=True),
         "g": distributions.CategoricalDistribution(["x", "y", "z"]),
     }
 
@@ -337,7 +337,7 @@ def test_sample_relative_int_uniform_distributions(step: int) -> None:
         random.seed(idx)
         return step * random.randint(0, 100 // step)
 
-    int_dist = optuna.distributions.IntUniformDistribution(0, 100, step=step)
+    int_dist = optuna.distributions.IntDistribution(0, 100, step=step)
     past_trials = [
         frozen_trial_factory(i, dist=int_dist, value_fn=int_value_fn) for i in range(1, 8)
     ]
@@ -361,7 +361,7 @@ def test_sample_relative_int_loguniform_distributions() -> None:
         random.seed(idx)
         return random.randint(0, 100)
 
-    intlog_dist = optuna.distributions.IntLogUniformDistribution(1, 100)
+    intlog_dist = optuna.distributions.IntDistribution(1, 100, log=True)
     past_trials = [
         frozen_trial_factory(i, dist=intlog_dist, value_fn=int_value_fn) for i in range(1, 8)
     ]
@@ -640,7 +640,7 @@ def test_sample_independent_int_uniform_distributions() -> None:
         random.seed(idx)
         return random.randint(0, 100)
 
-    int_dist = optuna.distributions.IntUniformDistribution(1, 100)
+    int_dist = optuna.distributions.IntDistribution(1, 100)
     past_trials = [
         frozen_trial_factory(i, dist=int_dist, value_fn=int_value_fn) for i in range(1, 8)
     ]
@@ -661,7 +661,7 @@ def test_sample_independent_int_loguniform_distributions() -> None:
         random.seed(idx)
         return random.randint(0, 100)
 
-    intlog_dist = optuna.distributions.IntLogUniformDistribution(1, 100)
+    intlog_dist = optuna.distributions.IntDistribution(1, 100, log=True)
     past_trials = [
         frozen_trial_factory(i, dist=intlog_dist, value_fn=int_value_fn) for i in range(1, 8)
     ]
@@ -993,7 +993,7 @@ def test_group() -> None:
         study.optimize(lambda t: t.suggest_int("x", 0, 10), n_trials=2)
         assert mock.call_count == 1
     assert study.trials[-1].distributions == {
-        "x": distributions.IntUniformDistribution(low=0, high=10)
+        "x": distributions.IntDistribution(low=0, high=10)
     }
 
     with patch.object(sampler, "_sample_relative", wraps=sampler._sample_relative) as mock:
@@ -1002,7 +1002,7 @@ def test_group() -> None:
         )
         assert mock.call_count == 1
     assert study.trials[-1].distributions == {
-        "y": distributions.IntUniformDistribution(low=0, high=10),
+        "y": distributions.IntDistribution(low=0, high=10),
         "z": distributions.FloatDistribution(low=-3, high=3),
     }
 
@@ -1018,7 +1018,7 @@ def test_group() -> None:
     assert study.trials[-1].distributions == {
         "u": distributions.FloatDistribution(low=1e-2, high=1e2, log=True),
         "v": distributions.CategoricalDistribution(choices=["A", "B", "C"]),
-        "y": distributions.IntUniformDistribution(low=0, high=10),
+        "y": distributions.IntDistribution(low=0, high=10),
         "z": distributions.FloatDistribution(low=-3, high=3),
     }
 
@@ -1035,15 +1035,15 @@ def test_group() -> None:
         )
         assert mock.call_count == 4
     assert study.trials[-1].distributions == {
-        "y": distributions.IntUniformDistribution(low=0, high=10),
-        "w": distributions.IntLogUniformDistribution(low=2, high=8),
+        "y": distributions.IntDistribution(low=0, high=10),
+        "w": distributions.IntDistribution(low=2, high=8, log=True),
     }
 
     with patch.object(sampler, "_sample_relative", wraps=sampler._sample_relative) as mock:
         study.optimize(lambda t: t.suggest_int("x", 0, 10), n_trials=1)
         assert mock.call_count == 6
     assert study.trials[-1].distributions == {
-        "x": distributions.IntUniformDistribution(low=0, high=10)
+        "x": distributions.IntDistribution(low=0, high=10)
     }
 
 

--- a/tests/samplers_tests/tpe_tests/test_sampler.py
+++ b/tests/samplers_tests/tpe_tests/test_sampler.py
@@ -992,9 +992,7 @@ def test_group() -> None:
     with patch.object(sampler, "_sample_relative", wraps=sampler._sample_relative) as mock:
         study.optimize(lambda t: t.suggest_int("x", 0, 10), n_trials=2)
         assert mock.call_count == 1
-    assert study.trials[-1].distributions == {
-        "x": distributions.IntDistribution(low=0, high=10)
-    }
+    assert study.trials[-1].distributions == {"x": distributions.IntDistribution(low=0, high=10)}
 
     with patch.object(sampler, "_sample_relative", wraps=sampler._sample_relative) as mock:
         study.optimize(
@@ -1042,9 +1040,7 @@ def test_group() -> None:
     with patch.object(sampler, "_sample_relative", wraps=sampler._sample_relative) as mock:
         study.optimize(lambda t: t.suggest_int("x", 0, 10), n_trials=1)
         assert mock.call_count == 6
-    assert study.trials[-1].distributions == {
-        "x": distributions.IntDistribution(low=0, high=10)
-    }
+    assert study.trials[-1].distributions == {"x": distributions.IntDistribution(low=0, high=10)}
 
 
 def test_invalid_multivariate_and_group() -> None:

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -2,7 +2,6 @@ import copy
 import json
 from typing import Any
 from typing import Dict
-from typing import List
 from typing import Optional
 import warnings
 
@@ -13,25 +12,31 @@ from optuna import distributions
 
 EXAMPLE_DISTRIBUTIONS: Dict[str, Any] = {
     "i": distributions.IntDistribution(low=1, high=9, log=False),
+    # i2 and i3 are identical to i, and tested for cases when `log` and `step` are omitted in json.
+    "i2": distributions.IntDistribution(low=1, high=9, log=False),
+    "i3": distributions.IntDistribution(low=1, high=9, log=False),
     "il": distributions.IntDistribution(low=2, high=12, log=True),
+    "il2": distributions.IntDistribution(low=2, high=12, log=True),
     "id": distributions.IntDistribution(low=1, high=9, log=False, step=2),
+    "id2": distributions.IntDistribution(low=1, high=9, log=False, step=2),
     "f": distributions.FloatDistribution(low=1.0, high=2.0, log=False),
     "fl": distributions.FloatDistribution(low=0.001, high=100.0, log=True),
     "fd": distributions.FloatDistribution(low=1.0, high=9.0, log=False, step=2.0),
-    "iu": distributions.IntUniformDistribution(low=1, high=9),
-    "iuq": distributions.IntUniformDistribution(low=1, high=9, step=2),
     "c1": distributions.CategoricalDistribution(choices=(2.71, -float("inf"))),
     "c2": distributions.CategoricalDistribution(choices=("Roppongi", "Azabu")),
     "c3": distributions.CategoricalDistribution(choices=["Roppongi", "Azabu"]),
-    "ilu": distributions.IntLogUniformDistribution(low=2, high=12),
 }
 
 EXAMPLE_JSONS = {
-    "i": '{"name": "IntDistribution", '
+    "i": '{"name": "IntDistribution", "attributes": {"low": 1, "high": 9}}',
+    "i2": '{"name": "IntDistribution", "attributes": {"low": 1, "high": 9, "log": false}}',
+    "i3": '{"name": "IntDistribution", '
     '"attributes": {"low": 1, "high": 9, "log": false, "step": 1}}',
-    "il": '{"name": "IntDistribution", '
+    "il": '{"name": "IntDistribution", ' '"attributes": {"low": 2, "high": 12, "log": true}}',
+    "il2": '{"name": "IntDistribution", '
     '"attributes": {"low": 2, "high": 12, "log": true, "step": 1}}',
-    "id": '{"name": "IntDistribution", '
+    "id": '{"name": "IntDistribution", ' '"attributes": {"low": 1, "high": 9, "step": 2}}',
+    "id2": '{"name": "IntDistribution", '
     '"attributes": {"low": 1, "high": 9, "log": false, "step": 2}}',
     "f": '{"name": "FloatDistribution", '
     '"attributes": {"low": 1.0, "high": 2.0, "log": false, "step": null}}',
@@ -39,24 +44,25 @@ EXAMPLE_JSONS = {
     '"attributes": {"low": 0.001, "high": 100.0, "log": true, "step": null}}',
     "fd": '{"name": "FloatDistribution", '
     '"attributes": {"low": 1.0, "high": 9.0, "step": 2.0, "log": false}}',
-    "iu": '{"name": "IntUniformDistribution", "attributes": {"low": 1, "high": 9}}',
-    "iuq": '{"name": "IntUniformDistribution", "attributes": {"low": 1, "high": 9, "step": 2}}',
     "c1": '{"name": "CategoricalDistribution", "attributes": {"choices": [2.71, -Infinity]}}',
     "c2": '{"name": "CategoricalDistribution", "attributes": {"choices": ["Roppongi", "Azabu"]}}',
     "c3": '{"name": "CategoricalDistribution", "attributes": {"choices": ["Roppongi", "Azabu"]}}',
-    "ilu": '{"name": "IntLogUniformDistribution", "attributes": {"low": 2, "high": 12}}',
 }
 
 EXAMPLE_ABBREVIATED_JSONS = {
+    "i": '{"type": "int", "low": 1, "high": 9}',
+    "i2": '{"type": "int", "low": 1, "high": 9, "log": false}',
+    "i3": '{"type": "int", "low": 1, "high": 9, "log": false, "step": 1}',
+    "il": '{"type": "int", "low": 2, "high": 12, "log": true}',
+    "il2": '{"type": "int", "low": 2, "high": 12, "log": true, "step": 1}',
+    "id": '{"type": "int", "low": 1, "high": 9, "step": 2}',
+    "id2": '{"type": "int", "low": 1, "high": 9, "log": false, "step": 2}',
     "f": '{"type": "float", "low": 1.0, "high": 2.0, "log": false, "step": null}',
     "fl": '{"type": "float", "low": 0.001, "high": 100, "log": true, "step": null}',
     "fd": '{"type": "float", "low": 1.0, "high": 9.0, "log": false, "step": 2.0}',
-    "iu": '{"type": "int", "low": 1, "high": 9}',
-    "iuq": '{"type": "int", "low": 1, "high": 9, "step": 2}',
     "c1": '{"type": "categorical", "choices": [2.71, -Infinity]}',
     "c2": '{"type": "categorical", "choices": ["Roppongi", "Azabu"]}',
     "c3": '{"type": "categorical", "choices": ["Roppongi", "Azabu"]}',
-    "ilu": '{"type": "int", "low": 2, "high": 12, "log": true}',
 }
 
 
@@ -96,24 +102,15 @@ def test_abbreviated_json_to_distribution() -> None:
         pytest.raises(ValueError, lambda: distributions.json_to_distribution(distribution))
 
 
-def test_backward_compatibility_int_uniform_distribution() -> None:
-
-    json_str = '{"name": "IntUniformDistribution", "attributes": {"low": 1, "high": 10}}'
-    actual = distributions.json_to_distribution(json_str)
-    expected = distributions.IntUniformDistribution(low=1, high=10)
-    assert actual == expected
-
-
 def test_distribution_to_json() -> None:
 
     for key in EXAMPLE_JSONS:
         json_actual = json.loads(distributions.distribution_to_json(EXAMPLE_DISTRIBUTIONS[key]))
         json_expect = json.loads(EXAMPLE_JSONS[key])
-        if (
-            json_expect["name"] in ("IntUniformDistribution", "IntLogUniformDistribution")
-            and "step" not in json_expect["attributes"]
-        ):
+        if json_expect["name"] == "IntDistribution" and "step" not in json_expect["attributes"]:
             json_expect["attributes"]["step"] = 1
+        if json_expect["name"] == "IntDistribution" and "log" not in json_expect["attributes"]:
+            json_expect["attributes"]["log"] = False
         assert json_actual == json_expect
 
 
@@ -183,15 +180,6 @@ def test_check_distribution_compatibility() -> None:
     distributions.check_distribution_compatibility(
         EXAMPLE_DISTRIBUTIONS["fd"], distributions.FloatDistribution(low=-1.0, high=11.0, step=0.5)
     )
-    distributions.check_distribution_compatibility(
-        EXAMPLE_DISTRIBUTIONS["iu"], distributions.IntUniformDistribution(low=-1, high=1)
-    )
-    distributions.check_distribution_compatibility(
-        EXAMPLE_DISTRIBUTIONS["iuq"], distributions.IntUniformDistribution(low=-1, high=1)
-    )
-    distributions.check_distribution_compatibility(
-        EXAMPLE_DISTRIBUTIONS["ilu"], distributions.IntLogUniformDistribution(low=1, high=13)
-    )
 
 
 @pytest.mark.parametrize(
@@ -238,30 +226,7 @@ def test_float_contains(expected: bool, value: float, step: Optional[float]) -> 
     assert f._contains(value) == expected
 
 
-def test_contains() -> None:
-
-    iu = distributions.IntUniformDistribution(low=1, high=10)
-    assert not iu._contains(0.9)
-    assert iu._contains(1)
-    assert iu._contains(4)
-    assert iu._contains(6)
-    assert iu._contains(10)
-    assert not iu._contains(10.1)
-    assert not iu._contains(11)
-
-    # IntUniformDistribution with a 'step' parameter.
-    with warnings.catch_warnings():
-        # UserWarning will be raised since the range is not divisible by 2.
-        # The range will be replaced with [1, 9].
-        warnings.simplefilter("ignore", category=UserWarning)
-        iuq = distributions.IntUniformDistribution(low=1, high=10, step=2)
-    assert not iuq._contains(0.9)
-    assert iuq._contains(1)
-    assert not iuq._contains(4)
-    assert not iuq._contains(6)
-    assert iuq._contains(9)
-    assert not iuq._contains(9.1)
-    assert not iuq._contains(10)
+def test_categorical_contains() -> None:
 
     c = distributions.CategoricalDistribution(choices=("Roppongi", "Azabu"))
     assert not c._contains(-1)
@@ -270,15 +235,6 @@ def test_contains() -> None:
     assert c._contains(1.5)
     assert not c._contains(3)
 
-    ilu = distributions.IntLogUniformDistribution(low=2, high=12)
-    assert not ilu._contains(0.9)
-    assert ilu._contains(2)
-    assert ilu._contains(4)
-    assert ilu._contains(6)
-    assert ilu._contains(12)
-    assert not ilu._contains(12.1)
-    assert not ilu._contains(13)
-
 
 def test_empty_range_contains() -> None:
 
@@ -286,6 +242,11 @@ def test_empty_range_contains() -> None:
     assert not i._contains(0)
     assert i._contains(1)
     assert not i._contains(2)
+
+    iq = distributions.IntDistribution(low=1, high=1, step=2)
+    assert not iq._contains(0)
+    assert iq._contains(1)
+    assert not iq._contains(2)
 
     f = distributions.FloatDistribution(low=1.0, high=1.0)
     assert not f._contains(0.9)
@@ -296,21 +257,6 @@ def test_empty_range_contains() -> None:
     assert not fd._contains(0.9)
     assert fd._contains(1.0)
     assert not fd._contains(1.1)
-
-    iu = distributions.IntUniformDistribution(low=1, high=1)
-    assert not iu._contains(0)
-    assert iu._contains(1)
-    assert not iu._contains(2)
-
-    iuq = distributions.IntUniformDistribution(low=1, high=1, step=2)
-    assert not iuq._contains(0)
-    assert iuq._contains(1)
-    assert not iuq._contains(2)
-
-    ilu = distributions.IntLogUniformDistribution(low=1, high=1)
-    assert not ilu._contains(0)
-    assert ilu._contains(1)
-    assert not ilu._contains(2)
 
 
 @pytest.mark.parametrize(
@@ -352,64 +298,9 @@ def test_float_single(
     assert distribution.single() == expected
 
 
-def test_single() -> None:
-
-    with warnings.catch_warnings():
-        # UserWarning will be raised since the range is not divisible by step.
-        warnings.simplefilter("ignore", category=UserWarning)
-        single_distributions: List[distributions.BaseDistribution] = [
-            distributions.FloatDistribution(low=1.0, high=1.0),
-            distributions.FloatDistribution(low=7.3, high=7.3, log=True),
-            distributions.FloatDistribution(low=2.22, high=2.22, step=0.1),
-            distributions.FloatDistribution(low=2.22, high=2.24, step=0.3),
-            distributions.IntUniformDistribution(low=-123, high=-123),
-            distributions.IntUniformDistribution(low=-123, high=-120, step=4),
-            distributions.CategoricalDistribution(choices=("foo",)),
-            distributions.IntLogUniformDistribution(low=2, high=2),
-        ]
-    for distribution in single_distributions:
-        assert distribution.single()
-
-    nonsingle_distributions: List[distributions.BaseDistribution] = [
-        distributions.FloatDistribution(low=1.0, high=1.001),
-        distributions.FloatDistribution(low=7.3, high=10, log=True),
-        distributions.FloatDistribution(low=-30, high=-20, step=2),
-        distributions.FloatDistribution(low=-30, high=-20, step=10),
-        # In Python, "0.3 - 0.2 != 0.1" is True.
-        distributions.FloatDistribution(low=0.2, high=0.3, step=0.1),
-        distributions.FloatDistribution(low=0.7, high=0.8, step=0.1),
-        distributions.IntUniformDistribution(low=-123, high=0),
-        distributions.IntUniformDistribution(low=-123, high=0, step=123),
-        distributions.CategoricalDistribution(choices=("foo", "bar")),
-        distributions.IntLogUniformDistribution(low=2, high=4),
-    ]
-    for distribution in nonsingle_distributions:
-        assert not distribution.single()
-
-
-def test_empty_distribution() -> None:
-
-    # Empty distributions cannot be instantiated.
-    with pytest.raises(ValueError):
-        distributions.FloatDistribution(low=0.0, high=-100.0)
-
-    with pytest.raises(ValueError):
-        distributions.FloatDistribution(low=7.3, high=7.2, log=True)
-
-    with pytest.raises(ValueError):
-        distributions.FloatDistribution(low=-30, high=-40, step=3)
-
-    with pytest.raises(ValueError):
-        distributions.IntUniformDistribution(low=123, high=100)
-
-    with pytest.raises(ValueError):
-        distributions.IntUniformDistribution(low=123, high=100, step=2)
-
-    with pytest.raises(ValueError):
-        distributions.CategoricalDistribution(choices=())
-
-    with pytest.raises(ValueError):
-        distributions.IntLogUniformDistribution(low=123, high=100)
+def test_categorical_single() -> None:
+    assert distributions.CategoricalDistribution(choices=("foo",)).single()
+    assert not distributions.CategoricalDistribution(choices=("foo", "bar")).single()
 
 
 def test_invalid_distribution() -> None:
@@ -427,13 +318,13 @@ def test_eq_ne_hash() -> None:
         assert hash(d) == hash(d_copy)
 
     # Different field values.
-    di0 = distributions.FloatDistribution(low=1, high=2)
-    di1 = distributions.FloatDistribution(low=1, high=3)
-    assert di0 != di1
+    d0 = distributions.FloatDistribution(low=1, high=2)
+    d1 = distributions.FloatDistribution(low=1, high=3)
+    assert d0 != d1
 
     # Different distribution classes.
-    di2 = distributions.IntDistribution(low=1, high=2)
-    assert di0 != di2
+    d2 = distributions.IntDistribution(low=1, high=2)
+    assert d0 != d2
 
 
 def test_repr() -> None:
@@ -472,17 +363,6 @@ def test_float_distribution_asdict(
 ) -> None:
     expected_dict = {"low": low, "high": high, "log": log, "step": step}
     assert EXAMPLE_DISTRIBUTIONS[key]._asdict() == expected_dict
-
-
-def test_int_uniform_distribution_asdict() -> None:
-
-    assert EXAMPLE_DISTRIBUTIONS["iu"]._asdict() == {"low": 1, "high": 9, "step": 1}
-    assert EXAMPLE_DISTRIBUTIONS["iuq"]._asdict() == {"low": 1, "high": 9, "step": 2}
-
-
-def test_int_log_uniform_distribution_asdict() -> None:
-
-    assert EXAMPLE_DISTRIBUTIONS["ilu"]._asdict() == {"low": 2, "high": 12, "step": 1}
 
 
 def test_int_init_error() -> None:
@@ -531,15 +411,6 @@ def test_float_init_error() -> None:
 
     with pytest.raises(ValueError):
         distributions.FloatDistribution(low=1.0, high=100.0, step=-1)
-
-
-def test_int_uniform_distribution_invalid_step() -> None:
-
-    with pytest.raises(ValueError):
-        distributions.IntUniformDistribution(low=1, high=100, step=0)
-
-    with pytest.raises(ValueError):
-        distributions.IntUniformDistribution(low=1, high=100, step=-1)
 
 
 def test_categorical_distribution_different_sequence_types() -> None:

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -413,6 +413,11 @@ def test_float_init_error() -> None:
         distributions.FloatDistribution(low=1.0, high=100.0, step=-1)
 
 
+def test_categorical_init_error() -> None:
+    with pytest.raises(ValueError):
+        distributions.CategoricalDistribution(choices=())
+
+
 def test_categorical_distribution_different_sequence_types() -> None:
 
     c1 = distributions.CategoricalDistribution(choices=("Roppongi", "Azabu"))

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -7,8 +7,11 @@ import pytest
 from optuna._transform import _SearchSpaceTransform
 from optuna.distributions import BaseDistribution
 from optuna.distributions import CategoricalDistribution
+from optuna.distributions import DiscreteUniformDistribution
 from optuna.distributions import FloatDistribution
 from optuna.distributions import IntDistribution
+from optuna.distributions import LogUniformDistribution
+from optuna.distributions import UniformDistribution
 
 
 @pytest.mark.parametrize(
@@ -17,6 +20,9 @@ from optuna.distributions import IntDistribution
         (0, IntDistribution(0, 3)),
         (1, IntDistribution(1, 10, log=True)),
         (2, IntDistribution(0, 10, step=2)),
+        (0.0, UniformDistribution(0, 3)),
+        (1.0, LogUniformDistribution(1, 10)),
+        (0.2, DiscreteUniformDistribution(0, 1, q=0.2)),
         (0.0, FloatDistribution(0, 3)),
         (1.0, FloatDistribution(1, 10, log=True)),
         (0.2, FloatDistribution(0, 1, step=0.2)),
@@ -55,9 +61,9 @@ def test_search_space_transform_encoding() -> None:
 
     trans = _SearchSpaceTransform(
         {
-            "x0": FloatDistribution(0, 3),
+            "x0": UniformDistribution(0, 3),
             "x1": CategoricalDistribution(["foo", "bar", "baz"]),
-            "x3": FloatDistribution(0, 1, step=0.2),
+            "x3": DiscreteUniformDistribution(0, 1, q=0.2),
         }
     )
 
@@ -78,6 +84,12 @@ def test_search_space_transform_encoding() -> None:
         (1, IntDistribution(1, 10, log=True)),
         (10, IntDistribution(1, 10, log=True)),
         (2, IntDistribution(0, 10, step=2)),
+        (0.0, UniformDistribution(0, 3)),
+        (3.0, UniformDistribution(0, 3)),
+        (1.0, LogUniformDistribution(1, 10)),
+        (10.0, LogUniformDistribution(1, 10)),
+        (0.2, DiscreteUniformDistribution(0, 1, q=0.2)),
+        (1.0, DiscreteUniformDistribution(0, 1, q=0.2)),
         (0.0, FloatDistribution(0, 3)),
         (3.0, FloatDistribution(0, 3)),
         (1.0, FloatDistribution(1, 10, log=True)),
@@ -97,7 +109,16 @@ def test_search_space_transform_numerical(
     expected_low = distribution.low  # type: ignore
     expected_high = distribution.high  # type: ignore
 
-    if isinstance(distribution, FloatDistribution):
+    if isinstance(distribution, LogUniformDistribution):
+        if transform_log:
+            expected_low = math.log(expected_low)
+            expected_high = math.log(expected_high)
+    elif isinstance(distribution, DiscreteUniformDistribution):
+        if transform_step:
+            half_step = 0.5 * distribution.q
+            expected_low -= half_step
+            expected_high += half_step
+    elif isinstance(distribution, FloatDistribution):
         if transform_log and distribution.log:
             expected_low = math.log(expected_low)
             expected_high = math.log(expected_high)
@@ -158,6 +179,11 @@ def test_search_space_transform_untransform_params() -> None:
         "x8": IntDistribution(2, 4),
         "x9": IntDistribution(1, 10, log=True),
         "x10": IntDistribution(1, 9, step=2),
+        "x11": DiscreteUniformDistribution(0, 1, q=0.2),
+        "x12": UniformDistribution(2, 3),
+        "x13": LogUniformDistribution(1, 10),
+        "x14": UniformDistribution(-2, -2),
+        "x15": LogUniformDistribution(1, 1),
     }
 
     params = {
@@ -172,6 +198,11 @@ def test_search_space_transform_untransform_params() -> None:
         "x8": 2,
         "x9": 1,
         "x10": 3,
+        "x11": 0.2,
+        "x12": 2.0,
+        "x13": 1.0,
+        "x14": -2.0,
+        "x15": 1.0,
     }
 
     trans = _SearchSpaceTransform(search_space)

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -7,27 +7,16 @@ import pytest
 from optuna._transform import _SearchSpaceTransform
 from optuna.distributions import BaseDistribution
 from optuna.distributions import CategoricalDistribution
-from optuna.distributions import DiscreteUniformDistribution
 from optuna.distributions import FloatDistribution
 from optuna.distributions import IntDistribution
-from optuna.distributions import IntLogUniformDistribution
-from optuna.distributions import IntUniformDistribution
-from optuna.distributions import LogUniformDistribution
-from optuna.distributions import UniformDistribution
 
 
 @pytest.mark.parametrize(
     "param,distribution",
     [
-        (0, IntUniformDistribution(0, 3)),
-        (1, IntLogUniformDistribution(1, 10)),
-        (2, IntUniformDistribution(0, 10, step=2)),
         (0, IntDistribution(0, 3)),
         (1, IntDistribution(1, 10, log=True)),
         (2, IntDistribution(0, 10, step=2)),
-        (0.0, UniformDistribution(0, 3)),
-        (1.0, LogUniformDistribution(1, 10)),
-        (0.2, DiscreteUniformDistribution(0, 1, q=0.2)),
         (0.0, FloatDistribution(0, 3)),
         (1.0, FloatDistribution(1, 10, log=True)),
         (0.2, FloatDistribution(0, 1, step=0.2)),
@@ -52,7 +41,7 @@ def test_search_space_transform_shapes_dtypes(param: Any, distribution: BaseDist
 
 
 def test_search_space_transform_encoding() -> None:
-    trans = _SearchSpaceTransform({"x0": IntUniformDistribution(0, 3)})
+    trans = _SearchSpaceTransform({"x0": IntDistribution(0, 3)})
 
     assert len(trans.column_to_encoded_columns) == 1
     numpy.testing.assert_equal(trans.column_to_encoded_columns[0], numpy.array([0]))
@@ -66,9 +55,9 @@ def test_search_space_transform_encoding() -> None:
 
     trans = _SearchSpaceTransform(
         {
-            "x0": UniformDistribution(0, 3),
+            "x0": FloatDistribution(0, 3),
             "x1": CategoricalDistribution(["foo", "bar", "baz"]),
-            "x3": DiscreteUniformDistribution(0, 1, q=0.2),
+            "x3": FloatDistribution(0, 1, step=0.2),
         }
     )
 
@@ -84,24 +73,17 @@ def test_search_space_transform_encoding() -> None:
 @pytest.mark.parametrize(
     "param,distribution",
     [
-        (0, IntUniformDistribution(0, 3)),
-        (3, IntUniformDistribution(0, 3)),
-        (1, IntLogUniformDistribution(1, 10)),
-        (10, IntLogUniformDistribution(1, 10)),
-        (2, IntUniformDistribution(0, 10, step=2)),
         (0, IntDistribution(0, 3)),
+        (3, IntDistribution(0, 3)),
         (1, IntDistribution(1, 10, log=True)),
+        (10, IntDistribution(1, 10, log=True)),
         (2, IntDistribution(0, 10, step=2)),
-        (10, IntUniformDistribution(0, 10, step=2)),
-        (0.0, UniformDistribution(0, 3)),
-        (3.0, UniformDistribution(0, 3)),
-        (1.0, LogUniformDistribution(1, 10)),
-        (10.0, LogUniformDistribution(1, 10)),
-        (0.2, DiscreteUniformDistribution(0, 1, q=0.2)),
-        (1.0, DiscreteUniformDistribution(0, 1, q=0.2)),
         (0.0, FloatDistribution(0, 3)),
+        (3.0, FloatDistribution(0, 3)),
         (1.0, FloatDistribution(1, 10, log=True)),
+        (10.0, FloatDistribution(1, 10, log=True)),
         (0.2, FloatDistribution(0, 1, step=0.2)),
+        (1.0, FloatDistribution(0, 1, step=0.2)),
     ],
 )
 def test_search_space_transform_numerical(
@@ -115,16 +97,7 @@ def test_search_space_transform_numerical(
     expected_low = distribution.low  # type: ignore
     expected_high = distribution.high  # type: ignore
 
-    if isinstance(distribution, LogUniformDistribution):
-        if transform_log:
-            expected_low = math.log(expected_low)
-            expected_high = math.log(expected_high)
-    elif isinstance(distribution, DiscreteUniformDistribution):
-        if transform_step:
-            half_step = 0.5 * distribution.q
-            expected_low -= half_step
-            expected_high += half_step
-    elif isinstance(distribution, FloatDistribution):
+    if isinstance(distribution, FloatDistribution):
         if transform_log and distribution.log:
             expected_low = math.log(expected_low)
             expected_high = math.log(expected_high)
@@ -132,19 +105,6 @@ def test_search_space_transform_numerical(
             half_step = 0.5 * distribution.step
             expected_low -= half_step
             expected_high += half_step
-    elif isinstance(distribution, IntUniformDistribution):
-        if transform_step:
-            half_step = 0.5 * distribution.step
-            expected_low -= half_step
-            expected_high += half_step
-    elif isinstance(distribution, IntLogUniformDistribution):
-        if transform_step:
-            half_step = 0.5
-            expected_low -= half_step
-            expected_high += half_step
-        if transform_log:
-            expected_low = math.log(expected_low)
-            expected_high = math.log(expected_high)
     elif isinstance(distribution, IntDistribution):
         if transform_step:
             half_step = 0.5 * distribution.step
@@ -187,45 +147,31 @@ def test_search_space_transform_values_categorical(
 
 def test_search_space_transform_untransform_params() -> None:
     search_space = {
-        "x0": DiscreteUniformDistribution(0, 1, q=0.2),
+        "x0": CategoricalDistribution(["corge"]),
         "x1": CategoricalDistribution(["foo", "bar", "baz", "qux"]),
-        "x2": IntLogUniformDistribution(1, 10),
-        "x3": CategoricalDistribution(["quux", "quuz"]),
-        "x4": UniformDistribution(2, 3),
-        "x5": LogUniformDistribution(1, 10),
-        "x6": IntUniformDistribution(2, 4),
-        "x7": CategoricalDistribution(["corge"]),
-        "x8": UniformDistribution(-2, -2),
-        "x9": LogUniformDistribution(1, 1),
-        "x10": FloatDistribution(2, 3),
-        "x11": FloatDistribution(-2, 2),
-        "x12": FloatDistribution(1, 10),
-        "x13": FloatDistribution(1, 1),
-        "x14": FloatDistribution(0, 1, step=0.2),
-        "x15": IntDistribution(2, 4),
-        "x16": IntDistribution(1, 10, log=True),
-        "x17": IntDistribution(1, 9, step=2),
+        "x2": CategoricalDistribution(["quux", "quuz"]),
+        "x3": FloatDistribution(2, 3),
+        "x4": FloatDistribution(-2, 2),
+        "x5": FloatDistribution(1, 10),
+        "x6": FloatDistribution(1, 1),
+        "x7": FloatDistribution(0, 1, step=0.2),
+        "x8": IntDistribution(2, 4),
+        "x9": IntDistribution(1, 10, log=True),
+        "x10": IntDistribution(1, 9, step=2),
     }
 
     params = {
-        "x0": 0.2,
+        "x0": "corge",
         "x1": "qux",
-        "x2": 1,
-        "x3": "quux",
-        "x4": 2.0,
+        "x2": "quux",
+        "x3": 2.0,
+        "x4": -2,
         "x5": 1.0,
-        "x6": 2,
-        "x7": "corge",
-        "x8": -2.0,
-        "x9": 1.0,
-        "x10": 2.0,
-        "x11": -2,
-        "x12": 1.0,
-        "x13": 1.0,
-        "x14": 0.2,
-        "x15": 2,
-        "x16": 1,
-        "x17": 3,
+        "x6": 1.0,
+        "x7": 0.2,
+        "x8": 2,
+        "x9": 1,
+        "x10": 3,
     }
 
     trans = _SearchSpaceTransform(search_space)

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -84,6 +84,7 @@ def test_search_space_transform_encoding() -> None:
         (1, IntDistribution(1, 10, log=True)),
         (10, IntDistribution(1, 10, log=True)),
         (2, IntDistribution(0, 10, step=2)),
+        (10, IntDistribution(0, 10, step=2)),
         (0.0, UniformDistribution(0, 3)),
         (3.0, UniformDistribution(0, 3)),
         (1.0, LogUniformDistribution(1, 10)),

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -91,11 +91,8 @@ def test_search_space_transform_encoding() -> None:
         (0.2, DiscreteUniformDistribution(0, 1, q=0.2)),
         (1.0, DiscreteUniformDistribution(0, 1, q=0.2)),
         (0.0, FloatDistribution(0, 3)),
-        (3.0, FloatDistribution(0, 3)),
         (1.0, FloatDistribution(1, 10, log=True)),
-        (10.0, FloatDistribution(1, 10, log=True)),
         (0.2, FloatDistribution(0, 1, step=0.2)),
-        (1.0, FloatDistribution(0, 1, step=0.2)),
     ],
 )
 def test_search_space_transform_numerical(

--- a/tests/trial_tests/test_frozen.py
+++ b/tests/trial_tests/test_frozen.py
@@ -344,7 +344,7 @@ def test_not_contained_param() -> None:
     trial = create_trial(
         value=0.2,
         params={"x": 1},
-        distributions={"x": IntDistribution(1, 10, 1)},
+        distributions={"x": IntDistribution(1, 10)},
     )
     with pytest.warns(UserWarning):
         assert trial.suggest_int("x", 10, 100, 1) == 1

--- a/tests/trial_tests/test_frozen.py
+++ b/tests/trial_tests/test_frozen.py
@@ -12,8 +12,7 @@ from optuna import create_study
 from optuna.distributions import BaseDistribution
 from optuna.distributions import CategoricalDistribution
 from optuna.distributions import FloatDistribution
-from optuna.distributions import IntLogUniformDistribution
-from optuna.distributions import IntUniformDistribution
+from optuna.distributions import IntDistribution
 from optuna.testing.storage import STORAGE_MODES
 from optuna.testing.storage import StorageSupplier
 from optuna.trial import BaseTrial
@@ -221,7 +220,7 @@ def test_suggest_int() -> None:
         datetime_start=datetime.datetime.now(),
         datetime_complete=datetime.datetime.now(),
         params={"x": 1},
-        distributions={"x": IntUniformDistribution(0, 10)},
+        distributions={"x": IntDistribution(0, 10)},
         user_attrs={},
         system_attrs={},
         intermediate_values={},
@@ -243,7 +242,7 @@ def test_suggest_int_log() -> None:
         datetime_start=datetime.datetime.now(),
         datetime_complete=datetime.datetime.now(),
         params={"x": 1},
-        distributions={"x": IntLogUniformDistribution(1, 10)},
+        distributions={"x": IntDistribution(1, 10, log=True)},
         user_attrs={},
         system_attrs={},
         intermediate_values={},
@@ -337,7 +336,7 @@ def test_not_contained_param() -> None:
     trial = create_trial(
         value=0.2,
         params={"x": 1.0},
-        distributions={"x": IntUniformDistribution(1, 10)},
+        distributions={"x": IntDistribution(1, 10)},
     )
     with pytest.warns(UserWarning):
         assert trial.suggest_int("x", 10, 100) == 1
@@ -345,7 +344,7 @@ def test_not_contained_param() -> None:
     trial = create_trial(
         value=0.2,
         params={"x": 1},
-        distributions={"x": IntUniformDistribution(1, 10, 1)},
+        distributions={"x": IntDistribution(1, 10, 1)},
     )
     with pytest.warns(UserWarning):
         assert trial.suggest_int("x", 10, 100, 1) == 1
@@ -353,7 +352,7 @@ def test_not_contained_param() -> None:
     trial = create_trial(
         value=0.2,
         params={"x": 1},
-        distributions={"x": IntLogUniformDistribution(1, 10)},
+        distributions={"x": IntDistribution(1, 10, log=True)},
     )
     with pytest.warns(UserWarning):
         assert trial.suggest_int("x", 10, 100, log=True) == 1

--- a/tests/trial_tests/test_trial.py
+++ b/tests/trial_tests/test_trial.py
@@ -21,8 +21,7 @@ from optuna import storages
 from optuna.distributions import BaseDistribution
 from optuna.distributions import CategoricalDistribution
 from optuna.distributions import FloatDistribution
-from optuna.distributions import IntLogUniformDistribution
-from optuna.distributions import IntUniformDistribution
+from optuna.distributions import IntDistribution
 from optuna.testing.integration import DeterministicPruner
 from optuna.testing.sampler import DeterministicRelativeSampler
 from optuna.testing.storage import STORAGE_MODES
@@ -384,7 +383,7 @@ def test_suggest_int(storage_mode: str) -> None:
     ) as storage:
         study = create_study(storage=storage, sampler=sampler)
         trial = Trial(study, study._storage.create_new_trial(study._study_id))
-        distribution = IntUniformDistribution(low=0, high=3)
+        distribution = IntDistribution(low=0, high=3)
 
         assert trial._suggest("x", distribution) == 1  # Test suggesting a param.
         assert trial._suggest("x", distribution) == 1  # Test suggesting the same param.
@@ -464,7 +463,7 @@ def test_suggest_int_log(storage_mode: str) -> None:
     ) as storage:
         study = create_study(storage=storage, sampler=sampler)
         trial = Trial(study, study._storage.create_new_trial(study._study_id))
-        distribution = IntLogUniformDistribution(low=1, high=3)
+        distribution = IntDistribution(low=1, high=3, log=True)
 
         assert trial._suggest("x", distribution) == 1  # Test suggesting a param.
         assert trial._suggest("x", distribution) == 1  # Test suggesting the same param.
@@ -509,9 +508,9 @@ def test_distributions(storage_mode: str) -> None:
             "a": FloatDistribution(low=0, high=10),
             "b": FloatDistribution(low=0.1, high=10, log=True),
             "c": FloatDistribution(low=0, high=10, step=1),
-            "d": IntUniformDistribution(low=0, high=10),
+            "d": IntDistribution(low=0, high=10),
             "e": CategoricalDistribution(choices=("foo", "bar", "baz")),
-            "f": IntLogUniformDistribution(low=1, high=10),
+            "f": IntDistribution(low=1, high=10, log=True),
         }
 
 
@@ -559,7 +558,7 @@ def test_relative_parameters(storage_mode: str) -> None:
 
         # Error (due to incompatible distribution class).
         trial3 = create_trial()
-        distribution3 = IntUniformDistribution(low=1, high=100)
+        distribution3 = IntDistribution(low=1, high=100)
         with pytest.raises(ValueError):
             trial3._suggest("y", distribution3)
 
@@ -571,7 +570,7 @@ def test_relative_parameters(storage_mode: str) -> None:
 
         # Error (due to incompatible distribution class).
         trial5 = create_trial()
-        distribution5 = IntLogUniformDistribution(low=1, high=100)
+        distribution5 = IntDistribution(low=1, high=100, log=True)
         with pytest.raises(ValueError):
             trial5._suggest("y", distribution5)
 

--- a/tutorial/20_recipes/008_specify_params.py
+++ b/tutorial/20_recipes/008_specify_params.py
@@ -120,8 +120,8 @@ study.add_trial(
         },
         distributions={
             "bagging_fraction": optuna.distributions.FloatDistribution(0.4, 1.0 + 1e-12),
-            "bagging_freq": optuna.distributions.IntUniformDistribution(0, 7),
-            "min_child_samples": optuna.distributions.IntUniformDistribution(5, 100),
+            "bagging_freq": optuna.distributions.IntDistribution(0, 7),
+            "min_child_samples": optuna.distributions.IntDistribution(5, 100),
         },
         value=0.94,
     )
@@ -135,8 +135,8 @@ study.add_trial(
         },
         distributions={
             "bagging_fraction": optuna.distributions.FloatDistribution(0.4, 1.0 + 1e-12),
-            "bagging_freq": optuna.distributions.IntUniformDistribution(0, 7),
-            "min_child_samples": optuna.distributions.IntUniformDistribution(5, 100),
+            "bagging_freq": optuna.distributions.IntDistribution(0, 7),
+            "min_child_samples": optuna.distributions.IntDistribution(5, 100),
         },
         value=0.95,
     )


### PR DESCRIPTION
## Motivation
In short, this PR is a part of issue #2941, and IntDistribution version of PR #3166 .

This PR makes the switch from old `IntUniformDistribution` classes to unified `IntDistribution` by instantiating it in suggest APIs and few other minor places in codebase. Additionally, all instances of old distributions in test suite are replaced with new one, and parametrization over deprecated classes is removed.

## Description of the changes
Please kindly note that only `optuna/distributions.py` and `tests/test_distributions.py` have been pushed at this moment. Will update other changes later.
