### PR TITLE
Add the `pytest` dependency for asv.

### DIFF
--- a/asv.conf.json
+++ b/asv.conf.json
@@ -73,6 +73,7 @@
     //
     "matrix": {
         "fakeredis": [""],
+        "pytest": [""],
     },
 
     // Combinations of libraries/python versions can be excluded/included


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

Follow-up #4176 

Fix https://github.com/optuna/optuna/actions/runs/3690074016

## Description of the changes
<!-- Describe the changes in this PR. -->

This PR adds the `pytest` dependency for asv to fix the speed benchmark. It was broken at #4176.

https://github.com/optuna/optuna/blob/7cb75a060833e7d934fa7164c834d103288603d5/optuna/testing/storages.py#L13
