### PR TITLE
Restore virtualenv for benchmark extras

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ def get_extras_require() -> Dict[str, List[str]]:
         "benchmark": [
             "asv>=0.5.0",
             "botorch",
+            "virtualenv",
         ],
         "checking": [
             "black",


### PR DESCRIPTION
## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

I removed `virtualenv` from benchmark extras since I thought it was installed in Python by default. It was wrong.
https://github.com/optuna/optuna/actions/runs/2381070905

This PR restores `virtualenv`.
