### PR TITLE
Remove `verbose_eval` argument from lightgbm callback in tutorial pages

### DIFF
--- a/tutorial/10_key_features/005_visualization.py
+++ b/tutorial/10_key_features/005_visualization.py
@@ -77,7 +77,7 @@ def objective(trial):
     # Add a callback for pruning.
     pruning_callback = optuna.integration.LightGBMPruningCallback(trial, "auc")
     gbm = lgb.train(
-        param, dtrain, valid_sets=[dvalid], verbose_eval=False, callbacks=[pruning_callback]
+        param, dtrain, valid_sets=[dvalid], callbacks=[pruning_callback, lgb.log_evaluation(0)]
     )
 
     preds = gbm.predict(valid_x)

--- a/tutorial/10_key_features/005_visualization.py
+++ b/tutorial/10_key_features/005_visualization.py
@@ -77,7 +77,7 @@ def objective(trial):
     # Add a callback for pruning.
     pruning_callback = optuna.integration.LightGBMPruningCallback(trial, "auc")
     gbm = lgb.train(
-        param, dtrain, valid_sets=[dvalid], callbacks=[pruning_callback, lgb.log_evaluation(0)]
+        param, dtrain, valid_sets=[dvalid], callbacks=[pruning_callback]
     )
 
     preds = gbm.predict(valid_x)

--- a/tutorial/10_key_features/005_visualization.py
+++ b/tutorial/10_key_features/005_visualization.py
@@ -76,9 +76,7 @@ def objective(trial):
 
     # Add a callback for pruning.
     pruning_callback = optuna.integration.LightGBMPruningCallback(trial, "auc")
-    gbm = lgb.train(
-        param, dtrain, valid_sets=[dvalid], callbacks=[pruning_callback]
-    )
+    gbm = lgb.train(param, dtrain, valid_sets=[dvalid], callbacks=[pruning_callback])
 
     preds = gbm.predict(valid_x)
     pred_labels = np.rint(preds)

--- a/tutorial/20_recipes/008_specify_params.py
+++ b/tutorial/20_recipes/008_specify_params.py
@@ -59,7 +59,7 @@ def objective(trial):
     # Add a callback for pruning.
     pruning_callback = optuna.integration.LightGBMPruningCallback(trial, "auc")
     gbm = lgb.train(
-        param, dtrain, valid_sets=[dvalid], callbacks=[pruning_callback, lgb.log_evaluation(0)]
+        param, dtrain, valid_sets=[dvalid], callbacks=[pruning_callback]
     )
 
     preds = gbm.predict(valid_x)

--- a/tutorial/20_recipes/008_specify_params.py
+++ b/tutorial/20_recipes/008_specify_params.py
@@ -58,9 +58,7 @@ def objective(trial):
 
     # Add a callback for pruning.
     pruning_callback = optuna.integration.LightGBMPruningCallback(trial, "auc")
-    gbm = lgb.train(
-        param, dtrain, valid_sets=[dvalid], callbacks=[pruning_callback]
-    )
+    gbm = lgb.train(param, dtrain, valid_sets=[dvalid], callbacks=[pruning_callback])
 
     preds = gbm.predict(valid_x)
     pred_labels = np.rint(preds)

--- a/tutorial/20_recipes/008_specify_params.py
+++ b/tutorial/20_recipes/008_specify_params.py
@@ -59,7 +59,7 @@ def objective(trial):
     # Add a callback for pruning.
     pruning_callback = optuna.integration.LightGBMPruningCallback(trial, "auc")
     gbm = lgb.train(
-        param, dtrain, valid_sets=[dvalid], verbose_eval=False, callbacks=[pruning_callback]
+        param, dtrain, valid_sets=[dvalid], callbacks=[pruning_callback, lgb.log_evaluation(0)]
     )
 
     preds = gbm.predict(valid_x)


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

Resolve https://github.com/optuna/optuna/issues/4248

## Description of the changes
<!-- Describe the changes in this PR. -->

Apply similar changes to https://github.com/optuna/optuna/pull/3086. 

---

One of the problem pages would be 

<img width="1163" alt="Screenshot 2023-01-14 at 22 14 55" src="https://user-images.githubusercontent.com/7121753/212473398-869d2e9e-dfbd-4d1d-a3d4-22953438c3ac.png">

https://optuna--4335.org.readthedocs.build/en/4335/tutorial/10_key_features/005_visualization.html#sphx-glr-tutorial-10-key-features-005-visualization-py
