### PR TITLE
Change the noise value in `_BoTorchGaussianProcess` to suppress warning messages

### DIFF
--- a/optuna/terminator/improvement/gp/botorch.py
+++ b/optuna/terminator/improvement/gp/botorch.py
@@ -33,6 +33,14 @@ __all__ = [
 ]
 
 
+class _StandadizeIgnoringYvar(Standardize):
+    def forward(
+        self, Y: torch.Tensor, Yvar: Optional[torch.Tensor] = None
+    ) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
+        Y, _ = super().forward(Y, None)
+        return Y, Yvar
+
+
 class _BoTorchGaussianProcess(BaseGaussianProcess):
     def __init__(self) -> None:
         _imports.check()
@@ -60,7 +68,7 @@ class _BoTorchGaussianProcess(BaseGaussianProcess):
             y,
             torch.full_like(y, 1e-8),
             input_transform=Normalize(d=self._n_params, bounds=bounds),
-            outcome_transform=Standardize(m=1),
+            outcome_transform=_StandadizeIgnoringYvar(m=1),
         )
 
         mll = gpytorch.mlls.ExactMarginalLogLikelihood(self._gp.likelihood, self._gp)

--- a/optuna/terminator/improvement/gp/botorch.py
+++ b/optuna/terminator/improvement/gp/botorch.py
@@ -60,6 +60,7 @@ class _BoTorchGaussianProcess(BaseGaussianProcess):
         self._n_params: Optional[float] = None
         self._n_trials: Optional[float] = None
         self._gp: Optional[FixedNoiseGP] = None
+        self._noise = gpytorch.settings.min_fixed_noise.value(torch.float64)
 
     def fit(
         self,
@@ -78,7 +79,7 @@ class _BoTorchGaussianProcess(BaseGaussianProcess):
         self._gp = FixedNoiseGP(
             x,
             y,
-            torch.full_like(y, 1e-8),
+            torch.full_like(y, self._noise),
             input_transform=Normalize(d=self._n_params, bounds=bounds),
             outcome_transform=_StandadizeIgnoringYvar(m=1),
         )

--- a/optuna/terminator/improvement/gp/botorch.py
+++ b/optuna/terminator/improvement/gp/botorch.py
@@ -34,6 +34,18 @@ __all__ = [
 
 
 class _StandadizeIgnoringYvar(Standardize):
+    """Customized Standardize module that does not standardize `Yvar`
+
+    This class is meant to be used in the
+    :class:`~optuna.terminator.improvement.gp.botorch._BoTorchGaussianProcess` class to coordinate
+    the scale of the noise with that of standardized `Y`.
+
+    Note that this class overrides and breaks the bahaviour of the `forward` method of the parent
+    class, although its instance can still be typed as the Standardize class. Please avoid using
+    this class outside the context of
+    :class:`~optuna.terminator.improvement.gp.botorch._BoTorchGaussianProcess`.
+    """
+
     def forward(
         self, Y: torch.Tensor, Yvar: Optional[torch.Tensor] = None
     ) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:


### PR DESCRIPTION
Please marge this PR after #4488.

This PR sets the noise value of `FixedNoiseGP` in `_BoTorchGaussianProcess` according to the minimum setting of `gpytorch`.

## Motivation
`gpytorch` defines the minimum noise value [here](https://github.com/cornellius-gp/gpytorch/blob/eb5066ca508dcf5630bd7e6b569591ba9cbe6200/gpytorch/settings.py#L281-L293). 

Currently, the noise value of `_BoTorchGaussianProcess` is set to `1e-8`, but it is actually overwritten by the minimum value setting of `gpytorch`. This frequently causes the following warning message in the Optuna Terminator.

```
.../python3.9/site-packages/gpytorch/likelihoods/noise_models.py:144: NumericalWarning: Very small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.
  warnings.warn(
```

## Description of the changes
This PR suppresses the warning message by using the minimum setting of `gpytorch` as the noise value instead of hardcoding it. The specific noise value is changed from `1e-8` to `1e-6`.
