### PR TITLE
[hotfix] Add onnx and version constrained protobuf to document dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -75,6 +75,9 @@ def get_extras_require() -> Dict[str, List[str]]:
             "pandas",
             "pillow",
             "plotly>=4.0.0",  # optuna/visualization.
+            # TODO(nzw0301): Remove protobuf after
+            # https://github.com/onnx/onnx/issues/4239 is resolved.
+            "protobuf<=3.20.1",
             "scikit-learn",
             "scikit-optimize",
             "sphinx",

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ def get_extras_require() -> Dict[str, List[str]]:
             "lightgbm",
             "matplotlib",
             "mlflow",
-            # TODO(nzw0301): Remove onnx if thop add onnx to its dependencies.
+            # TODO(nzw0301): Remove onnx if thop adds onnx to its dependencies.
             "onnx",
             "pandas",
             "pillow",

--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,8 @@ def get_extras_require() -> Dict[str, List[str]]:
             "lightgbm",
             "matplotlib",
             "mlflow",
+            # TODO(nzw0301): Remove onnx if thop add onnx to its dependencies.
+            "onnx",
             "pandas",
             "pillow",
             "plotly>=4.0.0",  # optuna/visualization.


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

The master branch's documentation builds are broken due to missing onnx, ex: https://github.com/optuna/optuna/runs/6841134629?check_suite_focus=true.
 
## Description of the changes
<!-- Describe the changes in this PR. -->

As a hotfix, 
- Add `onnx` to `document` of `setup.py` because `thop` doesn't install onnx explicitly.
- Add protobuf version constraint by following onnx's [`requirements.txt`](https://github.com/onnx/onnx/blob/64e79b78a410e69a804f4f198bbaf45193fb3c32/requirements.txt). Otherwise documentation builds are broken, ex. https://github.com/optuna/optuna/runs/6841513286?check_suite_focus=true.