### PR TITLE
Use truncated norm cdf instead of norm cdf

### DIFF
--- a/optuna/samplers/_tpe/parzen_estimator.py
+++ b/optuna/samplers/_tpe/parzen_estimator.py
@@ -193,6 +193,10 @@ class _ParzenEstimator:
                         scale=sigmas,
                     )
                 else:
+                    # TODO(nzw0301): Simplify the logic by following
+                    # https://github.com/optuna/optuna/pull/3985#issuecomment-1253637444
+                    # when we can assume scipy 1.9.2 is commonly used, which includes
+                    # accurate logcdf https://github.com/scipy/scipy/pull/17064.
                     cdf_func = _ParzenEstimator._trunc_normal_cdf
                     p_accept = cdf_func(high, mus, sigmas, low, high) - cdf_func(
                         low, mus, sigmas, low, high

--- a/optuna/samplers/_tpe/parzen_estimator.py
+++ b/optuna/samplers/_tpe/parzen_estimator.py
@@ -184,8 +184,10 @@ class _ParzenEstimator:
                 assert mus is not None
                 assert sigmas is not None
 
-                cdf_func = _ParzenEstimator._normal_cdf
-                p_accept = cdf_func(high, mus, sigmas) - cdf_func(low, mus, sigmas)
+                cdf_func = _ParzenEstimator._trunc_normal_cdf
+                p_accept = cdf_func(high, mus, sigmas, low, high) - cdf_func(
+                    low, mus, sigmas, low, high
+                )
                 if q is None:
                     distance = samples[:, None] - mus
                     mahalanobis = distance / np.maximum(sigmas, EPS)
@@ -195,9 +197,9 @@ class _ParzenEstimator:
                 else:
                     upper_bound = np.minimum(samples + q / 2.0, high)
                     lower_bound = np.maximum(samples - q / 2.0, low)
-                    cdf = cdf_func(upper_bound[:, None], mus[None], sigmas[None]) - cdf_func(
-                        lower_bound[:, None], mus[None], sigmas[None]
-                    )
+                    cdf = cdf_func(
+                        upper_bound[:, None], mus[None], sigmas[None], low, high
+                    ) - cdf_func(lower_bound[:, None], mus[None], sigmas[None], low, high)
                     log_pdf = np.log(cdf + EPS) - np.log(p_accept + EPS)
             component_log_pdf += log_pdf
         ret = special.logsumexp(component_log_pdf + np.log(self._weights), axis=1)
@@ -458,13 +460,19 @@ class _ParzenEstimator:
         return mus, sigmas
 
     @staticmethod
-    def _normal_cdf(x: np.ndarray, mu: np.ndarray, sigma: np.ndarray) -> np.ndarray:
+    def _trunc_normal_cdf(
+        x: np.ndarray,
+        mu: np.ndarray,
+        sigma: np.ndarray,
+        pre_trunc_low: np.ndarray,
+        pre_trunc_high: np.ndarray,
+    ) -> np.ndarray:
 
         mu, sigma = map(np.asarray, (mu, sigma))
-        denominator = x - mu
-        numerator = np.maximum(np.sqrt(2) * sigma, EPS)
-        z = denominator / numerator
-        return 0.5 * (1 + special.erf(z))
+        trunc_low = (pre_trunc_low - mu) / sigma
+        trunc_high = (pre_trunc_high - mu) / sigma
+
+        return stats.truncnorm.cdf(x, trunc_low, trunc_high, loc=mu, scale=sigma)
 
     @staticmethod
     def _sample_from_categorical_dist(

--- a/optuna/samplers/_tpe/parzen_estimator.py
+++ b/optuna/samplers/_tpe/parzen_estimator.py
@@ -184,17 +184,20 @@ class _ParzenEstimator:
                 assert mus is not None
                 assert sigmas is not None
 
-                cdf_func = _ParzenEstimator._trunc_normal_cdf
-                p_accept = cdf_func(high, mus, sigmas, low, high) - cdf_func(
-                    low, mus, sigmas, low, high
-                )
                 if q is None:
-                    distance = samples[:, None] - mus
-                    mahalanobis = distance / np.maximum(sigmas, EPS)
-                    z = np.sqrt(2 * np.pi) * sigmas
-                    coefficient = 1 / z / p_accept
-                    log_pdf = -0.5 * mahalanobis**2 + np.log(coefficient)
+                    log_pdf = stats.truncnorm.logpdf(
+                        samples[:, None],
+                        (low - mus) / sigmas,
+                        (high - mus) / sigmas,
+                        loc=mus,
+                        scale=sigmas,
+                    )
                 else:
+                    cdf_func = _ParzenEstimator._trunc_normal_cdf
+                    p_accept = cdf_func(high, mus, sigmas, low, high) - cdf_func(
+                        low, mus, sigmas, low, high
+                    )
+
                     upper_bound = np.minimum(samples + q / 2.0, high)
                     lower_bound = np.maximum(samples - q / 2.0, low)
                     cdf = cdf_func(


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

When we run the following optuna optimisation with dynamic search space, 

```python
import optuna

def objective1(trial):
    return trial.suggest_float("x", -1, 1)

def objective2(trial):
    return trial.suggest_float("x", -100, -90)

study = optuna.create_study(sampler=optuna.samplers.TPESampler(seed=2))
study.optimize(objective1, n_trials=10)
study.optimize(objective2, n_trials=10)
```

TPE sampler (specifically, Parzen Estimator) raises the `RuntimeWarning` as follows:

```
/Users/nzw/optuna/optuna/samplers/_tpe/parzen_estimator.py:193: RuntimeWarning: divide by zero encountered in divide
  coefficient = 1 / z / p_accept
/Users/nzw/optuna/optuna/samplers/_tpe/sampler.py:494: RuntimeWarning: invalid value encountered in subtract
```

One concern is to break the test `tests/samplers_tests/tpe_tests/test_sampler.py::test_sample_relative_handle_unsuccessful_states` that I'm not familiar with. So I really appreciate any feedback from others.

## Description of the changes
<!-- Describe the changes in this PR. -->

Replace `cdf` with truncated cdf.
