### PR TITLE
Remove `# type: ignore` for mypy 0.981

### DIFF
--- a/tests/integration_tests/test_pytorch_lightning.py
+++ b/tests/integration_tests/test_pytorch_lightning.py
@@ -23,22 +23,18 @@ class Model(pl.LightningModule):
         super().__init__()
         self._model = nn.Sequential(nn.Linear(4, 8))
 
-    def forward(self, data: torch.Tensor) -> torch.Tensor:  # type: ignore
+    def forward(self, data: torch.Tensor) -> torch.Tensor:
 
         return self._model(data)
 
-    def training_step(  # type: ignore
-        self, batch: List[torch.Tensor], batch_nb: int
-    ) -> Dict[str, torch.Tensor]:
+    def training_step(self, batch: List[torch.Tensor], batch_nb: int) -> Dict[str, torch.Tensor]:
 
         data, target = batch
         output = self.forward(data)
         loss = F.nll_loss(output, target)
         return {"loss": loss}
 
-    def validation_step(  # type: ignore
-        self, batch: List[torch.Tensor], batch_nb: int
-    ) -> Dict[str, torch.Tensor]:
+    def validation_step(self, batch: List[torch.Tensor], batch_nb: int) -> Dict[str, torch.Tensor]:
 
         data, target = batch
         output = self.forward(data)

--- a/tests/multi_objective_tests/visualization_tests/test_pareto_front.py
+++ b/tests/multi_objective_tests/visualization_tests/test_pareto_front.py
@@ -99,9 +99,7 @@ def test_plot_pareto_front_2d(
 
 
 @pytest.mark.parametrize("include_dominated_trials", [False, True])
-@pytest.mark.parametrize(
-    "axis_order", [None] + list(itertools.permutations(range(3), 3))  # type: ignore
-)
+@pytest.mark.parametrize("axis_order", [None] + list(itertools.permutations(range(3), 3)))
 def test_plot_pareto_front_3d(
     include_dominated_trials: bool, axis_order: Optional[List[int]]
 ) -> None:


### PR DESCRIPTION
## Motivation
The CI of checks with integration failed because some `# type: ignore` are no longer needed with the release of mypy 0.981. https://github.com/optuna/optuna/actions/runs/3131673503
The CI was checked in my fork. https://github.com/not522/optuna/actions/runs/3133428300

## Description of the changes
Remove unused `# type: ignore`