### PR TITLE
Hotfix `botorch` module by adding the version constraint of `gpytorch`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -69,7 +69,8 @@ jobs:
 
     # TODO(nzw): Move `run` part to the end of `Install` after Optuna drops Python 3.6 support.
     - name: Install PyTorch and BoTorch.
-      run: pip install botorch torch==1.11.0 --extra-index-url https://download.pytorch.org/whl/cpu
+      # TODO(nzw0301): Remove gpytorch if botorch supports gpytorch>1.8.
+      run: pip install botorch "gpytorch<1.9.0" torch==1.11.0 --extra-index-url https://download.pytorch.org/whl/cpu
       if: matrix.python-version != '3.6'
 
     - name: Tests

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,8 @@ def get_extras_require() -> Dict[str, List[str]]:
             "asv>=0.5.0",
             "botorch",
             "cma",
+            # TODO(nzw0301): Remove gpytorch if botorch supports gpytorch>1.8.
+            "gpytorch<1.9.0",
             "scikit-optimize",
             "virtualenv",
         ],
@@ -100,6 +102,8 @@ def get_extras_require() -> Dict[str, List[str]]:
             "chainer>=5.0.0",
             "cma",
             "fastai ; python_version>'3.6'",
+            # TODO(nzw0301): Remove gpytorch if botorch supports gpytorch>1.8.
+            "gpytorch<1.9.0 ; python_version>'3.6'",
             "lightgbm",
             "mlflow",
             "mpi4py",


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

BoTorch doesn't work with the latest stable gpytorch, 1.9.0 as we can see in CI results such as https://github.com/optuna/optuna/runs/8107161055?check_suite_focus=true.

## Description of the changes
<!-- Describe the changes in this PR. -->

Add a version constraint of gpytorch as hotfix.

Related issue of botorch: https://github.com/pytorch/botorch/issues/1370