### PR TITLE
Use reseeding method of `np.random.RandomState`  and fix `test_reseed_rng`

### DIFF
--- a/optuna/multi_objective/samplers/_nsga2.py
+++ b/optuna/multi_objective/samplers/_nsga2.py
@@ -94,7 +94,7 @@ class NSGAIIMultiObjectiveSampler(BaseMultiObjectiveSampler):
 
     def reseed_rng(self) -> None:
         self._random_sampler.reseed_rng()
-        self._rng = np.random.RandomState()
+        self._rng.seed()
 
     def infer_relative_search_space(
         self,

--- a/optuna/samplers/_random.py
+++ b/optuna/samplers/_random.py
@@ -44,7 +44,7 @@ class RandomSampler(BaseSampler):
 
     def reseed_rng(self) -> None:
 
-        self._rng = numpy.random.RandomState()
+        self._rng.seed()
 
     def infer_relative_search_space(
         self, study: Study, trial: FrozenTrial

--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -280,7 +280,7 @@ class TPESampler(BaseSampler):
 
     def reseed_rng(self) -> None:
 
-        self._rng = np.random.RandomState()
+        self._rng.seed()
         self._random_sampler.reseed_rng()
 
     def infer_relative_search_space(

--- a/optuna/samplers/nsgaii/_sampler.py
+++ b/optuna/samplers/nsgaii/_sampler.py
@@ -174,7 +174,7 @@ class NSGAIISampler(BaseSampler):
 
     def reseed_rng(self) -> None:
         self._random_sampler.reseed_rng()
-        self._rng = np.random.RandomState()
+        self._rng.seed()
 
     def infer_relative_search_space(
         self, study: Study, trial: FrozenTrial


### PR DESCRIPTION

<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

As briefly summarised by #3563, we can reuse the same instance `np.random.RandomState` for reseeding by calling `seed()` method rather than instantiate a new `np.random.RandomState` instance. 

Related to this,  the current `test_reseed_rng`s do not test the expected behaviours of `reseed` methods.

## Description of the changes
<!-- Describe the changes in this PR. -->

[x]  Replace `np.random.RandomState()` with `seed()` method
[ ] Refactor `test_reseed_rng`