### PR TITLE
suggest_categorical: Add overloads for type narrowing

### DIFF
--- a/optuna/multi_objective/trial.py
+++ b/optuna/multi_objective/trial.py
@@ -3,6 +3,7 @@ from typing import Any
 from typing import Dict
 from typing import List
 from typing import Optional
+from typing import overload
 from typing import Sequence
 from typing import Union
 
@@ -94,6 +95,32 @@ class MultiObjectiveTrial:
         """
 
         return self._trial.suggest_int(name, low, high, step=step, log=log)
+
+    @overload
+    def suggest_categorical(self, name: str, choices: Sequence[None]) -> None:
+        ...
+
+    @overload
+    def suggest_categorical(self, name: str, choices: Sequence[bool]) -> bool:
+        ...
+
+    @overload
+    def suggest_categorical(self, name: str, choices: Sequence[int]) -> int:
+        ...
+
+    @overload
+    def suggest_categorical(self, name: str, choices: Sequence[float]) -> float:
+        ...
+
+    @overload
+    def suggest_categorical(self, name: str, choices: Sequence[str]) -> str:
+        ...
+
+    @overload
+    def suggest_categorical(
+        self, name: str, choices: Sequence[CategoricalChoiceType]
+    ) -> CategoricalChoiceType:
+        ...
 
     def suggest_categorical(
         self, name: str, choices: Sequence[CategoricalChoiceType]

--- a/optuna/trial/_base.py
+++ b/optuna/trial/_base.py
@@ -3,6 +3,7 @@ import datetime
 from typing import Any
 from typing import Dict
 from typing import Optional
+from typing import overload
 from typing import Sequence
 
 from optuna._deprecated import deprecated_func
@@ -51,6 +52,38 @@ class BaseTrial(abc.ABC):
     def suggest_int(self, name: str, low: int, high: int, step: int = 1, log: bool = False) -> int:
 
         raise NotImplementedError
+
+    @overload
+    @abc.abstractmethod
+    def suggest_categorical(self, name: str, choices: Sequence[None]) -> None:
+        ...
+
+    @overload
+    @abc.abstractmethod
+    def suggest_categorical(self, name: str, choices: Sequence[bool]) -> bool:
+        ...
+
+    @overload
+    @abc.abstractmethod
+    def suggest_categorical(self, name: str, choices: Sequence[int]) -> int:
+        ...
+
+    @overload
+    @abc.abstractmethod
+    def suggest_categorical(self, name: str, choices: Sequence[float]) -> float:
+        ...
+
+    @overload
+    @abc.abstractmethod
+    def suggest_categorical(self, name: str, choices: Sequence[str]) -> str:
+        ...
+
+    @overload
+    @abc.abstractmethod
+    def suggest_categorical(
+        self, name: str, choices: Sequence[CategoricalChoiceType]
+    ) -> CategoricalChoiceType:
+        ...
 
     @abc.abstractmethod
     def suggest_categorical(

--- a/optuna/trial/_fixed.py
+++ b/optuna/trial/_fixed.py
@@ -2,6 +2,7 @@ import datetime
 from typing import Any
 from typing import Dict
 from typing import Optional
+from typing import overload
 from typing import Sequence
 import warnings
 
@@ -95,6 +96,32 @@ class FixedTrial(BaseTrial):
 
     def suggest_int(self, name: str, low: int, high: int, step: int = 1, log: bool = False) -> int:
         return int(self._suggest(name, IntDistribution(low, high, log=log, step=step)))
+
+    @overload
+    def suggest_categorical(self, name: str, choices: Sequence[None]) -> None:
+        ...
+
+    @overload
+    def suggest_categorical(self, name: str, choices: Sequence[bool]) -> bool:
+        ...
+
+    @overload
+    def suggest_categorical(self, name: str, choices: Sequence[int]) -> int:
+        ...
+
+    @overload
+    def suggest_categorical(self, name: str, choices: Sequence[float]) -> float:
+        ...
+
+    @overload
+    def suggest_categorical(self, name: str, choices: Sequence[str]) -> str:
+        ...
+
+    @overload
+    def suggest_categorical(
+        self, name: str, choices: Sequence[CategoricalChoiceType]
+    ) -> CategoricalChoiceType:
+        ...
 
     def suggest_categorical(
         self, name: str, choices: Sequence[CategoricalChoiceType]

--- a/optuna/trial/_frozen.py
+++ b/optuna/trial/_frozen.py
@@ -3,6 +3,7 @@ from typing import Any
 from typing import Dict
 from typing import List
 from typing import Optional
+from typing import overload
 from typing import Sequence
 import warnings
 
@@ -233,6 +234,32 @@ class FrozenTrial(BaseTrial):
 
     def suggest_int(self, name: str, low: int, high: int, step: int = 1, log: bool = False) -> int:
         return int(self._suggest(name, IntDistribution(low, high, log=log, step=step)))
+
+    @overload
+    def suggest_categorical(self, name: str, choices: Sequence[None]) -> None:
+        ...
+
+    @overload
+    def suggest_categorical(self, name: str, choices: Sequence[bool]) -> bool:
+        ...
+
+    @overload
+    def suggest_categorical(self, name: str, choices: Sequence[int]) -> int:
+        ...
+
+    @overload
+    def suggest_categorical(self, name: str, choices: Sequence[float]) -> float:
+        ...
+
+    @overload
+    def suggest_categorical(self, name: str, choices: Sequence[str]) -> str:
+        ...
+
+    @overload
+    def suggest_categorical(
+        self, name: str, choices: Sequence[CategoricalChoiceType]
+    ) -> CategoricalChoiceType:
+        ...
 
     def suggest_categorical(
         self, name: str, choices: Sequence[CategoricalChoiceType]

--- a/optuna/trial/_trial.py
+++ b/optuna/trial/_trial.py
@@ -3,6 +3,7 @@ import datetime
 from typing import Any
 from typing import Dict
 from typing import Optional
+from typing import overload
 from typing import Sequence
 import warnings
 
@@ -316,6 +317,32 @@ class Trial(BaseTrial):
         suggested_value = int(self._suggest(name, distribution))
         self._check_distribution(name, distribution)
         return suggested_value
+
+    @overload
+    def suggest_categorical(self, name: str, choices: Sequence[None]) -> None:
+        ...
+
+    @overload
+    def suggest_categorical(self, name: str, choices: Sequence[bool]) -> bool:
+        ...
+
+    @overload
+    def suggest_categorical(self, name: str, choices: Sequence[int]) -> int:
+        ...
+
+    @overload
+    def suggest_categorical(self, name: str, choices: Sequence[float]) -> float:
+        ...
+
+    @overload
+    def suggest_categorical(self, name: str, choices: Sequence[str]) -> str:
+        ...
+
+    @overload
+    def suggest_categorical(
+        self, name: str, choices: Sequence[CategoricalChoiceType]
+    ) -> CategoricalChoiceType:
+        ...
 
     def suggest_categorical(
         self, name: str, choices: Sequence[CategoricalChoiceType]

--- a/tests/importance_tests/test_init.py
+++ b/tests/importance_tests/test_init.py
@@ -55,7 +55,6 @@ def test_get_param_importance_target_is_none_and_study_is_multi_obj(
             # Conditional parameters are ignored unless `params` is specified and is not `None`.
             x7 = trial.suggest_float("x7", 0.1, 3)
 
-        assert isinstance(x6, float)
         value = x1**4 + x2 + x3 - x4**2 - x5 + x6
         if trial.number % 2 == 0:
             value += x7
@@ -86,7 +85,6 @@ def test_get_param_importances(
             # Conditional parameters are ignored unless `params` is specified and is not `None`.
             x7 = trial.suggest_float("x7", 0.1, 3)
 
-        assert isinstance(x6, float)
         value = x1**4 + x2 + x3 - x4**2 - x5 + x6
         if trial.number % 2 == 0:
             value += x7

--- a/tests/integration_tests/test_botorch.py
+++ b/tests/integration_tests/test_botorch.py
@@ -1,5 +1,4 @@
 from typing import Any
-from typing import cast
 from typing import Optional
 from typing import Sequence
 from typing import Tuple
@@ -424,7 +423,7 @@ def test_botorch_distributions() -> None:
         x3 = trial.suggest_int("x3", 0, 2)
         x4 = trial.suggest_int("x4", 2, 4, log=True)
         x5 = trial.suggest_int("x5", 0, 4, step=2)
-        x6 = cast(float, trial.suggest_categorical("x6", [0.1, 0.2, 0.3]))
+        x6 = trial.suggest_categorical("x6", [0.1, 0.2, 0.3])
         return x0 + x1 + x2 + x3 + x4 + x5 + x6
 
     sampler = BoTorchSampler()

--- a/tests/integration_tests/test_mlflow.py
+++ b/tests/integration_tests/test_mlflow.py
@@ -26,7 +26,6 @@ def _objective_func(trial: optuna.trial.Trial) -> float:
     x = trial.suggest_float("x", -1.0, 1.0)
     y = trial.suggest_float("y", 20, 30, log=True)
     z = trial.suggest_categorical("z", (-1.0, 1.0))
-    assert isinstance(z, float)
     trial.set_user_attr("my_user_attr", "my_user_attr_value")
     return (x - 2) ** 2 + (y - 25) ** 2 + z
 
@@ -36,7 +35,6 @@ def _multiobjective_func(trial: optuna.trial.Trial) -> Tuple[float, float]:
     x = trial.suggest_float("x", low=-1.0, high=1.0)
     y = trial.suggest_float("y", low=20, high=30, log=True)
     z = trial.suggest_categorical("z", (-1.0, 1.0))
-    assert isinstance(z, float)
     first_objective = (x - 2) ** 2 + (y - 25) ** 2 + z
     second_objective = (x - 2) ** 3 + (y - 25) ** 3 - z
 
@@ -53,7 +51,6 @@ def _objective_func_long_user_attr(trial: optuna.trial.Trial) -> float:
     x = trial.suggest_float("x", -1.0, 1.0)
     y = trial.suggest_float("y", 20, 30, log=True)
     z = trial.suggest_categorical("z", (-1.0, 1.0))
-    assert isinstance(z, float)
     long_str = str(list(range(5000)))
     trial.set_user_attr("my_user_attr", long_str)
     return (x - 2) ** 2 + (y - 25) ** 2 + z
@@ -408,7 +405,6 @@ def test_track_in_mlflow_decorator(tmpdir: py.path.local, n_jobs: int) -> None:
         x = trial.suggest_float("x", -1.0, 1.0)
         y = trial.suggest_float("y", 20, 30, log=True)
         z = trial.suggest_categorical("z", (-1.0, 1.0))
-        assert isinstance(z, float)
         trial.set_user_attr("my_user_attr", "my_user_attr_value")
         mlflow.log_metric(metric_name, metric)
         return (x - 2) ** 2 + (y - 25) ** 2 + z

--- a/tests/integration_tests/test_shap.py
+++ b/tests/integration_tests/test_shap.py
@@ -19,8 +19,7 @@ def objective(trial: Trial) -> float:
     x1: float = trial.suggest_float("x1", 0.1, 3)
     x2: float = trial.suggest_float("x2", 0.1, 3, log=True)
     x3: int = trial.suggest_int("x3", 2, 4, log=True)
-    x4 = trial.suggest_categorical("x4", [0.1, 1.0, 10.0])
-    assert isinstance(x4, float)
+    x4: float = trial.suggest_categorical("x4", [0.1, 1.0, 10.0])
     return x1 + x2 * x3 + x4
 
 
@@ -97,8 +96,7 @@ def test_multi_objective_shap_importance_evaluator_with_infinite(
         x1: float = trial.suggest_float("x1", 0.1, 3)
         x2: float = trial.suggest_float("x2", 0.1, 3, log=True)
         x3: int = trial.suggest_int("x3", 2, 4, log=True)
-        x4 = trial.suggest_categorical("x4", [0.1, 1.0, 10.0])
-        assert isinstance(x4, float)
+        x4: float = trial.suggest_categorical("x4", [0.1, 1.0, 10.0])
         return (x1 + x2 * x3 + x4, x1 * x4)
 
     # The test ensures that trials with infinite values are ignored to calculate importance scores.

--- a/tests/integration_tests/test_skopt.py
+++ b/tests/integration_tests/test_skopt.py
@@ -172,7 +172,6 @@ def _objective(trial: optuna.trial.Trial) -> float:
     p8 = trial.suggest_float("p8", 0.1, 1.0, step=0.1)
     p9 = trial.suggest_float("p9", 2.2, 2.2, step=0.5)
     p10 = trial.suggest_categorical("p10", ["9", "3", "0", "8"])
-    assert isinstance(p10, str)
 
     return p0 + p1 + p2 + p3 + p4 + p5 + p6 + p7 + p8 + p9 + int(p10)
 

--- a/tests/integration_tests/test_tensorboard.py
+++ b/tests/integration_tests/test_tensorboard.py
@@ -22,7 +22,6 @@ def _objective_func(trial: optuna.trial.Trial) -> float:
     x = trial.suggest_float("x", -1.0, 1.0)
     y = trial.suggest_float("y", 20.0, 30.0, log=True)
     z = trial.suggest_categorical("z", (-1.0, 1.0))
-    assert isinstance(z, float)
     trial.set_user_attr("my_user_attr", "my_user_attr_value")
     return u + v + w + (x - 2) ** 2 + (y - 25) ** 2 + z
 

--- a/tests/multi_objective_tests/test_trial.py
+++ b/tests/multi_objective_tests/test_trial.py
@@ -1,5 +1,4 @@
 import datetime
-from typing import cast
 from typing import List
 from typing import Tuple
 
@@ -23,7 +22,7 @@ def test_suggest() -> None:
         p2 = trial.suggest_float("p2", 0.00001, 0.1, log=True)
         p3 = trial.suggest_float("p3", 100, 200, step=5)
         p4 = trial.suggest_int("p4", -20, -15)
-        p5 = cast(int, trial.suggest_categorical("p5", [7, 1, 100]))
+        p5 = trial.suggest_categorical("p5", [7, 1, 100])
         p6 = trial.suggest_float("p6", -10, 10, step=1.0)
         p7 = trial.suggest_int("p7", 1, 7, log=True)
         return (

--- a/tests/samplers_tests/test_grid.py
+++ b/tests/samplers_tests/test_grid.py
@@ -1,6 +1,5 @@
 from collections import OrderedDict
 import itertools
-from typing import cast
 from typing import Dict
 from typing import List
 from typing import Mapping
@@ -247,8 +246,6 @@ def test_nan() -> None:
     sampler = optuna.samplers.GridSampler({"x": [0, float("nan")]})
     study = optuna.create_study(sampler=sampler)
     study.optimize(
-        lambda trial: 1
-        if np.isnan(cast(float, trial.suggest_categorical("x", [0, float("nan")])))
-        else 0
+        lambda trial: 1 if np.isnan(trial.suggest_categorical("x", [0, float("nan")])) else 0
     )
     assert len(study.get_trials()) == 2

--- a/tests/samplers_tests/test_partial_fixed.py
+++ b/tests/samplers_tests/test_partial_fixed.py
@@ -1,4 +1,3 @@
-from typing import cast
 from unittest.mock import patch
 import warnings
 
@@ -83,7 +82,6 @@ def test_out_of_the_range_categorical() -> None:
     def objective(trial: Trial) -> float:
         x = trial.suggest_int("x", -1, 1)
         y = trial.suggest_categorical("y", [-1, 0, 1])
-        y = cast(int, y)
         return x**2 + y**2
 
     fixed_y = 2

--- a/tests/samplers_tests/test_qmc.py
+++ b/tests/samplers_tests/test_qmc.py
@@ -97,7 +97,7 @@ def test_infer_initial_search_space() -> None:
 
 def test_sample_independent() -> None:
 
-    objective: Callable[[Trial], Any] = lambda t: t.suggest_categorical("x", [1.0, 2.0])
+    objective: Callable[[Trial], float] = lambda t: t.suggest_categorical("x", [1.0, 2.0])
     independent_sampler = optuna.samplers.RandomSampler()
 
     with patch.object(
@@ -124,7 +124,7 @@ def test_warn_asynchronous_seeding() -> None:
     # Relative sampling of `QMCSampler` does not support categorical distribution.
     # Thus, `independent_sampler.sample_independent` is called twice.
     # '_log_independent_sampling is not called in the first trial so called once in total.
-    objective: Callable[[Trial], Any] = lambda t: t.suggest_categorical("x", [1.0, 2.0])
+    objective: Callable[[Trial], float] = lambda t: t.suggest_categorical("x", [1.0, 2.0])
 
     with patch.object(optuna.samplers.QMCSampler, "_log_asynchronous_seeding") as mock_log_async:
 
@@ -147,7 +147,7 @@ def test_warn_independent_sampling() -> None:
     # Relative sampling of `QMCSampler` does not support categorical distribution.
     # Thus, `independent_sampler.sample_independent` is called twice.
     # '_log_independent_sampling is not called in the first trial so called once in total.
-    objective: Callable[[Trial], Any] = lambda t: t.suggest_categorical("x", [1.0, 2.0])
+    objective: Callable[[Trial], float] = lambda t: t.suggest_categorical("x", [1.0, 2.0])
 
     with patch.object(optuna.samplers.QMCSampler, "_log_independent_sampling") as mock_log_indep:
 

--- a/tests/samplers_tests/test_samplers.py
+++ b/tests/samplers_tests/test_samplers.py
@@ -5,7 +5,6 @@ import os
 import pickle
 from typing import Any
 from typing import Callable
-from typing import cast
 from typing import Dict
 from typing import List
 from typing import Optional
@@ -227,7 +226,7 @@ def parametrize_suggest_method(name: str) -> MarkDecorator:
         [
             lambda t: t.suggest_float(name, 0, 10),
             lambda t: t.suggest_int(name, 0, 10),
-            lambda t: cast(float, t.suggest_categorical(name, [0, 1, 2])),
+            lambda t: t.suggest_categorical(name, [0, 1, 2]),
             lambda t: t.suggest_float(name, 0, 10, step=0.5),
             lambda t: t.suggest_float(name, 1e-7, 10, log=True),
             lambda t: t.suggest_int(name, 1, 10, log=True),
@@ -984,7 +983,7 @@ def test_reproducible(sampler_class: Callable[[int], BaseSampler], objective_fun
         d = trial.suggest_int("d", 1, 9)
         e = trial.suggest_int("e", 1, 9, log=True)
         f = trial.suggest_int("f", 1, 9, step=2)
-        g = cast(int, trial.suggest_categorical("g", range(1, 10)))
+        g = trial.suggest_categorical("g", range(1, 10))
         return objective_func(a, b, c, d, e, f, g)
 
     study = optuna.create_study(sampler=sampler_class(1))
@@ -1012,7 +1011,7 @@ def test_reseed_rng_change_sampling(sampler_class: Callable[[int], BaseSampler])
         d = trial.suggest_int("d", 1, 9)
         e = trial.suggest_int("e", 1, 9, log=True)
         f = trial.suggest_int("f", 1, 9, step=2)
-        g = cast(int, trial.suggest_categorical("g", range(1, 10)))
+        g = trial.suggest_categorical("g", range(1, 10))
         return a + b + c + d + e + f + g
 
     sampler = sampler_class(1)
@@ -1043,7 +1042,7 @@ def run_optimize(
         d = trial.suggest_int("d", 1, 9)
         e = trial.suggest_int("e", 1, 9, log=True)
         f = trial.suggest_int("f", 1, 9, step=2)
-        g = cast(int, trial.suggest_categorical("g", range(1, 10)))
+        g = trial.suggest_categorical("g", range(1, 10))
         return a + b + c + d + e + f + g
 
     hash_dict[k] = hash("nondeterministic hash")

--- a/tests/storages_tests/rdb_tests/create_db.py
+++ b/tests/storages_tests/rdb_tests/create_db.py
@@ -38,7 +38,6 @@ If you use `venv`, simply `deactivate` and re-activate your development environm
 
 
 from argparse import ArgumentParser
-from typing import cast
 from typing import Tuple
 
 from packaging import version
@@ -49,7 +48,8 @@ import optuna
 def objective_test_upgrade(trial: optuna.trial.Trial) -> float:
     x = trial.suggest_float("x", -5, 5)  # optuna==0.9.0 does not have suggest_float.
     y = trial.suggest_int("y", 0, 10)
-    z = cast(float, trial.suggest_categorical("z", [-5, 0, 5]))
+    z = trial.suggest_categorical("z", [-5, 0, 5])
+    trial.set_system_attr("a", 0)
     trial.set_user_attr("b", 1)
     trial.report(0.5, step=0)
     return x**2 + y**2 + z**2
@@ -58,7 +58,8 @@ def objective_test_upgrade(trial: optuna.trial.Trial) -> float:
 def mo_objective_test_upgrade(trial: optuna.trial.Trial) -> Tuple[float, float]:
     x = trial.suggest_float("x", -5, 5)
     y = trial.suggest_int("y", 0, 10)
-    z = cast(float, trial.suggest_categorical("z", [-5, 0, 5]))
+    z = trial.suggest_categorical("z", [-5, 0, 5])
+    trial.set_system_attr("a", 0)
     trial.set_user_attr("b", 1)
     return x, x**2 + y**2 + z**2
 
@@ -70,7 +71,7 @@ def objective_test_upgrade_distributions(trial: optuna.trial.Trial) -> float:
     y1 = trial.suggest_int("y1", 0, 10)
     y2 = trial.suggest_int("y2", 1, 20, log=True)
     y3 = trial.suggest_int("y3", 5, 15, step=3)
-    z = cast(float, trial.suggest_categorical("z", [-5, 0, 5]))
+    z = trial.suggest_categorical("z", [-5, 0, 5])
     return x1**2 + x2**2 + x3**2 + y1**2 + y2**2 + y3**2 + z**2
 
 

--- a/tests/study_tests/test_dataframe.py
+++ b/tests/study_tests/test_dataframe.py
@@ -54,7 +54,6 @@ def test_trials_dataframe(storage_mode: str, attrs: Tuple[str, ...], multi_index
 
         x = trial.suggest_int("x", 1, 1)
         y = trial.suggest_categorical("y", (2.5,))
-        assert isinstance(y, float)
         trial.set_user_attr("train_loss", 3)
         trial.storage.set_trial_system_attr(trial._trial_id, "foo", "bar")
         value = x + y  # 3.5

--- a/tests/study_tests/test_study.py
+++ b/tests/study_tests/test_study.py
@@ -46,7 +46,6 @@ def func(trial: Trial) -> float:
     x = trial.suggest_float("x", -10.0, 10.0)
     y = trial.suggest_float("y", 20, 30, log=True)
     z = trial.suggest_categorical("z", (-1.0, 1.0))
-    assert isinstance(z, float)
     return (x - 2) ** 2 + (y - 25) ** 2 + z
 
 

--- a/tests/trial_tests/test_frozen.py
+++ b/tests/trial_tests/test_frozen.py
@@ -87,7 +87,6 @@ def test_sampling(storage_mode: str) -> None:
         e = trial.suggest_categorical("e", [0, 1, 2])
         f = trial.suggest_int("f", 1, 10, log=True)
 
-        assert isinstance(e, int)
         return a + b + c + d + e + f
 
     with StorageSupplier(storage_mode) as storage:

--- a/tests/trial_tests/test_trial.py
+++ b/tests/trial_tests/test_trial.py
@@ -2,7 +2,6 @@ import datetime
 import math
 import tempfile
 from typing import Any
-from typing import cast
 from typing import Dict
 from typing import List
 from typing import Optional
@@ -656,7 +655,7 @@ def test_suggest_with_multi_objectives() -> None:
         p2 = trial.suggest_float("p2", 0.00001, 0.1, log=True)
         p3 = trial.suggest_float("p3", 100, 200, step=5)
         p4 = trial.suggest_int("p4", -20, -15)
-        p5 = cast(int, trial.suggest_categorical("p5", [7, 1, 100]))
+        p5 = trial.suggest_categorical("p5", [7, 1, 100])
         p6 = trial.suggest_float("p6", -10, 10, step=1.0)
         p7 = trial.suggest_int("p7", 1, 7, log=True)
         return (


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

When sampling from a categorical distribution where all elements share the same type, we expect the sampled value to have that type. Currently, this is not the case.

Given the values `[1,2,3,4]`, the value returned from `suggest_categorical` is `CategoricalChoiceType = Union[None, bool, int, float, str]`. This loss of type specificity manifests in the test suite in the use of `cast` and `assert` in an attempt to regain it.

## Description of the changes
<!-- Describe the changes in this PR. -->

This change adds overloads for each inhabitant of `CategoricalChoiceType` and allows us to drop the use of `cast` and `assert` in several places.