### PR TITLE
Ignore `RuntimeWarning` when `nanmin` and `nanmax` take an array only containing nan values from `pruners_tests`

### DIFF
--- a/tests/pruners_tests/test_median.py
+++ b/tests/pruners_tests/test_median.py
@@ -37,6 +37,7 @@ def test_median_pruner_intermediate_values(direction_value: Tuple[str, float]) -
     assert trial.should_prune()
 
 
+@pytest.mark.filterwarnings("ignore::RuntimeWarning")
 def test_median_pruner_intermediate_values_nan() -> None:
 
     pruner = optuna.pruners.MedianPruner(0, 0)

--- a/tests/pruners_tests/test_patient.py
+++ b/tests/pruners_tests/test_patient.py
@@ -39,6 +39,7 @@ def test_patient_pruner_with_one_trial() -> None:
     assert not trial.should_prune()
 
 
+@pytest.mark.filterwarnings("ignore::RuntimeWarning")
 def test_patient_pruner_intermediate_values_nan() -> None:
 
     pruner = optuna.pruners.PatientPruner(None, 0, 0)

--- a/tests/pruners_tests/test_percentile.py
+++ b/tests/pruners_tests/test_percentile.py
@@ -1,6 +1,7 @@
 import math
 from typing import List
 from typing import Tuple
+import warnings
 
 import pytest
 
@@ -90,6 +91,7 @@ def test_25_percentile_pruner_intermediate_values(
     assert trial.should_prune()
 
 
+@pytest.mark.filterwarnings("ignore::RuntimeWarning")
 def test_25_percentile_pruner_intermediate_values_nan() -> None:
 
     pruner = optuna.pruners.PercentilePruner(25.0, 0, 0)
@@ -159,9 +161,11 @@ def test_get_best_intermediate_result_over_steps(
     trial_nan = optuna.trial.Trial(study, trial_id_nan)
     trial_nan.report(float("nan"), step=0)
     frozen_trial_nan = study._storage.get_trial(trial_id_nan)
-    assert math.isnan(
-        _percentile._get_best_intermediate_result_over_steps(frozen_trial_nan, direction)
-    )
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", category=RuntimeWarning)
+        assert math.isnan(
+            _percentile._get_best_intermediate_result_over_steps(frozen_trial_nan, direction)
+        )
 
 
 def test_get_percentile_intermediate_result_over_trials() -> None:
@@ -227,15 +231,17 @@ def test_get_percentile_intermediate_result_over_trials() -> None:
     study = setup_study(9, intermediate_values)
     all_trials = study.get_trials()
     direction = study.direction
-    assert math.isnan(
-        _percentile._get_percentile_intermediate_result_over_trials(
-            all_trials, direction, 2, 75, 1
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", category=RuntimeWarning)
+        assert math.isnan(
+            _percentile._get_percentile_intermediate_result_over_trials(
+                all_trials, direction, 2, 75, 1
+            )
         )
-    )
 
-    # n_min_trials = 2
-    assert math.isnan(
-        _percentile._get_percentile_intermediate_result_over_trials(
-            all_trials, direction, 2, 75, 2
+        # n_min_trials = 2.
+        assert math.isnan(
+            _percentile._get_percentile_intermediate_result_over_trials(
+                all_trials, direction, 2, 75, 2
+            )
         )
-    )


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

As a part of #3815, this PR remove all expected warning messages from `tests/pruners_tests`. 

## Description of the changes
<!-- Describe the changes in this PR. -->

Ignore RuntimeWarning from `np.nanmin` and `np.nanmax` because they show `RuntimeWarning` when they take only nan values as the argument. 