### PR TITLE
Add `workflow_dispatch` trigger to the integration tests

### DIFF
--- a/.github/workflows/tests-integration.yml
+++ b/.github/workflows/tests-integration.yml
@@ -60,7 +60,7 @@ jobs:
         pip install --progress-bar off .[integration] --extra-index-url https://download.pytorch.org/whl/cpu
 
     - name: Scheduled tests
-      if:  ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'}}
+      if:  ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
       run: |
         pytest tests -m "integration" \
           --ignore tests/integration_tests/test_pytorch_lightning.py

--- a/.github/workflows/tests-integration.yml
+++ b/.github/workflows/tests-integration.yml
@@ -7,6 +7,7 @@ on:
   pull_request: {}
   schedule:
     - cron: '0 23 * * SUN-THU'
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/master' && github.run_number || github.ref }}
@@ -59,7 +60,7 @@ jobs:
         pip install --progress-bar off .[integration] --extra-index-url https://download.pytorch.org/whl/cpu
 
     - name: Scheduled tests
-      if:  ${{ github.event_name == 'schedule' }}
+      if:  ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'}}
       run: |
         pytest tests -m "integration" \
           --ignore tests/integration_tests/test_pytorch_lightning.py

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,7 @@ on:
   pull_request: {}
   schedule:
     - cron: '0 23 * * SUN-THU'
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/master' && github.run_number || github.ref }}
@@ -63,7 +64,7 @@ jobs:
         pip install --progress-bar off .[optional]
 
     - name: Scheduled tests
-      if:  ${{ github.event_name == 'schedule' }}
+      if:  ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
       run: |
         pytest tests -m "not integration"
 


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
This is a follow-up for https://github.com/optuna/optuna/pull/4162. 
The `slow` tests are skipped from #4162. This PR suggests to add a trigger for manual execution of integration tests. This is a same strategy of `checks-integration`.

## Description of the changes
<!-- Describe the changes in this PR. -->
Add `workflow_dispatch` trigger to the integration tests
