### PR TITLE
Simplify `bayesmark` benchmark report rendering

### DIFF
--- a/.github/workflows/performance-benchmarks-bayesmark.yml
+++ b/.github/workflows/performance-benchmarks-bayesmark.yml
@@ -105,7 +105,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install --progress-bar off -U setuptools wheel
-        pip install --progress-bar off numpy scipy pandas
+        pip install --progress-bar off numpy scipy pandas Jinja2
 
     - name: Run benchmark report builder
       run: |

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -145,7 +145,7 @@ See [this doc](https://bayesmark.readthedocs.io/en/stable/scoring.html) for more
 
 CI runs benchmarks on all model/dataset combination in parallel, hovever running benchmark on single problem locally is possoble. To do this, first install required Python packages.
 ```bash
-pip install bayesmark matplotlib
+pip install bayesmark matplotlib numpy scipy pandas Jinja2
 ```
 
 Benchmark run can be started with

--- a/benchmarks/bayesmark/report_bayesmark.py
+++ b/benchmarks/bayesmark/report_bayesmark.py
@@ -189,18 +189,17 @@ class DewanckerRanker:
 class BayesmarkReportBuilder:
     def __init__(self) -> None:
 
-        self._solvers: Set[str] = set()
-        self._datasets: Set[str] = set()
-        self._models: Set[str] = set()
-        self._firsts: Dict[str, int] = defaultdict(int)
-        self._borda: Dict[str, int] = defaultdict(int)
-        self._metric_precedence = str()
-        self._problems_counter = 1
-        self._problems_body = io.StringIO()
+        self.solvers: Set[str] = set()
+        self.datasets: Set[str] = set()
+        self.models: Set[str] = set()
+        self.firsts: Dict[str, int] = defaultdict(int)
+        self.borda: Dict[str, int] = defaultdict(int)
+        self.metric_precedence = str()
+        self.problems: List[Problem] = list()
 
     def set_precedence(self, metrics: List[BaseMetric]) -> None:
 
-        self._metric_precedence = " -> ".join([m.name for m in metrics])
+        self.metric_precedence = " -> ".join([m.name for m in metrics])
 
     def add_problem(
         self,
@@ -242,18 +241,18 @@ class BayesmarkReportBuilder:
 
         for solver, borda in ranking:
             if borda == max(ranking.borda):
-                self._firsts[solver] += 1
-            self._borda[solver] += borda
+                self.firsts[solver] += 1
+            self.borda[solver] += borda
         return self
 
     def add_dataset(self, dataset: str) -> "BayesmarkReportBuilder":
 
-        self._datasets.update(dataset)
+        self.datasets.update(dataset)
         return self
 
     def add_model(self, model: str) -> "BayesmarkReportBuilder":
 
-        self._models.update(model)
+        self.models.update(model)
         return self
 
     def assemble_report(self) -> str:

--- a/benchmarks/bayesmark/report_bayesmark.py
+++ b/benchmarks/bayesmark/report_bayesmark.py
@@ -1,6 +1,6 @@
 import abc
 from collections import defaultdict
-import io
+from dataclasses import dataclass
 import itertools
 import os
 from typing import Dict
@@ -10,16 +10,13 @@ from typing import Optional
 from typing import Set
 from typing import Tuple
 
+from jinja2 import Environment
+from jinja2 import FileSystemLoader
 import numpy as np
 import pandas as pd
 from scipy.special import binom
 from scipy.stats import mannwhitneyu
 
-
-_LINE_BREAK = "\n"
-_TABLE_HEADER = "|Ranking|Solver|"
-_HEADER_FORMAT = "|:---|---:|"
-_OVERALL_HEADER = "|Solver|Borda|Firsts|\n|:---|---:|---:|\n"
 
 Moments = Tuple[float, float]
 Samples = Dict[str, List[float]]
@@ -260,32 +257,10 @@ class BayesmarkReportBuilder:
 
     def assemble_report(self) -> str:
 
-        num_datasets = len(self._datasets)
-        num_models = len(self._models)
-
-        overall_body = io.StringIO()
-        overall_body.write(_OVERALL_HEADER)
-        for solver in self._solvers:
-            row = f"|{solver}|{self._borda[solver]}|{self._firsts[solver]}|"
-            overall_body.write("".join([row, _LINE_BREAK]))
-
-        with open(os.path.join("benchmarks", "bayesmark", "report_template.md")) as file:
-            report_template = file.read()
-
-        # TODO(xadrianzetx) Consider using proper templating engine.
-        report = report_template.format(
-            num_solvers=len(self._solvers),
-            num_datasets=num_datasets,
-            num_models=num_models,
-            precedence=self._metric_precedence,
-            num_problems=num_datasets * num_models,
-            overall=overall_body.getvalue(),
-            leaderboards=self._problems_body.getvalue(),
-        )
-
-        overall_body.close()
-        self._problems_body.close()
-        return report
+        loader = FileSystemLoader(os.path.join("benchmarks", "bayesmark"))
+        env = Environment(loader=loader)
+        report_template = env.get_template("report_template.md")
+        return report_template.render(report=self)
 
 
 def build_report() -> None:

--- a/benchmarks/bayesmark/report_bayesmark.py
+++ b/benchmarks/bayesmark/report_bayesmark.py
@@ -206,8 +206,8 @@ class BayesmarkReportBuilder:
         self.models: Set[str] = set()
         self.firsts: Dict[str, int] = defaultdict(int)
         self.borda: Dict[str, int] = defaultdict(int)
-        self.metric_precedence = str()
-        self.problems: List[Problem] = list()
+        self.metric_precedence = ""
+        self.problems: List[Problem] = []
 
     def set_precedence(self, metrics: List[BaseMetric]) -> None:
 

--- a/benchmarks/bayesmark/report_template.md
+++ b/benchmarks/bayesmark/report_template.md
@@ -1,10 +1,10 @@
 # Benchmark Result Report
 
-* Number of Solvers: {num_solvers}
-* Number of Models: {num_models}
-* Number of Datasets: {num_datasets}
-* Number of Problems: {num_problems}
-* Metrics Precedence: {precedence}
+* Number of Solvers: {{ report.solvers|length }}
+* Number of Models: {{ report.models|length }}
+* Number of Datasets: {{ report.datasets|length }}
+* Number of Problems: {{ report.problems|length }}
+* Metrics Precedence: {{ report.metric_precedence }}
 
 Please refer to ["A Strategy for Ranking Optimizers using Multiple Criteria"][Dewancker, Ian, et al., 2016] for the ranking strategy used in this report.
 
@@ -19,11 +19,23 @@ Please refer to ["A Strategy for Ranking Optimizers using Multiple Criteria"][De
 
 ## Overall Results
 
-{overall}
+|Solver|Borda|Firsts|
+|:---|---:|---:|
+{% for solver in report.solvers -%}
+|{{ solver }}|{{ report.borda[solver] }}|{{ report.firsts[solver] }}|
+{% endfor %}
 
 ## Individual Results
 
-{leaderboards}
+{% for problem in report.problems %}
+### ({{ problem.number }}) Problem: {{ problem.name }}
+
+|Ranking|Solver|{%- for metric in problem.metrics -%}{{ metric.name }} (avg +- std)|{% endfor %}
+|:---|---:|{%- for _ in range(problem.metrics|length) -%}---:|{% endfor %}
+{% for solver in problem.solvers -%}
+|{{ solver.rank }}|{{ solver.name }}|{{ solver.results|join('|') }}|
+{% endfor -%}
+{% endfor %}
 
 ## Datasets
 


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
Previously, `BayesmarkReportBuilder` class was responsible for handling report data as well as rendering the benchmark report. This was accomplished somewhat awkwardly with multiple string buffers, which made it hard to read and difficult to extend as any additions to report structure (such as ones mentioned in https://github.com/optuna/optuna/pull/3584#discussion_r885216386) would significantly bump code complexity. In this PR, we are offloading all rendering related tasks to templating engine, leaving aforementioned class to deal only with data. This simplifies code by a fair margin and makes it a bit more SOLID and easy to extend.

## Description of the changes
<!-- Describe the changes in this PR. -->
* Remove all string buffers from `BayesmarkReportBuilder`
* Introduce simple abstractions over report data
* Offload report rendering to templating engine