### PR TITLE
calculate the feature importance with mean absolute SHAP values

### DIFF
--- a/optuna/importance/__init__.py
+++ b/optuna/importance/__init__.py
@@ -5,6 +5,7 @@ from typing import Optional
 
 from optuna.importance._base import BaseImportanceEvaluator
 from optuna.importance._fanova import FanovaImportanceEvaluator
+from optuna.importance._mean_abs_shap import ShapleyImportanceEvaluator
 from optuna.importance._mean_decrease_impurity import MeanDecreaseImpurityImportanceEvaluator
 from optuna.study import Study
 from optuna.trial import FrozenTrial
@@ -14,6 +15,7 @@ __all__ = [
     "BaseImportanceEvaluator",
     "FanovaImportanceEvaluator",
     "MeanDecreaseImpurityImportanceEvaluator",
+    "ShapleyImportanceEvaluator",
     "get_param_importances",
 ]
 

--- a/optuna/importance/_mean_abs_shap.py
+++ b/optuna/importance/_mean_abs_shap.py
@@ -1,0 +1,79 @@
+from collections import OrderedDict
+from typing import Callable
+from typing import Dict
+from typing import List
+from typing import Optional
+
+import pandas as pd
+
+from optuna._imports import try_import
+from optuna.importance._mean_decrease_impurity import MeanDecreaseImpurityImportanceEvaluator
+from optuna.study import Study
+from optuna.trial import FrozenTrial
+
+
+with try_import() as _imports:
+    from shap import TreeExplainer
+
+
+class ShapleyImportanceEvaluator(MeanDecreaseImpurityImportanceEvaluator):
+    """Shapley (SHAP) parameter importance evaluator.
+
+    This evaluator fits a random forest that predicts objective values given hyperparameter
+    configurations. Feature importances are then computed using the mean absolute SHAP value for each feature.
+
+    .. note::
+
+        This evaluator requires the `sklean <https://scikit-learn.org/stable/>`_ Python package and
+        `SHAP <https://shap.readthedocs.io/en/latest/index.html>`_.
+        The model for the SHAP calculation is based on `sklearn.ensemble.RandomForestClassifier
+        <https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.RandomForestClassifier.html>`_.
+
+    Args:
+        n_trees:
+            Number of trees in the random forest.
+        max_depth:
+            The maximum depth of each tree in the random forest.
+        seed:
+            Seed for the random forest.
+    """
+
+    def __init__(
+        self, *, n_trees: int = 64, max_depth: int = 64, seed: Optional[int] = None
+    ) -> None:
+        _imports.check()
+
+        MeanDecreaseImpurityImportanceEvaluator.__init__(
+            self, n_trees=n_trees, max_depth=max_depth, seed=seed
+        )
+        # Explainer from SHAP
+        self._explainer: TreeExplainer = None
+
+    def evaluate(
+        self,
+        study: Study,
+        params: Optional[List[str]] = None,
+        *,
+        target: Optional[Callable[[FrozenTrial], float]] = None,
+    ) -> Dict[str, float]:
+
+        # Train a RandomForest from the parent class
+        super().evaluate(study=study, params=params, target=target)
+
+        # Create Tree Explainer object that can calculate shap values
+        self._explainer = TreeExplainer(self._forest)
+
+        # Generate SHAP values for the parameters during the trials
+        shap_values = self._explainer.shap_values(self._trans_params)
+        df_shap = pd.DataFrame(shap_values, columns=self._param_names)
+
+        # Calculate the mean absolute SHAP value for each parameter
+        mean_abs_shap_values = []
+        for param in df_shap.columns:
+            mean_abs_shap_values.append((param, df_shap[param].abs().mean()))
+
+        # Use the mean absolute SHAP values as the feature importance
+        mean_abs_shap_values.sort(key=lambda t: t[1], reverse=True)
+        feature_importances = OrderedDict(mean_abs_shap_values)
+
+        return feature_importances

--- a/optuna/importance/_mean_decrease_impurity.py
+++ b/optuna/importance/_mean_decrease_impurity.py
@@ -52,6 +52,9 @@ class MeanDecreaseImpurityImportanceEvaluator(BaseImportanceEvaluator):
             min_samples_leaf=1,
             random_state=seed,
         )
+        self._trans_params = numpy.empty(0)
+        self._trans_values = numpy.empty(0)
+        self._param_names: List[str] = list()
 
     def evaluate(
         self,
@@ -82,27 +85,27 @@ class MeanDecreaseImpurityImportanceEvaluator(BaseImportanceEvaluator):
         trans = _SearchSpaceTransform(distributions, transform_log=False, transform_step=False)
 
         n_trials = len(trials)
-        trans_params = numpy.empty((n_trials, trans.bounds.shape[0]), dtype=numpy.float64)
-        trans_values = numpy.empty(n_trials, dtype=numpy.float64)
+        self._trans_params = numpy.empty((n_trials, trans.bounds.shape[0]), dtype=numpy.float64)
+        self._trans_values = numpy.empty(n_trials, dtype=numpy.float64)
 
         for trial_idx, trial in enumerate(trials):
-            trans_params[trial_idx] = trans.transform(trial.params)
-            trans_values[trial_idx] = trial.value if target is None else target(trial)
+            self._trans_params[trial_idx] = trans.transform(trial.params)
+            self._trans_values[trial_idx] = trial.value if target is None else target(trial)
 
         encoded_column_to_column = trans.encoded_column_to_column
 
-        if trans_params.size == 0:  # `params` were given but as an empty list.
+        if self._trans_params.size == 0:  # `params` were given but as an empty list.
             return OrderedDict()
 
         forest = self._forest
-        forest.fit(trans_params, trans_values)
+        forest.fit(self._trans_params, self._trans_values)
         feature_importances = forest.feature_importances_
         feature_importances_reduced = numpy.zeros(len(distributions))
         numpy.add.at(feature_importances_reduced, encoded_column_to_column, feature_importances)
 
         param_importances = OrderedDict()
-        param_names = list(distributions.keys())
+        self._param_names = list(distributions.keys())
         for i in feature_importances_reduced.argsort()[::-1]:
-            param_importances[param_names[i]] = feature_importances_reduced[i].item()
+            param_importances[self._param_names[i]] = feature_importances_reduced[i].item()
 
         return param_importances

--- a/tests/importance_tests/test_mean_abs_shap.py
+++ b/tests/importance_tests/test_mean_abs_shap.py
@@ -1,0 +1,73 @@
+from optuna import create_study
+from optuna import Trial
+from optuna.importance import ShapleyImportanceEvaluator
+from optuna.samplers import RandomSampler
+
+
+def objective(trial: Trial) -> float:
+    x1 = trial.suggest_float("x1", 0.1, 3)
+    x2 = trial.suggest_float("x2", 0.1, 3, log=True)
+    x3 = trial.suggest_float("x3", 2, 4, log=True)
+    return x1 + x2 * x3
+
+
+def test_mean_decrease_impurity_importance_evaluator_n_trees() -> None:
+    # Assumes that `seed` can be fixed to reproduce identical results.
+
+    study = create_study(sampler=RandomSampler(seed=0))
+    study.optimize(objective, n_trials=3)
+
+    evaluator = ShapleyImportanceEvaluator(n_trees=10, seed=0)
+    param_importance = evaluator.evaluate(study)
+
+    evaluator = ShapleyImportanceEvaluator(n_trees=20, seed=0)
+    param_importance_different_n_trees = evaluator.evaluate(study)
+
+    assert param_importance != param_importance_different_n_trees
+
+
+def test_mean_decrease_impurity_importance_evaluator_max_depth() -> None:
+    # Assumes that `seed` can be fixed to reproduce identical results.
+
+    study = create_study(sampler=RandomSampler(seed=0))
+    study.optimize(objective, n_trials=3)
+
+    evaluator = ShapleyImportanceEvaluator(max_depth=1, seed=0)
+    param_importance = evaluator.evaluate(study)
+
+    evaluator = ShapleyImportanceEvaluator(max_depth=2, seed=0)
+    param_importance_different_max_depth = evaluator.evaluate(study)
+
+    assert param_importance != param_importance_different_max_depth
+
+
+def test_mean_decrease_impurity_importance_evaluator_seed() -> None:
+    study = create_study(sampler=RandomSampler(seed=0))
+    study.optimize(objective, n_trials=3)
+
+    evaluator = ShapleyImportanceEvaluator(seed=2)
+    param_importance = evaluator.evaluate(study)
+
+    evaluator = ShapleyImportanceEvaluator(seed=2)
+    param_importance_same_seed = evaluator.evaluate(study)
+    assert param_importance == param_importance_same_seed
+
+    evaluator = ShapleyImportanceEvaluator(seed=3)
+    param_importance_different_seed = evaluator.evaluate(study)
+    assert param_importance != param_importance_different_seed
+
+
+def test_mean_decrease_impurity_importance_evaluator_with_target() -> None:
+    # Assumes that `seed` can be fixed to reproduce identical results.
+
+    study = create_study(sampler=RandomSampler(seed=0))
+    study.optimize(objective, n_trials=3)
+
+    evaluator = ShapleyImportanceEvaluator(seed=0)
+    param_importance = evaluator.evaluate(study)
+    param_importance_with_target = evaluator.evaluate(
+        study,
+        target=lambda t: t.params["x1"] + t.params["x2"],
+    )
+
+    assert param_importance != param_importance_with_target


### PR DESCRIPTION

## Motivation
This PR adds the functionality to calculate the feature importance for the hyperparameters during the trial, based on the [SHAP values](https://shap.readthedocs.io/en/latest/index.html).  

## Description of the changes
Here is [the issue](https://github.com/optuna/optuna/issues/3448) that this PR is addressing. 
In order to calculate the SHAP values, we need a surrogate model, _e.g._ RandomForest. This PR uses the RandomForest model from the `MeanDecreaseImpurityImportanceEvaluator`. 
