### PR TITLE
Warn unused parameters in `enqueue_trial()`

### DIFF
--- a/optuna/_callbacks.py
+++ b/optuna/_callbacks.py
@@ -1,7 +1,7 @@
-import warnings
 from typing import Container
 from typing import List
 from typing import Optional
+import warnings
 
 import optuna
 from optuna._experimental import experimental_class

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -1,6 +1,14 @@
+import warnings
+from typing import Dict, Any
+
+import pytest
+
 from optuna import create_study
+from optuna.distributions import IntDistribution, FloatDistribution, CategoricalDistribution
 from optuna.study import MaxTrialsCallback
 from optuna.testing.objectives import pruned_objective
+from optuna.testing.samplers import DeterministicRelativeSampler
+from optuna.trial import Trial
 from optuna.trial import TrialState
 
 
@@ -18,3 +26,33 @@ def test_stop_with_MaxTrialsCallback() -> None:
         callbacks=[MaxTrialsCallback(5, states=(TrialState.PRUNED,))],
     )
     assert len(study.trials) == 5
+
+
+def objective_for_warn_unused_parameter_callback_tests(trial: Trial) -> float:
+    _ = trial.suggest_int("x0", 0, 10)
+    _ = trial.suggest_float("x1", 0, 1.0)
+    _ = trial.suggest_categorical("x2", ["foo", "bar"])
+    return 1.0
+
+
+@pytest.mark.parametrize("param", [
+    {"x0": 0, "x1": 0, "x2": "foo"},  # enqueue all valid parameters
+    {"x0": 0},  # enqueue partial valid parameters
+])
+def test_warn_unused_parameter_callback_raise_no_warnings(param: Dict[str, Any]) -> None:
+    study = create_study()
+    study.enqueue_trial(param)
+    with warnings.catch_warnings():
+        study.optimize(objective_for_warn_unused_parameter_callback_tests, n_trials=1)
+
+
+@pytest.mark.parametrize("param", [
+    {"x0": 0, "x1": 0, "x2": "foo", "x3": 0},  # x3 is not exist in search space
+    {"x0": -1},  # x0 is invalid
+])
+def test_warn_unused_parameter_callback_raise_warnings(param: Dict[str, Any]) -> None:
+    study = create_study()
+    study.enqueue_trial(param)
+
+    with warnings.catch_warnings():
+        study.optimize(objective_for_warn_unused_parameter_callback_tests, n_trials=1)

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -1,13 +1,12 @@
+from typing import Any
+from typing import Dict
 import warnings
-from typing import Dict, Any
 
 import pytest
 
 from optuna import create_study
-from optuna.distributions import IntDistribution, FloatDistribution, CategoricalDistribution
 from optuna.study import MaxTrialsCallback
 from optuna.testing.objectives import pruned_objective
-from optuna.testing.samplers import DeterministicRelativeSampler
 from optuna.trial import Trial
 from optuna.trial import TrialState
 
@@ -35,10 +34,13 @@ def objective_for_warn_unused_parameter_callback_tests(trial: Trial) -> float:
     return 1.0
 
 
-@pytest.mark.parametrize("param", [
-    {"x0": 0, "x1": 0, "x2": "foo"},  # enqueue all valid parameters
-    {"x0": 0},  # enqueue partial valid parameters
-])
+@pytest.mark.parametrize(
+    "param",
+    [
+        {"x0": 0, "x1": 0, "x2": "foo"},  # enqueue all valid parameters
+        {"x0": 0},  # enqueue partial valid parameters
+    ],
+)
 def test_warn_unused_parameter_callback_raise_no_warnings(param: Dict[str, Any]) -> None:
     study = create_study()
     study.enqueue_trial(param)
@@ -46,10 +48,13 @@ def test_warn_unused_parameter_callback_raise_no_warnings(param: Dict[str, Any])
         study.optimize(objective_for_warn_unused_parameter_callback_tests, n_trials=1)
 
 
-@pytest.mark.parametrize("param", [
-    {"x0": 0, "x1": 0, "x2": "foo", "x3": 0},  # x3 is not exist in search space
-    {"x0": -1},  # x0 is invalid
-])
+@pytest.mark.parametrize(
+    "param",
+    [
+        {"x0": 0, "x1": 0, "x2": "foo", "x3": 0},  # x3 is not exist in search space
+        {"x0": -1},  # x0 is invalid
+    ],
+)
 def test_warn_unused_parameter_callback_raise_warnings(param: Dict[str, Any]) -> None:
     study = create_study()
     study.enqueue_trial(param)


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
Close #3770

## Description of the changes
<!-- Describe the changes in this PR. -->
Add `warn_unused_parameter_callback` callback function and enable it by default.

## TODO

* [ ] Check whether this change shows duplicated warning messages when using this callback with GridSampler or PartialFixedSampler.