### PR TITLE
Improve HyperBand docs

### DIFF
--- a/optuna/pruners/_hyperband.py
+++ b/optuna/pruners/_hyperband.py
@@ -34,12 +34,12 @@ class HyperbandPruner(BasePruner):
 
     .. note::
         If you use ``HyperbandPruner`` with :class:`~optuna.samplers.TPESampler`,
-        it's recommended to consider to set larger ``n_trials`` or ``timeout`` to make full use of
+        it's recommended to consider setting larger ``n_trials`` or ``timeout`` to make full use of
         the characteristics of :class:`~optuna.samplers.TPESampler`
         because :class:`~optuna.samplers.TPESampler` uses some (by default, :math:`10`)
         :class:`~optuna.trial.Trial`\\ s for its startup.
 
-        As Hyperband runs multiple :class:`~optuna.pruners.SuccessiveHalvingPruner` and collect
+        As Hyperband runs multiple :class:`~optuna.pruners.SuccessiveHalvingPruner` and collects
         trials based on the current :class:`~optuna.trial.Trial`\\ 's bracket ID, each bracket
         needs to observe more than :math:`10` :class:`~optuna.trial.Trial`\\ s
         for :class:`~optuna.samplers.TPESampler` to adapt its search space.
@@ -48,18 +48,17 @@ class HyperbandPruner(BasePruner):
         at least :math:`4 \\times 10` trials are consumed for startup.
 
     .. note::
-        Hyperband has several :class:`~optuna.pruners.SuccessiveHalvingPruner`. Each
-        :class:`~optuna.pruners.SuccessiveHalvingPruner` is referred as "bracket" in the original
-        paper. The number of brackets is an important factor to control the early stopping behavior
-        of Hyperband and is automatically determined by ``min_resource``, ``max_resource`` and
-        ``reduction_factor`` as
-        `The number of brackets = floor(log_{reduction_factor}(max_resource / min_resource)) + 1`.
+        Hyperband has several :class:`~optuna.pruners.SuccessiveHalvingPruner`\\ s. Each
+        :class:`~optuna.pruners.SuccessiveHalvingPruner` is referred to as "bracket" in the
+        original paper. The number of brackets is an important factor to control the early
+        stopping behavior of Hyperband and is automatically determined by ``min_resource``,
+        ``max_resource`` and ``reduction_factor`` as
+        :math:`\\mathrm{The\\ number\\ of\\ brackets} =
+        \\mathrm{floor}(\\log_{\\texttt{reduction_factor}}
+        (\\frac{\\texttt{max_resource}}{\\texttt{min_resource}})) + 1`.
         Please set ``reduction_factor`` so that the number of brackets is not too large (about 4 –
         6 in most use cases). Please see Section 3.6 of the `original paper
         <http://www.jmlr.org/papers/volume18/16-558/16-558.pdf>`_ for the detail.
-
-    .. seealso::
-        Please refer to :meth:`~optuna.trial.Trial.report`.
 
     Example:
 


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

I'd like to suggest a few changes to improve the docstring of HyperBand Pruner.

## Description of the changes
<!-- Describe the changes in this PR. -->

- Fix typos
- Use math syntax for the definition of #bracket since the current definition is slightly difficult to read.
- Remove less informative `seealso` because `report` is only used in examples like other pruners and the first `seealso` section of `max_resource` argument.


