### PR TITLE
Add note not to share pickle files in bug reports.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -43,7 +43,7 @@ body:
     id: steps-to-reproduce
     attributes:
       label: Steps to reproduce
-      description: Please provide how we reproduce your reported bugs. If possible, it is highly recommended to provide the reproducible example codes.
+      description: Please provide how we reproduce your reported bugs. If possible, it is highly recommended to provide the reproducible example codes. Note that pickle files will not be accepted due to possible [security issues](https://docs.python.org/3/library/pickle.html).
       value: |
         1.
         2.


### PR DESCRIPTION
## Motivation

See #4210.

## Description of the changes

- Add a note about pickle files to the issue template of bug reports.

![image](https://user-images.githubusercontent.com/3255979/204419359-6dfadcca-2e4f-41f3-a658-089452103df7.png)
