### PR TITLE
Remove "Edit on GitHub" button from readthedocs

### DIFF
--- a/docs/source/_templates/breadcrumbs.html
+++ b/docs/source/_templates/breadcrumbs.html
@@ -1,0 +1,6 @@
+<!-- This file is necessary to remove "Edit on Github" button from readthedocs by following https://docs.readthedocs.io/en/stable/guides/remove-edit-buttons.html#remove-links-from-top-right-corner -->
+
+{%- extends "sphinx_rtd_theme/breadcrumbs.html" %}
+
+{% block breadcrumbs_aside %}
+{% endblock %}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -103,9 +103,6 @@ html_logo = "../image/optuna-logo.png"
 html_static_path = ["_static"]
 html_css_files = ["css/custom.css"]
 
-# Remove "Edit on GitHub."
-html_show_sourcelink = False
-
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.
 #


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->


Resolve https://github.com/optuna/optuna/issues/3494 because https://github.com/optuna/optuna/pull/3777 didn't resolve the original issue on the [official docs](https://optuna.readthedocs.io/en/stable/index.html).

## Description of the changes
<!-- Describe the changes in this PR. -->

- Revert the change by https://github.com/optuna/optuna/pull/3777 because this change cannot remove the button on the docs hosted by readthedocs
- Create an HTML file by following the official way recommended by readthedocs https://docs.readthedocs.io/en/stable/guides/remove-edit-buttons.html#remove-links-from-top-right-corner