### PR TITLE
Support `constraints_func` in `plot_pareto_front` in matplotlib visualization.

### DIFF
--- a/optuna/visualization/matplotlib/_pareto_front.py
+++ b/optuna/visualization/matplotlib/_pareto_front.py
@@ -124,12 +124,15 @@ def _get_pareto_front_2d(info: _ParetoFrontInfo) -> "Axes":
     ax.set_xlabel(info.target_names[info.axis_order[0]])
     ax.set_ylabel(info.target_names[info.axis_order[1]])
 
-    if info.infeasible_trials_with_values is not None and len(info.infeasible_trials_with_values) > 0:
+    if (
+        info.infeasible_trials_with_values is not None
+        and len(info.infeasible_trials_with_values) > 0
+    ):
         ax.scatter(
             x=[values[info.axis_order[0]] for _, values in info.infeasible_trials_with_values],
             y=[values[info.axis_order[1]] for _, values in info.infeasible_trials_with_values],
             color="#cccccc",
-            label="Infeasible",
+            label="Infeasible Trial",
         )
     if info.non_best_trials_with_values is not None and len(info.non_best_trials_with_values) > 0:
         ax.scatter(
@@ -164,12 +167,15 @@ def _get_pareto_front_3d(info: _ParetoFrontInfo) -> "Axes":
     ax.set_ylabel(info.target_names[info.axis_order[1]])
     ax.set_zlabel(info.target_names[info.axis_order[2]])
 
-    if info.infeasible_trials_with_values is not None and len(info.infeasible_trials_with_values) > 0:
+    if (
+        info.infeasible_trials_with_values is not None
+        and len(info.infeasible_trials_with_values) > 0
+    ):
         ax.scatter(
             xs=[values[info.axis_order[0]] for _, values in info.infeasible_trials_with_values],
             ys=[values[info.axis_order[1]] for _, values in info.infeasible_trials_with_values],
             zs=[values[info.axis_order[2]] for _, values in info.infeasible_trials_with_values],
-            color=cmap(1),
+            color="#cccccc",
             label="Infeasible",
         )
 

--- a/optuna/visualization/matplotlib/_pareto_front.py
+++ b/optuna/visualization/matplotlib/_pareto_front.py
@@ -128,7 +128,7 @@ def _get_pareto_front_2d(info: _ParetoFrontInfo) -> "Axes":
         ax.scatter(
             x=[values[info.axis_order[0]] for _, values in info.infeasible_trials_with_values],
             y=[values[info.axis_order[1]] for _, values in info.infeasible_trials_with_values],
-            color=cmap(1),
+            color="#cccccc",
             label="Infeasible",
         )
     if info.non_best_trials_with_values is not None and len(info.non_best_trials_with_values) > 0:

--- a/optuna/visualization/matplotlib/_pareto_front.py
+++ b/optuna/visualization/matplotlib/_pareto_front.py
@@ -176,7 +176,7 @@ def _get_pareto_front_3d(info: _ParetoFrontInfo) -> "Axes":
             ys=[values[info.axis_order[1]] for _, values in info.infeasible_trials_with_values],
             zs=[values[info.axis_order[2]] for _, values in info.infeasible_trials_with_values],
             color="#cccccc",
-            label="Infeasible",
+            label="Infeasible Trial",
         )
 
     if info.non_best_trials_with_values is not None and len(info.non_best_trials_with_values) > 0:

--- a/tests/visualization_tests/matplotlib_tests/test_pareto_front.py
+++ b/tests/visualization_tests/matplotlib_tests/test_pareto_front.py
@@ -6,6 +6,7 @@ from typing import Optional
 from typing import Sequence
 from typing import Union
 
+from matplotlib.axes._axes import Axes
 import matplotlib.figure
 import matplotlib.pyplot as plt
 import numpy as np
@@ -25,7 +26,7 @@ def allclose_as_set(
     return np.allclose(sorted(p1), sorted(p2))
 
 
-def _check_data(figure: matplotlib.figure, axis: str, expected: Sequence[int]) -> None:
+def _check_data(figure: Axes, axis: str, expected: Sequence[int]) -> None:
     """Compare `figure` against `expected`.
 
     Concatenate `data` in `figure` in reverse order, pick the desired `axis`, and compare with

--- a/tests/visualization_tests/matplotlib_tests/test_pareto_front.py
+++ b/tests/visualization_tests/matplotlib_tests/test_pareto_front.py
@@ -6,10 +6,10 @@ from typing import Optional
 from typing import Sequence
 from typing import Union
 
-import numpy.ma.testutils
-from matplotlib.collections import PathCollection
+import matplotlib.figure
 import matplotlib.pyplot as plt
 import numpy as np
+import numpy.ma.testutils
 import pytest
 
 import optuna
@@ -25,7 +25,7 @@ def allclose_as_set(
     return np.allclose(sorted(p1), sorted(p2))
 
 
-def _check_data(figure: "go.Figure", axis: str, expected: Sequence[int]) -> None:
+def _check_data(figure: matplotlib.figure, axis: str, expected: Sequence[int]) -> None:
     """Compare `figure` against `expected`.
 
     Concatenate `data` in `figure` in reverse order, pick the desired `axis`, and compare with
@@ -37,10 +37,10 @@ def _check_data(figure: "go.Figure", axis: str, expected: Sequence[int]) -> None
         expected: The expected result.
     """
     axis_map = {"x": 0, "y": 1, "z": 2}
-    axis = axis_map[axis]
     n_data = len(figure.collections)
     actual = tuple(
-        itertools.chain(*list(map(lambda i: figure.collections[i].get_offsets()[:, axis], reversed(range(n_data)))))
+        itertools.chain(*list(map(lambda i: figure.collections[i].get_offsets()[:, axis_map[axis]],
+                                  reversed(range(n_data)))))
     )
     numpy.ma.testutils.assert_array_equal(actual, expected)
 

--- a/tests/visualization_tests/matplotlib_tests/test_pareto_front.py
+++ b/tests/visualization_tests/matplotlib_tests/test_pareto_front.py
@@ -39,8 +39,14 @@ def _check_data(figure: matplotlib.figure, axis: str, expected: Sequence[int]) -
     axis_map = {"x": 0, "y": 1, "z": 2}
     n_data = len(figure.collections)
     actual = tuple(
-        itertools.chain(*list(map(lambda i: figure.collections[i].get_offsets()[:, axis_map[axis]],
-                                  reversed(range(n_data)))))
+        itertools.chain(
+            *list(
+                map(
+                    lambda i: figure.collections[i].get_offsets()[:, axis_map[axis]],
+                    reversed(range(n_data)),
+                )
+            )
+        )
     )
     numpy.ma.testutils.assert_array_equal(actual, expected)
 

--- a/tests/visualization_tests/matplotlib_tests/test_pareto_front.py
+++ b/tests/visualization_tests/matplotlib_tests/test_pareto_front.py
@@ -251,6 +251,7 @@ def test_plot_pareto_front_3d(
 
     _check_data(figure, "x", data[actual_axis_order[0]])
     _check_data(figure, "y", data[actual_axis_order[1]])
+    # TODO(fukatani): check z data.
     # _check_data(figure, "z", data[actual_axis_order[2]])
     plt.savefig(BytesIO())
 

--- a/tests/visualization_tests/matplotlib_tests/test_pareto_front.py
+++ b/tests/visualization_tests/matplotlib_tests/test_pareto_front.py
@@ -7,7 +7,6 @@ from typing import Sequence
 from typing import Union
 
 from matplotlib.axes._axes import Axes
-import matplotlib.figure
 import matplotlib.pyplot as plt
 import numpy as np
 import numpy.ma.testutils


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
Resolve #3116 
In current, only `plotly` backend supports `constraints_func` in `pareto-front` visualization.
In this PR `matplotlib` backend  also supports `constraints_func`.

## Description of the changes
<!-- Describe the changes in this PR. -->
Results:

![2d](https://user-images.githubusercontent.com/8858287/164957848-4840874c-69dc-4271-9d60-5f1a6acb61b4.png)
![3d](https://user-images.githubusercontent.com/8858287/164957849-abe0b32a-37eb-4885-9540-d4bdcec85158.png)
