### PR TITLE
Remove `RedisStorage` from docstring

### DIFF
--- a/optuna/storages/_heartbeat.py
+++ b/optuna/storages/_heartbeat.py
@@ -27,8 +27,7 @@ class BaseHeartbeat(metaclass=abc.ABCMeta):
     and :class:`~optuna.storages._heartbeat.BaseHeartbeat`.
 
     .. seealso::
-        See :class:`~optuna.storages.RDBStorage` and :class:`~optuna.storages.RedisStorage`, where
-        those backends support heartbeat.
+        See :class:`~optuna.storages.RDBStorage`, where the backend supports heartbeat.
     """
 
     @abc.abstractmethod


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
RedisStorage is removed at https://github.com/optuna/optuna/pull/4156

## Description of the changes
<!-- Describe the changes in this PR. -->
Fix an error message while building the sphinx documentation.

```
reading sources... [100%] reference/generated/optuna.storages.RedisStorage
WARNING: autodoc: failed to import class 'RedisStorage' from module 'optuna.storages'; the following exception was raised:
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/site-packages/sphinx/util/inspect.py", line 376, in safe_getattr
    return getattr(obj, name, *defargs)
AttributeError: module 'optuna.storages' has no attribute 'RedisStorage'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/local/lib/python3.10/site-packages/sphinx/ext/autodoc/importer.py", line 98, in import_object
    obj = attrgetter(obj, mangled_name)
  File "/usr/local/lib/python3.10/site-packages/sphinx/ext/autodoc/__init__.py", line 306, in get_attr
    return autodoc_attrgetter(self.env.app, obj, name, *defargs)
  File "/usr/local/lib/python3.10/site-packages/sphinx/ext/autodoc/__init__.py", line 2804, in autodoc_attrgetter
    return safe_getattr(obj, name, *defargs)
  File "/usr/local/lib/python3.10/site-packages/sphinx/util/inspect.py", line 392, in safe_getattr
    raise AttributeError(name) from exc
AttributeError: RedisStorage
```