### PR TITLE
Avoid latest `click==8.1.0` that removed a deprecated feature

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -125,6 +125,7 @@ def get_extras_require() -> Dict[str, List[str]]:
             "allennlp>=2.2.0,<2.9.1 ; python_version>'3.6'",
             "botorch>=0.4.0 ; python_version>'3.6'",
             "fastai ; python_version>'3.6'",
+            "click<8.1.0",  # See https://github.com/tiangolo/typer/pull/375.
         ],
         "tests": [
             "fakeredis",
@@ -170,6 +171,7 @@ def get_extras_require() -> Dict[str, List[str]]:
             "allennlp>=2.2.0,<2.9.1 ; python_version>'3.6'",
             "botorch>=0.4.0 ; python_version>'3.6'",
             "fastai ; python_version>'3.6'",
+            "click<8.1.0",  # See https://github.com/tiangolo/typer/pull/375.
         ],
         "benchmark": [
             "asv>=0.5.0",


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation

Fixes a broken test rooted in a recent release of `click==8.1.0`.

```
___ ERROR collecting tests/integration_tests/allennlp_tests/test_allennlp.py ___
ImportError while importing test module '/home/runner/work/optuna/optuna/tests/integration_tests/allennlp_tests/test_allennlp.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/importlib/__init__.py:1[27](https://github.com/optuna/optuna/runs/5729471389?check_suite_focus=true#step:7:27): in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
tests/integration_tests/allennlp_tests/test_allennlp.py:10: in <module>
    import allennlp.data
/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/allennlp/__init__.py:18: in <module>
    import transformers, spacy, torch, numpy  # noqa
/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/spacy/__init__.py:15: in <module>
    from .cli.info import info  # noqa: F[40](https://github.com/optuna/optuna/runs/5729471389?check_suite_focus=true#step:7:40)1
/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/spacy/cli/__init__.py:3: in <module>
    from ._util import app, setup_cli  # noqa: F401
/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/spacy/cli/_util.py:9: in <module>
    import typer
/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/typer/__init__.py:12: in <module>
    from click.termui import get_terminal_size as get_terminal_size
E   ImportError: cannot import name 'get_terminal_size' from 'click.termui' (/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/click/termui.py)
```

https://github.com/optuna/optuna/runs/5729471389?check_suite_focus=true

## Description of the changes

Temporarily avoid the latest `click` to keep the previous working behavior.
This change can be undone once https://github.com/tiangolo/typer/pull/375 is released.
