### PR TITLE
Remove unused `# type: ignore` in `optuna/integration`

### DIFF
--- a/optuna/integration/allennlp/_pruner.py
+++ b/optuna/integration/allennlp/_pruner.py
@@ -116,7 +116,7 @@ class AllenNLPPruningCallback(TrainerCallback):
     ):
         _imports.check()
 
-        if version.parse(allennlp.__version__) < version.parse("2.0.0"):  # type: ignore
+        if version.parse(allennlp.__version__) < version.parse("2.0.0"):
             raise ImportError(
                 "`AllenNLPPruningCallback` requires AllenNLP>=v2.0.0."
                 "If you want to use a callback with an old version of AllenNLP, "

--- a/optuna/integration/chainer.py
+++ b/optuna/integration/chainer.py
@@ -11,7 +11,7 @@ with optuna._imports.try_import() as _imports:
     from chainer.training.triggers import ManualScheduleTrigger
 
 if not _imports.is_successful():
-    Extension = object  # type: ignore  # NOQA
+    Extension = object  # NOQA
 
 
 class ChainerPruningExtension(Extension):
@@ -54,7 +54,7 @@ class ChainerPruningExtension(Extension):
 
         self._trial = trial
         self._observation_key = observation_key
-        self._pruner_trigger = chainer.training.get_trigger(pruner_trigger)  # type: ignore
+        self._pruner_trigger = chainer.training.get_trigger(pruner_trigger)
         if not isinstance(self._pruner_trigger, (IntervalTrigger, ManualScheduleTrigger)):
             pruner_type = type(self._pruner_trigger)
             raise TypeError(
@@ -64,15 +64,13 @@ class ChainerPruningExtension(Extension):
             )
 
     @staticmethod
-    def _get_float_value(
-        observation_value: Union[float, "chainer.Variable"]  # type: ignore
-    ) -> float:
+    def _get_float_value(observation_value: Union[float, "chainer.Variable"]) -> float:
 
         _imports.check()
 
         try:
-            if isinstance(observation_value, chainer.Variable):  # type: ignore
-                return float(observation_value.data)  # type: ignore
+            if isinstance(observation_value, chainer.Variable):
+                return float(observation_value.data)
             else:
                 return float(observation_value)
         except TypeError:
@@ -81,11 +79,11 @@ class ChainerPruningExtension(Extension):
                 "{} cannot be cast to float.".format(type(observation_value))
             ) from None
 
-    def _observation_exists(self, trainer: "chainer.training.Trainer") -> bool:  # type: ignore
+    def _observation_exists(self, trainer: "chainer.training.Trainer") -> bool:
 
         return self._pruner_trigger(trainer) and self._observation_key in trainer.observation
 
-    def __call__(self, trainer: "chainer.training.Trainer") -> None:  # type: ignore
+    def __call__(self, trainer: "chainer.training.Trainer") -> None:
 
         if not self._observation_exists(trainer):
             return

--- a/optuna/integration/pytorch_distributed.py
+++ b/optuna/integration/pytorch_distributed.py
@@ -22,6 +22,7 @@ from optuna.distributions import CategoricalChoiceType
 with try_import() as _imports:
     import torch
     import torch.distributed as dist
+    import torch.distributed.ProcessGroup as ProcessGroup
 
 
 if TYPE_CHECKING:
@@ -35,7 +36,7 @@ _suggest_deprecated_msg = (
     "Use :func:`~optuna.integration.TorchDistributedTrial.suggest_float` instead."
 )
 
-_g_pg: List[Optional["torch.distributed.ProcessGroup"]] = [None]
+_g_pg: List[Optional["ProcessGroup"]] = [None]
 
 
 def broadcast_properties(f: "Callable[_P, _T]") -> "Callable[_P, _T]":
@@ -118,7 +119,7 @@ class TorchDistributedTrial(optuna.trial.BaseTrial):
     def __init__(
         self,
         trial: Optional[optuna.trial.Trial],
-        group: Optional["torch.distributed.ProcessGroup"] = None,
+        group: Optional["ProcessGroup"] = None,
         device: Optional[Any] = None,
     ) -> None:
         _imports.check()
@@ -128,22 +129,22 @@ class TorchDistributedTrial(optuna.trial.BaseTrial):
             )
 
         if group is not None:
-            self._group: "torch.distributed.ProcessGroup" = group
+            self._group: "ProcessGroup" = group
         else:
             if _g_pg[0] is None:
                 if dist.group.WORLD is None:
                     raise RuntimeError("torch distributed is not initialized.")
-                default_pg: "torch.distributed.ProcessGroup" = dist.group.WORLD
-                if dist.get_backend(default_pg) == "nccl":
-                    new_group: "torch.distributed.ProcessGroup" = dist.new_group(
+                default_pg: "ProcessGroup" = dist.group.WORLD
+                if dist.get_backend(default_pg) == "nccl":  # type: ignore[no-untyped-call]
+                    new_group: "ProcessGroup" = dist.new_group(  # type: ignore[no-untyped-call]
                         backend="gloo"
-                    )  # type: ignore
+                    )
                     _g_pg[0] = new_group
                 else:
                     _g_pg[0] = default_pg
-            self._group = _g_pg[0]  # type: ignore
+            self._group = _g_pg[0]
 
-        if dist.get_rank(self._group) == 0:  # type: ignore
+        if dist.get_rank(self._group) == 0:  # type: ignore[no-untyped-call]
             if not isinstance(trial, optuna.trial.Trial):
                 raise ValueError(
                     "Rank 0 node expects an optuna.trial.Trial instance as the trial argument."
@@ -214,7 +215,7 @@ class TorchDistributedTrial(optuna.trial.BaseTrial):
     @broadcast_properties
     def report(self, value: float, step: int) -> None:
         err = None
-        if dist.get_rank(self._group) == 0:  # type: ignore
+        if dist.get_rank(self._group) == 0:  # type: ignore[no-untyped-call]
             try:
                 assert self._delegate is not None
                 self._delegate.report(value, step)
@@ -241,7 +242,7 @@ class TorchDistributedTrial(optuna.trial.BaseTrial):
     @broadcast_properties
     def set_user_attr(self, key: str, value: Any) -> None:
         err = None
-        if dist.get_rank(self._group) == 0:  # type: ignore
+        if dist.get_rank(self._group) == 0:  # type: ignore[no-untyped-call]
             try:
                 assert self._delegate is not None
                 self._delegate.set_user_attr(key, value)
@@ -259,7 +260,7 @@ class TorchDistributedTrial(optuna.trial.BaseTrial):
     def set_system_attr(self, key: str, value: Any) -> None:
         err = None
 
-        if dist.get_rank(self._group) == 0:  # type: ignore
+        if dist.get_rank(self._group) == 0:  # type: ignore[no-untyped-call]
             try:
                 assert self._delegate is not None
                 self._delegate.storage.set_trial_system_attr(self._delegate._trial_id, key, value)
@@ -298,31 +299,31 @@ class TorchDistributedTrial(optuna.trial.BaseTrial):
 
     def _call_and_communicate(self, func: Callable, dtype: "torch.dtype") -> Any:
         buffer = torch.empty(1, dtype=dtype)
-        rank = dist.get_rank(self._group)  # type: ignore
+        rank = dist.get_rank(self._group)  # type: ignore[no-untyped-call]
         if rank == 0:
             result = func()
             buffer[0] = result
-        dist.broadcast(buffer, src=0, group=self._group)  # type: ignore
+        dist.broadcast(buffer, src=0, group=self._group)  # type: ignore[no-untyped-call]
         return buffer.item()
 
     def _call_and_communicate_obj(self, func: Callable) -> Any:
-        rank = dist.get_rank(self._group)  # type: ignore
+        rank = dist.get_rank(self._group)  # type: ignore[no-untyped-call]
         result = func() if rank == 0 else None
         return self._broadcast(result)
 
     def _broadcast(self, value: Optional[Any]) -> Any:
         buffer = None
         size_buffer = torch.empty(1, dtype=torch.int)
-        rank = dist.get_rank(self._group)  # type: ignore
+        rank = dist.get_rank(self._group)  # type: ignore[no-untyped-call]
         if rank == 0:
             buffer = _to_tensor(value)
             size_buffer[0] = buffer.shape[0]
-        dist.broadcast(size_buffer, src=0, group=self._group)  # type: ignore
+        dist.broadcast(size_buffer, src=0, group=self._group)  # type: ignore[no-untyped-call]
         buffer_size = int(size_buffer.item())
         if rank != 0:
             buffer = torch.empty(buffer_size, dtype=torch.uint8)
         assert buffer is not None
-        dist.broadcast(buffer, src=0, group=self._group)  # type: ignore
+        dist.broadcast(buffer, src=0, group=self._group)  # type: ignore[no-untyped-call]
         return _from_tensor(buffer)
 
 

--- a/optuna/integration/pytorch_lightning.py
+++ b/optuna/integration/pytorch_lightning.py
@@ -19,9 +19,9 @@ with optuna._imports.try_import() as _imports:
     from pytorch_lightning.callbacks import Callback
 
 if not _imports.is_successful():
-    Callback = object  # type: ignore  # NOQA
-    LightningModule = object  # type: ignore  # NOQA
-    Trainer = object  # type: ignore  # NOQA
+    Callback = object  # NOQA
+    LightningModule = object  # NOQA
+    Trainer = object  # NOQA
 
 
 class PyTorchLightningPruningCallback(Callback):
@@ -57,11 +57,9 @@ class PyTorchLightningPruningCallback(Callback):
         self.is_ddp_backend = False
 
     def on_init_start(self, trainer: Trainer) -> None:
-        self.is_ddp_backend = (
-            trainer._accelerator_connector.distributed_backend is not None  # type: ignore
-        )
+        self.is_ddp_backend = trainer._accelerator_connector.distributed_backend is not None
         if self.is_ddp_backend:
-            if version.parse(pl.__version__) < version.parse("1.5.0"):  # type: ignore
+            if version.parse(pl.__version__) < version.parse("1.5.0"):
                 raise ValueError("PyTorch Lightning>=1.5.0 is required in DDP.")
             if not (
                 isinstance(self._trial.study._storage, _CachedStorage)

--- a/optuna/integration/xgboost.py
+++ b/optuna/integration/xgboost.py
@@ -76,7 +76,7 @@ if _imports.is_successful() and use_callback_cls:
 
 elif _imports.is_successful():
 
-    def _get_callback_context(env: "xgb.core.CallbackEnv") -> str:  # type: ignore
+    def _get_callback_context(env: "xgb.core.CallbackEnv") -> str:
         """Return whether the current callback context is cv or train.
 
         .. note::
@@ -97,7 +97,7 @@ elif _imports.is_successful():
             self._trial = trial
             self._observation_key = observation_key
 
-        def __call__(self, env: "xgb.core.CallbackEnv") -> None:  # type: ignore
+        def __call__(self, env: "xgb.core.CallbackEnv") -> None:
 
             context = _get_callback_context(env)
             evaluation_result_list = env.evaluation_result_list


### PR DESCRIPTION
## Motivation
Solve scheduled Checks (Integration) failure
## Description of the changes
Currently, scheduled Checks (Integration) fails die to mypy check with `--warn-unused-ignores` option. This PR removes a part of the cause by eliminating unused `# type: ignore`.
