### PR TITLE
Add version constraint for `typing_extensions` to use `ParamSpec`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ def get_install_requires() -> List[str]:
         "scipy!=1.4.0,<1.9.0" if sys.version[:3] == "3.6" else "scipy>=1.7.0,<1.9.0",
         "sqlalchemy>=1.1.0",
         "tqdm",
-        "typing_extensions",
+        "typing_extensions>=3.10.0.0",
         "PyYAML",  # Only used in `optuna/cli.py`.
     ]
     return requirements


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

Optuna uses `typing_extensions.ParamSpec` that has been available since `typing_extensions` v 3.10.0.0 (specifically, https://github.com/python/typing_extensions/commit/b697a12f2793655db99dde660bb47458ad36aa55). When a user upgrades their oputna version to v3 with older `typing_extensions`: `typing_extensions<3.10.0.0`, the user cannot import optuna due to using an older `typing_extensions` as reported in https://github.com/optuna/optuna/issues/3558.


## Description of the changes
<!-- Describe the changes in this PR. -->

Add version specification to use appropriate `typing_extensions`.

