### PR TITLE
Normalize importance values

### DIFF
--- a/optuna/importance/__init__.py
+++ b/optuna/importance/__init__.py
@@ -25,17 +25,17 @@ def get_param_importances(
     evaluator: Optional[BaseImportanceEvaluator] = None,
     params: Optional[List[str]] = None,
     target: Optional[Callable[[FrozenTrial], float]] = None,
-    normalize_importances: bool = True,
+    normalize: bool = True,
 ) -> Dict[str, float]:
     """Evaluate parameter importances based on completed trials in the given study.
 
     The parameter importances are returned as a dictionary where the keys consist of parameter
     names and their values importances.
-    The importances are represented by floating point numbers that sum to 1.0 over the entire
-    dictionary.
-    The higher the value, the more important.
+    The importances are represented by non-negative floating point numbers, where higher values
+    mean that the parameters are more important.
     The returned dictionary is of type :class:`collections.OrderedDict` and is ordered by
     its values in a descending order.
+    If ``normalize`` is :obj:`True`, the sum of the importance values are normalized to 1.0.
 
     If ``params`` is :obj:`None`, all parameter that are present in all of the completed trials are
     assessed.
@@ -77,6 +77,10 @@ def get_param_importances(
                 Specify this argument if ``study`` is being used for multi-objective
                 optimization. For example, to get the hyperparameter importance of the first
                 objective, use ``target=lambda t: t.values[0]`` for the target parameter.
+        normalize:
+            A boolean option to specify whether the sum of the importance values should be
+            normalized to 1.0.
+            Defaults to :obj:`True`.
 
     Returns:
         An :class:`collections.OrderedDict` where the keys are parameter names and the values are
@@ -90,7 +94,7 @@ def get_param_importances(
         raise TypeError("Evaluator must be a subclass of BaseImportanceEvaluator.")
 
     res = evaluator.evaluate(study, params=params, target=target)
-    if normalize_importances:
+    if normalize:
         s = sum(res.values())
         if s == 0.0:
             n_params = len(res)

--- a/optuna/importance/__init__.py
+++ b/optuna/importance/__init__.py
@@ -3,7 +3,9 @@ from typing import Callable
 from typing import Dict
 from typing import List
 from typing import Optional
+import warnings
 
+from optuna.exceptions import ExperimentalWarning
 from optuna.importance._base import BaseImportanceEvaluator
 from optuna.importance._fanova import FanovaImportanceEvaluator
 from optuna.importance._mean_decrease_impurity import MeanDecreaseImpurityImportanceEvaluator
@@ -82,6 +84,11 @@ def get_param_importances(
             normalized to 1.0.
             Defaults to :obj:`True`.
 
+            .. note::
+                Added in v3.0.0 as an experimental feature. The interface may change in newer
+                versions without prior notice. See
+                https://github.com/optuna/optuna/releases/tag/v3.0.0.
+
     Returns:
         An :class:`collections.OrderedDict` where the keys are parameter names and the values are
         assessed importances.
@@ -102,4 +109,9 @@ def get_param_importances(
         else:
             return OrderedDict((param, value / s) for (param, value) in res.items())
     else:
+        warnings.warn(
+            "`normalize` option is an experimental feature."
+            " The interface can change in the future.",
+            ExperimentalWarning,
+        )
         return res

--- a/optuna/importance/__init__.py
+++ b/optuna/importance/__init__.py
@@ -2,7 +2,7 @@ from typing import Callable
 from typing import Dict
 from typing import List
 from typing import Optional
-from typing import OrderedDict
+from collections import OrderedDict
 
 from optuna.importance._base import BaseImportanceEvaluator
 from optuna.importance._fanova import FanovaImportanceEvaluator

--- a/optuna/importance/__init__.py
+++ b/optuna/importance/__init__.py
@@ -1,8 +1,8 @@
+from collections import OrderedDict
 from typing import Callable
 from typing import Dict
 from typing import List
 from typing import Optional
-from collections import OrderedDict
 
 from optuna.importance._base import BaseImportanceEvaluator
 from optuna.importance._fanova import FanovaImportanceEvaluator

--- a/tests/importance_tests/test_init.py
+++ b/tests/importance_tests/test_init.py
@@ -108,7 +108,7 @@ def test_get_param_importances(
         # Sanity check for param importances
         assert all(0 <= x < float("inf") for x in param_importance.values())
         if normalize:
-            assert len(param_importance) == 0 or np.isclose(sum(param_importance.values()), 1.0)
+            assert np.isclose(sum(param_importance.values()), 1.0)
 
 
 @parametrize_evaluator
@@ -207,7 +207,7 @@ def test_get_param_importances_with_target(
         # Sanity check for param importances
         assert all(0 <= x < float("inf") for x in param_importance.values())
         if normalize:
-            assert len(param_importance) == 0 or np.isclose(sum(param_importance.values()), 1.0)
+            assert np.isclose(sum(param_importance.values()), 1.0)
 
 
 @parametrize_evaluator

--- a/tests/importance_tests/test_init.py
+++ b/tests/importance_tests/test_init.py
@@ -9,6 +9,7 @@ import pytest
 
 import optuna
 from optuna import samplers
+from optuna.exceptions import ExperimentalWarning
 from optuna.importance import BaseImportanceEvaluator
 from optuna.importance import FanovaImportanceEvaluator
 from optuna.importance import get_param_importances
@@ -151,6 +152,17 @@ def test_get_param_importances_with_params(
         assert all(0 <= x < float("inf") for x in param_importance.values())
         if normalize:
             assert len(param_importance) == 0 or np.isclose(sum(param_importance.values()), 1.0)
+
+
+def test_get_param_importances_unnormalized_experimental() -> None:
+    def objective(trial: Trial) -> float:
+        x1 = trial.suggest_float("x1", 0.1, 3)
+        return x1**2
+
+    study = create_study()
+    study.optimize(objective, n_trials=4)
+    with pytest.warns(ExperimentalWarning):
+        get_param_importances(study, normalize=False)
 
 
 @parametrize_evaluator

--- a/tests/importance_tests/test_init.py
+++ b/tests/importance_tests/test_init.py
@@ -89,7 +89,7 @@ def test_get_param_importances(
         study.optimize(objective, n_trials=3)
 
         param_importance = get_param_importances(
-            study, evaluator=evaluator_init_func(), normalize_importances=normalize
+            study, evaluator=evaluator_init_func(), normalize=normalize
         )
 
         assert isinstance(param_importance, OrderedDict)
@@ -137,7 +137,7 @@ def test_get_param_importances_with_params(
         study.optimize(objective, n_trials=10)
 
         param_importance = get_param_importances(
-            study, evaluator=evaluator_init_func(), params=params, normalize_importances=normalize
+            study, evaluator=evaluator_init_func(), params=params, normalize=normalize
         )
 
         assert isinstance(param_importance, OrderedDict)
@@ -179,7 +179,7 @@ def test_get_param_importances_with_target(
             study,
             evaluator=evaluator_init_func(),
             target=lambda t: t.params["x1"] + t.params["x2"],
-            normalize_importances=normalize,
+            normalize=normalize,
         )
 
         assert isinstance(param_importance, OrderedDict)


### PR DESCRIPTION
## Motivation
The documentation of `get_params_importance` states that the returned importance values should sum up to 1.0. However, `ShapleyImportanceEvaluator` currently does not normalize its output to 1.0.

It is more natural (and fits to many people's intuition) that the mean absolute SHAP value be *not* normalized to 1.0. We propose to add an option `normalize` to `get_params_importance` that controls whether the returned importance values should be normalized to 1.0. This option is defaulted to `True`, and the normalized version is displayed in `plot_params_importance`.

## Description of the changes
* Add `normalize` option to `get_params_importance`
* Add tests

## Alternative approach
There are possible alternative approaches to this problem.
* Specify `normalize` option in `ShapleyImportanceEvaluator`. This way, `plot_params_importance` can also display the unnormalized values. However, we may have to change the way `<0.01` is displayed in `plot_params_importance`.
* Force all importance values to be normalized/unnormalized. 
