### PR TITLE
Test serialize/deserialize storage on parametrized conditions

### DIFF
--- a/tests/storages_tests/rdb_tests/test_storage.py
+++ b/tests/storages_tests/rdb_tests/test_storage.py
@@ -1,5 +1,4 @@
 import os
-import pickle
 import shutil
 import sys
 import tempfile
@@ -141,18 +140,6 @@ def create_test_storage(engine_kwargs: Optional[Dict[str, Any]] = None) -> RDBSt
 
     storage = RDBStorage("sqlite:///:memory:", engine_kwargs=engine_kwargs)
     return storage
-
-
-def test_pickle_storage() -> None:
-
-    storage = create_test_storage()
-    restored_storage = pickle.loads(pickle.dumps(storage))
-    assert storage.url == restored_storage.url
-    assert storage.engine_kwargs == restored_storage.engine_kwargs
-    assert storage.skip_compatibility_check == restored_storage.skip_compatibility_check
-    assert storage.engine != restored_storage.engine
-    assert storage.scoped_session != restored_storage.scoped_session
-    assert storage._version_manager != restored_storage._version_manager
 
 
 def test_create_scoped_session() -> None:


### PR DESCRIPTION
In https://github.com/optuna/optuna/pull/3347, we observed the unexpected coverage degradation found. The cause is under investigation but the degradation disappears if pickle/unpickle is explicitly tested (https://github.com/optuna/optuna/pull/3385#issuecomment-1068838907). I personally feels reasonable to run test of serialization/deserialization on parametrized conditions.

The existing code tests pickle/unpickle on `RDBStorage`. This PR tests it on `RDBStorage`, `CachedStorage` (with `RDBStorage`), and `InMemoryStorage` (I'm not sure whether `test_storages.py` is a good place because `__setstate__` and `__getstate__` are not defined in `BaseStorage`).