### PR TITLE
Add note for `constant_liar` with multi-objective function

### DIFF
--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -206,6 +206,10 @@ class TPESampler(BaseSampler):
                 workers is high.
 
             .. note::
+                This feature can be used for only single-objective optimization; this argument is
+                ignored for multi-objective optimization.
+
+            .. note::
                 Added in v2.8.0 as an experimental feature. The interface may change in newer
                 versions without prior notice. See
                 https://github.com/optuna/optuna/releases/tag/v2.8.0.

--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -191,12 +191,12 @@ class TPESampler(BaseSampler):
 
             .. note::
                 Abnormally terminated trials often leave behind a record with a state of
-                `RUNNING` in the storage.
+                ``RUNNING`` in the storage.
                 Such "zombie" trial parameters will be avoided by the constant liar algorithm
                 during subsequent sampling.
                 When using an :class:`~optuna.storages.RDBStorage`, it is possible to enable the
                 ``heartbeat_interval`` to change the records for abnormally terminated trials to
-                `FAIL`.
+                ``FAIL``.
 
             .. note::
                 It is recommended to set this value to :obj:`True` during distributed


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

Currently, TPE sampler's `constant_liar` argument is ignored for multi-objective function as pointed out by https://github.com/optuna/optuna/issues/3565. This feature should be clarified in the documentation as suggested by https://github.com/optuna/optuna/issues/3565#issuecomment-1166913554.

## Description of the changes
<!-- Describe the changes in this PR. -->

- Add a note section to explain when we can use `constant_liar`.
- Minor document fix (https://github.com/optuna/optuna/pull/3881/commits/9970d20392a54ec5addc25536fb7cc77ff05388e)