### PR TITLE
Make `days-before-issue-stale` 300 days

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -18,7 +18,7 @@ jobs:
         stale-pr-message: 'This pull request has not seen any recent activity.'
         close-issue-message: 'This issue was closed automatically because it had not seen any recent activity. If you want to discuss it, you can reopen it freely.'
         close-pr-message: 'This pull request was closed automatically because it had not seen any recent activity. If you want to discuss it, you can reopen it freely.'
-        days-before-issue-stale: 100
+        days-before-issue-stale: 300
         days-before-issue-close: 0
         days-before-pr-stale: 7
         days-before-pr-close: 14


### PR DESCRIPTION
This PR is for a minor change in our issue operation, changing `days-before-issue-stale` from `100` to `300`. We think the current number of days, `100`, is a bit short for a typical issue lifecycle especially about `contribution-welcome`.