### PR TITLE
Make tests of `plot_optimization_history` methods consistent

### DIFF
--- a/optuna/visualization/matplotlib/_optimization_history.py
+++ b/optuna/visualization/matplotlib/_optimization_history.py
@@ -250,7 +250,7 @@ def _get_optimization_histories(
                 marker="o",
                 color=cmap(3) if len(studies) == 1 else cmap(2 * i + 1),
                 alpha=0.5,
-                label="Best Value" if len(studies) == 1 else f"Best Values of {study.study_name}",
+                label="Best Value" if len(studies) == 1 else f"Best Value of {study.study_name}",
             )
 
             ax.legend()

--- a/tests/visualization_tests/matplotlib_tests/test_optimization_history.py
+++ b/tests/visualization_tests/matplotlib_tests/test_optimization_history.py
@@ -55,11 +55,12 @@ def test_plot_optimization_history(direction: str) -> None:
     assert np.array_equal(xydata[:, 1], [0.0, 1.0, 2.0])
 
     # Test customized target name.
-    figure = plot_optimization_history(study, target_name="Target Name")
+    custom_target_name = "Target Name"
+    figure = plot_optimization_history(study, target_name=custom_target_name)
     assert len(figure.get_lines()) == 1
     legend_texts = [legend.get_text() for legend in figure.legend().get_texts()]
-    assert legend_texts == ["Target Name", "Best Value"]
-    assert figure.get_ylabel() == "Target Name"
+    assert legend_texts == [custom_target_name, "Best Value"]
+    assert figure.get_ylabel() == custom_target_name
 
     # Ignore failed trials.
     def fail_objective(_: Trial) -> float:
@@ -188,11 +189,11 @@ def test_plot_optimization_history_with_error_bar(direction: str) -> None:
     assert np.array_equal(xydata[:, 1], [0.0, 1.0, 2.0])
 
     # Test customized target name.
-    target_name = "Target Name"
-    figure = plot_optimization_history(studies, target_name=target_name, error_bar=True)
+    custom_target_name = "Target Name"
+    figure = plot_optimization_history(studies, target_name=custom_target_name, error_bar=True)
     legend_texts = [legend.get_text() for legend in figure.legend().get_texts()]
-    assert sorted(legend_texts) == ["Best Value", target_name]
-    assert figure.get_ylabel() == target_name
+    assert sorted(legend_texts) == ["Best Value", custom_target_name]
+    assert figure.get_ylabel() == custom_target_name
 
     # Ignore failed trials.
     def fail_objective(_: Trial) -> float:

--- a/tests/visualization_tests/matplotlib_tests/test_optimization_history.py
+++ b/tests/visualization_tests/matplotlib_tests/test_optimization_history.py
@@ -43,7 +43,7 @@ def test_plot_optimization_history(direction: str) -> None:
     else:
         assert np.array_equal(ydata, [1.0, 2.0, 2.0])
     legend_texts = [legend.get_text() for legend in figure.legend().get_texts()]
-    assert legend_texts == ["Objective Value", "Best Value"]
+    assert sorted(legend_texts) == ["Best Value", "Objective Value"]
     assert figure.get_ylabel() == "Objective Value"
 
     # Test customized target.
@@ -59,7 +59,7 @@ def test_plot_optimization_history(direction: str) -> None:
     figure = plot_optimization_history(study, target_name=custom_target_name)
     assert len(figure.get_lines()) == 1
     legend_texts = [legend.get_text() for legend in figure.legend().get_texts()]
-    assert legend_texts == [custom_target_name, "Best Value"]
+    assert sorted(legend_texts) == ["Best Value", custom_target_name]
     assert figure.get_ylabel() == custom_target_name
 
     # Ignore failed trials.

--- a/tests/visualization_tests/matplotlib_tests/test_optimization_history.py
+++ b/tests/visualization_tests/matplotlib_tests/test_optimization_history.py
@@ -1,5 +1,4 @@
 import numpy as np
-from numpy.testing import assert_almost_equal
 import pytest
 
 from optuna.study import create_study
@@ -222,6 +221,6 @@ def test_error_bar_in_optimization_history(direction: str) -> None:
     mean = np.mean(suggested_params)
     std = np.std(suggested_params)
 
-    assert_almost_equal(figure.get_lines()[0].get_ydata(), mean)
-    assert_almost_equal(figure.get_lines()[1].get_ydata(), mean - std)
-    assert_almost_equal(figure.get_lines()[2].get_ydata(), mean + std)
+    np.testing.assert_almost_equal(figure.get_lines()[0].get_ydata(), mean)
+    np.testing.assert_almost_equal(figure.get_lines()[1].get_ydata(), mean - std)
+    np.testing.assert_almost_equal(figure.get_lines()[2].get_ydata(), mean + std)

--- a/tests/visualization_tests/matplotlib_tests/test_optimization_history.py
+++ b/tests/visualization_tests/matplotlib_tests/test_optimization_history.py
@@ -36,7 +36,7 @@ def test_plot_optimization_history(direction: str) -> None:
     study.optimize(objective, n_trials=3)
     figure = plot_optimization_history(study)
     assert len(figure.get_lines()) == 1
-    assert list(figure.get_lines()[0].get_xdata()) == [0, 1, 2]
+    assert np.array_equal(figure.get_lines()[0].get_xdata(), [0, 1, 2])
     ydata = figure.get_lines()[0].get_ydata()
     if direction == "minimize":
         assert np.array_equal(ydata, [1.0, 1.0, 0.0])
@@ -50,9 +50,9 @@ def test_plot_optimization_history(direction: str) -> None:
     with pytest.warns(UserWarning):
         figure = plot_optimization_history(study, target=lambda t: t.number)
     assert len(figure.get_lines()) == 0
-    offsets = figure.collections[0].get_offsets()
-    assert np.array_equal(offsets.data[:, 0], [0.0, 1.0, 2.0])
-    assert np.array_equal(offsets.data[:, 1], [0.0, 1.0, 2.0])
+    xydata = figure.collections[0].get_offsets().data
+    assert np.array_equal(xydata[:, 0], [0.0, 1.0, 2.0])
+    assert np.array_equal(xydata[:, 1], [0.0, 1.0, 2.0])
 
     # Test customized target name.
     figure = plot_optimization_history(study, target_name="Target Name")
@@ -98,7 +98,7 @@ def test_plot_optimization_history_with_multiple_studies(direction: str) -> None
     figure = plot_optimization_history(studies)
     assert len(figure.get_lines()) == n_studies
     for i in range(n_studies):
-        assert list(figure.get_lines()[i].get_xdata()) == [0, 1, 2]
+        assert np.array_equal(figure.get_lines()[i].get_xdata(), [0, 1, 2])
         ydata = figure.get_lines()[i].get_ydata()
         if direction == "minimize":
             assert np.array_equal(ydata, [1.0, 1.0, 0.0])
@@ -117,9 +117,9 @@ def test_plot_optimization_history_with_multiple_studies(direction: str) -> None
         figure = plot_optimization_history(studies, target=lambda t: t.number)
     assert len(figure.get_lines()) == 0
     assert len(figure.get_legend().get_texts()) == n_studies
-    offsets = figure.collections[0].get_offsets()
-    assert np.array_equal(offsets.data[:, 0], [0.0, 1.0, 2.0])
-    assert np.array_equal(offsets.data[:, 1], [0.0, 1.0, 2.0])
+    xydata = figure.collections[0].get_offsets()
+    assert np.array_equal(xydata[:, 0], [0.0, 1.0, 2.0])
+    assert np.array_equal(xydata[:, 1], [0.0, 1.0, 2.0])
 
     # Test customized target name.
     custom_target_name = "Target Name"
@@ -170,7 +170,7 @@ def test_plot_optimization_history_with_error_bar(direction: str) -> None:
 
     figure = plot_optimization_history(studies, error_bar=True)
     assert len(figure.get_lines()) == 4
-    assert list(figure.get_lines()[-1].get_xdata()) == [0, 1, 2]
+    assert np.array_equal(figure.get_lines()[-1].get_xdata(), [0, 1, 2])
     ydata = figure.get_lines()[-1].get_ydata()
     if direction == "minimize":
         assert np.array_equal(ydata, [1.0, 1.0, 0.0])
@@ -183,9 +183,9 @@ def test_plot_optimization_history_with_error_bar(direction: str) -> None:
     with pytest.warns(UserWarning):
         figure = plot_optimization_history(studies, target=lambda t: t.number, error_bar=True)
     assert len(figure.get_lines()) == 3
-    offsets = figure.collections[1].get_offsets()
-    assert np.array_equal(offsets.data[:, 0], [0.0, 1.0, 2.0])
-    assert np.array_equal(offsets.data[:, 1], [0.0, 1.0, 2.0])
+    xydata = figure.collections[1].get_offsets()
+    assert np.array_equal(xydata[:, 0], [0.0, 1.0, 2.0])
+    assert np.array_equal(xydata[:, 1], [0.0, 1.0, 2.0])
 
     # Test customized target name.
     target_name = "Target Name"

--- a/tests/visualization_tests/test_optimization_history.py
+++ b/tests/visualization_tests/test_optimization_history.py
@@ -177,7 +177,7 @@ def test_plot_optimization_history_with_error_bar(direction: str) -> None:
         assert np.array_equal(ydata, [1.0, 1.0, 0.0])
     else:
         assert np.array_equal(ydata, [1.0, 2.0, 2.0])
-    # Scatters for error bar don't have `name`
+    # Scatters for error bar don't have `name`.
     legend_texts = [scatter.name for scatter in figure.data if scatter.name is not None]
     assert sorted(legend_texts) == ["Best Value", "Objective Value"]
     assert figure.layout.yaxis.title.text == "Objective Value"

--- a/tests/visualization_tests/test_optimization_history.py
+++ b/tests/visualization_tests/test_optimization_history.py
@@ -56,10 +56,11 @@ def test_plot_optimization_history(direction: str) -> None:
     assert np.array_equal(figure.data[0].y, [0.0, 1.0, 2.0])
 
     # Test customized target name.
-    figure = plot_optimization_history(study, target_name="Target Name")
+    custom_target_name = "Target Name"
+    figure = plot_optimization_history(study, target_name=custom_target_name)
     legend_texts = [x.name for x in figure.data]
-    assert legend_texts == ["Target Name", "Best Value"]
-    assert figure.layout.yaxis.title.text == "Target Name"
+    assert legend_texts == [custom_target_name, "Best Value"]
+    assert figure.layout.yaxis.title.text == custom_target_name
 
     # Ignore failed trials.
     def fail_objective(_: Trial) -> float:
@@ -189,11 +190,11 @@ def test_plot_optimization_history_with_error_bar(direction: str) -> None:
     assert np.array_equal(figure.data[0].y, [0, 1, 2])
 
     # Test customized target name.
-    target_name = "Target Name"
-    figure = plot_optimization_history(studies, target_name=target_name, error_bar=True)
+    custom_target_name = "Target Name"
+    figure = plot_optimization_history(studies, target_name=custom_target_name, error_bar=True)
     legend_texts = [scatter.name for scatter in figure.data if scatter.name is not None]
-    assert sorted(legend_texts) == ["Best Value", target_name]
-    assert figure.layout.yaxis.title.text == target_name
+    assert sorted(legend_texts) == ["Best Value", custom_target_name]
+    assert figure.layout.yaxis.title.text == custom_target_name
 
     # Ignore failed trials.
     def fail_objective(_: Trial) -> float:

--- a/tests/visualization_tests/test_optimization_history.py
+++ b/tests/visualization_tests/test_optimization_history.py
@@ -36,13 +36,14 @@ def test_plot_optimization_history(direction: str) -> None:
     study.optimize(objective, n_trials=3)
     figure = plot_optimization_history(study)
     assert len(figure.data) == 2
-    assert figure.data[0].x == (0, 1, 2)
-    assert figure.data[0].y == (1.0, 2.0, 0.0)
-    assert figure.data[1].x == (0, 1, 2)
+    assert np.array_equal(figure.data[0].x, [0, 1, 2])
+    assert np.array_equal(figure.data[0].y, [1.0, 2.0, 0.0])
+    assert np.array_equal(figure.data[1].x, [0, 1, 2])
+    ydata = figure.data[1].y
     if direction == "minimize":
-        assert np.array_equal(figure.data[1].y, [1.0, 1.0, 0.0])
+        assert np.array_equal(ydata, [1.0, 1.0, 0.0])
     else:
-        assert np.array_equal(figure.data[1].y, [1.0, 2.0, 2.0])
+        assert np.array_equal(ydata, [1.0, 2.0, 2.0])
     legend_texts = [x.name for x in figure.data]
     assert legend_texts == ["Objective Value", "Best Value"]
     assert figure.layout.yaxis.title.text == "Objective Value"
@@ -51,7 +52,7 @@ def test_plot_optimization_history(direction: str) -> None:
     with pytest.warns(UserWarning):
         figure = plot_optimization_history(study, target=lambda t: t.number)
     assert len(figure.data) == 1
-    assert np.array_equal(figure.data[0].x, [0.0, 1.0, 2.0])
+    assert np.array_equal(figure.data[0].x, [0, 1, 2])
     assert np.array_equal(figure.data[0].y, [0.0, 1.0, 2.0])
 
     # Test customized target name.
@@ -96,9 +97,9 @@ def test_plot_optimization_history_with_multiple_studies(direction: str) -> None
         study.optimize(objective, n_trials=3)
     figure = plot_optimization_history(studies)
     assert len(figure.data) == 2 * n_studies
-    assert figure.data[0].x == (0, 1, 2)
-    assert figure.data[0].y == (1.0, 2.0, 0.0)
-    assert figure.data[1].x == (0, 1, 2)
+    assert np.array_equal(figure.data[0].x, [0, 1, 2])
+    assert np.array_equal(figure.data[0].y, [1.0, 2.0, 0.0])
+    assert np.array_equal(figure.data[1].x, [0, 1, 2])
     ydata = figure.data[1].y
     if direction == "minimize":
         assert np.array_equal(ydata, [1.0, 1.0, 0.0])

--- a/tests/visualization_tests/test_optimization_history.py
+++ b/tests/visualization_tests/test_optimization_history.py
@@ -1,5 +1,4 @@
 import numpy as np
-from numpy.testing import assert_almost_equal
 import pytest
 
 from optuna.study import create_study
@@ -223,6 +222,6 @@ def test_error_bar_in_optimization_history(direction: str) -> None:
     mean = np.mean(suggested_params)
     std = np.std(suggested_params)
 
-    assert_almost_equal(figure.data[0].y, mean)
-    assert_almost_equal(figure.data[2].y, mean + std)
-    assert_almost_equal(figure.data[3].y, mean - std)
+    np.testing.assert_almost_equal(figure.data[0].y, mean)
+    np.testing.assert_almost_equal(figure.data[2].y, mean + std)
+    np.testing.assert_almost_equal(figure.data[3].y, mean - std)


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

Resolve a sub-task of https://github.com/optuna/optuna/issues/3226

## Description of the changes
<!-- Describe the changes in this PR. -->

- Make tests similar; use `np.array_equal` to compare expected value and x/y values from plot object
- Fix minor bug of the legend label for Matplotlib's `plot_optimization_history `
- Implement test function for plotly's error bar

