### PR TITLE
Update warning message and add a test when a trial fails with exception

### DIFF
--- a/optuna/study/_optimize.py
+++ b/optuna/study/_optimize.py
@@ -27,6 +27,7 @@ from optuna import progress_bar as pbar_module
 from optuna import storages
 from optuna import trial as trial_module
 from optuna.study._tell import _tell_with_warning
+from optuna.study._tell import STUDY_TELL_WARNING_KEY
 from optuna.trial import FrozenTrial
 from optuna.trial import TrialState
 
@@ -235,8 +236,8 @@ def _run_trial(
         elif frozen_trial.state == TrialState.FAIL:
             if func_err is not None:
                 _log_failed_trial(frozen_trial, repr(func_err), exc_info=func_err_fail_exc_info)
-            elif "study_tell_warning" in frozen_trial.system_attrs:
-                _log_failed_trial(frozen_trial, frozen_trial.system_attrs["study_tell_warning"])
+            elif STUDY_TELL_WARNING_KEY in frozen_trial.system_attrs:
+                _log_failed_trial(frozen_trial, frozen_trial.system_attrs[STUDY_TELL_WARNING_KEY])
             else:
                 assert False, "Should not reach."
         else:

--- a/optuna/study/_tell.py
+++ b/optuna/study/_tell.py
@@ -68,7 +68,7 @@ def _check_single_value(
 
     if value is not None and math.isnan(value):
         value = None
-        failure_message = f"The objective function returned {original_value}."
+        failure_message = f"The value {original_value} is not acceptable."
 
     return value, failure_message
 

--- a/optuna/study/_tell.py
+++ b/optuna/study/_tell.py
@@ -15,6 +15,10 @@ from optuna.trial import FrozenTrial
 from optuna.trial import TrialState
 
 
+# This is used for propagating warning message to Study.optimize.
+STUDY_TELL_WARNING_KEY = "STUDY_TELL_WARNING"
+
+
 _logger = logging.get_logger(__name__)
 
 
@@ -190,6 +194,7 @@ def _tell_with_warning(
         study._storage.set_trial_state_values(trial_id, state, values)
 
     frozen_trial = copy.deepcopy(study._storage.get_trial(trial_id))
+
     if warning_message is not None:
-        frozen_trial.set_system_attr("study_tell_warning", warning_message)
+        frozen_trial.set_system_attr(STUDY_TELL_WARNING_KEY, warning_message)
     return frozen_trial

--- a/tests/study_tests/test_optimize.py
+++ b/tests/study_tests/test_optimize.py
@@ -12,6 +12,7 @@ from optuna import Trial
 from optuna import TrialPruned
 from optuna.study import _optimize
 from optuna.study._tell import _tell_with_warning
+from optuna.study._tell import STUDY_TELL_WARNING_KEY
 from optuna.testing.storage import STORAGE_MODES
 from optuna.testing.storage import StorageSupplier
 from optuna.trial import TrialState
@@ -67,7 +68,7 @@ def test_run_trial_automatically_fail(storage_mode: str, caplog: LogCaptureFixtu
         assert frozen_trial.state == TrialState.FAIL
         assert frozen_trial.value is None
         assert "Trial 0 failed because of the following error:" in caplog.text
-        assert "The objective function returned nan." in caplog.text
+        assert "The value nan is not acceptable." in caplog.text
 
         caplog.clear()
         frozen_trial = _optimize._run_trial(study, lambda _: None, catch=())  # type: ignore
@@ -133,6 +134,7 @@ def test_run_trial_catch_exception(storage_mode: str) -> None:
         study = create_study(storage=storage)
         frozen_trial = _optimize._run_trial(study, func_value_error, catch=(ValueError,))
         assert frozen_trial.state == TrialState.FAIL
+        assert STUDY_TELL_WARNING_KEY not in frozen_trial.system_attrs
 
 
 @pytest.mark.parametrize("storage_mode", STORAGE_MODES)


### PR DESCRIPTION
Followup of https://github.com/optuna/optuna/pull/3144.

## Description of the changes
- Fix a confusing message in values validation: 24fb56e
  - 🔗 https://github.com/optuna/optuna/pull/3144#discussion_r844104105
- Add a test not to write anything to system_attrs when a trial fails with an exception
  - 🔗 https://github.com/optuna/optuna/pull/3144#pullrequestreview-933710529
  - I might misunderstand the intention of the review. The reviewer might suggest to check `Trial`'s system attributes. But I'm not sure it is needed since `set_system_attr` is invoked for `FrozenTrial`