### PR TITLE
Add a version constraint of `matplotlib`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ def get_extras_require() -> Dict[str, List[str]]:
             "cma",
             "fvcore",
             "lightgbm",
-            "matplotlib",
+            "matplotlib!=3.6.0",
             "mlflow",
             "pandas",
             "pillow",
@@ -117,7 +117,7 @@ def get_extras_require() -> Dict[str, List[str]]:
             "xgboost",
         ],
         "optional": [
-            "matplotlib",  # optuna/visualization/matplotlib
+            "matplotlib!=3.6.0",  # optuna/visualization/matplotlib
             "pandas",  # optuna/study.py
             "plotly>=4.0.0",  # optuna/visualization.
             "redis",  # optuna/storages/redis.py.


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
As I commented https://github.com/optuna/optuna/pull/4043#issuecomment-1267991297, there is a regression bug in matplotlib 3.6.0 release.
See https://github.com/matplotlib/matplotlib/issues/23973 for details.

## Description of the changes
<!-- Describe the changes in this PR. -->
Avoid to install `matplotlib==3.6.0`.