### PR TITLE
Reduce trivial warning messages from `tests/sampler_tests`

### DIFF
--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -714,7 +714,7 @@ def _split_observation_pairs(
             (infeasible_idx,) = (violation_1d > 0).nonzero()
             assert len(feasible_idx) >= n_below
             feasible_below, feasible_above = _split_observation_pairs(
-                list(np.array(loss_vals)[feasible_idx]), n_below, None
+                [loss_vals[i] for i in feasible_idx], n_below, None
             )
             indices_below = feasible_idx[feasible_below]
             indices_above = np.concatenate([feasible_idx[feasible_above], infeasible_idx])

--- a/tests/samplers_tests/test_grid.py
+++ b/tests/samplers_tests/test_grid.py
@@ -37,7 +37,7 @@ def test_study_optimize_with_single_search_space() -> None:
     search_space = {
         "b": np.arange(-0.1, 0.1, 0.05),
         "c": ("x", "y", None, 1, 2.0),
-        "d": [-0.5, 0.5],
+        "d": [5.0, 5.0],
         "e": [0.1],
         "a": list(range(0, 100, 20)),
     }

--- a/tests/samplers_tests/test_grid.py
+++ b/tests/samplers_tests/test_grid.py
@@ -37,7 +37,7 @@ def test_study_optimize_with_single_search_space() -> None:
     search_space = {
         "b": np.arange(-0.1, 0.1, 0.05),
         "c": ("x", "y", None, 1, 2.0),
-        "d": [5.0, 5.0],
+        "d": [-5.0, 5.0],
         "e": [0.1],
         "a": list(range(0, 100, 20)),
     }

--- a/tests/samplers_tests/test_partial_fixed.py
+++ b/tests/samplers_tests/test_partial_fixed.py
@@ -52,7 +52,10 @@ def test_float_to_int() -> None:
         study.sampler = PartialFixedSampler(
             fixed_params={"y": fixed_y}, base_sampler=study.sampler
         )
-    study.optimize(objective, n_trials=1)
+    # Since `fixed_y` is out-of-the-range value in the corresponding suggest_int,
+    # `UserWarning` will occur.
+    with pytest.warns(UserWarning):
+        study.optimize(objective, n_trials=1)
     assert study.trials[0].params["y"] == int(fixed_y)
 
 

--- a/tests/samplers_tests/test_samplers.py
+++ b/tests/samplers_tests/test_samplers.py
@@ -349,7 +349,7 @@ def test_categorical(
         FloatDistribution(-10, 10, step=0.5),
         IntDistribution(3, 10),
         IntDistribution(1, 100, log=True),
-        IntDistribution(3, 10, step=2),
+        IntDistribution(3, 9, step=2),
     ],
 )
 @pytest.mark.parametrize(
@@ -360,7 +360,7 @@ def test_categorical(
         FloatDistribution(-10, 10, step=0.5),
         IntDistribution(3, 10),
         IntDistribution(1, 100, log=True),
-        IntDistribution(3, 10, step=2),
+        IntDistribution(3, 9, step=2),
     ],
 )
 def test_sample_relative_numerical(

--- a/tests/samplers_tests/tpe_tests/test_multi_objective_sampler.py
+++ b/tests/samplers_tests/tpe_tests/test_multi_objective_sampler.py
@@ -227,9 +227,9 @@ def test_multi_objective_sample_int_distributions(log: bool, step: int) -> None:
     random.seed(128)
 
     def int_value_fn(idx: int) -> float:
-        return random.randint(1, 100)
+        return random.randint(1, 99)
 
-    int_dist = optuna.distributions.IntDistribution(1, 100, log, step)
+    int_dist = optuna.distributions.IntDistribution(1, 99, log, step)
     past_trials = [
         frozen_trial_factory(
             i, [random.random(), random.random()], dist=int_dist, value_fn=int_value_fn
@@ -240,7 +240,7 @@ def test_multi_objective_sample_int_distributions(log: bool, step: int) -> None:
     trial = frozen_trial_factory(16, [0, 0])
     sampler = TPESampler(seed=0)
     int_suggestion = suggest(sampler, study, trial, int_dist, past_trials)
-    assert 1 <= int_suggestion <= 100
+    assert 1 <= int_suggestion <= 99
     assert isinstance(int_suggestion, int)
 
 


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

A part of #3815. 

## Description of the changes
<!-- Describe the changes in this PR. -->

- Resolve `step` related warning message such as `suggest_int(low=1, high=10, step=2`)
- Ignore the expected `UserWarning`
- Resolve numpy warning message via TPE (see the following my comment too)


Note that there are still several warning messages from TPE sampler and BoTorchSampler, I don't remove such messages because I suppose such changes make this PR more complicated.