### PR TITLE
Match Python versions between `bayesmark` CI jobs

### DIFF
--- a/.github/workflows/performance-benchmarks-bayesmark.yml
+++ b/.github/workflows/performance-benchmarks-bayesmark.yml
@@ -100,7 +100,12 @@ jobs:
       with:
         name: partial-reports
         path: partial
-    
+
+    - name: Setup Python3.9
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
+
     - name: Install Python libraries
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
I noticed that jobs within bayesmark benchmark CI pipeline can run different Python versions, as `report` job did not explicitly specify one. It's probably better to match them, and this PR does that.

## Description of the changes
<!-- Describe the changes in this PR. -->
* Match Python versions between `bayesmark` CI jobs
