### PR TITLE
Move tests for `create_trial`

### DIFF
--- a/tests/trial_tests/test_trial.py
+++ b/tests/trial_tests/test_trial.py
@@ -18,7 +18,6 @@ from optuna import distributions
 from optuna import load_study
 from optuna import samplers
 from optuna import storages
-from optuna.distributions import BaseDistribution
 from optuna.distributions import CategoricalDistribution
 from optuna.distributions import FloatDistribution
 from optuna.distributions import IntDistribution
@@ -26,10 +25,7 @@ from optuna.testing.pruners import DeterministicPruner
 from optuna.testing.samplers import DeterministicRelativeSampler
 from optuna.testing.storages import STORAGE_MODES
 from optuna.testing.storages import StorageSupplier
-from optuna.trial import create_trial
-from optuna.trial import FrozenTrial
 from optuna.trial import Trial
-from optuna.trial import TrialState
 
 
 @pytest.mark.parametrize("storage_mode", STORAGE_MODES)
@@ -640,110 +636,6 @@ def test_study_id() -> None:
     trial = Trial(study, study._storage.create_new_trial(study._study_id))
 
     assert trial._study_id == trial.study._study_id
-
-
-# TODO(hvy): Write exhaustive test include invalid combinations when feature is no longer
-# experimental.
-@pytest.mark.parametrize("state", [TrialState.COMPLETE, TrialState.FAIL])
-def test_create_trial(state: TrialState) -> None:
-    value = 0.2
-    params = {"x": 10}
-    distributions: Dict[str, BaseDistribution] = {"x": FloatDistribution(5, 12)}
-    user_attrs = {"foo": "bar"}
-    system_attrs = {"baz": "qux"}
-    intermediate_values = {0: 0.0, 1: 0.1, 2: 0.1}
-
-    trial = create_trial(
-        state=state,
-        value=value,
-        params=params,
-        distributions=distributions,
-        user_attrs=user_attrs,
-        system_attrs=system_attrs,
-        intermediate_values=intermediate_values,
-    )
-
-    assert isinstance(trial, FrozenTrial)
-    assert trial.state == state
-    assert trial.value == value
-    assert trial.params == params
-    assert trial.distributions == distributions
-    assert trial.user_attrs == user_attrs
-    assert trial.system_attrs == system_attrs
-    assert trial.intermediate_values == intermediate_values
-    assert trial.datetime_start is not None
-    assert (trial.datetime_complete is not None) == state.is_finished()
-
-    with pytest.raises(ValueError):
-        create_trial(state=state, value=value, values=(value,))
-
-
-# Deprecated distributions are internally converted to corresponding distributions.
-def test_create_trial_distribution_conversion() -> None:
-    fixed_params = {
-        "ud": 0,
-        "dud": 2,
-        "lud": 1,
-        "id": 0,
-        "idd": 2,
-        "ild": 1,
-    }
-
-    fixed_distributions = {
-        "ud": distributions.UniformDistribution(low=0, high=10),
-        "dud": distributions.DiscreteUniformDistribution(low=0, high=10, q=2),
-        "lud": distributions.LogUniformDistribution(low=1, high=10),
-        "id": distributions.IntUniformDistribution(low=0, high=10),
-        "idd": distributions.IntUniformDistribution(low=0, high=10, step=2),
-        "ild": distributions.IntLogUniformDistribution(low=1, high=10),
-    }
-
-    with pytest.warns(
-        FutureWarning,
-        match="See https://github.com/optuna/optuna/issues/2941",
-    ) as record:
-
-        trial = create_trial(params=fixed_params, distributions=fixed_distributions, value=1)
-        assert len(record) == 6
-
-    expected_distributions = {
-        "ud": distributions.FloatDistribution(low=0, high=10, log=False, step=None),
-        "dud": distributions.FloatDistribution(low=0, high=10, log=False, step=2),
-        "lud": distributions.FloatDistribution(low=1, high=10, log=True, step=None),
-        "id": distributions.IntDistribution(low=0, high=10, log=False, step=1),
-        "idd": distributions.IntDistribution(low=0, high=10, log=False, step=2),
-        "ild": distributions.IntDistribution(low=1, high=10, log=True, step=1),
-    }
-
-    assert trial.distributions == expected_distributions
-
-
-# It confirms that ask doesn't convert non-deprecated distributions.
-def test_create_trial_distribution_conversion_noop() -> None:
-    fixed_params = {
-        "ud": 0,
-        "dud": 2,
-        "lud": 1,
-        "id": 0,
-        "idd": 2,
-        "ild": 1,
-        "cd": "a",
-    }
-
-    fixed_distributions = {
-        "ud": distributions.FloatDistribution(low=0, high=10, log=False, step=None),
-        "dud": distributions.FloatDistribution(low=0, high=10, log=False, step=2),
-        "lud": distributions.FloatDistribution(low=1, high=10, log=True, step=None),
-        "id": distributions.IntDistribution(low=0, high=10, log=False, step=1),
-        "idd": distributions.IntDistribution(low=0, high=10, log=False, step=2),
-        "ild": distributions.IntDistribution(low=1, high=10, log=True, step=1),
-        "cd": distributions.CategoricalDistribution(choices=["a", "b", "c"]),
-    }
-
-    trial = create_trial(params=fixed_params, distributions=fixed_distributions, value=1)
-
-    # Check fixed_distributions doesn't change.
-    assert trial.distributions == fixed_distributions
 
 
 def test_suggest_with_multi_objectives() -> None:


### PR DESCRIPTION
## Motivation
Move tests for `create_trial` from `test_trial.py` to `test_frozen.py` because it is implemented in `_frozen.py`.

## Description of the changes
Move tests for `create_trial` from `test_trial.py` to `test_frozen.py`.
