### PR TITLE
Update `actions/setup-python` in `mac-tests` (follow-up for #4307)

### DIFF
--- a/.github/workflows/mac-tests.yml
+++ b/.github/workflows/mac-tests.yml
@@ -28,7 +28,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Setup Python3.8
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v2
       with:
         python-version: 3.8
 
@@ -67,7 +67,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Setup Python3.8
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v2
       with:
         python-version: 3.8
 

--- a/.github/workflows/mac-tests.yml
+++ b/.github/workflows/mac-tests.yml
@@ -28,7 +28,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Setup Python3.8
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.8
 
@@ -67,7 +67,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Setup Python3.8
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.8
 


### PR DESCRIPTION
## Motivation

- A follow-up for https://github.com/optuna/optuna/pull/4307
- See https://github.com/optuna/optuna/pull/4328#issuecomment-1383487909
- `mac-tests` passed today https://github.com/optuna/optuna/actions/runs/3925698977

## Description of the changes

- Revert https://github.com/optuna/optuna/commit/7dff1aee99ad3be902e987a4ae5939201fd52c9f