### PR TITLE
Remove `-v` option of `optuna study set-user-attr` command

### DIFF
--- a/optuna/cli.py
+++ b/optuna/cli.py
@@ -312,7 +312,7 @@ class _StudySetUserAttribute(_BaseCommand):
             help="The name of the study to set the user attribute to.",
         )
         parser.add_argument("--key", "-k", required=True, help="Key of the user attribute.")
-        parser.add_argument("--value", "-v", required=True, help="Value to be set.")
+        parser.add_argument("--value", required=True, help="Value to be set.")
         return parser
 
     def take_action(self, parsed_args: Namespace) -> None:


### PR DESCRIPTION
## Motivation
To address the issue #3483.

## Description of the changes
Removed `-v` option of `optuna study set-user-attr` in `_StudySetUserAttr()` because it conflicts with `--verbose` while it was intended for `--value`.

Please kindly let me know if I missed any point, sorry I'm still new with CLI.