### PR TITLE
Add a history of retried trial numbers in `Trial.system_attrs`

### DIFF
--- a/optuna/_callbacks.py
+++ b/optuna/_callbacks.py
@@ -143,7 +143,7 @@ class RetryFailedTrialCallback:
         return trial.system_attrs.get("failed_trial", None)
 
     @staticmethod
-    @experimental("2.11.0")
+    @experimental("3.0.0")
     def retry_history(trial: FrozenTrial) -> List[int]:
         """Return the list of trial IDs from the original trial to the specified one.
 

--- a/optuna/_callbacks.py
+++ b/optuna/_callbacks.py
@@ -67,11 +67,11 @@ class RetryFailedTrialCallback:
     recreate the trial in :obj:`TrialState.WAITING` to queue up the trial to be run again.
 
     The failed trial can be identified by the
-    :func:`~optuna.storage.RetryFailedTrialCallback.retried_trial_number` function.
+    :func:`~optuna.storages.RetryFailedTrialCallback.retried_trial_number` function.
     Even if repetitive failure occurrs (a retried trial fails again),
     this method returns the number of the original trial.
     To get a full list including the numbers of the retried trials as well as their original trial,
-    call the :func:`~optuna.storage.RetryFailedTrialCallback.retry_history` function.
+    call the :func:`~optuna.storages.RetryFailedTrialCallback.retry_history` function.
 
     This callback is helpful in environments where trials may fail due to external conditions,
     such as being preempted by other processes.
@@ -158,7 +158,7 @@ class RetryFailedTrialCallback:
         Returns:
             A list of trial numbers in ascending order of the series of retried trials.
             The first item of the list indicates the original trial which is identical
-            to the :func:`~optuna.storage.RetryFailedTrialCallback.retried_trial_number`,
+            to the :func:`~optuna.storages.RetryFailedTrialCallback.retried_trial_number`,
             and the last item is the one right before the specified trial in the retry series.
             If the specified trial is not a retry of any trial, returns an empty list.
         """

--- a/optuna/_callbacks.py
+++ b/optuna/_callbacks.py
@@ -64,6 +64,9 @@ class RetryFailedTrialCallback:
 
     When a trial fails, this callback can be used with the :class:`optuna.storage` class to
     recreate the trial in :obj:`TrialState.WAITING` to queue up the trial to be run again.
+    In case the retried trial fails again and is to be retried further,
+    the :func:`~optuna.storage.RetryFailedTrialCallback.retried_trial_number` of the next
+    recreated trial will point to the latest failed one.
 
     This is helpful in environments where trials may fail due to external conditions, such as
     being preempted by other processes.
@@ -136,7 +139,7 @@ class RetryFailedTrialCallback:
                 The trial object.
 
         Returns:
-            The number of the first failed trial. If not retry of a previous trial,
+            The number of the latest failed trial. If not retry of a previous trial,
             returns :obj:`None`.
         """
 

--- a/optuna/_callbacks.py
+++ b/optuna/_callbacks.py
@@ -145,7 +145,7 @@ class RetryFailedTrialCallback:
     @staticmethod
     @experimental("3.0.0")
     def retry_history(trial: FrozenTrial) -> List[int]:
-        """Return the list of trial IDs from the original trial to the specified one.
+        """Return the list of retried trial IDs with respect to the specified trial.
 
         Args:
             trial:

--- a/optuna/_callbacks.py
+++ b/optuna/_callbacks.py
@@ -106,14 +106,14 @@ class RetryFailedTrialCallback:
         self._inherit_intermediate_values = inherit_intermediate_values
 
     def __call__(self, study: "optuna.study.Study", trial: FrozenTrial) -> None:
-        retry_count = trial.system_attrs.get('retry_count', 0) + 1
+        retry_count = trial.system_attrs.get("retry_count", 0) + 1
         if self._max_retry is not None and retry_count > self._max_retry:
             return
 
         system_attrs = {
             **trial.system_attrs,
             "failed_trial": trial.number,
-            "retry_count": retry_count
+            "retry_count": retry_count,
         }
 
         study.add_trial(

--- a/optuna/_callbacks.py
+++ b/optuna/_callbacks.py
@@ -68,7 +68,7 @@ class RetryFailedTrialCallback:
 
     The failed trial can be identified by the
     :func:`~optuna.storages.RetryFailedTrialCallback.retried_trial_number` function.
-    Even if repetitive failure occurrs (a retried trial fails again),
+    Even if repetitive failure occurs (a retried trial fails again),
     this method returns the number of the original trial.
     To get a full list including the numbers of the retried trials as well as their original trial,
     call the :func:`~optuna.storages.RetryFailedTrialCallback.retry_history` function.

--- a/optuna/_callbacks.py
+++ b/optuna/_callbacks.py
@@ -103,20 +103,15 @@ class RetryFailedTrialCallback:
         self._inherit_intermediate_values = inherit_intermediate_values
 
     def __call__(self, study: "optuna.study.Study", trial: FrozenTrial) -> None:
-        system_attrs = {"failed_trial": trial.number}
-
-        # Update the new object with the values in the trial.system_attrs.
-        # By doing this, if this failed try is already a rety, the 'failed_trial' value
-        # will be the first failed trial number.
-        system_attrs.update(trial.system_attrs)
-
-        retries = sum(
-            ("failed_trial", system_attrs["failed_trial"]) in t.system_attrs.items()
-            for t in study.trials
-        )
-
-        if self._max_retry is not None and retries + 1 > self._max_retry:
+        retry_count = trial.system_attrs.get('retry_count', 0) + 1
+        if self._max_retry is not None and retry_count > self._max_retry:
             return
+
+        system_attrs = {
+            **trial.system_attrs,
+            "failed_trial": trial.number,
+            "retry_count": retry_count
+        }
 
         study.add_trial(
             optuna.create_trial(

--- a/optuna/_callbacks.py
+++ b/optuna/_callbacks.py
@@ -145,14 +145,14 @@ class RetryFailedTrialCallback:
     @staticmethod
     @experimental("3.0.0")
     def retry_history(trial: FrozenTrial) -> List[int]:
-        """Return the list of retried trial IDs with respect to the specified trial.
+        """Return the list of retried trial numbers with respect to the specified trial.
 
         Args:
             trial:
                 The trial object.
 
         Returns:
-            A list of trial IDs in ascending order of the series of retried trials.
+            A list of trial numbers in ascending order of the series of retried trials.
             The first item of the list indicates the original trial which is identical
             to the :func:`~optuna.storage.RetryFailedTrialCallback.retried_trial_number`,
             and the last item is the one right before the specified trial in the retry series.

--- a/optuna/_callbacks.py
+++ b/optuna/_callbacks.py
@@ -136,7 +136,7 @@ class RetryFailedTrialCallback:
                 The trial object.
 
         Returns:
-            The number of the latest failed trial. If not retry of a previous trial,
+            The number of the first failed trial. If not retry of a previous trial,
             returns :obj:`None`.
         """
 

--- a/optuna/_callbacks.py
+++ b/optuna/_callbacks.py
@@ -65,12 +65,16 @@ class RetryFailedTrialCallback:
 
     When a trial fails, this callback can be used with the :class:`optuna.storage` class to
     recreate the trial in :obj:`TrialState.WAITING` to queue up the trial to be run again.
-    In case the retried trial fails again and is to be retried further,
-    the :func:`~optuna.storage.RetryFailedTrialCallback.retried_trial_number` of the next
-    recreated trial will point to the latest failed one.
 
-    This is helpful in environments where trials may fail due to external conditions, such as
-    being preempted by other processes.
+    The failed trial can be identified by the
+    :func:`~optuna.storage.RetryFailedTrialCallback.retried_trial_number` function.
+    Even if repetitive failure occurrs (a retried trial fails again),
+    this method returns the number of the original trial.
+    To get a full list including the numbers of the retried trials as well as their original trial,
+    call the :func:`~optuna.storage.RetryFailedTrialCallback.retry_history` function.
+
+    This callback is helpful in environments where trials may fail due to external conditions,
+    such as being preempted by other processes.
 
     Usage:
 

--- a/tests/storages_tests/test_storages.py
+++ b/tests/storages_tests/test_storages.py
@@ -1361,20 +1361,20 @@ def test_retry_failed_trial_callback_repetitive_failure(storage_mode: str) -> No
         assert len(trials) == n_trials + 1
 
         assert "failed_trial" not in trials[0].system_attrs
-        assert "retry_count" not in trials[0].system_attrs
+        assert "retry_history" not in trials[0].system_attrs
 
-        # trial 1-3 are retried ones of the trial 0
+        # trial 1-3 are retried ones originated from the trial 0
         assert trials[1].system_attrs["failed_trial"] == 0
-        assert trials[1].system_attrs["retry_count"] == 1
+        assert trials[1].system_attrs["retry_history"] == [0]
 
-        assert trials[2].system_attrs["failed_trial"] == 1
-        assert trials[2].system_attrs["retry_count"] == 2
+        assert trials[2].system_attrs["failed_trial"] == 0
+        assert trials[2].system_attrs["retry_history"] == [0, 1]
 
-        assert trials[3].system_attrs["failed_trial"] == 2
-        assert trials[3].system_attrs["retry_count"] == 3
+        assert trials[3].system_attrs["failed_trial"] == 0
+        assert trials[3].system_attrs["retry_history"] == [0, 1, 2]
 
         # trial 4~ are the newly started one and its retry after exceededing max_retry
         assert "failed_trial" not in trials[4].system_attrs
-        assert "retry_count" not in trials[4].system_attrs
+        assert "retry_history" not in trials[4].system_attrs
         assert trials[5].system_attrs["failed_trial"] == 4
-        assert trials[5].system_attrs["retry_count"] == 1
+        assert trials[5].system_attrs["retry_history"] == [4]

--- a/tests/storages_tests/test_storages.py
+++ b/tests/storages_tests/test_storages.py
@@ -1378,11 +1378,3 @@ def test_retry_failed_trial_callback_repetitive_failure(storage_mode: str) -> No
         assert 'retry_count' not in trials[4].system_attrs
         assert trials[5].system_attrs['failed_trial'] == 4
         assert trials[5].system_attrs['retry_count'] == 1
-
-        # Current behavior                                                                    
-        # assert 'failed_trial' not in trials[0].system_attrs                                 
-        # assert trials[1].system_attrs['failed_trial'] == 0                                  
-        # assert trials[2].system_attrs['failed_trial'] == 0                                  
-        # assert trials[3].system_attrs['failed_trial'] == 0 
-        # assert 'failed_trial' not in trials[4].system_attrs                                 
-        # assert trials[5].system_attrs['failed_trial'] == 4                                  

--- a/tests/storages_tests/test_storages.py
+++ b/tests/storages_tests/test_storages.py
@@ -1360,21 +1360,21 @@ def test_retry_failed_trial_callback_repetitive_failure(storage_mode: str) -> No
 
         assert len(trials) == n_trials + 1
 
-        assert 'failed_trial' not in trials[0].system_attrs
-        assert 'retry_count' not in trials[0].system_attrs
+        assert "failed_trial" not in trials[0].system_attrs
+        assert "retry_count" not in trials[0].system_attrs
 
         # trial 1-3 are retried ones of the trial 0
-        assert trials[1].system_attrs['failed_trial'] == 0
-        assert trials[1].system_attrs['retry_count'] == 1
+        assert trials[1].system_attrs["failed_trial"] == 0
+        assert trials[1].system_attrs["retry_count"] == 1
 
-        assert trials[2].system_attrs['failed_trial'] == 1
-        assert trials[2].system_attrs['retry_count'] == 2
+        assert trials[2].system_attrs["failed_trial"] == 1
+        assert trials[2].system_attrs["retry_count"] == 2
 
-        assert trials[3].system_attrs['failed_trial'] == 2
-        assert trials[3].system_attrs['retry_count'] == 3
+        assert trials[3].system_attrs["failed_trial"] == 2
+        assert trials[3].system_attrs["retry_count"] == 3
 
         # trial 4~ are the newly started one and its retry after exceededing max_retry
-        assert 'failed_trial' not in trials[4].system_attrs
-        assert 'retry_count' not in trials[4].system_attrs
-        assert trials[5].system_attrs['failed_trial'] == 4
-        assert trials[5].system_attrs['retry_count'] == 1
+        assert "failed_trial" not in trials[4].system_attrs
+        assert "retry_count" not in trials[4].system_attrs
+        assert trials[5].system_attrs["failed_trial"] == 4
+        assert trials[5].system_attrs["retry_count"] == 1

--- a/tests/storages_tests/test_storages.py
+++ b/tests/storages_tests/test_storages.py
@@ -1349,7 +1349,7 @@ def test_retry_failed_trial_callback_repetitive_failure(storage_mode: str) -> No
     ) as storage:
         study = optuna.create_study(storage=storage)
 
-        # Make repeatedly failed and retried trials by heartbeat
+        # Make repeatedly failed and retried trials by heartbeat.
         for _ in range(n_trials):
             trial = study.ask()
             storage.record_heartbeat(trial._trial_id)
@@ -1363,7 +1363,7 @@ def test_retry_failed_trial_callback_repetitive_failure(storage_mode: str) -> No
         assert "failed_trial" not in trials[0].system_attrs
         assert "retry_history" not in trials[0].system_attrs
 
-        # trial 1-3 are retried ones originated from the trial 0
+        # The trials 1-3 are retried ones originating from the trial 0.
         assert trials[1].system_attrs["failed_trial"] == 0
         assert trials[1].system_attrs["retry_history"] == [0]
 
@@ -1373,7 +1373,8 @@ def test_retry_failed_trial_callback_repetitive_failure(storage_mode: str) -> No
         assert trials[3].system_attrs["failed_trial"] == 0
         assert trials[3].system_attrs["retry_history"] == [0, 1, 2]
 
-        # trial 4~ are the newly started one and its retry after exceededing max_retry
+        # Trials 4 and later are the newly started ones and
+        # they are retried after exceeding max_retry.
         assert "failed_trial" not in trials[4].system_attrs
         assert "retry_history" not in trials[4].system_attrs
         assert trials[5].system_attrs["failed_trial"] == 4


### PR DESCRIPTION
This PR originally proposed to change `Trial.system_attrs['failed_trial']` inserted by `RetryFailedTrialCallback` to be the trial number of the latest failure rather than the first, in order to help user to identify the latest situation of (repeatedly) failed trials, such as training snapshots in deep learning workloads.
Through the discussions, it turned into
- Keep `system_attrs['failed_trial']` as it is
- Add `system_attrs['retry_history']` which is a list of trial IDs in the ascending order, whose last item is identical to `'failed_trial'` (if exists)

Below is my _original_ proposal which is now obsolete but the motivation is still relevant.

-----

This PR proposes to introduce a breaking change for the experimental feature `RetryFailedTrialCallback`, in order to make retries always from the latest failure instead of the first one, to better support the case of repetitive failure and retry.

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

In the current implementation of `RetryFailedTrialCallback`, it always retries from *the first failed trial*, meaning that its `failed_trial` system attribute (`Trial.system_attrs['failed_trial']`) always points to the first one even in case of repetitive failure is occurred.
https://github.com/optuna/optuna/blob/v3.0.0-a0/optuna/_callbacks.py#L102-L105

The typical use of the `RetryFailedTrialCallback` in case of long-running workloads (such as deep learning) would be to recreate a new trial when failure, identify the failed trial using `retried_trial_number()` method, bring the intermediate results from the failed one (e.g., training snapshots) and run the new trial as a restarted process from them.
If the retried trials always point to the very first failed one, it means we can only restart from the time that failed first, no matter how many retries are made and how they progressed.

Here is an example of time series:
* trial=0 fails at step 5
    * `RetryFailedTrialCallback` adds a new trial=1 as the retry of the trial=0 (creates a new trial and set `system_attrs['failed_trial']=0`)
* trial=1 restarts from step 5, but failed again at step 15
    * The callback adds a new trial=2, *still as the retry of the trial=0*
* trial=2 restarts from step 5, rather than from step 10
* ...

and its brief diagram (`>` indicates when each trial has started, `*` is trial step in progress, `X` is failure).
```
-> step
trial 0 | >*****X
trial 1 |        >**********X
trial 2 |        >********...       # <---- trial 2 restarts from the time the trial=0 failed
```

As stated in the documentation, `RetryFailedTrialCallback` is particularly useful in case of the situation where preemption can happen. In that sense, we basically don't want to throw away any progress in the retried (but failed again) trials, i.e. step 6-15 in the trial=1 in the above example, so I'd say the current strategy is not efficient.
Moreover if there is a higher chance that the retried trial gets failed again before its completion (maybe due to too frequent preemption), we can basically expect no trials completed.
https://optuna.readthedocs.io/en/v3.0.0-a0/reference/generated/optuna.storages.RetryFailedTrialCallback.html

Therefore, I think it's better to change the behavior of the `RetryFailedTrialCallback` so it makes a retry from the latest failure instead of the first one, which would look like:
```
-> step
trial 0 | >*****X
trial 1 |        >**********X
trial 2 |                    >********...
```

## Description of the changes
<!-- Describe the changes in this PR. -->

* I modify `Trial.system_attrs['failed_trial']` to point to the last failed trial.
* Doing this will make it a bit difficult to identify how many retries originated from a certain trial are made (therefore difficult to realize the `max_retry` feature), I introduced a retry counter as `Trial.system_attrs['retry_count']` that increments every time `RetryFailedTrialCallback` makes a retry, which is simple and efficient.

Although I think the proposed behavior is more useful in practice as far as I can think of, if there would be a situation where the original one should still be better (or better to keep compatibility), I think it's possible to provide some sort of option.