### PR TITLE
Remove trailing spaces in CI configs

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -30,11 +30,11 @@ jobs:
         python -m pip install -U pip
         pip install --progress-bar off -U .[checking]
         pip install "sqlalchemy<2.0.0"
-        
+
     - name: Output installed packages
       run: |
         pip freeze --all
-        
+
     - name: black
       run: black . --check --diff
     - name: flake8

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -56,7 +56,7 @@ jobs:
         pip install --progress-bar off .[integration] --extra-index-url https://download.pytorch.org/whl/cpu
 
         echo 'import coverage; coverage.process_startup()' > sitecustomize.py
-        
+
     - name: Output installed packages
       run: |
         pip freeze --all

--- a/.github/workflows/performance-benchmarks-bayesmark.yml
+++ b/.github/workflows/performance-benchmarks-bayesmark.yml
@@ -75,13 +75,13 @@ jobs:
           --pruner-list '${{ github.event.inputs.pruner-list }}' \
           --pruner-kwargs-list '${{ github.event.inputs.pruner-kwargs-list }}' \
           --plot-warmup '${{ github.event.inputs.plot-warmup }}'
-    
+
     - name: Upload plot
       uses: actions/upload-artifact@v3
       with:
         name: benchmark-plots
         path: plots
-    
+
     - name: Upload partial report
       uses: actions/upload-artifact@v3
       with:
@@ -116,13 +116,13 @@ jobs:
     - name: Run benchmark report builder
       run: |
         python benchmarks/bayesmark/report_bayesmark.py
-    
+
     - name: Upload report
       uses: actions/upload-artifact@v3
       with:
         name: benchmark-report
         path: report
-    
+
     - name: Cleanup partial reports
       uses: geekyeggo/delete-artifact@v1
       with:

--- a/.github/workflows/tests-integration.yml
+++ b/.github/workflows/tests-integration.yml
@@ -86,7 +86,7 @@ jobs:
             --ignore tests/importance_tests/test_init.py \
             --ignore tests/samplers_tests/test_samplers.py
         else
-          pytest tests -m "integration" 
+          pytest tests -m "integration"
         fi
 
     - name: Tests


### PR DESCRIPTION
## Motivation

Unlike Python scripts, YAML files for GitHub actions are not checked by linters or formatters.
Some files contains trailing spaces and VS Code warns about them.

## Description of the changes

Removes trailing spaces.