### PR TITLE
Ignore `FutureWarning` in `tests/storages_tests/rdb_tests/test_storage.py`

### DIFF
--- a/tests/storages_tests/rdb_tests/create_db.py
+++ b/tests/storages_tests/rdb_tests/create_db.py
@@ -39,6 +39,7 @@ If you use `venv`, simply `deactivate` and re-activate your development environm
 
 from argparse import ArgumentParser
 from typing import Tuple
+import warnings
 
 from packaging import version
 
@@ -49,7 +50,9 @@ def objective_test_upgrade(trial: optuna.trial.Trial) -> float:
     x = trial.suggest_float("x", -5, 5)  # optuna==0.9.0 does not have suggest_float.
     y = trial.suggest_int("y", 0, 10)
     z = trial.suggest_categorical("z", [-5, 0, 5])
-    trial.set_system_attr("a", 0)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", category=FutureWarning)
+        trial.set_system_attr("a", 0)
     trial.set_user_attr("b", 1)
     trial.report(0.5, step=0)
     return x**2 + y**2 + z**2
@@ -59,7 +62,9 @@ def mo_objective_test_upgrade(trial: optuna.trial.Trial) -> Tuple[float, float]:
     x = trial.suggest_float("x", -5, 5)
     y = trial.suggest_int("y", 0, 10)
     z = trial.suggest_categorical("z", [-5, 0, 5])
-    trial.set_system_attr("a", 0)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", category=FutureWarning)
+        trial.set_system_attr("a", 0)
     trial.set_user_attr("b", 1)
     return x, x**2 + y**2 + z**2
 


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

I found warning messages by running the following test 

```sh
$ pytest tests/storages_tests/rdb_tests/test_storage.py::test_upgrade_multi_objective_optimization

tests/storages_tests/rdb_tests/test_storage.py ......                                                                                   [100%]

============================================================== warnings summary ===============================================================
tests/storages_tests/rdb_tests/test_storage.py::test_upgrade_multi_objective_optimization[2.4.0.a]
tests/storages_tests/rdb_tests/test_storage.py::test_upgrade_multi_objective_optimization[2.6.0.a]
tests/storages_tests/rdb_tests/test_storage.py::test_upgrade_multi_objective_optimization[3.0.0.a]
tests/storages_tests/rdb_tests/test_storage.py::test_upgrade_multi_objective_optimization[3.0.0.b]
tests/storages_tests/rdb_tests/test_storage.py::test_upgrade_multi_objective_optimization[3.0.0.c]
tests/storages_tests/rdb_tests/test_storage.py::test_upgrade_multi_objective_optimization[3.0.0.d]
  /Users/nzw/Documents/optuna/tests/storages_tests/rdb_tests/create_db.py:62: FutureWarning: set_system_attr has been deprecated in v3.1.0. This feature will be removed in v6.0.0. See https://github.com/optuna/optuna/releases/tag/v3.1.0.
    trial.set_system_attr("a", 0)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================================================== 6 passed, 6 warnings in 1.38s ========================================================
```

Since these warning messages come from functions for storage tests, we can ignore them.

## Description of the changes
<!-- Describe the changes in this PR. -->

Ignore the warning message when we call `set_system_attr`.