### PR TITLE
Stop using hash function in _get_bracket_id in Hyperband

### DIFF
--- a/optuna/pruners/_hyperband.py
+++ b/optuna/pruners/_hyperband.py
@@ -250,10 +250,7 @@ class HyperbandPruner(BasePruner):
             return 0
 
         assert self._n_brackets is not None
-        n = (
-            hash("{}_{}".format(study.study_name, trial.number))
-            % self._total_trial_allocation_budget
-        )
+        n = trial.number % self._total_trial_allocation_budget
         for bracket_id in range(self._n_brackets):
             n -= self._trial_allocation_budgets[bracket_id]
             if n < 0:


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

Fix the bug reported in https://github.com/optuna/optuna/issues/3083  that _get_bracket_id of Hyperband returns different results depending on the process.

## Description of the changes
<!-- Describe the changes in this PR. -->

Simply stopped using `hash`