### PR TITLE
Remove deprecated LightGBM arguments in integration tests

### DIFF
--- a/tests/integration_tests/lightgbm_tuner_tests/test_optimize.py
+++ b/tests/integration_tests/lightgbm_tuner_tests/test_optimize.py
@@ -10,6 +10,7 @@ from typing import Union
 from unittest import mock
 import warnings
 
+from lightgbm import early_stopping
 from lightgbm import log_evaluation
 import numpy as np
 import pytest
@@ -284,7 +285,7 @@ class TestLightGBMTuner:
         dummy_dataset = lgb.Dataset(None)
 
         kwargs = dict(
-            num_boost_round=5, early_stopping_rounds=2, valid_sets=dummy_dataset, study=study
+            num_boost_round=5, callbacks=[early_stopping(2)], valid_sets=dummy_dataset, study=study
         )
         kwargs.update(kwargs_options)
 
@@ -302,7 +303,7 @@ class TestLightGBMTuner:
         params: Dict[str, Any] = {}
         train_set = lgb.Dataset(None)
         with pytest.raises(ValueError) as excinfo:
-            lgb.LightGBMTuner(params, train_set, num_boost_round=5, early_stopping_rounds=2)
+            lgb.LightGBMTuner(params, train_set, num_boost_round=5, callbacks=[early_stopping(2)])
 
         assert excinfo.type == ValueError
         assert str(excinfo.value) == "`valid_sets` is required."
@@ -329,7 +330,7 @@ class TestLightGBMTuner:
                 train_set,
                 valid_sets=[train_set, valid_set],
                 num_boost_round=5,
-                early_stopping_rounds=2,
+                callbacks=[early_stopping(2)],
                 study=study,
             )
 
@@ -350,7 +351,7 @@ class TestLightGBMTuner:
         val_set = lgb.Dataset(None)
         kwargs = dict(
             num_boost_round=12,
-            early_stopping_rounds=10,
+            callbacks=[early_stopping(10)],
             valid_sets=val_set,
             time_budget=600,
             sample_size=1000,
@@ -460,9 +461,8 @@ class TestLightGBMTuner:
             params,
             train_dataset,
             num_boost_round=3,
-            early_stopping_rounds=2,
             valid_sets=valid_dataset,
-            callbacks=[log_evaluation(-1)],
+            callbacks=[log_evaluation(-1), early_stopping(2)],
         )
         runner.tune_num_leaves()
         assert len(runner.study.trials) == 20
@@ -767,9 +767,8 @@ class TestLightGBMTuner:
             params,
             train,
             valid_sets=valid,
-            early_stopping_rounds=3,
             optuna_seed=10,
-            callbacks=[log_evaluation(-1)],
+            callbacks=[log_evaluation(-1), early_stopping(3)],
         )
         tuner_first_try.run()
         best_score_first_try = tuner_first_try.best_score
@@ -778,9 +777,8 @@ class TestLightGBMTuner:
             params,
             train,
             valid_sets=valid,
-            early_stopping_rounds=3,
             optuna_seed=10,
-            callbacks=[log_evaluation(-1)],
+            callbacks=[log_evaluation(-1), early_stopping(3)],
         )
         tuner_second_try.run()
         best_score_second_try = tuner_second_try.best_score
@@ -798,7 +796,9 @@ class TestLightGBMTunerCV:
     ) -> LightGBMTunerCV:
 
         # Required keyword arguments.
-        kwargs: Dict[str, Any] = dict(num_boost_round=5, early_stopping_rounds=2, study=study)
+        kwargs: Dict[str, Any] = dict(
+            num_boost_round=5, callbacks=[early_stopping(2)], study=study
+        )
         kwargs.update(kwargs_options)
 
         runner = LightGBMTunerCV(params, train_set, **kwargs)
@@ -827,7 +827,7 @@ class TestLightGBMTunerCV:
         study = optuna.create_study(direction=study_direction)
         with pytest.raises(ValueError) as excinfo:
             LightGBMTunerCV(
-                params, train_set, num_boost_round=5, early_stopping_rounds=2, study=study
+                params, train_set, num_boost_round=5, callbacks=[early_stopping(2)], study=study
             )
 
         assert excinfo.type == ValueError
@@ -1087,7 +1087,7 @@ class TestLightGBMTunerCV:
         tuner_first_try = lgb.LightGBMTunerCV(
             params,
             train,
-            early_stopping_rounds=3,
+            callbacks=[early_stopping(3)],
             folds=KFold(n_splits=3),
             optuna_seed=10,
         )
@@ -1097,7 +1097,7 @@ class TestLightGBMTunerCV:
         tuner_second_try = lgb.LightGBMTunerCV(
             params,
             train,
-            early_stopping_rounds=3,
+            callbacks=[early_stopping(3)],
             folds=KFold(n_splits=3),
             optuna_seed=10,
         )

--- a/tests/integration_tests/test_lightgbm.py
+++ b/tests/integration_tests/test_lightgbm.py
@@ -176,7 +176,6 @@ def objective(
             {"objective": "binary", "metric": ["auc", "binary_error"]},
             dtrain,
             num_boost_round,
-            verbose_eval=False,
             nfold=2,
             callbacks=[pruning_callback],
         )
@@ -187,7 +186,6 @@ def objective(
             num_boost_round,
             valid_sets=[dtest],
             valid_names=valid_names,
-            verbose_eval=False,
             callbacks=[pruning_callback],
         )
     return 1.0


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
Remove deprecated LightGBM arguments in integration tests.
ref: https://github.com/optuna/optuna/issues/3771


## Description of the changes
<!-- Describe the changes in this PR. -->
With referring to https://github.com/optuna/optuna-examples/pull/64, I made the following updates.
- Replaced deprecated arguments with callbacks.
- Specify lightgbm version because the callbacks were introduced at v3.3.0.

I confirmed this issue was resolved in my local environment. (Please see https://github.com/optuna/optuna/issues/3771#issue-1298359702 for comparison)

```
$ pytest tests/integration_tests/test_lightgbm.py tests/integration_tests/lightgbm_tuner_tests
========================================================================== test session starts ===========================================================================
platform darwin -- Python 3.8.13, pytest-7.1.2, pluggy-1.0.0
rootdir: /Users/shimada/Work/git/optuna, configfile: pyproject.toml
collected 117 items                                                                                                                                                      

tests/integration_tests/test_lightgbm.py ............                                                                                                              [ 10%]
tests/integration_tests/lightgbm_tuner_tests/test_alias.py ..................                                                                                      [ 25%]
tests/integration_tests/lightgbm_tuner_tests/test_optimize.py .......................................................................................              [100%]

============================================================================ warnings summary ============================================================================
tests/integration_tests/test_lightgbm.py: 14 warnings
  /Users/shimada/Work/miniconda3/envs/optuna/lib/python3.8/site-packages/sklearn/model_selection/_split.py:676: UserWarning: The least populated class in y has only 1 members, which is less than n_splits=2.
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================================== 117 passed, 14 warnings in 275.65s (0:04:35) ==============================================================
```