### PR TITLE
Support inf values in TPE

### DIFF
--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -908,9 +908,7 @@ def _clamp_inf_and_calc_reference_point(lvals: np.ndarray) -> Tuple[np.ndarray, 
         ]
     )
     worst_point[worst_point == -np.inf] = 0.0
-    posinf_replacement = np.maximum(
-        np.maximum(1.1 * worst_point, 0.9 * worst_point), worst_point + EPS
-    )
+    posinf_replacement = np.maximum.reduce([1.1 * worst_point, 0.9 * worst_point, worst_point + EPS])
 
     best_point = np.array(
         [

--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -887,14 +887,11 @@ def _calculate_weights_below_for_multi_objective(
         )
         neginf_replacement = np.minimum(2 * best_point, 0.5 * best_point)
 
-        print(lvals)
         is_posinf = lvals == np.inf
         lvals[is_posinf] = np.broadcast_to(posinf_replacement, lvals.shape, subok=True)[is_posinf]
         is_neginf = lvals == -np.inf
         lvals[is_neginf] = np.broadcast_to(neginf_replacement, lvals.shape, subok=True)[is_neginf]
 
-        print(is_posinf)
-        print(lvals)
         hv = _compute_hypervolume(lvals, reference_point)
         indices_mat = ~np.eye(n_below).astype(bool)
         contributions = np.asarray(

--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -897,7 +897,7 @@ def _clamp_inf_and_calc_reference_point(lvals: np.ndarray) -> Tuple[np.ndarray, 
     """Clamp inf values in lvals and calculate the reference point.
     
     This function satisfies the following axioms:
-    1. Clamped lvals and the calculated reference point only contains finite values.
+    1. Clamped lvals and the calculated reference point only contain finite values.
     2. Clamping preserves the original order of lvals.
     3. Clamped lvals are always smaller than or equal to the calculated reference point.
     """

--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -895,7 +895,7 @@ def _calculate_weights_below_for_multi_objective(
 
 def _clamp_inf_and_calc_reference_point(lvals: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
     """Clamp inf values in lvals and calculate the reference point.
-    
+
     This function satisfies the following axioms:
     1. Clamped lvals and the calculated reference point only contain finite values.
     2. Clamping preserves the original order of lvals.

--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -902,6 +902,7 @@ def _clamp_inf_and_calc_reference_point(lvals: np.ndarray) -> Tuple[np.ndarray, 
     3. Clamped lvals are always smaller than or equal to the calculated reference point.
     """
     worst_point = np.amax(lvals, axis=0, initial=-np.inf, where=~np.isposinf(lvals))
+    # When there are no finite values for a dimension, the reference point could be any finite value.
     worst_point[worst_point == -np.inf] = 0.0
     posinf_replacement = np.maximum.reduce([1.1 * worst_point, 0.9 * worst_point, worst_point + EPS])
 

--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -904,6 +904,9 @@ def _clamp_inf_and_calc_reference_point(lvals: np.ndarray) -> Tuple[np.ndarray, 
     worst_point = np.amax(lvals, axis=0, initial=-np.inf, where=~np.isposinf(lvals))
     # When there are no finite values for a dimension, the reference point could be any finite value.
     worst_point[worst_point == -np.inf] = 0.0
+    # For positive worst_point, we use 1.1 * worst_point as the reference point.
+    # For negative worst_point, we use 0.9 * worst_point as the reference point.
+    # For worst point that is almost zero, we use worst_point + EPS as the reference point.
     posinf_replacement = np.maximum.reduce([1.1 * worst_point, 0.9 * worst_point, worst_point + EPS])
 
     best_point = np.amin(lvals, axis=0, initial=np.inf, where=~np.isneginf(lvals))

--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -901,12 +901,7 @@ def _clamp_inf_and_calc_reference_point(lvals: np.ndarray) -> Tuple[np.ndarray, 
     2. Clamping preserves the original order of lvals.
     3. Clamped lvals are always smaller than or equal to the calculated reference point.
     """
-    worst_point = np.array(
-        [
-            np.max(lvals[:, i][lvals[:, i] != np.inf], initial=-np.inf)
-            for i in range(lvals.shape[1])
-        ]
-    )
+    worst_point = np.amax(lvals, axis=0, initial=-np.inf, where=~np.isposinf(lvals))
     worst_point[worst_point == -np.inf] = 0.0
     posinf_replacement = np.maximum.reduce([1.1 * worst_point, 0.9 * worst_point, worst_point + EPS])
 

--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -917,7 +917,7 @@ def _clamp_inf_and_calc_reference_point(lvals: np.ndarray) -> Tuple[np.ndarray, 
         ]
     )
     best_point[best_point == np.inf] = 0.0
-    neginf_replacement = np.minimum(np.minimum(2 * best_point, 0.5 * best_point), best_point - EPS)
+    neginf_replacement = np.minimum.reduce([2 * best_point, 0.5 * best_point, best_point - EPS])
 
     new_lvals = lvals.copy()
     is_posinf = lvals == np.inf

--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -905,12 +905,7 @@ def _clamp_inf_and_calc_reference_point(lvals: np.ndarray) -> Tuple[np.ndarray, 
     worst_point[worst_point == -np.inf] = 0.0
     posinf_replacement = np.maximum.reduce([1.1 * worst_point, 0.9 * worst_point, worst_point + EPS])
 
-    best_point = np.array(
-        [
-            np.min(lvals[:, i][lvals[:, i] != -np.inf], initial=np.inf)
-            for i in range(lvals.shape[1])
-        ]
-    )
+    best_point = np.amin(lvals, axis=0, initial=np.inf, where=~np.isneginf(lvals))
     best_point[best_point == np.inf] = 0.0
     neginf_replacement = np.minimum.reduce([2 * best_point, 0.5 * best_point, best_point - EPS])
 

--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -773,7 +773,7 @@ def _split_observation_pairs(
         if subset_size > 0:
             rank_i_lvals = lvals[nondomination_ranks == i]
             rank_i_indices = indices[nondomination_ranks == i]
-            rank_i_lvals, reference_point = _clamp_inf_and_calc_reference_point(rank_i_lvals)
+            rank_i_lvals, reference_point = _clip_inf_and_calc_reference_point(rank_i_lvals)
             selected_indices = _solve_hssp(
                 rank_i_lvals, rank_i_indices, subset_size, reference_point
             )
@@ -872,7 +872,7 @@ def _calculate_weights_below_for_multi_objective(
         weights_below = np.asarray([1.0])
     else:
 
-        lvals, reference_point = _clamp_inf_and_calc_reference_point(lvals)
+        lvals, reference_point = _clip_inf_and_calc_reference_point(lvals)
 
         hv = _compute_hypervolume(lvals, reference_point)
         indices_mat = ~np.eye(n_below).astype(bool)
@@ -893,13 +893,13 @@ def _calculate_weights_below_for_multi_objective(
     return weights_below_all
 
 
-def _clamp_inf_and_calc_reference_point(lvals: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
-    """Clamp inf values in lvals and calculate the reference point.
+def _clip_inf_and_calc_reference_point(lvals: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
+    """Clip inf values in lvals and calculate the reference point.
 
     This function satisfies the following axioms:
-    1. Clamped lvals and the calculated reference point only contain finite values.
-    2. Clamping preserves the original order of lvals.
-    3. Clamped lvals are always smaller than or equal to the calculated reference point.
+    1. Clipped lvals and the calculated reference point only contain finite values.
+    2. Clipping preserves the original order of lvals.
+    3. Clipped lvals are always smaller than or equal to the calculated reference point.
     """
     worst_point = np.amax(lvals, axis=0, initial=-np.inf, where=~np.isposinf(lvals))
     # When there are no finite values for a dimension, the reference point could be any finite value.

--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -774,7 +774,6 @@ def _split_observation_pairs(
             rank_i_lvals = lvals[nondomination_ranks == i]
             rank_i_indices = indices[nondomination_ranks == i]
             rank_i_lvals, reference_point = _normalize_and_calc_reference_point(rank_i_lvals)
-            print(lvals, rank_i_lvals, reference_point)
             selected_indices = _solve_hssp(
                 rank_i_lvals, rank_i_indices, subset_size, reference_point
             )

--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -902,15 +902,21 @@ def _clip_inf_and_calc_reference_point(lvals: np.ndarray) -> Tuple[np.ndarray, n
     3. Clipped lvals are always smaller than or equal to the calculated reference point.
     """
     worst_point = np.amax(lvals, axis=0, initial=-np.inf, where=~np.isposinf(lvals))
-    # When there are no finite values for a dimension, the reference point could be any finite value.
+    # When there are no finite values for a dimension, we replace +inf as +EPS and -inf as -EPS.
     worst_point[worst_point == -np.inf] = 0.0
-    # For positive worst_point, we use 1.1 * worst_point as the reference point.
-    # For negative worst_point, we use 0.9 * worst_point as the reference point.
-    # For worst point that is almost zero, we use worst_point + EPS as the reference point.
-    posinf_replacement = np.maximum.reduce([1.1 * worst_point, 0.9 * worst_point, worst_point + EPS])
+    # For positive worst_point, we use 1.1 * worst_point as the replacement of +inf.
+    # For negative worst_point, we use 0.9 * worst_point as the replacement of +inf.
+    # For worst point that is almost zero, we use worst_point + EPS as the replacement of +inf.
+    posinf_replacement = np.maximum.reduce(
+        [1.1 * worst_point, 0.9 * worst_point, worst_point + EPS]
+    )
 
     best_point = np.amin(lvals, axis=0, initial=np.inf, where=~np.isneginf(lvals))
+    # When there are no finite values for a dimension, we replace +inf as +EPS and -inf as -EPS.
     best_point[best_point == np.inf] = 0.0
+    # For positive worst_point, we use 0.5 * best_point as the replacement of -inf.
+    # For negative worst_point, we use 2.0 * best_point as the replacement of -inf.
+    # For worst point that is almost zero, we use best_point - EPS as the replacement of -inf.
     neginf_replacement = np.minimum.reduce([2 * best_point, 0.5 * best_point, best_point - EPS])
 
     new_lvals = lvals.copy()

--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -908,12 +908,9 @@ def _clamp_inf_and_calc_reference_point(lvals: np.ndarray) -> Tuple[np.ndarray, 
         ]
     )
     worst_point[worst_point == -np.inf] = 0.0
-    reference_point = np.maximum(
+    posinf_replacement = np.maximum(
         np.maximum(1.1 * worst_point, 0.9 * worst_point), worst_point + EPS
     )
-
-    # If values contain +inf, it has zero contribution to hypervolume.
-    posinf_replacement = reference_point
 
     best_point = np.array(
         [
@@ -929,4 +926,6 @@ def _clamp_inf_and_calc_reference_point(lvals: np.ndarray) -> Tuple[np.ndarray, 
     new_lvals[is_posinf] = np.broadcast_to(posinf_replacement, lvals.shape, subok=True)[is_posinf]
     is_neginf = lvals == -np.inf
     new_lvals[is_neginf] = np.broadcast_to(neginf_replacement, lvals.shape, subok=True)[is_neginf]
+
+    reference_point = posinf_replacement
     return new_lvals, reference_point

--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -897,7 +897,7 @@ def _clamp_inf_and_calc_reference_point(lvals: np.ndarray) -> Tuple[np.ndarray, 
     """Clamp inf values in lvals and calculate the reference point.
     
     This function satisfies the following axioms:
-    1. Clamped lvals only contains finite values.
+    1. Clamped lvals and the calculated reference point only contains finite values.
     2. Clamping preserves the original order of lvals.
     3. Clamped lvals are always smaller than or equal to the calculated reference point.
     """

--- a/tests/samplers_tests/tpe_tests/test_multi_objective_sampler.py
+++ b/tests/samplers_tests/tpe_tests/test_multi_objective_sampler.py
@@ -515,7 +515,7 @@ def test_calculate_weights_below_for_multi_objective() -> None:
     assert np.isclose(weights_below[1], weights_below[2])
     assert sum(weights_below) > 0
 
-    # Test -inf objective values.
+    # Test +/-inf objective values.
     weights_below = _tpe.sampler._calculate_weights_below_for_multi_objective(
         {"x": np.array([1.0, 2.0, 3.0, 4.0], dtype=float)},
         [

--- a/tests/samplers_tests/tpe_tests/test_multi_objective_sampler.py
+++ b/tests/samplers_tests/tpe_tests/test_multi_objective_sampler.py
@@ -635,11 +635,11 @@ def test_solve_hssp(dim: int) -> None:
         [[float("inf")], [0.0]],
     ],
 )
-def test_normalize_and_calc_reference_point(
+def test_clamp_inf_and_calc_reference_point(
     test_case: Union[np.ndarray, List[List[float]]]
 ) -> None:
     test_case = np.array(test_case)
-    normalized, reference_point = _tpe.sampler._normalize_and_calc_reference_point(test_case)
+    normalized, reference_point = _tpe.sampler._clamp_inf_and_calc_reference_point(test_case)
     assert np.all(np.isfinite(normalized))
     assert np.all(np.isfinite(reference_point))
     assert np.all(normalized <= reference_point)

--- a/tests/samplers_tests/tpe_tests/test_multi_objective_sampler.py
+++ b/tests/samplers_tests/tpe_tests/test_multi_objective_sampler.py
@@ -635,11 +635,11 @@ def test_solve_hssp(dim: int) -> None:
         [[float("inf")], [0.0]],
     ],
 )
-def test_clamp_inf_and_calc_reference_point(
+def test_clip_inf_and_calc_reference_point(
     test_case: Union[np.ndarray, List[List[float]]]
 ) -> None:
     test_case = np.array(test_case)
-    normalized, reference_point = _tpe.sampler._clamp_inf_and_calc_reference_point(test_case)
+    normalized, reference_point = _tpe.sampler._clip_inf_and_calc_reference_point(test_case)
     assert np.all(np.isfinite(normalized))
     assert np.all(np.isfinite(reference_point))
     assert np.all(normalized <= reference_point)


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
Resolve #3676, #3677 
## Description of the changes
We add a function `_clamp_inf_and_calc_reference_point` and use that function in `_calculate_weights_below_for_multi_objective` and `_split_observation_pairs`.
In `_clamp_inf_and_calc_reference_point`, we
* make `reference_point` consider only finite values.
* replace `-inf` to be the minimum of `2 * best_value` and `0.5 * best_value`.
* replace `+inf` to be the `reference_point`, such that `+inf` makes zero contribution to the hypervolume.


