### PR TITLE
Remove dynamic search space based objective from a parallel job test

### DIFF
--- a/tests/study_tests/test_study.py
+++ b/tests/study_tests/test_study.py
@@ -39,9 +39,9 @@ from optuna.trial import TrialState
 CallbackFuncType = Callable[[Study, FrozenTrial], None]
 
 
-def func(trial: Trial, x_max: float = 1.0) -> float:
+def func(trial: Trial) -> float:
 
-    x = trial.suggest_float("x", -x_max, x_max)
+    x = trial.suggest_float("x", -10.0, 10.0)
     y = trial.suggest_float("y", 20, 30, log=True)
     z = trial.suggest_categorical("z", (-1.0, 1.0))
     assert isinstance(z, float)
@@ -54,20 +54,17 @@ class Func:
         self.n_calls = 0
         self.sleep_sec = sleep_sec
         self.lock = threading.Lock()
-        self.x_max = 10.0
 
     def __call__(self, trial: Trial) -> float:
 
         with self.lock:
             self.n_calls += 1
-            x_max = self.x_max
-            self.x_max *= 0.9
 
         # Sleep for testing parallelism
         if self.sleep_sec is not None:
             time.sleep(self.sleep_sec)
 
-        value = func(trial, x_max)
+        value = func(trial)
         check_params(trial.params)
         return value
 


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

The aim of the dynamic range in the objective function `func` in `test_study.py`, which was originally introduced for the tests to support the dynamic range by https://github.com/optuna/optuna/pull/66, is supposed to be unclear from the current test file. By product, we have warning messages from this test as described in https://github.com/optuna/optuna/pull/3915#issuecomment-1222477832.

## Description of the changes
<!-- Describe the changes in this PR. -->

- I'd like to suggest removing the dynamic range from the objective function at least from `test_study.py`.
- Possibly define a similar test in another test file if necessary.
    - sampler already has a dynamic range test in https://github.com/optuna/optuna/blob/3a646e86fb8a2ca93a5937ac6b667296bf10ee47/tests/samplers_tests/test_samplers.py#L916-L942