### PR TITLE
Fix duplicated sampling of `SkoptSampler`

### DIFF
--- a/optuna/integration/skopt.py
+++ b/optuna/integration/skopt.py
@@ -136,6 +136,7 @@ class SkoptSampler(BaseSampler):
 
         if seed is not None and "random_state" not in self._skopt_kwargs:
             self._skopt_kwargs["random_state"] = seed
+        self._rng: Optional[np.random.RandomState] = None
 
     def reseed_rng(self) -> None:
 
@@ -177,12 +178,12 @@ class SkoptSampler(BaseSampler):
             return {}
 
         optimizer = _Optimizer(search_space, self._skopt_kwargs)
-
-        if "random_state" in self._skopt_kwargs:
-            self._skopt_kwargs["random_state"] += 1
-
+        if self._rng is not None:
+            optimizer._optimizer.rng = self._rng
         optimizer.tell(study, complete_trials)
-        return optimizer.ask()
+        params = optimizer.ask()
+        self._rng = optimizer._optimizer.rng
+        return params
 
     def sample_independent(
         self,

--- a/optuna/integration/skopt.py
+++ b/optuna/integration/skopt.py
@@ -177,6 +177,10 @@ class SkoptSampler(BaseSampler):
             return {}
 
         optimizer = _Optimizer(search_space, self._skopt_kwargs)
+
+        if "random_state" in self._skopt_kwargs:
+            self._skopt_kwargs["random_state"] += 1
+
         optimizer.tell(study, complete_trials)
         return optimizer.ask()
 


### PR DESCRIPTION
## Motivation
Fix #4022.
`SkoptSampler` samples duplicated parameters because `_Optimizer` is created using the same random seed.

## Description of the changes
Update `random_state` after creating `_Optimizer`.
