### PR TITLE
Avoid running `Tests` and `Tests (Storage with server)` with Python 3.6 to pass the CI

### DIFF
--- a/.github/workflows/tests-storage.yml
+++ b/.github/workflows/tests-storage.yml
@@ -21,7 +21,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
 
     services:
       mysql:
@@ -64,8 +64,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-      env:
-        AGENT_TOOLSDIRECTORY: /opt/hostedtoolcache
 
     - name: Setup cache
       uses: actions/cache@v2

--- a/.github/workflows/tests-storage.yml
+++ b/.github/workflows/tests-storage.yml
@@ -17,11 +17,11 @@ jobs:
   # RDB. Since current name "tests-rdbstorage" is required in the Branch protection rules, you
   # need to modify the Branch protection rules as well.
   tests-rdbstorage:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
 
     services:
       mysql:

--- a/.github/workflows/tests-storage.yml
+++ b/.github/workflows/tests-storage.yml
@@ -64,6 +64,8 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+      env:
+        AGENT_TOOLSDIRECTORY: /opt/hostedtoolcache
 
     - name: Setup cache
       uses: actions/cache@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,11 +14,11 @@ concurrency:
 
 jobs:
   tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
 
     services:
       redis:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,6 +37,8 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+      env:
+        AGENT_TOOLSDIRECTORY: /opt/hostedtoolcache
 
     - name: Setup cache
       uses: actions/cache@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.6.15', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
 
     services:
       redis:
@@ -31,17 +31,17 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Setup Python${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
       env:
         AGENT_TOOLSDIRECTORY: /opt/hostedtoolcache
 
     - name: Setup cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       env:
         cache-name: test
       with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
 
     services:
       redis:
@@ -31,17 +31,15 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v2
 
     - name: Setup Python${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-      env:
-        AGENT_TOOLSDIRECTORY: /opt/hostedtoolcache
 
     - name: Setup cache
-      uses: actions/cache@v3
+      uses: actions/cache@v2
       env:
         cache-name: test
       with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.6.15', '3.7', '3.8', '3.9', '3.10']
 
     services:
       redis:


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
~Fix the CI error in the master. According to https://github.com/actions/setup-python/issues/401#issuecomment-1150571132, we should add an environment variable `AGENT_TOOLSDIRECTORY`. The error seems to be fixed in my [forked repo](https://github.com/HideakiImamura/optuna/pull/3).~ This is a fix for the self-hosted runners. Sorry for the confusion.

The current CI of the master branch fails due to the installation fail of Python 3.6. This is because that the `ubuntu-latest` has been changed from `20.04` to `22.04`. So, I will pin the version to `20.04` in the failing workflow: `Tests` and `Tests (Storage with server)`. 

## Description of the changes
<!-- Describe the changes in this PR. -->
- Pin ubuntu version to `20.04` in the CI workflows `Tests` and `Tests (Storage with server)`.
