### PR TITLE
Use `functools.wraps` in `track_in_mlflow` decorator

### DIFF
--- a/optuna/integration/mlflow.py
+++ b/optuna/integration/mlflow.py
@@ -1,3 +1,4 @@
+import functools
 from typing import Any
 from typing import Callable
 from typing import Dict
@@ -214,6 +215,7 @@ class MLflowCallback(object):
         """
 
         def decorator(func: ObjectiveFuncType) -> ObjectiveFuncType:
+            @functools.wraps(func)
             def wrapper(trial: optuna.trial.Trial) -> Union[float, Sequence[float]]:
                 study = trial.study
                 self._initialize_experiment(study)

--- a/tests/integration_tests/test_mlflow.py
+++ b/tests/integration_tests/test_mlflow.py
@@ -389,6 +389,7 @@ def test_track_in_mlflow_decorator(tmpdir: py.path.local) -> None:
 
     @mlflc.track_in_mlflow()
     def _objective_func(trial: optuna.trial.Trial) -> float:
+        """Objective function"""
 
         x = trial.suggest_float("x", -1.0, 1.0)
         y = trial.suggest_float("y", 20, 30, log=True)
@@ -418,6 +419,9 @@ def test_track_in_mlflow_decorator(tmpdir: py.path.local) -> None:
 
     assert metric_name in first_run_dict["data"]["metrics"]
     assert first_run_dict["data"]["metrics"][metric_name] == metric
+
+    assert _objective_func.__name__ == "_objective_func"
+    assert _objective_func.__doc__ == "Objective function"
 
 
 def test_initialize_experiment(tmpdir: py.path.local) -> None:

--- a/tests/integration_tests/test_mlflow.py
+++ b/tests/integration_tests/test_mlflow.py
@@ -387,7 +387,6 @@ def test_track_in_mlflow_decorator(tmpdir: py.path.local) -> None:
 
     mlflc = MLflowCallback(tracking_uri=tracking_file_name)
 
-    @mlflc.track_in_mlflow()
     def _objective_func(trial: optuna.trial.Trial) -> float:
         """Objective function"""
 
@@ -399,8 +398,10 @@ def test_track_in_mlflow_decorator(tmpdir: py.path.local) -> None:
         mlflow.log_metric(metric_name, metric)
         return (x - 2) ** 2 + (y - 25) ** 2 + z
 
+    tracked_objective = mlflc.track_in_mlflow()(_objective_func)
+
     study = optuna.create_study(study_name=study_name)
-    study.optimize(_objective_func, n_trials=n_trials, callbacks=[mlflc])
+    study.optimize(tracked_objective, n_trials=n_trials, callbacks=[mlflc])
 
     mlfl_client = MlflowClient(tracking_file_name)
     experiments = mlfl_client.list_experiments()
@@ -420,8 +421,8 @@ def test_track_in_mlflow_decorator(tmpdir: py.path.local) -> None:
     assert metric_name in first_run_dict["data"]["metrics"]
     assert first_run_dict["data"]["metrics"][metric_name] == metric
 
-    assert _objective_func.__name__ == "_objective_func"
-    assert _objective_func.__doc__ == "Objective function"
+    assert tracked_objective.__name__ == _objective_func.__name__
+    assert tracked_objective.__doc__ == _objective_func.__doc__
 
 
 def test_initialize_experiment(tmpdir: py.path.local) -> None:


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

Without `functools.wraps` decorator, `track_in_mlflow` overwrites the function name and docstring. This might be undesirable for users. Indeed,  `experimental` decorator uses this syntax as in https://github.com/optuna/optuna/blob/1a4e46c48f3fbdcf6ce5cb23f12a6659dbcae92c/optuna/_experimental.py#L57

## Description of the changes
<!-- Describe the changes in this PR. -->

- Add `functools.wraps` to MLFlow's `track_in_mlflow` decorator
- Add its test.
