### PR TITLE
Apply `@overload` to `ChainerMNTrial` and `TorchDistributedTrial` (Follow-up of #4143)

### DIFF
--- a/optuna/integration/chainermn.py
+++ b/optuna/integration/chainermn.py
@@ -232,7 +232,9 @@ class ChainerMNTrial(BaseTrial):
     ) -> CategoricalChoiceType:
         ...
 
-    def suggest_categorical(self, name: str, choices: Sequence[CategoricalChoiceType]) -> CategoricalChoiceType:
+    def suggest_categorical(
+        self, name: str, choices: Sequence[CategoricalChoiceType]
+    ) -> CategoricalChoiceType:
         def func() -> CategoricalChoiceType:
 
             assert self.delegate is not None

--- a/optuna/integration/chainermn.py
+++ b/optuna/integration/chainermn.py
@@ -3,6 +3,7 @@ from typing import Any
 from typing import Callable
 from typing import Dict
 from typing import Optional
+from typing import overload
 from typing import Sequence
 from typing import Tuple
 from typing import Type
@@ -205,7 +206,33 @@ class ChainerMNTrial(BaseTrial):
 
         return self._call_with_mpi(func)
 
-    def suggest_categorical(self, name: str, choices: Sequence[CategoricalChoiceType]) -> Any:
+    @overload
+    def suggest_categorical(self, name: str, choices: Sequence[None]) -> None:
+        ...
+
+    @overload
+    def suggest_categorical(self, name: str, choices: Sequence[bool]) -> bool:
+        ...
+
+    @overload
+    def suggest_categorical(self, name: str, choices: Sequence[int]) -> int:
+        ...
+
+    @overload
+    def suggest_categorical(self, name: str, choices: Sequence[float]) -> float:
+        ...
+
+    @overload
+    def suggest_categorical(self, name: str, choices: Sequence[str]) -> str:
+        ...
+
+    @overload
+    def suggest_categorical(
+        self, name: str, choices: Sequence[CategoricalChoiceType]
+    ) -> CategoricalChoiceType:
+        ...
+
+    def suggest_categorical(self, name: str, choices: Sequence[CategoricalChoiceType]) -> CategoricalChoiceType:
         def func() -> CategoricalChoiceType:
 
             assert self.delegate is not None

--- a/optuna/integration/pytorch_distributed.py
+++ b/optuna/integration/pytorch_distributed.py
@@ -6,6 +6,7 @@ from typing import Callable
 from typing import Dict
 from typing import List
 from typing import Optional
+from typing import overload
 from typing import Sequence
 from typing import TYPE_CHECKING
 from typing import TypeVar
@@ -194,8 +195,34 @@ class TorchDistributedTrial(optuna.trial.BaseTrial):
 
         return self._call_and_communicate(func, torch.int)
 
+    @overload
+    def suggest_categorical(self, name: str, choices: Sequence[None]) -> None:
+        ...
+
+    @overload
+    def suggest_categorical(self, name: str, choices: Sequence[bool]) -> bool:
+        ...
+
+    @overload
+    def suggest_categorical(self, name: str, choices: Sequence[int]) -> int:
+        ...
+
+    @overload
+    def suggest_categorical(self, name: str, choices: Sequence[float]) -> float:
+        ...
+
+    @overload
+    def suggest_categorical(self, name: str, choices: Sequence[str]) -> str:
+        ...
+
+    @overload
+    def suggest_categorical(
+        self, name: str, choices: Sequence[CategoricalChoiceType]
+    ) -> CategoricalChoiceType:
+        ...
+
     @broadcast_properties
-    def suggest_categorical(self, name: str, choices: Sequence["CategoricalChoiceType"]) -> Any:
+    def suggest_categorical(self, name: str, choices: Sequence[CategoricalChoiceType]) -> CategoricalChoiceType:
         def func() -> CategoricalChoiceType:
             assert self._delegate is not None
             return self._delegate.suggest_categorical(name, choices)

--- a/optuna/integration/pytorch_distributed.py
+++ b/optuna/integration/pytorch_distributed.py
@@ -222,7 +222,9 @@ class TorchDistributedTrial(optuna.trial.BaseTrial):
         ...
 
     @broadcast_properties
-    def suggest_categorical(self, name: str, choices: Sequence[CategoricalChoiceType]) -> CategoricalChoiceType:
+    def suggest_categorical(
+        self, name: str, choices: Sequence[CategoricalChoiceType]
+    ) -> CategoricalChoiceType:
         def func() -> CategoricalChoiceType:
             assert self._delegate is not None
             return self._delegate.suggest_categorical(name, choices)


### PR DESCRIPTION
## Motivation

This PR should be merged after #4143. See https://github.com/optuna/optuna/pull/4143#pullrequestreview-1235524074.
The return type of `ChainerMNTrial.suggest_categorical` and `TorchDistributedTrial.suggest_categorical` was set to `Any`, and the type checking passed in #4143.

## Description of the changes

- Apply `@overload` to `ChainerMNTrial` and `TorchDistributedTrial`