### PR TITLE
Add a reference for MOTPE

### DIFF
--- a/optuna/multi_objective/samplers/_motpe.py
+++ b/optuna/multi_objective/samplers/_motpe.py
@@ -32,6 +32,7 @@ class MOTPEMultiObjectiveSampler(BaseMultiObjectiveSampler):
 
     - `Multiobjective tree-structured parzen estimator for computationally expensive optimization
       problems <https://dl.acm.org/doi/abs/10.1145/3377930.3389817>`_
+    - `Multiobjective Tree-Structured Parzen Estimator <https://doi.org/10.1613/jair.1.13188>`_
 
     Args:
         consider_prior:

--- a/optuna/samplers/_tpe/multi_objective_sampler.py
+++ b/optuna/samplers/_tpe/multi_objective_sampler.py
@@ -28,6 +28,7 @@ class MOTPESampler(TPESampler):
 
     - `Multiobjective tree-structured parzen estimator for computationally expensive optimization
       problems <https://dl.acm.org/doi/abs/10.1145/3377930.3389817>`_
+    - `Multiobjective Tree-Structured Parzen Estimator <https://doi.org/10.1613/jair.1.13188>`_
 
     Args:
         consider_prior:

--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -76,6 +76,7 @@ class TPESampler(BaseSampler):
       Dimensions for Vision Architectures <http://proceedings.mlr.press/v28/bergstra13.pdf>`_
     - `Multiobjective tree-structured parzen estimator for computationally expensive optimization
       problems <https://dl.acm.org/doi/10.1145/3377930.3389817>`_
+    - `Multiobjective Tree-Structured Parzen Estimator <https://doi.org/10.1613/jair.1.13188>`_
 
     Example:
 


### PR DESCRIPTION
## Motivation and description of the changes

[The following new journal article on MOTPE](https://doi.org/10.1613/jair.1.13188) is available.
```
Ozaki, Y., Tanigaki, Y., Watanabe, S., Nomura, M. and Onishi, M., 2022.
Multiobjective Tree-Structured Parzen Estimator.
Journal of Artificial Intelligence Research, 73, pp.1209-1250.
https://doi.org/10.1613/jair.1.13188
```
This PR adds a reference to the paper to the Optuna documentation to provide further information for users.
