### PR TITLE
Remove read_trials_from_remote_storage

### DIFF
--- a/optuna/storages/_base.py
+++ b/optuna/storages/_base.py
@@ -678,19 +678,6 @@ class BaseStorage(object, metaclass=abc.ABCMeta):
         """
         return self.get_trial(trial_id).system_attrs
 
-    def read_trials_from_remote_storage(self, study_id: int) -> None:
-        """Make an internal cache of trials up-to-date.
-
-        Args:
-            study_id:
-                ID of the study.
-
-        Raises:
-            :exc:`KeyError`:
-                If no study with the matching ``study_id`` exists.
-        """
-        raise NotImplementedError
-
     def remove_session(self) -> None:
         """Clean up all connections to a database."""
         pass

--- a/optuna/storages/_cached_storage.py
+++ b/optuna/storages/_cached_storage.py
@@ -334,8 +334,8 @@ class _CachedStorage(BaseStorage):
         deepcopy: bool = True,
         states: Optional[Container[TrialState]] = None,
     ) -> List[FrozenTrial]:
-        if study_id not in self._studies:
-            self.read_trials_from_remote_storage(study_id)
+
+        self.read_trials_from_remote_storage(study_id)
 
         with self._lock:
             study = self._studies[study_id]

--- a/optuna/storages/_in_memory.py
+++ b/optuna/storages/_in_memory.py
@@ -441,9 +441,6 @@ class InMemoryStorage(BaseStorage):
 
         return trials
 
-    def read_trials_from_remote_storage(self, study_id: int) -> None:
-        self._check_study_id(study_id)
-
     def _check_study_id(self, study_id: int) -> None:
 
         if study_id not in self._studies:

--- a/optuna/storages/_rdb/storage.py
+++ b/optuna/storages/_rdb/storage.py
@@ -1072,11 +1072,6 @@ class RDBStorage(BaseStorage):
 
         return self.get_trial(trial_id)
 
-    def read_trials_from_remote_storage(self, study_id: int) -> None:
-        # Make sure that the given study exists.
-        with _create_scoped_session(self.scoped_session) as session:
-            models.StudyModel.find_or_raise_by_id(study_id, session)
-
     @staticmethod
     def _set_default_engine_kwargs_for_mysql(url: str, engine_kwargs: Dict[str, Any]) -> None:
 

--- a/optuna/storages/_redis.py
+++ b/optuna/storages/_redis.py
@@ -717,9 +717,6 @@ class RedisStorage(BaseStorage):
 
         return trials
 
-    def read_trials_from_remote_storage(self, study_id: int) -> None:
-        self._check_study_id(study_id)
-
     def _check_study_id(self, study_id: int) -> None:
 
         if not self._redis.exists("study_id:{:010d}:study_name".format(study_id)):

--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -242,7 +242,6 @@ class Study:
             A list of :class:`~optuna.trial.FrozenTrial` objects.
         """
 
-        self._storage.read_trials_from_remote_storage(self._study_id)
         return self._storage.get_all_trials(self._study_id, deepcopy=deepcopy, states=states)
 
     @property
@@ -479,9 +478,6 @@ class Study:
                 warnings.warn("Heartbeat of storage is supposed to be used with Study.optimize.")
 
         fixed_distributions = fixed_distributions or {}
-
-        # Sync storage once every trial.
-        self._storage.read_trials_from_remote_storage(self._study_id)
 
         trial_id = self._pop_waiting_trial_id()
         if trial_id is None:

--- a/tests/storages_tests/test_cached_storage.py
+++ b/tests/storages_tests/test_cached_storage.py
@@ -30,7 +30,7 @@ def test_create_trial() -> None:
     storage.create_new_trial(study_id)
 
 
-def test_read_trials_from_remote_storage(storage_mode: str) -> None:
+def test_read_trials_from_remote_storage() -> None:
     base_storage = RDBStorage("sqlite:///:memory:")
     storage = _CachedStorage(base_storage)
 

--- a/tests/storages_tests/test_cached_storage.py
+++ b/tests/storages_tests/test_cached_storage.py
@@ -1,5 +1,7 @@
 from unittest.mock import patch
 
+import pytest
+
 import optuna
 from optuna.storages._cached_storage import _CachedStorage
 from optuna.storages._cached_storage import RDBStorage
@@ -28,7 +30,18 @@ def test_create_trial() -> None:
     storage.create_new_trial(study_id)
 
 
-def test_set_trial_state_values() -> None:
+def test_read_trials_from_remote_storage(storage_mode: str) -> None:
+    base_storage = RDBStorage("sqlite:///:memory:")
+    storage = _CachedStorage(base_storage)
+
+    with pytest.raises(KeyError):
+        storage.read_trials_from_remote_storage(-1)
+
+    study_id = storage.create_new_study()
+    storage.read_trials_from_remote_storage(study_id)
+
+
+def test_set_trial_state() -> None:
     base_storage = RDBStorage("sqlite:///:memory:")
     storage = _CachedStorage(base_storage)
     study_id = storage.create_new_study("test-study")

--- a/tests/storages_tests/test_storages.py
+++ b/tests/storages_tests/test_storages.py
@@ -1414,17 +1414,6 @@ def test_fail_stale_trials_raw(storage_mode: str) -> None:
         assert storage.fail_stale_trials(study_id) == []
 
 
-@pytest.mark.parametrize("storage_mode", STORAGE_MODES)
-def test_read_trials_from_remote_storage(storage_mode: str) -> None:
-
-    with StorageSupplier(storage_mode) as storage:
-        with pytest.raises(KeyError):
-            storage.read_trials_from_remote_storage(-1)
-
-        study_id = storage.create_new_study()
-        storage.read_trials_from_remote_storage(study_id)
-
-
 @pytest.mark.parametrize("storage_mode", STORAGE_MODES_HEARTBEAT)
 def test_retry_failed_trial_callback_repetitive_failure(storage_mode: str) -> None:
     heartbeat_interval = 1


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
Currently, the method `read_trials_from_remote_storage` is implemented in the all storages classes. However, only the `CachedStorage` has meaningful implementation actually, because:

1. The `read_trials_from_remote_storage` in `RDBStorage` and `RedisStorage` is never called, because they are always wrapped by `CachedStorage`, and `CachedStorage` never calls `read_trials_from_remote_storage` in the wrapped storages.
2. The `read_trials_from_remote_storage` in `InMemoryStorage` just checks if study_id exists or not.

As a result, we can remove `read_trials_from_remote_storage` implementations other than `CachedStorage`.

To remove the implementations, we can move the calls of `read_trials_from_remote_storage` from study to `get_all_trials` in CachedStorage, because `read_trials_from_remote_storage` is always called before the calls of `get_all_trials`.

## Description of the changes
<!-- Describe the changes in this PR. -->
- [x] Remove the `read_trials_from_remote_storage` implementations other than `CachedStorage`
- [x] Move the calls of `read_trials_from_remote_storage` from study to `get_all_trials` in CachedStorage