### PR TITLE
Fix docstring in `FrozenTrial`

### DIFF
--- a/optuna/trial/_frozen.py
+++ b/optuna/trial/_frozen.py
@@ -113,12 +113,18 @@ class FrozenTrial(BaseTrial):
             Datetime where the :class:`~optuna.trial.Trial` finished.
         params:
             Dictionary that contains suggested parameters.
+        distributions:
+            Dictionary that contains parameter distributions.
         user_attrs:
             Dictionary that contains the attributes of the :class:`~optuna.trial.Trial` set with
             :func:`optuna.trial.Trial.set_user_attr`.
+        system_attrs:
+            Dictionary that contains the attributes of the :class:`~optuna.trial.Trial` set with
+            :func:`optuna.trial.Trial.set_system_attr`.
         intermediate_values:
             Intermediate objective values set with :func:`optuna.trial.Trial.report`.
-
+        trial_id:
+            ID of the :class:`~optuna.trial.Trial`
     """
 
     def __init__(

--- a/optuna/trial/_frozen.py
+++ b/optuna/trial/_frozen.py
@@ -123,8 +123,6 @@ class FrozenTrial(BaseTrial):
             :func:`optuna.trial.Trial.set_system_attr`.
         intermediate_values:
             Intermediate objective values set with :func:`optuna.trial.Trial.report`.
-        trial_id:
-            ID of the :class:`~optuna.trial.Trial`
     """
 
     def __init__(

--- a/optuna/trial/_frozen.py
+++ b/optuna/trial/_frozen.py
@@ -114,7 +114,7 @@ class FrozenTrial(BaseTrial):
         params:
             Dictionary that contains suggested parameters.
         distributions:
-            Dictionary that contains parameter distributions.
+            Dictionary that contains the distributions of :attr:`params`.
         user_attrs:
             Dictionary that contains the attributes of the :class:`~optuna.trial.Trial` set with
             :func:`optuna.trial.Trial.set_user_attr`.
@@ -427,7 +427,6 @@ class FrozenTrial(BaseTrial):
 
     @property
     def distributions(self) -> Dict[str, BaseDistribution]:
-        """Dictionary that contains the distributions of :attr:`params`."""
 
         return self._distributions
 


### PR DESCRIPTION
## Motivation
Fix docstring in `FrozenTrial`.

## Description of the changes
Added docstring for `distributions`, `system_attrs`, and `trial_id` for `FrozenTrial`.
