### PR TITLE
Remove duplicated period at the end of copyright

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -26,7 +26,7 @@ __version__ = pkg_resources.get_distribution("optuna").version
 # -- Project information -----------------------------------------------------
 
 project = "Optuna"
-copyright = "2018, Optuna Contributors."
+copyright = "2018, Optuna Contributors"
 author = "Optuna Contributors."
 
 # The short X.Y version


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

I found there was an unnecessary period at the end of the copyright part at the bottom of [every API page](https://optuna.readthedocs.io/en/latest/index.html):

<img width="549" alt="Screenshot 2022-07-10 at 16 24 24" src="https://user-images.githubusercontent.com/7121753/178135381-ca7dae61-3b3d-4b18-ae95-0797ad8f8c11.png">


## Description of the changes
<!-- Describe the changes in this PR. -->

Remove the period in the copyright value in `docs/source/conf.py`. The updated copyright part will be as follows:

<img width="309" alt="Screenshot 2022-07-10 at 16 27 12" src="https://user-images.githubusercontent.com/7121753/178135422-5784af82-bac1-4d1a-ba96-e65cf01b415d.png">


---

I believe that this PR is trivial, so one approval is enough.