### PR TITLE
[hotfix] Fix CI errors when using `mlflow==2.0.1`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,8 @@ def get_extras_require() -> Dict[str, List[str]]:
             "fvcore",
             "lightgbm",
             "matplotlib!=3.6.0",
-            "mlflow",
+            # TODO(c-bata): Remove the version constraint of mlflow.
+            "mlflow<2.0.1",
             "pandas",
             "pillow",
             "plotly>=4.0.0",  # optuna/visualization.
@@ -96,7 +97,7 @@ def get_extras_require() -> Dict[str, List[str]]:
             "distributed",
             "fastai",
             "lightgbm",
-            "mlflow",
+            "mlflow<2.0.1",
             "mpi4py",
             "mxnet",
             "pandas",

--- a/tests/integration_tests/test_dask.py
+++ b/tests/integration_tests/test_dask.py
@@ -58,13 +58,13 @@ def objective_slow(trial: Trial) -> float:
 
 
 @pytest.fixture
-def client() -> Client:
+def client() -> "Client":
     with clean():
         with Client(dashboard_address=":0") as client:
             yield client
 
 
-def test_experimental(client: Client) -> None:
+def test_experimental(client: "Client") -> None:
     with pytest.warns(optuna.exceptions.ExperimentalWarning):
         DaskStorage()
 
@@ -76,7 +76,7 @@ def test_no_client_informative_error() -> None:
 
 @gen_cluster(client=True)
 async def test_daskstorage_registers_extension(
-    c: Client, s: Scheduler, a: Worker, b: Worker
+    c: "Client", s: Scheduler, a: Worker, b: Worker
 ) -> None:
     assert "optuna" not in s.extensions
     await DaskStorage()
@@ -85,7 +85,7 @@ async def test_daskstorage_registers_extension(
 
 
 @gen_cluster(client=True)
-async def test_name(c: Client, s: Scheduler, a: Worker, b: Worker) -> None:
+async def test_name(c: "Client", s: Scheduler, a: Worker, b: Worker) -> None:
     await DaskStorage(name="foo")
     ext = s.extensions["optuna"]
     assert len(ext.storages) == 1
@@ -96,14 +96,14 @@ async def test_name(c: Client, s: Scheduler, a: Worker, b: Worker) -> None:
     assert type(ext.storages["bar"]) is optuna.storages.InMemoryStorage
 
 
-def test_name_unique(client: Client) -> None:
+def test_name_unique(client: "Client") -> None:
     s1 = DaskStorage()
     s2 = DaskStorage()
     assert s1.name != s2.name
 
 
 @pytest.mark.parametrize("storage_specifier", STORAGE_MODES)
-def test_study_optimize(client: Client, storage_specifier: str) -> None:
+def test_study_optimize(client: "Client", storage_specifier: str) -> None:
     with get_storage_url(storage_specifier) as url:
         storage = DaskStorage(storage=url)
         study = optuna.create_study(storage=storage)
@@ -116,7 +116,7 @@ def test_study_optimize(client: Client, storage_specifier: str) -> None:
 
 
 @pytest.mark.parametrize("storage_specifier", STORAGE_MODES)
-def test_get_base_storage(client: Client, storage_specifier: str) -> None:
+def test_get_base_storage(client: "Client", storage_specifier: str) -> None:
     with get_storage_url(storage_specifier) as url:
         dask_storage = DaskStorage(url)
         storage = dask_storage.get_base_storage()
@@ -125,7 +125,7 @@ def test_get_base_storage(client: Client, storage_specifier: str) -> None:
 
 
 @pytest.mark.parametrize("direction", ["maximize", "minimize"])
-def test_study_direction_best_value(client: Client, direction: str) -> None:
+def test_study_direction_best_value(client: "Client", direction: str) -> None:
     # Regression test for https://github.com/jrbourbeau/dask-optuna/issues/15
     pytest.importorskip("pandas")
     storage = DaskStorage()

--- a/tests/integration_tests/test_dask.py
+++ b/tests/integration_tests/test_dask.py
@@ -3,24 +3,25 @@ import tempfile
 import time
 from typing import Iterator
 
-from distributed import Client
-from distributed import Scheduler
-from distributed import wait
-from distributed import Worker
-from distributed.utils_test import clean
-from distributed.utils_test import gen_cluster
 import numpy as np
 import pytest
 
 import optuna
+from optuna._imports import try_import
 from optuna.integration.dask import _OptunaSchedulerExtension
 from optuna.integration.dask import DaskStorage
 from optuna.trial import Trial
 
 
-# Ensure experimental warnings related to the Dask integration
-# aren't included in the pytest warning summary for tests in this module
-pytestmark = pytest.mark.filterwarnings("ignore:DaskStorage is experimental")
+with try_import():
+    from distributed import Client
+    from distributed import Scheduler
+    from distributed import wait
+    from distributed import Worker
+    from distributed.utils_test import clean
+    from distributed.utils_test import gen_cluster
+
+pytestmark = pytest.mark.integration
 
 
 STORAGE_MODES = ["inmemory", "sqlite"]

--- a/tests/integration_tests/test_dask.py
+++ b/tests/integration_tests/test_dask.py
@@ -123,15 +123,15 @@ def test_study_direction_best_value(client: "Client", direction: str) -> None:
 
 
 if _imports.is_successful():
+
     @gen_cluster(client=True)
     async def test_daskstorage_registers_extension(
-            c: "Client", s: "Scheduler", a: "Worker", b: "Worker"
+        c: "Client", s: "Scheduler", a: "Worker", b: "Worker"
     ) -> None:
         assert "optuna" not in s.extensions
         await DaskStorage()
         assert "optuna" in s.extensions
         assert type(s.extensions["optuna"]) is _OptunaSchedulerExtension
-
 
     @gen_cluster(client=True)
     async def test_name(c: "Client", s: "Scheduler", a: "Worker", b: "Worker") -> None:


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
refs https://github.com/optuna/optuna/pull/4170#issuecomment-1314929209

## Description of the changes
<!-- Describe the changes in this PR. -->
`test_mlflow.py` is broken with mlflow v2.0.1, which was released yesterday.
https://github.com/mlflow/mlflow/releases