### PR TITLE
hotfix: Add a version constraint of cached-path

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -92,6 +92,8 @@ def get_extras_require() -> Dict[str, List[str]]:
         ],
         "integration": [
             "allennlp>=2.2.0 ; python_version>'3.6'",
+            # TODO(c-bata): Remove cached-path after allennllp supports v1.1.3
+            "cached-path<=1.1.2 ; python_version>'3.6'",
             "botorch>=0.4.0 ; python_version>'3.6'",
             "catalyst>=21.3 ; python_version>'3.6'",
             "catboost>=0.26",


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
Fix the tests of allennlp integration.
https://github.com/optuna/optuna/runs/6871089185?check_suite_focus=true

## Description of the changes
<!-- Describe the changes in this PR. -->
AllenNLP uses `cached_path.file_friendly_logging()` function [here](https://github.com/allenai/allennlp/blob/a6271a319cb92f73e798cf3a33ac49ee18cd7cc5/allennlp/common/file_utils.py#L135). However, [config-path v1.1.3](https://github.com/allenai/cached_path/releases/tag/v1.1.3) removed it.

In this PR, I add a version constraint as a hotfix.
