### PR TITLE
Merge `set_trial_state()` and `set_trial_values()` into one  function

### DIFF
--- a/optuna/storages/_base.py
+++ b/optuna/storages/_base.py
@@ -334,31 +334,6 @@ class BaseStorage(object, metaclass=abc.ABCMeta):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def set_trial_state(self, trial_id: int, state: TrialState) -> bool:
-        """Update the state of a trial.
-
-        Args:
-            trial_id:
-                ID of the trial.
-            state:
-                New state of the trial.
-
-        Returns:
-            :obj:`True` if the state is successfully updated.
-            :obj:`False` if the state is kept the same.
-            The latter happens when this method tries to update the state of
-            :obj:`~optuna.trial.TrialState.RUNNING` trial to
-            :obj:`~optuna.trial.TrialState.RUNNING`.
-
-        Raises:
-            :exc:`KeyError`:
-                If no trial with the matching ``trial_id`` exists.
-            :exc:`RuntimeError`:
-                If the trial is already finished.
-        """
-        raise NotImplementedError
-
-    @abc.abstractmethod
     def set_trial_param(
         self,
         trial_id: int,
@@ -445,16 +420,28 @@ class BaseStorage(object, metaclass=abc.ABCMeta):
         return trial.distributions[param_name].to_internal_repr(trial.params[param_name])
 
     @abc.abstractmethod
-    def set_trial_values(self, trial_id: int, values: Sequence[float]) -> None:
-        """Set return values of an objective function.
+    def set_trial_state_values(
+        self, trial_id: int, state: TrialState, values: Optional[Sequence[float]] = None
+    ) -> bool:
+        """Update the state and values of a trial.
 
-        This method overwrites any existing trial values.
+        Set return values of an objective function to values argument.
+        If values argument is not :obj:`None`, this method overwrites any existing trial values.
 
         Args:
             trial_id:
                 ID of the trial.
+            state:
+                New state of the trial.
             values:
                 Values of the objective function.
+
+        Returns:
+            :obj:`True` if the state is successfully updated.
+            :obj:`False` if the state is kept the same.
+            The latter happens when this method tries to update the state of
+            :obj:`~optuna.trial.TrialState.RUNNING` trial to
+            :obj:`~optuna.trial.TrialState.RUNNING`.
 
         Raises:
             :exc:`KeyError`:

--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -669,10 +669,7 @@ class Study:
         except Exception:
             raise
         finally:
-            if values is not None:
-                self._storage.set_trial_values(trial_id, values)
-
-            self._storage.set_trial_state(trial_id, state)
+            self._storage.set_trial_state_values(trial_id, state, values)
 
     def set_user_attr(self, key: str, value: Any) -> None:
         """Set a user attribute to the study.
@@ -1007,7 +1004,7 @@ class Study:
         for trial in self._storage.get_all_trials(
             self._study_id, deepcopy=False, states=(TrialState.WAITING,)
         ):
-            if not self._storage.set_trial_state(trial._trial_id, TrialState.RUNNING):
+            if not self._storage.set_trial_state_values(trial._trial_id, state=TrialState.RUNNING):
                 continue
 
             _logger.debug("Trial {} popped from the trial queue.".format(trial.number))

--- a/optuna/testing/integration.py
+++ b/optuna/testing/integration.py
@@ -14,5 +14,6 @@ class DeterministicPruner(optuna.pruners.BasePruner):
 def create_running_trial(study: "optuna.study.Study", value: float) -> optuna.trial.Trial:
 
     trial_id = study._storage.create_new_trial(study._study_id)
-    study._storage.set_trial_values(trial_id, [value])
+    trial = study._storage.get_trial(trial_id)
+    study._storage.set_trial_state_values(trial_id, state=trial.state, values=[value])
     return optuna.trial.Trial(study, trial_id)

--- a/optuna/testing/storage.py
+++ b/optuna/testing/storage.py
@@ -4,6 +4,7 @@ from typing import Any
 from typing import IO
 from typing import Optional
 from typing import Type
+from typing import Union
 
 import fakeredis
 
@@ -35,7 +36,14 @@ class StorageSupplier(object):
         self.tempfile: Optional[IO[Any]] = None
         self.extra_args = kwargs
 
-    def __enter__(self) -> optuna.storages.BaseStorage:
+    def __enter__(
+        self,
+    ) -> Union[
+        optuna.storages.InMemoryStorage,
+        optuna.storages._CachedStorage,
+        optuna.storages.RDBStorage,
+        optuna.storages.RedisStorage,
+    ]:
 
         if self.storage_specifier == "inmemory":
             if len(self.extra_args) > 0:

--- a/tests/pruners_tests/test_percentile.py
+++ b/tests/pruners_tests/test_percentile.py
@@ -186,7 +186,7 @@ def test_get_percentile_intermediate_result_over_trials() -> None:
 
         # Set trial states complete because this method ignores incomplete trials.
         for trial_id in trial_ids:
-            _study._storage.set_trial_state(trial_id, TrialState.COMPLETE)
+            _study._storage.set_trial_state_values(trial_id, state=TrialState.COMPLETE)
 
         return _study
 

--- a/tests/storages_tests/test_cached_storage.py
+++ b/tests/storages_tests/test_cached_storage.py
@@ -28,12 +28,12 @@ def test_create_trial() -> None:
     storage.create_new_trial(study_id)
 
 
-def test_set_trial_state() -> None:
+def test_set_trial_state_values() -> None:
     base_storage = RDBStorage("sqlite:///:memory:")
     storage = _CachedStorage(base_storage)
     study_id = storage.create_new_study("test-study")
     trial_id = storage.create_new_trial(study_id)
-    storage.set_trial_state(trial_id, TrialState.COMPLETE)
+    storage.set_trial_state_values(trial_id, state=TrialState.COMPLETE)
 
     cached_trial = storage.get_trial(trial_id)
     base_trial = base_storage.get_trial(trial_id)
@@ -54,8 +54,9 @@ def test_uncached_set() -> None:
     study_id = storage.create_new_study("test-study")
 
     trial_id = storage.create_new_trial(study_id)
-    with patch.object(base_storage, "set_trial_values", return_value=True) as set_mock:
-        storage.set_trial_values(trial_id, (0.3,))
+    trial = storage.get_trial(trial_id)
+    with patch.object(base_storage, "set_trial_state_values", return_value=True) as set_mock:
+        storage.set_trial_state_values(trial_id, state=trial.state, values=(0.3,))
         assert set_mock.call_count == 1
 
     trial_id = storage.create_new_trial(study_id)
@@ -76,8 +77,8 @@ def test_uncached_set() -> None:
 
     for state in [TrialState.COMPLETE, TrialState.PRUNED, TrialState.FAIL, TrialState.WAITING]:
         trial_id = storage.create_new_trial(study_id)
-        with patch.object(base_storage, "set_trial_state", return_value=True) as set_mock:
-            storage.set_trial_state(trial_id, state)
+        with patch.object(base_storage, "set_trial_state_values", return_value=True) as set_mock:
+            storage.set_trial_state_values(trial_id, state=state)
             assert set_mock.call_count == 1
 
     trial_id = storage.create_new_trial(study_id)

--- a/tests/storages_tests/test_storages.py
+++ b/tests/storages_tests/test_storages.py
@@ -448,6 +448,9 @@ def test_set_trial_state(storage_mode: str) -> None:
 
     with StorageSupplier(storage_mode) as storage:
 
+        if isinstance(storage, (InMemoryStorage, _CachedStorage)):
+            pytest.skip("InMemoryStorage and _CachedStorage does not have set_trial_state()")
+            return  # needed for mypy
         study_id = storage.create_new_study()
         trial_ids = [storage.create_new_trial(study_id) for _ in ALL_STATES]
 
@@ -478,6 +481,42 @@ def test_set_trial_state(storage_mode: str) -> None:
                 # Cannot update states of finished trials.
                 with pytest.raises(RuntimeError):
                     storage.set_trial_state(trial_id, state2)
+
+
+@pytest.mark.parametrize("storage_mode", STORAGE_MODES)
+def test_set_trial_state_values_for_state(storage_mode: str) -> None:
+
+    with StorageSupplier(storage_mode) as storage:
+
+        study_id = storage.create_new_study()
+        trial_ids = [storage.create_new_trial(study_id) for _ in ALL_STATES]
+
+        for trial_id, state in zip(trial_ids, ALL_STATES):
+            if state == TrialState.WAITING:
+                continue
+            assert storage.get_trial(trial_id).state == TrialState.RUNNING
+            datetime_start_prev = storage.get_trial(trial_id).datetime_start
+            storage.set_trial_state_values(
+                trial_id, state=state, values=(0.0,) if state.is_finished() else None
+            )
+            assert storage.get_trial(trial_id).state == state
+            # Repeated state changes to RUNNING should not trigger further datetime_start changes.
+            if state == TrialState.RUNNING:
+                assert storage.get_trial(trial_id).datetime_start == datetime_start_prev
+            if state.is_finished():
+                assert storage.get_trial(trial_id).datetime_complete is not None
+            else:
+                assert storage.get_trial(trial_id).datetime_complete is None
+
+        for state in ALL_STATES:
+            if not state.is_finished():
+                continue
+            trial_id = storage.create_new_trial(study_id)
+            storage.set_trial_state_values(trial_id, state=state, values=(0.0,))
+            for state2 in ALL_STATES:
+                # Cannot update states of finished trials.
+                with pytest.raises(RuntimeError):
+                    storage.set_trial_state_values(trial_id, state=state2)
 
 
 @pytest.mark.parametrize("storage_mode", STORAGE_MODES)
@@ -556,7 +595,7 @@ def test_set_trial_param(storage_mode: str) -> None:
                 trial_id_2, "y", 2, CategoricalDistribution(choices=("Meguro", "Shibuya", "Ebisu"))
             )
 
-        storage.set_trial_state(trial_id_2, TrialState.COMPLETE)
+        storage.set_trial_state_values(trial_id_2, state=TrialState.COMPLETE)
         # Cannot assign params to finished trial.
         with pytest.raises(RuntimeError):
             storage.set_trial_param(trial_id_2, "y", 2, distribution_y_1)
@@ -584,6 +623,9 @@ def test_set_trial_values(storage_mode: str) -> None:
 
     with StorageSupplier(storage_mode) as storage:
 
+        if isinstance(storage, (InMemoryStorage, _CachedStorage)):
+            pytest.skip("InMemoryStorage and _CachedStorage does not have set_trial_values()")
+            return  # needed for mypy
         # Setup test across multiple studies and trials.
         study_id = storage.create_new_study()
         trial_id_1 = storage.create_new_trial(study_id)
@@ -619,6 +661,48 @@ def test_set_trial_values(storage_mode: str) -> None:
 
 
 @pytest.mark.parametrize("storage_mode", STORAGE_MODES)
+def test_set_trial_state_values_for_values(storage_mode: str) -> None:
+
+    with StorageSupplier(storage_mode) as storage:
+
+        # Setup test across multiple studies and trials.
+        study_id = storage.create_new_study()
+        trial_id_1 = storage.create_new_trial(study_id)
+        trial_id_2 = storage.create_new_trial(study_id)
+        trial_id_3 = storage.create_new_trial(storage.create_new_study())
+        trial_id_4 = storage.create_new_trial(study_id)
+        trial_id_5 = storage.create_new_trial(study_id)
+
+        # Test setting new value.
+        storage.set_trial_state_values(trial_id_1, state=TrialState.COMPLETE, values=(0.5,))
+        storage.set_trial_state_values(
+            trial_id_3, state=TrialState.COMPLETE, values=(float("inf"),)
+        )
+        storage.set_trial_state_values(
+            trial_id_4, state=TrialState.WAITING, values=(0.1, 0.2, 0.3)
+        )
+        storage.set_trial_state_values(
+            trial_id_5, state=TrialState.WAITING, values=[0.1, 0.2, 0.3]
+        )
+
+        assert storage.get_trial(trial_id_1).value == 0.5
+        assert storage.get_trial(trial_id_2).value is None
+        assert storage.get_trial(trial_id_3).value == float("inf")
+        assert storage.get_trial(trial_id_4).values == [0.1, 0.2, 0.3]
+        assert storage.get_trial(trial_id_5).values == [0.1, 0.2, 0.3]
+
+        non_existent_trial_id = max(trial_id_1, trial_id_2, trial_id_3, trial_id_4, trial_id_5) + 1
+        with pytest.raises(KeyError):
+            storage.set_trial_state_values(
+                non_existent_trial_id, state=TrialState.COMPLETE, values=(1,)
+            )
+
+        # Cannot change values of finished trials.
+        with pytest.raises(RuntimeError):
+            storage.set_trial_state_values(trial_id_1, state=TrialState.COMPLETE, values=(1,))
+
+
+@pytest.mark.parametrize("storage_mode", STORAGE_MODES)
 def test_set_trial_intermediate_value(storage_mode: str) -> None:
 
     with StorageSupplier(storage_mode) as storage:
@@ -648,7 +732,7 @@ def test_set_trial_intermediate_value(storage_mode: str) -> None:
         with pytest.raises(KeyError):
             storage.set_trial_intermediate_value(non_existent_trial_id, 0, 0.2)
 
-        storage.set_trial_state(trial_id_1, TrialState.COMPLETE)
+        storage.set_trial_state_values(trial_id_1, state=TrialState.COMPLETE)
         # Cannot change values of finished trials.
         with pytest.raises(RuntimeError):
             storage.set_trial_intermediate_value(trial_id_1, 0, 0.2)
@@ -701,7 +785,7 @@ def test_set_trial_user_attr(storage_mode: str) -> None:
             storage.set_trial_user_attr(non_existent_trial_id, "key", "value")
 
         # Cannot set attributes of finished trials.
-        storage.set_trial_state(trial_id_1, TrialState.COMPLETE)
+        storage.set_trial_state_values(trial_id_1, state=TrialState.COMPLETE)
         with pytest.raises(RuntimeError):
             storage.set_trial_user_attr(trial_id_1, "key", "value")
 
@@ -755,7 +839,7 @@ def test_set_trial_system_attr(storage_mode: str) -> None:
             storage.set_trial_system_attr(non_existent_trial_id, "key", "value")
 
         # Cannot set attributes of finished trials.
-        storage.set_trial_state(trial_id_1, TrialState.COMPLETE)
+        storage.set_trial_state_values(trial_id_1, state=TrialState.COMPLETE)
         with pytest.raises(RuntimeError):
             storage.set_trial_system_attr(trial_id_1, "key", "value")
 

--- a/tests/storages_tests/test_with_server.py
+++ b/tests/storages_tests/test_with_server.py
@@ -10,6 +10,7 @@ import pytest
 import optuna
 from optuna.storages import RDBStorage
 from optuna.storages import RedisStorage
+from optuna.trial import TrialState
 
 
 _STUDY_NAME = "_test_multiprocess"
@@ -52,7 +53,7 @@ def storage_url() -> str:
 
 def _check_trials(trials: Sequence[optuna.trial.FrozenTrial]) -> None:
     # Check trial states.
-    assert all(trial.state == optuna.trial.TrialState.COMPLETE for trial in trials)
+    assert all(trial.state == TrialState.COMPLETE for trial in trials)
 
     # Check trial values and params.
     assert all("x" in trial.params for trial in trials)
@@ -130,7 +131,7 @@ def test_store_infinite_values(input: float, expected: float, storage_url: str) 
     study_id = storage.create_new_study()
     trial_id = storage.create_new_trial(study_id)
     storage.set_trial_intermediate_value(trial_id, 1, input)
-    storage.set_trial_values(trial_id, (input,))
+    storage.set_trial_state_values(trial_id, state=TrialState.COMPLETE, values=(input,))
     assert storage.get_trial(trial_id).value == expected
     assert storage.get_trial(trial_id).intermediate_values[1] == expected
 


### PR DESCRIPTION
## Motivation
In `tell()` of `Study` class, there is trailing code.

```
    if values is not None:
        self._storage.set_trial_values(trial_id, values)

    self._storage.set_trial_state(trial_id, state)
```

Consider process A is running ask-and-tell, process B is getting trial information by `study.get_trials()`. There are 3 steps at this code.

At step 1 of process A, process B get state=`TrialState.RUNNING`, value=`None`.
At step 2 of process A, process B get state=`TrialState.RUNNING`, value!=`None`.
At step 3 of process A, process B get state=`TrialState.COMPLETE`, value!=`None`.

```
    #step 1

    if values is not None:
        self._storage.set_trial_values(trial_id, values)

    #step 2

    self._storage.set_trial_state(trial_id, state)

    #step 3
```

We can get state=`TrialState.RUNNING`, value!=`None` at step 2 unexpectedly. It breaks consistency of trials because we expects only these combinations.
   - state=`TrialState.RUNNING`, value=`None`
   - state=`TrialState.COMPLETE`, value!=`None`

This issue is reported by @not522 in https://github.com/optuna/optuna/issues/2943#issuecomment-997744058.

## Description of the changes
To resolve the issue, this patch merges `set_trial_state()` and `set_trial_values()` into one function. To keep backward compatibility, we leaved `set_trial_state()` and `set_trial_values()` as deprecated.

