### PR TITLE
Fix import of `ProcessGroup` from `torch.distributed`

### DIFF
--- a/optuna/integration/pytorch_distributed.py
+++ b/optuna/integration/pytorch_distributed.py
@@ -22,7 +22,7 @@ from optuna.distributions import CategoricalChoiceType
 with try_import() as _imports:
     import torch
     import torch.distributed as dist
-    import torch.distributed.ProcessGroup as ProcessGroup
+    from torch.distributed import ProcessGroup
 
 
 if TYPE_CHECKING:


### PR DESCRIPTION
## Motivation

TBD

## Description of the changes

- import `ProcessGroup` from `torch.distributed` instead of importing `torch.distributed.ProcessGroup`