### PR TITLE
Follow up for {Float, Int} distributions

### DIFF
--- a/optuna/distributions.py
+++ b/optuna/distributions.py
@@ -137,14 +137,14 @@ class FloatDistribution(BaseDistribution):
         self, low: float, high: float, log: bool = False, step: Union[None, float] = None
     ) -> None:
 
+        if log and step is not None:
+            raise ValueError("The parameter `step` is not supported when `log` is true.")
+
         if low > high:
             raise ValueError(
                 "The `low` value must be smaller than or equal to the `high` value "
                 "(low={}, high={}).".format(low, high)
             )
-
-        if log and step is not None:
-            raise ValueError("The parameter `step` is not supported when `log` is true.")
 
         if log and low <= 0.0:
             raise ValueError(
@@ -335,6 +335,13 @@ class IntDistribution(BaseDistribution):
     """
 
     def __init__(self, low: int, high: int, log: bool = False, step: int = 1) -> None:
+
+        if log and step != 1:
+            raise ValueError(
+                "Samplers and other components in Optuna only accept step is 1 "
+                "when `log` argument is True."
+            )
+
         if low > high:
             raise ValueError(
                 "The `low` value must be smaller than or equal to the `high` value "
@@ -350,12 +357,6 @@ class IntDistribution(BaseDistribution):
         if step <= 0:
             raise ValueError(
                 "The `step` value must be non-zero positive value, but step={}.".format(step)
-            )
-
-        if log and step != 1:
-            raise ValueError(
-                "Samplers and other components in Optuna only accept step is 1 "
-                "when `log` argument is True."
             )
 
         self.log = log

--- a/tests/integration_tests/test_chainermn.py
+++ b/tests/integration_tests/test_chainermn.py
@@ -317,7 +317,7 @@ class TestChainerMNTrial(object):
 
     @staticmethod
     @pytest.mark.parametrize("storage_mode", STORAGE_MODES)
-    def test_suggest_discrete_uniform(storage_mode: str, comm: CommunicatorBase) -> None:
+    def test_suggest_float_with_step(storage_mode: str, comm: CommunicatorBase) -> None:
 
         with MultiNodeStorageSupplier(storage_mode, comm) as storage:
             study = TestChainerMNStudy._create_shared_study(storage, comm)

--- a/tests/samplers_tests/tpe_tests/test_multi_objective_sampler.py
+++ b/tests/samplers_tests/tpe_tests/test_multi_objective_sampler.py
@@ -359,6 +359,7 @@ def test_multi_objective_sample_independent_categorical_distributions() -> None:
     "log, step",
     [
         (False, 1),
+        (True, 1),
         (False, 2),
     ],
 )
@@ -369,7 +370,7 @@ def test_multi_objective_sample_int_distributions(log: bool, step: int) -> None:
     random.seed(128)
 
     def int_value_fn(idx: int) -> float:
-        return random.randint(0, 100)
+        return random.randint(1, 100)
 
     int_dist = optuna.distributions.IntDistribution(1, 100, log, step)
     past_trials = [
@@ -379,7 +380,7 @@ def test_multi_objective_sample_int_distributions(log: bool, step: int) -> None:
         for i in range(16)
     ]
 
-    trial = frozen_trial_factory(16, [0, 0])
+    trial = frozen_trial_factory(16, [1, 1])
     sampler = TPESampler(seed=0)
     attrs = MockSystemAttr()
     with patch.object(study._storage, "get_all_trials", return_value=past_trials), patch.object(

--- a/tests/samplers_tests/tpe_tests/test_multi_objective_sampler.py
+++ b/tests/samplers_tests/tpe_tests/test_multi_objective_sampler.py
@@ -378,7 +378,7 @@ def test_multi_objective_sample_int_distributions(log: bool, step: int) -> None:
         for i in range(16)
     ]
 
-    trial = frozen_trial_factory(16, [1, 1])
+    trial = frozen_trial_factory(16, [0, 0])
     sampler = TPESampler(seed=0)
     attrs = MockSystemAttr()
     with patch.object(study._storage, "get_all_trials", return_value=past_trials), patch.object(

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -248,6 +248,11 @@ def test_empty_range_contains() -> None:
     assert iq._contains(1)
     assert not iq._contains(2)
 
+    il = distributions.IntDistribution(low=1, high=1, log=True)
+    assert not il._contains(0)
+    assert il._contains(1)
+    assert not il._contains(2)
+
     f = distributions.FloatDistribution(low=1.0, high=1.0)
     assert not f._contains(0.9)
     assert f._contains(1.0)
@@ -257,6 +262,11 @@ def test_empty_range_contains() -> None:
     assert not fd._contains(0.9)
     assert fd._contains(1.0)
     assert not fd._contains(1.1)
+
+    fl = distributions.FloatDistribution(low=1.0, high=1.0, log=True)
+    assert not fl._contains(0.9)
+    assert fl._contains(1.0)
+    assert not fl._contains(1.1)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Motivation
As mentioned in below comment, this is follow up PR relating to #3166.
https://github.com/optuna/optuna/pull/3166#issuecomment-1048607416

## Description of the changes

- [x] In `tests/integration_tests/test_chainermn.py`, renamed the test of `test_suggest_discrete_uniform` to `test_suggest_float_with_step`
- [x] Remove `UniformDistribution` appearance from `test_multi_objective_sample_independent_uniform_distributions` in `tests/samplers_tests/tpe_tests/test_multi_objective.py`. Also, similar tests are parametrized.
- [x] Parametrizing `test_multi_objective_sample_independent_int_distributions` in `tests/samplers_tests/tpe_tests/test_multi_objective.py`. 
- [x] Add tests for `FloatDistribution(log=True)` and `IntDistribution(log=True)` to `test_empty_range_contains` in `tests/test_distributions.py`.
- [x] Given distribution class will handle the error case "log=True & step" (while it was handled in `suggest_{int, float}()` before creating distribution), re-ordered the error handling to be consistent with what used to be. 