### PR TITLE
Update actions/cache@v2 -> v3

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -28,7 +28,7 @@ jobs:
         python-version: 3.8
 
     - name: Setup cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       env:
         cache-name: coverage
       with:

--- a/.github/workflows/mac-tests.yml
+++ b/.github/workflows/mac-tests.yml
@@ -33,7 +33,7 @@ jobs:
         python-version: 3.8
 
     - name: Setup cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       env:
         cache-name: test
       with:
@@ -72,7 +72,7 @@ jobs:
         python-version: 3.8
 
     - name: Setup cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       env:
         cache-name: test-integration
       with:

--- a/.github/workflows/mac-tests.yml
+++ b/.github/workflows/mac-tests.yml
@@ -72,7 +72,7 @@ jobs:
         python-version: 3.8
 
     - name: Setup cache
-      uses: actions/cache@v3
+      uses: actions/cache@v2
       env:
         cache-name: test-integration
       with:

--- a/.github/workflows/mac-tests.yml
+++ b/.github/workflows/mac-tests.yml
@@ -33,7 +33,7 @@ jobs:
         python-version: 3.8
 
     - name: Setup cache
-      uses: actions/cache@v3
+      uses: actions/cache@v2
       env:
         cache-name: test
       with:

--- a/.github/workflows/performance-benchmarks-kurobako.yml
+++ b/.github/workflows/performance-benchmarks-kurobako.yml
@@ -52,7 +52,7 @@ jobs:
         sudo apt -y install gnuplot
 
     - name: Setup cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       env:
         # Caches them under a common name so that they can be used by other performance benchmark.
         cache-name: performance-benchmarks
@@ -78,7 +78,7 @@ jobs:
 
     - name: Cache kurobako CLI
       id: cache-kurobako
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ./kurobako
         key: kurobako-0-2-9
@@ -93,7 +93,7 @@ jobs:
 
     - name: Cache hpobench dataset
       id: cache-hpobench-dataset
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ./fcnet_tabular_benchmarks
         key: hpobench-dataset
@@ -106,7 +106,7 @@ jobs:
 
     - name: Cache nasbench dataset
       id: cache-nasbench-dataset
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ./nasbench_full.bin
         key: nasbench-dataset

--- a/.github/workflows/performance-benchmarks-mo-kurobako.yml
+++ b/.github/workflows/performance-benchmarks-mo-kurobako.yml
@@ -44,7 +44,7 @@ jobs:
         sudo apt -y install gnuplot
 
     - name: Setup cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       env:
         # Caches them under a common name so that they can be used by other performance benchmark.
         cache-name: performance-benchmarks
@@ -70,7 +70,7 @@ jobs:
 
     - name: Cache kurobako CLI
       id: cache-kurobako
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ./kurobako
         key: kurobako-0-2-9
@@ -85,7 +85,7 @@ jobs:
 
     - name: Cache nasbench dataset
       id: cache-nasbench-dataset
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ./nasbench_full.bin
         key: nasbench-dataset

--- a/.github/workflows/performance-benchmarks-naslib.yml
+++ b/.github/workflows/performance-benchmarks-naslib.yml
@@ -52,7 +52,7 @@ jobs:
         sudo apt -y install gnuplot
 
     - name: Setup cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       env:
         # Caches them under a common name so that they can be used by other performance benchmark.
         cache-name: performance-benchmarks
@@ -76,7 +76,7 @@ jobs:
 
     - name: Cache kurobako CLI
       id: cache-kurobako
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ./kurobako
         key: kurobako-0-2-10
@@ -101,7 +101,7 @@ jobs:
 
     - name: Cache nasbench201-cifar10 dataset
       id: cache-nb201-cifar10-dataset
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: NASLib/naslib/data/nb201_cifar10_full_training.pickle
         key: cache-nb201-cifar10
@@ -125,7 +125,7 @@ jobs:
 
     - name: Cache nasbench201-cifar100 dataset
       id: cache-nb201-cifar100-dataset
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: NASLib/naslib/data/nb201_cifar100_full_training.pickle
         key: cache-nb201-cifar100
@@ -149,7 +149,7 @@ jobs:
 
     - name: Cache nasbench201-imagenet16 dataset
       id: cache-nb201-imagenet16-dataset
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: NASLib/naslib/data/nb201_ImageNet16_full_training.pickle
         key: cache-nb201-imagenet16

--- a/.github/workflows/speed-benchmarks.yml
+++ b/.github/workflows/speed-benchmarks.yml
@@ -21,7 +21,7 @@ jobs:
         python-version: 3.11
 
     - name: Setup cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       env:
         cache-name: speed-benchmarks
       with:

--- a/.github/workflows/sphinx-build.yml
+++ b/.github/workflows/sphinx-build.yml
@@ -26,7 +26,7 @@ jobs:
     # note (crcrpar): We've not updated tutorial frequently enough so far thus
     # it'd be okay to discard cache by any small changes including typo fix under tutorial directory.
     - name: Sphinx Gallery Cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       env:
         cache-name: sphx-glry-documentation
       with:
@@ -71,7 +71,7 @@ jobs:
         python-version: 3.8
 
     - name: Sphinx Gallery Cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       env:
         cache-name: sphx-glry-doctest
       with:

--- a/.github/workflows/tests-integration.yml
+++ b/.github/workflows/tests-integration.yml
@@ -32,7 +32,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Setup cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       env:
         cache-name: test-integration
       with:

--- a/.github/workflows/tests-mpi.yml
+++ b/.github/workflows/tests-mpi.yml
@@ -31,7 +31,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Setup cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       env:
         cache-name: test-mpi
       with:

--- a/.github/workflows/tests-storage.yml
+++ b/.github/workflows/tests-storage.yml
@@ -67,7 +67,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Setup cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       env:
         cache-name: test-storage-with-server
       with:

--- a/.github/workflows/tests-with-minimum-versions.yml
+++ b/.github/workflows/tests-with-minimum-versions.yml
@@ -40,7 +40,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Setup cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       env:
         cache-name: test-with-minimum-versions
       with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,7 +41,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Setup cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       env:
         cache-name: test
       with:


### PR DESCRIPTION
## Motivation
Resolve a part of https://github.com/optuna/optuna/issues/4165.

## Description of the changes
Update action/cache@v2 -> v3 in all workflow except `.github/workflows/mac-tests.yml`.
[Release note](https://github.com/actions/cache/blob/main/RELEASES.md)

Pros:
- Fix minor bug.
- Update @actions/core to v1.10.0 to support updated feature in @actions/core.
- Support new feature: custom timeout, restore and save

Detail: 
v3.0.0: Updated minimum runner version support from node 12 to node 16.
v3.0.1-v3.0.10, 3.1.0-beta.1-3: Fixed minor bugs, Added new features for GHES.
v3.0.8: Allowed users to provide a custom timeout as input for aborting download of a cache segment.
v3.0.10: Updated definition for restore-keys in README.md.
v3.0.11: Updated toolkit version to 3.0.5 and @actions/cache to v1.10.0.
v3.1.0-beta.2: Added support for fallback to gzip to restore old caches on windows.
v3.2.0: Released new actions, restore and save for granular control on cache.

Note:
The version of action/cache stays at v2 in `.github/workflows/mac-tests.yml` because `test-integration-mac` fails due to an irrelevant error to this change.
