### PR TITLE
Make TPESampler reproducible

### DIFF
--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -702,7 +702,7 @@ def _split_observation_pairs(
     # 3. Feasible trials are sorted by loss_vals.
     if violations is not None:
         violation_1d = np.array(violations, dtype=float)
-        idx = violation_1d.argsort()
+        idx = violation_1d.argsort(kind="stable")
         if n_below >= len(idx) or violation_1d[idx[n_below]] > 0:
             # Below is filled by all feasible trials and trials with smaller violation values.
             indices_below = idx[:n_below]
@@ -730,7 +730,7 @@ def _split_observation_pairs(
             [(s, v[0]) for s, v in loss_vals], dtype=[("step", float), ("score", float)]
         )
 
-        index_loss_ascending = np.argsort(loss_values)
+        index_loss_ascending = np.argsort(loss_values, kind="stable")
         # `np.sort` is used to keep chronological order.
         indices_below = np.sort(index_loss_ascending[:n_below])
         indices_above = np.sort(index_loss_ascending[n_below:])

--- a/tests/samplers_tests/test_samplers.py
+++ b/tests/samplers_tests/test_samplers.py
@@ -942,8 +942,10 @@ def test_dynamic_range_objective(
     assert all(t.state == TrialState.COMPLETE for t in study.trials)
 
 
+# We add tests for constant objective functions to ensure the reproducibility of sorting.
 @parametrize_sampler_with_seed
-def test_reproducible(sampler_class: Callable[[int], BaseSampler]) -> None:
+@pytest.mark.parametrize("objective_func", [lambda *args: sum(args), lambda *args: 0.0])
+def test_reproducible(sampler_class: Callable[[int], BaseSampler], objective_func: Any) -> None:
     def objective(trial: Trial) -> float:
         a = trial.suggest_float("a", 1, 9)
         b = trial.suggest_float("b", 1, 9, log=True)
@@ -952,7 +954,7 @@ def test_reproducible(sampler_class: Callable[[int], BaseSampler]) -> None:
         e = trial.suggest_int("e", 1, 9, log=True)
         f = trial.suggest_int("f", 1, 9, step=2)
         g = cast(int, trial.suggest_categorical("g", range(1, 10)))
-        return a + b + c + d + e + f + g
+        return objective_func(a, b, c, d, e, f, g)
 
     study = optuna.create_study(sampler=sampler_class(1))
     study.optimize(objective, n_trials=20)


### PR DESCRIPTION
## Motivation
It seems that currently `TPESampler` is not strictly reproducible because the results of `np.argsort` have randomness by default when there are multiple equal objective values. To make it reproducible, we need to specify `kind="stable"`. 

## Description of the changes
Specify `kind="stable"` to `np.argsort` in `split_observation_pairs`.
