### PR TITLE
Allow `fail_state_trials` show warning when heartbeat is enabled

### DIFF
--- a/optuna/study/_optimize.py
+++ b/optuna/study/_optimize.py
@@ -187,8 +187,7 @@ def _run_trial(
     func: "optuna.study.study.ObjectiveFuncType",
     catch: Tuple[Type[Exception], ...],
 ) -> trial_module.Trial:
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", ExperimentalWarning)
+    if study._storage.is_heartbeat_enabled():
         optuna.storages.fail_stale_trials(study)
 
     trial = study.ask()

--- a/optuna/study/_optimize.py
+++ b/optuna/study/_optimize.py
@@ -29,7 +29,6 @@ from optuna import logging
 from optuna import progress_bar as pbar_module
 from optuna import storages
 from optuna import trial as trial_module
-from optuna.exceptions import ExperimentalWarning
 from optuna.trial import FrozenTrial
 from optuna.trial import TrialState
 


### PR DESCRIPTION
In the current latest alpha release, the same warning message is displayed repeatedly, which is not intentional.
This behavior seemingly comes from the known issue of `warnings.catch_warnings`, which was reported in https://bugs.python.org/issue29672.

Invoking `warnings.catch_warnings` has a side-effect, and it would be better not to invoke it for not only Optuna but also the library users. So, in this PR, I remove `catch_warnings` in `_run_trial` and check if heartbeat is enabled by the user instead.

## Motivation
Stop showing a warning repeatedly.

## Description of the changes
- ecb80fb remove `catch_warnings` and check if heartbeat is enabled
- 9e2bea9 flake8 fix (remove unused import)

```python
import optuna


def objective(trial):
    return trial.suggest_float("x", 0, 1)


study = optuna.create_study()
study.optimize(objective, n_trials=5)
```


### Before

```
> python tmp/optimize_test.py                                                                                                                                                                                                          2022-02-09 12:11:42
[I 2022-02-09 12:11:45,937] A new study created in memory with name: no-name-47406b8b-8af8-40b1-9c90-d9cb1e2a8d42
/Users/himkt/work/github.com/himkt/optuna/optuna/trial/_trial.py:169: FutureWarning: UniformDistribution has been deprecated in v3.0.0. This feature will be removed in v6.0.0. See https://github.com/optuna/optuna/releases/tag/v3.0.0. Use :class:`~optuna.distributions.FloatDistribution` instead.
  distribution = UniformDistribution(low=low, high=high)
[I 2022-02-09 12:11:45,939] Trial 0 finished with value: 0.7981646615533516 and parameters: {'x': 0.7981646615533516}. Best is trial 0 with value: 0.7981646615533516.
/Users/himkt/work/github.com/himkt/optuna/optuna/trial/_trial.py:169: FutureWarning: UniformDistribution has been deprecated in v3.0.0. This feature will be removed in v6.0.0. See https://github.com/optuna/optuna/releases/tag/v3.0.0. Use :class:`~optuna.distributions.FloatDistribution` instead.
  distribution = UniformDistribution(low=low, high=high)
[I 2022-02-09 12:11:45,939] Trial 1 finished with value: 0.7292757393008622 and parameters: {'x': 0.7292757393008622}. Best is trial 1 with value: 0.7292757393008622.
/Users/himkt/work/github.com/himkt/optuna/optuna/trial/_trial.py:169: FutureWarning: UniformDistribution has been deprecated in v3.0.0. This feature will be removed in v6.0.0. See https://github.com/optuna/optuna/releases/tag/v3.0.0. Use :class:`~optuna.distributions.FloatDistribution` instead.
  distribution = UniformDistribution(low=low, high=high)
[I 2022-02-09 12:11:45,959] Trial 2 finished with value: 0.4639811119742068 and parameters: {'x': 0.4639811119742068}. Best is trial 2 with value: 0.4639811119742068.
/Users/himkt/work/github.com/himkt/optuna/optuna/trial/_trial.py:169: FutureWarning: UniformDistribution has been deprecated in v3.0.0. This feature will be removed in v6.0.0. See https://github.com/optuna/optuna/releases/tag/v3.0.0. Use :class:`~optuna.distributions.FloatDistribution` instead.
  distribution = UniformDistribution(low=low, high=high)
[I 2022-02-09 12:11:45,974] Trial 3 finished with value: 0.9529777145282745 and parameters: {'x': 0.9529777145282745}. Best is trial 2 with value: 0.4639811119742068.
/Users/himkt/work/github.com/himkt/optuna/optuna/trial/_trial.py:169: FutureWarning: UniformDistribution has been deprecated in v3.0.0. This feature will be removed in v6.0.0. See https://github.com/optuna/optuna/releases/tag/v3.0.0. Use :class:`~optuna.distributions.FloatDistribution` instead.
  distribution = UniformDistribution(low=low, high=high)
[I 2022-02-09 12:11:45,975] Trial 4 finished with value: 0.5049101745390385 and parameters: {'x': 0.5049101745390385}. Best is trial 2 with value: 0.4639811119742068.
```


### After

```
> python tmp/optimize_test.py                                                                                                                                                                                                          2022-02-09 12:11:35
[I 2022-02-09 12:11:39,216] A new study created in memory with name: no-name-76610cf6-85f2-42da-aabb-51442d6e6c4e
/Users/himkt/work/github.com/himkt/optuna/optuna/trial/_trial.py:169: FutureWarning: UniformDistribution has been deprecated in v3.0.0. This feature will be removed in v6.0.0. See https://github.com/optuna/optuna/releases/tag/v3.0.0. Use :class:`~optuna.distributions.FloatDistribution` instead.
  distribution = UniformDistribution(low=low, high=high)
[I 2022-02-09 12:11:39,221] Trial 0 finished with value: 0.12598191592979535 and parameters: {'x': 0.12598191592979535}. Best is trial 0 with value: 0.12598191592979535.
[I 2022-02-09 12:11:39,222] Trial 1 finished with value: 0.5999996391722033 and parameters: {'x': 0.5999996391722033}. Best is trial 0 with value: 0.12598191592979535.
[I 2022-02-09 12:11:39,223] Trial 2 finished with value: 0.9303211620451699 and parameters: {'x': 0.9303211620451699}. Best is trial 0 with value: 0.12598191592979535.
[I 2022-02-09 12:11:39,224] Trial 3 finished with value: 0.9111266953883 and parameters: {'x': 0.9111266953883}. Best is trial 0 with value: 0.12598191592979535.
[I 2022-02-09 12:11:39,224] Trial 4 finished with value: 0.9499001545534816 and parameters: {'x': 0.9499001545534816}. Best is trial 0 with value: 0.12598191592979535.
```