### PR TITLE
Speed up `tests/samplers_tests/test_nsgaii.py::test_fast_non_dominated_sort_with_constraints`

### DIFF
--- a/optuna/samplers/nsgaii/_sampler.py
+++ b/optuna/samplers/nsgaii/_sampler.py
@@ -345,10 +345,12 @@ class NSGAIISampler(BaseSampler):
         population: List[FrozenTrial],
         directions: List[optuna.study.StudyDirection],
     ) -> List[List[FrozenTrial]]:
-        for _trial in population:
-            _constraints = _trial.system_attrs.get(_CONSTRAINTS_KEY)
-            if np.any(np.isnan(_constraints)):
-                raise ValueError("NaN is not acceptable as constraint value.")
+        if self._constraints_func is not None:
+            for _trial in population:
+                _constraints = _trial.system_attrs.get(_CONSTRAINTS_KEY)
+                if np.any(np.isnan(_constraints)):
+                    raise ValueError("NaN is not acceptable as constraint value.")
+
         dominated_count: DefaultDict[int, int] = defaultdict(int)
         dominates_list = defaultdict(list)
 

--- a/optuna/samplers/nsgaii/_sampler.py
+++ b/optuna/samplers/nsgaii/_sampler.py
@@ -348,7 +348,9 @@ class NSGAIISampler(BaseSampler):
         if self._constraints_func is not None:
             for _trial in population:
                 _constraints = _trial.system_attrs.get(_CONSTRAINTS_KEY)
-                if np.any(np.isnan(_constraints)):
+                if _constraints is None:
+                    continue
+                if np.any(np.isnan(np.array(_constraints))):
                     raise ValueError("NaN is not acceptable as constraint value.")
 
         dominated_count: DefaultDict[int, int] = defaultdict(int)

--- a/optuna/samplers/nsgaii/_sampler.py
+++ b/optuna/samplers/nsgaii/_sampler.py
@@ -351,6 +351,7 @@ class NSGAIISampler(BaseSampler):
                 raise ValueError("NaN is not acceptable as constraint value.")
         dominated_count: DefaultDict[int, int] = defaultdict(int)
         dominates_list = defaultdict(list)
+
         dominates = _dominates if self._constraints_func is None else _constrained_dominates
 
         for p, q in itertools.combinations(population, 2):

--- a/optuna/samplers/nsgaii/_sampler.py
+++ b/optuna/samplers/nsgaii/_sampler.py
@@ -495,9 +495,6 @@ def _constrained_dominates(
     assert isinstance(constraints0, (list, tuple))
     assert isinstance(constraints1, (list, tuple))
 
-    if np.any(np.isnan(constraints0)) or np.any(np.isnan(constraints1)):
-        raise ValueError("NaN is not acceptable as constraint value.")
-
     if len(constraints0) != len(constraints1):
         raise ValueError("Trials with different numbers of constraints cannot be compared.")
 

--- a/optuna/samplers/nsgaii/_sampler.py
+++ b/optuna/samplers/nsgaii/_sampler.py
@@ -345,9 +345,12 @@ class NSGAIISampler(BaseSampler):
         population: List[FrozenTrial],
         directions: List[optuna.study.StudyDirection],
     ) -> List[List[FrozenTrial]]:
+        for _trial in population:
+            _constraints = _trial.system_attrs.get(_CONSTRAINTS_KEY)
+            if np.any(np.isnan(_constraints)):
+                raise ValueError("NaN is not acceptable as constraint value.")
         dominated_count: DefaultDict[int, int] = defaultdict(int)
         dominates_list = defaultdict(list)
-
         dominates = _dominates if self._constraints_func is None else _constrained_dominates
 
         for p, q in itertools.combinations(population, 2):

--- a/tests/samplers_tests/test_nsgaii.py
+++ b/tests/samplers_tests/test_nsgaii.py
@@ -159,15 +159,6 @@ def test_constraints_func(constraint_value: float) -> None:
             assert x == y
 
 
-def test_constrained_dominates_with_nan_constraint() -> None:
-    directions = [StudyDirection.MINIMIZE, StudyDirection.MINIMIZE]
-
-    t1 = _create_frozen_trial(0, [1], [0, float("nan")])
-    t2 = _create_frozen_trial(0, [0], [1, -1])
-    with pytest.raises(ValueError):
-        _constrained_dominates(t1, t2, directions)
-
-
 def test_constraints_func_nan() -> None:
     n_trials = 4
     n_objectives = 2
@@ -399,6 +390,17 @@ def test_fast_non_dominated_sort_with_constraints() -> None:
     directions = [StudyDirection.MINIMIZE, StudyDirection.MAXIMIZE]
     population_per_rank = sampler._fast_non_dominated_sort(copy.copy(trials), directions)
     _assert_population_per_rank(trials, directions, population_per_rank)
+
+
+def test_fast_non_dominated_sort_with_nan_constraint() -> None:
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", optuna.exceptions.ExperimentalWarning)
+        sampler = NSGAIISampler(constraints_func=lambda _: [0])
+    directions = [StudyDirection.MINIMIZE, StudyDirection.MINIMIZE]
+    with pytest.raises(ValueError):
+        sampler._fast_non_dominated_sort(
+            [_create_frozen_trial(0, [1], [0, float("nan")])], directions
+        )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
Speed up `tests/samplers_tests/test_nsgaii.py::test_fast_non_dominated_sort_with_constraints` 

## Description of the changes
<!-- Describe the changes in this PR. -->
When I measured the profile, calls to numpy arrays were dominant.
```
❯ pytest --profile-svg tests/samplers_tests/test_nsgaii.py::test_fast_non_dominated_sort_with_constraints
===================================================== test session starts =====================================================
platform darwin -- Python 3.9.9, pytest-7.1.3, pluggy-1.0.0
rootdir: /Users/akita/optuna, configfile: pyproject.toml
plugins: profiling-1.7.0
collected 1 item                                                                                                              

tests/samplers_tests/test_nsgaii.py .                                                                                   [100%]dyld[21443]: Library not loaded: /usr/local/lib/libgvc.6.dylib
  Referenced from: /usr/local/bin/dot
  Reason: tried: '/usr/local/lib/libgvc.6.dylib' (no such file), '/usr/lib/libgvc.6.dylib' (no such file)
sh: line 1: 21443 Abort trap: 6           dot -Tsvg -o $OUT

Profiling (from /Users/akita/optuna/prof/combined.prof):
Sun Nov  6 10:51:47 2022    /Users/akita/optuna/prof/combined.prof

         209468002 function calls (209467954 primitive calls) in 174.445 seconds

   Ordered by: cumulative time
   List reduced from 420 to 20 due to restriction <20>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.000    0.000  174.445  174.445 runner.py:108(pytest_runtest_protocol)
    15/11    0.000    0.000  174.445   15.859 _hooks.py:244(__call__)
    15/11    0.000    0.000  174.445   15.859 _manager.py:77(_hookexec)
    15/11    0.000    0.000  174.445   15.859 _callers.py:9(_multicall)
        1    0.000    0.000  174.444  174.444 runner.py:116(runtestprotocol)
        3    0.000    0.000  174.444   58.148 runner.py:216(call_and_report)
        3    0.000    0.000  174.443   58.148 runner.py:244(call_runtest_hook)
        3    0.000    0.000  174.443   58.148 runner.py:315(from_call)
        3    0.000    0.000  174.443   58.148 runner.py:259(<lambda>)
        1    0.000    0.000  174.442  174.442 runner.py:157(pytest_runtest_call)
        1    0.000    0.000  174.441  174.441 python.py:1759(runtest)
        1    0.001    0.001  174.441  174.441 python.py:185(pytest_pyfunc_call)
        1    0.009    0.009  174.440  174.440 test_nsgaii.py:384(test_fast_non_dominated_sort_with_constraints)
  5347909   63.511    0.000  166.533    0.000 _sampler.py:455(_constrained_dominates)
        1    5.817    5.817  148.972  148.972 _sampler.py:343(_fast_non_dominated_sort)
 10695818    7.651    0.000   76.200    0.000 <__array_function__ internals>:177(any)
 10695820   12.049    0.000   66.661    0.000 {built-in method numpy.core._multiarray_umath.implement_array_function}
 10695818   10.340    0.000   54.612    0.000 fromnumeric.py:2305(any)
 10695818   14.756    0.000   44.272    0.000 fromnumeric.py:69(_wrapreduction)
        1    0.335    0.335   25.422   25.422 test_nsgaii.py:341(_assert_population_per_rank)
```

This function call results from validation using `np.isnan`.
This validation should be done outside of `_constrained_dominates`.
This PR reduces the number of function calls from O(n^2) to O(n).

master([e467683](https://github.com/optuna/optuna/commit/e467683999552218437b25aa581211059a1e0757))
```
❯ pytest tests/samplers_tests/test_nsgaii.py::test_fast_non_dominated_sort_with_constraints
===================================================== test session starts =====================================================
platform darwin -- Python 3.9.9, pytest-7.1.3, pluggy-1.0.0
rootdir: /Users/akita/optuna, configfile: pyproject.toml
collected 1 item                                                                                                              

tests/samplers_tests/test_nsgaii.py .                                                                                   [100%]

================================================ 1 passed in 104.81s (0:01:44) ================================================
```

This PR
```
❯ pytest tests/samplers_tests/test_nsgaii.py::test_fast_non_dominated_sort_with_constraints
===================================================== test session starts =====================================================
platform darwin -- Python 3.9.9, pytest-7.1.3, pluggy-1.0.0
rootdir: /Users/akita/optuna, configfile: pyproject.toml
plugins: profiling-1.7.0
collected 1 item                                                                                                              

tests/samplers_tests/test_nsgaii.py .                                                                                   [100%]

===================================================== 1 passed in 27.51s ======================================================
```