### PR TITLE
Replace `thop` with `fvcore`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,17 +67,13 @@ def get_extras_require() -> Dict[str, List[str]]:
         ],
         "document": [
             "cma",
+            "fvcore",
             "lightgbm",
             "matplotlib",
             "mlflow",
-            # TODO(nzw0301): Remove onnx if thop adds onnx to its dependencies.
-            "onnx",
             "pandas",
             "pillow",
             "plotly>=4.0.0",  # optuna/visualization.
-            # TODO(nzw0301): Remove protobuf after
-            # https://github.com/onnx/onnx/issues/4239 is resolved.
-            "protobuf<=3.20.1",
             "scikit-learn",
             "scikit-optimize",
             "sphinx",
@@ -85,7 +81,6 @@ def get_extras_require() -> Dict[str, List[str]]:
             "sphinx-gallery",
             "sphinx-plotly-directive",
             "sphinx_rtd_theme",
-            "thop",
             "torch==1.11.0 ; python_version>'3.6'",
             "torchaudio==0.11.0 ; python_version>'3.6'",
             "torchvision==0.12.0 ; python_version>'3.6'",

--- a/tutorial/20_recipes/002_multi_objective.py
+++ b/tutorial/20_recipes/002_multi_objective.py
@@ -7,14 +7,14 @@ Multi-objective Optimization with Optuna
 This tutorial showcases Optuna's multi-objective optimization feature by
 optimizing the validation accuracy of Fashion MNIST dataset and the FLOPS of the model implemented in PyTorch.
 
-We use `thop <https://github.com/Lyken17/pytorch-OpCounter>`_ to measure FLOPS.
+We use `fvcore <https://github.com/facebookresearch/fvcore>`_ to measure FLOPS.
 """
 
-import thop
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
 import torchvision
+from fvcore.nn import FlopCountAnalysis
 
 import optuna
 
@@ -67,7 +67,7 @@ def eval_model(model, valid_loader):
 
     accuracy = correct / N_VALID_EXAMPLES
 
-    flops, _ = thop.profile(model, inputs=(torch.randn(1, 28 * 28).to(DEVICE),), verbose=False)
+    flops = FlopCountAnalysis(model, inputs=(torch.randn(1, 28 * 28).to(DEVICE),)).total()
     return flops, accuracy
 
 


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

Multi-objective tutorial code uses [`thop`](https://github.com/Lyken17/pytorch-OpCounter/) that requires `onnx` to measure flops. Due to `onnx`'s dependency and `thop`'s `setup.py`, Optuna's `setup.py`'s `documenet` part introduces additional constraints. This PR ails to replace `htop` with `fvcore`, which provides a similar functionality as described  https://github.com/facebookresearch/fvcore/blob/main/docs/flop_count.md, without `onnx`.

## Description of the changes
<!-- Describe the changes in this PR. -->

- Replace `thop` with `fvcore`.
- Remove a few lines for `thop` in `setup.py`.

I locally confirmed the calculated flops are the same between these packages.