### PR TITLE
Fix a variable name of ask-and-tell tutorial

### DIFF
--- a/tutorial/20_recipes/009_ask_and_tell.py
+++ b/tutorial/20_recipes/009_ask_and_tell.py
@@ -208,7 +208,7 @@ def batched_objective(xs: np.ndarray, ys: np.ndarray):
 # In the following example, the number of pairs of hyperparameters in a batch is :math:`10`,
 # and ``batched_objective`` is evaluated three times.
 # Thus, the number of trials is :math:`30`.
-# Note that you need to store either ``trial_ids`` or ``trial`` to call
+# Note that you need to store either ``trial_numbers`` or ``trial`` to call
 # :func:`optuna.study.Study.tell` method after the batched evaluations.
 
 batch_size = 10
@@ -217,12 +217,12 @@ study = optuna.create_study(sampler=optuna.samplers.CmaEsSampler())
 for _ in range(3):
 
     # create batch
-    trial_ids = []
+    trial_numbers = []
     x_batch = []
     y_batch = []
     for _ in range(batch_size):
         trial = study.ask()
-        trial_ids.append(trial.number)
+        trial_numbers.append(trial.number)
         x_batch.append(trial.suggest_float("x", -10, 10))
         y_batch.append(trial.suggest_float("y", -10, 10))
 
@@ -232,5 +232,5 @@ for _ in range(3):
     objectives = batched_objective(x_batch, y_batch)
 
     # finish all trials in the batch
-    for trial_id, objective in zip(trial_ids, objectives):
-        study.tell(trial_id, objective)
+    for trial_number, objective in zip(trial_numbers, objectives):
+        study.tell(trial_number, objective)


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

The first argument of `study.tell(trial: Union[Trial, int], ...)` is expected to pass `trial.number`, not a trial_id.
https://optuna.readthedocs.io/en/stable/reference/generated/optuna.study.Study.html#optuna.study.Study.tell

## Description of the changes
<!-- Describe the changes in this PR. -->
Rename `trial_ids` with `trial_numbers`.