### PR TITLE
Fix kurobako benchmark code to run it locally

### DIFF
--- a/benchmarks/run_kurobako.py
+++ b/benchmarks/run_kurobako.py
@@ -12,11 +12,13 @@ def run(args: argparse.Namespace) -> None:
 
     os.makedirs(args.out_dir, exist_ok=True)
     study_json_fn = os.path.join(args.out_dir, "studies.json")
-    subprocess.check_call(f"echo >| {study_json_fn}", shell=True)
     solvers_filename = os.path.join(args.out_dir, "solvers.json")
-    subprocess.check_call(f"echo >| {solvers_filename}", shell=True)
     problems_filename = os.path.join(args.out_dir, "problems.json")
-    subprocess.check_call(f"echo >| {problems_filename}", shell=True)
+
+    # Ensure all files are empty.
+    for filename in [study_json_fn, solvers_filename, problems_filename]:
+        with open(filename, "w"):
+            pass
 
     # Create HPO bench problem.
     datasets = [
@@ -98,7 +100,9 @@ if __name__ == "__main__":
     parser.add_argument("--n-jobs", type=int, default=10)
     parser.add_argument("--sampler-list", type=str, default="RandomSampler TPESampler")
     parser.add_argument(
-        "--sampler-kwargs-list", type=str, default='{} {\\\"multivariate\\\":true\,\\\"constant_liar\\\":true}'
+        "--sampler-kwargs-list",
+        type=str,
+        default='{} {\\"multivariate\\":true\,\\"constant_liar\\":true}',  # NOQA: W605
     )
     parser.add_argument("--pruner-list", type=str, default="NopPruner")
     parser.add_argument("--pruner-kwargs-list", type=str, default="{}")

--- a/benchmarks/run_kurobako.py
+++ b/benchmarks/run_kurobako.py
@@ -12,11 +12,11 @@ def run(args: argparse.Namespace) -> None:
 
     os.makedirs(args.out_dir, exist_ok=True)
     study_json_fn = os.path.join(args.out_dir, "studies.json")
-    subprocess.check_call(f"echo -n >| {study_json_fn}", shell=True)
+    subprocess.check_call(f"echo >| {study_json_fn}", shell=True)
     solvers_filename = os.path.join(args.out_dir, "solvers.json")
-    subprocess.check_call(f"echo -n >| {solvers_filename}", shell=True)
+    subprocess.check_call(f"echo >| {solvers_filename}", shell=True)
     problems_filename = os.path.join(args.out_dir, "problems.json")
-    subprocess.check_call(f"echo -n >| {problems_filename}", shell=True)
+    subprocess.check_call(f"echo >| {problems_filename}", shell=True)
 
     # Create HPO bench problem.
     datasets = [
@@ -98,7 +98,7 @@ if __name__ == "__main__":
     parser.add_argument("--n-jobs", type=int, default=10)
     parser.add_argument("--sampler-list", type=str, default="RandomSampler TPESampler")
     parser.add_argument(
-        "--sampler-kwargs-list", type=str, default='{} {"multivariate":true,"constant_liar":true}'
+        "--sampler-kwargs-list", type=str, default='{} {\\\"multivariate\\\":true\,\\\"constant_liar\\\":true}'
     )
     parser.add_argument("--pruner-list", type=str, default="NopPruner")
     parser.add_argument("--pruner-kwargs-list", type=str, default="{}")

--- a/benchmarks/run_kurobako.py
+++ b/benchmarks/run_kurobako.py
@@ -102,7 +102,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--sampler-kwargs-list",
         type=str,
-        default='{} {\\"multivariate\\":true\,\\"constant_liar\\":true}',  # NOQA: W605
+        default=r"{} {\"multivariate\":true\,\"constant_liar\":true}",
     )
     parser.add_argument("--pruner-list", type=str, default="NopPruner")
     parser.add_argument("--pruner-kwargs-list", type=str, default="{}")


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
The current kurobako benchmark code `benchmarks/run_kurobako.py` has two drawbacks.
- It cannot be run in macOS, since we cannot use `-n` option of `echo` command in the environment.
- Its default value of `--sampler-kwargs` cause an gramatical error.

## Description of the changes
<!-- Describe the changes in this PR. -->
Fix above points to run the script locally. (I confirmed that it is executable in macOS Monterey 12.2.1)
