### PR TITLE
Unset `PYTHONHASHSEED` for the hash-depedenet test

### DIFF
--- a/tests/samplers_tests/test_samplers.py
+++ b/tests/samplers_tests/test_samplers.py
@@ -1021,7 +1021,9 @@ def run_optimize(
 def test_reproducible_in_other_process(sampler_class_index: int) -> None:
     # This test should be tested without `PYTHONHASHSEED`. However, tox sets the
     # environmental variable "PYTHONHASHSEED" by default.
-    os.unsetenv("PYTHONHASHSEED")
+    hash_seed = os.getenv("PYTHONHASHSEED")
+    if hash_seed is not None:
+        del os.environ["PYTHONHASHSEED"]
 
     # Multiprocessing supports three way to start a process.
     # We use `spawn` option to create a child process as a fresh python process.
@@ -1040,3 +1042,6 @@ def test_reproducible_in_other_process(sampler_class_index: int) -> None:
     assert not (hash_dict[0] == hash_dict[1] == hash_dict[2])
     # But the sequences are expected to be the same.
     assert sequence_dict[0] == sequence_dict[1] == sequence_dict[2]
+
+    if hash_seed is not None:
+        os.environ["PYTHONHASHSEED"] = hash_seed

--- a/tests/samplers_tests/test_samplers.py
+++ b/tests/samplers_tests/test_samplers.py
@@ -1039,9 +1039,9 @@ def test_reproducible_in_other_process(sampler_class_index: int) -> None:
         p.start()
         p.join()
     # Hashes are expected to be different because string hashing is nondeterministic per process.
+    if hash_seed is not None:
+        os.environ["PYTHONHASHSEED"] = hash_seed
+
     assert not (hash_dict[0] == hash_dict[1] == hash_dict[2])
     # But the sequences are expected to be the same.
     assert sequence_dict[0] == sequence_dict[1] == sequence_dict[2]
-
-    if hash_seed is not None:
-        os.environ["PYTHONHASHSEED"] = hash_seed

--- a/tests/samplers_tests/test_samplers.py
+++ b/tests/samplers_tests/test_samplers.py
@@ -1,6 +1,7 @@
 from collections import OrderedDict
 import multiprocessing
 from multiprocessing.managers import DictProxy
+import os
 import pickle
 import sys
 from typing import Any
@@ -1018,6 +1019,10 @@ def run_optimize(
 
 @pytest.mark.parametrize("sampler_class_index", range(len(sampler_class_with_seed)))
 def test_reproducible_in_other_process(sampler_class_index: int) -> None:
+    # This test should be tested without `PYTHONHASHSEED`. However, tox sets the
+    # environmental variable "PYTHONHASHSEED" by default.
+    os.unsetenv("PYTHONHASHSEED")
+
     # Multiprocessing supports three way to start a process.
     # We use `spawn` option to create a child process as a fresh python process.
     # For more detail, see https://github.com/optuna/optuna/pull/3187#issuecomment-997673037.

--- a/tests/samplers_tests/test_samplers.py
+++ b/tests/samplers_tests/test_samplers.py
@@ -1019,8 +1019,9 @@ def run_optimize(
 
 @pytest.mark.parametrize("sampler_class_index", range(len(sampler_class_with_seed)))
 def test_reproducible_in_other_process(sampler_class_index: int) -> None:
-    # This test should be tested without `PYTHONHASHSEED`. However, tox sets the
-    # environmental variable "PYTHONHASHSEED" by default.
+    # This test should be tested without `PYTHONHASHSEED`. However, some tool such as tox
+    # set the environmental variable "PYTHONHASHSEED" by default.
+
     hash_seed = os.getenv("PYTHONHASHSEED")
     if hash_seed is not None:
         del os.environ["PYTHONHASHSEED"]
@@ -1038,10 +1039,11 @@ def test_reproducible_in_other_process(sampler_class_index: int) -> None:
         )
         p.start()
         p.join()
-    # Hashes are expected to be different because string hashing is nondeterministic per process.
+
     if hash_seed is not None:
         os.environ["PYTHONHASHSEED"] = hash_seed
 
+    # Hashes are expected to be different because string hashing is nondeterministic per process.
     assert not (hash_dict[0] == hash_dict[1] == hash_dict[2])
     # But the sequences are expected to be the same.
     assert sequence_dict[0] == sequence_dict[1] == sequence_dict[2]


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

Resolve https://github.com/optuna/optuna/issues/4028, which describes the motivation quite well.

## Description of the changes
<!-- Describe the changes in this PR. -->

Unset the environmental variable `PYTHONHASHSEED`. I've conformed `tox` doesn't fail anymore by adding the following lines to `tox.ini`

```
[testenv:pytest]
extras =
    test
    optional
deps =
    scikit-optimize
    cma
    botorch
commands = pytest tests/samplers_tests/test_samplers.py::test_reproducible_in_other_process
```

and run the following command on the CLI: 

```bash
tox -e pytest
```