### PR TITLE
Use `log_loss` instead of deprecated `log` since `sklearn` 1.1

### DIFF
--- a/tutorial/20_recipes/006_user_defined_pruner.py
+++ b/tutorial/20_recipes/006_user_defined_pruner.py
@@ -108,7 +108,7 @@ def objective(trial):
         iris.data, iris.target, train_size=100, test_size=50, random_state=0
     )
 
-    loss = trial.suggest_categorical("loss", ["hinge", "log", "perceptron"])
+    loss = trial.suggest_categorical("loss", ["hinge", "log_loss", "perceptron"])
     alpha = trial.suggest_float("alpha", 0.00001, 0.001, log=True)
     clf = SGDClassifier(loss=loss, alpha=alpha, random_state=0)
     score = 0


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

The `loss` argument of skelarn's [`SGDClassifier`](https://scikit-learn.org/stable/modules/classes.html#module-sklearn.linear_model) reads

> Deprecated since version 1.1: The loss ‘log’ was deprecated in v1.1 and will be removed in version 1.3. Use loss='log_loss' which is equivalent.

By this deprecation, the output of [a tutorial](https://optuna.readthedocs.io/en/stable/tutorial/20_recipes/006_user_defined_pruner.html#sphx-glr-tutorial-20-recipes-006-user-defined-pruner-py) looks a little bit messy as follows:

<img width="1159" alt="Screenshot 2022-09-12 at 21 41 20" src="https://user-images.githubusercontent.com/7121753/189656238-6d9293e9-6ca4-4462-b94d-9f144500b218.png">

## Description of the changes
<!-- Describe the changes in this PR. -->

By following sklearn, replace `"log"` with `"log_loss"` in the code of the tutorial.
 