### PR TITLE
Add a `directions` arg to `storage.create_new_study`

### DIFF
--- a/optuna/integration/dask.py
+++ b/optuna/integration/dask.py
@@ -67,7 +67,6 @@ class _OptunaSchedulerExtension:
             "delete_study",
             "set_study_user_attr",
             "set_study_system_attr",
-            "set_study_directions",
             "get_study_id_from_name",
             "get_study_name_from_id",
             "get_study_directions",
@@ -99,9 +98,12 @@ class _OptunaSchedulerExtension:
         self,
         comm: "distributed.comm.tcp.TCP",
         storage_name: str,
+        directions: Sequence[StudyDirection],
         study_name: Optional[str] = None,
     ) -> int:
-        return self.get_storage(storage_name).create_new_study(study_name=study_name)
+        return self.get_storage(storage_name).create_new_study(
+            directions=directions, study_name=study_name
+        )
 
     def delete_study(
         self,
@@ -135,18 +137,6 @@ class _OptunaSchedulerExtension:
             study_id=study_id,
             key=key,
             value=value,
-        )
-
-    def set_study_directions(
-        self,
-        comm: "distributed.comm.tcp.TCP",
-        storage_name: str,
-        study_id: int,
-        directions: List[str],
-    ) -> None:
-        return self.get_storage(storage_name).set_study_directions(
-            study_id=study_id,
-            directions=[StudyDirection[direction] for direction in directions],
         )
 
     def get_study_id_from_name(
@@ -445,11 +435,14 @@ class DaskStorage(BaseStorage):
 
         return self.client.run_on_scheduler(_get_base_storage, name=self.name)
 
-    def create_new_study(self, study_name: Optional[str] = None) -> int:
+    def create_new_study(
+        self, directions: Sequence[StudyDirection], study_name: Optional[str] = None
+    ) -> int:
         return self.client.sync(
             self.client.scheduler.optuna_create_new_study,
             storage_name=self.name,
             study_name=study_name,
+            directions=directions,
         )
 
     def delete_study(self, study_id: int) -> None:
@@ -475,14 +468,6 @@ class DaskStorage(BaseStorage):
             study_id=study_id,
             key=key,
             value=value,
-        )
-
-    def set_study_directions(self, study_id: int, directions: Sequence[StudyDirection]) -> None:
-        return self.client.sync(
-            self.client.scheduler.optuna_set_study_directions,
-            storage_name=self.name,
-            study_id=study_id,
-            directions=[direction.name for direction in directions],
         )
 
     # Basic study access

--- a/optuna/integration/dask.py
+++ b/optuna/integration/dask.py
@@ -98,11 +98,12 @@ class _OptunaSchedulerExtension:
         self,
         comm: "distributed.comm.tcp.TCP",
         storage_name: str,
-        directions: Sequence[StudyDirection],
+        directions: List[str],
         study_name: Optional[str] = None,
     ) -> int:
         return self.get_storage(storage_name).create_new_study(
-            directions=directions, study_name=study_name
+            directions=[StudyDirection[direction] for direction in directions],
+            study_name=study_name,
         )
 
     def delete_study(
@@ -442,7 +443,7 @@ class DaskStorage(BaseStorage):
             self.client.scheduler.optuna_create_new_study,
             storage_name=self.name,
             study_name=study_name,
-            directions=directions,
+            directions=[direction.name for direction in directions],
         )
 
     def delete_study(self, study_id: int) -> None:

--- a/optuna/storages/_base.py
+++ b/optuna/storages/_base.py
@@ -50,7 +50,9 @@ class BaseStorage(abc.ABC):
     # Basic study manipulation
 
     @abc.abstractmethod
-    def create_new_study(self, study_name: Optional[str] = None) -> int:
+    def create_new_study(
+        self, directions: Sequence[StudyDirection], study_name: Optional[str] = None
+    ) -> int:
         """Create a new study from a name.
 
         If no name is specified, the storage class generates a name.
@@ -121,27 +123,6 @@ class BaseStorage(abc.ABC):
         Raises:
             :exc:`KeyError`:
                 If no study with the matching ``study_id`` exists.
-        """
-        raise NotImplementedError
-
-    @abc.abstractmethod
-    def set_study_directions(self, study_id: int, directions: Sequence[StudyDirection]) -> None:
-        """Register optimization problem directions to a study.
-
-        Args:
-            study_id:
-                ID of the study.
-            directions:
-                A sequence of direction whose element is either
-                :obj:`~optuna.study.StudyDirection.MAXIMIZE` or
-                :obj:`~optuna.study.StudyDirection.MINIMIZE`.
-
-        Raises:
-            :exc:`KeyError`:
-                If no study with the matching ``study_id`` exists.
-            :exc:`ValueError`:
-                If the directions are already set and the each coordinate of passed ``directions``
-                is the opposite direction or :obj:`~optuna.study.StudyDirection.NOT_SET`.
         """
         raise NotImplementedError
 

--- a/optuna/storages/_base.py
+++ b/optuna/storages/_base.py
@@ -59,6 +59,10 @@ class BaseStorage(abc.ABC):
         The returned study ID is unique among all current and deleted studies.
 
         Args:
+            directions:
+                 A sequence of direction whose element is either
+                 :obj:`~optuna.study.StudyDirection.MAXIMIZE` or
+                 :obj:`~optuna.study.StudyDirection.MINIMIZE`.
             study_name:
                 Name of the new study to create.
 

--- a/optuna/storages/_cached_storage.py
+++ b/optuna/storages/_cached_storage.py
@@ -30,7 +30,7 @@ class _StudyInfo:
         self.owned_or_finished_trial_ids: Set[int] = set()
         # Cache distributions to avoid storage access on distribution consistency check.
         self.param_distribution: Dict[str, distributions.BaseDistribution] = {}
-        self.directions: List[StudyDirection] = [StudyDirection.NOT_SET]
+        self.directions: List[StudyDirection] = []
         self.name: Optional[str] = None
 
 
@@ -154,7 +154,7 @@ class _CachedStorage(BaseStorage, BaseHeartbeat):
         with self._lock:
             if study_id in self._studies:
                 directions = self._studies[study_id].directions
-                if len(directions) > 1 or directions[0] != StudyDirection.NOT_SET:
+                if len(directions) > 1:
                     return directions
 
         directions = self._backend.get_study_directions(study_id)

--- a/optuna/storages/_cached_storage.py
+++ b/optuna/storages/_cached_storage.py
@@ -30,7 +30,7 @@ class _StudyInfo:
         self.owned_or_finished_trial_ids: Set[int] = set()
         # Cache distributions to avoid storage access on distribution consistency check.
         self.param_distribution: Dict[str, distributions.BaseDistribution] = {}
-        self.directions: List[StudyDirection] = []
+        self.directions: Optional[List[StudyDirection]] = None
         self.name: Optional[str] = None
 
 
@@ -104,6 +104,7 @@ class _CachedStorage(BaseStorage, BaseHeartbeat):
         with self._lock:
             study = _StudyInfo()
             study.name = study_name
+            study.directions = list(directions)
             self._studies[study_id] = study
 
         return study_id
@@ -154,7 +155,7 @@ class _CachedStorage(BaseStorage, BaseHeartbeat):
         with self._lock:
             if study_id in self._studies:
                 directions = self._studies[study_id].directions
-                if len(directions) > 1:
+                if directions is not None:
                     return directions
 
         directions = self._backend.get_study_directions(study_id)

--- a/optuna/storages/_cached_storage.py
+++ b/optuna/storages/_cached_storage.py
@@ -96,13 +96,16 @@ class _CachedStorage(BaseStorage, BaseHeartbeat):
         self.__dict__.update(state)
         self._lock = threading.Lock()
 
-    def create_new_study(self, study_name: Optional[str] = None) -> int:
+    def create_new_study(
+        self, directions: Sequence[StudyDirection], study_name: Optional[str] = None
+    ) -> int:
 
-        study_id = self._backend.create_new_study(study_name)
+        study_id = self._backend.create_new_study(directions=directions, study_name=study_name)
         with self._lock:
             study = _StudyInfo()
             study.name = study_name
             self._studies[study_id] = study
+
         return study_id
 
     def delete_study(self, study_id: int) -> None:
@@ -118,23 +121,6 @@ class _CachedStorage(BaseStorage, BaseHeartbeat):
                 del self._studies[study_id]
 
         self._backend.delete_study(study_id)
-
-    def set_study_directions(self, study_id: int, directions: Sequence[StudyDirection]) -> None:
-
-        with self._lock:
-            if study_id in self._studies:
-                current_directions = self._studies[study_id].directions
-                if directions == current_directions:
-                    return
-                elif (
-                    len(current_directions) == 1
-                    and current_directions[0] == StudyDirection.NOT_SET
-                ):
-                    self._studies[study_id].directions = list(directions)
-                    self._backend.set_study_directions(study_id, directions)
-                    return
-
-        self._backend.set_study_directions(study_id, directions)
 
     def set_study_user_attr(self, study_id: int, key: str, value: Any) -> None:
 

--- a/optuna/storages/_in_memory.py
+++ b/optuna/storages/_in_memory.py
@@ -65,8 +65,7 @@ class InMemoryStorage(BaseStorage):
             else:
                 study_uuid = str(uuid.uuid4())
                 study_name = DEFAULT_STUDY_NAME_PREFIX + study_uuid
-            study = _StudyInfo(study_name)
-            study.directions = list(directions)
+            study = _StudyInfo(study_name, list(directions))
 
             self._studies[study_id] = study
             self._study_name_to_id[study_name] = study_id
@@ -119,7 +118,6 @@ class InMemoryStorage(BaseStorage):
         with self._lock:
             self._check_study_id(study_id)
             directions = self._studies[study_id].directions
-            assert directions is not None  # Study directions are never `None`.
             return directions
 
     def get_study_user_attrs(self, study_id: int) -> Dict[str, Any]:
@@ -251,7 +249,6 @@ class InMemoryStorage(BaseStorage):
             best_trial_id = self._studies[study_id].best_trial_id
 
             directions = self._studies[study_id].directions
-            assert directions is not None  # Study directions are never `None`.
 
             if best_trial_id is None:
                 raise ValueError("No trials are completed yet.")
@@ -418,11 +415,11 @@ class InMemoryStorage(BaseStorage):
 
 
 class _StudyInfo:
-    def __init__(self, name: str) -> None:
+    def __init__(self, name: str, directions: List[StudyDirection]) -> None:
         self.trials: List[FrozenTrial] = []
         self.param_distribution: Dict[str, distributions.BaseDistribution] = {}
         self.user_attrs: Dict[str, Any] = {}
         self.system_attrs: Dict[str, Any] = {}
         self.name: str = name
-        self.directions: Optional[List[StudyDirection]] = None
+        self.directions: List[StudyDirection] = directions
         self.best_trial_id: Optional[int] = None

--- a/optuna/storages/_in_memory.py
+++ b/optuna/storages/_in_memory.py
@@ -71,14 +71,6 @@ class InMemoryStorage(BaseStorage):
 
             _logger.info("A new study created in memory with name: {}".format(study_name))
 
-            if study.directions[0] != StudyDirection.NOT_SET and study.directions != list(
-                directions
-            ):
-                raise ValueError(
-                    "Cannot overwrite study direction from {} to {}.".format(
-                        study.directions, directions
-                    )
-                )
             study.directions = list(directions)
 
             return study_id
@@ -426,5 +418,5 @@ class _StudyInfo:
         self.user_attrs: Dict[str, Any] = {}
         self.system_attrs: Dict[str, Any] = {}
         self.name: str = name
-        self.directions: List[StudyDirection] = [StudyDirection.NOT_SET]
+        self.directions: List[StudyDirection] = []
         self.best_trial_id: Optional[int] = None

--- a/optuna/storages/_in_memory.py
+++ b/optuna/storages/_in_memory.py
@@ -65,9 +65,8 @@ class InMemoryStorage(BaseStorage):
             else:
                 study_uuid = str(uuid.uuid4())
                 study_name = DEFAULT_STUDY_NAME_PREFIX + study_uuid
-            study = _StudyInfo(study_name, list(directions))
 
-            self._studies[study_id] = study
+            self._studies[study_id] = _StudyInfo(study_name, list(directions))
             self._study_name_to_id[study_name] = study_id
 
             _logger.info("A new study created in memory with name: {}".format(study_name))
@@ -117,8 +116,7 @@ class InMemoryStorage(BaseStorage):
 
         with self._lock:
             self._check_study_id(study_id)
-            directions = self._studies[study_id].directions
-            return directions
+            return self._studies[study_id].directions
 
     def get_study_user_attrs(self, study_id: int) -> Dict[str, Any]:
 
@@ -248,11 +246,9 @@ class InMemoryStorage(BaseStorage):
 
             best_trial_id = self._studies[study_id].best_trial_id
 
-            directions = self._studies[study_id].directions
-
             if best_trial_id is None:
                 raise ValueError("No trials are completed yet.")
-            elif len(directions) > 1:
+            elif len(self._studies[study_id].directions) > 1:
                 raise RuntimeError(
                     "Best trial can be obtained only for single-objective optimization."
                 )

--- a/optuna/storages/_journal/storage.py
+++ b/optuna/storages/_journal/storage.py
@@ -455,7 +455,7 @@ class JournalStorageReplayResult:
 
     def _apply_create_study(self, log: Dict[str, Any]) -> None:
         study_name = log["study_name"]
-        directions = [StudyDirection(i) for i in log["directions"]]
+        directions = [StudyDirection(d) for d in log["directions"]]
 
         if study_name in [s.study_name for s in self._studies.values()]:
             if self._is_issued_by_this_worker(log):

--- a/optuna/storages/_journal/storage.py
+++ b/optuna/storages/_journal/storage.py
@@ -160,8 +160,6 @@ class JournalStorage(BaseStorage):
                 ):
                     self._backend.save_snapshot(pickle.dumps(self._replay_result))
 
-                self._sync_with_backend()
-
                 return study_id
             assert False, "Should not reach."
 

--- a/optuna/storages/_journal/storage.py
+++ b/optuna/storages/_journal/storage.py
@@ -40,13 +40,12 @@ class JournalOperation(enum.IntEnum):
     DELETE_STUDY = 1
     SET_STUDY_USER_ATTR = 2
     SET_STUDY_SYSTEM_ATTR = 3
-    SET_STUDY_DIRECTIONS = 4
-    CREATE_TRIAL = 5
-    SET_TRIAL_PARAM = 6
-    SET_TRIAL_STATE_VALUES = 7
-    SET_TRIAL_INTERMEDIATE_VALUE = 8
-    SET_TRIAL_USER_ATTR = 9
-    SET_TRIAL_SYSTEM_ATTR = 10
+    CREATE_TRIAL = 4
+    SET_TRIAL_PARAM = 5
+    SET_TRIAL_STATE_VALUES = 6
+    SET_TRIAL_INTERMEDIATE_VALUE = 7
+    SET_TRIAL_USER_ATTR = 8
+    SET_TRIAL_SYSTEM_ATTR = 9
 
 
 @experimental_class("3.1.0")
@@ -135,11 +134,15 @@ class JournalStorage(BaseStorage):
         logs = self._backend.read_logs(self._replay_result.log_number_read)
         self._replay_result.apply_logs(logs)
 
-    def create_new_study(self, study_name: Optional[str] = None) -> int:
+    def create_new_study(
+        self, directions: Sequence[StudyDirection], study_name: Optional[str] = None
+    ) -> int:
         study_name = study_name or DEFAULT_STUDY_NAME_PREFIX + str(uuid.uuid4())
 
         with self._thread_lock:
-            self._write_log(JournalOperation.CREATE_STUDY, {"study_name": study_name})
+            self._write_log(
+                JournalOperation.CREATE_STUDY, {"study_name": study_name, "directions": directions}
+            )
             self._sync_with_backend()
 
             for frozen_study in self._replay_result.get_all_studies():
@@ -156,6 +159,9 @@ class JournalStorage(BaseStorage):
                     and study_id % SNAPSHOT_INTERVAL == 0
                 ):
                     self._backend.save_snapshot(pickle.dumps(self._replay_result))
+
+                self._sync_with_backend()
+
                 return study_id
             assert False, "Should not reach."
 
@@ -174,12 +180,6 @@ class JournalStorage(BaseStorage):
         log: Dict[str, Any] = {"study_id": study_id, "system_attr": {key: value}}
         with self._thread_lock:
             self._write_log(JournalOperation.SET_STUDY_SYSTEM_ATTR, log)
-            self._sync_with_backend()
-
-    def set_study_directions(self, study_id: int, directions: Sequence[StudyDirection]) -> None:
-        log: Dict[str, Any] = {"study_id": study_id, "directions": directions}
-        with self._thread_lock:
-            self._write_log(JournalOperation.SET_STUDY_DIRECTIONS, log)
             self._sync_with_backend()
 
     def get_study_id_from_name(self, study_name: str) -> int:
@@ -394,8 +394,6 @@ class JournalStorageReplayResult:
                 self._apply_set_study_user_attr(log)
             elif op == JournalOperation.SET_STUDY_SYSTEM_ATTR:
                 self._apply_set_study_system_attr(log)
-            elif op == JournalOperation.SET_STUDY_DIRECTIONS:
-                self._apply_set_study_directions(log)
             elif op == JournalOperation.CREATE_TRIAL:
                 self._apply_create_trial(log)
             elif op == JournalOperation.SET_TRIAL_PARAM:
@@ -500,26 +498,6 @@ class JournalStorageReplayResult:
         if self._study_exists(study_id, log):
             assert len(log["system_attr"]) == 1
             self._studies[study_id].system_attrs.update(log["system_attr"])
-
-    def _apply_set_study_directions(self, log: Dict[str, Any]) -> None:
-        study_id = log["study_id"]
-
-        if not self._study_exists(study_id, log):
-            return
-
-        directions = [StudyDirection(d) for d in log["directions"]]
-
-        current_directions = self._studies[study_id]._directions
-        if current_directions[0] != StudyDirection.NOT_SET and current_directions != directions:
-            if self._is_issued_by_this_worker(log):
-                raise ValueError(
-                    "Cannot overwrite study direction from {} to {}.".format(
-                        current_directions, directions
-                    )
-                )
-            return
-
-        self._studies[study_id]._directions = [StudyDirection(d) for d in directions]
 
     def _apply_create_trial(self, log: Dict[str, Any]) -> None:
         study_id = log["study_id"]

--- a/optuna/storages/_journal/storage.py
+++ b/optuna/storages/_journal/storage.py
@@ -455,7 +455,7 @@ class JournalStorageReplayResult:
 
     def _apply_create_study(self, log: Dict[str, Any]) -> None:
         study_name = log["study_name"]
-        directions = log["directions"]
+        directions = [StudyDirection(i) for i in log["directions"]]
 
         if study_name in [s.study_name for s in self._studies.values()]:
             if self._is_issued_by_this_worker(log):
@@ -472,10 +472,11 @@ class JournalStorageReplayResult:
 
         self._studies[study_id] = FrozenStudy(
             study_name=study_name,
-            direction=directions,
+            direction=None,
             user_attrs={},
             system_attrs={},
             study_id=study_id,
+            directions=directions,
         )
         self._study_id_to_trial_ids[study_id] = []
 

--- a/optuna/storages/_journal/storage.py
+++ b/optuna/storages/_journal/storage.py
@@ -455,6 +455,7 @@ class JournalStorageReplayResult:
 
     def _apply_create_study(self, log: Dict[str, Any]) -> None:
         study_name = log["study_name"]
+        directions = log["directions"]
 
         if study_name in [s.study_name for s in self._studies.values()]:
             if self._is_issued_by_this_worker(log):
@@ -471,7 +472,7 @@ class JournalStorageReplayResult:
 
         self._studies[study_id] = FrozenStudy(
             study_name=study_name,
-            direction=StudyDirection.NOT_SET,
+            direction=directions,
             user_attrs={},
             system_attrs={},
             study_id=study_id,

--- a/optuna/storages/_rdb/models.py
+++ b/optuna/storages/_rdb/models.py
@@ -91,19 +91,6 @@ class StudyDirectionModel(BaseModel):
     )
 
     @classmethod
-    def find_by_study_and_objective(
-        cls, study: StudyModel, objective: int, session: orm.Session
-    ) -> Optional["StudyDirectionModel"]:
-        study_direction = (
-            session.query(cls)
-            .filter(cls.study_id == study.study_id)
-            .filter(cls.objective == objective)
-            .one_or_none()
-        )
-
-        return study_direction
-
-    @classmethod
     def where_study_id(cls, study_id: int, session: orm.Session) -> List["StudyDirectionModel"]:
 
         return session.query(cls).filter(cls.study_id == study_id).all()

--- a/optuna/storages/_rdb/storage.py
+++ b/optuna/storages/_rdb/storage.py
@@ -7,7 +7,6 @@ import logging
 import os
 from typing import Any
 from typing import Callable
-from typing import cast
 from typing import Container
 from typing import Dict
 from typing import Generator
@@ -270,10 +269,7 @@ class RDBStorage(BaseStorage, BaseHeartbeat):
                     for objective, d in enumerate(list(directions))
                 ]
 
-                study = models.StudyModel(study_name=study_name, directions=direction_models)
-                session.add(study)
-
-            study_id = self.get_study_id_from_name(study_name)
+                session.add(models.StudyModel(study_name=study_name, directions=direction_models))
 
         except sqlalchemy_exc.IntegrityError:
             raise optuna.exceptions.DuplicatedStudyError(
@@ -285,7 +281,7 @@ class RDBStorage(BaseStorage, BaseHeartbeat):
 
         _logger.info("A new study created in RDB with name: {}".format(study_name))
 
-        return study_id
+        return self.get_study_id_from_name(study_name)
 
     def delete_study(self, study_id: int) -> None:
 

--- a/optuna/study/_study_direction.py
+++ b/optuna/study/_study_direction.py
@@ -5,11 +5,14 @@ class StudyDirection(enum.IntEnum):
     """Direction of a :class:`~optuna.study.Study`.
 
     Attributes:
+        NOT_SET:
+            Direction has not been set.
         MINIMIZE:
             :class:`~optuna.study.Study` minimizes the objective function.
         MAXIMIZE:
             :class:`~optuna.study.Study` maximizes the objective function.
     """
 
+    NOT_SET = 0
     MINIMIZE = 1
     MAXIMIZE = 2

--- a/optuna/study/_study_direction.py
+++ b/optuna/study/_study_direction.py
@@ -5,14 +5,11 @@ class StudyDirection(enum.IntEnum):
     """Direction of a :class:`~optuna.study.Study`.
 
     Attributes:
-        NOT_SET:
-            Direction has not been set.
         MINIMIZE:
             :class:`~optuna.study.Study` minimizes the objective function.
         MAXIMIZE:
             :class:`~optuna.study.Study` maximizes the objective function.
     """
 
-    NOT_SET = 0
     MINIMIZE = 1
     MAXIMIZE = 2

--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -1153,7 +1153,7 @@ def create_study(
 
     storage = storages.get_storage(storage)
     try:
-        study_id = storage.create_new_study(study_name)
+        study_id = storage.create_new_study(direction_objects, study_name)
     except exceptions.DuplicatedStudyError:
         if load_if_exists:
             assert study_name is not None
@@ -1170,7 +1170,6 @@ def create_study(
         sampler = samplers.NSGAIISampler()
 
     study_name = storage.get_study_name_from_id(study_id)
-    storage.set_study_directions(study_id, direction_objects)
     study = Study(study_name=study_name, storage=storage, sampler=sampler, pruner=pruner)
 
     return study

--- a/tests/storages_tests/rdb_tests/test_models.py
+++ b/tests/storages_tests/rdb_tests/test_models.py
@@ -48,16 +48,6 @@ class TestStudyDirectionModel:
         return study
 
     @staticmethod
-    def test_find_by_study_and_objective(session: Session) -> None:
-
-        study = TestStudyDirectionModel._create_model(session)
-        direction = StudyDirectionModel.find_by_study_and_objective(study, 0, session)
-        assert direction is not None
-        assert direction.direction == StudyDirection.MINIMIZE
-
-        assert StudyDirectionModel.find_by_study_and_objective(study, 1, session) is None
-
-    @staticmethod
     def test_where_study_id(session: Session) -> None:
 
         study = TestStudyDirectionModel._create_model(session)

--- a/tests/storages_tests/test_cached_storage.py
+++ b/tests/storages_tests/test_cached_storage.py
@@ -5,13 +5,16 @@ import pytest
 import optuna
 from optuna.storages._cached_storage import _CachedStorage
 from optuna.storages._rdb.storage import RDBStorage
+from optuna.study import StudyDirection
 from optuna.trial import TrialState
 
 
 def test_create_trial() -> None:
     base_storage = RDBStorage("sqlite:///:memory:")
     storage = _CachedStorage(base_storage)
-    study_id = storage.create_new_study("test-study")
+    study_id = storage.create_new_study(
+        directions=[StudyDirection.MINIMIZE], study_name="test-study"
+    )
     frozen_trial = optuna.trial.FrozenTrial(
         number=1,
         state=TrialState.RUNNING,
@@ -33,7 +36,9 @@ def test_create_trial() -> None:
 def test_set_trial_state_values() -> None:
     base_storage = RDBStorage("sqlite:///:memory:")
     storage = _CachedStorage(base_storage)
-    study_id = storage.create_new_study("test-study")
+    study_id = storage.create_new_study(
+        directions=[StudyDirection.MINIMIZE], study_name="test-study"
+    )
     trial_id = storage.create_new_trial(study_id)
     storage.set_trial_state_values(trial_id, state=TrialState.COMPLETE)
 
@@ -53,7 +58,9 @@ def test_uncached_set() -> None:
 
     base_storage = RDBStorage("sqlite:///:memory:")
     storage = _CachedStorage(base_storage)
-    study_id = storage.create_new_study("test-study")
+    study_id = storage.create_new_study(
+        directions=[StudyDirection.MINIMIZE], study_name="test-study"
+    )
 
     trial_id = storage.create_new_trial(study_id)
     trial = storage.get_trial(trial_id)
@@ -103,7 +110,9 @@ def test_read_trials_from_remote_storage() -> None:
 
     base_storage = RDBStorage("sqlite:///:memory:")
     storage = _CachedStorage(base_storage)
-    study_id = storage.create_new_study("test-study")
+    study_id = storage.create_new_study(
+        directions=[StudyDirection.MINIMIZE], study_name="test-study"
+    )
 
     storage.read_trials_from_remote_storage(study_id)
 

--- a/tests/storages_tests/test_storages.py
+++ b/tests/storages_tests/test_storages.py
@@ -164,7 +164,6 @@ def test_get_study_id_from_name_and_get_study_name_from_id(storage_mode: str) ->
             storage.get_study_name_from_id(study_id + 1)
 
 
-# TODO(gen740): write a test create_study directions and get_study_directions
 @pytest.mark.parametrize("storage_mode", STORAGE_MODES)
 def test_set_and_get_study_directions(storage_mode: str) -> None:
 

--- a/tests/storages_tests/test_storages.py
+++ b/tests/storages_tests/test_storages.py
@@ -184,18 +184,15 @@ def test_set_and_get_study_directions(storage_mode: str) -> None:
                 got_directions = storage.get_study_directions(study_id)
 
                 assert got_directions == list(
-                    directions
+                    target
                 ), "Direction of a study should be a tuple of `StudyDirection` objects."
-
-            directions = storage.get_study_directions(study_id)
-            assert len(directions) == 1
-            assert directions[0] == StudyDirection.NOT_SET
 
             # Test setting value.
             check_get()
 
             # Test non-existent study.
             non_existent_study_id = study_id + 1
+
             with pytest.raises(KeyError):
                 storage.get_study_directions(non_existent_study_id)
 

--- a/tests/storages_tests/test_with_server.py
+++ b/tests/storages_tests/test_with_server.py
@@ -1,4 +1,5 @@
 from concurrent.futures import ProcessPoolExecutor
+from concurrent.futures import ThreadPoolExecutor
 import os
 import pickle
 from typing import Sequence
@@ -148,7 +149,20 @@ def test_store_nan_intermediate_values(storage: BaseStorage) -> None:
     assert np.isnan(got_value)
 
 
-def test_multiprocess(storage: BaseStorage) -> None:
+def test_multithread_create_study(storage: BaseStorage) -> None:
+    with ThreadPoolExecutor(10) as pool:
+        for _ in range(10):
+            pool.submit(
+                optuna.create_study,
+                storage=storage,
+                study_name="test-multithread-create-study",
+                load_if_exists=True,
+            )
+
+    assert len(storage.get_all_studies()) == 1
+
+
+def test_multiprocess_run_optimize(storage: BaseStorage) -> None:
     n_workers = 8
     n_trials = 20
     study_name = _STUDY_NAME

--- a/tests/storages_tests/test_with_server.py
+++ b/tests/storages_tests/test_with_server.py
@@ -159,7 +159,7 @@ def test_multithread_create_study(storage: BaseStorage) -> None:
                 load_if_exists=True,
             )
 
-    assert len(storage.get_all_studies()) == 1
+    assert len(storage.get_all_studies()) >= 1
 
 
 def test_multiprocess_run_optimize(storage: BaseStorage) -> None:

--- a/tests/storages_tests/test_with_server.py
+++ b/tests/storages_tests/test_with_server.py
@@ -159,8 +159,6 @@ def test_multithread_create_study(storage: BaseStorage) -> None:
                 load_if_exists=True,
             )
 
-    assert len(storage.get_all_studies()) >= 1
-
 
 def test_multiprocess_run_optimize(storage: BaseStorage) -> None:
     n_workers = 8

--- a/tests/storages_tests/test_with_server.py
+++ b/tests/storages_tests/test_with_server.py
@@ -8,6 +8,7 @@ import pytest
 
 import optuna
 from optuna.storages import BaseStorage
+from optuna.study import StudyDirection
 from optuna.trial import TrialState
 
 
@@ -127,7 +128,7 @@ def test_loaded_trials(storage: BaseStorage) -> None:
 )
 def test_store_infinite_values(input_value: float, expected: float, storage: BaseStorage) -> None:
 
-    study_id = storage.create_new_study()
+    study_id = storage.create_new_study(directions=[StudyDirection.MINIMIZE])
     trial_id = storage.create_new_trial(study_id)
     storage.set_trial_intermediate_value(trial_id, 1, input_value)
     storage.set_trial_state_values(trial_id, state=TrialState.COMPLETE, values=(input_value,))
@@ -137,7 +138,7 @@ def test_store_infinite_values(input_value: float, expected: float, storage: Bas
 
 def test_store_nan_intermediate_values(storage: BaseStorage) -> None:
 
-    study_id = storage.create_new_study()
+    study_id = storage.create_new_study(directions=[StudyDirection.MINIMIZE])
     trial_id = storage.create_new_trial(study_id)
 
     value = float("nan")
@@ -164,7 +165,7 @@ def test_multiprocess(storage: BaseStorage) -> None:
 
 
 def test_pickle_storage(storage: BaseStorage) -> None:
-    study_id = storage.create_new_study()
+    study_id = storage.create_new_study(directions=[StudyDirection.MINIMIZE])
     storage.set_study_system_attr(study_id, "key", "pickle")
 
     restored_storage = pickle.loads(pickle.dumps(storage))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -247,7 +247,9 @@ def test_study_set_user_attr_command() -> None:
         storage_url = str(storage.engine.url)
 
         # Create study.
-        study_name = storage.get_study_name_from_id(storage.create_new_study())
+        study_name = storage.get_study_name_from_id(
+            storage.create_new_study(directions=[StudyDirection.MINIMIZE])
+        )
 
         base_command = [
             "optuna",
@@ -965,7 +967,9 @@ def test_study_optimize_command() -> None:
         assert isinstance(storage, RDBStorage)
         storage_url = str(storage.engine.url)
 
-        study_name = storage.get_study_name_from_id(storage.create_new_study())
+        study_name = storage.get_study_name_from_id(
+            storage.create_new_study(directions=[StudyDirection.MINIMIZE])
+        )
         command = [
             "optuna",
             "study",


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
Now, optuna's storage has a member function `set_study_directions`. But it is not necessary, because the study's `directions` is not changeable after creating the study.

So, I create a `directions` arg on `storage.create_new_study` and delete `set_study_directions`.

## Description of the changes
<!-- Describe the changes in this PR. -->
- Add `directions` arg to `storage.create_new_study` for all storages.
- Delete `set_study_directions` members from all storages including `dask`.
- Delete `SET_STUDY_DIRECTIONS` from `JournalOperation`.
- Rewrite `test_set_and_get_study_directions`.