### PR TITLE
Avoid to decode log string in `JournalRedisStorage`.

### DIFF
--- a/optuna/storages/_journal/redis.py
+++ b/optuna/storages/_journal/redis.py
@@ -64,12 +64,11 @@ class JournalRedisStorage(BaseJournalLogStorage, BaseJournalLogSnapshot):
         for log_number in range(log_number_from, max_log_number + 1):
             sleep_secs = 0.1
             while True:
-                log_bytes = self._redis.get(self._key_log_id(log_number))
-                if log_bytes is not None:
+                log = self._redis.get(self._key_log_id(log_number))
+                if log is not None:
                     break
                 time.sleep(sleep_secs)
                 sleep_secs = min(sleep_secs * 2, 10)
-            log = log_bytes.decode("utf-8")
             try:
                 logs.append(json.loads(log))
             except json.JSONDecodeError as err:


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
Follow-up #4086

## Description of the changes
<!-- Describe the changes in this PR. -->
Because `json.loads` accepts `bytes` object.
