### PR TITLE
Exclude benchmark directories from the sdist package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -146,7 +146,7 @@ setup(
         "Documentation": "https://optuna.readthedocs.io",
         "Bug Tracker": "https://github.com/optuna/optuna/issues",
     },
-    packages=find_packages(exclude=("tests", "tests.*", "benchmarks")),
+    packages=find_packages(exclude=("tests", "tests.*", "benchmarks", "benchmarks.*")),
     package_data={
         "optuna": [
             "storages/_rdb/alembic.ini",


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
@himkt found that the sdist packages from Optuna v3.0.0 unintentionally contain `benchmarks` directory.
https://pypi.org/project/optuna/#files

The cause of the problem is that some Python packages were created in `benchmarks` directory in v3.0.0.

* https://github.com/optuna/optuna/tree/v2.10.1/benchmarks
* https://github.com/optuna/optuna/tree/v3.0.0/benchmarks


## Description of the changes
<!-- Describe the changes in this PR. -->

Like `tests` packages, I added `benchmarks.*` to the exclude argument of `find_packages` for now. Perhaps, adding `recursive-exclude benchmarks` in `MANIFEST.in` would be safer.
https://packaging.python.org/en/latest/guides/using-manifest-in/