### PR TITLE
Include both venv and .venv in the exclude setting of the formatters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,6 +89,7 @@ celerybeat-schedule
 .env
 
 # virtualenv
+.venv/
 venv/
 ENV/
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -163,6 +163,7 @@ exclude = '''
   | \.hg
   | \.mypy_cache
   | \.venv
+  | venv
   | _build
   | buck-out
   | build

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,7 @@ ignore =
     H306
 max-line-length = 99
 statistics = True
-exclude = venv,build,tutorial,.asv
+exclude = .venv,venv,build,tutorial,.asv
 
 # This section is for mypy.
 [mypy]
@@ -25,4 +25,4 @@ strict_concatenate = True
 no_implicit_reexport = True
 
 ignore_missing_imports = True
-exclude = venv|build|docs|tutorial|optuna/storages/_rdb/alembic
+exclude = .venv|venv|build|docs|tutorial|optuna/storages/_rdb/alembic


### PR DESCRIPTION
The name of the virtualenv directory is inconsistent among the following files:
- https://github.com/optuna/optuna/blob/73e8b747023b85a3687b32306ca671bcc1d863b9/pyproject.toml#L165 
- https://github.com/optuna/optuna/blob/73e8b747023b85a3687b32306ca671bcc1d863b9/setup.cfg#L11
- https://github.com/optuna/optuna/blob/73e8b747023b85a3687b32306ca671bcc1d863b9/.gitignore#L92

This PR adds both `venv` and `.venv` to those setting.
