### PR TITLE
Update to Sphinx 6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,8 +75,7 @@ document = [
     "plotly>=4.9.0",  # optuna/visualization.
     "scikit-learn",
     "scikit-optimize",
-    # TODO(not522): Remove the constraint after sphinx_rtd_theme supports Sphinx 6
-    "sphinx<6",
+    "sphinx",
     "sphinx-copybutton",
     "sphinx-gallery",
     "sphinx-plotly-directive",


### PR DESCRIPTION
## Motivation
Resolve #4342.

The latest `sphinx_rtd_theme` (v1.2.0) supports Sphinx 6. So, the version constraint should no longer be needed.

## Description of the changes
- Remove the version constraint.
