### PR TITLE
Query studies for trials only once in EDF plots

### DIFF
--- a/optuna/visualization/matplotlib/_edf.py
+++ b/optuna/visualization/matplotlib/_edf.py
@@ -1,4 +1,3 @@
-import itertools
 from typing import Callable
 from typing import cast
 from typing import List
@@ -138,22 +137,6 @@ def _get_edf_plot(
         _logger.warning("There are no studies.")
         return ax
 
-    all_trials = list(
-        itertools.chain.from_iterable(
-            (
-                trial
-                for trial in study.get_trials(deepcopy=False)
-                if trial.state == TrialState.COMPLETE
-            )
-            for study in studies
-        )
-    )
-    all_trials = _filter_nonfinite(all_trials, target, with_message=False)
-
-    if len(all_trials) == 0:
-        _logger.warning("There are no complete trials.")
-        return ax
-
     if target is None:
 
         def _target(t: FrozenTrial) -> float:
@@ -161,19 +144,26 @@ def _get_edf_plot(
 
         target = _target
 
-    min_x_value = min(target(trial) for trial in all_trials)
-    max_x_value = max(target(trial) for trial in all_trials)
-    x_values = np.linspace(min_x_value, max_x_value, 100)
-
-    # Draw multiple line plots.
-    for i, study in enumerate(studies):
+    all_values: List[np.ndarray] = []
+    for study in studies:
         trials = _filter_nonfinite(
             study.get_trials(deepcopy=False, states=(TrialState.COMPLETE,)), target=target
         )
 
-        values = np.asarray([target(trial) for trial in trials])
-        y_values = np.sum(values[:, np.newaxis] <= x_values, axis=0) / values.size
+        values = np.array([target(trial) for trial in trials])
+        all_values.append(values)
 
+    if all(len(values) == 0 for values in all_values):
+        _logger.warning("There are no complete trials.")
+        return ax
+
+    min_x_value = np.min(all_values)
+    max_x_value = np.max(all_values)
+    x_values = np.linspace(min_x_value, max_x_value, 100)
+
+    # Draw multiple line plots.
+    for i, (values, study) in enumerate(zip(all_values, studies)):
+        y_values = np.sum(values[:, np.newaxis] <= x_values, axis=0) / values.size
         ax.plot(x_values, y_values, color=cmap(i), alpha=0.7, label=study.study_name)
 
     if len(studies) >= 2:


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
As mentioned in https://github.com/optuna/optuna/pull/3435#issuecomment-1086804217, EDF plot functions are re-implemented to avoid calling `study.get_trials` unnecessarily multiple times. This should make those functions a bit faster.

## Description of the changes
<!-- Describe the changes in this PR. -->
* Re-implemented EDF plots across both backends
