### PR TITLE
Replace `q` with `step` in private function and warning message

### DIFF
--- a/optuna/distributions.py
+++ b/optuna/distributions.py
@@ -655,20 +655,20 @@ def check_distribution_compatibility(
         )
 
 
-def _adjust_discrete_uniform_high(low: float, high: float, q: float) -> float:
+def _adjust_discrete_uniform_high(low: float, high: float, step: float) -> float:
     d_high = decimal.Decimal(str(high))
     d_low = decimal.Decimal(str(low))
-    d_q = decimal.Decimal(str(q))
+    d_step = decimal.Decimal(str(step))
 
     d_r = d_high - d_low
 
-    if d_r % d_q != decimal.Decimal("0"):
+    if d_r % d_step != decimal.Decimal("0"):
         old_high = high
-        high = float((d_r // d_q) * d_q + d_low)
+        high = float((d_r // d_step) * d_step + d_low)
         warnings.warn(
-            "The distribution is specified by [{low}, {old_high}] and q={step}, but the range "
-            "is not divisible by `q`. It will be replaced by [{low}, {high}].".format(
-                low=low, old_high=old_high, high=high, step=q
+            "The distribution is specified by [{low}, {old_high}] and step={step}, but the range "
+            "is not divisible by `step`. It will be replaced by [{low}, {high}].".format(
+                low=low, old_high=old_high, high=high, step=step
             )
         )
 


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

A warning message in `FloatDistribution` uses the deprecated class / function's argument `q` when we run the following code:

```python
import optuna

optuna.distributions.FloatDistribution(1, 2, step=0.3)
```

```bash
/Users/nzw/Documents/optuna/optuna/distributions.py:668:
    UserWarning: The distribution is specified by [1, 2] and q=0.3, but the range is not divisible by `q`. It will be replaced by [1, 1.9].
  warnings.warn(
```

In the warming message, `q` isn't clear for users from the current API.

On the other hand, the deprecated class `DiscreteUniformDistribution` and method `suggest_discrete_uniform`  refer to `q` as "A discretization step. q must be larger than 0." and "A step of discretization.", respectively. So I suggest replacing `q` with `step` in the warning message since we can infer the meaning of `step` from the docs of deprecated class/function.

## Description of the changes
<!-- Describe the changes in this PR. -->

Replace `q` with `step` in the warning message and the private method of the distribution module.
