### PR TITLE
Remove tests_require since setup.py test is deprecated

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,11 +45,6 @@ def get_install_requires() -> List[str]:
     return requirements
 
 
-def get_tests_require() -> List[str]:
-
-    return get_extras_require()["testing"]
-
-
 def get_extras_require() -> Dict[str, List[str]]:
 
     requirements = {
@@ -218,7 +213,6 @@ setup(
     },
     python_requires=">=3.6",
     install_requires=get_install_requires(),
-    tests_require=get_tests_require(),
     extras_require=get_extras_require(),
     entry_points={
         "console_scripts": ["optuna = optuna.cli:main"],


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
With the deprecation of `python setup.py test`, `tests_require` is also a deprecated option.
See https://setuptools.pypa.io/en/latest/userguide/dependency_management.html#optional-dependencies

## Description of the changes
<!-- Describe the changes in this PR. -->
Remove the use of tests_require argument.
