### PR TITLE
Skip constraint check for running trial

### DIFF
--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -670,7 +670,7 @@ def _get_observation_pairs(
                 param_value = None
             values[param_name].append(param_value)
 
-        if constraints_enabled:
+        if constraints_enabled and trial.state != TrialState.RUNNING:
             assert violations is not None
             constraint = trial.system_attrs.get(_CONSTRAINTS_KEY)
             if constraint is None:


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

Resolve #4221

## Description of the changes
<!-- Describe the changes in this PR. -->

As described in #4221, skip checking the constraint of trials when their states are `RUNNING` not to show the unnecessary warning.

---

I've checked the warning doesn't appear anymore with the slightly modified reproducible code provided in #4221.

```python
import optuna


def objective(trial):

    x = trial.suggest_float("x", -1, 1)
    trial.set_user_attr("constraint", (-x,))

    if trial.number == 2:
        raise optuna.exceptions.TrialPruned()
    return x


def constraints_func(trial):
    return trial.user_attrs["constraint"]


sampler = optuna.samplers.TPESampler(constraints_func=constraints_func, constant_liar=True)
study = optuna.create_study(sampler=sampler)
study.optimize(objective, n_trials=4)

```

```bash
/Users/nzw/Documents/optuna/optuna/samplers/_tpe/sampler.py:301: ExperimentalWarning: ``constant_liar`` option is an experimental feature. The interface can change in the future.
  warnings.warn(
/Users/nzw/Documents/optuna/optuna/samplers/_tpe/sampler.py:308: ExperimentalWarning: The ``constraints_func`` option is an experimental feature. The interface can change in the future.
  warnings.warn(
[I 2022-12-23 10:16:25,444] A new study created in memory with name: no-name-97edb984-06f2-465b-9ed7-510ee93213b7
[I 2022-12-23 10:16:25,445] Trial 0 finished with value: 0.6581330973294237 and parameters: {'x': 0.6581330973294237}. Best is trial 0 with value: 0.6581330973294237.
[I 2022-12-23 10:16:25,445] Trial 1 finished with value: -0.7749583637360082 and parameters: {'x': -0.7749583637360082}. Best is trial 1 with value: -0.7749583637360082.
[I 2022-12-23 10:16:25,446] Trial 2 pruned.
[I 2022-12-23 10:16:25,446] Trial 3 finished with value: 0.743792292814812 and parameters: {'x': 0.743792292814812}. Best is trial 1 with value: -0.7749583637360082.
```