### PR TITLE
Fix objective scale in parallel coordinate of Matplotlib

### DIFF
--- a/optuna/visualization/matplotlib/_parallel_coordinate.py
+++ b/optuna/visualization/matplotlib/_parallel_coordinate.py
@@ -197,7 +197,7 @@ def _get_parallel_coordinate_plot(
     xs = [range(len(sorted_params) + 1) for _ in range(len(dims_obj_base))]
     segments = [np.column_stack([x, y]) for x, y in zip(xs, dims_obj_base)]
     lc = LineCollection(segments, cmap=cmap)
-    lc.set_array(np.asarray([target(t) for t in trials] + [0]))
+    lc.set_array(np.asarray([target(t) for t in trials]))
     axcb = fig.colorbar(lc, pad=0.1)
     axcb.set_label(target_name)
     plt.xticks(range(len(sorted_params) + 1), var_names, rotation=330)


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

The motivation can be categorised into `2. Unify appearance between Plotly and Matplotlib` in https://github.com/optuna/optuna/issues/2959. 

The colourbar of `optuna.visualize.matplotlib.plot_parallel_coordinate` always includes `0` by default. As a result, the generated colourbar is inconsistent with Plotly's counterpart when zero is not in the range of objective values. For example, 


```python
import optuna
def objective(trial):
    return trial.suggest_int("x", 10, 20)


study = optuna.create_study()
study.optimize(objective, n_trials=10)
optuna.visualization.matplotlib.plot_parallel_coordinate(study)
```

Clearly, `objective` does not return zero. However, the generated colour bar always includes `0` as follows:

<img width="503" alt="Screenshot 2022-03-10 at 22 35 00" src="https://user-images.githubusercontent.com/7121753/157673848-9713ece6-52f1-40de-8ce3-c17d8c559db9.png">

Plotly's counterpart does not use this trick (at least in the latest stable). So the plot looks like

<img width="939" alt="Screenshot 2022-03-10 at 22 34 37" src="https://user-images.githubusercontent.com/7121753/157673865-89129e09-8625-4538-bdfc-054ad63b25a7.png">



## Description of the changes
<!-- Describe the changes in this PR. -->

Remove the hard-coded zero. The generated plots will be like

<img width="444" alt="Screenshot 2022-03-10 at 22 34 34" src="https://user-images.githubusercontent.com/7121753/157673910-61ff475f-3e98-47ec-9582-ce792ca2ebd4.png">
