### PR TITLE
Remove redundant `_check_trial_id`

### DIFF
--- a/optuna/storages/_redis.py
+++ b/optuna/storages/_redis.py
@@ -401,7 +401,6 @@ class RedisStorage(BaseStorage):
 
     def set_trial_state(self, trial_id: int, state: TrialState) -> bool:
 
-        self._check_trial_id(trial_id)
         trial = self.get_trial(trial_id)
         self.check_trial_is_updatable(trial_id, trial.state)
 
@@ -435,7 +434,6 @@ class RedisStorage(BaseStorage):
         distribution: distributions.BaseDistribution,
     ) -> None:
 
-        self._check_trial_id(trial_id)
         self.check_trial_is_updatable(trial_id, self.get_trial(trial_id).state)
 
         # Check param distribution compatibility with previous trial(s).
@@ -543,7 +541,6 @@ class RedisStorage(BaseStorage):
 
     def set_trial_values(self, trial_id: int, values: Sequence[float]) -> None:
 
-        self._check_trial_id(trial_id)
         trial = self.get_trial(trial_id)
         self.check_trial_is_updatable(trial_id, trial.state)
 
@@ -588,7 +585,6 @@ class RedisStorage(BaseStorage):
         self, trial_id: int, step: int, intermediate_value: float
     ) -> None:
 
-        self._check_trial_id(trial_id)
         frozen_trial = self.get_trial(trial_id)
         self.check_trial_is_updatable(trial_id, frozen_trial.state)
         frozen_trial.intermediate_values[step] = intermediate_value
@@ -596,7 +592,6 @@ class RedisStorage(BaseStorage):
 
     def set_trial_user_attr(self, trial_id: int, key: str, value: Any) -> None:
 
-        self._check_trial_id(trial_id)
         trial = self.get_trial(trial_id)
         self.check_trial_is_updatable(trial_id, trial.state)
         trial.user_attrs[key] = value
@@ -604,7 +599,6 @@ class RedisStorage(BaseStorage):
 
     def set_trial_system_attr(self, trial_id: int, key: str, value: Any) -> None:
 
-        self._check_trial_id(trial_id)
         trial = self.get_trial(trial_id)
         self.check_trial_is_updatable(trial_id, trial.state)
         trial.system_attrs[key] = value
@@ -686,7 +680,7 @@ class RedisStorage(BaseStorage):
     def _check_trial_id(self, trial_id: int) -> None:
 
         if not self._redis.exists(self._key_trial(trial_id)):
-            raise KeyError("study_id {} does not exist.".format(trial_id))
+            raise KeyError("trial_id {} does not exist.".format(trial_id))
 
     def record_heartbeat(self, trial_id: int) -> None:
         study_id = self.get_study_id_from_trial_id(trial_id)


### PR DESCRIPTION
## Description of the changes
Remove redundant `_check_trial_id()` because `get_trial()` already calls `_check_trial_id()`.

Signed-off-by: Masashi Honma <masashi.honma@gmail.com>

