### PR TITLE
Disable colored log when `NO_COLOR` env or not tty.

### DIFF
--- a/optuna/logging.py
+++ b/optuna/logging.py
@@ -7,7 +7,6 @@ from logging import INFO
 from logging import WARN
 from logging import WARNING
 import os
-import platform
 import sys
 import threading
 from typing import Optional

--- a/optuna/logging.py
+++ b/optuna/logging.py
@@ -6,6 +6,7 @@ from logging import FATAL
 from logging import INFO
 from logging import WARN
 from logging import WARNING
+import sys
 import threading
 from typing import Optional
 
@@ -32,9 +33,12 @@ def create_default_formatter() -> colorlog.ColoredFormatter:
     This function is not supposed to be directly accessed by library users.
     """
 
-    return colorlog.ColoredFormatter(
-        "%(log_color)s[%(levelname)1.1s %(asctime)s]%(reset)s %(message)s"
-    )
+    if sys.stdout.isatty():
+        return colorlog.ColoredFormatter(
+            "%(log_color)s[%(levelname)1.1s %(asctime)s]%(reset)s %(message)s"
+        )
+    else:
+        return colorlog.ColoredFormatter("[%(levelname)1.1s %(asctime)s] %(message)s")
 
 
 def _get_library_name() -> str:

--- a/optuna/logging.py
+++ b/optuna/logging.py
@@ -6,6 +6,8 @@ from logging import FATAL
 from logging import INFO
 from logging import WARN
 from logging import WARNING
+import os
+import platform
 import sys
 import threading
 from typing import Optional
@@ -33,12 +35,24 @@ def create_default_formatter() -> colorlog.ColoredFormatter:
     This function is not supposed to be directly accessed by library users.
     """
 
-    if sys.stdout.isatty():
+    if _color_supported():
         return colorlog.ColoredFormatter(
             "%(log_color)s[%(levelname)1.1s %(asctime)s]%(reset)s %(message)s"
         )
     else:
         return colorlog.ColoredFormatter("[%(levelname)1.1s %(asctime)s] %(message)s")
+
+
+def _color_supported() -> bool:
+    """Detection of color support."""
+    # NO_COLOR environment variable:
+    if os.environ.get("NO_COLOR", None):
+        return False
+
+    if not hasattr(sys.stderr, "isatty") or not sys.stderr.isatty():
+        return False
+    else:
+        return True
 
 
 def _get_library_name() -> str:

--- a/optuna/logging.py
+++ b/optuna/logging.py
@@ -33,13 +33,10 @@ def create_default_formatter() -> colorlog.ColoredFormatter:
 
     This function is not supposed to be directly accessed by library users.
     """
-
-    if _color_supported():
-        return colorlog.ColoredFormatter(
-            "%(log_color)s[%(levelname)1.1s %(asctime)s]%(reset)s %(message)s"
-        )
-    else:
-        return colorlog.ColoredFormatter("[%(levelname)1.1s %(asctime)s] %(message)s")
+    return colorlog.ColoredFormatter(
+        "%(log_color)s[%(levelname)1.1s %(asctime)s]%(reset)s %(message)s",
+        no_color=False if _color_supported() else True,
+    )
 
 
 def _color_supported() -> bool:


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
When piping optuna's log output to the file, escape sequences are also captured.

Given the following code.
```
python3 -c "import optuna;study = optuna.create_study()" &> log.txt 
```

log.txt would be like
```
[32m[I 2023-01-31 10:25:25,449][0m A new study created in memory with name: no-name-7c296450-89b2-45d3-9f6c-c363edf688f3[0m
```

Many python tools including `pip` would disable coloring when stdout is not a tty, so it is more natural to do this in optuna.

And also natural to disable coloring when `NO_COLOR` environment variable is set, (ref. https://no-color.org).

## Description of the changes
<!-- Describe the changes in this PR. -->
- Created a function `_color_supported` to check the environment variable and tty state.
