### PR TITLE
Add `budget` option to benchmarks

### DIFF
--- a/.github/workflows/performance-benchmarks-bayesmark.yml
+++ b/.github/workflows/performance-benchmarks-bayesmark.yml
@@ -19,7 +19,7 @@ on:
         description: 'Pruner Arguments List: A list of pruner keyword arguments. Should be a whitespace-separated list of json format dictionaries.'
         required: false
         default: '{}'
-     budget:
+      budget:
         description: 'Number of Trials if the pruning is not enabled. If the pruning is enabled, the total number of steps is equal to `budget * (steps per trial)`.'
         required: false
         default: '80'
@@ -67,7 +67,7 @@ jobs:
         python benchmarks/run_bayesmark.py \
           --dataset ${{ matrix.dataset }} \
           --model ${{ matrix.model }} \
-          --n-trials ${{ github.event.inputs.budget }} \
+          --budget ${{ github.event.inputs.budget }} \
           --repeat ${{ github.event.inputs.repeat }} \
           --sampler-list '${{ github.event.inputs.sampler-list }}' \
           --sampler-kwargs-list '${{ github.event.inputs.sampler-kwargs-list }}' \

--- a/.github/workflows/performance-benchmarks-bayesmark.yml
+++ b/.github/workflows/performance-benchmarks-bayesmark.yml
@@ -19,7 +19,7 @@ on:
         description: 'Pruner Arguments List: A list of pruner keyword arguments. Should be a whitespace-separated list of json format dictionaries.'
         required: false
         default: '{}'
-      budget:
+      n-trials:
         description: 'Number of Trials'
         required: false
         default: '80'
@@ -67,7 +67,7 @@ jobs:
         python benchmarks/run_bayesmark.py \
           --dataset ${{ matrix.dataset }} \
           --model ${{ matrix.model }} \
-          --budget ${{ github.event.inputs.budget }} \
+          --n-trials ${{ github.event.inputs.n-trials }} \
           --repeat ${{ github.event.inputs.repeat }} \
           --sampler-list '${{ github.event.inputs.sampler-list }}' \
           --sampler-kwargs-list '${{ github.event.inputs.sampler-kwargs-list }}' \

--- a/.github/workflows/performance-benchmarks-bayesmark.yml
+++ b/.github/workflows/performance-benchmarks-bayesmark.yml
@@ -19,8 +19,8 @@ on:
         description: 'Pruner Arguments List: A list of pruner keyword arguments. Should be a whitespace-separated list of json format dictionaries.'
         required: false
         default: '{}'
-      n-trials:
-        description: 'Number of Trials'
+     budget:
+        description: 'Number of Trials if the pruning is not enabled. If the pruning is enabled, the total number of steps is equal to `budget * (steps per trial)`.'
         required: false
         default: '80'
       repeat:
@@ -67,7 +67,7 @@ jobs:
         python benchmarks/run_bayesmark.py \
           --dataset ${{ matrix.dataset }} \
           --model ${{ matrix.model }} \
-          --n-trials ${{ github.event.inputs.n-trials }} \
+          --n-trials ${{ github.event.inputs.budget }} \
           --repeat ${{ github.event.inputs.repeat }} \
           --sampler-list '${{ github.event.inputs.sampler-list }}' \
           --sampler-kwargs-list '${{ github.event.inputs.sampler-kwargs-list }}' \

--- a/.github/workflows/performance-benchmarks-kurobako.yml
+++ b/.github/workflows/performance-benchmarks-kurobako.yml
@@ -19,8 +19,8 @@ on:
         description: 'Pruner Arguments List: A list of pruner keyword arguments. Should be a whitespace-separated list of json format dictionaries.'
         required: false
         default: '{}'
-      n-trials:
-        description: 'Number of Trials'
+      budget:
+        description: 'Number of Trials if the pruning is not enabled. If the pruning is enabled, the total number of steps is equal to `budget * (steps per trial)`.'
         required: false
         default: '80'
       n-runs:
@@ -119,7 +119,7 @@ jobs:
         python benchmarks/run_kurobako.py \
           --path-to-kurobako "." \
           --name-prefix "" \
-          --n-trials ${{ github.event.inputs.n-trials }} \
+          --n-trials ${{ github.event.inputs.budget }} \
           --n-runs ${{ github.event.inputs.n-runs }} \
           --n-jobs 10 \
           --sampler-list '${{ github.event.inputs.sampler-list }}' \

--- a/.github/workflows/performance-benchmarks-kurobako.yml
+++ b/.github/workflows/performance-benchmarks-kurobako.yml
@@ -19,6 +19,10 @@ on:
         description: 'Pruner Arguments List: A list of pruner keyword arguments. Should be a whitespace-separated list of json format dictionaries.'
         required: false
         default: '{}'
+      n-trials:
+        description: 'Number of Trials'
+        required: false
+        default: '80'
       n-runs:
         description: 'Number of Studies'
         required: false
@@ -115,6 +119,7 @@ jobs:
         python benchmarks/run_kurobako.py \
           --path-to-kurobako "." \
           --name-prefix "" \
+          --n-trials ${{ github.event.inputs.n-trials }} \
           --n-runs ${{ github.event.inputs.n-runs }} \
           --n-jobs 10 \
           --sampler-list '${{ github.event.inputs.sampler-list }}' \

--- a/.github/workflows/performance-benchmarks-kurobako.yml
+++ b/.github/workflows/performance-benchmarks-kurobako.yml
@@ -119,7 +119,7 @@ jobs:
         python benchmarks/run_kurobako.py \
           --path-to-kurobako "." \
           --name-prefix "" \
-          --n-trials ${{ github.event.inputs.budget }} \
+          --budget ${{ github.event.inputs.budget }} \
           --n-runs ${{ github.event.inputs.n-runs }} \
           --n-jobs 10 \
           --sampler-list '${{ github.event.inputs.sampler-list }}' \

--- a/.github/workflows/performance-benchmarks-mo-kurobako.yml
+++ b/.github/workflows/performance-benchmarks-mo-kurobako.yml
@@ -98,7 +98,7 @@ jobs:
         python benchmarks/run_mo_kurobako.py \
           --path-to-kurobako "." \
           --name-prefix "" \
-          --n-trials ${{ github.event.inputs.budget }} \
+          --budget ${{ github.event.inputs.budget }} \
           --n-runs ${{ github.event.inputs.n-runs }} \
           --n-jobs 10 \
           --sampler-list '${{ github.event.inputs.sampler-list }}' \

--- a/.github/workflows/performance-benchmarks-mo-kurobako.yml
+++ b/.github/workflows/performance-benchmarks-mo-kurobako.yml
@@ -11,6 +11,10 @@ on:
         description: 'Sampler Arguments List: A list of sampler keyword arguments. Should be a whitespace-separated list of json format dictionaries.'
         required: false
         default: '{} {\"multivariate\":true,\"constant_liar\":true} {\"population_size\":20}'
+      n-trials:
+        description: 'Number of Trials'
+        required: false
+        default: '120'
       n-runs:
         description: 'Number of Studies'
         required: false
@@ -94,6 +98,7 @@ jobs:
         python benchmarks/run_mo_kurobako.py \
           --path-to-kurobako "." \
           --name-prefix "" \
+          --n-trials ${{ github.event.inputs.n-trials }} \
           --n-runs ${{ github.event.inputs.n-runs }} \
           --n-jobs 10 \
           --sampler-list '${{ github.event.inputs.sampler-list }}' \

--- a/.github/workflows/performance-benchmarks-mo-kurobako.yml
+++ b/.github/workflows/performance-benchmarks-mo-kurobako.yml
@@ -11,8 +11,8 @@ on:
         description: 'Sampler Arguments List: A list of sampler keyword arguments. Should be a whitespace-separated list of json format dictionaries.'
         required: false
         default: '{} {\"multivariate\":true,\"constant_liar\":true} {\"population_size\":20}'
-      n-trials:
-        description: 'Number of Trials'
+      budget:
+        description: 'Number of Trials if the pruning is not enabled. If the pruning is enabled, the total number of steps is equal to `budget * (steps per trial)`.'
         required: false
         default: '120'
       n-runs:
@@ -98,7 +98,7 @@ jobs:
         python benchmarks/run_mo_kurobako.py \
           --path-to-kurobako "." \
           --name-prefix "" \
-          --n-trials ${{ github.event.inputs.n-trials }} \
+          --n-trials ${{ github.event.inputs.budget }} \
           --n-runs ${{ github.event.inputs.n-runs }} \
           --n-jobs 10 \
           --sampler-list '${{ github.event.inputs.sampler-list }}' \

--- a/.github/workflows/performance-benchmarks-naslib.yml
+++ b/.github/workflows/performance-benchmarks-naslib.yml
@@ -173,7 +173,7 @@ jobs:
         python benchmarks/run_naslib.py \
           --path-to-kurobako "." \
           --name-prefix "" \
-          --n-trials ${{ github.event.inputs.budget }} \
+          --budget ${{ github.event.inputs.budget }} \
           --n-runs ${{ github.event.inputs.n-runs }} \
           --n-jobs 6 \
           --sampler-list '${{ github.event.inputs.sampler-list }}' \

--- a/.github/workflows/performance-benchmarks-naslib.yml
+++ b/.github/workflows/performance-benchmarks-naslib.yml
@@ -19,6 +19,10 @@ on:
         description: 'Pruner Arguments List: A list of pruner keyword arguments. Should be a whitespace-separated list of json format dictionaries.'
         required: false
         default: '{}'
+      n-trials:
+        description: 'Number of Trials'
+        required: false
+        default: '100'
       n-runs:
         description: 'Number of Studies'
         required: false
@@ -169,6 +173,7 @@ jobs:
         python benchmarks/run_naslib.py \
           --path-to-kurobako "." \
           --name-prefix "" \
+          --n-trials ${{ github.event.inputs.n-trials }} \
           --n-runs ${{ github.event.inputs.n-runs }} \
           --n-jobs 6 \
           --sampler-list '${{ github.event.inputs.sampler-list }}' \

--- a/.github/workflows/performance-benchmarks-naslib.yml
+++ b/.github/workflows/performance-benchmarks-naslib.yml
@@ -19,8 +19,8 @@ on:
         description: 'Pruner Arguments List: A list of pruner keyword arguments. Should be a whitespace-separated list of json format dictionaries.'
         required: false
         default: '{}'
-      n-trials:
-        description: 'Number of Trials'
+      budget:
+        description: 'Number of Trials if the pruning is not enabled. If the pruning is enabled, the total number of steps is equal to `budget * (steps per trial)`.'
         required: false
         default: '100'
       n-runs:
@@ -173,7 +173,7 @@ jobs:
         python benchmarks/run_naslib.py \
           --path-to-kurobako "." \
           --name-prefix "" \
-          --n-trials ${{ github.event.inputs.n-trials }} \
+          --n-trials ${{ github.event.inputs.budget }} \
           --n-runs ${{ github.event.inputs.n-runs }} \
           --n-jobs 6 \
           --sampler-list '${{ github.event.inputs.sampler-list }}' \

--- a/benchmarks/run_bayesmark.py
+++ b/benchmarks/run_bayesmark.py
@@ -45,7 +45,7 @@ def run_benchmark(args: argparse.Namespace) -> None:
     samplers = " ".join(config.keys())
     metric = "nll" if args.dataset in ["breast", "iris", "wine", "digits"] else "mse"
     cmd = (
-        f"bayesmark-launch -n {args.budget} -r {args.repeat} "
+        f"bayesmark-launch -n {args.n_trials} -r {args.repeat} "
         f"-dir runs -b {_DB} "
         f"-o {samplers} "
         f"-c {args.model} -d {args.dataset} "
@@ -164,7 +164,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--dataset", type=str, default="iris")
     parser.add_argument("--model", type=str, default="kNN")
-    parser.add_argument("--budget", type=int, default=80)
+    parser.add_argument("--n-trials", type=int, default=80)
     parser.add_argument("--repeat", type=int, default=10)
     parser.add_argument("--sampler-list", type=str, default="TPESampler CmaEsSampler")
     parser.add_argument(

--- a/benchmarks/run_bayesmark.py
+++ b/benchmarks/run_bayesmark.py
@@ -45,7 +45,7 @@ def run_benchmark(args: argparse.Namespace) -> None:
     samplers = " ".join(config.keys())
     metric = "nll" if args.dataset in ["breast", "iris", "wine", "digits"] else "mse"
     cmd = (
-        f"bayesmark-launch -n {args.n_trials} -r {args.repeat} "
+        f"bayesmark-launch -n {args.budget} -r {args.repeat} "
         f"-dir runs -b {_DB} "
         f"-o {samplers} "
         f"-c {args.model} -d {args.dataset} "
@@ -164,7 +164,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--dataset", type=str, default="iris")
     parser.add_argument("--model", type=str, default="kNN")
-    parser.add_argument("--n-trials", type=int, default=80)
+    parser.add_argument("--budget", type=int, default=80)
     parser.add_argument("--repeat", type=int, default=10)
     parser.add_argument("--sampler-list", type=str, default="TPESampler CmaEsSampler")
     parser.add_argument(

--- a/benchmarks/run_kurobako.py
+++ b/benchmarks/run_kurobako.py
@@ -68,7 +68,7 @@ def run(args: argparse.Namespace) -> None:
 
     # Create study.
     cmd = (
-        f"{kurobako_cmd} studies --budget {args.n_trials} "
+        f"{kurobako_cmd} studies --budget {args.budget} "
         f"--solvers $(cat {solvers_filename}) --problems $(cat {problems_filename}) "
         f"--repeats {args.n_runs} --seed {args.seed} "
         f"> {study_json_fn}"
@@ -96,7 +96,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--path-to-kurobako", type=str, default="")
     parser.add_argument("--name-prefix", type=str, default="")
-    parser.add_argument("--n-trials", type=int, default=80)
+    parser.add_argument("--budget", type=int, default=80)
     parser.add_argument("--n-runs", type=int, default=100)
     parser.add_argument("--n-jobs", type=int, default=10)
     parser.add_argument("--sampler-list", type=str, default="RandomSampler TPESampler")

--- a/benchmarks/run_kurobako.py
+++ b/benchmarks/run_kurobako.py
@@ -68,7 +68,7 @@ def run(args: argparse.Namespace) -> None:
 
     # Create study.
     cmd = (
-        f"{kurobako_cmd} studies --budget 80 "
+        f"{kurobako_cmd} studies --budget {args.n_trials} "
         f"--solvers $(cat {solvers_filename}) --problems $(cat {problems_filename}) "
         f"--repeats {args.n_runs} --seed {args.seed} "
         f"> {study_json_fn}"
@@ -96,6 +96,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--path-to-kurobako", type=str, default="")
     parser.add_argument("--name-prefix", type=str, default="")
+    parser.add_argument("--n-trials", type=int, default=80)
     parser.add_argument("--n-runs", type=int, default=100)
     parser.add_argument("--n-jobs", type=int, default=10)
     parser.add_argument("--sampler-list", type=str, default="RandomSampler TPESampler")

--- a/benchmarks/run_mo_kurobako.py
+++ b/benchmarks/run_mo_kurobako.py
@@ -76,7 +76,7 @@ def run(args: argparse.Namespace) -> None:
 
     # Create study.
     cmd = (
-        f"{kurobako_cmd} studies --budget {args.n_trials} "
+        f"{kurobako_cmd} studies --budget {args.budget} "
         f"--solvers $(cat {solvers_filename}) --problems $(cat {problems_filename}) "
         f"--repeats {args.n_runs} --seed {args.seed} "
         f"> {study_json_filename}"
@@ -134,7 +134,7 @@ if __name__ == "__main__":
         "--path-to-create-study", type=str, default="benchmarks/kurobako/mo_create_study.py"
     )
     parser.add_argument("--name-prefix", type=str, default="")
-    parser.add_argument("--n-trials", type=int, default=120)
+    parser.add_argument("--budget", type=int, default=120)
     parser.add_argument("--n-runs", type=int, default=100)
     parser.add_argument("--n-jobs", type=int, default=10)
     parser.add_argument(

--- a/benchmarks/run_mo_kurobako.py
+++ b/benchmarks/run_mo_kurobako.py
@@ -76,7 +76,7 @@ def run(args: argparse.Namespace) -> None:
 
     # Create study.
     cmd = (
-        f"{kurobako_cmd} studies --budget 120 "
+        f"{kurobako_cmd} studies --budget {args.n_trials} "
         f"--solvers $(cat {solvers_filename}) --problems $(cat {problems_filename}) "
         f"--repeats {args.n_runs} --seed {args.seed} "
         f"> {study_json_filename}"
@@ -134,6 +134,7 @@ if __name__ == "__main__":
         "--path-to-create-study", type=str, default="benchmarks/kurobako/mo_create_study.py"
     )
     parser.add_argument("--name-prefix", type=str, default="")
+    parser.add_argument("--n-trials", type=int, default=120)
     parser.add_argument("--n-runs", type=int, default=100)
     parser.add_argument("--n-jobs", type=int, default=10)
     parser.add_argument(

--- a/benchmarks/run_naslib.py
+++ b/benchmarks/run_naslib.py
@@ -63,7 +63,7 @@ def run(args: argparse.Namespace) -> None:
 
     # Create study.
     cmd = (
-        f"{kurobako_cmd} studies --budget {args.n_trials} "
+        f"{kurobako_cmd} studies --budget {args.budget} "
         f"--solvers $(cat {solvers_filename}) --problems $(cat {problems_filename}) "
         f"--repeats {args.n_runs} --seed {args.seed} "
         f"> {study_json_filename}"
@@ -92,7 +92,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--path-to-kurobako", type=str, default="")
     parser.add_argument("--name-prefix", type=str, default="")
-    parser.add_argument("--n-trials", type=int, default=100)
+    parser.add_argument("--budget", type=int, default=100)
     parser.add_argument("--n-runs", type=int, default=10)
     parser.add_argument("--n-jobs", type=int, default=10)
     parser.add_argument("--sampler-list", type=str, default="RandomSampler TPESampler")

--- a/benchmarks/run_naslib.py
+++ b/benchmarks/run_naslib.py
@@ -63,7 +63,7 @@ def run(args: argparse.Namespace) -> None:
 
     # Create study.
     cmd = (
-        f"{kurobako_cmd} studies --budget 100 "
+        f"{kurobako_cmd} studies --budget {args.n_trials} "
         f"--solvers $(cat {solvers_filename}) --problems $(cat {problems_filename}) "
         f"--repeats {args.n_runs} --seed {args.seed} "
         f"> {study_json_filename}"
@@ -92,6 +92,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--path-to-kurobako", type=str, default="")
     parser.add_argument("--name-prefix", type=str, default="")
+    parser.add_argument("--n-trials", type=int, default=100)
     parser.add_argument("--n-runs", type=int, default=10)
     parser.add_argument("--n-jobs", type=int, default=10)
     parser.add_argument("--sampler-list", type=str, default="RandomSampler TPESampler")


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
Currently, we cannot specify `budget` in benchmarks. This PR adds the option.

## Description of the changes
<!-- Describe the changes in this PR. -->
- Add the `budget` option to kurobako and naslib benchmarks.
