### PR TITLE
Avoid error at import time for `optuna.terminator.improvement.gp.botorch`

### DIFF
--- a/optuna/terminator/improvement/gp/botorch.py
+++ b/optuna/terminator/improvement/gp/botorch.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import List
 from typing import Optional
 from typing import Tuple

--- a/optuna/terminator/improvement/gp/botorch.py
+++ b/optuna/terminator/improvement/gp/botorch.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
-from typing import List
 from typing import Optional
-from typing import Tuple
 
 import numpy as np
 
@@ -45,7 +43,7 @@ class _BoTorchGaussianProcess(BaseGaussianProcess):
 
     def fit(
         self,
-        trials: List[FrozenTrial],
+        trials: list[FrozenTrial],
     ) -> None:
         self._trials = trials
 
@@ -71,8 +69,8 @@ class _BoTorchGaussianProcess(BaseGaussianProcess):
 
     def predict_mean_std(
         self,
-        trials: List[FrozenTrial],
-    ) -> Tuple[np.ndarray, np.ndarray]:
+        trials: list[FrozenTrial],
+    ) -> tuple[np.ndarray, np.ndarray]:
         assert self._gp is not None
 
         x, _ = _convert_trials_to_tensors(trials)

--- a/optuna/terminator/improvement/gp/botorch.py
+++ b/optuna/terminator/improvement/gp/botorch.py
@@ -84,7 +84,7 @@ class _BoTorchGaussianProcess(BaseGaussianProcess):
         return mean.detach().numpy(), std.detach().numpy()
 
 
-def _convert_trials_to_tensors(trials: List[FrozenTrial]) -> Tuple[torch.Tensor, torch.Tensor]:
+def _convert_trials_to_tensors(trials: List[FrozenTrial]) -> Tuple["torch.Tensor", "torch.Tensor"]:
     """Convert a list of FrozenTrial objects to tensors inputs and bounds.
 
     This function assumes the following condition for input trials:


### PR DESCRIPTION
## Motivation

Delaying import error when `torch` is missing to when the component is actually used and not at submodule import time. 
It's made similar to e.g. https://github.com/optuna/optuna/blob/release-v3.1.0/optuna/integration/botorch.py#L55-L58.

## Description of the changes

Changes to use string type type hinting for optional dependencies.
