### PR TITLE
Refactor tests of constrained TPE

### DIFF
--- a/tests/samplers_tests/tpe_tests/test_sampler.py
+++ b/tests/samplers_tests/tpe_tests/test_sampler.py
@@ -768,7 +768,7 @@ def test_constrained_sample_independent_zero_startup() -> None:
     sampler.sample_independent(study, trial, "param-a", dist)
 
 
-@pytest.mark.parametrize("direction, sign", [("minimize", 1), ("maximize", -1)])
+@pytest.mark.parametrize("direction", ["minimize", "maximize"])
 @pytest.mark.parametrize(
     "constraints_enabled, constraints_func, expected_violations",
     [
@@ -778,7 +778,6 @@ def test_constrained_sample_independent_zero_startup() -> None:
 )
 def test_get_observation_pairs(
     direction: str,
-    sign: int,
     constraints_enabled: bool,
     constraints_func: Optional[Callable[[optuna.trial.FrozenTrial], Sequence[float]]],
     expected_violations: List[float],
@@ -805,6 +804,7 @@ def test_get_observation_pairs(
     study = optuna.create_study(direction=direction, sampler=sampler)
     study.optimize(objective, n_trials=5, catch=(RuntimeError,))
 
+    sign = 1 if direction == "minimize" else -1
     scores = [
         (-float("inf"), [sign * 5.0]),  # COMPLETE
         (-7, [sign * 2]),  # PRUNED (with intermediate values)
@@ -855,7 +855,7 @@ def test_get_observation_pairs(
     )
 
 
-@pytest.mark.parametrize("direction, sign", [("minimize", 1), ("maximize", -1)])
+@pytest.mark.parametrize("direction", ["minimize", "maximize"])
 @pytest.mark.parametrize(
     "constraints_enabled, constraints_func, expected_violations",
     [
@@ -865,7 +865,6 @@ def test_get_observation_pairs(
 )
 def test_get_observation_pairs_multi(
     direction: str,
-    sign: int,
     constraints_enabled: bool,
     constraints_func: Optional[Callable[[optuna.trial.FrozenTrial], Sequence[float]]],
     expected_violations: List[float],
@@ -892,6 +891,7 @@ def test_get_observation_pairs_multi(
     study = optuna.create_study(direction=direction, sampler=sampler)
     study.optimize(objective, n_trials=5, catch=(RuntimeError,))
 
+    sign = 1 if direction == "minimize" else -1
     assert _tpe.sampler._get_observation_pairs(
         study, ["x", "y"], True, constraints_enabled=constraints_enabled
     ) == (


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
Follow-up task of #3506 (review comment: https://github.com/optuna/optuna/pull/3506/files#r886353871). The logic of the original tests was made complex by parametrizing `constraints_enabled`.

## Description of the changes
<!-- Describe the changes in this PR. -->
~I split the tests for constrained TPE into different functions.~
According to the private discussion with @HideakiImamura, we decided to keep the parametrization in one function. Instead of branching inside the functions, they are defined by parametrizing tuple.
