### PR TITLE
Clip untransformed values sampled from int uniform distributions

### DIFF
--- a/optuna/_transform.py
+++ b/optuna/_transform.py
@@ -319,7 +319,7 @@ def _untransform_numerical_param(
     elif isinstance(d, DiscreteUniformDistribution):
         # Clip since result may slightly exceed range due to round-off errors.
         param = float(
-            min(max(numpy.round((trans_param - d.low) / d.q) * d.q + d.low, d.low), d.high)
+            numpy.clip(numpy.round((trans_param - d.low) / d.q) * d.q + d.low, d.low, d.high)
         )
     elif isinstance(d, FloatDistribution):
         if d.log:
@@ -330,9 +330,8 @@ def _untransform_numerical_param(
                 param = min(param, numpy.nextafter(d.high, d.high - 1))
         elif d.step is not None:
             param = float(
-                min(
-                    max(numpy.round((trans_param - d.low) / d.step) * d.step + d.low, d.low),
-                    d.high,
+                numpy.clip(
+                    numpy.round((trans_param - d.low) / d.step) * d.step + d.low, d.low, d.high
                 )
             )
         else:
@@ -341,20 +340,26 @@ def _untransform_numerical_param(
             else:
                 param = min(trans_param, numpy.nextafter(d.high, d.high - 1))
     elif isinstance(d, IntUniformDistribution):
-        param = int(numpy.clip(numpy.round((trans_param - d.low) / d.step) * d.step + d.low, d.low, d.high))
+        param = int(
+            numpy.clip(numpy.round((trans_param - d.low) / d.step) * d.step + d.low, d.low, d.high)
+        )
     elif isinstance(d, IntLogUniformDistribution):
         if transform_log:
-            param = int(min(max(numpy.round(math.exp(trans_param)), d.low), d.high))
+            param = int(numpy.clip(numpy.round(math.exp(trans_param)), d.low, d.high))
         else:
             param = int(trans_param)
     elif isinstance(d, IntDistribution):
         if d.log:
             if transform_log:
-                param = int(min(max(numpy.round(math.exp(trans_param)), d.low), d.high))
+                param = int(numpy.clip(numpy.round(math.exp(trans_param)), d.low, d.high))
             else:
                 param = int(trans_param)
         else:
-            param = int(numpy.clip(numpy.round((trans_param - d.low) / d.step) * d.step + d.low, d.low, d.high))
+            param = int(
+                numpy.clip(
+                    numpy.round((trans_param - d.low) / d.step) * d.step + d.low, d.low, d.high
+                )
+            )
     else:
         assert False, "Should not reach. Unexpected distribution."
 

--- a/optuna/_transform.py
+++ b/optuna/_transform.py
@@ -341,9 +341,7 @@ def _untransform_numerical_param(
             else:
                 param = min(trans_param, numpy.nextafter(d.high, d.high - 1))
     elif isinstance(d, IntUniformDistribution):
-        param = int(
-            min(max(numpy.round((trans_param - d.low) / d.step) * d.step + d.low, d.low), d.high)
-        )
+        param = int(numpy.clip(numpy.round((trans_param - d.low) / d.step) * d.step + d.low, d.low, d.high))
     elif isinstance(d, IntLogUniformDistribution):
         if transform_log:
             param = int(min(max(numpy.round(math.exp(trans_param)), d.low), d.high))

--- a/optuna/_transform.py
+++ b/optuna/_transform.py
@@ -354,12 +354,7 @@ def _untransform_numerical_param(
             else:
                 param = int(trans_param)
         else:
-            param = int(
-                min(
-                    max(numpy.round((trans_param - d.low) / d.step) * d.step + d.low, d.low),
-                    d.high,
-                )
-            )
+            param = int(numpy.clip(numpy.round((trans_param - d.low) / d.step) * d.step + d.low, d.low, d.high))
     else:
         assert False, "Should not reach. Unexpected distribution."
 

--- a/optuna/_transform.py
+++ b/optuna/_transform.py
@@ -341,7 +341,9 @@ def _untransform_numerical_param(
             else:
                 param = min(trans_param, numpy.nextafter(d.high, d.high - 1))
     elif isinstance(d, IntUniformDistribution):
-        param = int(numpy.round((trans_param - d.low) / d.step) * d.step + d.low)
+        param = int(
+            min(max(numpy.round((trans_param - d.low) / d.step) * d.step + d.low, d.low), d.high)
+        )
     elif isinstance(d, IntLogUniformDistribution):
         if transform_log:
             param = int(min(max(numpy.round(math.exp(trans_param)), d.low), d.high))
@@ -354,7 +356,12 @@ def _untransform_numerical_param(
             else:
                 param = int(trans_param)
         else:
-            param = int(numpy.round((trans_param - d.low) / d.step) * d.step + d.low)
+            param = int(
+                min(
+                    max(numpy.round((trans_param - d.low) / d.step) * d.step + d.low, d.low),
+                    d.high,
+                )
+            )
     else:
         assert False, "Should not reach. Unexpected distribution."
 

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -266,7 +266,7 @@ def test_transform_untransform_params_at_bounds(
 
     trans = _SearchSpaceTransform({"x0": distribution}, transform_log, transform_step)
 
-    # Manually crete round-off errors.
+    # Manually create round-off errors.
     lower_bound = trans.bounds[0][0] - EPS
     upper_bound = trans.bounds[0][1] + EPS
 


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

Resolve #3316 

## Description of the changes
<!-- Describe the changes in this PR. -->

- Apply `DiscreteUniformDistribution`'s un-transformation logic to the values sampled from `IntUniform`.
- Define a new test function in https://github.com/optuna/optuna/blob/master/tests/test_transform.py to check untransformation with clip operation
- ~Use `clip` instead of `min` and `max` for simplexity~: mypy was unhappy with this.
