### PR TITLE
Use `get_trials` with `states` argument to filter trials depending on trial state

### DIFF
--- a/optuna/integration/botorch.py
+++ b/optuna/integration/botorch.py
@@ -445,7 +445,7 @@ class BoTorchSampler(BaseSampler):
         if len(search_space) == 0:
             return {}
 
-        trials = [t for t in study.get_trials(deepcopy=False) if t.state == TrialState.COMPLETE]
+        trials = study.get_trials(deepcopy=False, states=(TrialState.COMPLETE,))
 
         n_trials = len(trials)
         if n_trials < self._n_startup_trials:

--- a/optuna/integration/cma.py
+++ b/optuna/integration/cma.py
@@ -183,7 +183,7 @@ class PyCmaSampler(BaseSampler):
         self._raise_error_if_multi_objective(study)
 
         if self._warn_independent_sampling:
-            complete_trials = [t for t in study.trials if t.state == TrialState.COMPLETE]
+            complete_trials = study.get_trials(deepcopy=False, states=(TrialState.COMPLETE,))
             if len(complete_trials) >= self._n_startup_trials:
                 self._log_independent_sampling(trial, param_name)
 
@@ -210,7 +210,7 @@ class PyCmaSampler(BaseSampler):
             self._warn_independent_sampling = False
             return {}
 
-        complete_trials = [t for t in study.trials if t.state == TrialState.COMPLETE]
+        complete_trials = study.get_trials(deepcopy=False, states=(TrialState.COMPLETE,))
         if len(complete_trials) < self._n_startup_trials:
             return {}
 

--- a/optuna/pruners/_hyperband.py
+++ b/optuna/pruners/_hyperband.py
@@ -178,12 +178,8 @@ class HyperbandPruner(BasePruner):
 
     def _try_initialization(self, study: "optuna.study.Study") -> None:
         if self._max_resource == "auto":
-            trials = study.get_trials(deepcopy=False)
-            n_steps = [
-                t.last_step
-                for t in trials
-                if t.state == TrialState.COMPLETE and t.last_step is not None
-            ]
+            trials = study.get_trials(deepcopy=False, states=(TrialState.COMPLETE,))
+            n_steps = [t.last_step for t in trials if t.last_step is not None]
 
             if not n_steps:
                 return

--- a/optuna/pruners/_percentile.py
+++ b/optuna/pruners/_percentile.py
@@ -22,14 +22,12 @@ def _get_best_intermediate_result_over_steps(
 
 
 def _get_percentile_intermediate_result_over_trials(
-    all_trials: List["optuna.trial.FrozenTrial"],
+    completed_trials: List["optuna.trial.FrozenTrial"],
     direction: StudyDirection,
     step: int,
     percentile: float,
     n_min_trials: int,
 ) -> float:
-
-    completed_trials = [t for t in all_trials if t.state == TrialState.COMPLETE]
 
     if len(completed_trials) == 0:
         raise ValueError("No trials have been completed.")
@@ -176,8 +174,8 @@ class PercentilePruner(BasePruner):
 
     def prune(self, study: "optuna.study.Study", trial: "optuna.trial.FrozenTrial") -> bool:
 
-        all_trials = study.get_trials(deepcopy=False)
-        n_trials = len([t for t in all_trials if t.state == TrialState.COMPLETE])
+        completed_trials = study.get_trials(deepcopy=False, states=(TrialState.COMPLETE,))
+        n_trials = len(completed_trials)
 
         if n_trials == 0:
             return False
@@ -204,7 +202,7 @@ class PercentilePruner(BasePruner):
             return True
 
         p = _get_percentile_intermediate_result_over_trials(
-            all_trials, direction, step, self._percentile, self._n_min_trials
+            completed_trials, direction, step, self._percentile, self._n_min_trials
         )
         if math.isnan(p):
             return False

--- a/optuna/visualization/_optimization_history.py
+++ b/optuna/visualization/_optimization_history.py
@@ -103,11 +103,7 @@ def _get_optimization_history_plot(
 
     all_trials = list(
         itertools.chain.from_iterable(
-            (
-                trial
-                for trial in study.get_trials(deepcopy=False)
-                if trial.state == TrialState.COMPLETE
-            )
+            (trial for trial in study.get_trials(deepcopy=False, states=(TrialState.COMPLETE,)))
             for study in studies
         )
     )

--- a/optuna/visualization/_optimization_history.py
+++ b/optuna/visualization/_optimization_history.py
@@ -103,8 +103,7 @@ def _get_optimization_history_plot(
 
     all_trials = list(
         itertools.chain.from_iterable(
-            (trial for trial in study.get_trials(deepcopy=False, states=(TrialState.COMPLETE,)))
-            for study in studies
+            study.get_trials(deepcopy=False, states=(TrialState.COMPLETE,)) for study in studies
         )
     )
 

--- a/optuna/visualization/_pareto_front.py
+++ b/optuna/visualization/_pareto_front.py
@@ -220,7 +220,7 @@ def _get_pareto_front_info(
     if constraints_func is not None:
         feasible_trials = []
         infeasible_trials = []
-        for trial in study.get_trials(states=(TrialState.COMPLETE,)):
+        for trial in study.get_trials(deepcopy=False, states=(TrialState.COMPLETE,)):
             if all(map(lambda x: x <= 0.0, constraints_func(trial))):
                 feasible_trials.append(trial)
             else:
@@ -240,7 +240,7 @@ def _get_pareto_front_info(
 
         if include_dominated_trials:
             non_best_trials = _get_non_pareto_front_trials(
-                study.get_trials(deepcopy=False), best_trials
+                study.get_trials(deepcopy=False, states=(TrialState.COMPLETE,)), best_trials
             )
         else:
             non_best_trials = []
@@ -348,7 +348,7 @@ def _get_non_pareto_front_trials(
 
     non_pareto_trials = []
     for trial in trials:
-        if trial.state == TrialState.COMPLETE and trial not in pareto_trials:
+        if trial not in pareto_trials:
             non_pareto_trials.append(trial)
     return non_pareto_trials
 

--- a/optuna/visualization/_slice.py
+++ b/optuna/visualization/_slice.py
@@ -86,7 +86,7 @@ def _get_slice_plot(
 
     layout = go.Layout(title="Slice Plot")
 
-    trials = [trial for trial in study.trials if trial.state == TrialState.COMPLETE]
+    trials = study.get_trials(deepcopy=False, states=(TrialState.COMPLETE,))
 
     if len(trials) == 0:
         _logger.warning("Your study does not have any completed trials.")

--- a/optuna/visualization/matplotlib/_optimization_history.py
+++ b/optuna/visualization/matplotlib/_optimization_history.py
@@ -115,8 +115,7 @@ def _get_optimization_history_plot(
     # Prepare data for plotting.
     all_trials = list(
         itertools.chain.from_iterable(
-            (trial for trial in study.get_trials(deepcopy=False, states=(TrialState.COMPLETE,)))
-            for study in studies
+            study.get_trials(deepcopy=False, states=(TrialState.COMPLETE,)) for study in studies
         )
     )
 

--- a/optuna/visualization/matplotlib/_optimization_history.py
+++ b/optuna/visualization/matplotlib/_optimization_history.py
@@ -115,11 +115,7 @@ def _get_optimization_history_plot(
     # Prepare data for plotting.
     all_trials = list(
         itertools.chain.from_iterable(
-            (
-                trial
-                for trial in study.get_trials(deepcopy=False)
-                if trial.state == TrialState.COMPLETE
-            )
+            (trial for trial in study.get_trials(deepcopy=False, states=(TrialState.COMPLETE,)))
             for study in studies
         )
     )

--- a/optuna/visualization/matplotlib/_slice.py
+++ b/optuna/visualization/matplotlib/_slice.py
@@ -93,7 +93,7 @@ def _get_slice_plot(
 ) -> "Axes":
 
     # Calculate basic numbers for plotting.
-    trials = [trial for trial in study.trials if trial.state == TrialState.COMPLETE]
+    trials = study.get_trials(deepcopy=False, states=(TrialState.COMPLETE,))
 
     if len(trials) == 0:
         _logger.warning("Your study does not have any completed trials.")

--- a/tests/pruners_tests/test_percentile.py
+++ b/tests/pruners_tests/test_percentile.py
@@ -171,12 +171,12 @@ def test_get_percentile_intermediate_result_over_trials() -> None:
         trial_ids = [_study._storage.create_new_trial(_study._study_id) for _ in range(trial_num)]
 
         for step, values in enumerate(_intermediate_values):
-            # Study does not have any trials.
+            # Study does not have any complete trials.
             with pytest.raises(ValueError):
-                _all_trials = _study.get_trials()
+                completed_trials = _study.get_trials(deepcopy=False, states=(TrialState.COMPLETE,))
                 _direction = _study.direction
                 _percentile._get_percentile_intermediate_result_over_trials(
-                    _all_trials, _direction, step, 25, 1
+                    completed_trials, _direction, step, 25, 1
                 )
 
             for i in range(trial_num):

--- a/tests/study_tests/test_study.py
+++ b/tests/study_tests/test_study.py
@@ -96,7 +96,7 @@ def check_study(study: Study) -> None:
 
     assert not study._is_multi_objective()
 
-    complete_trials = [t for t in study.trials if t.state == TrialState.COMPLETE]
+    complete_trials = study.get_trials(deepcopy=False, states=(TrialState.COMPLETE,))
     if len(complete_trials) == 0:
         with pytest.raises(ValueError):
             study.best_params


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

`study.get_trials` method can fetch the trials depending on their trial state. By using this, we can remove several `if` filtering in optuna codebase.

## Description of the changes
<!-- Describe the changes in this PR. -->

As the title, use `get_trials` with explicit states values rather than get all trials then filter them by their state.