### PR TITLE
Output installed packages in Coverage CI

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -30,7 +30,11 @@ jobs:
         python -m pip install -U pip
         pip install --progress-bar off -U .[checking]
         pip install "sqlalchemy<2.0.0"
-
+        
+    - name: Output installed packages
+      run: |
+        pip freeze --all
+        
     - name: black
       run: black . --check --diff
     - name: flake8

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -56,6 +56,10 @@ jobs:
         pip install --progress-bar off .[integration] --extra-index-url https://download.pytorch.org/whl/cpu
 
         echo 'import coverage; coverage.process_startup()' > sitecustomize.py
+        
+    - name: Output installed packages
+      run: |
+        pip freeze --all
 
     - name: Tests
       env:


### PR DESCRIPTION


## Motivation
When debugging CI fails, the installed package versions are important information. This PR makes it easy to check them.
This PR changes only for Coverage CI. Other PRs will update the remaining CIs.

## Description of the changes
Add pip freeze in Coverage CI

Solves part of https://github.com/optuna/optuna/issues/4396






