### PR TITLE
Remove version constraint of `cached-path`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -92,8 +92,6 @@ def get_extras_require() -> Dict[str, List[str]]:
         ],
         "integration": [
             "allennlp>=2.2.0 ; python_version>'3.6'",
-            # TODO(c-bata): Remove cached-path after allennllp supports v1.1.3
-            "cached-path<=1.1.2 ; python_version>'3.6'",
             "botorch>=0.4.0 ; python_version>'3.6'",
             "catalyst>=21.3 ; python_version>'3.6'",
             "catboost>=0.26",


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

Revert than change by https://github.com/optuna/optuna/pull/3665 because the latest stable allennlp doesn't require an older `cached-path` anymore according to https://github.com/allenai/allennlp/blob/2d8fe00904d4b1a249dab2784309c86618ffa1a0/requirements.txt#L6.

## Description of the changes
<!-- Describe the changes in this PR. -->

Remove the changes by https://github.com/optuna/optuna/pull/3665.