### PR TITLE
Fix `asv` speed benchmark

### DIFF
--- a/asv.conf.json
+++ b/asv.conf.json
@@ -71,7 +71,9 @@
     // pip (with all the conda available packages installed first,
     // followed by the pip installed packages).
     //
-    "matrix": {},
+    "matrix": {
+        "fakeredis": [""],
+    },
 
     // Combinations of libraries/python versions can be excluded/included
     // from the set to test. Each entry is a dictionary containing additional

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,6 @@ def get_extras_require() -> Dict[str, List[str]]:
             "asv>=0.5.0",
             "botorch",
             "cma",
-            "fakeredis",
             "scikit-optimize",
             "virtualenv",
         ],


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
Fix https://github.com/optuna/optuna/actions/runs/3483819068

## Description of the changes
<!-- Describe the changes in this PR. -->
I added fakeredis In https://github.com/optuna/optuna/pull/4177, but seemingly it must be listed in `asv.conf.json` since `asv` create a virtualenv environment and then install dependencies.

## Before
```
$ asv run
· Creating environments
.
· Discovering benchmarks
·· Uninstalling from virtualenv-py3.9
·· Building db1837cb <master> for virtualenv-py3.9...
·· Installing db1837cb <master> into virtualenv-py3.9......
·· Error running /Users/c-bata/go/src/github.com/optuna/optuna/.asv/env/63b4d1e2919fcd950c89910ea84c38ee/bin/python /Users/c-bata/go/src/github.com/optuna/optuna/venv/lib/python3.9/site-packages/asv/benchmark.py discover /Users/c-bata/go/src/github.com/optuna/optuna/benchmarks/asv /var/folders/n0/b3ndkfyx6k74lkh_fv2tb59w0000gn/T/tmp_35af7bl/result.json (exit status 1)
   STDOUT -------->

   STDERR -------->
   Traceback (most recent call last):
     File "/Users/c-bata/go/src/github.com/optuna/optuna/venv/lib/python3.9/site-packages/asv/benchmark.py", line 1435, in <module>
       main()
     File "/Users/c-bata/go/src/github.com/optuna/optuna/venv/lib/python3.9/site-packages/asv/benchmark.py", line 1428, in main
       commands[mode](args)
     File "/Users/c-bata/go/src/github.com/optuna/optuna/venv/lib/python3.9/site-packages/asv/benchmark.py", line 1103, in main_discover
       list_benchmarks(benchmark_dir, fp)
     File "/Users/c-bata/go/src/github.com/optuna/optuna/venv/lib/python3.9/site-packages/asv/benchmark.py", line 1088, in list_benchmarks
       for benchmark in disc_benchmarks(root):
     File "/Users/c-bata/go/src/github.com/optuna/optuna/venv/lib/python3.9/site-packages/asv/benchmark.py", line 985, in disc_benchmarks
       for module in disc_modules(root_name, ignore_import_errors=ignore_import_errors):
     File "/Users/c-bata/go/src/github.com/optuna/optuna/venv/lib/python3.9/site-packages/asv/benchmark.py", line 967, in disc_modules
       for item in disc_modules(name, ignore_import_errors=ignore_import_errors):
     File "/Users/c-bata/go/src/github.com/optuna/optuna/venv/lib/python3.9/site-packages/asv/benchmark.py", line 950, in disc_modules
       module = import_module(module_name)
     File "/Users/c-bata/.pyenv_x64/versions/3.9.11/lib/python3.9/importlib/__init__.py", line 127, in import_module
       return _bootstrap._gcd_import(name[level:], package, level)
     File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
     File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
     File "<frozen importlib._bootstrap>", line 986, in _find_and_load_unlocked
     File "<frozen importlib._bootstrap>", line 680, in _load_unlocked
     File "<frozen importlib._bootstrap_external>", line 850, in exec_module
     File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
     File "/Users/c-bata/go/src/github.com/optuna/optuna/benchmarks/asv/optimize.py", line 10, in <module>
       from optuna.testing.storages import StorageSupplier
     File "/Users/c-bata/go/src/github.com/optuna/optuna/.asv/env/63b4d1e2919fcd950c89910ea84c38ee/lib/python3.9/site-packages/optuna/testing/storages.py", line 9, in <module>
       import fakeredis
   ModuleNotFoundError: No module named 'fakeredis'

·· Failed to build the project and import the benchmark suite.
```

## After

```
$ asv run
· Creating environments..
· Discovering benchmarks
·· Uninstalling from virtualenv-py3.9-fakeredis
·· Building db1837cb <master> for virtualenv-py3.9-fakeredis..
·· Installing db1837cb <master> into virtualenv-py3.9-fakeredis....
· Running 1 total benchmarks (1 commits * 1 environments * 1 benchmarks)
[  0.00%] · For Optuna commit db1837cb <master>:
[  0.00%] ·· Benchmarking virtualenv-py3.9-fakeredis
[ 50.00%] ··· Running (optimize.OptimizeSuite.time_optimize--).
[100.00%] ··· optimize.OptimizeSuite.time_optimize                                                                                                                                          ok
[100.00%] ··· ============================= ============
                storage, sampler, n_trials
              ----------------------------- ------------
                  inmemory, random, 1000      327±1ms
                 inmemory, random, 10000     7.36±0.01s
                   inmemory, tpe, 1000        5.50±0s
                  inmemory, cmaes, 1000       926±5ms
                   sqlite, random, 1000      14.6±0.04s
               cached_sqlite, random, 1000   16.5±0.8s
              ============================= ============
```