### PR TITLE
Control metric decimal digits precision in `bayesmark` benchmark report

### DIFF
--- a/benchmarks/bayesmark/report_bayesmark.py
+++ b/benchmarks/bayesmark/report_bayesmark.py
@@ -33,6 +33,13 @@ class BaseMetric(object, metaclass=abc.ABCMeta):
 
         raise NotImplementedError
 
+    @property
+    @abc.abstractmethod
+    def precision(self) -> int:
+        """Number of digits following decimal point displayed in final report."""
+
+        raise NotImplementedError
+
     @abc.abstractmethod
     def calculate(self, data: pd.DataFrame) -> List[float]:
         """Calculates metric for each study in data frame."""
@@ -42,6 +49,7 @@ class BaseMetric(object, metaclass=abc.ABCMeta):
 
 class BestValueMetric(BaseMetric):
     name = "Best value"
+    precision = 6
 
     def calculate(self, data: pd.DataFrame) -> List[float]:
 
@@ -50,6 +58,7 @@ class BestValueMetric(BaseMetric):
 
 class AUCMetric(BaseMetric):
     name = "AUC"
+    precision = 3
 
     def calculate(self, data: pd.DataFrame) -> List[float]:
 
@@ -62,6 +71,7 @@ class AUCMetric(BaseMetric):
 
 class ElapsedMetric(BaseMetric):
     name = "Elapsed"
+    precision = 3
 
     def calculate(self, data: pd.DataFrame) -> List[float]:
 
@@ -219,7 +229,8 @@ class BayesmarkReportBuilder:
             row_buffer.write(f"|{pos}|{solver}|")
             for metric in metrics:
                 mean, variance = report.summarize_solver(solver, metric)
-                row_buffer.write(f"{mean:.5f} +- {np.sqrt(variance):.5f}|")
+                precision = metric.precision
+                row_buffer.write(f"{mean:.{precision}f} +- {np.sqrt(variance):.{precision}f}|")
 
             self._problems_body.write("".join([row_buffer.getvalue(), _LINE_BREAK]))
             row_buffer.close()


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
This allows each metric to be formatted individually, depending on required precision. Defaults are set to mirror kurobako settings - 6 digits for `best value` metric, 3 for everything else. Follow up to #3584 (one of outstanding tasks mentioned in https://github.com/optuna/optuna/pull/3584#issuecomment-1149669967).

## Description of the changes
<!-- Describe the changes in this PR. -->
* Introduce `precision` property in `BaseMetric` class
* Set precision in all metrics to mirror kurobako
