### PR TITLE
Fix postgres primarykey unsorted problem

### DIFF
--- a/optuna/storages/_rdb/storage.py
+++ b/optuna/storages/_rdb/storage.py
@@ -997,6 +997,7 @@ class RDBStorage(BaseStorage, BaseHeartbeat):
                         models.TrialModel.trial_id.in_(trial_ids),
                         models.TrialModel.study_id == study_id,
                     )
+                    .order_by(models.TrialModel.trial_id)
                     .all()
                 )
             except sqlalchemy_exc.OperationalError as e:
@@ -1018,6 +1019,7 @@ class RDBStorage(BaseStorage, BaseHeartbeat):
                     .options(sqlalchemy_orm.selectinload(models.TrialModel.system_attributes))
                     .options(sqlalchemy_orm.selectinload(models.TrialModel.intermediate_values))
                     .filter(models.TrialModel.study_id == study_id)
+                    .order_by(models.TrialModel.trial_id)
                     .all()
                 )
                 trial_models = [t for t in trial_models if t.trial_id in trial_ids]


### PR DESCRIPTION
## Motivation
fix #3605 

## Description of the changes
added `order_by(trial_id)` to the query getting the list of trial_id from the backend. 
