### PR TITLE
Update label of feasible trials if `constraints_func` is specified

### DIFF
--- a/optuna/visualization/matplotlib/_pareto_front.py
+++ b/optuna/visualization/matplotlib/_pareto_front.py
@@ -169,6 +169,7 @@ def _get_pareto_front_3d(info: _ParetoFrontInfo) -> "Axes":
     ax.set_ylabel(info.target_names[info.axis_order[1]])
     ax.set_zlabel(info.target_names[info.axis_order[2]])
 
+    trial_label: str = "Trial"
     if (
         info.infeasible_trials_with_values is not None
         and len(info.infeasible_trials_with_values) > 0
@@ -180,6 +181,7 @@ def _get_pareto_front_3d(info: _ParetoFrontInfo) -> "Axes":
             color="#cccccc",
             label="Infeasible Trial",
         )
+        trial_label = "Feasible Trial"
 
     if info.non_best_trials_with_values is not None and len(info.non_best_trials_with_values) > 0:
         ax.scatter(
@@ -187,7 +189,7 @@ def _get_pareto_front_3d(info: _ParetoFrontInfo) -> "Axes":
             ys=[values[info.axis_order[1]] for _, values in info.non_best_trials_with_values],
             zs=[values[info.axis_order[2]] for _, values in info.non_best_trials_with_values],
             color=cmap(0),
-            label="Trial",
+            label=trial_label,
         )
 
     if info.best_trials_with_values is not None and len(info.best_trials_with_values):

--- a/optuna/visualization/matplotlib/_pareto_front.py
+++ b/optuna/visualization/matplotlib/_pareto_front.py
@@ -124,6 +124,7 @@ def _get_pareto_front_2d(info: _ParetoFrontInfo) -> "Axes":
     ax.set_xlabel(info.target_names[info.axis_order[0]])
     ax.set_ylabel(info.target_names[info.axis_order[1]])
 
+    trial_label: str = "Trial"
     if (
         info.infeasible_trials_with_values is not None
         and len(info.infeasible_trials_with_values) > 0
@@ -134,12 +135,13 @@ def _get_pareto_front_2d(info: _ParetoFrontInfo) -> "Axes":
             color="#cccccc",
             label="Infeasible Trial",
         )
+        trial_label = "Feasible Trial"
     if info.non_best_trials_with_values is not None and len(info.non_best_trials_with_values) > 0:
         ax.scatter(
             x=[values[info.axis_order[0]] for _, values in info.non_best_trials_with_values],
             y=[values[info.axis_order[1]] for _, values in info.non_best_trials_with_values],
             color=cmap(0),
-            label="Trial",
+            label=trial_label,
         )
     if info.best_trials_with_values is not None and len(info.best_trials_with_values) > 0:
         ax.scatter(


### PR DESCRIPTION
## Motivation

A follow-up for #3497. Originally mentioned in https://github.com/optuna/optuna/pull/3497#issuecomment-1134527709 by @knshnb .

## Description of the changes

- Update trial label to `Feasible Trial`.

without `constraints_func`

![image](https://user-images.githubusercontent.com/3255979/170425284-a4fcfd20-2d11-48ff-8a93-160496cd4f90.png)

with `constraints_func`

![image](https://user-images.githubusercontent.com/3255979/170425331-05565af8-5302-4688-97f8-79f44cda1122.png)

<details>
<summary>Reproducible code</summary>

```python
import optuna
def objective(trial):
    # Binh and Korn function with constraints.
    x = trial.suggest_float("x", -15, 30)
    y = trial.suggest_float("y", -15, 30)

    # Constraints which are considered feasible if less than or equal to zero.
    # The feasible region is basically the intersection of a circle centered at (x=5, y=0)
    # and the complement to a circle centered at (x=8, y=-3).
    c0 = (x - 5) ** 2 + y**2 - 25
    c1 = -((x - 8) ** 2) - (y + 3) ** 2 + 7.7

    # Store the constraints as user attributes so that they can be restored after optimization.
    trial.set_user_attr("constraint", (c0, c1))

    v0 = 4 * x**2 + 4 * y**2
    v1 = (x - 5) ** 2 + (y - 5) ** 2

    return v0, v1


def constraints(trial):
    return trial.user_attrs["constraint"]

sampler = optuna.samplers.NSGAIISampler(
    constraints_func=constraints,
)
study = optuna.create_study(
    directions=["minimize", "minimize"],
    sampler=sampler,
)
study.optimize(objective, n_trials=100)

optuna.visualization.matplotlib.plot_pareto_front(study)

optuna.visualization.matplotlib.plot_pareto_front(study, constraints_func=constraints)
```

</details>