### PR TITLE
Enable cache for `study.tell()`

### DIFF
--- a/optuna/storages/_cached_storage.py
+++ b/optuna/storages/_cached_storage.py
@@ -50,6 +50,7 @@ class _CachedStorage(BaseStorage):
         self._backend = backend
         self._studies: Dict[int, _StudyInfo] = {}
         self._trial_id_to_study_id_and_number: Dict[int, Tuple[int, int]] = {}
+        self._study_id_and_number_to_trial_id: Dict[Tuple[int, int], int] = {}
         self._lock = threading.Lock()
 
     def __getstate__(self) -> Dict[Any, Any]:
@@ -76,6 +77,9 @@ class _CachedStorage(BaseStorage):
             if study_id in self._studies:
                 for trial_id in self._studies[study_id].trials:
                     if trial_id in self._trial_id_to_study_id_and_number:
+                        del self._study_id_and_number_to_trial_id[
+                            self._trial_id_to_study_id_and_number[trial_id]
+                        ]
                         del self._trial_id_to_study_id_and_number[trial_id]
                 del self._studies[study_id]
 
@@ -257,7 +261,11 @@ class _CachedStorage(BaseStorage):
 
     def get_trial_id_from_study_id_trial_number(self, study_id: int, trial_number: int) -> int:
 
-        # TODO(hvy): Optimize to not issue a query to the backend storage.
+        key = (study_id, trial_number)
+        with self._lock:
+            if key in self._study_id_and_number_to_trial_id:
+                return self._study_id_and_number_to_trial_id[key]
+
         return self._backend.get_trial_id_from_study_id_trial_number(study_id, trial_number)
 
     def get_trial_number_from_id(self, trial_id: int) -> int:
@@ -377,6 +385,7 @@ class _CachedStorage(BaseStorage):
                 study_id,
                 trial.number,
             )
+            self._study_id_and_number_to_trial_id[(study_id, trial.number)] = trial._trial_id
             study.trials[trial.number] = trial
 
     @staticmethod


### PR DESCRIPTION
## Motivation
Fix a TODO.

## Description of the changes
Enable cache for `study.tell()`.
By adding `_study_id_and_number_to_trial_id` which is reverse dictionary of `_trial_id_to_study_id_and_number`.

This patch makes performance of `get_trial_id_from_study_id_trial_number()` from 1.5(msec) to 4(usec). `get_trial_id_from_study_id_trial_number()` is called only when calling `study.tell` by trial number. So I used this code.

```python
n_trials = 1000
for i in range(n_trials):
    trial = study.ask()
    x = trial.suggest_float('x', -10, 10)
    study.tell(trial.number, (x - 2) ** 2)
```
![graph](https://user-images.githubusercontent.com/1505016/155861335-a235559f-05b4-4463-b379-2dafd3d1b6e6.png)

Signed-off-by: Masashi Honma <masashi.honma@gmail.com>