### PR TITLE
Fix CMAEvolutionStrategy link in integration.PyCmaSampler document

### DIFF
--- a/optuna/integration/cma.py
+++ b/optuna/integration/cma.py
@@ -90,7 +90,8 @@ class PyCmaSampler(BaseSampler):
         cma_opts:
             Options passed to the constructor of cma.CMAEvolutionStrategy_ class.
 
-            Note that ``BoundaryHandler``, ``bounds``, ``CMA_stds`` and ``seed`` arguments in
+            Note that default option is cma_default_options_,
+            but ``BoundaryHandler``, ``bounds``, ``CMA_stds`` and ``seed`` arguments in
             ``cma_opts`` will be ignored because it is added by
             :class:`~optuna.integration.PyCmaSampler` automatically.
 
@@ -120,8 +121,10 @@ class PyCmaSampler(BaseSampler):
             Note that the parameters of the first trial in a study are always sampled
             via an independent sampler, so no warning messages are emitted in this case.
 
-    .. _cma.CMAEvolutionStrategy: http://cma.gforge.inria.fr/apidocs-pycma/\
+    .. _cma.CMAEvolutionStrategy: https://cma-es.github.io/apidocs-pycma/\
     cma.evolution_strategy.CMAEvolutionStrategy.html
+    .. _cma_default_options: https://cma-es.github.io/apidocs-pycma/\
+    cma.evolution_strategy.html#cma_default_options_
     """
 
     def __init__(


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

- Fixed outdated link to `cma.CMAEvolutionStrategy` in `optuna.integration.PyCmaSampler`.
  - I was redirected to the above when I clicked on the link in Optuna's documentation
- Added a reference to the default options in the cma library, since it is not clear in detail what can be entered in `cma_opts`

## Description of the changes
<!-- Describe the changes in this PR. -->

- Fix link `http://cma.gforge.inria.fr` to `https://cma-es.github.io`
- Add `cma.evolution_strategy.cma_default_options_` function link 
