### PR TITLE
Unify the logic of intermediate plot

### DIFF
--- a/optuna/visualization/_intermediate_values.py
+++ b/optuna/visualization/_intermediate_values.py
@@ -1,3 +1,7 @@
+from typing import List
+from typing import NamedTuple
+from typing import Tuple
+
 from optuna.logging import get_logger
 from optuna.study import Study
 from optuna.trial import TrialState
@@ -8,6 +12,35 @@ if _imports.is_successful():
     from optuna.visualization._plotly_imports import go
 
 _logger = get_logger(__name__)
+
+
+class _TrialInfo(NamedTuple):
+    trial_number: int
+    sorted_intermediate_values: List[Tuple[int, float]]
+
+
+class _IntermediatePlotInfo(NamedTuple):
+    trial_infos: List[_TrialInfo]
+
+
+def _get_intermediate_plot_info(study: Study) -> _IntermediatePlotInfo:
+    trials = study.get_trials(
+        deepcopy=False, states=(TrialState.PRUNED, TrialState.COMPLETE, TrialState.RUNNING)
+    )
+    trial_infos = [
+        _TrialInfo(trial.number, sorted(trial.intermediate_values.items()))
+        for trial in trials
+        if len(trial.intermediate_values) > 0
+    ]
+
+    if len(trials) == 0:
+        _logger.warning("Study instance does not contain trials.")
+    elif len(trial_infos) == 0:
+        _logger.warning(
+            "You need to set up the pruning feature to utilize `plot_intermediate_values()`"
+        )
+
+    return _IntermediatePlotInfo(trial_infos)
 
 
 def plot_intermediate_values(study: Study) -> "go.Figure":
@@ -76,32 +109,21 @@ def _get_intermediate_plot(study: Study) -> "go.Figure":
         showlegend=False,
     )
 
-    target_state = [TrialState.PRUNED, TrialState.COMPLETE, TrialState.RUNNING]
-    trials = [trial for trial in study.trials if trial.state in target_state]
+    info = _get_intermediate_plot_info(study)
+    trial_infos = info.trial_infos
 
-    if len(trials) == 0:
-        _logger.warning("Study instance does not contain trials.")
+    if len(trial_infos) == 0:
         return go.Figure(data=[], layout=layout)
 
-    traces = []
-    for trial in trials:
-        if trial.intermediate_values:
-            sorted_intermediate_values = sorted(trial.intermediate_values.items())
-            trace = go.Scatter(
-                x=tuple((x for x, _ in sorted_intermediate_values)),
-                y=tuple((y for _, y in sorted_intermediate_values)),
-                mode="lines+markers",
-                marker={"maxdisplayed": 10},
-                name="Trial{}".format(trial.number),
-            )
-            traces.append(trace)
-
-    if not traces:
-        _logger.warning(
-            "You need to set up the pruning feature to utilize `plot_intermediate_values()`"
+    traces = [
+        go.Scatter(
+            x=tuple((x for x, _ in tinfo.sorted_intermediate_values)),
+            y=tuple((y for _, y in tinfo.sorted_intermediate_values)),
+            mode="lines+markers",
+            marker={"maxdisplayed": 10},
+            name="Trial{}".format(tinfo.trial_number),
         )
-        return go.Figure(data=[], layout=layout)
+        for tinfo in trial_infos
+    ]
 
-    figure = go.Figure(data=traces, layout=layout)
-
-    return figure
+    return go.Figure(data=traces, layout=layout)

--- a/optuna/visualization/matplotlib/_intermediate_values.py
+++ b/optuna/visualization/matplotlib/_intermediate_values.py
@@ -1,7 +1,7 @@
 from optuna._experimental import experimental_func
 from optuna.logging import get_logger
 from optuna.study import Study
-from optuna.trial import TrialState
+from optuna.visualization._intermediate_values import _get_intermediate_plot_info
 from optuna.visualization.matplotlib._matplotlib_imports import _imports
 
 
@@ -87,35 +87,19 @@ def _get_intermediate_plot(study: Study) -> "Axes":
     ax.set_ylabel("Intermediate Value")
     cmap = plt.get_cmap("tab20")  # Use tab20 colormap for multiple line plots.
 
-    # Prepare data for plotting.
-    target_state = [TrialState.PRUNED, TrialState.COMPLETE, TrialState.RUNNING]
-    trials = [trial for trial in study.trials if trial.state in target_state]
+    info = _get_intermediate_plot_info(study)
+    trial_infos = info.trial_infos
 
-    if len(trials) == 0:
-        _logger.warning("Study instance does not contain trials.")
-        return ax
-
-    # Draw multiple line plots.
-    traces = []
-    for i, trial in enumerate(trials):
-        if trial.intermediate_values:
-            sorted_intermediate_values = sorted(trial.intermediate_values.items())
-            trace = ax.plot(
-                tuple((x for x, _ in sorted_intermediate_values)),
-                tuple((y for _, y in sorted_intermediate_values)),
-                color=cmap(i),
-                alpha=0.7,
-                label="Trial{}".format(trial.number),
-            )
-            traces.append(trace)
-
-    if not traces:
-        _logger.warning(
-            "You need to set up the pruning feature to utilize `plot_intermediate_values()`"
+    for i, tinfo in enumerate(trial_infos):
+        ax.plot(
+            tuple((x for x, _ in tinfo.sorted_intermediate_values)),
+            tuple((y for _, y in tinfo.sorted_intermediate_values)),
+            color=cmap(i),
+            alpha=0.7,
+            label="Trial{}".format(tinfo.trial_number),
         )
-        return ax
 
-    if len(trials) >= 2:
+    if len(trial_infos) >= 2:
         ax.legend(bbox_to_anchor=(1.05, 1), loc="upper left", borderaxespad=0.0)
 
     return ax


### PR DESCRIPTION

## Motivation
Since `optuan.visualization.plot_intermediate_values` and `optuan.visualization.matplotlib.plot_intermediate_values` have almost the same logic to generate figures, this PR aims to reduce the number of lines of duplicated lines in intermediate plot-related files for consistent tests, which are follow-up.

Related issue: #3586 
Related PRs: #3389 #3698 #3730

## Description of the changes
<!-- Describe the changes in this PR. -->

By taking the same approach as in https://github.com/optuna/optuna/blob/master/optuna/visualization/_pareto_front.py

- Define `_IntermediatePlotInfo` that stores minimal information for the plot independent of the backend visualisation packages.
- Calls `_get_intermediate_plot_info` to gather information for the plot from each concrete plot function.