### PR TITLE
Reduced warning messages from tests/visualization_tests/test_slice.py

### DIFF
--- a/tests/visualization_tests/test_slice.py
+++ b/tests/visualization_tests/test_slice.py
@@ -215,7 +215,10 @@ def test_get_slice_plot_info_customized_target() -> None:
     params = ["param_a"]
     study = prepare_study_with_trials()
     info = _get_slice_plot_info(
-        study, params=params, target=lambda t: t.params["param_d"], target_name="Testing Customized Target"
+        study, 
+        params=params, 
+        target=lambda t: t.params["param_d"], 
+        target_name="Testing Customized Target"
     )
     assert info == _SlicePlotInfo(
         target_name="Testing Customized Target",

--- a/tests/visualization_tests/test_slice.py
+++ b/tests/visualization_tests/test_slice.py
@@ -75,6 +75,7 @@ def _create_study_mixture_category_types() -> Study:
     return study
 
 
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
 @parametrize_plot_slice
 def test_plot_slice_customized_target_name(plot_slice: Callable[..., Any]) -> None:
 
@@ -101,6 +102,8 @@ def test_plot_slice_customized_target_name(plot_slice: Callable[..., Any]) -> No
         [_create_study_mixture_category_types, None],
     ],
 )
+
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
 def test_plot_slice(
     plot_slice: Callable[..., Any],
     specific_create_study: Callable[[], Study],
@@ -213,10 +216,10 @@ def test_get_slice_plot_info_customized_target() -> None:
     params = ["param_a"]
     study = prepare_study_with_trials()
     info = _get_slice_plot_info(
-        study, params=params, target=lambda t: t.params["param_d"], target_name="Objective Value"
+        study, params=params, target=lambda t: t.params["param_d"], target_name="Testing Customized Target"
     )
     assert info == _SlicePlotInfo(
-        target_name="Objective Value",
+        target_name="Testing Customized Target",
         subplots=[
             _SliceSubplotInfo(
                 param_name="param_a",
@@ -374,10 +377,10 @@ def test_get_slice_plot_info_nonfinite_multiobjective(objective: int, value: flo
         study,
         params=["param_b", "param_d"],
         target=lambda t: t.values[objective],
-        target_name="Objective Value",
+        target_name="Testing Nonfinite Multiobjective",
     )
     assert info == _SlicePlotInfo(
-        target_name="Objective Value",
+        target_name="Testing Nonfinite Multiobjective",
         subplots=[
             _SliceSubplotInfo(
                 param_name="param_b",

--- a/tests/visualization_tests/test_slice.py
+++ b/tests/visualization_tests/test_slice.py
@@ -379,7 +379,7 @@ def test_get_slice_plot_info_nonfinite_multiobjective(objective: int, value: flo
         study,
         params=["param_b", "param_d"],
         target=lambda t: t.values[objective],
-        target_name="Testing Nonfinite Multiobjective",
+        target_name="Target Name",
     )
     assert info == _SlicePlotInfo(
         target_name="Testing Nonfinite Multiobjective",

--- a/tests/visualization_tests/test_slice.py
+++ b/tests/visualization_tests/test_slice.py
@@ -101,7 +101,6 @@ def test_plot_slice_customized_target_name(plot_slice: Callable[..., Any]) -> No
         [_create_study_mixture_category_types, None],
     ],
 )
-@pytest.mark.filterwarnings("ignore::DeprecationWarning")
 def test_plot_slice(
     plot_slice: Callable[..., Any],
     specific_create_study: Callable[[], Study],

--- a/tests/visualization_tests/test_slice.py
+++ b/tests/visualization_tests/test_slice.py
@@ -75,7 +75,6 @@ def _create_study_mixture_category_types() -> Study:
     return study
 
 
-@pytest.mark.filterwarnings("ignore::DeprecationWarning")
 @parametrize_plot_slice
 def test_plot_slice_customized_target_name(plot_slice: Callable[..., Any]) -> None:
 

--- a/tests/visualization_tests/test_slice.py
+++ b/tests/visualization_tests/test_slice.py
@@ -218,7 +218,7 @@ def test_get_slice_plot_info_customized_target() -> None:
         study, 
         params=params, 
         target=lambda t: t.params["param_d"], 
-        target_name="Testing Customized Target"
+        target_name="Testing Customized Target",
     )
     assert info == _SlicePlotInfo(
         target_name="Testing Customized Target",

--- a/tests/visualization_tests/test_slice.py
+++ b/tests/visualization_tests/test_slice.py
@@ -215,9 +215,9 @@ def test_get_slice_plot_info_customized_target() -> None:
     params = ["param_a"]
     study = prepare_study_with_trials()
     info = _get_slice_plot_info(
-        study, 
-        params=params, 
-        target=lambda t: t.params["param_d"], 
+        study,
+        params=params,
+        target=lambda t: t.params["param_d"],
         target_name="Testing Customized Target",
     )
     assert info == _SlicePlotInfo(

--- a/tests/visualization_tests/test_slice.py
+++ b/tests/visualization_tests/test_slice.py
@@ -221,7 +221,7 @@ def test_get_slice_plot_info_customized_target() -> None:
         target_name="param_d",
     )
     assert info == _SlicePlotInfo(
-        target_name="Testing Customized Target",
+        target_name="param_d",
         subplots=[
             _SliceSubplotInfo(
                 param_name="param_a",

--- a/tests/visualization_tests/test_slice.py
+++ b/tests/visualization_tests/test_slice.py
@@ -102,7 +102,6 @@ def test_plot_slice_customized_target_name(plot_slice: Callable[..., Any]) -> No
         [_create_study_mixture_category_types, None],
     ],
 )
-
 @pytest.mark.filterwarnings("ignore::DeprecationWarning")
 def test_plot_slice(
     plot_slice: Callable[..., Any],

--- a/tests/visualization_tests/test_slice.py
+++ b/tests/visualization_tests/test_slice.py
@@ -218,7 +218,7 @@ def test_get_slice_plot_info_customized_target() -> None:
         study,
         params=params,
         target=lambda t: t.params["param_d"],
-        target_name="Testing Customized Target",
+        target_name="param_d",
     )
     assert info == _SlicePlotInfo(
         target_name="Testing Customized Target",

--- a/tests/visualization_tests/test_slice.py
+++ b/tests/visualization_tests/test_slice.py
@@ -380,7 +380,7 @@ def test_get_slice_plot_info_nonfinite_multiobjective(objective: int, value: flo
         target_name="Target Name",
     )
     assert info == _SlicePlotInfo(
-        target_name="Testing Nonfinite Multiobjective",
+        target_name="Target Name",
         subplots=[
             _SliceSubplotInfo(
                 param_name="param_b",


### PR DESCRIPTION
## Motivation:

As part of #3815

## Description:

Suppressed user warnings for tests involving the _check_plot_args function in the tests/visualization_tests/test_slice.py file.

<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

## Description of the changes
<!-- Describe the changes in this PR. -->
