### PR TITLE
Remove warning from a few visualizaiton tests

### DIFF
--- a/optuna/visualization/matplotlib/_parallel_coordinate.py
+++ b/optuna/visualization/matplotlib/_parallel_coordinate.py
@@ -122,7 +122,7 @@ def _get_parallel_coordinate_plot(info: _ParallelCoordinateInfo) -> "Axes":
     segments = [np.column_stack([x, y]) for x, y in zip(xs, dims_obj_base)]
     lc = LineCollection(segments, cmap=cmap)
     lc.set_array(np.asarray(info.dim_objective.values))
-    axcb = fig.colorbar(lc, pad=0.1)
+    axcb = fig.colorbar(lc, pad=0.1, ax=ax)
     axcb.set_label(target_name)
     var_names = [info.dim_objective.label] + [dim.label for dim in info.dims_params]
     plt.xticks(range(n_params + 1), var_names, rotation=330)

--- a/tests/visualization_tests/test_edf.py
+++ b/tests/visualization_tests/test_edf.py
@@ -173,7 +173,9 @@ def test_nonfinite_removed(value: float) -> None:
 def test_nonfinite_multiobjective(objective: int, value: float) -> None:
 
     study = prepare_study_with_trials(n_objectives=2, value_for_first_trial=value)
-    edf_info = _get_edf_info(study, target=lambda t: t.values[objective], target_name="Target Name")
+    edf_info = _get_edf_info(
+        study, target=lambda t: t.values[objective], target_name="Target Name"
+    )
     assert all(np.isfinite(edf_info.x_values))
 
 

--- a/tests/visualization_tests/test_edf.py
+++ b/tests/visualization_tests/test_edf.py
@@ -150,7 +150,7 @@ def test_get_edf_info(n_studies: int, target: Callable[[optuna.trial.FrozenTrial
         study.optimize(lambda t: t.suggest_float("x", 0, max_target), n_trials=n_trials)
         studies.append(study)
 
-    info = _get_edf_info(studies, target=target)
+    info = _get_edf_info(studies, target=target, target_name="Target Name")
     assert info.x_values.shape == (NUM_SAMPLES_X_AXIS,)
     assert all([0 <= x <= max_target for x in info.x_values])
     assert len(info.lines) == n_studies
@@ -173,7 +173,7 @@ def test_nonfinite_removed(value: float) -> None:
 def test_nonfinite_multiobjective(objective: int, value: float) -> None:
 
     study = prepare_study_with_trials(n_objectives=2, value_for_first_trial=value)
-    edf_info = _get_edf_info(study, target=lambda t: t.values[objective])
+    edf_info = _get_edf_info(study, target=lambda t: t.values[objective], target_name="Target Name")
     assert all(np.isfinite(edf_info.x_values))
 
 

--- a/tests/visualization_tests/test_parallel_coordinate.py
+++ b/tests/visualization_tests/test_parallel_coordinate.py
@@ -703,7 +703,9 @@ def test_color_map(direction: str) -> None:
         assert not line["reversescale"]
 
     # When `target` is not `None`, `reversescale` is always `True`.
-    line = plotly_plot_parallel_coordinate(study, target=lambda t: t.number, target_name="Target Name").data[0]["line"]
+    line = plotly_plot_parallel_coordinate(
+        study, target=lambda t: t.number, target_name="Target Name"
+    ).data[0]["line"]
     assert COLOR_SCALE == [v[1] for v in line["colorscale"]]
     assert line["reversescale"]
 
@@ -720,7 +722,9 @@ def test_color_map(direction: str) -> None:
                 },
             )
         )
-    line = plotly_plot_parallel_coordinate(study, target=lambda t: t.number, target_name="Target Name").data[0]["line"]
+    line = plotly_plot_parallel_coordinate(
+        study, target=lambda t: t.number, target_name="Target Name"
+    ).data[0]["line"]
     assert COLOR_SCALE == [v[1] for v in line["colorscale"]]
     assert line["reversescale"]
 
@@ -778,5 +782,7 @@ def test_nonfinite_removed(value: float) -> None:
 def test_nonfinite_multiobjective(objective: int, value: float) -> None:
 
     study = prepare_study_with_trials(n_objectives=2, value_for_first_trial=value)
-    info = _get_parallel_coordinate_info(study, target=lambda t: t.values[objective], target_name="Target Name")
+    info = _get_parallel_coordinate_info(
+        study, target=lambda t: t.values[objective], target_name="Target Name"
+    )
     assert all(np.isfinite(info.dim_objective.values))

--- a/tests/visualization_tests/test_parallel_coordinate.py
+++ b/tests/visualization_tests/test_parallel_coordinate.py
@@ -703,7 +703,7 @@ def test_color_map(direction: str) -> None:
         assert not line["reversescale"]
 
     # When `target` is not `None`, `reversescale` is always `True`.
-    line = plotly_plot_parallel_coordinate(study, target=lambda t: t.number).data[0]["line"]
+    line = plotly_plot_parallel_coordinate(study, target=lambda t: t.number, target_name="Target Name").data[0]["line"]
     assert COLOR_SCALE == [v[1] for v in line["colorscale"]]
     assert line["reversescale"]
 
@@ -720,7 +720,7 @@ def test_color_map(direction: str) -> None:
                 },
             )
         )
-    line = plotly_plot_parallel_coordinate(study, target=lambda t: t.number).data[0]["line"]
+    line = plotly_plot_parallel_coordinate(study, target=lambda t: t.number, target_name="Target Name").data[0]["line"]
     assert COLOR_SCALE == [v[1] for v in line["colorscale"]]
     assert line["reversescale"]
 
@@ -778,5 +778,5 @@ def test_nonfinite_removed(value: float) -> None:
 def test_nonfinite_multiobjective(objective: int, value: float) -> None:
 
     study = prepare_study_with_trials(n_objectives=2, value_for_first_trial=value)
-    info = _get_parallel_coordinate_info(study, target=lambda t: t.values[objective])
+    info = _get_parallel_coordinate_info(study, target=lambda t: t.values[objective], target_name="Target Name")
     assert all(np.isfinite(info.dim_objective.values))

--- a/tests/visualization_tests/test_param_importances.py
+++ b/tests/visualization_tests/test_param_importances.py
@@ -199,7 +199,7 @@ def test_multi_objective_trial_with_infinite_value_ignored(
         return x1, x2 * x3
 
     seed = 13
-    target_name = "Objective Value"
+    target_name = "Target Name"
 
     study = create_study(directions=["minimize", "minimize"], sampler=RandomSampler(seed=seed))
     study.optimize(_multi_objective_function, n_trials=n_trial)


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

A part of #3815.

## Description of the changes
<!-- Describe the changes in this PR. -->

- Specify non-default `target_name` with non-default `target` argument
- Resolve `colormap`-related warning by matplotlib, which is explained below as a comment on a modified line