### PR TITLE
Output installed packages in Tests CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -66,6 +66,10 @@ jobs:
         pip install --progress-bar off .[test]
         pip install --progress-bar off .[optional]
 
+    - name: Output installed packages
+      run: |
+        pip freeze --all
+
     - name: Scheduled tests
       if:  ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
       run: |


### PR DESCRIPTION
## Motivation
When debugging CI fails, the installed package versions are important information. This PR makes it easy to check them.
This PR changes only for Tests CI. Other PRs will update the remaining CIs.

## Description of the changes
- Add `pip freeze` in Tests CI