### PR TITLE
Remove `OPTUNA_STORAGE` environment variable to check missing storage errors

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -131,7 +131,10 @@ def test_create_study_command_with_study_name() -> None:
 def test_create_study_command_without_storage_url() -> None:
 
     with pytest.raises(subprocess.CalledProcessError) as err:
-        subprocess.check_output(["optuna", "create-study"])
+        subprocess.check_output(
+            ["optuna", "create-study"],
+            env={k: v for k, v in os.environ.items() if k != "OPTUNA_STORAGE"},
+        )
     usage = err.value.output.decode()
     assert usage.startswith("usage:")
 
@@ -259,7 +262,10 @@ def test_delete_study_command() -> None:
 def test_delete_study_command_without_storage_url() -> None:
 
     with pytest.raises(subprocess.CalledProcessError):
-        subprocess.check_output(["optuna", "delete-study", "--study-name", "dummy_study"])
+        subprocess.check_output(
+            ["optuna", "delete-study", "--study-name", "dummy_study"],
+            env={k: v for k, v in os.environ.items() if k != "OPTUNA_STORAGE"},
+        )
 
 
 @pytest.mark.skip_coverage
@@ -1071,7 +1077,10 @@ def test_storage_upgrade_command() -> None:
 
         command = ["optuna", "storage", "upgrade"]
         with pytest.raises(CalledProcessError):
-            subprocess.check_call(command)
+            subprocess.check_call(
+                command,
+                env={k: v for k, v in os.environ.items() if k != "OPTUNA_STORAGE"},
+            )
 
         command.extend(["--storage", storage_url])
         subprocess.check_call(command)


### PR DESCRIPTION
## Motivation

#4299 enabled optuna commands to read storage URLs from the `OPTUNA_STORAGE` environment variable.
So, if `OPTUNA_STORAGE` exists in `os.environ`, some test cases in `tests/test_cli.py` fail. And it updates the users' storage unintendedly.

## Description of the changes

Remove `OPTUNA_STORAGE` from the `env` option of `subprocess.check_call` and `subprocess.check_output` to check missing storage errors.

Note that the current changes seem to be cumbersome, please feel free to correct them.