### PR TITLE
Make existing int/float distributions wrapper of {Int,Float}Distribution

### DIFF
--- a/optuna/distributions.py
+++ b/optuna/distributions.py
@@ -15,7 +15,7 @@ CategoricalChoiceType = Union[None, bool, int, float, str]
 
 
 _float_distribution_deprecated_msg = "Use :class:`~optuna.distributions.FloatDistribution` instead."
-_int_distribution_deprecated_msg = "Use :class:`~optuna.distributions.IntDistribution` instead"
+_int_distribution_deprecated_msg = "Use :class:`~optuna.distributions.IntDistribution` instead."
 
 
 class BaseDistribution(object, metaclass=abc.ABCMeta):

--- a/optuna/distributions.py
+++ b/optuna/distributions.py
@@ -178,7 +178,7 @@ class FloatDistribution(BaseDistribution):
             return self.low <= value <= self.high and abs(k - round(k)) < 1.0e-8
 
 
-@deprecated("3.0.0", "5.0.0", text=_float_distribution_deprecated_msg)
+@deprecated("3.0.0", "6.0.0", text=_float_distribution_deprecated_msg)
 class UniformDistribution(FloatDistribution):
     """A uniform distribution in the linear domain.
 
@@ -210,7 +210,7 @@ class UniformDistribution(FloatDistribution):
         return "{}({})".format(self.__class__.__name__, kwargs)
 
 
-@deprecated("3.0.0", "5.0.0", text=_float_distribution_deprecated_msg)
+@deprecated("3.0.0", "6.0.0", text=_float_distribution_deprecated_msg)
 class LogUniformDistribution(FloatDistribution):
     """A uniform distribution in the log domain.
 
@@ -243,7 +243,7 @@ class LogUniformDistribution(FloatDistribution):
         return "{}({})".format(self.__class__.__name__, kwargs)
 
 
-@deprecated("3.0.0", "5.0.0", text=_float_distribution_deprecated_msg)
+@deprecated("3.0.0", "6.0.0", text=_float_distribution_deprecated_msg)
 class DiscreteUniformDistribution(FloatDistribution):
     """A discretized uniform distribution in the linear domain.
 
@@ -363,7 +363,7 @@ class IntDistribution(BaseDistribution):
         return self.low <= value <= self.high and (value - self.low) % self.step == 0
 
 
-@deprecated("3.0.0", "5.0.0", text=_int_distribution_deprecated_msg)
+@deprecated("3.0.0", "6.0.0", text=_int_distribution_deprecated_msg)
 class IntUniformDistribution(IntDistribution):
     """A uniform distribution on integers.
 
@@ -403,7 +403,7 @@ class IntUniformDistribution(IntDistribution):
         return "{}({})".format(self.__class__.__name__, kwargs)
 
 
-@deprecated("3.0.0", "5.0.0", text=_int_distribution_deprecated_msg)
+@deprecated("3.0.0", "6.0.0", text=_int_distribution_deprecated_msg)
 class IntLogUniformDistribution(IntDistribution):
     """A uniform distribution on integers in the log domain.
 

--- a/optuna/distributions.py
+++ b/optuna/distributions.py
@@ -14,7 +14,9 @@ from optuna._deprecated import deprecated
 CategoricalChoiceType = Union[None, bool, int, float, str]
 
 
-_float_distribution_deprecated_msg = "Use :class:`~optuna.distributions.FloatDistribution` instead."
+_float_distribution_deprecated_msg = (
+    "Use :class:`~optuna.distributions.FloatDistribution` instead."
+)
 _int_distribution_deprecated_msg = "Use :class:`~optuna.distributions.IntDistribution` instead."
 
 

--- a/optuna/distributions.py
+++ b/optuna/distributions.py
@@ -14,7 +14,7 @@ from optuna._deprecated import deprecated
 CategoricalChoiceType = Union[None, bool, int, float, str]
 
 
-_float_distribution_deprecated_msg = "Use :class:`~optuna.distributions.FloatDistribution` instead"
+_float_distribution_deprecated_msg = "Use :class:`~optuna.distributions.FloatDistribution` instead."
 _int_distribution_deprecated_msg = "Use :class:`~optuna.distributions.IntDistribution` instead"
 
 

--- a/optuna/distributions.py
+++ b/optuna/distributions.py
@@ -3,6 +3,7 @@ import copy
 import decimal
 import json
 from typing import Any
+from typing import cast
 from typing import Dict
 from typing import Sequence
 from typing import Union
@@ -288,7 +289,7 @@ class DiscreteUniformDistribution(FloatDistribution):
 
     @property
     def q(self) -> float:
-        return self.step
+        return cast(float, self.step)
 
 
 class IntDistribution(BaseDistribution):

--- a/optuna/distributions.py
+++ b/optuna/distributions.py
@@ -98,7 +98,7 @@ class BaseDistribution(object, metaclass=abc.ABCMeta):
 
     def __repr__(self) -> str:
 
-        kwargs = ", ".join("{}={}".format(k, v) for k, v in sorted(self.__dict__.items()))
+        kwargs = ", ".join("{}={}".format(k, v) for k, v in sorted(self._asdict().items()))
         return "{}({})".format(self.__class__.__name__, kwargs)
 
 
@@ -208,10 +208,6 @@ class UniformDistribution(FloatDistribution):
         d.pop("step")
         return d
 
-    def __repr__(self) -> str:
-        kwargs = ", ".join("{}={}".format(k, v) for k, v in sorted(self._asdict().items()))
-        return "{}({})".format(self.__class__.__name__, kwargs)
-
 
 @deprecated("3.0.0", "6.0.0", text=_float_distribution_deprecated_msg)
 class LogUniformDistribution(FloatDistribution):
@@ -240,10 +236,6 @@ class LogUniformDistribution(FloatDistribution):
         d.pop("log")
         d.pop("step")
         return d
-
-    def __repr__(self) -> str:
-        kwargs = ", ".join("{}={}".format(k, v) for k, v in sorted(self._asdict().items()))
-        return "{}({})".format(self.__class__.__name__, kwargs)
 
 
 @deprecated("3.0.0", "6.0.0", text=_float_distribution_deprecated_msg)
@@ -282,10 +274,6 @@ class DiscreteUniformDistribution(FloatDistribution):
         step = d.pop("step")
         d["q"] = step
         return d
-
-    def __repr__(self) -> str:
-        kwargs = ", ".join("{}={}".format(k, v) for k, v in sorted(self._asdict().items()))
-        return "{}({})".format(self.__class__.__name__, kwargs)
 
     @property
     def q(self) -> float:
@@ -404,10 +392,6 @@ class IntUniformDistribution(IntDistribution):
         d.pop("log")
         return d
 
-    def __repr__(self) -> str:
-        kwargs = ", ".join("{}={}".format(k, v) for k, v in sorted(self._asdict().items()))
-        return "{}({})".format(self.__class__.__name__, kwargs)
-
 
 @deprecated("3.0.0", "6.0.0", text=_int_distribution_deprecated_msg)
 class IntLogUniformDistribution(IntDistribution):
@@ -446,10 +430,6 @@ class IntLogUniformDistribution(IntDistribution):
         d = copy.deepcopy(self.__dict__)
         d.pop("log")
         return d
-
-    def __repr__(self) -> str:
-        kwargs = ", ".join("{}={}".format(k, v) for k, v in sorted(self._asdict().items()))
-        return "{}({})".format(self.__class__.__name__, kwargs)
 
 
 class CategoricalDistribution(BaseDistribution):

--- a/optuna/distributions.py
+++ b/optuna/distributions.py
@@ -271,7 +271,6 @@ class DiscreteUniformDistribution(FloatDistribution):
 
     def __init__(self, low: float, high: float, q: float) -> None:
         super().__init__(low=low, high=high, step=q)
-        self.q = q
 
     def _asdict(self) -> Dict:
         d = copy.deepcopy(self.__dict__)
@@ -284,6 +283,10 @@ class DiscreteUniformDistribution(FloatDistribution):
     def __repr__(self) -> str:
         kwargs = ", ".join("{}={}".format(k, v) for k, v in sorted(self._asdict().items()))
         return "{}({})".format(self.__class__.__name__, kwargs)
+
+    @property
+    def q(self) -> float:
+        return self.step
 
 
 class IntDistribution(BaseDistribution):

--- a/optuna/integration/skopt.py
+++ b/optuna/integration/skopt.py
@@ -323,15 +323,15 @@ class _Optimizer(object):
                 value = float(value)
             if isinstance(distribution, distributions.DiscreteUniformDistribution):
                 value = value * distribution.q + distribution.low
-            if isinstance(distribution, distributions.IntUniformDistribution):
+            elif isinstance(distribution, distributions.IntUniformDistribution):
                 value = int(value * distribution.step + distribution.low)
-            if isinstance(distribution, distributions.IntLogUniformDistribution):
+            elif isinstance(distribution, distributions.IntLogUniformDistribution):
                 value = int(np.round(value))
                 value = min(max(value, distribution.low), distribution.high)
-            if isinstance(distribution, distributions.FloatDistribution):
+            elif isinstance(distribution, distributions.FloatDistribution):
                 if distribution.step is not None:
                     value = value * distribution.step + distribution.low
-            if isinstance(distribution, distributions.IntDistribution):
+            elif isinstance(distribution, distributions.IntDistribution):
                 if distribution.log:
                     value = int(np.round(value))
                     value = min(max(value, distribution.low), distribution.high)
@@ -372,12 +372,12 @@ class _Optimizer(object):
 
             if isinstance(distribution, distributions.DiscreteUniformDistribution):
                 param_value = (param_value - distribution.low) // distribution.q
-            if isinstance(distribution, distributions.FloatDistribution):
+            elif isinstance(distribution, distributions.FloatDistribution):
                 if distribution.step is not None:
                     param_value = (param_value - distribution.low) // distribution.step
-            if isinstance(distribution, distributions.IntUniformDistribution):
+            elif isinstance(distribution, distributions.IntUniformDistribution):
                 param_value = (param_value - distribution.low) // distribution.step
-            if isinstance(distribution, distributions.IntDistribution):
+            elif isinstance(distribution, distributions.IntDistribution):
                 if not distribution.log:
                     param_value = (param_value - distribution.low) // distribution.step
 

--- a/optuna/samplers/_tpe/parzen_estimator.py
+++ b/optuna/samplers/_tpe/parzen_estimator.py
@@ -309,7 +309,7 @@ class _ParzenEstimator:
             ):
                 samples = np.log(samples)
 
-            if isinstance(
+            elif isinstance(
                 distribution,
                 (distributions.FloatDistribution, distributions.IntDistribution),
             ):

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -27,7 +27,6 @@ EXAMPLE_DISTRIBUTIONS: Dict[str, Any] = {
     "c2": distributions.CategoricalDistribution(choices=("Roppongi", "Azabu")),
     "c3": distributions.CategoricalDistribution(choices=["Roppongi", "Azabu"]),
     "ilu": distributions.IntLogUniformDistribution(low=2, high=12),
-    "iluq": distributions.IntLogUniformDistribution(low=2, high=12, step=2),
 }
 
 EXAMPLE_JSONS = {
@@ -53,8 +52,6 @@ EXAMPLE_JSONS = {
     "c2": '{"name": "CategoricalDistribution", "attributes": {"choices": ["Roppongi", "Azabu"]}}',
     "c3": '{"name": "CategoricalDistribution", "attributes": {"choices": ["Roppongi", "Azabu"]}}',
     "ilu": '{"name": "IntLogUniformDistribution", "attributes": {"low": 2, "high": 12}}',
-    "iluq": '{"name": "IntLogUniformDistribution", '
-    '"attributes": {"low": 2, "high": 12, "step": 2}}',
 }
 
 EXAMPLE_ABBREVIATED_JSONS = {
@@ -67,7 +64,6 @@ EXAMPLE_ABBREVIATED_JSONS = {
     "c2": '{"type": "categorical", "choices": ["Roppongi", "Azabu"]}',
     "c3": '{"type": "categorical", "choices": ["Roppongi", "Azabu"]}',
     "ilu": '{"type": "int", "low": 2, "high": 12, "log": true}',
-    "iluq": '{"type": "int", "low": 2, "high": 12, "step": 2, "log": true}',
 }
 
 
@@ -220,9 +216,6 @@ def test_check_distribution_compatibility() -> None:
     distributions.check_distribution_compatibility(
         EXAMPLE_DISTRIBUTIONS["ilu"], distributions.IntLogUniformDistribution(low=1, high=13)
     )
-    distributions.check_distribution_compatibility(
-        EXAMPLE_DISTRIBUTIONS["iluq"], distributions.IntLogUniformDistribution(low=1, high=13)
-    )
 
 
 @pytest.mark.parametrize(
@@ -337,17 +330,6 @@ def test_contains() -> None:
     assert not ilu._contains(12.1)
     assert not ilu._contains(13)
 
-    # `step` is ignored and assumed to be 1.
-    iluq = distributions.IntLogUniformDistribution(low=2, high=7, step=2)
-    assert not iluq._contains(0.9)
-    assert iluq._contains(2)
-    assert iluq._contains(4)
-    assert iluq._contains(5)
-    assert iluq._contains(6)
-    assert iluq._contains(7)
-    assert not iluq._contains(7.1)
-    assert not iluq._contains(8)
-
 
 def test_empty_range_contains() -> None:
 
@@ -395,11 +377,6 @@ def test_empty_range_contains() -> None:
     assert not ilu._contains(0)
     assert ilu._contains(1)
     assert not ilu._contains(2)
-
-    iluq = distributions.IntLogUniformDistribution(low=1, high=1, step=2)
-    assert not iluq._contains(0)
-    assert iluq._contains(1)
-    assert not iluq._contains(2)
 
 
 @pytest.mark.parametrize(
@@ -596,7 +573,6 @@ def test_int_uniform_distribution_asdict() -> None:
 def test_int_log_uniform_distribution_asdict() -> None:
 
     assert EXAMPLE_DISTRIBUTIONS["ilu"]._asdict() == {"low": 2, "high": 12, "step": 1}
-    assert EXAMPLE_DISTRIBUTIONS["iluq"]._asdict() == {"low": 2, "high": 12, "step": 2}
 
 
 def test_int_init_error() -> None:
@@ -663,35 +639,6 @@ def test_int_uniform_distribution_invalid_step() -> None:
 
     with pytest.raises(ValueError):
         distributions.IntUniformDistribution(low=1, high=100, step=-1)
-
-
-def test_int_log_uniform_distribution_deprecation() -> None:
-
-    # step != 1 is deprecated
-
-    d = distributions.IntLogUniformDistribution(low=1, high=100)
-
-    with pytest.warns(FutureWarning):
-        # `step` should always be assumed to be 1 and samplers and other components should never
-        # have to get/set the attribute.
-        assert d.step == 1
-
-    with pytest.warns(FutureWarning):
-        d.step = 2
-
-    with pytest.warns(FutureWarning):
-        d = distributions.IntLogUniformDistribution(low=1, high=100, step=2)
-
-    with pytest.warns(FutureWarning):
-        assert d.step == 2
-
-    with pytest.warns(FutureWarning):
-        d.step = 1
-        assert d.step == 1
-
-    with pytest.warns(FutureWarning):
-        d.step = 2
-        assert d.step == 2
 
 
 def test_categorical_distribution_different_sequence_types() -> None:

--- a/tests/trial_tests/test_trial.py
+++ b/tests/trial_tests/test_trial.py
@@ -154,8 +154,10 @@ def test_check_distribution_suggest_int(storage_mode: str, enable_log: bool) -> 
             trial.suggest_int("x", 10, 20, log=enable_log)
             trial.suggest_int("x", 10, 22, log=enable_log)
 
-        # We expect exactly one warning.
-        assert len(record) == 1
+        # We expect exactly four warnings.
+        # One is RuntimeWarning for inconsistent parameter specification.
+        # Three are FutureWarning for deprecated distributions.
+        assert len(record) == 4
 
         with pytest.raises(ValueError):
             trial.suggest_float("x", 10, 20, log=enable_log)


### PR DESCRIPTION
This PR make existing distributions (except for categorical) subclasses of `FloatDistribution` and `IntDistribution`, which was introduced in https://github.com/optuna/optuna/pull/3063.

## Motivation
In v3.0.0, Optuna will aggregate distributions (except for `CategoricalDistribution`) into `FloatDistribution` and `IntDistribution`. Existing distributions such as `UniformDistribution` and `IntUniformDistribution` will be kept until v5.0.0 for backward compatibilities but these will be changed to be subclasses of `FloatDistribution` and `IntDistribution`.

An entire transition process will be done in https://github.com/optuna/optuna/pull/3246 but changing class architectures can be introduced in advance, which makes codebase simple that removes `if-then` rules for old distributions. For example, sampler implementation will change as following:

```diff
diff --git a/optuna/integration/skopt.py b/optuna/integration/skopt.py
index 81cc5bf3..c76a9ebe 100644
--- a/optuna/integration/skopt.py
+++ b/optuna/integration/skopt.py
@@ -243,22 +243,7 @@ class _Optimizer(object):

         dimensions = []
         for name, distribution in sorted(self._search_space.items()):
-            if isinstance(distribution, distributions.UniformDistribution):
-                # Convert the upper bound from exclusive (optuna) to inclusive (skopt).
-                high = np.nextafter(distribution.high, float("-inf"))
-                dimension = space.Real(distribution.low, high)
-            elif isinstance(distribution, distributions.LogUniformDistribution):
-                # Convert the upper bound from exclusive (optuna) to inclusive (skopt).
-                high = np.nextafter(distribution.high, float("-inf"))
-                dimension = space.Real(distribution.low, high, prior="log-uniform")
-            elif isinstance(distribution, distributions.IntUniformDistribution):
-                count = (distribution.high - distribution.low) // distribution.step
-                dimension = space.Integer(0, count)
-            elif isinstance(distribution, distributions.IntLogUniformDistribution):
-                low = distribution.low - 0.5
-                high = distribution.high + 0.5
-                dimension = space.Real(low, high, prior="log-uniform")
-            elif isinstance(distribution, distributions.IntDistribution):
+            if isinstance(distribution, distributions.IntDistribution):
                 if distribution.log:
                     low = distribution.low - 0.5
                     high = distribution.high + 0.5
@@ -266,9 +251,6 @@ class _Optimizer(object):
                 else:
                     count = (distribution.high - distribution.low) // distribution.step
                     dimension = space.Integer(0, count)
-            elif isinstance(distribution, distributions.DiscreteUniformDistribution):
-                count = int((distribution.high - distribution.low) // distribution.q)
-                dimension = space.Integer(0, count)
             elif isinstance(distribution, distributions.CategoricalDistribution):
                 dimension = space.Categorical(distribution.choices)
             elif isinstance(distribution, distributions.FloatDistribution):
```

## Description of the changes
- a9ddf6d update existing distributions to be wrappers of {Int,Float}Distribution
- 6cb654c remove tests for IntLogUniformDistribution with step larger than 1
- e06229e fix if-then rules to avoid multiple value transformation
- d3d61b8 update tests

#2941