### PR TITLE
Pin `botorch` to avoid CI failure

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,7 @@ def get_extras_require() -> Dict[str, List[str]]:
             "allennlp>=2.2.0",
             # TODO(c-bata): Remove cached-path after allennllp supports v1.1.3
             "cached-path<=1.1.2",
-            "botorch>=0.4.0",
+            "botorch>=0.4.0,<0.8.0",
             "catalyst>=21.3",
             "catboost>=0.26",
             "chainer>=5.0.0",


### PR DESCRIPTION
## Motivation

Attempts to fix CI breakage caused by a recent update of `botorch` https://github.com/optuna/optuna/actions/runs/3643581717/jobs/6151954039#step:7:59 by temporarily avoiding it.

Note that `botorch` no longer creates releases for Python 3.7, which Optuna still does. So upgrading the support in Optuna to the latest `botorch` may require branching based on Python versions. Edit: We could alternatively drop the support for `botorch`-related features for Python 3.7. @toshihikoyanase 

See similar PR https://github.com/optuna/optuna/pull/3834

## Description of the changes

Pin version of `botorch`
