### PR TITLE
Fix a typo.

### DIFF
--- a/optuna/_imports.py
+++ b/optuna/_imports.py
@@ -77,7 +77,7 @@ class _DeferredImportExceptionContextManager(object):
         return self._deferred is None
 
     def check(self) -> None:
-        """Check whether the context manger has caught any exceptions.
+        """Check whether the context manager has caught any exceptions.
 
         Raises:
             :exc:`ImportError`:


### PR DESCRIPTION
## Motivation

`manger` seems to be a typo for `manager`.

## Description of the changes

- Fix a typo in a docstring.