### PR TITLE
OptunaSearchCV rejects deprecated distributions in param_distributions

### DIFF
--- a/optuna/integration/sklearn.py
+++ b/optuna/integration/sklearn.py
@@ -713,12 +713,16 @@ class OptunaSearchCV(BaseEstimator):
         if not isinstance(param_distributions, dict):
             raise TypeError("param_distributions must be a dictionary.")
 
-        # TODO(himkt): Remove this method with the deletion of deprecated distributions.
-        # https://github.com/optuna/optuna/issues/2941
-        param_distributions = {
-            key: _convert_old_distribution_to_new_distribution(dist)
-            for key, dist in param_distributions.items()
-        }
+        # Rejecting deprecated distributions as they may cause cryptic error
+        # when cloning OptunaSearchCV instance.
+        # https://github.com/optuna/optuna/issues/4084
+        for key, dist in param_distributions.items():
+            if dist != _convert_old_distribution_to_new_distribution(dist):
+                raise ValueError(
+                    f"Deprecated distribution is specified in `{key}` of param_distributions. "
+                    "Rejecting this because it may cause unexpected behavior. "
+                    "Please use new distributions such as FloatDistribution etc."
+                )
 
         self.cv = cv
         self.enable_pruning = enable_pruning

--- a/tests/integration_tests/test_sklearn.py
+++ b/tests/integration_tests/test_sklearn.py
@@ -331,12 +331,11 @@ def test_optuna_search_convert_deprecated_distribution() -> None:
         "ild": distributions.IntDistribution(low=1, high=10, log=True, step=1),
     }
 
-    optuna_search = integration.OptunaSearchCV(
-        KernelDensity(),
-        param_dist,
-    )
-
-    assert optuna_search.param_distributions == expected_param_dist
+    with pytest.raises(ValueError):
+        optuna_search = integration.OptunaSearchCV(
+            KernelDensity(),
+            param_dist,
+        )
 
     # It confirms that ask doesn't convert non-deprecated distributions.
     optuna_search = integration.OptunaSearchCV(


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
OptunaSearchCV constructed with deprecated distributions in param_distributions throws an exception when it is cloned. [issue](https://github.com/optuna/optuna/issues/4084)

This change is to reject the deprecated distributions in OptunaSearchCV to prevent from this error.

## Description of the changes

The cause of the issue is that sklearn's `clone` method runs sanity check to ensure that the estimator's constructor argument is not edited. OptunaSearchCV's implementation [violates this sanity check](https://github.com/optuna/optuna/issues/4084#issuecomment-1283320431).

I compared several options that solve this issue
- Reject deprecated distributions (selected)
  - (+) Users will know how to fix their code because they will get better error messages.
  - (-) some of existing code will not work after this change. I guess it is okay because `OptunaSearchCV` is marked as experimental and deprecated distributions are marked as deprecated.
- Only edit values of dict object passed to `param_distributions` argument
  - (+) The reported issue will be fixed and the there is no backward incompatibility.
  - (-) it is weird if the estimator tweaks the parameter given to its constructor.