### PR TITLE
Replace `ValueError` with `warning` in `GridSearchSampler`

### DIFF
--- a/optuna/samplers/_grid.py
+++ b/optuna/samplers/_grid.py
@@ -211,11 +211,12 @@ class GridSampler(BaseSampler):
         if param_value is None or isinstance(param_value, (str, int, float, bool)):
             return
 
-        raise ValueError(
+        message = (
             "{} contains a value with the type of {}, which is not supported by "
             "`GridSampler`. Please make sure a value is `str`, `int`, `float`, `bool`"
-            " or `None`.".format(param_name, type(param_value))
+            " or `None` for persistent storage.".format(param_name, type(param_value))
         )
+        warnings.warn(message)
 
     def _get_unvisited_grid_ids(self, study: Study) -> List[int]:
 

--- a/tests/samplers_tests/test_grid.py
+++ b/tests/samplers_tests/test_grid.py
@@ -153,7 +153,7 @@ def test_cast_value() -> None:
     samplers.GridSampler._check_value("x", "foo")
     samplers.GridSampler._check_value("x", "")
 
-    with pytest.raises(ValueError):
+    with pytest.warns(UserWarning):
         samplers.GridSampler._check_value("x", [1])
 
 


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

Resolve #3540.
## Description of the changes
<!-- Describe the changes in this PR. -->

By following `CategoricalDistribution`, the grid sampler shows a warning message when search space contains unsupported types.