### PR TITLE
Use `Trial` not `FrozenTrial` in a test of `WeightsAndBiasesCallback`

### DIFF
--- a/tests/integration_tests/test_wandb.py
+++ b/tests/integration_tests/test_wandb.py
@@ -59,7 +59,7 @@ def test_run_initialized(wandb: mock.MagicMock) -> None:
     study = optuna.create_study(direction="minimize")
     _wrapped_func = wandbc.track_in_wandb()(lambda t: 1.0)
     wandb.init.reset_mock()
-    trial = optuna.create_trial(value=1.0)
+    trial = study.ask()
     _wrapped_func(trial)
 
     wandb.init.assert_called_once_with(


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

Usually, objective takes a `Trial`, not `FrozenTrial`.  By chance, I found a test code that evaluates an objective with a `FrozenTrial` made by `create_trial`.

## Description of the changes
<!-- Describe the changes in this PR. -->

Instead, use `study.ask` to create a trial.