### PR TITLE
Raise `ValueError` when waiting trial is told

### DIFF
--- a/optuna/study/_tell.py
+++ b/optuna/study/_tell.py
@@ -158,6 +158,8 @@ def _tell_with_warning(
             f"Finished trial has values {frozen_trial.values} and state {frozen_trial.state}."
         )
         return copy.deepcopy(frozen_trial)
+    elif frozen_trial.state == TrialState.WAITING:
+        raise ValueError("Cannot tell a waiting trial.")
 
     if state == TrialState.PRUNED:
         # Register the last intermediate value if present as the value of the trial.

--- a/tests/study_tests/test_study.py
+++ b/tests/study_tests/test_study.py
@@ -1437,6 +1437,11 @@ def test_tell_invalid() -> None:
     with pytest.raises(ValueError):
         study.tell(study.ask().number + 1, 1.0)
 
+    # Waiting trial cannot be told.
+    with pytest.raises(ValueError):
+        study.enqueue_trial({})
+        study.tell(len(study.trials) - 1, 1.0)
+
     # It must be Trial or int for trial.
     with pytest.raises(TypeError):
         study.tell("1", 1.0)  # type: ignore

--- a/tests/study_tests/test_study.py
+++ b/tests/study_tests/test_study.py
@@ -1440,7 +1440,7 @@ def test_tell_invalid() -> None:
     # Waiting trial cannot be told.
     with pytest.raises(ValueError):
         study.enqueue_trial({})
-        study.tell(len(study.trials) - 1, 1.0)
+        study.tell(study.trials[-1].number, 1.0)
 
     # It must be Trial or int for trial.
     with pytest.raises(TypeError):


### PR DESCRIPTION
## Motivation
The told trial should be `RUNNING`, not `WAITING`.

## Description of the changes
Fix `_tell_with_warning` and add a test.