### PR TITLE
Fix `test_calculate_weights_below`

### DIFF
--- a/tests/samplers_tests/tpe_tests/test_multi_objective_sampler.py
+++ b/tests/samplers_tests/tpe_tests/test_multi_objective_sampler.py
@@ -441,13 +441,13 @@ def test_calculate_nondomination_rank() -> None:
 
 def test_calculate_weights_below_for_multi_objective() -> None:
     # No sample.
-    with pytest.raises(IndexError):
-        _ = _tpe.sampler._calculate_weights_below_for_multi_objective(
-            {"x": np.array([1.0, 2.0, 3.0], dtype=float)},
-            [(0, [0.2, 0.5]), (0, [0.9, 0.4]), (0, [1, 1])],
-            np.array([]),
-            None,
-        )
+    weights_below = _tpe.sampler._calculate_weights_below_for_multi_objective(
+        {"x": np.array([1.0, 2.0, 3.0], dtype=float)},
+        [(0, [0.2, 0.5]), (0, [0.9, 0.4]), (0, [1, 1])],
+        np.array([], np.int64),
+        None,
+    )
+    assert len(weights_below) == 0
 
     # One sample.
     weights_below = _tpe.sampler._calculate_weights_below_for_multi_objective(


### PR DESCRIPTION

## Motivation
Related issue: #3675 
We fix a bug in `test_calculate_weights_below` about empty input.

## Description of the changes
Specify `np.array([], dtype=np.int64)` as `indices` instead of `np.array([])`.
