### PR TITLE
Support older `typing_extension` versions

### DIFF
--- a/optuna/_convert_positional_args.py
+++ b/optuna/_convert_positional_args.py
@@ -12,7 +12,7 @@ try:
 
     _P = ParamSpec("_P")
 except ImportError:
-    _P = Any
+    pass
 
 
 _T = TypeVar("_T")
@@ -22,7 +22,7 @@ def convert_positional_args(
     *,
     previous_positional_arg_names: Sequence[str],
     warning_stacklevel: int = 2,
-) -> Callable[[Callable[_P, _T]], Callable[_P, _T]]:
+) -> "Callable[[Callable[_P, _T]], Callable[_P, _T]]":
     """Convert positional arguments to keyword arguments.
 
     Args:
@@ -30,7 +30,7 @@ def convert_positional_args(
         warning_stacklevel: Level of the stack trace where decorated function locates.
     """
 
-    def converter_decorator(func: Callable[_P, _T]) -> Callable[_P, _T]:
+    def converter_decorator(func: "Callable[_P, _T]") -> "Callable[_P, _T]":
 
         assert set(previous_positional_arg_names).issubset(set(signature(func).parameters)), (
             f"{set(previous_positional_arg_names)} is not a subset of"

--- a/optuna/_convert_positional_args.py
+++ b/optuna/_convert_positional_args.py
@@ -6,11 +6,16 @@ from typing import Sequence
 from typing import TypeVar
 import warnings
 
-from typing_extensions import ParamSpec
+
+try:
+    from typing_extensions import ParamSpec
+
+    _P = ParamSpec("_P")
+except ImportError:
+    _P = Any
 
 
 _T = TypeVar("_T")
-_P = ParamSpec("_P")
 
 
 def convert_positional_args(

--- a/optuna/_deprecated.py
+++ b/optuna/_deprecated.py
@@ -7,14 +7,19 @@ from typing import TypeVar
 import warnings
 
 from packaging import version
-from typing_extensions import ParamSpec
 
 from optuna._experimental import _get_docstring_indent
 from optuna._experimental import _validate_version
 
 
+try:
+    from typing_extensions import ParamSpec
+
+    FP = ParamSpec("FP")
+except ImportError:
+    FP = Any
+
 FT = TypeVar("FT")
-FP = ParamSpec("FP")
 CT = TypeVar("CT")
 
 

--- a/optuna/_deprecated.py
+++ b/optuna/_deprecated.py
@@ -17,7 +17,7 @@ try:
 
     FP = ParamSpec("FP")
 except ImportError:
-    FP = Any
+    pass
 
 FT = TypeVar("FT")
 CT = TypeVar("CT")
@@ -57,7 +57,7 @@ def deprecated_func(
     removed_version: str,
     name: Optional[str] = None,
     text: Optional[str] = None,
-) -> Callable[[Callable[FP, FT]], Callable[FP, FT]]:
+) -> "Callable[[Callable[FP, FT]], Callable[FP, FT]]":
     """Decorate function as deprecated.
 
     Args:
@@ -86,7 +86,7 @@ def deprecated_func(
     _validate_version(removed_version)
     _validate_two_version(deprecated_version, removed_version)
 
-    def decorator(func: Callable[FP, FT]) -> Callable[FP, FT]:
+    def decorator(func: "Callable[FP, FT]") -> "Callable[FP, FT]":
         if func.__doc__ is None:
             func.__doc__ = ""
 

--- a/optuna/_experimental.py
+++ b/optuna/_experimental.py
@@ -14,7 +14,7 @@ try:
 
     FP = ParamSpec("FP")
 except ImportError:
-    FP = Any
+    pass
 
 
 FT = TypeVar("FT")
@@ -45,7 +45,7 @@ def _get_docstring_indent(docstring: str) -> str:
 def experimental_func(
     version: str,
     name: Optional[str] = None,
-) -> Callable[[Callable[FP, FT]], Callable[FP, FT]]:
+) -> "Callable[[Callable[FP, FT]], Callable[FP, FT]]":
     """Decorate function as experimental.
 
     Args:
@@ -55,7 +55,7 @@ def experimental_func(
 
     _validate_version(version)
 
-    def decorator(func: Callable[FP, FT]) -> Callable[FP, FT]:
+    def decorator(func: "Callable[FP, FT]") -> "Callable[FP, FT]":
         if func.__doc__ is None:
             func.__doc__ = ""
 

--- a/optuna/_experimental.py
+++ b/optuna/_experimental.py
@@ -6,13 +6,18 @@ from typing import Optional
 from typing import TypeVar
 import warnings
 
-from typing_extensions import ParamSpec
-
 from optuna.exceptions import ExperimentalWarning
 
 
+try:
+    from typing_extensions import ParamSpec
+
+    FP = ParamSpec("FP")
+except ImportError:
+    FP = Any
+
+
 FT = TypeVar("FT")
-FP = ParamSpec("FP")
 CT = TypeVar("CT")
 
 _EXPERIMENTAL_NOTE_TEMPLATE = """

--- a/optuna/integration/pytorch_distributed.py
+++ b/optuna/integration/pytorch_distributed.py
@@ -8,8 +8,6 @@ from typing import Optional
 from typing import Sequence
 from typing import TypeVar
 
-from typing_extensions import ParamSpec
-
 import optuna
 from optuna._deprecated import deprecated_func
 from optuna._experimental import experimental_class
@@ -23,8 +21,15 @@ with try_import() as _imports:
     import torch.distributed as dist
 
 
+try:
+    from typing_extensions import ParamSpec
+
+    _P = ParamSpec("_P")
+except ImportError:
+    _P = Any
+
+
 _T = TypeVar("_T")
-_P = ParamSpec("_P")
 
 
 _suggest_deprecated_msg = (

--- a/optuna/integration/pytorch_distributed.py
+++ b/optuna/integration/pytorch_distributed.py
@@ -26,7 +26,7 @@ try:
 
     _P = ParamSpec("_P")
 except ImportError:
-    _P = Any
+    pass
 
 
 _T = TypeVar("_T")
@@ -37,7 +37,7 @@ _suggest_deprecated_msg = (
 )
 
 
-def broadcast_properties(f: Callable[_P, _T]) -> Callable[_P, _T]:
+def broadcast_properties(f: "Callable[_P, _T]") -> "Callable[_P, _T]":
     """Method decorator to fetch updated trial properties from rank 0 after ``f`` is run.
 
     This decorator ensures trial properties (params, distributions, etc.) on all distributed
@@ -47,7 +47,7 @@ def broadcast_properties(f: Callable[_P, _T]) -> Callable[_P, _T]:
     """
 
     @functools.wraps(f)
-    def wrapped(*args: _P.args, **kwargs: _P.kwargs) -> _T:
+    def wrapped(*args: "_P.args", **kwargs: "_P.kwargs") -> _T:
         # TODO(nlgranger): Remove type ignore after mypy includes
         # https://github.com/python/mypy/pull/12668
         self: TorchDistributedTrial = args[0]  # type: ignore

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ def get_install_requires() -> List[str]:
         "scipy!=1.4.0" if sys.version[:3] == "3.6" else "scipy>=1.7.0",
         "sqlalchemy>=1.1.0",
         "tqdm",
-        "typing_extensions>=3.10.0.0",
+        "typing_extensions",
         "PyYAML",  # Only used in `optuna/cli.py`.
     ]
     return requirements


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
We set the version constraint of typing_extensions `typing_extensions>=3.10.0.0` at #3926. However, `typing_extension==3.10.0.0` is not too older version since it was released at May 2021. So it may causes the installation issues (e.g. We cannot install `tensorflow=2.5.0` with `typing_extensions>=3.10.0.0`).

## Description of the changes
<!-- Describe the changes in this PR. -->
If `typing_extensions.ParamSpec` is unavailable, use `typing.Any` instead.
