### PR TITLE
Replace `youtube.com` with `youtube-nocookie.com`

### DIFF
--- a/tutorial/10_key_features/004_distributed.py
+++ b/tutorial/10_key_features/004_distributed.py
@@ -18,7 +18,7 @@ To just see how parallel optimization works in Optuna, check the below video.
 
 .. raw:: html
 
-    <iframe width="560" height="315" src="https://www.youtube.com/embed/J_aymk4YXhg?start=427" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+    <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/J_aymk4YXhg?start=427" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 
 Create a Study

--- a/tutorial/README.rst
+++ b/tutorial/README.rst
@@ -5,7 +5,7 @@ If you are new to Optuna or want a general introduction, we highly recommend the
 
 .. raw:: html
 
-    <iframe width="560" height="315" src="https://www.youtube.com/embed/P6NwZVl8ttc" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+    <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/P6NwZVl8ttc" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
     <br />
     <br />
     <br />


### PR DESCRIPTION
## Motivation

- Removes cookies created by embedded youtube movies.

## Description of the changes

- Replace `youtube.com` with `youtube-nocookie.com`. See https://support.google.com/youtube/answer/171780