### PR TITLE
Add test cases for crossovers of NSGAII

### DIFF
--- a/tests/samplers_tests/test_nsgaii.py
+++ b/tests/samplers_tests/test_nsgaii.py
@@ -652,9 +652,10 @@ def test_crossover_duplicated_param_values(crossover: BaseCrossover) -> None:
         (VSBXCrossover(), 0.0, np.array([2.0, 3.0])),  # c1 = (p1 + p2) / 2.
         (VSBXCrossover(), 0.5, np.array([3.0, 4.0])),  # p2.
         (VSBXCrossover(), 1.0, np.array([3.0, 4.0])),  # p2.
+        # p1, p2 and p3 are on x + 1, and distance from child to PSL is 0.
+        (UNDXCrossover(), -0.5, np.array([3.0, 4.0])),  # [2, 3] + [-1, -1] + [0, 0].
         (UNDXCrossover(), 0.0, np.array([2.0, 3.0])),  # [2, 3] + [0, 0] + [0, 0].
-        (UNDXCrossover(), 0.5, np.array([1.0, 2.0])),  # [2, 3] + [-1, -1] + [1, 1].
-        (UNDXCrossover(), 1.0, np.array([0.0, 1.0])),  # [2, 3] + [-2, -2] + [0, 0].
+        (UNDXCrossover(), 0.5, np.array([1.0, 2.0])),  # [2, 3] + [-1, -1] + [0, 0].
     ],
 )
 def test_crossover_deterministic(

--- a/tests/samplers_tests/test_nsgaii.py
+++ b/tests/samplers_tests/test_nsgaii.py
@@ -540,7 +540,8 @@ def test_crossover_dims(n_params: int, sampler_class: Callable[[], BaseSampler])
     assert len(study.trials) == n_trials
 
 
-@pytest.mark.parametrize("crossover,population_size",
+@pytest.mark.parametrize(
+    "crossover,population_size",
     [
         (UniformCrossover(), 1),
         (BLXAlphaCrossover(), 1),
@@ -657,9 +658,7 @@ def test_crossover_duplicated_param_values(crossover: BaseCrossover) -> None:
     ],
 )
 def test_crossover_deterministic(
-    crossover: BaseCrossover,
-    rand_value: float,
-    expected_params: np.ndarray
+    crossover: BaseCrossover, rand_value: float, expected_params: np.ndarray
 ) -> None:
 
     study = optuna.study.create_study()

--- a/tests/samplers_tests/test_nsgaii.py
+++ b/tests/samplers_tests/test_nsgaii.py
@@ -540,18 +540,19 @@ def test_crossover_dims(n_params: int, sampler_class: Callable[[], BaseSampler])
     assert len(study.trials) == n_trials
 
 
-@pytest.mark.parametrize("crossover", [UNDXCrossover(), SPXCrossover()])
-def test_crossover_invalid_population(crossover: BaseCrossover) -> None:
-    n_objectives = 2
-    n_trials = 8
-
+@pytest.mark.parametrize("crossover,population_size",
+    [
+        (UniformCrossover(), 1),
+        (BLXAlphaCrossover(), 1),
+        (SBXCrossover(), 1),
+        (VSBXCrossover(), 1),
+        (UNDXCrossover(), 2),
+        (SPXCrossover(), 2),
+    ],
+)
+def test_crossover_invalid_population(crossover: BaseCrossover, population_size: int) -> None:
     with pytest.raises(ValueError):
-        sampler = NSGAIISampler(population_size=2, crossover=crossover)
-        study = optuna.create_study(directions=["minimize"] * n_objectives, sampler=sampler)
-        study.optimize(
-            lambda t: [t.suggest_float(f"x{i}", 0, 1) for i in range(n_objectives)],
-            n_trials=n_trials,
-        )
+        NSGAIISampler(population_size=population_size, crossover=crossover)
 
 
 @pytest.mark.parametrize(

--- a/tests/samplers_tests/test_nsgaii.py
+++ b/tests/samplers_tests/test_nsgaii.py
@@ -579,8 +579,8 @@ def test_crossover_numerical_distribution(crossover: BaseCrossover) -> None:
     child_params = crossover.crossover(parent_params, rng, study, numerical_transform.bounds)
     assert child_params.ndim == 1
     assert len(child_params) == len(search_space)
-    assert np.nan not in child_params
-    assert np.inf not in child_params
+    assert not any(np.isnan(child_params))
+    assert not any(np.isinf(child_params))
 
 
 def test_crossover_inlined_categorical_distribution() -> None:


### PR DESCRIPTION
## Motivation

Recently, several PRs such as https://github.com/optuna/optuna/pull/3683 and https://github.com/optuna/optuna/pull/3706 improves the unit tests of `NSGAIISampler`. This PR is trying to improve the `crossover` tests.

### Test scenario

- The crossovers handle `parameters`. They are `float` values but they does not take `inf`, `-inf`, `nan` unlike trial values and trial intermediate values. So, I didn't add such test cases.
- The return values of crossovers should not be `nan` `inf` and the corresponding test cases exist. I'm not fully sure if it is enough to check a random input. I guess it is acceptable if the next item (edge case checking) can detect the errors of algorithm logic.
- The logic of the crossover algorithms are checked in `test_crossover_deterministic`. Previously, it checks only the center point (roughly speaking) of the crossover models and this PR adds edges of the crossover models.

### Discussions

- All points of `test_crossover_deterministic` test case are on a line (`y = x + 1`). They shrink the distributions of `SPX` and `UNDX` and I don't think it is a typical case.
- If we want to check the crossover algorithms in detail, we can create individual test files. On the other hand, we can check the algorithm implementation using benchmark, not unit tests.

## Description of the changes

- Use `np.isnan` and `np.isinf` instead of `np.nan in ...` and `np.inf in ...`
- Check the invalid population size of all crossovers.
- Check the end-point of crossover models in addition to the mean points.