### PR TITLE
Add device argument to BoTorchSampler

### DIFF
--- a/optuna/integration/botorch.py
+++ b/optuna/integration/botorch.py
@@ -387,7 +387,8 @@ class BoTorchSampler(BaseSampler):
         seed:
             Seed for random number generator.
         device:
-            PyTorch's device instance to store input and output data of BoTorch.
+            A ``torch.device`` to store input and output data of BoTorch. Please set a CUDA device
+            if you fasten sampling.
     """
 
     def __init__(
@@ -408,7 +409,7 @@ class BoTorchSampler(BaseSampler):
         n_startup_trials: int = 10,
         independent_sampler: Optional[BaseSampler] = None,
         seed: Optional[int] = None,
-        device: "torch.device" = torch.device("cpu"),
+        device: Optional["torch.device"] = None,
     ):
         _imports.check()
 
@@ -420,7 +421,7 @@ class BoTorchSampler(BaseSampler):
 
         self._study_id: Optional[int] = None
         self._search_space = IntersectionSearchSpace()
-        self._device = device
+        self._device = device if device is not None else torch.device("cpu")
 
     def infer_relative_search_space(
         self,

--- a/optuna/integration/botorch.py
+++ b/optuna/integration/botorch.py
@@ -386,6 +386,8 @@ class BoTorchSampler(BaseSampler):
             conditional.
         seed:
             Seed for random number generator.
+        device:
+            PyTorch's device instance to store input and output data of BoTorch.
     """
 
     def __init__(
@@ -406,6 +408,7 @@ class BoTorchSampler(BaseSampler):
         n_startup_trials: int = 10,
         independent_sampler: Optional[BaseSampler] = None,
         seed: Optional[int] = None,
+        device: "torch.device" = torch.device("cpu"),
     ):
         _imports.check()
 
@@ -417,6 +420,7 @@ class BoTorchSampler(BaseSampler):
 
         self._study_id: Optional[int] = None
         self._search_space = IntersectionSearchSpace()
+        self._device = device
 
     def infer_relative_search_space(
         self,
@@ -505,11 +509,11 @@ class BoTorchSampler(BaseSampler):
                     "constraints. Constraints passed to `candidates_func` will contain NaN."
                 )
 
-        values = torch.from_numpy(values)
-        params = torch.from_numpy(params)
+        values = torch.from_numpy(values).to(self._device)
+        params = torch.from_numpy(params).to(self._device)
         if con is not None:
-            con = torch.from_numpy(con)
-        bounds = torch.from_numpy(bounds)
+            con = torch.from_numpy(con).to(self._device)
+        bounds = torch.from_numpy(bounds).to(self._device)
 
         if con is not None:
             if con.dim() == 1:
@@ -546,7 +550,7 @@ class BoTorchSampler(BaseSampler):
                 f"{candidates.size(0)}, bounds: {bounds.size(1)}."
             )
 
-        return trans.untransform(candidates.numpy())
+        return trans.untransform(candidates.cpu().numpy())
 
     def sample_independent(
         self,

--- a/optuna/integration/botorch.py
+++ b/optuna/integration/botorch.py
@@ -419,7 +419,7 @@ class BoTorchSampler(BaseSampler):
 
         self._study_id: Optional[int] = None
         self._search_space = IntersectionSearchSpace()
-        self._device = device if device is not None else torch.device("cpu")
+        self._device = device or torch.device("cpu")
 
     def infer_relative_search_space(
         self,

--- a/optuna/integration/botorch.py
+++ b/optuna/integration/botorch.py
@@ -328,8 +328,6 @@ def _get_default_candidates_func(
         return qei_candidates_func
 
 
-# TODO(hvy): Allow utilizing GPUs via some parameter, not having to rewrite the callback
-# functions.
 @experimental_class("2.4.0")
 class BoTorchSampler(BaseSampler):
     """A sampler that uses BoTorch, a Bayesian optimization library built on top of PyTorch.


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

Resolve https://github.com/optuna/optuna/issues/4096.

## Description of the changes
<!-- Describe the changes in this PR. -->

Add `device` argument to `BoTorchSampler` and send input data of BoTorch's candidate functions to the device.


Naive benchmark results on Google colab were 1 min (GPU) vs 2 min (CPU). The code I used as follows:


```python
import torch
import optuna
from optuna.integration import BoTorchSampler


def o(t):
    for i in range(30):
        t.suggest_int(f"x_{i}", -100, 100)
        t.suggest_categorical(f"y_{i}", list(range(-100, 100)))

    return t.suggest_float("z", 1e-4, 10000, log=True)

# GPU
s = optuna.create_study(sampler=BoTorchSampler(device=torch.device("cuda:0")))
s.optimize(o, n_trials=50) # about 1 min

# CPU
s = optuna.create_study(sampler=BoTorchSampler(device=torch.device("cpu")))
s.optimize(o, n_trials=50) # about 2 min
```

## [updated]

The colab notebook is available at https://colab.research.google.com/drive/1PMfHH2ZlZ_FL1aFez5V56XzUmAFM2eil?usp=sharing.