### PR TITLE
Make RedisStorage fast when running multiple trials

### DIFF
--- a/optuna/storages/_redis.py
+++ b/optuna/storages/_redis.py
@@ -665,10 +665,16 @@ class RedisStorage(BaseStorage):
 
         self._check_study_id(study_id)
 
-        trials = []
+        queries = []
         trial_ids = set(self._get_study_trials(study_id)) - excluded_trial_ids
         for trial_id in trial_ids:
-            frozen_trial = self.get_trial(trial_id)
+            queries.append(self._key_trial(trial_id))
+
+        trials = []
+        frozen_trial_pkls = self._redis.mget(queries)
+        for frozen_trial_pkl in frozen_trial_pkls:
+            assert frozen_trial_pkl is not None
+            frozen_trial = pickle.loads(frozen_trial_pkl)
 
             if states is None or frozen_trial.state in states:
                 trials.append(frozen_trial)


### PR DESCRIPTION
## Motivation
`RedisStorage` takes more time per trial as the number of trials increases.

## Description of the changes
This PR fixes this issue by combining multiple `get()` into a single `mget()`.
Even after applying this fix, `_get_trials()` is still O(N). This is because `mget()` is O(N) <https://redis.io/commands/mget>.

![graph](https://user-images.githubusercontent.com/1505016/151684186-b36f71c1-6283-45fc-ad4e-1eb691d1618f.png)

Signed-off-by: Masashi Honma <masashi.honma@gmail.com>
