### PR TITLE
Fix `inf`-related issue on implementation of `_calculate_nondomination_rank`

### DIFF
--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -580,13 +580,11 @@ def _calculate_nondomination_rank(loss_vals: np.ndarray) -> np.ndarray:
     ranks = np.full(len(loss_vals), -1)
     num_unranked = len(loss_vals)
     rank = 0
+    domination_mat = np.all(loss_vals[:, None, :] >= loss_vals[None, :, :], axis=2) & np.any(
+        loss_vals[:, None, :] > loss_vals[None, :, :], axis=2
+    )
     while num_unranked > 0:
-        counts = np.sum(
-            (ranks == -1)[None, :]
-            & np.all(loss_vals[:, None, :] >= loss_vals[None, :, :], axis=2)
-            & np.any(loss_vals[:, None, :] > loss_vals[None, :, :], axis=2),
-            axis=1,
-        )
+        counts = np.sum((ranks == -1)[None, :] & domination_mat, axis=1)
         num_unranked -= np.sum((counts == 0) & (ranks == -1))
         ranks[(counts == 0) & (ranks == -1)] = rank
         rank += 1

--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -577,16 +577,14 @@ class TPESampler(BaseSampler):
 
 
 def _calculate_nondomination_rank(loss_vals: np.ndarray) -> np.ndarray:
-    vecs = loss_vals
-
-    ranks = np.full(len(vecs), -1)
-    num_unranked = len(vecs)
+    ranks = np.full(len(loss_vals), -1)
+    num_unranked = len(loss_vals)
     rank = 0
     while num_unranked > 0:
         counts = np.sum(
             (ranks == -1)[None, :]
-            & np.all(vecs[:, None, :] >= vecs[None, :, :], axis=2)
-            & np.any(vecs[:, None, :] > vecs[None, :, :], axis=2),
+            & np.all(loss_vals[:, None, :] >= loss_vals[None, :, :], axis=2)
+            & np.any(loss_vals[:, None, :] > loss_vals[None, :, :], axis=2),
             axis=1,
         )
         num_unranked -= np.sum((counts == 0) & (ranks == -1))

--- a/tests/samplers_tests/tpe_tests/test_multi_objective_sampler.py
+++ b/tests/samplers_tests/tpe_tests/test_multi_objective_sampler.py
@@ -429,14 +429,14 @@ def test_calculate_nondomination_rank() -> None:
         [[1, 1], [1, float("inf")], [float("inf"), 1], [float("inf"), float("inf")]]
     )
     ranks = list(_tpe.sampler._calculate_nondomination_rank(test_case))
-    assert ranks == [0, 0, 0, 0]
+    assert ranks == [0, 1, 1, 2]
 
     # The -inf is included.
     test_case = np.asarray(
         [[1, 1], [1, -float("inf")], [-float("inf"), 1], [-float("inf"), -float("inf")]]
     )
     ranks = list(_tpe.sampler._calculate_nondomination_rank(test_case))
-    assert ranks == [0, 0, 0, 0]
+    assert ranks == [2, 1, 1, 0]
 
 
 def test_calculate_weights_below_for_multi_objective() -> None:


### PR DESCRIPTION
## Motivation
Resolve #3674.

## Description of the changes
Fix implementation of `_calculate_nondomination_rank` such that it returns correct values even when there are `inf` values.
