### PR TITLE
Avoid using px.colors.sequential.Blues that introduces pandas dep

### DIFF
--- a/optuna/visualization/_utils.py
+++ b/optuna/visualization/_utils.py
@@ -36,7 +36,10 @@ def is_available() -> bool:
     return _plotly_imports._imports.is_successful()
 
 
-COLOR_SCALE = "Blues"
+if is_available():
+    import plotly.colors
+
+    COLOR_SCALE = plotly.colors.sequential.Blues
 
 
 def _check_plot_args(

--- a/optuna/visualization/_utils.py
+++ b/optuna/visualization/_utils.py
@@ -36,10 +36,7 @@ def is_available() -> bool:
     return _plotly_imports._imports.is_successful()
 
 
-if is_available():
-    import plotly.express as px
-
-    COLOR_SCALE = px.colors.sequential.Blues
+COLOR_SCALE = "Blues"
 
 
 def _check_plot_args(


### PR DESCRIPTION
https://github.com/optuna/optuna/pull/3376 unifies our color scale in plotly visualization. This change is really awesome but it introduces (might unintentionally) `pandas` dependency. This PR uses `plotly.colors.sequential.Blues` instead of `px.colors.sequential.Blues` to remove the importing of `plotly.express` from Optuna.

## Motivation
Remove `plotly.express` dependency. It also depends on `pandas`: https://github.com/plotly/plotly.py/issues/2279

---

It confirms on my environment that the colormap of contour visualization is the same as other visualizations.

v2.10.0 | This PR
-- | --
![_Users_himkt_Downloads_Untitled%20(1) html](https://user-images.githubusercontent.com/5164000/160955248-5c84ad19-788d-436b-b72e-f43809be8b02.png) | ![_Users_himkt_Downloads_Untitled html](https://user-images.githubusercontent.com/5164000/160955229-227e87a4-9cac-4f49-abe6-8cd82cfa6b92.png)
