### PR TITLE
Remove `warnings: UserWarning` from `tests/visualization_tests/test_utils.py`

### DIFF
--- a/tests/visualization_tests/test_utils.py
+++ b/tests/visualization_tests/test_utils.py
@@ -176,7 +176,7 @@ def test_filter_inf_trials_message(caplog: LogCaptureFixture, with_message: bool
         assert msg not in caplog.text
 
 
-@pytest.mark.filterwarningslter("ignore::UserWarning")
+@pytest.mark.filterwarnings("ignore::UserWarning")
 def test_filter_nonfinite_with_invalid_target() -> None:
     study = prepare_study_with_trials()
     trials = study.get_trials(states=(TrialState.COMPLETE,))

--- a/tests/visualization_tests/test_utils.py
+++ b/tests/visualization_tests/test_utils.py
@@ -176,6 +176,7 @@ def test_filter_inf_trials_message(caplog: LogCaptureFixture, with_message: bool
         assert msg not in caplog.text
 
 
+@pytest.mark.filterwarningslter("ignore::UserWarning")
 def test_filter_nonfinite_with_invalid_target() -> None:
     study = prepare_study_with_trials()
     trials = study.get_trials(states=(TrialState.COMPLETE,))


### PR DESCRIPTION
## Motivation

Resolving unit tests #3815, silenced the `UserWarnings` coming from the def `test_filter_nonfinite_with_invalid_target` test function.

## Description of the changes

Ignored: intended warning messages from `test_filter_nonfinite_with_invalid_target` by using `@pytest.mark.filterwarnings`.
