### PR TITLE
Fix the data migration script for v3 release.

### DIFF
--- a/optuna/storages/_rdb/alembic/versions/v3.0.0.c.py
+++ b/optuna/storages/_rdb/alembic/versions/v3.0.0.c.py
@@ -95,6 +95,7 @@ def upgrade():
                 sa.or_(
                     IntermediateValueModel.intermediate_value > RDB_MAX_FLOAT - 1,
                     IntermediateValueModel.intermediate_value < RDB_MIN_FLOAT + 1,
+                    IntermediateValueModel.intermediate_value.is_(None),
                 )
             )
             .all()
@@ -102,7 +103,9 @@ def upgrade():
         mapping = []
         for r in records:
             value: float
-            if np.isclose(r.intermediate_value, RDB_MAX_FLOAT) or np.isposinf(
+            if r.intermediate_value is None or np.isnan(r.intermediate_value):
+                value = float("nan")
+            elif np.isclose(r.intermediate_value, RDB_MAX_FLOAT) or np.isposinf(
                 r.intermediate_value
             ):
                 value = float("inf")
@@ -110,8 +113,6 @@ def upgrade():
                 r.intermediate_value
             ):
                 value = float("-inf")
-            elif np.isnan(r.intermediate_value):
-                value = float("nan")
             else:
                 value = r.intermediate_value
             (

--- a/optuna/storages/_rdb/alembic/versions/v3.0.0.c.py
+++ b/optuna/storages/_rdb/alembic/versions/v3.0.0.c.py
@@ -89,7 +89,16 @@ def upgrade():
 
     session = orm.Session(bind=bind)
     try:
-        records = session.query(IntermediateValueModel).all()
+        records = (
+            session.query(IntermediateValueModel)
+            .filter(
+                sa.or_(
+                    IntermediateValueModel.intermediate_value > RDB_MAX_FLOAT - 1,
+                    IntermediateValueModel.intermediate_value < RDB_MIN_FLOAT + 1,
+                )
+            )
+            .all()
+        )
         mapping = []
         for r in records:
             value: float

--- a/optuna/storages/_rdb/alembic/versions/v3.0.0.c.py
+++ b/optuna/storages/_rdb/alembic/versions/v3.0.0.c.py
@@ -93,8 +93,8 @@ def upgrade():
             session.query(IntermediateValueModel)
             .filter(
                 sa.or_(
-                    IntermediateValueModel.intermediate_value > RDB_MAX_FLOAT - 1,
-                    IntermediateValueModel.intermediate_value < RDB_MIN_FLOAT + 1,
+                    IntermediateValueModel.intermediate_value > 1e16,
+                    IntermediateValueModel.intermediate_value < -1e16,
                     IntermediateValueModel.intermediate_value.is_(None),
                 )
             )

--- a/optuna/storages/_rdb/alembic/versions/v3.0.0.d.py
+++ b/optuna/storages/_rdb/alembic/versions/v3.0.0.d.py
@@ -102,7 +102,16 @@ def upgrade():
 
     session = orm.Session(bind=bind)
     try:
-        records = session.query(TrialValueModel).all()
+        records = (
+            session.query(TrialValueModel)
+            .filter(
+                sa.or_(
+                    TrialValueModel.value > RDB_MAX_FLOAT - 1,
+                    TrialValueModel.value < RDB_MIN_FLOAT + 1,
+                )
+            )
+            .all()
+        )
         mapping = []
         for r in records:
             value: float

--- a/optuna/storages/_rdb/alembic/versions/v3.0.0.d.py
+++ b/optuna/storages/_rdb/alembic/versions/v3.0.0.d.py
@@ -108,7 +108,6 @@ def upgrade():
                 sa.or_(
                     TrialValueModel.value > 1e16,
                     TrialValueModel.value < -1e16,
-                    TrialValueModel.value.is_(None),
                 )
             )
             .all()

--- a/optuna/storages/_rdb/alembic/versions/v3.0.0.d.py
+++ b/optuna/storages/_rdb/alembic/versions/v3.0.0.d.py
@@ -108,6 +108,7 @@ def upgrade():
                 sa.or_(
                     TrialValueModel.value > RDB_MAX_FLOAT - 1,
                     TrialValueModel.value < RDB_MIN_FLOAT + 1,
+                    TrialValueModel.value.is_(None),
                 )
             )
             .all()

--- a/optuna/storages/_rdb/alembic/versions/v3.0.0.d.py
+++ b/optuna/storages/_rdb/alembic/versions/v3.0.0.d.py
@@ -106,8 +106,8 @@ def upgrade():
             session.query(TrialValueModel)
             .filter(
                 sa.or_(
-                    TrialValueModel.value > RDB_MAX_FLOAT - 1,
-                    TrialValueModel.value < RDB_MIN_FLOAT + 1,
+                    TrialValueModel.value > 1e16,
+                    TrialValueModel.value < -1e16,
                     TrialValueModel.value.is_(None),
                 )
             )


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

Follow-up https://github.com/optuna/optuna/pull/4015

The data migration written in v3.0.0.c.py takes a long time if there are a lot of `trial_intermediate_values` records.

## Description of the changes
<!-- Describe the changes in this PR. -->
Make the data migration scripts `v3.0.0.c.py` and `v3.0.0.d.py` faster.

## Note for reviewers.

### optuna-e2e scripts

I tested this change with the following optuna-e2e's scripts.
https://github.com/c-bata/optuna-e2e/tree/optuna-303-data-migration

### About `nan` support

We may omit `nan` support since `trial.report()` accepts `nan` value from [v3.0.0-b1](https://github.com/optuna/optuna/pull/3348) and `v3.0.0.c.py` script is also added at [v3.0.0-b1](https://github.com/optuna/optuna/pull/3564). The users do not store `nan` value in their databases unless Optuna is directly installed from GitHub, not PyPI. I added support for such cases in this PR though.