### PR TITLE
Add a note for copy_study: it craetes a copy regardless of its state

### DIFF
--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -1323,6 +1323,10 @@ def copy_study(
     The direction(s) of the objective(s) in the study, trials, user attributes and system
     attributes are copied.
 
+    .. note::
+        :func:`optuna.copy_study` copies a study even if the optimization is working on.
+        It means users will get a copied study that contains a trial that is not finished.
+
     Example:
 
         .. testsetup::

--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -1324,7 +1324,7 @@ def copy_study(
     attributes are copied.
 
     .. note::
-        :func:`optuna.copy_study` copies a study even if the optimization is working on.
+        :func:`~optuna.copy_study` copies a study even if the optimization is working on.
         It means users will get a copied study that contains a trial that is not finished.
 
     Example:


### PR DESCRIPTION
🔗 https://github.com/optuna/optuna/issues/2955

This PR adds a note for `optuna.copy_study`.
It explicitly mentions that `copy_study` will create a copy regardless of its status.