### PR TITLE
Skip to add `intermediate_value_type` and `value_type` columns if exists

### DIFF
--- a/optuna/storages/_rdb/alembic/versions/v3.0.0.c.py
+++ b/optuna/storages/_rdb/alembic/versions/v3.0.0.c.py
@@ -82,15 +82,15 @@ def upgrade():
                     server_default="FINITE",
                 ),
             )
-        with op.batch_alter_table("trial_intermediate_values") as batch_op:
-            batch_op.alter_column(
-                "intermediate_value_type",
-                existing_type=sa.Enum(
-                    "FINITE", "INF_POS", "INF_NEG", "NAN", name="trialintermediatevaluetype"
-                ),
-                existing_nullable=False,
-                server_default=None,
-            )
+    with op.batch_alter_table("trial_intermediate_values") as batch_op:
+        batch_op.alter_column(
+            "intermediate_value_type",
+            existing_type=sa.Enum(
+                "FINITE", "INF_POS", "INF_NEG", "NAN", name="trialintermediatevaluetype"
+            ),
+            existing_nullable=False,
+            server_default=None,
+        )
 
     session = orm.Session(bind=bind)
     try:

--- a/optuna/storages/_rdb/alembic/versions/v3.0.0.c.py
+++ b/optuna/storages/_rdb/alembic/versions/v3.0.0.c.py
@@ -75,7 +75,9 @@ def upgrade():
             batch_op.add_column(
                 sa.Column(
                     "intermediate_value_type",
-                    sa.Enum("FINITE", "INF_POS", "INF_NEG", "NAN", name="trialintermediatevaluetype"),
+                    sa.Enum(
+                        "FINITE", "INF_POS", "INF_NEG", "NAN", name="trialintermediatevaluetype"
+                    ),
                     nullable=False,
                     server_default="FINITE",
                 ),

--- a/optuna/storages/_rdb/alembic/versions/v3.0.0.d.py
+++ b/optuna/storages/_rdb/alembic/versions/v3.0.0.d.py
@@ -71,6 +71,8 @@ class TrialValueModel(BaseModel):
 
 def upgrade():
     bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    column_names = [c["name"] for c in inspector.get_columns("trial_values")]
 
     sa.Enum(TrialValueModel.TrialValueType).create(bind, checkfirst=True)
 
@@ -78,27 +80,28 @@ def upgrade():
     # ADD COLUMN <col_name> ... DEFAULT "FINITE"', but seemingly Alembic
     # does not support such a SQL statement. So first add a column with schema-level
     # default value setting, then remove it by `batch_op.alter_column()`.
-    with op.batch_alter_table("trial_values") as batch_op:
-        batch_op.add_column(
-            sa.Column(
+    if "value_type" not in column_names:
+        with op.batch_alter_table("trial_values") as batch_op:
+            batch_op.add_column(
+                sa.Column(
+                    "value_type",
+                    sa.Enum("FINITE", "INF_POS", "INF_NEG", name="trialvaluetype"),
+                    nullable=False,
+                    server_default="FINITE",
+                ),
+            )
+        with op.batch_alter_table("trial_values") as batch_op:
+            batch_op.alter_column(
                 "value_type",
-                sa.Enum("FINITE", "INF_POS", "INF_NEG", name="trialvaluetype"),
-                nullable=False,
-                server_default="FINITE",
-            ),
-        )
-    with op.batch_alter_table("trial_values") as batch_op:
-        batch_op.alter_column(
-            "value_type",
-            existing_type=sa.Enum("FINITE", "INF_POS", "INF_NEG", name="trialvaluetype"),
-            existing_nullable=False,
-            server_default=None,
-        )
-        batch_op.alter_column(
-            "value",
-            existing_type=sa.Float(precision=FLOAT_PRECISION),
-            nullable=True,
-        )
+                existing_type=sa.Enum("FINITE", "INF_POS", "INF_NEG", name="trialvaluetype"),
+                existing_nullable=False,
+                server_default=None,
+            )
+            batch_op.alter_column(
+                "value",
+                existing_type=sa.Float(precision=FLOAT_PRECISION),
+                nullable=True,
+            )
 
     session = orm.Session(bind=bind)
     try:

--- a/optuna/storages/_rdb/alembic/versions/v3.0.0.d.py
+++ b/optuna/storages/_rdb/alembic/versions/v3.0.0.d.py
@@ -90,18 +90,18 @@ def upgrade():
                     server_default="FINITE",
                 ),
             )
-        with op.batch_alter_table("trial_values") as batch_op:
-            batch_op.alter_column(
-                "value_type",
-                existing_type=sa.Enum("FINITE", "INF_POS", "INF_NEG", name="trialvaluetype"),
-                existing_nullable=False,
-                server_default=None,
-            )
-            batch_op.alter_column(
-                "value",
-                existing_type=sa.Float(precision=FLOAT_PRECISION),
-                nullable=True,
-            )
+    with op.batch_alter_table("trial_values") as batch_op:
+        batch_op.alter_column(
+            "value_type",
+            existing_type=sa.Enum("FINITE", "INF_POS", "INF_NEG", name="trialvaluetype"),
+            existing_nullable=False,
+            server_default=None,
+        )
+        batch_op.alter_column(
+            "value",
+            existing_type=sa.Float(precision=FLOAT_PRECISION),
+            nullable=True,
+        )
 
     session = orm.Session(bind=bind)
     try:


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
The data migration written in `v3.0.0.c.py` is sometimes failed if there are a lot of `trial_intermediate_values` records since  it takes long time. At that time, users cannot resume the database migration.

## Description of the changes
<!-- Describe the changes in this PR. -->
Skip to add `intermediate_value_type` and `value_type` columns if exists to make the migration idempotent.