### PR TITLE
Remove duplicate calls to `study.get_trials` in `ImportanceEvaluator`s

### DIFF
--- a/optuna/importance/_base.py
+++ b/optuna/importance/_base.py
@@ -4,17 +4,13 @@ from typing import Callable
 from typing import Collection
 from typing import Dict
 from typing import List
-from typing import Optional
 from typing import Union
 
 import numpy
 
 from optuna._transform import _SearchSpaceTransform
 from optuna.distributions import BaseDistribution
-from optuna.samplers import intersection_search_space
-from optuna.study import Study
 from optuna.trial import FrozenTrial
-from optuna.trial import TrialState
 
 
 class BaseImportanceEvaluator(object, metaclass=abc.ABCMeta):
@@ -23,7 +19,7 @@ class BaseImportanceEvaluator(object, metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def evaluate(
         self,
-        study: Study,
+        completed_trials: List[FrozenTrial],
         params: List[str],
         *,
         target: Callable[[FrozenTrial], float],
@@ -60,86 +56,38 @@ class BaseImportanceEvaluator(object, metaclass=abc.ABCMeta):
         raise NotImplementedError
 
 
-def _get_distributions(study: Study, params: Optional[List[str]]) -> Dict[str, BaseDistribution]:
-    completed_trials = study.get_trials(deepcopy=False, states=(TrialState.COMPLETE,))
-    _check_evaluate_args(completed_trials, params)
+def _get_distributions(
+    completed_trials: List[FrozenTrial], params: List[str]
+) -> Dict[str, BaseDistribution]:
+    filtered_trials = (trial for trial in completed_trials if set(params) <= set(trial.params))
 
-    if params is None:
-        return intersection_search_space(study, ordered_dict=True)
+    first_trial = next(filtered_trials)
+    distributions = {name: first_trial.distributions[name] for name in params}
 
-    # New temporary required to pass mypy. Seems like a bug.
-    params_not_none = params
-    assert params_not_none is not None
+    # Check that all remaining trials have the same distributions.
+    if any(
+        trial.distributions[name] != distribution
+        for trial in filtered_trials
+        for name, distribution in distributions.items()
+    ):
+        raise ValueError(
+            "Parameters importances cannot be assessed with dynamic search spaces if "
+            "parameters are specified. Specified parameters: {}.".format(params)
+        )
 
-    # Compute the search space based on the subset of trials containing all parameters.
-    distributions = None
-    for trial in completed_trials:
-        trial_distributions = trial.distributions
-        if not all(name in trial_distributions for name in params_not_none):
-            continue
-
-        if distributions is None:
-            distributions = dict(
-                filter(
-                    lambda name_and_distribution: name_and_distribution[0] in params_not_none,
-                    trial_distributions.items(),
-                )
-            )
-            continue
-
-        if any(
-            trial_distributions[name] != distribution
-            for name, distribution in distributions.items()
-        ):
-            raise ValueError(
-                "Parameters importances cannot be assessed with dynamic search spaces if "
-                "parameters are specified. Specified parameters: {}.".format(params)
-            )
-
-    assert distributions is not None  # Required to pass mypy.
-    distributions = OrderedDict(
+    return OrderedDict(
         sorted(distributions.items(), key=lambda name_and_distribution: name_and_distribution[0])
     )
-    return distributions
-
-
-def _check_evaluate_args(completed_trials: List[FrozenTrial], params: Optional[List[str]]) -> None:
-    if len(completed_trials) == 0:
-        raise ValueError("Cannot evaluate parameter importances without completed trials.")
-    if len(completed_trials) == 1:
-        raise ValueError("Cannot evaluate parameter importances with only a single trial.")
-
-    if params is not None:
-        if not isinstance(params, (list, tuple)):
-            raise TypeError(
-                "Parameters must be specified as a list. Actual parameters: {}.".format(params)
-            )
-        if any(not isinstance(p, str) for p in params):
-            raise TypeError(
-                "Parameters must be specified by their names with strings. Actual parameters: "
-                "{}.".format(params)
-            )
-
-        if len(params) > 0:
-            at_least_one_trial = False
-            for trial in completed_trials:
-                if all(p in trial.distributions for p in params):
-                    at_least_one_trial = True
-                    break
-            if not at_least_one_trial:
-                raise ValueError(
-                    "Study must contain completed trials with all specified parameters. "
-                    "Specified parameters: {}.".format(params)
-                )
 
 
 def _get_filtered_trials(
-    study: Study, params: Collection[str], target: Callable[[FrozenTrial], float]
+    completed_trials: List[FrozenTrial],
+    params: Collection[str],
+    target: Callable[[FrozenTrial], float],
 ) -> List[FrozenTrial]:
-    trials = study.get_trials(deepcopy=False, states=(TrialState.COMPLETE,))
     return [
         trial
-        for trial in trials
+        for trial in completed_trials
         if set(params) <= set(trial.params) and numpy.isfinite(target(trial))
     ]
 

--- a/optuna/importance/_mean_decrease_impurity.py
+++ b/optuna/importance/_mean_decrease_impurity.py
@@ -13,7 +13,6 @@ from optuna.importance._base import _get_target_values
 from optuna.importance._base import _get_trans_params
 from optuna.importance._base import _param_importances_to_dict
 from optuna.importance._base import BaseImportanceEvaluator
-from optuna.study import Study
 from optuna.trial import FrozenTrial
 
 
@@ -56,14 +55,16 @@ class MeanDecreaseImpurityImportanceEvaluator(BaseImportanceEvaluator):
 
     def evaluate(
         self,
-        study: Study,
+        completed_trials: List[FrozenTrial],
         params: List[str],
         *,
         target: Callable[[FrozenTrial], float],
     ) -> Dict[str, float]:
-        distributions = _get_distributions(study, params=params)
 
-        trials: List[FrozenTrial] = _get_filtered_trials(study, params=params, target=target)
+        trials: List[FrozenTrial] = _get_filtered_trials(
+            completed_trials, params=params, target=target
+        )
+        distributions = _get_distributions(trials, params=params)
         trans = _SearchSpaceTransform(distributions, transform_log=False, transform_step=False)
         trans_params: numpy.ndarray = _get_trans_params(trials, trans)
         target_values: numpy.ndarray = _get_target_values(trials, target)

--- a/optuna/integration/shap.py
+++ b/optuna/integration/shap.py
@@ -14,7 +14,6 @@ from optuna.importance._base import _get_target_values
 from optuna.importance._base import _get_trans_params
 from optuna.importance._base import _param_importances_to_dict
 from optuna.importance._base import BaseImportanceEvaluator
-from optuna.study import Study
 from optuna.trial import FrozenTrial
 
 
@@ -62,15 +61,16 @@ class ShapleyImportanceEvaluator(BaseImportanceEvaluator):
 
     def evaluate(
         self,
-        study: Study,
+        completed_trials: List[FrozenTrial],
         params: List[str],
         *,
         target: Callable[[FrozenTrial], float],
     ) -> Dict[str, float]:
 
-        distributions = _get_distributions(study, params=params)
-
-        trials: List[FrozenTrial] = _get_filtered_trials(study, params=params, target=target)
+        trials: List[FrozenTrial] = _get_filtered_trials(
+            completed_trials, params=params, target=target
+        )
+        distributions = _get_distributions(trials, params=params)
         trans = _SearchSpaceTransform(distributions, transform_log=False, transform_step=False)
         trans_params: np.ndarray = _get_trans_params(trials, trans)
         target_values: np.ndarray = _get_target_values(trials, target)

--- a/optuna/integration/shap.py
+++ b/optuna/integration/shap.py
@@ -1,4 +1,3 @@
-from collections import OrderedDict
 from typing import Callable
 from typing import Dict
 from typing import List
@@ -14,7 +13,6 @@ from optuna.importance._base import _get_filtered_trials
 from optuna.importance._base import _get_target_values
 from optuna.importance._base import _get_trans_params
 from optuna.importance._base import _param_importances_to_dict
-from optuna.importance._base import _sort_dict_by_importance
 from optuna.importance._base import BaseImportanceEvaluator
 from optuna.study import Study
 from optuna.trial import FrozenTrial
@@ -65,24 +63,12 @@ class ShapleyImportanceEvaluator(BaseImportanceEvaluator):
     def evaluate(
         self,
         study: Study,
-        params: Optional[List[str]] = None,
+        params: List[str],
         *,
-        target: Optional[Callable[[FrozenTrial], float]] = None,
+        target: Callable[[FrozenTrial], float],
     ) -> Dict[str, float]:
 
-        if target is None and study._is_multi_objective():
-            raise ValueError(
-                "If the `study` is being used for multi-objective optimization, "
-                "please specify the `target`. For example, use "
-                "`target=lambda t: t.values[0]` for the first objective value."
-            )
-
         distributions = _get_distributions(study, params=params)
-        if params is None:
-            params = list(distributions.keys())
-        assert params is not None
-        if len(params) == 0:
-            return OrderedDict()
 
         trials: List[FrozenTrial] = _get_filtered_trials(study, params=params, target=target)
         trans = _SearchSpaceTransform(distributions, transform_log=False, transform_step=False)
@@ -104,4 +90,4 @@ class ShapleyImportanceEvaluator(BaseImportanceEvaluator):
         # List of tuples ("feature_name": mean_abs_shap_value).
         mean_abs_shap_values = np.abs(param_shap_values).mean(axis=0)
 
-        return _sort_dict_by_importance(_param_importances_to_dict(params, mean_abs_shap_values))
+        return _param_importances_to_dict(params, mean_abs_shap_values)

--- a/tests/importance_tests/test_fanova.py
+++ b/tests/importance_tests/test_fanova.py
@@ -40,10 +40,12 @@ def test_fanova_importance_evaluator_n_trees() -> None:
     study.optimize(objective, n_trials=3)
 
     evaluator = FanovaImportanceEvaluator(n_trees=10, seed=0)
-    param_importance = evaluator.evaluate(study, params=params, target=get_value)
+    param_importance = evaluator.evaluate(study.get_trials(), params=params, target=get_value)
 
     evaluator = FanovaImportanceEvaluator(n_trees=20, seed=0)
-    param_importance_different_n_trees = evaluator.evaluate(study, params=params, target=get_value)
+    param_importance_different_n_trees = evaluator.evaluate(
+        study.get_trials(), params=params, target=get_value
+    )
 
     assert param_importance != param_importance_different_n_trees
 
@@ -55,11 +57,11 @@ def test_fanova_importance_evaluator_max_depth() -> None:
     study.optimize(objective, n_trials=3)
 
     evaluator = FanovaImportanceEvaluator(max_depth=1, seed=0)
-    param_importance = evaluator.evaluate(study, params=params, target=get_value)
+    param_importance = evaluator.evaluate(study.get_trials(), params=params, target=get_value)
 
     evaluator = FanovaImportanceEvaluator(max_depth=2, seed=0)
     param_importance_different_max_depth = evaluator.evaluate(
-        study, params=params, target=get_value
+        study.get_trials(), params=params, target=get_value
     )
 
     assert param_importance != param_importance_different_max_depth
@@ -70,14 +72,18 @@ def test_fanova_importance_evaluator_seed() -> None:
     study.optimize(objective, n_trials=3)
 
     evaluator = FanovaImportanceEvaluator(seed=2)
-    param_importance = evaluator.evaluate(study, params=params, target=get_value)
+    param_importance = evaluator.evaluate(study.get_trials(), params=params, target=get_value)
 
     evaluator = FanovaImportanceEvaluator(seed=2)
-    param_importance_same_seed = evaluator.evaluate(study, params=params, target=get_value)
+    param_importance_same_seed = evaluator.evaluate(
+        study.get_trials(), params=params, target=get_value
+    )
     assert param_importance == param_importance_same_seed
 
     evaluator = FanovaImportanceEvaluator(seed=3)
-    param_importance_different_seed = evaluator.evaluate(study, params=params, target=get_value)
+    param_importance_different_seed = evaluator.evaluate(
+        study.get_trials(), params=params, target=get_value
+    )
     assert param_importance != param_importance_different_seed
 
 
@@ -88,9 +94,9 @@ def test_fanova_importance_evaluator_with_target() -> None:
     study.optimize(objective, n_trials=3)
 
     evaluator = FanovaImportanceEvaluator(seed=0)
-    param_importance = evaluator.evaluate(study, params=params, target=get_value)
+    param_importance = evaluator.evaluate(study.get_trials(), params=params, target=get_value)
     param_importance_with_target = evaluator.evaluate(
-        study,
+        study.get_trials(),
         params=params,
         target=lambda t: t.params["x1"] + t.params["x2"],
     )
@@ -109,7 +115,9 @@ def test_fanova_importance_evaluator_with_infinite(inf_value: float) -> None:
     study.optimize(objective, n_trials=n_trial)
 
     evaluator = FanovaImportanceEvaluator(seed=seed)
-    param_importance_without_inf = evaluator.evaluate(study, params=params, target=get_value)
+    param_importance_without_inf = evaluator.evaluate(
+        study.get_trials(), params=params, target=get_value
+    )
 
     # A trial with an inf value is added into the study manually.
     study.add_trial(
@@ -124,7 +132,9 @@ def test_fanova_importance_evaluator_with_infinite(inf_value: float) -> None:
         )
     )
     # Importance scores are calculated with a trial with an inf value.
-    param_importance_with_inf = evaluator.evaluate(study, params=params, target=get_value)
+    param_importance_with_inf = evaluator.evaluate(
+        study.get_trials(), params=params, target=get_value
+    )
 
     # Obtained importance scores should be the same between with inf and without inf,
     # because the last trial whose objective value is an inf is ignored.
@@ -146,7 +156,7 @@ def test_multi_objective_fanova_importance_evaluator_with_infinite(
 
     evaluator = FanovaImportanceEvaluator(seed=seed)
     param_importance_without_inf = evaluator.evaluate(
-        study, params=params, target=lambda t: t.values[target_idx]
+        study.get_trials(), params=params, target=lambda t: t.values[target_idx]
     )
 
     # A trial with an inf value is added into the study manually.
@@ -163,7 +173,7 @@ def test_multi_objective_fanova_importance_evaluator_with_infinite(
     )
     # Importance scores are calculated with a trial with an inf value.
     param_importance_with_inf = evaluator.evaluate(
-        study, params=params, target=lambda t: t.values[target_idx]
+        study.get_trials(), params=params, target=lambda t: t.values[target_idx]
     )
 
     # Obtained importance scores should be the same between with inf and without inf,

--- a/tests/importance_tests/test_init.py
+++ b/tests/importance_tests/test_init.py
@@ -264,24 +264,6 @@ def test_get_param_importances_invalid_dynamic_search_space_params(
 
 
 @parametrize_evaluator
-def test_get_param_importances_invalid_params_type(
-    evaluator_init_func: Callable[[], BaseImportanceEvaluator]
-) -> None:
-    def objective(trial: Trial) -> float:
-        x1 = trial.suggest_float("x1", 0.1, 3)
-        return x1**2
-
-    study = create_study()
-    study.optimize(objective, n_trials=3)
-
-    with pytest.raises(TypeError):
-        get_param_importances(study, evaluator=evaluator_init_func(), params={})  # type: ignore
-
-    with pytest.raises(TypeError):
-        get_param_importances(study, evaluator=evaluator_init_func(), params=[0])  # type: ignore
-
-
-@parametrize_evaluator
 def test_get_param_importances_empty_search_space(
     evaluator_init_func: Callable[[], BaseImportanceEvaluator]
 ) -> None:

--- a/tests/importance_tests/test_mean_decrease_impurity.py
+++ b/tests/importance_tests/test_mean_decrease_impurity.py
@@ -40,10 +40,12 @@ def test_mean_decrease_impurity_importance_evaluator_n_trees() -> None:
     study.optimize(objective, n_trials=3)
 
     evaluator = MeanDecreaseImpurityImportanceEvaluator(n_trees=10, seed=0)
-    param_importance = evaluator.evaluate(study, params=params, target=get_value)
+    param_importance = evaluator.evaluate(study.get_trials(), params=params, target=get_value)
 
     evaluator = MeanDecreaseImpurityImportanceEvaluator(n_trees=20, seed=0)
-    param_importance_different_n_trees = evaluator.evaluate(study, params=params, target=get_value)
+    param_importance_different_n_trees = evaluator.evaluate(
+        study.get_trials(), params=params, target=get_value
+    )
 
     assert param_importance != param_importance_different_n_trees
 
@@ -55,11 +57,11 @@ def test_mean_decrease_impurity_importance_evaluator_max_depth() -> None:
     study.optimize(objective, n_trials=3)
 
     evaluator = MeanDecreaseImpurityImportanceEvaluator(max_depth=1, seed=0)
-    param_importance = evaluator.evaluate(study, params=params, target=get_value)
+    param_importance = evaluator.evaluate(study.get_trials(), params=params, target=get_value)
 
     evaluator = MeanDecreaseImpurityImportanceEvaluator(max_depth=2, seed=0)
     param_importance_different_max_depth = evaluator.evaluate(
-        study, params=params, target=get_value
+        study.get_trials(), params=params, target=get_value
     )
 
     assert param_importance != param_importance_different_max_depth
@@ -70,14 +72,18 @@ def test_mean_decrease_impurity_importance_evaluator_seed() -> None:
     study.optimize(objective, n_trials=3)
 
     evaluator = MeanDecreaseImpurityImportanceEvaluator(seed=2)
-    param_importance = evaluator.evaluate(study, params=params, target=get_value)
+    param_importance = evaluator.evaluate(study.get_trials(), params=params, target=get_value)
 
     evaluator = MeanDecreaseImpurityImportanceEvaluator(seed=2)
-    param_importance_same_seed = evaluator.evaluate(study, params=params, target=get_value)
+    param_importance_same_seed = evaluator.evaluate(
+        study.get_trials(), params=params, target=get_value
+    )
     assert param_importance == param_importance_same_seed
 
     evaluator = MeanDecreaseImpurityImportanceEvaluator(seed=3)
-    param_importance_different_seed = evaluator.evaluate(study, params=params, target=get_value)
+    param_importance_different_seed = evaluator.evaluate(
+        study.get_trials(), params=params, target=get_value
+    )
     assert param_importance != param_importance_different_seed
 
 
@@ -88,9 +94,9 @@ def test_mean_decrease_impurity_importance_evaluator_with_target() -> None:
     study.optimize(objective, n_trials=3)
 
     evaluator = MeanDecreaseImpurityImportanceEvaluator(seed=0)
-    param_importance = evaluator.evaluate(study, params=params, target=get_value)
+    param_importance = evaluator.evaluate(study.get_trials(), params=params, target=get_value)
     param_importance_with_target = evaluator.evaluate(
-        study,
+        study.get_trials(),
         params=params,
         target=lambda t: t.params["x1"] + t.params["x2"],
     )
@@ -109,7 +115,9 @@ def test_mean_decrease_impurity_importance_evaluator_with_infinite(inf_value: fl
     study.optimize(objective, n_trials=n_trial)
 
     evaluator = MeanDecreaseImpurityImportanceEvaluator(seed=seed)
-    param_importance_without_inf = evaluator.evaluate(study, params=params, target=get_value)
+    param_importance_without_inf = evaluator.evaluate(
+        study.get_trials(), params=params, target=get_value
+    )
 
     # A trial with an inf value is added into the study manually.
     study.add_trial(
@@ -124,7 +132,9 @@ def test_mean_decrease_impurity_importance_evaluator_with_infinite(inf_value: fl
         )
     )
     # Importance scores are calculated with a trial with an inf value.
-    param_importance_with_inf = evaluator.evaluate(study, params=params, target=get_value)
+    param_importance_with_inf = evaluator.evaluate(
+        study.get_trials(), params=params, target=get_value
+    )
 
     # Obtained importance scores should be the same between with inf and without inf,
     # because the last trial whose objective value is an inf is ignored.
@@ -146,7 +156,7 @@ def test_multi_objective_mean_decrease_impurity_importance_evaluator_with_infini
 
     evaluator = MeanDecreaseImpurityImportanceEvaluator(seed=seed)
     param_importance_without_inf = evaluator.evaluate(
-        study, params=params, target=lambda t: t.values[target_idx]
+        study.get_trials(), params=params, target=lambda t: t.values[target_idx]
     )
 
     # A trial with an inf value is added into the study manually.
@@ -163,7 +173,7 @@ def test_multi_objective_mean_decrease_impurity_importance_evaluator_with_infini
     )
     # Importance scores are calculated with a trial with an inf value.
     param_importance_with_inf = evaluator.evaluate(
-        study, params=params, target=lambda t: t.values[target_idx]
+        study.get_trials(), params=params, target=lambda t: t.values[target_idx]
     )
 
     # Obtained importance scores should be the same between with inf and without inf,

--- a/tests/importance_tests/test_mean_decrease_impurity.py
+++ b/tests/importance_tests/test_mean_decrease_impurity.py
@@ -1,3 +1,4 @@
+from typing import cast
 from typing import Tuple
 
 import pytest
@@ -8,6 +9,7 @@ from optuna.distributions import FloatDistribution
 from optuna.importance import MeanDecreaseImpurityImportanceEvaluator
 from optuna.samplers import RandomSampler
 from optuna.trial import create_trial
+from optuna.trial import FrozenTrial
 
 
 def objective(trial: Trial) -> float:
@@ -24,6 +26,13 @@ def multi_objective_function(trial: Trial) -> Tuple[float, float]:
     return x1, x2 * x3
 
 
+def get_value(trial: FrozenTrial) -> float:
+    return cast(float, trial.value)
+
+
+params = ["x1", "x2", "x3"]
+
+
 def test_mean_decrease_impurity_importance_evaluator_n_trees() -> None:
     # Assumes that `seed` can be fixed to reproduce identical results.
 
@@ -31,10 +40,10 @@ def test_mean_decrease_impurity_importance_evaluator_n_trees() -> None:
     study.optimize(objective, n_trials=3)
 
     evaluator = MeanDecreaseImpurityImportanceEvaluator(n_trees=10, seed=0)
-    param_importance = evaluator.evaluate(study)
+    param_importance = evaluator.evaluate(study, params=params, target=get_value)
 
     evaluator = MeanDecreaseImpurityImportanceEvaluator(n_trees=20, seed=0)
-    param_importance_different_n_trees = evaluator.evaluate(study)
+    param_importance_different_n_trees = evaluator.evaluate(study, params=params, target=get_value)
 
     assert param_importance != param_importance_different_n_trees
 
@@ -46,10 +55,12 @@ def test_mean_decrease_impurity_importance_evaluator_max_depth() -> None:
     study.optimize(objective, n_trials=3)
 
     evaluator = MeanDecreaseImpurityImportanceEvaluator(max_depth=1, seed=0)
-    param_importance = evaluator.evaluate(study)
+    param_importance = evaluator.evaluate(study, params=params, target=get_value)
 
     evaluator = MeanDecreaseImpurityImportanceEvaluator(max_depth=2, seed=0)
-    param_importance_different_max_depth = evaluator.evaluate(study)
+    param_importance_different_max_depth = evaluator.evaluate(
+        study, params=params, target=get_value
+    )
 
     assert param_importance != param_importance_different_max_depth
 
@@ -59,14 +70,14 @@ def test_mean_decrease_impurity_importance_evaluator_seed() -> None:
     study.optimize(objective, n_trials=3)
 
     evaluator = MeanDecreaseImpurityImportanceEvaluator(seed=2)
-    param_importance = evaluator.evaluate(study)
+    param_importance = evaluator.evaluate(study, params=params, target=get_value)
 
     evaluator = MeanDecreaseImpurityImportanceEvaluator(seed=2)
-    param_importance_same_seed = evaluator.evaluate(study)
+    param_importance_same_seed = evaluator.evaluate(study, params=params, target=get_value)
     assert param_importance == param_importance_same_seed
 
     evaluator = MeanDecreaseImpurityImportanceEvaluator(seed=3)
-    param_importance_different_seed = evaluator.evaluate(study)
+    param_importance_different_seed = evaluator.evaluate(study, params=params, target=get_value)
     assert param_importance != param_importance_different_seed
 
 
@@ -77,9 +88,10 @@ def test_mean_decrease_impurity_importance_evaluator_with_target() -> None:
     study.optimize(objective, n_trials=3)
 
     evaluator = MeanDecreaseImpurityImportanceEvaluator(seed=0)
-    param_importance = evaluator.evaluate(study)
+    param_importance = evaluator.evaluate(study, params=params, target=get_value)
     param_importance_with_target = evaluator.evaluate(
         study,
+        params=params,
         target=lambda t: t.params["x1"] + t.params["x2"],
     )
 
@@ -97,7 +109,7 @@ def test_mean_decrease_impurity_importance_evaluator_with_infinite(inf_value: fl
     study.optimize(objective, n_trials=n_trial)
 
     evaluator = MeanDecreaseImpurityImportanceEvaluator(seed=seed)
-    param_importance_without_inf = evaluator.evaluate(study)
+    param_importance_without_inf = evaluator.evaluate(study, params=params, target=get_value)
 
     # A trial with an inf value is added into the study manually.
     study.add_trial(
@@ -112,7 +124,7 @@ def test_mean_decrease_impurity_importance_evaluator_with_infinite(inf_value: fl
         )
     )
     # Importance scores are calculated with a trial with an inf value.
-    param_importance_with_inf = evaluator.evaluate(study)
+    param_importance_with_inf = evaluator.evaluate(study, params=params, target=get_value)
 
     # Obtained importance scores should be the same between with inf and without inf,
     # because the last trial whose objective value is an inf is ignored.
@@ -133,7 +145,9 @@ def test_multi_objective_mean_decrease_impurity_importance_evaluator_with_infini
     study.optimize(multi_objective_function, n_trials=n_trial)
 
     evaluator = MeanDecreaseImpurityImportanceEvaluator(seed=seed)
-    param_importance_without_inf = evaluator.evaluate(study, target=lambda t: t.values[target_idx])
+    param_importance_without_inf = evaluator.evaluate(
+        study, params=params, target=lambda t: t.values[target_idx]
+    )
 
     # A trial with an inf value is added into the study manually.
     study.add_trial(
@@ -148,7 +162,9 @@ def test_multi_objective_mean_decrease_impurity_importance_evaluator_with_infini
         )
     )
     # Importance scores are calculated with a trial with an inf value.
-    param_importance_with_inf = evaluator.evaluate(study, target=lambda t: t.values[target_idx])
+    param_importance_with_inf = evaluator.evaluate(
+        study, params=params, target=lambda t: t.values[target_idx]
+    )
 
     # Obtained importance scores should be the same between with inf and without inf,
     # because the last trial whose objective value is an inf is ignored.

--- a/tests/integration_tests/test_botorch.py
+++ b/tests/integration_tests/test_botorch.py
@@ -1,3 +1,4 @@
+from typing import Any
 from typing import cast
 from typing import Optional
 from typing import Sequence
@@ -78,9 +79,9 @@ def test_botorch_candidates_func_invalid_type() -> None:
         train_obj: torch.Tensor,
         train_con: Optional[torch.Tensor],
         bounds: torch.Tensor,
-    ) -> torch.Tensor:
+    ) -> Any:
         # Must be a `torch.Tensor`, not a list.
-        return [torch.rand(1).tolist()]  # type: ignore
+        return [torch.rand(1).tolist()]
 
     sampler = BoTorchSampler(candidates_func=candidates_func, n_startup_trials=1)
 

--- a/tests/integration_tests/test_botorch.py
+++ b/tests/integration_tests/test_botorch.py
@@ -80,7 +80,7 @@ def test_botorch_candidates_func_invalid_type() -> None:
         bounds: torch.Tensor,
     ) -> torch.Tensor:
         # Must be a `torch.Tensor`, not a list.
-        return torch.rand(1).tolist()
+        return cast(list, torch.rand(1).tolist())  # type: ignore
 
     sampler = BoTorchSampler(candidates_func=candidates_func, n_startup_trials=1)
 

--- a/tests/integration_tests/test_botorch.py
+++ b/tests/integration_tests/test_botorch.py
@@ -80,7 +80,7 @@ def test_botorch_candidates_func_invalid_type() -> None:
         bounds: torch.Tensor,
     ) -> torch.Tensor:
         # Must be a `torch.Tensor`, not a list.
-        return cast(list, torch.rand(1).tolist())  # type: ignore
+        return [torch.rand(1).tolist()]  # type: ignore
 
     sampler = BoTorchSampler(candidates_func=candidates_func, n_startup_trials=1)
 

--- a/tests/integration_tests/test_shap.py
+++ b/tests/integration_tests/test_shap.py
@@ -44,10 +44,12 @@ def test_mean_abs_shap_importance_evaluator_n_trees() -> None:
     study.optimize(objective, n_trials=3)
 
     evaluator = ShapleyImportanceEvaluator(n_trees=10, seed=0)
-    param_importance = evaluator.evaluate(study, params=params, target=get_value)
+    param_importance = evaluator.evaluate(study.get_trials(), params=params, target=get_value)
 
     evaluator = ShapleyImportanceEvaluator(n_trees=20, seed=0)
-    param_importance_different_n_trees = evaluator.evaluate(study, params=params, target=get_value)
+    param_importance_different_n_trees = evaluator.evaluate(
+        study.get_trials(), params=params, target=get_value
+    )
 
     assert param_importance != param_importance_different_n_trees
 
@@ -59,11 +61,11 @@ def test_mean_abs_shap_importance_evaluator_max_depth() -> None:
     study.optimize(objective, n_trials=3)
 
     evaluator = ShapleyImportanceEvaluator(max_depth=1, seed=0)
-    param_importance = evaluator.evaluate(study, params=params, target=get_value)
+    param_importance = evaluator.evaluate(study.get_trials(), params=params, target=get_value)
 
     evaluator = ShapleyImportanceEvaluator(max_depth=2, seed=0)
     param_importance_different_max_depth = evaluator.evaluate(
-        study, params=params, target=get_value
+        study.get_trials(), params=params, target=get_value
     )
 
     assert param_importance != param_importance_different_max_depth
@@ -74,14 +76,18 @@ def test_mean_abs_shap_importance_evaluator_seed() -> None:
     study.optimize(objective, n_trials=3)
 
     evaluator = ShapleyImportanceEvaluator(seed=2)
-    param_importance = evaluator.evaluate(study, params=params, target=get_value)
+    param_importance = evaluator.evaluate(study.get_trials(), params=params, target=get_value)
 
     evaluator = ShapleyImportanceEvaluator(seed=2)
-    param_importance_same_seed = evaluator.evaluate(study, params=params, target=get_value)
+    param_importance_same_seed = evaluator.evaluate(
+        study.get_trials(), params=params, target=get_value
+    )
     assert param_importance == param_importance_same_seed
 
     evaluator = ShapleyImportanceEvaluator(seed=3)
-    param_importance_different_seed = evaluator.evaluate(study, params=params, target=get_value)
+    param_importance_different_seed = evaluator.evaluate(
+        study.get_trials(), params=params, target=get_value
+    )
     assert param_importance != param_importance_different_seed
 
 
@@ -92,9 +98,9 @@ def test_mean_abs_shap_importance_evaluator_with_target() -> None:
     study.optimize(objective, n_trials=3)
 
     evaluator = ShapleyImportanceEvaluator(seed=0)
-    param_importance = evaluator.evaluate(study, params=params, target=get_value)
+    param_importance = evaluator.evaluate(study.get_trials(), params=params, target=get_value)
     param_importance_with_target = evaluator.evaluate(
-        study,
+        study.get_trials(),
         params=params,
         target=lambda t: t.params["x1"] + t.params["x2"],
     )
@@ -113,7 +119,9 @@ def test_shap_importance_evaluator_with_infinite(inf_value: float) -> None:
     study.optimize(objective, n_trials=n_trial)
 
     evaluator = ShapleyImportanceEvaluator(seed=seed)
-    param_importance_without_inf = evaluator.evaluate(study, params=params, target=get_value)
+    param_importance_without_inf = evaluator.evaluate(
+        study.get_trials(), params=params, target=get_value
+    )
 
     # A trial with an inf value is added into the study manually.
     study.add_trial(
@@ -129,7 +137,9 @@ def test_shap_importance_evaluator_with_infinite(inf_value: float) -> None:
         )
     )
     # Importance scores are calculated with a trial with an inf value.
-    param_importance_with_inf = evaluator.evaluate(study, params=params, target=get_value)
+    param_importance_with_inf = evaluator.evaluate(
+        study.get_trials(), params=params, target=get_value
+    )
 
     # Obtained importance scores should be the same between with inf and without inf,
     # because the last trial whose objective value is an inf is ignored.
@@ -159,7 +169,7 @@ def test_multi_objective_shap_importance_evaluator_with_infinite(
 
     evaluator = ShapleyImportanceEvaluator(seed=seed)
     param_importance_without_inf = evaluator.evaluate(
-        study, params=params, target=lambda t: t.values[target_idx]
+        study.get_trials(), params=params, target=lambda t: t.values[target_idx]
     )
 
     # A trial with an inf value is added into the study manually.
@@ -177,7 +187,7 @@ def test_multi_objective_shap_importance_evaluator_with_infinite(
     )
     # Importance scores are calculated with a trial with an inf value.
     param_importance_with_inf = evaluator.evaluate(
-        study, params=params, target=lambda t: t.values[target_idx]
+        study.get_trials(), params=params, target=lambda t: t.values[target_idx]
     )
 
     # Obtained importance scores should be the same between with inf and without inf,


### PR DESCRIPTION

## Motivation
This is a followup PR from #3589. @c-bata had a performance concern in #3589. We resolve the problem by removing the duplicated calls to `study.get_trials`.

## Description of the changes
We change the interface of `BaseImportanceEvaluator.evaluate` to pass the list of `completed_trials`, rather than `study` itself. 

In addition to performance improvement, this also makes it easier to test the functions. However, refactoring the tests is out of scope of this PR.
