### PR TITLE
Wrap RedisStorage in CachedStorage

### DIFF
--- a/optuna/integration/pytorch_lightning.py
+++ b/optuna/integration/pytorch_lightning.py
@@ -4,6 +4,7 @@ from packaging import version
 
 import optuna
 from optuna.storages._cached_storage import _CachedStorage
+from optuna.storages._rdb.storage import RDBStorage
 
 
 # Define key names of `Trial.system_attrs`.
@@ -60,7 +61,10 @@ class PyTorchLightningPruningCallback(Callback):
         if self.is_ddp_backend:
             if version.parse(pl.__version__) < version.parse("1.5.0"):
                 raise ValueError("PyTorch Lightning>=1.5.0 is required in DDP.")
-            if not isinstance(self._trial.study._storage, _CachedStorage):
+            if not (
+                isinstance(self._trial.study._storage, _CachedStorage)
+                and isinstance(self._trial.study._storage._backend, RDBStorage)
+            ):
                 raise ValueError(
                     "optuna.integration.PyTorchLightningPruningCallback"
                     " supports only optuna.storages.RDBStorage in DDP."

--- a/optuna/storages/__init__.py
+++ b/optuna/storages/__init__.py
@@ -26,10 +26,10 @@ def get_storage(storage: Union[None, str, BaseStorage]) -> BaseStorage:
         return InMemoryStorage()
     if isinstance(storage, str):
         if storage.startswith("redis"):
-            return RedisStorage(storage)
+            return _CachedStorage(RedisStorage(storage))
         else:
             return _CachedStorage(RDBStorage(storage))
-    elif isinstance(storage, RDBStorage):
+    elif isinstance(storage, (RDBStorage, RedisStorage)):
         return _CachedStorage(storage)
     else:
         return storage

--- a/optuna/storages/_cached_storage.py
+++ b/optuna/storages/_cached_storage.py
@@ -14,6 +14,7 @@ import optuna
 from optuna import distributions
 from optuna.storages import BaseStorage
 from optuna.storages._rdb.storage import RDBStorage
+from optuna.storages._redis import RedisStorage
 from optuna.study._study_direction import StudyDirection
 from optuna.study._study_summary import StudySummary
 from optuna.trial import FrozenTrial
@@ -36,14 +37,16 @@ class _CachedStorage(BaseStorage):
     """A wrapper class of storage backends.
 
     This class is used in :func:`~optuna.get_storage` function and automatically
-    wraps :class:`~optuna.storages.RDBStorage` class.
+    wraps :class:`~optuna.storages.RDBStorage` class or
+    :class:`~optuna.storages.RedisStorage` class.
 
     Args:
         backend:
-            :class:`~optuna.storages.BaseStorage` class instance to wrap.
+            :class:`~optuna.storages.RDBStorage` class or :class:`~optuna.storages.RedisStorage`
+            class instance to wrap.
     """
 
-    def __init__(self, backend: RDBStorage) -> None:
+    def __init__(self, backend: Union[RDBStorage, RedisStorage]) -> None:
         self._backend = backend
         self._studies: Dict[int, _StudyInfo] = {}
         self._trial_id_to_study_id_and_number: Dict[int, Tuple[int, int]] = {}
@@ -403,4 +406,4 @@ class _CachedStorage(BaseStorage):
         return self._backend.get_heartbeat_interval()
 
     def get_failed_trial_callback(self) -> Optional[Callable[["optuna.Study", FrozenTrial], None]]:
-        return self._backend.failed_trial_callback
+        return self._backend.get_failed_trial_callback()

--- a/optuna/storages/_rdb/storage.py
+++ b/optuna/storages/_rdb/storage.py
@@ -506,7 +506,7 @@ class RDBStorage(BaseStorage):
     def _create_new_trial(
         self, study_id: int, template_trial: Optional[FrozenTrial] = None
     ) -> FrozenTrial:
-        """Create a new trial and returns its trial_id and a :class:`~optuna.trial.FrozenTrial`.
+        """Create a new trial and returns a :class:`~optuna.trial.FrozenTrial`.
 
         Args:
             study_id:

--- a/optuna/storages/_redis.py
+++ b/optuna/storages/_redis.py
@@ -103,9 +103,9 @@ class RedisStorage(BaseStorage):
 
         self._url = url
         self._redis = redis.Redis.from_url(url)
-        self._heartbeat_interval = heartbeat_interval
-        self._grace_period = grace_period
-        self._failed_trial_callback = failed_trial_callback
+        self.heartbeat_interval = heartbeat_interval
+        self.grace_period = grace_period
+        self.failed_trial_callback = failed_trial_callback
 
     def create_new_study(self, study_name: Optional[str] = None) -> int:
 
@@ -705,12 +705,12 @@ class RedisStorage(BaseStorage):
         return confirmed
 
     def _get_stale_trial_ids(self, study_id: int) -> List[int]:
-        assert self._heartbeat_interval is not None
+        assert self.heartbeat_interval is not None
 
-        if self._grace_period is None:
-            grace_period = 2 * self._heartbeat_interval
+        if self.grace_period is None:
+            grace_period = 2 * self.heartbeat_interval
         else:
-            grace_period = self._grace_period
+            grace_period = self.grace_period
 
         current_time = self._get_redis_time()
         heartbeats = self._redis.hgetall(self._key_study_heartbeats(study_id))
@@ -730,11 +730,11 @@ class RedisStorage(BaseStorage):
         return True
 
     def get_heartbeat_interval(self) -> Optional[int]:
-        return self._heartbeat_interval
+        return self.heartbeat_interval
 
     @staticmethod
     def _key_study_heartbeats(study_id: int) -> str:
         return "study_id:{:010d}:heartbeats".format(study_id)
 
     def get_failed_trial_callback(self) -> Optional[Callable[["optuna.Study", FrozenTrial], None]]:
-        return self._failed_trial_callback
+        return self.failed_trial_callback

--- a/optuna/storages/_redis.py
+++ b/optuna/storages/_redis.py
@@ -8,6 +8,7 @@ from typing import Dict
 from typing import List
 from typing import Optional
 from typing import Sequence
+from typing import Set
 from typing import Tuple
 
 import optuna
@@ -321,6 +322,24 @@ class RedisStorage(BaseStorage):
 
     def create_new_trial(self, study_id: int, template_trial: Optional[FrozenTrial] = None) -> int:
 
+        return self._create_new_trial(study_id, template_trial)._trial_id
+
+    def _create_new_trial(
+        self, study_id: int, template_trial: Optional[FrozenTrial] = None
+    ) -> FrozenTrial:
+        """Create a new trial and returns a :class:`~optuna.trial.FrozenTrial`.
+
+        Args:
+            study_id:
+                Study id.
+            template_trial:
+                A :class:`~optuna.trial.FrozenTrial` with default values for trial attributes.
+
+        Returns:
+            A :class:`~optuna.trial.FrozenTrial` instance.
+
+        """
+
         self._check_study_id(study_id)
 
         if template_trial is None:
@@ -361,7 +380,7 @@ class RedisStorage(BaseStorage):
         if trial.state.is_finished():
             self._update_cache(trial_id)
 
-        return trial_id
+        return trial
 
     @staticmethod
     def _create_running_trial() -> FrozenTrial:
@@ -505,6 +524,18 @@ class RedisStorage(BaseStorage):
             pipe.set(self._key_study_summary(study_id), pickle.dumps(study_summary))
             pipe.execute()
 
+    def _check_and_set_param_distribution(
+        self,
+        study_id: int,
+        trial_id: int,
+        param_name: str,
+        param_value_internal: float,
+        distribution: distributions.BaseDistribution,
+    ) -> None:
+
+        self._check_study_id(study_id)
+        self.set_trial_param(trial_id, param_name, param_value_internal, distribution)
+
     def get_trial_param(self, trial_id: int, param_name: str) -> float:
 
         distribution = self.get_trial(trial_id).distributions[param_name]
@@ -618,20 +649,31 @@ class RedisStorage(BaseStorage):
         states: Optional[Tuple[TrialState, ...]] = None,
     ) -> List[FrozenTrial]:
 
+        trials = self._get_trials(study_id, states, set())
+
+        if deepcopy:
+            return copy.deepcopy(trials)
+        else:
+            return trials
+
+    def _get_trials(
+        self,
+        study_id: int,
+        states: Optional[Tuple[TrialState, ...]],
+        excluded_trial_ids: Set[int],
+    ) -> List[FrozenTrial]:
+
         self._check_study_id(study_id)
 
         trials = []
-        trial_ids = self._get_study_trials(study_id)
+        trial_ids = set(self._get_study_trials(study_id)) - excluded_trial_ids
         for trial_id in trial_ids:
             frozen_trial = self.get_trial(trial_id)
 
             if states is None or frozen_trial.state in states:
                 trials.append(frozen_trial)
 
-        if deepcopy:
-            return copy.deepcopy(trials)
-        else:
-            return trials
+        return trials
 
     def read_trials_from_remote_storage(self, study_id: int) -> None:
         self._check_study_id(study_id)

--- a/optuna/testing/storage.py
+++ b/optuna/testing/storage.py
@@ -13,14 +13,16 @@ import optuna
 STORAGE_MODES = [
     "inmemory",
     "sqlite",
-    "cache",
+    "cached_sqlite",
     "redis",
+    "cached_redis",
 ]
 
 STORAGE_MODES_HEARTBEAT = [
     "sqlite",
-    "cache",
+    "cached_sqlite",
     "redis",
+    "cached_redis",
 ]
 
 SQLITE3_TIMEOUT = 300
@@ -39,28 +41,27 @@ class StorageSupplier(object):
             if len(self.extra_args) > 0:
                 raise ValueError("InMemoryStorage does not accept any arguments!")
             return optuna.storages.InMemoryStorage()
-        elif self.storage_specifier == "sqlite":
+        elif "sqlite" in self.storage_specifier:
             self.tempfile = tempfile.NamedTemporaryFile()
             url = "sqlite:///{}".format(self.tempfile.name)
-            return optuna.storages.RDBStorage(
+            rdb_storage = optuna.storages.RDBStorage(
                 url,
                 engine_kwargs={"connect_args": {"timeout": SQLITE3_TIMEOUT}},
                 **self.extra_args,
             )
-        elif self.storage_specifier == "cache":
-            self.tempfile = tempfile.NamedTemporaryFile()
-            url = "sqlite:///{}".format(self.tempfile.name)
-            return optuna.storages._CachedStorage(
-                optuna.storages.RDBStorage(
-                    url,
-                    engine_kwargs={"connect_args": {"timeout": SQLITE3_TIMEOUT}},
-                    **self.extra_args,
-                )
+            return (
+                optuna.storages._CachedStorage(rdb_storage)
+                if "cached" in self.storage_specifier
+                else rdb_storage
             )
-        elif self.storage_specifier == "redis":
-            storage = optuna.storages.RedisStorage("redis://localhost", **self.extra_args)
-            storage._redis = fakeredis.FakeStrictRedis()
-            return storage
+        elif "redis" in self.storage_specifier:
+            redis_storage = optuna.storages.RedisStorage("redis://localhost", **self.extra_args)
+            redis_storage._redis = fakeredis.FakeStrictRedis()
+            return (
+                optuna.storages._CachedStorage(redis_storage)
+                if "cached" in self.storage_specifier
+                else redis_storage
+            )
         else:
             assert False
 

--- a/tests/integration_tests/test_pytorch_lightning.py
+++ b/tests/integration_tests/test_pytorch_lightning.py
@@ -134,7 +134,7 @@ def test_pytorch_lightning_pruning_callback_monitor_is_invalid() -> None:
         callback.on_validation_end(trainer, model)
 
 
-@pytest.mark.parametrize("storage_mode", ["sqlite", "cache"])
+@pytest.mark.parametrize("storage_mode", ["sqlite", "cached_sqlite"])
 def test_pytorch_lightning_pruning_callback_ddp_monitor(
     storage_mode: str,
 ) -> None:

--- a/tests/storages_tests/rdb_tests/test_storage.py
+++ b/tests/storages_tests/rdb_tests/test_storage.py
@@ -267,22 +267,6 @@ def test_upgrade_multi_objective_optimization(optuna_version: str) -> None:
         assert study.user_attrs["d"] == 3
 
 
-def test_get_trials_excluded_trial_ids() -> None:
-
-    storage = create_test_storage()
-    study_id = storage.create_new_study()
-
-    storage.create_new_trial(study_id)
-
-    trials = storage._get_trials(study_id, states=None, excluded_trial_ids=set())
-    assert len(trials) == 1
-
-    # A large exclusion list used to raise errors. Check that it is not an issue.
-    # See https://github.com/optuna/optuna/issues/1457.
-    trials = storage._get_trials(study_id, states=None, excluded_trial_ids=set(range(500000)))
-    assert len(trials) == 0
-
-
 def test_record_heartbeat() -> None:
 
     heartbeat_interval = 1

--- a/tests/storages_tests/test_storages.py
+++ b/tests/storages_tests/test_storages.py
@@ -1229,6 +1229,23 @@ def test_fail_stale_trials(storage_mode: str) -> None:
         assert study.trials[0].state is TrialState.FAIL
 
 
+# This test is a workaround. This test should be removed when get_storage()
+# can return raw RDBStorage and RedisStorage. Because then test_fail_stale_trials
+# can test the fail_stale_trials().
+@pytest.mark.parametrize("storage_mode", ["sqlite", "redis"])
+def test_fail_stale_trials_raw(storage_mode: str) -> None:
+    heartbeat_interval = 1
+    grace_period = 2
+
+    with StorageSupplier(storage_mode) as storage:
+        assert isinstance(storage, (RDBStorage, RedisStorage))
+        storage.heartbeat_interval = heartbeat_interval
+        storage.grace_period = grace_period
+
+        study_id = storage.create_new_study()
+        assert storage.fail_stale_trials(study_id) == []
+
+
 @pytest.mark.parametrize("storage_mode", STORAGE_MODES)
 def test_read_trials_from_remote_storage(storage_mode: str) -> None:
 

--- a/tests/storages_tests/test_storages.py
+++ b/tests/storages_tests/test_storages.py
@@ -157,7 +157,6 @@ def test_get_study_id_from_name_and_get_study_name_from_id(storage_mode: str) ->
         # Generate unique study_name from the current function name and storage_mode.
         function_name = test_get_study_id_from_name_and_get_study_name_from_id.__name__
         study_name = function_name + "/" + storage_mode
-        storage = optuna.storages.get_storage(storage)
         study_id = storage.create_new_study(study_name=study_name)
 
         # Test existing study.
@@ -176,9 +175,6 @@ def test_get_study_id_from_name_and_get_study_name_from_id(storage_mode: str) ->
 def test_get_study_id_from_trial_id(storage_mode: str) -> None:
 
     with StorageSupplier(storage_mode) as storage:
-
-        # Generate unique study_name from the current function name and storage_mode.
-        storage = optuna.storages.get_storage(storage)
 
         # Check if trial_number starts from 0.
         study_id = storage.create_new_study()
@@ -434,8 +430,6 @@ def test_create_new_trial_with_template_trial(storage_mode: str) -> None:
 def test_get_trial_number_from_id(storage_mode: str) -> None:
 
     with StorageSupplier(storage_mode) as storage:
-        storage = optuna.storages.get_storage(storage)
-
         # Check if trial_number starts from 0.
         study_id = storage.create_new_study()
 

--- a/tests/storages_tests/test_storages.py
+++ b/tests/storages_tests/test_storages.py
@@ -1227,3 +1227,14 @@ def test_fail_stale_trials(storage_mode: str) -> None:
         optuna.storages.fail_stale_trials(study)
 
         assert study.trials[0].state is TrialState.FAIL
+
+
+@pytest.mark.parametrize("storage_mode", STORAGE_MODES)
+def test_read_trials_from_remote_storage(storage_mode: str) -> None:
+
+    with StorageSupplier(storage_mode) as storage:
+        with pytest.raises(KeyError):
+            storage.read_trials_from_remote_storage(-1)
+
+        study_id = storage.create_new_study()
+        storage.read_trials_from_remote_storage(study_id)

--- a/tests/storages_tests/test_storages.py
+++ b/tests/storages_tests/test_storages.py
@@ -24,7 +24,6 @@ from optuna.storages import _CachedStorage
 from optuna.storages import BaseStorage
 from optuna.storages import InMemoryStorage
 from optuna.storages import RDBStorage
-from optuna.storages import RedisStorage
 from optuna.storages._base import DEFAULT_STUDY_NAME_PREFIX
 from optuna.study._study_direction import StudyDirection
 from optuna.study._study_summary import StudySummary
@@ -50,7 +49,7 @@ def test_get_storage() -> None:
     assert isinstance(optuna.storages.get_storage(None), InMemoryStorage)
     assert isinstance(optuna.storages.get_storage("sqlite:///:memory:"), _CachedStorage)
     assert isinstance(
-        optuna.storages.get_storage("redis://test_user:passwd@localhost:6379/0"), RedisStorage
+        optuna.storages.get_storage("redis://test_user:passwd@localhost:6379/0"), _CachedStorage
     )
 
 

--- a/tests/study_tests/test_study.py
+++ b/tests/study_tests/test_study.py
@@ -28,7 +28,6 @@ from optuna import Study
 from optuna import Trial
 from optuna import TrialPruned
 from optuna.exceptions import DuplicatedStudyError
-from optuna.storages import get_storage
 from optuna.study import StudyDirection
 from optuna.testing.storage import STORAGE_MODES
 from optuna.testing.storage import StorageSupplier
@@ -409,10 +408,6 @@ def test_load_study_study_name_none(storage_mode: str) -> None:
 def test_delete_study(storage_mode: str) -> None:
 
     with StorageSupplier(storage_mode) as storage:
-        # Get storage object because delete_study does not accept None.
-        storage = get_storage(storage=storage)
-        assert storage is not None
-
         # Test deleting a non-existing study.
         with pytest.raises(KeyError):
             delete_study("invalid-study-name", storage)
@@ -915,8 +910,6 @@ def test_callbacks(n_jobs: int) -> None:
 def test_get_trials(storage_mode: str) -> None:
 
     with StorageSupplier(storage_mode) as storage:
-        storage = get_storage(storage=storage)
-
         study = create_study(storage=storage)
         study.optimize(lambda t: t.suggest_int("x", 1, 5), n_trials=5)
 
@@ -940,8 +933,6 @@ def test_get_trials(storage_mode: str) -> None:
 def test_get_trials_state_option(storage_mode: str) -> None:
 
     with StorageSupplier(storage_mode) as storage:
-        storage = get_storage(storage=storage)
-
         study = create_study(storage=storage)
 
         def objective(trial: Trial) -> float:


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
This PR fixes issue #2938.

Before this PR, ```study.optimize()``` required 305 seconds when ```n_trials=1000```, after this PR, it requires 128 seconds. This PR reduced the execution time about 58%.

<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

## Description of the changes
<!-- Describe the changes in this PR. -->
Previously ```CachedStorage``` only wrap the ```RDBStorage```. This PR wrap RedisStorage in CachedStorage also.

Signed-off-by: Masashi Honma <masashi.honma@gmail.com>
