### PR TITLE
Fix typos and remove unused argument in QMC

### DIFF
--- a/optuna/samplers/_qmc.py
+++ b/optuna/samplers/_qmc.py
@@ -44,7 +44,7 @@ class QMCSampler(BaseSampler):
     <https://scipy.github.io/devdocs/reference/stats.qmc.html>`_.
 
     .. note:
-        If your search space contains categorical parameters, it samples the catagorical
+        If your search space contains categorical parameters, it samples the categorical
         parameters by its `independent_sampler` without using QMC algorithm.
 
     .. note::
@@ -111,7 +111,7 @@ class QMCSampler(BaseSampler):
             Note that the parameters of the first trial in a study are sampled via an
             independent sampler in most cases, so no warning messages are emitted in such cases.
 
-        warn_asyncronous_seeding:
+        warn_asynchronous_seeding:
             If this is :obj:`True`, a warning message is emitted when the scrambling
             (randomization) is applied to the QMC sequence and the random seed of the sampler is
             not set manually.
@@ -120,7 +120,7 @@ class QMCSampler(BaseSampler):
                 When using parallel and/or distributed optimization without manually
                 setting the seed, the seed is set randomly for each instances of
                 :class:`~optuna.samplers.QMCSampler` for different workers, which ends up
-                asyncronous seeding for multiple samplers used in the optimization.
+                asynchronous seeding for multiple samplers used in the optimization.
 
             .. seealso::
                 See parameter ``seed`` in :class:`~optuna.samplers.QMCSampler`.
@@ -153,7 +153,7 @@ class QMCSampler(BaseSampler):
         scramble: bool = False,  # default is False for simplicity in distributed environment.
         seed: Optional[int] = None,
         independent_sampler: Optional[BaseSampler] = None,
-        warn_asyncronous_seeding: bool = True,
+        warn_asynchronous_seeding: bool = True,
         warn_independent_sampling: bool = True,
     ) -> None:
 
@@ -181,9 +181,9 @@ class QMCSampler(BaseSampler):
             )
             raise ValueError(message)
 
-        if seed is None and scramble and warn_asyncronous_seeding:
+        if seed is None and scramble and warn_asynchronous_seeding:
             # Sobol/Halton sequences without scrambling do not use seed.
-            self._log_asyncronous_seeding()
+            self._log_asynchronous_seeding()
 
     def reseed_rng(self) -> None:
 
@@ -222,7 +222,7 @@ class QMCSampler(BaseSampler):
         return search_space
 
     @staticmethod
-    def _log_asyncronous_seeding() -> None:
+    def _log_asynchronous_seeding() -> None:
         _logger.warning(
             "No seed is provided for `QMCSampler` and the seed is set randomly. "
             "If you are running multiple `QMCSampler`s in parallel and/or distributed "
@@ -283,7 +283,7 @@ class QMCSampler(BaseSampler):
         # Lazy import because the `scipy.stats.qmc` is slow to import.
         qmc_module = _LazyImport("scipy.stats.qmc")
 
-        sample_id = self._find_sample_id(study, search_space)
+        sample_id = self._find_sample_id(study)
         d = len(search_space)
 
         if self._qmc_type == "halton":
@@ -299,7 +299,7 @@ class QMCSampler(BaseSampler):
 
         return sample
 
-    def _find_sample_id(self, study: Study, search_space: Dict[str, BaseDistribution]) -> int:
+    def _find_sample_id(self, study: Study) -> int:
 
         qmc_id = ""
         qmc_id += self._qmc_type

--- a/tests/samplers_tests/test_qmc.py
+++ b/tests/samplers_tests/test_qmc.py
@@ -72,7 +72,7 @@ def test_invalid_qmc_type(qmc_type: str) -> None:
     sys.version_info < (3, 7, 0), reason="QMCSampler is not supported in Python 3.6"
 )
 def test_initial_seeding() -> None:
-    with patch.object(optuna.samplers.QMCSampler, "_log_asyncronous_seeding") as mock_log_async:
+    with patch.object(optuna.samplers.QMCSampler, "_log_asynchronous_seeding") as mock_log_async:
         sampler = _init_QMCSampler_without_exp_warning(scramble=True)
     mock_log_async.assert_called_once()
     assert isinstance(sampler._seed, int)
@@ -160,16 +160,16 @@ def test_sample_independent() -> None:
 @pytest.mark.skipif(
     sys.version_info < (3, 7, 0), reason="QMCSampler is not supported in Python 3.6"
 )
-def test_warn_asyncronous_seeding() -> None:
+def test_warn_asynchronous_seeding() -> None:
     # Relative sampling of `QMCSampler` does not support categorical distribution.
     # Thus, `independent_sampler.sample_independent` is called twice.
     # '_log_independent_sampling is not called in the first trial so called once in total.
     objective: Callable[[Trial], Any] = lambda t: t.suggest_categorical("x", [1.0, 2.0])
 
-    with patch.object(optuna.samplers.QMCSampler, "_log_asyncronous_seeding") as mock_log_async:
+    with patch.object(optuna.samplers.QMCSampler, "_log_asynchronous_seeding") as mock_log_async:
 
         sampler = _init_QMCSampler_without_exp_warning(
-            scramble=True, warn_asyncronous_seeding=False
+            scramble=True, warn_asynchronous_seeding=False
         )
         study = optuna.create_study(sampler=sampler)
         study.optimize(objective, n_trials=2)
@@ -388,20 +388,19 @@ def test_sample_qmc(qmc_type: str) -> None:
 )
 def test_find_sample_id() -> None:
 
-    search_space = _SEARCH_SPACE.copy()
     sampler = _init_QMCSampler_without_exp_warning(qmc_type="halton", seed=0)
     study = optuna.create_study()
     for i in range(5):
-        assert sampler._find_sample_id(study, search_space) == i
+        assert sampler._find_sample_id(study) == i
 
     # Change seed but without scramble. The hash should remain the same.
     with patch.object(sampler, "_seed", 1) as _:
-        assert sampler._find_sample_id(study, search_space) == 5
+        assert sampler._find_sample_id(study) == 5
 
         # Seed is considered only when scrambling is enabled
         with patch.object(sampler, "_scramble", True) as _:
-            assert sampler._find_sample_id(study, search_space) == 0
+            assert sampler._find_sample_id(study) == 0
 
     # Change qmc_type
     with patch.object(sampler, "_qmc_type", "sobol") as _:
-        assert sampler._find_sample_id(study, search_space) == 0
+        assert sampler._find_sample_id(study) == 0


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

By chance, I found a few typos and unused argument in a method in qmc sampler files.

## Description of the changes
<!-- Describe the changes in this PR. -->

The introduced changes are as follows:
Fix typos:
    - catagorical -> categorical
    - asyncronous -> asynchronous
- Remove `search_space` argument in `_find_sample_id` method since it is not used