### PR TITLE
Unify pareto front

### DIFF
--- a/optuna/visualization/_pareto_front.py
+++ b/optuna/visualization/_pareto_front.py
@@ -229,10 +229,8 @@ def _get_pareto_front_info(
 
     _targets = targets
     if _targets is None:
-        if len(study.directions) == 2:
-            _targets = _targets_default_2d
-        elif len(study.directions) == 3:
-            _targets = _targets_default_3d
+        if len(study.directions) in (2, 3):
+            _targets = _targets_default
         else:
             raise ValueError(
                 "`plot_pareto_front` function only supports 2 or 3 objective"
@@ -315,12 +313,8 @@ def _get_pareto_front_info(
     )
 
 
-def _targets_default_2d(trial: FrozenTrial) -> Sequence[float]:
-    return trial.values[0], trial.values[1]
-
-
-def _targets_default_3d(trial: FrozenTrial) -> Sequence[float]:
-    return trial.values[0], trial.values[1], trial.values[2]
+def _targets_default(trial: FrozenTrial) -> Sequence[float]:
+    return trial.values
 
 
 def _get_non_pareto_front_trials(

--- a/optuna/visualization/_pareto_front.py
+++ b/optuna/visualization/_pareto_front.py
@@ -29,7 +29,7 @@ _logger = optuna.logging.get_logger(__name__)
 class _ParetoFrontInfo(NamedTuple):
     n_targets: int
     target_names: Sequence[str]
-    best_trials_with_values: Sequence[Tuple[FrozenTrial, Sequence[float]]]
+    best_trials_with_values: Optional[Sequence[Tuple[FrozenTrial, Sequence[float]]]]
     non_best_trials_with_values: Optional[Sequence[Tuple[FrozenTrial, Sequence[float]]]]
     infeasible_trials_with_values: Optional[Sequence[Tuple[FrozenTrial, Sequence[float]]]]
     axis_order: Sequence[int]
@@ -308,7 +308,7 @@ def _get_pareto_front_info(
     return _ParetoFrontInfo(
         n_targets=n_targets,
         target_names=target_names,
-        best_trials_with_values=best_trials_with_values,  # type: ignore
+        best_trials_with_values=best_trials_with_values,
         non_best_trials_with_values=non_best_trials_with_values,
         infeasible_trials_with_values=infeasible_trials_with_values,
         axis_order=axis_order,

--- a/optuna/visualization/_pareto_front.py
+++ b/optuna/visualization/_pareto_front.py
@@ -28,11 +28,11 @@ _logger = optuna.logging.get_logger(__name__)
 
 class _ParetoFrontInfo(NamedTuple):
     n_targets: int
-    target_names: List[str]
-    best_trials_with_values: List[Tuple[FrozenTrial, Sequence[float]]]
+    target_names: Sequence[str]
+    best_trials_with_values: Sequence[Tuple[FrozenTrial, Sequence[float]]]
     non_best_trials_with_values: Optional[Sequence[Tuple[FrozenTrial, Sequence[float]]]]
     infeasible_trials_with_values: Optional[Sequence[Tuple[FrozenTrial, Sequence[float]]]]
-    axis_order: List[int]
+    axis_order: Sequence[int]
 
 
 @experimental("2.4.0")
@@ -345,7 +345,7 @@ def _make_json_compatible(value: Any) -> Any:
 
 def _make_scatter_object(
     n_targets: int,
-    axis_order: List[int],
+    axis_order: Sequence[int],
     include_dominated_trials: bool,
     trials_with_values: Optional[Sequence[Tuple[FrozenTrial, Sequence[float]]]],
     hovertemplate: str,

--- a/optuna/visualization/_pareto_front.py
+++ b/optuna/visualization/_pareto_front.py
@@ -111,30 +111,20 @@ def plot_pareto_front(
         study, target_names, include_dominated_trials, axis_order, constraints_func
     )
 
-    def _make_scatter_object(
-        trials_with_values: Optional[Sequence[Tuple[FrozenTrial, Sequence[float]]]],
-        hovertemplate: str,
-        infeasible: bool = False,
-        dominated_trials: bool = False,
-    ) -> Union["go.Scatter", "go.Scatter3d"]:
-        return _make_scatter_object_base(
-            info.n_targets,
-            trials_with_values or [],
-            info.axis_order,
-            include_dominated_trials,
-            hovertemplate=hovertemplate,
-            infeasible=infeasible,
-            dominated_trials=dominated_trials,
-        )
-
     if constraints_func is None:
         data = [
             _make_scatter_object(
+                info.n_targets,
+                info.axis_order,
+                include_dominated_trials,
                 info.non_best_trials_with_values,
                 hovertemplate="%{text}<extra>Trial</extra>",
                 dominated_trials=True,
             ),
             _make_scatter_object(
+                info.n_targets,
+                info.axis_order,
+                include_dominated_trials,
                 info.best_trials_with_values,
                 hovertemplate="%{text}<extra>Best Trial</extra>",
                 dominated_trials=False,
@@ -143,16 +133,25 @@ def plot_pareto_front(
     else:
         data = [
             _make_scatter_object(
+                info.n_targets,
+                info.axis_order,
+                include_dominated_trials,
                 info.infeasible_trials_with_values,
                 hovertemplate="%{text}<extra>Infeasible Trial</extra>",
                 infeasible=True,
             ),
             _make_scatter_object(
+                info.n_targets,
+                info.axis_order,
+                include_dominated_trials,
                 info.non_best_trials_with_values,
                 hovertemplate="%{text}<extra>Feasible Trial</extra>",
                 dominated_trials=True,
             ),
             _make_scatter_object(
+                info.n_targets,
+                info.axis_order,
+                include_dominated_trials,
                 info.best_trials_with_values,
                 hovertemplate="%{text}<extra>Best Trial</extra>",
                 dominated_trials=False,
@@ -344,15 +343,17 @@ def _make_json_compatible(value: Any) -> Any:
         return str(value)
 
 
-def _make_scatter_object_base(
+def _make_scatter_object(
     n_targets: int,
-    trials_with_values: Sequence[Tuple[FrozenTrial, Sequence[float]]],
     axis_order: List[int],
     include_dominated_trials: bool,
+    trials_with_values: Optional[Sequence[Tuple[FrozenTrial, Sequence[float]]]],
     hovertemplate: str,
     infeasible: bool = False,
     dominated_trials: bool = False,
 ) -> Union["go.Scatter", "go.Scatter3d"]:
+    trials_with_values = trials_with_values or []
+
     assert n_targets in (2, 3)
     marker = _make_marker(
         [trial for trial, _ in trials_with_values],

--- a/optuna/visualization/_pareto_front.py
+++ b/optuna/visualization/_pareto_front.py
@@ -264,10 +264,10 @@ def _get_pareto_front_info(
             return len(trials_with_values[0][1])
         return None
 
-    n_targets = (
-        _infer_n_targets(best_trials_with_values)
-        or _infer_n_targets(non_best_trials_with_values)
-        or _infer_n_targets(infeasible_trials_with_values)
+    # Check for `non_best_trials_with_values` can be skipped, because if `best_trials_with_values`
+    # is empty, then `non_best_trials_with_values` will also be empty.
+    n_targets = _infer_n_targets(best_trials_with_values) or _infer_n_targets(
+        infeasible_trials_with_values
     )
     if n_targets is None:
         if target_names is not None:

--- a/optuna/visualization/matplotlib/_pareto_front.py
+++ b/optuna/visualization/matplotlib/_pareto_front.py
@@ -129,7 +129,7 @@ def _get_pareto_front_2d(info: _ParetoFrontInfo) -> "Axes":
             color=cmap(0),
             label="Trial",
         )
-    if len(info.best_trials_with_values) > 0:
+    if info.best_trials_with_values is not None and len(info.best_trials_with_values) > 0:
         ax.scatter(
             x=[values[info.axis_order[0]] for _, values in info.best_trials_with_values],
             y=[values[info.axis_order[1]] for _, values in info.best_trials_with_values],
@@ -164,7 +164,7 @@ def _get_pareto_front_3d(info: _ParetoFrontInfo) -> "Axes":
             label="Trial",
         )
 
-    if len(info.best_trials_with_values):
+    if info.best_trials_with_values is not None and len(info.best_trials_with_values):
         ax.scatter(
             xs=[values[info.axis_order[0]] for _, values in info.best_trials_with_values],
             ys=[values[info.axis_order[1]] for _, values in info.best_trials_with_values],

--- a/optuna/visualization/matplotlib/_pareto_front.py
+++ b/optuna/visualization/matplotlib/_pareto_front.py
@@ -1,15 +1,14 @@
-import collections
 from typing import Callable
 from typing import List
 from typing import Optional
 from typing import Sequence
-import warnings
 
 import optuna
 from optuna._experimental import experimental
 from optuna.study import Study
 from optuna.trial import FrozenTrial
-from optuna.trial import TrialState
+from optuna.visualization._pareto_front import _get_pareto_front_info
+from optuna.visualization._pareto_front import _ParetoFrontInfo
 from optuna.visualization.matplotlib._matplotlib_imports import _imports
 
 
@@ -100,166 +99,54 @@ def plot_pareto_front(
     """
 
     _imports.check()
-    if axis_order is not None:
-        warnings.warn(
-            "`axis_order` has been deprecated in v3.0.0. "
-            "This feature will be removed in v5.0.0. "
-            "See https://github.com/optuna/optuna/releases/tag/v3.0.0.",
-            DeprecationWarning,
-        )
-    trials = _get_trials(study, include_dominated_trials)
-    if targets is not None and axis_order is not None:
-        raise ValueError(
-            "Using both `targets` and `axis_order` is not supported. "
-            "Use either `targets` or `axis_order`."
-        )
-    _targets = targets
-    if _targets is None:
-        if len(study.directions) == 2:
-            _targets = _targets_default_2d
-        elif len(study.directions) == 3:
-            _targets = _targets_default_3d
-        else:
-            raise ValueError(
-                "`plot_pareto_front` function only supports 2 or 3 objective"
-                " studies when using `targets` is `None`. Please use `targets`"
-                " if your objective studies have more than 3 objectives."
-            )
-    target_values = [_targets(t) for t in trials]
-    if len(target_values) > 0 and not isinstance(target_values[0], collections.abc.Sequence):
-        raise ValueError(
-            "`targets` should return a sequence of target values."
-            " your `targets` returns {}".format(type(target_values[0]))
-        )
 
-    if len(target_values) > 0:
-        n_targets = len(target_values[0])
-    elif target_names is not None:
-        n_targets = len(target_names)
-    elif targets is None:
-        n_targets = len(study.directions)
-    else:
-        raise ValueError(
-            "If `targets` is specified for empty studies, `target_names` must be specified."
-        )
+    info = _get_pareto_front_info(
+        study, target_names, include_dominated_trials, axis_order, None, targets
+    )
 
-    if n_targets == 2:
-        return _get_pareto_front_2d(
-            study, target_values, target_names, include_dominated_trials, axis_order
-        )
-    elif n_targets == 3:
-        return _get_pareto_front_3d(
-            study, target_values, target_names, include_dominated_trials, axis_order
-        )
+    if info.n_targets == 2:
+        return _get_pareto_front_2d(info)
+    elif info.n_targets == 3:
+        return _get_pareto_front_3d(info)
     else:
         raise ValueError(
             "`plot_pareto_front` function only supports 2 or 3 targets."
-            " you used {} targets now.".format(n_targets)
+            " you used {} targets now.".format(info.n_targets)
         )
 
 
-def _targets_default_2d(trial: FrozenTrial) -> Sequence[float]:
-    return trial.values[0], trial.values[1]
-
-
-def _targets_default_3d(trial: FrozenTrial) -> Sequence[float]:
-    return trial.values[0], trial.values[1], trial.values[2]
-
-
-def _get_non_pareto_front_trials(
-    study: Study, pareto_trials: List[FrozenTrial]
-) -> List[FrozenTrial]:
-
-    non_pareto_trials = []
-    for trial in study.get_trials():
-        if trial.state == TrialState.COMPLETE and trial not in pareto_trials:
-            non_pareto_trials.append(trial)
-    return non_pareto_trials
-
-
-def _get_trials(study: Study, include_dominated_trials: bool) -> List[FrozenTrial]:
-    trials = study.best_trials
-    if len(trials) == 0:
-        _logger.warning("Your study does not have any completed trials.")
-
-    if include_dominated_trials:
-        non_pareto_trials = _get_non_pareto_front_trials(study, trials)
-        trials += non_pareto_trials
-    return trials
-
-
-def _get_pareto_front_2d(
-    study: Study,
-    target_values: Sequence[Sequence[float]],
-    target_names: Optional[List[str]],
-    include_dominated_trials: bool = False,
-    axis_order: Optional[List[int]] = None,
-) -> "Axes":
-
+def _get_pareto_front_2d(info: _ParetoFrontInfo) -> "Axes":
     # Set up the graph style.
     plt.style.use("ggplot")  # Use ggplot style sheet for similar outputs to plotly.
     _, ax = plt.subplots()
     ax.set_title("Pareto-front Plot")
     cmap = plt.get_cmap("tab10")  # Use tab10 colormap for similar outputs to plotly.
 
-    if target_names is None:
-        target_names = ["Objective 0", "Objective 1"]
-    elif len(target_names) != 2:
-        raise ValueError("The length of `target_names` is supposed to be 2.")
+    ax.set_xlabel(info.target_names[info.axis_order[0]])
+    ax.set_ylabel(info.target_names[info.axis_order[1]])
 
-    # Prepare data for plotting.
-    if axis_order is None:
-        axis_order = list(range(2))
-    else:
-        if len(axis_order) != 2:
-            raise ValueError(
-                f"Size of `axis_order` {axis_order}. Expect: 2, Actual: {len(axis_order)}."
-            )
-        if len(set(axis_order)) != 2:
-            raise ValueError(f"Elements of given `axis_order` {axis_order} are not unique!")
-        if max(axis_order) > 1:
-            raise ValueError(
-                f"Given `axis_order` {axis_order} contains invalid index {max(axis_order)} "
-                "higher than 1."
-            )
-        if min(axis_order) < 0:
-            raise ValueError(
-                f"Given `axis_order` {axis_order} contains invalid index {min(axis_order)} "
-                "lower than 0."
-            )
-
-    ax.set_xlabel(target_names[axis_order[0]])
-    ax.set_ylabel(target_names[axis_order[1]])
-
-    if len(target_values) - len(study.best_trials) != 0:
+    if info.non_best_trials_with_values is not None and len(info.non_best_trials_with_values) > 0:
         ax.scatter(
-            x=[v[axis_order[0]] for v in target_values[len(study.best_trials) :]],
-            y=[v[axis_order[1]] for v in target_values[len(study.best_trials) :]],
+            x=[values[info.axis_order[0]] for _, values in info.non_best_trials_with_values],
+            y=[values[info.axis_order[1]] for _, values in info.non_best_trials_with_values],
             color=cmap(0),
             label="Trial",
         )
-    if len(study.best_trials):
+    if len(info.best_trials_with_values) > 0:
         ax.scatter(
-            x=[v[axis_order[0]] for v in target_values[: len(study.best_trials)]],
-            y=[v[axis_order[1]] for v in target_values[: len(study.best_trials)]],
+            x=[values[info.axis_order[0]] for _, values in info.best_trials_with_values],
+            y=[values[info.axis_order[1]] for _, values in info.best_trials_with_values],
             color=cmap(3),
             label="Best Trial",
         )
 
-    if include_dominated_trials and ax.has_data():
+    if info.non_best_trials_with_values is not None and ax.has_data():
         ax.legend()
 
     return ax
 
 
-def _get_pareto_front_3d(
-    study: Study,
-    target_values: Sequence[Sequence[float]],
-    target_names: Optional[List[str]],
-    include_dominated_trials: bool = False,
-    axis_order: Optional[List[int]] = None,
-) -> "Axes":
-
+def _get_pareto_front_3d(info: _ParetoFrontInfo) -> "Axes":
     # Set up the graph style.
     plt.style.use("ggplot")  # Use ggplot style sheet for similar outputs to plotly.
     fig = plt.figure()
@@ -267,54 +154,29 @@ def _get_pareto_front_3d(
     ax.set_title("Pareto-front Plot")
     cmap = plt.get_cmap("tab10")  # Use tab10 colormap for similar outputs to plotly.
 
-    if target_names is None:
-        target_names = ["Objective 0", "Objective 1", "Objective 2"]
-    elif len(target_names) != 3:
-        raise ValueError("The length of `target_names` is supposed to be 3.")
+    ax.set_xlabel(info.target_names[info.axis_order[0]])
+    ax.set_ylabel(info.target_names[info.axis_order[1]])
+    ax.set_zlabel(info.target_names[info.axis_order[2]])
 
-    if axis_order is None:
-        axis_order = list(range(3))
-    else:
-        if len(axis_order) != 3:
-            raise ValueError(
-                f"Size of `axis_order` {axis_order}. Expect: 3, Actual: {len(axis_order)}."
-            )
-        if len(set(axis_order)) != 3:
-            raise ValueError(f"Elements of given `axis_order` {axis_order} are not unique!.")
-        if max(axis_order) > 2:
-            raise ValueError(
-                f"Given `axis_order` {axis_order} contains invalid index {max(axis_order)} "
-                "higher than 2."
-            )
-        if min(axis_order) < 0:
-            raise ValueError(
-                f"Given `axis_order` {axis_order} contains invalid index {min(axis_order)} "
-                "lower than 0."
-            )
-
-    ax.set_xlabel(target_names[axis_order[0]])
-    ax.set_ylabel(target_names[axis_order[1]])
-    ax.set_zlabel(target_names[axis_order[2]])
-
-    if len(target_values) - len(study.best_trials) != 0:
+    if info.non_best_trials_with_values is not None and len(info.non_best_trials_with_values) > 0:
         ax.scatter(
-            xs=[v[axis_order[0]] for v in target_values[len(study.best_trials) :]],
-            ys=[v[axis_order[1]] for v in target_values[len(study.best_trials) :]],
-            zs=[v[axis_order[2]] for v in target_values[len(study.best_trials) :]],
+            xs=[values[info.axis_order[0]] for _, values in info.non_best_trials_with_values],
+            ys=[values[info.axis_order[1]] for _, values in info.non_best_trials_with_values],
+            zs=[values[info.axis_order[2]] for _, values in info.non_best_trials_with_values],
             color=cmap(0),
             label="Trial",
         )
 
-    if len(study.best_trials):
+    if len(info.best_trials_with_values):
         ax.scatter(
-            xs=[v[axis_order[0]] for v in target_values[: len(study.best_trials)]],
-            ys=[v[axis_order[1]] for v in target_values[: len(study.best_trials)]],
-            zs=[v[axis_order[2]] for v in target_values[: len(study.best_trials)]],
+            xs=[values[info.axis_order[0]] for _, values in info.best_trials_with_values],
+            ys=[values[info.axis_order[1]] for _, values in info.best_trials_with_values],
+            zs=[values[info.axis_order[2]] for _, values in info.best_trials_with_values],
             color=cmap(3),
             label="Best Trial",
         )
 
-    if include_dominated_trials and ax.has_data():
+    if info.non_best_trials_with_values is not None and ax.has_data():
         ax.legend()
 
     return ax

--- a/optuna/visualization/matplotlib/_pareto_front.py
+++ b/optuna/visualization/matplotlib/_pareto_front.py
@@ -3,7 +3,6 @@ from typing import List
 from typing import Optional
 from typing import Sequence
 
-import optuna
 from optuna._experimental import experimental
 from optuna.study import Study
 from optuna.trial import FrozenTrial
@@ -15,8 +14,6 @@ from optuna.visualization.matplotlib._matplotlib_imports import _imports
 if _imports.is_successful():
     from optuna.visualization.matplotlib._matplotlib_imports import Axes
     from optuna.visualization.matplotlib._matplotlib_imports import plt
-
-_logger = optuna.logging.get_logger(__name__)
 
 
 @experimental("2.8.0")


### PR DESCRIPTION
## Motivation
We have two separate implementations of `plot_pareto_front`s for pyplot and matplotlib. Here we have 2 issues:

- They should essentially do the same things, except how the plots are rendered using respective libraries. Therefore, we have redundant codes in two versions of `plot_pareto_front`.
- They are slightly different in supported features (`constraints_func` is supported only by pyplot, while `targets` is supported only by matplotlib).

## Description of the changes
"Backend" (logic for obtaining the necessary information to plot) is now factored out as `_get_pareto_front_info`.

At present, signatures of `plot_pareto_front`s as well as their supported features are unchanged. I'm not sure whether we should enhance features (`targets` to pyplot version, `constraints_func` to matplotlib version) in this PR or another PR.
