### PR TITLE
Drop python 3.6 from integration CIs

### DIFF
--- a/.github/workflows/tests-integration.yml
+++ b/.github/workflows/tests-integration.yml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
 
     steps:
     - name: Checkout
@@ -59,22 +59,5 @@ jobs:
 
     - name: Tests
       run: |
-        if [ ${{ matrix.python-version }} = 3.6 ]; then
-          pytest tests/integration_tests \
-            --ignore tests/integration_tests/allennlp_tests/ \
-            --ignore tests/integration_tests/test_botorch.py \
-            --ignore tests/integration_tests/test_catalyst.py \
-            --ignore tests/integration_tests/test_fastaiv2.py \
-            --ignore tests/integration_tests/test_keras.py \
-            --ignore tests/integration_tests/test_pytorch_distributed.py \
-            --ignore tests/integration_tests/test_pytorch_ignite.py \
-            --ignore tests/integration_tests/test_pytorch_lightning.py \
-            --ignore tests/integration_tests/test_skorch.py \
-            --ignore tests/integration_tests/test_tensorboard.py \
-            --ignore tests/integration_tests/test_tensorflow.py \
-            --ignore tests/integration_tests/test_tfkeras.py
-
-        else
-          pytest -s tests/integration_tests \
-            --ignore tests/integration_tests/test_pytorch_lightning.py
-        fi
+        pytest -s tests/integration_tests \
+          --ignore tests/integration_tests/test_pytorch_lightning.py

--- a/.github/workflows/tests-mpi.yml
+++ b/.github/workflows/tests-mpi.yml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
 
     steps:
     - name: Checkout
@@ -61,10 +61,6 @@ jobs:
       run: |
         export OMPI_MCA_rmaps_base_oversubscribe=yes
         mpirun -n 2 -- pytest tests/integration_tests/test_chainermn.py
-
-        if [ ${{ matrix.python-version }} != 3.6 ]; then
-          mpirun -n 2 -- pytest tests/integration_tests/test_pytorch_distributed.py
-        fi
 
       env:
         OMP_NUM_THREADS: 1


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

https://github.com/optuna/optuna/issues/3021#issuecomment-1129545028: remove Python 3.6 tests from the CI of the integrations. Note that we keep using python 3.6 to test Optuna's core functionality.

## Description of the changes
<!-- Describe the changes in this PR. -->

Remove python 3.6 from `python-version` in `.github/workflows/tests-integration.yml` and `.github/workflows/tests-mpi.yml` and `run` branches depending on python version.
