### PR TITLE
Pin AllenNLP version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -120,7 +120,9 @@ def get_extras_require() -> Dict[str, List[str]]:
             # TODO(himkt): Remove `nltk` after solving
             # https://github.com/allenai/allennlp/issues/5521
             "nltk<3.6.6",
-            "allennlp>=2.2.0 ; python_version>'3.6'",
+            # TODO(himkt): Remove upper bound constraint
+            # after solving https://github.com/optuna/optuna/issues/3366
+            "allennlp>=2.2.0,<2.9.1 ; python_version>'3.6'",
             "botorch>=0.4.0 ; python_version>'3.6'",
             "fastai",
         ],
@@ -162,7 +164,9 @@ def get_extras_require() -> Dict[str, List[str]]:
             # TODO(himkt): Remove `nltk` after solving
             # https://github.com/allenai/allennlp/issues/5521
             "nltk<3.6.6",
-            "allennlp>=2.2.0 ; python_version>'3.6'",
+            # TODO(himkt): Remove upper bound constraint
+            # after solving https://github.com/optuna/optuna/issues/3366
+            "allennlp>=2.2.0,<2.9.1 ; python_version>'3.6'",
             "botorch>=0.4.0 ; python_version>'3.6'",
             "fastai",
         ],


### PR DESCRIPTION
## Motivation
Pin AllenNLP version in `setup.py`.

## Description of the changes
Our CI failed due to the error in AllenNLP (https://github.com/optuna/optuna/issues/3366). The latest version of AllenNLP was released and it would be the cause. This PR temporarily adds the version constraint for the library.