### PR TITLE
Force implementation of `_check_and_set_param_distribution()` by `BaseStorage`

### DIFF
--- a/optuna/storages/_base.py
+++ b/optuna/storages/_base.py
@@ -10,6 +10,7 @@ from typing import Tuple
 from typing import Union
 
 import optuna
+from optuna import distributions
 from optuna.distributions import BaseDistribution
 from optuna.study._study_direction import StudyDirection
 from optuna.study._study_summary import StudySummary
@@ -363,6 +364,43 @@ class BaseStorage(object, metaclass=abc.ABCMeta):
         """Set a parameter to a trial.
 
         Args:
+            trial_id:
+                ID of the trial.
+            param_name:
+                Name of the parameter.
+            param_value_internal:
+                Internal representation of the parameter value.
+            distribution:
+                Sampled distribution of the parameter.
+
+        Raises:
+            :exc:`KeyError`:
+                If no trial with the matching ``trial_id`` exists.
+            :exc:`RuntimeError`:
+                If the trial is already finished.
+        """
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def _check_and_set_param_distribution(
+        self,
+        study_id: int,
+        trial_id: int,
+        param_name: str,
+        param_value_internal: float,
+        distribution: distributions.BaseDistribution,
+    ) -> None:
+        """Check existance of study and set a parameter to a trial.
+
+        Called by _CachedStorage when distribution does not exist in _CachedStorage cache.
+        On the cache miss, check compatibility against previous trials in the database
+        and INSERT immediately to prevent other processes from creating incompatible
+        ones. By INSERT, it is assumed that no previous entry has been persisted
+        already.
+
+        Args:
+            study_id:
+                ID of the study.
             trial_id:
                 ID of the trial.
             param_name:

--- a/optuna/storages/_cached_storage.py
+++ b/optuna/storages/_cached_storage.py
@@ -230,11 +230,7 @@ class _CachedStorage(BaseStorage):
                 if cached_dist:
                     distributions.check_distribution_compatibility(cached_dist, distribution)
                 else:
-                    # On cache miss, check compatibility against previous trials in the database
-                    # and INSERT immediately to prevent other processes from creating incompatible
-                    # ones. By INSERT, it is assumed that no previous entry has been persisted
-                    # already.
-                    self._backend._check_and_set_param_distribution(
+                    self._check_and_set_param_distribution(
                         study_id, trial_id, param_name, param_value_internal, distribution
                     )
                     self._studies[study_id].param_distribution[param_name] = distribution
@@ -254,6 +250,18 @@ class _CachedStorage(BaseStorage):
                 return
 
         self._backend.set_trial_param(trial_id, param_name, param_value_internal, distribution)
+
+    def _check_and_set_param_distribution(
+        self,
+        study_id: int,
+        trial_id: int,
+        param_name: str,
+        param_value_internal: float,
+        distribution: distributions.BaseDistribution,
+    ) -> None:
+        self._backend._check_and_set_param_distribution(
+            study_id, trial_id, param_name, param_value_internal, distribution
+        )
 
     def get_trial_id_from_study_id_trial_number(self, study_id: int, trial_number: int) -> int:
 

--- a/optuna/storages/_in_memory.py
+++ b/optuna/storages/_in_memory.py
@@ -274,6 +274,22 @@ class InMemoryStorage(BaseStorage):
             trial.distributions[param_name] = distribution
             self._set_trial(trial_id, trial)
 
+    def _check_and_set_param_distribution(
+        self,
+        study_id: int,
+        trial_id: int,
+        param_name: str,
+        param_value_internal: float,
+        distribution: distributions.BaseDistribution,
+    ) -> None:
+        if study_id != self._trial_id_to_study_id_and_number[trial_id][0]:
+            raise KeyError(
+                "Invalid study_id {}. {} is expected.".format(
+                    study_id, self._trial_id_to_study_id_and_number[trial_id][0]
+                )
+            )
+        self.set_trial_param(trial_id, param_name, param_value_internal, distribution)
+
     def get_trial_id_from_study_id_trial_number(self, study_id: int, trial_number: int) -> int:
 
         with self._lock:

--- a/tests/storages_tests/test_storages.py
+++ b/tests/storages_tests/test_storages.py
@@ -577,6 +577,22 @@ def test_set_trial_param(storage_mode: str) -> None:
             storage.set_trial_param(non_existent_trial_id, "x", 0.1, distribution_x)
 
 
+@pytest.mark.parametrize("storage_mode", ["inmemory", "sqlite", "redis"])
+def test_check_and_set_param_distribution_raw(storage_mode: str) -> None:
+
+    with StorageSupplier(storage_mode) as storage:
+
+        study_id = storage.create_new_study()
+        trial_id = storage.create_new_trial(study_id)
+        distribution_x = UniformDistribution(low=1.0, high=2.0)
+
+        storage._check_and_set_param_distribution(study_id, trial_id, "x", 0.5, distribution_x)
+        assert storage.get_trial_param(trial_id, "x") == 0.5
+
+        with pytest.raises(KeyError):
+            storage._check_and_set_param_distribution(-1, trial_id, "x", 0.5, distribution_x)
+
+
 @pytest.mark.parametrize("storage_mode", STORAGE_MODES)
 def test_set_trial_values(storage_mode: str) -> None:
 


### PR DESCRIPTION
## Description of the changes
To make it easy to add new cacheable storage, this patch make the implementation of `_check_and_set_param_distribution()` mandatory.

This is requested by Hideaki Imamura and Keisuke Umezawa in this discussion.
https://github.com/optuna/optuna/pull/3204#pullrequestreview-866850847

Signed-off-by: Masashi Honma <masashi.honma@gmail.com>

