### PR TITLE
Introduce `DeterministicSampler` instead of `DeterministicRelativeSampler`

### DIFF
--- a/optuna/testing/samplers.py
+++ b/optuna/testing/samplers.py
@@ -2,23 +2,17 @@ from typing import Any
 from typing import Dict
 
 import optuna
-from optuna import distributions
 from optuna.distributions import BaseDistribution
 
 
-class DeterministicRelativeSampler(optuna.samplers.BaseSampler):
-    def __init__(
-        self, relative_search_space: Dict[str, BaseDistribution], relative_params: Dict[str, Any]
-    ) -> None:
-
-        self.relative_search_space = relative_search_space
-        self.relative_params = relative_params
+class DeterministicSampler(optuna.samplers.BaseSampler):
+    def __init__(self, params: Dict[str, Any]) -> None:
+        self.params = params
 
     def infer_relative_search_space(
         self, study: "optuna.study.Study", trial: "optuna.trial.FrozenTrial"
     ) -> Dict[str, BaseDistribution]:
-
-        return self.relative_search_space
+        return {}
 
     def sample_relative(
         self,
@@ -26,8 +20,7 @@ class DeterministicRelativeSampler(optuna.samplers.BaseSampler):
         trial: "optuna.trial.FrozenTrial",
         search_space: Dict[str, BaseDistribution],
     ) -> Dict[str, Any]:
-
-        return self.relative_params
+        return {}
 
     def sample_independent(
         self,
@@ -36,16 +29,8 @@ class DeterministicRelativeSampler(optuna.samplers.BaseSampler):
         param_name: str,
         param_distribution: BaseDistribution,
     ) -> Any:
-
-        if isinstance(
-            param_distribution, (distributions.FloatDistribution, distributions.IntDistribution)
-        ):
-            param_value: Any = param_distribution.low
-        elif isinstance(param_distribution, distributions.CategoricalDistribution):
-            param_value = param_distribution.choices[0]
-        else:
-            raise NotImplementedError
-
+        param_value = self.params[param_name]
+        assert param_distribution._contains(param_value)
         return param_value
 
 

--- a/optuna/testing/samplers.py
+++ b/optuna/testing/samplers.py
@@ -30,7 +30,7 @@ class DeterministicSampler(optuna.samplers.BaseSampler):
         param_distribution: BaseDistribution,
     ) -> Any:
         param_value = self.params[param_name]
-        assert param_distribution._contains(param_value)
+        assert param_distribution._contains(param_distribution.to_internal_repr(param_value))
         return param_value
 
 

--- a/tests/integration_tests/test_chainermn.py
+++ b/tests/integration_tests/test_chainermn.py
@@ -222,8 +222,8 @@ class TestChainerMNStudy:
     @pytest.mark.parametrize("storage_mode", STORAGE_MODES)
     def test_relative_sampling(storage_mode: str, comm: CommunicatorBase) -> None:
 
-        relative_params = {"x": 1.0, "y": 25.0, "z": -1.0}
-        sampler = DeterministicSampler(relative_params)
+        params = {"x": 1.0, "y": 25.0, "z": -1.0}
+        sampler = DeterministicSampler(params)
 
         with MultiNodeStorageSupplier(storage_mode, comm) as storage:
             study = TestChainerMNStudy._create_shared_study(storage, comm, sampler=sampler)
@@ -237,9 +237,9 @@ class TestChainerMNStudy:
             # Assert trial counts.
             assert len(mn_study.trials) == n_trials
 
-            # Assert the parameters in `relative_params` have been suggested among all nodes.
+            # Assert the parameters in `params` have been suggested among all nodes.
             for trial in mn_study.trials:
-                assert trial.params == relative_params
+                assert trial.params == params
 
     @staticmethod
     def _create_shared_study(

--- a/tests/integration_tests/test_chainermn.py
+++ b/tests/integration_tests/test_chainermn.py
@@ -22,7 +22,6 @@ from optuna.storages import BaseStorage
 from optuna.storages import InMemoryStorage
 from optuna.storages import RDBStorage
 from optuna.testing.pruners import DeterministicPruner
-from optuna.testing.samplers import DeterministicSampler
 from optuna.testing.storages import StorageSupplier
 from optuna.trial import Trial
 from optuna.trial import TrialState
@@ -217,29 +216,6 @@ class TestChainerMNStudy:
             # Assert failed trial count.
             failed_trials = [t for t in mn_study.trials if t.state == TrialState.FAIL]
             assert len(failed_trials) == n_trials + 1
-
-    @staticmethod
-    @pytest.mark.parametrize("storage_mode", STORAGE_MODES)
-    def test_relative_sampling(storage_mode: str, comm: CommunicatorBase) -> None:
-
-        params = {"x": 1.0, "y": 25.0, "z": -1.0}
-        sampler = DeterministicSampler(params)
-
-        with MultiNodeStorageSupplier(storage_mode, comm) as storage:
-            study = TestChainerMNStudy._create_shared_study(storage, comm, sampler=sampler)
-            mn_study = ChainerMNStudy(study, comm)
-
-            # Invoke optimize.
-            n_trials = 20
-            func = Func()
-            mn_study.optimize(func, n_trials=n_trials)
-
-            # Assert trial counts.
-            assert len(mn_study.trials) == n_trials
-
-            # Assert the parameters in `params` have been suggested among all nodes.
-            for trial in mn_study.trials:
-                assert trial.params == params
 
     @staticmethod
     def _create_shared_study(

--- a/tests/integration_tests/test_chainermn.py
+++ b/tests/integration_tests/test_chainermn.py
@@ -22,7 +22,7 @@ from optuna.storages import BaseStorage
 from optuna.storages import InMemoryStorage
 from optuna.storages import RDBStorage
 from optuna.testing.pruners import DeterministicPruner
-from optuna.testing.samplers import DeterministicRelativeSampler
+from optuna.testing.samplers import DeterministicSampler
 from optuna.testing.storages import StorageSupplier
 from optuna.trial import Trial
 from optuna.trial import TrialState
@@ -222,13 +222,8 @@ class TestChainerMNStudy:
     @pytest.mark.parametrize("storage_mode", STORAGE_MODES)
     def test_relative_sampling(storage_mode: str, comm: CommunicatorBase) -> None:
 
-        relative_search_space = {
-            "x": distributions.FloatDistribution(low=-10, high=10),
-            "y": distributions.FloatDistribution(low=20, high=30, log=True),
-            "z": distributions.CategoricalDistribution(choices=(-1.0, 1.0)),
-        }
         relative_params = {"x": 1.0, "y": 25.0, "z": -1.0}
-        sampler = DeterministicRelativeSampler(relative_search_space, relative_params)
+        sampler = DeterministicSampler(relative_params)
 
         with MultiNodeStorageSupplier(storage_mode, comm) as storage:
             study = TestChainerMNStudy._create_shared_study(storage, comm, sampler=sampler)

--- a/tests/integration_tests/test_chainermn.py
+++ b/tests/integration_tests/test_chainermn.py
@@ -222,13 +222,12 @@ class TestChainerMNStudy:
         storage: BaseStorage,
         comm: CommunicatorBase,
         pruner: Optional[BasePruner] = None,
-        sampler: Optional[BaseSampler] = None,
     ) -> Study:
 
         name_local = create_study(storage=storage).study_name if comm.rank == 0 else None
         name_bcast = comm.mpi_comm.bcast(name_local)
 
-        return Study(name_bcast, storage, pruner=pruner, sampler=sampler)
+        return Study(name_bcast, storage, pruner=pruner)
 
     @staticmethod
     def _check_multi_node(comm: CommunicatorBase) -> None:

--- a/tests/integration_tests/test_chainermn.py
+++ b/tests/integration_tests/test_chainermn.py
@@ -17,7 +17,6 @@ from optuna import TrialPruned
 from optuna.integration.chainermn import ChainerMNStudy
 from optuna.integration.chainermn import ChainerMNTrial
 from optuna.pruners import BasePruner
-from optuna.samplers import BaseSampler
 from optuna.storages import BaseStorage
 from optuna.storages import InMemoryStorage
 from optuna.storages import RDBStorage

--- a/tests/integration_tests/test_cma.py
+++ b/tests/integration_tests/test_cma.py
@@ -35,7 +35,6 @@ class TestPyCmaSampler:
             cma_stds={"x": 1, "y": 1},
             seed=1,
             cma_opts={"popsize": 5},
-            independent_sampler=optuna.samplers.RandomSampler(),
         )
         study = optuna.create_study(sampler=sampler)
 

--- a/tests/integration_tests/test_cma.py
+++ b/tests/integration_tests/test_cma.py
@@ -16,7 +16,6 @@ from optuna.distributions import IntDistribution
 from optuna.integration.cma import _Optimizer
 from optuna.study._study_direction import StudyDirection
 from optuna.testing.distributions import UnsupportedDistribution
-from optuna.testing.samplers import DeterministicRelativeSampler
 from optuna.trial import FrozenTrial
 from optuna.trial import TrialState
 
@@ -36,7 +35,7 @@ class TestPyCmaSampler:
             cma_stds={"x": 1, "y": 1},
             seed=1,
             cma_opts={"popsize": 5},
-            independent_sampler=DeterministicRelativeSampler({}, {}),
+            independent_sampler=optuna.samplers.RandomSampler(),
         )
         study = optuna.create_study(sampler=sampler)
 
@@ -79,7 +78,7 @@ class TestPyCmaSampler:
     @staticmethod
     def test_sample_relative_1d() -> None:
 
-        independent_sampler = DeterministicRelativeSampler({}, {})
+        independent_sampler = optuna.samplers.RandomSampler()
         sampler = optuna.integration.PyCmaSampler(independent_sampler=independent_sampler)
         study = optuna.create_study(sampler=sampler)
 
@@ -93,7 +92,7 @@ class TestPyCmaSampler:
     @staticmethod
     def test_sample_relative_n_startup_trials() -> None:
 
-        independent_sampler = DeterministicRelativeSampler({}, {})
+        independent_sampler = optuna.samplers.RandomSampler()
         sampler = optuna.integration.PyCmaSampler(
             n_startup_trials=2, independent_sampler=independent_sampler
         )

--- a/tests/integration_tests/test_skopt.py
+++ b/tests/integration_tests/test_skopt.py
@@ -11,7 +11,6 @@ from skopt.space import space
 
 import optuna
 from optuna import distributions
-from optuna.testing.samplers import DeterministicRelativeSampler
 from optuna.trial import FrozenTrial
 
 
@@ -151,7 +150,7 @@ def _objective(trial: optuna.trial.Trial) -> float:
 
 def test_sample_relative_n_startup_trials() -> None:
 
-    independent_sampler = DeterministicRelativeSampler({}, {})
+    independent_sampler = optuna.samplers.RandomSampler()
     sampler = optuna.integration.SkoptSampler(
         n_startup_trials=2, independent_sampler=independent_sampler
     )

--- a/tests/samplers_tests/test_cmaes.py
+++ b/tests/samplers_tests/test_cmaes.py
@@ -17,7 +17,6 @@ from optuna import create_trial
 from optuna._transform import _SearchSpaceTransform
 from optuna.samplers._cmaes import _concat_optimizer_attrs
 from optuna.samplers._cmaes import _split_optimizer_str
-from optuna.testing.samplers import DeterministicRelativeSampler
 from optuna.trial import FrozenTrial
 from optuna.trial import TrialState
 
@@ -41,7 +40,7 @@ def test_init_cmaes_opts(
         sigma0=0.1,
         seed=1,
         n_startup_trials=1,
-        independent_sampler=DeterministicRelativeSampler({}, {}),
+        independent_sampler=optuna.samplers.RandomSampler(),
         use_separable_cma=use_separable_cma,
         popsize=popsize,
     )
@@ -176,7 +175,7 @@ def test_infer_relative_search_space_1d() -> None:
 
 
 def test_sample_relative_1d() -> None:
-    independent_sampler = DeterministicRelativeSampler({}, {})
+    independent_sampler = optuna.samplers.RandomSampler()
     sampler = optuna.samplers.CmaEsSampler(independent_sampler=independent_sampler)
     study = optuna.create_study(sampler=sampler)
 
@@ -189,7 +188,7 @@ def test_sample_relative_1d() -> None:
 
 
 def test_sample_relative_n_startup_trials() -> None:
-    independent_sampler = DeterministicRelativeSampler({}, {})
+    independent_sampler = optuna.samplers.RandomSampler()
     sampler = optuna.samplers.CmaEsSampler(
         n_startup_trials=2, independent_sampler=independent_sampler
     )
@@ -272,7 +271,7 @@ def test_population_size_is_multiplied_when_enable_ipop(popsize: Optional[int]) 
         sigma0=0.1,
         seed=1,
         n_startup_trials=1,
-        independent_sampler=DeterministicRelativeSampler({}, {}),
+        independent_sampler=optuna.samplers.RandomSampler(),
         restart_strategy="ipop",
         popsize=popsize,
         inc_popsize=inc_popsize,

--- a/tests/samplers_tests/test_cmaes.py
+++ b/tests/samplers_tests/test_cmaes.py
@@ -40,7 +40,6 @@ def test_init_cmaes_opts(
         sigma0=0.1,
         seed=1,
         n_startup_trials=1,
-        independent_sampler=optuna.samplers.RandomSampler(),
         use_separable_cma=use_separable_cma,
         popsize=popsize,
     )
@@ -271,7 +270,6 @@ def test_population_size_is_multiplied_when_enable_ipop(popsize: Optional[int]) 
         sigma0=0.1,
         seed=1,
         n_startup_trials=1,
-        independent_sampler=optuna.samplers.RandomSampler(),
         restart_strategy="ipop",
         popsize=popsize,
         inc_popsize=inc_popsize,

--- a/tests/samplers_tests/test_samplers.py
+++ b/tests/samplers_tests/test_samplers.py
@@ -28,7 +28,7 @@ from optuna.samplers import BaseSampler
 from optuna.study import Study
 from optuna.testing.objectives import fail_objective
 from optuna.testing.objectives import pruned_objective
-from optuna.testing.samplers import DeterministicRelativeSampler
+from optuna.testing.samplers import DeterministicSampler
 from optuna.trial import FrozenTrial
 from optuna.trial import Trial
 from optuna.trial import TrialState
@@ -684,7 +684,7 @@ def test_after_trial() -> None:
     n_calls = 0
     n_trials = 3
 
-    class SamplerAfterTrial(DeterministicRelativeSampler):
+    class SamplerAfterTrial(optuna.samplers.RandomSampler):
         def after_trial(
             self,
             study: Study,
@@ -701,7 +701,7 @@ def test_after_trial() -> None:
             nonlocal n_calls
             n_calls += 1
 
-    sampler = SamplerAfterTrial({}, {})
+    sampler = SamplerAfterTrial()
     study = optuna.create_study(directions=["minimize", "minimize"], sampler=sampler)
 
     study.optimize(lambda t: [t.suggest_float("y", -3, 3), t.suggest_int("x", 0, 10)], n_trials=3)
@@ -713,7 +713,7 @@ def test_after_trial_pruning() -> None:
     n_calls = 0
     n_trials = 3
 
-    class SamplerAfterTrial(DeterministicRelativeSampler):
+    class SamplerAfterTrial(DeterministicSampler):
         def after_trial(
             self,
             study: Study,
@@ -729,7 +729,7 @@ def test_after_trial_pruning() -> None:
             nonlocal n_calls
             n_calls += 1
 
-    sampler = SamplerAfterTrial({}, {})
+    sampler = SamplerAfterTrial({})
     study = optuna.create_study(directions=["minimize", "minimize"], sampler=sampler)
 
     study.optimize(pruned_objective, n_trials=n_trials)
@@ -741,7 +741,7 @@ def test_after_trial_failing() -> None:
     n_calls = 0
     n_trials = 3
 
-    class SamplerAfterTrial(DeterministicRelativeSampler):
+    class SamplerAfterTrial(DeterministicSampler):
         def after_trial(
             self,
             study: Study,
@@ -757,7 +757,7 @@ def test_after_trial_failing() -> None:
             nonlocal n_calls
             n_calls += 1
 
-    sampler = SamplerAfterTrial({}, {})
+    sampler = SamplerAfterTrial({})
     study = optuna.create_study(directions=["minimize", "minimize"], sampler=sampler)
 
     with pytest.raises(ValueError):
@@ -771,7 +771,7 @@ def test_after_trial_failing_in_after_trial() -> None:
     n_calls = 0
     n_trials = 3
 
-    class SamplerAfterTrialAlwaysFail(DeterministicRelativeSampler):
+    class SamplerAfterTrialAlwaysFail(DeterministicSampler):
         def after_trial(
             self,
             study: Study,
@@ -783,7 +783,7 @@ def test_after_trial_failing_in_after_trial() -> None:
             n_calls += 1
             raise NotImplementedError  # Arbitrary error for testing purpose.
 
-    sampler = SamplerAfterTrialAlwaysFail({}, {})
+    sampler = SamplerAfterTrialAlwaysFail({})
     study = optuna.create_study(sampler=sampler)
 
     with pytest.raises(NotImplementedError):
@@ -792,7 +792,7 @@ def test_after_trial_failing_in_after_trial() -> None:
     assert len(study.trials) == 1
     assert n_calls == 1
 
-    sampler = SamplerAfterTrialAlwaysFail({}, {})
+    sampler = SamplerAfterTrialAlwaysFail({})
     study = optuna.create_study(sampler=sampler)
 
     # Not affected by `catch`.
@@ -808,7 +808,7 @@ def test_after_trial_failing_in_after_trial() -> None:
 def test_after_trial_with_study_tell() -> None:
     n_calls = 0
 
-    class SamplerAfterTrial(DeterministicRelativeSampler):
+    class SamplerAfterTrial(DeterministicSampler):
         def after_trial(
             self,
             study: Study,
@@ -819,7 +819,7 @@ def test_after_trial_with_study_tell() -> None:
             nonlocal n_calls
             n_calls += 1
 
-    sampler = SamplerAfterTrial({}, {})
+    sampler = SamplerAfterTrial({})
     study = optuna.create_study(sampler=sampler)
 
     assert n_calls == 0

--- a/tests/samplers_tests/test_samplers.py
+++ b/tests/samplers_tests/test_samplers.py
@@ -28,7 +28,6 @@ from optuna.samplers import BaseSampler
 from optuna.study import Study
 from optuna.testing.objectives import fail_objective
 from optuna.testing.objectives import pruned_objective
-from optuna.testing.samplers import DeterministicSampler
 from optuna.trial import FrozenTrial
 from optuna.trial import Trial
 from optuna.trial import TrialState
@@ -713,7 +712,7 @@ def test_after_trial_pruning() -> None:
     n_calls = 0
     n_trials = 3
 
-    class SamplerAfterTrial(DeterministicSampler):
+    class SamplerAfterTrial(optuna.samplers.RandomSampler):
         def after_trial(
             self,
             study: Study,
@@ -729,7 +728,7 @@ def test_after_trial_pruning() -> None:
             nonlocal n_calls
             n_calls += 1
 
-    sampler = SamplerAfterTrial({})
+    sampler = SamplerAfterTrial()
     study = optuna.create_study(directions=["minimize", "minimize"], sampler=sampler)
 
     study.optimize(pruned_objective, n_trials=n_trials)
@@ -741,7 +740,7 @@ def test_after_trial_failing() -> None:
     n_calls = 0
     n_trials = 3
 
-    class SamplerAfterTrial(DeterministicSampler):
+    class SamplerAfterTrial(optuna.samplers.RandomSampler):
         def after_trial(
             self,
             study: Study,
@@ -757,7 +756,7 @@ def test_after_trial_failing() -> None:
             nonlocal n_calls
             n_calls += 1
 
-    sampler = SamplerAfterTrial({})
+    sampler = SamplerAfterTrial()
     study = optuna.create_study(directions=["minimize", "minimize"], sampler=sampler)
 
     with pytest.raises(ValueError):
@@ -771,7 +770,7 @@ def test_after_trial_failing_in_after_trial() -> None:
     n_calls = 0
     n_trials = 3
 
-    class SamplerAfterTrialAlwaysFail(DeterministicSampler):
+    class SamplerAfterTrialAlwaysFail(optuna.samplers.RandomSampler):
         def after_trial(
             self,
             study: Study,
@@ -783,7 +782,7 @@ def test_after_trial_failing_in_after_trial() -> None:
             n_calls += 1
             raise NotImplementedError  # Arbitrary error for testing purpose.
 
-    sampler = SamplerAfterTrialAlwaysFail({})
+    sampler = SamplerAfterTrialAlwaysFail()
     study = optuna.create_study(sampler=sampler)
 
     with pytest.raises(NotImplementedError):
@@ -792,7 +791,7 @@ def test_after_trial_failing_in_after_trial() -> None:
     assert len(study.trials) == 1
     assert n_calls == 1
 
-    sampler = SamplerAfterTrialAlwaysFail({})
+    sampler = SamplerAfterTrialAlwaysFail()
     study = optuna.create_study(sampler=sampler)
 
     # Not affected by `catch`.
@@ -808,7 +807,7 @@ def test_after_trial_failing_in_after_trial() -> None:
 def test_after_trial_with_study_tell() -> None:
     n_calls = 0
 
-    class SamplerAfterTrial(DeterministicSampler):
+    class SamplerAfterTrial(optuna.samplers.RandomSampler):
         def after_trial(
             self,
             study: Study,
@@ -819,7 +818,7 @@ def test_after_trial_with_study_tell() -> None:
             nonlocal n_calls
             n_calls += 1
 
-    sampler = SamplerAfterTrial({})
+    sampler = SamplerAfterTrial()
     study = optuna.create_study(sampler=sampler)
 
     assert n_calls == 0

--- a/tests/trial_tests/test_trial.py
+++ b/tests/trial_tests/test_trial.py
@@ -522,7 +522,6 @@ def test_should_prune() -> None:
 
 @pytest.mark.parametrize("storage_mode", STORAGE_MODES)
 def test_relative_parameters(storage_mode: str) -> None:
-
     class SamplerStubForTestRelativeParameters(samplers.BaseSampler):
         def infer_relative_search_space(
             self, study: "optuna.study.Study", trial: "optuna.trial.FrozenTrial"


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
DeterministicRelativeSampler 
`DeterministicRelativeSampler` is a bit bothering to use since it requires `relative_search_space` just for sampling specific parameter values. In this PR, I introduce `DeterministicSampler` that does not require `relative_search_space` since it returns parameter values in `sample_independent`.

```python
class DeterministicSampler(optuna.samplers.BaseSampler):
    def __init__(self, params: Dict[str, Any]) -> None:
        self.params = params

    def infer_relative_search_space(
        self, study: "optuna.study.Study", trial: "optuna.trial.FrozenTrial"
    ) -> Dict[str, BaseDistribution]:
        return {}

    def sample_relative(
        self,
        study: "optuna.study.Study",
        trial: "optuna.trial.FrozenTrial",
        search_space: Dict[str, BaseDistribution],
    ) -> Dict[str, Any]:
        return {}

    def sample_independent(
        self,
        study: "optuna.study.Study",
        trial: "optuna.trial.FrozenTrial",
        param_name: str,
        param_distribution: BaseDistribution,
    ) -> Any:
        param_value = self.params[param_name]
        assert param_distribution._contains(param_distribution.to_internal_repr(param_value))
        return param_value
```


## Description of the changes
<!-- Describe the changes in this PR. -->

* Introduce `DeterministicSampler` and use it instead.
* Replace the use of `DeterministicRelativeSampler` with `RandomSampler` if it doesn't need to use it.

## TODO

* This PR conflicts with https://github.com/optuna/optuna/pull/3807. Please merge #3807 first, then I will push https://github.com/keisuke-umezawa/optuna/compare/feature/use-relative-sampler-test-trial...c-bata:opuna:use-deterministic-sampler?expand=1 and will make this PR ready for review.