### PR TITLE
Remove deprecated storage functions

### DIFF
--- a/optuna/storages/_rdb/storage.py
+++ b/optuna/storages/_rdb/storage.py
@@ -20,7 +20,6 @@ import uuid
 import optuna
 from optuna import distributions
 from optuna import version
-from optuna._deprecated import deprecated_func
 from optuna._imports import _LazyImport
 from optuna.storages._base import BaseStorage
 from optuna.storages._base import DEFAULT_STUDY_NAME_PREFIX
@@ -676,32 +675,6 @@ class RDBStorage(BaseStorage, BaseHeartbeat):
 
         return trial
 
-    @deprecated_func(
-        "3.0.0",
-        "5.0.0",
-        text="Use :func:`~optuna.storages.RDBStorage.set_trial_state_values` instead.",
-    )
-    def set_trial_state(self, trial_id: int, state: TrialState) -> bool:
-
-        try:
-            with _create_scoped_session(self.scoped_session) as session:
-                trial = models.TrialModel.find_or_raise_by_id(trial_id, session, for_update=True)
-                self.check_trial_is_updatable(trial_id, trial.state)
-
-                if state == TrialState.RUNNING and trial.state != TrialState.WAITING:
-                    return False
-
-                trial.state = state
-
-                if state == TrialState.RUNNING:
-                    trial.datetime_start = datetime.now()
-
-                if state.is_finished():
-                    trial.datetime_complete = datetime.now()
-        except sqlalchemy_exc.IntegrityError:
-            return False
-        return True
-
     def set_trial_param(
         self,
         trial_id: int,
@@ -781,19 +754,6 @@ class RDBStorage(BaseStorage, BaseHeartbeat):
             param_value = trial_param.param_value
 
         return param_value
-
-    @deprecated_func(
-        "3.0.0",
-        "5.0.0",
-        text="Use :func:`~optuna.storages.RDBStorage.set_trial_state_values` instead.",
-    )
-    def set_trial_values(self, trial_id: int, values: Sequence[float]) -> None:
-
-        with _create_scoped_session(self.scoped_session) as session:
-            trial = models.TrialModel.find_or_raise_by_id(trial_id, session)
-            self.check_trial_is_updatable(trial_id, trial.state)
-            for objective, v in enumerate(values):
-                self._set_trial_value_without_commit(session, trial_id, objective, v)
 
     def set_trial_state_values(
         self, trial_id: int, state: TrialState, values: Optional[Sequence[float]] = None
@@ -1159,21 +1119,6 @@ class RDBStorage(BaseStorage, BaseHeartbeat):
                 session.add(heartbeat)
             else:
                 heartbeat.heartbeat = session.execute(sqlalchemy.func.now()).scalar()
-
-    @deprecated_func(
-        "3.0.0",
-        "5.0.0",
-        text="Use :func:`~optuna.storages.fail_stale_trials` instead.",
-    )
-    def fail_stale_trials(self, study_id: int) -> List[int]:
-        stale_trial_ids = self._get_stale_trial_ids(study_id)
-        confirmed_stale_trial_ids = []
-
-        for trial_id in stale_trial_ids:
-            if self.set_trial_state_values(trial_id, state=TrialState.FAIL):
-                confirmed_stale_trial_ids.append(trial_id)
-
-        return confirmed_stale_trial_ids
 
     def _get_stale_trial_ids(self, study_id: int) -> List[int]:
         assert self.heartbeat_interval is not None

--- a/optuna/storages/_redis.py
+++ b/optuna/storages/_redis.py
@@ -16,7 +16,6 @@ from typing import Union
 import optuna
 from optuna import distributions
 from optuna import exceptions
-from optuna._deprecated import deprecated_func
 from optuna._experimental import experimental_class
 from optuna._imports import try_import
 from optuna.storages import BaseStorage
@@ -422,38 +421,6 @@ class RedisStorage(BaseStorage, BaseHeartbeat):
             datetime_complete=None,
         )
 
-    @deprecated_func(
-        "3.0.0",
-        "5.0.0",
-        text="Use :func:`~optuna.storages.RedisStorage.set_trial_state_values` instead.",
-    )
-    def set_trial_state(self, trial_id: int, state: TrialState) -> bool:
-
-        trial = self.get_trial(trial_id)
-        self.check_trial_is_updatable(trial_id, trial.state)
-
-        if state == TrialState.RUNNING and trial.state != TrialState.WAITING:
-            return False
-
-        trial.state = state
-
-        if state == TrialState.RUNNING:
-            trial.datetime_start = datetime.now()
-
-        if state.is_finished():
-            trial.datetime_complete = datetime.now()
-            self._redis.set(self._key_trial(trial_id), pickle.dumps(trial))
-            self._update_cache(trial_id)
-
-            # To ensure that there are no failed trials with heartbeats in the DB
-            # under any circumstances
-            study_id = self._get_study_id_from_trial_id(trial_id)
-            self._redis.hdel(self._key_study_heartbeats(study_id), str(trial_id))
-        else:
-            self._redis.set(self._key_trial(trial_id), pickle.dumps(trial))
-
-        return True
-
     def set_trial_param(
         self,
         trial_id: int,
@@ -558,19 +525,6 @@ class RedisStorage(BaseStorage, BaseHeartbeat):
 
         self._check_study_id(study_id)
         self.set_trial_param(trial_id, param_name, param_value_internal, distribution)
-
-    @deprecated_func(
-        "3.0.0",
-        "5.0.0",
-        text="Use :func:`~optuna.storages.RedisStorage.set_trial_state_values` instead.",
-    )
-    def set_trial_values(self, trial_id: int, values: Sequence[float]) -> None:
-
-        trial = self.get_trial(trial_id)
-        self.check_trial_is_updatable(trial_id, trial.state)
-
-        trial.values = values
-        self._redis.set(self._key_trial(trial_id), pickle.dumps(trial))
 
     def set_trial_state_values(
         self, trial_id: int, state: TrialState, values: Optional[Sequence[float]] = None
@@ -739,19 +693,6 @@ class RedisStorage(BaseStorage, BaseHeartbeat):
             str(trial_id),
             pickle.dumps(self._get_redis_time()),
         )
-
-    @deprecated_func(
-        "3.0.0",
-        "5.0.0",
-        text="Use :func:`~optuna.storages.fail_stale_trials` instead.",
-    )
-    def fail_stale_trials(self, study_id: int) -> List[int]:
-        confirmed = []
-        for trial_id in self._get_stale_trial_ids(study_id):
-            if self.set_trial_state_values(trial_id, state=TrialState.FAIL):
-                confirmed.append(trial_id)
-
-        return confirmed
 
     def _get_stale_trial_ids(self, study_id: int) -> List[int]:
         assert self.heartbeat_interval is not None

--- a/tests/storages_tests/test_heartbeat.py
+++ b/tests/storages_tests/test_heartbeat.py
@@ -224,20 +224,6 @@ def test_fail_stale_trials(storage_mode: str, grace_period: Optional[int]) -> No
 
 
 @pytest.mark.parametrize("storage_mode", ["sqlite", "redis"])
-def test_fail_stale_trials_raw(storage_mode: str) -> None:
-    heartbeat_interval = 1
-    grace_period = 2
-
-    with StorageSupplier(storage_mode) as storage:
-        assert isinstance(storage, (RDBStorage, RedisStorage))
-        storage.heartbeat_interval = heartbeat_interval
-        storage.grace_period = grace_period
-
-        study_id = storage.create_new_study()
-        assert storage.fail_stale_trials(study_id) == []
-
-
-@pytest.mark.parametrize("storage_mode", ["sqlite", "redis"])
 def test_get_stale_trial_ids(storage_mode: str) -> None:
     heartbeat_interval = 1
     grace_period = 2

--- a/tests/storages_tests/test_storages.py
+++ b/tests/storages_tests/test_storages.py
@@ -438,54 +438,6 @@ def test_get_trial_number_from_id(storage_mode: str) -> None:
 
 
 @pytest.mark.parametrize("storage_mode", STORAGE_MODES)
-def test_set_trial_state(storage_mode: str) -> None:
-
-    with StorageSupplier(storage_mode) as storage:
-
-        if isinstance(storage, (InMemoryStorage, _CachedStorage)):
-            pytest.skip("InMemoryStorage and _CachedStorage does not have set_trial_state()")
-            return  # needed for mypy
-        study_id = storage.create_new_study()
-        trial_ids = [storage.create_new_trial(study_id) for _ in ALL_STATES]
-
-        for trial_id, state in zip(trial_ids, ALL_STATES):
-            if state == TrialState.WAITING:
-                continue
-            assert storage.get_trial(trial_id).state == TrialState.RUNNING
-            datetime_start_prev = storage.get_trial(trial_id).datetime_start
-            if state.is_finished():
-                storage.set_trial_values(trial_id, (0.0,))
-            storage.set_trial_state(trial_id, state)
-            assert storage.get_trial(trial_id).state == state
-            # Repeated state changes to RUNNING should not trigger further datetime_start changes.
-            if state == TrialState.RUNNING:
-                assert storage.get_trial(trial_id).datetime_start == datetime_start_prev
-            if state.is_finished():
-                assert storage.get_trial(trial_id).datetime_complete is not None
-            else:
-                assert storage.get_trial(trial_id).datetime_complete is None
-
-        # Non-existent study.
-        with pytest.raises(KeyError):
-            non_existent_trial_id = max(trial_ids) + 1
-            storage.set_trial_state(
-                non_existent_trial_id,
-                state=TrialState.COMPLETE,
-            )
-
-        for state in ALL_STATES:
-            if not state.is_finished():
-                continue
-            trial_id = storage.create_new_trial(study_id)
-            storage.set_trial_values(trial_id, (0.0,))
-            storage.set_trial_state(trial_id, state)
-            for state2 in ALL_STATES:
-                # Cannot update states of finished trials.
-                with pytest.raises(RuntimeError):
-                    storage.set_trial_state(trial_id, state2)
-
-
-@pytest.mark.parametrize("storage_mode", STORAGE_MODES)
 def test_set_trial_state_values_for_state(storage_mode: str) -> None:
 
     with StorageSupplier(storage_mode) as storage:
@@ -624,48 +576,6 @@ def test_set_trial_param(storage_mode: str) -> None:
         non_existent_trial_id = max([trial_id_1, trial_id_2, trial_id_3]) + 1
         with pytest.raises(KeyError):
             storage.set_trial_param(non_existent_trial_id, "x", 0.1, distribution_x)
-
-
-@pytest.mark.parametrize("storage_mode", STORAGE_MODES)
-def test_set_trial_values(storage_mode: str) -> None:
-
-    with StorageSupplier(storage_mode) as storage:
-
-        if isinstance(storage, (InMemoryStorage, _CachedStorage)):
-            pytest.skip("InMemoryStorage and _CachedStorage does not have set_trial_values()")
-            return  # needed for mypy
-        # Setup test across multiple studies and trials.
-        study_id = storage.create_new_study()
-        trial_id_1 = storage.create_new_trial(study_id)
-        trial_id_2 = storage.create_new_trial(study_id)
-        trial_id_3 = storage.create_new_trial(storage.create_new_study())
-        trial_id_4 = storage.create_new_trial(study_id)
-        trial_id_5 = storage.create_new_trial(study_id)
-
-        # Test setting new value.
-        storage.set_trial_values(trial_id_1, (0.5,))
-        storage.set_trial_values(trial_id_3, (float("inf"),))
-        storage.set_trial_values(trial_id_4, (0.1, 0.2, 0.3))
-        storage.set_trial_values(trial_id_5, [0.1, 0.2, 0.3])
-
-        assert storage.get_trial(trial_id_1).value == 0.5
-        assert storage.get_trial(trial_id_2).value is None
-        assert storage.get_trial(trial_id_3).value == float("inf")
-        assert storage.get_trial(trial_id_4).values == [0.1, 0.2, 0.3]
-        assert storage.get_trial(trial_id_5).values == [0.1, 0.2, 0.3]
-
-        # Values can be overwritten.
-        storage.set_trial_values(trial_id_1, (0.2,))
-        assert storage.get_trial(trial_id_1).value == 0.2
-
-        non_existent_trial_id = max(trial_id_1, trial_id_2, trial_id_3, trial_id_4, trial_id_5) + 1
-        with pytest.raises(KeyError):
-            storage.set_trial_values(non_existent_trial_id, (1,))
-
-        storage.set_trial_state(trial_id_1, TrialState.COMPLETE)
-        # Cannot change values of finished trials.
-        with pytest.raises(RuntimeError):
-            storage.set_trial_values(trial_id_1, (1,))
 
 
 @pytest.mark.parametrize("storage_mode", STORAGE_MODES)


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
Remove deprecated functions in storage classes.
Development team decided to remove them before V3 release, to reduce future maintenance cost.

## Description of the changes
<!-- Describe the changes in this PR. -->
- Remove `set_trial_state`, `set_trial_values`,  and `fail_stale_trials` from `RDBStorage` and `RedisStorage`.
- Remove tests associated with the above functions.