### PR TITLE
Fix label of `pypigh-action-pypi-publish`

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -47,7 +47,7 @@ jobs:
     - name: Publish distribution to TestPyPI
       # The following upload action cannot be executed in the forked repository.
       if: (github.event_name == 'schedule') || (github.event_name == 'release')
-      uses: pypa/gh-action-pypi-publish@v1
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
         user: __token__
         password: ${{ secrets.test_pypi_password }}
@@ -56,7 +56,7 @@ jobs:
     - name: Publish distribution to PyPI
       # The following upload action cannot be executed in the forked repository.
       if: github.event_name == 'release'
-      uses: pypa/gh-action-pypi-publish@v1
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
         user: __token__
         password: ${{ secrets.pypi_password }}


### PR DESCRIPTION
## Motivation

The [TestPyPI CI job](https://github.com/optuna/optuna/actions/runs/3980233311/jobs/6823174203) failed due to missing action of `pypa/gh-action-pypi-publish@v1`.
> Error: Unable to resolve action `pypa/gh-action-pypi-publish@v1`, unable to find version `v1`

According to the [official site of the action](https://github.com/pypa/gh-action-pypi-publish/tree/release/v1), the label is supposed to be `pypa/gh-action-pypi-publish@release/v1` to distinguish it from `unstable/v1`.

## Description of the changes

- Change the label of `pypa/gh-action-pypi-publish` in `pypi-publish.yml`