### PR TITLE
Fix speed benchmarks

### DIFF
--- a/.github/workflows/speed-benchmarks.yml
+++ b/.github/workflows/speed-benchmarks.yml
@@ -45,4 +45,4 @@ jobs:
 
     - name: Speed benchmarks
       run: |
-        asv run
+        asv run --strict

--- a/benchmarks/optimize.py
+++ b/benchmarks/optimize.py
@@ -63,8 +63,10 @@ class OptimizeSuite:
         "inmemory, tpe, 1000",
         "inmemory, cmaes, 1000",
         "sqlite, random, 1000",
-        "cache, random, 1000",
-        "redis, random, 1000",  # This benchmark uses fakeredis instead of Redis.
+        "cached_sqlite, random, 1000",
+        # Following benchmarks use fakeredis instead of Redis.
+        "redis, random, 1000",
+        "cached_redis, random, 1000",
     )
     param_names = ["storage, sampler, n_trials"]
     timeout = 600

--- a/setup.py
+++ b/setup.py
@@ -167,7 +167,7 @@ def get_extras_require() -> Dict[str, List[str]]:
             "fastai",
         ],
         "benchmark": [
-            "asv",
+            "asv>=0.5.0",
             "virtualenv",
             "botorch",
         ],


### PR DESCRIPTION
## Motivation
This PR will fix the failure of speed benchmarks due to the change of `STORAGE_MODES` (#3204).

## Description of the changes
- Fix speed benchmarks
- Add `--strict` option of `asv` to fail the CI when some cases failing (https://github.com/airspeed-velocity/asv/pull/865)
