### PR TITLE
Deprecate description-checked label

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -24,6 +24,6 @@ jobs:
         days-before-pr-close: 14
         stale-issue-label: 'stale'
         stale-pr-label: 'stale'
-        exempt-issue-labels: 'no-stale,description-checked'
+        exempt-issue-labels: 'no-stale'
         exempt-pr-labels: 'no-stale'
         operations-per-run: 1000


### PR DESCRIPTION
This PR deprecates `description-checked` label. Since we no longer use the label in the issue operation, let's remove it from `exempt-issue-labels` in `stale.yml`.