### PR TITLE
Extend type hints of catch and states

### DIFF
--- a/optuna/study/_optimize.py
+++ b/optuna/study/_optimize.py
@@ -43,7 +43,7 @@ def _optimize(
     n_trials: Optional[int] = None,
     timeout: Optional[float] = None,
     n_jobs: int = 1,
-    catch: Tuple[Type[Exception], ...] = (),
+    catch: Optional[Union[Sequence[Type[Exception]], Type[Exception]]] = None,
     callbacks: Optional[List[Callable[["optuna.Study", FrozenTrial], None]]] = None,
     gc_after_trial: bool = False,
     show_progress_bar: bool = False,

--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -201,7 +201,7 @@ class Study:
     def get_trials(
         self,
         deepcopy: bool = True,
-        states: Optional[Tuple[TrialState, ...]] = None,
+        states: Optional[Sequence[TrialState]] = None,
     ) -> List[FrozenTrial]:
         """Return all trials in the study.
 


### PR DESCRIPTION
## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
As mentioned in #3230 , the tuple type annotation for `catch` is inconvenient. Sequence provides more options. Same goes for `states`.

## Description of the changes
<!-- Describe the changes in this PR. -->
Changed type annotation for `catch` to `Optional[Union[Sequence[Type[Exception]], Type[Exception]]]`
Changed type annotation for `states` to `Optional[Sequence[TrialState]]`