### PR TITLE
Align font size between `plotly` and `matplotlib` in `plot_optimization_history `

### DIFF
--- a/optuna/visualization/matplotlib/_matplotlib_imports.py
+++ b/optuna/visualization/matplotlib/_matplotlib_imports.py
@@ -15,6 +15,8 @@ with try_import() as _imports:  # NOQA
     from matplotlib.colors import Colormap  # NOQA
     from matplotlib.contour import ContourSet  # NOQA
     from matplotlib.patches import Rectangle  # NOQA
+    # The default font size of plotly.
+    DEFAULT_FONT_SIZE = 12
 
     # TODO(ytknzw): Set precise version.
     if version.parse(matplotlib_version) < version.parse("3.0.0"):

--- a/optuna/visualization/matplotlib/_matplotlib_imports.py
+++ b/optuna/visualization/matplotlib/_matplotlib_imports.py
@@ -15,6 +15,7 @@ with try_import() as _imports:  # NOQA
     from matplotlib.colors import Colormap  # NOQA
     from matplotlib.contour import ContourSet  # NOQA
     from matplotlib.patches import Rectangle  # NOQA
+
     # The default font size of plotly.
     DEFAULT_FONT_SIZE = 12
 

--- a/optuna/visualization/matplotlib/_optimization_history.py
+++ b/optuna/visualization/matplotlib/_optimization_history.py
@@ -21,6 +21,7 @@ from optuna.visualization.matplotlib._matplotlib_imports import _imports
 if _imports.is_successful():
     from optuna.visualization.matplotlib._matplotlib_imports import Axes
     from optuna.visualization.matplotlib._matplotlib_imports import plt
+    from optuna.visualization.matplotlib._matplotlib_imports import DEFAULT_FONT_SIZE
 
 _logger = get_logger(__name__)
 
@@ -110,9 +111,11 @@ def _get_optimization_history_plot(
     plt.style.use("ggplot")  # Use ggplot style sheet for similar outputs to plotly.
 
     _, ax = plt.subplots()
-    ax.set_title("Optimization History Plot")
-    ax.set_xlabel("Trial")
-    ax.set_ylabel(target_name)
+    ax.set_title("Optimization History Plot", fontsize=DEFAULT_FONT_SIZE)
+    ax.set_xlabel("Trial", fontsize=DEFAULT_FONT_SIZE)
+    plt.xticks(fontsize=DEFAULT_FONT_SIZE)
+    plt.yticks(fontsize=DEFAULT_FONT_SIZE)
+    ax.set_ylabel(target_name, fontsize=DEFAULT_FONT_SIZE)
 
     if len(studies) == 0:
         _logger.warning("There are no studies.")
@@ -139,6 +142,7 @@ def _get_optimization_history_plot(
         ax = _get_optimization_histories(studies, target, target_name, ax)
 
     plt.legend(bbox_to_anchor=(1.05, 1.0), loc="upper left")
+    plt.rc('legend', fontsize=DEFAULT_FONT_SIZE)
     return ax
 
 

--- a/optuna/visualization/matplotlib/_optimization_history.py
+++ b/optuna/visualization/matplotlib/_optimization_history.py
@@ -20,8 +20,8 @@ from optuna.visualization.matplotlib._matplotlib_imports import _imports
 
 if _imports.is_successful():
     from optuna.visualization.matplotlib._matplotlib_imports import Axes
-    from optuna.visualization.matplotlib._matplotlib_imports import plt
     from optuna.visualization.matplotlib._matplotlib_imports import DEFAULT_FONT_SIZE
+    from optuna.visualization.matplotlib._matplotlib_imports import plt
 
 _logger = get_logger(__name__)
 
@@ -142,7 +142,7 @@ def _get_optimization_history_plot(
         ax = _get_optimization_histories(studies, target, target_name, ax)
 
     plt.legend(bbox_to_anchor=(1.05, 1.0), loc="upper left")
-    plt.rc('legend', fontsize=DEFAULT_FONT_SIZE)
+    plt.rc("legend", fontsize=DEFAULT_FONT_SIZE)
     return ax
 
 

--- a/setup.py
+++ b/setup.py
@@ -129,6 +129,7 @@ def get_extras_require() -> Dict[str, List[str]]:
         "tests": [
             "fakeredis",
             "pytest",
+            "kaleido",
         ],
         "optional": [
             "matplotlib>=3.0.0",  # optuna/visualization/matplotlib

--- a/tests/visualization_tests/matplotlib_tests/test_optimization_history.py
+++ b/tests/visualization_tests/matplotlib_tests/test_optimization_history.py
@@ -59,7 +59,9 @@ def test_plot_optimization_history(direction: str) -> None:
     for tick in figure.yaxis.get_ticklabels():
         assert tick.get_fontsize() == expected_fontsize
 
-    assert figure.xaxis.label.get_fontsize() == figure.yaxis.label.get_fontsize() == expected_fontsize
+    assert (
+        figure.xaxis.label.get_fontsize() == figure.yaxis.label.get_fontsize() == expected_fontsize
+    )
     assert figure.title.get_fontsize() == expected_fontsize
 
     for text in figure.get_legend().texts:

--- a/tests/visualization_tests/matplotlib_tests/test_optimization_history.py
+++ b/tests/visualization_tests/matplotlib_tests/test_optimization_history.py
@@ -7,6 +7,7 @@ import pytest
 from optuna.study import create_study
 from optuna.trial import Trial
 from optuna.visualization.matplotlib import plot_optimization_history
+from optuna.visualization.matplotlib._matplotlib_imports import DEFAULT_FONT_SIZE
 
 
 def test_target_is_none_and_study_is_multi_obj() -> None:
@@ -48,6 +49,22 @@ def test_plot_optimization_history(direction: str) -> None:
     legend_texts = [legend.get_text() for legend in figure.legend().get_texts()]
     assert sorted(legend_texts) == ["Best Value", "Objective Value"]
     assert figure.get_ylabel() == "Objective Value"
+
+    # Check all the font sizes.
+    expected_fontsize = DEFAULT_FONT_SIZE
+
+    for tick in figure.xaxis.get_ticklabels():
+        assert tick.get_fontsize() == expected_fontsize
+
+    for tick in figure.yaxis.get_ticklabels():
+        assert tick.get_fontsize() == expected_fontsize
+
+    assert figure.xaxis.label.get_fontsize() == figure.yaxis.label.get_fontsize() == expected_fontsize
+    assert figure.title.get_fontsize() == expected_fontsize
+
+    for text in figure.get_legend().texts:
+        assert text.get_fontsize() == expected_fontsize
+
     plt.savefig(BytesIO())
 
     # Test customized target.

--- a/tests/visualization_tests/test_optimization_history.py
+++ b/tests/visualization_tests/test_optimization_history.py
@@ -46,6 +46,12 @@ def test_plot_optimization_history(direction: str) -> None:
     legend_texts = [x.name for x in figure.data]
     assert legend_texts == ["Objective Value", "Best Value"]
     assert figure.layout.yaxis.title.text == "Objective Value"
+    # if the font size is specified
+    font_size = figure.layout.font.size
+    if font_size is None:
+        # if not, use the default font size
+        font_size = figure.full_figure_for_development(warn=False).layout.font.size
+    assert font_size == 12
 
     # Test customized target.
     with pytest.warns(UserWarning):


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
The `plotly` and `matplotlib` have different default font size, and we want to match them.
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

## Description of the changes
This PR is part of fontsize of https://github.com/optuna/optuna/issues/3375. This PR changes the `plot_optimization_history`, and contains the following changes:

- Add tests in `plotly` to check the default font size is used.
- Set font in `matplotlib` to match the default value in `plotly`.
- Add tests in `plotly` to check the correct font size is used.
- `kaleido` is added to check the default values via `full_figure_for_development`
<!-- Describe the changes in this PR. -->
