### PR TITLE
Make nsgaii docs informative

### DIFF
--- a/docs/source/reference/samplers/index.rst
+++ b/docs/source/reference/samplers/index.rst
@@ -85,6 +85,9 @@ The :mod:`~optuna.samplers` module defines a base class for parameter sampling a
     optuna.samplers.IntersectionSearchSpace
     optuna.samplers.intersection_search_space
 
+.. note::
+    The following :mod:`optuna.samplers.nsgaii` module defines crossover operations used by :class:`~optuna.samplers.NSGAIISampler`.
+
 .. toctree::
     :maxdepth: 1
 


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

Resolve #3512

## Description of the changes
<!-- Describe the changes in this PR. -->

As suggested by https://github.com/optuna/optuna/issues/3512#issuecomment-1134075708: 
>  I think it is sufficient to add a note section above the `optuna.samplers.nsgaii` part like that above the following `optuna.visdualization.matplotlib` section. https://optuna.readthedocs.io/en/latest/reference/visualization/index.html

this PR adds a note section to explain `optuna.samplers.nsgaii` module. The sentence comes from https://github.com/optuna/optuna/blob/master/docs/source/reference/samplers/nsgaii.rst.