### PR TITLE
Partially follow `sklearn.model_selection.GridSearchCV`'s arguments

### DIFF
--- a/optuna/integration/sklearn.py
+++ b/optuna/integration/sklearn.py
@@ -376,8 +376,9 @@ class OptunaSearchCV(BaseEstimator):
         cv:
             Cross-validation strategy. Possible inputs for cv are:
 
+            - :obj:`None`, to use the default 5-fold cross validation,
             - integer to specify the number of folds in a CV splitter,
-            - a CV splitter,
+            - `CV splitter <https://scikit-learn.org/stable/glossary.html#term-CV-splitter>`_,
             - an iterable yielding (train, validation) splits as arrays of indices.
 
             For integer, if ``estimator`` is a classifier and ``y`` is
@@ -692,7 +693,7 @@ class OptunaSearchCV(BaseEstimator):
         estimator: "BaseEstimator",
         param_distributions: Mapping[str, distributions.BaseDistribution],
         *,
-        cv: Optional[Union["BaseCrossValidator", int]] = 5,
+        cv: Optional[Union[int, "BaseCrossValidator", Iterable]] = None,
         enable_pruning: bool = False,
         error_score: Union[Number, float, str] = np.nan,
         max_iter: int = 1000,

--- a/optuna/integration/sklearn.py
+++ b/optuna/integration/sklearn.py
@@ -400,8 +400,8 @@ class OptunaSearchCV(BaseEstimator):
             estimator supports ``partial_fit``.
 
         n_jobs:
-            Number of :obj:`threading` based parallel jobs. ``-1`` means
-            using the number is set to CPU count.
+            Number of :obj:`threading` based parallel jobs. :obj:`None` means ``1``.
+            ``-1`` means using the number is set to CPU count.
 
                 .. note::
                     ``n_jobs`` allows parallelization using :obj:`threading` and may suffer from
@@ -691,11 +691,12 @@ class OptunaSearchCV(BaseEstimator):
         self,
         estimator: "BaseEstimator",
         param_distributions: Mapping[str, distributions.BaseDistribution],
+        *,
         cv: Optional[Union["BaseCrossValidator", int]] = 5,
         enable_pruning: bool = False,
         error_score: Union[Number, float, str] = np.nan,
         max_iter: int = 1000,
-        n_jobs: int = 1,
+        n_jobs: Optional[int] = None,
         n_trials: int = 10,
         random_state: Optional[Union[int, np.random.RandomState]] = None,
         refit: bool = True,
@@ -730,7 +731,7 @@ class OptunaSearchCV(BaseEstimator):
         self.estimator = estimator
         self.max_iter = max_iter
         self.n_trials = n_trials
-        self.n_jobs = n_jobs
+        self.n_jobs = n_jobs if n_jobs else 1
         self.param_distributions = param_distributions
         self.random_state = random_state
         self.refit = refit


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

A part of https://github.com/optuna/optuna/issues/3521

## Description of the changes
<!-- Describe the changes in this PR. -->

1. `n_jobs`'s default value has been `None` since scikit-learn v0.20. This change isn't backwards-breaking change.
2. Follow keyword only argument rather than positional one. This convention has been introduced since scikit-learn 1.0 See https://scikit-learn.org/stable/auto_examples/release_highlights/plot_release_highlights_1_0_0.html#keyword-and-positional-arguments for more details.
3. update `cv` type hint, default value, and docstring. This change also isn't backwards-breaking change