### PR TITLE
Fix check for number of objective values

### DIFF
--- a/optuna/study/_tell.py
+++ b/optuna/study/_tell.py
@@ -26,19 +26,19 @@ def _check_and_convert_to_values(
     n_objectives: int, original_value: Optional[Union[float, Sequence[float]]], trial_number: int
 ) -> Tuple[Optional[List[float]], Optional[str]]:
     if isinstance(original_value, Sequence):
-        if n_objectives != len(original_value):
-            return (
-                None,
-                (
-                    f"The number of the values "
-                    f"{len(original_value)} did not match the number of the objectives "
-                    f"{n_objectives}."
-                ),
-            )
-        else:
-            _original_values: Sequence[Optional[float]] = list(original_value)
+        _original_values: Sequence[Optional[float]] = list(original_value)
     else:
         _original_values = [original_value]
+
+    if n_objectives != len(_original_values):
+        return (
+            None,
+            (
+                f"The number of the values "
+                f"{len(_original_values)} did not match the number of the objectives "
+                f"{n_objectives}."
+            ),
+        )
 
     _checked_values = []
     for v in _original_values:

--- a/tests/study_tests/test_study.py
+++ b/tests/study_tests/test_study.py
@@ -1409,6 +1409,12 @@ def test_tell_multi_objective_automatically_fail() -> None:
         assert study.trials[-1].state == TrialState.FAIL
         assert study.trials[-1].values is None
 
+    with pytest.warns(UserWarning):
+        study.tell(study.ask(), 1.0)
+        assert len(study.trials) == 6
+        assert study.trials[-1].state == TrialState.FAIL
+        assert study.trials[-1].values is None
+
 
 def test_tell_invalid() -> None:
     study = create_study()


### PR DESCRIPTION
## Motivation
The master's implementation incorrectly accepts single objective value for multi-objective optimization.

## Description of the changes
Fix `_check_and_convert_to_values` and add a test.