### PR TITLE
support None in slice plot

### DIFF
--- a/optuna/visualization/_slice.py
+++ b/optuna/visualization/_slice.py
@@ -195,9 +195,12 @@ def _get_slice_plot(info: _SlicePlotInfo) -> "go.Figure":
 
 
 def _generate_slice_subplot(subplot_info: _SliceSubplotInfo) -> "Scatter":
+    x = [x if x is not None else "None" for x in subplot_info.x]
+    y = [y if y is not None else "None" for y in subplot_info.y]
+
     return go.Scatter(
-        x=subplot_info.x,
-        y=subplot_info.y,
+        x=x,
+        y=y,
         mode="markers",
         marker={
             "line": {"width": 0.5, "color": "Grey"},


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
This PR fixes #4108, adding support to plotting `None` categorical.
## Description of the changes
<!-- Describe the changes in this PR. -->
This PR scans the `x`, `y` in the slice plot for None and replaces it with "None".
With This PR

![test](https://user-images.githubusercontent.com/5637270/200154633-8224b6a8-5afd-493f-85b0-186e0df42b93.png)

