### PR TITLE
Cache `study.directions` to reduce the number of `get_study_directions()` calls.

### DIFF
--- a/optuna/pruners/_hyperband.py
+++ b/optuna/pruners/_hyperband.py
@@ -274,6 +274,7 @@ class HyperbandPruner(BasePruner):
                 "get_trials",
                 "directions",
                 "direction",
+                "_directions",
                 "_storage",
                 "_study_id",
                 "pruner",

--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -203,7 +203,7 @@ class Study:
             A list of :class:`~optuna.study.StudyDirection` objects.
         """
 
-        if not self._directions:
+        if self._directions is None:
             self._directions = self._storage.get_study_directions(self._study_id)
         return self._directions
 

--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -1170,9 +1170,8 @@ def create_study(
         sampler = samplers.NSGAIISampler()
 
     study_name = storage.get_study_name_from_id(study_id)
+    storage.set_study_directions(study_id, direction_objects)
     study = Study(study_name=study_name, storage=storage, sampler=sampler, pruner=pruner)
-
-    study._storage.set_study_directions(study_id, direction_objects)
 
     return study
 

--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -82,7 +82,7 @@ class Study:
         study_id = storage.get_study_id_from_name(study_name)
         self._study_id = study_id
         self._storage = storage
-        self._directions: Optional[List[StudyDirection]] = None
+        self._directions = storage.get_study_directions(study_id)
 
         self.sampler = sampler or samplers.TPESampler()
         self.pruner = pruner or pruners.MedianPruner()
@@ -203,8 +203,6 @@ class Study:
             A list of :class:`~optuna.study.StudyDirection` objects.
         """
 
-        if self._directions is None:
-            self._directions = self._storage.get_study_directions(self._study_id)
         return self._directions
 
     @property

--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -1,4 +1,5 @@
 import copy
+from functools import cached_property
 from numbers import Real
 import threading
 from typing import Any
@@ -194,7 +195,7 @@ class Study:
 
         return self.directions[0]
 
-    @property
+    @cached_property
     def directions(self) -> List[StudyDirection]:
         """Return the directions of the study.
 

--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -1,5 +1,4 @@
 import copy
-from functools import cached_property
 from numbers import Real
 import threading
 from typing import Any
@@ -83,6 +82,7 @@ class Study:
         study_id = storage.get_study_id_from_name(study_name)
         self._study_id = study_id
         self._storage = storage
+        self._directions: Optional[List[StudyDirection]] = None
 
         self.sampler = sampler or samplers.TPESampler()
         self.pruner = pruner or pruners.MedianPruner()
@@ -195,7 +195,7 @@ class Study:
 
         return self.directions[0]
 
-    @cached_property
+    @property
     def directions(self) -> List[StudyDirection]:
         """Return the directions of the study.
 
@@ -203,7 +203,9 @@ class Study:
             A list of :class:`~optuna.study.StudyDirection` objects.
         """
 
-        return self._storage.get_study_directions(self._study_id)
+        if not self._directions:
+            self._directions = self._storage.get_study_directions(self._study_id)
+        return self._directions
 
     @property
     def trials(self) -> List[FrozenTrial]:


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

As discussed at https://github.com/optuna/optuna/pull/2023#issuecomment-1303069347, `study.directions` property method is called many times during the optimization. `study.directions` is set when creating a study via the `optuna.create_study(..., directions=...)` function and never be modified, so that we can obviously use `cached_property` and reduce the calls of `storage.get_study_directions()`.

## Description of the changes
<!-- Describe the changes in this PR. -->
~~Use `functools.cached_property` instead of `property`.~~

`functools.cached_property` seemed to be introduced in Python 3.8. So I pushed [1e145ca](https://github.com/optuna/optuna/pull/4146/commits/1e145caeb825ac62eff8013650202920fa185739).