### PR TITLE
Remove version constraint of `setuptools`

### DIFF
--- a/.github/workflows/mac-tests.yml
+++ b/.github/workflows/mac-tests.yml
@@ -98,8 +98,7 @@ jobs:
     - name: Install
       run: |
         python -m pip install --upgrade pip
-        # TODO(nzw0301): remove setuptools version constraint after resolving https://github.com/mpi4py/mpi4py/issues/157
-        pip install --progress-bar off -U "setuptools<60.1.0"
+        pip install --progress-bar off -U setuptools
 
         # Install minimal dependencies and confirm that `import optuna` is successful.
         pip install --progress-bar off .

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,12 +4,11 @@ FROM python:${PYTHON_VERSION}
 
 ENV PIP_OPTIONS "--no-cache-dir --progress-bar off"
 
-# TODO(nzw0301): remove setuptools version constraint after resolving https://github.com/mpi4py/mpi4py/issues/157
 RUN apt-get update \
     && apt-get -y install openmpi-bin libopenmpi-dev libopenblas-dev \
     && rm -rf /var/lib/apt/lists/* \
     && pip install --no-cache-dir -U pip \
-    && pip install ${PIP_OPTIONS} -U "setuptools<60.1.0"
+    && pip install ${PIP_OPTIONS} -U setuptools
 
 WORKDIR /workspaces
 COPY . .


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

`setuptools` 60.5.0 has been released, https://github.com/pypa/setuptools/releases/tag/v60.5.0. 


## Description of the changes
<!-- Describe the changes in this PR. -->
Undo the version constraints introduced by https://github.com/optuna/optuna/pull/3207