### PR TITLE
Resolve warnings by sphinx with nitpicky option and fix typos

### DIFF
--- a/docs/source/reference/importance.rst
+++ b/docs/source/reference/importance.rst
@@ -3,7 +3,7 @@
 optuna.importance
 =================
 
-The :mod:`~optuna.importance` module provides functionality for evaluating hyperparameter importances based on completed trials in a given study. The utility function :func:`~optuna.importance.get_param_importances` takes a ``Study`` and optional evaluator as two of its inputs. The evaluator must derive from :class:`~optuna.importance.BaseImportanceEvaluator`, and is initialized as a :class:`~optuna.importance.FanovaImportanceEvaluator` by default when not passed in. Users implementing custom evaluators should refer to either :class:`~optuna.importance.FanovaImportanceEvaluator` or :class:`~optuna.importance.MeanDecreaseImpurityImportanceEvaluator` as a guide, paying close attention to the format of the return value from the Evaluator's :meth:`evaluate` function.
+The :mod:`~optuna.importance` module provides functionality for evaluating hyperparameter importances based on completed trials in a given study. The utility function :func:`~optuna.importance.get_param_importances` takes a :class:`~optuna.study.Study` and optional evaluator as two of its inputs. The evaluator must derive from :class:`~optuna.importance.BaseImportanceEvaluator`, and is initialized as a :class:`~optuna.importance.FanovaImportanceEvaluator` by default when not passed in. Users implementing custom evaluators should refer to either :class:`~optuna.importance.FanovaImportanceEvaluator` or :class:`~optuna.importance.MeanDecreaseImpurityImportanceEvaluator` as a guide, paying close attention to the format of the return value from the Evaluator's ``evaluate`` function.
 
 
 .. autosummary::

--- a/docs/source/reference/integration.rst
+++ b/docs/source/reference/integration.rst
@@ -7,7 +7,7 @@ The :mod:`~optuna.integration` module contains classes used to integrate Optuna 
 
 For most of the ML frameworks supported by Optuna, the corresponding Optuna integration class serves only to implement a callback object and functions, compliant with the framework's specific callback API, to be called with each intermediate step in the model training. The functionality implemented in these callbacks across the different ML frameworks includes:
 
-(1) Reporting intermediate model scores back to the Optuna trial using :func:`optuna.trial.report`,
+(1) Reporting intermediate model scores back to the Optuna trial using :func:`optuna.trial.Trial.report`,
 (2) According to the results of :func:`optuna.trial.Trial.should_prune`, pruning the current model by raising :func:`optuna.TrialPruned`, and
 (3) Reporting intermediate Optuna data such as the current trial number back to the framework, as done in :class:`~optuna.integration.MLflowCallback`.
 

--- a/optuna/_callbacks.py
+++ b/optuna/_callbacks.py
@@ -12,10 +12,10 @@ from optuna.trial import TrialState
 class MaxTrialsCallback:
     """Set a maximum number of trials before ending the study.
 
-    While the :obj:`n_trials` argument of :obj:`optuna.optimize` sets the number of trials that
-    will be run, you may want to continue running until you have a certain number of successfullly
-    completed trials or stop the study when you have a certain number of trials that fail.
-    This :obj:`MaxTrialsCallback` class allows you to set a maximum number of trials for a
+    While the ``n_trials`` argument of :meth:`optuna.study.Study.optimize` sets the number of
+    trials that will be run, you may want to continue running until you have a certain number of
+    successfully completed trials or stop the study when you have a certain number of trials that
+    fail. This ``MaxTrialsCallback`` class allows you to set a maximum number of trials for a
     particular :class:`~optuna.trial.TrialState` before stopping the study.
 
     Example:
@@ -43,7 +43,7 @@ class MaxTrialsCallback:
             The max number of trials. Must be set to an integer.
         states:
             Tuple of the :class:`~optuna.trial.TrialState` to be counted
-            towards the max trials limit. Default value is :obj:`(TrialState.COMPLETE,)`.
+            towards the max trials limit. Default value is ``(TrialState.COMPLETE,)``.
             If :obj:`None`, count all states.
     """
 
@@ -64,8 +64,8 @@ class MaxTrialsCallback:
 class RetryFailedTrialCallback:
     """Retry a failed trial up to a maximum number of times.
 
-    When a trial fails, this callback can be used with the :class:`optuna.storage` class to
-    recreate the trial in :obj:`TrialState.WAITING` to queue up the trial to be run again.
+    When a trial fails, this callback can be used with a class in :mod:`optuna.storages` to
+    recreate the trial in ``TrialState.WAITING`` to queue up the trial to be run again.
 
     The failed trial can be identified by the
     :func:`~optuna.storages.RetryFailedTrialCallback.retried_trial_number` function.

--- a/optuna/integration/_lightgbm_tuner/optimize.py
+++ b/optuna/integration/_lightgbm_tuner/optimize.py
@@ -767,10 +767,10 @@ class LightGBMTuner(_LightGBMBaseTuner):
         model_dir:
             A directory to save boosters. By default, it is set to :obj:`None` and no boosters are
             saved. Please set shared directory (e.g., directories on NFS) if you want to access
-            :meth:`~optuna.integration.LightGBMTuner.get_best_booster` in distributed environments.
-            Otherwise, it may raise :obj:`ValueError`. If the directory does not exist, it will be
-            created. The filenames of the boosters will be ``{model_dir}/{trial_number}.pkl``
-            (e.g., ``./boosters/0.pkl``).
+            :meth:`~optuna.integration.lightgbm.LightGBMTuner.get_best_booster` in distributed
+            environments. Otherwise, it may raise :obj:`ValueError`. If the directory does not
+            exist, it will be created. The filenames of the boosters will be
+            ``{model_dir}/{trial_number}.pkl`` (e.g., ``./boosters/0.pkl``).
 
         verbosity:
             A verbosity level to change Optuna's logging level. The level is aligned to
@@ -920,7 +920,7 @@ class LightGBMTunerCV(_LightGBMBaseTuner):
         model_dir:
             A directory to save boosters. By default, it is set to :obj:`None` and no boosters are
             saved. Please set shared directory (e.g., directories on NFS) if you want to access
-            :meth:`~optuna.integration.LightGBMTunerCV.get_best_booster`
+            :meth:`~optuna.integration.lightgbm.LightGBMTunerCV.get_best_booster`
             in distributed environments.
             Otherwise, it may raise :obj:`ValueError`. If the directory does not exist, it will be
             created. The filenames of the boosters will be ``{model_dir}/{trial_number}.pkl``
@@ -945,7 +945,7 @@ class LightGBMTunerCV(_LightGBMBaseTuner):
                 Please suppress such messages to show the progress bars properly.
 
         return_cvbooster:
-            Flag to enable :meth:`~optuna.integration.LightGBMTunerCV.get_best_booster`.
+            Flag to enable :meth:`~optuna.integration.lightgbm.LightGBMTunerCV.get_best_booster`.
 
         optuna_seed:
             ``seed`` of :class:`~optuna.samplers.TPESampler` for random number generator

--- a/optuna/integration/mlflow.py
+++ b/optuna/integration/mlflow.py
@@ -202,7 +202,7 @@ class MLflowCallback:
                 study.optimize(objective, n_trials=10, callbacks=[mlflc])
 
         Returns:
-            ObjectiveFuncType: Objective function with tracking to MLflow enabled.
+            Objective function with tracking to MLflow enabled.
         """
 
         def decorator(func: ObjectiveFuncType) -> ObjectiveFuncType:

--- a/optuna/integration/sklearn.py
+++ b/optuna/integration/sklearn.py
@@ -380,7 +380,7 @@ class OptunaSearchCV(BaseEstimator):
             - a CV splitter,
             - an iterable yielding (train, validation) splits as arrays of indices.
 
-            For integer, if :obj:`estimator` is a classifier and :obj:`y` is
+            For integer, if :obj:`estimator` is a classifier and ``y`` is
             either binary or multiclass,
             ``sklearn.model_selection.StratifiedKFold`` is used. otherwise,
             ``sklearn.model_selection.KFold`` is used.
@@ -400,7 +400,7 @@ class OptunaSearchCV(BaseEstimator):
             estimator supports ``partial_fit``.
 
         n_jobs:
-            Number of :obj:`threading` based parallel jobs. :obj:`-1` means
+            Number of :obj:`threading` based parallel jobs. ``-1`` means
             using the number is set to CPU count.
 
                 .. note::
@@ -411,7 +411,7 @@ class OptunaSearchCV(BaseEstimator):
 
         n_trials:
             Number of trials. If :obj:`None`, there is no limitation on the
-            number of trials. If :obj:`timeout` is also set to :obj:`None`,
+            number of trials. If ``timeout`` is also set to :obj:`None`,
             the study continues to create trials until it receives a
             termination signal such as Ctrl+C or SIGTERM. This trades off
             runtime vs quality of the solution.
@@ -455,7 +455,7 @@ class OptunaSearchCV(BaseEstimator):
         timeout:
             Time limit in seconds for the search of appropriate models. If
             :obj:`None`, the study is executed without time limitation. If
-            :obj:`n_trials` is also set to :obj:`None`, the study continues to
+            ``n_trials`` is also set to :obj:`None`, the study continues to
             create trials until it receives a termination signal such as
             Ctrl+C or SIGTERM. This trades off runtime vs quality of the
             solution.
@@ -825,8 +825,7 @@ class OptunaSearchCV(BaseEstimator):
                 Parameters passed to ``fit`` on the estimator.
 
         Returns:
-            self:
-                Return self.
+            self.
         """
 
         self._check_params()
@@ -930,8 +929,7 @@ class OptunaSearchCV(BaseEstimator):
                 Target variable.
 
         Returns:
-            score:
-                Scaler score.
+            Scaler score.
         """
 
         return self.scorer_(self.best_estimator_, X, y)

--- a/optuna/integration/wandb.py
+++ b/optuna/integration/wandb.py
@@ -213,7 +213,7 @@ class WeightsAndBiasesCallback:
 
 
         Returns:
-            ObjectiveFuncType: Objective function with W&B tracking enabled.
+            Objective function with W&B tracking enabled.
         """
 
         def decorator(func: ObjectiveFuncType) -> ObjectiveFuncType:

--- a/optuna/logging.py
+++ b/optuna/logging.py
@@ -249,7 +249,7 @@ def disable_propagation() -> None:
     """Disable propagation of the library log outputs.
 
     Note that log propagation is disabled by default. You only need to use this function
-    to stop log propagation when you use :func:`~optuna.logging.enable_propogation()`.
+    to stop log propagation when you use :func:`~optuna.logging.enable_propagation()`.
 
     Example:
 

--- a/optuna/samplers/_qmc.py
+++ b/optuna/samplers/_qmc.py
@@ -28,7 +28,7 @@ class QMCSampler(BaseSampler):
     """A Quasi Monte Carlo Sampler that generates low-discrepancy sequences.
 
     Quasi Monte Carlo (QMC) sequences are designed to have lower discrepancies than
-    standard random seqeunces. They are known to perform better than the standard
+    standard random sequences. They are known to perform better than the standard
     randam sequences in hyperparameter optimization.
 
     For further information about the use of QMC sequences for hyperparameter optimization,
@@ -77,7 +77,7 @@ class QMCSampler(BaseSampler):
             sequences.
 
         seed:
-            A seed for `QMCSampler`. This argument is used only when `scramble` is :obj:`True`.
+            A seed for ``QMCSampler``. This argument is used only when ``scramble`` is :obj:`True`.
             If this is :obj:`None`, the seed is initialized randomly. Default is :obj:`None`.
 
             .. note::

--- a/optuna/storages/_base.py
+++ b/optuna/storages/_base.py
@@ -239,7 +239,7 @@ class BaseStorage(abc.ABC):
             study_id:
                 ID of the study.
             template_trial:
-                Template :class:`~optuna.trial.FronzenTrial` with default user-attributes,
+                Template :class:`~optuna.trial.FrozenTrial` with default user-attributes,
                 system-attributes, intermediate-values, and a state.
 
         Returns:

--- a/optuna/storages/_rdb/storage.py
+++ b/optuna/storages/_rdb/storage.py
@@ -193,7 +193,9 @@ class RDBStorage(BaseStorage, BaseHeartbeat):
         *,
         heartbeat_interval: Optional[int] = None,
         grace_period: Optional[int] = None,
-        failed_trial_callback: Optional[Callable[["optuna.Study", FrozenTrial], None]] = None,
+        failed_trial_callback: Optional[
+            Callable[["optuna.study.Study", FrozenTrial], None]
+        ] = None,
         skip_table_creation: bool = False,
     ) -> None:
 
@@ -1041,7 +1043,9 @@ class RDBStorage(BaseStorage, BaseHeartbeat):
 
         return self.heartbeat_interval
 
-    def get_failed_trial_callback(self) -> Optional[Callable[["optuna.Study", FrozenTrial], None]]:
+    def get_failed_trial_callback(
+        self,
+    ) -> Optional[Callable[["optuna.study.Study", FrozenTrial], None]]:
 
         return self.failed_trial_callback
 

--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -339,7 +339,7 @@ class Study:
 
         Optimization will be stopped when receiving a termination signal such as SIGINT and
         SIGTERM. Unlike other signals, a trial is automatically and cleanly failed when receiving
-        SIGINT (Ctrl+C). If :obj:`n_jobs` is greater than one or if another signal than SIGINT
+        SIGINT (Ctrl+C). If ``n_jobs`` is greater than one or if another signal than SIGINT
         is used, the interrupted trial state won't be properly updated.
 
         Example:
@@ -377,7 +377,7 @@ class Study:
                 :func:`~optuna.study.Study.stop` is called or, a termination signal such as
                 SIGTERM or Ctrl+C is received.
             n_jobs:
-                The number of parallel jobs. If this argument is set to :obj:`-1`, the number is
+                The number of parallel jobs. If this argument is set to ``-1``, the number is
                 set to CPU count.
 
                 .. note::

--- a/optuna/visualization/_pareto_front.py
+++ b/optuna/visualization/_pareto_front.py
@@ -100,7 +100,7 @@ def plot_pareto_front(
             be a sequence of :obj:`float` s. A value strictly larger than 0 means that a
             constraint is violated. A value equal to or smaller than 0 is considered feasible.
             This specification is the same as in, for example,
-            :class:`~optuna.integration.NSGAIISampler`.
+            :class:`~optuna.samplers.NSGAIISampler`.
 
             If given, trials are classified into three categories: feasible and best, feasible but
             non-best, and infeasible. Categories are shown in different colors. Here, whether a

--- a/optuna/visualization/matplotlib/_pareto_front.py
+++ b/optuna/visualization/matplotlib/_pareto_front.py
@@ -79,7 +79,7 @@ def plot_pareto_front(
             be a sequence of :obj:`float` s. A value strictly larger than 0 means that a
             constraint is violated. A value equal to or smaller than 0 is considered feasible.
             This specification is the same as in, for example,
-            :class:`~optuna.integration.NSGAIISampler`.
+            :class:`~optuna.samplers.NSGAIISampler`.
 
             If given, trials are classified into three categories: feasible and best, feasible but
             non-best, and infeasible. Categories are shown in different colors. Here, whether a

--- a/tutorial/10_key_features/003_efficient_optimization_algorithms.py
+++ b/tutorial/10_key_features/003_efficient_optimization_algorithms.py
@@ -146,7 +146,7 @@ study.optimize(objective, n_trials=20)
 # From the benchmark results which are available at `optuna/optuna - wiki "Benchmarks with Kurobako" <https://github.com/optuna/optuna/wiki/Benchmarks-with-Kurobako>`_, at least for not deep learning tasks, we would say that
 #
 # * For :class:`~optuna.samplers.RandomSampler`, :class:`~optuna.pruners.MedianPruner` is the best.
-# * For :class:`~optuna.samplers.TPESampler`, :class:`~optuna.pruners.Hyperband` is the best.
+# * For :class:`~optuna.samplers.TPESampler`, :class:`~optuna.pruners.HyperbandPruner` is the best.
 #
 # However, note that the benchmark is not deep learning.
 # For deep learning tasks,

--- a/tutorial/20_recipes/003_attributes.py
+++ b/tutorial/20_recipes/003_attributes.py
@@ -28,13 +28,13 @@ study.set_user_attr("dataset", "MNIST")
 
 
 ###################################################################################################
-# We can access annotated attributes with :attr:`~optuna.study.Study.user_attr` property.
+# We can access annotated attributes with :attr:`~optuna.study.Study.user_attrs` property.
 
 
 study.user_attrs  # {'contributors': ['Akiba', 'Sano'], 'dataset': 'MNIST'}
 
 ###################################################################################################
-# :class:`~optuna.struct.StudySummary` object, which can be retrieved by
+# :class:`~optuna.study.StudySummary` object, which can be retrieved by
 # :func:`~optuna.study.get_all_study_summaries`, also contains user-defined attributes.
 
 

--- a/tutorial/20_recipes/006_user_defined_pruner.py
+++ b/tutorial/20_recipes/006_user_defined_pruner.py
@@ -20,7 +20,7 @@ pruner should implement the abstract method
 associated :class:`~optuna.study.Study` and :class:`~optuna.trial.Trial` and
 returns a boolean value: :obj:`True` if the trial should be pruned and :obj:`False`
 otherwise. Using the Study and Trial objects, you can access all other trials
-through the :func:`~optuna.study.Study.get_trial` method and, and from a trial,
+through the :func:`~optuna.study.Study.get_trials` method and, and from a trial,
 its reported intermediate values through the
 :func:`~optuna.trial.FrozenTrial.intermediate_values` (a
 dictionary which maps an integer ``step`` to a float value).


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

As described at https://github.com/optuna/optuna/issues/4213, Optuna's documentation built with the `nitpicky` option shows warnings. This PR fixes trivial warnings to fix the links to the correct optuna modules.

## Description of the changes
<!-- Describe the changes in this PR. -->

- Fix typos
- Fix the paths of referenced modules, classes, etc.