### PR TITLE
Fix mypy error about `Chainer`

### DIFF
--- a/tests/integration_tests/test_chainer.py
+++ b/tests/integration_tests/test_chainer.py
@@ -20,7 +20,7 @@ with try_import() as _imports:
     from chainer.training import triggers
 
 if not _imports.is_successful():
-    DatasetMixin = object  # NOQA
+    DatasetMixin = object  # type: ignore[assignment, misc]  # NOQA
 
 pytestmark = pytest.mark.integration
 


### PR DESCRIPTION
## Motivation
Resolve #4116

## Description of the changes
Ignore mypy error which occurs at the 23rd line of `tests/integration_tests/test_chainer.py`.
Note that mypy error of the line was used to be ignored before PR #4276 but I removed `type: ignore` to reduce unused warnings. Mypy recognize this as error again from 1.0.0.