### PR TITLE
Isolate tests with minimum version

### DIFF
--- a/.github/workflows/tests-with-minimum-version.yml
+++ b/.github/workflows/tests-with-minimum-version.yml
@@ -14,7 +14,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  tests:
+  tests-with-minimum-version:
     if: (github.event_name == 'schedule' && github.repository == 'optuna/optuna') || (github.event_name != 'schedule')
     runs-on: ubuntu-latest
 

--- a/.github/workflows/tests-with-minimum-version.yml
+++ b/.github/workflows/tests-with-minimum-version.yml
@@ -72,6 +72,7 @@ jobs:
         # Install dependencies with minimum versions.
         pip uninstall -y alembic cmaes packaging sqlalchemy plotly scikit-learn
         pip install alembic==1.5.0 cmaes==0.9.0 packaging==20.0 sqlalchemy==1.3.0
+        pip list | grep setuptools
         pip install plotly==4.9.0 scikit-learn==0.24.2  # optional extras
 
     - name: Scheduled tests

--- a/.github/workflows/tests-with-minimum-version.yml
+++ b/.github/workflows/tests-with-minimum-version.yml
@@ -43,10 +43,10 @@ jobs:
     - name: Setup cache
       uses: actions/cache@v2
       env:
-        cache-name: test
+        cache-name: test-with-minimum-version
       with:
         path: ~/.cache/pip
-        key: ${{ runner.os }}-${{ matrix.python-version }}-${{ env.cache-name }}-${{ hashFiles('**/setup.py') }}-${{ matrix.third-party-package-installation-strategy }}-v1
+        key: ${{ runner.os }}-${{ matrix.python-version }}-${{ env.cache-name }}-${{ hashFiles('**/setup.py') }}-v1
         restore-keys: |
           ${{ runner.os }}-${{ matrix.python-version }}-${{ env.cache-name }}-${{ hashFiles('**/setup.py') }}
 

--- a/.github/workflows/tests-with-minimum-version.yml
+++ b/.github/workflows/tests-with-minimum-version.yml
@@ -55,7 +55,7 @@ jobs:
     - name: Setup pip
       run: |
         python -m pip install --upgrade pip
-        pip install --progress-bar off -U "setuptools<60.0"
+        pip install --progress-bar off -U "setuptools<65.6.0"
 
     - name: Install
       run: |
@@ -70,7 +70,6 @@ jobs:
     - name: Install dependencies with minimum versions
       run: |
         # Install dependencies with minimum versions.
-        pip install "numpy<1.23.5"
         pip uninstall -y alembic cmaes packaging sqlalchemy plotly scikit-learn
         pip install alembic==1.5.0 cmaes==0.9.0 packaging==20.0 sqlalchemy==1.3.0
         pip install plotly==4.9.0 scikit-learn==0.24.2  # optional extras

--- a/.github/workflows/tests-with-minimum-version.yml
+++ b/.github/workflows/tests-with-minimum-version.yml
@@ -19,6 +19,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: false
       matrix:
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
 
@@ -69,6 +70,7 @@ jobs:
     - name: Install dependencies with minimum versions
       run: |
         # Install dependencies with minimum versions.
+        pip install "numpy<=1.23.5"
         pip uninstall -y alembic cmaes packaging sqlalchemy plotly scikit-learn
         pip install alembic==1.5.0 cmaes==0.9.0 packaging==20.0 sqlalchemy==1.3.0
         pip install plotly==4.9.0 scikit-learn==0.24.2  # optional extras

--- a/.github/workflows/tests-with-minimum-version.yml
+++ b/.github/workflows/tests-with-minimum-version.yml
@@ -70,7 +70,7 @@ jobs:
     - name: Install dependencies with minimum versions
       run: |
         # Install dependencies with minimum versions.
-        pip install "numpy<=1.23.5"
+        pip install "numpy<1.23.5"
         pip uninstall -y alembic cmaes packaging sqlalchemy plotly scikit-learn
         pip install alembic==1.5.0 cmaes==0.9.0 packaging==20.0 sqlalchemy==1.3.0
         pip install plotly==4.9.0 scikit-learn==0.24.2  # optional extras

--- a/.github/workflows/tests-with-minimum-version.yml
+++ b/.github/workflows/tests-with-minimum-version.yml
@@ -55,7 +55,7 @@ jobs:
     - name: Setup pip
       run: |
         python -m pip install --upgrade pip
-        pip install --progress-bar off -U "setuptools<65.6.0"
+        pip install --progress-bar off -U setuptools
 
     - name: Install
       run: |

--- a/.github/workflows/tests-with-minimum-version.yml
+++ b/.github/workflows/tests-with-minimum-version.yml
@@ -54,7 +54,7 @@ jobs:
     - name: Setup pip
       run: |
         python -m pip install --upgrade pip
-        pip install --progress-bar off -U "setuptools<65.6.0"
+        pip install --progress-bar off -U "setuptools<60.0"
 
     - name: Install
       run: |

--- a/.github/workflows/tests-with-minimum-version.yml
+++ b/.github/workflows/tests-with-minimum-version.yml
@@ -1,4 +1,4 @@
-name: Tests
+name: Tests with minimum version
 
 on:
   push:
@@ -46,7 +46,7 @@ jobs:
         cache-name: test
       with:
         path: ~/.cache/pip
-        key: ${{ runner.os }}-${{ matrix.python-version }}-${{ env.cache-name }}-${{ hashFiles('**/setup.py') }}-v1
+        key: ${{ runner.os }}-${{ matrix.python-version }}-${{ env.cache-name }}-${{ hashFiles('**/setup.py') }}-${{ matrix.third-party-package-installation-strategy }}-v1
         restore-keys: |
           ${{ runner.os }}-${{ matrix.python-version }}-${{ env.cache-name }}-${{ hashFiles('**/setup.py') }}
 
@@ -54,7 +54,7 @@ jobs:
     - name: Setup pip
       run: |
         python -m pip install --upgrade pip
-        pip install --progress-bar off -U setuptools
+        pip install --progress-bar off -U "setuptools<65.6.0"
 
     - name: Install
       run: |
@@ -65,6 +65,13 @@ jobs:
 
         pip install --progress-bar off .[test]
         pip install --progress-bar off .[optional]
+
+    - name: Install dependencies with minimum versions
+      run: |
+        # Install dependencies with minimum versions.
+        pip uninstall -y alembic cmaes packaging sqlalchemy plotly scikit-learn
+        pip install alembic==1.5.0 cmaes==0.9.0 packaging==20.0 sqlalchemy==1.3.0
+        pip install plotly==4.9.0 scikit-learn==0.24.2  # optional extras
 
     - name: Scheduled tests
       if:  ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ def get_install_requires() -> List[str]:
         "sqlalchemy>=1.3.0",
         "tqdm",
         "PyYAML",  # Only used in `optuna/cli.py`.
+        "setuptools<65.6.0",
     ]
     return requirements
 


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
To fix the CI.

The latest release of `setuptools` breaks the installation of libraries using `numpy.distutils`. See https://github.com/pypa/setuptools/issues/3693 and https://github.com/numpy/numpy/issues/22623.

This PR suggests to avoid the latest `setuptools` when we use libraries using `numpy.distutils`, that is, the tests with minimum versions. This is a temporary fix. We don't have to avoid the latest `setuptools` for normal tests, so I isolate the normal tests and those with minimum versions.

The merits of this isolation are as follows.
- As the current problem suggests, tests with minimum versions are fragile. It is possible for a version unspecified library update to cause a test to fail at an unexpected time. By splitting up the workflow, when a test fails, it becomes clear whether the problem is with tests with minimum versions or not.
- In addition, in the current GitHub Actions configuration, normal tests are required, but tests with minimum versions are not. If they are in the same workflow, a failure of tests with minimum versions may cause the entire workflow to be canceled and the required tests to not be executed.

## Description of the changes
<!-- Describe the changes in this PR. -->
- Isolate the normal tests and tests with minimum versions.
- Add version constraint `setuptools<65.6.0` for tests with minimum versions.