### PR TITLE
Fix a typo in `TorchDistributedTrial`

### DIFF
--- a/optuna/integration/pytorch_distributed.py
+++ b/optuna/integration/pytorch_distributed.py
@@ -142,7 +142,7 @@ class TorchDistributedTrial(optuna.trial.BaseTrial):
         else:
             if trial is not None:
                 raise ValueError(
-                    "Non-rank 0 node is supposed to recieve None as the trial argument."
+                    "Non-rank 0 node is supposed to receive None as the trial argument."
                 )
 
             assert trial is None, "error message"


### PR DESCRIPTION
## Motivation
Fix a typo in a comment of `TorchDistributedTrial`

## Description of the changes
This PR fixes a typo in a comment of pytorch_distributed.py.
