### PR TITLE
Fix type hints for Python 3.8.

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -21,7 +21,7 @@ jobs:
 
     - uses: actions/setup-python@v2
       with:
-        python-version: 3.7
+        python-version: 3.8
 
     - name: Install
       run: |

--- a/optuna/integration/sklearn.py
+++ b/optuna/integration/sklearn.py
@@ -248,7 +248,8 @@ class _Objective(object):
 
         if is_classifier(estimator):
             partial_fit_params = self.fit_params.copy()
-            classes = np.unique(self.y)
+            y = self.y.values if isinstance(self.y, pd.Series) else self.y
+            classes  = np.unique(y)
 
             partial_fit_params.setdefault("classes", classes)
 

--- a/optuna/integration/sklearn.py
+++ b/optuna/integration/sklearn.py
@@ -249,7 +249,7 @@ class _Objective(object):
         if is_classifier(estimator):
             partial_fit_params = self.fit_params.copy()
             y = self.y.values if isinstance(self.y, pd.Series) else self.y
-            classes  = np.unique(y)
+            classes = np.unique(y)
 
             partial_fit_params.setdefault("classes", classes)
 

--- a/optuna/samplers/_tpe/parzen_estimator.py
+++ b/optuna/samplers/_tpe/parzen_estimator.py
@@ -171,8 +171,8 @@ class _ParzenEstimator:
                 log_pdf = np.log(categorical_weights.T[samples, :])
             else:
                 # We restore parameters of parzen estimators.
-                low = self._low[param_name]
-                high = self._high[param_name]
+                low = np.asarray(self._low[param_name])
+                high = np.asarray(self._high[param_name])
                 q = self._q[param_name]
                 mus = self._mus[param_name]
                 sigmas = self._sigmas[param_name]
@@ -182,9 +182,7 @@ class _ParzenEstimator:
                 assert sigmas is not None
 
                 cdf_func = _ParzenEstimator._normal_cdf
-                p_accept = cdf_func(np.asarray(high), mus, sigmas) - cdf_func(
-                    np.asarray(low), mus, sigmas
-                )
+                p_accept = cdf_func(high, mus, sigmas) - cdf_func(low, mus, sigmas)
                 if q is None:
                     distance = samples[:, None] - mus
                     mahalanobis = distance / np.maximum(sigmas, EPS)

--- a/optuna/samplers/_tpe/parzen_estimator.py
+++ b/optuna/samplers/_tpe/parzen_estimator.py
@@ -182,7 +182,9 @@ class _ParzenEstimator:
                 assert sigmas is not None
 
                 cdf_func = _ParzenEstimator._normal_cdf
-                p_accept = cdf_func(np.asarray(high), mus, sigmas) - cdf_func(np.asarray(low), mus, sigmas)
+                p_accept = cdf_func(np.asarray(high), mus, sigmas) - cdf_func(
+                    np.asarray(low), mus, sigmas
+                )
                 if q is None:
                     distance = samples[:, None] - mus
                     mahalanobis = distance / np.maximum(sigmas, EPS)

--- a/optuna/samplers/_tpe/parzen_estimator.py
+++ b/optuna/samplers/_tpe/parzen_estimator.py
@@ -182,7 +182,7 @@ class _ParzenEstimator:
                 assert sigmas is not None
 
                 cdf_func = _ParzenEstimator._normal_cdf
-                p_accept = cdf_func(high, mus, sigmas) - cdf_func(low, mus, sigmas)
+                p_accept = cdf_func(np.asarray(high), mus, sigmas) - cdf_func(np.asarray(low), mus, sigmas)
                 if q is None:
                     distance = samples[:, None] - mus
                     mahalanobis = distance / np.maximum(sigmas, EPS)
@@ -493,7 +493,7 @@ class _ParzenEstimator:
         return mus, sigmas
 
     @staticmethod
-    def _normal_cdf(x: float, mu: np.ndarray, sigma: np.ndarray) -> np.ndarray:
+    def _normal_cdf(x: np.ndarray, mu: np.ndarray, sigma: np.ndarray) -> np.ndarray:
 
         mu, sigma = map(np.asarray, (mu, sigma))
         denominator = x - mu

--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -776,6 +776,7 @@ def _calculate_weights_below_for_multi_objective(
 
     # Calculate weights based on hypervolume contributions.
     n_below = len(lvals)
+    weights_below: np.ndarray
     if n_below == 0:
         weights_below = np.asarray([])
     elif n_below == 1:

--- a/optuna/samplers/nsgaii/_crossovers/_undx.py
+++ b/optuna/samplers/nsgaii/_crossovers/_undx.py
@@ -36,7 +36,7 @@ class UNDXCrossover(BaseCrossover):
         self._sigma_xi = sigma_xi
         self._sigma_eta = sigma_eta
 
-    def _distance_from_x_to_psl(self, parents_params: np.ndarray) -> np.ndarray:
+    def _distance_from_x_to_psl(self, parents_params: np.ndarray) -> np.floating:
 
         # The line connecting x1 to x2 is called psl (primary search line).
         # Compute the 2-norm of the vector orthogonal to psl from x3.

--- a/optuna/visualization/matplotlib/_contour.py
+++ b/optuna/visualization/matplotlib/_contour.py
@@ -323,9 +323,9 @@ def _calculate_griddata(
 
     # Calculate grid data points.
     # For x and y, create 1-D array of evenly spaced coordinates on linear or log scale.
-    xi = np.array([])
-    yi = np.array([])
-    zi = np.array([])
+    xi: np.ndarray = np.array([])
+    yi: np.ndarray = np.array([])
+    zi: np.ndarray = np.array([])
 
     if _is_log_scale(trials, x_param):
         padding_x = (np.log10(x_values_max) - np.log10(x_values_min)) * AXES_PADDING_RATIO

--- a/tests/samplers_tests/test_grid.py
+++ b/tests/samplers_tests/test_grid.py
@@ -39,7 +39,7 @@ def test_study_optimize_with_single_search_space() -> None:
         "e": [0.1],
         "a": list(range(0, 100, 20)),
     }
-    study = optuna.create_study(sampler=samplers.GridSampler(search_space))
+    study = optuna.create_study(sampler=samplers.GridSampler(search_space))  # type: ignore
     study.optimize(objective)
 
     def sorted_values(
@@ -48,13 +48,13 @@ def test_study_optimize_with_single_search_space() -> None:
 
         return OrderedDict(sorted(d.items())).values()
 
-    all_grids = itertools.product(*sorted_values(search_space))
+    all_grids = itertools.product(*sorted_values(search_space))  # type: ignore
     all_suggested_values = [tuple([p for p in sorted_values(t.params)]) for t in study.trials]
     assert set(all_grids) == set(all_suggested_values)
 
     # Test a non-existing parameter name in the grid.
     search_space = {"a": list(range(0, 100, 20))}
-    study = optuna.create_study(sampler=samplers.GridSampler(search_space))
+    study = optuna.create_study(sampler=samplers.GridSampler(search_space))  # type: ignore
     with pytest.raises(ValueError):
         study.optimize(objective)
 
@@ -66,7 +66,7 @@ def test_study_optimize_with_single_search_space() -> None:
         "d": [0],
         "e": [0.1],
     }
-    study = optuna.create_study(sampler=samplers.GridSampler(search_space))
+    study = optuna.create_study(sampler=samplers.GridSampler(search_space))  # type: ignore
     with pytest.warns(UserWarning):
         study.optimize(objective)
 

--- a/tests/samplers_tests/tpe_tests/test_parzen_estimator.py
+++ b/tests/samplers_tests/tpe_tests/test_parzen_estimator.py
@@ -316,6 +316,9 @@ def test_calculate(
     s_weights, s_mus, s_sigmas = mpe._weights, mpe._mus["a"], mpe._sigmas["a"]
 
     # Result contains an additional value for a prior distribution if consider_prior is True.
+    assert isinstance(s_weights, np.ndarray)
+    assert isinstance(s_mus, np.ndarray)
+    assert isinstance(s_sigmas, np.ndarray)
     np.testing.assert_almost_equal(s_weights, expected["weights"])
     np.testing.assert_almost_equal(s_mus, expected["mus"])
     np.testing.assert_almost_equal(s_sigmas, expected["sigmas"])

--- a/tests/visualization_tests/matplotlib_tests/test_contour.py
+++ b/tests/visualization_tests/matplotlib_tests/test_contour.py
@@ -21,13 +21,13 @@ from optuna.visualization.matplotlib._contour import AXES_PADDING_RATIO
 
 def test_create_zmap() -> None:
 
-    x_values = np.arange(10).tolist()
-    y_values = np.arange(10).tolist()
+    x_values = np.arange(10)
+    y_values = np.arange(10)
     z_values = list(np.random.rand(10))
 
     # we are testing for exact placement of z_values
     # so also passing x_values and y_values as xi and yi
-    zmap = _create_zmap(x_values, y_values, z_values, x_values, y_values)
+    zmap = _create_zmap(x_values.tolist(), y_values.tolist(), z_values, x_values, y_values)
 
     assert len(zmap) == len(z_values)
     for coord, value in zmap.items():

--- a/tests/visualization_tests/matplotlib_tests/test_contour.py
+++ b/tests/visualization_tests/matplotlib_tests/test_contour.py
@@ -21,8 +21,8 @@ from optuna.visualization.matplotlib._contour import AXES_PADDING_RATIO
 
 def test_create_zmap() -> None:
 
-    x_values = np.arange(10)
-    y_values = np.arange(10)
+    x_values = np.arange(10).tolist()
+    y_values = np.arange(10).tolist()
     z_values = list(np.random.rand(10))
 
     # we are testing for exact placement of z_values


### PR DESCRIPTION
## Motivation

See https://github.com/optuna/optuna/pull/3239#issuecomment-1017110304.

## Description of the changes

- Add missing type hints
- Fix type of some values
- Ignore type checking of the `search_space` argument of GridSampler in tests/samplers_tests/test_grid.py
- Fix type hint of `_normal_cdf` in optuna/samplers/_tpe/parzen_estimator.py