### PR TITLE
Replace `ValueError` with `RuntimeError` in `get_best_trial`

### DIFF
--- a/optuna/storages/_in_memory.py
+++ b/optuna/storages/_in_memory.py
@@ -287,7 +287,7 @@ class InMemoryStorage(BaseStorage):
             if best_trial_id is None:
                 raise ValueError("No trials are completed yet.")
             elif len(self._studies[study_id].directions) > 1:
-                raise ValueError(
+                raise RuntimeError(
                     "Best trial can be obtained only for single-objective optimization."
                 )
             return self.get_trial(best_trial_id)

--- a/optuna/storages/_rdb/storage.py
+++ b/optuna/storages/_rdb/storage.py
@@ -1093,7 +1093,7 @@ class RDBStorage(BaseStorage):
         with _create_scoped_session(self.scoped_session) as session:
             _directions = self.get_study_directions(study_id)
             if len(_directions) > 1:
-                raise ValueError(
+                raise RuntimeError(
                     "Best trial can be obtained only for single-objective optimization."
                 )
             direction = _directions[0]

--- a/optuna/storages/_redis.py
+++ b/optuna/storages/_redis.py
@@ -515,7 +515,7 @@ class RedisStorage(BaseStorage):
 
             _direction = self.get_study_directions(study_id)
             if len(_direction) > 1:
-                raise ValueError(
+                raise RuntimeError(
                     "Best trial can be obtained only for single-objective optimization."
                 )
             direction = _direction[0]

--- a/tests/storages_tests/test_storages.py
+++ b/tests/storages_tests/test_storages.py
@@ -1175,7 +1175,7 @@ def test_get_best_trial_for_multi_objective_optimization(storage_mode: str) -> N
             template_trial.state = TrialState.COMPLETE
             template_trial.values = [i, i + 1]
             storage.create_new_trial(study_id, template_trial=template_trial)
-        with pytest.raises(ValueError):
+        with pytest.raises(RuntimeError):
             storage.get_best_trial(study_id)
 
 


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

Resolve #3491.

[`optuna.storages.RDBStorage.get_best_trial`](
https://optuna.readthedocs.io/en/latest/reference/generated/optuna.storages.RDBStorage.html#optuna.storages.RDBStorage.get_best_trial) says 
>[RuntimeError](https://docs.python.org/3/library/exceptions.html#RuntimeError) – If the study has more than one direction.

However, the implementations raise `ValueError` except for [`BaseStorage`](https://github.com/optuna/optuna/blob/f00abac7d53bb29e53e7c8bd13e9b4be9e0f9d44/optuna/storages/_base.py#L619-L623). 

## Description of the changes
<!-- Describe the changes in this PR. -->

Replace `ValueError` with `RuntimeError` in `get_best_trial` when a study has multiple objective values.