### PR TITLE
Add a new note to mention unsupported GPU case for `CatBoostPruningCallback `

### DIFF
--- a/optuna/integration/catboost.py
+++ b/optuna/integration/catboost.py
@@ -32,6 +32,11 @@ class CatBoostPruningCallback:
         after training manually unlike other pruning callbacks
         to raise :class:`optuna.TrialPruned`.
 
+    .. note::
+        This callback cannot be used with CatBoost on GPUs because CatBoost doesn't support
+        a user-defined callback for GPU.
+        Please refer to `CatBoost issue <https://github.com/catboost/catboost/issues/1792>`_.
+
     Args:
         trial:
             A :class:`~optuna.trial.Trial` corresponding to the current evaluation of the


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

Resolve https://github.com/optuna/optuna/issues/3550

## Description of the changes
<!-- Describe the changes in this PR. -->

Add a new note to clarify  that`CatBoostPruningCallback` doesn't support GPU based catboost model.