### PR TITLE
Remove markup from NaN in FAQ.

### DIFF
--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -232,9 +232,9 @@ You can also find the failed trials by checking the trial states as follows:
 How are NaNs returned by trials handled?
 ----------------------------------------
 
-Trials that return :obj:`NaN` (``float('nan')``) are treated as failures, but they will not abort studies.
+Trials that return NaN (``float('nan')``) are treated as failures, but they will not abort studies.
 
-Trials which return :obj:`NaN` are shown as follows:
+Trials which return NaN are shown as follows:
 
 .. code-block:: sh
 


### PR DESCRIPTION
## Motivation
I got the following error when I build the document with `-n` (nitpicky) option.

```console
optuna/docs/source/faq.rst:235: WARNING: py:obj reference target not found: NaN`
```


## Description of the changes
`NaN` is not a Python object, so remove `:obj:` from NaN
