### PR TITLE
Fix `_is_reverse_scale`

### DIFF
--- a/optuna/visualization/_contour.py
+++ b/optuna/visualization/_contour.py
@@ -148,13 +148,13 @@ def _get_contour_plot(
 
         param_values_range[p_name] = (min_value, max_value)
 
-    reversescale = _is_reverse_scale(study, target)
+    reverse_scale = _is_reverse_scale(study, target)
 
     if len(sorted_params) == 2:
         x_param = sorted_params[0]
         y_param = sorted_params[1]
         sub_plots = _generate_contour_subplot(
-            trials, x_param, y_param, reversescale, param_values_range, target, target_name
+            trials, x_param, y_param, reverse_scale, param_values_range, target, target_name
         )
         figure = go.Figure(data=sub_plots, layout=layout)
         figure.update_xaxes(title_text=x_param, range=param_values_range[x_param])
@@ -186,7 +186,7 @@ def _get_contour_plot(
                         trials,
                         x_param,
                         y_param,
-                        reversescale,
+                        reverse_scale,
                         param_values_range,
                         target,
                         target_name,
@@ -226,7 +226,7 @@ def _generate_contour_subplot(
     trials: List[FrozenTrial],
     x_param: str,
     y_param: str,
-    reversescale: bool,
+    reverse_scale: bool,
     param_values_range: Optional[Dict[str, Tuple[float, float]]] = None,
     target: Optional[Callable[[FrozenTrial], float]] = None,
     target_name: str = "Objective Value",
@@ -294,7 +294,7 @@ def _generate_contour_subplot(
         contours_coloring="heatmap",
         hoverinfo="none",
         line_smoothing=1.3,
-        reversescale=reversescale,
+        reversescale=reverse_scale,
     )
 
     scatter = go.Scatter(

--- a/optuna/visualization/_contour.py
+++ b/optuna/visualization/_contour.py
@@ -9,7 +9,6 @@ from packaging import version
 
 from optuna.logging import get_logger
 from optuna.study import Study
-from optuna.study._study_direction import StudyDirection
 from optuna.trial import FrozenTrial
 from optuna.trial import TrialState
 from optuna.visualization._plotly_imports import _imports
@@ -149,11 +148,13 @@ def _get_contour_plot(
 
         param_values_range[p_name] = (min_value, max_value)
 
+    reversescale = _is_reverse_scale(study, target)
+
     if len(sorted_params) == 2:
         x_param = sorted_params[0]
         y_param = sorted_params[1]
         sub_plots = _generate_contour_subplot(
-            trials, x_param, y_param, study.directions[0], param_values_range, target, target_name
+            trials, x_param, y_param, reversescale, param_values_range, target, target_name
         )
         figure = go.Figure(data=sub_plots, layout=layout)
         figure.update_xaxes(title_text=x_param, range=param_values_range[x_param])
@@ -185,7 +186,7 @@ def _get_contour_plot(
                         trials,
                         x_param,
                         y_param,
-                        study.directions[0],
+                        reversescale,
                         param_values_range,
                         target,
                         target_name,
@@ -225,7 +226,7 @@ def _generate_contour_subplot(
     trials: List[FrozenTrial],
     x_param: str,
     y_param: str,
-    direction: StudyDirection,
+    reversescale: bool,
     param_values_range: Optional[Dict[str, Tuple[float, float]]] = None,
     target: Optional[Callable[[FrozenTrial], float]] = None,
     target_name: str = "Objective Value",
@@ -293,7 +294,7 @@ def _generate_contour_subplot(
         contours_coloring="heatmap",
         hoverinfo="none",
         line_smoothing=1.3,
-        reversescale=_is_reverse_scale(target, direction),
+        reversescale=reversescale,
     )
 
     scatter = go.Scatter(

--- a/optuna/visualization/_parallel_coordinate.py
+++ b/optuna/visualization/_parallel_coordinate.py
@@ -98,7 +98,11 @@ def _get_parallel_coordinate_plot(
 ) -> "go.Figure":
 
     layout = go.Layout(title="Parallel Coordinate Plot")
-    reverse_scale = _is_reverse_scale(target, study.direction)
+    # `target` isn't `None` for multi-objective study and
+    # accessing `study.direction` raises `RuntimeError`.
+    reverse_scale = (
+        _is_reverse_scale(target, study.direction) if not study._is_multi_objective() else True
+    )
 
     trials = [trial for trial in study.trials if trial.state == TrialState.COMPLETE]
 

--- a/optuna/visualization/_parallel_coordinate.py
+++ b/optuna/visualization/_parallel_coordinate.py
@@ -98,11 +98,7 @@ def _get_parallel_coordinate_plot(
 ) -> "go.Figure":
 
     layout = go.Layout(title="Parallel Coordinate Plot")
-    # `target` isn't `None` for multi-objective study and
-    # accessing `study.direction` raises `RuntimeError`.
-    reverse_scale = (
-        _is_reverse_scale(target, study.direction) if not study._is_multi_objective() else True
-    )
+    reverse_scale = _is_reverse_scale(study, target)
 
     trials = [trial for trial in study.trials if trial.state == TrialState.COMPLETE]
 

--- a/optuna/visualization/_utils.py
+++ b/optuna/visualization/_utils.py
@@ -142,7 +142,6 @@ def _filter_nonfinite(
     return filtered_trials
 
 
-def _is_reverse_scale(
-    target: Optional[Callable[[FrozenTrial], float]], direction: StudyDirection
-) -> bool:
-    return target is not None or direction == StudyDirection.MINIMIZE
+def _is_reverse_scale(study: Study, target: Optional[Callable[[FrozenTrial], float]]) -> bool:
+
+    return target is not None or study.direction == StudyDirection.MINIMIZE

--- a/tests/visualization_tests/test_contour.py
+++ b/tests/visualization_tests/test_contour.py
@@ -301,3 +301,9 @@ def test_color_map(direction: str) -> None:
     contour = plot_contour(study, target=lambda t: t.number).data[0]
     assert COLOR_SCALE == [v[1] for v in contour["colorscale"]]
     assert contour["reversescale"]
+
+    # Multi-objective optimization.
+    study = prepare_study_with_trials(with_c_d=False, n_objectives=2, direction=direction)
+    contour = plot_contour(study, target=lambda t: t.number).data[0]
+    assert COLOR_SCALE == [v[1] for v in contour["colorscale"]]
+    assert contour["reversescale"]

--- a/tests/visualization_tests/test_contour.py
+++ b/tests/visualization_tests/test_contour.py
@@ -11,12 +11,12 @@ import pytest
 from optuna.distributions import CategoricalDistribution
 from optuna.distributions import LogUniformDistribution
 from optuna.study import create_study
-from optuna.study import StudyDirection
 from optuna.testing.visualization import prepare_study_with_trials
 from optuna.trial import create_trial
 from optuna.trial import Trial
 from optuna.visualization import plot_contour
 from optuna.visualization._contour import _generate_contour_subplot
+from optuna.visualization._utils import _is_reverse_scale
 from optuna.visualization._utils import COLOR_SCALE
 
 
@@ -138,19 +138,16 @@ def test_generate_contour_plot_for_few_observations() -> None:
 
     study = prepare_study_with_trials(less_than_two=True)
     trials = study.trials
+    reverse_scale = _is_reverse_scale(study, target=None)
 
     # `x_axis` has one observation.
     params = ["param_a", "param_b"]
-    contour, scatter = _generate_contour_subplot(
-        trials, params[0], params[1], StudyDirection.MINIMIZE
-    )
+    contour, scatter = _generate_contour_subplot(trials, params[0], params[1], reverse_scale)
     assert contour.x is None and contour.y is None and scatter.x is None and scatter.y is None
 
     # `y_axis` has one observation.
     params = ["param_b", "param_a"]
-    contour, scatter = _generate_contour_subplot(
-        trials, params[0], params[1], StudyDirection.MINIMIZE
-    )
+    contour, scatter = _generate_contour_subplot(trials, params[0], params[1], reverse_scale)
     assert contour.x is None and contour.y is None and scatter.x is None and scatter.y is None
 
 

--- a/tests/visualization_tests/test_parallel_coordinate.py
+++ b/tests/visualization_tests/test_parallel_coordinate.py
@@ -381,6 +381,12 @@ def test_color_map(direction: str) -> None:
     assert COLOR_SCALE == [v[1] for v in line["colorscale"]]
     assert line["reversescale"]
 
+    # Multi-objective optimization.
+    study = prepare_study_with_trials(with_c_d=False, n_objectives=2, direction=direction)
+    line = plot_parallel_coordinate(study, target=lambda t: t.number).data[0]["line"]
+    assert COLOR_SCALE == [v[1] for v in line["colorscale"]]
+    assert line["reversescale"]
+
 
 def test_plot_parallel_coordinate_only_missing_params() -> None:
     # All trials contains only a part of parameters,

--- a/tests/visualization_tests/test_parallel_coordinate.py
+++ b/tests/visualization_tests/test_parallel_coordinate.py
@@ -286,7 +286,7 @@ def test_plot_parallel_coordinate_unique_hyper_param() -> None:
 
 
 def test_plot_parallel_coordinate_with_categorical_numeric_params() -> None:
-    # Test with sample from mulitiple distributions including categorical params
+    # Test with sample from multiple distributions including categorical params
     # that can be interpreted as numeric params.
     study_multi_distro_params = create_study()
     study_multi_distro_params.add_trial(
@@ -389,7 +389,7 @@ def test_color_map(direction: str) -> None:
 
 
 def test_plot_parallel_coordinate_only_missing_params() -> None:
-    # All trials contains only a part of parameters,
+    # All trials contain only a part of parameters,
     # the plot returns an empty figure.
     study = create_study()
     study.add_trial(


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

The current implementation of `optuna.visualization.plot_parallel_coordinate` raises an error as reported in https://github.com/optuna/optuna/issues/3423#issuecomment-1084602443. This bug has been introduced by https://github.com/optuna/optuna/pull/3376 (me!).

## Description of the changes
<!-- Describe the changes in this PR. -->

- Add tests to cover the case raising an error in https://github.com/optuna/optuna/issues/3423#issuecomment-1084602443
- Update the definition of `_is_reverse_scale`
- Fix typos