### PR TITLE
Assume current head is not None (alembic)

### DIFF
--- a/optuna/storages/_rdb/storage.py
+++ b/optuna/storages/_rdb/storage.py
@@ -1356,7 +1356,9 @@ class _VersionManager(object):
     def get_head_version(self) -> str:
 
         script = self._create_alembic_script()
-        return script.get_current_head()
+        current_head = script.get_current_head()
+        assert current_head is not None
+        return current_head
 
     def _get_base_version(self) -> str:
 


### PR DESCRIPTION
This PR aims to fix the checks CI failure in the master branch.
Alembic v1.8.0 is now available with many typehint improvements. In the past versions, `get_current_head` is not annotated but v1.8.0 annotates it with `get_current_head(self) -> Optional[str]`. This is not compatible with the current implementation of Optuna.

I'm not confident but I think it would be okay to assume the head to be non-null in our codebase. Based on the idea, I simply added to type assertion to the method calling.

https://github.com/sqlalchemy/alembic/commit/cfe92fac6794515d3aa3b995e288b11d5c9437fa#diff-293a229cac60cd74ca6eebb535433ef307b286c8d96961ba7abd5f9093972d1bL356

<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get two or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

## Description of the changes
<!-- Describe the changes in this PR. -->
