### PR TITLE
Make log message user-friendly when objective returns a sequence of unsupported values

### DIFF
--- a/optuna/study/_optimize.py
+++ b/optuna/study/_optimize.py
@@ -255,4 +255,4 @@ def _log_failed_trial(
         exc_info=exc_info,
     )
 
-    _logger.warning("Trial {} failed with value {}.".format(trial.number, value_or_values))
+    _logger.warning("Trial {} failed with value {}.".format(trial.number, repr(value_or_values)))

--- a/optuna/study/_optimize.py
+++ b/optuna/study/_optimize.py
@@ -218,9 +218,18 @@ def _run_trial(
             _logger.info("Trial {} pruned. {}".format(frozen_trial.number, str(func_err)))
         elif frozen_trial.state == TrialState.FAIL:
             if func_err is not None:
-                _log_failed_trial(frozen_trial, repr(func_err), exc_info=func_err_fail_exc_info)
+                _log_failed_trial(
+                    frozen_trial,
+                    repr(func_err),
+                    exc_info=func_err_fail_exc_info,
+                    value_or_values=value_or_values,
+                )
             elif STUDY_TELL_WARNING_KEY in frozen_trial.system_attrs:
-                _log_failed_trial(frozen_trial, frozen_trial.system_attrs[STUDY_TELL_WARNING_KEY])
+                _log_failed_trial(
+                    frozen_trial,
+                    frozen_trial.system_attrs[STUDY_TELL_WARNING_KEY],
+                    value_or_values=value_or_values,
+                )
             else:
                 assert False, "Should not reach."
         else:
@@ -236,9 +245,14 @@ def _run_trial(
 
 
 def _log_failed_trial(
-    trial: FrozenTrial, message: Union[str, Warning], exc_info: Any = None
+    trial: FrozenTrial,
+    message: Union[str, Warning],
+    exc_info: Any = None,
+    value_or_values: Any = None,
 ) -> None:
     _logger.warning(
         "Trial {} failed because of the following error: {}".format(trial.number, message),
         exc_info=exc_info,
     )
+
+    _logger.warning("Trial {} failed with value {}.".format(trial.number, value_or_values))

--- a/optuna/study/_tell.py
+++ b/optuna/study/_tell.py
@@ -30,16 +30,6 @@ def _check_and_convert_to_values(
     else:
         _original_values = [original_value]
 
-    if n_objectives != len(_original_values):
-        return (
-            None,
-            (
-                f"The number of the values "
-                f"{len(_original_values)} did not match the number of the objectives "
-                f"{n_objectives}."
-            ),
-        )
-
     _checked_values = []
     for v in _original_values:
         checked_v, failure_message = _check_single_value(v, trial_number)
@@ -52,6 +42,16 @@ def _check_and_convert_to_values(
             _checked_values.append(checked_v)
         else:
             assert False
+
+    if n_objectives != len(_original_values):
+        return (
+            None,
+            (
+                f"The number of the values "
+                f"{len(_checked_values)} did not match the number of the objectives "
+                f"{n_objectives}."
+            ),
+        )
 
     return _checked_values, None
 


### PR DESCRIPTION

<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

As reported by https://github.com/optuna/optuna/issues/3699, the logger's message might be unclear for users when the objective returns `str` (technically, a sequence of a value that cannot be converted into a float value). For example,

```python
import optuna


def objective(trial):
    x = trial.suggest_float("x", -100, 100)
    y = trial.suggest_categorical("y", [-1, 0, 1])
    return "sample"



for num_objectives in [1, 2]:
    sampler = optuna.samplers.TPESampler(seed=10)
    study = optuna.create_study(sampler=sampler, directions=["minimize"]*num_objectives)
    study.optimize(objective, n_trials=2)
```

The output is as follows:

```shell
# single objective
[I 2022-08-10 13:14:33,683] A new study created in memory with name: no-name-0a782794-38dd-4fcc-a9a0-9d624184d70d
[W 2022-08-10 13:14:33,686] Trial 0 failed because of the following error: The number of the values 6 did not match the number of the objectives 1.
[W 2022-08-10 13:14:33,686] Trial 1 failed because of the following error: The number of the values 6 did not match the number of the objectives 1.

# multi-objective
[I 2022-08-10 13:14:33,687] A new study created in memory with name: no-name-5d52d04d-1ccd-4649-91dc-2fe78ec4288b
[W 2022-08-10 13:14:33,688] Trial 0 failed because of the following error: The number of the values 6 did not match the number of the objectives 2.
[W 2022-08-10 13:14:33,689] Trial 1 failed because of the following error: The number of the values 6 did not match the number of the objectives 2.
```

By applying the change in this PR, the output will be as follows:

```shell
# single objective
[I 2022-08-10 13:09:45,755] A new study created in memory with name: no-name-f2888b23-e568-4d6e-b1e0-9f5310ad7960
[W 2022-08-10 13:09:45,757] Trial 0 failed because of the following error: The value 's' could not be cast to float.
[W 2022-08-10 13:09:45,759] Trial 1 failed because of the following error: The value 's' could not be cast to float.

# multi-objective
[I 2022-08-10 13:09:45,761] A new study created in memory with name: no-name-3437816d-e80d-4c6f-ba69-b6daa0ce834a
[W 2022-08-10 13:09:45,762] Trial 0 failed because of the following error: The value 's' could not be cast to float.
[W 2022-08-10 13:09:45,764] Trial 1 failed because of the following error: The value 's' could not be cast to float.
```


## Description of the changes
<!-- Describe the changes in this PR. -->

Move the logic that checks the consistency between the number of objectives and directions.

## Discussions

Note that this PR cannot detect the following case, where the sequence of `str` digit, to maintain backwards compatibility of the master brach:

```python
import optuna


def objective(trial):
    x = trial.suggest_float("x", -100, 100)
    y = trial.suggest_categorical("y", [-1, 0, 1])
    return "12"


sampler = optuna.samplers.TPESampler(seed=10)
study = optuna.create_study(sampler=sampler, directions=["minimize"]*2)
study.optimize(objective, n_trials=2)
```
