### PR TITLE
Fix `param_mask` for multivariate TPE with `constant_liar`

### DIFF
--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -392,10 +392,9 @@ class TPESampler(BaseSampler):
         indices_below, indices_above = _split_observation_pairs(scores, self._gamma(n), violations)
         # `None` items are intentionally converted to `nan` and then filtered out.
         # For `nan` conversion, the dtype must be float.
-        # `None` items appear only when `group=True`. We just use the first parameter because the
-        # masks are the same for all parameters in one group.
+        # `None` items appear when `group=True` or `constant_liar=True`.
         config_values = {k: np.asarray(v, dtype=float) for k, v in values.items()}
-        param_mask = ~np.isnan(list(config_values.values())[0])
+        param_mask = np.all(~np.isnan(list(config_values.values())), axis=0)
         param_mask_below, param_mask_above = param_mask[indices_below], param_mask[indices_above]
         below = {k: v[indices_below[param_mask_below]] for k, v in config_values.items()}
         above = {k: v[indices_above[param_mask_above]] for k, v in config_values.items()}

--- a/tests/samplers_tests/tpe_tests/test_sampler.py
+++ b/tests/samplers_tests/tpe_tests/test_sampler.py
@@ -1154,3 +1154,34 @@ def test_constant_liar_observation_pairs(direction: str) -> None:
 def test_constant_liar_experimental_warning() -> None:
     with pytest.warns(optuna.exceptions.ExperimentalWarning):
         _ = TPESampler(constant_liar=True)
+
+
+@pytest.mark.parametrize("multivariate", [True, False])
+def test_constant_liar_with_running_trial(multivariate: bool) -> None:
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", optuna.exceptions.ExperimentalWarning)
+        sampler = TPESampler(multivariate=multivariate, constant_liar=True, n_startup_trials=0)
+
+    study = optuna.create_study(sampler=sampler)
+
+    # Add a complete trial.
+    trial0 = study.ask()
+    trial0.suggest_int("x", 0, 10)
+    trial0.suggest_float("y", 0, 10)
+    trial0.suggest_categorical("z", [0, 1, 2])
+    study.tell(trial0, 0)
+
+    # Add running trials.
+    trial1 = study.ask()
+    trial1.suggest_int("x", 0, 10)
+    trial2 = study.ask()
+    trial2.suggest_float("y", 0, 10)
+    trial3 = study.ask()
+    trial3.suggest_categorical("z", [0, 1, 2])
+
+    # Test suggestion with running trials.
+    trial = study.ask()
+    trial.suggest_int("x", 0, 10)
+    trial.suggest_float("y", 0, 10)
+    trial.suggest_categorical("z", [0, 1, 2])
+    study.tell(trial, 0)


### PR DESCRIPTION
## Motivation
Fix #4459.

When `multivariate=True` and `constant_liar=True`, running trials may partially sample parameters in a relative search space. In this case, we need to check all parameters to make the mask.

## Description of the changes
Check all parameters to make `param_mask`.