### PR TITLE
Add `last_value_if_duplicate`

### DIFF
--- a/optuna/trial/_trial.py
+++ b/optuna/trial/_trial.py
@@ -5,6 +5,7 @@ from typing import Dict
 from typing import Optional
 from typing import overload
 from typing import Sequence
+from typing import List
 import warnings
 
 import optuna
@@ -19,7 +20,8 @@ from optuna.distributions import FloatDistribution
 from optuna.distributions import IntDistribution
 from optuna.trial import FrozenTrial
 from optuna.trial._base import BaseTrial
-
+from optuna.trial import TrialState
+from optuna.distributions import _categorical_choice_equal
 
 _logger = logging.get_logger(__name__)
 _suggest_deprecated_msg = "Use :func:`~optuna.trial.Trial.suggest_float` instead."
@@ -754,3 +756,23 @@ class Trial(BaseTrial):
         """
 
         return self._cached_frozen_trial.number
+    
+    def last_value_if_duplicate(self) -> Optional[List[float]]:
+        """Return the last value of the objective function if the same 
+        parameters have been suggested before.
+
+        Returns:
+            If the same parameters have been suggested before, 
+            return the values of the objective function in the last trial.
+            Otherwise, return None.
+        """
+        complete_trials = self.study.get_trials(deepcopy=False, states=(TrialState.COMPLETE,))
+        current_params = set(self.params.keys())
+        for trial in complete_trials[::-1]:
+            past_trial_params = set(trial.params.keys())
+            if current_params == past_trial_params and all(
+                _categorical_choice_equal(trial.params[param], self.params[param]) 
+                    for param in (current_params | past_trial_params)
+            ):
+                return trial.values
+        return None

--- a/optuna/trial/_trial.py
+++ b/optuna/trial/_trial.py
@@ -2,10 +2,10 @@ import copy
 import datetime
 from typing import Any
 from typing import Dict
+from typing import List
 from typing import Optional
 from typing import overload
 from typing import Sequence
-from typing import List
 import warnings
 
 import optuna
@@ -13,15 +13,16 @@ from optuna import distributions
 from optuna import logging
 from optuna import pruners
 from optuna._deprecated import deprecated_func
+from optuna.distributions import _categorical_choice_equal
 from optuna.distributions import BaseDistribution
 from optuna.distributions import CategoricalChoiceType
 from optuna.distributions import CategoricalDistribution
 from optuna.distributions import FloatDistribution
 from optuna.distributions import IntDistribution
 from optuna.trial import FrozenTrial
-from optuna.trial._base import BaseTrial
 from optuna.trial import TrialState
-from optuna.distributions import _categorical_choice_equal
+from optuna.trial._base import BaseTrial
+
 
 _logger = logging.get_logger(__name__)
 _suggest_deprecated_msg = "Use :func:`~optuna.trial.Trial.suggest_float` instead."
@@ -756,23 +757,23 @@ class Trial(BaseTrial):
         """
 
         return self._cached_frozen_trial.number
-    
+
     def last_value_if_duplicate(self) -> Optional[List[float]]:
-        """Return the last value of the objective function if the same 
-        parameters have been suggested before.
+        """Return the values of last trial with the exactly the same params, if exists.
 
         Returns:
-            If the same parameters have been suggested before, 
+            If the same parameters have been suggested before,
             return the values of the objective function in the last trial.
             Otherwise, return None.
         """
+
         complete_trials = self.study.get_trials(deepcopy=False, states=(TrialState.COMPLETE,))
         current_params = set(self.params.keys())
         for trial in complete_trials[::-1]:
             past_trial_params = set(trial.params.keys())
             if current_params == past_trial_params and all(
-                _categorical_choice_equal(trial.params[param], self.params[param]) 
-                    for param in (current_params | past_trial_params)
+                _categorical_choice_equal(trial.params[param], self.params[param])
+                for param in (current_params | past_trial_params)
             ):
                 return trial.values
         return None

--- a/optuna/trial/_trial.py
+++ b/optuna/trial/_trial.py
@@ -768,12 +768,11 @@ class Trial(BaseTrial):
         """
 
         complete_trials = self.study.get_trials(deepcopy=False, states=(TrialState.COMPLETE,))
-        current_params = set(self.params.keys())
+        current_params = list(self.params.keys())
         for trial in complete_trials[::-1]:
-            past_trial_params = set(trial.params.keys())
-            if current_params == past_trial_params and all(
+            if current_params == list(trial.params.keys()) and all(
                 _categorical_choice_equal(trial.params[param], self.params[param])
-                for param in (current_params | past_trial_params)
+                for param in current_params
             ):
                 return trial.values
         return None

--- a/tests/trial_tests/test_trial.py
+++ b/tests/trial_tests/test_trial.py
@@ -705,3 +705,45 @@ def test_persisted_param() -> None:
         study = load_study(storage=storage, study_name=study_name)
 
         assert all("x" in t.params for t in study.trials)
+
+def test_last_value_if_duplicate() -> None:
+    study = create_study(directions=["minimize", "minimize"])
+    study.add_trials([
+        optuna.trial.create_trial(values=[1.0, 2.0], params={"x": 1, "y": "a"}, 
+            distributions={"x": optuna.distributions.IntDistribution(0, 2),
+                           "y": optuna.distributions.CategoricalDistribution(("a", "b"))}),
+                                                                              
+        optuna.trial.create_trial(values=[2.0, 2.0], params={"x": 2, "y": "a", "z": 2}, 
+            distributions={"x": optuna.distributions.IntDistribution(0, 2),
+                           "y": optuna.distributions.CategoricalDistribution(("a", "b")),
+                           "z": optuna.distributions.IntDistribution(0, 2),}),
+                                                                              
+        optuna.trial.create_trial(values=[3.0, 2.0], params={"x": 2, "y": "a"}, 
+            distributions={"x": optuna.distributions.IntDistribution(0, 2),
+                           "y": optuna.distributions.CategoricalDistribution(("a", "b"))}),
+                                                                              
+        optuna.trial.create_trial(values=[4.0, 2.0], params={"x": 2, "y": "a"}, 
+            distributions={"x": optuna.distributions.IntDistribution(0, 2),
+                           "y": optuna.distributions.CategoricalDistribution(("a", "b"))}),
+    ])
+
+    study.enqueue_trial({"x": 0, "y": "a"})
+    trial = study.ask()
+    trial.suggest_int("x", 0, 2)
+    trial.suggest_categorical("y", ("a", "b"))
+    assert trial.last_value_if_duplicate() is None
+
+    study.enqueue_trial({"x": 1, "y": "a", "z": 1})
+    trial = study.ask()
+    trial.suggest_int("x", 0, 2)
+    trial.suggest_categorical("y", ("a", "b"))
+    trial.suggest_int("z", 0, 2)
+    assert trial.last_value_if_duplicate() is None
+
+    study.enqueue_trial({"x": 2, "y": "a"})
+    trial = study.ask()
+    trial.suggest_int("x", 0, 2)
+    trial.suggest_categorical("y", ("a", "b"))
+    assert trial.last_value_if_duplicate() == [4.0, 2.0]
+
+    

--- a/tests/trial_tests/test_trial.py
+++ b/tests/trial_tests/test_trial.py
@@ -706,26 +706,46 @@ def test_persisted_param() -> None:
 
         assert all("x" in t.params for t in study.trials)
 
+
 def test_last_value_if_duplicate() -> None:
     study = create_study(directions=["minimize", "minimize"])
-    study.add_trials([
-        optuna.trial.create_trial(values=[1.0, 2.0], params={"x": 1, "y": "a"}, 
-            distributions={"x": optuna.distributions.IntDistribution(0, 2),
-                           "y": optuna.distributions.CategoricalDistribution(("a", "b"))}),
-                                                                              
-        optuna.trial.create_trial(values=[2.0, 2.0], params={"x": 2, "y": "a", "z": 2}, 
-            distributions={"x": optuna.distributions.IntDistribution(0, 2),
-                           "y": optuna.distributions.CategoricalDistribution(("a", "b")),
-                           "z": optuna.distributions.IntDistribution(0, 2),}),
-                                                                              
-        optuna.trial.create_trial(values=[3.0, 2.0], params={"x": 2, "y": "a"}, 
-            distributions={"x": optuna.distributions.IntDistribution(0, 2),
-                           "y": optuna.distributions.CategoricalDistribution(("a", "b"))}),
-                                                                              
-        optuna.trial.create_trial(values=[4.0, 2.0], params={"x": 2, "y": "a"}, 
-            distributions={"x": optuna.distributions.IntDistribution(0, 2),
-                           "y": optuna.distributions.CategoricalDistribution(("a", "b"))}),
-    ])
+    study.add_trials(
+        [
+            optuna.trial.create_trial(
+                values=[1.0, 2.0],
+                params={"x": 1, "y": "a"},
+                distributions={
+                    "x": optuna.distributions.IntDistribution(0, 2),
+                    "y": optuna.distributions.CategoricalDistribution(("a", "b")),
+                },
+            ),
+            optuna.trial.create_trial(
+                values=[2.0, 2.0],
+                params={"x": 2, "y": "a", "z": 2},
+                distributions={
+                    "x": optuna.distributions.IntDistribution(0, 2),
+                    "y": optuna.distributions.CategoricalDistribution(("a", "b")),
+                    "z": optuna.distributions.IntDistribution(0, 2),
+                },
+            ),
+            optuna.trial.create_trial(
+                values=[3.0, 2.0],
+                params={"x": 2, "y": "a"},
+                distributions={
+                    "x": optuna.distributions.IntDistribution(0, 2),
+                    "y": optuna.distributions.CategoricalDistribution(("a", "b")),
+                },
+            ),
+            optuna.trial.create_trial(
+                values=[4.0, 2.0],
+                params={"x": 2, "y": "a"},
+                distributions={
+                    "x": optuna.distributions.IntDistribution(0, 2),
+                    "y": optuna.distributions.CategoricalDistribution(("a", "b")),
+                },
+            ),
+        ]
+    )
 
     study.enqueue_trial({"x": 0, "y": "a"})
     trial = study.ask()
@@ -745,5 +765,3 @@ def test_last_value_if_duplicate() -> None:
     trial.suggest_int("x", 0, 2)
     trial.suggest_categorical("y", ("a", "b"))
     assert trial.last_value_if_duplicate() == [4.0, 2.0]
-
-    


### PR DESCRIPTION
## Motivation
Provide workaround for #2021.

## Description of the changes
This PR adds a function `Trial.last_value_if_duplicate` that returns the values of the last trial that has exactly the same params as suggested in this trial, if exists.

Example: 
```python3
def objective(trial):
    x = trial.suggest_float("x", 0, 1)

    past_value = trial.last_value_if_duplicate()
    if past_value is not None: 
        return past_value

    ...
```
This utility function makes it easy to add a simple memoization mechanism in the objective function.

## Alternative options
Add a freestanding function `optuna.last_value_if_duplicate(optuna.Trial)` that does the same.