### PR TITLE
Add {Float,Int}Distribution to docs

### DIFF
--- a/docs/source/reference/distributions.rst
+++ b/docs/source/reference/distributions.rst
@@ -11,6 +11,8 @@ Optuna users should not use distribution classes directly, but instead use utili
    :toctree: generated/
    :nosignatures:
 
+   optuna.distributions.FloatDistribution
+   optuna.distributions.IntDistribution
    optuna.distributions.UniformDistribution
    optuna.distributions.LogUniformDistribution
    optuna.distributions.DiscreteUniformDistribution


### PR DESCRIPTION
This PR is follow-up for #3063.
I found that `FloatDistribution` and `IntDistribution` don't appear in the docs of distribution.