### PR TITLE
Unify implementation of `plot_optimization_history` between plotly and matplotlib

### DIFF
--- a/optuna/visualization/_optimization_history.py
+++ b/optuna/visualization/_optimization_history.py
@@ -89,7 +89,8 @@ def _get_optimization_history_info_list(
     # When error_bar=True, a list of 0 or 1 element is returned.
     if len(info_list) == 0:
         return []
-    max_num_trial = max(max(info.trial_numbers) for info in info_list) + 1
+    all_trial_numbers = [number for info in info_list for number in info.trial_numbers]
+    max_num_trial = max(all_trial_numbers) + 1
 
     def _aggregate(label_name: str, use_best_value: bool) -> Tuple[List[int], _ValuesInfo]:
         # Calculate mean and std of values for each trial number.

--- a/optuna/visualization/_optimization_history.py
+++ b/optuna/visualization/_optimization_history.py
@@ -94,12 +94,11 @@ def _get_optimization_history_error_bar_info(
     info_list = _get_optimization_history_info_list(study, target, target_name)
     if len(info_list) == 0:
         return None
-    max_trial_number = max(max(info.trial_numbers) for info in info_list)
+    max_num_trial = max(max(info.trial_numbers) for info in info_list) + 1
 
     def _aggregate(label_name: str, use_best_value: bool) -> Tuple[List[int], _ValuesInfo]:
         # Calculate mean and std of values for each trial number.
-        values: List[List[float]] = [[] for _ in range(max_trial_number + 2)]
-        # TODO(knshnb): Took over `+2` from the previous code, but not sure why it is necessary.
+        values: List[List[float]] = [[] for _ in range(max_num_trial)]
         assert info_list is not None
         for trial_numbers, values_info, best_values_info in info_list:
             if use_best_value:
@@ -109,9 +108,7 @@ def _get_optimization_history_error_bar_info(
                 values[trial_number].append(value)
         mean_of_values = [np.mean(v) if len(v) > 0 else None for v in values]
         std_of_values = [np.std(v) if len(v) > 0 else None for v in values]
-        eb_trial_numbers = list(
-            np.arange(max_trial_number + 2)[[v is not None for v in mean_of_values]]
-        )
+        eb_trial_numbers = list(np.arange(max_num_trial)[[v is not None for v in mean_of_values]])
         value_means = list(np.asarray(mean_of_values)[eb_trial_numbers])
         value_stds = list(np.asarray(std_of_values)[eb_trial_numbers])
         return eb_trial_numbers, _ValuesInfo(value_means, value_stds, label_name)

--- a/optuna/visualization/_optimization_history.py
+++ b/optuna/visualization/_optimization_history.py
@@ -42,6 +42,7 @@ def _get_optimization_history_info_list(
     target_name: str,
 ) -> List[_OptimizationHistoryInfo]:
 
+    _check_plot_args(study, target, target_name)
     if isinstance(study, Study):
         studies = [study]
     else:
@@ -173,8 +174,6 @@ def plot_optimization_history(
     """
 
     _imports.check()
-    _check_plot_args(study, target, target_name)
-
     layout = go.Layout(
         title="Optimization History Plot",
         xaxis={"title": "Trial"},

--- a/optuna/visualization/_optimization_history.py
+++ b/optuna/visualization/_optimization_history.py
@@ -101,12 +101,10 @@ def _get_optimization_history_info_list(
                 values_info = best_values_info
             for trial_number, value in zip(trial_numbers, values_info.values):
                 values[trial_number].append(value)
-        mean_of_values = [np.mean(v) if len(v) > 0 else None for v in values]
-        std_of_values = [np.std(v) if len(v) > 0 else None for v in values]
-        eb_trial_numbers = list(np.arange(max_num_trial)[[v is not None for v in mean_of_values]])
-        value_means = list(np.asarray(mean_of_values)[eb_trial_numbers])
-        value_stds = list(np.asarray(std_of_values)[eb_trial_numbers])
-        return eb_trial_numbers, _ValuesInfo(value_means, value_stds, label_name)
+        trial_numbers_union = [i for i in range(max_num_trial) if len(values[i]) > 0]
+        value_means = [np.mean(v) for v in values if len(v) > 0]
+        value_stds = [np.std(v) for v in values if len(v) > 0]
+        return trial_numbers_union, _ValuesInfo(value_means, value_stds, label_name)
 
     eb_trial_numbers, eb_values_info = _aggregate(target_name, False)
     eb_best_values_info: Optional[_ValuesInfo] = None

--- a/optuna/visualization/_optimization_history.py
+++ b/optuna/visualization/_optimization_history.py
@@ -102,8 +102,8 @@ def _get_optimization_history_info_list(
             for trial_number, value in zip(trial_numbers, values_info.values):
                 values[trial_number].append(value)
         trial_numbers_union = [i for i in range(max_num_trial) if len(values[i]) > 0]
-        value_means = [np.mean(v) for v in values if len(v) > 0]
-        value_stds = [np.std(v) for v in values if len(v) > 0]
+        value_means = [np.mean(v).item() for v in values if len(v) > 0]
+        value_stds = [np.std(v).item() for v in values if len(v) > 0]
         return trial_numbers_union, _ValuesInfo(value_means, value_stds, label_name)
 
     eb_trial_numbers, eb_values_info = _aggregate(target_name, False)

--- a/optuna/visualization/_optimization_history.py
+++ b/optuna/visualization/_optimization_history.py
@@ -101,13 +101,13 @@ def _get_optimization_history_error_bar_info(
             values[trial_number].append(value)
     mean_of_values = [np.mean(v) if len(v) > 0 else None for v in values]
     std_of_values = [np.std(v) if len(v) > 0 else None for v in values]
-    trial_numbers = np.arange(max_trial_number + 2)[[v is not None for v in mean_of_values]]
-    value_means = np.asarray(mean_of_values)[trial_numbers]
-    value_stds = np.asarray(std_of_values)[trial_numbers]
+    eb_trial_numbers = np.arange(max_trial_number + 2)[[v is not None for v in mean_of_values]]
+    value_means = np.asarray(mean_of_values)[eb_trial_numbers]
+    value_stds = np.asarray(std_of_values)[eb_trial_numbers]
     eb_values_info = _ValuesInfo(value_means, value_stds, target_name)
 
     if target is not None:
-        return _OptimizationHistoryInfo(trial_numbers, eb_values_info, None)
+        return _OptimizationHistoryInfo(eb_trial_numbers, eb_values_info, None)
 
     # Calculate mean and std of previous best target values for each trial number.
     best_values: List[List[float]] = [[] for _ in range(max_trial_number + 2)]
@@ -117,10 +117,10 @@ def _get_optimization_history_error_bar_info(
             best_values[trial_number].append(best_value)
     mean_of_best_values = [np.mean(v) if len(v) > 0 else None for v in best_values]
     std_of_best_values = [np.std(v) if len(v) > 0 else None for v in best_values]
-    best_value_means = list(np.asarray(mean_of_best_values)[trial_numbers])
-    best_value_stds = list(np.asarray(std_of_best_values)[trial_numbers])
+    best_value_means = list(np.asarray(mean_of_best_values)[eb_trial_numbers])
+    best_value_stds = list(np.asarray(std_of_best_values)[eb_trial_numbers])
     eb_best_values_info = _ValuesInfo(best_value_means, best_value_stds, "Best Value")
-    return _OptimizationHistoryInfo(trial_numbers, eb_values_info, eb_best_values_info)
+    return _OptimizationHistoryInfo(eb_trial_numbers, eb_values_info, eb_best_values_info)
 
 
 def plot_optimization_history(

--- a/optuna/visualization/_optimization_history.py
+++ b/optuna/visualization/_optimization_history.py
@@ -174,24 +174,25 @@ def plot_optimization_history(
     """
 
     _imports.check()
-    layout = go.Layout(
-        title="Optimization History Plot",
-        xaxis={"title": "Trial"},
-        yaxis={"title": target_name},
-    )
 
     if error_bar:
         info = _get_optimization_history_error_bar_info(study, target, target_name)
         info_list = [] if info is None else [info]
     else:
         info_list = _get_optimization_history_info_list(study, target, target_name)
-    return _get_optimization_history_plot(info_list, layout)
+    return _get_optimization_history_plot(info_list, target_name)
 
 
 def _get_optimization_history_plot(
     info_list: List[_OptimizationHistoryInfo],
-    layout: "go.Layout",
+    target_name: str,
 ) -> "go.Figure":
+
+    layout = go.Layout(
+        title="Optimization History Plot",
+        xaxis={"title": "Trial"},
+        yaxis={"title": target_name},
+    )
 
     traces = []
     for trial_numbers, values_info, best_values_info in info_list:

--- a/optuna/visualization/_optimization_history.py
+++ b/optuna/visualization/_optimization_history.py
@@ -40,7 +40,7 @@ def _get_optimization_history_info_list(
     study: Union[Study, Sequence[Study]],
     target: Optional[Callable[[FrozenTrial], float]],
     target_name: str,
-) -> Optional[List[_OptimizationHistoryInfo]]:
+) -> List[_OptimizationHistoryInfo]:
 
     if isinstance(study, Study):
         studies = [study]
@@ -76,11 +76,10 @@ def _get_optimization_history_info_list(
 
     if len(optimization_history_info_list) == 0:
         _logger.warning("There are no studies.")
-        return None
 
     if sum(len(info.trial_numbers) for info in optimization_history_info_list) == 0:
         _logger.warning("There are no complete trials.")
-        return None
+        optimization_history_info_list.clear()
 
     return optimization_history_info_list
 
@@ -92,7 +91,7 @@ def _get_optimization_history_error_bar_info(
 ) -> Optional[_OptimizationHistoryInfo]:
 
     info_list = _get_optimization_history_info_list(study, target, target_name)
-    if info_list is None:
+    if len(info_list) == 0:
         return None
     max_trial_number = max(max(info.trial_numbers) for info in info_list)
 
@@ -184,19 +183,16 @@ def plot_optimization_history(
 
     if error_bar:
         info = _get_optimization_history_error_bar_info(study, target, target_name)
-        info_list = None if info is None else [info]
+        info_list = [] if info is None else [info]
     else:
         info_list = _get_optimization_history_info_list(study, target, target_name)
     return _get_optimization_history_plot(info_list, layout)
 
 
 def _get_optimization_history_plot(
-    info_list: Optional[List[_OptimizationHistoryInfo]],
+    info_list: List[_OptimizationHistoryInfo],
     layout: "go.Layout",
 ) -> "go.Figure":
-
-    if info_list is None:
-        return go.Figure(data=[], layout=layout)
 
     traces = []
     for trial_numbers, values_info, best_values_info in info_list:

--- a/optuna/visualization/_optimization_history.py
+++ b/optuna/visualization/_optimization_history.py
@@ -103,6 +103,7 @@ def _get_optimization_history_error_bar_info(
         assert info_list is not None
         for trial_numbers, values_info, best_values_info in info_list:
             if use_best_value:
+                assert best_values_info is not None
                 values_info = best_values_info
             for trial_number, value in zip(trial_numbers, values_info.values):
                 values[trial_number].append(value)

--- a/optuna/visualization/_optimization_history.py
+++ b/optuna/visualization/_optimization_history.py
@@ -32,10 +32,15 @@ class _OptimizationHistoryInfo(NamedTuple):
 
 
 def _get_optimization_history_info_list(
-    studies: List[Study],
+    study: Union[Study, Sequence[Study]],
     target: Optional[Callable[[FrozenTrial], float]],
     target_name: str,
 ) -> Optional[List[_OptimizationHistoryInfo]]:
+
+    if isinstance(study, Study):
+        studies = [study]
+    else:
+        studies = list(study)
 
     optimization_history_info_list: List[_OptimizationHistoryInfo] = []
     for study in studies:
@@ -88,12 +93,12 @@ class _OptimizationHistoryErrorBarInfo(NamedTuple):
 
 
 def _get_optimization_history_error_bar_info(
-    studies: List[Study],
+    study: Union[Study, Sequence[Study]],
     target: Optional[Callable[[FrozenTrial], float]],
     target_name: str,
 ) -> Optional[_OptimizationHistoryErrorBarInfo]:
 
-    info_list = _get_optimization_history_info_list(studies, target, target_name)
+    info_list = _get_optimization_history_info_list(study, target, target_name)
     if info_list is None:
         return None
     max_trial_number = max(max(info.trial_numbers) for info in info_list)
@@ -192,13 +197,7 @@ def plot_optimization_history(
     """
 
     _imports.check()
-
-    if isinstance(study, Study):
-        studies = [study]
-    else:
-        studies = list(study)
-
-    _check_plot_args(studies, target, target_name)
+    _check_plot_args(study, target, target_name)
 
     layout = go.Layout(
         title="Optimization History Plot",
@@ -207,10 +206,10 @@ def plot_optimization_history(
     )
 
     if error_bar:
-        eb_info = _get_optimization_history_error_bar_info(studies, target, target_name)
+        eb_info = _get_optimization_history_error_bar_info(study, target, target_name)
         return _get_optimization_histories_with_error_bar(eb_info, layout)
     else:
-        info_list = _get_optimization_history_info_list(studies, target, target_name)
+        info_list = _get_optimization_history_info_list(study, target, target_name)
         return _get_optimization_histories(info_list, layout)
 
 

--- a/optuna/visualization/_optimization_history.py
+++ b/optuna/visualization/_optimization_history.py
@@ -207,19 +207,18 @@ def plot_optimization_history(
     )
 
     if error_bar:
-        return _get_optimization_histories_with_error_bar(studies, target, target_name, layout)
+        eb_info = _get_optimization_history_error_bar_info(studies, target, target_name)
+        return _get_optimization_histories_with_error_bar(eb_info, layout)
     else:
-        return _get_optimization_histories(studies, target, target_name, layout)
+        info_list = _get_optimization_history_info_list(studies, target, target_name)
+        return _get_optimization_histories(info_list, layout)
 
 
 def _get_optimization_histories_with_error_bar(
-    studies: List[Study],
-    target: Optional[Callable[[FrozenTrial], float]],
-    target_name: str,
+    eb_info: Optional[_OptimizationHistoryErrorBarInfo],
     layout: "go.Layout",
 ) -> "go.Figure":
 
-    eb_info = _get_optimization_history_error_bar_info(studies, target, target_name)
     if eb_info is None:
         return go.Figure(data=[], layout=layout)
 
@@ -273,13 +272,10 @@ def _get_optimization_histories_with_error_bar(
 
 
 def _get_optimization_histories(
-    studies: List[Study],
-    target: Optional[Callable[[FrozenTrial], float]],
-    target_name: str,
+    info_list: Optional[List[_OptimizationHistoryInfo]],
     layout: "go.Layout",
 ) -> "go.Figure":
 
-    info_list = _get_optimization_history_info_list(studies, target, target_name)
     if info_list is None:
         return go.Figure(data=[], layout=layout)
 

--- a/optuna/visualization/_optimization_history.py
+++ b/optuna/visualization/_optimization_history.py
@@ -41,6 +41,8 @@ def _get_optimization_history_info_list(
     for study in studies:
         trials = study.get_trials(states=(TrialState.COMPLETE,))
         label_name = target_name if len(studies) == 1 else f"{target_name} of {study.study_name}"
+        best_values: Optional[List[float]]
+        best_label_name: Optional[str]
         if target is None:
             values = [cast(float, t.value) for t in trials]
             if study.direction == StudyDirection.MINIMIZE:
@@ -109,7 +111,7 @@ def _get_optimization_history_error_bar_info(
         best_value_stds = np.asarray(std_of_best_values)[trial_numbers]
 
     return _OptimizationHistoryErrorBarInfo(
-        trial_numbers=trial_numbers,
+        trial_numbers=list(trial_numbers),
         value_means=list(value_means),
         value_stds=list(value_stds),
         label_name=target_name,

--- a/optuna/visualization/_optimization_history.py
+++ b/optuna/visualization/_optimization_history.py
@@ -36,6 +36,7 @@ def _get_optimization_history_info_list(
     target: Optional[Callable[[FrozenTrial], float]],
     target_name: str,
 ) -> Optional[List[_OptimizationHistoryInfo]]:
+
     optimization_history_info_list: List[_OptimizationHistoryInfo] = []
     for study in studies:
         trials = study.get_trials(states=(TrialState.COMPLETE,))
@@ -91,6 +92,7 @@ def _get_optimization_history_error_bar_info(
     target: Optional[Callable[[FrozenTrial], float]],
     target_name: str,
 ) -> Optional[_OptimizationHistoryErrorBarInfo]:
+
     info_list = _get_optimization_history_info_list(studies, target, target_name)
     if info_list is None:
         return None
@@ -216,6 +218,7 @@ def _get_optimization_histories_with_error_bar(
     target_name: str,
     layout: "go.Layout",
 ) -> "go.Figure":
+
     eb_info = _get_optimization_history_error_bar_info(studies, target, target_name)
     if eb_info is None:
         return go.Figure(data=[], layout=layout)

--- a/optuna/visualization/_optimization_history.py
+++ b/optuna/visualization/_optimization_history.py
@@ -207,13 +207,13 @@ def plot_optimization_history(
 
     if error_bar:
         eb_info = _get_optimization_history_error_bar_info(study, target, target_name)
-        return _get_optimization_histories_with_error_bar(eb_info, layout)
+        return _get_optimization_history_plot_with_error_bar(eb_info, layout)
     else:
         info_list = _get_optimization_history_info_list(study, target, target_name)
-        return _get_optimization_histories(info_list, layout)
+        return _get_optimization_history_plot(info_list, layout)
 
 
-def _get_optimization_histories_with_error_bar(
+def _get_optimization_history_plot_with_error_bar(
     eb_info: Optional[_OptimizationHistoryErrorBarInfo],
     layout: "go.Layout",
 ) -> "go.Figure":
@@ -270,7 +270,7 @@ def _get_optimization_histories_with_error_bar(
     return figure
 
 
-def _get_optimization_histories(
+def _get_optimization_history_plot(
     info_list: Optional[List[_OptimizationHistoryInfo]],
     layout: "go.Layout",
 ) -> "go.Figure":

--- a/optuna/visualization/_optimization_history.py
+++ b/optuna/visualization/_optimization_history.py
@@ -197,15 +197,6 @@ def plot_optimization_history(
         studies = list(study)
 
     _check_plot_args(studies, target, target_name)
-    return _get_optimization_history_plot(studies, target, target_name, error_bar)
-
-
-def _get_optimization_history_plot(
-    studies: List[Study],
-    target: Optional[Callable[[FrozenTrial], float]],
-    target_name: str,
-    error_bar: bool,
-) -> "go.Figure":
 
     layout = go.Layout(
         title="Optimization History Plot",

--- a/optuna/visualization/_optimization_history.py
+++ b/optuna/visualization/_optimization_history.py
@@ -98,6 +98,9 @@ def _get_optimization_history_error_bar_info(
     value_means = np.asarray(mean_of_values)[trial_numbers]
     value_stds = np.asarray(std_of_values)[trial_numbers]
 
+    best_value_means: Optional[List[float]]
+    best_value_stds: Optional[List[float]]
+    best_label_name: Optional[str]
     if target is None:
         # Calculate mean and std of previous best target values for each trial number.
         best_values: List[List[float]] = [[] for _ in range(max_trial_number + 2)]
@@ -107,17 +110,22 @@ def _get_optimization_history_error_bar_info(
                 best_values[trial_number].append(best_value)
         mean_of_best_values = [np.mean(v) if len(v) > 0 else None for v in best_values]
         std_of_best_values = [np.std(v) if len(v) > 0 else None for v in best_values]
-        best_value_means = np.asarray(mean_of_best_values)[trial_numbers]
-        best_value_stds = np.asarray(std_of_best_values)[trial_numbers]
+        best_value_means = list(np.asarray(mean_of_best_values)[trial_numbers])
+        best_value_stds = list(np.asarray(std_of_best_values)[trial_numbers])
+        best_label_name = "Best Value"
+    else:
+        best_value_means = None
+        best_value_stds = None
+        best_label_name = None
 
     return _OptimizationHistoryErrorBarInfo(
         trial_numbers=list(trial_numbers),
         value_means=list(value_means),
         value_stds=list(value_stds),
         label_name=target_name,
-        best_value_means=list(best_value_means),
-        best_value_stds=list(best_value_stds),
-        best_label_name="Best Value",
+        best_value_means=best_value_means,
+        best_value_stds=best_value_stds,
+        best_label_name=best_label_name,
     )
 
 

--- a/optuna/visualization/matplotlib/_optimization_history.py
+++ b/optuna/visualization/matplotlib/_optimization_history.py
@@ -9,7 +9,6 @@ import numpy as np
 from optuna._experimental import experimental_func
 from optuna.study import Study
 from optuna.trial import FrozenTrial
-from optuna.visualization._optimization_history import _get_optimization_history_error_bar_info
 from optuna.visualization._optimization_history import _get_optimization_history_info_list
 from optuna.visualization._optimization_history import _OptimizationHistoryInfo
 from optuna.visualization.matplotlib._matplotlib_imports import _imports
@@ -81,11 +80,7 @@ def plot_optimization_history(
 
     _imports.check()
 
-    if error_bar:
-        eb_info = _get_optimization_history_error_bar_info(study, target, target_name)
-        info_list = [] if eb_info is None else [eb_info]
-    else:
-        info_list = _get_optimization_history_info_list(study, target, target_name)
+    info_list = _get_optimization_history_info_list(study, target, target_name, error_bar)
     return _get_optimization_history_plot(info_list, target_name)
 
 

--- a/optuna/visualization/matplotlib/_optimization_history.py
+++ b/optuna/visualization/matplotlib/_optimization_history.py
@@ -93,7 +93,7 @@ def plot_optimization_history(
 
     if error_bar:
         eb_info = _get_optimization_history_error_bar_info(study, target, target_name)
-        info_list = None if eb_info is None else [eb_info]
+        info_list = [] if eb_info is None else [eb_info]
     else:
         info_list = _get_optimization_history_info_list(study, target, target_name)
     ax = _get_optimization_history_plot(info_list, ax)
@@ -102,12 +102,9 @@ def plot_optimization_history(
 
 
 def _get_optimization_history_plot(
-    info_list: Optional[List[_OptimizationHistoryInfo]],
+    info_list: List[_OptimizationHistoryInfo],
     ax: "Axes",
 ) -> "Axes":
-
-    if info_list is None:
-        return ax
 
     cmap = plt.get_cmap("tab10")  # Use tab10 colormap for similar outputs to plotly.
 

--- a/optuna/visualization/matplotlib/_optimization_history.py
+++ b/optuna/visualization/matplotlib/_optimization_history.py
@@ -7,7 +7,6 @@ from typing import Union
 import numpy as np
 
 from optuna._experimental import experimental_func
-from optuna.logging import get_logger
 from optuna.study import Study
 from optuna.trial import FrozenTrial
 from optuna.visualization._optimization_history import _get_optimization_history_error_bar_info
@@ -21,8 +20,6 @@ from optuna.visualization.matplotlib._matplotlib_imports import _imports
 if _imports.is_successful():
     from optuna.visualization.matplotlib._matplotlib_imports import Axes
     from optuna.visualization.matplotlib._matplotlib_imports import plt
-
-_logger = get_logger(__name__)
 
 
 @experimental_func("2.2.0")

--- a/optuna/visualization/matplotlib/_optimization_history.py
+++ b/optuna/visualization/matplotlib/_optimization_history.py
@@ -12,7 +12,6 @@ from optuna.trial import FrozenTrial
 from optuna.visualization._optimization_history import _get_optimization_history_error_bar_info
 from optuna.visualization._optimization_history import _get_optimization_history_info_list
 from optuna.visualization._optimization_history import _OptimizationHistoryInfo
-from optuna.visualization._utils import _check_plot_args
 from optuna.visualization.matplotlib._matplotlib_imports import _imports
 
 
@@ -81,7 +80,6 @@ def plot_optimization_history(
     """
 
     _imports.check()
-    _check_plot_args(study, target, target_name)
 
     # Set up the graph style.
     plt.style.use("ggplot")  # Use ggplot style sheet for similar outputs to plotly.

--- a/optuna/visualization/matplotlib/_optimization_history.py
+++ b/optuna/visualization/matplotlib/_optimization_history.py
@@ -81,29 +81,25 @@ def plot_optimization_history(
 
     _imports.check()
 
-    # Set up the graph style.
-    plt.style.use("ggplot")  # Use ggplot style sheet for similar outputs to plotly.
-
-    _, ax = plt.subplots()
-    ax.set_title("Optimization History Plot")
-    ax.set_xlabel("Trial")
-    ax.set_ylabel(target_name)
-
     if error_bar:
         eb_info = _get_optimization_history_error_bar_info(study, target, target_name)
         info_list = [] if eb_info is None else [eb_info]
     else:
         info_list = _get_optimization_history_info_list(study, target, target_name)
-    ax = _get_optimization_history_plot(info_list, ax)
-    plt.legend(bbox_to_anchor=(1.05, 1.0), loc="upper left")
-    return ax
+    return _get_optimization_history_plot(info_list, target_name)
 
 
 def _get_optimization_history_plot(
     info_list: List[_OptimizationHistoryInfo],
-    ax: "Axes",
+    target_name: str,
 ) -> "Axes":
 
+    # Set up the graph style.
+    plt.style.use("ggplot")  # Use ggplot style sheet for similar outputs to plotly.
+    _, ax = plt.subplots()
+    ax.set_title("Optimization History Plot")
+    ax.set_xlabel("Trial")
+    ax.set_ylabel(target_name)
     cmap = plt.get_cmap("tab10")  # Use tab10 colormap for similar outputs to plotly.
 
     for i, (trial_numbers, values_info, best_values_info) in enumerate(info_list):
@@ -144,4 +140,5 @@ def _get_optimization_history_plot(
                     alpha=0.4,
                 )
             ax.legend()
+    plt.legend(bbox_to_anchor=(1.05, 1.0), loc="upper left")
     return ax

--- a/optuna/visualization/matplotlib/_optimization_history.py
+++ b/optuna/visualization/matplotlib/_optimization_history.py
@@ -97,16 +97,16 @@ def plot_optimization_history(
 
     if error_bar:
         eb_info = _get_optimization_history_error_bar_info(study, target, target_name)
-        ax = _get_optimization_histories_with_error_bar(eb_info, ax)
+        ax = _get_optimization_history_plot_with_error_bar(eb_info, ax)
     else:
         info_list = _get_optimization_history_info_list(study, target, target_name)
-        ax = _get_optimization_histories(info_list, ax)
+        ax = _get_optimization_history_plot(info_list, ax)
 
     plt.legend(bbox_to_anchor=(1.05, 1.0), loc="upper left")
     return ax
 
 
-def _get_optimization_histories_with_error_bar(
+def _get_optimization_history_plot_with_error_bar(
     eb_info: Optional[_OptimizationHistoryErrorBarInfo],
     ax: "Axes",
 ) -> "Axes":
@@ -144,7 +144,7 @@ def _get_optimization_histories_with_error_bar(
     return ax
 
 
-def _get_optimization_histories(
+def _get_optimization_history_plot(
     info_list: Optional[List[_OptimizationHistoryInfo]],
     ax: "Axes",
 ) -> "Axes":

--- a/optuna/visualization/matplotlib/_optimization_history.py
+++ b/optuna/visualization/matplotlib/_optimization_history.py
@@ -1,4 +1,3 @@
-import itertools
 from typing import Callable
 from typing import List
 from typing import Optional
@@ -11,7 +10,6 @@ from optuna._experimental import experimental_func
 from optuna.logging import get_logger
 from optuna.study import Study
 from optuna.trial import FrozenTrial
-from optuna.trial import TrialState
 from optuna.visualization._optimization_history import _get_optimization_history_error_bar_info
 from optuna.visualization._optimization_history import _get_optimization_history_info_list
 from optuna.visualization._utils import _check_plot_args

--- a/optuna/visualization/matplotlib/_optimization_history.py
+++ b/optuna/visualization/matplotlib/_optimization_history.py
@@ -85,11 +85,6 @@ def plot_optimization_history(
     """
 
     _imports.check()
-
-    if isinstance(study, Study):
-        studies = [study]
-    else:
-        studies = list(study)
     _check_plot_args(study, target, target_name)
 
     # Set up the graph style.
@@ -101,10 +96,10 @@ def plot_optimization_history(
     ax.set_ylabel(target_name)
 
     if error_bar:
-        eb_info = _get_optimization_history_error_bar_info(studies, target, target_name)
+        eb_info = _get_optimization_history_error_bar_info(study, target, target_name)
         ax = _get_optimization_histories_with_error_bar(eb_info, ax)
     else:
-        info_list = _get_optimization_history_info_list(studies, target, target_name)
+        info_list = _get_optimization_history_info_list(study, target, target_name)
         ax = _get_optimization_histories(info_list, ax)
 
     plt.legend(bbox_to_anchor=(1.05, 1.0), loc="upper left")

--- a/optuna/visualization/matplotlib/_optimization_history.py
+++ b/optuna/visualization/matplotlib/_optimization_history.py
@@ -156,6 +156,7 @@ def _get_optimization_histories(
     target_name: str,
     ax: "Axes",
 ) -> "Axes":
+
     info_list = _get_optimization_history_info_list(studies, target, target_name)
     if info_list is None:
         return ax

--- a/optuna/visualization/matplotlib/_optimization_history.py
+++ b/optuna/visualization/matplotlib/_optimization_history.py
@@ -12,6 +12,8 @@ from optuna.study import Study
 from optuna.trial import FrozenTrial
 from optuna.visualization._optimization_history import _get_optimization_history_error_bar_info
 from optuna.visualization._optimization_history import _get_optimization_history_info_list
+from optuna.visualization._optimization_history import _OptimizationHistoryErrorBarInfo
+from optuna.visualization._optimization_history import _OptimizationHistoryInfo
 from optuna.visualization._utils import _check_plot_args
 from optuna.visualization.matplotlib._matplotlib_imports import _imports
 
@@ -99,22 +101,21 @@ def plot_optimization_history(
     ax.set_ylabel(target_name)
 
     if error_bar:
-        ax = _get_optimization_histories_with_error_bar(studies, target, target_name, ax)
+        eb_info = _get_optimization_history_error_bar_info(studies, target, target_name)
+        ax = _get_optimization_histories_with_error_bar(eb_info, ax)
     else:
-        ax = _get_optimization_histories(studies, target, target_name, ax)
+        info_list = _get_optimization_history_info_list(studies, target, target_name)
+        ax = _get_optimization_histories(info_list, ax)
 
     plt.legend(bbox_to_anchor=(1.05, 1.0), loc="upper left")
     return ax
 
 
 def _get_optimization_histories_with_error_bar(
-    studies: List[Study],
-    target: Optional[Callable[[FrozenTrial], float]],
-    target_name: str,
+    eb_info: Optional[_OptimizationHistoryErrorBarInfo],
     ax: "Axes",
 ) -> "Axes":
 
-    eb_info = _get_optimization_history_error_bar_info(studies, target, target_name)
     if eb_info is None:
         return ax
 
@@ -149,13 +150,10 @@ def _get_optimization_histories_with_error_bar(
 
 
 def _get_optimization_histories(
-    studies: List[Study],
-    target: Optional[Callable[[FrozenTrial], float]],
-    target_name: str,
+    info_list: Optional[List[_OptimizationHistoryInfo]],
     ax: "Axes",
 ) -> "Axes":
 
-    info_list = _get_optimization_history_info_list(studies, target, target_name)
     if info_list is None:
         return ax
 
@@ -166,7 +164,7 @@ def _get_optimization_histories(
         ax.scatter(
             x=info.trial_numbers,
             y=info.values,
-            color=cmap(0) if len(studies) == 1 else cmap(2 * i),
+            color=cmap(0) if len(info_list) == 1 else cmap(2 * i),
             alpha=1,
             label=info.label_name,
         )
@@ -175,7 +173,7 @@ def _get_optimization_histories(
                 info.trial_numbers,
                 info.best_values,
                 marker="o",
-                color=cmap(3) if len(studies) == 1 else cmap(2 * i + 1),
+                color=cmap(3) if len(info_list) == 1 else cmap(2 * i + 1),
                 alpha=0.5,
                 label=info.best_label_name,
             )

--- a/optuna/visualization/matplotlib/_optimization_history.py
+++ b/optuna/visualization/matplotlib/_optimization_history.py
@@ -109,20 +109,6 @@ def _get_optimization_history_plot(
     ax.set_xlabel("Trial")
     ax.set_ylabel(target_name)
 
-    if len(studies) == 0:
-        _logger.warning("There are no studies.")
-        return ax
-    # Prepare data for plotting.
-    all_trials = list(
-        itertools.chain.from_iterable(
-            study.get_trials(deepcopy=False, states=(TrialState.COMPLETE,)) for study in studies
-        )
-    )
-
-    if len(all_trials) == 0:
-        _logger.warning("Study instance does not contain trials.")
-        return ax
-
     if error_bar:
         ax = _get_optimization_histories_with_error_bar(studies, target, target_name, ax)
     else:
@@ -140,6 +126,9 @@ def _get_optimization_histories_with_error_bar(
 ) -> "Axes":
 
     eb_info = _get_optimization_history_error_bar_info(studies, target, target_name)
+    if eb_info is None:
+        return ax
+
     plt.errorbar(
         x=eb_info.trial_numbers,
         y=eb_info.value_means,
@@ -176,10 +165,14 @@ def _get_optimization_histories(
     target_name: str,
     ax: "Axes",
 ) -> "Axes":
+    info_list = _get_optimization_history_info_list(studies, target, target_name)
+    if info_list is None:
+        return ax
+
     cmap = plt.get_cmap("tab10")  # Use tab10 colormap for similar outputs to plotly.
 
     # Draw a scatter plot and a line plot.
-    for i, info in enumerate(_get_optimization_history_info_list(studies, target, target_name)):
+    for i, info in enumerate(info_list):
         ax.scatter(
             x=info.trial_numbers,
             y=info.values,

--- a/optuna/visualization/matplotlib/_optimization_history.py
+++ b/optuna/visualization/matplotlib/_optimization_history.py
@@ -91,15 +91,6 @@ def plot_optimization_history(
     else:
         studies = list(study)
     _check_plot_args(study, target, target_name)
-    return _get_optimization_history_plot(studies, target, target_name, error_bar)
-
-
-def _get_optimization_history_plot(
-    studies: List[Study],
-    target: Optional[Callable[[FrozenTrial], float]],
-    target_name: str,
-    error_bar: bool = False,
-) -> "Axes":
 
     # Set up the graph style.
     plt.style.use("ggplot")  # Use ggplot style sheet for similar outputs to plotly.


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
Part of #3586.
This PR unifies a part of `plot_optimization_history` that can be commonly used in plotly and matplotlib backends. It also aims at unifying some logic in `_get_optimization_histories` and `_get_optimization_histories_with_error_bar`.

## Description of the changes
<!-- Describe the changes in this PR. -->
- ~Introduce `_OptimizationHistoryInfo` for `_get_optimization_histories` and `_OptimizationHistoryErrorBarInfo` for `_get_optimization_histories_with_error_bar`.~
- ~Reuse `_get_optimization_history_info_list` inside `_get_optimization_history_error_bar_info`~
- Introduced `_OptimizationHistoryInfo`, which is used for both plotting with and without error bars.
- Refactored the logic of calculating mean and std for error bars.