### PR TITLE
Replace `optuna.testing.integration.create_running_trial` with `study.ask`

### DIFF
--- a/optuna/testing/integration.py
+++ b/optuna/testing/integration.py
@@ -9,11 +9,3 @@ class DeterministicPruner(optuna.pruners.BasePruner):
     def prune(self, study: "optuna.study.Study", trial: "optuna.trial.FrozenTrial") -> bool:
 
         return self.is_pruning
-
-
-def create_running_trial(study: "optuna.study.Study", value: float) -> optuna.trial.Trial:
-
-    trial_id = study._storage.create_new_trial(study._study_id)
-    trial = study._storage.get_trial(trial_id)
-    study._storage.set_trial_state_values(trial_id, state=trial.state, values=[value])
-    return optuna.trial.Trial(study, trial_id)

--- a/tests/integration_tests/test_catboost.py
+++ b/tests/integration_tests/test_catboost.py
@@ -6,14 +6,13 @@ import pytest
 
 import optuna
 from optuna.integration.catboost import CatBoostPruningCallback
-from optuna.testing.integration import create_running_trial
 from optuna.testing.integration import DeterministicPruner
 
 
 def test_catboost_pruning_callback_call() -> None:
     # The pruner is deactivated.
     study = optuna.create_study(pruner=DeterministicPruner(False))
-    trial = create_running_trial(study, 1.0)
+    trial = study.ask()
     pruning_callback = CatBoostPruningCallback(trial, "Logloss")
     info = types.SimpleNamespace(
         iteration=1, metrics={"learn": {"Logloss": [1.0]}, "validation": {"Logloss": [1.0]}}
@@ -22,7 +21,7 @@ def test_catboost_pruning_callback_call() -> None:
 
     # The pruner is activated.
     study = optuna.create_study(pruner=DeterministicPruner(True))
-    trial = create_running_trial(study, 1.0)
+    trial = study.ask()
     pruning_callback = CatBoostPruningCallback(trial, "Logloss")
     info = types.SimpleNamespace(
         iteration=1, metrics={"learn": {"Logloss": [1.0]}, "validation": {"Logloss": [1.0]}}

--- a/tests/integration_tests/test_chainer.py
+++ b/tests/integration_tests/test_chainer.py
@@ -12,7 +12,6 @@ import pytest
 
 import optuna
 from optuna.integration.chainer import ChainerPruningExtension
-from optuna.testing.integration import create_running_trial
 from optuna.testing.integration import DeterministicPruner
 
 
@@ -32,7 +31,7 @@ class FixedValueDataset(chainer.dataset.DatasetMixin):
 def test_chainer_pruning_extension_trigger() -> None:
 
     study = optuna.create_study()
-    trial = create_running_trial(study, 1.0)
+    trial = study.ask()
 
     extension = ChainerPruningExtension(trial, "main/loss", (1, "epoch"))
     assert isinstance(extension._pruner_trigger, triggers.IntervalTrigger)
@@ -77,7 +76,7 @@ def test_chainer_pruning_extension() -> None:
 def test_chainer_pruning_extension_observation_nan() -> None:
 
     study = optuna.create_study(pruner=DeterministicPruner(True))
-    trial = create_running_trial(study, 1.0)
+    trial = study.ask()
     extension = ChainerPruningExtension(trial, "main/loss", (1, "epoch"))
 
     MockTrainer = namedtuple("MockTrainer", ("observation", "updater"))
@@ -93,7 +92,7 @@ def test_chainer_pruning_extension_observation_nan() -> None:
 def test_observation_exists() -> None:
 
     study = optuna.create_study()
-    trial = create_running_trial(study, 1.0)
+    trial = study.ask()
     MockTrainer = namedtuple("MockTrainer", ("observation",))
     trainer = MockTrainer(observation={"OK": 0})
 

--- a/tests/integration_tests/test_keras.py
+++ b/tests/integration_tests/test_keras.py
@@ -5,7 +5,6 @@ import pytest
 
 import optuna
 from optuna.integration import KerasPruningCallback
-from optuna.testing.integration import create_running_trial
 from optuna.testing.integration import DeterministicPruner
 
 
@@ -43,7 +42,7 @@ def test_keras_pruning_callback(interval: int, epochs: int) -> None:
 def test_keras_pruning_callback_observation_isnan() -> None:
 
     study = optuna.create_study(pruner=DeterministicPruner(True))
-    trial = create_running_trial(study, 1.0)
+    trial = study.ask()
     callback = KerasPruningCallback(trial, "loss")
 
     with pytest.raises(optuna.TrialPruned):
@@ -56,7 +55,7 @@ def test_keras_pruning_callback_observation_isnan() -> None:
 def test_keras_pruning_callback_monitor_is_invalid() -> None:
 
     study = optuna.create_study(pruner=DeterministicPruner(True))
-    trial = create_running_trial(study, 1.0)
+    trial = study.ask()
     callback = KerasPruningCallback(trial, "InvalidMonitor")
 
     with pytest.warns(UserWarning):

--- a/tests/integration_tests/test_lightgbm.py
+++ b/tests/integration_tests/test_lightgbm.py
@@ -7,7 +7,6 @@ import pytest
 
 import optuna
 from optuna.integration.lightgbm import LightGBMPruningCallback
-from optuna.testing.integration import create_running_trial
 from optuna.testing.integration import DeterministicPruner
 
 
@@ -34,13 +33,13 @@ def test_lightgbm_pruning_callback_call(cv: bool) -> None:
 
     # The pruner is deactivated.
     study = optuna.create_study(pruner=DeterministicPruner(False))
-    trial = create_running_trial(study, 1.0)
+    trial = study.ask()
     pruning_callback = LightGBMPruningCallback(trial, "binary_error", valid_name="validation")
     pruning_callback(env)
 
     # The pruner is activated.
     study = optuna.create_study(pruner=DeterministicPruner(True))
-    trial = create_running_trial(study, 1.0)
+    trial = study.ask()
     pruning_callback = LightGBMPruningCallback(trial, "binary_error", valid_name="validation")
     with pytest.raises(optuna.TrialPruned):
         pruning_callback(env)

--- a/tests/integration_tests/test_pytorch_ignite.py
+++ b/tests/integration_tests/test_pytorch_ignite.py
@@ -5,7 +5,6 @@ from ignite.engine import Engine
 import pytest
 
 import optuna
-from optuna.testing.integration import create_running_trial
 from optuna.testing.integration import DeterministicPruner
 
 
@@ -19,7 +18,7 @@ def test_pytorch_ignite_pruning_handler() -> None:
 
     # The pruner is activated.
     study = optuna.create_study(pruner=DeterministicPruner(True))
-    trial = create_running_trial(study, 1.0)
+    trial = study.ask()
 
     handler = optuna.integration.PyTorchIgnitePruningHandler(trial, "accuracy", trainer)
     with patch.object(trainer, "state", epoch=3):
@@ -30,7 +29,7 @@ def test_pytorch_ignite_pruning_handler() -> None:
 
     # The pruner is not activated.
     study = optuna.create_study(pruner=DeterministicPruner(False))
-    trial = create_running_trial(study, 1.0)
+    trial = study.ask()
 
     handler = optuna.integration.PyTorchIgnitePruningHandler(trial, "accuracy", trainer)
     with patch.object(trainer, "state", epoch=5):

--- a/tests/integration_tests/test_pytorch_lightning.py
+++ b/tests/integration_tests/test_pytorch_lightning.py
@@ -10,7 +10,6 @@ import torch.nn.functional as F
 
 import optuna
 from optuna.integration import PyTorchLightningPruningCallback
-from optuna.testing.integration import create_running_trial
 from optuna.testing.integration import DeterministicPruner
 from optuna.testing.storage import StorageSupplier
 
@@ -120,7 +119,7 @@ def test_pytorch_lightning_pruning_callback() -> None:
 def test_pytorch_lightning_pruning_callback_monitor_is_invalid() -> None:
 
     study = optuna.create_study(pruner=DeterministicPruner(True))
-    trial = create_running_trial(study, 1.0)
+    trial = study.ask()
     callback = PyTorchLightningPruningCallback(trial, "InvalidMonitor")
 
     trainer = pl.Trainer(

--- a/tests/integration_tests/test_tfkeras.py
+++ b/tests/integration_tests/test_tfkeras.py
@@ -5,7 +5,6 @@ import tensorflow as tf
 
 import optuna
 from optuna.integration import TFKerasPruningCallback
-from optuna.testing.integration import create_running_trial
 from optuna.testing.integration import DeterministicPruner
 
 
@@ -45,7 +44,7 @@ def test_tfkeras_pruning_callback() -> None:
 def test_tfkeras_pruning_callback_observation_isnan() -> None:
 
     study = optuna.create_study(pruner=DeterministicPruner(True))
-    trial = create_running_trial(study, 1.0)
+    trial = study.ask()
     callback = TFKerasPruningCallback(trial, "loss")
 
     with pytest.raises(optuna.TrialPruned):
@@ -58,7 +57,7 @@ def test_tfkeras_pruning_callback_observation_isnan() -> None:
 def test_tfkeras_pruning_callback_monitor_is_invalid() -> None:
 
     study = optuna.create_study(pruner=DeterministicPruner(True))
-    trial = create_running_trial(study, 1.0)
+    trial = study.ask()
     callback = TFKerasPruningCallback(trial, "InvalidMonitor")
 
     with pytest.warns(UserWarning):

--- a/tests/integration_tests/test_xgboost.py
+++ b/tests/integration_tests/test_xgboost.py
@@ -6,14 +6,13 @@ import xgboost as xgb
 
 import optuna
 from optuna.integration.xgboost import XGBoostPruningCallback
-from optuna.testing.integration import create_running_trial
 from optuna.testing.integration import DeterministicPruner
 
 
 def test_xgboost_pruning_callback_call() -> None:
     # The pruner is deactivated.
     study = optuna.create_study(pruner=DeterministicPruner(False))
-    trial = create_running_trial(study, 1.0)
+    trial = study.ask()
     pruning_callback = XGBoostPruningCallback(trial, "validation-logloss")
     pruning_callback.after_iteration(
         model=None, epoch=1, evals_log={"validation": OrderedDict({"logloss": [1.0]})}
@@ -21,7 +20,7 @@ def test_xgboost_pruning_callback_call() -> None:
 
     # The pruner is activated.
     study = optuna.create_study(pruner=DeterministicPruner(True))
-    trial = create_running_trial(study, 1.0)
+    trial = study.ask()
     pruning_callback = XGBoostPruningCallback(trial, "validation-logloss")
     with pytest.raises(optuna.TrialPruned):
         pruning_callback.after_iteration(


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

Resolve https://github.com/optuna/optuna/issues/3463.

## Description of the changes
<!-- Describe the changes in this PR. -->

- Replace `optuna.testing.integration.create_running_trial` with `study.ask` in tests.
- Delete `optuna.testing.integration.create_running_trial`

`optuna.testing.integration.create_running_trial` is no longer in optuna codebase:

```bash
> grep  -i "create_running_trial" -r optuna tests
optuna/storages/_in_memory.py:                trial = self._create_running_trial()
optuna/storages/_in_memory.py:    def _create_running_trial() -> FrozenTrial:
optuna/storages/_redis.py:            trial = self._create_running_trial()
optuna/storages/_redis.py:    def _create_running_trial() -> FrozenTrial:
```

Note that a few storage classes define `_create_running_trial` to create `FrozenTrial`, not `Trial`, so we cannot remove them.