### PR TITLE
Raise error on `nan` in `_constrained_dominates`

### DIFF
--- a/optuna/samplers/nsgaii/_sampler.py
+++ b/optuna/samplers/nsgaii/_sampler.py
@@ -485,6 +485,9 @@ def _constrained_dominates(
     assert isinstance(constraints0, (list, tuple))
     assert isinstance(constraints1, (list, tuple))
 
+    if np.any(np.isnan(constraints0)) or np.any(np.isnan(constraints1)):
+        raise ValueError("NaN is not acceptable as constraint value.")
+
     if len(constraints0) != len(constraints1):
         raise ValueError("Trials with different numbers of constraints cannot be compared.")
 

--- a/tests/samplers_tests/test_nsgaii.py
+++ b/tests/samplers_tests/test_nsgaii.py
@@ -153,7 +153,7 @@ def test_constraints_func(constraint_value: float) -> None:
     assert constraints_func_call_count == n_trials
     for trial in study.trials:
         for x, y in zip(trial.system_attrs[_CONSTRAINTS_KEY], (constraint_value + trial.number,)):
-            assert _nan_equal(x, y)
+            assert x == y
 
 
 def test_constrained_dominates_with_nan_constraint() -> None:

--- a/tests/samplers_tests/test_nsgaii.py
+++ b/tests/samplers_tests/test_nsgaii.py
@@ -1,5 +1,4 @@
 from collections import Counter
-from optuna.samplers.nsgaii._sampler import _constrained_dominates
 from typing import Any
 from typing import Callable
 from typing import Dict
@@ -30,6 +29,7 @@ from optuna.samplers.nsgaii import UNDXCrossover
 from optuna.samplers.nsgaii import UniformCrossover
 from optuna.samplers.nsgaii import VSBXCrossover
 from optuna.samplers.nsgaii._crossover import _inlined_categorical_uniform_crossover
+from optuna.samplers.nsgaii._sampler import _constrained_dominates
 from optuna.samplers.nsgaii._sampler import _CONSTRAINTS_KEY
 from optuna.study._study_direction import StudyDirection
 from optuna.trial import FrozenTrial
@@ -128,9 +128,7 @@ def test_constraints_func_none() -> None:
         assert _CONSTRAINTS_KEY not in trial.system_attrs
 
 
-@pytest.mark.parametrize(
-    "constraint_value", [-1.0, 0.0, 1.0, -float("inf"), float("inf")]
-)
+@pytest.mark.parametrize("constraint_value", [-1.0, 0.0, 1.0, -float("inf"), float("inf")])
 def test_constraints_func(constraint_value: float) -> None:
     n_trials = 4
     n_objectives = 2
@@ -156,6 +154,7 @@ def test_constraints_func(constraint_value: float) -> None:
     for trial in study.trials:
         for x, y in zip(trial.system_attrs[_CONSTRAINTS_KEY], (constraint_value + trial.number,)):
             assert _nan_equal(x, y)
+
 
 def test_constrained_dominates_with_nan_constraint() -> None:
     directions = [StudyDirection.MINIMIZE, StudyDirection.MINIMIZE]

--- a/tests/samplers_tests/test_nsgaii.py
+++ b/tests/samplers_tests/test_nsgaii.py
@@ -1,4 +1,5 @@
 from collections import Counter
+from optuna.samplers.nsgaii._sampler import _constrained_dominates
 from typing import Any
 from typing import Callable
 from typing import Dict
@@ -128,7 +129,7 @@ def test_constraints_func_none() -> None:
 
 
 @pytest.mark.parametrize(
-    "constraint_value", [-1.0, 0.0, 1.0, -float("inf"), float("inf"), float("nan")]
+    "constraint_value", [-1.0, 0.0, 1.0, -float("inf"), float("inf")]
 )
 def test_constraints_func(constraint_value: float) -> None:
     n_trials = 4
@@ -155,6 +156,14 @@ def test_constraints_func(constraint_value: float) -> None:
     for trial in study.trials:
         for x, y in zip(trial.system_attrs[_CONSTRAINTS_KEY], (constraint_value + trial.number,)):
             assert _nan_equal(x, y)
+
+def test_constrained_dominates_with_nan_constraint() -> None:
+    directions = [StudyDirection.MINIMIZE, StudyDirection.MINIMIZE]
+
+    t1 = _create_frozen_trial(0, [1], [0, float("nan")])
+    t2 = _create_frozen_trial(0, [0], [1, -1])
+    with pytest.raises(ValueError):
+        _constrained_dominates(t1, t2, directions)
 
 
 def test_fast_non_dominated_sort() -> None:


### PR DESCRIPTION

## Motivation
Currently, NSGA-II behaves very counterintuitively when `nan` is given as constraint values. `nan` values are treated as infeasible, but it is currently treated as zero violation.

We resolve this issue by simply raising `ValueError` when a `nan` is found.

## Description of the changes
Raise `ValueError` in `_constrained_dominates` function when a `nan` constraint is encountered.
