### PR TITLE
Add a flush to `JournalFileStorage.append_logs`

### DIFF
--- a/optuna/storages/_journal/file.py
+++ b/optuna/storages/_journal/file.py
@@ -192,4 +192,5 @@ class JournalFileStorage(BaseJournalLogStorage):
             what_to_write = "\n".join([json.dumps(log) for log in logs]) + "\n"
             with open(self._file_path, "a", encoding="utf-8") as f:
                 f.write(what_to_write)
+                f.flush()
                 os.fsync(f.fileno())


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
According to the [reference](https://docs.python.org/3.10/library/os.html#os.fsync), if we want to write all internal buffers associated with `f` to disk, we should do `f.flush()` and then do `os.fsync(f.fileno())`. I suggest to add `f.flush()` before `os.fsync(f.fileno())`.

## Description of the changes
<!-- Describe the changes in this PR. -->

Add `f.flush()` before `os.fsync(f.fileno())`.
