### PR TITLE
Increase time precision to check heart beat interval

### DIFF
--- a/tests/storages_tests/rdb_tests/test_storage.py
+++ b/tests/storages_tests/rdb_tests/test_storage.py
@@ -332,6 +332,6 @@ def test_record_heartbeat() -> None:
             datetime_start = trials[i + 1].datetime_start
             prev_datetime_complete = trials[i].datetime_complete
             assert datetime_start is not None and prev_datetime_complete is not None
-            trial_prep = (datetime_start - prev_datetime_complete).seconds
-            heartbeats_interval = (trial_heartbeats[i + 1] - trial_heartbeats[i]).seconds
+            trial_prep = (datetime_start - prev_datetime_complete).total_seconds()
+            heartbeats_interval = (trial_heartbeats[i + 1] - trial_heartbeats[i]).total_seconds()
             assert heartbeats_interval - sleep_sec - trial_prep <= 1


### PR DESCRIPTION
## Motivation

`tests-mac` is promoted to be a required test in #[4458](https://github.com/optuna/optuna/pull/4458), but it sometimes failed. More specifically, the `test_record_heartbeat` failed at the following assertion:

https://github.com/optuna/optuna/blob/51d159fae12de3f5c143c4bd9e5d255e270d29fb/tests/storages_tests/rdb_tests/test_storage.py#L335-L337

https://github.com/optuna/optuna/actions/runs/4434158826/jobs/7779875352?pr=4522
> FAILED tests/storages_tests/rdb_tests/test_storage.py::test_record_heartbeat - assert ((4 - 2) - 0) <= 1

I think `trial_prep` and `heartbeats_interval` lose the subsecond information since they are `datetime.timedelta.second`. So, I'd like to increase their time precision.

## Description of the changes

- Use [`datetime.timedelta.total_seconds()`](https://docs.python.org/3/library/datetime.html#datetime.timedelta.total_seconds) instead of [`datetime.timedelta.second`](https://docs.python.org/3/library/datetime.html#datetime.timedelta)