### PR TITLE
Improve Ctrl-C interruption handling

### DIFF
--- a/optuna/study/_optimize.py
+++ b/optuna/study/_optimize.py
@@ -193,7 +193,7 @@ def _run_trial(
 
     state: Optional[TrialState] = None
     values: Optional[List[float]] = None
-    func_err: Optional[Exception] = None
+    func_err: Optional[BaseException] = None
     func_err_fail_exc_info: Optional[Any] = None
     # Set to a string if `func` returns correctly but the return value violates assumptions.
     values_conversion_failure_message: Optional[str] = None
@@ -212,6 +212,9 @@ def _run_trial(
     except exceptions.TrialPruned as e:
         # TODO(mamu): Handle multi-objective cases.
         state = TrialState.PRUNED
+        func_err = e
+    except KeyboardInterrupt as e:
+        state = TrialState.FAIL
         func_err = e
     except Exception as e:
         state = TrialState.FAIL

--- a/optuna/study/_optimize.py
+++ b/optuna/study/_optimize.py
@@ -193,7 +193,7 @@ def _run_trial(
 
     state: Optional[TrialState] = None
     values: Optional[List[float]] = None
-    func_err: Optional[BaseException] = None
+    func_err: Optional[Union[Exception, KeyboardInterrupt]] = None
     func_err_fail_exc_info: Optional[Any] = None
     # Set to a string if `func` returns correctly but the return value violates assumptions.
     values_conversion_failure_message: Optional[str] = None
@@ -213,10 +213,7 @@ def _run_trial(
         # TODO(mamu): Handle multi-objective cases.
         state = TrialState.PRUNED
         func_err = e
-    except KeyboardInterrupt as e:
-        state = TrialState.FAIL
-        func_err = e
-    except Exception as e:
+    except (Exception, KeyboardInterrupt) as e:
         state = TrialState.FAIL
         func_err = e
         func_err_fail_exc_info = sys.exc_info()

--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -307,6 +307,9 @@ class Study:
         default choice for the sampler is TPE.
         See also :class:`~optuna.samplers.TPESampler` for more details on 'TPE'.
 
+        An optimization will be stopped when receiving a termination signal such as SIGINT and SIGTERM.
+        Unlike other signals, trial is automatically failed when receiving SIGINT (ctrl+c).
+
         Example:
 
             .. testcode::
@@ -329,7 +332,7 @@ class Study:
                 The number of trials for each process. If this argument is set to :obj:`None`,
                 there is no limitation on the number of trials. If ``timeout`` is also set to
                 :obj:`None`, the study continues to create trials until it receives a termination
-                signal such as Ctrl+C or SIGTERM, in which case it also kills the current trial.
+                signal such as Ctrl+C or SIGTERM.
 
                 .. seealso::
                     :class:`optuna.study.MaxTrialsCallback` can ensure how many times trials
@@ -338,8 +341,7 @@ class Study:
                 Stop study after the given number of second(s). If this argument is set to
                 :obj:`None`, the study is executed without time limitation. If :obj:`n_trials` is
                 also set to :obj:`None`, the study continues to create trials until it receives a
-                termination signal such as Ctrl+C or SIGTERM, in which case it also kills the
-                current trial.
+                termination signal such as Ctrl+C or SIGTERM.
             n_jobs:
                 The number of parallel jobs. If this argument is set to :obj:`-1`, the number is
                 set to CPU count.

--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -307,8 +307,10 @@ class Study:
         default choice for the sampler is TPE.
         See also :class:`~optuna.samplers.TPESampler` for more details on 'TPE'.
 
-        An optimization will be stopped when receiving a termination signal such as SIGINT and SIGTERM.
-        Unlike other signals, trial is automatically failed when receiving SIGINT (ctrl+c).
+        An optimization will be stopped when receiving a termination signal such as SIGINT and
+        SIGTERM. Unlike other signals, trial is automatically and cleanly failed when receiving
+        SIGINT (Ctrl+C). If :obj:`n_jobs` is greater than one or if another signal than SIGINT
+        is used, the interrupted trial state won't be properly updated.
 
         Example:
 

--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -329,7 +329,7 @@ class Study:
                 The number of trials for each process. If this argument is set to :obj:`None`,
                 there is no limitation on the number of trials. If ``timeout`` is also set to
                 :obj:`None`, the study continues to create trials until it receives a termination
-                signal such as Ctrl+C or SIGTERM.
+                signal such as Ctrl+C or SIGTERM, in which case it also kills the current trial.
 
                 .. seealso::
                     :class:`optuna.study.MaxTrialsCallback` can ensure how many times trials
@@ -338,7 +338,8 @@ class Study:
                 Stop study after the given number of second(s). If this argument is set to
                 :obj:`None`, the study is executed without time limitation. If :obj:`n_trials` is
                 also set to :obj:`None`, the study continues to create trials until it receives a
-                termination signal such as Ctrl+C or SIGTERM.
+                termination signal such as Ctrl+C or SIGTERM, in which case it also kills the
+                current trial.
             n_jobs:
                 The number of parallel jobs. If this argument is set to :obj:`-1`, the number is
                 set to CPU count.

--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -307,8 +307,8 @@ class Study:
         default choice for the sampler is TPE.
         See also :class:`~optuna.samplers.TPESampler` for more details on 'TPE'.
 
-        An optimization will be stopped when receiving a termination signal such as SIGINT and
-        SIGTERM. Unlike other signals, trial is automatically and cleanly failed when receiving
+        Optimization will be stopped when receiving a termination signal such as SIGINT and
+        SIGTERM. Unlike other signals, a trial is automatically and cleanly failed when receiving
         SIGINT (Ctrl+C). If :obj:`n_jobs` is greater than one or if another signal than SIGINT
         is used, the interrupted trial state won't be properly updated.
 


### PR DESCRIPTION
In case of a keyboard interruption during a non parallel optimization,
will set the proper FAIL log and status for the interrupted trial.

<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
As mentioned in #3336

## Description of the changes
<!-- Describe the changes in this PR. -->
Add an except for `KeyboardInterrupt` during optimization. Also a minor tweaks to a type hint for `func_err`, which is now not always an `Exception` as `KeyboardInterrupt` is only a `BaseException`.
