### PR TITLE
Remove abstractmethod decorator from `get_trial_id_from_study_id_trial_number`

### DIFF
--- a/optuna/storages/_base.py
+++ b/optuna/storages/_base.py
@@ -331,7 +331,6 @@ class BaseStorage(object, metaclass=abc.ABCMeta):
         """
         raise NotImplementedError
 
-    @abc.abstractmethod
     def get_trial_id_from_study_id_trial_number(self, study_id: int, trial_number: int) -> int:
         """Read the trial ID of a trial.
 


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
Revert changes in #3870.

## Description of the changes
<!-- Describe the changes in this PR. -->
@knshnb told me that `get_trial_id_from_study_id_trial_number` is actually not an abstractmethod though it raises NotImplementedError. When `NotImplementedError` is raised, following lines handles an exception and returns trial_id.

https://github.com/optuna/optuna/blob/5a1bb75bcb92173c7ee99ebe8b1abf1335f85b3d/optuna/study/_tell.py#L122-L142

I think we should implement the default logic in BaseSampler. However, this PR revert #3870 for now, since we plan to release v3.0 next week.