### PR TITLE
[Backport] Skip to add `intermediate_value_type` and `value_type` columns if exists

### DIFF
--- a/optuna/storages/_rdb/alembic/versions/v3.0.0.c.py
+++ b/optuna/storages/_rdb/alembic/versions/v3.0.0.c.py
@@ -61,6 +61,8 @@ class IntermediateValueModel(BaseModel):
 
 def upgrade():
     bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    column_names = [c["name"] for c in inspector.get_columns("trial_intermediate_values")]
 
     sa.Enum(IntermediateValueModel.TrialIntermediateValueType).create(bind, checkfirst=True)
 
@@ -68,15 +70,18 @@ def upgrade():
     # ADD COLUMN <col_name> ... DEFAULT "FINITE_OR_NAN"', but seemingly Alembic
     # does not support such a SQL statement. So first add a column with schema-level
     # default value setting, then remove it by `batch_op.alter_column()`.
-    with op.batch_alter_table("trial_intermediate_values") as batch_op:
-        batch_op.add_column(
-            sa.Column(
-                "intermediate_value_type",
-                sa.Enum("FINITE", "INF_POS", "INF_NEG", "NAN", name="trialintermediatevaluetype"),
-                nullable=False,
-                server_default="FINITE",
-            ),
-        )
+    if "intermediate_value_type" not in column_names:
+        with op.batch_alter_table("trial_intermediate_values") as batch_op:
+            batch_op.add_column(
+                sa.Column(
+                    "intermediate_value_type",
+                    sa.Enum(
+                        "FINITE", "INF_POS", "INF_NEG", "NAN", name="trialintermediatevaluetype"
+                    ),
+                    nullable=False,
+                    server_default="FINITE",
+                ),
+            )
     with op.batch_alter_table("trial_intermediate_values") as batch_op:
         batch_op.alter_column(
             "intermediate_value_type",


### PR DESCRIPTION
Skip to add `intermediate_value_type` and `value_type` columns if exists

<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
Backport https://github.com/optuna/optuna/pull/4015 for v3.0.3 release.

## Description of the changes
<!-- Describe the changes in this PR. -->
