### PR TITLE
Revise docstring in MLFflow and WandB callbacks

### DIFF
--- a/optuna/integration/mlflow.py
+++ b/optuna/integration/mlflow.py
@@ -63,33 +63,6 @@ class MLflowCallback(object):
 
             shutil.rmtree(tempdir)
 
-        Add additional logging to MLflow
-
-        .. testcode::
-
-            import optuna
-            import mlflow
-            from optuna.integration.mlflow import MLflowCallback
-
-            mlflc = MLflowCallback(
-                tracking_uri=YOUR_TRACKING_URI,
-                metric_name="my metric score",
-            )
-
-
-            @mlflc.track_in_mlflow()
-            def objective(trial):
-                x = trial.suggest_float("x", -10, 10)
-                mlflow.log_param("power", 2)
-                mlflow.log_metric("base of metric", x - 2)
-
-                return (x - 2) ** 2
-
-
-            study = optuna.create_study(study_name="my_other_study")
-            study.optimize(objective, n_trials=10, callbacks=[mlflc])
-
-
     Args:
         tracking_uri:
             The URI of the MLflow tracking server.
@@ -119,6 +92,12 @@ class MLflowCallback(object):
             Please refer to `MLflow API documentation
             <https://www.mlflow.org/docs/latest/python_api/mlflow.html#mlflow.start_run>`_
             for more details.
+
+                .. note::
+                    ``nest_trials`` argument added in v2.3.0 is a part of ``mlflow_kwargs``
+                    since v3.0.0. Anyone using ``nest_trials=True`` should migrate to
+                    ``mlflow_kwargs={"nested": True}`` to avoid raising :exc:`TypeError`.
+
         tag_study_user_attrs:
             Flag indicating whether or not to add the study's user attrs
             to the mlflow trial as tags. Please note that when this flag is
@@ -130,10 +109,6 @@ class MLflowCallback(object):
             study user attributes are logged, the latter will supersede the former
             in case of a collison.
 
-    .. note::
-        ``nest_trials`` argument added in v2.3.0 is a part of ``mlflow_kwargs`` since v3.0.0.
-        Anyone using ``nest_trials=True`` should migrate to ``mlflow_kwargs={"nested": True}``
-        to avoid raising :exc:`TypeError`.
 
     Raises:
         :exc:`ValueError`:
@@ -197,6 +172,34 @@ class MLflowCallback(object):
 
         All information logged in the decorated objective function will be added to the MLflow
         run for the trial created by the callback.
+
+        Example:
+
+            Add additional logging to MLflow.
+
+            .. testcode::
+
+                import optuna
+                import mlflow
+                from optuna.integration.mlflow import MLflowCallback
+
+                mlflc = MLflowCallback(
+                    tracking_uri=YOUR_TRACKING_URI,
+                    metric_name="my metric score",
+                )
+
+
+                @mlflc.track_in_mlflow()
+                def objective(trial):
+                    x = trial.suggest_float("x", -10, 10)
+                    mlflow.log_param("power", 2)
+                    mlflow.log_metric("base of metric", x - 2)
+
+                    return (x - 2) ** 2
+
+
+                study = optuna.create_study(study_name="my_other_study")
+                study.optimize(objective, n_trials=10, callbacks=[mlflc])
 
         Returns:
             ObjectiveFuncType: Objective function with tracking to MLflow enabled.

--- a/optuna/integration/wandb.py
+++ b/optuna/integration/wandb.py
@@ -73,7 +73,7 @@ class WeightsAndBiasesCallback(object):
             from optuna.integration.wandb import WeightsAndBiasesCallback
 
             wandb_kwargs = {"project": "my-project"}
-            wandbc = WeightsAndBiasesCallback(wandb_kwargs=wandb_kwargs)
+            wandbc = WeightsAndBiasesCallback(wandb_kwargs=wandb_kwargs, as_multirun=True)
 
 
             @wandbc.track_in_wandb()
@@ -82,7 +82,7 @@ class WeightsAndBiasesCallback(object):
                 return (x - 2) ** 2
 
 
-            study = optuna.create_study(as_multirun=True)
+            study = optuna.create_study()
             study.optimize(objective, n_trials=10, callbacks=[wandbc])
 
 

--- a/optuna/integration/wandb.py
+++ b/optuna/integration/wandb.py
@@ -86,29 +86,6 @@ class WeightsAndBiasesCallback(object):
             study.optimize(objective, n_trials=10, callbacks=[wandbc])
 
 
-        Add additional logging to Weights & Biases.
-
-        .. code::
-
-            import optuna
-            from optuna.integration.wandb import WeightsAndBiasesCallback
-            import wandb
-
-            wandb_kwargs = {"project": "my-project"}
-            wandbc = WeightsAndBiasesCallback(wandb_kwargs=wandb_kwargs)
-
-
-            @wandbc.track_in_wandb()
-            def objective(trial):
-                x = trial.suggest_float("x", -10, 10)
-                loss = (x - 2) ** 2
-                wandb.log({"loss": loss})
-                return loss
-
-
-            study = optuna.create_study()
-            study.optimize(objective, n_trials=10, callbacks=[wandbc])
-
     Args:
         metric_name:
             Name assigned to optimized metric. In case of multi-objective optimization,
@@ -211,6 +188,33 @@ class WeightsAndBiasesCallback(object):
         The run is initialized with the same ``wandb_kwargs`` that are passed to the callback.
         All the metrics from inside the objective function will be logged into the same run
         which stores the parameters for a given trial.
+
+        Example:
+
+            Add additional logging to Weights & Biases.
+
+            .. code::
+
+                import optuna
+                from optuna.integration.wandb import WeightsAndBiasesCallback
+                import wandb
+
+                wandb_kwargs = {"project": "my-project"}
+                wandbc = WeightsAndBiasesCallback(wandb_kwargs=wandb_kwargs)
+
+
+                @wandbc.track_in_wandb()
+                def objective(trial):
+                    x = trial.suggest_float("x", -10, 10)
+                    mlflow.log_param("power", 2)
+                    mlflow.log_metric("base of metric", x - 2)
+
+                    return (x - 2) ** 2
+
+
+                study = optuna.create_study()
+                study.optimize(objective, n_trials=10, callbacks=[wandbc])
+
 
         Returns:
             ObjectiveFuncType: Objective function with W&B tracking enabled.

--- a/optuna/integration/wandb.py
+++ b/optuna/integration/wandb.py
@@ -200,14 +200,13 @@ class WeightsAndBiasesCallback(object):
                 import wandb
 
                 wandb_kwargs = {"project": "my-project"}
-                wandbc = WeightsAndBiasesCallback(wandb_kwargs=wandb_kwargs)
+                wandbc = WeightsAndBiasesCallback(wandb_kwargs=wandb_kwargs, as_multirun=True)
 
 
                 @wandbc.track_in_wandb()
                 def objective(trial):
                     x = trial.suggest_float("x", -10, 10)
-                    mlflow.log_param("power", 2)
-                    mlflow.log_metric("base of metric", x - 2)
+                    wandb.log({"power": 2, "base of metric": x - 2})
 
                     return (x - 2) ** 2
 


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

I suppose we have room to improve the docstring in the callback pages as introduced by this PR. In addition, [the description of the `MLflowCallback` docstring](https://optuna.readthedocs.io/en/latest/reference/generated/optuna.integration.MLflowCallback.html#optuna.integration.MLflowCallback) is broken. A note section is added between `Retuned Types` and `Raises`, as a result, we see two- `Parameters` sections. See the following screenshot:

<img width="570" alt="Screenshot 2022-04-20 at 20 16 37" src="https://user-images.githubusercontent.com/7121753/164220097-93bb9999-2687-41a6-ab9f-9c377b1f0c4a.png">



## Description of the changes
<!-- Describe the changes in this PR. -->

- The decorator's examples can move to the more exact place: `track_in_*` method section.
- We would like to use an informative example in `track_in_wandb`. To do so, this PR uses the same objective definition in the example as MLFLow's `track_in_mlflow` example.
- Fix the note section in mlflow. As a result, the note section is shown as follows:


<img width="902" alt="Screenshot 2022-04-20 at 20 23 48" src="https://user-images.githubusercontent.com/7121753/164220442-e02a084a-e210-4a2c-8940-253d26ad0902.png">

