### PR TITLE
Mitigate a blocking issue while running migrations with SQLAlchemy 2.0

### DIFF
--- a/optuna/storages/_rdb/storage.py
+++ b/optuna/storages/_rdb/storage.py
@@ -1094,8 +1094,9 @@ class _VersionManager:
         raise RuntimeError(message)
 
     def get_current_version(self) -> str:
-        context = alembic_migration.MigrationContext.configure(self.engine.connect())
-        version = context.get_current_revision()
+        with self.engine.connect() as connection:
+            context = alembic_migration.MigrationContext.configure(connection)
+            version = context.get_current_revision()
         assert version is not None
 
         return version

--- a/optuna/storages/_rdb/storage.py
+++ b/optuna/storages/_rdb/storage.py
@@ -1039,27 +1039,28 @@ class _VersionManager:
     def _init_alembic(self) -> None:
         logging.getLogger("alembic").setLevel(logging.WARN)
 
-        context = alembic_migration.MigrationContext.configure(self.engine.connect())
-        is_initialized = context.get_current_revision() is not None
+        with self.engine.connect() as connection:
+            context = alembic_migration.MigrationContext.configure(connection)
+            is_initialized = context.get_current_revision() is not None
 
-        if is_initialized:
-            # The `alembic_version` table already exists and is not empty.
-            return
+            if is_initialized:
+                # The `alembic_version` table already exists and is not empty.
+                return
 
-        if self._is_alembic_supported():
-            revision = self.get_head_version()
-        else:
-            # The storage has been created before alembic is introduced.
-            revision = self._get_base_version()
+            if self._is_alembic_supported():
+                revision = self.get_head_version()
+            else:
+                # The storage has been created before alembic is introduced.
+                revision = self._get_base_version()
 
         self._set_alembic_revision(revision)
 
     def _set_alembic_revision(self, revision: str) -> None:
-        connection = self.engine.connect()
-        context = alembic_migration.MigrationContext.configure(connection)
-        with connection.begin():
-            script = self._create_alembic_script()
-            context.stamp(script, revision)
+        with self.engine.connect() as connection:
+            context = alembic_migration.MigrationContext.configure(connection)
+            with connection.begin():
+                script = self._create_alembic_script()
+                context.stamp(script, revision)
 
     def check_table_schema_compatibility(self) -> None:
         with _create_scoped_session(self.scoped_session) as session:


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
Refs #4371 

## Summary

The cause is a "Waiting for metadata lock" in MySQL when creating the *alembic_version` table and inserting the revision, so MySQL driver keeps waiting to read the query result from the socket.

```
mysql> show full processlist;
+----+--------+------------------+--------+---------+------+---------------------------------+--------------------------------------------------------------------------------------------------------------------------------+
| Id | User   | Host             | db     | Command | Time | State                           | Info                                                                                                                           |
+----+--------+------------------+--------+---------+------+---------------------------------+--------------------------------------------------------------------------------------------------------------------------------+
|  8 | optuna | 172.17.0.1:35254 | optuna | Query   |    0 | init                            | show full processlist                                                                                                          |
|  9 | optuna | 172.17.0.1:50758 | optuna | Sleep   |   64 |                                 | NULL                                                                                                                           |
| 10 | optuna | 172.17.0.1:50760 | optuna | Query   |   64 | Waiting for table metadata lock | CREATE TABLE alembic_version (
	version_num VARCHAR(32) NOT NULL,
	CONSTRAINT alembic_version_pkc PRIMARY KEY (version_num)
) |
+----+--------+------------------+--------+---------+------+---------------------------------+--------------------------------------------------------------------------------------------------------------------------------+
3 rows in set (0.00 sec)
```

By applying this patch, the frequency of the problem was mitigated to 2 out of 11 attempts. There still seems to be another problem, but that is currently being investigated and will be addressed in a following PR.

https://github.com/optuna/optuna/actions/runs/4071530931/jobs/7013678631

## Compare SQL queries

### SQLAlchemy v1.4.46 (master)

```
INFO:sqlalchemy.engine.Engine:SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = %(table_schema)s AND table_name = %(table_name)s
INFO:sqlalchemy.engine.Engine:[cached since 43.12s ago] {'table_schema': 'optuna', 'table_name': 'alembic_version'}
INFO:sqlalchemy.engine.Engine:SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = %(table_schema)s AND table_name = %(table_name)s
INFO:sqlalchemy.engine.Engine:[cached since 43.13s ago] {'table_schema': 'optuna', 'table_name': 'alembic_version'}
INFO:sqlalchemy.engine.Engine:
CREATE TABLE alembic_version (
	version_num VARCHAR(32) NOT NULL,
	CONSTRAINT alembic_version_pkc PRIMARY KEY (version_num)
)

INFO:sqlalchemy.engine.Engine:[no key 0.00037s] {}
INFO:sqlalchemy.engine.Engine:INSERT INTO alembic_version (version_num) VALUES ('v3.0.0.d')
INFO:sqlalchemy.engine.Engine:[generated in 0.00020s] {}
INFO:sqlalchemy.engine.Engine:COMMIT
--Return--
> /Users/c-bata/go/src/github.com/optuna/optuna/optuna/storages/_rdb/storage.py(1063)_set_alembic_revision()->None
-> context.stamp(script, revision)
```

### SQLAlchemy v2.0.1 (master)

```
INFO:sqlalchemy.engine.Engine:DESCRIBE `optuna`.`alembic_version`
INFO:sqlalchemy.engine.Engine:[raw sql] {}
INFO:sqlalchemy.engine.Engine:DESCRIBE `optuna`.`alembic_version`
INFO:sqlalchemy.engine.Engine:[raw sql] {}
INFO:sqlalchemy.engine.Engine:
CREATE TABLE alembic_version (
	version_num VARCHAR(32) NOT NULL,
	CONSTRAINT alembic_version_pkc PRIMARY KEY (version_num)
)

INFO:sqlalchemy.engine.Engine:[no key 0.00033s] {}
```

### SQLAlchemy v2.0.1 (this PR)

```
INFO:sqlalchemy.engine.Engine:DESCRIBE `optuna`.`alembic_version`
INFO:sqlalchemy.engine.Engine:[raw sql] {}
INFO:sqlalchemy.engine.Engine:DESCRIBE `optuna`.`alembic_version`
INFO:sqlalchemy.engine.Engine:[raw sql] {}
INFO:sqlalchemy.engine.Engine:
CREATE TABLE alembic_version (
	version_num VARCHAR(32) NOT NULL,
	CONSTRAINT alembic_version_pkc PRIMARY KEY (version_num)
)


INFO:sqlalchemy.engine.Engine:[no key 0.00039s] {}
INFO:sqlalchemy.engine.Engine:INSERT INTO alembic_version (version_num) VALUES ('v3.0.0.d')
INFO:sqlalchemy.engine.Engine:[generated in 0.00023s] {}
INFO:sqlalchemy.engine.Engine:COMMIT
--Return--
> /Users/c-bata/go/src/github.com/optuna/optuna/optuna/storages/_rdb/storage.py(1064)_set_alembic_revision()->None
-> context.stamp(script, revision)
```