### PR TITLE
Import only train_model in AllenNLP integration

### DIFF
--- a/optuna/integration/allennlp/_executor.py
+++ b/optuna/integration/allennlp/_executor.py
@@ -18,8 +18,8 @@ from optuna.integration.allennlp._variables import SPECIAL_DELIMITER as DELIMITE
 
 
 with try_import() as _imports:
-    from allennlp.commands.train import train_model
     import allennlp
+    from allennlp.commands.train import train_model
     import allennlp.common.cached_transformers
     import allennlp.common.util
 

--- a/optuna/integration/allennlp/_executor.py
+++ b/optuna/integration/allennlp/_executor.py
@@ -18,8 +18,8 @@ from optuna.integration.allennlp._variables import SPECIAL_DELIMITER as DELIMITE
 
 
 with try_import() as _imports:
+    from allennlp.commands.train import train_model
     import allennlp
-    import allennlp.commands
     import allennlp.common.cached_transformers
     import allennlp.common.util
 
@@ -227,7 +227,7 @@ class AllenNLPExecutor(object):
             os.environ[OPTUNA_ALLENNLP_DISTRIBUTED_FLAG] = "1"
 
         try:
-            allennlp.commands.train.train_model(
+            train_model(
                 params=params,
                 serialization_dir=self._serialization_dir,
                 file_friendly_logging=self._file_friendly_logging,

--- a/optuna/integration/allennlp/_pruner.py
+++ b/optuna/integration/allennlp/_pruner.py
@@ -20,7 +20,6 @@ from optuna.integration.allennlp._variables import SPECIAL_DELIMITER as DELIMITE
 
 with try_import() as _imports:
     import allennlp
-    import allennlp.commands
     import allennlp.common.cached_transformers
     import allennlp.common.util
 

--- a/tests/integration_tests/allennlp_tests/test_allennlp.py
+++ b/tests/integration_tests/allennlp_tests/test_allennlp.py
@@ -20,6 +20,7 @@ import pytest
 import torch.optim
 
 import optuna
+import optuna.integration.allennlp._executor
 from optuna.integration.allennlp import AllenNLPPruningCallback
 from optuna.integration.allennlp._pruner import _create_pruner
 from optuna.integration.allennlp._variables import _VariableManager
@@ -198,7 +199,7 @@ def test_allennlp_executor_with_options() -> None:
             json.dump({executor._metrics: 1.0}, fout)
 
         expected_include_packages = [package_name, "optuna.integration.allennlp"]
-        with mock.patch("allennlp.commands.train.train_model", return_value=None) as mock_obj:
+        with mock.patch("optuna.integration.allennlp._executor.train_model", return_value=None) as mock_obj:  # noqa
             executor.run()
             assert mock_obj.call_args[1]["force"]
             assert mock_obj.call_args[1]["file_friendly_logging"]

--- a/tests/integration_tests/allennlp_tests/test_allennlp.py
+++ b/tests/integration_tests/allennlp_tests/test_allennlp.py
@@ -199,7 +199,10 @@ def test_allennlp_executor_with_options() -> None:
             json.dump({executor._metrics: 1.0}, fout)
 
         expected_include_packages = [package_name, "optuna.integration.allennlp"]
-        with mock.patch("optuna.integration.allennlp._executor.train_model", return_value=None) as mock_obj:  # noqa
+        with mock.patch(
+            "optuna.integration.allennlp._executor.train_model",
+            return_value=None,
+        ) as mock_obj:
             executor.run()
             assert mock_obj.call_args[1]["force"]
             assert mock_obj.call_args[1]["file_friendly_logging"]

--- a/tests/integration_tests/allennlp_tests/test_allennlp.py
+++ b/tests/integration_tests/allennlp_tests/test_allennlp.py
@@ -20,8 +20,8 @@ import pytest
 import torch.optim
 
 import optuna
-import optuna.integration.allennlp._executor
 from optuna.integration.allennlp import AllenNLPPruningCallback
+import optuna.integration.allennlp._executor
 from optuna.integration.allennlp._pruner import _create_pruner
 from optuna.integration.allennlp._variables import _VariableManager
 from optuna.testing.integration import DeterministicPruner


### PR DESCRIPTION
After releasing `nltk` v3.6.6, CIs fail when loading wordnet stuff.
🔗 https://github.com/optuna/optuna/runs/4591822163?check_suite_focus=true

The error occurs in the checklist module of AllenNLP, which does not need to import in Optuna in nature.
(The current implementation of AllenNLP integration imports `allennlp.commands` which includes `checklist` module`)
🔗 https://github.com/allenai/allennlp/issues/5521

This PR changes the way to import a method `train_model`: from module-level import to only function import.

## Motivation
- Fix CI failure
- Reduce number of imported stuff

## Description of the changes
<!-- Describe the changes in this PR. -->
