### PR TITLE
Remove `no_trials` option of `prepare_study_with_trials`.

### DIFF
--- a/optuna/testing/visualization.py
+++ b/optuna/testing/visualization.py
@@ -5,7 +5,6 @@ from optuna.trial import create_trial
 
 
 def prepare_study_with_trials(
-    no_trials: bool = False,
     less_than_two: bool = False,
     more_than_three: bool = False,
     with_c_d: bool = True,
@@ -17,7 +16,6 @@ def prepare_study_with_trials(
     """Prepare a study for tests.
 
     Args:
-        no_trials: If :obj:`False`, create a study with no trials.
         less_than_two: If :obj:`True`, create a study with two/four hyperparameters where
             'param_a' (and 'param_c') appear(s) only once while 'param_b' (and 'param_d')
             appear(s) twice in `study.trials`.
@@ -38,8 +36,6 @@ def prepare_study_with_trials(
     """
 
     study = create_study(directions=[direction] * n_objectives)
-    if no_trials:
-        return study
     study.add_trial(
         create_trial(
             values=[value_for_first_trial] * n_objectives,

--- a/tests/visualization_tests/matplotlib_tests/test_contour.py
+++ b/tests/visualization_tests/matplotlib_tests/test_contour.py
@@ -87,7 +87,7 @@ def test_target_is_not_none_and_study_is_multi_obj() -> None:
 def test_plot_contour(params: Optional[List[str]]) -> None:
 
     # Test with no trial.
-    study_without_trials = prepare_study_with_trials(no_trials=True)
+    study_without_trials = create_study(direction="minimize")
     figure = plot_contour(study_without_trials, params=params)
     assert len(figure.get_lines()) == 0
     plt.savefig(BytesIO())

--- a/tests/visualization_tests/matplotlib_tests/test_intermediate_plot.py
+++ b/tests/visualization_tests/matplotlib_tests/test_intermediate_plot.py
@@ -4,7 +4,6 @@ import matplotlib.pyplot as plt
 
 from optuna.study import create_study
 from optuna.testing.objectives import fail_objective
-from optuna.testing.visualization import prepare_study_with_trials
 from optuna.trial import Trial
 from optuna.visualization.matplotlib import plot_intermediate_values
 
@@ -12,7 +11,7 @@ from optuna.visualization.matplotlib import plot_intermediate_values
 def test_plot_intermediate_values() -> None:
 
     # Test with no trials.
-    study = prepare_study_with_trials(no_trials=True)
+    study = create_study(direction="minimize")
     figure = plot_intermediate_values(study)
     assert len(figure.get_lines()) == 0
     plt.savefig(BytesIO())

--- a/tests/visualization_tests/matplotlib_tests/test_slice.py
+++ b/tests/visualization_tests/matplotlib_tests/test_slice.py
@@ -23,7 +23,7 @@ def test_target_is_none_and_study_is_multi_obj() -> None:
 def test_plot_slice() -> None:
 
     # Test with no trial.
-    study = prepare_study_with_trials(no_trials=True)
+    study = create_study(direction="minimize")
     figure = plot_slice(study)
     assert len(figure.findobj(PathCollection)) == 0
     plt.savefig(BytesIO())

--- a/tests/visualization_tests/test_contour.py
+++ b/tests/visualization_tests/test_contour.py
@@ -56,7 +56,7 @@ def test_target_is_not_none_and_study_is_multi_obj() -> None:
 def test_plot_contour(params: Optional[List[str]]) -> None:
 
     # Test with no trial.
-    study_without_trials = prepare_study_with_trials(no_trials=True)
+    study_without_trials = create_study(direction="minimize")
     figure = plot_contour(study_without_trials, params=params)
     assert len(figure.data) == 0
 

--- a/tests/visualization_tests/test_intermediate_plot.py
+++ b/tests/visualization_tests/test_intermediate_plot.py
@@ -1,6 +1,5 @@
 from optuna.study import create_study
 from optuna.testing.objectives import fail_objective
-from optuna.testing.visualization import prepare_study_with_trials
 from optuna.trial import Trial
 from optuna.visualization import plot_intermediate_values
 
@@ -8,7 +7,7 @@ from optuna.visualization import plot_intermediate_values
 def test_plot_intermediate_values() -> None:
 
     # Test with no trials.
-    study = prepare_study_with_trials(no_trials=True)
+    study = create_study(direction="minimize")
     figure = plot_intermediate_values(study)
     assert not figure.data
 

--- a/tests/visualization_tests/test_slice.py
+++ b/tests/visualization_tests/test_slice.py
@@ -19,7 +19,7 @@ def test_target_is_none_and_study_is_multi_obj() -> None:
 def test_plot_slice() -> None:
 
     # Test with no trial.
-    study = prepare_study_with_trials(no_trials=True)
+    study = create_study(direction="minimize")
     figure = plot_slice(study)
     assert len(figure.data) == 0
 


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
`prepare_study_with_trials` is a factory function for study stubs. By using `no_trials` option, it returns empty study. However, we can simply replace all usages of `with_no_trials` option with `create_study(direction="minimize")` that makes tests more clear. 

## Description of the changes
<!-- Describe the changes in this PR. -->
Simplify `prepare_study_with_trials` function by removing `no_trials` option.