### PR TITLE
making sure that n_trials will run in parallel mode

### DIFF
--- a/optuna/study/_optimize.py
+++ b/optuna/study/_optimize.py
@@ -149,7 +149,7 @@ def _optimize(
     callbacks: Optional[List[Callable[["optuna.Study", FrozenTrial], None]]] = None,
     gc_after_trial: bool = False,
     show_progress_bar: bool = False,
-    optimize_function: Optional[Callable] = _optimize_sequential,
+    optimize_function: Callable = _optimize_sequential,
 ) -> None:
     if not isinstance(catch, tuple):
         raise TypeError(

--- a/optuna/study/_optimize.py
+++ b/optuna/study/_optimize.py
@@ -99,7 +99,7 @@ def _optimize_parallel(
     reseed_sampler_rng: bool,
     time_start: Optional[datetime.datetime],
     progress_bar: Optional[pbar_module._ProgressBar],
-):
+) -> None:
     if reseed_sampler_rng:
         study.sampler.reseed_rng()
 

--- a/optuna/study/_optimize.py
+++ b/optuna/study/_optimize.py
@@ -147,7 +147,7 @@ def _optimize_sequential(
             break
 
         if n_trials is not None:
-            if i_trial >= n_trials:
+            if study.get_n_trials() >= n_trials:
                 break
             i_trial += 1
 

--- a/optuna/study/_optimize.py
+++ b/optuna/study/_optimize.py
@@ -150,7 +150,7 @@ def _optimize(
     callbacks: Optional[List[Callable[["optuna.Study", FrozenTrial], None]]] = None,
     gc_after_trial: bool = False,
     show_progress_bar: bool = False,
-    optimize_function: Optional[Callable] = _optimize_sequential
+    optimize_function: Optional[Callable] = _optimize_sequential,
 ) -> None:
     if not isinstance(catch, tuple):
         raise TypeError(

--- a/optuna/study/_optimize.py
+++ b/optuna/study/_optimize.py
@@ -18,7 +18,6 @@ from typing import Type
 from typing import Union
 import warnings
 
-
 import optuna
 from optuna import exceptions
 from optuna import logging

--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -434,7 +434,8 @@ class Study:
             show_progress_bar=show_progress_bar,
         )
 
-    def optimize_parallel( self,
+    def optimize_parallel(
+        self,
         func: ObjectiveFuncType,
         n_trials: Optional[int] = None,
         timeout: Optional[float] = None,

--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -443,7 +443,8 @@ class Study:
         catch: Tuple[Type[Exception], ...] = (),
         callbacks: Optional[List[Callable[["Study", FrozenTrial], None]]] = None,
         gc_after_trial: bool = False,
-        show_progress_bar: bool = False,):
+        show_progress_bar: bool = False,
+    ):
         _optimize(
             study=self,
             func=func,

--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -266,7 +266,7 @@ class Study:
 
     def get_n_trials(self) -> int:
         state = (state for state in optuna.trial.TrialState)
-        return self._storage.get_n_trials(study_id=self._study_id,state=state)
+        return self._storage.get_n_trials(study_id=self._study_id, state=state)
 
     @property
     def user_attrs(self) -> Dict[str, Any]:

--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -32,8 +32,8 @@ from optuna.distributions import BaseDistribution
 from optuna.storages._cached_storage import _CachedStorage
 from optuna.storages._heartbeat import is_heartbeat_enabled
 from optuna.study._multi_objective import _get_pareto_front_trials
-from optuna.study._optimize import _optimize_parallel
 from optuna.study._optimize import _optimize
+from optuna.study._optimize import _optimize_parallel
 from optuna.study._study_direction import StudyDirection
 from optuna.study._study_summary import StudySummary  # NOQA
 from optuna.study._tell import _tell_with_warning

--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -18,6 +18,7 @@ import warnings
 
 import numpy as np
 
+import optuna
 from optuna import exceptions
 from optuna import logging
 from optuna import pruners
@@ -262,6 +263,10 @@ class Study:
             self._storage.read_trials_from_remote_storage(self._study_id)
 
         return self._storage.get_all_trials(self._study_id, deepcopy=deepcopy, states=states)
+
+    def get_n_trials(self) -> int:
+        state = (state for state in optuna.trial.TrialState)
+        return self._storage.get_n_trials(study_id=self._study_id,state=state)
 
     @property
     def user_attrs(self) -> Dict[str, Any]:

--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -445,7 +445,7 @@ class Study:
         callbacks: Optional[List[Callable[["Study", FrozenTrial], None]]] = None,
         gc_after_trial: bool = False,
         show_progress_bar: bool = False,
-    ):
+    ) -> None:
         _optimize(
             study=self,
             func=func,

--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -265,8 +265,10 @@ class Study:
         return self._storage.get_all_trials(self._study_id, deepcopy=deepcopy, states=states)
 
     def get_n_trials(self) -> int:
-        state = (state for state in optuna.trial.TrialState)
-        return self._storage.get_n_trials(study_id=self._study_id, state=state)
+        states = []
+        for state in optuna.trial.TrialState:
+            states.append(state)
+        return self._storage.get_n_trials(study_id=self._study_id, state=tuple(states))
 
     @property
     def user_attrs(self) -> Dict[str, Any]:

--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -32,8 +32,8 @@ from optuna.distributions import BaseDistribution
 from optuna.storages._cached_storage import _CachedStorage
 from optuna.storages._heartbeat import is_heartbeat_enabled
 from optuna.study._multi_objective import _get_pareto_front_trials
-from optuna.study._optimize import _optimize
 from optuna.study._optimize import _optimize_parallel
+from optuna.study._optimize import _optimize
 from optuna.study._study_direction import StudyDirection
 from optuna.study._study_summary import StudySummary  # NOQA
 from optuna.study._tell import _tell_with_warning

--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -32,7 +32,8 @@ from optuna.distributions import BaseDistribution
 from optuna.storages._cached_storage import _CachedStorage
 from optuna.storages._heartbeat import is_heartbeat_enabled
 from optuna.study._multi_objective import _get_pareto_front_trials
-from optuna.study._optimize import _optimize, _optimize_parallel
+from optuna.study._optimize import _optimize
+from optuna.study._optimize import _optimize_parallel
 from optuna.study._study_direction import StudyDirection
 from optuna.study._study_summary import StudySummary  # NOQA
 from optuna.study._tell import _tell_with_warning

--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -453,7 +453,7 @@ class Study:
             callbacks=callbacks,
             gc_after_trial=gc_after_trial,
             show_progress_bar=show_progress_bar,
-            optimize_function=_optimize_parallel
+            optimize_function=_optimize_parallel,
         )
 
     def ask(


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
Suggesting solution to #3518 and #3938.
In this way you will be able to make sure that the number of trials that is delivered in the parameter n_trials will be exact when running in parallel. 

## Description of the changes
Added the ability to get the amount of trials in the study and to stop after the number of trials is reached
