### PR TITLE
Remove `cached-path` from `setup.py`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -85,8 +85,6 @@ def get_extras_require() -> Dict[str, List[str]]:
         ],
         "integration": [
             "allennlp>=2.2.0; python_version<'3.11'",
-            # TODO(c-bata): Remove cached-path after allennllp supports v1.1.3
-            "cached-path<=1.1.2; python_version<'3.11'",
             "botorch>=0.4.0,<0.8.0; python_version<'3.11'",
             "catalyst>=21.3; python_version<'3.11'",
             "catboost>=0.26; python_version<'3.11'",


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

Allennlp 2.10.1 specifies `cached-path` version: `cached-path>=1.1.3,<1.2.0` in https://github.com/allenai/allennlp/blob/0dc554f975a0130a79a9b43a2cad7a52ed579d7f/requirements.txt#L6. So we remove `cached-path` in `setup.py` by following TODO comment. This version specification also causes installation error in https://github.com/optuna/optuna/actions/runs/3964442009/jobs/6793305565#logs.

## Description of the changes
<!-- Describe the changes in this PR. -->

Remove `cached-path` from `setup.py`.