### PR TITLE
Cleanup `MLflowCallback` tests

### DIFF
--- a/tests/integration_tests/test_mlflow.py
+++ b/tests/integration_tests/test_mlflow.py
@@ -64,38 +64,13 @@ def test_study_name(tmpdir: py.path.local) -> None:
     study.optimize(_objective_func, n_trials=n_trials, callbacks=[mlflc])
 
     mlfl_client = MlflowClient(tracking_uri)
-    experiments = mlfl_client.list_experiments()
-    assert len(experiments) == 1
+    assert len(mlfl_client.list_experiments()) == 1
 
-    experiment = experiments[0]
+    experiment = mlfl_client.list_experiments()[0]
+    runs = mlfl_client.list_run_infos(experiment.experiment_id)
+
     assert experiment.name == study_name
-    experiment_id = experiment.experiment_id
-
-    run_infos = mlfl_client.list_run_infos(experiment_id)
-    assert len(run_infos) == n_trials
-
-    first_run_id = run_infos[0].run_id
-    first_run = mlfl_client.get_run(first_run_id)
-    first_run_dict = first_run.to_dictionary()
-    assert "value" in first_run_dict["data"]["metrics"]
-    assert "x" in first_run_dict["data"]["params"]
-    assert "y" in first_run_dict["data"]["params"]
-    assert "z" in first_run_dict["data"]["params"]
-    assert first_run_dict["data"]["tags"]["direction"] == "MINIMIZE"
-    assert first_run_dict["data"]["tags"]["state"] == "COMPLETE"
-    assert (
-        first_run_dict["data"]["tags"]["x_distribution"]
-        == "UniformDistribution(high=1.0, low=-1.0)"
-    )
-    assert (
-        first_run_dict["data"]["tags"]["y_distribution"]
-        == "LogUniformDistribution(high=30.0, low=20.0)"
-    )
-    assert (
-        first_run_dict["data"]["tags"]["z_distribution"]
-        == "CategoricalDistribution(choices=(-1.0, 1.0))"
-    )
-    assert first_run_dict["data"]["tags"]["my_user_attr"] == "my_user_attr_value"
+    assert len(runs) == n_trials
 
 
 @pytest.mark.parametrize("name,expected", [(None, "Default"), ("foo", "foo")])

--- a/tests/integration_tests/test_mlflow.py
+++ b/tests/integration_tests/test_mlflow.py
@@ -428,24 +428,6 @@ def test_track_in_mlflow_decorator(tmpdir: py.path.local) -> None:
     assert tracked_objective.__doc__ == _objective_func.__doc__
 
 
-def test_initialize_experiment(tmpdir: py.path.local) -> None:
-    tracking_file_name = "file:{}".format(tmpdir)
-    metric_name = "my_metric_name"
-    study_name = "my_study"
-
-    mlflc = MLflowCallback(tracking_uri=tracking_file_name, metric_name=metric_name)
-    study = optuna.create_study(study_name=study_name)
-
-    mlflc._initialize_experiment(study)
-
-    mlfl_client = MlflowClient(tracking_file_name)
-    experiments = mlfl_client.list_experiments()
-    assert len(experiments) == 1
-
-    experiment = experiments[0]
-    assert experiment.name == study_name
-
-
 @pytest.mark.parametrize(
     "names,values", [(["metric"], [3.17]), (["metric1", "metric2"], [3.17, 3.18])]
 )

--- a/tests/integration_tests/test_mlflow.py
+++ b/tests/integration_tests/test_mlflow.py
@@ -28,8 +28,10 @@ def _multiobjective_func(trial: optuna.trial.Trial) -> Tuple[float, float]:
 
     x = trial.suggest_float("x", low=-10, high=10)
     y = trial.suggest_float("y", low=1, high=10, log=True)
-    first_objective = (x - 2) ** 2 + (y - 25) ** 2
-    second_objective = (x - 2) ** 3 + (y - 25) ** 3
+    z = trial.suggest_categorical("z", (-1.0, 1.0))
+    assert isinstance(z, float)
+    first_objective = (x - 2) ** 2 + (y - 25) ** 2 + z
+    second_objective = (x - 2) ** 3 + (y - 25) ** 3 - z
 
     return first_objective, second_objective
 

--- a/tests/integration_tests/test_mlflow.py
+++ b/tests/integration_tests/test_mlflow.py
@@ -8,6 +8,7 @@ from typing import Union
 import mlflow
 from mlflow.tracking import MlflowClient
 from mlflow.utils.mlflow_tags import MLFLOW_PARENT_RUN_ID
+import numpy as np
 import py
 import pytest
 
@@ -469,7 +470,7 @@ def test_log_metric_none(tmpdir: py.path.local) -> None:
 
     mlflc = MLflowCallback(tracking_uri=tracking_uri, metric_name=metric_name)
     study = optuna.create_study(study_name=study_name)
-    study.optimize(lambda _: None, n_trials=1, callbacks=[mlflc])
+    study.optimize(lambda _: np.nan, n_trials=1, callbacks=[mlflc])
 
     mlfl_client = MlflowClient(tracking_uri)
     experiments = mlfl_client.list_experiments()

--- a/tests/integration_tests/test_mlflow.py
+++ b/tests/integration_tests/test_mlflow.py
@@ -314,9 +314,7 @@ def test_tag_study_user_attrs(tmpdir: py.path.local, tag_study_user_attrs: bool)
     study_name = "my_study"
     n_trials = 3
 
-    mlflc = MLflowCallback(
-        tracking_uri=tracking_uri, tag_study_user_attrs=tag_study_user_attrs
-    )
+    mlflc = MLflowCallback(tracking_uri=tracking_uri, tag_study_user_attrs=tag_study_user_attrs)
     study = optuna.create_study(study_name=study_name)
     study.set_user_attr("my_study_attr", "a")
     study.optimize(_objective_func_long_user_attr, n_trials=n_trials, callbacks=[mlflc])


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
A bit overdue cleanup of `MLflowCallback` tests as discussed in https://github.com/optuna/optuna/pull/2912#issuecomment-915462924 and https://github.com/optuna/optuna/pull/2912#discussion_r720187136.

## Description of the changes
<!-- Describe the changes in this PR. -->
* Reduced test duplication
* Fixed `tracking_uri` naming
* Refactored `test_log_*` to use only public APIs
* simplified `test_study_name`