### PR TITLE
Fix CmaEs system attribution key

### DIFF
--- a/optuna/samplers/_cmaes.py
+++ b/optuna/samplers/_cmaes.py
@@ -3,14 +3,14 @@ import math
 import pickle
 from typing import Any
 from typing import Callable
-from typing import cast
 from typing import Dict
 from typing import List
 from typing import Optional
 from typing import Sequence
 from typing import Tuple
-from typing import TypedDict
 from typing import Union
+from typing import cast
+from typing_extensions import TypedDict
 import warnings
 
 from cmaes import CMA

--- a/tests/integration_tests/test_chainer.py
+++ b/tests/integration_tests/test_chainer.py
@@ -15,12 +15,12 @@ from optuna.testing.pruners import DeterministicPruner
 
 with try_import() as _imports:
     import chainer
-    from chainer.dataset import DatasetMixin
+    from chainer.dataset import DatasetMixin  # type: ignore
     import chainer.links as L
     from chainer.training import triggers
 
 if not _imports.is_successful():
-    DatasetMixin = object  # type: ignore # NOQA
+    DatasetMixin = object  # NOQA
 
 pytestmark = pytest.mark.integration
 

--- a/tests/integration_tests/test_chainer.py
+++ b/tests/integration_tests/test_chainer.py
@@ -15,12 +15,12 @@ from optuna.testing.pruners import DeterministicPruner
 
 with try_import() as _imports:
     import chainer
-    from chainer.dataset import DatasetMixin  # type: ignore
+    from chainer.dataset import DatasetMixin
     import chainer.links as L
     from chainer.training import triggers
 
 if not _imports.is_successful():
-    DatasetMixin = object  # NOQA
+    DatasetMixin = object  # type: ignore # NOQA
 
 pytestmark = pytest.mark.integration
 

--- a/tests/samplers_tests/test_cmaes.py
+++ b/tests/samplers_tests/test_cmaes.py
@@ -321,7 +321,7 @@ def _create_trials() -> List[FrozenTrial]:
         ({"with_margin": False, "use_separable_cma": True}, "sepcma:"),
     ],
 )
-def test_sampler_attr_key(options: Dict[str, bool], key: str):
+def test_sampler_attr_key(options: Dict[str, bool], key: str) -> None:
     # Test sampler attr_key propery
     sampler = optuna.samplers.CmaEsSampler(
         with_margin=options["with_margin"], use_separable_cma=options["use_separable_cma"]

--- a/tests/samplers_tests/test_cmaes.py
+++ b/tests/samplers_tests/test_cmaes.py
@@ -15,8 +15,6 @@ import pytest
 import optuna
 from optuna import create_trial
 from optuna._transform import _SearchSpaceTransform
-from optuna.samplers._cmaes import _concat_optimizer_attrs
-from optuna.samplers._cmaes import _split_optimizer_str
 from optuna.trial import FrozenTrial
 from optuna.trial import TrialState
 
@@ -384,7 +382,7 @@ def test_restore_optimizer_from_substrings() -> None:
     optimizer = CMA(np.zeros(10), sigma=1.3)
     optimizer_str = pickle.dumps(optimizer).hex()
 
-    system_attrs: Dict[str, Any] = _split_optimizer_str(optimizer_str)
+    system_attrs: Dict[str, Any] = sampler._split_optimizer_str(optimizer_str)
     assert len(system_attrs) > 1
     system_attrs["cma:n_restarts"] = 1
 
@@ -411,10 +409,11 @@ def test_restore_optimizer_from_substrings() -> None:
     ],
 )
 def test_split_and_concat_optimizer_string(dummy_optimizer_str: str, attr_len: int) -> None:
+    sampler = optuna.samplers.CmaEsSampler()
     with patch("optuna.samplers._cmaes._SYSTEM_ATTR_MAX_LENGTH", 5):
-        attrs = _split_optimizer_str(dummy_optimizer_str)
+        attrs = sampler._split_optimizer_str(dummy_optimizer_str)
         assert len(attrs) == attr_len
-        actual = _concat_optimizer_attrs(attrs)
+        actual = sampler._concat_optimizer_attrs(attrs)
         assert dummy_optimizer_str == actual
 
 

--- a/tests/samplers_tests/test_cmaes.py
+++ b/tests/samplers_tests/test_cmaes.py
@@ -313,6 +313,30 @@ def _create_trials() -> List[FrozenTrial]:
     return trials
 
 
+@pytest.mark.parametrize(
+    "options, key",
+    [
+        ({"with_margin": False, "use_separable_cma": False}, "cma:"),
+        ({"with_margin": True, "use_separable_cma": False}, "cmawm:"),
+        ({"with_margin": False, "use_separable_cma": True}, "sepcma:"),
+    ],
+)
+def test_sampler_attr_key(options: Dict[str, bool], key: str):
+    # Test sampler attr_key propery
+    sampler = optuna.samplers.CmaEsSampler(
+        with_margin=options["with_margin"], use_separable_cma=options["use_separable_cma"]
+    )
+    assert sampler._attr_keys.optimizer.startswith(key)
+    assert sampler._attr_keys.n_restarts.startswith(key)
+    assert sampler._attr_keys.generation(0).startswith(key)
+
+    sampler._restart_strategy = "ipop"
+    for i in range(3):
+        assert sampler._attr_keys.generation(i).startswith(
+            (key + "restart_{}:".format(i) + "generation")
+        )
+
+
 @pytest.mark.parametrize("popsize", [None, 16])
 def test_population_size_is_multiplied_when_enable_ipop(popsize: Optional[int]) -> None:
     inc_popsize = 2


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
Related to #4016 and #4142.

As noted in #4142, CmaEs's trial attribution is not properly working. Keys are different in Setting and Getting. This PR will fix this issue.

## Description of the changes
<!-- Describe the changes in this PR. -->
- Add a new private property method `_attr_keys` to `CmaEsSampler`
- Using `NamedTuple` to confirm the `_attr_keys`'s key
- Let `CmaEsSampler`'s `_concat_optimizer_attrs` and `_split_optimizer_str` member function, since it require `use_separable_cma` and `with_margin` information.
- Rewrite cmaes_test. (This is WIP)

Could anyone explain what [backward compatibility](https://github.com/gen740/optuna/blob/master/optuna/samplers/_cmaes.py#L452-L456) means?
