### PR TITLE
Make EDF plots handle trials with nonfinite values

### DIFF
--- a/optuna/visualization/_edf.py
+++ b/optuna/visualization/_edf.py
@@ -14,6 +14,7 @@ from optuna.trial import FrozenTrial
 from optuna.trial import TrialState
 from optuna.visualization._plotly_imports import _imports
 from optuna.visualization._utils import _check_plot_args
+from optuna.visualization._utils import _filter_nonfinite
 
 
 if _imports.is_successful():
@@ -142,6 +143,7 @@ def _get_edf_plot(
             for study in studies
         )
     )
+    all_trials = _filter_nonfinite(all_trials, target)
 
     if len(all_trials) == 0:
         _logger.warning("There are no complete trials.")
@@ -160,14 +162,11 @@ def _get_edf_plot(
 
     traces = []
     for study in studies:
-        values = np.asarray(
-            [
-                target(trial)
-                for trial in study.get_trials(deepcopy=False)
-                if trial.state == TrialState.COMPLETE
-            ]
+        trials = _filter_nonfinite(
+            study.get_trials(deepcopy=False, states=(TrialState.COMPLETE,)), target=target
         )
 
+        values = np.asarray([target(trial) for trial in trials])
         y_values = np.sum(values[:, np.newaxis] <= x_values, axis=0) / values.size
 
         traces.append(go.Scatter(x=x_values, y=y_values, name=study.study_name, mode="lines"))

--- a/optuna/visualization/_edf.py
+++ b/optuna/visualization/_edf.py
@@ -143,7 +143,7 @@ def _get_edf_plot(
             for study in studies
         )
     )
-    all_trials = _filter_nonfinite(all_trials, target)
+    all_trials = _filter_nonfinite(all_trials, target, with_message=False)
 
     if len(all_trials) == 0:
         _logger.warning("There are no complete trials.")

--- a/optuna/visualization/matplotlib/_edf.py
+++ b/optuna/visualization/matplotlib/_edf.py
@@ -148,7 +148,7 @@ def _get_edf_plot(
             for study in studies
         )
     )
-    all_trials = _filter_nonfinite(all_trials, target)
+    all_trials = _filter_nonfinite(all_trials, target, with_message=False)
 
     if len(all_trials) == 0:
         _logger.warning("There are no complete trials.")

--- a/optuna/visualization/matplotlib/_edf.py
+++ b/optuna/visualization/matplotlib/_edf.py
@@ -14,6 +14,7 @@ from optuna.study import Study
 from optuna.trial import FrozenTrial
 from optuna.trial import TrialState
 from optuna.visualization._utils import _check_plot_args
+from optuna.visualization._utils import _filter_nonfinite
 from optuna.visualization.matplotlib._matplotlib_imports import _imports
 
 
@@ -147,6 +148,7 @@ def _get_edf_plot(
             for study in studies
         )
     )
+    all_trials = _filter_nonfinite(all_trials, target)
 
     if len(all_trials) == 0:
         _logger.warning("There are no complete trials.")
@@ -165,14 +167,11 @@ def _get_edf_plot(
 
     # Draw multiple line plots.
     for i, study in enumerate(studies):
-        values = np.asarray(
-            [
-                target(trial)
-                for trial in study.get_trials(deepcopy=False)
-                if trial.state == TrialState.COMPLETE
-            ]
+        trials = _filter_nonfinite(
+            study.get_trials(deepcopy=False, states=(TrialState.COMPLETE,)), target=target
         )
 
+        values = np.asarray([target(trial) for trial in trials])
         y_values = np.sum(values[:, np.newaxis] <= x_values, axis=0) / values.size
 
         ax.plot(x_values, y_values, color=cmap(i), alpha=0.7, label=study.study_name)

--- a/tests/visualization_tests/test_edf.py
+++ b/tests/visualization_tests/test_edf.py
@@ -3,7 +3,9 @@ from typing import Sequence
 import numpy as np
 import pytest
 
+from optuna.distributions import FloatDistribution
 from optuna.study import create_study
+from optuna.trial import create_trial
 from optuna.visualization import plot_edf
 
 
@@ -71,3 +73,59 @@ def test_plot_optimization_history(direction: str) -> None:
     _validate_edf_values(figure.data[0]["y"])
     assert len(figure.data) == 1
     assert figure.layout.xaxis.title.text == "Target Name"
+
+
+@pytest.mark.parametrize("value", [float("inf"), -float("inf"), float("nan")])
+def test_nonfinite_removed(value: int) -> None:
+
+    study = create_study()
+    study.add_trial(
+        create_trial(
+            value=0.0,
+            params={"x": 1.0},
+            distributions={"x": FloatDistribution(0.0, 1.0)},
+        )
+    )
+    study.add_trial(
+        create_trial(
+            value=value,
+            params={"x": 0.0},
+            distributions={"x": FloatDistribution(0.0, 1.0)},
+        )
+    )
+
+    figure = plot_edf(study)
+    assert all(np.isfinite(figure.data[0]["x"]))
+
+
+@pytest.mark.parametrize(
+    "objective,value",
+    [
+        (0, float("inf")),
+        (0, -float("inf")),
+        (0, float("nan")),
+        (1, float("inf")),
+        (1, -float("inf")),
+        (1, float("nan")),
+    ],
+)
+def test_nonfinite_multiobjective(objective: int, value: int) -> None:
+
+    study = create_study(directions=["minimize", "maximize"])
+    study.add_trial(
+        create_trial(
+            values=[0.0, 1.0],
+            params={"x": 1.0},
+            distributions={"x": FloatDistribution(0.0, 1.0)},
+        )
+    )
+    study.add_trial(
+        create_trial(
+            values=[value, value],
+            params={"x": 0.0},
+            distributions={"x": FloatDistribution(0.0, 1.0)},
+        )
+    )
+
+    figure = plot_edf(study, target=lambda t: t.values[objective])
+    assert all(np.isfinite(figure.data[0]["x"]))


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->
## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
Part of #3382

## Description of the changes
<!-- Describe the changes in this PR. -->
* Update EDF plot on both Plotly and Matplotlib backends
* Tests

## Example
Examples are generated using [this](https://gist.github.com/HideakiImamura/67a150dec5774a18732527875774a9fe) notebook. Current master yields empty plots for both backends. This PR:

* Plotly
![Screenshot from 2022-04-02 18-08-38](https://user-images.githubusercontent.com/37713008/161391759-ac6b4180-48f6-46d3-8786-b3e7952bc87d.png)

* Matplotlib
![Screenshot from 2022-04-02 18-09-01](https://user-images.githubusercontent.com/37713008/161391766-88d36fd9-4177-4e3a-a294-9877cba4732b.png)