### PR TITLE
Remove unnecessary sklearn version condition

### DIFF
--- a/optuna/integration/sklearn.py
+++ b/optuna/integration/sklearn.py
@@ -32,7 +32,6 @@ with try_import() as _imports:
     import pandas as pd
     import scipy as sp
     from scipy.sparse import spmatrix
-    import sklearn
     from sklearn.base import BaseEstimator
     from sklearn.base import clone
     from sklearn.base import is_classifier
@@ -40,13 +39,9 @@ with try_import() as _imports:
     from sklearn.model_selection import BaseCrossValidator
     from sklearn.model_selection import check_cv
     from sklearn.model_selection import cross_validate
+    from sklearn.utils import _safe_indexing as sklearn_safe_indexing
     from sklearn.utils import check_random_state
     from sklearn.utils.metaestimators import _safe_split
-
-    if sklearn.__version__ >= "0.22":
-        from sklearn.utils import _safe_indexing as sklearn_safe_indexing
-    else:
-        from sklearn.utils import safe_indexing as sklearn_safe_indexing
     from sklearn.utils.validation import check_is_fitted
 
 if not _imports.is_successful():


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

As in https://github.com/optuna/optuna/blob/ead2e13953915bf4ebb50d5880f069a29bb34ffb/pyproject.toml#L103, sklearn's integration assumes `sklearn>=0.24.2`. However, integration code has  unnecessary condition for this: `sklearn>=0.22`.

## Description of the changes
<!-- Describe the changes in this PR. -->

Remove the condition.