### PR TITLE
Split normal tests and tests with minimum versions

### DIFF
--- a/.github/workflows/tests-with-minimum-versions.yml
+++ b/.github/workflows/tests-with-minimum-versions.yml
@@ -1,10 +1,9 @@
-name: Tests
+name: Tests with minimum versions
 
 on:
   push:
     branches:
       - master
-  pull_request: {}
   schedule:
     - cron: '0 23 * * SUN-THU'
   workflow_dispatch:
@@ -20,7 +19,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.7', '3.8', '3.9']
 
     services:
       redis:
@@ -43,7 +42,7 @@ jobs:
     - name: Setup cache
       uses: actions/cache@v2
       env:
-        cache-name: test
+        cache-name: test-with-minimum-versions
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-${{ matrix.python-version }}-${{ env.cache-name }}-${{ hashFiles('**/setup.py') }}-v1
@@ -65,6 +64,13 @@ jobs:
 
         pip install --progress-bar off .[test]
         pip install --progress-bar off .[optional]
+
+    - name: Install dependencies with minimum versions
+      run: |
+        # Install dependencies with minimum versions.
+        pip uninstall -y alembic cmaes packaging sqlalchemy plotly scikit-learn
+        pip install alembic==1.5.0 cmaes==0.9.0 packaging==20.0 sqlalchemy==1.3.0
+        pip install plotly==4.9.0 scikit-learn==0.24.2  # optional extras
 
     - name: Scheduled tests
       if:  ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}

--- a/.github/workflows/tests-with-minimum-versions.yml
+++ b/.github/workflows/tests-with-minimum-versions.yml
@@ -13,7 +13,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  tests:
+  tests-with-minimum-versions:
     if: (github.event_name == 'schedule' && github.repository == 'optuna/optuna') || (github.event_name != 'schedule')
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
Follow up of https://github.com/optuna/optuna/pull/4199

This PR suggests to split normal tests and tests with minimum versions.

The merits of this split are as follows.

- As #4199 suggests, tests with minimum versions are fragile. It is possible for a version unspecified library update to cause a test to fail at an unexpected time. By splitting up the workflow, when a test fails, it becomes clear whether the problem is with tests with minimum versions or not.
- In addition, in the current GitHub Actions configuration, normal tests are required, but tests with minimum versions are not. If they are in the same workflow, a failure of tests with minimum versions may cause the entire workflow to be canceled and the required tests to not be executed. (This is avoided by the [`fail-fast` option](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast) of GitHub Actions, but it is costly. I prefer this split solution.)
- IMO, we don't have to run the tests with minimum version per PR. It is enough to run the tests daily. The split of workflow files make this easy.

## Description of the changes
<!-- Describe the changes in this PR. -->
- Split the workflow file of normal tests and tests with minimum versions
- Tests with minimum versions are not to be executed per PR.
