### PR TITLE
Add note to recommend Python3.8 or later in documentation build with artifacts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,7 +107,7 @@ To avoid having to run the tutorials, you may download executed tutorial artifac
 extracting the files in the zip to `docs/source/tutorial` directory.
 Note that the CI runs with Python 3.8 and the generated artifacts contain pickle files.
 The pickle files are serialized with [the protocol version 5](https://docs.python.org/3/library/pickle.html#data-stream-format) so you will see the error with Python 3.7 or older.
-Please use Python3.8 or later if you want to build the documentation with artifacts.
+Please use Python 3.8 or later if you build the documentation with artifacts.
 
 ![image](https://user-images.githubusercontent.com/16191443/107472296-0b211400-6bb2-11eb-9203-e2c42ce499ad.png)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,7 +106,7 @@ Whether you edit any tutorial or not doesn't matter.
 To avoid having to run the tutorials, you may download executed tutorial artifacts named "tutorial" from our CI (see the capture below) and put them in `docs/build` before
 extracting the files in the zip to `docs/source/tutorial` directory.
 Note that the CI runs with Python 3.8 and the generated artifacts contain pickle files.
-The artifacts are serialized with [the protocol version 5](https://docs.python.org/3/library/pickle.html#data-stream-format) so you will see the error with Python 3.7 or older.
+The pickle files are serialized with [the protocol version 5](https://docs.python.org/3/library/pickle.html#data-stream-format) so you will see the error with Python 3.7 or older.
 Please use Python3.8 or later if you want to build the documentation with artifacts.
 
 ![image](https://user-images.githubusercontent.com/16191443/107472296-0b211400-6bb2-11eb-9203-e2c42ce499ad.png)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,6 +105,9 @@ Whether you edit any tutorial or not doesn't matter.
 
 To avoid having to run the tutorials, you may download executed tutorial artifacts named "tutorial" from our CI (see the capture below) and put them in `docs/build` before
 extracting the files in the zip to `docs/source/tutorial` directory.
+Note that the CI runs with Python 3.8 and the generated artifacts contain pickle files.
+The artifacts are serialized with [the protocol version 5](https://docs.python.org/3/library/pickle.html#data-stream-format) so you will see the error with Python 3.7 or older.
+Please use Python3.8 or later if you want to build the documentation with artifacts.
 
 ![image](https://user-images.githubusercontent.com/16191443/107472296-0b211400-6bb2-11eb-9203-e2c42ce499ad.png)
 


### PR DESCRIPTION
🔗 https://github.com/optuna/optuna/issues/3250

I added the note that suggests Python3.8 or later for building the documentation if a contributor wants to use uploaded artifacts.