### PR TITLE
Add line to Pareto front visualisation

### DIFF
--- a/optuna/visualization/_pareto_front.py
+++ b/optuna/visualization/_pareto_front.py
@@ -11,6 +11,8 @@ from typing import Tuple
 from typing import Union
 import warnings
 
+import numpy as np
+
 import optuna
 from optuna.exceptions import ExperimentalWarning
 from optuna.study import Study
@@ -387,7 +389,9 @@ def _make_scatter_object(
         y = [values[axis_order[1]] for _, values in trials_with_values]
         # If a line is being added, the points need to be in order.
         if "lines" in mode:
-            x, y = zip(*sorted(zip(x, y), key=lambda p: p[0]))
+            idx_order = np.argsort(x)
+            x = [x[idx] for idx in idx_order]
+            y = [y[idx] for idx in idx_order]
         return go.Scatter(
             x=x,
             y=y,
@@ -400,10 +404,13 @@ def _make_scatter_object(
     elif n_targets == 3:
         x = [values[axis_order[0]] for _, values in trials_with_values]
         y = [values[axis_order[1]] for _, values in trials_with_values]
-        z = [values[axis_order[1]] for _, values in trials_with_values]
+        z = [values[axis_order[2]] for _, values in trials_with_values]
         # If a line is being added, the points need to be in order.
         if "lines" in mode:
-            x, y, z = zip(*sorted(zip(x, y, z), key=lambda p: p[0]))
+            idx_order = np.argsort(x)
+            x = [x[idx] for idx in idx_order]
+            y = [y[idx] for idx in idx_order]
+            z = [z[idx] for idx in idx_order]
         return go.Scatter3d(
             x=x,
             y=y,

--- a/optuna/visualization/_pareto_front.py
+++ b/optuna/visualization/_pareto_front.py
@@ -159,7 +159,6 @@ def plot_pareto_front(
                 info.best_trials_with_values,
                 hovertemplate="%{text}<extra>Best Trial</extra>",
                 dominated_trials=False,
-                mode="markers",
             ),
         ]
     else:
@@ -193,7 +192,6 @@ def plot_pareto_front(
                 info.best_trials_with_values,
                 hovertemplate="%{text}<extra>Best Trial</extra>",
                 dominated_trials=False,
-                mode="markers",
             ),
         ]
 
@@ -437,7 +435,6 @@ def _make_scatter_object(
     hovertemplate: str,
     infeasible: bool = False,
     dominated_trials: bool = False,
-    mode: str = "markers",
 ) -> Union["go.Scatter", "go.Scatter3d"]:
     trials_with_values = trials_with_values or []
 
@@ -448,38 +445,22 @@ def _make_scatter_object(
         infeasible=infeasible,
     )
     if n_targets == 2:
-        x = [values[axis_order[0]] for _, values in trials_with_values]
-        y = [values[axis_order[1]] for _, values in trials_with_values]
-        # If a line is being added, the points need to be in order.
-        if "lines" in mode:
-            idx_order = np.argsort(x)
-            x = [x[idx] for idx in idx_order]
-            y = [y[idx] for idx in idx_order]
         return go.Scatter(
-            x=x,
-            y=y,
+            x=[values[axis_order[0]] for _, values in trials_with_values],
+            y=[values[axis_order[1]] for _, values in trials_with_values],
             text=[_make_hovertext(trial) for trial, _ in trials_with_values],
-            mode=mode,
+            mode="markers",
             hovertemplate=hovertemplate,
             marker=marker,
             showlegend=False,
         )
     elif n_targets == 3:
-        x = [values[axis_order[0]] for _, values in trials_with_values]
-        y = [values[axis_order[1]] for _, values in trials_with_values]
-        z = [values[axis_order[2]] for _, values in trials_with_values]
-        # If a line is being added, the points need to be in order.
-        if "lines" in mode:
-            idx_order = np.argsort(x)
-            x = [x[idx] for idx in idx_order]
-            y = [y[idx] for idx in idx_order]
-            z = [z[idx] for idx in idx_order]
         return go.Scatter3d(
-            x=x,
-            y=y,
-            z=z,
+            x=[values[axis_order[0]] for _, values in trials_with_values],
+            y=[values[axis_order[1]] for _, values in trials_with_values],
+            z=[values[axis_order[2]] for _, values in trials_with_values],
             text=[_make_hovertext(trial) for trial, _ in trials_with_values],
-            mode=mode,
+            mode="markers",
             hovertemplate=hovertemplate,
             marker=marker,
             showlegend=False,

--- a/optuna/visualization/_pareto_front.py
+++ b/optuna/visualization/_pareto_front.py
@@ -141,7 +141,7 @@ def plot_pareto_front(
                 info.best_trials_with_values,
                 hovertemplate="%{text}<extra>Best Trial</extra>",
                 dominated_trials=False,
-                mode="lines+markers"
+                mode="lines+markers",
             ),
         ]
     else:
@@ -175,7 +175,7 @@ def plot_pareto_front(
                 info.best_trials_with_values,
                 hovertemplate="%{text}<extra>Best Trial</extra>",
                 dominated_trials=False,
-                mode="lines+markers"
+                mode="lines+markers",
             ),
         ]
 
@@ -385,7 +385,7 @@ def _make_scatter_object(
     if n_targets == 2:
         x = [values[axis_order[0]] for _, values in trials_with_values]
         y = [values[axis_order[1]] for _, values in trials_with_values]
-        # If a line is being added, the points need to be in order. Otherwise, we can avoid doing the sorting.
+        # If a line is being added, the points need to be in order.
         if "lines" in mode:
             x, y = zip(*sorted(zip(x, y), key=lambda p: p[0]))
         return go.Scatter(
@@ -401,7 +401,7 @@ def _make_scatter_object(
         x = [values[axis_order[0]] for _, values in trials_with_values]
         y = [values[axis_order[1]] for _, values in trials_with_values]
         z = [values[axis_order[1]] for _, values in trials_with_values]
-        # If a line is being added, the points need to be in order. Otherwise, we can avoid doing the sorting.
+        # If a line is being added, the points need to be in order.
         if "lines" in mode:
             x, y, z = zip(*sorted(zip(x, y, z), key=lambda p: p[0]))
         return go.Scatter3d(

--- a/optuna/visualization/_pareto_front.py
+++ b/optuna/visualization/_pareto_front.py
@@ -141,6 +141,7 @@ def plot_pareto_front(
                 info.best_trials_with_values,
                 hovertemplate="%{text}<extra>Best Trial</extra>",
                 dominated_trials=False,
+                mode="lines+markers"
             ),
         ]
     else:
@@ -174,6 +175,7 @@ def plot_pareto_front(
                 info.best_trials_with_values,
                 hovertemplate="%{text}<extra>Best Trial</extra>",
                 dominated_trials=False,
+                mode="lines+markers"
             ),
         ]
 
@@ -370,6 +372,7 @@ def _make_scatter_object(
     hovertemplate: str,
     infeasible: bool = False,
     dominated_trials: bool = False,
+    mode: str = "markers",
 ) -> Union["go.Scatter", "go.Scatter3d"]:
     trials_with_values = trials_with_values or []
 
@@ -380,22 +383,33 @@ def _make_scatter_object(
         infeasible=infeasible,
     )
     if n_targets == 2:
+        x = [values[axis_order[0]] for _, values in trials_with_values]
+        y = [values[axis_order[1]] for _, values in trials_with_values]
+        # If a line is being added, the points need to be in order. Otherwise, we can avoid doing the sorting.
+        if "lines" in mode:
+            x, y = zip(*sorted(zip(x, y), key=lambda p: p[0]))
         return go.Scatter(
-            x=[values[axis_order[0]] for _, values in trials_with_values],
-            y=[values[axis_order[1]] for _, values in trials_with_values],
+            x=x,
+            y=y,
             text=[_make_hovertext(trial) for trial, _ in trials_with_values],
-            mode="markers",
+            mode=mode,
             hovertemplate=hovertemplate,
             marker=marker,
             showlegend=False,
         )
     elif n_targets == 3:
+        x = [values[axis_order[0]] for _, values in trials_with_values]
+        y = [values[axis_order[1]] for _, values in trials_with_values]
+        z = [values[axis_order[1]] for _, values in trials_with_values]
+        # If a line is being added, the points need to be in order. Otherwise, we can avoid doing the sorting.
+        if "lines" in mode:
+            x, y, z = zip(*sorted(zip(x, y, z), key=lambda p: p[0]))
         return go.Scatter3d(
-            x=[values[axis_order[0]] for _, values in trials_with_values],
-            y=[values[axis_order[1]] for _, values in trials_with_values],
-            z=[values[axis_order[2]] for _, values in trials_with_values],
+            x=x,
+            y=y,
+            z=z,
             text=[_make_hovertext(trial) for trial, _ in trials_with_values],
-            mode="markers",
+            mode=mode,
             hovertemplate=hovertemplate,
             marker=marker,
             showlegend=False,

--- a/tests/visualization_tests/test_pareto_front.py
+++ b/tests/visualization_tests/test_pareto_front.py
@@ -25,7 +25,9 @@ def _check_data(figure: "go.Figure", axis: str, expected: Sequence[int]) -> None
     """Compare `figure` against `expected`.
 
     Concatenate `data` in `figure` in reverse order, pick the desired `axis`, and compare with
-    the `expected` result.
+    the `expected` result. Both the `actual` and `expected` results are sorted prior to
+    comparison as the order may change during plotting (due to adding the Pareto front line).
+    The crucial part is that the content of both lists is the same, not the order.
 
     Args:
         figure: A figure.
@@ -37,7 +39,7 @@ def _check_data(figure: "go.Figure", axis: str, expected: Sequence[int]) -> None
     actual = tuple(
         itertools.chain(*list(map(lambda i: figure.data[i][axis], reversed(range(n_data)))))
     )
-    assert actual == expected
+    assert sorted(actual) == sorted(expected)
 
 
 @pytest.mark.parametrize("include_dominated_trials", [False, True])


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
Currently, for the Pareto plots, the dominating points are not connected, only shown in another colour. Adding a line connecting the dominating points would make it clearer which points are on the front and which are not. I find it especially hard to distinguish between dominating and non-dominating points for the extreme lights and darks of the marker colour gradients.

See #3747.

## Description of the changes
The plotting function `_make_scatter_object` in `_pareto_front.py` now has an additional argument `mode` . This determines whether a line should be added. Other thing of note is that if a line is being added, the points have to be sorted. For efficiency, this sorting is only performed if the line is required (i.e., when plotting the points with the line, the points are not sorted).