### PR TITLE
Pin pytorch lightning version

### DIFF
--- a/.github/workflows/checks-integration.yml
+++ b/.github/workflows/checks-integration.yml
@@ -30,6 +30,7 @@ jobs:
         sudo apt-get -y install openmpi-bin libopenmpi-dev libopenblas-dev
 
     # TODO(Shinichi): Remove the version constraint on SQLAlchemy
+    # TODO(Shinichi): Remove the version constraint on PyTorch Lightning
     - name: Install
       run: |
         python -m pip install -U pip

--- a/.github/workflows/checks-integration.yml
+++ b/.github/workflows/checks-integration.yml
@@ -40,6 +40,7 @@ jobs:
         pip install --progress-bar off -U bayesmark
         pip install --progress-bar off -U kurobako
         pip install "sqlalchemy<2.0.0"
+        pip install "pytorch-lightning<2.0.0"
 
     - name: Output installed packages
       run: |

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -42,6 +42,7 @@ jobs:
         sudo apt-get update
         sudo apt-get -y install openmpi-bin libopenmpi-dev libopenblas-dev
 
+    # TODO(Shinichi): Remove the version constraint on PyTorch Lightning
     - name: Install
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -54,6 +54,7 @@ jobs:
         pip install --progress-bar off .[test]
         pip install --progress-bar off .[optional]
         pip install --progress-bar off .[integration] --extra-index-url https://download.pytorch.org/whl/cpu
+        pip install "pytorch-lightning<2.0.0"
 
         echo 'import coverage; coverage.process_startup()' > sitecustomize.py
 

--- a/.github/workflows/mac-tests.yml
+++ b/.github/workflows/mac-tests.yml
@@ -51,6 +51,7 @@ jobs:
         optuna --version
         pip install --progress-bar off .[test]
         pip install --progress-bar off .[optional]
+        pip install "pytorch-lightning<2.0.0"
 
     - name: Output installed packages
       run: |

--- a/.github/workflows/mac-tests.yml
+++ b/.github/workflows/mac-tests.yml
@@ -99,6 +99,7 @@ jobs:
         brew install open-mpi
         brew install openblas
 
+    # TODO(Shinichi): Remove the version constraint on PyTorch Lightning
     - name: Install
       run: |
         python -m pip install --upgrade pip
@@ -111,6 +112,7 @@ jobs:
         pip install --progress-bar off .[test]
         pip install --progress-bar off .[optional]
         pip install --progress-bar off .[integration]
+        pip install "pytorch-lightning<2.0.0"
 
     - name: Output installed packages
       run: |

--- a/.github/workflows/mac-tests.yml
+++ b/.github/workflows/mac-tests.yml
@@ -41,6 +41,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-3.8-${{ env.cache-name }}-${{ hashFiles('**/pyproject.toml') }}
 
+    # TODO(Shinichi): Remove the version constraint on PyTorch Lightning
     - name: Install
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/tests-integration.yml
+++ b/.github/workflows/tests-integration.yml
@@ -46,6 +46,7 @@ jobs:
         sudo apt-get update
         sudo apt-get -y install openmpi-bin libopenmpi-dev libopenblas-dev
 
+    # TODO(Shinichi): Remove the version constraint on PyTorch Lightning
     - name: Install
       run: |
         python -m pip install --upgrade pip
@@ -58,6 +59,7 @@ jobs:
         pip install --progress-bar off .[test]
         pip install --progress-bar off .[optional]
         pip install --progress-bar off .[integration] --extra-index-url https://download.pytorch.org/whl/cpu
+        pip install "pytorch-lightning<2.0.0"
 
     - name: Output installed packages
       run: |


### PR DESCRIPTION
## Motivation
Fix CI failure on pull request.

## Description of the changes
As `PyTorch Lightning==2.0.0` is released `test_pytorch_lightning` fails for some reasons.
This PR restrict `PyTorch Lightning<2.0.0` in CI for now.
