### PR TITLE
Refactor importances plot

### DIFF
--- a/optuna/visualization/_param_importances.py
+++ b/optuna/visualization/_param_importances.py
@@ -29,6 +29,8 @@ class _ImportancesInfo(NamedTuple):
     importance_values: List[float]
     param_names: List[str]
     importance_labels: List[str]
+    target_name: str
+    hover_template: List[str]
 
 
 def _get_importances_info(
@@ -50,6 +52,7 @@ def _get_importances_info(
             importance_values=[],
             param_names=[],
             importance_labels=[],
+            target_name=target_name,
         )
 
     importances = optuna.importance.get_param_importances(
@@ -60,11 +63,17 @@ def _get_importances_info(
     importance_values = list(importances.values())
     param_names = list(importances.keys())
     importance_labels = [f"{val:.2f}" if val >= 0.01 else "<0.01" for val in importance_values]
+    hover_template = [
+        _make_hovertext(param_name, importance, study)
+        for param_name, importance in zip(param_names, importance_values)
+    ]
 
     return _ImportancesInfo(
         importance_values=importance_values,
         param_names=param_names,
         importance_labels=importance_labels,
+        target_name=target_name,
+        hover_template= hover_template
     )
 
 
@@ -135,34 +144,33 @@ def plot_param_importances(
     _imports.check()
 
     importances_info = _get_importances_info(study, evaluator, params, target, target_name)
+    return _get_importances_plot(importances_info)
+
+
+def _get_importances_plot(info: _ImportancesInfo) -> "go.Figure":
 
     layout = go.Layout(
         title="Hyperparameter Importances",
-        xaxis={"title": f"Importance for {target_name}"},
+        xaxis={"title": f"Importance for {info.target_name}"},
         yaxis={"title": "Hyperparameter"},
         showlegend=False,
     )
 
-    param_names = importances_info.param_names
-    importance_values = importances_info.importance_values
+    param_names = info.param_names
+    importance_values = info.importance_values
 
     if len(importance_values) == 0:
         return go.Figure(data=[], layout=layout)
-
-    hovertemplate = [
-        _make_hovertext(param_name, importance, study)
-        for param_name, importance in zip(param_names, importance_values)
-    ]
 
     fig = go.Figure(
         data=[
             go.Bar(
                 x=importance_values,
                 y=param_names,
-                text=importances_info.importance_labels,
+                text=info.importance_labels,
                 textposition="outside",
                 cliponaxis=False,  # Ensure text is not clipped.
-                hovertemplate=hovertemplate,
+                hovertemplate=info.hover_template,
                 marker_color=plotly.colors.sequential.Blues[-4],
                 orientation="h",
             )

--- a/optuna/visualization/_param_importances.py
+++ b/optuna/visualization/_param_importances.py
@@ -53,6 +53,7 @@ def _get_importances_info(
             param_names=[],
             importance_labels=[],
             target_name=target_name,
+            hover_template=[],
         )
 
     importances = optuna.importance.get_param_importances(
@@ -73,7 +74,7 @@ def _get_importances_info(
         param_names=param_names,
         importance_labels=importance_labels,
         target_name=target_name,
-        hover_template= hover_template
+        hover_template=hover_template,
     )
 
 

--- a/optuna/visualization/matplotlib/_param_importances.py
+++ b/optuna/visualization/matplotlib/_param_importances.py
@@ -10,6 +10,7 @@ from optuna.logging import get_logger
 from optuna.study import Study
 from optuna.trial import FrozenTrial
 from optuna.visualization._param_importances import _get_importances_info
+from optuna.visualization._param_importances import _ImportancesInfo
 from optuna.visualization.matplotlib._matplotlib_imports import _imports
 
 
@@ -91,17 +92,20 @@ def plot_param_importances(
     _imports.check()
 
     importances_info = _get_importances_info(study, evaluator, params, target, target_name)
+    return _get_importances_plot(importances_info)
 
+
+def _get_importances_plot(info: _ImportancesInfo) -> "Axes":
     # Set up the graph style.
     plt.style.use("ggplot")  # Use ggplot style sheet for similar outputs to plotly.
     fig, ax = plt.subplots()
     ax.set_title("Hyperparameter Importances")
-    ax.set_xlabel(f"Importance for {target_name}")
+    ax.set_xlabel(f"Importance for {info.target_name}")
     ax.set_ylabel("Hyperparameter")
 
-    param_names = importances_info.param_names
+    param_names = info.param_names
     pos = np.arange(len(param_names))
-    importance_values = importances_info.importance_values
+    importance_values = info.importance_values
 
     if len(importance_values) == 0:
         return ax
@@ -116,7 +120,7 @@ def plot_param_importances(
     )
 
     renderer = fig.canvas.get_renderer()
-    for idx, (val, label) in enumerate(zip(importance_values, importances_info.importance_labels)):
+    for idx, (val, label) in enumerate(zip(importance_values, info.importance_labels)):
         text = ax.text(val, idx, label, va="center")
 
         # Sometimes horizontal axis needs to be re-scaled


### PR DESCRIPTION

## Motivation
For testability, we should separate `_get_importances_info` and `_get_importances_plot`.
See the discussions in #2524.

## Description of the changes
Separate `_get_importances_info` and `_get_importances_plot`. The latter takes a single `_ImportanceInfo` object and returns the plotted figure object.
