### PR TITLE
add targets and deprecate axis_order in optuna.visualization.matplotlib.plot_pareto_front

### DIFF
--- a/optuna/visualization/matplotlib/_pareto_front.py
+++ b/optuna/visualization/matplotlib/_pareto_front.py
@@ -126,7 +126,7 @@ def plot_pareto_front(
                 " if your objective studies have more than 3 objectives."
             )
     target_values = [_targets(t) for t in trials]
-    if len(target_values) > 0 and not isinstance(target_values[0], collections.Sequence):
+    if len(target_values) > 0 and not isinstance(target_values[0], collections.abc.Sequence):
         raise ValueError(
             "`targets` should return a sequence of target values."
             " your `targets` returns {}".format(type(target_values[0]))

--- a/optuna/visualization/matplotlib/_pareto_front.py
+++ b/optuna/visualization/matplotlib/_pareto_front.py
@@ -83,22 +83,25 @@ def plot_pareto_front(
     _imports.check()
     if axis_order:
         warnings.warn(
-            "``axis_order`` option is deprecated."
-            " This feature will be removed in the future.",
+            "``axis_order`` option is deprecated. This feature will be removed in the future.",
             DeprecationWarning,
         )
     trials = _get_trials(study, include_dominated_trials)
     if targets is not None and axis_order is not None:
-        raise ValueError("Using both ``targets`` and ``axis_order`` is not supported. "
-                         " Use either `targets` or `axis_order`.")
+        raise ValueError(
+            "Using both ``targets`` and ``axis_order`` is not supported. "
+            " Use either `targets` or `axis_order`."
+        )
     if targets is None:
         if len(study.directions) == 2:
             targets = _targets_default_2d
         elif len(study.directions) == 3:
             targets = _targets_default_3d
         else:
-            raise ValueError("``plot_pareto_front`` function only supports 2 or 3 objective"
-                             " studies when using ``targets`` is ``None``. Please use`targets`")
+            raise ValueError(
+                "``plot_pareto_front`` function only supports 2 or 3 objective"
+                " studies when using ``targets`` is ``None``. Please use`targets`"
+            )
     target_values = [targets(t) for t in trials]
     n_targets = len(study.directions)
     if target_names is not None:
@@ -114,8 +117,10 @@ def plot_pareto_front(
             study, target_values, target_names, include_dominated_trials, axis_order
         )
     else:
-        raise ValueError("``plot_pareto_front`` function only supports 2 or 3 targets. "
-                         " you used {} targets now.".format(n_targets))
+        raise ValueError(
+            "``plot_pareto_front`` function only supports 2 or 3 targets. "
+            " you used {} targets now.".format(n_targets)
+        )
 
 
 def _targets_default_2d(trial: FrozenTrial) -> Sequence[float]:

--- a/optuna/visualization/matplotlib/_pareto_front.py
+++ b/optuna/visualization/matplotlib/_pareto_front.py
@@ -153,7 +153,7 @@ def plot_pareto_front(
         )
     else:
         raise ValueError(
-            "`plot_pareto_front` function only supports 2 or 3 targets. "
+            "`plot_pareto_front` function only supports 2 or 3 targets."
             " you used {} targets now.".format(n_targets)
         )
 

--- a/optuna/visualization/matplotlib/_pareto_front.py
+++ b/optuna/visualization/matplotlib/_pareto_front.py
@@ -96,7 +96,7 @@ def plot_pareto_front(
         :exc:`ValueError`:
             If ``targets`` is specified for empty studies and ``target_names`` is ``None``
         :exc:`ValueError`:
-            if using both ``targets`` and ``axis_order``.
+            If using both ``targets`` and ``axis_order``.
     """
 
     _imports.check()
@@ -110,8 +110,8 @@ def plot_pareto_front(
     trials = _get_trials(study, include_dominated_trials)
     if targets is not None and axis_order is not None:
         raise ValueError(
-            "Using both ``targets`` and ``axis_order`` is not supported. "
-            " Use either `targets` or `axis_order`."
+            "Using both `targets` and `axis_order` is not supported. "
+            "Use either `targets` or `axis_order`."
         )
     _targets = targets
     if _targets is None:
@@ -121,15 +121,15 @@ def plot_pareto_front(
             _targets = _targets_default_3d
         else:
             raise ValueError(
-                "``plot_pareto_front`` function only supports 2 or 3 objective"
-                " studies when using ``targets`` is ``None``. Please use ``targets``"
+                "`plot_pareto_front` function only supports 2 or 3 objective"
+                " studies when using `targets` is `None`. Please use `targets`"
                 " if your objective studies have more than 3 objectives."
             )
     target_values = [_targets(t) for t in trials]
     if len(target_values) > 0 and not isinstance(target_values[0], collections.Sequence):
         raise ValueError(
-            "``targets`` should return a sequence of target values."
-            " your ``targets`` returns {}".format(type(target_values[0]))
+            "`targets` should return a sequence of target values."
+            " your `targets` returns {}".format(type(target_values[0]))
         )
 
     if len(target_values) > 0:
@@ -140,7 +140,7 @@ def plot_pareto_front(
         n_targets = len(study.directions)
     else:
         raise ValueError(
-            "If ``targets`` is specified for empty studies, ``target_names`` must be specified."
+            "If `targets` is specified for empty studies, `target_names` must be specified."
         )
 
     if n_targets == 2:
@@ -153,7 +153,7 @@ def plot_pareto_front(
         )
     else:
         raise ValueError(
-            "``plot_pareto_front`` function only supports 2 or 3 targets. "
+            "`plot_pareto_front` function only supports 2 or 3 targets. "
             " you used {} targets now.".format(n_targets)
         )
 

--- a/optuna/visualization/matplotlib/_pareto_front.py
+++ b/optuna/visualization/matplotlib/_pareto_front.py
@@ -88,13 +88,13 @@ def plot_pareto_front(
 
     Raises:
         :exc:`ValueError`:
-            If ``targets`` is ``None`` when your objective studies have more than 3 objectives.
+            If ``targets`` is :obj:`None` when your objective studies have more than 3 objectives.
         :exc:`ValueError`:
             If ``targets`` returns something other than sequence.
         :exc:`ValueError`:
             If the number of target values to display isn't 2 or 3.
         :exc:`ValueError`:
-            If ``targets`` is specified for empty studies and ``target_names`` is ``None``
+            If ``targets`` is specified for empty studies and ``target_names`` is :obj:`None`.
         :exc:`ValueError`:
             If using both ``targets`` and ``axis_order``.
     """

--- a/optuna/visualization/matplotlib/_pareto_front.py
+++ b/optuna/visualization/matplotlib/_pareto_front.py
@@ -70,7 +70,7 @@ def plot_pareto_front(
             default order is used.
         targets:
             A function that returns a tuple of target values to display.
-            The argument to this function is ``FrozenTrial``.
+            The argument to this function is :class:`~optuna.trial.FrozenTrial`.
 
     Returns:
         A :class:`matplotlib.axes.Axes` object.
@@ -100,7 +100,8 @@ def plot_pareto_front(
         else:
             raise ValueError(
                 "``plot_pareto_front`` function only supports 2 or 3 objective"
-                " studies when using ``targets`` is ``None``. Please use`targets`"
+                " studies when using ``targets`` is ``None``. Please specify the used values with"
+                " `targets`."
             )
     target_values = [targets(t) for t in trials]
     n_targets = len(study.directions)

--- a/optuna/visualization/matplotlib/_pareto_front.py
+++ b/optuna/visualization/matplotlib/_pareto_front.py
@@ -1,3 +1,4 @@
+import collections
 from typing import Callable
 from typing import List
 from typing import Optional
@@ -89,6 +90,8 @@ def plot_pareto_front(
         :exc:`ValueError`:
             If ``targets`` is ``None`` when your objective studies have more than 3 objectives.
         :exc:`ValueError`:
+            If ``targets`` returns something other than sequence.
+        :exc:`ValueError`:
             If the number of target values to display isn't 2 or 3.
         :exc:`ValueError`:
             If ``targets`` is specified for empty studies and ``target_names`` is ``None``
@@ -123,6 +126,12 @@ def plot_pareto_front(
                 " if your objective studies have more than 3 objectives."
             )
     target_values = [_targets(t) for t in trials]
+    if len(target_values) > 0 and not isinstance(target_values[0], collections.Sequence):
+        raise ValueError(
+            "``targets`` should return a sequence of target values."
+            " your ``targets`` returns {}".format(type(target_values[0]))
+        )
+
     if len(target_values) > 0:
         n_targets = len(target_values[0])
     elif target_names is not None:

--- a/tests/visualization_tests/matplotlib_tests/test_pareto_front.py
+++ b/tests/visualization_tests/matplotlib_tests/test_pareto_front.py
@@ -140,9 +140,7 @@ def test_plot_pareto_front_2d(
 @pytest.mark.parametrize(
     "axis_order", [None] + list(itertools.permutations(range(3), 3))  # type: ignore
 )
-@pytest.mark.parametrize(
-    "targets",
-    [None, lambda t: (t.values[0], t.values[1], t.values[2])])
+@pytest.mark.parametrize("targets", [None, lambda t: (t.values[0], t.values[1], t.values[2])])
 def test_plot_pareto_front_3d(
     include_dominated_trials: bool,
     axis_order: Optional[List[int]],

--- a/tests/visualization_tests/matplotlib_tests/test_pareto_front.py
+++ b/tests/visualization_tests/matplotlib_tests/test_pareto_front.py
@@ -333,6 +333,7 @@ def test_plot_pareto_front_invalid_axis_order(
         )
 
 
+@pytest.mark.filterwarnings("ignore::optuna.exceptions.ExperimentalWarning")
 def test_plot_pareto_front_targets_without_target_names() -> None:
     study = optuna.create_study(directions=["minimize", "minimize", "minimize"])
     with pytest.raises(
@@ -346,6 +347,7 @@ def test_plot_pareto_front_targets_without_target_names() -> None:
         )
 
 
+@pytest.mark.filterwarnings("ignore::optuna.exceptions.ExperimentalWarning")
 @pytest.mark.parametrize(
     "targets",
     [
@@ -356,18 +358,7 @@ def test_plot_pareto_front_invalid_target_values(
     targets: Optional[Callable[[FrozenTrial], Sequence[float]]]
 ) -> None:
     study = optuna.create_study(directions=["minimize", "minimize", "minimize", "minimize"])
-    study.enqueue_trial({"w": 1, "x": 1, "y": 1, "z": 1})
-    study.enqueue_trial({"w": 0, "x": 1, "y": 0, "z": 1})
-    study.enqueue_trial({"w": 1, "x": 1, "y": 1, "z": 0})
-    study.optimize(
-        lambda t: [
-            t.suggest_int("w", 0, 1),
-            t.suggest_int("x", 0, 1),
-            t.suggest_int("y", 0, 1),
-            t.suggest_int("z", 0, 1),
-        ],
-        n_trials=3,
-    )
+    study.optimize(lambda t: [0, 0, 0, 0], n_trials=3)
     with pytest.raises(
         ValueError,
         match="targets` should return a sequence of target values. your `targets`"
@@ -379,6 +370,7 @@ def test_plot_pareto_front_invalid_target_values(
         )
 
 
+@pytest.mark.filterwarnings("ignore::optuna.exceptions.ExperimentalWarning")
 @pytest.mark.parametrize(
     "targets",
     [
@@ -390,18 +382,7 @@ def test_plot_pareto_front_n_targets_unsupported(
     targets: Callable[[FrozenTrial], Sequence[float]]
 ) -> None:
     study = optuna.create_study(directions=["minimize", "minimize", "minimize", "minimize"])
-    study.enqueue_trial({"w": 1, "x": 1, "y": 1, "z": 1})
-    study.enqueue_trial({"w": 0, "x": 1, "y": 0, "z": 1})
-    study.enqueue_trial({"w": 1, "x": 1, "y": 1, "z": 0})
-    study.optimize(
-        lambda t: [
-            t.suggest_int("w", 0, 1),
-            t.suggest_int("x", 0, 1),
-            t.suggest_int("y", 0, 1),
-            t.suggest_int("z", 0, 1),
-        ],
-        n_trials=3,
-    )
+    study.optimize(lambda t: [0, 0, 0, 0], n_trials=3)
     n_targets = len(targets(study.best_trials[0]))
     with pytest.raises(
         ValueError,
@@ -414,6 +395,7 @@ def test_plot_pareto_front_n_targets_unsupported(
         )
 
 
+@pytest.mark.filterwarnings("ignore::optuna.exceptions.ExperimentalWarning")
 def test_plot_pareto_front_using_axis_order_and_targets() -> None:
     study = optuna.create_study(directions=["minimize", "minimize", "minimize"])
     with pytest.raises(

--- a/tests/visualization_tests/matplotlib_tests/test_pareto_front.py
+++ b/tests/visualization_tests/matplotlib_tests/test_pareto_front.py
@@ -346,7 +346,8 @@ def test_plot_pareto_front_targets_without_target_names() -> None:
 @pytest.mark.parametrize(
     "targets",
     [
-        lambda t: (t.values[0], t.values[1]),
+        lambda t: (t.values[0]),
+        lambda t: (t.values[0],),
         lambda t: (t.values[0], t.values[1], t.values[2], t.values[3]),
     ],
 )
@@ -355,10 +356,15 @@ def test_plot_pareto_front_invalid_targets(
 ) -> None:
     study = optuna.create_study(directions=["minimize", "minimize", "minimize", "minimize"])
     study.enqueue_trial({"w": 1, "x": 1, "y": 1, "z": 1})
-    study.enqueue_trial({"w": 1, "x": 1, "y": 0, "z": 1})
+    study.enqueue_trial({"w": 0, "x": 1, "y": 0, "z": 1})
     study.enqueue_trial({"w": 1, "x": 1, "y": 1, "z": 0})
     study.optimize(
-        lambda t: [t.suggest_int("x", 0, 1), t.suggest_int("y", 0, 1), t.suggest_int("z", 0, 1)],
+        lambda t: [
+            t.suggest_int("w", 0, 1),
+            t.suggest_int("x", 0, 1),
+            t.suggest_int("y", 0, 1),
+            t.suggest_int("z", 0, 1),
+        ],
         n_trials=3,
     )
     with pytest.raises(ValueError):


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
This PR solves this the matplotlib part of issue https://github.com/optuna/optuna/issues/2973 

## Description of the changes
<!-- Describe the changes in this PR. -->
This PR changes followings:

1. add `targets` to optuna.visualization.matplotlib.plot_pareto_front. targets is described in the issue.
2. add duplicated warning of `axis_order` 
3. refactor getting trials from study in optuna.visualization.matplotlib.plot_pareto_front.