### PR TITLE
Fix mypy error abut dask.py in Checks (integration)

### DIFF
--- a/optuna/integration/dask.py
+++ b/optuna/integration/dask.py
@@ -29,7 +29,7 @@ with try_import() as _imports:
     import distributed
     from distributed.protocol.pickle import dumps
     from distributed.protocol.pickle import loads
-    from distributed.utils import thread_state
+    from distributed.utils import thread_state  # type: ignore[attr-defined]
     from distributed.worker import get_client
 
 
@@ -39,8 +39,14 @@ def _serialize_frozentrial(trial: FrozenTrial) -> dict:
     attrs = [a for a in data.keys() if a.startswith("_")]
     for attr in attrs:
         data[attr[1:]] = data.pop(attr)
-    data["system_attrs"] = dumps(data["system_attrs"]) if data["system_attrs"] else {}
-    data["user_attrs"] = dumps(data["user_attrs"]) if data["user_attrs"] else {}
+    data["system_attrs"] = (
+        dumps(data["system_attrs"])  # type: ignore[no-untyped-call]
+        if data["system_attrs"]
+        else {}
+    )
+    data["user_attrs"] = (
+        dumps(data["user_attrs"]) if data["user_attrs"] else {}  # type: ignore[no-untyped-call]
+    )
     data["distributions"] = {k: distribution_to_json(v) for k, v in data["distributions"].items()}
     if data["datetime_start"] is not None:
         data["datetime_start"] = data["datetime_start"].isoformat(timespec="microseconds")
@@ -57,8 +63,14 @@ def _deserialize_frozentrial(data: dict) -> FrozenTrial:
         data["datetime_start"] = datetime.fromisoformat(data["datetime_start"])
     if data["datetime_complete"] is not None:
         data["datetime_complete"] = datetime.fromisoformat(data["datetime_complete"])
-    data["system_attrs"] = loads(data["system_attrs"]) if data["system_attrs"] else {}
-    data["user_attrs"] = loads(data["user_attrs"]) if data["user_attrs"] else {}
+    data["system_attrs"] = (
+        loads(data["system_attrs"])  # type: ignore[no-untyped-call]
+        if data["system_attrs"]
+        else {}
+    )
+    data["user_attrs"] = (
+        loads(data["user_attrs"]) if data["user_attrs"] else {}  # type: ignore[no-untyped-call]
+    )
     return FrozenTrial(**data)
 
 
@@ -67,8 +79,12 @@ def _serialize_frozenstudy(study: FrozenStudy) -> dict:
         "directions": [d.name for d in study._directions],
         "study_id": study._study_id,
         "study_name": study.study_name,
-        "user_attrs": dumps(study.user_attrs) if study.user_attrs else {},
-        "system_attrs": dumps(study.system_attrs) if study.system_attrs else {},
+        "user_attrs": dumps(study.user_attrs)  # type: ignore[no-untyped-call]
+        if study.user_attrs
+        else {},
+        "system_attrs": dumps(study.system_attrs)  # type: ignore[no-untyped-call]
+        if study.system_attrs
+        else {},
     }
     return data
 
@@ -76,8 +92,14 @@ def _serialize_frozenstudy(study: FrozenStudy) -> dict:
 def _deserialize_frozenstudy(data: dict) -> FrozenStudy:
     data["directions"] = [StudyDirection[d] for d in data["directions"]]
     data["direction"] = None
-    data["system_attrs"] = loads(data["system_attrs"]) if data["system_attrs"] else {}
-    data["user_attrs"] = loads(data["user_attrs"]) if data["user_attrs"] else {}
+    data["system_attrs"] = (
+        loads(data["system_attrs"])  # type: ignore[no-untyped-call]
+        if data["system_attrs"]
+        else {}
+    )
+    data["user_attrs"] = (
+        loads(data["user_attrs"]) if data["user_attrs"] else {}  # type: ignore[no-untyped-call]
+    )
     return FrozenStudy(**data)
 
 
@@ -147,7 +169,7 @@ class _OptunaSchedulerExtension:
         value: Any,
     ) -> None:
         return self.get_storage(storage_name).set_study_user_attr(
-            study_id=study_id, key=key, value=loads(value)
+            study_id=study_id, key=key, value=loads(value)  # type: ignore[no-untyped-call]
         )
 
     def set_study_system_attr(
@@ -161,7 +183,7 @@ class _OptunaSchedulerExtension:
         return self.get_storage(storage_name).set_study_system_attr(
             study_id=study_id,
             key=key,
-            value=loads(value),
+            value=loads(value),  # type: ignore[no-untyped-call]
         )
 
     def get_study_id_from_name(
@@ -195,7 +217,11 @@ class _OptunaSchedulerExtension:
         storage_name: str,
         study_id: int,
     ) -> Dict[str, Any]:
-        return dumps(self.get_storage(storage_name).get_study_user_attrs(study_id=study_id))
+        return dumps(
+            self.get_storage(storage_name).get_study_user_attrs(  # type: ignore[no-untyped-call]
+                study_id=study_id
+            )
+        )
 
     def get_study_system_attrs(
         self,
@@ -203,7 +229,11 @@ class _OptunaSchedulerExtension:
         storage_name: str,
         study_id: int,
     ) -> Dict[str, Any]:
-        return dumps(self.get_storage(storage_name).get_study_system_attrs(study_id=study_id))
+        return dumps(
+            self.get_storage(storage_name).get_study_system_attrs(  # type: ignore[no-untyped-call]
+                study_id=study_id
+            )
+        )
 
     def get_all_studies(self, comm: "distributed.comm.tcp.TCP", storage_name: str) -> List[dict]:
         studies = self.get_storage(storage_name).get_all_studies()
@@ -307,7 +337,7 @@ class _OptunaSchedulerExtension:
         return self.get_storage(storage_name).set_trial_user_attr(
             trial_id=trial_id,
             key=key,
-            value=loads(value),
+            value=loads(value),  # type: ignore[no-untyped-call]
         )
 
     def set_trial_system_attr(
@@ -321,7 +351,7 @@ class _OptunaSchedulerExtension:
         return self.get_storage(storage_name).set_trial_system_attr(
             trial_id=trial_id,
             key=key,
-            value=loads(value),
+            value=loads(value),  # type: ignore[no-untyped-call]
         )
 
     def get_trial(
@@ -427,14 +457,16 @@ class DaskStorage(BaseStorage):
         if self.client.asynchronous or getattr(thread_state, "on_event_loop_thread", False):
 
             async def _register() -> DaskStorage:
-                await self.client.run_on_scheduler(  # type: ignore
+                await self.client.run_on_scheduler(  # type: ignore[no-untyped-call]
                     _register_with_scheduler, storage=storage, name=self.name
                 )
                 return self
 
             self._started = asyncio.ensure_future(_register())
         else:
-            self.client.run_on_scheduler(_register_with_scheduler, storage=storage, name=self.name)
+            self.client.run_on_scheduler(  # type: ignore[no-untyped-call]
+                _register_with_scheduler, storage=storage, name=self.name
+            )
 
     def __await__(self) -> Generator[Any, None, "DaskStorage"]:
         if hasattr(self, "_started"):
@@ -463,88 +495,90 @@ class DaskStorage(BaseStorage):
         def _get_base_storage(dask_scheduler: distributed.Scheduler, name: str) -> BaseStorage:
             return dask_scheduler.extensions["optuna"].storages[name]
 
-        return self.client.run_on_scheduler(_get_base_storage, name=self.name)
+        return self.client.run_on_scheduler(  # type: ignore[no-untyped-call]
+            _get_base_storage, name=self.name
+        )
 
     def create_new_study(
         self, directions: Sequence[StudyDirection], study_name: Optional[str] = None
     ) -> int:
-        return self.client.sync(
-            self.client.scheduler.optuna_create_new_study,
+        return self.client.sync(  # type: ignore[no-untyped-call]
+            self.client.scheduler.optuna_create_new_study,  # type: ignore[union-attr]
             storage_name=self.name,
             study_name=study_name,
             directions=[direction.name for direction in directions],
         )
 
     def delete_study(self, study_id: int) -> None:
-        return self.client.sync(
-            self.client.scheduler.optuna_delete_study,
+        return self.client.sync(  # type: ignore[no-untyped-call]
+            self.client.scheduler.optuna_delete_study,  # type: ignore[union-attr]
             storage_name=self.name,
             study_id=study_id,
         )
 
     def set_study_user_attr(self, study_id: int, key: str, value: Any) -> None:
-        return self.client.sync(
-            self.client.scheduler.optuna_set_study_user_attr,
+        return self.client.sync(  # type: ignore[no-untyped-call]
+            self.client.scheduler.optuna_set_study_user_attr,  # type: ignore[union-attr]
             storage_name=self.name,
             study_id=study_id,
             key=key,
-            value=dumps(value),
+            value=dumps(value),  # type: ignore[no-untyped-call]
         )
 
     def set_study_system_attr(self, study_id: int, key: str, value: Any) -> None:
         return self.client.sync(
-            self.client.scheduler.optuna_set_study_system_attr,
+            self.client.scheduler.optuna_set_study_system_attr,  # type: ignore[union-attr]
             storage_name=self.name,
             study_id=study_id,
             key=key,
-            value=dumps(value),
+            value=dumps(value),  # type: ignore[no-untyped-call]
         )
 
     # Basic study access
 
     def get_study_id_from_name(self, study_name: str) -> int:
-        return self.client.sync(
-            self.client.scheduler.optuna_get_study_id_from_name,
+        return self.client.sync(  # type: ignore[no-untyped-call]
+            self.client.scheduler.optuna_get_study_id_from_name,  # type: ignore[union-attr]
             study_name=study_name,
             storage_name=self.name,
         )
 
     def get_study_name_from_id(self, study_id: int) -> str:
-        return self.client.sync(
-            self.client.scheduler.optuna_get_study_name_from_id,
+        return self.client.sync(  # type: ignore[no-untyped-call]
+            self.client.scheduler.optuna_get_study_name_from_id,  # type: ignore[union-attr]
             storage_name=self.name,
             study_id=study_id,
         )
 
     def get_study_directions(self, study_id: int) -> List[StudyDirection]:
-        directions = self.client.sync(
-            self.client.scheduler.optuna_get_study_directions,
+        directions = self.client.sync(  # type: ignore[no-untyped-call]
+            self.client.scheduler.optuna_get_study_directions,  # type: ignore[union-attr]
             storage_name=self.name,
             study_id=study_id,
         )
         return [StudyDirection[direction] for direction in directions]
 
     def get_study_user_attrs(self, study_id: int) -> Dict[str, Any]:
-        return loads(
-            self.client.sync(
-                self.client.scheduler.optuna_get_study_user_attrs,
+        return loads(  # type: ignore[no-untyped-call]
+            self.client.sync(  # type: ignore[no-untyped-call]
+                self.client.scheduler.optuna_get_study_user_attrs,  # type: ignore[union-attr]
                 storage_name=self.name,
                 study_id=study_id,
             )
         )
 
     def get_study_system_attrs(self, study_id: int) -> Dict[str, Any]:
-        return loads(
-            self.client.sync(
-                self.client.scheduler.optuna_get_study_system_attrs,
+        return loads(  # type: ignore[no-untyped-call]
+            self.client.sync(  # type: ignore[no-untyped-call]
+                self.client.scheduler.optuna_get_study_system_attrs,  # type: ignore[union-attr]
                 storage_name=self.name,
                 study_id=study_id,
             )
         )
 
     def get_all_studies(self) -> List[FrozenStudy]:
-        results = self.client.sync(
-            self.client.scheduler.optuna_get_all_studies,
+        results = self.client.sync(  # type: ignore[no-untyped-call]
+            self.client.scheduler.optuna_get_all_studies,  # type: ignore[union-attr]
             storage_name=self.name,
         )
         return [_deserialize_frozenstudy(i) for i in results]
@@ -555,8 +589,8 @@ class DaskStorage(BaseStorage):
         serialized_template_trial = None
         if template_trial is not None:
             serialized_template_trial = _serialize_frozentrial(template_trial)
-        return self.client.sync(
-            self.client.scheduler.optuna_create_new_trial,
+        return self.client.sync(  # type: ignore[no-untyped-call]
+            self.client.scheduler.optuna_create_new_trial,  # type: ignore[union-attr]
             storage_name=self.name,
             study_id=study_id,
             template_trial=serialized_template_trial,
@@ -569,8 +603,8 @@ class DaskStorage(BaseStorage):
         param_value_internal: float,
         distribution: BaseDistribution,
     ) -> None:
-        return self.client.sync(
-            self.client.scheduler.optuna_set_trial_param,
+        return self.client.sync(  # type: ignore[no-untyped-call]
+            self.client.scheduler.optuna_set_trial_param,  # type: ignore[union-attr]
             storage_name=self.name,
             trial_id=trial_id,
             param_name=param_name,
@@ -579,23 +613,23 @@ class DaskStorage(BaseStorage):
         )
 
     def get_trial_id_from_study_id_trial_number(self, study_id: int, trial_number: int) -> int:
-        return self.client.sync(
-            self.client.scheduler.optuna_get_trial_id_from_study_id_trial_number,
+        return self.client.sync(  # type: ignore[no-untyped-call]
+            self.client.scheduler.optuna_get_trial_id_from_study_id_trial_number,  # type: ignore[union-attr]  # NOQA: E501
             storage_name=self.name,
             study_id=study_id,
             trial_number=trial_number,
         )
 
     def get_trial_number_from_id(self, trial_id: int) -> int:
-        return self.client.sync(
-            self.client.scheduler.optuna_get_trial_number_from_id,
+        return self.client.sync(  # type: ignore[no-untyped-call]
+            self.client.scheduler.optuna_get_trial_number_from_id,  # type: ignore[union-attr]
             storage_name=self.name,
             trial_id=trial_id,
         )
 
     def get_trial_param(self, trial_id: int, param_name: str) -> float:
-        return self.client.sync(
-            self.client.scheduler.optuna_get_trial_param,
+        return self.client.sync(  # type: ignore[no-untyped-call]
+            self.client.scheduler.optuna_get_trial_param,  # type: ignore[union-attr]
             storage_name=self.name,
             trial_id=trial_id,
             param_name=param_name,
@@ -604,8 +638,8 @@ class DaskStorage(BaseStorage):
     def set_trial_state_values(
         self, trial_id: int, state: TrialState, values: Optional[Sequence[float]] = None
     ) -> bool:
-        return self.client.sync(
-            self.client.scheduler.optuna_set_trial_state_values,
+        return self.client.sync(  # type: ignore[no-untyped-call]
+            self.client.scheduler.optuna_set_trial_state_values,  # type: ignore[union-attr]
             storage_name=self.name,
             trial_id=trial_id,
             state=state.name,
@@ -615,8 +649,8 @@ class DaskStorage(BaseStorage):
     def set_trial_intermediate_value(
         self, trial_id: int, step: int, intermediate_value: float
     ) -> None:
-        return self.client.sync(
-            self.client.scheduler.optuna_set_trial_intermediate_value,
+        return self.client.sync(  # type: ignore[no-untyped-call]
+            self.client.scheduler.optuna_set_trial_intermediate_value,  # type: ignore[union-attr]
             storage_name=self.name,
             trial_id=trial_id,
             step=step,
@@ -624,33 +658,35 @@ class DaskStorage(BaseStorage):
         )
 
     def set_trial_user_attr(self, trial_id: int, key: str, value: Any) -> None:
-        return self.client.sync(
-            self.client.scheduler.optuna_set_trial_user_attr,
+        return self.client.sync(  # type: ignore[no-untyped-call]
+            self.client.scheduler.optuna_set_trial_user_attr,  # type: ignore[union-attr]
             storage_name=self.name,
             trial_id=trial_id,
             key=key,
-            value=dumps(value),
+            value=dumps(value),  # type: ignore[no-untyped-call]
         )
 
     def set_trial_system_attr(self, trial_id: int, key: str, value: Any) -> None:
-        return self.client.sync(
-            self.client.scheduler.optuna_set_trial_system_attr,
+        return self.client.sync(  # type: ignore[no-untyped-call]
+            self.client.scheduler.optuna_set_trial_system_attr,  # type: ignore[union-attr]
             storage_name=self.name,
             trial_id=trial_id,
             key=key,
-            value=dumps(value),
+            value=dumps(value),  # type: ignore[no-untyped-call]
         )
 
     # Basic trial access
 
     async def _get_trial(self, trial_id: int) -> FrozenTrial:
-        serialized_trial = await self.client.scheduler.optuna_get_trial(
+        serialized_trial = await self.client.scheduler.optuna_get_trial(  # type: ignore[union-attr]  # NOQA: E501
             trial_id=trial_id, storage_name=self.name
         )
         return _deserialize_frozentrial(serialized_trial)
 
     def get_trial(self, trial_id: int) -> FrozenTrial:
-        return self.client.sync(self._get_trial, trial_id=trial_id)
+        return self.client.sync(  # type: ignore[no-untyped-call]
+            self._get_trial, trial_id=trial_id
+        )
 
     async def _get_all_trials(
         self, study_id: int, deepcopy: bool = True, states: Optional[Iterable[TrialState]] = None
@@ -658,7 +694,7 @@ class DaskStorage(BaseStorage):
         serialized_states = None
         if states is not None:
             serialized_states = tuple(s.name for s in states)
-        serialized_trials = await self.client.scheduler.optuna_get_all_trials(
+        serialized_trials = await self.client.scheduler.optuna_get_all_trials(  # type: ignore[union-attr]  # NOQA: E501
             storage_name=self.name,
             study_id=study_id,
             deepcopy=deepcopy,
@@ -669,7 +705,7 @@ class DaskStorage(BaseStorage):
     def get_all_trials(
         self, study_id: int, deepcopy: bool = True, states: Optional[Container[TrialState]] = None
     ) -> List[FrozenTrial]:
-        return self.client.sync(
+        return self.client.sync(  # type: ignore[no-untyped-call]
             self._get_all_trials,
             study_id=study_id,
             deepcopy=deepcopy,
@@ -685,8 +721,8 @@ class DaskStorage(BaseStorage):
                 serialized_state = state.name
             else:
                 serialized_state = tuple(s.name for s in state)
-        return self.client.sync(
-            self.client.scheduler.optuna_get_n_trials,
+        return self.client.sync(  # type: ignore[no-untyped-call]
+            self.client.scheduler.optuna_get_n_trials,  # type: ignore[union-attr]
             storage_name=self.name,
             study_id=study_id,
             state=serialized_state,

--- a/optuna/testing/storages.py
+++ b/optuna/testing/storages.py
@@ -94,7 +94,7 @@ class StorageSupplier:
             file_storage = JournalFileStorage(tempfile.NamedTemporaryFile().name)
             return optuna.storages.JournalStorage(file_storage)
         elif self.storage_specifier == "dask":
-            self.dask_client = distributed.Client()
+            self.dask_client = distributed.Client()  # type: ignore[no-untyped-call]
 
             return optuna.integration.DaskStorage(client=self.dask_client, **self.extra_args)
         else:
@@ -108,5 +108,5 @@ class StorageSupplier:
             self.tempfile.close()
 
         if self.dask_client:
-            self.dask_client.shutdown()
-            self.dask_client.close()
+            self.dask_client.shutdown()  # type: ignore[no-untyped-call]
+            self.dask_client.close()  # type: ignore[no-untyped-call]

--- a/tests/integration_tests/test_dask.py
+++ b/tests/integration_tests/test_dask.py
@@ -58,9 +58,9 @@ def objective_slow(trial: Trial) -> float:
 
 
 @pytest.fixture
-def client() -> "Client":
+def client() -> "Client":  # type: ignore[misc]
     with clean():
-        with Client(dashboard_address=":0") as client:
+        with Client(dashboard_address=":0") as client:  # type: ignore[no-untyped-call]
             yield client
 
 
@@ -87,9 +87,12 @@ def test_study_optimize(client: "Client", storage_specifier: str) -> None:
         study = optuna.create_study(storage=storage)
         assert not study.trials
         futures = [
-            client.submit(study.optimize, objective, n_trials=1, pure=False) for _ in range(10)
+            client.submit(  # type: ignore[no-untyped-call]
+                study.optimize, objective, n_trials=1, pure=False
+            )
+            for _ in range(10)
         ]
-        wait(futures)
+        wait(futures)  # type: ignore[no-untyped-call]
         assert len(study.trials) == 10
 
 
@@ -108,8 +111,8 @@ def test_study_direction_best_value(client: "Client", direction: str) -> None:
     pytest.importorskip("pandas")
     storage = DaskStorage()
     study = optuna.create_study(storage=storage, direction=direction)
-    f = client.submit(study.optimize, objective, n_trials=10)
-    wait(f)
+    f = client.submit(study.optimize, objective, n_trials=10)  # type: ignore[no-untyped-call]
+    wait(f)  # type: ignore[no-untyped-call]
 
     # Ensure that study.best_value matches up with the expected value from
     # the trials DataFrame


### PR DESCRIPTION
## Motivation
Solve scheduled Checks (Integration) failure

## Description of the changes
Currently, scheduled Checks (Integration) fails die to mypy check with --warn-unused-ignores option. This PR removes a part of the cause related dask.py.
