### PR TITLE
Restrict `nltk` version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -116,6 +116,9 @@ def get_extras_require() -> Dict[str, List[str]]:
             "torchvision==0.11.1 ; sys_platform=='darwin'",
             "torchvision==0.11.1+cpu ; sys_platform!='darwin'",
             "torchaudio==0.10.0",
+            # TODO (himkt): Remove `nltk` after solving
+            # https://github.com/allenai/allennlp/issues/5521
+            "nltk<3.6.6",
             "allennlp>=2.2.0 ; python_version>'3.6'",
             "botorch>=0.4.0 ; python_version>'3.6'",
             "fastai",
@@ -155,6 +158,9 @@ def get_extras_require() -> Dict[str, List[str]]:
             "torchvision==0.11.1 ; sys_platform=='darwin'",
             "torchvision==0.11.1+cpu ; sys_platform!='darwin'",
             "torchaudio==0.10.0",
+            # TODO (himkt): Remove `nltk` after solving
+            # https://github.com/allenai/allennlp/issues/5521
+            "nltk<3.6.6",
             "allennlp>=2.2.0 ; python_version>'3.6'",
             "botorch>=0.4.0 ; python_version>'3.6'",
             "fastai",

--- a/setup.py
+++ b/setup.py
@@ -116,7 +116,7 @@ def get_extras_require() -> Dict[str, List[str]]:
             "torchvision==0.11.1 ; sys_platform=='darwin'",
             "torchvision==0.11.1+cpu ; sys_platform!='darwin'",
             "torchaudio==0.10.0",
-            # TODO (himkt): Remove `nltk` after solving
+            # TODO(himkt): Remove `nltk` after solving
             # https://github.com/allenai/allennlp/issues/5521
             "nltk<3.6.6",
             "allennlp>=2.2.0 ; python_version>'3.6'",
@@ -158,7 +158,7 @@ def get_extras_require() -> Dict[str, List[str]]:
             "torchvision==0.11.1 ; sys_platform=='darwin'",
             "torchvision==0.11.1+cpu ; sys_platform!='darwin'",
             "torchaudio==0.10.0",
-            # TODO (himkt): Remove `nltk` after solving
+            # TODO(himkt): Remove `nltk` after solving
             # https://github.com/allenai/allennlp/issues/5521
             "nltk<3.6.6",
             "allennlp>=2.2.0 ; python_version>'3.6'",


### PR DESCRIPTION
After releasing nltk v3.6.6, CIs fail when loading wordnet stuff.
🔗 https://github.com/optuna/optuna/runs/4591822163?check_suite_focus=true

This PR avoids to install the latest `nltk`. This patch should be reverted after the next version of `AllenNLP is released.

## Motivation
- Fix CI failure

## Description of the changes
<!-- Describe the changes in this PR. -->
