### PR TITLE
Close stale issues immediately after labeling `stale`

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -18,8 +18,8 @@ jobs:
         stale-pr-message: 'This pull request has not seen any recent activity.'
         close-issue-message: 'This issue was closed automatically because it had not seen any recent activity. If you want to discuss it, you can reopen it freely.'
         close-pr-message: 'This pull request was closed automatically because it had not seen any recent activity. If you want to discuss it, you can reopen it freely.'
-        days-before-issue-stale: 14
-        days-before-issue-close: 100
+        days-before-issue-stale: 100
+        days-before-issue-close: 0
         days-before-pr-stale: 7
         days-before-pr-close: 14
         stale-issue-label: 'stale'


### PR DESCRIPTION
This PR changes `days-before-issue-stale` and `days-before-issue-close` so that an issue is immediately closed after the bot's labeling `stale`. 

## Motivation
The `stale` label has not been cared in recent communication in Optuna issues, and become noises both for the users and maintainers. Thus, this PR abolishes the stale term of open issues. Instead of maintaining inactive issues with `stale`, we suggest the users and maintainers not to hesitate reopening the closed issue if it's still alive.

## Description of the changes
- Make `days-before-issue-close` `0`
- Move `days-before-issue-close` number, `100`, to `days-before-issue-stale`

