### PR TITLE
Fix parallel coordinate with missing value

### DIFF
--- a/optuna/visualization/_parallel_coordinate.py
+++ b/optuna/visualization/_parallel_coordinate.py
@@ -132,7 +132,7 @@ def _get_parallel_coordinate_plot(
     objectives = tuple([target(t) for t in trials if t.number not in skipped_trial_ids])
 
     if len(objectives) == 0:
-        _logger.warning("Your study has ony completed trials with missing parameters.")
+        _logger.warning("Your study has only completed trials with missing parameters.")
         return go.Figure(data=[], layout=layout)
 
     dims: List[Dict[str, Any]] = [

--- a/optuna/visualization/_parallel_coordinate.py
+++ b/optuna/visualization/_parallel_coordinate.py
@@ -122,11 +122,19 @@ def _get_parallel_coordinate_plot(
     else:
         reversescale = True
 
+    skipped_trial_ids = set()
+    for trial in trials:
+        for used_param in sorted_params:
+            if used_param not in trial.params.keys():
+                skipped_trial_ids.add(trial.number)
+                break
+
+    objectives = tuple([target(t) for t in trials if t.number not in skipped_trial_ids])
     dims: List[Dict[str, Any]] = [
         {
             "label": target_name,
-            "values": tuple([target(t) for t in trials]),
-            "range": (min([target(t) for t in trials]), max([target(t) for t in trials])),
+            "values": objectives,
+            "range": (min(objectives), max(objectives)),
         }
     ]
 
@@ -134,6 +142,9 @@ def _get_parallel_coordinate_plot(
     for dim_index, p_name in enumerate(sorted_params, start=1):
         values = []
         for t in trials:
+            if t.number in skipped_trial_ids:
+                continue
+
             if p_name in t.params:
                 values.append(t.params[p_name])
 

--- a/optuna/visualization/_parallel_coordinate.py
+++ b/optuna/visualization/_parallel_coordinate.py
@@ -130,6 +130,11 @@ def _get_parallel_coordinate_plot(
                 break
 
     objectives = tuple([target(t) for t in trials if t.number not in skipped_trial_ids])
+
+    if len(objectives) == 0:
+        _logger.warning("Your study has ony completed trials with missing parameters.")
+        return go.Figure(data=[], layout=layout)
+
     dims: List[Dict[str, Any]] = [
         {
             "label": target_name,

--- a/tests/visualization_tests/test_parallel_coordinate.py
+++ b/tests/visualization_tests/test_parallel_coordinate.py
@@ -386,6 +386,5 @@ def test_plot_parallel_coordinate_only_missing_params() -> None:
         )
     )
 
-    study = create_study()
     figure = plot_parallel_coordinate(study)
     assert len(figure.data) == 0

--- a/tests/visualization_tests/test_parallel_coordinate.py
+++ b/tests/visualization_tests/test_parallel_coordinate.py
@@ -31,21 +31,21 @@ def test_plot_parallel_coordinate() -> None:
     figure = plot_parallel_coordinate(study)
     assert len(figure.data[0]["dimensions"]) == 3
     assert figure.data[0]["dimensions"][0]["label"] == "Objective Value"
-    assert figure.data[0]["dimensions"][0]["range"] == (0.0, 2.0)
-    assert figure.data[0]["dimensions"][0]["values"] == (0.0, 2.0, 1.0)
+    assert figure.data[0]["dimensions"][0]["range"] == (0.0, 1.0)
+    assert figure.data[0]["dimensions"][0]["values"] == (0.0, 1.0)
     assert figure.data[0]["dimensions"][1]["label"] == "param_a"
     assert figure.data[0]["dimensions"][1]["range"] == (1.0, 2.5)
     assert figure.data[0]["dimensions"][1]["values"] == (1.0, 2.5)
     assert figure.data[0]["dimensions"][2]["label"] == "param_b"
-    assert figure.data[0]["dimensions"][2]["range"] == (0.0, 2.0)
-    assert figure.data[0]["dimensions"][2]["values"] == (2.0, 0.0, 1.0)
+    assert figure.data[0]["dimensions"][2]["range"] == (1.0, 2.0)
+    assert figure.data[0]["dimensions"][2]["values"] == (2.0, 1.0)
 
     # Test with a trial to select parameter.
     figure = plot_parallel_coordinate(study, params=["param_a"])
     assert len(figure.data[0]["dimensions"]) == 2
     assert figure.data[0]["dimensions"][0]["label"] == "Objective Value"
-    assert figure.data[0]["dimensions"][0]["range"] == (0.0, 2.0)
-    assert figure.data[0]["dimensions"][0]["values"] == (0.0, 2.0, 1.0)
+    assert figure.data[0]["dimensions"][0]["range"] == (0.0, 1.0)
+    assert figure.data[0]["dimensions"][0]["values"] == (0.0, 1.0)
     assert figure.data[0]["dimensions"][1]["label"] == "param_a"
     assert figure.data[0]["dimensions"][1]["range"] == (1.0, 2.5)
     assert figure.data[0]["dimensions"][1]["values"] == (1.0, 2.5)
@@ -57,8 +57,8 @@ def test_plot_parallel_coordinate() -> None:
         )
     assert len(figure.data[0]["dimensions"]) == 2
     assert figure.data[0]["dimensions"][0]["label"] == "Objective Value"
-    assert figure.data[0]["dimensions"][0]["range"] == (0.0, 2.0)
-    assert figure.data[0]["dimensions"][0]["values"] == (2.0, 0.0, 1.0)
+    assert figure.data[0]["dimensions"][0]["range"] == (1.0, 2.0)
+    assert figure.data[0]["dimensions"][0]["values"] == (2.0, 1.0)
     assert figure.data[0]["dimensions"][1]["label"] == "param_a"
     assert figure.data[0]["dimensions"][1]["range"] == (1.0, 2.5)
     assert figure.data[0]["dimensions"][1]["values"] == (1.0, 2.5)
@@ -67,14 +67,14 @@ def test_plot_parallel_coordinate() -> None:
     figure = plot_parallel_coordinate(study, target_name="Target Name")
     assert len(figure.data[0]["dimensions"]) == 3
     assert figure.data[0]["dimensions"][0]["label"] == "Target Name"
-    assert figure.data[0]["dimensions"][0]["range"] == (0.0, 2.0)
-    assert figure.data[0]["dimensions"][0]["values"] == (0.0, 2.0, 1.0)
+    assert figure.data[0]["dimensions"][0]["range"] == (0.0, 1.0)
+    assert figure.data[0]["dimensions"][0]["values"] == (0.0, 1.0)
     assert figure.data[0]["dimensions"][1]["label"] == "param_a"
     assert figure.data[0]["dimensions"][1]["range"] == (1.0, 2.5)
     assert figure.data[0]["dimensions"][1]["values"] == (1.0, 2.5)
     assert figure.data[0]["dimensions"][2]["label"] == "param_b"
-    assert figure.data[0]["dimensions"][2]["range"] == (0.0, 2.0)
-    assert figure.data[0]["dimensions"][2]["values"] == (2.0, 0.0, 1.0)
+    assert figure.data[0]["dimensions"][2]["range"] == (1.0, 2.0)
+    assert figure.data[0]["dimensions"][2]["values"] == (2.0, 1.0)
 
     # Test with wrong params that do not exist in trials
     with pytest.raises(ValueError, match="Parameter optuna does not exist in your study."):

--- a/tests/visualization_tests/test_parallel_coordinate.py
+++ b/tests/visualization_tests/test_parallel_coordinate.py
@@ -361,3 +361,31 @@ def test_plot_parallel_coordinate_with_categorical_numeric_params() -> None:
     assert figure.data[0]["dimensions"][4]["range"] == (0, 2)
     assert figure.data[0]["dimensions"][4]["values"] == (2, 0, 2, 1)
     assert figure.data[0]["dimensions"][4]["ticktext"] == (-1, 1, 2)
+
+
+def test_plot_parallel_coordinate_only_missing_params() -> None:
+    # All trials contains only a part of parameters,
+    # the plot returns an empty figure.
+    study = create_study()
+    study.add_trial(
+        create_trial(
+            value=0.0,
+            params={"param_a": 1e-6},
+            distributions={
+                "param_a": LogUniformDistribution(1e-7, 1e-2),
+            },
+        )
+    )
+    study.add_trial(
+        create_trial(
+            value=1.0,
+            params={"param_b": 200},
+            distributions={
+                "param_b": LogUniformDistribution(1, 1000),
+            },
+        )
+    )
+
+    study = create_study()
+    figure = plot_parallel_coordinate(study)
+    assert len(figure.data) == 0


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

Resolve https://github.com/optuna/optuna/issues/3372

## Description of the changes
<!-- Describe the changes in this PR. -->


If a trial has a missing parameter used in a parallel coordinate plot, remove the trail from the visualization data for Plotly. 

Note that by this change, coordinates' max/min values might change because the master's implementation set max/min based on all complete trials' values. On the other hand, this PR set max/min value based on only used trials that have no missing params. Personally, this PR's change makes sense since the parallel coordinate plot creates empty space in the coordinate as in the matplotlib's plot on https://github.com/optuna/optuna/issues/3372: 1--2 on `Objective Value` axis or 0--1 on `param_b` axis.


<img width="950" alt="Screenshot 2022-03-11 at 1 40 23" src="https://user-images.githubusercontent.com/7121753/157712017-96381183-0439-4d5e-a024-1909bb0ad625.png">


Implementing the same logic to determine the max/min range in matplotlib should be a follow-up.