### PR TITLE
Add BIPOP-CMA-ES support in `CmaEsSampler`.

### DIFF
--- a/optuna/samplers/_cmaes.py
+++ b/optuna/samplers/_cmaes.py
@@ -95,6 +95,9 @@ class CmaEsSampler(BaseSampler):
       size. In Proceedings of the IEEE Congress on Evolutionary Computation (CEC 2005),
       pages 1769–1776. IEEE Press, 2005.
       <http://www.cmap.polytechnique.fr/~nikolaus.hansen/cec2005ipopcmaes.pdf>`_
+    - `N. Hansen. Benchmarking a BI-Population CMA-ES on the BBOB-2009 Function Testbed.
+      GECCO Workshop, 2009.
+      <https://hal.inria.fr/inria-00382093/document>`_
     - `Raymond Ros, Nikolaus Hansen. A Simple Modification in CMA-ES Achieving Linear Time and
       Space Complexity. 10th International Conference on Parallel Problem Solving From Nature,
       Sep 2008, Dortmund, Germany. inria-00287367.
@@ -156,6 +159,8 @@ class CmaEsSampler(BaseSampler):
             Strategy for restarting CMA-ES optimization when converges to a local minimum.
             If given :obj:`None`, CMA-ES will not restart (default).
             If given 'ipop', CMA-ES will restart with increasing population size.
+            if given 'bipop', CMA-ES will restart with occasionally increasing
+            population size or small population size.
             Please see also ``inc_popsize`` parameter.
 
             .. note::
@@ -164,12 +169,14 @@ class CmaEsSampler(BaseSampler):
                 https://github.com/optuna/optuna/releases/tag/v2.1.0.
 
         popsize:
-            A population size of CMA-ES. When set ``restart_strategy = 'ipop'``, this is used
-            as the initial population size.
+            A population size of CMA-ES. When set ``restart_strategy = 'ipop'``
+            or ``restart_strategy = 'bipop'``,
+            this is used as the initial population size.
 
         inc_popsize:
             Multiplier for increasing population size before each restart.
-            This argument will be used when setting ``restart_strategy = 'ipop'``.
+            This argument will be used when setting ``restart_strategy = 'ipop'``
+            or ``restart_strategy = 'bipop'``.
 
         consider_pruned_trials:
             If this is :obj:`True`, the PRUNED trials are considered for sampling.
@@ -307,9 +314,8 @@ class CmaEsSampler(BaseSampler):
             None,
         ):
             raise ValueError(
-                "restart_strategy={} is unsupported. Please specify: 'ipop' or None.".format(
-                    restart_strategy
-                )
+                "restart_strategy={} is unsupported. "
+                "Please specify: 'ipop', 'bipop', or None.".format(restart_strategy)
             )
 
         # TODO(knshnb): Support sep-CMA-ES with margin.

--- a/optuna/samplers/_cmaes.py
+++ b/optuna/samplers/_cmaes.py
@@ -375,7 +375,8 @@ class CmaEsSampler(BaseSampler):
         # When `with_margin=True`, bounds in discrete dimensions are handled inside `CMAwM`.
         trans = _SearchSpaceTransform(search_space, transform_step=not self._with_margin)
 
-        # `poptype`, `small_n_eval`, `large_n_eval` are counter variables used for bipop-cma-es
+        # The variables `poptype`, `small_n_eval`, `large_n_eval` are
+        # counter variables used for bipop-cma-es.
         optimizer, n_restarts, poptype, small_n_eval, large_n_eval = self._restore_optimizer(
             completed_trials
         )

--- a/optuna/samplers/_cmaes.py
+++ b/optuna/samplers/_cmaes.py
@@ -391,7 +391,7 @@ class CmaEsSampler(BaseSampler):
                 trans, study.direction, population_size=self._initial_popsize
             )
             if self._initial_popsize is None:
-                self._initial_popsize = self._initial_popsize
+                self._initial_popsize = optimizer.population_size
             self._popsize = self._initial_popsize
 
         if optimizer.dim != len(trans.bounds):

--- a/optuna/samplers/_cmaes.py
+++ b/optuna/samplers/_cmaes.py
@@ -408,6 +408,28 @@ class CmaEsSampler(BaseSampler):
                     trans, study.direction, population_size=popsize, randomize_start_point=True
                 )
 
+            # if self._restart_strategy == "bipop" and optimizer.should_stop():
+            #     n_eval = optimizer.population_size * optimizer.generation
+            #     if poptype == "small":
+            #         small_n_eval += n_eval
+            #     else:  # poptype == "large"
+            #         large_n_eval += n_eval
+
+            #     if small_n_eval < large_n_eval:
+            #         poptype = "small"
+            #         popsize_multiplier = self._inc_popsize**n_restarts
+            #         popsize = math.floor(
+            #             self._popsize * popsize_multiplier ** (np.random.uniform() ** 2)
+            #         )
+            #     else:
+            #         poptype = "large"
+            #         n_restarts += 1
+            #         popsize = self._popsize * (self._inc_popsize**n_restarts)
+
+            #     optimizer = self._init_optimizer(
+            #         trans, study.direction, population_size=popsize, randomize_start_point=True
+            #     )
+
             # Store optimizer.
             optimizer_str = pickle.dumps(optimizer).hex()
             optimizer_attrs = self._split_optimizer_str(optimizer_str)

--- a/optuna/samplers/_cmaes.py
+++ b/optuna/samplers/_cmaes.py
@@ -375,7 +375,13 @@ class CmaEsSampler(BaseSampler):
         )
 
         if optimizer is None:
+            n_restarts = 0
+            poptype = "small"
+            small_n_eval = 0
+            large_n_eval = 0
             optimizer = self._init_optimizer(trans, study.direction, population_size=self._popsize)
+            if self._popsize is None:
+                self._popsize = optimizer.population_size
 
         if optimizer.dim != len(trans.bounds):
             if self._warn_independent_sampling:

--- a/optuna/samplers/_cmaes.py
+++ b/optuna/samplers/_cmaes.py
@@ -440,16 +440,16 @@ class CmaEsSampler(BaseSampler):
                 else:  # poptype == "large"
                     large_n_eval += n_eval
 
+                popsize_multiplier = self._inc_popsize**n_restarts
                 if small_n_eval < large_n_eval:
                     poptype = "small"
-                    popsize_multiplier = self._inc_popsize**n_restarts
                     popsize = math.floor(
                         self._initial_popsize * popsize_multiplier ** (np.random.uniform() ** 2)
                     )
                 else:
                     poptype = "large"
                     n_restarts += 1
-                    popsize = self._initial_popsize * (self._inc_popsize**n_restarts)
+                    popsize = self._initial_popsize * popsize_multiplier
 
                 self._popsize = popsize
                 optimizer = self._init_optimizer(

--- a/tests/samplers_tests/test_cmaes.py
+++ b/tests/samplers_tests/test_cmaes.py
@@ -502,7 +502,17 @@ def test_restore_optimizer_with_other_option(
     assert small_n_eval == 0
 
 
-@pytest.mark.parametrize("sampler_opts", [{}, {"use_separable_cma": True}, {"with_margin": True}])
+@pytest.mark.parametrize(
+    "sampler_opts",
+    [
+        {"restart_strategy": "ipop"},
+        {"restart_strategy": "bipop"},
+        {"restart_strategy": "ipop", "use_separable_cma": True},
+        {"restart_strategy": "bipop", "use_separable_cma": True},
+        {"restart_strategy": "ipop", "with_margin": True},
+        {"restart_strategy": "bipop", "with_margin": True},
+    ],
+)
 def test_get_solution_trials(sampler_opts: Dict[str, Any]) -> None:
     def objective(trial: optuna.Trial) -> float:
         x1 = trial.suggest_float("x1", -10, 10, step=1)
@@ -510,9 +520,7 @@ def test_get_solution_trials(sampler_opts: Dict[str, Any]) -> None:
         return x1**2 + x2**2
 
     popsize = 5
-    sampler = optuna.samplers.CmaEsSampler(
-        popsize=popsize, restart_strategy="ipop", **sampler_opts
-    )
+    sampler = optuna.samplers.CmaEsSampler(popsize=popsize, **sampler_opts)
     study = optuna.create_study(sampler=sampler)
     study.optimize(objective, n_trials=popsize + 2)
 
@@ -523,8 +531,18 @@ def test_get_solution_trials(sampler_opts: Dict[str, Any]) -> None:
     assert len(sampler._get_solution_trials(study.trials, 1, 0)) == 1
 
 
-@pytest.mark.parametrize("sampler_opts", [{"use_separable_cma": True}, {"with_margin": True}])
-def test_get_solution_trials_with_other_options(sampler_opts: Dict[str, Any]) -> None:
+@pytest.mark.parametrize(
+    "sampler_opts, restart_strategy",
+    [
+        ({"use_separable_cma": True}, "ipop"),
+        ({"use_separable_cma": True}, "bpop"),
+        ({"with_margin": True}, "ipop"),
+        ({"with_margin": True}, "bipop"),
+    ],
+)
+def test_get_solution_trials_with_other_options(
+    sampler_opts: Dict[str, Any], restart_strategy: str
+) -> None:
     def objective(trial: optuna.Trial) -> float:
         x1 = trial.suggest_float("x1", -10, 10, step=1)
         x2 = trial.suggest_float("x2", -10, 10)

--- a/tests/samplers_tests/test_cmaes.py
+++ b/tests/samplers_tests/test_cmaes.py
@@ -557,7 +557,17 @@ def test_get_solution_trials_with_other_options(
     assert len(sampler._get_solution_trials(study.trials, 0, 0)) == 0
 
 
-@pytest.mark.parametrize("sampler_opts", [{}, {"use_separable_cma": True}, {"with_margin": True}])
+@pytest.mark.parametrize(
+    "sampler_opts",
+    [
+        {"restart_strategy": "ipop"},
+        {"restart_strategy": "bipop"},
+        {"restart_strategy": "ipop", "use_separable_cma": True},
+        {"restart_strategy": "bipop", "use_separable_cma": True},
+        {"restart_strategy": "ipop", "with_margin": True},
+        {"restart_strategy": "bipop", "with_margin": True},
+    ],
+)
 def test_get_solution_trials_after_restart(sampler_opts: Dict[str, Any]) -> None:
     def objective(trial: optuna.Trial) -> float:
         x1 = trial.suggest_float("x1", -10, 10, step=1)
@@ -574,9 +584,7 @@ def test_get_solution_trials_after_restart(sampler_opts: Dict[str, Any]) -> None
     popsize = 5
     with patch.object(cma_class, "should_stop") as mock_method:
         mock_method.return_value = True
-        sampler = optuna.samplers.CmaEsSampler(
-            popsize=popsize, restart_strategy="ipop", **sampler_opts
-        )
+        sampler = optuna.samplers.CmaEsSampler(popsize=popsize, **sampler_opts)
         study = optuna.create_study(sampler=sampler)
         study.optimize(objective, n_trials=popsize + 2)
 


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
Current `CmaEsSampler` has IPOP-CMA-ES as the restart strategy. 
[BIPOP-CMA-ES](https://hal.inria.fr/hal-00818596v1/document) is a kind of extension of IPOP-CMA-ES to improve performance in some problems by adding device about the increment of population size.
I want to consider adding BIPOP-CMA-ES as new option if the introduction of new feature is reasonable and works better in some problem.

<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
## Description of the changes


Done
* [x] Add BIPOP-CMA-ES option in `optuna/samplers/_cmaes.py`

TODO
* [ ] Add test for BIPOP-CMA-ES in `tests/sampler_tests/test_cmaes.py`
* [ ] Benchmarking the performance

<!-- Describe the changes in this PR. -->
