### PR TITLE
Fix `--verbose` and `--quiet` options in CLI

### DIFF
--- a/optuna/cli.py
+++ b/optuna/cli.py
@@ -919,6 +919,7 @@ class _OptunaApp(App):
         assert len(stream_handlers) == 1
         stream_handler = stream_handlers[0]
         stream_handler.setFormatter(optuna.logging.create_default_formatter())
+        optuna.logging.set_verbosity(stream_handler.level)
 
     def clean_up(self, cmd: Command, result: int, err: Optional[Exception]) -> None:
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1560,7 +1560,8 @@ def test_configure_logging_verbosity(verbosity: str, expected: bool) -> None:
 
         # Create study.
         args = ["optuna", "create-study", "--storage", storage_url, verbosity]
-        # If `--verbose`, the INFO level log message should be generated.
+        # `--verbose` makes the log level DEBUG.
+        # `--quiet` makes the log level WARNING.
         result = subprocess.run(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         error_message = result.stderr.decode()
         assert ("A new study created in RDB with name" in error_message) == expected

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1542,3 +1542,25 @@ def test_tell_with_nan() -> None:
         assert len(study.trials) == 1
         assert study.trials[0].state == TrialState.FAIL
         assert study.trials[0].values is None
+
+
+@pytest.mark.skip_coverage
+@pytest.mark.parametrize(
+    "verbosity, expected",
+    [
+        ("--verbose", True),
+        ("--quiet", False),
+    ],
+)
+def test_configure_logging_verbosity(verbosity: str, expected: bool) -> None:
+
+    with StorageSupplier("sqlite") as storage:
+        assert isinstance(storage, RDBStorage)
+        storage_url = str(storage.engine.url)
+
+        # Create study.
+        args = ["optuna", "create-study", "--storage", storage_url, verbosity]
+        # If `--verbose`, the INFO level log message should be generated.
+        result = subprocess.run(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        error_message = result.stderr.decode()
+        assert ("A new study created in RDB with name" in error_message) == expected


### PR DESCRIPTION
## Motivation
To address the issue #3485.

## Description of the changes
`_OptunaApp` will set verbosity with the same value specified by its super `App` in `cliff.app`. Also test code is added.
Ref. https://github.com/openstack/cliff/blob/master/cliff/app.py#L211-L219