### PR TITLE
Add type ignore to `ProcessGroup` import from `torch.distributed`

### DIFF
--- a/optuna/integration/pytorch_distributed.py
+++ b/optuna/integration/pytorch_distributed.py
@@ -22,7 +22,7 @@ from optuna.distributions import CategoricalChoiceType
 with try_import() as _imports:
     import torch
     import torch.distributed as dist
-    from torch.distributed import ProcessGroup
+    from torch.distributed import ProcessGroup  # type: ignore[attr-defined]
 
 
 if TYPE_CHECKING:


### PR DESCRIPTION
## Motivation

- A follow-up for https://github.com/optuna/optuna/pull/4344
- Fix the following [CI error](https://github.com/optuna/optuna/actions/runs/3936998320/jobs/6734035936) of `checks(integration)`

```console
optuna/integration/pytorch_distributed.py:25: error: Module "torch.distributed" does not explicitly export attribute "ProcessGroup"  [attr-defined]
```

## Description of the changes

- Apply type ignore to `ProcessGroup` import