### PR TITLE
 Add .. seealso:: in Study.get_trials and Study.trials to refer to each other #3578 

### DIFF
--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -193,7 +193,7 @@ class Study:
     @property
     def directions(self) -> List[StudyDirection]:
         """Return the directions of the study.
-
+        
         Returns:
             A list of :class:`~optuna.study.StudyDirection` objects.
         """
@@ -210,6 +210,9 @@ class Study:
 
         Returns:
             A list of :class:`~optuna.trial.FrozenTrial` objects.
+            -- seealso::
+                See :func:`~optuna.study.Study.get_trails` for related method.
+                
         """
 
         return self.get_trials(deepcopy=True, states=None)
@@ -222,6 +225,8 @@ class Study:
         """Return all trials in the study.
 
         The returned trials are ordered by trial number.
+        -- seealso::
+            See :func:`~optuna.study.Study.trails` for related method.
 
         Example:
             .. testcode::

--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -193,7 +193,7 @@ class Study:
     @property
     def directions(self) -> List[StudyDirection]:
         """Return the directions of the study.
-        
+
         Returns:
             A list of :class:`~optuna.study.StudyDirection` objects.
         """
@@ -212,7 +212,7 @@ class Study:
             A list of :class:`~optuna.trial.FrozenTrial` objects.
             -- seealso::
                 See :func:`~optuna.study.Study.get_trails` for related method.
-                
+
         """
 
         return self.get_trials(deepcopy=True, states=None)


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
Documentation for the  Study.get_trials and Study.trials to refer to each other was requested on issue  #3578.

## Description of the changes
added a seealso to the returns docstring in methods Study.trials
added a seealso to the definition of the methods Study.get_trials
