### PR TITLE
Use a enqueued parameter that is out of range from suggest API

### DIFF
--- a/optuna/trial/_trial.py
+++ b/optuna/trial/_trial.py
@@ -656,7 +656,7 @@ class Trial(BaseTrial):
                 "Fixed parameter '{}' with value {} is out of range "
                 "for distribution {}.".format(name, param_value, distribution)
             )
-        return contained
+        return True
 
     def _is_relative_param(self, name: str, distribution: BaseDistribution) -> bool:
 

--- a/tests/study_tests/test_study.py
+++ b/tests/study_tests/test_study.py
@@ -647,12 +647,13 @@ def test_enqueue_trial_properly_sets_user_attr(storage_mode: str) -> None:
 
 @pytest.mark.parametrize("storage_mode", STORAGE_MODES)
 def test_enqueue_trial_with_out_of_range_parameters(storage_mode: str) -> None:
+    fixed_value = 11
 
     with StorageSupplier(storage_mode) as storage:
         study = create_study(storage=storage)
         assert len(study.trials) == 0
 
-        study.enqueue_trial(params={"x": 11})
+        study.enqueue_trial(params={"x": fixed_value})
 
         def objective(trial: Trial) -> float:
 
@@ -661,7 +662,7 @@ def test_enqueue_trial_with_out_of_range_parameters(storage_mode: str) -> None:
         with pytest.warns(UserWarning):
             study.optimize(objective, n_trials=1)
         t = study.trials[0]
-        assert -10 <= t.params["x"] <= 10
+        assert t.params["x"] == fixed_value
 
     # Internal logic might differ when distribution contains a single element.
     # Test it explicitly.
@@ -669,7 +670,7 @@ def test_enqueue_trial_with_out_of_range_parameters(storage_mode: str) -> None:
         study = create_study(storage=storage)
         assert len(study.trials) == 0
 
-        study.enqueue_trial(params={"x": 11})
+        study.enqueue_trial(params={"x": fixed_value})
 
         def objective(trial: Trial) -> float:
 
@@ -678,7 +679,7 @@ def test_enqueue_trial_with_out_of_range_parameters(storage_mode: str) -> None:
         with pytest.warns(UserWarning):
             study.optimize(objective, n_trials=1)
         t = study.trials[0]
-        assert t.params["x"] == 1
+        assert t.params["x"] == fixed_value
 
 
 @patch("optuna.study._optimize.gc.collect")


### PR DESCRIPTION
🔗 https://github.com/optuna/optuna/issues/2955

This PR changes the behavior of suggest APIs when a parameter specified in `enqueue_trial` is out of range for the search space given by suggest APIs.

### Before

```
>>> import optuna
>>> study = optuna.create_study()
[I 2022-02-08 10:36:55,467] A new study created in memory with name: no-name-8c1470a7-0521-477d-983c-b907413d39b5
>>> study.enqueue_trial({"x": 0})
<stdin>:1: ExperimentalWarning:...
>>> trial = study.ask()
>>> trial.suggest_float("x", 1, 10)
...trial/_trial.py:169: FutureWarning: ...
/Users/himkt/work/github.com/himkt/optuna/optuna/trial/_trial.py:655: UserWarning: Fixed parameter 'x' with value 0 is out of range for distribution UniformDistribution(high=10.0, low=1.0).
  warnings.warn(
5.1018399181976415  # enqueued parameter is ignored
```

### After

```
>>> import optuna
>>> study = optuna.create_study()
[I 2022-02-08 10:41:12,424] A new study created in memory with name: no-name-5e927ec5-813b-4780-a00f-8ac40f9ff9d2
>>> study.enqueue_trial({"x": 0})
<stdin>:1: ExperimentalWarning: ...
>>> trial = study.ask()
>>> trial.suggest_float("x", 1, 10)
/Users/himkt/work/github.com/himkt/optuna/optuna/trial/_trial.py:169: FutureWarning: ...
/Users/himkt/work/github.com/himkt/optuna/optuna/trial/_trial.py:655: UserWarning: Fixed parameter 'x' with value 0 is out of range for distribution UniformDistribution(high=10.0, low=1.0).
  warnings.warn(
0  # enqueued parameter is suggested
```


## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

## Description of the changes
<!-- Describe the changes in this PR. -->
