### PR TITLE
Avoid parse errors of `datetime.isoformat` strings

### DIFF
--- a/optuna/storages/_journal/storage.py
+++ b/optuna/storages/_journal/storage.py
@@ -176,7 +176,7 @@ class JournalStorage(BaseStorage):
     def create_new_trial(self, study_id: int, template_trial: Optional[FrozenTrial] = None) -> int:
         log: Dict[str, Any] = {
             "study_id": study_id,
-            "datetime_start": datetime.datetime.now().isoformat(),
+            "datetime_start": datetime.datetime.now().isoformat(timespec="microseconds"),
         }
 
         if template_trial:
@@ -188,11 +188,15 @@ class JournalStorage(BaseStorage):
                 log["value"] = template_trial.value
                 log["values"] = None
             if template_trial.datetime_start:
-                log["datetime_start"] = template_trial.datetime_start.isoformat()
+                log["datetime_start"] = template_trial.datetime_start.isoformat(
+                    timespec="microseconds"
+                )
             else:
                 log["datetime_start"] = None
             if template_trial.datetime_complete:
-                log["datetime_complete"] = template_trial.datetime_complete.isoformat()
+                log["datetime_complete"] = template_trial.datetime_complete.isoformat(
+                    timespec="microseconds"
+                )
 
             log["distributions"] = {
                 k: distribution_to_json(dist) for k, dist in template_trial.distributions.items()
@@ -249,9 +253,9 @@ class JournalStorage(BaseStorage):
         }
 
         if state == TrialState.RUNNING:
-            log["datetime_start"] = datetime.datetime.now().isoformat()
+            log["datetime_start"] = datetime.datetime.now().isoformat(timespec="microseconds")
         elif state.is_finished():
-            log["datetime_complete"] = datetime.datetime.now().isoformat()
+            log["datetime_complete"] = datetime.datetime.now().isoformat(timespec="microseconds")
 
         with self._thread_lock:
             self._write_log(JournalOperation.SET_TRIAL_STATE_VALUES, log)

--- a/tests/storages_tests/test_storages.py
+++ b/tests/storages_tests/test_storages.py
@@ -360,10 +360,14 @@ def test_create_new_trial(storage_mode: str) -> None:
 
 
 @pytest.mark.parametrize("storage_mode", STORAGE_MODES)
-def test_create_new_trial_with_template_trial(storage_mode: str) -> None:
+@pytest.mark.parametrize(
+    "start_time,complete_time",
+    [(datetime.now(), datetime.now()), (datetime(2022, 9, 1), datetime(2022, 9, 2))],
+)
+def test_create_new_trial_with_template_trial(
+    storage_mode: str, start_time: datetime, complete_time: datetime
+) -> None:
 
-    start_time = datetime.now()
-    complete_time = datetime.now()
     template_trial = FrozenTrial(
         state=TrialState.COMPLETE,
         value=10000,


### PR DESCRIPTION
## Motivation
@nzw0301 found that [CI failed](https://github.com/optuna/optuna/actions/runs/3135276095/jobs/5090771082) due to the error of `JournalStorage`. They said the dumped strings of `datetime_start` (or `datetime_complete`) could lack microseconds but `datetime_from_isoformat` function always expects them.

```python
import datetime
datetime.datetime(2022, 9, 29, 2, 27, 32, 0).isoformat()
# '2022-09-29T02:27:32'
```

https://github.com/optuna/optuna/blob/31da4d00e8f96ae2a8f7fc211ab77449b16e415b/optuna/storages/_journal/storage.py#L48-L50

@hvy suggested workarounds in https://bugs.python.org/issue40076, and this PR employs the `timespec` argument of `datetime.isoformat` to always show microseconds.

## Description of the changes

- Specify `timespec="microseconds"` to `datetime.isoformat()`
- Add test case to handle template trials with `datetime_start`/`datetime_complete` whose `microseconds` values are zero.
