### PR TITLE
Stop running reproducibility tests on CI for PR

### DIFF
--- a/.github/workflows/tests-integration.yml
+++ b/.github/workflows/tests-integration.yml
@@ -58,7 +58,14 @@ jobs:
         pip install --progress-bar off .[optional]
         pip install --progress-bar off .[integration] --extra-index-url https://download.pytorch.org/whl/cpu
 
-    - name: Tests
+    - name: Scheduled tests
+      if:  ${{ github.event_name == 'schedule' }}
       run: |
         pytest tests -m "integration" \
+          --ignore tests/integration_tests/test_pytorch_lightning.py
+
+    - name: Tests
+      if:  ${{ github.event_name != 'schedule' }}
+      run: |
+        pytest tests -m "integration and not slow" \
           --ignore tests/integration_tests/test_pytorch_lightning.py


### PR DESCRIPTION
## Motivation
This is a follow-up of #4013 and #4138.

#4138 introduced the `slow` marker for the reproducibility tests.
#4013 moved the reproducibility tests of the integration samplers to the integration test.

## Description of the changes
- Add `not slow` option for PR's CI.