### PR TITLE
Add an experimental decorator to RegretBoundEvaluator

### DIFF
--- a/optuna/terminator/improvement/evaluator.py
+++ b/optuna/terminator/improvement/evaluator.py
@@ -14,9 +14,9 @@ from optuna.terminator.improvement._preprocessing import PreprocessingPipeline
 from optuna.terminator.improvement._preprocessing import SelectTopTrials
 from optuna.terminator.improvement._preprocessing import ToMinimize
 from optuna.terminator.improvement._preprocessing import UnscaleLog
+from optuna.terminator.improvement.gp.base import _min_lcb
+from optuna.terminator.improvement.gp.base import _min_ucb
 from optuna.terminator.improvement.gp.base import BaseGaussianProcess
-from optuna.terminator.improvement.gp.base import min_lcb
-from optuna.terminator.improvement.gp.base import min_ucb
 from optuna.terminator.improvement.gp.botorch import _BoTorchGaussianProcess
 from optuna.trial import FrozenTrial
 from optuna.trial import TrialState
@@ -26,6 +26,7 @@ DEFAULT_TOP_TRIALS_RATIO = 0.5
 DEFAULT_MIN_N_TRIALS = 20
 
 
+@experimental_class("3.2.0")
 class BaseImprovementEvaluator(metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def evaluate(
@@ -83,8 +84,8 @@ class RegretBoundEvaluator(BaseImprovementEvaluator):
 
         self._gp.fit(fit_trials)
 
-        ucb = min_ucb(trials=fit_trials, gp=self._gp, n_params=n_params, n_trials=n_trials)
-        lcb = min_lcb(trials=lcb_trials, gp=self._gp, n_params=n_params, n_trials=n_trials)
+        ucb = _min_ucb(trials=fit_trials, gp=self._gp, n_params=n_params, n_trials=n_trials)
+        lcb = _min_lcb(trials=lcb_trials, gp=self._gp, n_params=n_params, n_trials=n_trials)
 
         regret_bound = ucb - lcb
 

--- a/optuna/terminator/improvement/evaluator.py
+++ b/optuna/terminator/improvement/evaluator.py
@@ -3,6 +3,7 @@ from typing import Dict
 from typing import List
 from typing import Optional
 
+from optuna._experimental import experimental_class
 from optuna.distributions import BaseDistribution
 from optuna.study import StudyDirection
 from optuna.terminator._search_space.intersection import IntersectionSearchSpace
@@ -35,6 +36,7 @@ class BaseImprovementEvaluator(metaclass=abc.ABCMeta):
         pass
 
 
+@experimental_class("3.2.0")
 class RegretBoundEvaluator(BaseImprovementEvaluator):
     def __init__(
         self,

--- a/optuna/terminator/improvement/gp/base.py
+++ b/optuna/terminator/improvement/gp/base.py
@@ -4,9 +4,11 @@ from typing import Tuple
 
 import numpy as np
 
+from optuna._experimental import experimental_class
 from optuna.trial._frozen import FrozenTrial
 
 
+@experimental_class("3.2.0")
 class BaseGaussianProcess(metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def fit(
@@ -23,7 +25,7 @@ class BaseGaussianProcess(metaclass=abc.ABCMeta):
         pass
 
 
-def min_ucb(
+def _min_ucb(
     trials: List[FrozenTrial],
     gp: BaseGaussianProcess,
     n_params: int,
@@ -35,7 +37,7 @@ def min_ucb(
     return float(min(upper))
 
 
-def min_lcb(
+def _min_lcb(
     trials: List[FrozenTrial],
     gp: BaseGaussianProcess,
     n_params: int,


### PR DESCRIPTION
This is a follow-up PR of #4401 and adds the experimental decorator to `RegretBoundEvaluator`.