### PR TITLE
Add docstring for property `DiscreteUniformDistribution.q`

### DIFF
--- a/optuna/distributions.py
+++ b/optuna/distributions.py
@@ -278,6 +278,13 @@ class DiscreteUniformDistribution(FloatDistribution):
 
     @property
     def q(self) -> float:
+        """Return a discretization step.
+
+        :class:`~optuna.distributions.DiscreteUniformDistribution` is now subtype of
+        :class:`~optuna.distributions.FloatDistribution` and FloatDistribution has ``step``
+        parameter instaead of ``q``. This property is proxy such that users can get a
+        discretization step by ``distribution.q`` for keeping the backward compatibility.
+        """
         return cast(float, self.step)
 
 

--- a/optuna/distributions.py
+++ b/optuna/distributions.py
@@ -263,6 +263,12 @@ class DiscreteUniformDistribution(FloatDistribution):
         ValueError:
             If ``low`` value is larger than ``high`` value, or ``q`` value is smaller or
             equal to 0.
+
+    Attributes:
+        low:
+            Lower endpoint of the range of the distribution. ``low`` is included in the range.
+        high:
+            Upper endpoint of the range of the distribution. ``high`` is included in the range.
     """
 
     def __init__(self, low: float, high: float, q: float) -> None:

--- a/optuna/distributions.py
+++ b/optuna/distributions.py
@@ -251,7 +251,7 @@ class DiscreteUniformDistribution(FloatDistribution):
         :math:`\\mathsf{high}` will be replaced with the maximum of :math:`k q + \\mathsf{low}
         < \\mathsf{high}`, where :math:`k` is an integer.
 
-    Attributes:
+    Args:
         low:
             Lower endpoint of the range of the distribution. ``low`` is included in the range.
         high:

--- a/optuna/distributions.py
+++ b/optuna/distributions.py
@@ -284,7 +284,7 @@ class DiscreteUniformDistribution(FloatDistribution):
 
     @property
     def q(self) -> float:
-        """Return a discretization step.
+        """Discretization step.
 
         :class:`~optuna.distributions.DiscreteUniformDistribution` is now subtype of
         :class:`~optuna.distributions.FloatDistribution` and FloatDistribution has ``step``

--- a/optuna/distributions.py
+++ b/optuna/distributions.py
@@ -286,10 +286,9 @@ class DiscreteUniformDistribution(FloatDistribution):
     def q(self) -> float:
         """Discretization step.
 
-        :class:`~optuna.distributions.DiscreteUniformDistribution` is now subtype of
-        :class:`~optuna.distributions.FloatDistribution` and FloatDistribution has ``step``
-        parameter instaead of ``q``. This property is proxy such that users can get a
-        discretization step by ``distribution.q`` for keeping the backward compatibility.
+        :class:`~optuna.distributions.DiscreteUniformDistribution` is a subtype of
+        :class:`~optuna.distributions.FloatDistribution`.
+        This property is a proxy for its ``step`` attribute.
         """
         return cast(float, self.step)
 


### PR DESCRIPTION
This PR adds a docstring to `DiscreteUniformDistribution.q`, which is displayed with the empty explanation in the documentation.

Before | After
-- | --
<img width="632" alt="Screen Shot 2022-02-02 at 15 32 12" src="https://user-images.githubusercontent.com/5164000/152105339-aa7e075f-c30a-4e20-b980-200f9baf31d8.png"> | <img width="1174" alt="Screen Shot 2022-02-02 at 15 33 11" src="https://user-images.githubusercontent.com/5164000/152105437-bcf82efb-6772-476e-9495-e4004a8349ff.png">



:link: https://optuna.readthedocs.io/en/latest/reference/generated/optuna.distributions.DiscreteUniformDistribution.html