### PR TITLE
Add tests for inf/nan objectives for `ShapleyImportanceEvaluator`

### DIFF
--- a/tests/integration_tests/test_shap.py
+++ b/tests/integration_tests/test_shap.py
@@ -1,7 +1,13 @@
+from typing import Tuple
+
+import pytest
+
 from optuna import create_study
 from optuna import Trial
+from optuna.distributions import FloatDistribution
 from optuna.integration.shap import ShapleyImportanceEvaluator
 from optuna.samplers import RandomSampler
+from optuna.trial import create_trial
 
 
 def objective(trial: Trial) -> float:
@@ -71,3 +77,78 @@ def test_mean_abs_shap_importance_evaluator_with_target() -> None:
     )
 
     assert param_importance != param_importance_with_target
+
+
+@pytest.mark.parametrize("inf_value", [float("inf"), -float("inf")])
+def test_shap_importance_evaluator_with_infinite(inf_value: float) -> None:
+    # The test ensures that trials with infinite values are ignored to calculate importance scores.
+    n_trial = 10
+    seed = 13
+
+    # Importance scores are calculated without a trial with an inf value.
+    study = create_study(sampler=RandomSampler(seed=seed))
+    study.optimize(objective, n_trials=n_trial)
+
+    evaluator = ShapleyImportanceEvaluator(seed=seed)
+    param_importance_without_inf = evaluator.evaluate(study)
+
+    # A trial with an inf value is added into the study manually.
+    study.add_trial(
+        create_trial(
+            value=inf_value,
+            params={"x1": 1.0, "x2": 1.0, "x3": 3.0},
+            distributions={
+                "x1": FloatDistribution(low=0.1, high=3),
+                "x2": FloatDistribution(low=0.1, high=3, log=True),
+                "x3": FloatDistribution(low=2, high=4, log=True),
+            },
+        )
+    )
+    # Importance scores are calculated with a trial with an inf value.
+    param_importance_with_inf = evaluator.evaluate(study)
+
+    # Obtained importance scores should be the same between with inf and without inf,
+    # because the last trial whose objective value is an inf is ignored.
+    assert param_importance_with_inf == param_importance_without_inf
+
+
+@pytest.mark.parametrize("target_idx", [0, 1])
+@pytest.mark.parametrize("inf_value", [float("inf"), -float("inf")])
+def test_multi_objective_shap_importance_evaluator_with_infinite(
+    target_idx: int, inf_value: float
+) -> None:
+    def multi_objective_function(trial: Trial) -> Tuple[float, float]:
+        x1 = trial.suggest_float("x1", 0.1, 3)
+        x2 = trial.suggest_float("x2", 0.1, 3, log=True)
+        x3 = trial.suggest_float("x3", 2, 4, log=True)
+        return x1, x2 * x3
+
+    # The test ensures that trials with infinite values are ignored to calculate importance scores.
+    n_trial = 10
+    seed = 13
+
+    # Importance scores are calculated without a trial with an inf value.
+    study = create_study(directions=["minimize", "minimize"], sampler=RandomSampler(seed=seed))
+    study.optimize(multi_objective_function, n_trials=n_trial)
+
+    evaluator = ShapleyImportanceEvaluator(seed=seed)
+    param_importance_without_inf = evaluator.evaluate(study, target=lambda t: t.values[target_idx])
+
+    # A trial with an inf value is added into the study manually.
+    study.add_trial(
+        create_trial(
+            values=[inf_value, inf_value],
+            params={"x1": 1.0, "x2": 1.0, "x3": 3.0},
+            distributions={
+                "x1": FloatDistribution(low=0.1, high=3),
+                "x2": FloatDistribution(low=0.1, high=3, log=True),
+                "x3": FloatDistribution(low=2, high=4, log=True),
+            },
+        )
+    )
+    # Importance scores are calculated with a trial with an inf value.
+    param_importance_with_inf = evaluator.evaluate(study, target=lambda t: t.values[target_idx])
+
+    # Obtained importance scores should be the same between with inf and without inf,
+    # because the last trial whose objective value is an inf is ignored.
+    assert param_importance_with_inf == param_importance_without_inf


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

Followup of https://github.com/optuna/optuna/pull/3507.

After sending [the PR](https://github.com/optuna/optuna/pull/3507), https://github.com/optuna/optuna/pull/3500 has introduced two new tests:
`test_mean_decrease_impurity_importance_evaluator_with_infinite` and `test_multi_objective_mean_decrease_impurity_importance_evaluator_with_infinite` to the test of `MeanDecreaseImpurityImportanceEvaluator`. The counterpart of `ShapleyImportanceEvaluator` is not implemented yet.

## Description of the changes
<!-- Describe the changes in this PR. -->

Implement tests.