### PR TITLE
Fix a typo in `BruteForceSampler`

### DIFF
--- a/optuna/samplers/_brute_force.py
+++ b/optuna/samplers/_brute_force.py
@@ -45,7 +45,7 @@ class BruteForceSampler(BaseSampler):
 
     Note:
         The defined search space must be finite. Therefore, when using
-        :class:`~optuna.distributions.FloatDistibution`, ``step=None`` is not allowed.
+        :class:`~optuna.distributions.FloatDistribution`, ``step=None`` is not allowed.
 
     Note:
         This sampler assumes that it suggests all parameters and that the search space is fixed.


### PR DESCRIPTION
## Motivation
Fix a typo in BruteForceSampler

## Description of the changes
This PR fixes a typo in docstring of _brute_force.py.