### PR TITLE
Suppress warnings and minor code fixes in `tests/trial_tests`

### DIFF
--- a/optuna/trial/_trial.py
+++ b/optuna/trial/_trial.py
@@ -151,9 +151,9 @@ class Trial(BaseTrial):
         """
 
         distribution = FloatDistribution(low, high, log=log, step=step)
+        suggested_value = self._suggest(name, distribution)
         self._check_distribution(name, distribution)
-
-        return self._suggest(name, distribution)
+        return suggested_value
 
     @deprecated_func("3.0.0", "6.0.0", text=_suggest_deprecated_msg)
     def suggest_uniform(self, name: str, low: float, high: float) -> float:
@@ -311,8 +311,9 @@ class Trial(BaseTrial):
         """
 
         distribution = IntDistribution(low=low, high=high, log=log, step=step)
+        suggested_value = int(self._suggest(name, distribution))
         self._check_distribution(name, distribution)
-        return int(self._suggest(name, distribution))
+        return suggested_value
 
     def suggest_categorical(
         self, name: str, choices: Sequence[CategoricalChoiceType]

--- a/tests/trial_tests/test_fixed.py
+++ b/tests/trial_tests/test_fixed.py
@@ -7,7 +7,7 @@ def test_params() -> None:
     trial = FixedTrial(params)
     assert trial.params == {}
 
-    assert trial.suggest_uniform("x", 0, 10) == 1
+    assert trial.suggest_float("x", 0, 10) == 1
     assert trial.params == params
 
 

--- a/tests/trial_tests/test_frozen.py
+++ b/tests/trial_tests/test_frozen.py
@@ -76,6 +76,7 @@ def test_repr() -> None:
     assert trial == eval(repr(trial))
 
 
+@pytest.mark.filterwarnings("ignore::FutureWarning")
 @pytest.mark.parametrize("storage_mode", STORAGE_MODES)
 def test_sampling(storage_mode: str) -> None:
     def objective(trial: BaseTrial) -> float:
@@ -195,12 +196,12 @@ def test_params() -> None:
         distributions={"x": FloatDistribution(0, 10)},
     )
 
-    assert trial.suggest_uniform("x", 0, 10) == 1
+    assert trial.suggest_float("x", 0, 10) == 1
     assert trial.params == params
 
     params = {"x": 2}
     trial.params = params
-    assert trial.suggest_uniform("x", 0, 10) == 2
+    assert trial.suggest_float("x", 0, 10) == 2
     assert trial.params == params
 
 
@@ -335,6 +336,7 @@ def test_create_trial(state: TrialState) -> None:
 
 
 # Deprecated distributions are internally converted to corresponding distributions.
+@pytest.mark.filterwarnings("ignore::FutureWarning")
 def test_create_trial_distribution_conversion() -> None:
     fixed_params = {
         "ud": 0,

--- a/tests/trial_tests/test_frozen.py
+++ b/tests/trial_tests/test_frozen.py
@@ -76,14 +76,13 @@ def test_repr() -> None:
     assert trial == eval(repr(trial))
 
 
-@pytest.mark.filterwarnings("ignore::FutureWarning")
 @pytest.mark.parametrize("storage_mode", STORAGE_MODES)
 def test_sampling(storage_mode: str) -> None:
     def objective(trial: BaseTrial) -> float:
 
-        a = trial.suggest_uniform("a", 0.0, 10.0)
-        b = trial.suggest_loguniform("b", 0.1, 10.0)
-        c = trial.suggest_discrete_uniform("c", 0.0, 10.0, 1.0)
+        a = trial.suggest_float("a", 0.0, 10.0)
+        b = trial.suggest_float("b", 0.1, 10.0, log=True)
+        c = trial.suggest_float("c", 0.0, 10.0, step=1.0)
         d = trial.suggest_int("d", 0, 10)
         e = trial.suggest_categorical("e", [0, 1, 2])
         f = trial.suggest_int("f", 1, 10, log=True)

--- a/tests/trial_tests/test_trial.py
+++ b/tests/trial_tests/test_trial.py
@@ -139,7 +139,6 @@ def test_check_distribution_suggest_discrete_uniform(storage_mode: str) -> None:
             trial.suggest_int("x", 10, 20, 2)
 
 
-@pytest.mark.filterwarnings("ignore::FutureWarning")
 @pytest.mark.parametrize("storage_mode", STORAGE_MODES)
 @pytest.mark.parametrize("enable_log", [False, True])
 def test_check_distribution_suggest_int(storage_mode: str, enable_log: bool) -> None:

--- a/tests/trial_tests/test_trial.py
+++ b/tests/trial_tests/test_trial.py
@@ -31,7 +31,6 @@ from optuna.trial import Trial
 
 
 @pytest.mark.filterwarnings("ignore::FutureWarning")
-@pytest.mark.filterwarnings("ignore::RuntimeWarning")
 @pytest.mark.parametrize("storage_mode", STORAGE_MODES)
 def test_check_distribution_suggest_float(storage_mode: str) -> None:
 
@@ -66,7 +65,6 @@ def test_check_distribution_suggest_float(storage_mode: str) -> None:
 
 
 @pytest.mark.filterwarnings("ignore::FutureWarning")
-@pytest.mark.filterwarnings("ignore::RuntimeWarning")
 @pytest.mark.parametrize("storage_mode", STORAGE_MODES)
 def test_check_distribution_suggest_uniform(storage_mode: str) -> None:
 
@@ -92,7 +90,6 @@ def test_check_distribution_suggest_uniform(storage_mode: str) -> None:
 
 
 @pytest.mark.filterwarnings("ignore::FutureWarning")
-@pytest.mark.filterwarnings("ignore::RuntimeWarning")
 @pytest.mark.parametrize("storage_mode", STORAGE_MODES)
 def test_check_distribution_suggest_loguniform(storage_mode: str) -> None:
 
@@ -118,7 +115,6 @@ def test_check_distribution_suggest_loguniform(storage_mode: str) -> None:
 
 
 @pytest.mark.filterwarnings("ignore::FutureWarning")
-@pytest.mark.filterwarnings("ignore::RuntimeWarning")
 @pytest.mark.parametrize("storage_mode", STORAGE_MODES)
 def test_check_distribution_suggest_discrete_uniform(storage_mode: str) -> None:
 
@@ -144,7 +140,6 @@ def test_check_distribution_suggest_discrete_uniform(storage_mode: str) -> None:
 
 
 @pytest.mark.filterwarnings("ignore::FutureWarning")
-@pytest.mark.filterwarnings("ignore::RuntimeWarning")
 @pytest.mark.parametrize("storage_mode", STORAGE_MODES)
 @pytest.mark.parametrize("enable_log", [False, True])
 def test_check_distribution_suggest_int(storage_mode: str, enable_log: bool) -> None:
@@ -170,7 +165,6 @@ def test_check_distribution_suggest_int(storage_mode: str, enable_log: bool) -> 
             trial.suggest_float("x", 10, 20, log=enable_log)
 
 
-@pytest.mark.filterwarnings("ignore::RuntimeWarning")
 @pytest.mark.parametrize("storage_mode", STORAGE_MODES)
 def test_check_distribution_suggest_categorical(storage_mode: str) -> None:
 
@@ -231,7 +225,6 @@ def test_suggest_loguniform(storage_mode: str) -> None:
 
 
 @pytest.mark.filterwarnings("ignore::FutureWarning")
-@pytest.mark.filterwarnings("ignore::RuntimeWarning")
 @pytest.mark.parametrize("storage_mode", STORAGE_MODES)
 def test_suggest_discrete_uniform(storage_mode: str) -> None:
 

--- a/tests/trial_tests/test_trial.py
+++ b/tests/trial_tests/test_trial.py
@@ -30,6 +30,8 @@ from optuna.testing.storages import StorageSupplier
 from optuna.trial import Trial
 
 
+@pytest.mark.filterwarnings("ignore::FutureWarning")
+@pytest.mark.filterwarnings("ignore::RuntimeWarning")
 @pytest.mark.parametrize("storage_mode", STORAGE_MODES)
 def test_check_distribution_suggest_float(storage_mode: str) -> None:
 
@@ -63,6 +65,8 @@ def test_check_distribution_suggest_float(storage_mode: str) -> None:
             trial.suggest_int("x1", 10, 20)
 
 
+@pytest.mark.filterwarnings("ignore::FutureWarning")
+@pytest.mark.filterwarnings("ignore::RuntimeWarning")
 @pytest.mark.parametrize("storage_mode", STORAGE_MODES)
 def test_check_distribution_suggest_uniform(storage_mode: str) -> None:
 
@@ -87,6 +91,8 @@ def test_check_distribution_suggest_uniform(storage_mode: str) -> None:
             trial.suggest_int("x", 10, 20)
 
 
+@pytest.mark.filterwarnings("ignore::FutureWarning")
+@pytest.mark.filterwarnings("ignore::RuntimeWarning")
 @pytest.mark.parametrize("storage_mode", STORAGE_MODES)
 def test_check_distribution_suggest_loguniform(storage_mode: str) -> None:
 
@@ -111,6 +117,8 @@ def test_check_distribution_suggest_loguniform(storage_mode: str) -> None:
             trial.suggest_int("x", 10, 20)
 
 
+@pytest.mark.filterwarnings("ignore::FutureWarning")
+@pytest.mark.filterwarnings("ignore::RuntimeWarning")
 @pytest.mark.parametrize("storage_mode", STORAGE_MODES)
 def test_check_distribution_suggest_discrete_uniform(storage_mode: str) -> None:
 
@@ -135,6 +143,8 @@ def test_check_distribution_suggest_discrete_uniform(storage_mode: str) -> None:
             trial.suggest_int("x", 10, 20, 2)
 
 
+@pytest.mark.filterwarnings("ignore::FutureWarning")
+@pytest.mark.filterwarnings("ignore::RuntimeWarning")
 @pytest.mark.parametrize("storage_mode", STORAGE_MODES)
 @pytest.mark.parametrize("enable_log", [False, True])
 def test_check_distribution_suggest_int(storage_mode: str, enable_log: bool) -> None:
@@ -160,6 +170,7 @@ def test_check_distribution_suggest_int(storage_mode: str, enable_log: bool) -> 
             trial.suggest_float("x", 10, 20, log=enable_log)
 
 
+@pytest.mark.filterwarnings("ignore::RuntimeWarning")
 @pytest.mark.parametrize("storage_mode", STORAGE_MODES)
 def test_check_distribution_suggest_categorical(storage_mode: str) -> None:
 
@@ -181,6 +192,7 @@ def test_check_distribution_suggest_categorical(storage_mode: str) -> None:
             trial.suggest_int("x", 10, 20)
 
 
+@pytest.mark.filterwarnings("ignore::FutureWarning")
 @pytest.mark.parametrize("storage_mode", STORAGE_MODES)
 def test_suggest_uniform(storage_mode: str) -> None:
 
@@ -196,6 +208,7 @@ def test_suggest_uniform(storage_mode: str) -> None:
         assert trial.params == {"x": 1.0, "y": 2.0}
 
 
+@pytest.mark.filterwarnings("ignore::FutureWarning")
 @pytest.mark.parametrize("storage_mode", STORAGE_MODES)
 def test_suggest_loguniform(storage_mode: str) -> None:
 
@@ -217,6 +230,8 @@ def test_suggest_loguniform(storage_mode: str) -> None:
         assert trial.params == {"x": 1.0, "y": 2.0}
 
 
+@pytest.mark.filterwarnings("ignore::FutureWarning")
+@pytest.mark.filterwarnings("ignore::RuntimeWarning")
 @pytest.mark.parametrize("storage_mode", STORAGE_MODES)
 def test_suggest_discrete_uniform(storage_mode: str) -> None:
 
@@ -238,6 +253,7 @@ def test_suggest_discrete_uniform(storage_mode: str) -> None:
         assert trial.params == {"x": 1.0, "y": 2.0}
 
 
+@pytest.mark.filterwarnings("ignore::FutureWarning")
 @pytest.mark.parametrize("storage_mode", STORAGE_MODES)
 def test_suggest_low_equals_high(storage_mode: str) -> None:
 

--- a/tests/trial_tests/test_trials.py
+++ b/tests/trial_tests/test_trials.py
@@ -62,6 +62,7 @@ def test_suggest_float(trial_type: type) -> None:
         trial.suggest_float("y", 0.0, 1.0)
 
 
+@pytest.mark.filterwarnings("ignore::FutureWarning")
 @pytest.mark.parametrize("trial_type", [FixedTrial, FrozenTrial])
 def test_suggest_uniform(trial_type: type) -> None:
 
@@ -77,6 +78,7 @@ def test_suggest_uniform(trial_type: type) -> None:
         trial.suggest_uniform("y", 0.0, 1.0)
 
 
+@pytest.mark.filterwarnings("ignore::FutureWarning")
 @pytest.mark.parametrize("trial_type", [FixedTrial, FrozenTrial])
 def test_suggest_loguniform(trial_type: type) -> None:
 
@@ -91,6 +93,7 @@ def test_suggest_loguniform(trial_type: type) -> None:
         trial.suggest_loguniform("y", 0.0, 1.0)
 
 
+@pytest.mark.filterwarnings("ignore::FutureWarning")
 @pytest.mark.parametrize("trial_type", [FixedTrial, FrozenTrial])
 def test_suggest_discrete_uniform(trial_type: type) -> None:
 

--- a/tests/trial_tests/test_trials.py
+++ b/tests/trial_tests/test_trials.py
@@ -171,7 +171,7 @@ def test_suggest_categorical(trial_type: type) -> None:
             lambda trial, *args: trial.suggest_int(*args, log=True),
             IntDistribution(1, 10, log=True),
         ),
-        (lambda trial, *args: trial.suggest_int(*args, step=2), IntDistribution(1, 10, step=2)),
+        (lambda trial, *args: trial.suggest_int(*args, step=2), IntDistribution(1, 9, step=2)),
         (lambda trial, *args: trial.suggest_float(*args), FloatDistribution(1, 10)),
         (
             lambda trial, *args: trial.suggest_float(*args, log=True),


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

A part of https://github.com/optuna/optuna/issues/3815

## Description of the changes
<!-- Describe the changes in this PR. -->

- Add `@pytest.mark.filterwarnings` to remove warning messages from test log.
- Replace the deprecated `suggest_uniform` with `suggest_float`.

Note that we still find one warning message from `tests/trial_tests/test_trials.py` because `@pytest.mark.filterwarnings` decorator does not suppress the warning message from another parameterised decorator.