### PR TITLE
Fix log message formatting in `filter_nonfinite`

### DIFF
--- a/optuna/visualization/_utils.py
+++ b/optuna/visualization/_utils.py
@@ -133,8 +133,8 @@ def _filter_nonfinite(
         # Not a Number, positive infinity and negative infinity are considered to be non-finite.
         if not np.isfinite(target(trial)):
             _logger.info(
-                f"Trial {trial.number} is omitted in visualization ",
-                "because its objective value is inf or nan.",
+                f"Trial {trial.number} is omitted in visualization "
+                "because its objective value is inf or nan."
             )
         else:
             filtered_trials.append(trial)


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
Since commas were used to separate parts of log message, second part was passed as positional argument instead of being concatenated to first part, causing logger to raise warning.

## Description of the changes
<!-- Describe the changes in this PR. -->
* Fix log message