### PR TITLE
Convert `search_space` values of `GridSampler` explicitly

### DIFF
--- a/optuna/samplers/_grid.py
+++ b/optuna/samplers/_grid.py
@@ -109,7 +109,7 @@ class GridSampler(BaseSampler):
 
         self._search_space = collections.OrderedDict()
         for param_name, param_values in sorted(search_space.items()):
-            self._search_space[param_name] = param_values
+            self._search_space[param_name] = list(param_values)
 
         self._all_grids = list(itertools.product(*self._search_space.values()))
         self._param_names = sorted(search_space.keys())

--- a/tests/samplers_tests/test_grid.py
+++ b/tests/samplers_tests/test_grid.py
@@ -16,6 +16,7 @@ from optuna import samplers
 from optuna.samplers._grid import GridValueType
 from optuna.storages import RetryFailedTrialCallback
 from optuna.testing.objectives import pruned_objective
+from optuna.testing.storages import StorageSupplier
 from optuna.trial import Trial
 
 
@@ -95,6 +96,27 @@ def test_study_optimize_with_pruning() -> None:
     study = optuna.create_study(sampler=samplers.GridSampler(search_space))
     study.optimize(pruned_objective, n_trials=None)
     assert len(study.trials) == 2
+
+
+def test_study_optimize_with_numpy_related_search_space() -> None:
+    def objective(trial: Trial) -> float:
+
+        a = trial.suggest_float("a", 0, 10)
+        b = trial.suggest_float("b", -0.1, 0.1)
+
+        return a + b
+
+    # Test that all combinations of the grid is sampled.
+    search_space = {
+        "a": np.linspace(0, 10, 11),
+        "b": np.arange(-0.1, 0.1, 0.05),
+    }
+    with StorageSupplier("sqlite") as storage:
+        study = optuna.create_study(  # type: ignore
+            sampler=samplers.GridSampler(search_space),
+            storage=storage,
+        )
+        study.optimize(objective, n_trials=None)
 
 
 def test_study_optimize_with_multiple_search_spaces() -> None:

--- a/tests/samplers_tests/test_grid.py
+++ b/tests/samplers_tests/test_grid.py
@@ -112,8 +112,8 @@ def test_study_optimize_with_numpy_related_search_space() -> None:
         "b": np.arange(-0.1, 0.1, 0.05),
     }
     with StorageSupplier("sqlite") as storage:
-        study = optuna.create_study(  # type: ignore
-            sampler=samplers.GridSampler(search_space),
+        study = optuna.create_study(
+            sampler=samplers.GridSampler(search_space),  # type: ignore
             storage=storage,
         )
         study.optimize(objective, n_trials=None)


### PR DESCRIPTION
## Motivation

See #4058 .
In addition, I found that `study.optimize` raised errors when I use `RDBStorage` with search space defined with `numpy` functions such as `np.arange` and `np.linspace`.

```console
    def test_study_optimize_with_numpy_related_search_space() -> None:
        def objective(trial: Trial) -> float:
    
            a = trial.suggest_float("a", 0, 100)
            b = trial.suggest_float("b", -0.1, 0.1)
            return a + b
    
        # Test that all combinations of the grid is sampled.
        search_space = {
            "a": np.linspace(0, 10, 11),
            "b": np.arange(-0.1, 0.1, 0.05),
        }
        with StorageSupplier("sqlite") as storage:
            study = optuna.create_study(  # type: ignore
                sampler=samplers.GridSampler(search_space),
                storage=storage,
            )
>           study.optimize(objective, n_trials=None)
...
self = <json.encoder.JSONEncoder object at 0x7f0cbdf50ca0>, o = array([ 0.,  1.,  2.,  3.,  4.,  5.,  6.,  7.,  8.,  9., 10.])

    def default(self, o):
        """Implement this method in a subclass such that it returns
        a serializable object for ``o``, or calls the base implementation
        (to raise a ``TypeError``).
    
        For example, to support arbitrary iterators, you could
        implement default like this::
    
            def default(self, o):
                try:
                    iterable = iter(o)
                except TypeError:
                    pass
                else:
                    return list(iterable)
                # Let the base class default method raise the TypeError
                return JSONEncoder.default(self, o)
    
        """
>       raise TypeError(f'Object of type {o.__class__.__name__} '
                        f'is not JSON serializable')
E       TypeError: Object of type ndarray is not JSON serializable

/usr/lib/python3.8/json/encoder.py:179: TypeError
```

This is due to `np.arange` and `np.linspace` return `np.ndarray`, which is not json-serializable.
Users should cast them to lists by themselves, but I guess `GridSampler` will be more user-friendly if we take care of this issue.

## Description of the changes

- Cast values of `search_space` mapping of `GridSampler.__init__` to `list`
- Add a test case