### PR TITLE
Fix the bug of JournalFileStorage on Windows

### DIFF
--- a/optuna/storages/_journal/file.py
+++ b/optuna/storages/_journal/file.py
@@ -173,7 +173,11 @@ class JournalFileStorage(BaseJournalLogStorage):
                 if last_decode_error is not None:
                     raise last_decode_error
                 if log_number + 1 not in self._log_number_offset:
-                    byte_len = len(line.encode("utf-8"))
+                    # In text mode, platform-specific line endings (\n on Unix, \r\n on Windows)
+                    # converted to just \n. It causes the bug of on Windows platforms.
+                    # See https://docs.python.org/3/tutorial/inputoutput.html for details
+                    byte_len = len((line.rstrip("\n") + os.linesep).encode("utf-8"))
+
                     self._log_number_offset[log_number + 1] = (
                         self._log_number_offset[log_number] + byte_len
                     )

--- a/optuna/storages/_journal/file.py
+++ b/optuna/storages/_journal/file.py
@@ -157,7 +157,7 @@ class JournalFileStorage(BaseJournalLogStorage):
     def __init__(self, file_path: str, lock_obj: Optional[JournalFileBaseLock] = None) -> None:
         self._file_path: str = file_path
         self._lock = lock_obj or JournalFileSymlinkLock(self._file_path)
-        open(self._file_path, "a").close()  # Create a file if it does not exist
+        open(self._file_path, "ab").close()  # Create a file if it does not exist
         self._log_number_offset: Dict[int, int] = {0: 0}
 
     def read_logs(self, log_number_from: int) -> List[Dict[str, Any]]:
@@ -190,7 +190,7 @@ class JournalFileStorage(BaseJournalLogStorage):
     def append_logs(self, logs: List[Dict[str, Any]]) -> None:
         with get_lock_file(self._lock):
             what_to_write = "\n".join([json.dumps(log) for log in logs]) + "\n"
-            with open(self._file_path, "a", encoding="utf-8") as f:
-                f.write(what_to_write)
+            with open(self._file_path, "ab") as f:
+                f.write(what_to_write.encode("utf-8"))
                 f.flush()
                 os.fsync(f.fileno())

--- a/optuna/storages/_journal/file.py
+++ b/optuna/storages/_journal/file.py
@@ -174,7 +174,7 @@ class JournalFileStorage(BaseJournalLogStorage):
                     raise last_decode_error
                 if log_number + 1 not in self._log_number_offset:
                     # In text mode, platform-specific line endings (\n on Unix, \r\n on Windows)
-                    # converted to just \n. It causes the bug of on Windows platforms.
+                    # are converted to just \n. It causes the bug on Windows platforms.
                     # See https://docs.python.org/3/tutorial/inputoutput.html for details
                     byte_len = len((line.rstrip("\n") + os.linesep).encode("utf-8"))
 
@@ -193,7 +193,7 @@ class JournalFileStorage(BaseJournalLogStorage):
 
     def append_logs(self, logs: List[Dict[str, Any]]) -> None:
         with get_lock_file(self._lock):
-            what_to_write = os.linesep.join([json.dumps(log) for log in logs]) + os.linesep
+            what_to_write = "\n".join([json.dumps(log) for log in logs]) + "\n"
             with open(self._file_path, "a", encoding="utf-8") as f:
                 f.write(what_to_write)
                 f.flush()

--- a/optuna/storages/_journal/file.py
+++ b/optuna/storages/_journal/file.py
@@ -189,7 +189,7 @@ class JournalFileStorage(BaseJournalLogStorage):
 
     def append_logs(self, logs: List[Dict[str, Any]]) -> None:
         with get_lock_file(self._lock):
-            what_to_write = "\n".join([json.dumps(log) for log in logs]) + "\n"
+            what_to_write = os.linesep.join([json.dumps(log) for log in logs]) + os.linesep
             with open(self._file_path, "a", encoding="utf-8") as f:
                 f.write(what_to_write)
                 f.flush()

--- a/optuna/storages/_journal/file.py
+++ b/optuna/storages/_journal/file.py
@@ -1,5 +1,4 @@
 import abc
-import io
 from contextlib import contextmanager
 import errno
 import json
@@ -181,7 +180,7 @@ class JournalFileStorage(BaseJournalLogStorage):
                 if log_number < log_number_from:
                     continue
                 try:
-                    logs.append(json.load(io.BytesIO(line)))
+                    logs.append(json.loads(line))
                 except json.JSONDecodeError as err:
                     last_decode_error = err
                     del self._log_number_offset[log_number + 1]


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
To close #4148 

## Description of the changes
<!-- Describe the changes in this PR. -->

The bug is probably caused by JournalStorage using "\n" (LF) as a newline character in the following line. But it should be "\r\n" (CRLF) on Windows platforms. This PR replaces "\n" with `os.linesep`, but I don't have a Windows machine so not yet tested.