### PR TITLE
Use Sphinx 5 until `sphinx_rtd_theme` supports Sphinx 6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,8 @@ def get_extras_require() -> Dict[str, List[str]]:
             "plotly>=4.9.0",  # optuna/visualization.
             "scikit-learn",
             "scikit-optimize",
-            "sphinx",
+            # TODO(not522): Remove the constraint after sphinx_rtd_theme supports Sphinx 6
+            "sphinx<6",
             "sphinx-copybutton",
             "sphinx-gallery",
             "sphinx-plotly-directive",


### PR DESCRIPTION
## Motivation
`sphinx_rtd_theme` does not support Sphinx 6 yet.

At least, the following two problems should be fixed before updating to Sphinx 6.

- The upper left logo does not appear.
- The version selector does not work.

## Description of the changes
- Add upper limit of Sphinx