### PR TITLE
Add description field for question-and-help-support

### DIFF
--- a/.github/ISSUE_TEMPLATE/questions-help-support.yml
+++ b/.github/ISSUE_TEMPLATE/questions-help-support.yml
@@ -28,6 +28,14 @@ body:
     validations:
       required: true
   - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: |
+        Please describe your question.
+    validations:
+      required: true
+  - type: textarea
     id: logs
     attributes:
       label: Error messages, stack traces, or logs


### PR DESCRIPTION
I propose to add a field for describing the question to question-and-help-support.

Preview:

<img width="900" alt="Screen Shot 2022-02-09 at 21 49 34" src="https://user-images.githubusercontent.com/5164000/153204400-488584ef-2f16-4d6d-b852-5a10ec4731f6.png">
