### PR TITLE
Remove the implementation of `read_trials_from_remote_storage` in the all storages apart from CachedStorage

### DIFF
--- a/optuna/storages/_base.py
+++ b/optuna/storages/_base.py
@@ -60,8 +60,8 @@ class BaseStorage(object, metaclass=abc.ABCMeta):
     of a study and a trial. Generally, typical storages naturally hold this requirement. However,
     :class:`~optuna.storages._CachedStorage` does not, so we introduce the
     `read_trials_from_remote_storage(study_id)` method in the class. The detailed explanation how
-    :class:`~optuna.storages._CachedStorage` aquires this requirement, you can check this
-    class docstrings.
+    :class:`~optuna.storages._CachedStorage` aquires this requirement, is available at
+    the docstring.
 
     .. note::
 

--- a/optuna/storages/_base.py
+++ b/optuna/storages/_base.py
@@ -59,7 +59,7 @@ class BaseStorage(object, metaclass=abc.ABCMeta):
     Under a multi-worker setting, a storage class must return the latest values of any attributes
     of a study and a trial. Generally, typical storages naturally hold this requirement. However,
     :class:`~optuna.storages._CachedStorage` does not, so we introduce the
-    `read_trials_from_remote_storage(study_id)` method in the class.The detailed explanation how
+    `read_trials_from_remote_storage(study_id)` method in the class. The detailed explanation how
     :class:`~optuna.storages._CachedStorage` aquires this requirement, you can check this
     class docstrings.
 

--- a/optuna/storages/_base.py
+++ b/optuna/storages/_base.py
@@ -54,6 +54,25 @@ class BaseStorage(object, metaclass=abc.ABCMeta):
     any successive reads on data `X` from the same process must read the written
     value or one of the more recent values.
 
+    **Stronger consistency requirements for special data**
+
+    Under a multi-worker setting, a storage class must return the latest values of any attributes
+    of a study, not necessarily for the attributes of a `Trial`.
+    However, if the `read_trials_from_remote_storage(study_id)` method is called, any successive
+    reads on the `state` attribute of a `Trial` are guaranteed to return the same or more recent
+    values than the value at the time of the call to the
+    `read_trials_from_remote_storage(study_id)` method.
+    Let `T` be a `Trial`.
+    Let `P` be the process that last updated the `state` attribute of `T`.
+    Then, any reads on any attributes of `T` are guaranteed to return the same or
+    more recent values than any writes by `P` on the attribute before `P` updated
+    the `state` attribute of `T`.
+    The same applies for `user_attrs', 'system_attrs' and 'intermediate_values` attributes.
+
+    .. note::
+
+        These attribute behaviors may become user customizable in the future.
+
     **Data persistence**
 
     A storage class does not guarantee that write operations are logged into a persistent

--- a/optuna/storages/_base.py
+++ b/optuna/storages/_base.py
@@ -57,17 +57,11 @@ class BaseStorage(object, metaclass=abc.ABCMeta):
     **Stronger consistency requirements for special data**
 
     Under a multi-worker setting, a storage class must return the latest values of any attributes
-    of a study, not necessarily for the attributes of a `Trial`.
-    However, if the `read_trials_from_remote_storage(study_id)` method is called, any successive
-    reads on the `state` attribute of a `Trial` are guaranteed to return the same or more recent
-    values than the value at the time of the call to the
-    `read_trials_from_remote_storage(study_id)` method.
-    Let `T` be a `Trial`.
-    Let `P` be the process that last updated the `state` attribute of `T`.
-    Then, any reads on any attributes of `T` are guaranteed to return the same or
-    more recent values than any writes by `P` on the attribute before `P` updated
-    the `state` attribute of `T`.
-    The same applies for `user_attrs', 'system_attrs' and 'intermediate_values` attributes.
+    of a study and a trial. Generally, typical storages naturally hold this requirement. However,
+    :class:`~optuna.storages._CachedStorage` does not, so we introduce the
+    `read_trials_from_remote_storage(study_id)` method in the class.The detailed explanation how
+    :class:`~optuna.storages._CachedStorage` aquires this requirement, you can check this
+    class docstrings.
 
     .. note::
 

--- a/optuna/storages/_base.py
+++ b/optuna/storages/_base.py
@@ -54,25 +54,6 @@ class BaseStorage(object, metaclass=abc.ABCMeta):
     any successive reads on data `X` from the same process must read the written
     value or one of the more recent values.
 
-    **Stronger consistency requirements for special data**
-
-    Under a multi-worker setting, a storage class must return the latest values of any attributes
-    of a study, not necessarily for the attributes of a `Trial`.
-    However, if the `read_trials_from_remote_storage(study_id)` method is called, any successive
-    reads on the `state` attribute of a `Trial` are guaranteed to return the same or more recent
-    values than the value at the time of the call to the
-    `read_trials_from_remote_storage(study_id)` method.
-    Let `T` be a `Trial`.
-    Let `P` be the process that last updated the `state` attribute of `T`.
-    Then, any reads on any attributes of `T` are guaranteed to return the same or
-    more recent values than any writes by `P` on the attribute before `P` updated
-    the `state` attribute of `T`.
-    The same applies for `user_attrs', 'system_attrs' and 'intermediate_values` attributes.
-
-    .. note::
-
-        These attribute behaviors may become user customizable in the future.
-
     **Data persistence**
 
     A storage class does not guarantee that write operations are logged into a persistent
@@ -658,19 +639,6 @@ class BaseStorage(object, metaclass=abc.ABCMeta):
                 If no trial with the matching ``trial_id`` exists.
         """
         return self.get_trial(trial_id).system_attrs
-
-    def read_trials_from_remote_storage(self, study_id: int) -> None:
-        """Make an internal cache of trials up-to-date.
-
-        Args:
-            study_id:
-                ID of the study.
-
-        Raises:
-            :exc:`KeyError`:
-                If no study with the matching ``study_id`` exists.
-        """
-        raise NotImplementedError
 
     def remove_session(self) -> None:
         """Clean up all connections to a database."""

--- a/optuna/storages/_cached_storage.py
+++ b/optuna/storages/_cached_storage.py
@@ -42,6 +42,18 @@ class _CachedStorage(BaseStorage, BaseHeartbeat):
     wraps :class:`~optuna.storages.RDBStorage` class or
     :class:`~optuna.storages.RedisStorage` class.
 
+    To support **Stronger consistency requirements for special data** described in
+    :class:`~optuna.storages.BaseStorage`, this class has
+    `read_trials_from_remote_storage(study_id)` method. If the method is called, any successive
+    reads on the `state` attribute of a `Trial` are guaranteed to return the same or more recent
+    values than the value at the time of the call to the method.
+    Let `T` be a `Trial`.
+    Let `P` be the process that last updated the `state` attribute of `T`.
+    Then, any reads on any attributes of `T` are guaranteed to return the same or
+    more recent values than any writes by `P` on the attribute before `P` updated
+    the `state` attribute of `T`.
+    The same applies for `user_attrs', 'system_attrs' and 'intermediate_values` attributes.
+
     Args:
         backend:
             :class:`~optuna.storages.RDBStorage` class or :class:`~optuna.storages.RedisStorage`

--- a/optuna/storages/_cached_storage.py
+++ b/optuna/storages/_cached_storage.py
@@ -386,13 +386,3 @@ class _CachedStorage(BaseStorage, BaseHeartbeat):
 
     def get_failed_trial_callback(self) -> Optional[Callable[["optuna.Study", FrozenTrial], None]]:
         return self._backend.get_failed_trial_callback()
-
-
-def is_cached_storage(storage: BaseStorage) -> bool:
-    """Check whether the storage is the CachedStorage.
-
-    Returns:
-        :obj:`True` if the storage inherits
-        :class:`~optuna.storages._cached_storage._CachedStorage`, otherwise :obj:`False`.
-    """
-    return isinstance(storage, _CachedStorage)

--- a/optuna/storages/_cached_storage.py
+++ b/optuna/storages/_cached_storage.py
@@ -386,3 +386,13 @@ class _CachedStorage(BaseStorage, BaseHeartbeat):
 
     def get_failed_trial_callback(self) -> Optional[Callable[["optuna.Study", FrozenTrial], None]]:
         return self._backend.get_failed_trial_callback()
+
+
+def is_cached_storage(storage: BaseStorage) -> bool:
+    """Check whether the storage is the CachedStorage.
+
+    Returns:
+        :obj:`True` if the storage inherits
+        :class:`~optuna.storages._cached_storage._CachedStorage`, otherwise :obj:`False`.
+    """
+    return isinstance(storage, _CachedStorage)

--- a/optuna/storages/_in_memory.py
+++ b/optuna/storages/_in_memory.py
@@ -429,9 +429,6 @@ class InMemoryStorage(BaseStorage):
 
         return trials
 
-    def read_trials_from_remote_storage(self, study_id: int) -> None:
-        self._check_study_id(study_id)
-
     def _check_study_id(self, study_id: int) -> None:
 
         if study_id not in self._studies:

--- a/optuna/storages/_rdb/storage.py
+++ b/optuna/storages/_rdb/storage.py
@@ -1088,11 +1088,6 @@ class RDBStorage(BaseStorage, BaseHeartbeat):
 
         return self.get_trial(trial_id)
 
-    def read_trials_from_remote_storage(self, study_id: int) -> None:
-        # Make sure that the given study exists.
-        with _create_scoped_session(self.scoped_session) as session:
-            models.StudyModel.find_or_raise_by_id(study_id, session)
-
     @staticmethod
     def _set_default_engine_kwargs_for_mysql(url: str, engine_kwargs: Dict[str, Any]) -> None:
 

--- a/optuna/storages/_redis.py
+++ b/optuna/storages/_redis.py
@@ -719,9 +719,6 @@ class RedisStorage(BaseStorage, BaseHeartbeat):
 
         return trials
 
-    def read_trials_from_remote_storage(self, study_id: int) -> None:
-        self._check_study_id(study_id)
-
     def _check_study_id(self, study_id: int) -> None:
 
         if not self._redis.exists("study_id:{:010d}:study_name".format(study_id)):

--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -28,7 +28,7 @@ from optuna._deprecated import deprecated_func
 from optuna._imports import _LazyImport
 from optuna.distributions import _convert_old_distribution_to_new_distribution
 from optuna.distributions import BaseDistribution
-from optuna.storages._cached_storage import is_cached_storage
+from optuna.storages._cached_storage import _CachedStorage
 from optuna.storages._heartbeat import is_heartbeat_enabled
 from optuna.study._multi_objective import _get_pareto_front_trials
 from optuna.study._optimize import _optimize
@@ -250,7 +250,7 @@ class Study:
         Returns:
             A list of :class:`~optuna.trial.FrozenTrial` objects.
         """
-        if is_cached_storage(self._storage):
+        if isinstance(self._storage, _CachedStorage):
             self._storage.read_trials_from_remote_storage(self._study_id)
 
         return self._storage.get_all_trials(self._study_id, deepcopy=deepcopy, states=states)
@@ -497,7 +497,7 @@ class Study:
         }
 
         # Sync storage once every trial.
-        if is_cached_storage(self._storage):
+        if isinstance(self._storage, _CachedStorage):
             self._storage.read_trials_from_remote_storage(self._study_id)
 
         trial_id = self._pop_waiting_trial_id()

--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -28,6 +28,7 @@ from optuna._deprecated import deprecated_func
 from optuna._imports import _LazyImport
 from optuna.distributions import _convert_old_distribution_to_new_distribution
 from optuna.distributions import BaseDistribution
+from optuna.storages._cached_storage import is_cached_storage
 from optuna.storages._heartbeat import is_heartbeat_enabled
 from optuna.study._multi_objective import _get_pareto_front_trials
 from optuna.study._optimize import _optimize
@@ -249,8 +250,9 @@ class Study:
         Returns:
             A list of :class:`~optuna.trial.FrozenTrial` objects.
         """
+        if is_cached_storage(self._storage):
+            self._storage.read_trials_from_remote_storage(self._study_id)
 
-        self._storage.read_trials_from_remote_storage(self._study_id)
         return self._storage.get_all_trials(self._study_id, deepcopy=deepcopy, states=states)
 
     @property
@@ -495,7 +497,8 @@ class Study:
         }
 
         # Sync storage once every trial.
-        self._storage.read_trials_from_remote_storage(self._study_id)
+        if is_cached_storage(self._storage):
+            self._storage.read_trials_from_remote_storage(self._study_id)
 
         trial_id = self._pop_waiting_trial_id()
         if trial_id is None:

--- a/tests/storages_tests/test_cached_storage.py
+++ b/tests/storages_tests/test_cached_storage.py
@@ -1,5 +1,7 @@
 from unittest.mock import patch
 
+import pytest
+
 import optuna
 from optuna.storages._cached_storage import _CachedStorage
 from optuna.storages._cached_storage import RDBStorage
@@ -95,3 +97,16 @@ def test_uncached_set() -> None:
     with patch.object(base_storage, "set_trial_user_attr", return_value=None) as set_mock:
         storage.set_trial_user_attr(trial_id, "attrB", "bar")
         assert set_mock.call_count == 1
+
+
+def test_read_trials_from_remote_storage() -> None:
+
+    base_storage = RDBStorage("sqlite:///:memory:")
+    storage = _CachedStorage(base_storage)
+    study_id = storage.create_new_study("test-study")
+
+    storage.read_trials_from_remote_storage(study_id)
+
+    # Non-existent study.
+    with pytest.raises(KeyError):
+        storage.read_trials_from_remote_storage(study_id + 1)

--- a/tests/storages_tests/test_storages.py
+++ b/tests/storages_tests/test_storages.py
@@ -1215,19 +1215,6 @@ def test_get_trial_id_from_study_id_trial_number(storage_mode: str) -> None:
 
 
 @pytest.mark.parametrize("storage_mode", STORAGE_MODES)
-def test_read_trials_from_remote_storage(storage_mode: str) -> None:
-
-    with StorageSupplier(storage_mode) as storage:
-
-        study_id = storage.create_new_study()
-        storage.read_trials_from_remote_storage(study_id)
-
-        # Non-existent study.
-        with pytest.raises(KeyError):
-            storage.read_trials_from_remote_storage(study_id + 1)
-
-
-@pytest.mark.parametrize("storage_mode", STORAGE_MODES)
 def test_pickle_storage(storage_mode: str) -> None:
     if "redis" in storage_mode:
         pytest.skip("Redis storage is not picklable")


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
The method `read_trials_from_remote_storage` is an abstract method of `BaseStorage`, and is expected to be called for the `Stronger consistency requirements for special data` as follows:

```
    **Stronger consistency requirements for special data**
    Under a multi-worker setting, a storage class must return the latest values of any attributes
    of a study, not necessarily for the attributes of a `Trial`.
    However, if the `read_trials_from_remote_storage(study_id)` method is called, any successive
    reads on the `state` attribute of a `Trial` are guaranteed to return the same or more recent
    values than the value at the time of the call to the
    `read_trials_from_remote_storage(study_id)` method.
```

However, currently, all the other storages apart from `_CachedStorage` naturally hold this `Stronger consistency requirements for special data` without calling `read_trials_from_remote_storage`, and it is only needed for CachedStorage.

It means that we can assume that this method is only for CachedStorage to sync data from remote to local. Therefore, we decided that we remove the implementation of read_trials_from_remote_storage in the other storages apart from CachedStorages.

## Description of the changes
<!-- Describe the changes in this PR. -->
In [the PR](https://github.com/optuna/optuna/pull/3437), I removed `read_trials_from_remote_storage` from all storages, and CachedStorage automatically sync from the remote storage when it calls `get_all_trials` . But, the solution has some concerns to degrade performance of the network traffic.

In this PR, I just removed the implementation of `read_trials_from_remote_storage` in the all storages apart from `CachedStorage`. And, make `read_trials_from_remote_storage` called only when the storage is `CachedStorage`.
