### PR TITLE
Fix infinite loop bug in `TPESampler`

### DIFF
--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -748,7 +748,7 @@ def _split_observation_pairs(
         # Nondomination rank-based selection
         i = 0
         last_idx = 0
-        while last_idx + sum(nondomination_ranks == i) <= n_below:
+        while last_idx < n_below and last_idx + sum(nondomination_ranks == i) <= n_below:
             length = indices[nondomination_ranks == i].shape[0]
             indices_below[last_idx : last_idx + length] = indices[nondomination_ranks == i]
             last_idx += length

--- a/tests/samplers_tests/tpe_tests/test_multi_objective_sampler.py
+++ b/tests/samplers_tests/tpe_tests/test_multi_objective_sampler.py
@@ -398,6 +398,33 @@ def test_multi_objective_get_observation_pairs_constrained(constraint_value: int
     )
 
 
+def test_multi_objective_split_observation_pairs() -> None:
+    indices_below, indices_above = _tpe.sampler._split_observation_pairs(
+        [
+            (-float("inf"), [-2.0, -1.0]),
+            (-float("inf"), [3.0, 3.0]),
+            (-float("inf"), [0.0, 1.0]),
+            (-float("inf"), [-1.0, 0.0]),
+        ],
+        2,
+        None,
+    )
+    assert list(indices_below) == [0, 3]
+    assert list(indices_above) == [1, 2]
+
+
+def test_multi_objective_split_observation_pairs_with_all_indices_below() -> None:
+    indices_below, indices_above = _tpe.sampler._split_observation_pairs(
+        [
+            (-float("inf"), [1.0, 1.0]),
+        ],
+        1,
+        None,
+    )
+    assert list(indices_below) == [0]
+    assert list(indices_above) == []
+
+
 def test_calculate_nondomination_rank() -> None:
     # Single objective
     test_case = np.asarray([[10], [20], [20], [30]])

--- a/tests/samplers_tests/tpe_tests/test_sampler.py
+++ b/tests/samplers_tests/tpe_tests/test_sampler.py
@@ -915,6 +915,33 @@ def test_split_observation_pairs_with_constraints_below_include_infeasible() -> 
     assert list(indices_above) == [3]
 
 
+def test_split_observation_pairs_multi() -> None:
+    indices_below, indices_above = _tpe.sampler._split_observation_pairs(
+        [
+            (-float("inf"), [-2.0, -1.0]),
+            (-float("inf"), [3.0, 3.0]),
+            (-float("inf"), [0.0, 1.0]),
+            (-float("inf"), [-1.0, 0.0]),
+        ],
+        2,
+        None,
+    )
+    assert list(indices_below) == [0, 3]
+    assert list(indices_above) == [1, 2]
+
+
+def test_split_observation_pairs_multi_with_all_indices_below() -> None:
+    indices_below, indices_above = _tpe.sampler._split_observation_pairs(
+        [
+            (-float("inf"), [1.0, 1.0]),
+        ],
+        1,
+        None,
+    )
+    assert list(indices_below) == [0]
+    assert list(indices_above) == []
+
+
 def test_build_observation_dict() -> None:
     observation_dict = _tpe.sampler._build_observation_dict(
         {

--- a/tests/samplers_tests/tpe_tests/test_sampler.py
+++ b/tests/samplers_tests/tpe_tests/test_sampler.py
@@ -915,33 +915,6 @@ def test_split_observation_pairs_with_constraints_below_include_infeasible() -> 
     assert list(indices_above) == [3]
 
 
-def test_split_observation_pairs_multi() -> None:
-    indices_below, indices_above = _tpe.sampler._split_observation_pairs(
-        [
-            (-float("inf"), [-2.0, -1.0]),
-            (-float("inf"), [3.0, 3.0]),
-            (-float("inf"), [0.0, 1.0]),
-            (-float("inf"), [-1.0, 0.0]),
-        ],
-        2,
-        None,
-    )
-    assert list(indices_below) == [0, 3]
-    assert list(indices_above) == [1, 2]
-
-
-def test_split_observation_pairs_multi_with_all_indices_below() -> None:
-    indices_below, indices_above = _tpe.sampler._split_observation_pairs(
-        [
-            (-float("inf"), [1.0, 1.0]),
-        ],
-        1,
-        None,
-    )
-    assert list(indices_below) == [0]
-    assert list(indices_above) == []
-
-
 def test_build_observation_dict() -> None:
     observation_dict = _tpe.sampler._build_observation_dict(
         {


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
In some special cases, `TPESampler` did not halt.
https://github.com/optuna/optuna/issues/3670
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

## Description of the changes
- Fix the flaw of the logic
    - See https://github.com/optuna/optuna/issues/3670#issuecomment-1232963093
    - The behavior changes only when `last_idx == n_below && n_below == len(indices)`
        - the case which caused an infinite loop 
- Add tests for multi-objective cases of `_split_observation_pairs`
    -  One is a base case, and the other is a corner case that had caused an infinite loop.

## Check
In https://github.com/optuna/optuna/issues/3670, it is mentioned that the bug occurs when `n_startup_trials=0` or `n_startup_trials=1`.
I checked the code below works successfully.
```python
import optuna


def objective(trial):
    x = trial.suggest_float("x", -10, 10)
    y = trial.suggest_float("y", -10, 10)
    return x, y

study_0 = optuna.create_study(
    directions=["maximize", "maximize"],
    sampler=optuna.samplers.TPESampler(n_startup_trials=0),
)
    
study_1 = optuna.create_study(
    directions=["maximize", "maximize"],
    sampler=optuna.samplers.TPESampler(n_startup_trials=1),
)

study_0.optimize(objective, n_trials=10)
for trial_0 in study_0.best_trials:
    print(trial_0.values)

study_1.optimize(objective, n_trials=10)
for trial_1 in study_1.best_trials:
    print(trial_1.values)
```
<!-- Describe the changes in this PR. -->
