### PR TITLE
Fix bug of nondeterministic behavior of TPESampler when `group=True`

### DIFF
--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -303,7 +303,8 @@ class TPESampler(BaseSampler):
             assert self._group_decomposed_search_space is not None
             self._search_space_group = self._group_decomposed_search_space.calculate(study)
             for sub_space in self._search_space_group.search_spaces:
-                for name, distribution in sub_space.items():
+                # Sort keys because Python's string hashing is nondeterministic.
+                for name, distribution in sorted(sub_space.items()):
                     if distribution.single():
                         continue
                     search_space[name] = distribution
@@ -340,7 +341,8 @@ class TPESampler(BaseSampler):
             params = {}
             for sub_space in self._search_space_group.search_spaces:
                 search_space = {}
-                for name, distribution in sub_space.items():
+                # Sort keys because Python's string hashing is nondeterministic.
+                for name, distribution in sorted(sub_space.items()):
                     if not distribution.single():
                         search_space[name] = distribution
                 params.update(self._sample_relative(study, trial, search_space))

--- a/tests/samplers_tests/tpe_tests/test_sampler.py
+++ b/tests/samplers_tests/tpe_tests/test_sampler.py
@@ -1060,7 +1060,9 @@ def run_tpe(k: int, sequence_dict: Dict[int, List[int]], hash_dict: Dict[int, in
     hash_dict[k] = hash("nondeterministic hash")
     sampler = TPESampler(n_startup_trials=1, seed=2, multivariate=True, group=True)
     study = create_study(sampler=sampler)
-    study.optimize(lambda t: np.sum(t.suggest_int(f"x{i}", 0, 10) for i in range(10)), n_trials=2)
+    study.optimize(
+        lambda t: np.sum([t.suggest_int(f"x{i}", 0, 10) for i in range(10)]), n_trials=2
+    )
     sequence_dict[k] = list(study.trials[-1].params.values())
 
 

--- a/tests/samplers_tests/tpe_tests/test_sampler.py
+++ b/tests/samplers_tests/tpe_tests/test_sampler.py
@@ -1,3 +1,5 @@
+from multiprocessing import Manager
+from multiprocessing import Process
 import random
 from typing import Callable
 from typing import Dict
@@ -1066,11 +1068,7 @@ def run_tpe(k: int, sequence_dict: Dict[int, List[int]], hash_dict: Dict[int, in
     sequence_dict[k] = list(study.trials[-1].params.values())
 
 
-# Test deterministic iteration as discussed in https://github.com/optuna/optuna/issues/3137
 def test_group_deterministic_iteration() -> None:
-    from multiprocessing import Manager
-    from multiprocessing import Process
-
     manager = Manager()
     sequence_dict: Dict[int, List[int]] = manager.dict()
     hash_dict: Dict[int, int] = manager.dict()

--- a/tests/samplers_tests/tpe_tests/test_sampler.py
+++ b/tests/samplers_tests/tpe_tests/test_sampler.py
@@ -1057,8 +1057,8 @@ def test_group_experimental_warning() -> None:
         _ = TPESampler(multivariate=True, group=True)
 
 
-# This function is used only in test_group_deterministic_iteration, but declared at top-level because
-# local function cannot be pickled, which occurs within multiprocessing.
+# This function is used only in test_group_deterministic_iteration, but declared at top-level
+# because local function cannot be pickled, which occurs within multiprocessing.
 def run_tpe(k: int, sequence_dict: Dict[int, List[int]], hash_dict: Dict[int, int]) -> None:
     hash_dict[k] = hash("nondeterministic hash")
     sampler = TPESampler(n_startup_trials=1, seed=2, multivariate=True, group=True)

--- a/tests/samplers_tests/tpe_tests/test_sampler.py
+++ b/tests/samplers_tests/tpe_tests/test_sampler.py
@@ -1073,7 +1073,7 @@ def test_group_deterministic_iteration() -> None:
     # Multiprocessing supports three way to start a process.
     # We use `spawn` option to create a child process as a fresh python process.
     # For more detail, see https://github.com/optuna/optuna/pull/3187#issuecomment-997673037.
-    multiprocessing.set_start_method("spawn")
+    multiprocessing.set_start_method("spawn", force=True)
     manager = multiprocessing.Manager()
     sequence_dict: Dict[int, List[int]] = manager.dict()
     hash_dict: Dict[int, int] = manager.dict()

--- a/tests/samplers_tests/tpe_tests/test_sampler.py
+++ b/tests/samplers_tests/tpe_tests/test_sampler.py
@@ -1060,13 +1060,8 @@ def run_tpe(k: int, sequence_dict: Dict[int, List[int]], hash_dict: Dict[int, in
     hash_dict[k] = hash("nondeterministic hash")
     sampler = TPESampler(n_startup_trials=1, seed=2, multivariate=True, group=True)
     study = create_study(sampler=sampler)
-    sequence = []
-    for _ in range(10):
-        trial = study.ask()
-        picked = [i for i in range(10) if trial.suggest_int(str(i), 0, 1) == 1]
-        study.tell(trial, len(picked))
-        sequence.extend(picked)
-    sequence_dict[k] = sequence
+    study.optimize(lambda t: np.sum(t.suggest_int(f"x{i}", 0, 10) for i in range(10)), n_trials=2)
+    sequence_dict[k] = list(study.trials[-1].params.values())
 
 
 # Test deterministic iteration as discussed in https://github.com/optuna/optuna/issues/3137


### PR DESCRIPTION
## Motivation
Fix #3137

Due to Python's nondeterministic string hashing, the iteration of `Dict[str, BaseDistribution]` is in nondeterministic order.

## Description of the changes
Sorted the keys to make the iteration deterministic.



I don't think that this PR is perfect to resolve the original issue because:
* It is very hard for users and developers to always keep in mind that iterating distributions is nondeterministic while development.
* Moreover, such situation may usually happen because `Dict[str, BaseDistribution]` appears in various positions in the codebase.

One of possible solutions may be creating `SearchSpace` class instead of the raw `Dict[str, BaseDistribution]` and manually handle hashing, but this may require a large-scale modification.

If you have any ideas for modification, please let me know.