### PR TITLE
Add random tests for non-dominated sort

### DIFF
--- a/tests/samplers_tests/test_nsgaii.py
+++ b/tests/samplers_tests/test_nsgaii.py
@@ -340,7 +340,7 @@ def test_fast_non_dominated_sort_empty(n_dims: int) -> None:
     directions = [
         random.choice([StudyDirection.MINIMIZE, StudyDirection.MAXIMIZE]) for _ in range(n_dims)
     ]
-    trials = []
+    trials: List[FrozenTrial] = []
     sampler = NSGAIISampler()
     population_per_rank = sampler._fast_non_dominated_sort(trials, directions)
     assert population_per_rank == []


### PR DESCRIPTION
## Motivation
The tests in `test_nsgaii.py` misses some important edge cases. The missed edge cases include
* `inf` and `-inf` in values/constraints
* duplicated values/constraints
* apparently different constraint values with same meaning (e.g. both are feasible)
etc.
We try to cover these cases by randomly generating test cases and automatically checking whether the output is correct in those cases.

## Description of the changes
* Add random test cases in `test_nsgaii.py`
* Remove existing duplicate tests
