### PR TITLE
Output installed packages in all remaining CIs

### DIFF
--- a/.github/workflows/checks-integration.yml
+++ b/.github/workflows/checks-integration.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Output installed packages
       run: |
         pip freeze --all
-        
+
     - name: black
       run: black . --check --diff
     - name: flake8

--- a/.github/workflows/checks-integration.yml
+++ b/.github/workflows/checks-integration.yml
@@ -39,6 +39,10 @@ jobs:
         pip install --progress-bar off -U bayesmark
         pip install --progress-bar off -U kurobako
 
+    - name: Output installed packages
+      run: |
+        pip freeze --all
+        
     - name: black
       run: black . --check --diff
     - name: flake8

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -30,11 +30,11 @@ jobs:
         python -m pip install -U pip
         pip install --progress-bar off -U .[checking]
         pip install "sqlalchemy<2.0.0"
-        
+
     - name: Output installed packages
       run: |
         pip freeze --all
-        
+
     - name: black
       run: black . --check --diff
     - name: flake8

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -56,7 +56,7 @@ jobs:
         pip install --progress-bar off .[integration] --extra-index-url https://download.pytorch.org/whl/cpu
 
         echo 'import coverage; coverage.process_startup()' > sitecustomize.py
-        
+
     - name: Output installed packages
       run: |
         pip freeze --all

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -67,7 +67,7 @@ jobs:
     - name: Output installed packages
       run: |
         docker run "${HUB_TAG}" sh -c "pip freeze --all"
-        
+
     - name: Verify the built image
       run: |
         docker run "${HUB_TAG}" optuna --version

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -64,6 +64,10 @@ jobs:
       env:
         DOCKER_BUILDKIT: 1
 
+    - name: Output installed packages
+      run: |
+        pip freeze --all
+        
     - name: Verify the built image
       run: |
         docker run "${HUB_TAG}" optuna --version

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -66,7 +66,7 @@ jobs:
 
     - name: Output installed packages
       run: |
-        pip freeze --all
+        docker run "${HUB_TAG}" sh -c "pip freeze --all"
         
     - name: Verify the built image
       run: |

--- a/.github/workflows/performance-benchmarks-bayesmark.yml
+++ b/.github/workflows/performance-benchmarks-bayesmark.yml
@@ -117,6 +117,10 @@ jobs:
         pip install --progress-bar off -U setuptools wheel
         pip install --progress-bar off numpy scipy pandas Jinja2
 
+    - name: Output installed packages
+      run: |
+        pip freeze --all
+        
     - name: Run benchmark report builder
       run: |
         python benchmarks/bayesmark/report_bayesmark.py

--- a/.github/workflows/performance-benchmarks-bayesmark.yml
+++ b/.github/workflows/performance-benchmarks-bayesmark.yml
@@ -79,13 +79,13 @@ jobs:
           --pruner-list '${{ github.event.inputs.pruner-list }}' \
           --pruner-kwargs-list '${{ github.event.inputs.pruner-kwargs-list }}' \
           --plot-warmup '${{ github.event.inputs.plot-warmup }}'
-    
+
     - name: Upload plot
       uses: actions/upload-artifact@v3
       with:
         name: benchmark-plots
         path: plots
-    
+
     - name: Upload partial report
       uses: actions/upload-artifact@v3
       with:
@@ -120,17 +120,17 @@ jobs:
     - name: Output installed packages
       run: |
         pip freeze --all
-        
+
     - name: Run benchmark report builder
       run: |
         python benchmarks/bayesmark/report_bayesmark.py
-    
+
     - name: Upload report
       uses: actions/upload-artifact@v3
       with:
         name: benchmark-report
         path: report
-    
+
     - name: Cleanup partial reports
       uses: geekyeggo/delete-artifact@v1
       with:

--- a/.github/workflows/performance-benchmarks-bayesmark.yml
+++ b/.github/workflows/performance-benchmarks-bayesmark.yml
@@ -62,6 +62,10 @@ jobs:
         pip install --progress-bar off .[benchmark]
         pip install --progress-bar off bayesmark matplotlib pandas
 
+    - name: Output installed packages
+      run: |
+        pip freeze --all
+
     - name: Run performance benchmark
       run: |
         python benchmarks/run_bayesmark.py \

--- a/.github/workflows/performance-benchmarks-kurobako.yml
+++ b/.github/workflows/performance-benchmarks-kurobako.yml
@@ -90,11 +90,11 @@ jobs:
 
         chmod +x kurobako
         ./kurobako -h
-    
+
     - name: Output installed packages
       run: |
         pip freeze --all
-        
+
     - name: Cache hpobench dataset
       id: cache-hpobench-dataset
       uses: actions/cache@v3

--- a/.github/workflows/performance-benchmarks-kurobako.yml
+++ b/.github/workflows/performance-benchmarks-kurobako.yml
@@ -62,7 +62,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-3.9-${{ env.cache-name }}-${{ hashFiles('**/pyproject.toml') }}
 
-    - name: Install Python libralies
+    - name: Install Python libraries
       run: |
         python -m pip install --upgrade pip
         pip install --progress-bar off -U setuptools
@@ -90,7 +90,11 @@ jobs:
 
         chmod +x kurobako
         ./kurobako -h
-
+    
+    - name: Output installed packages
+      run: |
+        pip freeze --all
+        
     - name: Cache hpobench dataset
       id: cache-hpobench-dataset
       uses: actions/cache@v3

--- a/.github/workflows/performance-benchmarks-mo-kurobako.yml
+++ b/.github/workflows/performance-benchmarks-mo-kurobako.yml
@@ -54,7 +54,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-3.9-${{ env.cache-name }}-${{ hashFiles('**/pyproject.toml') }}
 
-    - name: Install Python libralies
+    - name: Install Python libraries
       run: |
         python -m pip install --upgrade pip
         pip install --progress-bar off -U setuptools
@@ -82,6 +82,10 @@ jobs:
 
         chmod +x kurobako
         ./kurobako -h
+        
+    - name: Output installed packages
+      run: |
+        pip freeze --all
 
     - name: Cache nasbench dataset
       id: cache-nasbench-dataset

--- a/.github/workflows/performance-benchmarks-mo-kurobako.yml
+++ b/.github/workflows/performance-benchmarks-mo-kurobako.yml
@@ -82,7 +82,7 @@ jobs:
 
         chmod +x kurobako
         ./kurobako -h
-        
+
     - name: Output installed packages
       run: |
         pip freeze --all

--- a/.github/workflows/performance-benchmarks-naslib.yml
+++ b/.github/workflows/performance-benchmarks-naslib.yml
@@ -98,11 +98,11 @@ jobs:
         pip install --upgrade pip setuptools wheel
         pip install -e .
         cd ..
-    
+
     - name: Output installed packages
       run: |
         pip freeze --all
-        
+
     - name: Cache nasbench201-cifar10 dataset
       id: cache-nb201-cifar10-dataset
       uses: actions/cache@v3

--- a/.github/workflows/performance-benchmarks-naslib.yml
+++ b/.github/workflows/performance-benchmarks-naslib.yml
@@ -98,7 +98,11 @@ jobs:
         pip install --upgrade pip setuptools wheel
         pip install -e .
         cd ..
-
+    
+    - name: Output installed packages
+      run: |
+        pip freeze --all
+        
     - name: Cache nasbench201-cifar10 dataset
       id: cache-nb201-cifar10-dataset
       uses: actions/cache@v3

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -29,6 +29,10 @@ jobs:
         python -m pip install -U pip
         python -m pip install -U twine wheel build
 
+    - name: Output installed packages
+      run: |
+        pip freeze --all
+
     - name: Change the version file for scheduled TestPyPI upload
       if: github.event_name == 'schedule'
       run: |

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -24,6 +24,10 @@ jobs:
         python -m pip install -U pip
         pip install --progress-bar off -U .[checking]
 
+    - name: Output installed packages
+      run: |
+        pip freeze --all
+
     - name: Apply formatters
       run: |
         black .

--- a/.github/workflows/speed-benchmarks.yml
+++ b/.github/workflows/speed-benchmarks.yml
@@ -43,6 +43,10 @@ jobs:
         pip install --progress-bar off .[benchmark]
         asv machine --yes
 
+    - name: Output installed packages
+      run: |
+        pip freeze --all
+
     - name: Speed benchmarks
       run: |
         asv run --strict

--- a/.github/workflows/sphinx-build.yml
+++ b/.github/workflows/sphinx-build.yml
@@ -40,6 +40,10 @@ jobs:
         python -m pip install -U pip
         pip install --progress-bar off -U .[document]
 
+    - name: Output installed packages
+      run: |
+        pip freeze --all
+
     - name: Build Document
       run: |
         cd docs

--- a/.github/workflows/sphinx-build.yml
+++ b/.github/workflows/sphinx-build.yml
@@ -40,10 +40,6 @@ jobs:
         python -m pip install -U pip
         pip install --progress-bar off -U .[document]
 
-    - name: Output installed packages
-      run: |
-        pip freeze --all
-
     - name: Build Document
       run: |
         cd docs
@@ -88,6 +84,10 @@ jobs:
       run: |
         python -m pip install -U pip
         pip install --progress-bar off -U .[document]
+
+    - name: Output installed packages
+      run: |
+        pip freeze --all
 
     - name: Run Doctest
       run: |

--- a/.github/workflows/tests-integration.yml
+++ b/.github/workflows/tests-integration.yml
@@ -59,6 +59,10 @@ jobs:
         pip install --progress-bar off .[optional]
         pip install --progress-bar off .[integration] --extra-index-url https://download.pytorch.org/whl/cpu
 
+    - name: Output installed packages
+      run: |
+        pip freeze --all
+        
     - name: Scheduled tests
       if:  ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
       run: |

--- a/.github/workflows/tests-integration.yml
+++ b/.github/workflows/tests-integration.yml
@@ -62,7 +62,7 @@ jobs:
     - name: Output installed packages
       run: |
         pip freeze --all
-        
+
     - name: Scheduled tests
       if:  ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
       run: |

--- a/.github/workflows/tests-mpi.yml
+++ b/.github/workflows/tests-mpi.yml
@@ -61,7 +61,7 @@ jobs:
     - name: Output installed packages
       run: |
         pip freeze --all
-        
+
     - name: Tests
       run: |
         export OMPI_MCA_rmaps_base_oversubscribe=yes

--- a/.github/workflows/tests-mpi.yml
+++ b/.github/workflows/tests-mpi.yml
@@ -58,6 +58,10 @@ jobs:
         pip install --progress-bar off .[optional]
         pip install --progress-bar off .[integration] --extra-index-url https://download.pytorch.org/whl/cpu
 
+    - name: Output installed packages
+      run: |
+        pip freeze --all
+        
     - name: Tests
       run: |
         export OMPI_MCA_rmaps_base_oversubscribe=yes

--- a/.github/workflows/tests-storage.yml
+++ b/.github/workflows/tests-storage.yml
@@ -97,7 +97,11 @@ jobs:
     - name: Install DB bindings
       run: |
         pip install --progress-bar off PyMySQL cryptography psycopg2-binary redis
-
+    
+    - name: Output installed packages
+      run: |
+        pip freeze --all
+        
     - name: Tests MySQL
       run: |
         pytest tests/storages_tests/test_with_server.py

--- a/.github/workflows/tests-storage.yml
+++ b/.github/workflows/tests-storage.yml
@@ -97,11 +97,11 @@ jobs:
     - name: Install DB bindings
       run: |
         pip install --progress-bar off PyMySQL cryptography psycopg2-binary redis
-    
+
     - name: Output installed packages
       run: |
         pip freeze --all
-        
+
     - name: Tests MySQL
       run: |
         pytest tests/storages_tests/test_with_server.py

--- a/.github/workflows/tests-with-minimum-versions.yml
+++ b/.github/workflows/tests-with-minimum-versions.yml
@@ -71,7 +71,7 @@ jobs:
         pip uninstall -y alembic cmaes packaging sqlalchemy plotly scikit-learn
         pip install alembic==1.5.0 cmaes==0.9.1 packaging==20.0 sqlalchemy==1.3.0 numpy==1.20.3 tqdm==4.27.0 colorlog==0.3 PyYAML==3.10
         pip install plotly==4.9.0 scikit-learn==0.24.2  # optional extras
-    
+
     - name: Output installed packages
       run: |
         pip freeze --all

--- a/.github/workflows/tests-with-minimum-versions.yml
+++ b/.github/workflows/tests-with-minimum-versions.yml
@@ -71,6 +71,10 @@ jobs:
         pip uninstall -y alembic cmaes packaging sqlalchemy plotly scikit-learn
         pip install alembic==1.5.0 cmaes==0.9.1 packaging==20.0 sqlalchemy==1.3.0 numpy==1.20.3 tqdm==4.27.0 colorlog==0.3 PyYAML==3.10
         pip install plotly==4.9.0 scikit-learn==0.24.2  # optional extras
+    
+    - name: Output installed packages
+      run: |
+        pip freeze --all
 
     - name: Scheduled tests
       if:  ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}


### PR DESCRIPTION

## Motivation
When debugging CI fails, the installed package versions are important information. This PR makes it easy to check them.
This PR changes all of the remaining CIs

## Description of the changes
Add pip freeze in all remaining CIs
