### PR TITLE
Fix type hints for mypy 0.971

### DIFF
--- a/tests/samplers_tests/tpe_tests/test_sampler.py
+++ b/tests/samplers_tests/tpe_tests/test_sampler.py
@@ -1,4 +1,5 @@
 import multiprocessing
+from multiprocessing.managers import DictProxy
 import random
 from typing import Callable
 from typing import Dict
@@ -1115,7 +1116,7 @@ def test_group_experimental_warning() -> None:
 
 # This function is used only in test_group_deterministic_iteration, but declared at top-level
 # because local function cannot be pickled, which occurs within multiprocessing.
-def run_tpe(k: int, sequence_dict: Dict[int, List[int]], hash_dict: Dict[int, int]) -> None:
+def run_tpe(k: int, sequence_dict: DictProxy, hash_dict: DictProxy) -> None:
     hash_dict[k] = hash("nondeterministic hash")
     sampler = TPESampler(n_startup_trials=1, seed=2, multivariate=True, group=True)
     study = create_study(sampler=sampler)
@@ -1131,8 +1132,8 @@ def test_group_deterministic_iteration() -> None:
     # For more detail, see https://github.com/optuna/optuna/pull/3187#issuecomment-997673037.
     multiprocessing.set_start_method("spawn", force=True)
     manager = multiprocessing.Manager()
-    sequence_dict: Dict[int, List[int]] = manager.dict()
-    hash_dict: Dict[int, int] = manager.dict()
+    sequence_dict: DictProxy = manager.dict()
+    hash_dict: DictProxy = manager.dict()
     for i in range(3):
         p = multiprocessing.Process(target=run_tpe, args=(i, sequence_dict, hash_dict))
         p.start()


### PR DESCRIPTION
## Motivation
Fix Checks CI fail.

## Description of the changes
Fix type hints of `multiprocessing.Manager().dict()`.