### PR TITLE
Fix `Checks(integration)` about `terminator/.../botorch.py`

### DIFF
--- a/optuna/terminator/improvement/gp/botorch.py
+++ b/optuna/terminator/improvement/gp/botorch.py
@@ -75,7 +75,7 @@ class _BoTorchGaussianProcess(BaseGaussianProcess):
 
         x, _ = _convert_trials_to_tensors(trials)
 
-        with torch.no_grad(), gpytorch.settings.fast_pred_var():
+        with torch.no_grad(), gpytorch.settings.fast_pred_var():  # type: ignore[no-untyped-call]
             posterior = self._gp.posterior(x)
             mean = posterior.mean
             variance = posterior.variance


### PR DESCRIPTION
## Motivation
Fix current [`Checks(integration)` failure](https://github.com/optuna/optuna/actions/runs/4230036371/jobs/7346954668)
## Description of the changes
Currently, mypy fails at `torch.no_grad()` when torch is installed. This PR adds a `type:ignore` to prevent this.
