### PR TITLE
Specify object type to numpy array init to avoid unintended str cast 

### DIFF
--- a/optuna/samplers/nsgaii/_crossover.py
+++ b/optuna/samplers/nsgaii/_crossover.py
@@ -41,7 +41,8 @@ def _try_crossover(
             [
                 [parent.params[p] for p in categorical_search_space]
                 for parent in [parents[0], parents[-1]]
-            ]
+            ],
+            dtype=object,
         )
 
         child_categorical_array = _inlined_categorical_uniform_crossover(


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

Fix the bug reported in #3982, specifically, the code shared in https://github.com/optuna/optuna/issues/3982#issuecomment-1263163810.

## Description of the changes
<!-- Describe the changes in this PR. -->

As mentioned by https://github.com/optuna/optuna/issues/3982#issuecomment-1263194047, current code casts the categorical values to `str` even elements in `choice` are not str type when values contain a str element. Such a minimal case is as follows:

```python
import numpy as np

print(np.array(["hoge", True]))
# array(['hoge', 'True'], dtype='<U5')

print(np.array(["hoge", 1]))
# array(['hoge', '1'], dtype='<U21')
```
