### PR TITLE
Make optuna.study.get_all_study_summaries() of RedisStorage fast

### DIFF
--- a/optuna/storages/_redis.py
+++ b/optuna/storages/_redis.py
@@ -312,11 +312,16 @@ class RedisStorage(BaseStorage):
 
     def get_all_study_summaries(self) -> List[StudySummary]:
 
-        study_summaries = []
+        queries = []
         study_ids = [pickle.loads(sid) for sid in self._redis.lrange("study_list", 0, -1)]
         for study_id in study_ids:
-            study_summary = self._get_study_summary(study_id)
-            study_summaries.append(study_summary)
+            queries.append(self._key_study_summary(study_id))
+
+        study_summaries = []
+        summary_pkls = self._redis.mget(queries)
+        for summary_pkl in summary_pkls:
+            assert summary_pkl is not None
+            study_summaries.append(pickle.loads(summary_pkl))
 
         return study_summaries
 


### PR DESCRIPTION
## Description of the changes
This patch make `optuna.study.get_all_study_summaries()` of `RedisStorage` fast by using `mget()` instead of `get()`.

When the database has 100,000 studies, the performance is improved from 7.38(sec) to 1.34(sec).

Signed-off-by: Masashi Honma <masashi.honma@gmail.com>
