### PR TITLE
Import `cmaes` package lazily

### DIFF
--- a/optuna/samplers/_cmaes.py
+++ b/optuna/samplers/_cmaes.py
@@ -10,17 +10,15 @@ from typing import NamedTuple
 from typing import Optional
 from typing import Sequence
 from typing import Tuple
+from typing import TYPE_CHECKING
 from typing import Union
 import warnings
 
-from cmaes import CMA
-from cmaes import CMAwM
-from cmaes import get_warm_start_mgd
-from cmaes import SepCMA
 import numpy as np
 
 import optuna
 from optuna import logging
+from optuna._imports import _LazyImport
 from optuna._transform import _SearchSpaceTransform
 from optuna.distributions import BaseDistribution
 from optuna.distributions import FloatDistribution
@@ -32,14 +30,18 @@ from optuna.trial import FrozenTrial
 from optuna.trial import TrialState
 
 
+if TYPE_CHECKING:
+    import cmaes
+
+    CmaClass = Union[cmaes.CMA, cmaes.SepCMA, cmaes.CMAwM]
+else:
+    cmaes = _LazyImport("cmaes")
+
 _logger = logging.get_logger(__name__)
 
 _EPS = 1e-10
 # The value of system_attrs must be less than 2046 characters on RDBStorage.
 _SYSTEM_ATTR_MAX_LENGTH = 2045
-
-
-CmaClass = Union[CMA, SepCMA, CMAwM]
 
 
 class _CmaEsAttrKeys(NamedTuple):
@@ -388,7 +390,7 @@ class CmaEsSampler(BaseSampler):
             solutions: List[Tuple[np.ndarray, float]] = []
             for t in solution_trials[: optimizer.population_size]:
                 assert t.value is not None, "completed trials must have a value"
-                if isinstance(optimizer, CMAwM):
+                if isinstance(optimizer, cmaes.CMAwM):
                     x = t.system_attrs["x_for_tell"]
                 else:
                     x = trans.transform(t.params)
@@ -413,7 +415,7 @@ class CmaEsSampler(BaseSampler):
         # Caution: optimizer should update its seed value.
         seed = self._cma_rng.randint(1, 2**16) + trial.number
         optimizer._rng.seed(seed)
-        if isinstance(optimizer, CMAwM):
+        if isinstance(optimizer, cmaes.CMAwM):
             params, x_for_tell = optimizer.ask()
             study._storage.set_trial_system_attr(trial._trial_id, "x_for_tell", x_for_tell)
         else:
@@ -470,7 +472,7 @@ class CmaEsSampler(BaseSampler):
     def _restore_optimizer(
         self,
         completed_trials: "List[optuna.trial.FrozenTrial]",
-    ) -> Tuple[Optional[CmaClass], int]:
+    ) -> Tuple[Optional["CmaClass"], int]:
         # Restore a previous CMA object.
         for trial in reversed(completed_trials):
             optimizer_attrs = {
@@ -492,7 +494,7 @@ class CmaEsSampler(BaseSampler):
         direction: StudyDirection,
         population_size: Optional[int] = None,
         randomize_start_point: bool = False,
-    ) -> CmaClass:
+    ) -> "CmaClass":
         lower_bounds = trans.bounds[:, 0]
         upper_bounds = trans.bounds[:, 1]
         n_dimension = len(trans.bounds)
@@ -531,13 +533,13 @@ class CmaEsSampler(BaseSampler):
                 raise ValueError("No compatible source_trials")
 
             # TODO(c-bata): Add options to change prior parameters (alpha and gamma).
-            mean, sigma0, cov = get_warm_start_mgd(source_solutions)
+            mean, sigma0, cov = cmaes.get_warm_start_mgd(source_solutions)
 
         # Avoid ZeroDivisionError in cmaes.
         sigma0 = max(sigma0, _EPS)
 
         if self._use_separable_cma:
-            return SepCMA(
+            return cmaes.SepCMA(
                 mean=mean,
                 sigma=sigma0,
                 bounds=trans.bounds,
@@ -553,7 +555,7 @@ class CmaEsSampler(BaseSampler):
                 # Set step 0.0 for continuous search space.
                 steps[i] = dist.step or 0.0
 
-            return CMAwM(
+            return cmaes.CMAwM(
                 mean=mean,
                 sigma=sigma0,
                 bounds=trans.bounds,
@@ -564,7 +566,7 @@ class CmaEsSampler(BaseSampler):
                 population_size=population_size,
             )
 
-        return CMA(
+        return cmaes.CMA(
             mean=mean,
             sigma=sigma0,
             cov=cov,

--- a/tests/samplers_tests/test_cmaes.py
+++ b/tests/samplers_tests/test_cmaes.py
@@ -33,7 +33,7 @@ def test_with_margin_experimental_warning() -> None:
 @pytest.mark.filterwarnings("ignore::optuna.exceptions.ExperimentalWarning")
 @pytest.mark.parametrize(
     "use_separable_cma, cma_class_str",
-    [(False, "optuna.samplers._cmaes.CMA"), (True, "optuna.samplers._cmaes.SepCMA")],
+    [(False, "optuna.samplers._cmaes.cmaes.CMA"), (True, "optuna.samplers._cmaes.cmaes.SepCMA")],
 )
 @pytest.mark.parametrize("popsize", [None, 8])
 def test_init_cmaes_opts(
@@ -82,7 +82,7 @@ def test_init_cmaes_opts_with_margin(popsize: Optional[int]) -> None:
     )
     study = optuna.create_study(sampler=sampler)
 
-    with patch("optuna.samplers._cmaes.CMAwM") as cma_class:
+    with patch("optuna.samplers._cmaes.cmaes.CMAwM") as cma_class:
         cma_obj = MagicMock()
         cma_obj.ask.return_value = np.array((-1, -1))
         cma_obj.generation = 0
@@ -115,7 +115,7 @@ def test_warm_starting_cmaes(with_margin: bool) -> None:
     source_study.optimize(objective, 20)
     source_trials = source_study.get_trials(deepcopy=False)
 
-    with patch("optuna.samplers._cmaes.get_warm_start_mgd") as mock_func_ws:
+    with patch("optuna.samplers._cmaes.cmaes.get_warm_start_mgd") as mock_func_ws:
         mock_func_ws.return_value = (np.zeros(2), 0.0, np.zeros((2, 2)))
         sampler = optuna.samplers.CmaEsSampler(
             seed=1, n_startup_trials=1, with_margin=with_margin, source_trials=source_trials
@@ -138,7 +138,7 @@ def test_warm_starting_cmaes_maximize(with_margin: bool) -> None:
     source_study.optimize(objective, 20)
     source_trials = source_study.get_trials(deepcopy=False)
 
-    with patch("optuna.samplers._cmaes.get_warm_start_mgd") as mock_func_ws:
+    with patch("optuna.samplers._cmaes.cmaes.get_warm_start_mgd") as mock_func_ws:
         mock_func_ws.return_value = (np.zeros(2), 0.0, np.zeros((2, 2)))
         sampler = optuna.samplers.CmaEsSampler(
             seed=1, n_startup_trials=1, with_margin=with_margin, source_trials=source_trials
@@ -356,7 +356,7 @@ def test_population_size_is_multiplied_when_enable_ipop(popsize: Optional[int]) 
         _ = trial.suggest_float("y", -1, 1)
         return 1.0
 
-    with patch("optuna.samplers._cmaes.CMA") as cma_class_mock, patch(
+    with patch("optuna.samplers._cmaes.cmaes.CMA") as cma_class_mock, patch(
         "optuna.samplers._cmaes.pickle"
     ) as pickle_mock:
         pickle_mock.dump.return_value = b"serialized object"
@@ -616,7 +616,7 @@ def test_internal_optimizer_with_margin() -> None:
 
     objectives = [objective_discrete, objective_mixed, objective_continuous]
     for objective in objectives:
-        with patch("optuna.samplers._cmaes.CMAwM") as cmawm_class_mock:
+        with patch("optuna.samplers._cmaes.cmaes.CMAwM") as cmawm_class_mock:
             sampler = optuna.samplers.CmaEsSampler(with_margin=True)
             study = optuna.create_study(sampler=sampler)
             study.optimize(objective, n_trials=2)


### PR DESCRIPTION
## Motivation
Takeover of #4393.
> From cmaes v0.9.0, cmaes imports SciPy if available. It increases the Optuna's import time.
https://github.com/CyberAgentAILab/cmaes/releases/tag/v0.9.0

## Description of the changes
Lazily import cmaes in `_cmaes.py`