### PR TITLE
Use `protobuf<4.0.0` to resolve Sphinx CI error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,9 @@ def get_extras_require() -> Dict[str, List[str]]:
             "pandas",
             "pillow",
             "plotly>=4.0.0",  # optuna/visualization.
+            # TODO(not522): remove this after mlflow is fixed.
+            # https://github.com/mlflow/mlflow/pull/5945
+            "protobuf<4.0.0",
             "scikit-learn>=0.24.2",
             "scikit-optimize",
             "sphinx",
@@ -102,6 +105,9 @@ def get_extras_require() -> Dict[str, List[str]]:
             "mpi4py",
             "mxnet",
             "pandas",
+            # TODO(not522): remove this after mlflow is fixed.
+            # https://github.com/mlflow/mlflow/pull/5945
+            "protobuf<4.0.0",
             "pytorch-ignite ; python_version>'3.6'",
             "pytorch-lightning>=1.5.0 ; python_version>'3.6'",
             "scikit-learn>=0.24.2",


### PR DESCRIPTION
## Motivation
Sphinx CI fails due to using latest `protobuf`. This problem will be resolved by https://github.com/mlflow/mlflow/pull/5945.

## Description of the changes
Add upper limit of `protobuf` version.