### PR TITLE
switch function order progbar tests

### DIFF
--- a/tests/study_tests/test_study.py
+++ b/tests/study_tests/test_study.py
@@ -732,6 +732,19 @@ def test_optimize_with_progbar_timeout(capsys: _pytest.capture.CaptureFixture) -
     assert "100%" in err
 
 
+def test_optimize_with_progbar_parallel_timeout(capsys: _pytest.capture.CaptureFixture) -> None:
+
+    study = create_study()
+    with pytest.warns(
+        UserWarning, match="The timeout-based progress bar is not supported with n_jobs != 1."
+    ):
+        study.optimize(lambda _: 1.0, timeout=2.0, show_progress_bar=True, n_jobs=2)
+    _, err = capsys.readouterr()
+
+    # Testing for a character that forms progress bar borders.
+    assert "|" not in err
+
+
 @pytest.mark.parametrize(
     "timeout,expected",
     [
@@ -826,19 +839,6 @@ def test_optimize_without_progbar_no_constraints(
 
     study = create_study()
     study.optimize(_objective, n_jobs=n_jobs)
-    _, err = capsys.readouterr()
-
-    # Testing for a character that forms progress bar borders.
-    assert "|" not in err
-
-
-def test_optimize_with_progbar_parallel_timeout(capsys: _pytest.capture.CaptureFixture) -> None:
-
-    study = create_study()
-    with pytest.warns(
-        UserWarning, match="The timeout-based progress bar is not supported with n_jobs != 1."
-    ):
-        study.optimize(lambda _: 1.0, timeout=2.0, show_progress_bar=True, n_jobs=2)
     _, err = capsys.readouterr()
 
     # Testing for a character that forms progress bar borders.


### PR DESCRIPTION

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
Test functions for progress bar in optimize were thought to be able to be simplified.
This would complicate the logic so we decided to leave it.
However, a change of order of functions puts similar tests next to each other, making it more clear.

## Description of the changes
<!-- Describe the changes in this PR. -->
Change order of test functions

