### PR TITLE
Remove the version constraint of `fakeredis`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -94,8 +94,7 @@ def get_extras_require() -> Dict[str, List[str]]:
         "testing": [
             "chainer>=5.0.0",
             "cma",
-            # TODO(HideakiImamura): Remove the version constraint after the next release.
-            "fakeredis<=1.7.1",
+            "fakeredis",
             "lightgbm",
             "matplotlib>=3.0.0",
             "mlflow",
@@ -128,8 +127,7 @@ def get_extras_require() -> Dict[str, List[str]]:
             "fastai ; python_version>'3.6' and python_version<'3.10'",
         ],
         "tests": [
-            # TODO(HideakiImamura): Remove the version constraint after the next release.
-            "fakeredis<=1.7.1",
+            "fakeredis",
             "pytest",
         ],
         "optional": [

--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,8 @@ def get_extras_require() -> Dict[str, List[str]]:
         "testing": [
             "chainer>=5.0.0",
             "cma",
-            "fakeredis",
+            "fakeredis<=1.7.1; python_version<'3.8'",
+            "fakeredis ; python_version>='3.8'",
             "lightgbm",
             "matplotlib>=3.0.0",
             "mlflow",
@@ -127,7 +128,8 @@ def get_extras_require() -> Dict[str, List[str]]:
             "fastai ; python_version>'3.6' and python_version<'3.10'",
         ],
         "tests": [
-            "fakeredis",
+            "fakeredis<=1.7.1; python_version<'3.8'",
+            "fakeredis ; python_version>='3.8'",
             "pytest",
         ],
         "optional": [


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

Revert [this hotfix](https://github.com/optuna/optuna/pull/3549) for fakeredis because [`fakeredis` 1.7.5](https://github.com/dsoftwareinc/fakeredis-py/releases/tag/v1.7.5), which fixes the issue, has been released.

## Description of the changes
<!-- Describe the changes in this PR. -->

Depending on the python version, we need to set the version constraint of fakeredis:

- `fakeredis<=1.7.1` if python 3.6 or 3.7 
- `fakeredis` otherwise

