### PR TITLE
Add mo-kurobako benchmark to CI

### DIFF
--- a/.github/workflows/performance-benchmarks-mo-kurobako.yml
+++ b/.github/workflows/performance-benchmarks-mo-kurobako.yml
@@ -75,7 +75,6 @@ jobs:
         chmod +x kurobako
         ./kurobako -h
 
-
     - name: Cache nasbench dataset
       id: cache-nasbench-dataset
       uses: actions/cache@v2

--- a/.github/workflows/performance-benchmarks-mo-kurobako.yml
+++ b/.github/workflows/performance-benchmarks-mo-kurobako.yml
@@ -75,18 +75,6 @@ jobs:
         chmod +x kurobako
         ./kurobako -h
 
-    - name: Cache hpobench dataset
-      id: cache-hpobench-dataset
-      uses: actions/cache@v2
-      with:
-        path: ./fcnet_tabular_benchmarks
-        key: hpobench-dataset
-
-    - name: Download hpobench dataset
-      if: steps.cache-hpobench-dataset.outputs.cache-hit != 'true'
-      run: |
-        wget http://ml4aad.org/wp-content/uploads/2019/01/fcnet_tabular_benchmarks.tar.gz
-        tar xf fcnet_tabular_benchmarks.tar.gz
 
     - name: Cache nasbench dataset
       id: cache-nasbench-dataset

--- a/.github/workflows/performance-benchmarks-mo-kurobako.yml
+++ b/.github/workflows/performance-benchmarks-mo-kurobako.yml
@@ -1,4 +1,4 @@
-name: Performance Benchmarks with kurobako
+name: Performance Benchmarks with mo-kurobako
 
 on:
   workflow_dispatch:

--- a/.github/workflows/performance-benchmarks-mo-kurobako.yml
+++ b/.github/workflows/performance-benchmarks-mo-kurobako.yml
@@ -1,4 +1,4 @@
-name: Performance Benchmarks with mo-kurobako
+name: Performance Benchmarks with kurobako for multi-objective optimization
 
 on:
   workflow_dispatch:

--- a/.github/workflows/performance-benchmarks-mo-kurobako.yml
+++ b/.github/workflows/performance-benchmarks-mo-kurobako.yml
@@ -1,0 +1,130 @@
+name: Performance Benchmarks with kurobako
+
+on:
+  workflow_dispatch:
+    inputs:
+      sampler-list:
+        description: 'Sampler List: A list of samplers to check the performance. Should be a whitespace-separated list of Optuna samplers. Each sampler must exist under `optuna.samplers` or `optuna.integration`.'
+        required: false
+        default: 'RandomSampler TPESampler  NSGAIISampler'
+      sampler-kwargs-list:
+        description: 'Sampler Arguments List: A list of sampler keyword arguments. Should be a whitespace-separated list of json format dictionaries.'
+        required: false
+        default: '{} {\"multivariate\":true,\"constant_liar\":true} {\"population_size\":20}'
+      n-runs:
+        description: 'Number of Studies'
+        required: false
+        default: '10'
+
+
+jobs:
+  performance-benchmarks-kurobako:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Setup Python3.9
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
+
+    - name: Install gnuplot
+      run: |
+        sudo apt update
+        sudo apt -y install gnuplot
+
+    - name: Setup cache
+      uses: actions/cache@v2
+      env:
+        # Caches them under a common name so that they can be used by other performance benchmark.
+        cache-name: performance-benchmarks
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-3.9-${{ env.cache-name }}-${{ hashFiles('**/setup.py') }}-v1
+        restore-keys: |
+          ${{ runner.os }}-3.9-${{ env.cache-name }}-${{ hashFiles('**/setup.py') }}
+
+    - name: Install Python libralies
+      run: |
+        python -m pip install --upgrade pip
+        pip install --progress-bar off -U setuptools
+
+        # Install minimal dependencies and confirm that `import optuna` is successful.
+        pip install --progress-bar off .
+        python -c 'import optuna'
+        optuna --version
+
+        pip install --progress-bar off .[benchmark]
+
+        pip install --progress-bar off kurobako
+
+    - name: Cache kurobako CLI
+      id: cache-kurobako
+      uses: actions/cache@v2
+      with:
+        path: ./kurobako
+        key: kurobako-0-2-9
+
+    - name: Install kurobako CLI
+      if: steps.cache-kurobako.outputs.cache-hit != 'true'
+      run: |
+        curl -L https://github.com/optuna/kurobako/releases/download/0.2.9/kurobako-0.2.9.linux-amd64 -o kurobako
+
+        chmod +x kurobako
+        ./kurobako -h
+
+    - name: Cache hpobench dataset
+      id: cache-hpobench-dataset
+      uses: actions/cache@v2
+      with:
+        path: ./fcnet_tabular_benchmarks
+        key: hpobench-dataset
+
+    - name: Download hpobench dataset
+      if: steps.cache-hpobench-dataset.outputs.cache-hit != 'true'
+      run: |
+        wget http://ml4aad.org/wp-content/uploads/2019/01/fcnet_tabular_benchmarks.tar.gz
+        tar xf fcnet_tabular_benchmarks.tar.gz
+
+    - name: Cache nasbench dataset
+      id: cache-nasbench-dataset
+      uses: actions/cache@v2
+      with:
+        path: ./nasbench_full.bin
+        key: nasbench-dataset
+
+    # Ref: https://github.com/optuna/kurobako/wiki/NASBench
+    - name: Download nasbench dataset
+      if: steps.cache-nasbench-dataset.outputs.cache-hit != 'true'
+      run: |
+        curl -L $(./kurobako dataset nasbench url) -o nasbench_full.tfrecord
+        ./kurobako dataset nasbench convert nasbench_full.tfrecord nasbench_full.bin
+
+    - name: Run performance benchmark
+      run: |
+        python benchmarks/run_mo_kurobako.py \
+          --path-to-kurobako "." \
+          --name-prefix "" \
+          --n-runs ${{ github.event.inputs.n-runs }} \
+          --n-jobs 10 \
+          --sampler-list '${{ github.event.inputs.sampler-list }}' \
+          --sampler-kwargs-list '${{ github.event.inputs.sampler-kwargs-list }}' \
+          --seed 0 \
+          --data-dir "." \
+          --out-dir "out"
+
+    - uses: actions/upload-artifact@v2
+      with:
+        name: benchmark-report
+        path: |
+          out/report.md
+          out/**/*.png
+
+    - uses: actions/download-artifact@v2
+      with:
+        name: benchmark-report
+        path: |
+          out/report.md
+          out/**/*.png

--- a/.github/workflows/performance-benchmarks-mo-kurobako.yml
+++ b/.github/workflows/performance-benchmarks-mo-kurobako.yml
@@ -18,7 +18,7 @@ on:
 
 
 jobs:
-  performance-benchmarks-kurobako:
+  performance-benchmarks-mo-kurobako:
     runs-on: ubuntu-latest
 
     steps:

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -96,6 +96,25 @@ Finally, you can run the script of `benchmarks/run_kurobako.py`.
 ```
 Please see `benchmarks/run_kurobako.py` to check the arguments and those default values.
 
+### Multi-objective support
+We also have benchmarks for multi-objective optimization in `kurobako`. Note that we do not have pruner support for multi-objective optimization yet.
+
+Multi-objective benchmarks can also be run from GitHub Actions or locally. To run it from GitHub Actions, please click `Performance Benchmarks with mo-kurobako` in Step 3. 
+
+To run it locally, please run `benchmarks/run_mo_kurobako.py`. 
+```bash
+% python benchmarks/run_mo_kurobako.py \
+          --path-to-kurobako "" \ # If the `kurobako` command is available.
+          --name "performance-benchmarks" \
+          --n-runs 10 \
+          --n-jobs 10 \
+          --sampler-list "RandomSampler TPESampler  NSGAIISampler" \
+          --sampler-kwargs-list "{} {\"multivariate\":true,\"constant_liar\":true} {\"population_size\":20}" \
+          --seed 0 \
+          --data-dir "." \
+          --out-dir "out"
+```
+
 ## Performance benchmarks with `bayesmark`
 
 This workflow allows to benchmark optimization algorithms available in Optuna with [`bayesmark`](https://github.com/uber/bayesmark). This is done by repeatedly performing hyperparameter search on set of `scikit-learn` models fitted to a list of [toy datasets](https://scikit-learn.org/stable/datasets/toy_dataset.html) and aggregating the results. Those are then compared to baseline provided by random sampler. This benchmark can be run with GitHub Actions or locally.


### PR DESCRIPTION
## Motivation
Currently, optuna has a benchmark `mo-kurobako` but cannot be run with GitHub Actions (cf. #3245). We add a YAML file to enable that.

## Description of the changes
Add `performance-benchmarks-mo-kurobako.yml`.
