### PR TITLE
Fix `_calculate_weights` such that it throws `ValueError` on invalid weights

### DIFF
--- a/optuna/samplers/_tpe/parzen_estimator.py
+++ b/optuna/samplers/_tpe/parzen_estimator.py
@@ -203,6 +203,7 @@ class _ParzenEstimator:
         return ret
 
     def _calculate_weights(self, predetermined_weights: Optional[np.ndarray]) -> np.ndarray:
+
         # We decide the weights.
         consider_prior = self._parameters.consider_prior
         prior_weight = self._parameters.prior_weight

--- a/optuna/samplers/_tpe/parzen_estimator.py
+++ b/optuna/samplers/_tpe/parzen_estimator.py
@@ -216,12 +216,12 @@ class _ParzenEstimator:
             w = weights_func(n_observations)[:n_observations]
             if w is not None:
                 if np.any(w < 0):
-                    raise ValueError("Negative parameters.weights are not allowed.")
+                    raise ValueError(f"The `weights` function is not allowed to return negative values {w}. The argument of the `weights` function is {n_observations}.")
                 if len(w) > 0 and np.sum(w) <= 0:
-                    raise ValueError("parameters.weights of all zeros are not allowed")
+                    raise ValueError(f"The `weight` function is not allowed to return all-zero values {w}. The argument of the `weights` function is {n_observations}.")
                 if not np.all(np.isfinite(w)):
                     raise ValueError(
-                        "parameters.weights of infinite or NaN values are not allowed."
+                        f"The `weights`function is not allowed to return infinite or NaN values {w}. The argument of the `weights` function is {n_observations}."
                     )
         else:
             w = predetermined_weights[:n_observations]

--- a/optuna/samplers/_tpe/parzen_estimator.py
+++ b/optuna/samplers/_tpe/parzen_estimator.py
@@ -1,4 +1,3 @@
-from multiprocessing.sharedctypes import Value
 from typing import Callable
 from typing import Dict
 from typing import NamedTuple
@@ -221,7 +220,9 @@ class _ParzenEstimator:
                 if len(w) > 0 and np.sum(w) <= 0:
                     raise ValueError("parameters.weights of all zeros are not allowed")
                 if not np.all(np.isfinite(w)):
-                    raise ValueError("parameters.weights of infinite or NaN values are not allowed.")
+                    raise ValueError(
+                        "parameters.weights of infinite or NaN values are not allowed."
+                    )
         else:
             w = predetermined_weights[:n_observations]
 

--- a/optuna/samplers/_tpe/parzen_estimator.py
+++ b/optuna/samplers/_tpe/parzen_estimator.py
@@ -218,12 +218,19 @@ class _ParzenEstimator:
             w = weights_func(n_observations)[:n_observations]
             if w is not None:
                 if np.any(w < 0):
-                    raise ValueError(f"The `weights` function is not allowed to return negative values {w}. The argument of the `weights` function is {n_observations}.")
+                    raise ValueError(
+                        f"The `weights` function is not allowed to return negative values {w}. "
+                        + f"The argument of the `weights` function is {n_observations}."
+                    )
                 if len(w) > 0 and np.sum(w) <= 0:
-                    raise ValueError(f"The `weight` function is not allowed to return all-zero values {w}. The argument of the `weights` function is {n_observations}.")
+                    raise ValueError(
+                        f"The `weight` function is not allowed to return all-zero values {w}."
+                        + f" The argument of the `weights` function is {n_observations}."
+                    )
                 if not np.all(np.isfinite(w)):
                     raise ValueError(
-                        f"The `weights`function is not allowed to return infinite or NaN values {w}. The argument of the `weights` function is {n_observations}."
+                        "The `weights`function is not allowed to return infinite or NaN values "
+                        + f"{w}. The argument of the `weights` function is {n_observations}."
                     )
         else:
             w = predetermined_weights[:n_observations]

--- a/optuna/samplers/_tpe/parzen_estimator.py
+++ b/optuna/samplers/_tpe/parzen_estimator.py
@@ -54,6 +54,7 @@ class _ParzenEstimator:
         parameters: _ParzenEstimatorParameters,
         predetermined_weights: Optional[np.ndarray] = None,
     ) -> None:
+
         self._search_space = search_space
         self._parameters = parameters
         self._n_observations = next(iter(observations.values())).size

--- a/tests/samplers_tests/tpe_tests/test_multi_objective_sampler.py
+++ b/tests/samplers_tests/tpe_tests/test_multi_objective_sampler.py
@@ -142,6 +142,7 @@ def test_multi_objective_sample_independent_misc_arguments() -> None:
     sampler = TPESampler(gamma=lambda _: 1, seed=0)
     assert suggest(sampler, study, trial, dist, past_trials) != suggestion
 
+
 @pytest.mark.parametrize("log, step", [(False, None), (True, None), (False, 0.1)])
 def test_multi_objective_sample_independent_float_distributions(
     log: bool, step: Optional[float]

--- a/tests/samplers_tests/tpe_tests/test_multi_objective_sampler.py
+++ b/tests/samplers_tests/tpe_tests/test_multi_objective_sampler.py
@@ -142,10 +142,6 @@ def test_multi_objective_sample_independent_misc_arguments() -> None:
     sampler = TPESampler(gamma=lambda _: 1, seed=0)
     assert suggest(sampler, study, trial, dist, past_trials) != suggestion
 
-    sampler = TPESampler(weights=lambda n: np.zeros(n), seed=0)
-    assert suggest(sampler, study, trial, dist, past_trials) != suggestion
-
-
 @pytest.mark.parametrize("log, step", [(False, None), (True, None), (False, 0.1)])
 def test_multi_objective_sample_independent_float_distributions(
     log: bool, step: Optional[float]

--- a/tests/samplers_tests/tpe_tests/test_parzen_estimator.py
+++ b/tests/samplers_tests/tpe_tests/test_parzen_estimator.py
@@ -1,4 +1,3 @@
-from multiprocessing.sharedctypes import Value
 from typing import Callable
 from typing import Dict
 from typing import List

--- a/tests/samplers_tests/tpe_tests/test_parzen_estimator.py
+++ b/tests/samplers_tests/tpe_tests/test_parzen_estimator.py
@@ -1,3 +1,4 @@
+from multiprocessing.sharedctypes import Value
 from typing import Callable
 from typing import Dict
 from typing import List
@@ -389,12 +390,7 @@ def test_invalid_weights(weights: Callable[[int], np.ndarray]) -> None:
         weights=weights,
         multivariate=False,
     )
-    mpe = _ParzenEstimator(
-        {"a": np.asarray([0.0])}, {"a": distributions.FloatDistribution(-1.0, 1.0)}, parameters
-    )
-
-    # TODO(HideakiImamura): Currently, the weight calculation does not raise if the specified
-    #  weights function is invalid. To be fixed to raise a `ValueError`.
-    assert len(mpe._weights) == 1
-    # If `weights = lambda x: -np.ones(x)`, the calculated weight is 1, otherwise nan.
-    assert np.isnan(mpe._weights[0]) or mpe._weights[0] == 1.0
+    with pytest.raises(ValueError):
+        _ParzenEstimator(
+            {"a": np.asarray([0.0])}, {"a": distributions.FloatDistribution(-1.0, 1.0)}, parameters
+        )


### PR DESCRIPTION

## Motivation
Resolve #3687.

## Description of the changes
Add checks for invalid weights in `_calculate_weights`.
