### PR TITLE
Remove pytest skip in catboost test

### DIFF
--- a/tests/integration_tests/test_catboost.py
+++ b/tests/integration_tests/test_catboost.py
@@ -79,7 +79,6 @@ def test_catboost_pruning_callback_init_param(metric: str, eval_set_index: int) 
     assert study.trials[0].value == 1.0
 
 
-@pytest.mark.skip(reason="Temporally skip due to unknown CatBoost error.")
 @pytest.mark.parametrize(
     "metric, eval_set_index",
     [


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

Resolve https://github.com/optuna/optuna/issues/3511

## Description of the changes
<!-- Describe the changes in this PR. -->

Remove `pytest.mark.skip`.