### PR TITLE
add marker to matplotlib `plot_intermediate_value`

### DIFF
--- a/optuna/visualization/matplotlib/_intermediate_values.py
+++ b/optuna/visualization/matplotlib/_intermediate_values.py
@@ -95,6 +95,7 @@ def _get_intermediate_plot(info: _IntermediatePlotInfo) -> "Axes":
             tuple((x for x, _ in tinfo.sorted_intermediate_values)),
             tuple((y for _, y in tinfo.sorted_intermediate_values)),
             color=cmap(i),
+            marker=".",
             alpha=0.7,
             label="Trial{}".format(tinfo.trial_number),
         )


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
This PR matches the `plotly` and `matplotlib` in `plot_intermediate_value` by adding the markers to `matplotlib`.

## Description of the changes
<!-- Describe the changes in this PR. -->
current master
https://optuna.readthedocs.io/en/stable/reference/visualization/generated/optuna.visualization.plot_intermediate_values.html#optuna.visualization.plot_intermediate_values
https://optuna.readthedocs.io/en/stable/reference/visualization/generated/optuna.visualization.matplotlib.plot_intermediate_values.html#optuna.visualization.matplotlib.plot_intermediate_values

With this PR
![test](https://user-images.githubusercontent.com/5637270/200155514-7f4f2d26-e7a5-442b-86b8-7c38f7e22103.png)

