### PR TITLE
Remove object inheritance from base classes

### DIFF
--- a/optuna/_hypervolume/base.py
+++ b/optuna/_hypervolume/base.py
@@ -3,7 +3,7 @@ import abc
 import numpy as np
 
 
-class BaseHypervolume(object, metaclass=abc.ABCMeta):
+class BaseHypervolume(abc.ABC):
     """Base class for hypervolume calculators.
 
     .. note::

--- a/optuna/distributions.py
+++ b/optuna/distributions.py
@@ -24,7 +24,7 @@ _float_distribution_deprecated_msg = (
 _int_distribution_deprecated_msg = "Use :class:`~optuna.distributions.IntDistribution` instead."
 
 
-class BaseDistribution(object, metaclass=abc.ABCMeta):
+class BaseDistribution(abc.ABC):
     """Base class for distributions.
 
     Note that distribution classes are not supposed to be called by library users.

--- a/optuna/importance/_base.py
+++ b/optuna/importance/_base.py
@@ -18,7 +18,7 @@ from optuna.trial import FrozenTrial
 from optuna.trial import TrialState
 
 
-class BaseImportanceEvaluator(object, metaclass=abc.ABCMeta):
+class BaseImportanceEvaluator(abc.ABC):
     """Abstract parameter importance evaluator."""
 
     @abc.abstractmethod

--- a/optuna/multi_objective/samplers/_base.py
+++ b/optuna/multi_objective/samplers/_base.py
@@ -8,7 +8,7 @@ from optuna.distributions import BaseDistribution
 
 
 @deprecated_class("2.4.0", "4.0.0")
-class BaseMultiObjectiveSampler(object, metaclass=abc.ABCMeta):
+class BaseMultiObjectiveSampler(abc.ABC):
     """Base class for multi-objective samplers.
 
     The abstract methods of this class are the same as ones defined by

--- a/optuna/pruners/_base.py
+++ b/optuna/pruners/_base.py
@@ -3,7 +3,7 @@ import abc
 import optuna
 
 
-class BasePruner(object, metaclass=abc.ABCMeta):
+class BasePruner(abc.ABC):
     """Base class for pruners."""
 
     @abc.abstractmethod

--- a/optuna/samplers/_base.py
+++ b/optuna/samplers/_base.py
@@ -14,7 +14,7 @@ from optuna.trial import FrozenTrial
 from optuna.trial import TrialState
 
 
-class BaseSampler(object, metaclass=abc.ABCMeta):
+class BaseSampler(abc.ABC):
     """Base class for samplers.
 
     Optuna combines two types of sampling strategies, which are called *relative sampling* and

--- a/optuna/samplers/nsgaii/_crossovers/_base.py
+++ b/optuna/samplers/nsgaii/_crossovers/_base.py
@@ -5,7 +5,7 @@ import numpy as np
 from optuna.study import Study
 
 
-class BaseCrossover(object, metaclass=abc.ABCMeta):
+class BaseCrossover(abc.ABC):
     """Base class for crossovers.
 
     A crossover operation is used by :class:`~optuna.samplers.NSGAIISampler`

--- a/optuna/storages/_base.py
+++ b/optuna/storages/_base.py
@@ -19,7 +19,7 @@ from optuna.trial import TrialState
 DEFAULT_STUDY_NAME_PREFIX = "no-name-"
 
 
-class BaseStorage(object, metaclass=abc.ABCMeta):
+class BaseStorage(abc.ABC):
     """Base class for storages.
 
     This class is not supposed to be directly accessed by library users.

--- a/optuna/trial/_base.py
+++ b/optuna/trial/_base.py
@@ -10,7 +10,7 @@ from optuna.distributions import BaseDistribution
 from optuna.distributions import CategoricalChoiceType
 
 
-class BaseTrial(object, metaclass=abc.ABCMeta):
+class BaseTrial(abc.ABC):
     """Base class for trials.
 
     Note that this class is not supposed to be directly accessed by library users.


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
A small refresh of base class definitions, to follow the standards. Related to #3628.

## Description of the changes
<!-- Describe the changes in this PR. -->
* Removes explicit inheritance of `object` in base classes
* Avoids `metaclass` usage as [doc](https://docs.python.org/3/library/abc.html#abc.ABC) suggests.