### PR TITLE
FIX PartialFixedSampler to handle `None` correctly

### DIFF
--- a/optuna/samplers/_partial_fixed.py
+++ b/optuna/samplers/_partial_fixed.py
@@ -92,9 +92,8 @@ class PartialFixedSampler(BaseSampler):
     ) -> Any:
 
         # If param_name isn't in self._fixed_params.keys(), param_value is set to None.
-        param_value = self._fixed_params.get(param_name)
-
-        if param_value is None:
+        # And if param_value is `None` itself it should be `None`
+        if param_name not in self._fixed_params.keys():
             # Unfixed params are sampled here.
             return self._base_sampler.sample_independent(
                 study, trial, param_name, param_distribution
@@ -102,6 +101,8 @@ class PartialFixedSampler(BaseSampler):
         else:
             # Fixed params are sampled here.
             # Check if a parameter value is contained in the range of this distribution.
+            param_value = self._fixed_params.get(param_name)
+
             param_value_in_internal_repr = param_distribution.to_internal_repr(param_value)
             contained = param_distribution._contains(param_value_in_internal_repr)
 

--- a/tests/samplers_tests/test_partial_fixed.py
+++ b/tests/samplers_tests/test_partial_fixed.py
@@ -117,19 +117,18 @@ def test_call_after_trial_of_base_sampler() -> None:
         assert mock_object.call_count == 1
 
 
-def test_fixed_none_value_sampling()-> None:
+def test_fixed_none_value_sampling() -> None:
     def objective(trial):
-        x = trial.suggest_categorical("x", (None,0))
+        x = trial.suggest_categorical("x", (None, 0))
         return 0
 
     tpe = optuna.samplers.TPESampler()
-    
+
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", optuna.exceptions.ExperimentalWarning)
         # In this following case , "x" should sample only `None`
-        sampler = optuna.samplers.PartialFixedSampler(
-            fixed_params={"x": None}, base_sampler=tpe)
-    
+        sampler = optuna.samplers.PartialFixedSampler(fixed_params={"x": None}, base_sampler=tpe)
+
     study = optuna.create_study(sampler=sampler)
     study.optimize(objective, n_trials=10)
 

--- a/tests/samplers_tests/test_partial_fixed.py
+++ b/tests/samplers_tests/test_partial_fixed.py
@@ -115,3 +115,23 @@ def test_call_after_trial_of_base_sampler() -> None:
     with patch.object(base_sampler, "after_trial", wraps=base_sampler.after_trial) as mock_object:
         study.optimize(lambda _: 1.0, n_trials=1)
         assert mock_object.call_count == 1
+
+
+def test_fixed_none_value_sampling()-> None:
+    def objective(trial):
+        x = trial.suggest_categorical("x", (None,0))
+        return 0
+
+    tpe = optuna.samplers.TPESampler()
+    
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", optuna.exceptions.ExperimentalWarning)
+        # In this following case , "x" should sample only `None`
+        sampler = optuna.samplers.PartialFixedSampler(
+            fixed_params={"x": None}, base_sampler=tpe)
+    
+    study = optuna.create_study(sampler=sampler)
+    study.optimize(objective, n_trials=10)
+
+    for trial in range(10):
+        assert study.trials[trial].params["x"] == None


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
Fix #4136

`PartialFixedSampler` dose not sample `None` as fixed parameter when it passed as `fixed_params`

## Description of the changes
<!-- Describe the changes in this PR. -->
When dictionary has item that has `None` value, it works same as key doesn't exists.
(Because `dict.get(key)` method return `None` when dictionary key doesn't exists.)
So I changed it from `if param_value is None:` to `if param_name not in self._fixed_params.keys():`
