### PR TITLE
Restrict pytorch-lightning version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,7 +99,7 @@ integration = [
     "mxnet; python_version<'3.11'",
     "pandas",
     "pytorch-ignite; python_version<'3.11'",
-    "pytorch-lightning>=1.6.0; python_version<'3.11'",
+    "pytorch-lightning>=1.6.0,<2.0.0; python_version<'3.11'",
     "scikit-learn>=0.24.2",
     "scikit-optimize; python_version<'3.11'",
     "shap; python_version<'3.11'",


### PR DESCRIPTION
## Motivation
Fix CI failure on pull request.

## Description of the changes
As `PyTorch Lightning==2.0.0` is released `test_pytorch_lightning` fails for some reason.
This PR restrict `PyTorch Lightning<2.0.0` for now.