### PR TITLE
Use `ubuntu-latest` in PyPI publish CI

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build-n-publish:
     name: Build and publish Python distributions to PyPI or TestPyPI
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     # Not intended for forks.
     if: github.repository == 'optuna/optuna'


### PR DESCRIPTION
## Motivation
The PyPI publish CI has used ubuntu-18.04, which is deprecated.

## Description of the changes
- Use `ubuntu-latest` in PyPI publish CI