### PR TITLE
Unify the logic of `plot_param_importances` functions

### DIFF
--- a/optuna/visualization/_param_importances.py
+++ b/optuna/visualization/_param_importances.py
@@ -26,9 +26,6 @@ logger = get_logger(__name__)
 
 
 class _ImportancesInfo(NamedTuple):
-    title: str
-    x_axis_name: str
-    y_axis_name: str
     importance_values: List[float]
     param_names: List[str]
     importance_labels: List[str]
@@ -43,12 +40,6 @@ def _get_importances_info(
 ) -> _ImportancesInfo:
     _check_plot_args(study, target, target_name)
 
-    title = "Hyperparameter Importances"
-    x_axis_name = f"Importance for {target_name}"
-    y_axis_name = "Hyperparameter"
-
-    # Importances cannot be evaluated without completed trials.
-    # Return an empty figure for consistency with other visualization functions.
     trials = _filter_nonfinite(
         study.get_trials(deepcopy=False, states=(TrialState.COMPLETE,)), target=target
     )
@@ -56,9 +47,6 @@ def _get_importances_info(
     if len(trials) == 0:
         logger.warning("Study instance does not contain completed trials.")
         return _ImportancesInfo(
-            title=title,
-            x_axis_name=x_axis_name,
-            y_axis_name=y_axis_name,
             importance_values=[],
             param_names=[],
             importance_labels=[],
@@ -74,9 +62,6 @@ def _get_importances_info(
     importance_labels = [f"{val:.2f}" if val >= 0.01 else "<0.01" for val in importance_values]
 
     return _ImportancesInfo(
-        title=title,
-        x_axis_name=x_axis_name,
-        y_axis_name=y_axis_name,
         importance_values=importance_values,
         param_names=param_names,
         importance_labels=importance_labels,
@@ -152,9 +137,9 @@ def plot_param_importances(
     importances_info = _get_importances_info(study, evaluator, params, target, target_name)
 
     layout = go.Layout(
-        title=importances_info.title,
-        xaxis={"title": importances_info.x_axis_name},
-        yaxis={"title": importances_info.y_axis_name},
+        title="Hyperparameter Importances",
+        xaxis={"title": f"Importance for {target_name}"},
+        yaxis={"title": "Hyperparameter"},
         showlegend=False,
     )
 

--- a/optuna/visualization/_param_importances.py
+++ b/optuna/visualization/_param_importances.py
@@ -166,7 +166,7 @@ def plot_param_importances(
 
     hovertemplate = [
         _make_hovertext(param_name, importance, study)
-        for (param_name, importance) in zip(param_names, importance_values)
+        for param_name, importance in zip(param_names, importance_values)
     ]
 
     fig = go.Figure(

--- a/optuna/visualization/matplotlib/_param_importances.py
+++ b/optuna/visualization/matplotlib/_param_importances.py
@@ -95,9 +95,9 @@ def plot_param_importances(
     # Set up the graph style.
     plt.style.use("ggplot")  # Use ggplot style sheet for similar outputs to plotly.
     fig, ax = plt.subplots()
-    ax.set_title(importances_info.title)
-    ax.set_xlabel(importances_info.x_axis_name)
-    ax.set_ylabel(importances_info.y_axis_name)
+    ax.set_title("Hyperparameter Importances")
+    ax.set_xlabel(f"Importance for {target_name}")
+    ax.set_ylabel("Hyperparameter")
 
     param_names = importances_info.param_names
     pos = np.arange(len(param_names))

--- a/optuna/visualization/matplotlib/_param_importances.py
+++ b/optuna/visualization/matplotlib/_param_importances.py
@@ -1,19 +1,15 @@
-from collections import OrderedDict
 from typing import Callable
 from typing import List
 from typing import Optional
 
 import numpy as np
 
-import optuna
 from optuna._experimental import experimental_func
 from optuna.importance._base import BaseImportanceEvaluator
 from optuna.logging import get_logger
 from optuna.study import Study
 from optuna.trial import FrozenTrial
-from optuna.trial import TrialState
-from optuna.visualization._utils import _check_plot_args
-from optuna.visualization._utils import _filter_nonfinite
+from optuna.visualization._param_importances import _get_importances_info
 from optuna.visualization.matplotlib._matplotlib_imports import _imports
 
 
@@ -93,43 +89,22 @@ def plot_param_importances(
     """
 
     _imports.check()
-    _check_plot_args(study, target, target_name)
-    return _get_param_importance_plot(study, evaluator, params, target, target_name)
 
-
-def _get_param_importance_plot(
-    study: Study,
-    evaluator: Optional[BaseImportanceEvaluator] = None,
-    params: Optional[List[str]] = None,
-    target: Optional[Callable[[FrozenTrial], float]] = None,
-    target_name: str = "Objective Value",
-) -> "Axes":
+    importances_info = _get_importances_info(study, evaluator, params, target, target_name)
 
     # Set up the graph style.
     plt.style.use("ggplot")  # Use ggplot style sheet for similar outputs to plotly.
     fig, ax = plt.subplots()
-    ax.set_title("Hyperparameter Importances")
-    ax.set_xlabel(f"Importance for {target_name}")
-    ax.set_ylabel("Hyperparameter")
+    ax.set_title(importances_info.title)
+    ax.set_xlabel(importances_info.x_axis_name)
+    ax.set_ylabel(importances_info.y_axis_name)
 
-    # Prepare data for plotting.
-    # Importances cannot be evaluated without completed trials.
-    # Return an empty figure for consistency with other visualization functions.
-    trials = _filter_nonfinite(
-        study.get_trials(deepcopy=False, states=(TrialState.COMPLETE,)), target=target
-    )
-    if len(trials) == 0:
-        _logger.warning("Study instance does not contain completed trials.")
-        return ax
-
-    importances = optuna.importance.get_param_importances(
-        study, evaluator=evaluator, params=params, target=target
-    )
-
-    importances = OrderedDict(reversed(list(importances.items())))
-    importance_values = list(importances.values())
-    param_names = list(importances.keys())
+    param_names = importances_info.param_names
     pos = np.arange(len(param_names))
+    importance_values = importances_info.importance_values
+
+    if len(importance_values) == 0:
+        return ax
 
     # Draw horizontal bars.
     ax.barh(
@@ -141,8 +116,7 @@ def _get_param_importance_plot(
     )
 
     renderer = fig.canvas.get_renderer()
-    for idx, val in enumerate(importance_values):
-        label = f" {val:.2f}" if val >= 0.01 else " <0.01"
+    for idx, (val, label) in enumerate(zip(importance_values, importances_info.importance_labels)):
         text = ax.text(val, idx, label, va="center")
 
         # Sometimes horizontal axis needs to be re-scaled


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

Since `optuan.visualization.plot_param_importances` and `optuan.visualization.matplotlib.plot_param_importances` have almost the same logic to generate figures, this PR aims to reduce the number of lines of duplicated lines in `plot_param_importances`-related files for consistent tests, which are follow-up.


## Description of the changes
<!-- Describe the changes in this PR. -->

By taking the same approach as in https://github.com/optuna/optuna/blob/master/optuna/visualization/_pareto_front.py and #3698,

- Define `_ImportancesInfo` that stores minimal information for the plot not depending on the backend visualisation packages.
- Calls `_get_importances_info` to gather information for the plot from each concrete plot function.