### PR TITLE
Fix an inline markup in distributed tutorial

### DIFF
--- a/tutorial/10_key_features/004_distributed.py
+++ b/tutorial/10_key_features/004_distributed.py
@@ -9,7 +9,7 @@ It's straightforward to parallelize :func:`optuna.study.Study.optimize`.
 If you want to manually execute Optuna optimization:
 
     1. start an RDB server (this example uses MySQL)
-    2. create a study with `--storage` argument
+    2. create a study with ``--storage`` argument
     3. share the study among multiple nodes and processes
 
 Of course, you can use Kubernetes as in `the kubernetes examples <https://github.com/optuna/optuna-examples/tree/main/kubernetes>`_.


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

As the following pages shows, `--storage` is broken.

Before:

<img width="1093" alt="Screenshot 2022-12-15 20 00 18" src="https://user-images.githubusercontent.com/5564044/207843184-60a394e3-bb88-452b-b60c-c9304717e8a7.png">

After:
<img width="1428" alt="Screenshot 2022-12-16 9 44 40" src="https://user-images.githubusercontent.com/5564044/207996423-00637008-1d56-4387-8d18-fdccd55d93f6.png">

https://optuna--4247.org.readthedocs.build/en/4247/tutorial/10_key_features/004_distributed.html#sphx-glr-tutorial-10-key-features-004-distributed-py

## Description of the changes
<!-- Describe the changes in this PR. -->
Use double backquotes as an inline markup.
https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html