### PR TITLE
Add more stats (`best_trial`, `best_value`) to tqdm's progress bar

### DIFF
--- a/optuna/progress_bar.py
+++ b/optuna/progress_bar.py
@@ -89,14 +89,14 @@ class _ProgressBar:
             elapsed_seconds:
                 The time past since :func:`~optuna.study.Study.optimize` started.
             study:
-                The current study object
+                The current study object.
         """
 
-        if not study._is_multi_objective():
-            msg = f"Best trial: {study.best_trial.number}. Best value: {study.best_value}"
-            self._progress_bar.set_description(msg)
-
         if self._is_valid:
+            if not study._is_multi_objective():
+                msg = f"Best trial: {study.best_trial.number}. Best value: {study.best_value}"
+                self._progress_bar.set_description(msg)
+
             if self._n_trials is not None:
                 self._progress_bar.update(1)
                 if self._timeout is not None:

--- a/optuna/progress_bar.py
+++ b/optuna/progress_bar.py
@@ -75,15 +75,25 @@ class _ProgressBar:
         optuna_logging.disable_default_handler()
         optuna_logging._get_library_root_logger().addHandler(_tqdm_handler)
 
-    def update(self, elapsed_seconds: float) -> None:
+    def update(self, elapsed_seconds: float, best_trial: int, best_value: Optional[float]) -> None:
         """Update the progress bars if ``is_valid`` is :obj:`True`.
 
         Args:
             elapsed_seconds:
                 The time past since :func:`~optuna.study.Study.optimize` started.
+            best_trial:
+                The number of the current best trial.
+            best_value:
+                The score of the current best trial.
         """
 
         if self._is_valid:
+            if self._n_trials is None and self._timeout is None:
+                assert False
+
+            msg = f"Best trial: {best_trial}. Best value: {best_value}"
+            self._progress_bar.set_description(msg)
+
             if self._n_trials is not None:
                 self._progress_bar.update(1)
                 if self._timeout is not None:
@@ -99,9 +109,6 @@ class _ProgressBar:
 
                 self._progress_bar.update(time_diff)
                 self._last_elapsed_seconds = elapsed_seconds
-
-            else:
-                assert False
 
     def close(self) -> None:
         """Close progress bars."""

--- a/optuna/progress_bar.py
+++ b/optuna/progress_bar.py
@@ -8,6 +8,7 @@ from tqdm.auto import tqdm
 from optuna import logging as optuna_logging
 from optuna._experimental import experimental_func
 
+
 if TYPE_CHECKING:
     from optuna.study import Study
 

--- a/optuna/progress_bar.py
+++ b/optuna/progress_bar.py
@@ -1,12 +1,15 @@
 import logging
 from typing import Any
 from typing import Optional
+from typing import TYPE_CHECKING
 
 from tqdm.auto import tqdm
 
 from optuna import logging as optuna_logging
 from optuna._experimental import experimental_func
 
+if TYPE_CHECKING:
+    from optuna.study import Study
 
 _tqdm_handler: Optional["_TqdmLoggingHandler"] = None
 
@@ -37,7 +40,10 @@ class _ProgressBar:
     """
 
     def __init__(
-        self, is_valid: bool, n_trials: Optional[int] = None, timeout: Optional[float] = None
+        self,
+        is_valid: bool,
+        n_trials: Optional[int] = None,
+        timeout: Optional[float] = None,
     ) -> None:
 
         self._is_valid = is_valid and (n_trials or timeout) is not None
@@ -75,25 +81,21 @@ class _ProgressBar:
         optuna_logging.disable_default_handler()
         optuna_logging._get_library_root_logger().addHandler(_tqdm_handler)
 
-    def update(self, elapsed_seconds: float, best_trial: int, best_value: Optional[float]) -> None:
+    def update(self, elapsed_seconds: float, study: "Study") -> None:
         """Update the progress bars if ``is_valid`` is :obj:`True`.
 
         Args:
             elapsed_seconds:
                 The time past since :func:`~optuna.study.Study.optimize` started.
-            best_trial:
-                The number of the current best trial.
-            best_value:
-                The score of the current best trial.
+            study:
+                The current study object
         """
 
-        if self._is_valid:
-            if self._n_trials is None and self._timeout is None:
-                assert False
-
-            msg = f"Best trial: {best_trial}. Best value: {best_value}"
+        if not study._is_multi_objective():
+            msg = f"Best trial: {study.best_trial.number}. Best value: {study.best_value}"
             self._progress_bar.set_description(msg)
 
+        if self._is_valid:
             if self._n_trials is not None:
                 self._progress_bar.update(1)
                 if self._timeout is not None:
@@ -109,6 +111,9 @@ class _ProgressBar:
 
                 self._progress_bar.update(time_diff)
                 self._last_elapsed_seconds = elapsed_seconds
+
+            else:
+                assert False
 
     def close(self) -> None:
         """Close progress bars."""

--- a/optuna/study/_optimize.py
+++ b/optuna/study/_optimize.py
@@ -174,7 +174,11 @@ def _optimize_sequential(
                 callback(study, frozen_trial)
 
         if progress_bar is not None:
-            progress_bar.update((datetime.datetime.now() - time_start).total_seconds())
+            elapsed_seconds = (datetime.datetime.now() - time_start).total_seconds()
+            best_trial = study.best_trial.number
+            best_value = study.best_trial.value
+
+            progress_bar.update(elapsed_seconds, best_trial, best_value)
 
     study._storage.remove_session()
 

--- a/optuna/study/_optimize.py
+++ b/optuna/study/_optimize.py
@@ -175,10 +175,7 @@ def _optimize_sequential(
 
         if progress_bar is not None:
             elapsed_seconds = (datetime.datetime.now() - time_start).total_seconds()
-            best_trial = study.best_trial.number
-            best_value = study.best_trial.value
-
-            progress_bar.update(elapsed_seconds, best_trial, best_value)
+            progress_bar.update(elapsed_seconds, study)
 
     study._storage.remove_session()
 


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
This PR tries to address #3661. Namely, it adds `best_trial` and `best_value` (from the `study` object) to tqdm's progress bar, on each update.

## Description of the changes
Namely, it adds `best_trial` and `best_value` (from the `study` object) to tqdm's progress bar, on each update.
