### PR TITLE
Skip `test_pop_waiting_trial_thread_safe` on RedisStorage

### DIFF
--- a/tests/study_tests/test_study.py
+++ b/tests/study_tests/test_study.py
@@ -1589,6 +1589,10 @@ def test_pop_waiting_trial_thread_safe(storage_mode: str) -> None:
     if "sqlite" == storage_mode or "cached_sqlite" == storage_mode:
         pytest.skip("study._pop_waiting_trial is not thread-safe on SQLite3")
 
+    if "redis" == storage_mode:
+        # TODO(c-bata): Make RedisStorage.set_trial_state_values() concurrent-safe.
+        pytest.skip("study._pop_waiting_trial is broken at RedisStorage")
+
     num_enqueued = 10
     with StorageSupplier(storage_mode) as storage:
         study = create_study(storage=storage)


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
In https://github.com/optuna/optuna/pull/4118, `test_pop_waiting_trial_thread_safe` is failed with `RedisStorage`.

> =========================== short test summary info ============================
> FAILED tests/study_tests/test_study.py::test_pop_waiting_trial_thread_safe[redis] - assert 1 == 10
>  +  where 1 = len({0})
> ==== 1 failed, 4325 passed, 37 skipped, 2031 warnings in 1242.91s (0:20:42) ====
> https://github.com/optuna/optuna/actions/runs/3392185067/jobs/5638086168


## Description of the changes
<!-- Describe the changes in this PR. -->
Skip `test_pop_waiting_trial_thread_safe` on RedisStorage.