### PR TITLE
Make `GridSampler` reproducible

### DIFF
--- a/optuna/samplers/_grid.py
+++ b/optuna/samplers/_grid.py
@@ -1,6 +1,5 @@
 import collections
 import itertools
-import random
 from typing import Any
 from typing import cast
 from typing import Dict
@@ -10,6 +9,8 @@ from typing import Optional
 from typing import Sequence
 from typing import Union
 import warnings
+
+import numpy as np
 
 from optuna.distributions import BaseDistribution
 from optuna.logging import get_logger
@@ -97,9 +98,12 @@ class GridSampler(BaseSampler):
         search_space:
             A dictionary whose key and value are a parameter name and the corresponding candidates
             of values, respectively.
+        seed: Seed for random number generator.
     """
 
-    def __init__(self, search_space: Mapping[str, Sequence[GridValueType]]) -> None:
+    def __init__(
+        self, search_space: Mapping[str, Sequence[GridValueType]], seed: Optional[int] = None
+    ) -> None:
 
         for param_name, param_values in search_space.items():
             for value in param_values:
@@ -114,6 +118,11 @@ class GridSampler(BaseSampler):
         self._all_grids = list(itertools.product(*self._search_space.values()))
         self._param_names = sorted(search_space.keys())
         self._n_min_trials = len(self._all_grids)
+        self._rng = np.random.RandomState(seed)
+
+    def reseed_rng(self) -> None:
+
+        self._rng = np.random.RandomState()
 
     def infer_relative_search_space(
         self, study: Study, trial: FrozenTrial
@@ -152,7 +161,7 @@ class GridSampler(BaseSampler):
 
         # In distributed optimization, multiple workers may simultaneously pick up the same grid.
         # To make the conflict less frequent, the grid is chosen randomly.
-        grid_id = random.choice(target_grids)
+        grid_id = self._rng.choice(target_grids)
 
         study._storage.set_trial_system_attr(trial._trial_id, "search_space", self._search_space)
         study._storage.set_trial_system_attr(trial._trial_id, "grid_id", grid_id)

--- a/optuna/samplers/_grid.py
+++ b/optuna/samplers/_grid.py
@@ -122,7 +122,7 @@ class GridSampler(BaseSampler):
 
     def reseed_rng(self) -> None:
 
-        self._rng = np.random.RandomState()
+        self._rng.seed()
 
     def infer_relative_search_space(
         self, study: Study, trial: FrozenTrial

--- a/optuna/samplers/_grid.py
+++ b/optuna/samplers/_grid.py
@@ -98,7 +98,7 @@ class GridSampler(BaseSampler):
         search_space:
             A dictionary whose key and value are a parameter name and the corresponding candidates
             of values, respectively.
-        seed: Seed for random number generator.
+        seed: A seed to specify the order of trials as the grid is randomly shuffled.
     """
 
     def __init__(

--- a/tests/samplers_tests/test_grid.py
+++ b/tests/samplers_tests/test_grid.py
@@ -197,6 +197,28 @@ def test_enqueued_trial() -> None:
     assert sorted([study.trials[1].params["a"], study.trials[2].params["a"]]) == [0, 50]
 
 
+def test_same_seed_trial() -> None:
+    sampler1 = samplers.GridSampler({"a": [0, 20, 40, 60, 80, 100]}, 0)
+    study1 = optuna.create_study(sampler=sampler1)
+    study1.optimize(lambda trial: trial.suggest_int("a", 0, 100))
+
+    sampler2 = samplers.GridSampler({"a": [0, 20, 40, 60, 80, 100]}, 0)
+    study2 = optuna.create_study(sampler=sampler2)
+    study2.optimize(lambda trial: trial.suggest_int("a", 0, 100))
+
+    for i in range(6):
+        assert study1.trials[i].params["a"] == study2.trials[i].params["a"]
+
+
+def test_reseed_rng() -> None:
+    sampler = samplers.GridSampler({"a": [0, 100]})
+    sampler.reseed_rng()
+    study = optuna.create_study(sampler=sampler)
+    study.optimize(lambda trial: trial.suggest_int("a", 0, 100))
+
+    assert sorted([study.trials[0].params["a"], study.trials[1].params["a"]]) == [0, 100]
+
+
 def test_enqueued_insufficient_trial() -> None:
     sampler = samplers.GridSampler({"a": [0, 50]})
     study = optuna.create_study(sampler=sampler)

--- a/tests/samplers_tests/test_grid.py
+++ b/tests/samplers_tests/test_grid.py
@@ -215,11 +215,10 @@ def test_same_seed_trials() -> None:
 
 def test_reseed_rng() -> None:
     sampler = samplers.GridSampler({"a": [0, 100]})
+    original_seed = sampler._rng.get_state()
     sampler.reseed_rng()
-    study = optuna.create_study(sampler=sampler)
-    study.optimize(lambda trial: trial.suggest_int("a", 0, 100))
 
-    assert sorted([study.trials[0].params["a"], study.trials[1].params["a"]]) == [0, 100]
+    assert str(original_seed) != str(sampler._rng.get_state())
 
 
 def test_enqueued_insufficient_trial() -> None:

--- a/tests/samplers_tests/test_grid.py
+++ b/tests/samplers_tests/test_grid.py
@@ -197,16 +197,19 @@ def test_enqueued_trial() -> None:
     assert sorted([study.trials[1].params["a"], study.trials[2].params["a"]]) == [0, 50]
 
 
-def test_same_seed_trial() -> None:
-    sampler1 = samplers.GridSampler({"a": [0, 20, 40, 60, 80, 100]}, 0)
+def test_same_seed_trials() -> None:
+    grid_values = [0, 20, 40, 60, 80, 100]
+    seed = 0
+
+    sampler1 = samplers.GridSampler({"a": grid_values}, seed)
     study1 = optuna.create_study(sampler=sampler1)
     study1.optimize(lambda trial: trial.suggest_int("a", 0, 100))
 
-    sampler2 = samplers.GridSampler({"a": [0, 20, 40, 60, 80, 100]}, 0)
+    sampler2 = samplers.GridSampler({"a": grid_values}, seed)
     study2 = optuna.create_study(sampler=sampler2)
     study2.optimize(lambda trial: trial.suggest_int("a", 0, 100))
 
-    for i in range(6):
+    for i in range(len(grid_values)):
         assert study1.trials[i].params["a"] == study2.trials[i].params["a"]
 
 


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
https://github.com/optuna/optuna/issues/3516
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

## Description of the changes
- `GridSampler` can receive a seed for its random number generator `_rng`
- add `reseed_rng` function like `TPESampler` and `RandomSampler`
- add tests for a fixed seed and `reseed_rng`

To check its behavior, I used the code below.
``` python
import optuna


def objective(trial):
    a = trial.suggest_int("a", 0, 5)
    return a + trial.number


for i in range(3):
    sampler = optuna.samplers.GridSampler({"a": [0, 1, 2, 3, 4, 5]}, 1)  # seed: 1
    study = optuna.create_study(sampler=sampler)
    study.optimize(objective)

    if i == 2:
        sampler.reseed_rng() # seed is randomized
        study = optuna.create_study(sampler=sampler)
        study.optimize(objective) # maybe different behavior

```