### PR TITLE
Remove `trial_values` records whose values are None

### DIFF
--- a/optuna/storages/_rdb/alembic/versions/v3.0.0.b.py
+++ b/optuna/storages/_rdb/alembic/versions/v3.0.0.b.py
@@ -60,7 +60,7 @@ def upgrade():
         .filter(and_(TrialModel.state == TrialState.COMPLETE, TrialValueModel.value.is_(None)))
         .count()
     ) != 0:
-        raise ValueError("Found invalid trial_values' records (value=None and state='Complete')")
+        raise ValueError("Found invalid trial_values records (value=None and state='COMPLETE')")
     session.query(TrialValueModel).filter(TrialValueModel.value.is_(None)).delete()
 
     with op.batch_alter_table("trial_intermediate_values") as batch_op:

--- a/optuna/storages/_rdb/alembic/versions/v3.0.0.b.py
+++ b/optuna/storages/_rdb/alembic/versions/v3.0.0.b.py
@@ -79,7 +79,7 @@ def upgrade():
         batch_op.alter_column(
             "value",
             type_=Float(precision=FLOAT_PRECISION),
-            existing_nullable=False,
+            nullable=False,
         )
 
 

--- a/optuna/storages/_rdb/alembic/versions/v3.0.0.b.py
+++ b/optuna/storages/_rdb/alembic/versions/v3.0.0.b.py
@@ -5,8 +5,17 @@ Revises: v3.0.0.a
 Create Date: 2022-04-27 16:31:42.012666
 
 """
+import enum
+
 from alembic import op
+from sqlalchemy import and_
+from sqlalchemy import Column
+from sqlalchemy import Enum
 from sqlalchemy import Float
+from sqlalchemy import ForeignKey
+from sqlalchemy import Integer
+from sqlalchemy.orm import declarative_base
+from sqlalchemy.orm import Session
 
 
 # revision identifiers, used by Alembic.
@@ -15,10 +24,45 @@ down_revision = "v3.0.0.a"
 branch_labels = None
 depends_on = None
 
+BaseModel = declarative_base()
 FLOAT_PRECISION = 53
 
 
+class TrialState(enum.Enum):
+    RUNNING = 0
+    COMPLETE = 1
+    PRUNED = 2
+    FAIL = 3
+    WAITING = 4
+
+
+class TrialModel(BaseModel):
+    __tablename__ = "trials"
+    trial_id = Column(Integer, primary_key=True)
+    number = Column(Integer)
+    state = Column(Enum(TrialState), nullable=False)
+
+
+class TrialValueModel(BaseModel):
+    __tablename__ = "trial_values"
+    trial_value_id = Column(Integer, primary_key=True)
+    trial_id = Column(Integer, ForeignKey("trials.trial_id"), nullable=False)
+    value = Column(Float, nullable=False)
+
+
 def upgrade():
+    bind = op.get_bind()
+    session = Session(bind=bind)
+
+    if (
+        session.query(TrialValueModel)
+        .join(TrialModel, TrialValueModel.trial_id == TrialModel.trial_id)
+        .filter(and_(TrialModel.state == TrialState.COMPLETE, TrialValueModel.value.is_(None)))
+        .count()
+    ) != 0:
+        raise ValueError("Found invalid trial_values' records (value=None and state='Complete')")
+    session.query(TrialValueModel).filter(TrialValueModel.value.is_(None)).delete()
+
     with op.batch_alter_table("trial_intermediate_values") as batch_op:
         batch_op.alter_column(
             "intermediate_value",


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
I found an Optuna DB that contains `trial_values` records which `value` column is `NULL` although the `value` column of `trial_values` table is defined as `nullable=False`. It causes a migration error while executing a migration script `v3.0.0.b.py`.
https://github.com/optuna/optuna/blob/master/optuna/storages/_rdb/alembic/versions/v3.0.0.b.py#L34-L39

The `value` column was supposed to changed `nullable=False` at #2030. However, the schema migration to make the column nullable is not added in `v2.4.0.a.py` script. Furthermore, it inserts trial_values records for RUNNING, WAITING, and PRUNED trials here:
https://github.com/optuna/optuna/blob/c51af67bde7f67daf9a19227400bc80a51a47ab2/optuna/storages/_rdb/alembic/versions/v2.4.0.a.py#L149-L154

## Description of the changes
<!-- Describe the changes in this PR. -->
The cause of the problem is actually located in `v2.4.0.a.py`. However, about 2.5 years have passed since we released [Optuna v2.4.0](https://github.com/optuna/optuna/releases/tag/v2.4.0). In this PR, I made changes to `v3.0.0.b.py` to fix this issue in the migration script that will be run on the next release of Optuna..
