### PR TITLE
Support DDP in `PyTorch-Lightning`

### DIFF
--- a/optuna/integration/pytorch_lightning.py
+++ b/optuna/integration/pytorch_lightning.py
@@ -135,7 +135,7 @@ class PyTorchLightningPruningCallback(Callback):
     def check_pruned(self) -> None:
         """Raise :class:`optuna.TrialPruned` manually if pruned.
 
-        Currently, intermediate_values are not properly propagated between processes due to
+        Currently, ``intermediate_values`` are not properly propagated between processes due to
         _CachedStorage. Therefore, necessary information is kept in trial_system_attrs when the
         trial runs in a distributed situation.
         Please do not call this method when you are not using DDP.

--- a/optuna/integration/pytorch_lightning.py
+++ b/optuna/integration/pytorch_lightning.py
@@ -43,69 +43,16 @@ class PyTorchLightningPruningCallback(Callback):
             how this dictionary is formatted.
 
 
-    Example:
-
-        .. testcode::
-
-            import optuna
-            from optuna.integration import PyTorchLightningPruningCallback
-            import pytorch_lightning as pl
-
-
-            def objective(trial: optuna.trial.Trial) -> float:
-                callback = PyTorchLightningPruningCallback(trial, monitor="accuracy")
-                trainer = pl.Trainer(max_epochs=10, callbacks=[callback])
-
-                model = MyModel()
-                trainer.fit(model)
-
-                return trainer.callback_metrics["val_acc"].item()
-
-
-            pruner = optuna.pruners.MedianPruner()
-            study = optuna.create_study(direction="maximize", pruner=pruner)
-            study.optimize(objective, n_trials=100, timeout=600)
-
-    Note:
-        If you would like to use PyTorchLightningPruningCallback in a distributed training
-        environment, you need to evoke `PyTorchLightningPruningCallback.check_pruned()`
-        manually so that :class:`~optuna.exceptions.TrialPruned` is properly handled.
-
-        .. testcode::
-
-            import optuna
-            from optuna.integration import PyTorchLightningPruningCallback
-            import pytorch_lightning as pl
-
-
-            def objective(trial: optuna.trial.Trial) -> float:
-                callback = PyTorchLightningPruningCallback(trial, monitor="accuracy")
-                trainer = pl.Trainer(
-                    max_epochs=10,
-                    accelerator="auto",
-                    devices=2,
-                    enable_checkpointing=False,
-                    callbacks=[callback],
-                    strategy=DDPSpawnStrategy(find_unused_parameters=False),
-                )
-
-                model = MyModel()
-                trainer.fit(model)
-
-                callback.check_pruned()
-
-                return trainer.callback_metrics["val_acc"].item()
-
-
-            pruner = optuna.pruners.MedianPruner()
-            study = optuna.create_study(direction="maximize", pruner=pruner)
-            study.optimize(objective, n_trials=100, timeout=600)
-
-
     .. note::
         For the distributed data parallel training, the version of PyTorchLightning needs to be
         higher than or equal to v1.6.0. In addition, :class:`~optuna.study.Study` should be
         instantiated with RDB storage.
+
+
+    .. note::
+        If you would like to use PyTorchLightningPruningCallback in a distributed training
+        environment, you need to evoke `PyTorchLightningPruningCallback.check_pruned()`
+        manually so that :class:`~optuna.exceptions.TrialPruned` is properly handled.
     """
 
     def __init__(self, trial: optuna.trial.Trial, monitor: str) -> None:

--- a/optuna/integration/pytorch_lightning.py
+++ b/optuna/integration/pytorch_lightning.py
@@ -59,7 +59,9 @@ class PyTorchLightningPruningCallback(Callback):
     def on_fit_start(self, trainer: Trainer, pl_module: "pl.LightningModule") -> None:
         self.is_ddp_backend = trainer._accelerator_connector.is_distributed
         if self.is_ddp_backend:
-            if version.parse(pl.__version__) < version.parse("1.6.0"):  # type: ignore
+            if version.parse(pl.__version__) < version.parse(  # type: ignore[attr-defined]
+                "1.6.0"
+            ):
                 raise ValueError("PyTorch Lightning>=1.6.0 is required in DDP.")
             # If it were not for this block, fitting is started even if unsupported storage
             # is used. Note that the ValueError is transformed into ProcessRaisedException inside
@@ -74,6 +76,7 @@ class PyTorchLightningPruningCallback(Callback):
                 )
             # It is necessary to store intermediate values directly in the backend storage because
             # they are not properly propagated to main process due to cached storage.
+            # TODO(Shinichi) Remove intermediate_values from system_attr after PR #4431 is merged.
             self._trial.storage.set_trial_system_attr(
                 self._trial._trial_id,
                 _INTERMEDIATE_VALUE,

--- a/optuna/integration/pytorch_lightning.py
+++ b/optuna/integration/pytorch_lightning.py
@@ -202,8 +202,10 @@ class PyTorchLightningPruningCallback(Callback):
         storage cache. Therefore, necessary information is kept in trial_system_attrs when the
         trial runs in a distributed situation. Please call this method right after calling
         ``pytorch_lightning.Trainer.fit()``.
-        Please do not call this method when you are not using DDP.
+        If a callback doesn't have any backend storage for DDP, this method does nothing.
         """
+        if self.is_ddp_backend is False:
+            return
 
         _trial_id = self._trial._trial_id
         _study = self._trial.study

--- a/optuna/integration/pytorch_lightning.py
+++ b/optuna/integration/pytorch_lightning.py
@@ -56,13 +56,13 @@ class PyTorchLightningPruningCallback(Callback):
         self._trial = trial
         self.monitor = monitor
         self.is_ddp_backend = False
+        # It is necessary to store intermediate values directly in the backend storage because they
+        # are not properly propagated to main process due to cached storage.
         self._trial.storage.set_trial_system_attr(
             self._trial._trial_id,
             _INTERMEDIATE_VALUE,
             dict(),
         )
-        # It is necessary to store intermediate values directly in the backend storage because they
-        # are not properly propagated to main process due to cached storage.
 
     def on_fit_start(self, trainer: Trainer, pl_module: "pl.LightningModule") -> None:
         self.is_ddp_backend = trainer._accelerator_connector.is_distributed

--- a/optuna/integration/pytorch_lightning.py
+++ b/optuna/integration/pytorch_lightning.py
@@ -9,9 +9,8 @@ from optuna.storages._rdb.storage import RDBStorage
 
 # Define key names of `Trial.system_attrs`.
 _EPOCH_KEY = "ddp_pl:epoch"
-_PRUNED_KEY = "ddp_pl:pruned"
-_MESSAGE_KEY = "ddp_pl:message"
 _INTERMEDIATE_VALUE = "ddp_pl:intermediate_value"
+_PRUNED_KEY = "ddp_pl:pruned"
 
 with optuna._imports.try_import() as _imports:
     import pytorch_lightning as pl
@@ -56,13 +55,6 @@ class PyTorchLightningPruningCallback(Callback):
         self._trial = trial
         self.monitor = monitor
         self.is_ddp_backend = False
-        # It is necessary to store intermediate values directly in the backend storage because they
-        # are not properly propagated to main process due to cached storage.
-        self._trial.storage.set_trial_system_attr(
-            self._trial._trial_id,
-            _INTERMEDIATE_VALUE,
-            dict(),
-        )
 
     def on_fit_start(self, trainer: Trainer, pl_module: "pl.LightningModule") -> None:
         self.is_ddp_backend = trainer._accelerator_connector.is_distributed
@@ -80,6 +72,13 @@ class PyTorchLightningPruningCallback(Callback):
                     "optuna.integration.PyTorchLightningPruningCallback"
                     " supports only optuna.storages.RDBStorage in DDP."
                 )
+            # It is necessary to store intermediate values directly in the backend storage because
+            # they are not properly propagated to main process due to cached storage.
+            self._trial.storage.set_trial_system_attr(
+                self._trial._trial_id,
+                _INTERMEDIATE_VALUE,
+                dict(),
+            )
 
     def on_validation_end(self, trainer: Trainer, pl_module: LightningModule) -> None:
         # Trainer calls `on_validation_end` for sanity check. Therefore, it is necessary to avoid
@@ -91,59 +90,68 @@ class PyTorchLightningPruningCallback(Callback):
         current_score = trainer.callback_metrics.get(self.monitor)
         if current_score is None:
             message = (
-                "The metric '{}' is not in the evaluation logs for pruning. "
-                "Please make sure you set the correct metric name.".format(self.monitor)
+                f"The metric '{self.monitor}' is not in the evaluation logs for pruning. "
+                "Please make sure you set the correct metric name."
             )
             warnings.warn(message)
             return
 
         epoch = pl_module.current_epoch
         should_stop = False
+
+        # Determine if the trial should be terminated in a single process.
+        if not self.is_ddp_backend:
+            self._trial.report(current_score.item(), step=epoch)
+            should_stop = self._trial.should_prune()
+            if not should_stop:
+                return
+            message = f"Trial was pruned at epoch {epoch}."
+            raise optuna.TrialPruned(message)
+
+        # Determine if the trial should be terminated in a DDP.
         if trainer.is_global_zero:
             self._trial.report(current_score.item(), step=epoch)
             should_stop = self._trial.should_prune()
-            # Update intermediate value in storage
+
+            # Update intermediate value in the storage.
             _trial_id = self._trial._trial_id
             _study = self._trial.study
             _trial_system_attrs = _study._storage.get_trial_system_attrs(_trial_id)
             intermediate_values = _trial_system_attrs.get(_INTERMEDIATE_VALUE)
-            intermediate_values[epoch] = current_score.item()  # type: ignore
+            intermediate_values[epoch] = current_score.item()  # type: ignore[index]
             self._trial.storage.set_trial_system_attr(
                 self._trial._trial_id, _INTERMEDIATE_VALUE, intermediate_values
             )
 
-        # Terminate every process if any world process decides to stop
-        should_stop = trainer.strategy.reduce_boolean_decision(should_stop, all=False)
+        # Terminate every process if any world process decides to stop.
+        should_stop = trainer.strategy.broadcast(should_stop)
         trainer.should_stop = trainer.should_stop or should_stop
         if not should_stop:
             return
 
-        self.stopped_epoch = epoch
-        if not self.is_ddp_backend:
-            message = "Trial was pruned at epoch {}.".format(epoch)
-            raise optuna.TrialPruned(message)
-        elif trainer.is_global_zero:
-            # Update system_attr from global zero process
+        if trainer.is_global_zero:
+            # Update system_attr from global zero process.
             self._trial.storage.set_trial_system_attr(self._trial._trial_id, _PRUNED_KEY, True)
             self._trial.storage.set_trial_system_attr(self._trial._trial_id, _EPOCH_KEY, epoch)
-            self._trial.storage.set_trial_system_attr(
-                self._trial._trial_id,
-                _MESSAGE_KEY,
-                "Trial was pruned at epoch {}.".format(epoch),
-            )
 
     def check_pruned(self) -> None:
-        """Raise :class:`optuna.TrialPruned` manually if pruned."""
+        """Raise :class:`optuna.TrialPruned` manually if pruned.
+
+        Currently, intermediate_values are not properly propagated between processes due to
+        _CachedStorage. Therefore, necessary information is kept in trial_system_attrs when the
+        trial runs in a distributed situation.
+        Please do not call this method when you are not using DDP.
+        """
 
         _trial_id = self._trial._trial_id
         _study = self._trial.study
-        _trial_system_attrs = _study._storage._backend.get_trial_system_attrs(  # type: ignore[attr-defined] # NOQA: E501
-            _trial_id
-        )
+        assert isinstance(_study._storage, _CachedStorage)
+        _trial_system_attrs = _study._storage._backend.get_trial_system_attrs(_trial_id)
         is_pruned = _trial_system_attrs.get(_PRUNED_KEY)
         intermediate_values = _trial_system_attrs.get(_INTERMEDIATE_VALUE)
-        for epoch, score in intermediate_values.items():
+
+        for epoch, score in intermediate_values.items():  # type: ignore[union-attr]
             self._trial.report(score, step=int(epoch))
         if is_pruned:
-            message = _trial_system_attrs.get(_MESSAGE_KEY)
-            raise optuna.TrialPruned(message)
+            epoch = _trial_system_attrs.get(_EPOCH_KEY)
+            raise optuna.TrialPruned(f"Trial was pruned at epoch {epoch}.")

--- a/optuna/integration/pytorch_lightning.py
+++ b/optuna/integration/pytorch_lightning.py
@@ -61,6 +61,7 @@ class PyTorchLightningPruningCallback(Callback):
 
                 return trainer.callback_metrics["val_acc"].item()
 
+
             pruner = optuna.pruners.MedianPruner()
             study = optuna.create_study(direction="maximize", pruner=pruner)
             study.optimize(objective, n_trials=100, timeout=600)
@@ -75,6 +76,7 @@ class PyTorchLightningPruningCallback(Callback):
             import optuna
             from optuna.integration import PyTorchLightningPruningCallback
             import pytorch_lightning as pl
+
 
             def objective(trial: optuna.trial.Trial) -> float:
                 callback = PyTorchLightningPruningCallback(trial, monitor="accuracy")
@@ -93,6 +95,7 @@ class PyTorchLightningPruningCallback(Callback):
                 callback.check_pruned()
 
                 return trainer.callback_metrics["val_acc"].item()
+
 
             pruner = optuna.pruners.MedianPruner()
             study = optuna.create_study(direction="maximize", pruner=pruner)

--- a/optuna/integration/pytorch_lightning.py
+++ b/optuna/integration/pytorch_lightning.py
@@ -205,12 +205,12 @@ class PyTorchLightningPruningCallback(Callback):
         ``pytorch_lightning.Trainer.fit()``.
         If a callback doesn't have any backend storage for DDP, this method does nothing.
         """
-        if self.is_ddp_backend is False:
-            return
 
         _trial_id = self._trial._trial_id
         _study = self._trial.study
-        assert isinstance(_study._storage, _CachedStorage)
+        if not isinstance(_study._storage, _CachedStorage):
+            return
+
         _trial_system_attrs = _study._storage._backend.get_trial_system_attrs(_trial_id)
         is_pruned = _trial_system_attrs.get(_PRUNED_KEY)
         intermediate_values = _trial_system_attrs.get(_INTERMEDIATE_VALUE)

--- a/optuna/integration/pytorch_lightning.py
+++ b/optuna/integration/pytorch_lightning.py
@@ -137,11 +137,12 @@ class PyTorchLightningPruningCallback(Callback):
             # It is necessary to store intermediate values directly in the backend storage because
             # they are not properly propagated to main process due to cached storage.
             # TODO(Shinichi) Remove intermediate_values from system_attr after PR #4431 is merged.
-            self._trial.storage.set_trial_system_attr(
-                self._trial._trial_id,
-                _INTERMEDIATE_VALUE,
-                dict(),
-            )
+            if trainer.is_global_zero:
+                self._trial.storage.set_trial_system_attr(
+                    self._trial._trial_id,
+                    _INTERMEDIATE_VALUE,
+                    dict(),
+                )
 
     def on_validation_end(self, trainer: Trainer, pl_module: LightningModule) -> None:
         # Trainer calls `on_validation_end` for sanity check. Therefore, it is necessary to avoid

--- a/optuna/integration/pytorch_lightning.py
+++ b/optuna/integration/pytorch_lightning.py
@@ -136,7 +136,7 @@ class PyTorchLightningPruningCallback(Callback):
         """Raise :class:`optuna.TrialPruned` manually if pruned.
 
         Currently, ``intermediate_values`` are not properly propagated between processes due to
-       storage cache. Therefore, necessary information is kept in trial_system_attrs when the
+        storage cache. Therefore, necessary information is kept in trial_system_attrs when the
         trial runs in a distributed situation.
         Please do not call this method when you are not using DDP.
         """

--- a/optuna/integration/pytorch_lightning.py
+++ b/optuna/integration/pytorch_lightning.py
@@ -148,7 +148,8 @@ class PyTorchLightningPruningCallback(Callback):
         is_pruned = _trial_system_attrs.get(_PRUNED_KEY)
         intermediate_values = _trial_system_attrs.get(_INTERMEDIATE_VALUE)
 
-        for epoch, score in intermediate_values.items():  # type: ignore[union-attr]
+        assert intermediate_values is not None
+        for epoch, score in intermediate_values.items():
             self._trial.report(score, step=int(epoch))
         if is_pruned:
             epoch = _trial_system_attrs.get(_EPOCH_KEY)

--- a/optuna/integration/pytorch_lightning.py
+++ b/optuna/integration/pytorch_lightning.py
@@ -136,7 +136,7 @@ class PyTorchLightningPruningCallback(Callback):
         """Raise :class:`optuna.TrialPruned` manually if pruned.
 
         Currently, ``intermediate_values`` are not properly propagated between processes due to
-        _CachedStorage. Therefore, necessary information is kept in trial_system_attrs when the
+       storage cache. Therefore, necessary information is kept in trial_system_attrs when the
         trial runs in a distributed situation.
         Please do not call this method when you are not using DDP.
         """

--- a/optuna/integration/pytorch_lightning.py
+++ b/optuna/integration/pytorch_lightning.py
@@ -102,11 +102,9 @@ class PyTorchLightningPruningCallback(Callback):
         # Determine if the trial should be terminated in a single process.
         if not self.is_ddp_backend:
             self._trial.report(current_score.item(), step=epoch)
-            should_stop = self._trial.should_prune()
-            if not should_stop:
+            if not self._trial.should_prune():
                 return
-            message = f"Trial was pruned at epoch {epoch}."
-            raise optuna.TrialPruned(message)
+            raise optuna.TrialPruned(f"Trial was pruned at epoch {epoch}.")
 
         # Determine if the trial should be terminated in a DDP.
         if trainer.is_global_zero:

--- a/tests/integration_tests/test_pytorch_lightning.py
+++ b/tests/integration_tests/test_pytorch_lightning.py
@@ -211,7 +211,7 @@ def test_pytorch_lightning_pruning_callback_ddp_unsupported_storage() -> None:
         model = ModelDDP()
         trainer.fit(model)
 
-        # evoke pruning manually.
+        # Evoke pruning manually.
         callback.check_pruned()
 
         return 1.0

--- a/tests/integration_tests/test_pytorch_lightning.py
+++ b/tests/integration_tests/test_pytorch_lightning.py
@@ -158,7 +158,6 @@ def test_pytorch_lightning_pruning_callback_ddp_monitor(
     storage_mode: str,
 ) -> None:
     def objective(trial: optuna.trial.Trial) -> float:
-
         callback = PyTorchLightningPruningCallback(trial, monitor="accuracy")
         trainer = pl.Trainer(
             max_epochs=2,

--- a/tests/integration_tests/test_pytorch_lightning.py
+++ b/tests/integration_tests/test_pytorch_lightning.py
@@ -171,7 +171,9 @@ def test_pytorch_lightning_pruning_callback_ddp_monitor(
         model = ModelDDP()
         trainer.fit(model)
 
-        # evoke pruning manually.
+        # Evoke pruning manually.
+``````suggestion
+        # Evoke pruning manually.
         callback.check_pruned()
 
         return 1.0

--- a/tests/integration_tests/test_pytorch_lightning.py
+++ b/tests/integration_tests/test_pytorch_lightning.py
@@ -2,6 +2,8 @@ from typing import Any
 from typing import cast
 from typing import Dict
 from typing import List
+from typing import Mapping
+from typing import Sequence
 from typing import Union
 
 import numpy as np
@@ -37,7 +39,7 @@ class Model(LightningModule):
         return self._model(data)
 
     def training_step(
-        self, batch: List["torch.Tensor"], batch_nb: int
+        self, batch: Sequence["torch.Tensor"], batch_nb: int
     ) -> Dict[str, "torch.Tensor"]:
         data, target = batch
         output = self.forward(data)
@@ -45,7 +47,7 @@ class Model(LightningModule):
         return {"loss": loss}
 
     def validation_step(
-        self, batch: List["torch.Tensor"], batch_nb: int
+        self, batch: Sequence["torch.Tensor"], batch_nb: int
     ) -> Dict[str, "torch.Tensor"]:
         data, target = batch
         output = self.forward(data)
@@ -56,8 +58,8 @@ class Model(LightningModule):
     def validation_epoch_end(
         self,
         outputs: Union[
-            List[Union["torch.Tensor", Dict[str, Any]]],
-            List[List[Union["torch.Tensor", Dict[str, Any]]]],
+            Sequence[Union["torch.Tensor", Mapping[str, Any]]],
+            Sequence[Sequence[Union["torch.Tensor", Mapping[str, Any]]]],
         ],
     ) -> None:
         if not len(outputs):
@@ -89,7 +91,7 @@ class ModelDDP(Model):
         super().__init__()
 
     def validation_step(
-        self, batch: List["torch.Tensor"], batch_nb: int
+        self, batch: Sequence["torch.Tensor"], batch_nb: int
     ) -> Dict[str, "torch.Tensor"]:
         data, target = batch
         output = self.forward(data)
@@ -106,8 +108,8 @@ class ModelDDP(Model):
     def validation_epoch_end(
         self,
         output: Union[
-            List[Union["torch.Tensor", Dict[str, Any]]],
-            List[List[Union["torch.Tensor", Dict[str, Any]]]],
+            Sequence[Union["torch.Tensor", Mapping[str, Any]]],
+            Sequence[Sequence[Union["torch.Tensor", Mapping[str, Any]]]],
         ],
     ) -> None:
         return
@@ -171,8 +173,6 @@ def test_pytorch_lightning_pruning_callback_ddp_monitor(
         model = ModelDDP()
         trainer.fit(model)
 
-        # Evoke pruning manually.
-``````suggestion
         # Evoke pruning manually.
         callback.check_pruned()
 


### PR DESCRIPTION
## Motivation
Follow up #4322. 
Temporary, DDP is not supported in `PyTorchLightningPruningCallback` because of the problem described in #4322.
This PR make `PyTorchLightningPruningCallback` support DDP again.

## Description of the changes
This PR
- **Require users to call `callback.check_pruned()` in objective functions when they use DDP**
- Activates `test_pytorch_lightning_pruning_callback_ddp_monitor` and `test_pytorch_lightning_pruning_callback_ddp_unsupported_storage`
- Store intermediate values, pruning state and message directly in the storage