### PR TITLE
Remove `optuna.TYPE_CHECKING`

### DIFF
--- a/optuna/__init__.py
+++ b/optuna/__init__.py
@@ -1,5 +1,3 @@
-from typing import TYPE_CHECKING
-
 from optuna import distributions
 from optuna import exceptions
 from optuna import integration
@@ -26,7 +24,6 @@ from optuna.version import __version__
 
 __all__ = [
     "Study",
-    "TYPE_CHECKING",
     "Trial",
     "TrialPruned",
     "__version__",


### PR DESCRIPTION
## Motivation

`optuna.TYPE_CHECKING` was introduced in #262 for Python 3.5.1 or older versions.
We already dropped support for these versions, and `optuna.TYPE_CHECKING` is not used anywhere.

## Description of the changes
- Remove `optuna.TYPE_CHECKING`
