### PR TITLE
Remove Sphinx version constraint

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,9 +71,7 @@ def get_extras_require() -> Dict[str, List[str]]:
             "mlflow",
         ],
         "document": [
-            # TODO(nzw): Remove the version constraint after resolving the issue
-            # https://github.com/optuna/optuna/issues/2658.
-            "sphinx<4.0.0",
+            "sphinx",
             "sphinx_rtd_theme",
             "sphinx-copybutton",
             "sphinx-gallery",


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

Resolve #2658

## Description of the changes
<!-- Describe the changes in this PR. -->
Just remove the version constraint of Sphinx that was introduced by https://github.com/optuna/optuna/pull/2657. 

Honestly, I'm not sure why the issue can be resolved, ~but there might be some bug fix in a recent sphinx because the documentation was built successfully with Sphinx 4.x.x.~ 

I ran `make html` under `docs` with sphinx 4.0.0 on my local machine. The build was complete without error unlike #2658; we do not need to introduce a version constraint for some specific sphinx. I suppose sphinx dependencies might have some bug.