### PR TITLE
[WIP] Prefer `FrozenStudy` over `Study` for data access

### DIFF
--- a/optuna/samplers/nsgaii/_crossover.py
+++ b/optuna/samplers/nsgaii/_crossover.py
@@ -12,7 +12,7 @@ from optuna.distributions import BaseDistribution
 from optuna.distributions import FloatDistribution
 from optuna.distributions import IntDistribution
 from optuna.samplers.nsgaii._crossovers._base import BaseCrossover
-from optuna.study import Study
+from optuna.study import FrozenStudy
 from optuna.study import StudyDirection
 from optuna.trial import FrozenTrial
 
@@ -26,7 +26,7 @@ _NUMERICAL_DISTRIBUTIONS = (
 def _try_crossover(
     parents: List[FrozenTrial],
     crossover: BaseCrossover,
-    study: Study,
+    study: FrozenStudy,
     rng: np.random.RandomState,
     swapping_prob: float,
     categorical_search_space: Dict[str, BaseDistribution],
@@ -80,7 +80,7 @@ def _try_crossover(
 
 def perform_crossover(
     crossover: BaseCrossover,
-    study: Study,
+    study: FrozenStudy,
     parent_population: Sequence[FrozenTrial],
     search_space: Dict[str, BaseDistribution],
     rng: np.random.RandomState,
@@ -121,7 +121,7 @@ def perform_crossover(
 
 def _select_parents(
     crossover: BaseCrossover,
-    study: Study,  # FrozenStudy
+    study: FrozenStudy,
     parent_population: Sequence[FrozenTrial],
     rng: np.random.RandomState,
     dominates: Callable[[FrozenTrial, FrozenTrial, Sequence[StudyDirection]], bool],
@@ -138,7 +138,7 @@ def _select_parents(
 
 
 def _select_parent(
-    study: Study,
+    study: FrozenStudy,
     parent_population: Sequence[FrozenTrial],
     rng: np.random.RandomState,
     dominates: Callable[[FrozenTrial, FrozenTrial, Sequence[StudyDirection]], bool],

--- a/optuna/samplers/nsgaii/_crossover.py
+++ b/optuna/samplers/nsgaii/_crossover.py
@@ -121,7 +121,7 @@ def perform_crossover(
 
 def _select_parents(
     crossover: BaseCrossover,
-    study: Study,
+    study: Study,  # FrozenStudy
     parent_population: Sequence[FrozenTrial],
     rng: np.random.RandomState,
     dominates: Callable[[FrozenTrial, FrozenTrial, Sequence[StudyDirection]], bool],

--- a/optuna/samplers/nsgaii/_crossovers/_base.py
+++ b/optuna/samplers/nsgaii/_crossovers/_base.py
@@ -2,7 +2,7 @@ import abc
 
 import numpy as np
 
-from optuna.study import Study
+from optuna.study import FrozenStudy
 
 
 class BaseCrossover(abc.ABC):
@@ -33,7 +33,7 @@ class BaseCrossover(abc.ABC):
         self,
         parents_params: np.ndarray,
         rng: np.random.RandomState,
-        study: Study,
+        study: FrozenStudy,
         search_space_bounds: np.ndarray,
     ) -> np.ndarray:
         """Perform crossover of selected parent individuals.

--- a/optuna/samplers/nsgaii/_crossovers/_blxalpha.py
+++ b/optuna/samplers/nsgaii/_crossovers/_blxalpha.py
@@ -2,7 +2,7 @@ import numpy as np
 
 from optuna._experimental import experimental_class
 from optuna.samplers.nsgaii._crossovers._base import BaseCrossover
-from optuna.study import Study
+from optuna.study import FrozenStudy
 
 
 @experimental_class("3.0.0")
@@ -32,7 +32,7 @@ class BLXAlphaCrossover(BaseCrossover):
         self,
         parents_params: np.ndarray,
         rng: np.random.RandomState,
-        study: Study,
+        study: FrozenStudy,
         search_space_bounds: np.ndarray,
     ) -> np.ndarray:
 

--- a/optuna/samplers/nsgaii/_crossovers/_sbx.py
+++ b/optuna/samplers/nsgaii/_crossovers/_sbx.py
@@ -51,7 +51,7 @@ class SBXCrossover(BaseCrossover):
         xs_min = np.min(parents_params, axis=0)
         xs_max = np.max(parents_params, axis=0)
         if self._eta is None:
-            eta = 20.0 if study._is_multi_objective() else 2.0
+            eta = 20.0 if len(study.directions) > 1 else 2.0
         else:
             eta = self._eta
 

--- a/optuna/samplers/nsgaii/_crossovers/_sbx.py
+++ b/optuna/samplers/nsgaii/_crossovers/_sbx.py
@@ -4,7 +4,7 @@ import numpy as np
 
 from optuna._experimental import experimental_class
 from optuna.samplers.nsgaii._crossovers._base import BaseCrossover
-from optuna.study import Study
+from optuna.study import FrozenStudy
 
 
 @experimental_class("3.0.0")
@@ -36,7 +36,7 @@ class SBXCrossover(BaseCrossover):
         self,
         parents_params: np.ndarray,
         rng: np.random.RandomState,
-        study: Study,
+        study: FrozenStudy,
         search_space_bounds: np.ndarray,
     ) -> np.ndarray:
 

--- a/optuna/samplers/nsgaii/_crossovers/_spx.py
+++ b/optuna/samplers/nsgaii/_crossovers/_spx.py
@@ -4,7 +4,7 @@ import numpy as np
 
 from optuna._experimental import experimental_class
 from optuna.samplers.nsgaii._crossovers._base import BaseCrossover
-from optuna.study import Study
+from optuna.study import FrozenStudy
 
 
 @experimental_class("3.0.0")
@@ -36,7 +36,7 @@ class SPXCrossover(BaseCrossover):
         self,
         parents_params: np.ndarray,
         rng: np.random.RandomState,
-        study: Study,
+        study: FrozenStudy,
         search_space_bounds: np.ndarray,
     ) -> np.ndarray:
 

--- a/optuna/samplers/nsgaii/_crossovers/_undx.py
+++ b/optuna/samplers/nsgaii/_crossovers/_undx.py
@@ -4,7 +4,7 @@ import numpy as np
 
 from optuna._experimental import experimental_class
 from optuna.samplers.nsgaii._crossovers._base import BaseCrossover
-from optuna.study import Study
+from optuna.study import FrozenStudy
 
 
 @experimental_class("3.0.0")
@@ -69,7 +69,7 @@ class UNDXCrossover(BaseCrossover):
         self,
         parents_params: np.ndarray,
         rng: np.random.RandomState,
-        study: Study,
+        study: FrozenStudy,
         search_space_bounds: np.ndarray,
     ) -> np.ndarray:
 

--- a/optuna/samplers/nsgaii/_crossovers/_uniform.py
+++ b/optuna/samplers/nsgaii/_crossovers/_uniform.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from optuna.samplers.nsgaii._crossovers._base import BaseCrossover
-from optuna.study import Study
+from optuna.study import FrozenStudy
 
 
 class UniformCrossover(BaseCrossover):
@@ -30,7 +30,7 @@ class UniformCrossover(BaseCrossover):
         self,
         parents_params: np.ndarray,
         rng: np.random.RandomState,
-        study: Study,
+        study: FrozenStudy,
         search_space_bounds: np.ndarray,
     ) -> np.ndarray:
 

--- a/optuna/samplers/nsgaii/_crossovers/_vsbx.py
+++ b/optuna/samplers/nsgaii/_crossovers/_vsbx.py
@@ -43,7 +43,7 @@ class VSBXCrossover(BaseCrossover):
         # https://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.422.952&rep=rep1&type=pdf
         # Section 3.2 Crossover Schemes (vSBX)
         if self._eta is None:
-            eta = 20.0 if study._is_multi_objective() else 2.0
+            eta = 20.0 if len(study.directions) > 1 else 2.0
         else:
             eta = self._eta
 

--- a/optuna/samplers/nsgaii/_crossovers/_vsbx.py
+++ b/optuna/samplers/nsgaii/_crossovers/_vsbx.py
@@ -4,7 +4,7 @@ import numpy as np
 
 from optuna._experimental import experimental_class
 from optuna.samplers.nsgaii._crossovers._base import BaseCrossover
-from optuna.study import Study
+from optuna.study import FrozenStudy
 
 
 @experimental_class("3.0.0")
@@ -36,7 +36,7 @@ class VSBXCrossover(BaseCrossover):
         self,
         parents_params: np.ndarray,
         rng: np.random.RandomState,
-        study: Study,
+        study: FrozenStudy,
         search_space_bounds: np.ndarray,
     ) -> np.ndarray:
 

--- a/optuna/samplers/nsgaii/_sampler.py
+++ b/optuna/samplers/nsgaii/_sampler.py
@@ -202,10 +202,7 @@ class NSGAIISampler(BaseSampler):
         search_space: Dict[str, BaseDistribution],
     ) -> Dict[str, Any]:
         attr_storage = _create_system_attr_storage(study, trial)
-        study, trials = _create_frozen_study(
-            study,
-            trial_states=(TrialState.COMPLETE, TrialState.RUNNING),
-        )
+        study, trials = _create_frozen_study(study)
 
         parent_generation, parent_population = self._collect_parent_population(
             study, trials, attr_storage

--- a/optuna/samplers/nsgaii/_sampler.py
+++ b/optuna/samplers/nsgaii/_sampler.py
@@ -25,8 +25,8 @@ from optuna.samplers._search_space import IntersectionSearchSpace
 from optuna.samplers.nsgaii._crossover import perform_crossover
 from optuna.samplers.nsgaii._crossovers._base import BaseCrossover
 from optuna.samplers.nsgaii._crossovers._uniform import UniformCrossover
-from optuna.storages import SystemAttributeStorage
 from optuna.storages import _create_system_attr_storage
+from optuna.storages import SystemAttributeStorage
 from optuna.study import _create_frozen_study
 from optuna.study import FrozenStudy
 from optuna.study import Study
@@ -202,10 +202,10 @@ class NSGAIISampler(BaseSampler):
         search_space: Dict[str, BaseDistribution],
     ) -> Dict[str, Any]:
         attr_storage = _create_system_attr_storage(study, trial)
-        study, trials = _create_frozen_study(study)
+        frozen_study, trials = _create_frozen_study(study)
 
         parent_generation, parent_population = self._collect_parent_population(
-            study, trials, attr_storage
+            frozen_study, trials, attr_storage
         )
 
         generation = parent_generation + 1
@@ -218,7 +218,7 @@ class NSGAIISampler(BaseSampler):
             if self._rng.rand() < self._crossover_prob:
                 child_params = perform_crossover(
                     self._crossover,
-                    study,
+                    frozen_study,
                     parent_population,
                     search_space,
                     self._rng,
@@ -337,7 +337,7 @@ class NSGAIISampler(BaseSampler):
         return parent_generation, parent_population
 
     def _select_elite_population(
-        self, study: Study, population: List[FrozenTrial]
+        self, study: FrozenStudy, population: List[FrozenTrial]
     ) -> List[FrozenTrial]:
         elite_population: List[FrozenTrial] = []
         population_per_rank = self._fast_non_dominated_sort(population, study.directions)

--- a/optuna/storages/__init__.py
+++ b/optuna/storages/__init__.py
@@ -1,8 +1,8 @@
 from typing import Union
 
 from optuna._callbacks import RetryFailedTrialCallback
-from optuna.storages._attr import SystemAttributeStorage
 from optuna.storages._attr import _create_system_attr_storage
+from optuna.storages._attr import SystemAttributeStorage
 from optuna.storages._base import BaseStorage
 from optuna.storages._cached_storage import _CachedStorage
 from optuna.storages._heartbeat import fail_stale_trials

--- a/optuna/storages/__init__.py
+++ b/optuna/storages/__init__.py
@@ -1,6 +1,8 @@
 from typing import Union
 
 from optuna._callbacks import RetryFailedTrialCallback
+from optuna.storages._attr_storage import AttributeStorage
+from optuna.storages._attr_storage import create_attr_storage
 from optuna.storages._base import BaseStorage
 from optuna.storages._cached_storage import _CachedStorage
 from optuna.storages._heartbeat import fail_stale_trials

--- a/optuna/storages/__init__.py
+++ b/optuna/storages/__init__.py
@@ -1,8 +1,8 @@
 from typing import Union
 
 from optuna._callbacks import RetryFailedTrialCallback
-from optuna.storages._attr_storage import AttributeStorage
-from optuna.storages._attr_storage import create_attr_storage
+from optuna.storages._attr import SystemAttributeStorage
+from optuna.storages._attr import _create_system_attr_storage
 from optuna.storages._base import BaseStorage
 from optuna.storages._cached_storage import _CachedStorage
 from optuna.storages._heartbeat import fail_stale_trials
@@ -27,7 +27,9 @@ __all__ = [
     "JournalFileStorage",
     "JournalRedisStorage",
     "RetryFailedTrialCallback",
+    "SystemAttributeStorage",
     "_CachedStorage",
+    "_create_system_attr_storage",
     "fail_stale_trials",
 ]
 

--- a/optuna/storages/_attr.py
+++ b/optuna/storages/_attr.py
@@ -34,7 +34,7 @@ class SystemAttributeStorage:
 
 
 def _create_system_attr_storage(
-    study: "optuna.study.Study", trial: "optuna.trial.Trial"
+    study: "optuna.study.Study", trial: "optuna.trial.FrozenTrial"
 ) -> SystemAttributeStorage:
     return SystemAttributeStorage(
         storage=study._storage,

--- a/optuna/storages/_attr.py
+++ b/optuna/storages/_attr.py
@@ -1,0 +1,43 @@
+from typing import Any
+from typing import Dict
+
+import optuna
+
+
+class SystemAttributeStorage:
+    def __init__(
+        self, storage: "optuna.storages.BaseStorage", study_id: int, trial_id: int
+    ) -> None:
+        self._storage = storage
+        self._study_id = study_id
+        self._trial_id = trial_id
+
+    def get_study_attrs(self) -> Dict[str, Any]:
+        return self._storage.get_study_system_attrs(self._study_id)
+
+    def set_study_attr(self, key: str, value: Any) -> None:
+        self._storage.set_study_system_attr(
+            self._study_id,
+            key,
+            value,
+        )
+
+    def get_trial_attrs(self) -> Dict[str, Any]:
+        return self._storage.get_trial_system_attrs(self._trial_id)
+
+    def set_trial_attr(self, key: str, value: Any) -> None:
+        self._storage.set_trial_system_attr(
+            self._trial_id,
+            key,
+            value,
+        )
+
+
+def _create_system_attr_storage(
+    study: "optuna.study.Study", trial: "optuna.trial.Trial"
+) -> SystemAttributeStorage:
+    return SystemAttributeStorage(
+        storage=study._storage,
+        study_id=study._study_id,
+        trial_id=None if trial is None else trial._trial_id,
+    )

--- a/optuna/study/__init__.py
+++ b/optuna/study/__init__.py
@@ -1,4 +1,6 @@
 from optuna._callbacks import MaxTrialsCallback
+from optuna.study._frozen import FrozenStudy
+from optuna.study._frozen import create_frozen_study
 from optuna.study._study_direction import StudyDirection
 from optuna.study._study_summary import StudySummary
 from optuna.study.study import copy_study

--- a/optuna/study/__init__.py
+++ b/optuna/study/__init__.py
@@ -1,6 +1,6 @@
 from optuna._callbacks import MaxTrialsCallback
+from optuna.study._frozen import _create_frozen_study
 from optuna.study._frozen import FrozenStudy
-from optuna.study._frozen import create_frozen_study
 from optuna.study._study_direction import StudyDirection
 from optuna.study._study_summary import StudySummary
 from optuna.study.study import copy_study
@@ -12,6 +12,7 @@ from optuna.study.study import Study
 
 
 __all__ = [
+    "FrozenStudy",
     "MaxTrialsCallback",
     "StudyDirection",
     "StudySummary",
@@ -21,4 +22,5 @@ __all__ = [
     "get_all_study_summaries",
     "load_study",
     "Study",
+    "_create_frozen_study",
 ]

--- a/optuna/study/_frozen.py
+++ b/optuna/study/_frozen.py
@@ -100,7 +100,7 @@ class FrozenStudy:
 
 def _create_frozen_study(
     study: "optuna.study.Study",
-    trial_states: Container["optuna.trial.TrialState"] = (optuna.trial.TrialState.COMPLETE,),
+    trial_states: Optional[Container["optuna.trial.TrialState"]] = None,
 ) -> Tuple["optuna.study.FrozenStudy", List["optuna.trial.FrozenTrial"]]:
     frozen_study = FrozenStudy(
         study_name=study.study_name,

--- a/optuna/study/_frozen.py
+++ b/optuna/study/_frozen.py
@@ -1,9 +1,12 @@
 from typing import Any
+from typing import Container
 from typing import Dict
 from typing import List
 from typing import Optional
 from typing import Sequence
+from typing import Tuple
 
+import optuna
 from optuna import logging
 from optuna.study._study_direction import StudyDirection
 
@@ -93,3 +96,28 @@ class FrozenStudy:
     def directions(self) -> List[StudyDirection]:
 
         return self._directions
+
+
+def create_frozen_study(
+        study: "optuna.study.Study",
+        trial_states: Container["optuna.trial.TrialState"] = (optuna.trial.TrialState.COMPLETE,),
+    ) -> Tuple["optuna.study.FrozenStudy", List["optuna.trial.FrozenTrial"]]:
+    storage = study._storage
+
+    frozen_study = FrozenStudy(
+        study_name=study.study_name,
+        direction=None,
+        directions=study.directions,
+        user_attrs=storage.get_study_user_attrs(study._study_id),
+        system_attrs=storage.get_study_system_attrs(study._study_id),
+        study_id=study._study_id,
+    )
+
+    frozen_trials = storage.get_all_trials(
+        study._study_id,
+        deepcopy=True,
+        states=trial_states,
+    )
+
+    return frozen_study, frozen_trials
+

--- a/optuna/study/_frozen.py
+++ b/optuna/study/_frozen.py
@@ -98,26 +98,22 @@ class FrozenStudy:
         return self._directions
 
 
-def create_frozen_study(
-        study: "optuna.study.Study",
-        trial_states: Container["optuna.trial.TrialState"] = (optuna.trial.TrialState.COMPLETE,),
-    ) -> Tuple["optuna.study.FrozenStudy", List["optuna.trial.FrozenTrial"]]:
-    storage = study._storage
-
+def _create_frozen_study(
+    study: "optuna.study.Study",
+    trial_states: Container["optuna.trial.TrialState"] = (optuna.trial.TrialState.COMPLETE,),
+) -> Tuple["optuna.study.FrozenStudy", List["optuna.trial.FrozenTrial"]]:
     frozen_study = FrozenStudy(
         study_name=study.study_name,
         direction=None,
         directions=study.directions,
-        user_attrs=storage.get_study_user_attrs(study._study_id),
-        system_attrs=storage.get_study_system_attrs(study._study_id),
+        user_attrs=study._storage.get_study_user_attrs(study._study_id),
+        system_attrs=study._storage.get_study_system_attrs(study._study_id),
         study_id=study._study_id,
     )
 
-    frozen_trials = storage.get_all_trials(
-        study._study_id,
+    frozen_trials = study.get_trials(
         deepcopy=True,
         states=trial_states,
     )
 
     return frozen_study, frozen_trials
-

--- a/tests/samplers_tests/test_nsgaii.py
+++ b/tests/samplers_tests/test_nsgaii.py
@@ -33,6 +33,7 @@ from optuna.samplers.nsgaii import UniformCrossover
 from optuna.samplers.nsgaii import VSBXCrossover
 from optuna.samplers.nsgaii._crossover import _inlined_categorical_uniform_crossover
 from optuna.samplers.nsgaii._sampler import _constrained_dominates
+from optuna.study import _create_frozen_study
 from optuna.study._multi_objective import _dominates
 from optuna.study._study_direction import StudyDirection
 from optuna.trial import FrozenTrial
@@ -641,7 +642,9 @@ def test_crossover_numerical_distribution(crossover: BaseCrossover) -> None:
     if crossover.n_parents == 3:
         parent_params = np.append(parent_params, [[5.0, 6]], axis=0)
 
-    child_params = crossover.crossover(parent_params, rng, study, numerical_transform.bounds)
+    child_params = crossover.crossover(
+        parent_params, rng, _create_frozen_study(study)[0], numerical_transform.bounds
+    )
     assert child_params.ndim == 1
     assert len(child_params) == len(search_space)
     assert not any(np.isnan(child_params))
@@ -691,7 +694,9 @@ def test_crossover_duplicated_param_values(crossover: BaseCrossover) -> None:
     if crossover.n_parents == 3:
         parent_params = np.append(parent_params, [param_values], axis=0)
 
-    child_params = crossover.crossover(parent_params, rng, study, numerical_transform.bounds)
+    child_params = crossover.crossover(
+        parent_params, rng, _create_frozen_study(study)[0], numerical_transform.bounds
+    )
     assert child_params.ndim == 1
     np.testing.assert_almost_equal(child_params, param_values)
 
@@ -749,5 +754,7 @@ def test_crossover_deterministic(
     rng = Mock()
     rng.rand = Mock(side_effect=_rand)
     rng.normal = Mock(side_effect=_normal)
-    child_params = crossover.crossover(parent_params, rng, study, numerical_transform.bounds)
+    child_params = crossover.crossover(
+        parent_params, rng, _create_frozen_study(study)[0], numerical_transform.bounds
+    )
     np.testing.assert_almost_equal(child_params, expected_params)


### PR DESCRIPTION
## Motivation

`Study` object are passed around ubiquitously inside samplers and pruners. Most of the time, we only need to access certain properties such as study directions, and read/write from/to system attributes, for a single trial/study. In this PR, we introduce some helpers to better clarify this.

## Description of the changes

Introduces two functions and a new class.

- New function to convert a `Study` to a `FrozenStudy`
- New function/class to restrict writes to storage