### PR TITLE
Fix mypy error abut `Chainer` in Checks (integration)

### DIFF
--- a/optuna/integration/chainer.py
+++ b/optuna/integration/chainer.py
@@ -7,11 +7,11 @@ import optuna
 with optuna._imports.try_import() as _imports:
     import chainer
     from chainer.training.extension import Extension
-    from chainer.training.triggers import IntervalTrigger
-    from chainer.training.triggers import ManualScheduleTrigger
+    from chainer.training.triggers import IntervalTrigger  # type: ignore[attr-defined]
+    from chainer.training.triggers import ManualScheduleTrigger  # type: ignore[attr-defined]
 
 if not _imports.is_successful():
-    Extension = object  # type: ignore  # NOQA
+    Extension = object  # type: ignore[assignment, misc]  # NOQA
 
 
 class ChainerPruningExtension(Extension):
@@ -54,7 +54,9 @@ class ChainerPruningExtension(Extension):
 
         self._trial = trial
         self._observation_key = observation_key
-        self._pruner_trigger = chainer.training.get_trigger(pruner_trigger)  # type: ignore
+        self._pruner_trigger = chainer.training.get_trigger(  # type: ignore[attr-defined]
+            pruner_trigger
+        )
         if not isinstance(self._pruner_trigger, (IntervalTrigger, ManualScheduleTrigger)):
             pruner_type = type(self._pruner_trigger)
             raise TypeError(
@@ -65,14 +67,14 @@ class ChainerPruningExtension(Extension):
 
     @staticmethod
     def _get_float_value(
-        observation_value: Union[float, "chainer.Variable"]  # type: ignore
+        observation_value: Union[float, "chainer.Variable"]  # type: ignore[name-defined]
     ) -> float:
 
         _imports.check()
 
         try:
-            if isinstance(observation_value, chainer.Variable):  # type: ignore
-                return float(observation_value.data)  # type: ignore
+            if isinstance(observation_value, chainer.Variable):  # type: ignore[attr-defined]
+                return float(observation_value.data)
             else:
                 return float(observation_value)
         except TypeError:
@@ -81,11 +83,13 @@ class ChainerPruningExtension(Extension):
                 "{} cannot be cast to float.".format(type(observation_value))
             ) from None
 
-    def _observation_exists(self, trainer: "chainer.training.Trainer") -> bool:  # type: ignore
+    def _observation_exists(
+        self, trainer: "chainer.training.Trainer"  # type: ignore[name-defined]
+    ) -> bool:
 
         return self._pruner_trigger(trainer) and self._observation_key in trainer.observation
 
-    def __call__(self, trainer: "chainer.training.Trainer") -> None:  # type: ignore
+    def __call__(self, trainer: "chainer.training.Trainer") -> None:  # type: ignore[name-defined]
 
         if not self._observation_exists(trainer):
             return

--- a/tests/integration_tests/test_chainer.py
+++ b/tests/integration_tests/test_chainer.py
@@ -15,12 +15,12 @@ from optuna.testing.pruners import DeterministicPruner
 
 with try_import() as _imports:
     import chainer
-    from chainer.dataset import DatasetMixin
+    from chainer.dataset import DatasetMixin  # type: ignore[attr-defined]
     import chainer.links as L
     from chainer.training import triggers
 
 if not _imports.is_successful():
-    DatasetMixin = object  # type: ignore # NOQA
+    DatasetMixin = object  # NOQA
 
 pytestmark = pytest.mark.integration
 
@@ -44,18 +44,28 @@ def test_chainer_pruning_extension_trigger() -> None:
     trial = study.ask()
 
     extension = ChainerPruningExtension(trial, "main/loss", (1, "epoch"))
-    assert isinstance(extension._pruner_trigger, triggers.IntervalTrigger)
-    extension = ChainerPruningExtension(
-        trial, "main/loss", triggers.IntervalTrigger(1, "epoch")  # type: ignore
+    assert isinstance(
+        extension._pruner_trigger, triggers.IntervalTrigger  # type: ignore[attr-defined]
     )
-    assert isinstance(extension._pruner_trigger, triggers.IntervalTrigger)
     extension = ChainerPruningExtension(
-        trial, "main/loss", triggers.ManualScheduleTrigger(1, "epoch")  # type: ignore
+        trial, "main/loss", triggers.IntervalTrigger(1, "epoch")  # type: ignore[attr-defined]
     )
-    assert isinstance(extension._pruner_trigger, triggers.ManualScheduleTrigger)
+    assert isinstance(
+        extension._pruner_trigger, triggers.IntervalTrigger  # type: ignore[attr-defined]
+    )
+    extension = ChainerPruningExtension(
+        trial,
+        "main/loss",
+        triggers.ManualScheduleTrigger(1, "epoch"),  # type: ignore[attr-defined]
+    )
+    assert isinstance(
+        extension._pruner_trigger, triggers.ManualScheduleTrigger  # type: ignore[attr-defined]
+    )
 
     with pytest.raises(TypeError):
-        ChainerPruningExtension(trial, "main/loss", triggers.TimeTrigger(1.0))  # type: ignore
+        ChainerPruningExtension(
+            trial, "main/loss", triggers.TimeTrigger(1.0)  # type: ignore[attr-defined]
+        )
 
 
 def test_chainer_pruning_extension() -> None:
@@ -98,7 +108,7 @@ def test_chainer_pruning_extension_observation_nan() -> None:
 
     with patch.object(extension, "_observation_exists", Mock(return_value=True)) as mock:
         with pytest.raises(optuna.TrialPruned):
-            extension(trainer)  # type: ignore
+            extension(trainer)
         assert mock.call_count == 1
 
 
@@ -110,19 +120,25 @@ def test_observation_exists() -> None:
     trainer = MockTrainer(observation={"OK": 0})
 
     # Trigger is deactivated. Return False whether trainer has observation or not.
-    with patch.object(triggers.IntervalTrigger, "__call__", Mock(return_value=False)) as mock:
+    with patch.object(
+        triggers.IntervalTrigger,  # type: ignore[attr-defined]
+        "__call__",
+        Mock(return_value=False),
+    ) as mock:
         extension = ChainerPruningExtension(trial, "NG", (1, "epoch"))
-        assert extension._observation_exists(trainer) is False  # type: ignore
+        assert extension._observation_exists(trainer) is False
         extension = ChainerPruningExtension(trial, "OK", (1, "epoch"))
-        assert extension._observation_exists(trainer) is False  # type: ignore
+        assert extension._observation_exists(trainer) is False
         assert mock.call_count == 2
 
     # Trigger is activated. Return True if trainer has observation.
-    with patch.object(triggers.IntervalTrigger, "__call__", Mock(return_value=True)) as mock:
+    with patch.object(
+        triggers.IntervalTrigger, "__call__", Mock(return_value=True)  # type: ignore[attr-defined]
+    ) as mock:
         extension = ChainerPruningExtension(trial, "NG", (1, "epoch"))
-        assert extension._observation_exists(trainer) is False  # type: ignore
+        assert extension._observation_exists(trainer) is False
         extension = ChainerPruningExtension(trial, "OK", (1, "epoch"))
-        assert extension._observation_exists(trainer) is True  # type: ignore
+        assert extension._observation_exists(trainer) is True
         assert mock.call_count == 2
 
 
@@ -130,6 +146,6 @@ def test_get_float_value() -> None:
 
     assert 1.0 == ChainerPruningExtension._get_float_value(1.0)
     assert 1.0 == ChainerPruningExtension._get_float_value(
-        chainer.Variable(np.array([1.0]))  # type: ignore
+        chainer.Variable(np.array([1.0]))  # type: ignore[attr-defined]
     )
     assert math.isnan(ChainerPruningExtension._get_float_value(float("nan")))


### PR DESCRIPTION
## Motivation
Solve scheduled Checks (Integration) failure

## Description of the changes
Currently, scheduled Checks (Integration) fails die to mypy check with `--warn-unused-ignores` option. This PR removes a part of the cause related to `Chainer`.
Although test for  Checks (Integration) does't run when PR in opened, I confirmed this PR together with other "Fix mypy error" series reduces mypy error at [CI on my fork](https://github.com/Alnusjaponica/optuna/pull/3).