### PR TITLE
Clarify which trials are used for importance evaluators

### DIFF
--- a/optuna/importance/_fanova/_evaluator.py
+++ b/optuna/importance/_fanova/_evaluator.py
@@ -26,9 +26,10 @@ class FanovaImportanceEvaluator(BaseImportanceEvaluator):
     `An Efficient Approach for Assessing Hyperparameter Importance
     <http://proceedings.mlr.press/v32/hutter14.html>`_.
 
-    Given a study, fANOVA fits a random forest regression model that predicts the objective value
-    given a parameter configuration. The more accurate this model is, the more reliable the
-    importances assessed by this class are.
+    Given a study, fANOVA fits a random forest regression model that predicts the objective values
+    such that their trial states are :class:`~optuna.trial.TrialState.COMPLETE` given a parameter
+    configuration. The more accurate this model is, the more reliable the importances assessed
+    by this class are.
 
     .. note::
 

--- a/optuna/importance/_fanova/_evaluator.py
+++ b/optuna/importance/_fanova/_evaluator.py
@@ -26,9 +26,9 @@ class FanovaImportanceEvaluator(BaseImportanceEvaluator):
     `An Efficient Approach for Assessing Hyperparameter Importance
     <http://proceedings.mlr.press/v32/hutter14.html>`_.
 
-    Given a study, fANOVA fits a random forest regression model that predicts the objective values
-    such that their trial states are :class:`~optuna.trial.TrialState.COMPLETE` given a parameter
-    configuration. The more accurate this model is, the more reliable the importances assessed
+    fANOVA fits a random forest regression model that predicts the objective values
+    of :class:`~optuna.trial.TrialState.COMPLETE` trials given their parameter configurations.
+    The more accurate this model is, the more reliable the importances assessed
     by this class are.
 
     .. note::

--- a/optuna/importance/_mean_decrease_impurity.py
+++ b/optuna/importance/_mean_decrease_impurity.py
@@ -26,8 +26,8 @@ with try_import() as _imports:
 class MeanDecreaseImpurityImportanceEvaluator(BaseImportanceEvaluator):
     """Mean Decrease Impurity (MDI) parameter importance evaluator.
 
-    This evaluator fits a random forest that predicts objective values such that their trial
-    states are :class:`~optuna.trial.TrialState.COMPLETE` given hyperparameter configurations.
+    This evaluator fits fits a random forest regression model that predicts the objective values
+    of :class:`~optuna.trial.TrialState.COMPLETE` trials given their parameter configurations.
     Feature importances are then computed using MDI.
 
     .. note::

--- a/optuna/importance/_mean_decrease_impurity.py
+++ b/optuna/importance/_mean_decrease_impurity.py
@@ -26,8 +26,9 @@ with try_import() as _imports:
 class MeanDecreaseImpurityImportanceEvaluator(BaseImportanceEvaluator):
     """Mean Decrease Impurity (MDI) parameter importance evaluator.
 
-    This evaluator fits a random forest that predicts objective values given hyperparameter
-    configurations. Feature importances are then computed using MDI.
+    This evaluator fits a random forest that predicts objective values such that their trial
+    states are :class:`~optuna.trial.TrialState.COMPLETE` given hyperparameter configurations.
+    Feature importances are then computed using MDI.
 
     .. note::
 

--- a/optuna/integration/shap.py
+++ b/optuna/integration/shap.py
@@ -29,8 +29,9 @@ with try_import() as _imports:
 class ShapleyImportanceEvaluator(BaseImportanceEvaluator):
     """Shapley (SHAP) parameter importance evaluator.
 
-    This evaluator fits a random forest that predicts objective values given hyperparameter
-    configurations. Feature importances are then computed as the mean absolute SHAP values.
+    This evaluator fits a random forest that predicts objective values such that their trial states
+    are :class:`~optuna.trial.TrialState.COMPLETE` given hyperparameter configurations. Feature
+    importances are then computed as the mean absolute SHAP values.
 
     .. note::
 

--- a/optuna/integration/shap.py
+++ b/optuna/integration/shap.py
@@ -29,9 +29,9 @@ with try_import() as _imports:
 class ShapleyImportanceEvaluator(BaseImportanceEvaluator):
     """Shapley (SHAP) parameter importance evaluator.
 
-    This evaluator fits a random forest that predicts objective values such that their trial states
-    are :class:`~optuna.trial.TrialState.COMPLETE` given hyperparameter configurations. Feature
-    importances are then computed as the mean absolute SHAP values.
+    This evaluator fits fits a random forest regression model that predicts the objective values
+    of :class:`~optuna.trial.TrialState.COMPLETE` trials given their parameter configurations.
+    Feature importances are then computed as the mean absolute SHAP values.
 
     .. note::
 


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

As commented by https://github.com/optuna/optuna/discussions/3703#discussioncomment-2993342, users expect pruned trials with intermediate values also used for importance score calculation when users read the docs. For example, fANOVA's page says

> Given a study, fANOVA fits a random forest regression model that predicts the objective value given a parameter configuration.

and in fact, pruned trials have objective values when they have intermediate values (which is also a debatable feature https://github.com/optuna/optuna/issues/3542). 


## Description of the changes
<!-- Describe the changes in this PR. -->

Clarify which trials are used for importance evaluators.