### PR TITLE
Remove news entry on Optuna user survey.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,6 @@ Optuna can dynamically construct the search spaces for the hyperparameters.
 
 - **2021-10-11**  Optuna 3.0 Roadmap published for review. Please take a look at the [planned improvements to Optuna](https://github.com/optuna/optuna/wiki/Optuna-V3-Roadmap), and share your feedback in the github issues. PR contributions also welcome!
 
-- **2021-07-14** Please take a few minutes to fill in this survey, and let us know how you use Optuna now and what improvements you'd like.🤔
-All questions optional. 🙇‍♂️
-https://forms.gle/mCAttqxVg5oUifKV8
-
 ## Key Features
 
 Optuna has modern functionalities as follows:


### PR DESCRIPTION
## Motivation

Optuna user survey was closed. The corresponding news entry can be removed.

We deeply appreciate all your answers.

## Description of the changes

Remove the news entry on the Optuna user survey.