### PR TITLE
Update actions/stale@v5 -> v6

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -11,7 +11,7 @@ jobs:
 
     if: github.repository == 'optuna/optuna'
     steps:
-    - uses: actions/stale@v5
+    - uses: actions/stale@v6
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'This issue has not seen any recent activity.'


### PR DESCRIPTION
## Motivation
Resolve a part of https://github.com/optuna/optuna/issues/4165.

## Description of the changes
Update action/stale@v5 -> v6 in all workflow.  
[Release note](https://github.com/actions/stale/blob/main/CHANGELOG.md)
Pros: 
  - Default value of `close-issue-reason` is set to `not-planned`.
  - Update @actions/core to v1.10.0.

Detail:
GitHub added issue closed reasons ([change log](https://github.blog/changelog/2022-05-19-the-new-github-issues-may-19th-update/)), which enables you to chose `completed` or `not-planned` as a reason  when closing an issue. Currently, the default value of `close-issue-reason` is set to be `completed` even if issues are closed by action/stales. However, the default value is `not-planned` from action/stale@v6.0.0.
