### PR TITLE
Minor fixes of Sampler comparison table

### DIFF
--- a/docs/source/reference/samplers/index.rst
+++ b/docs/source/reference/samplers/index.rst
@@ -26,7 +26,7 @@ The :mod:`~optuna.samplers` module defines a base class for parameter sampling a
 +----------------------------------+---------------+---------------+----------------------+----------------+----------------------------------------+---------------+----------------+
 | Conditional search space         |       ✅      |      ▲        |          ✅          |       ▲        |                   ▲                    |       ▲       |       ▲        |
 +----------------------------------+---------------+---------------+----------------------+----------------+----------------------------------------+---------------+----------------+
-| Multi-objective optimization     |       ✅      |      ▲        |          ✅          |       ❌       |       ✅(▲ for single-objective)       |       ▲       |       ✅       |
+| Multi-objective optimization     |       ✅      |      ▲        |          ✅          |       ❌       |       ✅ (▲ for single-objective)      |       ▲       |       ✅       |
 +----------------------------------+---------------+---------------+----------------------+----------------+----------------------------------------+---------------+----------------+
 | Batch optimization               |       ✅      |      ✅       |          ✅          |       ✅       |                   ✅                   |       ✅      |       ▲        |
 +----------------------------------+---------------+---------------+----------------------+----------------+----------------------------------------+---------------+----------------+
@@ -36,12 +36,12 @@ The :mod:`~optuna.samplers` module defines a base class for parameter sampling a
 +----------------------------------+---------------+---------------+----------------------+----------------+----------------------------------------+---------------+----------------+
 | Time complexity (per trial) (*)  |  :math:`O(d)` | :math:`O(dn)` | :math:`O(dn \log n)` | :math:`O(d^3)` |              :math:`O(mnp)`            | :math:`O(dn)` | :math:`O(n^3)` |
 +----------------------------------+---------------+---------------+----------------------+----------------+----------------------------------------+---------------+----------------+
-| Recommended budgets (#trials)    | as many as    | number of     |      100 ~ 1000      |  1000 ~ 10000  |                100 ~ 10000             | as many as    |    10 ~ 100    |
+| Recommended budgets (#trials)    | as many as    | number of     |      100 – 1000      |  1000 – 10000  |                100 – 10000             | as many as    |    10 – 100    |
 | (**)                             | one likes     | combinations  |                      |                |                                        | one likes     |                |
 +----------------------------------+---------------+---------------+----------------------+----------------+----------------------------------------+---------------+----------------+
 
 .. note::
-    ✅: Supports this feature. 
+    ✅: Supports this feature.
     ▲ : Works, but inefficiently.
     ❌: Causes an error, or has no interface.
 
@@ -53,37 +53,37 @@ The :mod:`~optuna.samplers` module defines a base class for parameter sampling a
     (**): The budget depends on the number of parameters and the number of objectives.
 
 .. note::
-   For float, integer, or categorical parameters, see :ref:`configurations` tutorial.
+    For float, integer, or categorical parameters, see :ref:`configurations` tutorial.
 
-   For pruning, see :ref:`pruning` tutorial.
-   
-   For multivariate optimization, see :class:`~optuna.samplers.BaseSampler`. The multivariate optimization is implemented as :func:`~optuna.samplers.BaseSampler.sample_relative` in Optuna. Please check the concrete documents of samplers for more details.
+    For pruning, see :ref:`pruning` tutorial.
 
-   For conditional search space, see :ref:`configurations` tutorial and :class:`~optuna.samplers.TPESampler`. The ``group`` option of :class:`~optuna.samplers.TPESampler` allows :class:`~optuna.samplers.TPESampler` to handle the conditional search space.
+    For multivariate optimization, see :class:`~optuna.samplers.BaseSampler`. The multivariate optimization is implemented as :func:`~optuna.samplers.BaseSampler.sample_relative` in Optuna. Please check the concrete documents of samplers for more details.
 
-   For multi-objective optimization, see :ref:`multi_objective` tutorial.
+    For conditional search space, see :ref:`configurations` tutorial and :class:`~optuna.samplers.TPESampler`. The ``group`` option of :class:`~optuna.samplers.TPESampler` allows :class:`~optuna.samplers.TPESampler` to handle the conditional search space.
 
-   For batch optimization, see :ref:`Batch-Optimization` tutorial. Note that the ``constant_liar`` option of :class:`~optuna.samplers.TPESampler` allows :class:`~optuna.samplers.TPESampler` to handle the batch optimization.
+    For multi-objective optimization, see :ref:`multi_objective` tutorial.
 
-   For distributed optimization, see :ref:`distributed` tutorial. Note that the ``constant_liar`` option of :class:`~optuna.samplers.TPESampler` allows :class:`~optuna.samplers.TPESampler` to handle the distributed optimization.
+    For batch optimization, see :ref:`Batch-Optimization` tutorial. Note that the ``constant_liar`` option of :class:`~optuna.samplers.TPESampler` allows :class:`~optuna.samplers.TPESampler` to handle the batch optimization.
 
-   For constrained optimization, see an `example <https://github.com/optuna/optuna-examples/blob/main/multi_objective/botorch_simple.py>`_.
+    For distributed optimization, see :ref:`distributed` tutorial. Note that the ``constant_liar`` option of :class:`~optuna.samplers.TPESampler` allows :class:`~optuna.samplers.TPESampler` to handle the distributed optimization.
+
+    For constrained optimization, see an `example <https://github.com/optuna/optuna-examples/blob/main/multi_objective/botorch_simple.py>`_.
 
 .. autosummary::
-   :toctree: generated/
-   :nosignatures:
+    :toctree: generated/
+    :nosignatures:
 
-   optuna.samplers.BaseSampler
-   optuna.samplers.GridSampler
-   optuna.samplers.RandomSampler
-   optuna.samplers.TPESampler
-   optuna.samplers.CmaEsSampler
-   optuna.samplers.PartialFixedSampler
-   optuna.samplers.NSGAIISampler
-   optuna.samplers.MOTPESampler
-   optuna.samplers.QMCSampler
-   optuna.samplers.IntersectionSearchSpace
-   optuna.samplers.intersection_search_space
+    optuna.samplers.BaseSampler
+    optuna.samplers.GridSampler
+    optuna.samplers.RandomSampler
+    optuna.samplers.TPESampler
+    optuna.samplers.CmaEsSampler
+    optuna.samplers.PartialFixedSampler
+    optuna.samplers.NSGAIISampler
+    optuna.samplers.MOTPESampler
+    optuna.samplers.QMCSampler
+    optuna.samplers.IntersectionSearchSpace
+    optuna.samplers.intersection_search_space
 
 .. toctree::
     :maxdepth: 1


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

This PR might be based on my preference, but I'd like to suggest a few really minor things to improve the comparison table and the rst file.

## Description of the changes
<!-- Describe the changes in this PR. -->

The changes are mainly three holds as follows:

1. Add a space between the emoji and `(` in the cell of `NSGAIISampler`'s `Multi-objective optimization` for readability.
2. Replace `~` with `–`. To represent a range of numbers (ex. $1 – 10$), en-dash might be a more standard sign than `~`, which is used in Japanese to represent a range.
     - https://en.wikipedia.org/wiki/Tilde#Japanese
     - en-dash: https://www.grammarly.com/blog/en-dash.
3. Unify indent size; replace a three-space indent with a four-space indent in the rst file.


As a reference, by applying the second change to the table, the table shows

<img width="1094" alt="Screenshot 2022-08-05 at 3 40 27" src="https://user-images.githubusercontent.com/7121753/182929010-a19475d8-2cc5-42b0-8b9a-e43352a02d60.png">
