### PR TITLE
Fix minor English errors in the docstring of `study.optimize`

### DIFF
--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -349,7 +349,7 @@ class Study:
                     will be performed across all processes.
             timeout:
                 Stop study after the given number of second(s). :obj:`None` represents no limit in
-                terms of elapsed time. The Study continue to create trials until the number of
+                terms of elapsed time. The study continues to create trials until the number of
                 trials reaches ``n_trials``, ``timeout`` period elapses,
                 :func:`~optuna.study.Study.stop` is called or, a termination signal such as
                 SIGTERM or Ctrl+C is received.


### PR DESCRIPTION
This is a followup PR of #3498, fixing minor English errors.