### PR TITLE
Handle non-numerical params in `matplotlib.contour_plot`

### DIFF
--- a/optuna/visualization/_contour.py
+++ b/optuna/visualization/_contour.py
@@ -1,5 +1,4 @@
 import math
-from typing import Any
 from typing import Callable
 from typing import Dict
 from typing import List
@@ -15,6 +14,7 @@ from optuna.trial import FrozenTrial
 from optuna.trial import TrialState
 from optuna.visualization._plotly_imports import _imports
 from optuna.visualization._utils import _check_plot_args
+from optuna.visualization._utils import _get_param_values
 from optuna.visualization._utils import _is_log_scale
 from optuna.visualization._utils import _is_numerical
 
@@ -88,13 +88,6 @@ def plot_contour(
     _imports.check()
     _check_plot_args(study, target, target_name)
     return _get_contour_plot(study, params, target, target_name)
-
-
-def _get_param_values(trials: List[FrozenTrial], p_name: str) -> List[Any]:
-    values = [t.params[p_name] for t in trials if p_name in t.params]
-    if _is_numerical(trials, p_name):
-        return values
-    return list(map(str, values))
 
 
 def _get_contour_plot(

--- a/optuna/visualization/_utils.py
+++ b/optuna/visualization/_utils.py
@@ -1,3 +1,4 @@
+from typing import Any
 from typing import Callable
 from typing import List
 from typing import Optional
@@ -90,3 +91,11 @@ def _is_numerical(trials: List[FrozenTrial], param: str) -> bool:
         for t in trials
         if param in t.params
     )
+
+
+def _get_param_values(trials: List[FrozenTrial], p_name: str) -> List[Any]:
+
+    values = [t.params[p_name] for t in trials if p_name in t.params]
+    if _is_numerical(trials, p_name):
+        return values
+    return list(map(str, values))

--- a/optuna/visualization/matplotlib/_contour.py
+++ b/optuna/visualization/matplotlib/_contour.py
@@ -17,6 +17,7 @@ from optuna.study import StudyDirection
 from optuna.trial import FrozenTrial
 from optuna.trial import TrialState
 from optuna.visualization._utils import _check_plot_args
+from optuna.visualization._utils import _get_param_values
 from optuna.visualization.matplotlib._matplotlib_imports import _imports
 from optuna.visualization.matplotlib._utils import _is_log_scale
 from optuna.visualization.matplotlib._utils import _is_numerical
@@ -369,8 +370,8 @@ def _generate_contour_subplot(
     target: Optional[Callable[[FrozenTrial], float]],
 ) -> "ContourSet":
 
-    x_indices = sorted({t.params[x_param] for t in trials if x_param in t.params})
-    y_indices = sorted({t.params[y_param] for t in trials if y_param in t.params})
+    x_indices = sorted(set(_get_param_values(trials, x_param)))
+    y_indices = sorted(set(_get_param_values(trials, y_param)))
     if len(x_indices) < 2:
         _logger.warning("Param {} unique value length is less than 2.".format(x_param))
         return ax

--- a/tests/visualization_tests/matplotlib_tests/test_contour.py
+++ b/tests/visualization_tests/matplotlib_tests/test_contour.py
@@ -4,8 +4,10 @@ from typing import Optional
 import numpy as np
 import pytest
 
+from optuna.distributions import CategoricalDistribution
 from optuna.study import create_study
 from optuna.testing.visualization import prepare_study_with_trials
+from optuna.trial import create_trial
 from optuna.trial import Trial
 from optuna.visualization.matplotlib import plot_contour
 from optuna.visualization.matplotlib._contour import _create_zmap
@@ -150,3 +152,32 @@ def test_plot_contour_customized_target_name(params: List[str]) -> None:
         assert figure.shape == (len(params), len(params))
         for i in range(len(params)):
             assert figure[i][0].yaxis.label.get_text() == list(params)[i]
+
+
+def test_plot_contour_mixture_category_types() -> None:
+
+    study = create_study()
+    study.add_trial(
+        create_trial(
+            value=0.0,
+            params={"param_a": None, "param_b": 101},
+            distributions={
+                "param_a": CategoricalDistribution([None, "100"]),
+                "param_b": CategoricalDistribution([101, 102.0]),
+            },
+        )
+    )
+    study.add_trial(
+        create_trial(
+            value=0.5,
+            params={"param_a": "100", "param_b": 102.0},
+            distributions={
+                "param_a": CategoricalDistribution([None, "100"]),
+                "param_b": CategoricalDistribution([101, 102.0]),
+            },
+        )
+    )
+
+    figure = plot_contour(study)
+    assert figure.get_xlim() == (-0.05, 1.05)
+    assert figure.get_ylim() == (100.95, 102.05)


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
Previously, an error was raised when matplotlib backed contour plot was created with non-numerical params from `CategoricalDistribution`. This PR introduces a handler for such cases, similar to plotly backend. Discovered while working on #3199, and implements one of the tests cases mentioned there, along with bugfix.

## Description of the changes
<!-- Describe the changes in this PR. -->
* Handle non-numerical params in `matplotlib.contour_plot`
* Write tests