### PR TITLE
Fix return value's type of `_get_node_value`

### DIFF
--- a/optuna/importance/_fanova/_tree.py
+++ b/optuna/importance/_fanova/_tree.py
@@ -255,7 +255,7 @@ class _FanovaTree:
         return self._get_node_left_child(node_index), self._get_node_right_child(node_index)
 
     def _get_node_value(self, node_index: int) -> float:
-        return float(self._tree.value[node_index])
+        return self._tree.value[node_index].item()
 
     def _get_node_split_threshold(self, node_index: int) -> float:
         return self._tree.threshold[node_index]

--- a/optuna/importance/_fanova/_tree.py
+++ b/optuna/importance/_fanova/_tree.py
@@ -255,7 +255,7 @@ class _FanovaTree:
         return self._get_node_left_child(node_index), self._get_node_right_child(node_index)
 
     def _get_node_value(self, node_index: int) -> float:
-        return self._tree.value[node_index]
+        return float(self._tree.value[node_index])
 
     def _get_node_split_threshold(self, node_index: int) -> float:
         return self._tree.threshold[node_index]

--- a/optuna/importance/_fanova/_tree.py
+++ b/optuna/importance/_fanova/_tree.py
@@ -255,7 +255,7 @@ class _FanovaTree:
         return self._get_node_left_child(node_index), self._get_node_right_child(node_index)
 
     def _get_node_value(self, node_index: int) -> float:
-        return self._tree.value[node_index].item()
+        return float(self._tree.value[node_index])
 
     def _get_node_split_threshold(self, node_index: int) -> float:
         return self._tree.threshold[node_index]


### PR DESCRIPTION
## Motivation
Part of #3815.
`self._tree.value[node_index]` is `numpy.ndarray` of size 1.

## Description of the changes
Cast the return value to `float` from `numpy.ndarray`.