### PR TITLE
Mention reproducibility of `HyperBandPruner`

### DIFF
--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -174,13 +174,15 @@ For example, you can save SVM models trained in the objective function as follow
 How can I obtain reproducible optimization results?
 ---------------------------------------------------
 
-To make the parameters suggested by Optuna reproducible, you can specify a fixed random seed via ``seed`` argument of :class:`~optuna.samplers.RandomSampler` or :class:`~optuna.samplers.TPESampler` as follows:
+To make the parameters suggested by Optuna reproducible, you can specify a fixed random seed via ``seed`` argument of an instance of :mod:`~optuna.samplers` as follows:
 
 .. code-block:: python
 
     sampler = TPESampler(seed=10)  # Make the sampler behave in a deterministic way.
     study = optuna.create_study(sampler=sampler)
     study.optimize(objective)
+
+To make the pruning by :class:`~optuna.pruners.HyperbandPruner` reproducible, you can specify ``study_name`` of :class:`~optuna.study.Study` and `hash seed <https://docs.python.org/3/using/cmdline.html#envvar-PYTHONHASHSEED>`_.
 
 However, there are two caveats.
 

--- a/optuna/pruners/_hyperband.py
+++ b/optuna/pruners/_hyperband.py
@@ -59,6 +59,13 @@ class HyperbandPruner(BasePruner):
         <http://www.jmlr.org/papers/volume18/16-558/16-558.pdf>`_ for the detail.
 
     .. seealso::
+        ``HyperbandPruner`` in Optuna randomly computes bracket ID for each trial with a hash
+        function taking ``study_name`` of :class:`~optuna.study.Study` and
+        :attr:`~optuna.trial.Trial.number`. Please specify ``study_name`` and
+        `hash seed <https://docs.python.org/3/using/cmdline.html#envvar-PYTHONHASHSEED>`_
+        to make pruning behavior reproducible.
+
+    .. seealso::
         Please refer to :meth:`~optuna.trial.Trial.report`.
 
     Example:


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

`HyperbandPruner` has randomness depending on `study_name` and `trial.number` by using the hash function as defined by https://github.com/optuna/optuna/blob/0dd1e0e81b475da91bba9b333b2539ce77ed3747/optuna/pruners/_hyperband.py#L247-L249. It would be great to explain how to get reproducible pruning results in Hyperband's page and FAQ's reproducibility section.

## Description of the changes
<!-- Describe the changes in this PR. -->

1. Add a new `seealso` section to `HyperBandPruner` page
2. Mention `HyperBandPruner`'s randomness in FAQ section on reproducibility
3. (a minor one) Update the sampler part too in the FAQ section since another sampler such as `NSGAIISampler` also takes `seed` argument to specify the random seed. 
