### PR TITLE
Replace gitter with GitHub Discussions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ We want to
 - implement features that make what you want to do possible and/or easy.
 - write more tutorials and [examples](https://github.com/optuna/optuna-examples) that help you get familiar with Optuna.
 - make issues and pull requests on GitHub fruitful.
-- have more conversations and discussions on Gitter.
+- have more conversations and discussions on [GitHub Discussions](https://github.com/optuna/optuna/discussions).
 
 We need your help and everything about Optuna you have in your mind pushes this project forward.
 Join Us!
@@ -23,7 +23,7 @@ If you feel like giving a hand, here are some ways:
 - Fix/Improve documentation
     - Documentation gets outdated easily and can always be better, so feel free to fix and improve
 - Let us and the Optuna community know your ideas and thoughts.
-    - __Contribution to Optuna includes not only sending pull requests, but also writing down your comments on issues and pull requests by others, and joining conversations/discussions on [Gitter](https://gitter.im/optuna/optuna).__
+    - __Contribution to Optuna includes not only sending pull requests, but also writing down your comments on issues and pull requests by others, and joining conversations/discussions on [GitHub Discussions](https://github.com/optuna/optuna/discussions).__
     - Also, sharing how you enjoy Optuna is a huge contribution! If you write a blog, let us know about it!
 
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@
 [![CircleCI](https://circleci.com/gh/optuna/optuna.svg?style=svg)](https://circleci.com/gh/optuna/optuna)
 [![Read the Docs](https://readthedocs.org/projects/optuna/badge/?version=stable)](https://optuna.readthedocs.io/en/stable/)
 [![Codecov](https://codecov.io/gh/optuna/optuna/branch/master/graph/badge.svg)](https://codecov.io/gh/optuna/optuna/branch/master)
-[![Gitter chat](https://badges.gitter.im/optuna/gitter.svg)](https://gitter.im/optuna/optuna)
 
 [**Website**](https://optuna.org/)
 | [**Docs**](https://optuna.readthedocs.io/en/stable/)
@@ -146,13 +145,9 @@ Also, we also provide Optuna docker images on [DockerHub](https://hub.docker.com
 
 - [GitHub Discussions] for questions.
 - [GitHub Issues] for bug reports and feature requests.
-- [Gitter] for interactive chat with developers.
-- [Stack Overflow] for questions.
 
 [GitHub Discussions]: https://github.com/optuna/optuna/discussions
 [GitHub issues]: https://github.com/optuna/optuna/issues
-[Gitter]: https://gitter.im/optuna/optuna
-[Stack Overflow]: https://stackoverflow.com/questions/tagged/optuna
 
 
 ## Contribution

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -82,13 +82,9 @@ optimization *studies*.
 Communication
 -------------
 
+-  `GitHub Discussions <https://github.com/optuna/optuna/discussions>`__ for questions.
 -  `GitHub Issues <https://github.com/optuna/optuna/issues>`__ for bug
-   reports, feature requests and questions.
--  `Gitter <https://gitter.im/optuna/optuna>`__ for interactive chat
-   with developers.
--  `Stack
-   Overflow <https://stackoverflow.com/questions/tagged/optuna>`__ for
-   questions.
+   reports and feature requests.
 
 Contribution
 ------------


### PR DESCRIPTION
## Motivation
The purpose of this PR is to gather the communication place into GitHub Discussions and Issues.

## Description of the changes
- Remove gitter and Stack Overflow from the document
- Recommend GitHub Discussions instead of gitter