### PR TITLE
Shorten the durations of the stale bot for PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -11,7 +11,7 @@ jobs:
 
     if: github.repository == 'optuna/optuna'
     steps:
-    - uses: actions/stale@v4
+    - uses: actions/stale@v5
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'This issue has not seen any recent activity.'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -11,15 +11,17 @@ jobs:
 
     if: github.repository == 'optuna/optuna'
     steps:
-    - uses: actions/stale@v3
+    - uses: actions/stale@v4
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'This issue has not seen any recent activity.'
         stale-pr-message: 'This pull request has not seen any recent activity.'
         close-issue-message: 'This issue was closed automatically because it had not seen any recent activity. If you want to discuss it, you can reopen it freely.'
         close-pr-message: 'This pull request was closed automatically because it had not seen any recent activity. If you want to discuss it, you can reopen it freely.'
-        days-before-stale: 14
-        days-before-close: 100
+        days-before-issue-stale: 14
+        days-before-issue-close: 100
+        days-before-pr-stale: 7
+        days-before-pr-close: 14
         stale-issue-label: 'stale'
         stale-pr-label: 'stale'
         exempt-issue-labels: 'no-stale'


### PR DESCRIPTION
This PR shortens the durations of the stale bot for pull requests.

## Motivation
To improve the following tendencies, this change encourages both contributors and maintainers to make earlier actions on pull requests.
- A long-running, inactive PR is going to be abandoned.
- The longer it takes for a PR, the harder the merge is, because of the gap b/w the PR and master branches.

## Description of changes
Change the duration of stale check as follows. This change does not affect issues but only pull requests.
- days before stale: `14` -> `7`
- days before close: `100` -> `14`

See also [the README of actions/stale](https://github.com/actions/stale#list-of-input-options) to check the options’ usages.