### PR TITLE
Unify fail_stale_trials in each Storage impl

### DIFF
--- a/optuna/storages/_base.py
+++ b/optuna/storages/_base.py
@@ -730,6 +730,8 @@ class BaseStorage(object, metaclass=abc.ABCMeta):
         Args:
             study_id:
                 ID of the study.
+        Returns:
+            List of IDs of trials whose heartbeat has not been updated for a long time.
         """
         return []
 

--- a/optuna/storages/_base.py
+++ b/optuna/storages/_base.py
@@ -724,20 +724,14 @@ class BaseStorage(object, metaclass=abc.ABCMeta):
         """
         pass
 
-    def fail_stale_trials(self, study_id: int) -> List[int]:
-        """Fail stale trials.
-
-        The running trials whose heartbeat has not been updated for a long time will be failed,
-        that is, those states will be changed to :obj:`~optuna.trial.TrialState.FAIL`.
-        The grace period is ``2 * heartbeat_interval``.
+    def _get_stale_trial_ids(self, study_id: int) -> List[int]:
+        """Get the stale trial ids of the study.
 
         Args:
             study_id:
-                ID of the related study.
-        Returns:
-            List of trial IDs of the failed trials.
+                ID of the study.
         """
-        pass
+        return []
 
     def is_heartbeat_enabled(self) -> bool:
         """Check whether the storage enables the heartbeat.

--- a/optuna/storages/_cached_storage.py
+++ b/optuna/storages/_cached_storage.py
@@ -385,15 +385,8 @@ class _CachedStorage(BaseStorage):
     def record_heartbeat(self, trial_id: int) -> None:
         self._backend.record_heartbeat(trial_id)
 
-    def fail_stale_trials(self, study_id: int) -> List[int]:
-        stale_trial_ids = self._backend._get_stale_trial_ids(study_id)
-        confirmed_stale_trial_ids = []
-
-        for trial_id in stale_trial_ids:
-            if self.set_trial_state_values(trial_id, state=TrialState.FAIL):
-                confirmed_stale_trial_ids.append(trial_id)
-
-        return confirmed_stale_trial_ids
+    def _get_stale_trial_ids(self, study_id: int) -> List[int]:
+        return self._backend._get_stale_trial_ids(study_id)
 
     def _is_heartbeat_supported(self) -> bool:
         return self._backend._is_heartbeat_supported()

--- a/optuna/storages/_heartbeat.py
+++ b/optuna/storages/_heartbeat.py
@@ -2,6 +2,7 @@ import copy
 
 import optuna
 from optuna._experimental import experimental
+from optuna.trial import TrialState
 
 
 @experimental("2.9.0")
@@ -24,7 +25,11 @@ def fail_stale_trials(study: "optuna.Study") -> None:
     if not storage.is_heartbeat_enabled():
         return
 
-    failed_trial_ids = storage.fail_stale_trials(study._study_id)
+    failed_trial_ids = []
+    for trial_id in storage._get_stale_trial_ids(study._study_id):
+        if storage.set_trial_state_values(trial_id, state=TrialState.FAIL):
+            failed_trial_ids.append(trial_id)
+
     failed_trial_callback = storage.get_failed_trial_callback()
     if failed_trial_callback is not None:
         for trial_id in failed_trial_ids:

--- a/optuna/storages/_rdb/storage.py
+++ b/optuna/storages/_rdb/storage.py
@@ -1144,16 +1144,6 @@ class RDBStorage(BaseStorage):
             else:
                 heartbeat.heartbeat = session.execute(func.now()).scalar()
 
-    def fail_stale_trials(self, study_id: int) -> List[int]:
-        stale_trial_ids = self._get_stale_trial_ids(study_id)
-        confirmed_stale_trial_ids = []
-
-        for trial_id in stale_trial_ids:
-            if self.set_trial_state_values(trial_id, state=TrialState.FAIL):
-                confirmed_stale_trial_ids.append(trial_id)
-
-        return confirmed_stale_trial_ids
-
     def _get_stale_trial_ids(self, study_id: int) -> List[int]:
         assert self.heartbeat_interval is not None
         if self.grace_period is None:

--- a/optuna/storages/_rdb/storage.py
+++ b/optuna/storages/_rdb/storage.py
@@ -1144,6 +1144,21 @@ class RDBStorage(BaseStorage):
             else:
                 heartbeat.heartbeat = session.execute(func.now()).scalar()
 
+    @deprecated(
+        "3.0.0",
+        "5.0.0",
+        text="Use :func:`~optuna.storages.fail_stale_trials` instead.",
+    )
+    def fail_stale_trials(self, study_id: int) -> List[int]:
+        stale_trial_ids = self._get_stale_trial_ids(study_id)
+        confirmed_stale_trial_ids = []
+
+        for trial_id in stale_trial_ids:
+            if self.set_trial_state_values(trial_id, state=TrialState.FAIL):
+                confirmed_stale_trial_ids.append(trial_id)
+
+        return confirmed_stale_trial_ids
+
     def _get_stale_trial_ids(self, study_id: int) -> List[int]:
         assert self.heartbeat_interval is not None
         if self.grace_period is None:

--- a/optuna/storages/_redis.py
+++ b/optuna/storages/_redis.py
@@ -738,14 +738,6 @@ class RedisStorage(BaseStorage):
             pickle.dumps(self._get_redis_time()),
         )
 
-    def fail_stale_trials(self, study_id: int) -> List[int]:
-        confirmed = []
-        for trial_id in self._get_stale_trial_ids(study_id):
-            if self.set_trial_state_values(trial_id, state=TrialState.FAIL):
-                confirmed.append(trial_id)
-
-        return confirmed
-
     def _get_stale_trial_ids(self, study_id: int) -> List[int]:
         assert self.heartbeat_interval is not None
 

--- a/optuna/storages/_redis.py
+++ b/optuna/storages/_redis.py
@@ -738,6 +738,19 @@ class RedisStorage(BaseStorage):
             pickle.dumps(self._get_redis_time()),
         )
 
+    @deprecated(
+        "3.0.0",
+        "5.0.0",
+        text="Use :func:`~optuna.storages.fail_stale_trials` instead.",
+    )
+    def fail_stale_trials(self, study_id: int) -> List[int]:
+        confirmed = []
+        for trial_id in self._get_stale_trial_ids(study_id):
+            if self.set_trial_state_values(trial_id, state=TrialState.FAIL):
+                confirmed.append(trial_id)
+
+        return confirmed
+
     def _get_stale_trial_ids(self, study_id: int) -> List[int]:
         assert self.heartbeat_interval is not None
 

--- a/tests/storages_tests/test_storages.py
+++ b/tests/storages_tests/test_storages.py
@@ -1401,6 +1401,20 @@ def test_fail_stale_trials(storage_mode: str, grace_period: Optional[int]) -> No
 
 
 @pytest.mark.parametrize("storage_mode", ["sqlite", "redis"])
+def test_fail_stale_trials_raw(storage_mode: str) -> None:
+    heartbeat_interval = 1
+    grace_period = 2
+
+    with StorageSupplier(storage_mode) as storage:
+        assert isinstance(storage, (RDBStorage, RedisStorage))
+        storage.heartbeat_interval = heartbeat_interval
+        storage.grace_period = grace_period
+
+        study_id = storage.create_new_study()
+        assert storage.fail_stale_trials(study_id) == []
+
+
+@pytest.mark.parametrize("storage_mode", ["sqlite", "redis"])
 def test_get_stale_trial_ids(storage_mode: str) -> None:
     heartbeat_interval = 1
     grace_period = 2


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
Currently, `fail_stale_trials` method is implemented in each Storage class (almost same functionality).

## Description of the changes
<!-- Describe the changes in this PR. -->
- added `_get_stale_trial_ids` method to `BaseStorage`
- unified `fail_stale_trials` and moved to `optuna/storages/_heartbeat.py`

I'm wondering if I should remove the first underscore of `_get_stale_trial_ids`.
