### PR TITLE
Minor refactoring of `tests/hypervolume_tests/test_hssp.py`

### DIFF
--- a/tests/hypervolume_tests/test_hssp.py
+++ b/tests/hypervolume_tests/test_hssp.py
@@ -1,5 +1,4 @@
 import itertools
-import random
 from typing import Tuple
 
 import numpy as np
@@ -22,39 +21,35 @@ def _compute_hssp_truth_and_approx(test_case: np.ndarray, subset_size: int) -> T
 
 @pytest.mark.parametrize("dim", [2, 3])
 def test_solve_hssp(dim: int) -> None:
-    random.seed(128)
+    rng = np.random.RandomState(128)
 
-    for i in range(8):
-        subset_size = int(random.random() * i) + 1
-        test_case = np.asarray([[random.random() for _ in range(dim)] for _ in range(8)])
+    for i in range(1, 9):
+        subset_size = np.random.randint(1, i + 1)
+        test_case = rng.rand(8, dim)
         truth, approx = _compute_hssp_truth_and_approx(test_case, subset_size)
         assert approx / truth > 0.6321  # 1 - 1/e
 
 
+@pytest.mark.filterwarnings("ignore::RuntimeWarning")
 def test_solve_hssp_infinite_loss() -> None:
-    random.seed(128)
+    rng = np.random.RandomState(128)
 
-    subset_size = int(random.random() * 4) + 1
-    test_case = np.asarray([[random.random() for _ in range(2)] for _ in range(8)])
-    test_case = np.vstack([test_case, [float("inf") for _ in range(2)]])
+    subset_size = 4
+    test_case = rng.rand(9, 2)
+    test_case[-1].fill(float("inf"))
     truth, approx = _compute_hssp_truth_and_approx(test_case, subset_size)
     assert np.isinf(truth)
     assert np.isinf(approx)
 
-    test_case = np.asarray([[random.random() for _ in range(3)] for _ in range(8)])
-    test_case = np.vstack([test_case, [float("inf") for _ in range(3)]])
+    test_case = rng.rand(9, 3)
+    test_case[-1].fill(float("inf"))
     truth, approx = _compute_hssp_truth_and_approx(test_case, subset_size)
     assert truth == 0
     assert np.isnan(approx)
 
-    test_case = np.asarray([[random.random() for _ in range(2)] for _ in range(8)])
-    test_case = np.vstack([test_case, [-float("inf") for _ in range(2)]])
-    truth, approx = _compute_hssp_truth_and_approx(test_case, subset_size)
-    assert np.isinf(truth)
-    assert np.isinf(approx)
-
-    test_case = np.asarray([[random.random() for _ in range(3)] for _ in range(8)])
-    test_case = np.vstack([test_case, [-float("inf") for _ in range(3)]])
-    truth, approx = _compute_hssp_truth_and_approx(test_case, subset_size)
-    assert np.isinf(truth)
-    assert np.isinf(approx)
+    for dim in range(2, 4):
+        test_case = rng.rand(9, dim)
+        test_case[-1].fill(-float("inf"))
+        truth, approx = _compute_hssp_truth_and_approx(test_case, subset_size)
+        assert np.isinf(truth)
+        assert np.isinf(approx)

--- a/tests/samplers_tests/tpe_tests/test_sampler.py
+++ b/tests/samplers_tests/tpe_tests/test_sampler.py
@@ -547,7 +547,7 @@ def test_sample_independent_log_uniform_distributions() -> None:
     assert uniform_suggestion != loguniform_suggestion
 
 
-def test_sample_independent_disrete_uniform_distributions() -> None:
+def test_sample_independent_discrete_uniform_distributions() -> None:
     """Test samples from discrete have expected intervals."""
 
     study = optuna.create_study()


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

1. https://github.com/optuna/optuna: I found `test_solve_hssp_infinite_loss` shows some warning message due to `inf` /issues/3815
2. I think the current test case looks a little hard to read


## Description of the changes
<!-- Describe the changes in this PR. -->

For 1: I added `@pytest.mark.filterwarnings("ignore::RuntimeWarning")`
Fro 2: I propose using numpy instead of `random.random` and list comprehension.