### PR TITLE
Validate length of values in `add_trial`

### DIFF
--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -898,8 +898,7 @@ class Study:
 
         if trial.values is not None and len(self.directions) != len(trial.values):
             raise ValueError(
-                f"Although the number of objectives is {len(self.directions)}, "
-                f"the trial has {len(trial.values)} length values."
+                f"The added trial has {len(trial.values)} values, which is different from the number of objectives {len(self.directions)} in the study (determined by Study.directions)."
             )
 
         self._storage.create_new_trial(self._study_id, template_trial=trial)

--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -896,6 +896,12 @@ class Study:
 
         trial._validate()
 
+        if trial.values is not None and len(self.directions) != len(trial.values):
+            raise ValueError(
+                f"Although the number of objectives is {len(self.directions)}, "
+                f"the trial has {len(trial.values)} length values."
+            )
+
         self._storage.create_new_trial(self._study_id, template_trial=trial)
 
     def add_trials(self, trials: Iterable[FrozenTrial]) -> None:

--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -898,7 +898,9 @@ class Study:
 
         if trial.values is not None and len(self.directions) != len(trial.values):
             raise ValueError(
-                f"The added trial has {len(trial.values)} values, which is different from the number of objectives {len(self.directions)} in the study (determined by Study.directions)."
+                f"The added trial has {len(trial.values)} values, which is different from the "
+                f"number of objectives {len(self.directions)} in the study (determined by "
+                "Study.directions)."
             )
 
         self._storage.create_new_trial(self._study_id, template_trial=trial)

--- a/tests/study_tests/test_study.py
+++ b/tests/study_tests/test_study.py
@@ -526,6 +526,18 @@ def test_add_trial(storage_mode: str) -> None:
         assert study.best_value == 0.8
 
 
+def test_add_trial_invalid_values_length() -> None:
+    study = create_study()
+    trial = create_trial(values=[0, 0])
+    with pytest.raises(ValueError):
+        study.add_trial(trial)
+
+    study = create_study(directions=["minimize", "minimize"])
+    trial = create_trial(value=0)
+    with pytest.raises(ValueError):
+        study.add_trial(trial)
+
+
 @pytest.mark.parametrize("storage_mode", STORAGE_MODES)
 def test_add_trials(storage_mode: str) -> None:
     with StorageSupplier(storage_mode) as storage:


### PR DESCRIPTION
## Motivation
Currently, `add_trial` does not check the length of trial's `values`. So, the study accepts an invalid trial.

```python
import optuna
study = optuna.create_study()
study.add_trial(optuna.create_trial(values=[0, 1]))  # No error!
```

## Description of the changes
- Raise `ValueError` if the length of `values` is invalid