### PR TITLE
Make requests in chunks due to limitations imposed by MLflow

### DIFF
--- a/optuna/integration/mlflow.py
+++ b/optuna/integration/mlflow.py
@@ -9,8 +9,6 @@ from typing import Optional
 from typing import Sequence
 from typing import Union
 
-from mlflow.utils.validation import MAX_METRICS_PER_BATCH
-from mlflow.utils.validation import MAX_PARAMS_TAGS_PER_BATCH
 
 import optuna
 from optuna._experimental import experimental
@@ -20,6 +18,8 @@ from optuna.study.study import ObjectiveFuncType
 
 with try_import() as _imports:
     import mlflow
+    from mlflow.utils.validation import MAX_METRICS_PER_BATCH
+    from mlflow.utils.validation import MAX_PARAMS_TAGS_PER_BATCH
 
 RUN_ID_ATTRIBUTE_KEY = "mlflow_run_id"
 

--- a/optuna/integration/mlflow.py
+++ b/optuna/integration/mlflow.py
@@ -2,6 +2,7 @@ import functools
 from typing import Any
 from typing import Callable
 from typing import Dict
+from typing import Generator
 from typing import List
 from typing import Optional
 from typing import Sequence
@@ -280,7 +281,9 @@ class MLflowCallback(object):
                 tags[key] = "{}...".format(value[: max_val_length - 3])
 
         # This sets the tags for MLflow.
-        mlflow.set_tags(tags)
+        # MLflow handles up to 100 tags per request
+        for tags_chunk in self._dict_chunks(tags, 100):
+            mlflow.set_tags(tags_chunk)
 
     def _log_metrics(self, values: Optional[List[float]]) -> None:
         """Log the trial results as metrics to MLflow.
@@ -312,15 +315,36 @@ class MLflowCallback(object):
             else:
                 names = [*self._metric_name]
 
+        # MLflow handles up to 1000 metrics per request
         metrics = {name: val for name, val in zip(names, values)}
-        mlflow.log_metrics(metrics)
+        for metric_chunk in self._dict_chunks(metrics, 1000):
+            mlflow.log_metrics(metric_chunk)
 
-    @staticmethod
-    def _log_params(params: Dict[str, Any]) -> None:
+    @classmethod
+    def _log_params(cls, params: Dict[str, Any]) -> None:
         """Log the parameters of the trial to MLflow.
 
         Args:
             params: Trial params.
         """
+        # MLflow handles up to 100 parameters per request
+        for params_chunk in cls._dict_chunks(params, 100):
+            mlflow.log_params(params_chunk)
 
-        mlflow.log_params(params)
+    @staticmethod
+    def _dict_chunks(d: Dict[str, Any], n: int) -> Generator[Dict, None, None]:
+        """Splits a dictionary into chunks of maximum size n.
+
+        Args:
+            d: Dictionary to be chunked.
+            n: Maximum size of each chunk.
+
+        Returns:
+            Generator of dictionaries.
+        """
+        chunk = {}
+        for i, param in enumerate(d.items(), 1):
+            chunk[param[0]] = param[1]
+            if len(chunk) % n == 0 or i == len(d):
+                yield chunk
+                chunk = {}

--- a/optuna/integration/mlflow.py
+++ b/optuna/integration/mlflow.py
@@ -1,4 +1,5 @@
 import functools
+from itertools import islice
 from typing import Any
 from typing import Callable
 from typing import Dict
@@ -7,6 +8,8 @@ from typing import List
 from typing import Optional
 from typing import Sequence
 from typing import Union
+
+from mlflow.utils.validation import MAX_PARAMS_TAGS_PER_BATCH, MAX_METRICS_PER_BATCH
 
 import optuna
 from optuna._experimental import experimental
@@ -18,6 +21,23 @@ with try_import() as _imports:
     import mlflow
 
 RUN_ID_ATTRIBUTE_KEY = "mlflow_run_id"
+
+
+def _dict_chunks(
+        dict_data: Dict[str, Any], num_elements_per_dict: int
+    ) -> Generator[Dict[str, Any], None, None]:
+    """Splits a dictionary into chunks of maximum size n.
+
+    Args:
+        d: Dictionary to be chunked.
+        n: Maximum size of each chunk.
+
+    Returns:
+        Generator of dictionaries.
+    """
+    it = iter(dict_data)
+    for _ in range(0, len(dict_data), num_elements_per_dict):
+        yield {k: dict_data[k] for k in islice(it, num_elements_per_dict)}
 
 
 @experimental("1.4.0")
@@ -282,7 +302,7 @@ class MLflowCallback(object):
 
         # This sets the tags for MLflow.
         # MLflow handles up to 100 tags per request
-        for tags_chunk in self._dict_chunks(tags, 100):
+        for tags_chunk in _dict_chunks(tags, MAX_PARAMS_TAGS_PER_BATCH):
             mlflow.set_tags(tags_chunk)
 
     def _log_metrics(self, values: Optional[List[float]]) -> None:
@@ -317,10 +337,10 @@ class MLflowCallback(object):
 
         # MLflow handles up to 1000 metrics per request
         metrics = {name: val for name, val in zip(names, values)}
-        for metric_chunk in self._dict_chunks(metrics, 1000):
+        for metric_chunk in _dict_chunks(metrics, MAX_METRICS_PER_BATCH):
             mlflow.log_metrics(metric_chunk)
 
-    @classmethod
+    @staticmethod
     def _log_params(cls, params: Dict[str, Any]) -> None:
         """Log the parameters of the trial to MLflow.
 
@@ -328,23 +348,5 @@ class MLflowCallback(object):
             params: Trial params.
         """
         # MLflow handles up to 100 parameters per request
-        for params_chunk in cls._dict_chunks(params, 100):
+        for params_chunk in _dict_chunks(params, MAX_PARAMS_TAGS_PER_BATCH):
             mlflow.log_params(params_chunk)
-
-    @staticmethod
-    def _dict_chunks(d: Dict[str, Any], n: int) -> Generator[Dict, None, None]:
-        """Splits a dictionary into chunks of maximum size n.
-
-        Args:
-            d: Dictionary to be chunked.
-            n: Maximum size of each chunk.
-
-        Returns:
-            Generator of dictionaries.
-        """
-        chunk = {}
-        for i, param in enumerate(d.items(), 1):
-            chunk[param[0]] = param[1]
-            if len(chunk) % n == 0 or i == len(d):
-                yield chunk
-                chunk = {}

--- a/optuna/integration/mlflow.py
+++ b/optuna/integration/mlflow.py
@@ -9,7 +9,8 @@ from typing import Optional
 from typing import Sequence
 from typing import Union
 
-from mlflow.utils.validation import MAX_PARAMS_TAGS_PER_BATCH, MAX_METRICS_PER_BATCH
+from mlflow.utils.validation import MAX_METRICS_PER_BATCH
+from mlflow.utils.validation import MAX_PARAMS_TAGS_PER_BATCH
 
 import optuna
 from optuna._experimental import experimental
@@ -24,13 +25,13 @@ RUN_ID_ATTRIBUTE_KEY = "mlflow_run_id"
 
 
 def _dict_chunks(
-        dict_data: Dict[str, Any], num_elements_per_dict: int
-    ) -> Generator[Dict[str, Any], None, None]:
+    dict_data: Dict[str, Any], num_elements_per_dict: int
+) -> Generator[Dict[str, Any], None, None]:
     """Splits a dictionary into chunks of maximum size n.
 
     Args:
-        d: Dictionary to be chunked.
-        n: Maximum size of each chunk.
+        dict_data: Dictionary to be chunked.
+        num_elements_per_dict: Maximum size of each chunk.
 
     Returns:
         Generator of dictionaries.
@@ -301,7 +302,7 @@ class MLflowCallback(object):
                 tags[key] = "{}...".format(value[: max_val_length - 3])
 
         # This sets the tags for MLflow.
-        # MLflow handles up to 100 tags per request
+        # MLflow handles up to 100 tags per request.
         for tags_chunk in _dict_chunks(tags, MAX_PARAMS_TAGS_PER_BATCH):
             mlflow.set_tags(tags_chunk)
 
@@ -335,18 +336,18 @@ class MLflowCallback(object):
             else:
                 names = [*self._metric_name]
 
-        # MLflow handles up to 1000 metrics per request
+        # MLflow handles up to 1000 metrics per request.
         metrics = {name: val for name, val in zip(names, values)}
         for metric_chunk in _dict_chunks(metrics, MAX_METRICS_PER_BATCH):
             mlflow.log_metrics(metric_chunk)
 
     @staticmethod
-    def _log_params(cls, params: Dict[str, Any]) -> None:
+    def _log_params(params: Dict[str, Any]) -> None:
         """Log the parameters of the trial to MLflow.
 
         Args:
             params: Trial params.
         """
-        # MLflow handles up to 100 parameters per request
+        # MLflow handles up to 100 parameters per request.
         for params_chunk in _dict_chunks(params, MAX_PARAMS_TAGS_PER_BATCH):
             mlflow.log_params(params_chunk)


### PR DESCRIPTION
## Motivation
Push fails in MLflow callback in case there are more than 100 parameters and tags or 1000 metrics, due to restrictions posed by MLflow (https://www.mlflow.org/docs/latest/rest-api.html#request-limits).

## Description of the changes
- Split information sent to MLflow into chunks of 100 or 1000
