### PR TITLE
Move `optuna.samplers._search_space.intersection.py` to `optuna.search_space.intersection.py` 

### DIFF
--- a/docs/source/reference/index.rst
+++ b/docs/source/reference/index.rst
@@ -13,6 +13,7 @@ API Reference
     logging
     pruners
     samplers/index
+    search_space
     storages
     study
     trial

--- a/docs/source/reference/search_space.rst
+++ b/docs/source/reference/search_space.rst
@@ -1,0 +1,14 @@
+.. module:: optuna.search_space
+
+optuna.search_space
+=================
+
+The :mod:`~optuna.search_space` module provides functionality for controlling search space of parameters.
+
+
+.. autosummary::
+   :toctree: generated/
+   :nosignatures:
+
+   optuna.search_space.IntersectionSearchSpace
+   optuna.search_space.intersection_search_space

--- a/docs/source/reference/search_space.rst
+++ b/docs/source/reference/search_space.rst
@@ -1,7 +1,7 @@
 .. module:: optuna.search_space
 
 optuna.search_space
-=================
+===================
 
 The :mod:`~optuna.search_space` module provides functionality for controlling search space of parameters.
 

--- a/optuna/__init__.py
+++ b/optuna/__init__.py
@@ -5,6 +5,7 @@ from optuna import logging
 from optuna import multi_objective
 from optuna import pruners
 from optuna import samplers
+from optuna import search_space
 from optuna import storages
 from optuna import study
 from optuna import trial
@@ -41,6 +42,7 @@ __all__ = [
     "multi_objective",
     "pruners",
     "samplers",
+    "search_space",
     "storages",
     "study",
     "trial",

--- a/optuna/importance/_base.py
+++ b/optuna/importance/_base.py
@@ -12,7 +12,7 @@ import numpy
 
 from optuna._transform import _SearchSpaceTransform
 from optuna.distributions import BaseDistribution
-from optuna.samplers import intersection_search_space
+from optuna.search_space import intersection_search_space
 from optuna.study import Study
 from optuna.trial import FrozenTrial
 from optuna.trial import TrialState

--- a/optuna/integration/botorch.py
+++ b/optuna/integration/botorch.py
@@ -88,7 +88,7 @@ def qei_candidates_func(
             ``(n_trials, n_objectives)``. ``n_trials`` is identical to that of ``train_x``.
             ``n_objectives`` is the number of objectives. Observations are not normalized.
         train_con:
-            Objective constraints. A ``torch.Tensofr`` of shape ``(n_trials, n_constraints)``.
+            Objective constraints. A ``torch.Tensor`` of shape ``(n_trials, n_constraints)``.
             ``n_trials`` is identical to that of ``train_x``. ``n_constraints`` is the number of
             constraints. A constraint is violated if strictly larger than 0. If no constraints are
             involved in the optimization, this argument will be :obj:`None`.

--- a/optuna/integration/botorch.py
+++ b/optuna/integration/botorch.py
@@ -16,10 +16,10 @@ from optuna._imports import try_import
 from optuna._transform import _SearchSpaceTransform
 from optuna.distributions import BaseDistribution
 from optuna.samplers import BaseSampler
-from optuna.samplers import IntersectionSearchSpace
 from optuna.samplers import RandomSampler
 from optuna.samplers._base import _CONSTRAINTS_KEY
 from optuna.samplers._base import _process_constraints_after_trial
+from optuna.search_space import IntersectionSearchSpace
 from optuna.study import Study
 from optuna.study import StudyDirection
 from optuna.trial import FrozenTrial
@@ -88,7 +88,7 @@ def qei_candidates_func(
             ``(n_trials, n_objectives)``. ``n_trials`` is identical to that of ``train_x``.
             ``n_objectives`` is the number of objectives. Observations are not normalized.
         train_con:
-            Objective constraints. A ``torch.Tensor`` of shape ``(n_trials, n_constraints)``.
+            Objective constraints. A ``torch.Tensofr`` of shape ``(n_trials, n_constraints)``.
             ``n_trials`` is identical to that of ``train_x``. ``n_constraints`` is the number of
             constraints. A constraint is violated if strictly larger than 0. If no constraints are
             involved in the optimization, this argument will be :obj:`None`.

--- a/optuna/integration/cma.py
+++ b/optuna/integration/cma.py
@@ -19,6 +19,7 @@ from optuna.distributions import CategoricalDistribution
 from optuna.distributions import FloatDistribution
 from optuna.distributions import IntDistribution
 from optuna.samplers import BaseSampler
+from optuna.search_space import IntersectionSearchSpace
 from optuna.study import Study
 from optuna.study import StudyDirection
 from optuna.trial import FrozenTrial
@@ -104,7 +105,7 @@ class PyCmaSampler(BaseSampler):
             sampling. The parameters not contained in the relative search space are sampled
             by this sampler.
             The search space for :class:`~optuna.integration.PyCmaSampler` is determined by
-            :func:`~optuna.samplers.intersection_search_space()`.
+            :func:`~optuna.search_space.intersection_search_space()`.
 
             If :obj:`None` is specified, :class:`~optuna.samplers.RandomSampler` is used
             as the default.
@@ -151,7 +152,7 @@ class PyCmaSampler(BaseSampler):
         self._n_startup_trials = n_startup_trials
         self._independent_sampler = independent_sampler or optuna.samplers.RandomSampler(seed=seed)
         self._warn_independent_sampling = warn_independent_sampling
-        self._search_space = optuna.samplers.IntersectionSearchSpace()
+        self._search_space = IntersectionSearchSpace()
 
     def reseed_rng(self) -> None:
         self._cma_opts["seed"] = random.randint(1, 2**32)

--- a/optuna/integration/skopt.py
+++ b/optuna/integration/skopt.py
@@ -16,6 +16,7 @@ from optuna import samplers
 from optuna._imports import try_import
 from optuna.exceptions import ExperimentalWarning
 from optuna.samplers import BaseSampler
+from optuna.search_space import IntersectionSearchSpace
 from optuna.study import Study
 from optuna.study._study_direction import StudyDirection
 from optuna.trial import FrozenTrial
@@ -55,7 +56,7 @@ class SkoptSampler(BaseSampler):
             sampling. The parameters not contained in the relative search space are sampled
             by this sampler.
             The search space for :class:`~optuna.integration.SkoptSampler` is determined by
-            :func:`~optuna.samplers.intersection_search_space()`.
+            :func:`~optuna.search_space.intersection_search_space()`.
 
             If :obj:`None` is specified, :class:`~optuna.samplers.RandomSampler` is used
             as the default.
@@ -123,7 +124,7 @@ class SkoptSampler(BaseSampler):
         self._independent_sampler = independent_sampler or samplers.RandomSampler(seed=seed)
         self._warn_independent_sampling = warn_independent_sampling
         self._n_startup_trials = n_startup_trials
-        self._search_space = samplers.IntersectionSearchSpace()
+        self._search_space = IntersectionSearchSpace()
         self._consider_pruned_trials = consider_pruned_trials
 
         if self._consider_pruned_trials:

--- a/optuna/multi_objective/samplers/_base.py
+++ b/optuna/multi_objective/samplers/_base.py
@@ -42,7 +42,7 @@ class BaseMultiObjectiveSampler(abc.ABC):
             A dictionary containing the parameter names and parameter's distributions.
 
         .. seealso::
-            Please refer to :func:`~optuna.samplers.intersection_search_space` as an
+            Please refer to :func:`~optuna.search_space.intersection_search_space` as an
             implementation of
             :func:`~optuna.multi_objective.samplers.BaseMultiObjectiveSampler.infer_relative_search_space`.
         """

--- a/optuna/samplers/_base.py
+++ b/optuna/samplers/_base.py
@@ -71,7 +71,7 @@ class BaseSampler(abc.ABC):
             A dictionary containing the parameter names and parameter's distributions.
 
         .. seealso::
-            Please refer to :func:`~optuna.samplers.intersection_search_space` as an
+            Please refer to :func:`~optuna.search_space.intersection_search_space` as an
             implementation of :func:`~optuna.samplers.BaseSampler.infer_relative_search_space`.
         """
 

--- a/optuna/samplers/_cmaes.py
+++ b/optuna/samplers/_cmaes.py
@@ -25,6 +25,7 @@ from optuna.distributions import FloatDistribution
 from optuna.distributions import IntDistribution
 from optuna.exceptions import ExperimentalWarning
 from optuna.samplers import BaseSampler
+from optuna.search_space import IntersectionSearchSpace
 from optuna.study._study_direction import StudyDirection
 from optuna.trial import FrozenTrial
 from optuna.trial import TrialState
@@ -132,7 +133,7 @@ class CmaEsSampler(BaseSampler):
             sampling. The parameters not contained in the relative search space are sampled
             by this sampler.
             The search space for :class:`~optuna.samplers.CmaEsSampler` is determined by
-            :func:`~optuna.samplers.intersection_search_space()`.
+            :func:`~optuna.search_space.intersection_search_space()`.
 
             If :obj:`None` is specified, :class:`~optuna.samplers.RandomSampler` is used
             as the default.
@@ -242,7 +243,7 @@ class CmaEsSampler(BaseSampler):
         self._n_startup_trials = n_startup_trials
         self._warn_independent_sampling = warn_independent_sampling
         self._cma_rng = np.random.RandomState(seed)
-        self._search_space = optuna.samplers.IntersectionSearchSpace()
+        self._search_space = IntersectionSearchSpace()
         self._consider_pruned_trials = consider_pruned_trials
         self._restart_strategy = restart_strategy
         self._popsize = popsize

--- a/optuna/samplers/_search_space/intersection.py
+++ b/optuna/samplers/_search_space/intersection.py
@@ -4,10 +4,18 @@ from typing import Dict
 from typing import Optional
 
 import optuna
+from optuna._deprecated import deprecated_class
+from optuna._deprecated import deprecated_func
 from optuna.distributions import BaseDistribution
 from optuna.study import Study
 
 
+@deprecated_class(
+    "3.2.0",
+    "6.0.0",
+    name="`optuna.samplers.IntersectionSearchSpace`",
+    text="Please use `optuna.search_space.IntersectionSearchSpace` instead.",
+)
 class IntersectionSearchSpace:
     """A class to calculate the intersection search space of a :class:`~optuna.study.Study`.
 
@@ -98,6 +106,12 @@ class IntersectionSearchSpace:
         return copy.deepcopy(search_space)
 
 
+@deprecated_func(
+    "3.2.0",
+    "6.0.0",
+    name="`optuna.samplers.intersection_search_space`",
+    text="Please use `optuna.search_space.intersection_search_space` instead.",
+)
 def intersection_search_space(
     study: Study, ordered_dict: bool = False, include_pruned: bool = False
 ) -> Dict[str, BaseDistribution]:

--- a/optuna/samplers/_search_space/intersection.py
+++ b/optuna/samplers/_search_space/intersection.py
@@ -13,8 +13,8 @@ from optuna.study import Study
 @deprecated_class(
     "3.2.0",
     "6.0.0",
-    name="`optuna.samplers.IntersectionSearchSpace`",
-    text="Please use `optuna.search_space.IntersectionSearchSpace` instead.",
+    name="optuna.samplers.IntersectionSearchSpace",
+    text="Please use optuna.search_space.IntersectionSearchSpace instead.",
 )
 class IntersectionSearchSpace:
     """A class to calculate the intersection search space of a :class:`~optuna.study.Study`.
@@ -109,8 +109,8 @@ class IntersectionSearchSpace:
 @deprecated_func(
     "3.2.0",
     "6.0.0",
-    name="`optuna.samplers.intersection_search_space`",
-    text="Please use `optuna.search_space.intersection_search_space` instead.",
+    name="optuna.samplers.intersection_search_space",
+    text="Please use optuna.search_space.intersection_search_space instead.",
 )
 def intersection_search_space(
     study: Study, ordered_dict: bool = False, include_pruned: bool = False

--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -21,11 +21,11 @@ from optuna.samplers._base import _CONSTRAINTS_KEY
 from optuna.samplers._base import _process_constraints_after_trial
 from optuna.samplers._base import BaseSampler
 from optuna.samplers._random import RandomSampler
-from optuna.samplers._search_space import IntersectionSearchSpace
 from optuna.samplers._search_space.group_decomposed import _GroupDecomposedSearchSpace
 from optuna.samplers._search_space.group_decomposed import _SearchSpaceGroup
 from optuna.samplers._tpe.parzen_estimator import _ParzenEstimator
 from optuna.samplers._tpe.parzen_estimator import _ParzenEstimatorParameters
+from optuna.search_space import IntersectionSearchSpace
 from optuna.study import Study
 from optuna.study._study_direction import StudyDirection
 from optuna.trial import FrozenTrial

--- a/optuna/samplers/nsgaii/_sampler.py
+++ b/optuna/samplers/nsgaii/_sampler.py
@@ -21,10 +21,10 @@ from optuna.samplers._base import _CONSTRAINTS_KEY
 from optuna.samplers._base import _process_constraints_after_trial
 from optuna.samplers._base import BaseSampler
 from optuna.samplers._random import RandomSampler
-from optuna.samplers._search_space import IntersectionSearchSpace
 from optuna.samplers.nsgaii._crossover import perform_crossover
 from optuna.samplers.nsgaii._crossovers._base import BaseCrossover
 from optuna.samplers.nsgaii._crossovers._uniform import UniformCrossover
+from optuna.search_space import IntersectionSearchSpace
 from optuna.study import Study
 from optuna.study import StudyDirection
 from optuna.study._multi_objective import _dominates

--- a/optuna/search_space/__init__.py
+++ b/optuna/search_space/__init__.py
@@ -1,0 +1,8 @@
+from optuna.search_space.intersection import intersection_search_space
+from optuna.search_space.intersection import IntersectionSearchSpace
+
+
+__all__ = [
+    "IntersectionSearchSpace",
+    "intersection_search_space",
+]

--- a/optuna/search_space/intersection.py
+++ b/optuna/search_space/intersection.py
@@ -1,0 +1,134 @@
+from collections import OrderedDict
+import copy
+from typing import Dict
+from typing import Optional
+
+import optuna
+from optuna.distributions import BaseDistribution
+from optuna.study import Study
+
+
+class IntersectionSearchSpace:
+    """A class to calculate the intersection search space of a :class:`~optuna.study.Study`.
+
+    Intersection search space contains the intersection of parameter distributions that have been
+    suggested in the completed trials of the study so far.
+    If there are multiple parameters that have the same name but different distributions,
+    neither is included in the resulting search space
+    (i.e., the parameters with dynamic value ranges are excluded).
+
+    Note that an instance of this class is supposed to be used for only one study.
+    If different studies are passed to :func:`~optuna.samplers.IntersectionSearchSpace.calculate`,
+    a :obj:`ValueError` is raised.
+
+    Args:
+        include_pruned:
+            Whether pruned trials should be included in the search space.
+    """
+
+    def __init__(self, include_pruned: bool = False) -> None:
+        self._cursor: int = -1
+        self._search_space: Optional[Dict[str, BaseDistribution]] = None
+        self._study_id: Optional[int] = None
+
+        self._include_pruned = include_pruned
+
+    def calculate(self, study: Study, ordered_dict: bool = False) -> Dict[str, BaseDistribution]:
+        """Returns the intersection search space of the :class:`~optuna.study.Study`.
+
+        Args:
+            study:
+                A study with completed trials. The same study must be passed for one instance
+                of this class through its lifetime.
+            ordered_dict:
+                A boolean flag determining the return type.
+                If :obj:`False`, the returned object will be a :obj:`dict`.
+                If :obj:`True`, the returned object will be an :obj:`collections.OrderedDict`
+                sorted by keys, i.e. parameter names.
+
+        Returns:
+            A dictionary containing the parameter names and parameter's distributions.
+
+        """
+
+        if self._study_id is None:
+            self._study_id = study._study_id
+        else:
+            # Note that the check below is meaningless when `InMemoryStorage` is used
+            # because `InMemoryStorage.create_new_study` always returns the same study ID.
+            if self._study_id != study._study_id:
+                raise ValueError("`IntersectionSearchSpace` cannot handle multiple studies.")
+
+        states_of_interest = [
+            optuna.trial.TrialState.COMPLETE,
+            optuna.trial.TrialState.WAITING,
+            optuna.trial.TrialState.RUNNING,
+        ]
+
+        if self._include_pruned:
+            states_of_interest.append(optuna.trial.TrialState.PRUNED)
+
+        trials = study.get_trials(deepcopy=False, states=states_of_interest)
+
+        next_cursor = trials[-1].number + 1 if len(trials) > 0 else -1
+        for trial in reversed(trials):
+            if self._cursor > trial.number:
+                break
+
+            if not trial.state.is_finished():
+                next_cursor = trial.number
+                continue
+
+            if self._search_space is None:
+                self._search_space = copy.copy(trial.distributions)
+                continue
+
+            self._search_space = {
+                name: distribution
+                for name, distribution in self._search_space.items()
+                if trial.distributions.get(name) == distribution
+            }
+
+        self._cursor = next_cursor
+        search_space = self._search_space or {}
+
+        if ordered_dict:
+            search_space = OrderedDict(sorted(search_space.items(), key=lambda x: x[0]))
+
+        return copy.deepcopy(search_space)
+
+
+def intersection_search_space(
+    study: Study, ordered_dict: bool = False, include_pruned: bool = False
+) -> Dict[str, BaseDistribution]:
+    """Return the intersection search space of the :class:`~optuna.study.Study`.
+
+    Intersection search space contains the intersection of parameter distributions that have been
+    suggested in the completed trials of the study so far.
+    If there are multiple parameters that have the same name but different distributions,
+    neither is included in the resulting search space
+    (i.e., the parameters with dynamic value ranges are excluded).
+
+    .. note::
+        :class:`~optuna.samplers.IntersectionSearchSpace` provides the same functionality with
+        a much faster way. Please consider using it if you want to reduce execution time
+        as much as possible.
+
+    Args:
+        study:
+            A study with completed trials.
+        ordered_dict:
+            A boolean flag determining the return type.
+            If :obj:`False`, the returned object will be a :obj:`dict`.
+            If :obj:`True`, the returned object will be an :obj:`collections.OrderedDict` sorted by
+            keys, i.e. parameter names.
+        include_pruned:
+            Whether pruned trials should be included in the search space.
+
+    Returns:
+        A dictionary containing the parameter names and parameter's distributions.
+    """
+
+    return IntersectionSearchSpace(include_pruned=include_pruned).calculate(
+        study, ordered_dict=ordered_dict
+    )

--- a/optuna/search_space/intersection.py
+++ b/optuna/search_space/intersection.py
@@ -18,7 +18,8 @@ class IntersectionSearchSpace:
     (i.e., the parameters with dynamic value ranges are excluded).
 
     Note that an instance of this class is supposed to be used for only one study.
-    If different studies are passed to :func:`~optuna.samplers.IntersectionSearchSpace.calculate`,
+    If different studies are passed to
+    :func:`~optuna.search_space.IntersectionSearchSpace.calculate`,
     a :obj:`ValueError` is raised.
 
     Args:
@@ -110,7 +111,7 @@ def intersection_search_space(
     (i.e., the parameters with dynamic value ranges are excluded).
 
     .. note::
-        :class:`~optuna.samplers.IntersectionSearchSpace` provides the same functionality with
+        :class:`~optuna.search_space.IntersectionSearchSpace` provides the same functionality with
         a much faster way. Please consider using it if you want to reduce execution time
         as much as possible.
 

--- a/tests/integration_tests/test_skopt.py
+++ b/tests/integration_tests/test_skopt.py
@@ -89,7 +89,7 @@ def test_is_compatible() -> None:
     study = optuna.create_study(sampler=sampler)
 
     study.optimize(lambda t: t.suggest_float("p0", 0, 10), n_trials=1)
-    search_space = optuna.samplers.intersection_search_space(study)
+    search_space = optuna.search_space.intersection_search_space(study)
     assert search_space == {"p0": distributions.FloatDistribution(low=0, high=10)}
 
     optimizer = optuna.integration.skopt._Optimizer(search_space, {})

--- a/tests/search_space_tests/test_intersection.py
+++ b/tests/search_space_tests/test_intersection.py
@@ -6,8 +6,8 @@ from optuna import create_study
 from optuna import TrialPruned
 from optuna.distributions import FloatDistribution
 from optuna.distributions import IntDistribution
-from optuna.samplers import intersection_search_space
-from optuna.samplers import IntersectionSearchSpace
+from optuna.search_space import intersection_search_space
+from optuna.search_space import IntersectionSearchSpace
 from optuna.testing.storages import StorageSupplier
 from optuna.trial import Trial
 

--- a/tutorial/20_recipes/005_user_defined_sampler.py
+++ b/tutorial/20_recipes/005_user_defined_sampler.py
@@ -95,7 +95,7 @@ class SimulatedAnnealingSampler(optuna.samplers.BaseSampler):
 
     # The rest are unrelated to SA algorithm: boilerplate
     def infer_relative_search_space(self, study, trial):
-        return optuna.samplers.intersection_search_space(study)
+        return optuna.search_space.intersection_search_space(study)
 
     def sample_independent(self, study, trial, param_name, param_distribution):
         independent_sampler = optuna.samplers.RandomSampler()
@@ -135,6 +135,6 @@ print("Parameters that achieve the best value: ", best_trial.params)
 # .. note::
 #     Strictly speaking, in the first trial,
 #     ``SimulatedAnnealingSampler.sample_independent`` method is used to sample parameter values.
-#     Because :func:`~optuna.samplers.intersection_search_space` used in
+#     Because :func:`~optuna.search_space.intersection_search_space` used in
 #     ``SimulatedAnnealingSampler.infer_relative_search_space`` cannot infer the search space
 #     if there are no complete trials.


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation

<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
This PR is the follow-up PR of #4491 .

## Description of the changes
<!-- Describe the changes in this PR. -->
* Copy `optuna.samplers._search_space.intersection.py` to `optuna.search_space.intersection.py`
* Deprecate class and functions in `optuna.samplers._search_space.intersection.py`
* Fix some import path, comments, and docs for the above change
* Change the module name `_search_space` to `search_space` since current `_search_space` module has some public API in `intersetion.py` 

**NOTE**: This PR **does not fix** import paths in `optuna.terminator` module. I will create the follow-up PR to do this.
  * Reason: `optuna.terminator` module has their original `search_space` module. This is almost the same as original `optuna.samplers._search_space`, but including some small differences. Therefore, I consider fix relating `optuna.terminator` should be tried later.