### PR TITLE
Use `copybutton_prompt_text` not to copy the bash prompt

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -179,6 +179,9 @@ autodoc_default_options = {
     "exclude-members": "with_traceback",
 }
 
+# sphinx_copybutton option to not copy prompt.
+copybutton_prompt_text = "$ "
+
 # Sphinx Gallery
 pio.renderers.default = "sphinx_gallery"
 


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

When we click the copy button (concretely, see also the bottom right corner in the screenshot below) on the code snippet of a command line example, the prompt sign, `$`,  is also copied, which is not ideal because users would like to run the copied command without unnecessary prompt removal.

<img width="1120" alt="Screenshot 2022-08-11 at 23 00 07" src="https://user-images.githubusercontent.com/7121753/184152101-f1e76c26-cd1b-4ed9-90c4-8d4dcab6e98a.png">

Page: https://optuna.readthedocs.io/en/latest/installation.html
 
## Description of the changes
<!-- Describe the changes in this PR. -->

Use `copybutton_prompt_text` variable by `sphinx-copybutton` that says

> When this variable is set, sphinx-copybutton will remove the prompt from the beginning of any lines that start with the text you specify. In addition, only the lines that contain prompts will be copied if any are discovered. If no lines with prompts are found, then the full contents of the cell will be copied.

Ref: https://sphinx-copybutton.readthedocs.io/en/latest/use.html#strip-and-configure-input-prompts-for-code-cells

As a result, we copy the command line without prompt `$`.
