### PR TITLE
Refactor ImportanceEvaluators

### DIFF
--- a/optuna/importance/_base.py
+++ b/optuna/importance/_base.py
@@ -1,10 +1,16 @@
 import abc
 from collections import OrderedDict
 from typing import Callable
+from typing import cast
+from typing import Collection
 from typing import Dict
 from typing import List
 from typing import Optional
+from typing import Union
 
+import numpy
+
+from optuna._transform import _SearchSpaceTransform
 from optuna.distributions import BaseDistribution
 from optuna.samplers import intersection_search_space
 from optuna.study import Study
@@ -132,3 +138,44 @@ def _check_evaluate_args(completed_trials: List[FrozenTrial], params: Optional[L
                     "Study must contain completed trials with all specified parameters. "
                     "Specified parameters: {}.".format(params)
                 )
+
+
+def _get_filtered_trials(
+    study: Study, params: Collection[str], target: Optional[Callable[[FrozenTrial], float]]
+) -> List[FrozenTrial]:
+    trials = study.get_trials(deepcopy=False, states=(TrialState.COMPLETE,))
+    return [
+        trial
+        for trial in trials
+        if set(params) <= set(trial.params)
+        and numpy.isfinite(target(trial) if target is not None else cast(float, trial.value))
+    ]
+
+
+def _param_importances_to_dict(
+    params: Collection[str], param_importances: Union[numpy.ndarray, float]
+) -> Dict[str, float]:
+    return {
+        name: value
+        for name, value in zip(params, numpy.broadcast_to(param_importances, (len(params),)))
+    }
+
+
+def _get_trans_params(trials: List[FrozenTrial], trans: _SearchSpaceTransform) -> numpy.ndarray:
+    return numpy.array([trans.transform(trial.params) for trial in trials])
+
+
+def _get_target_values(
+    trials: List[FrozenTrial], target: Optional[Callable[[FrozenTrial], float]]
+) -> numpy.ndarray:
+    return numpy.array([target(trial) if target is not None else trial.value for trial in trials])
+
+
+def _sort_dict_by_importance(param_importances: Dict[str, float]) -> Dict[str, float]:
+    return OrderedDict(
+        reversed(
+            sorted(
+                param_importances.items(), key=lambda name_and_importance: name_and_importance[1]
+            )
+        )
+    )

--- a/optuna/importance/_fanova/_evaluator.py
+++ b/optuna/importance/_fanova/_evaluator.py
@@ -115,13 +115,10 @@ class FanovaImportanceEvaluator(BaseImportanceEvaluator):
             non_single_distributions, transform_log=False, transform_step=False
         )
 
-        trans_params: numpy.ndarray = _get_trans_params(trials, trans)
-        values: numpy.ndarray = _get_target_values(trials, target)
-
         evaluator = self._evaluator
         evaluator.fit(
-            X=trans_params,
-            y=values,
+            X=_get_trans_params(trials, trans),
+            y=_get_target_values(trials, target),
             search_spaces=trans.bounds,
             column_to_encoded_columns=trans.column_to_encoded_columns,
         )

--- a/optuna/importance/_fanova/_evaluator.py
+++ b/optuna/importance/_fanova/_evaluator.py
@@ -3,17 +3,32 @@ from typing import Callable
 from typing import Dict
 from typing import List
 from typing import Optional
+from typing import Tuple
 
 import numpy
 
 from optuna._transform import _SearchSpaceTransform
+from optuna.distributions import BaseDistribution
 from optuna.importance._base import _get_distributions
+from optuna.importance._base import _get_filtered_trials
+from optuna.importance._base import _get_target_values
+from optuna.importance._base import _get_trans_params
+from optuna.importance._base import _param_importances_to_dict
+from optuna.importance._base import _sort_dict_by_importance
 from optuna.importance._base import BaseImportanceEvaluator
 from optuna.importance._fanova._fanova import _Fanova
 from optuna.study import Study
 from optuna.trial import FrozenTrial
-from optuna.trial import TrialState
-from optuna.visualization._utils import _filter_nonfinite
+
+
+def _split_nonsingle_and_single_distributions(
+    distributions: Dict[str, BaseDistribution]
+) -> Tuple[Dict[str, BaseDistribution], Dict[str, BaseDistribution]]:
+    non_single_distributions = {
+        name: dist for name, dist in distributions.items() if not dist.single()
+    }
+    single_distributions = {name: dist for name, dist in distributions.items() if dist.single()}
+    return (non_single_distributions, single_distributions)
 
 
 class FanovaImportanceEvaluator(BaseImportanceEvaluator):
@@ -79,67 +94,45 @@ class FanovaImportanceEvaluator(BaseImportanceEvaluator):
                 "`target=lambda t: t.values[0]` for the first objective value."
             )
 
-        distributions = _get_distributions(study, params)
-        if len(distributions) == 0:
-            return OrderedDict()
+        distributions = _get_distributions(study, params=params)
+        if params is None:
+            params = list(distributions.keys())
+        assert params is not None
 
         # fANOVA does not support parameter distributions with a single value.
         # However, there is no reason to calculate parameter importance in such case anyway,
         # since it will always be 0 as the parameter is constant in the objective function.
-        zero_importances = {name: 0.0 for name, dist in distributions.items() if dist.single()}
-        distributions = {name: dist for name, dist in distributions.items() if not dist.single()}
+        non_single_distributions, single_distributions = _split_nonsingle_and_single_distributions(
+            distributions
+        )
 
-        trials = []
-        for trial in _filter_nonfinite(
-            study.get_trials(deepcopy=False, states=(TrialState.COMPLETE,)), target=target
-        ):
-            if any(name not in trial.params for name in distributions.keys()):
-                continue
-            trials.append(trial)
-
-        trans = _SearchSpaceTransform(distributions, transform_log=False, transform_step=False)
-
-        n_trials = len(trials)
-        trans_params = numpy.empty((n_trials, trans.bounds.shape[0]), dtype=numpy.float64)
-        trans_values = numpy.empty(n_trials, dtype=numpy.float64)
-
-        for trial_idx, trial in enumerate(trials):
-            trans_params[trial_idx] = trans.transform(trial.params)
-            trans_values[trial_idx] = trial.value if target is None else target(trial)
-
-        trans_bounds = trans.bounds
-        column_to_encoded_columns = trans.column_to_encoded_columns
-
-        if trans_params.size == 0:  # `params` were given but as an empty list.
+        if len(non_single_distributions) == 0:
             return OrderedDict()
 
-        # Many (deep) copies of the search spaces are required during the tree traversal and using
-        # Optuna distributions will create a bottleneck.
-        # Therefore, search spaces (parameter distributions) are represented by a single
-        # `numpy.ndarray`, coupled with a list of flags that indicate whether they are categorical
-        # or not.
+        trials: List[FrozenTrial] = _get_filtered_trials(study, params=params, target=target)
+
+        trans = _SearchSpaceTransform(
+            non_single_distributions, transform_log=False, transform_step=False
+        )
+
+        trans_params: numpy.ndarray = _get_trans_params(trials, trans)
+        values: numpy.ndarray = _get_target_values(trials, target)
 
         evaluator = self._evaluator
         evaluator.fit(
             X=trans_params,
-            y=trans_values,
-            search_spaces=trans_bounds,
-            column_to_encoded_columns=column_to_encoded_columns,
+            y=values,
+            search_spaces=trans.bounds,
+            column_to_encoded_columns=trans.column_to_encoded_columns,
         )
-
-        importances = {}
-        for i, name in enumerate(distributions.keys()):
-            importance, _ = evaluator.get_importance(i)
-            importances[name] = importance
-
-        importances = {**importances, **zero_importances}
-        total_importance = sum(importances.values())
-        for name in importances:
-            importances[name] /= total_importance
-
-        sorted_importances = OrderedDict(
-            reversed(
-                sorted(importances.items(), key=lambda name_and_importance: name_and_importance[1])
-            )
+        param_importances = numpy.array(
+            [evaluator.get_importance(i)[0] for i in range(len(non_single_distributions))]
         )
-        return sorted_importances
+        param_importances /= numpy.sum(param_importances)
+
+        return _sort_dict_by_importance(
+            {
+                **_param_importances_to_dict(non_single_distributions.keys(), param_importances),
+                **_param_importances_to_dict(single_distributions.keys(), 0.0),
+            }
+        )

--- a/optuna/importance/_fanova/_evaluator.py
+++ b/optuna/importance/_fanova/_evaluator.py
@@ -3,12 +3,10 @@ from typing import Callable
 from typing import Dict
 from typing import List
 from typing import Optional
-from typing import Tuple
 
 import numpy
 
 from optuna._transform import _SearchSpaceTransform
-from optuna.distributions import BaseDistribution
 from optuna.importance._base import _get_distributions
 from optuna.importance._base import _get_filtered_trials
 from optuna.importance._base import _get_target_values
@@ -19,16 +17,6 @@ from optuna.importance._base import BaseImportanceEvaluator
 from optuna.importance._fanova._fanova import _Fanova
 from optuna.study import Study
 from optuna.trial import FrozenTrial
-
-
-def _split_nonsingle_and_single_distributions(
-    distributions: Dict[str, BaseDistribution]
-) -> Tuple[Dict[str, BaseDistribution], Dict[str, BaseDistribution]]:
-    non_single_distributions = {
-        name: dist for name, dist in distributions.items() if not dist.single()
-    }
-    single_distributions = {name: dist for name, dist in distributions.items() if dist.single()}
-    return (non_single_distributions, single_distributions)
 
 
 class FanovaImportanceEvaluator(BaseImportanceEvaluator):
@@ -102,9 +90,12 @@ class FanovaImportanceEvaluator(BaseImportanceEvaluator):
         # fANOVA does not support parameter distributions with a single value.
         # However, there is no reason to calculate parameter importance in such case anyway,
         # since it will always be 0 as the parameter is constant in the objective function.
-        non_single_distributions, single_distributions = _split_nonsingle_and_single_distributions(
-            distributions
-        )
+        non_single_distributions = {
+            name: dist for name, dist in distributions.items() if not dist.single()
+        }
+        single_distributions = {
+            name: dist for name, dist in distributions.items() if dist.single()
+        }
 
         if len(non_single_distributions) == 0:
             return OrderedDict()

--- a/optuna/importance/_mean_decrease_impurity.py
+++ b/optuna/importance/_mean_decrease_impurity.py
@@ -83,11 +83,9 @@ class MeanDecreaseImpurityImportanceEvaluator(BaseImportanceEvaluator):
 
         trials: List[FrozenTrial] = _get_filtered_trials(study, params=params, target=target)
         trans = _SearchSpaceTransform(distributions, transform_log=False, transform_step=False)
-        trans_params: numpy.ndarray = _get_trans_params(trials, trans)
-        values: numpy.ndarray = _get_target_values(trials, target)
 
         forest = self._forest
-        forest.fit(X=trans_params, y=values)
+        forest.fit(X=_get_trans_params(trials, trans), y=_get_target_values(trials, target))
         feature_importances = forest.feature_importances_
 
         # Untransform feature importances to param importances

--- a/optuna/importance/_mean_decrease_impurity.py
+++ b/optuna/importance/_mean_decrease_impurity.py
@@ -83,9 +83,11 @@ class MeanDecreaseImpurityImportanceEvaluator(BaseImportanceEvaluator):
 
         trials: List[FrozenTrial] = _get_filtered_trials(study, params=params, target=target)
         trans = _SearchSpaceTransform(distributions, transform_log=False, transform_step=False)
+        trans_params: numpy.ndarray = _get_trans_params(trials, trans)
+        target_values: numpy.ndarray = _get_target_values(trials, target)
 
         forest = self._forest
-        forest.fit(X=_get_trans_params(trials, trans), y=_get_target_values(trials, target))
+        forest.fit(X=trans_params, y=target_values)
         feature_importances = forest.feature_importances_
 
         # Untransform feature importances to param importances

--- a/optuna/integration/shap.py
+++ b/optuna/integration/shap.py
@@ -87,10 +87,10 @@ class ShapleyImportanceEvaluator(BaseImportanceEvaluator):
         trials: List[FrozenTrial] = _get_filtered_trials(study, params=params, target=target)
         trans = _SearchSpaceTransform(distributions, transform_log=False, transform_step=False)
         trans_params: np.ndarray = _get_trans_params(trials, trans)
-        values: np.ndarray = _get_target_values(trials, target)
+        target_values: np.ndarray = _get_target_values(trials, target)
 
         forest = self._forest
-        forest.fit(X=trans_params, y=values)
+        forest.fit(X=trans_params, y=target_values)
 
         # Create Tree Explainer object that can calculate shap values.
         explainer = TreeExplainer(forest)

--- a/optuna/integration/shap.py
+++ b/optuna/integration/shap.py
@@ -8,14 +8,21 @@ import numpy as np
 
 from optuna._experimental import experimental
 from optuna._imports import try_import
+from optuna._transform import _SearchSpaceTransform
+from optuna.importance._base import _get_distributions
+from optuna.importance._base import _get_filtered_trials
+from optuna.importance._base import _get_target_values
+from optuna.importance._base import _get_trans_params
+from optuna.importance._base import _param_importances_to_dict
+from optuna.importance._base import _sort_dict_by_importance
 from optuna.importance._base import BaseImportanceEvaluator
-from optuna.importance._mean_decrease_impurity import MeanDecreaseImpurityImportanceEvaluator
 from optuna.study import Study
 from optuna.trial import FrozenTrial
 
 
 with try_import() as _imports:
     from shap import TreeExplainer
+    from sklearn.ensemble import RandomForestRegressor
 
 
 @experimental("3.0.0")
@@ -47,11 +54,13 @@ class ShapleyImportanceEvaluator(BaseImportanceEvaluator):
         _imports.check()
 
         # Use the RandomForest as the surrogate model to evaluate the feature importances.
-        self._backend_evaluator = MeanDecreaseImpurityImportanceEvaluator(
-            n_trees=n_trees, max_depth=max_depth, seed=seed
+        self._forest = RandomForestRegressor(
+            n_estimators=n_trees,
+            max_depth=max_depth,
+            min_samples_split=2,
+            min_samples_leaf=1,
+            random_state=seed,
         )
-        # Use the TreeExplainer from the SHAP module.
-        self._explainer: TreeExplainer = None
 
     def evaluate(
         self,
@@ -61,23 +70,38 @@ class ShapleyImportanceEvaluator(BaseImportanceEvaluator):
         target: Optional[Callable[[FrozenTrial], float]] = None,
     ) -> Dict[str, float]:
 
-        # Train a RandomForest from the backend evaluator.
-        self._backend_evaluator.evaluate(study=study, params=params, target=target)
+        if target is None and study._is_multi_objective():
+            raise ValueError(
+                "If the `study` is being used for multi-objective optimization, "
+                "please specify the `target`. For example, use "
+                "`target=lambda t: t.values[0]` for the first objective value."
+            )
+
+        distributions = _get_distributions(study, params=params)
+        if params is None:
+            params = list(distributions.keys())
+        assert params is not None
+        if len(params) == 0:
+            return OrderedDict()
+
+        trials: List[FrozenTrial] = _get_filtered_trials(study, params=params, target=target)
+        trans = _SearchSpaceTransform(distributions, transform_log=False, transform_step=False)
+        trans_params: np.ndarray = _get_trans_params(trials, trans)
+        values: np.ndarray = _get_target_values(trials, target)
+
+        forest = self._forest
+        forest.fit(X=trans_params, y=values)
 
         # Create Tree Explainer object that can calculate shap values.
-        self._explainer = TreeExplainer(self._backend_evaluator._forest)
+        explainer = TreeExplainer(forest)
 
         # Generate SHAP values for the parameters during the trials.
-        shap_values = self._explainer.shap_values(self._backend_evaluator._trans_params)
+        feature_shap_values: np.ndarray = explainer.shap_values(trans_params)
+        param_shap_values = np.zeros((len(trials), len(params)))
+        np.add.at(param_shap_values.T, trans.encoded_column_to_column, feature_shap_values.T)
 
         # Calculate the mean absolute SHAP value for each parameter.
         # List of tuples ("feature_name": mean_abs_shap_value).
-        mean_abs_shap_values = list(
-            zip(self._backend_evaluator._param_names, np.abs(shap_values).mean(axis=0))
-        )
+        mean_abs_shap_values = np.abs(param_shap_values).mean(axis=0)
 
-        # Use the mean absolute SHAP values as the feature importance.
-        mean_abs_shap_values.sort(key=lambda t: t[1], reverse=True)
-        feature_importances = OrderedDict(mean_abs_shap_values)
-
-        return feature_importances
+        return _sort_dict_by_importance(_param_importances_to_dict(params, mean_abs_shap_values))

--- a/tests/integration_tests/test_shap.py
+++ b/tests/integration_tests/test_shap.py
@@ -1,20 +1,30 @@
+from collections import OrderedDict
+from typing import List
 from typing import Tuple
 
 import pytest
 
+import optuna
 from optuna import create_study
+from optuna import samplers
 from optuna import Trial
+from optuna.distributions import CategoricalDistribution
 from optuna.distributions import FloatDistribution
+from optuna.distributions import IntDistribution
 from optuna.integration.shap import ShapleyImportanceEvaluator
 from optuna.samplers import RandomSampler
+from optuna.testing.storage import STORAGE_MODES
+from optuna.testing.storage import StorageSupplier
 from optuna.trial import create_trial
 
 
 def objective(trial: Trial) -> float:
-    x1 = trial.suggest_float("x1", 0.1, 3)
-    x2 = trial.suggest_float("x2", 0.1, 3, log=True)
-    x3 = trial.suggest_float("x3", 2, 4, log=True)
-    return x1 + x2 * x3
+    x1: float = trial.suggest_float("x1", 0.1, 3)
+    x2: float = trial.suggest_float("x2", 0.1, 3, log=True)
+    x3: int = trial.suggest_int("x3", 2, 4, log=True)
+    x4 = trial.suggest_categorical("x4", [0.1, 1.0, 10.0])
+    assert isinstance(x4, float)
+    return x1 + x2 * x3 + x4
 
 
 def test_mean_abs_shap_importance_evaluator_n_trees() -> None:
@@ -96,11 +106,12 @@ def test_shap_importance_evaluator_with_infinite(inf_value: float) -> None:
     study.add_trial(
         create_trial(
             value=inf_value,
-            params={"x1": 1.0, "x2": 1.0, "x3": 3.0},
+            params={"x1": 1.0, "x2": 1.0, "x3": 3.0, "x4": 0.1},
             distributions={
                 "x1": FloatDistribution(low=0.1, high=3),
                 "x2": FloatDistribution(low=0.1, high=3, log=True),
-                "x3": FloatDistribution(low=2, high=4, log=True),
+                "x3": IntDistribution(low=2, high=4, log=True),
+                "x4": CategoricalDistribution([0.1, 1, 10]),
             },
         )
     )
@@ -118,10 +129,12 @@ def test_multi_objective_shap_importance_evaluator_with_infinite(
     target_idx: int, inf_value: float
 ) -> None:
     def multi_objective_function(trial: Trial) -> Tuple[float, float]:
-        x1 = trial.suggest_float("x1", 0.1, 3)
-        x2 = trial.suggest_float("x2", 0.1, 3, log=True)
-        x3 = trial.suggest_float("x3", 2, 4, log=True)
-        return x1, x2 * x3
+        x1: float = trial.suggest_float("x1", 0.1, 3)
+        x2: float = trial.suggest_float("x2", 0.1, 3, log=True)
+        x3: int = trial.suggest_int("x3", 2, 4, log=True)
+        x4 = trial.suggest_categorical("x4", [0.1, 1.0, 10.0])
+        assert isinstance(x4, float)
+        return (x1 + x2 * x3 + x4, x1 * x4)
 
     # The test ensures that trials with infinite values are ignored to calculate importance scores.
     n_trial = 10
@@ -138,11 +151,12 @@ def test_multi_objective_shap_importance_evaluator_with_infinite(
     study.add_trial(
         create_trial(
             values=[inf_value, inf_value],
-            params={"x1": 1.0, "x2": 1.0, "x3": 3.0},
+            params={"x1": 1.0, "x2": 1.0, "x3": 3.0, "x4": 0.1},
             distributions={
                 "x1": FloatDistribution(low=0.1, high=3),
                 "x2": FloatDistribution(low=0.1, high=3, log=True),
-                "x3": FloatDistribution(low=2, high=4, log=True),
+                "x3": IntDistribution(low=2, high=4, log=True),
+                "x4": CategoricalDistribution([0.1, 1, 10]),
             },
         )
     )
@@ -152,3 +166,220 @@ def test_multi_objective_shap_importance_evaluator_with_infinite(
     # Obtained importance scores should be the same between with inf and without inf,
     # because the last trial whose objective value is an inf is ignored.
     assert param_importance_with_inf == param_importance_without_inf
+
+
+@pytest.mark.parametrize("storage_mode", STORAGE_MODES)
+def test_get_param_importance_target_is_none_and_study_is_multi_obj(
+    storage_mode: str,
+) -> None:
+    def objective(trial: Trial) -> Tuple[float, float]:
+        x1 = trial.suggest_float("x1", 0.1, 3)
+        x2 = trial.suggest_float("x2", 0.1, 3, log=True)
+        x3 = trial.suggest_float("x3", 0, 3, step=1)
+        x4 = trial.suggest_int("x4", -3, 3)
+        x5 = trial.suggest_int("x5", 1, 5, log=True)
+        x6 = trial.suggest_categorical("x6", [1.0, 1.1, 1.2])
+        if trial.number % 2 == 0:
+            # Conditional parameters are ignored unless `params` is specified and is not `None`.
+            x7 = trial.suggest_float("x7", 0.1, 3)
+
+        assert isinstance(x6, float)
+        value = x1**4 + x2 + x3 - x4**2 - x5 + x6
+        if trial.number % 2 == 0:
+            value += x7
+        return value, 0.0
+
+    with StorageSupplier(storage_mode) as storage:
+        study = create_study(directions=["minimize", "minimize"], storage=storage)
+        study.optimize(objective, n_trials=3)
+
+        with pytest.raises(ValueError):
+            ShapleyImportanceEvaluator().evaluate(study)
+
+
+@pytest.mark.parametrize("storage_mode", STORAGE_MODES)
+def test_get_params_importance(
+    storage_mode: str,
+) -> None:
+    def objective(trial: Trial) -> float:
+        x1 = trial.suggest_float("x1", 0.1, 3)
+        x2 = trial.suggest_float("x2", 0.1, 3, log=True)
+        x3 = trial.suggest_float("x3", 0, 3, step=1)
+        x4 = trial.suggest_int("x4", -3, 3)
+        x5 = trial.suggest_int("x5", 1, 5, log=True)
+        x6 = trial.suggest_categorical("x6", [1.0, 1.1, 1.2])
+        if trial.number % 2 == 0:
+            # Conditional parameters are ignored unless `params` is specified and is not `None`.
+            x7 = trial.suggest_float("x7", 0.1, 3)
+
+        assert isinstance(x6, float)
+        value = x1**4 + x2 + x3 - x4**2 - x5 + x6
+        if trial.number % 2 == 0:
+            value += x7
+        return value
+
+    with StorageSupplier(storage_mode) as storage:
+        study = create_study(storage=storage, sampler=samplers.RandomSampler())
+        study.optimize(objective, n_trials=3)
+
+        param_importance = ShapleyImportanceEvaluator().evaluate(study)
+
+        assert isinstance(param_importance, OrderedDict)
+        assert len(param_importance) == 6
+        assert all(
+            param_name in param_importance for param_name in ["x1", "x2", "x3", "x4", "x5", "x6"]
+        )
+        prev_importance = float("inf")
+        for param_name, importance in param_importance.items():
+            assert isinstance(param_name, str)
+            assert isinstance(importance, float)
+            assert importance <= prev_importance
+            prev_importance = importance
+
+
+@pytest.mark.parametrize("storage_mode", STORAGE_MODES)
+@pytest.mark.parametrize("params", [[], ["x1"], ["x1", "x3"], ["x1", "x4"]])
+def test_get_param_importances_with_params(
+    storage_mode: str,
+    params: List[str],
+) -> None:
+    def objective(trial: Trial) -> float:
+        x1 = trial.suggest_float("x1", 0.1, 3)
+        x2 = trial.suggest_float("x2", 0.1, 3, log=True)
+        x3 = trial.suggest_float("x3", 0, 3, step=1)
+        if trial.number % 2 == 0:
+            x4 = trial.suggest_float("x4", 0.1, 3)
+
+        value = x1**4 + x2 + x3
+        if trial.number % 2 == 0:
+            value += x4
+        return value
+
+    with StorageSupplier(storage_mode) as storage:
+        study = create_study(storage=storage)
+        study.optimize(objective, n_trials=10)
+
+        param_importance = ShapleyImportanceEvaluator().evaluate(study, params=params)
+
+        assert isinstance(param_importance, OrderedDict)
+        assert len(param_importance) == len(params)
+        assert all(param in param_importance for param in params)
+        for param_name, importance in param_importance.items():
+            assert isinstance(param_name, str)
+            assert isinstance(importance, float)
+
+
+@pytest.mark.parametrize("storage_mode", STORAGE_MODES)
+def test_get_param_importances_with_target(
+    storage_mode: str,
+) -> None:
+    def objective(trial: Trial) -> float:
+        x1 = trial.suggest_float("x1", 0.1, 3)
+        x2 = trial.suggest_float("x2", 0.1, 3, log=True)
+        x3 = trial.suggest_float("x3", 0, 3, step=1)
+        if trial.number % 2 == 0:
+            x4 = trial.suggest_float("x4", 0.1, 3)
+
+        value = x1**4 + x2 + x3
+        if trial.number % 2 == 0:
+            value += x4
+        return value
+
+    with StorageSupplier(storage_mode) as storage:
+        study = create_study(storage=storage)
+        study.optimize(objective, n_trials=3)
+
+        param_importance = ShapleyImportanceEvaluator().evaluate(
+            study,
+            target=lambda t: t.params["x1"] + t.params["x2"],
+        )
+
+        assert isinstance(param_importance, OrderedDict)
+        assert len(param_importance) == 3
+        assert all(param_name in param_importance for param_name in ["x1", "x2", "x3"])
+        prev_importance = float("inf")
+        for param_name, importance in param_importance.items():
+            assert isinstance(param_name, str)
+            assert isinstance(importance, float)
+            assert importance <= prev_importance
+            prev_importance = importance
+
+
+def test_get_param_importances_invalid_empty_study() -> None:
+
+    study = create_study()
+
+    with pytest.raises(ValueError):
+        ShapleyImportanceEvaluator().evaluate(study)
+
+    def objective(trial: Trial) -> float:
+        raise optuna.TrialPruned
+
+    study.optimize(objective, n_trials=3)
+
+    with pytest.raises(ValueError):
+        ShapleyImportanceEvaluator().evaluate(study)
+
+
+def test_get_param_importances_invalid_single_trial() -> None:
+    def objective(trial: Trial) -> float:
+        x1 = trial.suggest_float("x1", 0.1, 3)
+        return x1**2
+
+    study = create_study()
+    study.optimize(objective, n_trials=1)
+
+    with pytest.raises(ValueError):
+        ShapleyImportanceEvaluator().evaluate(study)
+
+
+def test_get_param_importances_invalid_no_completed_trials_params() -> None:
+    def objective(trial: Trial) -> float:
+        x1 = trial.suggest_float("x1", 0.1, 3)
+        if trial.number % 2 == 0:
+            _ = trial.suggest_float("x2", 0.1, 3, log=True)
+            raise optuna.TrialPruned
+        return x1**2
+
+    study = create_study()
+    study.optimize(objective, n_trials=3)
+
+    # None of the trials with `x2` are completed.
+    with pytest.raises(ValueError):
+        ShapleyImportanceEvaluator().evaluate(study, params=["x2"])
+
+    # None of the trials with `x2` are completed. Adding "x1" should not matter.
+    with pytest.raises(ValueError):
+        ShapleyImportanceEvaluator().evaluate(study, params=["x1", "x2"])
+
+    # None of the trials contain `x3`.
+    with pytest.raises(ValueError):
+        ShapleyImportanceEvaluator().evaluate(study, params=["x3"])
+
+
+def test_get_param_importances_invalid_dynamic_search_space_params() -> None:
+    def objective(trial: Trial) -> float:
+        x1 = trial.suggest_float("x1", 0.1, trial.number + 0.1)
+        return x1**2
+
+    study = create_study()
+    study.optimize(objective, n_trials=3)
+
+    with pytest.raises(ValueError):
+        ShapleyImportanceEvaluator().evaluate(study, params=["x1"])
+
+
+def test_get_param_importances_empty_search_space() -> None:
+    def objective(trial: Trial) -> float:
+        x = trial.suggest_float("x", 0, 5)
+        y = trial.suggest_float("y", 1, 1)
+        return 4 * x**2 + 4 * y**2
+
+    study = create_study()
+    study.optimize(objective, n_trials=3)
+
+    param_importance = ShapleyImportanceEvaluator().evaluate(study)
+
+    assert len(param_importance) == 2
+    assert all([param in param_importance for param in ["x", "y"]])
+    assert param_importance["y"] == 0.0


### PR DESCRIPTION
## Motivation
There has been duplicates in preprocessing code of MeanDecreaseImpurityImportanceEvaluator and FanovaImportanceEvaluator. We propose to refactor the code and remove the duplication.

This is a remake of #3552.

## Description of the changes

* Refactor `BaseImportanceEvaluator` and its implementations.
* Add missing tests for `ShapleyImportanceEvaluator`.
* Fix `ShapleyImportanceEvaluator` to support categorical variables.