### PR TITLE
Remove experimental from `plot_pareto_front`

### DIFF
--- a/optuna/integration/shap.py
+++ b/optuna/integration/shap.py
@@ -28,7 +28,7 @@ class ShapleyImportanceEvaluator(BaseImportanceEvaluator):
     .. note::
 
         This evaluator requires the `sklearn <https://scikit-learn.org/stable/>`_ Python package
-         and `SHAP <https://shap.readthedocs.io/en/stable/index.html>`_.
+        and `SHAP <https://shap.readthedocs.io/en/stable/index.html>`_.
         The model for the SHAP calculation is based on `sklearn.ensemble.RandomForestClassifier
         <https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.RandomForestClassifier.html>`_.
 

--- a/optuna/visualization/_pareto_front.py
+++ b/optuna/visualization/_pareto_front.py
@@ -13,6 +13,7 @@ import warnings
 
 import optuna
 from optuna._experimental import experimental
+from optuna.exceptions import ExperimentalWarning
 from optuna.study import Study
 from optuna.study._multi_objective import _get_pareto_front_trials_by_trials
 from optuna.trial import FrozenTrial
@@ -99,6 +100,11 @@ def plot_pareto_front(
             If given, trials are classified into three categories: feasible and best, feasible but
             non-best, and infeasible. Categories are shown in different colors. Here, whether a
             trial is best (on Pareto front) or not is determined ignoring all infeasible trials.
+
+            .. note::
+                Added in v3.0.0 as an experimental feature. The interface may change in newer
+                versions without prior notice.
+                See https://github.com/optuna/optuna/releases/tag/v3.0.0.
         targets:
             A function that returns targets values to display.
             The argument to this function is :class:`~optuna.trial.FrozenTrial`.
@@ -140,6 +146,12 @@ def plot_pareto_front(
             ),
         ]
     else:
+        warnings.warn(
+            "``constraint_func`` argument is an experimental feature."
+            " The interface can change in the future.",
+            ExperimentalWarning,
+        )
+
         data = [
             _make_scatter_object(
                 info.n_targets,

--- a/optuna/visualization/_pareto_front.py
+++ b/optuna/visualization/_pareto_front.py
@@ -12,7 +12,6 @@ from typing import Union
 import warnings
 
 import optuna
-from optuna._experimental import experimental
 from optuna.exceptions import ExperimentalWarning
 from optuna.study import Study
 from optuna.study._multi_objective import _get_pareto_front_trials_by_trials
@@ -36,7 +35,6 @@ class _ParetoFrontInfo(NamedTuple):
     axis_order: Sequence[int]
 
 
-@experimental("2.4.0")
 def plot_pareto_front(
     study: Study,
     *,

--- a/tests/visualization_tests/matplotlib_tests/test_pareto_front.py
+++ b/tests/visualization_tests/matplotlib_tests/test_pareto_front.py
@@ -497,7 +497,7 @@ def test_constraints_func_experimental_warning() -> None:
     study = optuna.create_study(directions=["minimize", "minimize"])
 
     def constraints_func(t: FrozenTrial) -> Sequence[float]:
-        return [1.0] if t.params["x"] == 1 and t.params["y"] == 0 else [-1.0]
+        return [1.0]
 
     with pytest.warns(optuna.exceptions.ExperimentalWarning):
         plot_pareto_front(

--- a/tests/visualization_tests/matplotlib_tests/test_pareto_front.py
+++ b/tests/visualization_tests/matplotlib_tests/test_pareto_front.py
@@ -500,7 +500,7 @@ def test_constraints_func_experimental_warning() -> None:
         return [1.0] if t.params["x"] == 1 and t.params["y"] == 0 else [-1.0]
 
     with pytest.warns(optuna.exceptions.ExperimentalWarning):
-        figure = plot_pareto_front(
+        plot_pareto_front(
             study=study,
             constraints_func=constraints_func,
         )

--- a/tests/visualization_tests/matplotlib_tests/test_pareto_front.py
+++ b/tests/visualization_tests/matplotlib_tests/test_pareto_front.py
@@ -491,3 +491,16 @@ def test_plot_pareto_front_using_axis_order_and_targets() -> None:
             axis_order=[0, 1, 2],
             targets=lambda t: (t.values[0], t.values[1], t.values[2]),
         )
+
+
+def test_constraints_func_experimental_warning() -> None:
+    study = optuna.create_study(directions=["minimize", "minimize"])
+
+    def constraints_func(t: FrozenTrial) -> Sequence[float]:
+        return [1.0] if t.params["x"] == 1 and t.params["y"] == 0 else [-1.0]
+
+    with pytest.warns(optuna.exceptions.ExperimentalWarning):
+        figure = plot_pareto_front(
+            study=study,
+            constraints_func=constraints_func,
+        )


### PR DESCRIPTION
## Motivation
Resolve #2973.

## Description of the changes
* Remove experimental from `plot_pareto_front` function.
* Add experimental note and warning for `constraint_func` argument, because it is newly introduced in `v3.0.0`.
