### PR TITLE
Update `CONTRIBUTING.md`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ If you feel like giving a hand, here are some ways:
     - Also, sharing how you enjoy Optuna is a huge contribution! If you write a blog, let us know about it!
 
 
-# Pull Request Guidelines
+## Pull Request Guidelines
 
 If you make a pull request, please follow the guidelines below:
 
@@ -57,7 +57,7 @@ cd optuna
 pip install -e .
 ```
 
-## Checking the Format, Coding Style, and Type Hints
+### Checking the Format, Coding Style, and Type Hints
 
 Code is formatted with [black](https://github.com/psf/black),
 and docstrings are formatted with [blackdoc](https://github.com/keewis/blackdoc).
@@ -85,7 +85,7 @@ $ pip install ".[checking]"
 $ ./formats.sh
 ```
 
-## Documentation
+### Documentation
 
 When adding a new feature to the framework, you also need to document it in the reference.
 The documentation source is stored under the [docs](./docs) directory and written in [reStructuredText format](http://www.sphinx-doc.org/en/master/usage/restructuredtext/index.html).
@@ -139,7 +139,7 @@ Two specific conventions and limitations for Optuna tutorials:
 2. Execution time of the new content needs to be less than three minutes. This limitation derives from Read The Docs. If your content runs some hyperparameter optimization, set the `timeout` to 180 or less. You can check this limitation on [Read the Docs - Build Process](https://docs.readthedocs.io/en/stable/builds.html).
 
 
-## Unit Tests
+### Unit Tests
 
 When adding a new feature or fixing a bug, you also need to write sufficient test code.
 We use [pytest](https://pytest.org/) as the testing framework and
@@ -169,20 +169,18 @@ pytest tests/${TARGET_TEST_FILE_NAME} -k ${TARGET_TEST_FUNCTION_NAME}
 
 See also the [Optuna Test Policy](https://github.com/optuna/optuna/wiki/Test-Policy), which describes the principles to write and maintain Optuna tests to meet certain quality requirements.
 
-## Continuous Integration and Local Verification
+### Continuous Integration and Local Verification
 
 Optuna repository uses GitHub Actions and CircleCI.
 
 Currently, we are migrating to GitHub Actions but still we use CircleCI for testing `document`
 because it makes it much easier to check built documentation.
 
-## Creating a Pull Request
+### Creating a Pull Request
 
-When you are ready to create a pull request, please try to keep the following in mind:
+When you are ready to create a pull request, please try to keep the following in mind.
 
-### Title
-
-The title of your pull request should
+First, the **title** of your pull request should:
 
 - briefly describe and reflect the changes
 - wrap any code with backticks
@@ -190,19 +188,17 @@ The title of your pull request should
 
 *The title will be directly visible in the release notes.*
 
-#### Example
+For example:
 
-Introduces Tree-structured Parzen Estimator to `optuna.samplers`
+- Introduces Tree-structured Parzen Estimator to `optuna.samplers`
 
-### Description
-
-The description of your pull request should
+Second, the **description** of your pull request should:
 
 - describe the motivation
 - describe the changes
 - if still work-in-progress, describe remaining tasks
 
-# Learning Optuna's Implementation
+## Learning Optuna's Implementation
 
 With Optuna actively being developed and the amount of code growing,
 it has become difficult to get a hold of the overall flow from reading the code.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,15 +26,23 @@ If you feel like giving a hand, here are some ways:
     - __Contribution to Optuna includes not only sending pull requests, but also writing down your comments on issues and pull requests by others, and joining conversations/discussions on [Gitter](https://gitter.im/optuna/optuna).__
     - Also, sharing how you enjoy Optuna is a huge contribution! If you write a blog, let us know about it!
 
-If you write code, we have some conventions as follows.
 
-- [Guidelines](#guidelines)
+# Pull Request Guidelines
+
+If you make a pull request, please follow the guidelines below:
+
+- [Setup Optuna](#setup-optuna)
+- [Checking the Format, Coding Style, and Type Hints](#checking-the-format-coding-style-and-type-hints)
+- [Documentation](#documentation)
 - [Unit Tests](#unit-tests)
 - [Continuous Integration and Local Verification](#continuous-integration-and-local-verification)
 - [Creating a Pull Request](#creating-a-pull-request)
-- [Learning Optuna's Implementation](#learning-optunas-implementation)
 
-## Guidelines
+Detailed conventions and policies to write, test, and maintain Optuna code are described in the [Optuna Wiki](https://github.com/optuna/optuna/wiki).
+
+- [Coding Style Conventions](https://github.com/optuna/optuna/wiki/Coding-Style-Conventions)
+- [Deprecation Policy](https://github.com/optuna/optuna/wiki/Deprecation-policy)
+- [Test Policy](https://github.com/optuna/optuna/wiki/Test-Policy)
 
 ### Setup Optuna
 
@@ -49,7 +57,7 @@ cd optuna
 pip install -e .
 ```
 
-### Checking the Format, Coding Style, and Type Hints
+## Checking the Format, Coding Style, and Type Hints
 
 Code is formatted with [black](https://github.com/psf/black),
 and docstrings are formatted with [blackdoc](https://github.com/keewis/blackdoc).
@@ -77,7 +85,7 @@ $ pip install ".[checking]"
 $ ./formats.sh
 ```
 
-### Documentation
+## Documentation
 
 When adding a new feature to the framework, you also need to document it in the reference.
 The documentation source is stored under the [docs](./docs) directory and written in [reStructuredText format](http://www.sphinx-doc.org/en/master/usage/restructuredtext/index.html).
@@ -159,6 +167,8 @@ pytest tests/${TARGET_TEST_FILE_NAME}
 pytest tests/${TARGET_TEST_FILE_NAME} -k ${TARGET_TEST_FUNCTION_NAME}
 ```
 
+See also the [Optuna Test Policy](https://github.com/optuna/optuna/wiki/Test-Policy), which describes the principles to write and maintain Optuna tests to meet certain quality requirements.
+
 ## Continuous Integration and Local Verification
 
 Optuna repository uses GitHub Actions and CircleCI.
@@ -192,7 +202,7 @@ The description of your pull request should
 - describe the changes
 - if still work-in-progress, describe remaining tasks
 
-## Learning Optuna's Implementation
+# Learning Optuna's Implementation
 
 With Optuna actively being developed and the amount of code growing,
 it has become difficult to get a hold of the overall flow from reading the code.


### PR DESCRIPTION
## Motivation
- Currently, the information for contributors is cluttered between `CONTRIBUTING.md` and [Wiki](https://github.com/optuna/optuna/wiki). This PR recompiles those pieces of information referencing them from `CONTRIBUTING.md`.
- Currently, some parts of the section structure of `CONTRIBUTING.md` is asymmetry. For example, `Unit Tests` and `Documentation` are placed in different layer despite that both subsections are guidelines to create pull request. This PR restructures them.

## Description of the changes
- Reference the conventions and policies in Optuna Wiki
- Restructure the sections as:
    - Contribution Guidelines
    - Pull Request Guidelines
        - Setup Optuna
        - Checking the Format, Coding Style, and Typle Hinsts
        - Documentation
        - Unit Tests
        - Continuous Integration and Local Verification
        - Creating a Pull Request
    - Learning Optuna Implementation
