### PR TITLE
Suppress warnings in tests for `multi_objective` module

### DIFF
--- a/tests/multi_objective_tests/samplers_tests/test_nsga2.py
+++ b/tests/multi_objective_tests/samplers_tests/test_nsga2.py
@@ -10,6 +10,9 @@ from optuna import multi_objective
 from optuna.study._study_direction import StudyDirection
 
 
+pytestmark = pytest.mark.filterwarnings("ignore::FutureWarning")
+
+
 def test_population_size() -> None:
     # Set `population_size` to 10.
     sampler = multi_objective.samplers.NSGAIIMultiObjectiveSampler(population_size=10)

--- a/tests/multi_objective_tests/samplers_tests/test_samplers.py
+++ b/tests/multi_objective_tests/samplers_tests/test_samplers.py
@@ -13,6 +13,8 @@ from optuna.distributions import IntDistribution
 from optuna.multi_objective.samplers import BaseMultiObjectiveSampler
 
 
+pytestmark = pytest.mark.filterwarnings("ignore::FutureWarning")
+
 parametrize_sampler = pytest.mark.parametrize(
     "sampler_class",
     [

--- a/tests/multi_objective_tests/test_study.py
+++ b/tests/multi_objective_tests/test_study.py
@@ -10,6 +10,9 @@ from optuna.study._study_direction import StudyDirection
 from optuna.testing.storages import StorageSupplier
 
 
+pytestmark = pytest.mark.filterwarnings("ignore::FutureWarning")
+
+
 def test_create_study() -> None:
     study = optuna.multi_objective.create_study(["maximize"])
     assert study.n_objectives == 1

--- a/tests/multi_objective_tests/test_trial.py
+++ b/tests/multi_objective_tests/test_trial.py
@@ -11,6 +11,9 @@ from optuna.study._study_direction import StudyDirection
 from optuna.trial import TrialState
 
 
+pytestmark = pytest.mark.filterwarnings("ignore::FutureWarning")
+
+
 def test_suggest() -> None:
     study = optuna.multi_objective.create_study(["maximize", "maximize"])
 

--- a/tests/multi_objective_tests/visualization_tests/test_pareto_front.py
+++ b/tests/multi_objective_tests/visualization_tests/test_pareto_front.py
@@ -10,6 +10,9 @@ import optuna
 from optuna.multi_objective.visualization import plot_pareto_front
 
 
+pytestmark = pytest.mark.filterwarnings("ignore::FutureWarning")
+
+
 @pytest.mark.parametrize("include_dominated_trials", [False, True])
 @pytest.mark.parametrize("axis_order", [None, [0, 1], [1, 0]])
 def test_plot_pareto_front_2d(


### PR DESCRIPTION
## Motivation
Part of https://github.com/optuna/optuna/issues/3815.
`multi_objective` module is deprecated. We can ignore `FutureWarning` in its tests.

## Description of the changes
Ignore `FutureWarning` in tests for `multi_objective` module.