### PR TITLE
Fix2940 multiobjective

### DIFF
--- a/optuna/visualization/_pareto_front.py
+++ b/optuna/visualization/_pareto_front.py
@@ -90,8 +90,6 @@ def plot_pareto_front(
     Raises:
         :exc:`ValueError`:
             If the number of objectives of ``study`` isn't 2 or 3.
-
-    See also
     """
 
     _imports.check()

--- a/optuna/visualization/_pareto_front.py
+++ b/optuna/visualization/_pareto_front.py
@@ -33,6 +33,9 @@ def plot_pareto_front(
 ) -> "go.Figure":
     """Plot the Pareto front of a study.
 
+    .. seealso::
+        Please refer to :ref:`multi_objective` for the tutorial of the Pareto front visuallization.
+
     Example:
 
         The following code snippet shows how to plot the Pareto front of a study.
@@ -87,6 +90,8 @@ def plot_pareto_front(
     Raises:
         :exc:`ValueError`:
             If the number of objectives of ``study`` isn't 2 or 3.
+
+    See also
     """
 
     _imports.check()

--- a/optuna/visualization/_pareto_front.py
+++ b/optuna/visualization/_pareto_front.py
@@ -34,7 +34,7 @@ def plot_pareto_front(
     """Plot the Pareto front of a study.
 
     .. seealso::
-        Please refer to :ref:`multi_objective` for the tutorial of the Pareto front visuallization.
+        Please refer to :ref:`multi_objective` for the tutorial of the Pareto front visualization.
 
     Example:
 


### PR DESCRIPTION
## Motivation
Partially fixed #2940.

## Description of the changes
`seealso` link which leads to [optuna tutorial link](https://optuna.readthedocs.io/en/stable/tutorial/20_recipes/002_multi_objective.html) is added respectively to the method `plot_pareto_front()` in `optuna/visualization/_pareto_front.py`.