### PR TITLE
Fix calling storage API in study tests

### DIFF
--- a/tests/study_tests/test_study.py
+++ b/tests/study_tests/test_study.py
@@ -1423,11 +1423,11 @@ def test_study_summary_datetime_start_calculation(storage_mode: str) -> None:
         study.enqueue_trial(params={"x": 1})
 
         # Study summary with only enqueued trials should have null datetime_start
-        summaries = study._storage.get_all_study_summaries(include_best_trial=True)
+        summaries = get_all_study_summaries(study._storage, include_best_trial=True)
         assert summaries[0].datetime_start is None
 
         # Study summary with completed trials should have nonnull datetime_start
         study.optimize(objective, n_trials=1)
         study.enqueue_trial(params={"x": 1})
-        summaries = study._storage.get_all_study_summaries(include_best_trial=True)
+        summaries = get_all_study_summaries(study._storage, include_best_trial=True)
         assert summaries[0].datetime_start is not None

--- a/tests/study_tests/test_study_summary.py
+++ b/tests/study_tests/test_study_summary.py
@@ -3,6 +3,7 @@ import copy
 import pytest
 
 from optuna import create_study
+from optuna import get_all_study_summaries
 from optuna.storages import RDBStorage
 
 
@@ -13,7 +14,7 @@ def test_study_summary_eq_ne() -> None:
     create_study(storage=storage)
     study = create_study(storage=storage)
 
-    summaries = study._storage.get_all_study_summaries(include_best_trial=True)
+    summaries = get_all_study_summaries(study._storage, include_best_trial=True)
     assert len(summaries) == 2
 
     assert summaries[0] == copy.deepcopy(summaries[0])
@@ -33,7 +34,7 @@ def test_study_summary_lt_le() -> None:
     create_study(storage=storage)
     study = create_study(storage=storage)
 
-    summaries = study._storage.get_all_study_summaries(include_best_trial=True)
+    summaries = get_all_study_summaries(study._storage, include_best_trial=True)
     assert len(summaries) == 2
 
     summary_0 = summaries[0]


### PR DESCRIPTION
## Motivation
`test_study.py` and `test_study_summary.py` should call `study.get_all_study_summaries` instead of `storage.get_all_study_summaries`

## Description of the changes
changed from `storage.get_all_study_summaries` to `get_all_study_summaries` which is an alias of `study.get_all_study_summaries` in `test_study.py` and `test_study_summary.py`