### PR TITLE
Add setter method for DiscreteUniformDistribution.q

### DIFF
--- a/optuna/distributions.py
+++ b/optuna/distributions.py
@@ -280,6 +280,10 @@ class DiscreteUniformDistribution(FloatDistribution):
     def q(self) -> float:
         return cast(float, self.step)
 
+    @q.setter
+    def q(self, v: float) -> float:
+        self.step = v
+
 
 class IntDistribution(BaseDistribution):
     """A distribution on integers.

--- a/optuna/distributions.py
+++ b/optuna/distributions.py
@@ -281,7 +281,7 @@ class DiscreteUniformDistribution(FloatDistribution):
         return cast(float, self.step)
 
     @q.setter
-    def q(self, v: float) -> float:
+    def q(self, v: float) -> None:
         self.step = v
 
 


### PR DESCRIPTION
Follow up of #3244 

## Motivation
After #3244, `DiscreteUniformDistribution` is the subclass of `FloatDistribution`.
`DiscreteUniformDistribution` has `q` attribute as a discretization step on the other hand `FloatDistribution` has `step` attribute for the purpose. So I added the proxy method `q` to get `step` attribute but forgot to add a setter, which introduces a backward compatibility.

In this PR, I introduce the setter for `DiscreteUniformDistribution.q`.

## Description of the changes
- c76fd21f adds a setter