### PR TITLE
 Deprecate `set_system_attr` in Trial

### DIFF
--- a/optuna/integration/_lightgbm_tuner/optimize.py
+++ b/optuna/integration/_lightgbm_tuner/optimize.py
@@ -272,10 +272,14 @@ class _OptunaObjective(_BaseTuner):
             self.pbar.set_description(self.pbar_fmt.format(self.step_name, self.best_score))
             self.pbar.update(1)
 
-        trial.set_system_attr(_ELAPSED_SECS_KEY, elapsed_secs)
-        trial.set_system_attr(_AVERAGE_ITERATION_TIME_KEY, average_iteration_time)
-        trial.set_system_attr(_STEP_NAME_KEY, self.step_name)
-        trial.set_system_attr(_LGBM_PARAMS_KEY, json.dumps(self.lgbm_params))
+        trial.storage.set_trial_system_attr(trial._trial_id, _ELAPSED_SECS_KEY, elapsed_secs)
+        trial.storage.set_trial_system_attr(
+            trial._trial_id, _AVERAGE_ITERATION_TIME_KEY, average_iteration_time
+        )
+        trial.storage.set_trial_system_attr(trial._trial_id, _STEP_NAME_KEY, self.step_name)
+        trial.storage.set_trial_system_attr(
+            trial._trial_id, _LGBM_PARAMS_KEY, json.dumps(self.lgbm_params)
+        )
 
         self.trial_count += 1
 

--- a/optuna/integration/chainermn.py
+++ b/optuna/integration/chainermn.py
@@ -235,11 +235,12 @@ class ChainerMNTrial(BaseTrial):
             self.delegate.set_user_attr(key, value)
         self.comm.mpi_comm.barrier()
 
+    @deprecated_func("3.1.0", "6.0.0")
     def set_system_attr(self, key: str, value: Any) -> None:
 
         if self.comm.rank == 0:
             assert self.delegate is not None
-            self.delegate.set_system_attr(key, value)
+            self.delegate.storage.set_trial_system_attr(self.delegate._trial_id, key, value)
         self.comm.mpi_comm.barrier()
 
     @property

--- a/optuna/integration/mlflow.py
+++ b/optuna/integration/mlflow.py
@@ -214,7 +214,9 @@ class MLflowCallback:
                     nested = self._mlflow_kwargs.get("nested")
 
                     with mlflow.start_run(run_name=str(trial.number), nested=nested) as run:
-                        trial.set_system_attr(RUN_ID_ATTRIBUTE_KEY, run.info.run_id)
+                        trial.storage.set_trial_system_attr(
+                            trial._trial_id, RUN_ID_ATTRIBUTE_KEY, run.info.run_id
+                        )
 
                         return func(trial)
 

--- a/optuna/integration/pytorch_distributed.py
+++ b/optuna/integration/pytorch_distributed.py
@@ -226,6 +226,7 @@ class TorchDistributedTrial(optuna.trial.BaseTrial):
         if err is not None:
             raise err
 
+    @deprecated_func("3.1.0", "6.0.0")
     @broadcast_properties
     def set_system_attr(self, key: str, value: Any) -> None:
         err = None
@@ -233,7 +234,7 @@ class TorchDistributedTrial(optuna.trial.BaseTrial):
         if dist.get_rank() == 0:  # type: ignore
             try:
                 assert self._delegate is not None
-                self._delegate.set_system_attr(key, value)
+                self._delegate.storage.set_trial_system_attr(self._delegate._trial_id, key, value)
             except Exception as e:
                 err = e
             err = self._broadcast(err)

--- a/optuna/integration/pytorch_lightning.py
+++ b/optuna/integration/pytorch_lightning.py
@@ -107,8 +107,8 @@ class PyTorchLightningPruningCallback(Callback):
             # Stop every DDP process if global rank 0 process decides to stop.
             trainer.should_stop = True
             if trainer.is_global_zero:
-                self._trial.set_system_attr(_PRUNED_KEY, True)
-                self._trial.set_system_attr(_EPOCH_KEY, epoch)
+                self._trial.storage.set_trial_system_attr(self._trial._trial_id, _PRUNED_KEY, True)
+                self._trial.storage.set_trial_system_attr(self._trial._trial_id, _EPOCH_KEY, epoch)
 
     def on_fit_end(self, trainer: Trainer, pl_module: LightningModule) -> None:
         if not self.is_ddp_backend:

--- a/optuna/multi_objective/trial.py
+++ b/optuna/multi_objective/trial.py
@@ -169,7 +169,7 @@ class MultiObjectiveTrial:
         for further details.
         """
 
-        self._trial.set_system_attr(key, value)
+        self._trial.storage.set_trial_system_attr(self._trial._trial_id, key, value)
 
     @property
     def number(self) -> int:

--- a/optuna/trial/_trial.py
+++ b/optuna/trial/_trial.py
@@ -499,7 +499,7 @@ class Trial(BaseTrial):
                 "Trial.should_prune is not supported for multi-objective optimization."
             )
 
-        trial = copy.deepcopy(self._get_latest_trial())
+        trial = copy.deepcopy(self._cached_frozen_trial)
         return self.study.pruner.prune(self.study, trial)
 
     def set_user_attr(self, key: str, value: Any) -> None:
@@ -581,7 +581,7 @@ class Trial(BaseTrial):
         storage = self.storage
         trial_id = self._trial_id
 
-        trial = self._get_latest_trial()
+        trial = self._cached_frozen_trial
 
         if name in trial.distributions:
             # No need to sample if already suggested.
@@ -660,12 +660,6 @@ class Trial(BaseTrial):
                 "Using these values: {}".format(name, old_distribution._asdict()),
                 RuntimeWarning,
             )
-
-    def _get_latest_trial(self) -> FrozenTrial:
-        # TODO(eukaryo): Remove this method after `system_attrs` property is deprecated.
-        system_attrs = copy.deepcopy(self.storage.get_trial_system_attrs(self._trial_id))
-        self._cached_frozen_trial.system_attrs = system_attrs
-        return self._cached_frozen_trial
 
     @property
     def params(self) -> Dict[str, Any]:

--- a/tests/integration_tests/lightgbm_tuner_tests/test_optimize.py
+++ b/tests/integration_tests/lightgbm_tuner_tests/test_optimize.py
@@ -701,7 +701,8 @@ class TestLightGBMTuner:
 
         def objective(trial: optuna.trial.Trial, value: float) -> float:
 
-            trial.set_system_attr(
+            trial.storage.set_trial_system_attr(
+                trial._trial_id,
                 optuna.integration._lightgbm_tuner.optimize._STEP_NAME_KEY,
                 "step{:.0f}".format(value),
             )

--- a/tests/integration_tests/test_chainermn.py
+++ b/tests/integration_tests/test_chainermn.py
@@ -423,17 +423,6 @@ class TestChainerMNTrial:
 
     @staticmethod
     @pytest.mark.parametrize("storage_mode", STORAGE_MODES)
-    def test_system_attrs(storage_mode: str, comm: "CommunicatorBase") -> None:
-
-        with MultiNodeStorageSupplier(storage_mode, comm) as storage:
-            study = TestChainerMNStudy._create_shared_study(storage, comm)
-            mn_trial = _create_new_chainermn_trial(study, comm)
-
-            mn_trial.set_system_attr("system_message", "test")
-            assert mn_trial.system_attrs["system_message"] == "test"
-
-    @staticmethod
-    @pytest.mark.parametrize("storage_mode", STORAGE_MODES)
     def test_call_with_mpi(storage_mode: str, comm: "CommunicatorBase") -> None:
 
         with MultiNodeStorageSupplier(storage_mode, comm) as storage:

--- a/tests/integration_tests/test_pytorch_distributed.py
+++ b/tests/integration_tests/test_pytorch_distributed.py
@@ -245,36 +245,6 @@ def test_user_attrs_with_exception() -> None:
 
 @pytest.mark.filterwarnings("ignore::optuna.exceptions.ExperimentalWarning")
 @pytest.mark.parametrize("storage_mode", STORAGE_MODES)
-def test_system_attrs(storage_mode: str) -> None:
-    with StorageSupplier(storage_mode) as storage:
-        if dist.get_rank() == 0:  # type: ignore
-            study = optuna.create_study(storage=storage)
-            trial = TorchDistributedTrial(study.ask())
-        else:
-            trial = TorchDistributedTrial(None)
-
-        trial.set_system_attr("dataset", "mnist")
-        trial.set_system_attr("batch_size", 128)
-
-        assert trial.system_attrs["dataset"] == "mnist"
-        assert trial.system_attrs["batch_size"] == 128
-
-
-@pytest.mark.filterwarnings("ignore::optuna.exceptions.ExperimentalWarning")
-def test_system_attrs_with_exception() -> None:
-    with StorageSupplier("sqlite") as storage:
-        if dist.get_rank() == 0:  # type: ignore
-            study = optuna.create_study(storage=storage)
-            trial = TorchDistributedTrial(study.ask())
-        else:
-            trial = TorchDistributedTrial(None)
-
-        with pytest.raises(TypeError):
-            trial.set_system_attr("not serializable", torch.Tensor([1, 2]))
-
-
-@pytest.mark.filterwarnings("ignore::optuna.exceptions.ExperimentalWarning")
-@pytest.mark.parametrize("storage_mode", STORAGE_MODES)
 def test_number(storage_mode: str) -> None:
     with StorageSupplier(storage_mode) as storage:
         if dist.get_rank() == 0:  # type: ignore

--- a/tests/multi_objective_tests/test_trial.py
+++ b/tests/multi_objective_tests/test_trial.py
@@ -94,25 +94,6 @@ def test_user_attrs() -> None:
     assert study.trials[0].user_attrs == {"foo": "quux", "baz": "qux"}
 
 
-def test_system_attrs() -> None:
-    # We use `RandomMultiObjectiveSampler` here because the default `NSGAIIMultiObjectiveSampler`
-    # sets its own system attributes when sampling (these attributes would become noise in this
-    # test case).
-    sampler = optuna.multi_objective.samplers.RandomMultiObjectiveSampler()
-    study = optuna.multi_objective.create_study(
-        ["maximize", "minimize", "maximize"], sampler=sampler
-    )
-
-    def objective(trial: optuna.multi_objective.trial.MultiObjectiveTrial) -> List[float]:
-        trial.set_system_attr("foo", "bar")
-        assert trial.system_attrs == {"foo": "bar"}
-        return [0, 0, 0]
-
-    study.optimize(objective, n_trials=1)
-
-    assert study.trials[0].system_attrs == {"foo": "bar"}
-
-
 def test_params_and_distributions() -> None:
     study = optuna.multi_objective.create_study(["maximize", "minimize", "maximize"])
 

--- a/tests/storages_tests/rdb_tests/create_db.py
+++ b/tests/storages_tests/rdb_tests/create_db.py
@@ -50,7 +50,6 @@ def objective_test_upgrade(trial: optuna.trial.Trial) -> float:
     x = trial.suggest_float("x", -5, 5)  # optuna==0.9.0 does not have suggest_float.
     y = trial.suggest_int("y", 0, 10)
     z = cast(float, trial.suggest_categorical("z", [-5, 0, 5]))
-    trial.set_system_attr("a", 0)
     trial.set_user_attr("b", 1)
     trial.report(0.5, step=0)
     return x**2 + y**2 + z**2
@@ -60,7 +59,6 @@ def mo_objective_test_upgrade(trial: optuna.trial.Trial) -> Tuple[float, float]:
     x = trial.suggest_float("x", -5, 5)
     y = trial.suggest_int("y", 0, 10)
     z = cast(float, trial.suggest_categorical("z", [-5, 0, 5]))
-    trial.set_system_attr("a", 0)
     trial.set_user_attr("b", 1)
     return x, x**2 + y**2 + z**2
 
@@ -88,7 +86,6 @@ if __name__ == "__main__":
 
     # Create a study for single-objective optimization.
     study = optuna.create_study(storage=args.storage_url, study_name="single")
-    study.set_system_attr("c", 2)
     study.set_user_attr("d", 3)
     study.optimize(objective_test_upgrade, n_trials=1)
 
@@ -100,7 +97,6 @@ if __name__ == "__main__":
         study = optuna.create_study(
             storage=args.storage_url, study_name="multi", directions=["minimize", "minimize"]
         )
-        study.set_system_attr("c", 2)
         study.set_user_attr("d", 3)
         study.optimize(mo_objective_test_upgrade, n_trials=1)
     except TypeError:

--- a/tests/storages_tests/rdb_tests/test_storage.py
+++ b/tests/storages_tests/rdb_tests/test_storage.py
@@ -219,7 +219,6 @@ def test_upgrade_single_objective_optimization(optuna_version: str) -> None:
         study.optimize(objective_test_upgrade, n_trials=1)
         assert len(study.trials) == 2
         for trial in study.trials:
-            assert trial.system_attrs["a"] == 0
             assert trial.user_attrs["b"] == 1
             assert trial.intermediate_values[0] == 0.5
             assert -5 <= trial.params["x"] <= 5
@@ -227,7 +226,6 @@ def test_upgrade_single_objective_optimization(optuna_version: str) -> None:
             assert trial.params["z"] in (-5, 0, 5)
             assert trial.value is not None and 0 <= trial.value <= 150
 
-        assert study.system_attrs["c"] == 2
         assert study.user_attrs["d"] == 3
 
 
@@ -268,14 +266,12 @@ def test_upgrade_multi_objective_optimization(optuna_version: str) -> None:
         study.optimize(mo_objective_test_upgrade, n_trials=1)
         assert len(study.trials) == 2
         for trial in study.trials:
-            assert trial.system_attrs["a"] == 0
             assert trial.user_attrs["b"] == 1
             assert -5 <= trial.params["x"] <= 5
             assert 0 <= trial.params["y"] <= 10
             assert trial.params["z"] in (-5, 0, 5)
             assert -5 <= trial.values[0] < 5
             assert 0 <= trial.values[1] <= 150
-        assert study.system_attrs["c"] == 2
         assert study.user_attrs["d"] == 3
 
 

--- a/tests/storages_tests/test_heartbeat.py
+++ b/tests/storages_tests/test_heartbeat.py
@@ -90,7 +90,7 @@ def test_failed_trial_callback(storage_mode: str) -> None:
 
         with pytest.warns(UserWarning):
             trial = study.ask()
-        trial.set_system_attr("test", "B")
+        trial.storage.set_trial_system_attr(trial._trial_id, "test", "B")
         storage.record_heartbeat(trial._trial_id)
         time.sleep(grace_period + 1)
 
@@ -224,7 +224,7 @@ def test_fail_stale_trials(grace_period: Optional[int]) -> None:
 
         with pytest.warns(UserWarning):
             trial = study.ask()
-        trial.set_system_attr("test", "B")
+        trial.storage.set_trial_system_attr(trial._trial_id, "test", "B")
 
         time.sleep(_grace_period + 1)
         check_keep_trial_state_in_running(study)

--- a/tests/storages_tests/test_with_server.py
+++ b/tests/storages_tests/test_with_server.py
@@ -24,7 +24,6 @@ def objective(trial: optuna.Trial) -> float:
     trial.report(x, 0)
     trial.report(y, 1)
     trial.set_user_attr("x", x)
-    trial.set_system_attr("y", y)
     return f(x, y)
 
 
@@ -88,13 +87,6 @@ def _check_trials(trials: Sequence[optuna.trial.FrozenTrial]) -> None:
         np.isclose(
             [trial.user_attrs["x"] for trial in trials],
             [trial.params["x"] for trial in trials],
-            atol=1e-4,
-        ).tolist()
-    )
-    assert all(
-        np.isclose(
-            [trial.system_attrs["y"] for trial in trials],
-            [trial.params["y"] for trial in trials],
             atol=1e-4,
         ).tolist()
     )

--- a/tests/study_tests/test_dataframe.py
+++ b/tests/study_tests/test_dataframe.py
@@ -56,7 +56,7 @@ def test_trials_dataframe(storage_mode: str, attrs: Tuple[str, ...], multi_index
         y = trial.suggest_categorical("y", (2.5,))
         assert isinstance(y, float)
         trial.set_user_attr("train_loss", 3)
-        trial.set_system_attr("foo", "bar")
+        trial.storage.set_trial_system_attr(trial._trial_id, "foo", "bar")
         value = x + y  # 3.5
 
         # Test reported intermediate values, although it in practice is not "intermediate".

--- a/tests/study_tests/test_study.py
+++ b/tests/study_tests/test_study.py
@@ -314,21 +314,6 @@ def test_trial_set_and_get_user_attrs(storage_mode: str) -> None:
 
 
 @pytest.mark.parametrize("storage_mode", STORAGE_MODES)
-def test_trial_set_and_get_system_attrs(storage_mode: str) -> None:
-    def f(trial: Trial) -> float:
-
-        trial.set_system_attr("system_message", "test")
-        assert trial.system_attrs["system_message"] == "test"
-        return 0.0
-
-    with StorageSupplier(storage_mode) as storage:
-        study = create_study(storage=storage)
-        study.optimize(f, n_trials=1)
-        frozen_trial = study.trials[0]
-        assert frozen_trial.system_attrs["system_message"] == "test"
-
-
-@pytest.mark.parametrize("storage_mode", STORAGE_MODES)
 @pytest.mark.parametrize("include_best_trial", [True, False])
 def test_get_all_study_summaries(storage_mode: str, include_best_trial: bool) -> None:
 


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

cf. PR https://github.com/optuna/optuna/pull/4188 and PR https://github.com/optuna/optuna/pull/4240 .

PR#4240 introduced `_get_latest_trial` function. It can be removed after `set_system_attr` is deprecated and removed from the internal codes; the removal of `_get_latest_trial` will increase speed. PR#4188 will remove them from Trial and Study. The present PR will preempt PR#4188 only for Trial, and remove `_get_latest_trial` function.

## Description of the changes
<!-- Describe the changes in this PR. -->

`set_system_attr`s in trial are removed.

`_get_latest_trial` function is removed.