### PR TITLE
Stop running reproducibility tests for coverage

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -64,7 +64,7 @@ jobs:
         COVERAGE_PROCESS_START: .coveragerc  # https://coverage.readthedocs.io/en/6.4.1/subprocess.html
         COVERAGE_COVERAGE: yes  # https://github.com/nedbat/coveragepy/blob/65bf33fc03209ffb01bbbc0d900017614645ee7a/coverage/control.py#L255-L261
       run: |
-        coverage run --source=optuna -m pytest tests -m "not skip_coverage" \
+        coverage run --source=optuna -m pytest tests -m "not skip_coverage and not slow" \
             --ignore tests/integration_tests/test_pytorch_lightning.py
         coverage combine
         coverage xml


### PR DESCRIPTION
## Motivation
This is a follow-up of #4138.
The coverage CI can skip tests with `slow` marks.

## Description of the changes
- Add `not slow` option for coverage CI.
