### PR TITLE
Return Python's native float values.

### DIFF
--- a/benchmarks/bayesmark/report_bayesmark.py
+++ b/benchmarks/bayesmark/report_bayesmark.py
@@ -104,7 +104,7 @@ class PartialReport:
             raise ValueError(f"{solver} not found in report.")
 
         run_metrics = metric.calculate(solver_data)
-        return np.mean(run_metrics), np.var(run_metrics)
+        return np.mean(run_metrics).item(), np.var(run_metrics).item()
 
     def sample_performance(self, metric: BaseMetric) -> Samples:
 


### PR DESCRIPTION
## Motivation

Fix the mypy error of the daily CI https://github.com/optuna/optuna/runs/7014092845?check_suite_focus=true#step:8:10.
@not522 mentioned that the error might be related to numpy 1.23.0 release.
https://pypi.org/project/numpy/1.23.0/

## Description of the changes

- Convert `numpy.floating` to Python's native `float`.

```python
>>> import numpy as np
>>> y = np.var(1)
>>> y
0.0
>>> type(y)
<class 'numpy.float64'>
>>> type(y.item())
<class 'float'>
```