### PR TITLE
Add sep-CMA-ES in `parametrize_sampler`

### DIFF
--- a/tests/samplers_tests/test_samplers.py
+++ b/tests/samplers_tests/test_samplers.py
@@ -92,6 +92,7 @@ sampler_class_with_seed: List[Callable] = [
     lambda seed: optuna.samplers.TPESampler(seed=seed),
     lambda seed: optuna.samplers.TPESampler(multivariate=True, seed=seed),
     lambda seed: optuna.samplers.CmaEsSampler(seed=seed),
+    lambda seed: optuna.samplers.CmaEsSampler(seed=seed, use_separable_cma=True),
     lambda seed: optuna.integration.SkoptSampler(seed=seed),
     lambda seed: optuna.integration.PyCmaSampler(seed=seed),
     lambda seed: optuna.samplers.NSGAIISampler(seed=seed),

--- a/tests/samplers_tests/test_samplers.py
+++ b/tests/samplers_tests/test_samplers.py
@@ -40,6 +40,7 @@ parametrize_sampler = pytest.mark.parametrize(
         lambda: optuna.samplers.TPESampler(n_startup_trials=0),
         lambda: optuna.samplers.TPESampler(n_startup_trials=0, multivariate=True),
         lambda: optuna.samplers.CmaEsSampler(n_startup_trials=0),
+        lambda: optuna.samplers.CmaEsSampler(n_startup_trials=0, use_separable_cma=True),
         lambda: optuna.integration.SkoptSampler(
             skopt_kwargs={"base_estimator": "dummy", "n_initial_points": 1}
         ),
@@ -66,6 +67,7 @@ parametrize_relative_sampler = pytest.mark.parametrize(
     [
         lambda: optuna.samplers.TPESampler(n_startup_trials=0, multivariate=True),
         lambda: optuna.samplers.CmaEsSampler(n_startup_trials=0),
+        lambda: optuna.samplers.CmaEsSampler(n_startup_trials=0, use_separable_cma=True),
         lambda: optuna.integration.SkoptSampler(
             skopt_kwargs={"base_estimator": "dummy", "n_initial_points": 1}
         ),


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
As a Multivariate TPE is tested on `test_samplers`, perhaps sep-CMA-ES and CMA-ES with Margin, which is ongoing work at #4016, should also be tested there.

## Description of the changes
<!-- Describe the changes in this PR. -->
Add sep-CMA-ES sampler in `parametrize_sampler`.