### PR TITLE
DRY constraints in `Sampler.after_trial`

### DIFF
--- a/optuna/integration/botorch.py
+++ b/optuna/integration/botorch.py
@@ -8,7 +8,6 @@ from typing import Union
 import warnings
 
 import numpy
-from py import process
 
 from optuna import logging
 from optuna._experimental import experimental_class
@@ -19,7 +18,8 @@ from optuna.distributions import BaseDistribution
 from optuna.samplers import BaseSampler
 from optuna.samplers import IntersectionSearchSpace
 from optuna.samplers import RandomSampler
-from optuna.samplers._base import _process_constraint_after_trial, _CONSTRAINTS_KEY
+from optuna.samplers._base import _CONSTRAINTS_KEY
+from optuna.samplers._base import _process_constraint_after_trial
 from optuna.study import Study
 from optuna.study import StudyDirection
 from optuna.trial import FrozenTrial

--- a/optuna/integration/botorch.py
+++ b/optuna/integration/botorch.py
@@ -558,5 +558,5 @@ class BoTorchSampler(BaseSampler):
         values: Optional[Sequence[float]],
     ) -> None:
         if self._constraints_func is not None:
-            _process_constraint_after_trial(self._constraints_func, study, trial)
+            _process_constraint_after_trial(self._constraints_func, study, trial, state)
         self._independent_sampler.after_trial(study, trial, state, values)

--- a/optuna/integration/botorch.py
+++ b/optuna/integration/botorch.py
@@ -19,7 +19,7 @@ from optuna.samplers import BaseSampler
 from optuna.samplers import IntersectionSearchSpace
 from optuna.samplers import RandomSampler
 from optuna.samplers._base import _CONSTRAINTS_KEY
-from optuna.samplers._base import _process_constraint_after_trial
+from optuna.samplers._base import _process_constraints_after_trial
 from optuna.study import Study
 from optuna.study import StudyDirection
 from optuna.trial import FrozenTrial
@@ -558,5 +558,5 @@ class BoTorchSampler(BaseSampler):
         values: Optional[Sequence[float]],
     ) -> None:
         if self._constraints_func is not None:
-            _process_constraint_after_trial(self._constraints_func, study, trial, state)
+            _process_constraints_after_trial(self._constraints_func, study, trial, state)
         self._independent_sampler.after_trial(study, trial, state, values)

--- a/optuna/samplers/_base.py
+++ b/optuna/samplers/_base.py
@@ -201,9 +201,9 @@ _CONSTRAINTS_KEY = "sampler:constraints"
 
 
 def _process_constraint_after_trial(
-    constraints_func: Callable[[FrozenTrial], Sequence[float]], study: Study, trial: FrozenTrial
+    constraints_func: Callable[[FrozenTrial], Sequence[float]], study: Study, trial: FrozenTrial, state: TrialState
 ) -> None:
-    if trial.state not in [TrialState.COMPLETE, TrialState.PRUNED]:
+    if state not in [TrialState.COMPLETE, TrialState.PRUNED]:
         return
 
     constraints = None

--- a/optuna/samplers/_base.py
+++ b/optuna/samplers/_base.py
@@ -200,7 +200,7 @@ class BaseSampler(object, metaclass=abc.ABCMeta):
 _CONSTRAINTS_KEY = "constraints"
 
 
-def _process_constraint_after_trial(
+def _process_constraints_after_trial(
     constraints_func: Callable[[FrozenTrial], Sequence[float]],
     study: Study,
     trial: FrozenTrial,

--- a/optuna/samplers/_base.py
+++ b/optuna/samplers/_base.py
@@ -197,7 +197,7 @@ class BaseSampler(object, metaclass=abc.ABCMeta):
             )
 
 
-_CONSTRAINTS_KEY = "sampler:constraints"
+_CONSTRAINTS_KEY = "constraints"
 
 
 def _process_constraint_after_trial(

--- a/optuna/samplers/_base.py
+++ b/optuna/samplers/_base.py
@@ -1,5 +1,6 @@
 import abc
-from typing import Any, Callable
+from typing import Any
+from typing import Callable
 from typing import Dict
 from typing import Optional
 from typing import Sequence
@@ -9,7 +10,6 @@ from optuna.distributions import BaseDistribution
 from optuna.study import Study
 from optuna.trial import FrozenTrial
 from optuna.trial import TrialState
-from optuna.trial import FrozenTrial
 
 
 class BaseSampler(object, metaclass=abc.ABCMeta):
@@ -198,12 +198,14 @@ class BaseSampler(object, metaclass=abc.ABCMeta):
 
 
 _CONSTRAINTS_KEY = "sampler:constraints"
+
+
 def _process_constraint_after_trial(
     constraints_func: Callable[[FrozenTrial], Sequence[float]], study: Study, trial: FrozenTrial
 ) -> None:
     if trial.state not in [TrialState.COMPLETE, TrialState.PRUNED]:
         return
-    
+
     constraints = None
     try:
         con = constraints_func(trial)

--- a/optuna/samplers/_base.py
+++ b/optuna/samplers/_base.py
@@ -201,7 +201,10 @@ _CONSTRAINTS_KEY = "sampler:constraints"
 
 
 def _process_constraint_after_trial(
-    constraints_func: Callable[[FrozenTrial], Sequence[float]], study: Study, trial: FrozenTrial, state: TrialState
+    constraints_func: Callable[[FrozenTrial], Sequence[float]],
+    study: Study,
+    trial: FrozenTrial,
+    state: TrialState,
 ) -> None:
     if state not in [TrialState.COMPLETE, TrialState.PRUNED]:
         return

--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -17,7 +17,7 @@ from optuna.distributions import BaseDistribution
 from optuna.exceptions import ExperimentalWarning
 from optuna.logging import get_logger
 from optuna.samplers._base import _CONSTRAINTS_KEY
-from optuna.samplers._base import _process_constraint_after_trial
+from optuna.samplers._base import _process_constraints_after_trial
 from optuna.samplers._base import BaseSampler
 from optuna.samplers._random import RandomSampler
 from optuna.samplers._search_space import IntersectionSearchSpace
@@ -553,7 +553,7 @@ class TPESampler(BaseSampler):
     ) -> None:
         assert state in [TrialState.COMPLETE, TrialState.FAIL, TrialState.PRUNED]
         if self._constraints_func is not None:
-            _process_constraint_after_trial(self._constraints_func, study, trial, state)
+            _process_constraints_after_trial(self._constraints_func, study, trial, state)
         self._random_sampler.after_trial(study, trial, state, values)
 
 

--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -16,7 +16,9 @@ from optuna._hypervolume import WFG
 from optuna.distributions import BaseDistribution
 from optuna.exceptions import ExperimentalWarning
 from optuna.logging import get_logger
-from optuna.samplers._base import BaseSampler, _process_constraint_after_trial, _CONSTRAINTS_KEY
+from optuna.samplers._base import _CONSTRAINTS_KEY
+from optuna.samplers._base import _process_constraint_after_trial
+from optuna.samplers._base import BaseSampler
 from optuna.samplers._random import RandomSampler
 from optuna.samplers._search_space import IntersectionSearchSpace
 from optuna.samplers._search_space.group_decomposed import _GroupDecomposedSearchSpace
@@ -550,7 +552,8 @@ class TPESampler(BaseSampler):
         values: Optional[Sequence[float]],
     ) -> None:
         assert state in [TrialState.COMPLETE, TrialState.FAIL, TrialState.PRUNED]
-        _process_constraint_after_trial(self._constraints_func, study, trial)
+        if self._constraints_func is not None:
+            _process_constraint_after_trial(self._constraints_func, study, trial)
         self._random_sampler.after_trial(study, trial, state, values)
 
 

--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -553,7 +553,7 @@ class TPESampler(BaseSampler):
     ) -> None:
         assert state in [TrialState.COMPLETE, TrialState.FAIL, TrialState.PRUNED]
         if self._constraints_func is not None:
-            _process_constraint_after_trial(self._constraints_func, study, trial)
+            _process_constraint_after_trial(self._constraints_func, study, trial, state)
         self._random_sampler.after_trial(study, trial, state, values)
 
 

--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -16,7 +16,7 @@ from optuna._hypervolume import WFG
 from optuna.distributions import BaseDistribution
 from optuna.exceptions import ExperimentalWarning
 from optuna.logging import get_logger
-from optuna.samplers._base import BaseSampler
+from optuna.samplers._base import BaseSampler, _process_constraint_after_trial, _CONSTRAINTS_KEY
 from optuna.samplers._random import RandomSampler
 from optuna.samplers._search_space import IntersectionSearchSpace
 from optuna.samplers._search_space.group_decomposed import _GroupDecomposedSearchSpace
@@ -29,7 +29,6 @@ from optuna.trial import FrozenTrial
 from optuna.trial import TrialState
 
 
-_CONSTRAINTS_KEY = "tpe:constraints"
 EPS = 1e-12
 _logger = get_logger(__name__)
 
@@ -551,28 +550,7 @@ class TPESampler(BaseSampler):
         values: Optional[Sequence[float]],
     ) -> None:
         assert state in [TrialState.COMPLETE, TrialState.FAIL, TrialState.PRUNED]
-        if (
-            state in [TrialState.COMPLETE, TrialState.PRUNED]
-            and self._constraints_func is not None
-        ):
-            constraints = None
-            try:
-                con = self._constraints_func(trial)
-                if not isinstance(con, (tuple, list)):
-                    warnings.warn(
-                        f"Constraints should be a sequence of floats but got {type(con).__name__}."
-                    )
-                constraints = tuple(con)
-            except Exception:
-                raise
-            finally:
-                assert constraints is None or isinstance(constraints, tuple)
-
-                study._storage.set_trial_system_attr(
-                    trial._trial_id,
-                    _CONSTRAINTS_KEY,
-                    constraints,
-                )
+        _process_constraint_after_trial(self._constraints_func, study, trial)
         self._random_sampler.after_trial(study, trial, state, values)
 
 

--- a/optuna/samplers/nsgaii/_sampler.py
+++ b/optuna/samplers/nsgaii/_sampler.py
@@ -17,7 +17,7 @@ import numpy as np
 import optuna
 from optuna._experimental import ExperimentalWarning
 from optuna.distributions import BaseDistribution
-from optuna.samplers._base import BaseSampler
+from optuna.samplers._base import BaseSampler, _process_constraint_after_trial, _CONSTRAINTS_KEY
 from optuna.samplers._random import RandomSampler
 from optuna.samplers._search_space import IntersectionSearchSpace
 from optuna.samplers.nsgaii._crossover import perform_crossover
@@ -31,7 +31,6 @@ from optuna.trial import TrialState
 
 
 # Define key names of `Trial.system_attrs`.
-_CONSTRAINTS_KEY = "nsga2:constraints"
 _GENERATION_KEY = "nsga2:generation"
 _POPULATION_CACHE_KEY_PREFIX = "nsga2:population"
 
@@ -389,23 +388,8 @@ class NSGAIISampler(BaseSampler):
         values: Optional[Sequence[float]],
     ) -> None:
         assert state in [TrialState.COMPLETE, TrialState.FAIL, TrialState.PRUNED]
-        if state == TrialState.COMPLETE and self._constraints_func is not None:
-            constraints = None
-            try:
-                con = self._constraints_func(trial)
-                if not isinstance(con, (tuple, list)):
-                    warnings.warn(
-                        f"Constraints should be a sequence of floats but got {type(con).__name__}."
-                    )
-                constraints = tuple(con)
-            finally:
-                assert constraints is None or isinstance(constraints, tuple)
-
-                study._storage.set_trial_system_attr(
-                    trial._trial_id,
-                    _CONSTRAINTS_KEY,
-                    constraints,
-                )
+        if self._constraints_func is not None:
+            _process_constraint_after_trial(self._constraints_func, study, trial)
         self._random_sampler.after_trial(study, trial, state, values)
 
 

--- a/optuna/samplers/nsgaii/_sampler.py
+++ b/optuna/samplers/nsgaii/_sampler.py
@@ -391,7 +391,7 @@ class NSGAIISampler(BaseSampler):
     ) -> None:
         assert state in [TrialState.COMPLETE, TrialState.FAIL, TrialState.PRUNED]
         if self._constraints_func is not None:
-            _process_constraint_after_trial(self._constraints_func, study, trial)
+            _process_constraint_after_trial(self._constraints_func, study, trial, state)
         self._random_sampler.after_trial(study, trial, state, values)
 
 

--- a/optuna/samplers/nsgaii/_sampler.py
+++ b/optuna/samplers/nsgaii/_sampler.py
@@ -18,7 +18,7 @@ import optuna
 from optuna._experimental import ExperimentalWarning
 from optuna.distributions import BaseDistribution
 from optuna.samplers._base import _CONSTRAINTS_KEY
-from optuna.samplers._base import _process_constraint_after_trial
+from optuna.samplers._base import _process_constraints_after_trial
 from optuna.samplers._base import BaseSampler
 from optuna.samplers._random import RandomSampler
 from optuna.samplers._search_space import IntersectionSearchSpace
@@ -391,7 +391,7 @@ class NSGAIISampler(BaseSampler):
     ) -> None:
         assert state in [TrialState.COMPLETE, TrialState.FAIL, TrialState.PRUNED]
         if self._constraints_func is not None:
-            _process_constraint_after_trial(self._constraints_func, study, trial, state)
+            _process_constraints_after_trial(self._constraints_func, study, trial, state)
         self._random_sampler.after_trial(study, trial, state, values)
 
 

--- a/optuna/samplers/nsgaii/_sampler.py
+++ b/optuna/samplers/nsgaii/_sampler.py
@@ -17,7 +17,9 @@ import numpy as np
 import optuna
 from optuna._experimental import ExperimentalWarning
 from optuna.distributions import BaseDistribution
-from optuna.samplers._base import BaseSampler, _process_constraint_after_trial, _CONSTRAINTS_KEY
+from optuna.samplers._base import _CONSTRAINTS_KEY
+from optuna.samplers._base import _process_constraint_after_trial
+from optuna.samplers._base import BaseSampler
 from optuna.samplers._random import RandomSampler
 from optuna.samplers._search_space import IntersectionSearchSpace
 from optuna.samplers.nsgaii._crossover import perform_crossover

--- a/tests/integration_tests/test_botorch.py
+++ b/tests/integration_tests/test_botorch.py
@@ -15,6 +15,7 @@ from optuna.samplers import RandomSampler
 from optuna.storages import RDBStorage
 from optuna.trial import FrozenTrial
 from optuna.trial import Trial
+from optuna.samplers._base import _CONSTRAINTS_KEY
 
 
 @pytest.mark.parametrize("n_objectives", [1, 2, 4])
@@ -182,7 +183,7 @@ def test_botorch_constraints_func_raises() -> None:
     assert len(study.trials) == 2
 
     for trial in study.trials:
-        sys_con = trial.system_attrs["botorch:constraints"]
+        sys_con = trial.system_attrs[_CONSTRAINTS_KEY]
 
         expected_sys_con: Optional[Tuple[int]]
 

--- a/tests/integration_tests/test_botorch.py
+++ b/tests/integration_tests/test_botorch.py
@@ -12,10 +12,10 @@ import optuna
 from optuna import integration
 from optuna.integration import BoTorchSampler
 from optuna.samplers import RandomSampler
+from optuna.samplers._base import _CONSTRAINTS_KEY
 from optuna.storages import RDBStorage
 from optuna.trial import FrozenTrial
 from optuna.trial import Trial
-from optuna.samplers._base import _CONSTRAINTS_KEY
 
 
 @pytest.mark.parametrize("n_objectives", [1, 2, 4])


### PR DESCRIPTION
## Motivation
There is duplicate logic in `Sampler.after_trial` of samplers that support constraints, i.e., `TPESampler`, `NSGAIISampler`, and `BoTorchSampler`. We extract that logic in `process_constraints_after_trial`.

## Description of the changes
Extract common logic in `process_constraints_after_trial`.
