### PR TITLE
Deprecate `system_attrs` in `Study` class

### DIFF
--- a/optuna/multi_objective/samplers/_nsga2.py
+++ b/optuna/multi_objective/samplers/_nsga2.py
@@ -215,7 +215,8 @@ class NSGAIIMultiObjectiveSampler(BaseMultiObjectiveSampler):
                 hasher.update(bytes(str(trial.number), "utf-8"))
 
             cache_key = "{}:{}".format(_POPULATION_CACHE_KEY_PREFIX, hasher.hexdigest())
-            cached_generation, cached_population_numbers = study.system_attrs.get(
+            study_system_attrs = study._storage.get_study_system_attrs(study._study_id)
+            cached_generation, cached_population_numbers = study_system_attrs.get(
                 cache_key, (-1, [])
             )
             if cached_generation >= generation:

--- a/optuna/multi_objective/study.py
+++ b/optuna/multi_objective/study.py
@@ -358,7 +358,6 @@ class MultiObjectiveStudy:
         return self._study.user_attrs
 
     @property
-    @deprecated_func("3.1.0", "6.0.0")
     def system_attrs(self) -> Dict[str, Any]:
         """Return system attributes.
 

--- a/optuna/multi_objective/study.py
+++ b/optuna/multi_objective/study.py
@@ -227,7 +227,9 @@ class MultiObjectiveStudy:
         self._study = study
 
         self._directions = []
-        for d in study.system_attrs["multi_objective:study:directions"]:
+        for d in study._storage.get_study_system_attrs(study._study_id)[
+            "multi_objective:study:directions"
+        ]:
             if d == "minimize":
                 self._directions.append(StudyDirection.MINIMIZE)
             elif d == "maximize":
@@ -356,6 +358,7 @@ class MultiObjectiveStudy:
         return self._study.user_attrs
 
     @property
+    @deprecated_func("3.1.0", "6.0.0")
     def system_attrs(self) -> Dict[str, Any]:
         """Return system attributes.
 
@@ -363,7 +366,7 @@ class MultiObjectiveStudy:
             A dictionary containing all system attributes.
         """
 
-        return self._study.system_attrs
+        return self._study._storage.get_study_system_attrs(self._study._study_id)
 
     def set_user_attr(self, key: str, value: Any) -> None:
         """Set a user attribute to the study.

--- a/optuna/samplers/nsgaii/_sampler.py
+++ b/optuna/samplers/nsgaii/_sampler.py
@@ -300,7 +300,8 @@ class NSGAIISampler(BaseSampler):
                 hasher.update(bytes(str(trial.number), "utf-8"))
 
             cache_key = "{}:{}".format(_POPULATION_CACHE_KEY_PREFIX, hasher.hexdigest())
-            cached_generation, cached_population_numbers = study.system_attrs.get(
+            study_system_attrs = study._storage.get_study_system_attrs(study._study_id)
+            cached_generation, cached_population_numbers = study_system_attrs.get(
                 cache_key, (-1, [])
             )
             if cached_generation >= generation:

--- a/optuna/study/_study_summary.py
+++ b/optuna/study/_study_summary.py
@@ -124,7 +124,6 @@ class StudySummary:
             "but this schedule is subject to change. "
             "See https://github.com/optuna/optuna/releases/tag/v3.1.0.",
             FutureWarning,
-            stacklevel=2,
         )
 
         return self._system_attrs

--- a/optuna/study/_study_summary.py
+++ b/optuna/study/_study_summary.py
@@ -3,6 +3,7 @@ from typing import Any
 from typing import Dict
 from typing import Optional
 from typing import Sequence
+import warnings
 
 from optuna import logging
 from optuna import trial
@@ -74,7 +75,7 @@ class StudySummary:
             raise ValueError("Specify only one of `direction` and `directions`.")
         self.best_trial = best_trial
         self.user_attrs = user_attrs
-        self.system_attrs = system_attrs
+        self._system_attrs = system_attrs
         self.n_trials = n_trials
         self.datetime_start = datetime_start
         self._study_id = study_id
@@ -114,3 +115,16 @@ class StudySummary:
     def directions(self) -> Sequence[StudyDirection]:
 
         return self._directions
+
+    @property
+    def system_attrs(self) -> Dict[str, Any]:
+        warnings.warn(
+            "``system_attrs`` has been deprecated in v3.1.0. "
+            "The removal of this feature is currently scheduled for v6.0.0, "
+            "but this schedule is subject to change. "
+            "See https://github.com/optuna/optuna/releases/tag/v3.1.0.",
+            FutureWarning,
+            stacklevel=2,
+        )
+
+        return self._system_attrs

--- a/optuna/study/_study_summary.py
+++ b/optuna/study/_study_summary.py
@@ -6,7 +6,6 @@ from typing import Sequence
 
 from optuna import logging
 from optuna import trial
-from optuna._deprecated import deprecated_func
 from optuna.study._study_direction import StudyDirection
 
 
@@ -111,6 +110,5 @@ class StudySummary:
         return self._directions
 
     @property
-    @deprecated_func("3.1.0", "6.0.0")
     def system_attrs(self) -> Dict[str, Any]:
         return self._system_attrs

--- a/optuna/study/_study_summary.py
+++ b/optuna/study/_study_summary.py
@@ -119,7 +119,7 @@ class StudySummary:
     @property
     def system_attrs(self) -> Dict[str, Any]:
         warnings.warn(
-            "``system_attrs`` has been deprecated in v3.1.0. "
+            "`system_attrs` has been deprecated in v3.1.0. "
             "The removal of this feature is currently scheduled for v6.0.0, "
             "but this schedule is subject to change. "
             "See https://github.com/optuna/optuna/releases/tag/v3.1.0.",

--- a/optuna/study/_study_summary.py
+++ b/optuna/study/_study_summary.py
@@ -36,6 +36,12 @@ class StudySummary:
         system_attrs:
             Dictionary that contains the attributes of the :class:`~optuna.study.Study` internally
             set by Optuna.
+
+            .. warning::
+                Deprecated in v3.1.0. ``system_attrs`` argument will be removed in the future.
+                The removal of this feature is currently scheduled for v6.0.0,
+                but this schedule is subject to change.
+                See https://github.com/optuna/optuna/releases/tag/v3.1.0.
         n_trials:
             The number of trials ran in the :class:`~optuna.study.Study`.
         datetime_start:
@@ -68,7 +74,7 @@ class StudySummary:
             raise ValueError("Specify only one of `direction` and `directions`.")
         self.best_trial = best_trial
         self.user_attrs = user_attrs
-        self._system_attrs = system_attrs
+        self.system_attrs = system_attrs
         self.n_trials = n_trials
         self.datetime_start = datetime_start
         self._study_id = study_id
@@ -108,7 +114,3 @@ class StudySummary:
     def directions(self) -> Sequence[StudyDirection]:
 
         return self._directions
-
-    @property
-    def system_attrs(self) -> Dict[str, Any]:
-        return self._system_attrs

--- a/optuna/study/_study_summary.py
+++ b/optuna/study/_study_summary.py
@@ -6,6 +6,7 @@ from typing import Sequence
 
 from optuna import logging
 from optuna import trial
+from optuna._deprecated import deprecated_func
 from optuna.study._study_direction import StudyDirection
 
 
@@ -68,7 +69,7 @@ class StudySummary:
             raise ValueError("Specify only one of `direction` and `directions`.")
         self.best_trial = best_trial
         self.user_attrs = user_attrs
-        self.system_attrs = system_attrs
+        self._system_attrs = system_attrs
         self.n_trials = n_trials
         self.datetime_start = datetime_start
         self._study_id = study_id
@@ -108,3 +109,8 @@ class StudySummary:
     def directions(self) -> Sequence[StudyDirection]:
 
         return self._directions
+
+    @property
+    @deprecated_func("3.1.0", "6.0.0")
+    def system_attrs(self) -> Dict[str, Any]:
+        return self._system_attrs

--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -308,6 +308,7 @@ class Study:
         return copy.deepcopy(self._storage.get_study_user_attrs(self._study_id))
 
     @property
+    @deprecated_func("3.1.0", "6.0.0")
     def system_attrs(self) -> Dict[str, Any]:
         """Return system attributes.
 
@@ -1411,7 +1412,7 @@ def copy_study(
         load_if_exists=False,
     )
 
-    for key, value in from_study.system_attrs.items():
+    for key, value in from_study._storage.get_study_system_attrs(from_study._study_id).items():
         to_study._storage.set_study_system_attr(to_study._study_id, key, value)
 
     for key, value in from_study.user_attrs.items():

--- a/tests/multi_objective_tests/samplers_tests/test_nsga2.py
+++ b/tests/multi_objective_tests/samplers_tests/test_nsga2.py
@@ -167,9 +167,10 @@ def test_study_system_attr_for_population_cache() -> None:
     def get_cached_entries(
         study: multi_objective.study.MultiObjectiveStudy,
     ) -> List[Tuple[int, List[int]]]:
+        study_system_attrs = study._storage.get_study_system_attrs(study._study_id)
         return [
             v
-            for k, v in study.system_attrs.items()
+            for k, v in study_system_attrs.items()
             if k.startswith(multi_objective.samplers._nsga2._POPULATION_CACHE_KEY_PREFIX)
         ]
 

--- a/tests/samplers_tests/test_nsgaii.py
+++ b/tests/samplers_tests/test_nsgaii.py
@@ -504,13 +504,14 @@ def test_crowding_distance_sort(values: List[List[float]]) -> None:
 def test_study_system_attr_for_population_cache() -> None:
     sampler = NSGAIISampler(population_size=10)
     study = optuna.create_study(directions=["minimize"], sampler=sampler)
+    study_system_attrs = study._storage.get_study_system_attrs(study._study_id)
 
     def get_cached_entries(
         study: optuna.study.Study,
     ) -> List[Tuple[int, List[int]]]:
         return [
             v
-            for k, v in study.system_attrs.items()
+            for k, v in study_system_attrs.items()
             if k.startswith(optuna.samplers.nsgaii._sampler._POPULATION_CACHE_KEY_PREFIX)
         ]
 

--- a/tests/samplers_tests/test_nsgaii.py
+++ b/tests/samplers_tests/test_nsgaii.py
@@ -504,11 +504,11 @@ def test_crowding_distance_sort(values: List[List[float]]) -> None:
 def test_study_system_attr_for_population_cache() -> None:
     sampler = NSGAIISampler(population_size=10)
     study = optuna.create_study(directions=["minimize"], sampler=sampler)
-    study_system_attrs = study._storage.get_study_system_attrs(study._study_id)
 
     def get_cached_entries(
         study: optuna.study.Study,
     ) -> List[Tuple[int, List[int]]]:
+        study_system_attrs = study._storage.get_study_system_attrs(study._study_id)
         return [
             v
             for k, v in study_system_attrs.items()

--- a/tests/storages_tests/test_heartbeat.py
+++ b/tests/storages_tests/test_heartbeat.py
@@ -71,7 +71,7 @@ def test_failed_trial_callback(storage_mode: str) -> None:
     grace_period = 2
 
     def _failed_trial_callback(study: Study, trial: FrozenTrial) -> None:
-        assert study.system_attrs["test"] == "A"
+        assert study._storage.get_study_system_attrs(study._study_id)["test"] == "A"
         assert trial.system_attrs["test"] == "B"
 
     failed_trial_callback = Mock(wraps=_failed_trial_callback)
@@ -201,7 +201,7 @@ def test_fail_stale_trials(grace_period: Optional[int]) -> None:
     _grace_period = (heartbeat_interval * 2) if grace_period is None else grace_period
 
     def failed_trial_callback(study: "optuna.Study", trial: FrozenTrial) -> None:
-        assert study.system_attrs["test"] == "A"
+        assert study._storage.get_study_system_attrs(study._study_id)["test"] == "A"
         assert trial.system_attrs["test"] == "B"
 
     def check_change_trial_state_to_fail(study: "optuna.Study") -> None:

--- a/tests/study_tests/test_study.py
+++ b/tests/study_tests/test_study.py
@@ -454,7 +454,9 @@ def test_copy_study(from_storage_mode: str, to_storage_mode: str) -> None:
 
         assert to_study.study_name == from_study.study_name
         assert to_study.directions == from_study.directions
-        assert to_study.system_attrs == from_study.system_attrs
+        to_study_system_attrs = to_study._storage.get_study_system_attrs(to_study._study_id)
+        from_study_system_attrs = from_study._storage.get_study_system_attrs(from_study._study_id)
+        assert to_study_system_attrs == from_study_system_attrs
         assert to_study.user_attrs == from_study.user_attrs
         assert len(to_study.trials) == len(from_study.trials)
 


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
By the same motivation as https://github.com/optuna/optuna/pull/4188 , I propose to deprecate `system_attrs` property in `Study` class.
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

## Description of the changes
<!-- Describe the changes in this PR. -->
* Add `deprecatd_func("3.1.0", "6.0.0")` to `system_attrs` property in `optuna.study.Study` class and `optuna.multi_objective.study.MultiObjectiveStudy` class.
* Following the above deprecation, I replace reference of `system_attrs` used from other file by `study._storage.get_study_system_attrs(study._study_id)`.
* I also deprecate `system_attrs` property in `optuna.study.StudySummary` class.


NOTE:  I left `system_attrs` property in `FrozenStudy` because `FrozenStudy` is internal use only.
