### PR TITLE
Fix `matplotlib.plot_parallel_coordinate` with log distributions

### DIFF
--- a/optuna/visualization/matplotlib/_parallel_coordinate.py
+++ b/optuna/visualization/matplotlib/_parallel_coordinate.py
@@ -1,5 +1,4 @@
 from collections import defaultdict
-import math
 from typing import Callable
 from typing import cast
 from typing import DefaultDict

--- a/optuna/visualization/matplotlib/_parallel_coordinate.py
+++ b/optuna/visualization/matplotlib/_parallel_coordinate.py
@@ -160,8 +160,13 @@ def _get_parallel_coordinate_plot(
             cat_param_values.append([v[0] for v in vocab_item_sorted])
             cat_param_ticks.append([v[1] for v in vocab_item_sorted])
 
-        p_min = min(values)
-        p_max = max(values)
+        if _is_log_scale(trials, p_name):
+            _values = [np.log10(v) for v in values]
+        else:
+            _values = values
+
+        p_min = min(_values)
+        p_max = max(_values)
         p_w = p_max - p_min
 
         if p_w == 0.0:
@@ -169,7 +174,7 @@ def _get_parallel_coordinate_plot(
             for i in range(len(values)):
                 dims_obj_base[i].append(center)
         else:
-            for i, v in enumerate(values):
+            for i, v in enumerate(_values):
                 dims_obj_base[i].append((v - p_min) / p_w * obj_w + obj_min)
 
         var_names.append(p_name if len(p_name) < 20 else "{}...".format(p_name[:17]))

--- a/optuna/visualization/matplotlib/_parallel_coordinate.py
+++ b/optuna/visualization/matplotlib/_parallel_coordinate.py
@@ -161,12 +161,12 @@ def _get_parallel_coordinate_plot(
             cat_param_ticks.append([v[1] for v in vocab_item_sorted])
 
         if _is_log_scale(trials, p_name):
-            _values = [np.log10(v) for v in values]
+            values_for_lc = [np.log10(v) for v in values]
         else:
-            _values = values
+            values_for_lc = values
 
-        p_min = min(_values)
-        p_max = max(_values)
+        p_min = min(values_for_lc)
+        p_max = max(values_for_lc)
         p_w = p_max - p_min
 
         if p_w == 0.0:
@@ -174,7 +174,7 @@ def _get_parallel_coordinate_plot(
             for i in range(len(values)):
                 dims_obj_base[i].append(center)
         else:
-            for i, v in enumerate(_values):
+            for i, v in enumerate(values_for_lc):
                 dims_obj_base[i].append((v - p_min) / p_w * obj_w + obj_min)
 
         var_names.append(p_name if len(p_name) < 20 else "{}...".format(p_name[:17]))

--- a/optuna/visualization/matplotlib/_parallel_coordinate.py
+++ b/optuna/visualization/matplotlib/_parallel_coordinate.py
@@ -140,7 +140,6 @@ def _get_parallel_coordinate_plot(
     cat_param_names = []
     cat_param_values = []
     cat_param_ticks = []
-    log_param_names = []
     param_values = []
     var_names = [target_name]
     numeric_cat_params_indices: List[int] = []
@@ -148,10 +147,7 @@ def _get_parallel_coordinate_plot(
     for param_index, p_name in enumerate(sorted_params):
         values = [t.params[p_name] if p_name in t.params else np.nan for t in trials]
 
-        if _is_log_scale(trials, p_name):
-            values = [math.log10(v) for v in values]
-            log_param_names.append(p_name)
-        elif _is_categorical(trials, p_name):
+        if _is_categorical(trials, p_name):
             vocab = defaultdict(lambda: len(vocab))  # type: DefaultDict[str, int]
 
             if _is_numerical(trials, p_name):

--- a/tests/visualization_tests/matplotlib_tests/test_parallel_coordinate.py
+++ b/tests/visualization_tests/matplotlib_tests/test_parallel_coordinate.py
@@ -1,3 +1,6 @@
+import sys
+
+import matplotlib.pyplot as plt
 import pytest
 
 from optuna.distributions import CategoricalDistribution
@@ -22,16 +25,19 @@ def test_plot_parallel_coordinate() -> None:
     study = create_study()
     figure = plot_parallel_coordinate(study)
     assert len(figure.get_lines()) == 0
+    plt.savefig(sys.stdout.buffer)
 
     study = prepare_study_with_trials(with_c_d=False)
 
     # Test with a trial.
     figure = plot_parallel_coordinate(study)
     assert len(figure.get_lines()) == 0
+    plt.savefig(sys.stdout.buffer)
 
     # Test with a trial to select parameter.
     figure = plot_parallel_coordinate(study, params=["param_a"])
     assert len(figure.get_lines()) == 0
+    plt.savefig(sys.stdout.buffer)
 
     # Test with a customized target value.
     with pytest.warns(UserWarning):
@@ -39,10 +45,12 @@ def test_plot_parallel_coordinate() -> None:
             study, params=["param_a"], target=lambda t: t.params["param_b"]
         )
     assert len(figure.get_lines()) == 0
+    plt.savefig(sys.stdout.buffer)
 
     # Test with a customized target name.
     figure = plot_parallel_coordinate(study, target_name="Target Name")
     assert len(figure.get_lines()) == 0
+    plt.savefig(sys.stdout.buffer)
 
     # Test with wrong params that do not exist in trials
     with pytest.raises(ValueError, match="Parameter optuna does not exist in your study."):
@@ -57,6 +65,7 @@ def test_plot_parallel_coordinate() -> None:
     study.optimize(fail_objective, n_trials=1, catch=(ValueError,))
     figure = plot_parallel_coordinate(study)
     assert len(figure.get_lines()) == 0
+    plt.savefig(sys.stdout.buffer)
 
 
 def test_plot_parallel_coordinate_categorical_params() -> None:
@@ -84,6 +93,7 @@ def test_plot_parallel_coordinate_categorical_params() -> None:
     )
     figure = plot_parallel_coordinate(study_categorical_params)
     assert len(figure.get_lines()) == 0
+    plt.savefig(sys.stdout.buffer)
 
 
 def test_plot_parallel_coordinate_categorical_numeric_params() -> None:
@@ -123,6 +133,7 @@ def test_plot_parallel_coordinate_categorical_numeric_params() -> None:
     )
     figure = plot_parallel_coordinate(study_categorical_params)
     assert len(figure.get_lines()) == 0
+    plt.savefig(sys.stdout.buffer)
 
 
 def test_plot_parallel_coordinate_log_params() -> None:
@@ -160,6 +171,7 @@ def test_plot_parallel_coordinate_log_params() -> None:
     )
     figure = plot_parallel_coordinate(study_log_params)
     assert len(figure.get_lines()) == 0
+    plt.savefig(sys.stdout.buffer)
 
 
 def test_plot_parallel_coordinate_unique_hyper_param() -> None:
@@ -180,6 +192,7 @@ def test_plot_parallel_coordinate_unique_hyper_param() -> None:
     # both hyperparameters contain unique values
     figure = plot_parallel_coordinate(study_categorical_params)
     assert len(figure.get_lines()) == 0
+    plt.savefig(sys.stdout.buffer)
 
     study_categorical_params.add_trial(
         create_trial(
@@ -195,3 +208,4 @@ def test_plot_parallel_coordinate_unique_hyper_param() -> None:
     # still "category_a" contains unique suggested value during the optimization.
     figure = plot_parallel_coordinate(study_categorical_params)
     assert len(figure.get_lines()) == 0
+    plt.savefig(sys.stdout.buffer)


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
Resolve https://github.com/optuna/optuna/issues/3370

## Description of the changes
<!-- Describe the changes in this PR. -->

I think we do not need to take the log of parameters in this visualisation method except for line collection.

By this PR, the plot function generates

<img width="457" alt="Screenshot 2022-03-11 at 6 05 22" src="https://user-images.githubusercontent.com/7121753/157754717-b1eafb11-c948-4c6e-a8cf-3fc9ace78c6a.png">

As a reference, plotly shows the following plot:

<img width="994" alt="Screenshot 2022-03-11 at 6 07 33" src="https://user-images.githubusercontent.com/7121753/157754914-c7a8d332-eb9e-4da4-8538-93e5204cfc8b.png">


### Code

```python
from optuna.study import create_study
from optuna.visualization.matplotlib import plot_parallel_coordinate
from optuna.distributions import LogUniformDistribution
from optuna.trial import create_trial
import matplotlib.pyplot as plt


study_log_params = create_study()
study_log_params.add_trial(
    create_trial(
        value=0.0,
        params={"param_a": 1e-6, "param_b": 10},
        distributions={
            "param_a": LogUniformDistribution(1e-7, 1e-2),
            "param_b": LogUniformDistribution(1, 1000),
        },
    )
)
study_log_params.add_trial(
    create_trial(
        value=1.0,
        params={"param_a": 2e-5, "param_b": 200},
        distributions={
            "param_a": LogUniformDistribution(1e-7, 1e-2),
            "param_b": LogUniformDistribution(1, 1000),
        },
    )
)
study_log_params.add_trial(
    create_trial(
        value=0.1,
        params={"param_a": 1e-4, "param_b": 30},
        distributions={
            "param_a": LogUniformDistribution(1e-7, 1e-2),
            "param_b": LogUniformDistribution(1, 1000),
        },
    )
)
figure = plot_parallel_coordinate(study_log_params)
plt.savefig("lovely.png")
```

Adding `plt.savefig(sys.stdout.buffer)` to other matplotlib will be a followup.