### PR TITLE
Test old typing extensions

### DIFF
--- a/.github/workflows/tests-with-minimum-versions.yml
+++ b/.github/workflows/tests-with-minimum-versions.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+  pull_request: {}
   schedule:
     - cron: '0 23 * * SUN-THU'
   workflow_dispatch:

--- a/.github/workflows/tests-with-minimum-versions.yml
+++ b/.github/workflows/tests-with-minimum-versions.yml
@@ -69,7 +69,7 @@ jobs:
       run: |
         # Install dependencies with minimum versions.
         pip uninstall -y alembic cmaes packaging sqlalchemy plotly scikit-learn
-        pip install alembic==1.5.0 cmaes==0.9.0 packaging==20.0 sqlalchemy==1.3.0
+        pip install alembic==1.5.0 cmaes==0.9.0 packaging==20.0 sqlalchemy==1.3.0 typing_extensions==3.10.0.0
         pip install plotly==4.9.0 scikit-learn==0.24.2  # optional extras
 
     - name: Scheduled tests


### PR DESCRIPTION
Add minimum-version test for `typing_extensions`. 
Also, this PR fixes CI issue, introduced in #4200.