### PR TITLE
Import COLOR_SCALE inside import util context

### DIFF
--- a/optuna/visualization/_contour.py
+++ b/optuna/visualization/_contour.py
@@ -18,7 +18,6 @@ from optuna.visualization._utils import _get_param_values
 from optuna.visualization._utils import _is_log_scale
 from optuna.visualization._utils import _is_numerical
 from optuna.visualization._utils import _is_reverse_scale
-from optuna.visualization._utils import COLOR_SCALE
 
 
 if _imports.is_successful():
@@ -27,6 +26,7 @@ if _imports.is_successful():
     from optuna.visualization._plotly_imports import make_subplots
     from optuna.visualization._plotly_imports import plotly
     from optuna.visualization._plotly_imports import Scatter
+    from optuna.visualization._utils import COLOR_SCALE
 
 _logger = get_logger(__name__)
 

--- a/optuna/visualization/_parallel_coordinate.py
+++ b/optuna/visualization/_parallel_coordinate.py
@@ -21,11 +21,11 @@ from optuna.visualization._utils import _is_categorical
 from optuna.visualization._utils import _is_log_scale
 from optuna.visualization._utils import _is_numerical
 from optuna.visualization._utils import _is_reverse_scale
-from optuna.visualization._utils import COLOR_SCALE
 
 
 if _imports.is_successful():
     from optuna.visualization._plotly_imports import go
+    from optuna.visualization._utils import COLOR_SCALE
 
 _logger = get_logger(__name__)
 

--- a/optuna/visualization/_slice.py
+++ b/optuna/visualization/_slice.py
@@ -10,13 +10,13 @@ from optuna.trial import TrialState
 from optuna.visualization._plotly_imports import _imports
 from optuna.visualization._utils import _check_plot_args
 from optuna.visualization._utils import _is_log_scale
-from optuna.visualization._utils import COLOR_SCALE
 
 
 if _imports.is_successful():
     from optuna.visualization._plotly_imports import go
     from optuna.visualization._plotly_imports import make_subplots
     from optuna.visualization._plotly_imports import Scatter
+    from optuna.visualization._utils import COLOR_SCALE
 
 _logger = get_logger(__name__)
 


### PR DESCRIPTION
The error message when `plotly` is not available was unintentionally changed in https://github.com/optuna/optuna/pull/3376. This PR makes the behavior consistent with the current stable release of Optuna (Thank you for reporting @fukatani!).


### master

```sh
Traceback (most recent call last):
  File "/Users/himkt/work/github.com/himkt/optuna/main.py", line 12, in <module>
    optuna.visualization.plot_pareto_front(study)
  File "/Users/himkt/work/github.com/himkt/optuna/optuna/_imports.py", line 125, in __getattr__
    return getattr(self._load(), item)
  File "/Users/himkt/work/github.com/himkt/optuna/optuna/_imports.py", line 120, in _load
    module = importlib.import_module(self._name)
  File "/opt/homebrew-x86_64/Cellar/python@3.9/3.9.10/Frameworks/Python.framework/Versions/3.9/lib/python3.9/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 986, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 680, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 850, in exec_module
  File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
  File "/Users/himkt/work/github.com/himkt/optuna/optuna/visualization/__init__.py", line 2, in <module>
    from optuna.visualization._contour import plot_contour
  File "/Users/himkt/work/github.com/himkt/optuna/optuna/visualization/_contour.py", line 21, in <module>
    from optuna.visualization._utils import COLOR_SCALE
ImportError: cannot import name 'COLOR_SCALE' from 'optuna.visualization._utils' (/Users/himkt/work/github.com/himkt/optuna/optuna/visualization/_utils.py)
```

### This PR (v2.10.0)

```sh
/Users/himkt/work/github.com/himkt/optuna/main.py:12: ExperimentalWarning: plot_pareto_front is experimental (supported from v2.4.0). The interface can change in the future.
  optuna.visualization.plot_pareto_front(study)
Traceback (most recent call last):
  File "/Users/himkt/work/github.com/himkt/optuna/optuna/visualization/_plotly_imports.py", line 7, in <module>
    import plotly  # NOQA
ModuleNotFoundError: No module named 'plotly'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/himkt/work/github.com/himkt/optuna/main.py", line 12, in <module>
    optuna.visualization.plot_pareto_front(study)
  File "/Users/himkt/work/github.com/himkt/optuna/optuna/_experimental.py", line 68, in new_func
    return func(*args, **kwargs)  # type: ignore
  File "/Users/himkt/work/github.com/himkt/optuna/optuna/visualization/_pareto_front.py", line 108, in plot_pareto_front
    _imports.check()
  File "/Users/himkt/work/github.com/himkt/optuna/optuna/_imports.py", line 89, in check
    raise ImportError(message) from exc_value
ImportError: Tried to import 'plotly' but failed. Please make sure that the package is installed correctly to use this feature. Actual error: No module named 'plotly'.
```