### PR TITLE
Add test to check `error_score` is stored

### DIFF
--- a/tests/integration_tests/test_sklearn.py
+++ b/tests/integration_tests/test_sklearn.py
@@ -289,6 +289,14 @@ def test_objective_error_score_nan() -> None:
     ):
         optuna_search.fit(X)
 
+    for trial in optuna_search.study_.get_trials():
+        assert np.all(np.isnan(list(trial.intermediate_values.values())))
+
+        # "_score" stores every score value for train and test validation holds.
+        for name, value in trial.user_attrs.items():
+            if name.endswith("_score"):
+                assert np.isnan(value)
+
 
 @pytest.mark.filterwarnings("ignore::RuntimeWarning")
 def test_objective_error_score_invalid() -> None:


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

The current test of OptunaSearchCV doesn't check `error_score` is used when `error_score` is a numerical value.

## Description of the changes
<!-- Describe the changes in this PR. -->

Add assertions to check this. By using `error_score`, `intermediate_values` and several values in `trial.user_attrs` are set `error_score` value