### PR TITLE
Pin setup-tools

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -45,9 +45,6 @@ jobs:
     - name: Install
       run: |
         python -m pip install --upgrade pip
-        # TODO(nzw0301): remove the version constraint
-        # when resolving https://github.com/optuna/optuna/issues/3418
-        pip install --progress-bar off -U "setuptools==59.5.0"
 
         # Install minimal dependencies and confirm that `import optuna` is successful.
         pip install --progress-bar off .
@@ -58,6 +55,10 @@ jobs:
         pip install --progress-bar off .[optional]
         pip install --progress-bar off .[integration] -f https://download.pytorch.org/whl/torch_stable.html
         pip install --progress-bar off .[codecov]
+
+        # TODO(nzw0301): remove the version constraint
+        # when resolving https://github.com/optuna/optuna/issues/3418
+        pip install --progress-bar off -U "setuptools==59.5.0"
 
     - name: Tests
       env:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -45,7 +45,9 @@ jobs:
     - name: Install
       run: |
         python -m pip install --upgrade pip
-        pip install --progress-bar off -U setuptools
+        # TODO(nzw0301): remove the version constraint
+        # when resolving https://github.com/optuna/optuna/issues/3418
+        pip install --progress-bar off -U "setuptools==59.5.0"
 
         # Install minimal dependencies and confirm that `import optuna` is successful.
         pip install --progress-bar off .

--- a/.github/workflows/mac-tests.yml
+++ b/.github/workflows/mac-tests.yml
@@ -98,9 +98,6 @@ jobs:
     - name: Install
       run: |
         python -m pip install --upgrade pip
-        # TODO(nzw0301): remove the version constraint
-        # when resolving https://github.com/optuna/optuna/issues/3418
-        pip install --progress-bar off -U "setuptools==59.5.0"
 
         # Install minimal dependencies and confirm that `import optuna` is successful.
         pip install --progress-bar off .
@@ -109,6 +106,10 @@ jobs:
 
         pip install --progress-bar off .[tests]
         pip install --progress-bar off .[integration]
+
+        # TODO(nzw0301): remove the version constraint
+        # when resolving https://github.com/optuna/optuna/issues/3418
+        pip install --progress-bar off -U "setuptools==59.5.0"
 
     - name: Tests
       run: |

--- a/.github/workflows/mac-tests.yml
+++ b/.github/workflows/mac-tests.yml
@@ -98,7 +98,9 @@ jobs:
     - name: Install
       run: |
         python -m pip install --upgrade pip
-        pip install --progress-bar off -U setuptools
+        # TODO(nzw0301): remove the version constraint
+        # when resolving https://github.com/optuna/optuna/issues/3418
+        pip install --progress-bar off -U "setuptools==59.5.0"
 
         # Install minimal dependencies and confirm that `import optuna` is successful.
         pip install --progress-bar off .

--- a/.github/workflows/tests-integration.yml
+++ b/.github/workflows/tests-integration.yml
@@ -47,7 +47,9 @@ jobs:
     - name: Install
       run: |
         python -m pip install --upgrade pip
-        pip install --progress-bar off -U setuptools
+        # TODO(nzw0301): remove the version constraint
+        # when resolving https://github.com/optuna/optuna/issues/3418
+        pip install --progress-bar off -U "setuptools==59.5.0"
 
         # Install minimal dependencies and confirm that `import optuna` is successful.
         pip install --progress-bar off .

--- a/.github/workflows/tests-integration.yml
+++ b/.github/workflows/tests-integration.yml
@@ -47,9 +47,6 @@ jobs:
     - name: Install
       run: |
         python -m pip install --upgrade pip
-        # TODO(nzw0301): remove the version constraint
-        # when resolving https://github.com/optuna/optuna/issues/3418
-        pip install --progress-bar off -U "setuptools==59.5.0"
 
         # Install minimal dependencies and confirm that `import optuna` is successful.
         pip install --progress-bar off .
@@ -58,6 +55,10 @@ jobs:
 
         pip install --progress-bar off .[tests]
         pip install --progress-bar off .[integration] -f https://download.pytorch.org/whl/torch_stable.html
+
+        # TODO(nzw0301): remove the version constraint
+        # when resolving https://github.com/optuna/optuna/issues/3418
+        pip install --progress-bar off -U "setuptools==59.5.0"
 
     - name: Tests
       run: |


### PR DESCRIPTION
## Motivation
The latest setuptools doesn't work with our pytorch-lightning integration.
Previously, we pinned the version of pytorch-lightning (https://github.com/optuna/optuna/pull/3426) but it is not seemingly enough (see the failure of the daily CI https://github.com/optuna/optuna/runs/5779677748?check_suite_focus=true).

## Description of the changes
<!-- Describe the changes in this PR. -->
