### PR TITLE
Use the latest stable scipy

### DIFF
--- a/optuna/samplers/_qmc.py
+++ b/optuna/samplers/_qmc.py
@@ -294,6 +294,8 @@ class QMCSampler(BaseSampler):
             raise ValueError("Invalid `qmc_type`")
 
         forward_size = sample_id  # `sample_id` starts from 0.
+        # Skip fast_forward with forward_size==0 because Sobol doesn't support the case,
+        # and fast_forward(0) doesn't affect sampling.
         if forward_size > 0:
             qmc_engine.fast_forward(forward_size)
         sample = qmc_engine.random(1)

--- a/optuna/samplers/_qmc.py
+++ b/optuna/samplers/_qmc.py
@@ -294,7 +294,8 @@ class QMCSampler(BaseSampler):
             raise ValueError("Invalid `qmc_type`")
 
         forward_size = sample_id  # `sample_id` starts from 0.
-        qmc_engine.fast_forward(forward_size)
+        if forward_size > 0:
+            qmc_engine.fast_forward(forward_size)
         sample = qmc_engine.random(1)
 
         return sample

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ def get_install_requires() -> List[str]:
         "numpy",
         "packaging>=20.0",
         # TODO(kstoneriv3): remove this after deprecation of Python 3.6
-        "scipy!=1.4.0,<1.9.0" if sys.version[:3] == "3.6" else "scipy>=1.7.0,<1.9.0",
+        "scipy!=1.4.0" if sys.version[:3] == "3.6" else "scipy>=1.7.0",
         "sqlalchemy>=1.1.0",
         "tqdm",
         "typing_extensions>=3.10.0.0",


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
We want to use the latest stable scipy by removing CI errors.
https://github.com/optuna/optuna/issues/3836
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

## Description of the changes
As described in https://github.com/optuna/optuna/issues/3836#issuecomment-1211817560, errors occur when we try to use `fast_forward` method of `scipy.stats._qmc.Sobol`.
However, that happens only if the argument of the `fast_forward` method is `0`, which has no effect on `scipy.stats._qmc.Sobol`.
Therefore, simply skipping the `fast_forward` method when its argument is `0` will resolve the problem.

## CHECK
By CI.
<!-- Describe the changes in this PR. -->
