### PR TITLE
Remove warnings from `tests/visualization_tests/test_optimization_history.py`

### DIFF
--- a/tests/visualization_tests/test_optimization_history.py
+++ b/tests/visualization_tests/test_optimization_history.py
@@ -79,8 +79,9 @@ def test_ignore_failed_trials(direction: str, error_bar: bool) -> None:
 
 
 @pytest.mark.parametrize("direction", ["minimize", "maximize"])
-@pytest.mark.parametrize("target_name", ["Objective Value", "Target Name"])
-def test_get_optimization_history_info_list(direction: str, target_name: str) -> None:
+def test_get_optimization_history_info_list(direction: str) -> None:
+    target_name = "Target Name"
+
     def objective(trial: Trial) -> float:
 
         if trial.number == 0:
@@ -121,13 +122,11 @@ def test_get_optimization_history_info_list(direction: str, target_name: str) ->
 
 
 @pytest.mark.parametrize("direction", ["minimize", "maximize"])
-@pytest.mark.parametrize("target_name", ["Objective Value", "Target Name"])
-def test_get_optimization_history_info_list_with_multiple_studies(
-    direction: str, target_name: str
-) -> None:
+def test_get_optimization_history_info_list_with_multiple_studies(direction: str) -> None:
     n_studies = 10
     base_values = [1.0, 2.0, 0.0]
     base_best_values = [1.0, 1.0, 0.0] if direction == "minimize" else [1.0, 2.0, 2.0]
+    target_name = "Target Name"
 
     # Test with trials.
     studies = [create_study(direction=direction) for _ in range(n_studies)]
@@ -159,11 +158,9 @@ def test_get_optimization_history_info_list_with_multiple_studies(
 
 
 @pytest.mark.parametrize("direction", ["minimize", "maximize"])
-@pytest.mark.parametrize("target_name", ["Objective Value", "Target Name"])
-def test_get_optimization_history_info_list_with_error_bar(
-    direction: str, target_name: str
-) -> None:
+def test_get_optimization_history_info_list_with_error_bar(direction: str) -> None:
     n_studies = 10
+    target_name = "Target Name"
 
     def objective(trial: Trial) -> float:
 


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
A part of #3815.

## Description of the changes
<!-- Describe the changes in this PR. -->

Not parameterising `target_name` because the current parameters include the default value, which raises the warning, and they look unnecessary for me.