### PR TITLE
Fix label of issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,6 +1,6 @@
 name: "\U0001f4d6Documentation"
 description: Report an issue related to https://optuna.readthedocs.io/.
-labels: ["documentation"]
+labels: ["document"]
 body:
   - type: textarea
     id: explanation


### PR DESCRIPTION
Issue template for documentation was introduced in https://github.com/optuna/optuna/pull/3169.
`labels` specification is not correct, i.e. `labels` is `documentation` but the label in our GitHub issue is `document`.

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

## Description of the changes
<!-- Describe the changes in this PR. -->
