### PR TITLE
Skip limiting the value if it is `nan`

### DIFF
--- a/optuna/storages/_rdb/storage.py
+++ b/optuna/storages/_rdb/storage.py
@@ -742,6 +742,10 @@ class RDBStorage(BaseStorage):
     @staticmethod
     def _ensure_numerical_limit(value: float) -> float:
 
+        # If the value is nan, skip the limit on the value.
+        if np.isnan(value):
+            return value
+
         # Max and min trial values that can be stored are limited by
         # dialect. Most limiting one is MySQL which in current data
         # model will store floats as single precision (32 bit).

--- a/optuna/storages/_rdb/storage.py
+++ b/optuna/storages/_rdb/storage.py
@@ -742,15 +742,11 @@ class RDBStorage(BaseStorage):
     @staticmethod
     def _ensure_numerical_limit(value: float) -> float:
 
-        # If the value is nan, skip the limit on the value.
-        if np.isnan(value):
-            return value
-
         # Max and min trial values that can be stored are limited by
         # dialect. Most limiting one is MySQL which in current data
         # model will store floats as single precision (32 bit).
         # There is no support for +inf and -inf in this dialect.
-        return float(min(_RDB_MAX_FLOAT, max(_RDB_MIN_FLOAT, value)))
+        return np.clip(value, _RDB_MIN_FLOAT, _RDB_MAX_FLOAT)
 
     @staticmethod
     def _lift_numerical_limit(value: float) -> float:

--- a/optuna/storages/_rdb/storage.py
+++ b/optuna/storages/_rdb/storage.py
@@ -746,7 +746,7 @@ class RDBStorage(BaseStorage):
         # dialect. Most limiting one is MySQL which in current data
         # model will store floats as single precision (32 bit).
         # There is no support for +inf and -inf in this dialect.
-        return np.clip(value, _RDB_MIN_FLOAT, _RDB_MAX_FLOAT)
+        return float(np.clip(value, _RDB_MIN_FLOAT, _RDB_MAX_FLOAT))
 
     @staticmethod
     def _lift_numerical_limit(value: float) -> float:


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
In #3238, the objective value or intermediate values are clipped between `np.finfo(np.float32).min` and `np.finfo(np.float32).max`. If the value if `nan`, it clipped in `np.finfo(np.float32).min`. This PR skips limiting the value.

## Description of the changes
<!-- Describe the changes in this PR. -->
Skip limiting the value if if is `nan` by using `np.clip` as @not522 suggested.
