### PR TITLE
Warn if heartbeat is used with ask-and-tell.

### DIFF
--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -562,6 +562,12 @@ from :obj:`~optuna.trial.TrialState.RUNNING`.
     study = optuna.create_study(storage=storage)
     study.optimize(objective, n_trials=100)
 
+.. note::
+
+  The heartbeat is supposed to be used with :meth:`~optuna.study.Study.optimize`. If you use `:meth:`~optuna.study.Study.ask` and
+  `:meth:`~optuna.study.Study.tell`, please change the state of the killed trials by calling `:meth:`~optuna.study.Study.tell`
+  explicitly.
+
 You can also execute a callback function to process the failed trial.
 Optuna provides a callback to retry failed trials as :class:`~optuna.storages.RetryFailedTrialCallback`.
 Note that a callback is invoked at a beginning of each trial, which means :class:`~optuna.storages.RetryFailedTrialCallback`

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -564,8 +564,8 @@ from :obj:`~optuna.trial.TrialState.RUNNING`.
 
 .. note::
 
-  The heartbeat is supposed to be used with :meth:`~optuna.study.Study.optimize`. If you use `:meth:`~optuna.study.Study.ask` and
-  `:meth:`~optuna.study.Study.tell`, please change the state of the killed trials by calling `:meth:`~optuna.study.Study.tell`
+  The heartbeat is supposed to be used with :meth:`~optuna.study.Study.optimize`. If you use :meth:`~optuna.study.Study.ask` and
+  :meth:`~optuna.study.Study.tell`, please change the state of the killed trials by calling :meth:`~optuna.study.Study.tell`
   explicitly.
 
 You can also execute a callback function to process the failed trial.

--- a/optuna/storages/_rdb/storage.py
+++ b/optuna/storages/_rdb/storage.py
@@ -123,8 +123,8 @@ class RDBStorage(BaseStorage):
 
             .. note::
                 The heartbeat is supposed to be used with :meth:`~optuna.study.Study.optimize`.
-                If you use `:meth:`~optuna.study.Study.ask` and
-                `:meth:`~optuna.study.Study.tell` instead, it will not work.
+                If you use :meth:`~optuna.study.Study.ask` and
+                :meth:`~optuna.study.Study.tell` instead, it will not work.
 
         grace_period:
             Grace period before a running trial is failed from the last heartbeat.

--- a/optuna/storages/_rdb/storage.py
+++ b/optuna/storages/_rdb/storage.py
@@ -120,6 +120,12 @@ class RDBStorage(BaseStorage):
             Flag to skip schema compatibility check if set to True.
         heartbeat_interval:
             Interval to record the heartbeat. It is recorded every ``interval`` seconds.
+
+            .. note::
+                The heartbeat is supposed to be used with :meth:`~optuna.study.Study.optimize`.
+                If you use `:meth:`~optuna.study.Study.ask` and
+                `:meth:`~optuna.study.Study.tell` instead, it will not work.
+
         grace_period:
             Grace period before a running trial is failed from the last heartbeat.
             If it is :obj:`None`, the grace period will be `2 * heartbeat_interval`.

--- a/optuna/storages/_redis.py
+++ b/optuna/storages/_redis.py
@@ -63,6 +63,12 @@ class RedisStorage(BaseStorage):
         url: URL of the redis storage, password and db are optional. (ie: redis://localhost:6379)
         heartbeat_interval:
             Interval to record the heartbeat. It is recorded every ``interval`` seconds.
+
+            .. note::
+                The heartbeat is supposed to be used with :meth:`~optuna.study.Study.optimize`.
+                If you use `:meth:`~optuna.study.Study.ask` and
+                `:meth:`~optuna.study.Study.tell` instead, it will not work.
+
         grace_period:
             Grace period before a running trial is failed from the last heartbeat.
             If it is :obj:`None`, the grace period will be `2 * heartbeat_interval`.

--- a/optuna/storages/_redis.py
+++ b/optuna/storages/_redis.py
@@ -66,8 +66,8 @@ class RedisStorage(BaseStorage):
 
             .. note::
                 The heartbeat is supposed to be used with :meth:`~optuna.study.Study.optimize`.
-                If you use `:meth:`~optuna.study.Study.ask` and
-                `:meth:`~optuna.study.Study.tell` instead, it will not work.
+                If you use :meth:`~optuna.study.Study.ask` and
+                :meth:`~optuna.study.Study.tell` instead, it will not work.
 
         grace_period:
             Grace period before a running trial is failed from the last heartbeat.

--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -463,6 +463,17 @@ class Study:
             A :class:`~optuna.trial.Trial`.
         """
 
+        if self._optimize_lock.acquire(False):
+            _msg = "Heartbeat of RDBStorage is supposed to be used with Study.optimize."
+            if isinstance(self._storage, storages.RDBStorage):
+                if self._storage.heartbeat_interval is not None:
+                    warnings.warn(_msg)
+            elif isinstance(self._storage, storages._CachedStorage) and isinstance(
+                self._storage._backend, storages.RDBStorage
+            ):
+                if self._storage._backend.heartbeat_interval is not None:
+                    warnings.warn(_msg)
+
         fixed_distributions = fixed_distributions or {}
 
         # Sync storage once every trial.

--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -464,6 +464,7 @@ class Study:
         """
 
         if self._optimize_lock.acquire(False):
+            self._optimize_lock.release()
             _msg = "Heartbeat of RDBStorage is supposed to be used with Study.optimize."
             if isinstance(self._storage, storages.RDBStorage):
                 if self._storage.heartbeat_interval is not None:

--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -463,17 +463,9 @@ class Study:
             A :class:`~optuna.trial.Trial`.
         """
 
-        if self._optimize_lock.acquire(False):
-            self._optimize_lock.release()
-            _msg = "Heartbeat of storage is supposed to be used with Study.optimize."
-            if isinstance(self._storage, (storages.RDBStorage, storages.RedisStorage)):
-                if self._storage.heartbeat_interval is not None:
-                    warnings.warn(_msg)
-            elif isinstance(self._storage, storages._CachedStorage) and isinstance(
-                self._storage._backend, (storages.RDBStorage, storages.RedisStorage)
-            ):
-                if self._storage._backend.heartbeat_interval is not None:
-                    warnings.warn(_msg)
+        if not self._optimize_lock.locked():
+            if self._storage.is_heartbeat_enabled():
+                warnings.warn("Heartbeat of storage is supposed to be used with Study.optimize.")
 
         fixed_distributions = fixed_distributions or {}
 

--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -465,12 +465,12 @@ class Study:
 
         if self._optimize_lock.acquire(False):
             self._optimize_lock.release()
-            _msg = "Heartbeat of RDBStorage is supposed to be used with Study.optimize."
-            if isinstance(self._storage, storages.RDBStorage):
+            _msg = "Heartbeat of storage is supposed to be used with Study.optimize."
+            if isinstance(self._storage, (storages.RDBStorage, storages.RedisStorage)):
                 if self._storage.heartbeat_interval is not None:
                     warnings.warn(_msg)
             elif isinstance(self._storage, storages._CachedStorage) and isinstance(
-                self._storage._backend, storages.RDBStorage
+                self._storage._backend, (storages.RDBStorage, storages.RedisStorage)
             ):
                 if self._storage._backend.heartbeat_interval is not None:
                     warnings.warn(_msg)

--- a/tests/storages_tests/test_storages.py
+++ b/tests/storages_tests/test_storages.py
@@ -1122,8 +1122,9 @@ def test_fail_stale_trials_with_optimize(storage_mode: str) -> None:
         study1 = optuna.create_study(storage=storage)
         study2 = optuna.create_study(storage=storage)
 
-        trial1 = study1.ask()
-        trial2 = study2.ask()
+        with pytest.warns(UserWarning):
+            trial1 = study1.ask()
+            trial2 = study2.ask()
         storage.record_heartbeat(trial1._trial_id)
         storage.record_heartbeat(trial2._trial_id)
         time.sleep(grace_period + 1)
@@ -1173,7 +1174,8 @@ def test_failed_trial_callback(storage_mode: str) -> None:
         study = optuna.create_study(storage=storage)
         study.set_system_attr("test", "A")
 
-        trial = study.ask()
+        with pytest.warns(UserWarning):
+            trial = study.ask()
         trial.set_system_attr("test", "B")
         storage.record_heartbeat(trial._trial_id)
         time.sleep(grace_period + 1)
@@ -1201,7 +1203,8 @@ def test_retry_failed_trial_callback(storage_mode: str, max_retry: Optional[int]
 
         study = optuna.create_study(storage=storage)
 
-        trial = study.ask()
+        with pytest.warns(UserWarning):
+            trial = study.ask()
         trial.suggest_float("_", -1, -1)
         trial.report(0.5, 1)
         storage.record_heartbeat(trial._trial_id)
@@ -1291,7 +1294,8 @@ def test_fail_stale_trials(storage_mode: str, grace_period: Optional[int]) -> No
         study = optuna.create_study(storage=storage)
         study.set_system_attr("test", "A")
 
-        trial = study.ask()
+        with pytest.warns(UserWarning):
+            trial = study.ask()
         trial.set_system_attr("test", "B")
         storage.record_heartbeat(trial._trial_id)
         time.sleep(_grace_period + 1)


### PR DESCRIPTION
## Motivation

Related to #3256. Currently, the heartbeat feature of `RDBStorage` works with `Study.optimize`. In other words, the heartbeat signals are never sent if users use the ask-and-tell interface.

@himkt suggested the change to notify users that the heartbeat was disabled when they used ask-and-tell, and I created a prototypical implementation.

## Description of the changes

- Check the `Study._optimize_lock` to check if `Study.ask` is called in `Study.optimize`
- If not, check the storage is enabled the heartbeat feature
- If so, raise warnings 

Example code

```python
import time

import optuna


def objective(trial):
    time.sleep(3)
    return 1


if __name__ == "__main__":
    storage = optuna.storages.RDBStorage(
        "sqlite:///:memory:",
        heartbeat_interval=1,
        grace_period=2,
    )
    study = optuna.create_study(storage=storage)
    for i in range(2):
        trial = study.ask()
        value = objective(trial)
        # study.tell(trial=trial, values=value)
    print(study.trials_dataframe())
```