### PR TITLE
Cache all trials in Study with TTL

### DIFF
--- a/optuna/integration/_lightgbm_tuner/optimize.py
+++ b/optuna/integration/_lightgbm_tuner/optimize.py
@@ -702,9 +702,10 @@ class _LightGBMBaseTuner(_BaseTuner):
                 self,
                 deepcopy: bool = True,
                 states: Optional[Container[TrialState]] = None,
+                use_cache: bool = False,
             ) -> List[optuna.trial.FrozenTrial]:
 
-                trials = super().get_trials(deepcopy=deepcopy, states=states)
+                trials = super().get_trials(deepcopy=deepcopy, states=states, use_cache=use_cache)
                 return [t for t in trials if t.system_attrs.get(_STEP_NAME_KEY) == self._step_name]
 
             @property

--- a/optuna/pruners/_hyperband.py
+++ b/optuna/pruners/_hyperband.py
@@ -279,6 +279,7 @@ class HyperbandPruner(BasePruner):
                 "_is_multi_objective",
                 "stop",
                 "_study",
+                "_thread_local",
             )
 
             def __init__(

--- a/optuna/pruners/_hyperband.py
+++ b/optuna/pruners/_hyperband.py
@@ -297,8 +297,9 @@ class HyperbandPruner(BasePruner):
                 self,
                 deepcopy: bool = True,
                 states: Optional[Container[TrialState]] = None,
+                use_cache: bool = False,
             ) -> List["optuna.trial.FrozenTrial"]:
-                trials = super().get_trials(deepcopy=deepcopy, states=states)
+                trials = super().get_trials(deepcopy=deepcopy, states=states, use_cache=use_cache)
                 pruner = self.pruner
                 assert isinstance(pruner, HyperbandPruner)
                 return [t for t in trials if pruner._get_bracket_id(self, t) == self._bracket_id]

--- a/optuna/samplers/_cmaes.py
+++ b/optuna/samplers/_cmaes.py
@@ -611,7 +611,7 @@ class CmaEsSampler(BaseSampler):
 
     def _get_trials(self, study: "optuna.Study") -> List[FrozenTrial]:
         complete_trials = []
-        for t in study.get_trials(deepcopy=False):
+        for t in study.get_trials(deepcopy=False, use_cache=True):
             if t.state == TrialState.COMPLETE:
                 complete_trials.append(t)
             elif (

--- a/optuna/samplers/_qmc.py
+++ b/optuna/samplers/_qmc.py
@@ -187,7 +187,7 @@ class QMCSampler(BaseSampler):
         if self._initial_search_space is not None:
             return self._initial_search_space
 
-        past_trials = study.get_trials(deepcopy=False, states=_SUGGESTED_STATES)
+        past_trials = study.get_trials(deepcopy=False, states=_SUGGESTED_STATES, use_cache=True)
         # The initial trial is sampled by the independent sampler.
         if len(past_trials) == 0:
             return {}

--- a/optuna/samplers/_search_space/group_decomposed.py
+++ b/optuna/samplers/_search_space/group_decomposed.py
@@ -56,7 +56,7 @@ class _GroupDecomposedSearchSpace:
         else:
             states_of_interest = (TrialState.COMPLETE,)
 
-        for trial in study.get_trials(deepcopy=False, states=states_of_interest):
+        for trial in study.get_trials(deepcopy=False, states=states_of_interest, use_cache=True):
             self._search_space.add_distributions(trial.distributions)
 
         return copy.deepcopy(self._search_space)

--- a/optuna/samplers/_search_space/intersection.py
+++ b/optuna/samplers/_search_space/intersection.py
@@ -68,7 +68,7 @@ class IntersectionSearchSpace:
         if self._include_pruned:
             states_of_interest.append(optuna.trial.TrialState.PRUNED)
 
-        trials = study.get_trials(deepcopy=False, states=states_of_interest)
+        trials = study.get_trials(deepcopy=False, states=states_of_interest, use_cache=True)
 
         next_cursor = trials[-1].number + 1 if len(trials) > 0 else -1
         for trial in reversed(trials):

--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -632,7 +632,7 @@ def _get_observation_pairs(
     scores = []
     values: Dict[str, List[Optional[float]]] = {param_name: [] for param_name in param_names}
     violations: Optional[List[float]] = [] if constraints_enabled else None
-    for trial in study.get_trials(deepcopy=False, states=states):
+    for trial in study.get_trials(deepcopy=False, states=states, use_cache=True):
         # We extract score from the trial.
         if trial.state is TrialState.COMPLETE:
             if trial.values is None:

--- a/optuna/samplers/nsgaii/_sampler.py
+++ b/optuna/samplers/nsgaii/_sampler.py
@@ -253,7 +253,7 @@ class NSGAIISampler(BaseSampler):
         )
 
     def _collect_parent_population(self, study: Study) -> Tuple[int, List[FrozenTrial]]:
-        trials = study.get_trials(deepcopy=False)
+        trials = study.get_trials(deepcopy=False, use_cache=True)
 
         generation_to_runnings = defaultdict(list)
         generation_to_population = defaultdict(list)

--- a/optuna/study/_optimize.py
+++ b/optuna/study/_optimize.py
@@ -189,6 +189,7 @@ def _run_trial(
         optuna.storages.fail_stale_trials(study)
 
     trial = study.ask()
+    study._thread_local.cache_all_trials.activate(lambda: study.get_trials(deepcopy=False))
 
     state: Optional[TrialState] = None
     value_or_values: Optional[Union[float, Sequence[float]]] = None
@@ -220,6 +221,7 @@ def _run_trial(
         frozen_trial = study._storage.get_trial(trial._trial_id)
         raise
     finally:
+        study._thread_local.cache_all_trials.deactivate()
         if frozen_trial.state == TrialState.COMPLETE:
             study._log_completed_trial(frozen_trial)
         elif frozen_trial.state == TrialState.PRUNED:

--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -1,4 +1,5 @@
 import copy
+from datetime import datetime, timedelta
 from numbers import Real
 import threading
 from typing import Any
@@ -54,14 +55,18 @@ _logger = logging.get_logger(__name__)
 
 
 class AllTrialsCache:
+    CACHE_TTL = timedelta(minutes=1)
+
     _is_active: bool
     _cache: Optional[List["FrozenTrial"]]
     _getter: Optional[Callable[[], List["FrozenTrial"]]]
+    _last_updated: datetime
 
     def __init__(self) -> None:
         self._is_active = False
         self._cache = None
         self._getter = None
+        self._last_updated = datetime.now()
 
     def is_active(self) -> bool:
         return self._is_active
@@ -77,9 +82,10 @@ class AllTrialsCache:
 
     def get(self) -> List["FrozenTrial"]:
         assert self._is_active
-        if self._cache is None:
+        if self._cache is None or (datetime.now() - self._last_updated > AllTrialsCache.CACHE_TTL):
             assert self._getter is not None
             self._cache = self._getter()
+            self._last_updated = datetime.now()
         return self._cache
 
 

--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -53,8 +53,43 @@ ObjectiveFuncType = Callable[[trial_module.Trial], Union[float, Sequence[float]]
 _logger = logging.get_logger(__name__)
 
 
+class AllTrialsCache:
+    _is_active: bool
+    _cache: Optional[List["FrozenTrial"]]
+    _getter: Optional[Callable[[], List["FrozenTrial"]]]
+
+    def __init__(self) -> None:
+        self._is_active = False
+        self._cache = None
+        self._getter = None
+
+    def is_active(self) -> bool:
+        return self._is_active
+
+    def activate(self, getter: Callable[[], List["FrozenTrial"]]) -> None:
+        self._is_active = True
+        self._getter = getter
+
+    def deactivate(self) -> None:
+        self._is_active = False
+        self._cache = None
+        self._getter = None
+
+    def get(self) -> List["FrozenTrial"]:
+        assert self._is_active
+        if self._cache is None:
+            assert self._getter is not None
+            self._cache = self._getter()
+        return self._cache
+
+
 class _ThreadLocalStudyAttribute(threading.local):
-    in_optimize_loop: bool = False
+    in_optimize_loop: bool
+    cache_all_trials: AllTrialsCache
+
+    def __init__(self) -> None:
+        self.in_optimize_loop = False
+        self.cache_all_trials = AllTrialsCache()
 
 
 class Study:
@@ -227,6 +262,7 @@ class Study:
         self,
         deepcopy: bool = True,
         states: Optional[Container[TrialState]] = None,
+        use_cache: bool = False,
     ) -> List[FrozenTrial]:
         """Return all trials in the study.
 
@@ -259,10 +295,21 @@ class Study:
                 the study may corrupt and unexpected behavior may happen.
             states:
                 Trial states to filter on. If :obj:`None`, include all states.
+            use_cache:
+                If True, returns trials from an in-memory cache, which is cached
+                before evaluating the objective function.
 
         Returns:
             A list of :class:`~optuna.trial.FrozenTrial` objects.
         """
+        if use_cache and self._thread_local.cache_all_trials.is_active():
+            trials = self._thread_local.cache_all_trials.get()
+            if states is not None:
+                filtered_trials = [t for t in trials if t.state in states]
+            else:
+                filtered_trials = trials
+            return copy.deepcopy(filtered_trials) if deepcopy else filtered_trials
+
         if isinstance(self._storage, _CachedStorage):
             self._storage.read_trials_from_remote_storage(self._study_id)
 

--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -1,5 +1,5 @@
 import copy
-from datetime import datetime, timedelta
+import datetime
 from numbers import Real
 import threading
 from typing import Any
@@ -55,18 +55,18 @@ _logger = logging.get_logger(__name__)
 
 
 class AllTrialsCache:
-    CACHE_TTL = timedelta(minutes=1)
+    CACHE_TTL = datetime.timedelta(minutes=1)
 
     _is_active: bool
     _cache: Optional[List["FrozenTrial"]]
     _getter: Optional[Callable[[], List["FrozenTrial"]]]
-    _last_updated: datetime
+    _last_updated: datetime.datetime
 
     def __init__(self) -> None:
         self._is_active = False
         self._cache = None
         self._getter = None
-        self._last_updated = datetime.now()
+        self._last_updated = datetime.datetime.now()
 
     def is_active(self) -> bool:
         return self._is_active
@@ -82,10 +82,12 @@ class AllTrialsCache:
 
     def get(self) -> List["FrozenTrial"]:
         assert self._is_active
-        if self._cache is None or (datetime.now() - self._last_updated > AllTrialsCache.CACHE_TTL):
+        if self._cache is None or (
+            datetime.datetime.now() - self._last_updated > AllTrialsCache.CACHE_TTL
+        ):
             assert self._getter is not None
             self._cache = self._getter()
-            self._last_updated = datetime.now()
+            self._last_updated = datetime.datetime.now()
         return self._cache
 
 

--- a/tests/samplers_tests/test_cmaes.py
+++ b/tests/samplers_tests/test_cmaes.py
@@ -265,7 +265,10 @@ def test_sample_relative_n_startup_trials() -> None:
 
 
 def test_get_trials() -> None:
-    with patch("optuna.Study.get_trials", new=Mock(side_effect=lambda deepcopy: _create_trials())):
+    with patch(
+        "optuna.Study.get_trials",
+        new=Mock(side_effect=lambda deepcopy, use_cache: _create_trials()),
+    ):
         sampler = optuna.samplers.CmaEsSampler(consider_pruned_trials=False)
         study = optuna.create_study(sampler=sampler)
         trials = sampler._get_trials(study)


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

This PR is another try on #4141, with TTL.
## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
See #4141 for the cache itself.

#4141 implementation may result in less optimization capability because some independent samplings may not be able to use the latest trials history. 

```python
def objective(trial):
  huge_preprocess()
  trial.suggest()
  mode.fit()
```

In the objective function above, `trial.suggest()` may use the stale cache because there is `huge_preprocess()` between the trial creation, where multivairate sampling occurs, and `trial.suggest()`. The cache is only updated in the multivariate sampling in #4141. 

## Description of the changes
<!-- Describe the changes in this PR. -->
See #4141 for the cache itself.
My change adds the TTL to all trials cahce on `Study`. The cache becomes invalid after a minute.