### PR TITLE
Remove duplicated definition of CategoricalChoiceType from optuna.dis…

### DIFF
--- a/optuna/trial/_frozen.py
+++ b/optuna/trial/_frozen.py
@@ -12,6 +12,7 @@ from optuna import logging
 from optuna._deprecated import deprecated_func
 from optuna.distributions import _convert_old_distribution_to_new_distribution
 from optuna.distributions import BaseDistribution
+from optuna.distributions import CategoricalChoiceType
 from optuna.distributions import CategoricalDistribution
 from optuna.distributions import FloatDistribution
 from optuna.distributions import IntDistribution
@@ -21,8 +22,6 @@ from optuna.trial._state import TrialState
 
 _logger = logging.get_logger(__name__)
 _suggest_deprecated_msg = "Use :func:`~optuna.trial.FrozenTrial.suggest_float` instead."
-
-CategoricalChoiceType = Union[None, bool, int, float, str]
 
 
 class FrozenTrial(BaseTrial):


### PR DESCRIPTION
…tributions

<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
Remove duplicated definition of CategoricalChoiceType in [_frozen.py](https://github.com/optuna/optuna/blob/5df05086c1dd5fd8412bb2783d59f09932512bda/optuna/trial/_frozen.py#L25), as it was declared in [optuna/optuna/distributions.py](https://github.com/optuna/optuna/blob/5df05086c1dd5fd8412bb2783d59f09932512bda/optuna/distributions.py#L18)

## Description of the changes
Remove redeclaration of CategoricalChoiceType in [_frozen.py](https://github.com/optuna/optuna/blob/5df05086c1dd5fd8412bb2783d59f09932512bda/optuna/trial/_frozen.py#L25)
