### PR TITLE
Add inf & nan tests for test_constraints_func

### DIFF
--- a/tests/samplers_tests/test_nsgaii.py
+++ b/tests/samplers_tests/test_nsgaii.py
@@ -37,7 +37,7 @@ from optuna.trial import FrozenTrial
 def _nan_equal(a: Any, b: Any) -> bool:
     if isinstance(a, float) and isinstance(b, float) and np.isnan(a) and np.isnan(b):
         return True
-    
+
     return a == b
 
 

--- a/tests/samplers_tests/test_nsgaii.py
+++ b/tests/samplers_tests/test_nsgaii.py
@@ -39,6 +39,7 @@ def _nan_equal(a: Any, b: Any) -> bool:
         return True
     return a == b
 
+
 def test_population_size() -> None:
     # Set `population_size` to 10.
     sampler = NSGAIISampler(population_size=10)
@@ -124,10 +125,11 @@ def test_constraints_func_none() -> None:
     for trial in study.trials:
         assert _CONSTRAINTS_KEY not in trial.system_attrs
 
-@pytest.mark.parametrize("constraint_value", [-1.0, 0.0, 1.0,
-     -float("inf"), float("inf"), float("nan")
-    ])
-def test_constraints_func(constraint_value) -> None:
+
+@pytest.mark.parametrize(
+    "constraint_value", [-1.0, 0.0, 1.0, -float("inf"), float("inf"), float("nan")]
+)
+def test_constraints_func(constraint_value: float) -> None:
     n_trials = 4
     n_objectives = 2
     constraints_func_call_count = 0

--- a/tests/samplers_tests/test_nsgaii.py
+++ b/tests/samplers_tests/test_nsgaii.py
@@ -37,6 +37,7 @@ from optuna.trial import FrozenTrial
 def _nan_equal(a: Any, b: Any) -> bool:
     if isinstance(a, float) and isinstance(b, float) and np.isnan(a) and np.isnan(b):
         return True
+    
     return a == b
 
 
@@ -138,7 +139,7 @@ def test_constraints_func(constraint_value: float) -> None:
         nonlocal constraints_func_call_count
         constraints_func_call_count += 1
 
-        return (constraint_value,)
+        return (constraint_value + trial.number,)
 
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", optuna.exceptions.ExperimentalWarning)
@@ -152,7 +153,8 @@ def test_constraints_func(constraint_value: float) -> None:
     assert len(study.trials) == n_trials
     assert constraints_func_call_count == n_trials
     for trial in study.trials:
-        assert _nan_equal(trial.system_attrs[_CONSTRAINTS_KEY], (constraint_value,))
+        for x, y in zip(trial.system_attrs[_CONSTRAINTS_KEY], (constraint_value + trial.number,)):
+            assert _nan_equal(x, y)
 
 
 def test_fast_non_dominated_sort() -> None:


### PR DESCRIPTION

## Motivation
`test_constraints_func` in `test_nsgaii.py` lacks test cases for `inf` or `nan` values. We add those test cases.

## Description of the changes
Add `inf` and `nan` cases for `test_constraints_func`.
