### PR TITLE
Fix metric inconsistency between bayesmark plots and report

### DIFF
--- a/benchmarks/run_bayesmark.py
+++ b/benchmarks/run_bayesmark.py
@@ -92,25 +92,21 @@ def make_plot(
 ) -> None:
 
     start = 0 if plot_warmup else 10
-    argpos = summary.best_mean.expanding().apply(np.argmin).astype(int)
-    best_found = summary.best_mean.values[argpos.values]
-    sdev = summary.best_std.values[argpos.values]
-
-    if len(best_found) <= start:
+    if len(summary.best_mean) <= start:
         return
 
     ax.fill_between(
-        np.arange(len(best_found))[start:],
-        (best_found - sdev)[start:],
-        (best_found + sdev)[start:],
+        np.arange(len(summary.best_mean))[start:],
+        (summary.best_mean - summary.best_std)[start:],
+        (summary.best_mean + summary.best_std)[start:],
         color=color,
         alpha=0.25,
         step="mid",
     )
 
     ax.plot(
-        np.arange(len(best_found))[start:],
-        best_found[start:],
+        np.arange(len(summary.best_mean))[start:],
+        summary.best_mean[start:],
         color=color,
         label=optimizer,
         drawstyle="steps-mid",

--- a/benchmarks/run_bayesmark.py
+++ b/benchmarks/run_bayesmark.py
@@ -58,9 +58,10 @@ def make_plots(args: argparse.Namespace) -> None:
 
     filename = f"{args.dataset}-{args.model}-partial-report.json"
     df = pd.read_json(os.path.join("partial", filename))
+    df["best_value"] = df.groupby(["opt", "uuid"]).generalization.cummin()
     summaries = (
         df.groupby(["opt", "iter"])
-        .generalization.agg(["mean", "std"])
+        .best_value.agg(["mean", "std"])
         .rename(columns={"mean": "best_mean", "std": "best_std"})
         .reset_index()
     )


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
Plots should show statistics of best generalization errors observed up to specific iteration (best value metric), instead of generalization errors at specific iteration.

Closes #4066 where this issue was raised and discussed.

## Description of the changes
<!-- Describe the changes in this PR. -->
* [x] Fixed metric displayed on plots generated by bayesmark benchmark.

## Examples
### Before
![image](https://user-images.githubusercontent.com/37713008/195642649-a5e5ed44-8a94-4c8e-860d-86cfab3d829c.png)
![image](https://user-images.githubusercontent.com/37713008/195642669-b87ac470-dcb8-4a0c-ab4a-542005ab8cfa.png)


### After
![Screenshot from 2022-10-13 17-43-10](https://user-images.githubusercontent.com/37713008/195643190-6c881452-d52c-4c06-88d4-33211d2655e9.png)
![optuna-wine-SVM-sumamry](https://user-images.githubusercontent.com/37713008/195643308-be4065a2-5323-4b74-9310-52d144156e7a.png)

