### PR TITLE
Fix missing `user_attrs` and `system_attrs` in study summaries.

### DIFF
--- a/optuna/storages/_rdb/storage.py
+++ b/optuna/storages/_rdb/storage.py
@@ -420,16 +420,16 @@ class RDBStorage(BaseStorage):
             study_summary = study_summary_stmt.all()
 
             _directions = defaultdict(list)
-            for d in session.query(models.StudyDirectionModel).all():
-                _directions[d.study_id].append(d.direction)
+            for direction_model in session.query(models.StudyDirectionModel).all():
+                _directions[direction_model.study_id].append(direction_model.direction)
 
             _user_attrs = defaultdict(list)
-            for a in session.query(models.StudyUserAttributeModel).all():
-                _user_attrs[d.study_id].append(a)
+            for attribute_model in session.query(models.StudyUserAttributeModel).all():
+                _user_attrs[attribute_model.study_id].append(attribute_model)
 
             _system_attrs = defaultdict(list)
-            for a in session.query(models.StudySystemAttributeModel).all():
-                _system_attrs[d.study_id].append(a)
+            for attribute_model in session.query(models.StudySystemAttributeModel).all():
+                _system_attrs[attribute_model.study_id].append(attribute_model)
 
             study_summaries = []
             for study in study_summary:

--- a/tests/storages_tests/test_storages.py
+++ b/tests/storages_tests/test_storages.py
@@ -762,14 +762,7 @@ def test_set_trial_system_attr(storage_mode: str) -> None:
 def test_get_all_study_summaries(storage_mode: str) -> None:
 
     with StorageSupplier(storage_mode) as storage:
-        expected_summaries, _ = _setup_studies(
-            storage,
-            n_study=10,
-            n_trial=10,
-            seed=46,
-            use_study_user_attrs=True,
-            use_study_system_attrs=True,
-        )
+        expected_summaries, _ = _setup_studies(storage, n_study=10, n_trial=10, seed=46)
         summaries = storage.get_all_study_summaries()
         assert len(summaries) == len(expected_summaries)
         for _, expected_summary in expected_summaries.items():
@@ -975,8 +968,6 @@ def _setup_studies(
     n_trial: int,
     seed: int,
     direction: Optional[StudyDirection] = None,
-    use_study_user_attrs: bool = False,
-    use_study_system_attrs: bool = False,
 ) -> Tuple[Dict[int, StudySummary], Dict[int, Dict[int, FrozenTrial]]]:
     generator = random.Random(seed)
     study_id_to_summary: Dict[int, StudySummary] = {}
@@ -987,10 +978,8 @@ def _setup_studies(
         if direction is None:
             direction = generator.choice([StudyDirection.MINIMIZE, StudyDirection.MAXIMIZE])
         storage.set_study_directions(study_id, (direction,))
-        if use_study_user_attrs is not None:
-            storage.set_study_user_attr(study_id, "u", i)
-        if use_study_system_attrs is not None:
-            storage.set_study_system_attr(study_id, "s", i)
+        storage.set_study_user_attr(study_id, "u", i)
+        storage.set_study_system_attr(study_id, "s", i)
         best_trial = None
         trials = {}
         datetime_start = None
@@ -1016,8 +1005,8 @@ def _setup_studies(
             study_name=study_name,
             direction=direction,
             best_trial=best_trial,
-            user_attrs={} if use_study_user_attrs is None else {"u": i},
-            system_attrs={} if use_study_system_attrs is None else {"s": i},
+            user_attrs={"u": i},
+            system_attrs={"s": i},
             n_trials=len(trials),
             datetime_start=datetime_start,
             study_id=study_id,

--- a/tests/storages_tests/test_storages.py
+++ b/tests/storages_tests/test_storages.py
@@ -762,7 +762,14 @@ def test_set_trial_system_attr(storage_mode: str) -> None:
 def test_get_all_study_summaries(storage_mode: str) -> None:
 
     with StorageSupplier(storage_mode) as storage:
-        expected_summaries, _ = _setup_studies(storage, n_study=10, n_trial=10, seed=46)
+        expected_summaries, _ = _setup_studies(
+            storage,
+            n_study=10,
+            n_trial=10,
+            seed=46,
+            use_study_user_attrs=True,
+            use_study_system_attrs=True,
+        )
         summaries = storage.get_all_study_summaries()
         assert len(summaries) == len(expected_summaries)
         for _, expected_summary in expected_summaries.items():
@@ -968,6 +975,8 @@ def _setup_studies(
     n_trial: int,
     seed: int,
     direction: Optional[StudyDirection] = None,
+    use_study_user_attrs: bool = False,
+    use_study_system_attrs: bool = False,
 ) -> Tuple[Dict[int, StudySummary], Dict[int, Dict[int, FrozenTrial]]]:
     generator = random.Random(seed)
     study_id_to_summary: Dict[int, StudySummary] = {}
@@ -978,6 +987,10 @@ def _setup_studies(
         if direction is None:
             direction = generator.choice([StudyDirection.MINIMIZE, StudyDirection.MAXIMIZE])
         storage.set_study_directions(study_id, (direction,))
+        if use_study_user_attrs is not None:
+            storage.set_study_user_attr(study_id, "u", i)
+        if use_study_system_attrs is not None:
+            storage.set_study_system_attr(study_id, "s", i)
         best_trial = None
         trials = {}
         datetime_start = None
@@ -1003,8 +1016,8 @@ def _setup_studies(
             study_name=study_name,
             direction=direction,
             best_trial=best_trial,
-            user_attrs={},
-            system_attrs={},
+            user_attrs={} if use_study_user_attrs is None else {"u": i},
+            system_attrs={} if use_study_system_attrs is None else {"s": i},
             n_trials=len(trials),
             datetime_start=datetime_start,
             study_id=study_id,


### PR DESCRIPTION
## Motivation

This PR addresses the issue mentioned in https://github.com/optuna/optuna/pull/3105#issuecomment-1008990728.
@hvy kindly shared the reproducible code as follows:

```python
import optuna

for i in range(3):
    study = optuna.create_study(study_name=f"foo_{i}", storage="sqlite:///test.db")
    study.set_user_attr("a", "b")

    sss = optuna.get_all_study_summaries(study._storage)
    for ss in sss:
        print(ss.user_attrs)
```

The current master
```console
[I 2022-03-01 11:20:33,333] A new study created in RDB with name: foo_0
{'a': 'b'}
[I 2022-03-01 11:20:33,371] A new study created in RDB with name: foo_1
{}
{'a': 'b'}
[I 2022-03-01 11:20:33,408] A new study created in RDB with name: foo_2
{}
{}
{'a': 'b'}
```

This PR
```console
[I 2022-03-01 11:21:27,458] A new study created in RDB with name: foo_0
{'a': 'b'}
[I 2022-03-01 11:21:27,498] A new study created in RDB with name: foo_1
{'a': 'b'}
{'a': 'b'}
[I 2022-03-01 11:21:27,536] A new study created in RDB with name: foo_2
{'a': 'b'}
{'a': 'b'}
{'a': 'b'}
```

## Description of the changes

- The `study_id` to look up `user_attrs` and `system_attrs` is wrong. This PR fixes it.
- Add items of `user_attrs` and `system_attrs` to the test of study summaries.