### PR TITLE
Option to inherit intermediate values in RetryFailedTrialCallback

### DIFF
--- a/optuna/_callbacks.py
+++ b/optuna/_callbacks.py
@@ -92,8 +92,8 @@ class RetryFailedTrialCallback:
             integer. If set to the default value of :obj:`None` will retry indefinitely.
             If set to an integer, will only retry that many times.
         inherit_intermediate:
-            Option to inherit `trial.intermediate_values` reported by :func:`optuna.trial.Trial.report` from
-            the failed trial. Default is :obj:`False`.
+            Option to inherit `trial.intermediate_values` reported by
+            :func:`optuna.trial.Trial.report` from the failed trial. Default is :obj:`False`.
     """
 
     def __init__(

--- a/optuna/_callbacks.py
+++ b/optuna/_callbacks.py
@@ -91,16 +91,16 @@ class RetryFailedTrialCallback:
             The max number of times a trial can be retried. Must be set to :obj:`None` or an
             integer. If set to the default value of :obj:`None` will retry indefinitely.
             If set to an integer, will only retry that many times.
-        inherit_intermediate:
+        inherit_intermediate_values:
             Option to inherit `trial.intermediate_values` reported by
             :func:`optuna.trial.Trial.report` from the failed trial. Default is :obj:`False`.
     """
 
     def __init__(
-        self, max_retry: Optional[int] = None, inherit_intermediate: bool = False
+        self, max_retry: Optional[int] = None, inherit_intermediate_values: bool = False
     ) -> None:
         self._max_retry = max_retry
-        self._inherit_intermediate = inherit_intermediate
+        self._inherit_intermediate_values = inherit_intermediate_values
 
     def __call__(self, study: "optuna.study.Study", trial: FrozenTrial) -> None:
         system_attrs = {"failed_trial": trial.number}
@@ -126,7 +126,7 @@ class RetryFailedTrialCallback:
                 user_attrs=trial.user_attrs,
                 system_attrs=system_attrs,
                 intermediate_values=(
-                    trial.intermediate_values if self._inherit_intermediate else None
+                    trial.intermediate_values if self._inherit_intermediate_values else None
                 ),
             )
         )

--- a/optuna/_callbacks.py
+++ b/optuna/_callbacks.py
@@ -91,10 +91,16 @@ class RetryFailedTrialCallback:
             The max number of times a trial can be retried. Must be set to :obj:`None` or an
             integer. If set to the default value of :obj:`None` will retry indefinitely.
             If set to an integer, will only retry that many times.
+        inherit_intermediate:
+            Option to inherit `trial.intermediate_values` reported by `trial.report()` from
+            the failed trial. Default is `False`.
     """
 
-    def __init__(self, max_retry: Optional[int] = None) -> None:
+    def __init__(
+        self, max_retry: Optional[int] = None, inherit_intermediate: bool = False
+    ) -> None:
         self._max_retry = max_retry
+        self._inherit_intermediate = inherit_intermediate
 
     def __call__(self, study: "optuna.study.Study", trial: FrozenTrial) -> None:
         system_attrs = {"failed_trial": trial.number}
@@ -119,6 +125,9 @@ class RetryFailedTrialCallback:
                 distributions=trial.distributions,
                 user_attrs=trial.user_attrs,
                 system_attrs=system_attrs,
+                intermediate_values=(
+                    trial.intermediate_values if self._inherit_intermediate else None
+                ),
             )
         )
 

--- a/optuna/_callbacks.py
+++ b/optuna/_callbacks.py
@@ -92,8 +92,8 @@ class RetryFailedTrialCallback:
             integer. If set to the default value of :obj:`None` will retry indefinitely.
             If set to an integer, will only retry that many times.
         inherit_intermediate:
-            Option to inherit `trial.intermediate_values` reported by `trial.report()` from
-            the failed trial. Default is `False`.
+            Option to inherit `trial.intermediate_values` reported by :func:`optuna.trial.Trial.report` from
+            the failed trial. Default is :obj:`False`.
     """
 
     def __init__(

--- a/tests/storages_tests/test_storages.py
+++ b/tests/storages_tests/test_storages.py
@@ -1211,7 +1211,7 @@ def test_retry_failed_trial_callback(storage_mode: str, max_retry: Optional[int]
             assert study.trials[0].params == study.trials[1].params
             assert study.trials[0].distributions == study.trials[1].distributions
             assert study.trials[0].user_attrs == study.trials[1].user_attrs
-            # only `intermediate_values` are not inherited
+            # Only `intermediate_values` are not inherited.
             assert study.trials[1].intermediate_values == {}
 
 
@@ -1253,7 +1253,7 @@ def test_retry_failed_trial_callback_intermediate(
         assert RetryFailedTrialCallback.retried_trial_number(study.trials[1]) == (
             None if max_retry == 0 else 0
         )
-        # Test inheritance of trial fields
+        # Test inheritance of trial fields.
         if max_retry != 0:
             assert study.trials[0].params == study.trials[1].params
             assert study.trials[0].distributions == study.trials[1].distributions

--- a/tests/storages_tests/test_storages.py
+++ b/tests/storages_tests/test_storages.py
@@ -1229,7 +1229,7 @@ def test_retry_failed_trial_callback_intermediate(
         heartbeat_interval=heartbeat_interval,
         grace_period=grace_period,
         failed_trial_callback=RetryFailedTrialCallback(
-            max_retry=max_retry, inherit_intermediate=True
+            max_retry=max_retry, inherit_intermediate_values=True
         ),
     ) as storage:
         assert storage.is_heartbeat_enabled()

--- a/tests/storages_tests/test_storages.py
+++ b/tests/storages_tests/test_storages.py
@@ -1190,7 +1190,7 @@ def test_retry_failed_trial_callback(storage_mode: str, max_retry: Optional[int]
         study = optuna.create_study(storage=storage)
 
         trial = study.ask()
-        _ = trial.suggest_uniform("_", -1, -1)
+        trial.suggest_float("_", -1, -1)
         trial.report(0.5, 1)
         storage.record_heartbeat(trial._trial_id)
         time.sleep(grace_period + 1)
@@ -1206,7 +1206,7 @@ def test_retry_failed_trial_callback(storage_mode: str, max_retry: Optional[int]
         assert RetryFailedTrialCallback.retried_trial_number(study.trials[1]) == (
             None if max_retry == 0 else 0
         )
-        # Test inheritance of trial fields
+        # Test inheritance of trial fields.
         if max_retry != 0:
             assert study.trials[0].params == study.trials[1].params
             assert study.trials[0].distributions == study.trials[1].distributions

--- a/tests/storages_tests/test_storages.py
+++ b/tests/storages_tests/test_storages.py
@@ -1237,7 +1237,7 @@ def test_retry_failed_trial_callback_intermediate(
         study = optuna.create_study(storage=storage)
 
         trial = study.ask()
-        _ = trial.suggest_uniform("_", -1, -1)
+        trial.suggest_float("_", -1, -1)
         trial.report(0.5, 1)
         storage.record_heartbeat(trial._trial_id)
         time.sleep(grace_period + 1)


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
#2993 
Add an option to determine whether retry trials inherit intermediate values or not.

## Description of the changes
<!-- Describe the changes in this PR. -->
I added `inherit_intermediate` argument to `RetryFailedTrialCallback.__init__()`.
