### PR TITLE
Update minimum version of cmaes.

### DIFF
--- a/.github/workflows/tests-with-minimum-versions.yml
+++ b/.github/workflows/tests-with-minimum-versions.yml
@@ -69,7 +69,7 @@ jobs:
       run: |
         # Install dependencies with minimum versions.
         pip uninstall -y alembic cmaes packaging sqlalchemy plotly scikit-learn
-        pip install alembic==1.5.0 cmaes==0.9.0 packaging==20.0 sqlalchemy==1.3.0
+        pip install alembic==1.5.0 cmaes==0.9.1 packaging==20.0 sqlalchemy==1.3.0
         pip install plotly==4.9.0 scikit-learn==0.24.2  # optional extras
 
     - name: Scheduled tests


### PR DESCRIPTION
## Motivation

Fix the following CI error:
https://github.com/optuna/optuna/actions/runs/3897468069/jobs/6655182708#step:9:2168

```console
FAILED tests/samplers_tests/test_cmaes.py::test_incompatible_search_space[True] - AssertionError: steps should include at least one positive values corresponding to discrete
        dimensions.
```

## Description of the changes

- Update `cmaes` version from 0.9.0 to 0.9.1. See https://github.com/optuna/optuna/pull/4289.