### PR TITLE
Add sqlalchemy<2.0.0 in `Checks(integration)`

### DIFF
--- a/.github/workflows/checks-integration.yml
+++ b/.github/workflows/checks-integration.yml
@@ -28,7 +28,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get -y install openmpi-bin libopenmpi-dev libopenblas-dev
-  
+
     # TODO(Shinichi): Remove the version constraint on SQLAlchemy
     - name: Install
       run: |

--- a/.github/workflows/checks-integration.yml
+++ b/.github/workflows/checks-integration.yml
@@ -28,7 +28,8 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get -y install openmpi-bin libopenmpi-dev libopenblas-dev
-
+  
+    # TODO(Shinichi): Remove the version constraint on SQLAlchemy
     - name: Install
       run: |
         python -m pip install -U pip
@@ -38,6 +39,7 @@ jobs:
         pip install --progress-bar off -U .[benchmark]
         pip install --progress-bar off -U bayesmark
         pip install --progress-bar off -U kurobako
+        pip install "sqlalchemy<2.0.0"
 
     - name: Output installed packages
       run: |


### PR DESCRIPTION
## Motivation
To temporary resolve daily failure. See the latest result of [`Checks(integration)`](https://github.com/optuna/optuna/actions/runs/4319025731/jobs/7538011229).

## Description of the changes
Add version constraint for sqlalchemy to use version lower than 2.0.0. This restriction can be removed after https://github.com/optuna/optuna/issues/4365 is resolved.