### PR TITLE
Revert AllenNLP integration back to experimental

### DIFF
--- a/optuna/integration/allennlp/_executor.py
+++ b/optuna/integration/allennlp/_executor.py
@@ -9,6 +9,7 @@ import warnings
 
 import optuna
 from optuna import TrialPruned
+from optuna._experimental import experimental_class
 from optuna._imports import try_import
 from optuna.integration.allennlp._environment import _environment_variables
 from optuna.integration.allennlp._variables import _VariableManager
@@ -67,6 +68,7 @@ def _fetch_pruner_config(trial: optuna.Trial) -> Dict[str, Any]:
     return kwargs
 
 
+@experimental_class("1.4.0")
 class AllenNLPExecutor:
     """AllenNLP extension to use optuna with Jsonnet config file.
 

--- a/optuna/integration/allennlp/_pruner.py
+++ b/optuna/integration/allennlp/_pruner.py
@@ -10,6 +10,7 @@ from optuna import load_study
 from optuna import pruners
 from optuna import Trial
 from optuna import TrialPruned
+from optuna._experimental import experimental_class
 from optuna._imports import try_import
 from optuna.integration.allennlp._variables import _VariableManager
 from optuna.integration.allennlp._variables import OPTUNA_ALLENNLP_DISTRIBUTED_FLAG
@@ -71,6 +72,7 @@ def _create_pruner(
     return pruner(**pruner_kwargs)
 
 
+@experimental_class("2.0.0")
 @TrainerCallback.register("optuna_pruner")
 class AllenNLPPruningCallback(TrainerCallback):
     """AllenNLP callback to prune unpromising trials.


### PR DESCRIPTION
## Motivation
AllenNLP announced that it is now in maintenance mode. This PR reverts AllenNLP integration back to experimental (i.e., revert #3228) and make it easier to drop support in the future.

## Description of the changes
Add `experimental` decorator for the AllenNLP integration.