### PR TITLE
Remove downloading old libomp for mac tests

### DIFF
--- a/.github/workflows/mac-tests.yml
+++ b/.github/workflows/mac-tests.yml
@@ -88,9 +88,6 @@ jobs:
 
     - name: Setup mac environment
       run: |
-        # TODO(nzw0301): remove libomp version constraint if xgboost can work with libomp>11.1.0
-        # https://github.com/dmlc/xgboost/blob/c42e3fbcf3901eec73fcdbf02526f611ef3ed05f/.github/workflows/main.yml#L24-L25
-        wget https://raw.githubusercontent.com/Homebrew/homebrew-core/679923b4eb48a8dc7ecc1f05d06063cd79b3fc00/Formula/libomp.rb -O $(find $(brew --repository) -name libomp.rb)
         brew install libomp
         brew install open-mpi
         brew install openblas


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

Xgboost supports recent `libomp` according to https://github.com/dmlc/xgboost/blob/0725fd60819f9758fbed6ee54f34f3696a2fb2f8/.github/workflows/main.yml#L24. 

## Description of the changes
<!-- Describe the changes in this PR. -->


Revert the changes introduced by https://github.com/optuna/optuna/pull/3024.