### PR TITLE
Use Python 3.7 in checks CI job

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -21,7 +21,7 @@ jobs:
 
     - uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: 3.7
 
     - name: Install
       run: |


### PR DESCRIPTION
## Motivation

mypy failed after merging #3026 as follows:

https://github.com/optuna/optuna/runs/4877266490?check_suite_focus=true

## Description of the changes

Revert Python version of checks.