### PR TITLE
Minor fix of documents

### DIFF
--- a/optuna/pruners/_hyperband.py
+++ b/optuna/pruners/_hyperband.py
@@ -55,8 +55,8 @@ class HyperbandPruner(BasePruner):
         stopping behavior of Hyperband and is automatically determined by ``min_resource``,
         ``max_resource`` and ``reduction_factor`` as
         :math:`\\mathrm{The\\ number\\ of\\ brackets} =
-        \\mathrm{floor}(\\log_{\\texttt{reduction_factor}}
-        (\\frac{\\texttt{max_resource}}{\\texttt{min_resource}})) + 1`.
+        \\mathrm{floor}(\\log_{\\texttt{reduction}\\_\\texttt{factor}}
+        (\\frac{\\texttt{max}\\_\\texttt{resource}}{\\texttt{min}\\_\\texttt{resource}})) + 1`.
         Please set ``reduction_factor`` so that the number of brackets is not too large (about 4 –
         6 in most use cases). Please see Section 3.6 of the `original paper
         <http://www.jmlr.org/papers/volume18/16-558/16-558.pdf>`_ for the detail.

--- a/tutorial/10_key_features/001_first.py
+++ b/tutorial/10_key_features/001_first.py
@@ -105,7 +105,8 @@ study.best_trial
 # To get all trials:
 
 study.trials
-
+for trial in study.trials[:2]:  # Show first two trials
+    print(trial)
 
 ###################################################################################################
 # To get the number of trials:


### PR DESCRIPTION
## Motivation

During PDF build, some errors occurred as follows:
- Overflow of `study.trials` output
- Unescaped `_` in Hyperband formula.

This PR is related to #4349. Removed changes in CI settings.

## Description of the changes

- Fixed above two errors
