### PR TITLE
Skip run fastai job on py36

### DIFF
--- a/.github/workflows/tests-integration.yml
+++ b/.github/workflows/tests-integration.yml
@@ -66,7 +66,8 @@ jobs:
             --ignore tests/integration_tests/test_keras.py \
             --ignore tests/integration_tests/test_tensorboard.py \
             --ignore tests/integration_tests/test_tensorflow.py \
-            --ignore tests/integration_tests/test_tfkeras.py
+            --ignore tests/integration_tests/test_tfkeras.py \
+            --ignore tests/integration_tests/test_fastaiv2.py
         else
           pytest -s tests/integration_tests
         fi

--- a/setup.py
+++ b/setup.py
@@ -124,7 +124,7 @@ def get_extras_require() -> Dict[str, List[str]]:
             # after solving https://github.com/optuna/optuna/issues/3366
             "allennlp>=2.2.0,<2.9.1 ; python_version>'3.6'",
             "botorch>=0.4.0 ; python_version>'3.6'",
-            "fastai",
+            "fastai ; python_version>'3.6'",
         ],
         "tests": [
             "fakeredis",
@@ -169,7 +169,7 @@ def get_extras_require() -> Dict[str, List[str]]:
             # after solving https://github.com/optuna/optuna/issues/3366
             "allennlp>=2.2.0,<2.9.1 ; python_version>'3.6'",
             "botorch>=0.4.0 ; python_version>'3.6'",
-            "fastai",
+            "fastai ; python_version>'3.6'",
         ],
         "benchmark": [
             "asv>=0.5.0",


### PR DESCRIPTION
Same as https://github.com/optuna/optuna-examples/pull/93.

This PR stops running the fastai test on py36.