### PR TITLE
Remove unused `type: ignore`

### DIFF
--- a/benchmarks/run_bayesmark.py
+++ b/benchmarks/run_bayesmark.py
@@ -143,7 +143,7 @@ def partial_report(args: argparse.Namespace) -> None:
         for path in [eval_path, time_path]:
             with open(os.path.join(path, study), "r") as file:
                 data = json.load(file)
-                df = Dataset.from_dict(data["data"]).to_dataframe()  # type: ignore
+                df = Dataset.from_dict(data["data"]).to_dataframe()
                 df = df.droplevel("suggestion")
 
             for argument, meatadata in data["meta"]["args"].items():


### PR DESCRIPTION
Fix the CI failure in master branch.

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

## Description of the changes
- eb6df49 Remove `type: ignore`

I tested the CI on my mirrored repository:

- before (same as HEAD): https://github.com/himkt/optuna-warn-unused-ignores/commit/a079506e9a47fc9ec980be2a06a3ac5169bb4a86
- after: https://github.com/himkt/optuna-warn-unused-ignores/commit/dde32036d9909cead57233fdd9c9e408f1fdb6e3