### PR TITLE
Make `OPTUNA_STORAGE` environment variable experimental

### DIFF
--- a/optuna/cli.py
+++ b/optuna/cli.py
@@ -38,9 +38,17 @@ _DATETIME_FORMAT = "%Y-%m-%d %H:%M:%S"
 
 def _check_storage_url(storage_url: Optional[str]) -> str:
 
-    if storage_url is None:
+    env_storage = os.environ.get("OPTUNA_STORAGE")
+    if storage_url is None and env_storage is None:
         raise CLIUsageError("Storage URL is not specified.")
-    return storage_url
+
+    if env_storage is not None:
+        warnings.warn(
+            "Specifying the storage url via 'OPTUNA_STORAGE' environment variable"
+            " is an experimental feature. The interface can change in the future.",
+            ExperimentalWarning,
+        )
+    return storage_url or env_storage
 
 
 def _format_value(value: Any) -> Any:
@@ -904,7 +912,7 @@ _COMMANDS: Dict[str, Type[_BaseCommand]] = {
 def _add_common_arguments(parser: ArgumentParser) -> ArgumentParser:
     parser.add_argument(
         "--storage",
-        default=os.environ.get("OPTUNA_STORAGE"),
+        default=None,
         help=(
             "DB URL. (e.g. sqlite:///example.db) "
             "Also can be specified via OPTUNA_STORAGE environment variable."

--- a/optuna/cli.py
+++ b/optuna/cli.py
@@ -38,17 +38,18 @@ _DATETIME_FORMAT = "%Y-%m-%d %H:%M:%S"
 
 def _check_storage_url(storage_url: Optional[str]) -> str:
 
-    env_storage = os.environ.get("OPTUNA_STORAGE")
-    if storage_url is None and env_storage is None:
-        raise CLIUsageError("Storage URL is not specified.")
+    if storage_url is not None:
+        return storage_url
 
+    env_storage = os.environ.get("OPTUNA_STORAGE")
     if env_storage is not None:
         warnings.warn(
             "Specifying the storage url via 'OPTUNA_STORAGE' environment variable"
             " is an experimental feature. The interface can change in the future.",
             ExperimentalWarning,
         )
-    return storage_url or env_storage
+        return env_storage
+    raise CLIUsageError("Storage URL is not specified.")
 
 
 def _format_value(value: Any) -> Any:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -20,6 +20,7 @@ import yaml
 import optuna
 import optuna.cli
 from optuna.exceptions import CLIUsageError
+from optuna.exceptions import ExperimentalWarning
 from optuna.storages import RDBStorage
 from optuna.storages._base import DEFAULT_STUDY_NAME_PREFIX
 from optuna.study import StudyDirection
@@ -1065,8 +1066,9 @@ def test_check_storage_url() -> None:
     storage_in_args = "sqlite:///args.db"
     assert storage_in_args == optuna.cli._check_storage_url(storage_in_args)
 
-    with patch.dict("optuna.cli.os.environ", {"OPTUNA_STORAGE": "sqlite:///args.db"}):
-        optuna.cli._check_storage_url(None)
+    with pytest.warns(ExperimentalWarning):
+        with patch.dict("optuna.cli.os.environ", {"OPTUNA_STORAGE": "sqlite:///args.db"}):
+            optuna.cli._check_storage_url(None)
 
     with pytest.raises(CLIUsageError):
         optuna.cli._check_storage_url(None)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,6 +9,7 @@ from typing import Any
 from typing import Callable
 from typing import Optional
 from typing import Tuple
+from unittest.mock import patch
 
 import numpy as np
 from pandas import Timedelta
@@ -1063,6 +1064,9 @@ def test_check_storage_url() -> None:
 
     storage_in_args = "sqlite:///args.db"
     assert storage_in_args == optuna.cli._check_storage_url(storage_in_args)
+
+    with patch.dict("optuna.cli.os.environ", {"OPTUNA_STORAGE": "sqlite:///args.db"}):
+        optuna.cli._check_storage_url(None)
 
     with pytest.raises(CLIUsageError):
         optuna.cli._check_storage_url(None)


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
`OPTUNA_STORAGE` environment variable is introduced at #4299. However, this support is a bit tentative so we should emit experimental warnings.

## Description of the changes
<!-- Describe the changes in this PR. -->
Show experimental warnings when storage_url is referred from `OPTUNA_STORAGE` environment variable.
