### PR TITLE
Remove the CircleCI job `document`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,47 +4,9 @@ workflows:
   version: 2
   commit-build:
     jobs:
-      - document
       - visualization-regression-tests
 
 jobs:
-
-  # TODO (crcrpar): Set cache for sphinx gallery to avoid document job being bottleneck.
-  document:
-    docker:
-      - image: readthedocs/build:latest
-    steps:
-      - checkout
-
-      - run: &checkout-merge-master
-          name: checkout-merge-master
-          command: |
-            set -ex
-            if [[ -n "${CIRCLE_PR_NUMBER}" ]]; then
-                FETCH_REFS="${FETCH_REFS} +refs/pull/${CIRCLE_PR_NUMBER}/merge:pr/${CIRCLE_PR_NUMBER}/merge"
-                git fetch -u origin ${FETCH_REFS}
-                git checkout "pr/${CIRCLE_PR_NUMBER}/merge"
-            fi
-
-      - run:
-          name: install
-          command: |
-            python -m venv venv || virtualenv venv --python=python3.8
-            . venv/bin/activate
-            pip install -U pip
-            pip install --progress-bar off .[document]
-
-      - run:
-          name: build
-          command: |
-            . venv/bin/activate
-            cd docs
-            make html
-          environment:
-            OMP_NUM_THREADS: 1
-
-      - store_artifacts:
-          path: ./docs/build/html
 
   visualization-regression-tests:
     docker:

--- a/.github/workflows/circleci-artifacts-link.yml
+++ b/.github/workflows/circleci-artifacts-link.yml
@@ -3,15 +3,6 @@ name: Add redirect link to CircleCI Artifacts
 on: status
 
 jobs:
-  doc-link:
-    runs-on: ubuntu-latest
-    if: "github.event.context == 'ci/circleci: document'"
-    steps:
-    - uses: larsoner/circleci-artifacts-redirector-action@master
-      with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
-        artifact-path: 0/docs/build/html/index.html
-        circleci-jobs: document
   visualization-regression-tests-link:
     runs-on: ubuntu-latest
     if: "github.event.context == 'ci/circleci: visualization-regression-tests'"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -165,8 +165,8 @@ See also the [Optuna Test Policy](https://github.com/optuna/optuna/wiki/Test-Pol
 
 Optuna repository uses GitHub Actions and CircleCI.
 
-Currently, we are migrating to GitHub Actions but still we use CircleCI for testing `document`
-because it makes it much easier to check built documentation.
+Currently, we are migrating to GitHub Actions but still we use CircleCI for testing visualization module
+because it makes it much easier to check built figures.
 
 ### Creating a Pull Request
 


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
We would like to migrate CI jobs from CircleCI to GitHub Actions. The remaining CircleCI jobs are `document` and `visual-regression-test`. @himkt's investigation has revealed that we can use [the Read the Docs feature](https://docs.readthedocs.io/en/stable/pull-requests.html) to view the document preview for each PR. Since we have already activated this feature, we will remove the CircleCI job that are no longer needed in this PR.

## Description of the changes
<!-- Describe the changes in this PR. -->
- Remove the CircleCI job `document`