### PR TITLE
Allow users to call `study.optimize()` in multiple threads

### DIFF
--- a/optuna/study/_optimize.py
+++ b/optuna/study/_optimize.py
@@ -61,7 +61,6 @@ def _optimize(
 
     progress_bar = pbar_module._ProgressBar(show_progress_bar, n_trials, timeout)
 
-    _in_optimize_loop.set(True)
     study._stop_flag = False
 
     try:
@@ -137,6 +136,7 @@ def _optimize_sequential(
     time_start: Optional[datetime.datetime],
     progress_bar: Optional[pbar_module._ProgressBar],
 ) -> None:
+    _in_optimize_loop.set(True)
     if reseed_sampler_rng:
         study.sampler.reseed_rng()
 

--- a/optuna/study/_optimize.py
+++ b/optuna/study/_optimize.py
@@ -52,9 +52,6 @@ def _optimize(
             "The catch argument is of type '{}' but must be a tuple.".format(type(catch).__name__)
         )
 
-    if _in_optimize_loop.get():
-        raise RuntimeError("Nested invocation of `Study.optimize` method isn't allowed.")
-
     if show_progress_bar and n_trials is None and timeout is not None and n_jobs != 1:
         warnings.warn("The timeout-based progress bar is not supported with n_jobs != 1.")
         show_progress_bar = False

--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -399,10 +399,6 @@ class Study:
                 Currently, progress bar is experimental feature and disabled
                 when ``n_trials`` is :obj:`None`, ``timeout`` not is :obj:`None`, and
                 ``n_jobs`` :math:`\\ne 1`.
-
-        Raises:
-            RuntimeError:
-                If nested invocation of this method occurs.
         """
 
         ctx = copy_context()

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ def get_install_requires() -> List[str]:
         "sqlalchemy>=1.3.0",
         "tqdm",
         "PyYAML",  # Only used in `optuna/cli.py`.
+        'contextvars;python_version<"3.7"',
     ]
     return requirements
 

--- a/tests/study_tests/test_study.py
+++ b/tests/study_tests/test_study.py
@@ -507,18 +507,6 @@ def test_copy_study_to_study_name(from_storage_mode: str, to_storage_mode: str) 
         _ = load_study(study_name="bar", storage=to_storage)
 
 
-def test_nested_optimization() -> None:
-    def objective(trial: Trial) -> float:
-
-        with pytest.raises(RuntimeError):
-            trial.study.optimize(lambda _: 0.0, n_trials=1)
-
-        return 1.0
-
-    study = create_study()
-    study.optimize(objective, n_trials=10, catch=())
-
-
 def test_stop_in_objective() -> None:
 
     # Test stopping the optimization: it should stop once the trial number reaches 4.

--- a/tests/study_tests/test_study.py
+++ b/tests/study_tests/test_study.py
@@ -1,3 +1,4 @@
+import concurrent.futures
 import copy
 import itertools
 import multiprocessing
@@ -171,6 +172,17 @@ def test_optimize_parallel(n_trials: int, n_jobs: int, storage_mode: str) -> Non
         check_study(study)
 
 
+def test_optimize_with_thread_pool_executor() -> None:
+    def objective(t: Trial) -> float:
+        return t.suggest_float("x", -10, 10)
+
+    study = create_study()
+    with concurrent.futures.ThreadPoolExecutor(max_workers=5) as pool:
+        for _ in range(10):
+            pool.submit(study.optimize, objective, n_trials=10)
+    assert len(study.trials) == 100
+
+
 @pytest.mark.parametrize(
     "n_trials, n_jobs, storage_mode",
     itertools.product(
@@ -246,6 +258,21 @@ def test_optimize_with_reseeding(n_jobs: int, storage_mode: str) -> None:
         with patch.object(sampler, "reseed_rng", wraps=sampler.reseed_rng) as mock_object:
             study.optimize(f, n_trials=1, n_jobs=2)
             assert mock_object.call_count == 1
+
+
+def test_call_another_study_optimize_in_optimize() -> None:
+    def inner_objective(t: Trial) -> float:
+        return t.suggest_float("x", -10, 10)
+
+    def objective(t: Trial) -> float:
+        inner_study = create_study()
+        inner_study.enqueue_trial({"x": t.suggest_int("initial_point", -10, 10)})
+        inner_study.optimize(inner_objective, n_trials=10)
+        return inner_study.best_value
+
+    study = create_study()
+    study.optimize(objective, n_trials=10)
+    assert len(study.trials) == 10
 
 
 @pytest.mark.parametrize("storage_mode", STORAGE_MODES)


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
Close #4049

## Description of the changes
<!-- Describe the changes in this PR. -->
Use a context variable instead of using `threading.Lock`.
https://docs.python.org/3/library/contextvars.html

In this PR, I declare a module-global variable `_in_optimize_loop` holding a `ContextVar(..., default=False)`, which is a thread-local object, and then calls `_optimize()` function inside a new context.