### PR TITLE
Change the argument of `intersection_search_space` from `study` to `trials`

### DIFF
--- a/optuna/importance/_base.py
+++ b/optuna/importance/_base.py
@@ -72,7 +72,7 @@ def _get_distributions(study: Study, params: Optional[List[str]]) -> Dict[str, B
     _check_evaluate_args(completed_trials, params)
 
     if params is None:
-        return intersection_search_space(study, ordered_dict=True)
+        return intersection_search_space(study.get_trials(deepcopy=False), ordered_dict=True)
 
     # New temporary required to pass mypy. Seems like a bug.
     params_not_none = params

--- a/optuna/search_space/intersection.py
+++ b/optuna/search_space/intersection.py
@@ -27,7 +27,7 @@ def _calculate(
 
     trials_of_interest = [trial for trial in trials if trial.state in states_of_interest]
 
-    next_cursor = trials[-1].number + 1 if len(trials) > 0 else -1
+    next_cursor = trials_of_interest[-1].number + 1 if len(trials_of_interest) > 0 else -1
     for trial in reversed(trials_of_interest):
         if cursor > trial.number:
             break

--- a/optuna/search_space/intersection.py
+++ b/optuna/search_space/intersection.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from collections import OrderedDict
 import copy
 from typing import Dict
-from typing import List
 from typing import Tuple
 
 import optuna
@@ -12,7 +11,7 @@ from optuna.study import Study
 
 
 def _calculate(
-    trials: List[optuna.trial.FrozenTrial],
+    trials: list[optuna.trial.FrozenTrial],
     include_pruned: bool = False,
     search_space: Dict[str, BaseDistribution] | None = None,
     cursor: int = -1,
@@ -116,7 +115,7 @@ class IntersectionSearchSpace:
 
 
 def intersection_search_space(
-    trials: List[optuna.trial.FrozenTrial],
+    trials: list[optuna.trial.FrozenTrial],
     ordered_dict: bool = False,
     include_pruned: bool = False,
 ) -> Dict[str, BaseDistribution]:

--- a/optuna/search_space/intersection.py
+++ b/optuna/search_space/intersection.py
@@ -1,8 +1,9 @@
+from __future__ import annotations
+
 from collections import OrderedDict
 import copy
 from typing import Dict
 from typing import List
-from typing import Optional
 from typing import Tuple
 
 import optuna
@@ -13,9 +14,9 @@ from optuna.study import Study
 def _calculate(
     trials: List[optuna.trial.FrozenTrial],
     include_pruned: bool = False,
-    search_space: Optional[Dict[str, BaseDistribution]] = None,
+    search_space: Dict[str, BaseDistribution] | None = None,
     cursor: int = -1,
-) -> Tuple[Optional[Dict[str, BaseDistribution]], int]:
+) -> Tuple[Dict[str, BaseDistribution] | None, int]:
     states_of_interest = [
         optuna.trial.TrialState.COMPLETE,
         optuna.trial.TrialState.WAITING,
@@ -70,8 +71,8 @@ class IntersectionSearchSpace:
 
     def __init__(self, include_pruned: bool = False) -> None:
         self._cursor: int = -1
-        self._search_space: Optional[Dict[str, BaseDistribution]] = None
-        self._study_id: Optional[int] = None
+        self._search_space: Dict[str, BaseDistribution] | None = None
+        self._study_id: int | None = None
 
         self._include_pruned = include_pruned
 

--- a/tests/integration_tests/test_skopt.py
+++ b/tests/integration_tests/test_skopt.py
@@ -89,7 +89,7 @@ def test_is_compatible() -> None:
     study = optuna.create_study(sampler=sampler)
 
     study.optimize(lambda t: t.suggest_float("p0", 0, 10), n_trials=1)
-    search_space = optuna.search_space.intersection_search_space(study)
+    search_space = optuna.search_space.intersection_search_space(study.get_trials(deepcopy=False))
     assert search_space == {"p0": distributions.FloatDistribution(low=0, high=10)}
 
     optimizer = optuna.integration.skopt._Optimizer(search_space, {})

--- a/tests/search_space_tests/test_intersection.py
+++ b/tests/search_space_tests/test_intersection.py
@@ -18,14 +18,18 @@ def test_intersection_search_space() -> None:
 
     # No trial.
     assert search_space.calculate(study) == {}
-    assert search_space.calculate(study) == intersection_search_space(study)
+    assert search_space.calculate(study) == intersection_search_space(
+        study.get_trials(deepcopy=False)
+    )
 
     # Waiting trial.
     study.enqueue_trial(
         {"y": 0, "x": 5}, {"y": FloatDistribution(-3, 3), "x": IntDistribution(0, 10)}
     )
     assert search_space.calculate(study) == {}
-    assert search_space.calculate(study) == intersection_search_space(study)
+    assert search_space.calculate(study) == intersection_search_space(
+        study.get_trials(deepcopy=False)
+    )
 
     # First trial.
     study.optimize(lambda t: t.suggest_float("y", -3, 3) + t.suggest_int("x", 0, 10), n_trials=1)
@@ -33,7 +37,9 @@ def test_intersection_search_space() -> None:
         "x": IntDistribution(low=0, high=10),
         "y": FloatDistribution(low=-3, high=3),
     }
-    assert search_space.calculate(study) == intersection_search_space(study)
+    assert search_space.calculate(study) == intersection_search_space(
+        study.get_trials(deepcopy=False)
+    )
 
     # Returning sorted `OrderedDict` instead of `dict`.
     assert search_space.calculate(study, ordered_dict=True) == OrderedDict(
@@ -43,13 +49,15 @@ def test_intersection_search_space() -> None:
         ]
     )
     assert search_space.calculate(study, ordered_dict=True) == intersection_search_space(
-        study, ordered_dict=True
+        study.get_trials(deepcopy=False), ordered_dict=True
     )
 
     # Second trial (only 'y' parameter is suggested in this trial).
     study.optimize(lambda t: t.suggest_float("y", -3, 3), n_trials=1)
     assert search_space.calculate(study) == {"y": FloatDistribution(low=-3, high=3)}
-    assert search_space.calculate(study) == intersection_search_space(study)
+    assert search_space.calculate(study) == intersection_search_space(
+        study.get_trials(deepcopy=False)
+    )
 
     # Failed or pruned trials are not considered in the calculation of
     # an intersection search space.
@@ -60,18 +68,24 @@ def test_intersection_search_space() -> None:
     study.optimize(lambda t: objective(t, RuntimeError()), n_trials=1, catch=(RuntimeError,))
     study.optimize(lambda t: objective(t, TrialPruned()), n_trials=1)
     assert search_space.calculate(study) == {"y": FloatDistribution(low=-3, high=3)}
-    assert search_space.calculate(study) == intersection_search_space(study)
+    assert search_space.calculate(study) == intersection_search_space(
+        study.get_trials(deepcopy=False)
+    )
 
     # If two parameters have the same name but different distributions,
     # those are regarded as different parameters.
     study.optimize(lambda t: t.suggest_float("y", -1, 1), n_trials=1)
     assert search_space.calculate(study) == {}
-    assert search_space.calculate(study) == intersection_search_space(study)
+    assert search_space.calculate(study) == intersection_search_space(
+        study.get_trials(deepcopy=False)
+    )
 
     # The search space remains empty once it is empty.
     study.optimize(lambda t: t.suggest_float("y", -3, 3) + t.suggest_int("x", 0, 10), n_trials=1)
     assert search_space.calculate(study) == {}
-    assert search_space.calculate(study) == intersection_search_space(study)
+    assert search_space.calculate(study) == intersection_search_space(
+        study.get_trials(deepcopy=False)
+    )
 
 
 def test_intersection_search_space_class_with_different_studies() -> None:

--- a/tutorial/20_recipes/005_user_defined_sampler.py
+++ b/tutorial/20_recipes/005_user_defined_sampler.py
@@ -95,7 +95,7 @@ class SimulatedAnnealingSampler(optuna.samplers.BaseSampler):
 
     # The rest are unrelated to SA algorithm: boilerplate
     def infer_relative_search_space(self, study, trial):
-        return optuna.search_space.intersection_search_space(study)
+        return optuna.search_space.intersection_search_space(study.get_trials(deepcopy=False))
 
     def sample_independent(self, study, trial, param_name, param_distribution):
         independent_sampler = optuna.samplers.RandomSampler()


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
The current `calculate()` method of the `IntersectionSearchSpace` class takes `study` as input, but `study.trials` is sufficient for actual processing in this method.

Also, in the design of `optuna.terminator`, it is easier to implement if this method takes `trials` as input (see https://github.com/optuna/optuna/blob/master/optuna/terminator/_search_space/intersection.py and call point of this function). 

For these reasons, I would like to change the argument of the `calculate()` method from `study` to `trials`.

<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

## Description of the changes
* Change the argument of `IntersectionSearchSpace.calculate` and `intersection_search_space` from `Study` to `List[FrozenTrial]`
* Change the call of these functions from `calculate(study)` to `calculate(study.trials)`
<!-- Describe the changes in this PR. -->
