### PR TITLE
Make `BruteForceSampler` stateless

### DIFF
--- a/optuna/samplers/_brute_force.py
+++ b/optuna/samplers/_brute_force.py
@@ -1,6 +1,5 @@
 from dataclasses import dataclass
 import decimal
-import random
 from typing import Any
 from typing import Dict
 from typing import Iterable
@@ -8,7 +7,6 @@ from typing import List
 from typing import Optional
 from typing import Sequence
 from typing import Tuple
-from typing import NamedTuple
 
 import numpy as np
 
@@ -90,6 +88,7 @@ class _TreeNode:
         weights /= weights.sum()
         return rng.choice(list(self.children.keys()), p=weights)
 
+
 @experimental_class("3.1.0")
 class BruteForceSampler(BaseSampler):
     """Sampler using brute force.
@@ -167,7 +166,7 @@ class BruteForceSampler(BaseSampler):
             )
             if leaf is not None:
                 leaves.append(leaf)
-        # We add all leaf nodes at the end because running trials may not have complete search space.
+        # Add all leaf nodes at the end because running trials may not have complete search space.
         for leaf in leaves:
             leaf.set_leaf()
         return tree
@@ -236,6 +235,6 @@ def _enumerate_candidates(param_distribution: BaseDistribution) -> Sequence[Any]
             range(param_distribution.low, param_distribution.high + 1, param_distribution.step)
         )
     elif isinstance(param_distribution, CategoricalDistribution):
-        return list(range(len(param_distribution.choices))) # Internal representations.
+        return list(range(len(param_distribution.choices)))  # Internal representations.
     else:
         raise ValueError(f"Unknown distribution {param_distribution}.")

--- a/optuna/samplers/_brute_force.py
+++ b/optuna/samplers/_brute_force.py
@@ -78,6 +78,7 @@ class _TreeNode:
         )
 
     def sample_child(self, rng: np.random.RandomState) -> Any:
+        assert self.children is not None
         # Sample an unexpanded node in the subtree uniformly, and return the first
         # parameter value in the path to the node.
         # Equivalently, we sample the child node with weights proportional to the number

--- a/optuna/samplers/_brute_force.py
+++ b/optuna/samplers/_brute_force.py
@@ -119,7 +119,7 @@ class BruteForceSampler(BaseSampler):
 
     Note:
         The sampler may fail to try the entire search space in when the suggestion ranges or
-        parameters are changed in the same :class:`~optuna.study.Study`
+        parameters are changed in the same :class:`~optuna.study.Study`.
 
     Args:
         seed:
@@ -181,7 +181,6 @@ class BruteForceSampler(BaseSampler):
         param_name: str,
         param_distribution: BaseDistribution,
     ) -> Any:
-        print("hoge")
         trials = study.get_trials(
             deepcopy=False,
             states=(
@@ -192,7 +191,6 @@ class BruteForceSampler(BaseSampler):
         tree = self._build_tree((t for t in trials if t.number != trial.number), trial.params)
         candidates = _enumerate_candidates(param_distribution)
         tree.expand(param_name, candidates)
-        print(tree)
         if tree.count_unexpanded() == 0:
             return param_distribution.to_external_repr(self._rng.choice(candidates))
         else:

--- a/tests/samplers_tests/test_brute_force.py
+++ b/tests/samplers_tests/test_brute_force.py
@@ -1,11 +1,11 @@
+import numpy as np
 import pytest
 
 import optuna
 from optuna import samplers
 from optuna.samplers._brute_force import _TreeNode
-from optuna.samplers._brute_force import BruteForceSampler
 from optuna.trial import Trial
-import numpy as np
+
 
 def test_tree_node_add_paths() -> None:
     tree = _TreeNode()
@@ -138,7 +138,7 @@ def test_study_optimize_with_infinite_search_space() -> None:
 
 def test_study_optimize_with_nan() -> None:
     def objective(trial: Trial) -> float:
-        a = trial.suggest_categorical("a", [0.0, float("nan")])
+        trial.suggest_categorical("a", [0.0, float("nan")])
         return 1.0
 
     study = optuna.create_study(sampler=samplers.BruteForceSampler())

--- a/tests/samplers_tests/test_brute_force.py
+++ b/tests/samplers_tests/test_brute_force.py
@@ -152,7 +152,6 @@ def test_study_optimize_with_nan() -> None:
 
 def test_study_optimize_with_single_search_space_user_added() -> None:
     def objective(trial: Trial) -> float:
-
         a = trial.suggest_int("a", 0, 2)
 
         if a == 0:

--- a/tests/samplers_tests/test_brute_force.py
+++ b/tests/samplers_tests/test_brute_force.py
@@ -17,6 +17,7 @@ def test_tree_node_add_paths() -> None:
         tree.add_path([("a", [0, 1, 2], 1), ("b", [0.0, 1.0], 0.0)]),
     ]
     for leaf in leafs:
+        assert leaf is not None
         leaf.set_leaf()
 
     assert tree == _TreeNode(
@@ -59,7 +60,7 @@ def test_tree_node_add_paths_error() -> None:
         tree.add_path([("b", [0, 1, 2], 0)])
 
 
-def test_tree_node_count_unexpanded():
+def test_tree_node_count_unexpanded() -> None:
     tree = _TreeNode(
         param_name="a",
         children={

--- a/tests/samplers_tests/test_brute_force.py
+++ b/tests/samplers_tests/test_brute_force.py
@@ -2,7 +2,91 @@ import pytest
 
 import optuna
 from optuna import samplers
+from optuna.samplers._brute_force import _TreeNode
+from optuna.samplers._brute_force import BruteForceSampler
 from optuna.trial import Trial
+import numpy as np
+
+def test_tree_node_add_paths() -> None:
+    tree = _TreeNode()
+    leafs = [
+        tree.add_path([("a", [0, 1, 2], 0), ("b", [0.0, 1.0], 0.0)]),
+        tree.add_path([("a", [0, 1, 2], 0), ("b", [0.0, 1.0], 1.0)]),
+        tree.add_path([("a", [0, 1, 2], 0), ("b", [0.0, 1.0], 1.0)]),
+        tree.add_path([("a", [0, 1, 2], 1), ("b", [0.0, 1.0], 0.0), ("c", [0, 1], 0)]),
+        tree.add_path([("a", [0, 1, 2], 1), ("b", [0.0, 1.0], 0.0)]),
+    ]
+    for leaf in leafs:
+        leaf.set_leaf()
+
+    assert tree == _TreeNode(
+        param_name="a",
+        children={
+            0: _TreeNode(
+                param_name="b",
+                children={
+                    0.0: _TreeNode(param_name=None, children={}),
+                    1.0: _TreeNode(param_name=None, children={}),
+                },
+            ),
+            1: _TreeNode(
+                param_name="b",
+                children={
+                    0.0: _TreeNode(
+                        param_name="c",
+                        children={
+                            0: _TreeNode(param_name=None, children={}),
+                            1: _TreeNode(),
+                        },
+                    ),
+                    1.0: _TreeNode(),
+                },
+            ),
+            2: _TreeNode(),
+        },
+    )
+
+
+def test_tree_node_add_paths_error() -> None:
+    with pytest.raises(ValueError):
+        tree = _TreeNode()
+        tree.add_path([("a", [0, 1, 2], 0)])
+        tree.add_path([("a", [0, 1], 0)])
+
+    with pytest.raises(ValueError):
+        tree = _TreeNode()
+        tree.add_path([("a", [0, 1, 2], 0)])
+        tree.add_path([("b", [0, 1, 2], 0)])
+
+
+def test_tree_node_count_unexpanded():
+    tree = _TreeNode(
+        param_name="a",
+        children={
+            0: _TreeNode(
+                param_name="b",
+                children={
+                    0.0: _TreeNode(param_name=None, children={}),
+                    1.0: _TreeNode(param_name=None, children={}),
+                },
+            ),
+            1: _TreeNode(
+                param_name="b",
+                children={
+                    0.0: _TreeNode(
+                        param_name="c",
+                        children={
+                            0: _TreeNode(param_name=None, children={}),
+                            1: _TreeNode(),
+                        },
+                    ),
+                    1.0: _TreeNode(),
+                },
+            ),
+            2: _TreeNode(),
+        },
+    )
+    assert tree.count_unexpanded() == 3
 
 
 def test_study_optimize_with_single_search_space() -> None:
@@ -50,3 +134,67 @@ def test_study_optimize_with_infinite_search_space() -> None:
 
     with pytest.raises(ValueError):
         study.optimize(objective)
+
+
+def test_study_optimize_with_nan() -> None:
+    def objective(trial: Trial) -> float:
+        a = trial.suggest_categorical("a", [0.0, float("nan")])
+        return 1.0
+
+    study = optuna.create_study(sampler=samplers.BruteForceSampler())
+    study.optimize(objective)
+
+    all_suggested_values = [t.params["a"] for t in study.trials]
+    assert len(all_suggested_values) == 2
+    assert 0.0 in all_suggested_values
+    assert np.isnan(all_suggested_values[0]) or np.isnan(all_suggested_values[1])
+
+
+def test_study_optimize_with_single_search_space_user_added() -> None:
+    def objective(trial: Trial) -> float:
+
+        a = trial.suggest_int("a", 0, 2)
+
+        if a == 0:
+            b = trial.suggest_float("b", -1.0, 1.0, step=0.5)
+            return a + b
+        elif a == 1:
+            c = trial.suggest_categorical("c", ["x", "y", None])
+            if c == "x":
+                return a + 1
+            else:
+                return a - 1
+        else:
+            return a * 2
+
+    study = optuna.create_study(sampler=samplers.BruteForceSampler())
+
+    # Manually add a trial. This should not be tried again.
+    study.add_trial(
+        optuna.create_trial(
+            params={"a": 0, "b": -1.0},
+            value=0.0,
+            distributions={
+                "a": optuna.distributions.IntDistribution(0, 2),
+                "b": optuna.distributions.FloatDistribution(-1.0, 1.0, step=0.5),
+            },
+        )
+    )
+
+    study.optimize(objective)
+
+    expected_suggested_values = [
+        {"a": 0, "b": -1.0},
+        {"a": 0, "b": -0.5},
+        {"a": 0, "b": 0.0},
+        {"a": 0, "b": 0.5},
+        {"a": 0, "b": 1.0},
+        {"a": 1, "c": "x"},
+        {"a": 1, "c": "y"},
+        {"a": 1, "c": None},
+        {"a": 2},
+    ]
+    all_suggested_values = [t.params for t in study.trials]
+    assert len(all_suggested_values) == len(expected_suggested_values)
+    for a in all_suggested_values:
+        assert a in expected_suggested_values


### PR DESCRIPTION
## Motivation
Currently, `BruteForceSampler` uses `study.enqueue` mechanism to run a distributed breadth-first search. This causes problems when `BruteForceSampler` is used together with other samplers or with `enqueue_trial`/`add_trial`. Instead, we build a search-space tree every time `suggest_*` is called and sample an unexpanded node.

## Description of the changes
We add a `_TreeNode` class that explicitly handles the search-space tree, and sample an unexpanded node in `sample_independent`.