### PR TITLE
Fix `Study.tell` with invalid values

### DIFF
--- a/optuna/study/_tell.py
+++ b/optuna/study/_tell.py
@@ -172,6 +172,9 @@ def _tell_with_warning(
         len(study.directions), values, trial_number
     )
 
+    if state == TrialState.COMPLETE and values_conversion_failure_message is not None:
+        raise ValueError(values_conversion_failure_message)
+
     if state is None:
         if values_conversion_failure_message is None:
             state = TrialState.COMPLETE

--- a/tests/study_tests/test_study.py
+++ b/tests/study_tests/test_study.py
@@ -1417,6 +1417,22 @@ def test_tell_invalid() -> None:
     with pytest.raises(ValueError):
         study.tell(study.ask(), state=TrialState.COMPLETE)
 
+    # Invalid values for completions.
+    with pytest.raises(ValueError):
+        study.tell(study.ask(), "a", state=TrialState.COMPLETE)  # type: ignore
+
+    with pytest.raises(ValueError):
+        study.tell(study.ask(), None, state=TrialState.COMPLETE)
+
+    with pytest.raises(ValueError):
+        study.tell(study.ask(), [], state=TrialState.COMPLETE)
+
+    with pytest.raises(ValueError):
+        study.tell(study.ask(), [1.0, 2.0], state=TrialState.COMPLETE)
+
+    with pytest.raises(ValueError):
+        study.tell(study.ask(), float("nan"), state=TrialState.COMPLETE)
+
     # `state` must be None or finished state
     with pytest.raises(ValueError):
         study.tell(study.ask(), state=TrialState.RUNNING)


### PR DESCRIPTION
## Motivation
Fix unexpected behavior of `Study.tell` with invalid values and `state=TrialState.COMPLETE`.

```python
import optuna
from optuna.trial import TrialState

study = optuna.create_study()

trial = study.ask()
study.tell(trial, values="invalid", state=TrialState.COMPLETE)
print(study.trials[-1].state, study.trials[-1].value)
```

* master
```
TrialState.COMPLETE None
```

* PR
```
ValueError: The number of the values 7 did not match the number of the objectives 1.
```

## Description of the changes
Fix `Study.tell` and add tests.