### PR TITLE
refactor: import ordering

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -17,9 +17,9 @@
 # sys.path.insert(0, os.path.abspath('.'))
 
 import pkg_resources
-
 import plotly.io as pio
 from sphinx_gallery.sorting import FileNameSortKey
+
 
 __version__ = pkg_resources.get_distribution("optuna").version
 

--- a/optuna/storages/_rdb/alembic/versions/v0.9.0.a.py
+++ b/optuna/storages/_rdb/alembic/versions/v0.9.0.a.py
@@ -8,6 +8,7 @@ Create Date: 2019-03-12 12:30:31.178819
 from alembic import op
 import sqlalchemy as sa
 
+
 # revision identifiers, used by Alembic.
 revision = "v0.9.0.a"
 down_revision = None

--- a/optuna/storages/_rdb/alembic/versions/v1.3.0.a.py
+++ b/optuna/storages/_rdb/alembic/versions/v1.3.0.a.py
@@ -9,10 +9,10 @@ import json
 
 from alembic import op
 import sqlalchemy as sa
-
+from sqlalchemy import orm
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy import orm
+
 
 # revision identifiers, used by Alembic.
 revision = "v1.3.0.a"

--- a/optuna/storages/_rdb/alembic/versions/v2.4.0.a.py
+++ b/optuna/storages/_rdb/alembic/versions/v2.4.0.a.py
@@ -5,20 +5,20 @@ Revises: v1.3.0.a
 Create Date: 2020-11-17 02:16:16.536171
 
 """
-from alembic import op
-import sqlalchemy as sa
 from typing import Any
 
+from alembic import op
+import sqlalchemy as sa
 from sqlalchemy import Column
 from sqlalchemy import Enum
 from sqlalchemy import Float
 from sqlalchemy import ForeignKey
 from sqlalchemy import Integer
+from sqlalchemy import orm
 from sqlalchemy import UniqueConstraint
 from sqlalchemy.engine.reflection import Inspector
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy import orm
 
 from optuna.study import StudyDirection
 

--- a/optuna/storages/_rdb/alembic/versions/v3.0.0.c.py
+++ b/optuna/storages/_rdb/alembic/versions/v3.0.0.c.py
@@ -6,15 +6,15 @@ Create Date: 2022-05-16 17:17:28.810792
 
 """
 import enum
-
-import numpy as np
-from alembic import op
-import sqlalchemy as sa
-from sqlalchemy.exc import SQLAlchemyError
-from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy import orm
 from typing import Optional
 from typing import Tuple
+
+from alembic import op
+import numpy as np
+import sqlalchemy as sa
+from sqlalchemy import orm
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.ext.declarative import declarative_base
 
 
 # revision identifiers, used by Alembic.

--- a/optuna/storages/_rdb/alembic/versions/v3.0.0.d.py
+++ b/optuna/storages/_rdb/alembic/versions/v3.0.0.d.py
@@ -6,15 +6,16 @@ Create Date: 2022-06-02 09:57:22.818798
 
 """
 import enum
-
-import numpy as np
-from alembic import op
-import sqlalchemy as sa
-from sqlalchemy.exc import SQLAlchemyError
-from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy import orm
+from tkinter import W
 from typing import Optional
 from typing import Tuple
+
+from alembic import op
+import numpy as np
+import sqlalchemy as sa
+from sqlalchemy import orm
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.ext.declarative import declarative_base
 
 
 # revision identifiers, used by Alembic.

--- a/tox.ini
+++ b/tox.ini
@@ -99,7 +99,7 @@ commands = flake8 . {posargs}
 
 [testenv:isort]
 deps = isort
-commands = isort . --check --diff {posargs}
+commands = isort . --skip-glob docs/source/tutorial --check --diff {posargs}
 
 [testenv:black]
 deps = black

--- a/tutorial/10_key_features/005_visualization.py
+++ b/tutorial/10_key_features/005_visualization.py
@@ -13,6 +13,8 @@ please refer to the tutorial of :ref:`multi_objective`.
 """
 
 ###################################################################################################
+from tkinter import W
+
 import lightgbm as lgb
 import numpy as np
 import sklearn.datasets
@@ -30,6 +32,7 @@ from optuna.visualization import plot_optimization_history
 from optuna.visualization import plot_parallel_coordinate
 from optuna.visualization import plot_param_importances
 from optuna.visualization import plot_slice
+
 
 SEED = 42
 

--- a/tutorial/20_recipes/001_rdb.py
+++ b/tutorial/20_recipes/001_rdb.py
@@ -26,6 +26,7 @@ import sys
 
 import optuna
 
+
 # Add stream handler of stdout to show the messages
 optuna.logging.get_logger("optuna").addHandler(logging.StreamHandler(sys.stdout))
 study_name = "example-study"  # Unique identifier of the study.

--- a/tutorial/20_recipes/005_user_defined_sampler.py
+++ b/tutorial/20_recipes/005_user_defined_sampler.py
@@ -41,6 +41,7 @@ For example, the following code defines a sampler based on
 """
 
 import numpy as np
+
 import optuna
 
 

--- a/tutorial/20_recipes/006_user_defined_pruner.py
+++ b/tutorial/20_recipes/006_user_defined_pruner.py
@@ -57,8 +57,8 @@ last reported as the value of the trial.
 
 import numpy as np
 from sklearn.datasets import load_iris
-from sklearn.model_selection import train_test_split
 from sklearn.linear_model import SGDClassifier
+from sklearn.model_selection import train_test_split
 
 import optuna
 from optuna.pruners import BasePruner

--- a/tutorial/20_recipes/007_optuna_callback.py
+++ b/tutorial/20_recipes/007_optuna_callback.py
@@ -55,6 +55,7 @@ def objective(trial):
 import logging
 import sys
 
+
 # Add stream handler of stdout to show the messages
 optuna.logging.get_logger("optuna").addHandler(logging.StreamHandler(sys.stdout))
 

--- a/tutorial/20_recipes/008_specify_params.py
+++ b/tutorial/20_recipes/008_specify_params.py
@@ -96,6 +96,7 @@ study.enqueue_trial(
 import logging
 import sys
 
+
 # Add stream handler of stdout to show the messages to see Optuna works expectedly.
 optuna.logging.get_logger("optuna").addHandler(logging.StreamHandler(sys.stdout))
 study.optimize(objective, n_trials=100, timeout=600)

--- a/tutorial/20_recipes/010_reuse_best_trial.py
+++ b/tutorial/20_recipes/010_reuse_best_trial.py
@@ -28,7 +28,6 @@ from sklearn.datasets import make_classification
 from sklearn.linear_model import LogisticRegression
 from sklearn.model_selection import train_test_split
 
-
 import optuna
 
 


### PR DESCRIPTION

## Motivation

There were just error that were coming up when I ran Tox. I noticed that when I tried to do the fix "./formats.sh" that was in the contributors guide. That it did not fix everything. So I went in and made the adjustments.

Made changes to the import ordering of the following files:
    - modified: docs/source/conf.py
    - modified: optuna/storages/_rdb/alembic/versions/v0.9.0.a.py
    - modified: optuna/storages/_rdb/alembic/versions/v1.3.0.a.py
    - modified: optuna/storages/_rdb/alembic/versions/v2.4.0.a.py
    - modified: optuna/storages/_rdb/alembic/versions/v3.0.0.c.py
    - modified: optuna/storages/_rdb/alembic/versions/v3.0.0.d.py
    - modified: tutorial/10_key_features/005_visualization.py
    - modified: tutorial/20_recipes/001_rdb.py
    - modified: tutorial/20_recipes/005_user_defined_sampler.py
    - modified: tutorial/20_recipes/006_user_defined_pruner.py

Added a change to the tox.ini file that will ignore some files that don't show up on the repository and are built from docs.
    - modified: tox.ini

## Description of the Changes

Most of the changes were of python import ordering and spacing.  I went through the suggest files and made the changes that were suggested by Isort.

As for the tox.ini file.  Isort was getting caught up on an error that cannot be submitted via the repository, so an exception was put in place for this folder to ignore it when searching for errors.
