### PR TITLE
Fix mypy error abut `BoTorch` in Checks (integration)

### DIFF
--- a/tests/integration_tests/test_botorch.py
+++ b/tests/integration_tests/test_botorch.py
@@ -25,7 +25,7 @@ with try_import() as _imports:
 if not _imports.is_successful():
     from unittest.mock import MagicMock
 
-    torch = MagicMock()  # type: ignore # NOQA
+    torch = MagicMock()  # NOQA
 
 pytestmark = pytest.mark.integration
 


### PR DESCRIPTION
## Motivation
Solve scheduled Checks (Integration) failure

## Description of the changes
Currently, scheduled Checks (Integration) fails die to mypy check with `--warn-unused-ignores` option. This PR removes a part of the cause related to `BoTorch`.
Although test for  Checks (Integration) does't run when PR in opened, I confirmed this PR together with other "Fix mypy error" series reduces mypy error at [CI on my fork](https://github.com/Alnusjaponica/optuna/pull/3).