### PR TITLE
Add `AllTrialsCache` to `Study`

### DIFF
--- a/optuna/integration/_lightgbm_tuner/optimize.py
+++ b/optuna/integration/_lightgbm_tuner/optimize.py
@@ -698,9 +698,10 @@ class _LightGBMBaseTuner(_BaseTuner):
                 self,
                 deepcopy: bool = True,
                 states: Optional[Container[TrialState]] = None,
+                use_cache: bool = False,
             ) -> List[optuna.trial.FrozenTrial]:
 
-                trials = super().get_trials(deepcopy=deepcopy, states=states)
+                trials = super().get_trials(deepcopy=deepcopy, states=states, use_cache=use_cache)
                 return [t for t in trials if t.system_attrs.get(_STEP_NAME_KEY) == self._step_name]
 
             @property

--- a/optuna/pruners/_hyperband.py
+++ b/optuna/pruners/_hyperband.py
@@ -302,8 +302,9 @@ class HyperbandPruner(BasePruner):
                 self,
                 deepcopy: bool = True,
                 states: Optional[Container[TrialState]] = None,
+                use_cache: bool = False,
             ) -> List["optuna.trial.FrozenTrial"]:
-                trials = super().get_trials(deepcopy=deepcopy, states=states)
+                trials = super().get_trials(deepcopy=deepcopy, states=states, use_cache=use_cache)
                 pruner = self.pruner
                 assert isinstance(pruner, HyperbandPruner)
                 return [t for t in trials if pruner._get_bracket_id(self, t) == self._bracket_id]

--- a/optuna/samplers/_cmaes.py
+++ b/optuna/samplers/_cmaes.py
@@ -528,7 +528,7 @@ class CmaEsSampler(BaseSampler):
 
     def _get_trials(self, study: "optuna.Study") -> List[FrozenTrial]:
         complete_trials = []
-        for t in study.get_trials(deepcopy=False):
+        for t in study.get_trials(deepcopy=False, use_cache=True):
             if t.state == TrialState.COMPLETE:
                 complete_trials.append(t)
             elif (

--- a/optuna/samplers/_qmc.py
+++ b/optuna/samplers/_qmc.py
@@ -201,7 +201,7 @@ class QMCSampler(BaseSampler):
         if self._initial_search_space is not None:
             return self._initial_search_space
 
-        past_trials = study.get_trials(deepcopy=False, states=_SUGGESTED_STATES)
+        past_trials = study.get_trials(deepcopy=False, states=_SUGGESTED_STATES, use_cache=True)
         # The initial trial is sampled by the independent sampler.
         if len(past_trials) == 0:
             return {}

--- a/optuna/samplers/_search_space/group_decomposed.py
+++ b/optuna/samplers/_search_space/group_decomposed.py
@@ -56,7 +56,7 @@ class _GroupDecomposedSearchSpace:
         else:
             states_of_interest = (TrialState.COMPLETE,)
 
-        for trial in study.get_trials(deepcopy=False, states=states_of_interest):
+        for trial in study.get_trials(deepcopy=False, states=states_of_interest, use_cache=True):
             self._search_space.add_distributions(trial.distributions)
 
         return copy.deepcopy(self._search_space)

--- a/optuna/samplers/_search_space/intersection.py
+++ b/optuna/samplers/_search_space/intersection.py
@@ -68,7 +68,7 @@ class IntersectionSearchSpace:
         if self._include_pruned:
             states_of_interest.append(optuna.trial.TrialState.PRUNED)
 
-        trials = study.get_trials(deepcopy=False, states=states_of_interest)
+        trials = study.get_trials(deepcopy=False, states=states_of_interest, use_cache=True)
 
         next_cursor = trials[-1].number + 1 if len(trials) > 0 else -1
         for trial in reversed(trials):

--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -629,7 +629,7 @@ def _get_observation_pairs(
     scores = []
     values: Dict[str, List[Optional[float]]] = {param_name: [] for param_name in param_names}
     violations: Optional[List[float]] = [] if constraints_enabled else None
-    for trial in study.get_trials(deepcopy=False, states=states):
+    for trial in study.get_trials(deepcopy=False, states=states, use_cache=True):
         # If ``multivariate`` = True and ``group`` = True, we ignore the trials that are not
         # included in each subspace.
         # If ``multivariate`` = False, we skip the check.

--- a/optuna/samplers/nsgaii/_sampler.py
+++ b/optuna/samplers/nsgaii/_sampler.py
@@ -253,7 +253,7 @@ class NSGAIISampler(BaseSampler):
         )
 
     def _collect_parent_population(self, study: Study) -> Tuple[int, List[FrozenTrial]]:
-        trials = study.get_trials(deepcopy=False)
+        trials = study.get_trials(deepcopy=False, use_cache=True)
 
         generation_to_runnings = defaultdict(list)
         generation_to_population = defaultdict(list)

--- a/optuna/study/_optimize.py
+++ b/optuna/study/_optimize.py
@@ -188,6 +188,7 @@ def _run_trial(
         optuna.storages.fail_stale_trials(study)
 
     trial = study.ask()
+    study._thread_local.cache_all_trials.activate(lambda: study.get_trials(deepcopy=False))
 
     state: Optional[TrialState] = None
     value_or_values: Optional[Union[float, Sequence[float]]] = None
@@ -219,6 +220,7 @@ def _run_trial(
         frozen_trial = study._storage.get_trial(trial._trial_id)
         raise
     finally:
+        study._thread_local.cache_all_trials.deactivate()
         if frozen_trial.state == TrialState.COMPLETE:
             study._log_completed_trial(frozen_trial)
         elif frozen_trial.state == TrialState.PRUNED:

--- a/tests/samplers_tests/test_cmaes.py
+++ b/tests/samplers_tests/test_cmaes.py
@@ -213,7 +213,10 @@ def test_sample_relative_n_startup_trials() -> None:
 
 
 def test_get_trials() -> None:
-    with patch("optuna.Study.get_trials", new=Mock(side_effect=lambda deepcopy: _create_trials())):
+    with patch(
+        "optuna.Study.get_trials",
+        new=Mock(side_effect=lambda deepcopy, use_cache: _create_trials()),
+    ):
         sampler = optuna.samplers.CmaEsSampler(consider_pruned_trials=False)
         study = optuna.create_study(sampler=sampler)
         trials = sampler._get_trials(study)


### PR DESCRIPTION
Based on [c-bata san's implementation](https://github.com/c-bata/optuna/commit/cdd508f4d4c40f7c2ae5ac8b99f9403aee69032e), we introduce `AllTrialsCache` to `Study` so that

- unnecessary query to DB can be avoided, and
- the same all-trials lists are used during one sampling. 

The differences between the original implementation and this are:

- The cache is populated lazily in this PR because not all samplers call `get_trials` (for example, `RandomSampler` do not).
- `use_cache=True` is used more widely.
