### PR TITLE
Refactor pareto front

### DIFF
--- a/optuna/visualization/_pareto_front.py
+++ b/optuna/visualization/_pareto_front.py
@@ -151,6 +151,11 @@ def _get_pareto_front_plot(info: _ParetoFrontInfo) -> "go.Figure":
             ),
         ]
     else:
+        warnings.warn(
+            "``constraints_func`` argument is an experimental feature."
+            " The interface can change in the future.",
+            ExperimentalWarning,
+        )
 
         data = [
             _make_scatter_object(
@@ -220,12 +225,6 @@ def _get_pareto_front_info(
         )
 
     if constraints_func is not None:
-        warnings.warn(
-            "``constraints_func`` argument is an experimental feature."
-            " The interface can change in the future.",
-            ExperimentalWarning,
-        )
-
         feasible_trials = []
         infeasible_trials = []
         for trial in study.get_trials(deepcopy=False, states=(TrialState.COMPLETE,)):

--- a/optuna/visualization/_pareto_front.py
+++ b/optuna/visualization/_pareto_front.py
@@ -129,11 +129,8 @@ def plot_pareto_front(
 
 
 def _get_pareto_front_plot(info: _ParetoFrontInfo) -> "go.Figure":
-    # include_dominated_trials = len(info.non_best_trials_with_values) != 0
     include_dominated_trials = info.include_dominated_trials
-    # has_constraints_func = len(info.infeasible_trials_with_values) != 0:
     has_constraints_func = info.has_constraints_func
-    # if len(info.infeasible_trials_with_values) != 0:
     if not has_constraints_func:
         data = [
             _make_scatter_object(

--- a/optuna/visualization/matplotlib/_pareto_front.py
+++ b/optuna/visualization/matplotlib/_pareto_front.py
@@ -125,10 +125,7 @@ def _get_pareto_front_2d(info: _ParetoFrontInfo) -> "Axes":
     ax.set_ylabel(info.target_names[info.axis_order[1]])
 
     trial_label: str = "Trial"
-    if (
-        info.infeasible_trials_with_values is not None
-        and len(info.infeasible_trials_with_values) > 0
-    ):
+    if len(info.infeasible_trials_with_values) > 0:
         ax.scatter(
             x=[values[info.axis_order[0]] for _, values in info.infeasible_trials_with_values],
             y=[values[info.axis_order[1]] for _, values in info.infeasible_trials_with_values],
@@ -136,14 +133,14 @@ def _get_pareto_front_2d(info: _ParetoFrontInfo) -> "Axes":
             label="Infeasible Trial",
         )
         trial_label = "Feasible Trial"
-    if info.non_best_trials_with_values is not None and len(info.non_best_trials_with_values) > 0:
+    if len(info.non_best_trials_with_values) > 0:
         ax.scatter(
             x=[values[info.axis_order[0]] for _, values in info.non_best_trials_with_values],
             y=[values[info.axis_order[1]] for _, values in info.non_best_trials_with_values],
             color=cmap(0),
             label=trial_label,
         )
-    if info.best_trials_with_values is not None and len(info.best_trials_with_values) > 0:
+    if len(info.best_trials_with_values) > 0:
         ax.scatter(
             x=[values[info.axis_order[0]] for _, values in info.best_trials_with_values],
             y=[values[info.axis_order[1]] for _, values in info.best_trials_with_values],


### PR DESCRIPTION
## Motivation
Currently, `plot_pareto_front` calls `_get_pareto_front_info` internally and plots it. However, there is a testability issue in this design. We cannot separate the tests for `_get_pareto_front_info` and the tests for plotting, because we need a `study` object anyway for testing `plot_pareto_front`. 
We extract a function `_get_pareto_front_plot` that takes `_ParetoFrontInfo` and returns the plotted figure.

Dependent PRs: #3752 #3753 

## Description of the changes
* Extract a function `_get_pareto_front_plot` that takes `_ParetoFrontInfo` and returns the plotted figure.
* Add `include_dominated_trials` and `has_constraints_func` in `_ParetoFrontInfo` such that `_ParetoFrontInfo` is information-complete.