### PR TITLE
pruners: Use overloads to catch improper configurations as type errors

### DIFF
--- a/optuna/pruners/_hyperband.py
+++ b/optuna/pruners/_hyperband.py
@@ -3,6 +3,8 @@ import math
 from typing import Container
 from typing import List
 from typing import Optional
+from typing import overload
+from typing import TYPE_CHECKING
 from typing import Union
 
 import optuna
@@ -11,6 +13,9 @@ from optuna.pruners._base import BasePruner
 from optuna.pruners._successive_halving import SuccessiveHalvingPruner
 from optuna.trial._state import TrialState
 
+
+if TYPE_CHECKING:
+    from typing_extensions import Literal
 
 _logger = logging.get_logger(__name__)
 
@@ -136,10 +141,33 @@ class HyperbandPruner(BasePruner):
             See the details for :class:`~optuna.pruners.SuccessiveHalvingPruner`.
     """
 
+    @overload
     def __init__(
         self,
         min_resource: int = 1,
-        max_resource: Union[str, int] = "auto",
+        max_resource: "Literal['auto']" = "auto",
+        reduction_factor: int = 3,
+        bootstrap_count: "Literal[0]" = 0,
+    ) -> None:
+        ...
+
+    @overload
+    def __init__(
+        self,
+        min_resource: int = 1,
+        # NOTE: We must provide a defualt value or else we cannot write the arguments in order.
+        # This value is not used; if the case a default is not provided the original init is called
+        # and max_resource is set to "auto".
+        max_resource: int = 100,
+        reduction_factor: int = 3,
+        bootstrap_count: int = 0,
+    ) -> None:
+        ...
+
+    def __init__(
+        self,
+        min_resource: int = 1,
+        max_resource: "Union[Literal['auto'], int]" = "auto",
         reduction_factor: int = 3,
         bootstrap_count: int = 0,
     ) -> None:

--- a/optuna/pruners/_successive_halving.py
+++ b/optuna/pruners/_successive_halving.py
@@ -1,12 +1,18 @@
 import math
 from typing import List
 from typing import Optional
+from typing import overload
+from typing import TYPE_CHECKING
 from typing import Union
 
 import optuna
 from optuna.pruners._base import BasePruner
 from optuna.study._study_direction import StudyDirection
 from optuna.trial._state import TrialState
+
+
+if TYPE_CHECKING:
+    from typing_extensions import Literal
 
 
 class SuccessiveHalvingPruner(BasePruner):
@@ -109,9 +115,29 @@ class SuccessiveHalvingPruner(BasePruner):
             is considered for promotion into the next rung.
     """
 
+    @overload
     def __init__(
         self,
-        min_resource: Union[str, int] = "auto",
+        min_resource: "Literal['auto']" = "auto",
+        reduction_factor: int = 4,
+        min_early_stopping_rate: int = 0,
+        bootstrap_count: "Literal[0]" = 0,
+    ) -> None:
+        ...
+
+    @overload
+    def __init__(
+        self,
+        min_resource: int,
+        reduction_factor: int = 4,
+        min_early_stopping_rate: int = 0,
+        bootstrap_count: int = 0,
+    ) -> None:
+        ...
+
+    def __init__(
+        self,
+        min_resource: "Union[Literal['auto'], int]" = "auto",
         reduction_factor: int = 4,
         min_early_stopping_rate: int = 0,
         bootstrap_count: int = 0,

--- a/optuna/pruners/_threshold.py
+++ b/optuna/pruners/_threshold.py
@@ -1,10 +1,16 @@
 import math
 from typing import Any
 from typing import Optional
+from typing import overload
+from typing import TYPE_CHECKING
 
 import optuna
 from optuna.pruners import BasePruner
 from optuna.pruners._percentile import _is_first_in_interval_step
+
+
+if TYPE_CHECKING:
+    from typing_extensions import Literal
 
 
 def _check_value(value: Any) -> float:
@@ -76,6 +82,36 @@ class ThresholdPruner(BasePruner):
             will be postponed until a value is reported. Value must be at least 1.
 
     """
+
+    @overload
+    def __init__(
+        self,
+        lower: float = -float("inf"),
+        upper: "Literal[None]" = None,
+        n_warmup_steps: int = 0,
+        interval_steps: int = 1,
+    ) -> None:
+        ...
+
+    @overload
+    def __init__(
+        self,
+        lower: "Literal[None]" = None,
+        upper: float = float("inf"),
+        n_warmup_steps: int = 0,
+        interval_steps: int = 1,
+    ) -> None:
+        ...
+
+    @overload
+    def __init__(
+        self,
+        lower: float,
+        upper: float,
+        n_warmup_steps: int = 0,
+        interval_steps: int = 1,
+    ) -> None:
+        ...
 
     def __init__(
         self,

--- a/tests/pruners_tests/test_hyperband.py
+++ b/tests/pruners_tests/test_hyperband.py
@@ -90,7 +90,10 @@ def test_hyperband_max_resource_is_auto() -> None:
 
 def test_hyperband_max_resource_value_error() -> None:
     with pytest.raises(ValueError):
-        _ = optuna.pruners.HyperbandPruner(max_resource="not_appropriate")
+        # A string other than "auto" is not allowed.
+        # Because the __init__ uses a Literal type for the min_resource argument, we must ignore
+        # this type error.
+        _ = optuna.pruners.HyperbandPruner(max_resource="not_appropriate")  # type: ignore
 
 
 @pytest.mark.parametrize(
@@ -215,7 +218,9 @@ def test_hyperband_no_call_of_filter_study_in_should_prune(
 
 def test_incompatibility_between_bootstrap_count_and_auto_max_resource() -> None:
     with pytest.raises(ValueError):
-        optuna.pruners.HyperbandPruner(max_resource="auto", bootstrap_count=1)
+        # Because min_resource is "auto", the bootstrap_count must be zero.
+        # The type checker correctly detects this type error.
+        optuna.pruners.HyperbandPruner(max_resource="auto", bootstrap_count=1)  # type: ignore
 
 
 def test_hyperband_pruner_and_grid_sampler() -> None:

--- a/tests/pruners_tests/test_successive_halving.py
+++ b/tests/pruners_tests/test_successive_halving.py
@@ -131,7 +131,10 @@ def test_successive_halving_pruner_with_auto_min_resource(n_reports: int, n_tria
 def test_successive_halving_pruner_with_invalid_str_to_min_resource() -> None:
 
     with pytest.raises(ValueError):
-        optuna.pruners.SuccessiveHalvingPruner(min_resource="fixed")
+        # A string other than "auto" is not allowed.
+        # Because the __init__ uses a Literal type for the min_resource argument, we must ignore
+        # this type error.
+        optuna.pruners.SuccessiveHalvingPruner(min_resource="fixed")  # type: ignore
 
 
 def test_successive_halving_pruner_min_resource_parameter() -> None:
@@ -253,10 +256,15 @@ def test_successive_halving_pruner_min_early_stopping_rate_parameter() -> None:
 def test_successive_halving_pruner_bootstrap_parameter() -> None:
 
     with pytest.raises(ValueError):
-        optuna.pruners.SuccessiveHalvingPruner(bootstrap_count=-1)
+        # Because the default min_resource is "auto", the bootstrap_count must be zero.
+        # The type checker correctly detects this type error.
+        optuna.pruners.SuccessiveHalvingPruner(bootstrap_count=-1)  # type: ignore
 
     with pytest.raises(ValueError):
-        optuna.pruners.SuccessiveHalvingPruner(bootstrap_count=1, min_resource="auto")
+        # The type checker correctly catches this as a type error so we must ignore it.
+        optuna.pruners.SuccessiveHalvingPruner(
+            bootstrap_count=1, min_resource="auto"  # type: ignore
+        )
 
     pruner = optuna.pruners.SuccessiveHalvingPruner(
         min_resource=1, reduction_factor=2, bootstrap_count=1

--- a/tests/pruners_tests/test_threshold.py
+++ b/tests/pruners_tests/test_threshold.py
@@ -62,7 +62,7 @@ def test_threshold_pruner_with_invalid_inputs() -> None:
         optuna.pruners.ThresholdPruner(lower=0.0, upper="val")  # type: ignore
 
     with pytest.raises(TypeError):
-        optuna.pruners.ThresholdPruner(lower=None, upper=None)
+        optuna.pruners.ThresholdPruner(lower=None, upper=None)  # type: ignore
 
 
 def test_threshold_pruner_with_nan() -> None:


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation

Currently, improper arguments given to the pruners are only caught at runtime. Given the addition of `@overload` and `Literal` to `typing` and `typing_extensions`, we can provide warning about some improper uses of the pruners through the type checker.

## Description of the changes

This change adds a few overloads for the HyperBand, Successive Halving, and Threshold pruners to catch some invalid configurations at type checking time.

As an example:

```python
h1 = HyperbandPruner(1, "auto", 3, 0) # Works
# Argument of type Literal['cats'] cannot be assigned to parameter max_resource of type 
# int in function __init__
#   Literal['cats'] is incompatible with int
h2 = HyperbandPruner(1, "cats", 3, 0) # Type error! Not int or "auto".
# Argument of type Literal['cats'] cannot be assigned to parameter max_resource of type 
# int in function __init__
#   Literal['auto'] is incompatible with int
h3 = HyperbandPruner(1, "auto", 3, 1) # Type error! bootstrap_count>0 means we no auto
h4 = HyperbandPruner(max_resource="auto") # Works
h5 = HyperbandPruner(max_resource=1) # Works
```
