### PR TITLE
Pin scipy to avoid the CI failure

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ def get_install_requires() -> List[str]:
         "numpy",
         "packaging>=20.0",
         # TODO(kstoneriv3): remove this after deprecation of Python 3.6
-        "scipy!=1.4.0" if sys.version[:3] == "3.6" else "scipy>=1.7.0",
+        "scipy!=1.4.0,<1.9.0" if sys.version[:3] == "3.6" else "scipy>=1.7.0,<1.9.0",
         "sqlalchemy>=1.1.0",
         "tqdm",
         "typing_extensions",


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
Fix the [CI](https://github.com/optuna/optuna/runs/7597875494?check_suite_focus=true) related to scipy. Although I'm not sure why the error happened with the [search space](https://github.com/optuna/optuna/blob/aab38ef72ac816ca3c7395356260e2a1a173bee4/tests/samplers_tests/test_qmc.py#L18-L25), I think it is related to https://github.com/scipy/scipy/pull/15647#discussion_r819395454.


## Description of the changes
- Pin version of scipy bf6a1de

Please merge with squash if this PR is decided to be merged since I made the empty commit to demonstrate the CI failure.
