### PR TITLE
Remove `device` argument of `TorchDistributedTrial`.

### DIFF
--- a/optuna/integration/pytorch_distributed.py
+++ b/optuna/integration/pytorch_distributed.py
@@ -9,7 +9,6 @@ from typing import Optional
 from typing import Sequence
 from typing import TYPE_CHECKING
 from typing import TypeVar
-import warnings
 
 import optuna
 from optuna._deprecated import deprecated_func
@@ -105,9 +104,6 @@ class TorchDistributedTrial(optuna.trial.BaseTrial):
             Use `gloo` backend when group is None.
             Create a global `gloo` backend when group is None and WORLD is nccl.
 
-        device:
-            Deprecated parameter. Please use `group` instead.
-
     .. note::
         The methods of :class:`~optuna.integration.TorchDistributedTrial` are expected to be
         called by all workers at once. They invoke synchronous data transmission to share
@@ -119,13 +115,8 @@ class TorchDistributedTrial(optuna.trial.BaseTrial):
         self,
         trial: Optional[optuna.trial.Trial],
         group: Optional["torch.distributed.ProcessGroup"] = None,
-        device: Optional[Any] = None,
     ) -> None:
         _imports.check()
-        if device is not None:
-            warnings.warn(
-                "the device parameter is deprecated, please use group instead.", DeprecationWarning
-            )
 
         if group is not None:
             self._group: "torch.distributed.ProcessGroup" = group


### PR DESCRIPTION
## Motivation
This is a follow-up PR for #4106.
The `device` parameter is simply ignored in the current implementation, so we can just remove it.
`TorchDistributedTrial` is still experimental, and I'd prefer simplicity of implentation and interface over compatibility.

## Description of the changes

- Remove the `device` argument of `TorchDistributedTrial`