### PR TITLE
Create a new process group if `group` of `TorchDistributedTrial` is `None`.

### DIFF
--- a/optuna/integration/pytorch_distributed.py
+++ b/optuna/integration/pytorch_distributed.py
@@ -113,14 +113,13 @@ class TorchDistributedTrial(optuna.trial.BaseTrial):
         group: Optional["ProcessGroup"] = None,
     ) -> None:
         _imports.check()
-        global _g_pg
 
         if group is not None:
             self._group: "ProcessGroup" = group
         else:
             if dist.group.WORLD is None:
                 raise RuntimeError("torch distributed is not initialized.")
-            self._group = dist.new_group(backend="gloo")  # type: ignore
+            self._group = dist.new_group(backend="gloo")  # type: ignore[no-untyped-call]
 
         if dist.get_rank(self._group) == 0:  # type: ignore[no-untyped-call]
             if not isinstance(trial, optuna.trial.Trial):


### PR DESCRIPTION
## Motivation
This is a follow-up PR for #4106.


### Always create a new process group

Currently, behavior of `TorchDistributedTrial` with `group=None` is inconsistent depending on a default process group (i.e., process groups for neural network training). The process group is reused if the backend of the default process group is `gloo`, while a new process group is created if the backend is `nccl`.
I think we can separate the communication of optuna and neural network training if we create a new process group for `gloo`.

And also, the current implementation does not take care of `mpi` backend. 
https://pytorch.org/docs/stable/distributed.html

### Create a process group for Optuna locally

The current master creates a process group as a (package) global variable  (i.e., `_g_pg`) silently. Users may have difficulty to release such hidden variables. So, I'd like to change it to a member of the `TorchDistributedTrial` class, so that it can be released when a `TorchDistributedTrial` object is removed.
This change may take some time to recreate gloo process groups trial by trial, but users can reuse the process group by the `group` argument.

## Description of the changes

- Create a new process group if `group=None`
- Create a new process group as a member of `TorchDistributedTrial`
- Update docstring and fix the annotations