### PR TITLE
Make `_set_best_trial()` of `RedisStorage` faster

### DIFF
--- a/optuna/storages/_redis.py
+++ b/optuna/storages/_redis.py
@@ -534,14 +534,15 @@ class RedisStorage(BaseStorage):
 
     def _set_best_trial(self, study_id: int, trial_id: int) -> None:
 
-        with self._redis.pipeline() as pipe:
-            pipe.multi()
-            pipe.set(self._key_best_trial(study_id), pickle.dumps(trial_id))
+        queries: Mapping[Union[str, bytes], Union[bytes, float, int, str]]
+        queries = dict()
 
-            study_summary = self._get_study_summary(study_id)
-            study_summary.best_trial = self.get_trial(trial_id)
-            pipe.set(self._key_study_summary(study_id), pickle.dumps(study_summary))
-            pipe.execute()
+        queries[self._key_best_trial(study_id)] = pickle.dumps(trial_id)
+        study_summary = self._get_study_summary(study_id)
+        study_summary.best_trial = self.get_trial(trial_id)
+        queries[self._key_study_summary(study_id)] = pickle.dumps(study_summary)
+
+        self._redis.mset(queries)
 
     def _check_and_set_param_distribution(
         self,


### PR DESCRIPTION
## Description of the changes
By using `mset()` instead of `pipeline()`, this patch improve performance of `_set_best_trial()` from 455(usec) to 399(usec).

Signed-off-by: Masashi Honma <masashi.honma@gmail.com>

![chart](https://user-images.githubusercontent.com/1505016/159149669-7555215f-262f-4790-818f-7c5e0a2c7b58.png)

