### PR TITLE
Workaround `mypy` bug

### DIFF
--- a/tests/integration_tests/test_botorch.py
+++ b/tests/integration_tests/test_botorch.py
@@ -1,3 +1,4 @@
+from typing import Any
 from typing import cast
 from typing import Optional
 from typing import Sequence
@@ -78,9 +79,9 @@ def test_botorch_candidates_func_invalid_type() -> None:
         train_obj: torch.Tensor,
         train_con: Optional[torch.Tensor],
         bounds: torch.Tensor,
-    ) -> torch.Tensor:
+    ) -> Any:
         # Must be a `torch.Tensor`, not a list.
-        return torch.rand(1).tolist()
+        return [torch.rand(1).tolist()]
 
     sampler = BoTorchSampler(candidates_func=candidates_func, n_startup_trials=1)
 

--- a/tests/integration_tests/test_botorch.py
+++ b/tests/integration_tests/test_botorch.py
@@ -79,7 +79,7 @@ def test_botorch_candidates_func_invalid_type() -> None:
         train_obj: torch.Tensor,
         train_con: Optional[torch.Tensor],
         bounds: torch.Tensor,
-    ) -> Any:
+    ) -> Any:  # The return type is Any because we don't want mypy to check the type.
         # Must be a `torch.Tensor`, not a list.
         return [0.0]
 

--- a/tests/integration_tests/test_botorch.py
+++ b/tests/integration_tests/test_botorch.py
@@ -81,7 +81,7 @@ def test_botorch_candidates_func_invalid_type() -> None:
         bounds: torch.Tensor,
     ) -> Any:
         # Must be a `torch.Tensor`, not a list.
-        return [torch.rand(1).tolist()]
+        return [0.0]
 
     sampler = BoTorchSampler(candidates_func=candidates_func, n_startup_trials=1)
 


### PR DESCRIPTION
## Motivation
There seems to be a bug in `mypy` that does not correctly keep track of whether `# type: ignore` is used. The line reports error if `# type: ignore` is not there, but reports "unused type ignore" error if `# type: ignore` is there. We workaround this problem by using `typing.Any`.

## Description of the changes
* Use `typing.Any` instead of specifying `Tensor` as type.
* There is a bug that the function does not return a list but a scalar. We fix that bug.
