### PR TITLE
Avoid standardizing `Yvar` in `_BoTorchGaussianProcess`

### DIFF
--- a/optuna/terminator/improvement/gp/botorch.py
+++ b/optuna/terminator/improvement/gp/botorch.py
@@ -33,6 +33,14 @@ __all__ = [
 ]
 
 
+class _StandadizeIgnoringYvar(Standardize):
+    def forward(
+        self, Y: torch.Tensor, Yvar: Optional[torch.Tensor] = None
+    ) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
+        Y, _ = super().forward(Y, None)
+        return Y, Yvar
+
+
 class _BoTorchGaussianProcess(BaseGaussianProcess):
     def __init__(self) -> None:
         _imports.check()
@@ -60,7 +68,7 @@ class _BoTorchGaussianProcess(BaseGaussianProcess):
             y,
             torch.full_like(y, 1e-8),
             input_transform=Normalize(d=self._n_params, bounds=bounds),
-            outcome_transform=Standardize(m=1),
+            outcome_transform=_StandadizeIgnoringYvar(m=1),
         )
 
         mll = gpytorch.mlls.ExactMarginalLogLikelihood(self._gp.likelihood, self._gp)

--- a/optuna/terminator/improvement/gp/botorch.py
+++ b/optuna/terminator/improvement/gp/botorch.py
@@ -34,6 +34,18 @@ __all__ = [
 
 
 class _StandadizeIgnoringYvar(Standardize):
+    """Customized Standardize module that does not standardize `Yvar`
+
+    This class is meant to be used in the
+    :class:`~optuna.terminator.improvement.gp.botorch._BoTorchGaussianProcess` class to coordinate
+    the scale of the noise with that of standardized `Y`.
+
+    Note that this class overrides and breaks the bahaviour of the `forward` method of the parent
+    class, although its instance can still be typed as the Standardize class. Please avoid using
+    this class outside the context of
+    :class:`~optuna.terminator.improvement.gp.botorch._BoTorchGaussianProcess`.
+    """
+
     def forward(
         self, Y: torch.Tensor, Yvar: Optional[torch.Tensor] = None
     ) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:

--- a/optuna/terminator/improvement/gp/botorch.py
+++ b/optuna/terminator/improvement/gp/botorch.py
@@ -59,7 +59,7 @@ class _BoTorchGaussianProcess(BaseGaussianProcess):
         self._gp = FixedNoiseGP(
             x,
             y,
-            torch.full_like(y, noise),
+            torch.full_like(y, 1e-8 * y.std().item()),
             input_transform=Normalize(d=self._n_params, bounds=bounds),
             outcome_transform=Standardize(m=1),
         )

--- a/optuna/terminator/improvement/gp/botorch.py
+++ b/optuna/terminator/improvement/gp/botorch.py
@@ -55,7 +55,6 @@ class _BoTorchGaussianProcess(BaseGaussianProcess):
         y = torch.tensor([trial.value for trial in trials], dtype=torch.float64)
         y = torch.unsqueeze(y, 1)
 
-        noise = 1e-8 * y.std().item()
         self._gp = FixedNoiseGP(
             x,
             y,


### PR DESCRIPTION
This is a follow-up PR of #4401 and fixes the standardization process of `_BoTorchGaussianProcess`.

## Motivation
In the GP fitting logic of `_BoTorchGaussianProcess`, originally, the scale of the noise for `FixedNoiseGP` was not expected to be impacted by the scale of `Y`. However, in the current implementation, the noise value is scaled depending on `Y`, because [both `y` and `Yvar` are processed by the `Standardize` module](https://github.com/pytorch/botorch/blob/ba90c9b5069f85d3f071560e95f02984c8941f77/botorch/models/gp_regression.py#L246-L247) inside `FixedNoiseGP.__init__`.

## Description of the changes
This PR fixes the unintended behavior by introducing `_StandardizeIgnoringYvar`, which overrides `Standardize` and ignores `YVar` when standardizing. 
