### PR TITLE
Simplifying distribution comparison to improve performance for large number of trials

### DIFF
--- a/optuna/samplers/_search_space/intersection.py
+++ b/optuna/samplers/_search_space/intersection.py
@@ -94,7 +94,7 @@ class IntersectionSearchSpace:
             self._search_space = {
                 name: distribution
                 for name, distribution in self._search_space.items()
-                if trial.distributions.get(name) == distribution
+                if name in trial.distributions.keys()
             }
 
         self._cursor = next_cursor

--- a/optuna/search_space/intersection.py
+++ b/optuna/search_space/intersection.py
@@ -87,7 +87,7 @@ class IntersectionSearchSpace:
             self._search_space = {
                 name: distribution
                 for name, distribution in self._search_space.items()
-                if trial.distributions.get(name) == distribution
+                if name in trial.distributions.keys()
             }
 
         self._cursor = next_cursor


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
My optimisation was slowing down for large numbers of studies (around 30k), but want to keep going as my results are still improving. Ran profiler and saw that nearly 50% of the time was spent on this dictionary comprehension. I've not been using this software long but it looked to me that comparing objects wasn't necessary, assuming that duplicate distribution names aren't allowed (correct me if this constraint doesn't exist).

## Description of the changes
When comparing the contents of two dictionaries of distributions for overlap, replaced object comparison in dictionary comprehension with comparison of keys.

## Other
I have only ran this for the modified version of [optuna/samplers/_search_space/intersection.py](https://github.com/optuna/optuna/compare/master...JCCPort:optuna:master#diff-5104254274c329178cb376902163b38d1a604a6b3b241fcabc052686f64c450b) and not [optuna/search_space/intersection.py](https://github.com/optuna/optuna/compare/master...JCCPort:optuna:master#diff-45378a44b54d113530e85333a500d4f463c3c163df26fd2f69455e3a6a8a498c). If this needs specifically testing let me know, but I might not be able to get to it soon as I'm deep in thesis writing :'(

Reduced time spent in profiling on this dictionary comprehension from 64.3% to 16.8%.
