### PR TITLE
Skip tests with minimum version for Python 3.10 and 3.11

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -79,7 +79,7 @@ jobs:
         pip install alembic==1.5.0 cmaes==0.9.0 packaging==20.0 sqlalchemy==1.3.0
         pip install plotly==4.9.0 scikit-learn==0.24.2  # optional extras
         # TODO(HideakiImamura): Skip for the release of `setuptools==65.6.0`. Fix after https://github.com/pypa/setuptools/issues/3693.
-      if: ${{ matrix.third-party-package-installation-strategy == 'with-minimum-version' && (matrix.python-version == '3.10' || matrix.python-version == '3.11') }}
+      if: ${{ matrix.third-party-package-installation-strategy == 'with-minimum-version' && matrix.python-version != '3.10' and matrix.python-version != '3.11' }}
 
     - name: Tests
       if:  ${{ github.event_name != 'schedule' }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -79,7 +79,7 @@ jobs:
         pip install alembic==1.5.0 cmaes==0.9.0 packaging==20.0 sqlalchemy==1.3.0
         pip install plotly==4.9.0 scikit-learn==0.24.2  # optional extras
         # TODO(HideakiImamura): Skip for the release of `setuptools==65.6.0`. Fix after https://github.com/pypa/setuptools/issues/3693.
-      if: ${{ matrix.third-party-package-installation-strategy == 'with-minimum-version' && matrix.python-version != '3.10' and matrix.python-version != '3.11' }}
+      if: ${{ matrix.third-party-package-installation-strategy == 'with-minimum-version' && matrix.python-version != '3.10' && matrix.python-version != '3.11' }}
 
     - name: Tests
       if:  ${{ github.event_name != 'schedule' }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -78,7 +78,8 @@ jobs:
         pip uninstall -y alembic cmaes packaging sqlalchemy plotly scikit-learn
         pip install alembic==1.5.0 cmaes==0.9.0 packaging==20.0 sqlalchemy==1.3.0
         pip install plotly==4.9.0 scikit-learn==0.24.2  # optional extras
-      if: ${{ matrix.third-party-package-installation-strategy == 'with-minimum-version' }}
+        # TODO(HideakiImamura): Skip for the release of `setuptools==65.6.0`. Fix after https://github.com/pypa/setuptools/issues/3693.
+      if: ${{ matrix.third-party-package-installation-strategy == 'with-minimum-version' && (matrix.python-version == '3.10' || matrix.python-version == '3.11') }}
 
     - name: Tests
       if:  ${{ github.event_name != 'schedule' }}


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
To fix the CI.

The latest release of `setuptools` breaks the installation of libraries using `numpy.distutils`. See https://github.com/pypa/setuptools/issues/3693 and https://github.com/numpy/numpy/issues/22623.

I tried followings in https://github.com/optuna/optuna/pull/4198, but failed.
- Constraint the version of `setuptools` to `<65.6.0` (the latest one) on the workflow file of GitHub Actions
- Constraint the version of `numpy` to `<1.23.5` (the latest one) on the workflow file of GitHub Actions
- Constraint the version of `setuptools` to `<60.0` (the latest one) on the workflow file of GitHub Actions, since `numpy` officially supports `setuptools<60.0`
- Constraint the version of `setuptools` to `<65.6.0` (the latest one) on the `setup.py`

I found that the errors only occur for tests with minimum version and Python 3.10 and 3.11. This PR suggests a hot fix to avoid the tests with minimum version for Python 3.10 and 3.11.

## Description of the changes
<!-- Describe the changes in this PR. -->
- Avoid tests with minimum version for Python 3.10 and 3.11