### PR TITLE
Enable mypy's strict configs

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -12,11 +12,17 @@ exclude = venv,build,tutorial,.tox,.asv
 
 # This section is for mypy.
 [mypy]
+# Options configure mypy's strict mode.
+warn_unused_configs = True
+disallow_untyped_calls = True
 disallow_untyped_defs = True
-ignore_missing_imports = True
+disallow_incomplete_defs = True
+check_untyped_defs = True
 no_implicit_optional = True
 warn_redundant_casts = True
-strict_equality = True
 warn_unused_ignores = True
-disallow_untyped_calls = True
+strict_equality = True
+strict_concatenate = True
+
+ignore_missing_imports = True
 exclude = venv|build|docs|tutorial|optuna/storages/_rdb/alembic


### PR DESCRIPTION
## Motivation
#3579 

## Description of the changes
This PR sets mypy's strict options, `warn_unused_configs`, `disallow_incomplete_defs`, `check_untyped_defs`, and `strict_concatenate`, as `True` default.
