### PR TITLE
Remove torch.distributed calls from TorchDistributedTrial properties

### DIFF
--- a/optuna/integration/pytorch_distributed.py
+++ b/optuna/integration/pytorch_distributed.py
@@ -43,7 +43,9 @@ def updates_properties(f: Callable[_P, _T]) -> Callable[_P, _T]:
 
     @functools.wraps(f)
     def wrapped(*args: _P.args, **kwargs: _P.kwargs) -> _T:
-        self: TorchDistributedTrial = args[0]
+        # TODO(nlgranger): Remove type ignore after mypy includes
+        # https://github.com/python/mypy/pull/12668
+        self: TorchDistributedTrial = args[0]  # type: ignore
 
         def state() -> Sequence:
             assert self._delegate is not None

--- a/optuna/integration/pytorch_distributed.py
+++ b/optuna/integration/pytorch_distributed.py
@@ -30,7 +30,8 @@ def updates_properties(f: Callable[..., Any]) -> Callable[..., Any]:
 
     This decorator ensures trial properties (params, distributions, etc.) on all distributed
     processes are up-to-date with the wrapped trial stored on rank 0.
-    It should be applied to all :class:`~optuna.integration.TorchDistributedTrial` methods that update property values.
+    It should be applied to all :class:`~optuna.integration.TorchDistributedTrial`
+    methods that update property values.
     """
 
     @functools.wraps(f)

--- a/optuna/integration/pytorch_distributed.py
+++ b/optuna/integration/pytorch_distributed.py
@@ -6,6 +6,9 @@ from typing import Callable
 from typing import Dict
 from typing import Optional
 from typing import Sequence
+from typing import TypeVar
+
+from typing_extensions import ParamSpec
 
 import optuna
 from optuna._deprecated import deprecated
@@ -20,12 +23,16 @@ with try_import() as _imports:
     import torch.distributed as dist
 
 
+_T = TypeVar("_T")
+_P = ParamSpec("_P")
+
+
 _suggest_deprecated_msg = (
     "Use :func:`~optuna.integration.TorchDistributedTrial.suggest_float` instead."
 )
 
 
-def updates_properties(f: Callable[..., Any]) -> Callable[..., Any]:
+def updates_properties(f: Callable[_P, _T]) -> Callable[_P, _T]:
     """Method decorator to fetch updated trial properties from rank 0 after ``f`` is run.
 
     This decorator ensures trial properties (params, distributions, etc.) on all distributed
@@ -35,7 +42,7 @@ def updates_properties(f: Callable[..., Any]) -> Callable[..., Any]:
     """
 
     @functools.wraps(f)
-    def wrapped(*args: Any, **kwargs: Any) -> Any:
+    def wrapped(*args: _P.args, **kwargs: _P.kwargs) -> _T:
         self: TorchDistributedTrial = args[0]
 
         def state() -> Sequence:

--- a/optuna/integration/pytorch_distributed.py
+++ b/optuna/integration/pytorch_distributed.py
@@ -30,7 +30,7 @@ def updates_state(f: Callable[..., Any]) -> Callable[..., Any]:
 
     This decorator ensures trial properties (params, distributions, etc.) on all distributed
     processes are up-to-date with the wrapped trial stored on rank 0.
-    It should be applied to all Trial methods that update property values.
+    It should be applied to all :class:`~optuna.integration.TorchDistributedTrial` methods that update property values.
     """
 
     @functools.wraps(f)

--- a/optuna/integration/pytorch_distributed.py
+++ b/optuna/integration/pytorch_distributed.py
@@ -148,19 +148,16 @@ class TorchDistributedTrial(optuna.trial.BaseTrial):
         return self._call_and_communicate(func, torch.float)
 
     @deprecated("3.0.0", "6.0.0", text=_suggest_deprecated_msg)
-    @updates_properties
     def suggest_uniform(self, name: str, low: float, high: float) -> float:
 
         return self.suggest_float(name, low, high)
 
     @deprecated("3.0.0", "6.0.0", text=_suggest_deprecated_msg)
-    @updates_properties
     def suggest_loguniform(self, name: str, low: float, high: float) -> float:
 
         return self.suggest_float(name, low, high, log=True)
 
     @deprecated("3.0.0", "6.0.0", text=_suggest_deprecated_msg)
-    @updates_properties
     def suggest_discrete_uniform(self, name: str, low: float, high: float, q: float) -> float:
 
         return self.suggest_float(name, low, high, step=q)

--- a/optuna/integration/pytorch_distributed.py
+++ b/optuna/integration/pytorch_distributed.py
@@ -111,7 +111,6 @@ class TorchDistributedTrial(optuna.trial.BaseTrial):
             assert trial is None, "error message"
         self._delegate = trial
         self._device = device
-        self._params = {}
 
         self._number = self._broadcast(getattr(self._delegate, "number", None))
         self._params = self._broadcast(getattr(self._delegate, "params", None))

--- a/optuna/integration/pytorch_distributed.py
+++ b/optuna/integration/pytorch_distributed.py
@@ -26,7 +26,7 @@ _suggest_deprecated_msg = (
 
 
 def updates_state(f: Callable[..., Any]) -> Callable[..., Any]:
-    """Method decorator to fetch updated trial state from rank 0 after f is run.
+    """Method decorator to fetch updated trial properties from rank 0 after ``f`` is run.
 
     This decorator ensures trial properties (params, distributions, etc.) on all distributed
     processes are up-to-date with the wrapped trial stored on rank 0.

--- a/optuna/integration/pytorch_distributed.py
+++ b/optuna/integration/pytorch_distributed.py
@@ -25,9 +25,16 @@ _suggest_deprecated_msg = (
 )
 
 
-def updates_state(f: Callable) -> Any:
+def updates_state(f: Callable[..., Any]) -> Callable[..., Any]:
+    """Method decorator to fetch updated trial state from rank 0 after f is run.
+
+    This decorator ensures trial properties (params, distributions, etc.) on all distributed
+    processes are up-to-date with the wrapped trial stored on rank 0.
+    It should be applied to all Trial methods that update property values.
+    """
+
     @functools.wraps(f)
-    def wrapped(self, *args, **kwargs) -> Any:
+    def wrapped(self: Any, *args, **kwargs) -> Any:
         def state() -> Sequence:
             assert self._delegate is not None
             return (

--- a/optuna/integration/pytorch_distributed.py
+++ b/optuna/integration/pytorch_distributed.py
@@ -34,8 +34,9 @@ def updates_state(f: Callable[..., Any]) -> Callable[..., Any]:
     """
 
     @functools.wraps(f)
-    def wrapped(self: Any, *args, **kwargs) -> Any:
+    def wrapped(*args: Any, **kwargs: Any) -> Any:
         def state() -> Sequence:
+            self: TorchDistributedTrial = args[0]
             assert self._delegate is not None
             return (
                 self._delegate.number,
@@ -47,7 +48,7 @@ def updates_state(f: Callable[..., Any]) -> Callable[..., Any]:
             )
 
         try:
-            return f(self, *args, **kwargs)
+            return f(*args, **kwargs)
         finally:
             (
                 self._number,

--- a/setup.py
+++ b/setup.py
@@ -103,6 +103,7 @@ def get_extras_require() -> Dict[str, List[str]]:
             "pandas",
             "plotly>=4.0.0",
             "pytest",
+            "pytest-timeout",
             "scikit-learn>=0.24.2",
             "scikit-optimize",
             "xgboost",

--- a/setup.py
+++ b/setup.py
@@ -103,7 +103,6 @@ def get_extras_require() -> Dict[str, List[str]]:
             "pandas",
             "plotly>=4.0.0",
             "pytest",
-            "pytest-timeout",
             "scikit-learn>=0.24.2",
             "scikit-optimize",
             "xgboost",

--- a/tests/integration_tests/test_pytorch_distributed.py
+++ b/tests/integration_tests/test_pytorch_distributed.py
@@ -334,3 +334,38 @@ def test_distributions(storage_mode: str) -> None:
         assert distributions["i"] == optuna.distributions.IntDistribution(0, 1)
         assert distributions["il"] == optuna.distributions.IntDistribution(1, 128, log=True)
         assert distributions["c"] == optuna.distributions.CategoricalDistribution(("a", "b", "c"))
+
+
+@pytest.mark.filterwarnings("ignore::optuna.exceptions.ExperimentalWarning")
+@pytest.mark.parametrize("storage_mode", STORAGE_MODES)
+@pytest.mark.timeout(15, method="signal")
+def test_updates_state(storage_mode: str) -> None:
+    """Check for any distributed deadlock following a property read."""
+    with StorageSupplier(storage_mode) as storage:
+        if dist.get_rank() == 0:
+            study = optuna.create_study(storage=storage)
+            trial = TorchDistributedTrial(study.ask())
+        else:
+            trial = TorchDistributedTrial(None)
+
+        trial.suggest_float("f", 0, 1)
+        trial.suggest_int("i", 0, 1)
+        trial.suggest_categorical("c", ("a", "b", "c"))
+
+        property_names = [
+            p
+            for p in dir(TorchDistributedTrial)
+            if isinstance(getattr(TorchDistributedTrial, p), property)
+        ]
+
+        # rank 0 can read properties without messing up distributed state
+        if dist.get_rank() == 0:
+            [getattr(trial, p) for p in property_names]
+
+        dist.barrier()
+
+        # same with rank 1
+        if dist.get_rank() == 1:
+            [getattr(trial, p) for p in property_names]
+
+        dist.barrier()

--- a/tests/integration_tests/test_pytorch_distributed.py
+++ b/tests/integration_tests/test_pytorch_distributed.py
@@ -26,7 +26,7 @@ def init_process_group() -> None:
     os.environ["MASTER_ADDR"] = "127.0.0.1"
     os.environ["MASTER_PORT"] = "20000"
 
-    dist.init_process_group("gloo")
+    dist.init_process_group("gloo", timeout=datetime.timedelta(seconds=15))
 
 
 def test_torch_distributed_trial_experimental_warning() -> None:
@@ -338,8 +338,7 @@ def test_distributions(storage_mode: str) -> None:
 
 @pytest.mark.filterwarnings("ignore::optuna.exceptions.ExperimentalWarning")
 @pytest.mark.parametrize("storage_mode", STORAGE_MODES)
-@pytest.mark.timeout(15, method="signal")
-def test_updates_state(storage_mode: str) -> None:
+def test_updates_properties(storage_mode: str) -> None:
     """Check for any distributed deadlock following a property read."""
     with StorageSupplier(storage_mode) as storage:
         if dist.get_rank() == 0:

--- a/tests/integration_tests/test_pytorch_distributed.py
+++ b/tests/integration_tests/test_pytorch_distributed.py
@@ -358,7 +358,7 @@ def test_updates_state(storage_mode: str) -> None:
             if isinstance(getattr(TorchDistributedTrial, p), property)
         ]
 
-        # rank 0 can read properties without messing up distributed state
+        # Rank 0 can read properties without deadlock.
         if dist.get_rank() == 0:
             [getattr(trial, p) for p in property_names]
 

--- a/tests/integration_tests/test_pytorch_distributed.py
+++ b/tests/integration_tests/test_pytorch_distributed.py
@@ -364,7 +364,7 @@ def test_updates_state(storage_mode: str) -> None:
 
         dist.barrier()
 
-        # same with rank 1
+        # Same with rank 1.
         if dist.get_rank() == 1:
             [getattr(trial, p) for p in property_names]
 


### PR DESCRIPTION
Fixes #3484

## Motivation

Removes all calls to torch.distributed from TorchDistributedTrial properties as they have undesired side-effects: namely they break the synchronization of distributed processes if one forgets to call them simultaneously on all distributed processes.

## Description of the changes
<!-- Describe the changes in this PR. -->
Prior to this PR, reading properties on TorchDistributedTrial triggered a call to torch.distributed.broadcast in order to retrieve the values, this was necessary because they are solely stored on the process with rank 0.
This PR instead broadcasts the values to all processes each time they are updated by calls to suggest_uniform, etc. This is not inconvenient because these functions are already called on all distributed processes anyways and Optuna documentation is clear about this.