### PR TITLE
Output installed packages in Checks CI

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -30,7 +30,11 @@ jobs:
         python -m pip install -U pip
         pip install --progress-bar off -U .[checking]
         pip install "sqlalchemy<2.0.0"
-
+        
+    - name: Output installed packages
+      run: |
+        pip freeze --all
+        
     - name: black
       run: black . --check --diff
     - name: flake8


### PR DESCRIPTION

## Motivation
When debugging CI fails, the installed package versions are important information. This PR makes it easy to check them.
This PR changes only for Checks CI. Other PRs will update the remaining CIs.

## Description of the changes
Add pip freeze in Checks CI

Solves part of #4396 