### PR TITLE
Fix mypy error about `PyTorch Distributed`

### DIFF
--- a/optuna/integration/pytorch_distributed.py
+++ b/optuna/integration/pytorch_distributed.py
@@ -4,7 +4,6 @@ import pickle
 from typing import Any
 from typing import Callable
 from typing import Dict
-from typing import List
 from typing import Optional
 from typing import overload
 from typing import Sequence
@@ -119,6 +118,7 @@ class TorchDistributedTrial(optuna.trial.BaseTrial):
         group: Optional["ProcessGroup"] = None,
     ) -> None:
         _imports.check()
+        global _g_pg
 
         if group is not None:
             self._group: "ProcessGroup" = group


### PR DESCRIPTION
## Motivation
Resolve #4116

## Description of the changes
This PR fixes mypy error in `integration/pytorch_distributed.py`, by making it explicit that `__init__()` of `TorchDistributedTrial` changes a global variable. Note that mypy error of the line was used to be ignored before PR #4281 but I removed `type: ignore` to reduce unused warnings. Mypy recognize this as error again from 1.0.0.

