### PR TITLE
Add `n_concurrency` option to benchmarks

### DIFF
--- a/.github/workflows/performance-benchmarks-kurobako.yml
+++ b/.github/workflows/performance-benchmarks-kurobako.yml
@@ -23,6 +23,10 @@ on:
         description: 'Number of Studies'
         required: false
         default: '10'
+      n-concurrency:
+        description: 'Number of Concurrent Trials'
+        required: false
+        default: '1'
 
 
 jobs:
@@ -117,6 +121,7 @@ jobs:
           --name-prefix "" \
           --n-runs ${{ github.event.inputs.n-runs }} \
           --n-jobs 10 \
+          --n-concurrency ${{ github.event.inputs.n-concurrency }} \
           --sampler-list '${{ github.event.inputs.sampler-list }}' \
           --sampler-kwargs-list '${{ github.event.inputs.sampler-kwargs-list }}' \
           --pruner-list '${{ github.event.inputs.pruner-list }}' \

--- a/.github/workflows/performance-benchmarks-mo-kurobako.yml
+++ b/.github/workflows/performance-benchmarks-mo-kurobako.yml
@@ -15,6 +15,10 @@ on:
         description: 'Number of Studies'
         required: false
         default: '10'
+      n-concurrency:
+        description: 'Number of Concurrent Trials'
+        required: false
+        default: '1'
 
 
 jobs:
@@ -96,6 +100,7 @@ jobs:
           --name-prefix "" \
           --n-runs ${{ github.event.inputs.n-runs }} \
           --n-jobs 10 \
+          --n-concurrency ${{ github.event.inputs.n-concurrency }} \
           --sampler-list '${{ github.event.inputs.sampler-list }}' \
           --sampler-kwargs-list '${{ github.event.inputs.sampler-kwargs-list }}' \
           --seed 0 \

--- a/.github/workflows/performance-benchmarks-naslib.yml
+++ b/.github/workflows/performance-benchmarks-naslib.yml
@@ -23,6 +23,10 @@ on:
         description: 'Number of Studies'
         required: false
         default: '10'
+      n-concurrency:
+        description: 'Number of Concurrent Trials'
+        required: false
+        default: '1'
 
 
 jobs:
@@ -171,6 +175,7 @@ jobs:
           --name-prefix "" \
           --n-runs ${{ github.event.inputs.n-runs }} \
           --n-jobs 6 \
+          --n-concurrency ${{ github.event.inputs.n-concurrency }} \
           --sampler-list '${{ github.event.inputs.sampler-list }}' \
           --sampler-kwargs-list '${{ github.event.inputs.sampler-kwargs-list }}' \
           --pruner-list '${{ github.event.inputs.pruner-list }}' \

--- a/benchmarks/run_kurobako.py
+++ b/benchmarks/run_kurobako.py
@@ -70,7 +70,7 @@ def run(args: argparse.Namespace) -> None:
     cmd = (
         f"{kurobako_cmd} studies --budget 80 "
         f"--solvers $(cat {solvers_filename}) --problems $(cat {problems_filename}) "
-        f"--repeats {args.n_runs} --seed {args.seed} "
+        f"--repeats {args.n_runs} --seed {args.seed} --concurrency {args.n_concurrency} "
         f"> {study_json_fn}"
     )
     subprocess.run(cmd, shell=True)
@@ -98,6 +98,7 @@ if __name__ == "__main__":
     parser.add_argument("--name-prefix", type=str, default="")
     parser.add_argument("--n-runs", type=int, default=100)
     parser.add_argument("--n-jobs", type=int, default=10)
+    parser.add_argument("--n-concurrency", type=int, default=1)
     parser.add_argument("--sampler-list", type=str, default="RandomSampler TPESampler")
     parser.add_argument(
         "--sampler-kwargs-list",

--- a/benchmarks/run_mo_kurobako.py
+++ b/benchmarks/run_mo_kurobako.py
@@ -78,7 +78,7 @@ def run(args: argparse.Namespace) -> None:
     cmd = (
         f"{kurobako_cmd} studies --budget 120 "
         f"--solvers $(cat {solvers_filename}) --problems $(cat {problems_filename}) "
-        f"--repeats {args.n_runs} --seed {args.seed} "
+        f"--repeats {args.n_runs} --seed {args.seed} --concurrency {args.n_concurrency} "
         f"> {study_json_filename}"
     )
     subprocess.run(cmd, shell=True)
@@ -136,6 +136,7 @@ if __name__ == "__main__":
     parser.add_argument("--name-prefix", type=str, default="")
     parser.add_argument("--n-runs", type=int, default=100)
     parser.add_argument("--n-jobs", type=int, default=10)
+    parser.add_argument("--n-concurrency", type=int, default=1)
     parser.add_argument(
         "--sampler-list",
         type=str,

--- a/benchmarks/run_naslib.py
+++ b/benchmarks/run_naslib.py
@@ -65,7 +65,7 @@ def run(args: argparse.Namespace) -> None:
     cmd = (
         f"{kurobako_cmd} studies --budget 100 "
         f"--solvers $(cat {solvers_filename}) --problems $(cat {problems_filename}) "
-        f"--repeats {args.n_runs} --seed {args.seed} "
+        f"--repeats {args.n_runs} --seed {args.seed} --concurrency {args.n_concurrency} "
         f"> {study_json_filename}"
     )
     subprocess.run(cmd, shell=True)
@@ -94,6 +94,7 @@ if __name__ == "__main__":
     parser.add_argument("--name-prefix", type=str, default="")
     parser.add_argument("--n-runs", type=int, default=10)
     parser.add_argument("--n-jobs", type=int, default=10)
+    parser.add_argument("--n-concurrency", type=int, default=1)
     parser.add_argument("--sampler-list", type=str, default="RandomSampler TPESampler")
     parser.add_argument(
         "--sampler-kwargs-list",


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
Currently, we cannot specify `n_concurrrency` in benchmarks. It is an option for parallel optimization. This PR adds the option.

## Description of the changes
<!-- Describe the changes in this PR. -->
- Add the `n_concurrency` option to kurobako and naslib benchmarks.

