### PR TITLE
Return the best trial number, not worst trial number by `best_index_`

### DIFF
--- a/optuna/integration/sklearn.py
+++ b/optuna/integration/sklearn.py
@@ -513,7 +513,10 @@ class OptunaSearchCV(BaseEstimator):
 
     @property
     def best_index_(self) -> int:
-        """Index which corresponds to the best candidate parameter setting."""
+        """Trial number which corresponds to the best candidate parameter setting.
+
+        Retuned value is equivant to ``optuna_search.best_trial_.number``.
+        """
 
         return self.study_.best_trial.number
 

--- a/optuna/integration/sklearn.py
+++ b/optuna/integration/sklearn.py
@@ -518,7 +518,7 @@ class OptunaSearchCV(BaseEstimator):
         Retuned value is equivant to ``optuna_search.best_trial_.number``.
         """
 
-        return self.study_.best_trial.number
+        return self.best_trial_.number
 
     @property
     def best_params_(self) -> Dict[str, Any]:

--- a/optuna/integration/sklearn.py
+++ b/optuna/integration/sklearn.py
@@ -515,9 +515,7 @@ class OptunaSearchCV(BaseEstimator):
     def best_index_(self) -> int:
         """Index which corresponds to the best candidate parameter setting."""
 
-        df = self.trials_dataframe()
-
-        return df["value"].idxmin()
+        return self.study_.best_trial.number
 
     @property
     def best_params_(self) -> Dict[str, Any]:


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

Fix #3409.

The `OptunaSearchCV` supports only maximisation problem by following the convention of sklearn's scoring as described in [a note section](https://optuna.readthedocs.io/en/latest/reference/generated/optuna.integration.OptunaSearchCV.html). However the current implementation returns a trial index whose objective value is the lowest in the study; it returns the worst trial number.

## Description of the changes
<!-- Describe the changes in this PR. -->

- Return the best trial number
- Update docstring to clarify the behaviour of `best_index_`.