### PR TITLE
Add a lock to `MLflowCallback`.

### DIFF
--- a/tests/integration_tests/test_mlflow.py
+++ b/tests/integration_tests/test_mlflow.py
@@ -279,6 +279,14 @@ def test_multiple_jobs(tmpdir: py.path.local, n_jobs: int) -> None:
     study = optuna.create_study(study_name=study_name)
     study.optimize(_objective_func, n_trials=n_trials, callbacks=[mlflc], n_jobs=n_jobs)
 
+    mlfl_client = MlflowClient(tracking_uri)
+    assert len(mlfl_client.list_experiments()) == 1
+
+    experiment = mlfl_client.list_experiments()[0]
+    runs = mlfl_client.list_run_infos(experiment.experiment_id)
+
+    assert len(runs) == n_trials
+
 
 def test_mlflow_callback_fails_when_nest_trials_is_false_and_active_run_exists(
     tmpdir: py.path.local,

--- a/tests/integration_tests/test_mlflow.py
+++ b/tests/integration_tests/test_mlflow.py
@@ -393,11 +393,12 @@ def test_log_mlflow_tags(tmpdir: py.path.local) -> None:
     assert all([tags[key] == str(value) for key, value in expected_tags.items()])
 
 
-def test_track_in_mlflow_decorator(tmpdir: py.path.local) -> None:
+@pytest.mark.parametrize("n_jobs", [1, 2, 4, 6])
+def test_track_in_mlflow_decorator(tmpdir: py.path.local, n_jobs: int) -> None:
 
     tracking_uri = f"file:{tmpdir}"
     study_name = "my_study"
-    n_trials = 3
+    n_trials = n_jobs * 2
 
     metric_name = "additional_metric"
     metric = 3.14
@@ -418,7 +419,7 @@ def test_track_in_mlflow_decorator(tmpdir: py.path.local) -> None:
     tracked_objective = mlflc.track_in_mlflow()(_objective_func)
 
     study = optuna.create_study(study_name=study_name)
-    study.optimize(tracked_objective, n_trials=n_trials, callbacks=[mlflc])
+    study.optimize(tracked_objective, n_trials=n_trials, callbacks=[mlflc], n_jobs=n_jobs)
 
     mlfl_client = MlflowClient(tracking_uri)
     experiments = mlfl_client.list_experiments()

--- a/tests/integration_tests/test_mlflow.py
+++ b/tests/integration_tests/test_mlflow.py
@@ -393,7 +393,7 @@ def test_log_mlflow_tags(tmpdir: py.path.local) -> None:
     assert all([tags[key] == str(value) for key, value in expected_tags.items()])
 
 
-@pytest.mark.parametrize("n_jobs", [1, 2, 4, 6])
+@pytest.mark.parametrize("n_jobs", [1, 2, 4])
 def test_track_in_mlflow_decorator(tmpdir: py.path.local, n_jobs: int) -> None:
 
     tracking_uri = f"file:{tmpdir}"

--- a/tests/integration_tests/test_mlflow.py
+++ b/tests/integration_tests/test_mlflow.py
@@ -268,6 +268,18 @@ def test_nest_trials(tmpdir: py.path.local) -> None:
     assert all(set(r.data.metrics.keys()) == {"value"} for r in child_runs)
 
 
+@pytest.mark.parametrize("n_jobs", [2, 4, 6])
+def test_multiple_jobs(tmpdir: py.path.local, n_jobs: int) -> None:
+    tracking_uri = f"file:{tmpdir}"
+    study_name = "my_study"
+    # The race-condition usually happens after first trial for each job
+    n_trials = n_jobs * 2
+
+    mlflc = MLflowCallback(tracking_uri=tracking_uri)
+    study = optuna.create_study(study_name=study_name)
+    study.optimize(_objective_func, n_trials=n_trials, callbacks=[mlflc], n_jobs=n_jobs)
+
+
 def test_mlflow_callback_fails_when_nest_trials_is_false_and_active_run_exists(
     tmpdir: py.path.local,
 ) -> None:

--- a/tests/integration_tests/test_mlflow.py
+++ b/tests/integration_tests/test_mlflow.py
@@ -268,7 +268,7 @@ def test_nest_trials(tmpdir: py.path.local) -> None:
     assert all(set(r.data.metrics.keys()) == {"value"} for r in child_runs)
 
 
-@pytest.mark.parametrize("n_jobs", [2, 4, 6])
+@pytest.mark.parametrize("n_jobs", [2, 4])
 def test_multiple_jobs(tmpdir: py.path.local, n_jobs: int) -> None:
     tracking_uri = f"file:{tmpdir}"
     study_name = "my_study"


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
Fix #4088.

Optuna uses mlflow fluent API which is not threadsafe.
There is a way to use [Tracking API](https://mlflow.org/docs/latest/python_api/mlflow.client.html#module-mlflow.client) as mentioned in [this issue](https://github.com/mlflow/mlflow/issues/3592).
Instead of using Tracking API, I choose `threading.Lock()` to lock entire mlflow functions in order to avoid race-condition for simplicity.


## Description of the changes
Add a lock to `MLflowCallback` not to race-condition.
