### PR TITLE
Fix an import error of `sqlalchemy.orm.declarative_base`

### DIFF
--- a/optuna/storages/_rdb/alembic/versions/v3.0.0.b.py
+++ b/optuna/storages/_rdb/alembic/versions/v3.0.0.b.py
@@ -14,7 +14,7 @@ from sqlalchemy import Enum
 from sqlalchemy import Float
 from sqlalchemy import ForeignKey
 from sqlalchemy import Integer
-from sqlalchemy.orm import declarative_base
+from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import Session
 
 

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ def get_long_description() -> str:
 def get_install_requires() -> List[str]:
 
     requirements = [
-        "alembic",
+        "alembic>=1.5.0",
         "cliff",
         "cmaes>=0.8.2",
         "colorlog",
@@ -37,7 +37,7 @@ def get_install_requires() -> List[str]:
         "packaging>=20.0",
         # TODO(kstoneriv3): remove this after deprecation of Python 3.6
         "scipy!=1.4.0" if sys.version[:3] == "3.6" else "scipy>=1.7.0",
-        "sqlalchemy>=1.1.0",
+        "sqlalchemy>=1.3.0",
         "tqdm",
         "typing_extensions>=3.10.0.0",
         "PyYAML",  # Only used in `optuna/cli.py`.


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
Fix #3966 

## Description of the changes
<!-- Describe the changes in this PR. -->

`sqlalchemy.orm.declarative_base` is only available at SQLAlchemy v14 or later.

> The ORM Declarative system is now unified into the ORM itself, with new import spaces under sqlalchemy.orm and new kinds of mappings.
> https://docs.sqlalchemy.org/en/14/changelog/changelog_14.html#change-1383b8655e1f94451338941a393cdca6


## Steps to Reproduce

### Setup the test environment using optuna-e2e.

I prepared the fork of himkt/optuna-e2e to setup the test environment for this PR.
https://github.com/c-bata/optuna-e2e/tree/optuna-3967

```
$ git clone -b optuna-3967 git@github.com:c-bata/optuna-e2e.git
$ cd optuna-e2e
$ docker compose up -d --build  # please wait until databases are ready to listen
$ docker compose run --rm optuna-210 python src/init.py
```

* Python 3.9.10
* Alembic 1.5.1 (which is released at Jan 20, 2021)
     * Please note that v1.5.1 is the first version that drops sqlalchemy 1.2.0 or before.
     * https://pypi.org/project/alembic/#history
* SQLAlchemy 1.3.0 (which is released at Mar 5, 2019)
     * https://pypi.org/project/SQLAlchemy/#history

### Before (Optuna v3.0.0)

```
$ docker compose run --rm optuna-300 bash src/upgrade.sh
mysql
[E 2022-09-08 02:32:04,252] cannot import name 'declarative_base' from 'sqlalchemy.orm' (/usr/local/lib/python3.9/site-packages/sqlalchemy/orm/__init__.py)
postgresql
[E 2022-09-08 02:32:07,168] cannot import name 'declarative_base' from 'sqlalchemy.orm' (/usr/local/lib/python3.9/site-packages/sqlalchemy/orm/__init__.py)
sqlite
[E 2022-09-08 02:32:09,985] cannot import name 'declarative_base' from 'sqlalchemy.orm' (/usr/local/lib/python3.9/site-packages/sqlalchemy/orm/__init__.py)
2022-09-08T11:32:10+09:00 ERR root.go:128] pf failed: exit status 1
```

### After (this PR)

```
$ docker compose run --rm optuna-301 bash src/upgrade.sh
mysql
[I 2022-09-08 02:38:34,555] Upgrading the storage schema to the latest version.
/usr/local/lib/python3.9/site-packages/optuna/distributions.py:581: FutureWarning: UniformDistribution has been deprecated in v3.0.0. This feature will be removed in v6.0.0. See https://github.com/optuna/optuna/releases/tag/v3.0.0. Use :class:`~optuna.distributions.FloatDistribution` instead.
  return cls(**json_dict["attributes"])
/usr/local/lib/python3.9/site-packages/optuna/distributions.py:581: FutureWarning: LogUniformDistribution has been deprecated in v3.0.0. This feature will be removed in v6.0.0. See https://github.com/optuna/optuna/releases/tag/v3.0.0. Use :class:`~optuna.distributions.FloatDistribution` instead.
  return cls(**json_dict["attributes"])
/usr/local/lib/python3.9/site-packages/optuna/distributions.py:581: FutureWarning: DiscreteUniformDistribution has been deprecated in v3.0.0. This feature will be removed in v6.0.0. See https://github.com/optuna/optuna/releases/tag/v3.0.0. Use :class:`~optuna.distributions.FloatDistribution` instead.
  return cls(**json_dict["attributes"])
/usr/local/lib/python3.9/site-packages/optuna/distributions.py:581: FutureWarning: IntUniformDistribution has been deprecated in v3.0.0. This feature will be removed in v6.0.0. See https://github.com/optuna/optuna/releases/tag/v3.0.0. Use :class:`~optuna.distributions.IntDistribution` instead.
  return cls(**json_dict["attributes"])
/usr/local/lib/python3.9/site-packages/optuna/distributions.py:581: FutureWarning: IntLogUniformDistribution has been deprecated in v3.0.0. This feature will be removed in v6.0.0. See https://github.com/optuna/optuna/releases/tag/v3.0.0. Use :class:`~optuna.distributions.IntDistribution` instead.
  return cls(**json_dict["attributes"])
[I 2022-09-08 02:38:35,413] Completed to upgrade the storage.
postgresql
[I 2022-09-08 02:38:38,611] Upgrading the storage schema to the latest version.
/usr/local/lib/python3.9/site-packages/optuna/distributions.py:581: FutureWarning: UniformDistribution has been deprecated in v3.0.0. This feature will be removed in v6.0.0. See https://github.com/optuna/optuna/releases/tag/v3.0.0. Use :class:`~optuna.distributions.FloatDistribution` instead.
  return cls(**json_dict["attributes"])
/usr/local/lib/python3.9/site-packages/optuna/distributions.py:581: FutureWarning: LogUniformDistribution has been deprecated in v3.0.0. This feature will be removed in v6.0.0. See https://github.com/optuna/optuna/releases/tag/v3.0.0. Use :class:`~optuna.distributions.FloatDistribution` instead.
  return cls(**json_dict["attributes"])
/usr/local/lib/python3.9/site-packages/optuna/distributions.py:581: FutureWarning: DiscreteUniformDistribution has been deprecated in v3.0.0. This feature will be removed in v6.0.0. See https://github.com/optuna/optuna/releases/tag/v3.0.0. Use :class:`~optuna.distributions.FloatDistribution` instead.
  return cls(**json_dict["attributes"])
/usr/local/lib/python3.9/site-packages/optuna/distributions.py:581: FutureWarning: IntUniformDistribution has been deprecated in v3.0.0. This feature will be removed in v6.0.0. See https://github.com/optuna/optuna/releases/tag/v3.0.0. Use :class:`~optuna.distributions.IntDistribution` instead.
  return cls(**json_dict["attributes"])
/usr/local/lib/python3.9/site-packages/optuna/distributions.py:581: FutureWarning: IntLogUniformDistribution has been deprecated in v3.0.0. This feature will be removed in v6.0.0. See https://github.com/optuna/optuna/releases/tag/v3.0.0. Use :class:`~optuna.distributions.IntDistribution` instead.
  return cls(**json_dict["attributes"])
[I 2022-09-08 02:38:39,158] Completed to upgrade the storage.
sqlite
[I 2022-09-08 02:38:42,224] Upgrading the storage schema to the latest version.
/usr/local/lib/python3.9/site-packages/optuna/distributions.py:581: FutureWarning: UniformDistribution has been deprecated in v3.0.0. This feature will be removed in v6.0.0. See https://github.com/optuna/optuna/releases/tag/v3.0.0. Use :class:`~optuna.distributions.FloatDistribution` instead.
  return cls(**json_dict["attributes"])
/usr/local/lib/python3.9/site-packages/optuna/distributions.py:581: FutureWarning: LogUniformDistribution has been deprecated in v3.0.0. This feature will be removed in v6.0.0. See https://github.com/optuna/optuna/releases/tag/v3.0.0. Use :class:`~optuna.distributions.FloatDistribution` instead.
  return cls(**json_dict["attributes"])
/usr/local/lib/python3.9/site-packages/optuna/distributions.py:581: FutureWarning: DiscreteUniformDistribution has been deprecated in v3.0.0. This feature will be removed in v6.0.0. See https://github.com/optuna/optuna/releases/tag/v3.0.0. Use :class:`~optuna.distributions.FloatDistribution` instead.
  return cls(**json_dict["attributes"])
/usr/local/lib/python3.9/site-packages/optuna/distributions.py:581: FutureWarning: IntUniformDistribution has been deprecated in v3.0.0. This feature will be removed in v6.0.0. See https://github.com/optuna/optuna/releases/tag/v3.0.0. Use :class:`~optuna.distributions.IntDistribution` instead.
  return cls(**json_dict["attributes"])
/usr/local/lib/python3.9/site-packages/optuna/distributions.py:581: FutureWarning: IntLogUniformDistribution has been deprecated in v3.0.0. This feature will be removed in v6.0.0. See https://github.com/optuna/optuna/releases/tag/v3.0.0. Use :class:`~optuna.distributions.IntDistribution` instead.
  return cls(**json_dict["attributes"])
[I 2022-09-08 02:38:43,322] Completed to upgrade the storage.
```