### PR TITLE
Handle `-inf` and `inf` values in `RDBStorage`

### DIFF
--- a/optuna/storages/_rdb/storage.py
+++ b/optuna/storages/_rdb/storage.py
@@ -20,6 +20,7 @@ import alembic.command
 import alembic.config
 import alembic.migration
 import alembic.script
+import numpy as np
 from sqlalchemy import func
 from sqlalchemy import orm
 from sqlalchemy.engine import create_engine
@@ -39,6 +40,10 @@ from optuna.study._study_direction import StudyDirection
 from optuna.study._study_summary import StudySummary
 from optuna.trial import FrozenTrial
 from optuna.trial import TrialState
+
+
+_RDB_MAX_FLOAT = np.finfo(np.float32).max
+_RDB_MIN_FLOAT = np.finfo(np.float32).min
 
 
 _logger = optuna.logging.get_logger(__name__)
@@ -471,14 +476,17 @@ class RDBStorage(BaseStorage):
                     best_trial_frozen = FrozenTrial(
                         best_trial.number,
                         TrialState.COMPLETE,
-                        value.value,
+                        self._lift_numerical_limit(value.value),
                         best_trial.datetime_start,
                         best_trial.datetime_complete,
                         param_dict,
                         param_distributions,
                         {i.key: json.loads(i.value_json) for i in user_attrs},
                         {i.key: json.loads(i.value_json) for i in system_attrs},
-                        {value.step: value.intermediate_value for value in intermediate},
+                        {
+                            value.step: self._lift_numerical_limit(value.intermediate_value)
+                            for value in intermediate
+                        },
                         best_trial.trial_id,
                     )
                 user_attrs = _user_attrs.get(study.study_id, [])
@@ -731,6 +739,25 @@ class RDBStorage(BaseStorage):
 
         return param_value
 
+    @staticmethod
+    def _ensure_numerical_limit(value: float) -> float:
+
+        # Max and min trial values that can be stored are limited by
+        # dialect. Most limiting one is MySQL which in current data
+        # model will store floats as single precision (32 bit).
+        # There is no support for +inf and -inf in this dialect.
+        return float(min(_RDB_MAX_FLOAT, max(_RDB_MIN_FLOAT, value)))
+
+    @staticmethod
+    def _lift_numerical_limit(value: float) -> float:
+
+        # Floats can't be compared for equality because they are
+        # approximate and not stored as exact values.
+        # https://dev.mysql.com/doc/refman/8.0/en/problems-with-float.html
+        if np.isclose(value, _RDB_MIN_FLOAT) or np.isclose(value, _RDB_MAX_FLOAT):
+            return float(np.sign(value) * float("inf"))
+        return value
+
     def set_trial_values(self, trial_id: int, values: Sequence[float]) -> None:
 
         with _create_scoped_session(self.scoped_session) as session:
@@ -745,6 +772,7 @@ class RDBStorage(BaseStorage):
 
         trial = models.TrialModel.find_or_raise_by_id(trial_id, session)
         self.check_trial_is_updatable(trial_id, trial.state)
+        value = self._ensure_numerical_limit(value)
 
         trial_value = models.TrialValueModel.find_by_trial_and_objective(trial, objective, session)
         if trial_value is None:
@@ -770,6 +798,7 @@ class RDBStorage(BaseStorage):
 
         trial = models.TrialModel.find_or_raise_by_id(trial_id, session)
         self.check_trial_is_updatable(trial_id, trial.state)
+        intermediate_value = self._ensure_numerical_limit(intermediate_value)
 
         trial_intermediate_value = models.TrialIntermediateValueModel.find_by_trial_and_step(
             trial, step, session
@@ -932,14 +961,13 @@ class RDBStorage(BaseStorage):
 
         return trials
 
-    @staticmethod
-    def _build_frozen_trial_from_trial_model(trial: models.TrialModel) -> FrozenTrial:
+    def _build_frozen_trial_from_trial_model(self, trial: models.TrialModel) -> FrozenTrial:
 
         values: Optional[List[float]]
         if trial.values:
             values = [0 for _ in trial.values]
             for value_model in trial.values:
-                values[value_model.objective] = value_model.value
+                values[value_model.objective] = self._lift_numerical_limit(value_model.value)
         else:
             values = None
 
@@ -964,7 +992,10 @@ class RDBStorage(BaseStorage):
             system_attrs={
                 attr.key: json.loads(attr.value_json) for attr in trial.system_attributes
             },
-            intermediate_values={v.step: v.intermediate_value for v in trial.intermediate_values},
+            intermediate_values={
+                v.step: self._lift_numerical_limit(v.intermediate_value)
+                for v in trial.intermediate_values
+            },
             trial_id=trial.trial_id,
         )
 

--- a/tests/storages_tests/rdb_tests/test_with_server.py
+++ b/tests/storages_tests/rdb_tests/test_with_server.py
@@ -102,6 +102,26 @@ def test_loaded_trials(storage_url: str) -> None:
     _check_trials(loaded_study.trials)
 
 
+@pytest.mark.parametrize(
+    "input,expected",
+    [
+        (float("inf"), float("inf")),
+        (-float("inf"), -float("inf")),
+        (np.finfo(np.float32).max, float("inf")),
+        (np.finfo(np.float32).min, -float("inf")),
+    ],
+)
+def test_store_infinite_values(input: float, expected: float, storage_url: str) -> None:
+
+    storage = optuna.storages.RDBStorage(url=storage_url)
+    study_id = storage.create_new_study()
+    trial_id = storage.create_new_trial(study_id)
+    storage.set_trial_intermediate_value(trial_id, 1, input)
+    storage.set_trial_values(trial_id, (input,))
+    assert storage.get_trial(trial_id).value == expected
+    assert storage.get_trial(trial_id).intermediate_values[1] == expected
+
+
 def test_multiprocess(storage_url: str) -> None:
     n_workers = 8
     study_name = _STUDY_NAME

--- a/tests/storages_tests/rdb_tests/test_with_server.py
+++ b/tests/storages_tests/rdb_tests/test_with_server.py
@@ -109,6 +109,8 @@ def test_loaded_trials(storage_url: str) -> None:
         (-float("inf"), -float("inf")),
         (np.finfo(np.float32).max, float("inf")),
         (np.finfo(np.float32).min, -float("inf")),
+        (np.finfo(np.float64).max, float("inf")),
+        (np.finfo(np.float64).min, -float("inf")),
     ],
 )
 def test_store_infinite_values(input: float, expected: float, storage_url: str) -> None:


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
Previously an error could be raised when `-inf` or `inf` was registered in rdb storage. Depending on SQL dialect in backend, those special values might be supported or not. This PR introduces a simple way to get around this limitation by storing `-inf` and `inf` as minimum and maximum values of 32 bit float and providing thin translation layer between stored and true values on database reads and writes. This gives effective available range for trial values of `(-3.4028235e+38, 3.4028235e+38)`. Everything beyond that is interpreted as infinity. Closes #3206.

## Description of the changes
<!-- Describe the changes in this PR. -->
* Implement `inf` handling in `RDBStorage`
* Test