### PR TITLE
Extract float value from tensor for `trial.report` in `PyTorchLightningPruningCallback`

### DIFF
--- a/optuna/integration/pytorch_lightning.py
+++ b/optuna/integration/pytorch_lightning.py
@@ -94,7 +94,7 @@ class PyTorchLightningPruningCallback(Callback):
 
         should_stop = False
         if trainer.is_global_zero:
-            self._trial.report(current_score, step=epoch)
+            self._trial.report(current_score.item(), step=epoch)
             should_stop = self._trial.should_prune()
         should_stop = trainer.training_type_plugin.broadcast(should_stop)
         if not should_stop:


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

Fix the Master branch's CI for integration `checks`. The example failed job is  https://github.com/optuna/optuna/runs/7641899563?check_suite_focus=true.

## Description of the changes
<!-- Describe the changes in this PR. -->

Call `item` to get a float value from PyTorch tensor.


Note that Optuna doesn't support PyTorchLightning>=1.6.0 as in https://github.com/optuna/optuna/issues/3418.  Fortunately, the introduced change by this PR does not break backward compatibility: the callback still works with PyTorchLightning `1.5.*`, which I locally confined.