### PR TITLE
Add `fakeredis` in benchmark deps

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ def get_extras_require() -> Dict[str, List[str]]:
             "asv>=0.5.0",
             "botorch",
             "cma",
+            "fakeredis",
             "scikit-optimize",
             "virtualenv",
         ],


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
Fix https://github.com/optuna/optuna/actions/runs/3474837782/jobs/5808439364

```
Run asv run --strict
· Creating environments
· Discovering benchmarks
·· Uninstalling from virtualenv-py3.9
·· Building 18df86b3 <master> for virtualenv-py3.9
·· Installing 18df86b3 <master> into virtualenv-py3.9
·· Error running /home/runner/work/optuna/optuna/.asv/env/63b4d1e2919fcd950c89910ea84c38ee/bin/python /opt/hostedtoolcache/Python/3.9.15/x64/lib/python3.9/site-packages/asv/benchmark.py discover /home/runner/work/optuna/optuna/benchmarks/asv /tmp/tmpqw3b3rn5/result.json (exit status 1)
   STDOUT -------->
   
   STDERR -------->
   Traceback (most recent call last):
     File "/opt/hostedtoolcache/Python/3.9.15/x64/lib/python3.9/site-packages/asv/benchmark.py", line 1435, in <module>
       main()
     File "/opt/hostedtoolcache/Python/3.9.15/x64/lib/python3.9/site-packages/asv/benchmark.py", line 1428, in main
       commands[mode](args)
     File "/opt/hostedtoolcache/Python/3.9.15/x64/lib/python3.9/site-packages/asv/benchmark.py", line 1103, in main_discover
       list_benchmarks(benchmark_dir, fp)
     File "/opt/hostedtoolcache/Python/3.9.15/x64/lib/python3.9/site-packages/asv/benchmark.py", line 1088, in list_benchmarks
       for benchmark in disc_benchmarks(root):
     File "/opt/hostedtoolcache/Python/3.9.15/x64/lib/python3.9/site-packages/asv/benchmark.py", line 985, in disc_benchmarks
       for module in disc_modules(root_name, ignore_import_errors=ignore_import_errors):
     File "/opt/hostedtoolcache/Python/3.9.15/x64/lib/python3.9/site-packages/asv/benchmark.py", line 96[7](https://github.com/optuna/optuna/actions/runs/3474837782/jobs/5808439364#step:6:8), in disc_modules
       for item in disc_modules(name, ignore_import_errors=ignore_import_errors):
     File "/opt/hostedtoolcache/Python/3.9.15/x64/lib/python3.9/site-packages/asv/benchmark.py", line 950, in disc_modules
       module = import_module(module_name)
     File "/opt/hostedtoolcache/Python/3.9.15/x64/lib/python3.9/importlib/__init__.py", line 127, in import_module
       return _bootstrap._gcd_import(name[level:], package, level)
     File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
     File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
     File "<frozen importlib._bootstrap>", line 9[8](https://github.com/optuna/optuna/actions/runs/3474837782/jobs/5808439364#step:6:9)6, in _find_and_load_unlocked
     File "<frozen importlib._bootstrap>", line 680, in _load_unlocked
     File "<frozen importlib._bootstrap_external>", line 850, in exec_module
     File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
     File "/home/runner/work/optuna/optuna/benchmarks/asv/optimize.py", line 10, in <module>
       from optuna.testing.storages import StorageSupplier
     File "/home/runner/work/optuna/optuna/.asv/env/63b4d1e2[9](https://github.com/optuna/optuna/actions/runs/3474837782/jobs/5808439364#step:6:10)19fcd950c899[10](https://github.com/optuna/optuna/actions/runs/3474837782/jobs/5808439364#step:6:11)ea84c[38](https://github.com/optuna/optuna/actions/runs/3474837782/jobs/5808439364#step:6:39)ee/lib/python3.9/site-packages/optuna/testing/storages.py", line 9, in <module>
       import fakeredis
   ModuleNotFoundError: No module named 'fakeredis'
```

## Description of the changes
<!-- Describe the changes in this PR. -->

I'm still investigating why speed-benchmark was broken yesterday...

(updated) @not522 taught me that speed-test was broken by https://github.com/optuna/optuna/pull/4156/files#diff-d18ceac2def9772dfdf24d7a83cbe688bf5717e334108eff2aeb581d9992d531R74, which was introduced by me :bow: