### PR TITLE
Move the get_trial_xxx abstract functions to base

### DIFF
--- a/optuna/storages/_base.py
+++ b/optuna/storages/_base.py
@@ -398,7 +398,6 @@ class BaseStorage(object, metaclass=abc.ABCMeta):
         """
         raise NotImplementedError
 
-    @abc.abstractmethod
     def get_trial_number_from_id(self, trial_id: int) -> int:
         """Read the trial number of a trial.
 
@@ -417,9 +416,8 @@ class BaseStorage(object, metaclass=abc.ABCMeta):
             :exc:`KeyError`:
                 If no trial with the matching ``trial_id`` exists.
         """
-        raise NotImplementedError
+        return self.get_trial(trial_id).number
 
-    @abc.abstractmethod
     def get_trial_param(self, trial_id: int, param_name: str) -> float:
         """Read the parameter of a trial.
 
@@ -437,7 +435,8 @@ class BaseStorage(object, metaclass=abc.ABCMeta):
                 If no trial with the matching ``trial_id`` exists.
                 If no such parameter exists.
         """
-        raise NotImplementedError
+        trial = self.get_trial(trial_id)
+        return trial.distributions[param_name].to_internal_repr(trial.params[param_name])
 
     @abc.abstractmethod
     def set_trial_values(self, trial_id: int, values: Sequence[float]) -> None:

--- a/optuna/storages/_cached_storage.py
+++ b/optuna/storages/_cached_storage.py
@@ -260,18 +260,9 @@ class _CachedStorage(BaseStorage):
         # TODO(hvy): Optimize to not issue a query to the backend storage.
         return self._backend.get_trial_id_from_study_id_trial_number(study_id, trial_number)
 
-    def get_trial_number_from_id(self, trial_id: int) -> int:
-
-        return self.get_trial(trial_id).number
-
     def get_best_trial(self, study_id: int) -> FrozenTrial:
 
         return self._backend.get_best_trial(study_id)
-
-    def get_trial_param(self, trial_id: int, param_name: str) -> float:
-
-        trial = self.get_trial(trial_id)
-        return trial.distributions[param_name].to_internal_repr(trial.params[param_name])
 
     def set_trial_values(self, trial_id: int, values: Sequence[float]) -> None:
 

--- a/optuna/storages/_in_memory.py
+++ b/optuna/storages/_in_memory.py
@@ -315,6 +315,14 @@ class InMemoryStorage(BaseStorage):
                 )
             return self.get_trial(best_trial_id)
 
+    def get_trial_param(self, trial_id: int, param_name: str) -> float:
+
+        with self._lock:
+            trial = self._get_trial(trial_id)
+
+            distribution = trial.distributions[param_name]
+            return distribution.to_internal_repr(trial.params[param_name])
+
     def set_trial_values(self, trial_id: int, values: Sequence[float]) -> None:
 
         with self._lock:

--- a/optuna/storages/_in_memory.py
+++ b/optuna/storages/_in_memory.py
@@ -294,6 +294,13 @@ class InMemoryStorage(BaseStorage):
 
             return trial._trial_id
 
+    def get_trial_number_from_id(self, trial_id: int) -> int:
+
+        with self._lock:
+            self._check_trial_id(trial_id)
+
+            return self._trial_id_to_study_id_and_number[trial_id][1]
+
     def get_best_trial(self, study_id: int) -> FrozenTrial:
 
         with self._lock:

--- a/optuna/storages/_in_memory.py
+++ b/optuna/storages/_in_memory.py
@@ -294,13 +294,6 @@ class InMemoryStorage(BaseStorage):
 
             return trial._trial_id
 
-    def get_trial_number_from_id(self, trial_id: int) -> int:
-
-        with self._lock:
-            self._check_trial_id(trial_id)
-
-            return self._trial_id_to_study_id_and_number[trial_id][1]
-
     def get_best_trial(self, study_id: int) -> FrozenTrial:
 
         with self._lock:
@@ -314,14 +307,6 @@ class InMemoryStorage(BaseStorage):
                     "Best trial can be obtained only for single-objective optimization."
                 )
             return self.get_trial(best_trial_id)
-
-    def get_trial_param(self, trial_id: int, param_name: str) -> float:
-
-        with self._lock:
-            trial = self._get_trial(trial_id)
-
-            distribution = trial.distributions[param_name]
-            return distribution.to_internal_repr(trial.params[param_name])
 
     def set_trial_values(self, trial_id: int, values: Sequence[float]) -> None:
 

--- a/optuna/storages/_rdb/storage.py
+++ b/optuna/storages/_rdb/storage.py
@@ -734,17 +734,6 @@ class RDBStorage(BaseStorage):
                 distribution_json=distributions.distribution_to_json(distribution),
             ).check_and_add(session)
 
-    def get_trial_param(self, trial_id: int, param_name: str) -> float:
-
-        with _create_scoped_session(self.scoped_session) as session:
-            trial = models.TrialModel.find_or_raise_by_id(trial_id, session)
-            trial_param = models.TrialParamModel.find_or_raise_by_trial_and_param_name(
-                trial, param_name, session
-            )
-            param_value = trial_param.param_value
-
-        return param_value
-
     @staticmethod
     def _ensure_numerical_limit(value: float) -> float:
 
@@ -877,11 +866,6 @@ class RDBStorage(BaseStorage):
                     )
                 )
             return trial_id[0]
-
-    def get_trial_number_from_id(self, trial_id: int) -> int:
-
-        trial_number = self.get_trial(trial_id).number
-        return trial_number
 
     def get_trial(self, trial_id: int) -> FrozenTrial:
 

--- a/optuna/storages/_rdb/storage.py
+++ b/optuna/storages/_rdb/storage.py
@@ -734,6 +734,17 @@ class RDBStorage(BaseStorage):
                 distribution_json=distributions.distribution_to_json(distribution),
             ).check_and_add(session)
 
+    def get_trial_param(self, trial_id: int, param_name: str) -> float:
+
+        with _create_scoped_session(self.scoped_session) as session:
+            trial = models.TrialModel.find_or_raise_by_id(trial_id, session)
+            trial_param = models.TrialParamModel.find_or_raise_by_trial_and_param_name(
+                trial, param_name, session
+            )
+            param_value = trial_param.param_value
+
+        return param_value
+
     @staticmethod
     def _ensure_numerical_limit(value: float) -> float:
 

--- a/optuna/storages/_redis.py
+++ b/optuna/storages/_redis.py
@@ -483,10 +483,6 @@ class RedisStorage(BaseStorage):
 
         return trial_ids[trial_number]
 
-    def get_trial_number_from_id(self, trial_id: int) -> int:
-
-        return self.get_trial(trial_id).number
-
     @staticmethod
     def _key_best_trial(study_id: int) -> str:
 
@@ -544,11 +540,6 @@ class RedisStorage(BaseStorage):
 
         self._check_study_id(study_id)
         self.set_trial_param(trial_id, param_name, param_value_internal, distribution)
-
-    def get_trial_param(self, trial_id: int, param_name: str) -> float:
-
-        distribution = self.get_trial(trial_id).distributions[param_name]
-        return distribution.to_internal_repr(self.get_trial(trial_id).params[param_name])
 
     def set_trial_values(self, trial_id: int, values: Sequence[float]) -> None:
 


### PR DESCRIPTION
## Motivation
This PR is a part of https://github.com/optuna/optuna/issues/2943 to move the `get_trial_xxx` abstract functions to base class so that user do not need to implement them again

## Details
The following functions are removed from each subclass, and implemented in the `BaseStorage` class
```
get_trial_number_from_id
get_trial_param
get_trial_params
```

## Note
The following implementations are preserved as they are optimized for performance

- `get_trial_param` in `rdb`
- `get_trial_number_from_id` in `n_memory`