### PR TITLE
Add minimum version tests of numpy, tqdm, colorlog, PyYAML

### DIFF
--- a/.github/workflows/tests-with-minimum-versions.yml
+++ b/.github/workflows/tests-with-minimum-versions.yml
@@ -69,7 +69,7 @@ jobs:
       run: |
         # Install dependencies with minimum versions.
         pip uninstall -y alembic cmaes packaging sqlalchemy plotly scikit-learn
-        pip install alembic==1.5.0 cmaes==0.9.1 packaging==20.0 sqlalchemy==1.3.0
+        pip install alembic==1.5.0 cmaes==0.9.1 packaging==20.0 sqlalchemy==1.3.0 numpy==1.20.3 tqdm==4.27.0 colorlog==0.3 PyYAML==3.10
         pip install plotly==4.9.0 scikit-learn==0.24.2  # optional extras
 
     - name: Scheduled tests


### PR DESCRIPTION

## Motivation
Prevent issues like #4406 in the future.

## Description of the changes
Add minimum version tests with the following versions:
* numpy==1.20.3 (`import pandas` fails in earlier versions)
* tqdm==4.27.0 (`tqdm.auto` does not exist earlier versions)
* colorlog==0.3 (`import colorlog` fails in earlier versions)
* PyYAML==3.10 (This is the earliest version in PyPI)
