### PR TITLE
Securely deploy results of visual regression test on Netlify

### DIFF
--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -1,7 +1,8 @@
 name: Visual regression tests with Netlify
 
 on:
-  pull_request:
+  pull_request_target:
+    types: labeled
     paths:
       - 'optuna/visualization/**'
   workflow_dispatch:
@@ -15,8 +16,12 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    # Not intended for forks.
-    if: github.repository == 'optuna/optuna'
+    if: |
+      ( github.repository == 'optuna/optuna' ) && # Not intended for forks.
+      (
+         contains(github.event.pull_request.labels.*.name, 'safe-to-exec-visual-regression-test') ||
+         ( github.event_name == 'workflow_dispatch' )
+      )
 
     steps:
 

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -15,11 +15,11 @@ jobs:
     runs-on: ubuntu-latest
 
     # Not intended for forks.
-    if: github.repository == 'optuna/optuna'
-    if:  |
+    if: |
+      ( github.repository == 'optuna/optuna' ) && # Not intended for forks.
       (
-         contains(github.event.pull_request.labels.*.name, 'safe-to-run-visual-regression-tests') ||
-         (github.event_name == 'workflow_dispatch')
+         contains(github.event.pull_request.labels.*.name, 'safe-to-exec-visual-regression-test') ||
+         ( github.event_name == 'workflow_dispatch' )
       )
 
     steps:

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -14,11 +14,12 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    if: |
-      ( github.repository == 'optuna/optuna' ) && # Not intended for forks.
+    # Not intended for forks.
+    if: github.repository == 'optuna/optuna'
+    if:  |
       (
          contains(github.event.pull_request.labels.*.name, 'safe-to-run-visual-regression-tests') ||
-         ( github.event_name == 'workflow_dispatch' )
+         (github.event_name == 'workflow_dispatch')
       )
 
     steps:

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -3,8 +3,6 @@ name: Visual regression tests with Netlify
 on:
   pull_request_target:
     types: labeled
-    paths:
-      - 'optuna/visualization/**'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -2,7 +2,7 @@ name: Visual regression tests with Netlify
 
 on:
   pull_request_target:
-    types: labeled
+    types: [labeled]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -19,7 +19,7 @@ jobs:
     if: |
       ( github.repository == 'optuna/optuna' ) && # Not intended for forks.
       (
-         contains(github.event.pull_request.labels.*.name, 'safe-to-exec-visual-regression-test') ||
+         contains(github.event.pull_request.labels.*.name, 'safe-to-run-visual-regression-tests') ||
          ( github.event_name == 'workflow_dispatch' )
       )
 

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -14,9 +14,8 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    # Not intended for forks.
     if: |
-      ( github.repository == 'optuna/optuna' ) && # Not intended for forks.
+      ( github.repository == 'optuna/optuna' ) &&
       (
          contains(github.event.pull_request.labels.*.name, 'safe-to-run-visual-regression-tests') ||
          ( github.event_name == 'workflow_dispatch' )

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -18,7 +18,7 @@ jobs:
     if: |
       ( github.repository == 'optuna/optuna' ) && # Not intended for forks.
       (
-         contains(github.event.pull_request.labels.*.name, 'safe-to-exec-visual-regression-test') ||
+         contains(github.event.pull_request.labels.*.name, 'safe-to-run-visual-regression-tests') ||
          ( github.event_name == 'workflow_dispatch' )
       )
 


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
[PR#4507](https://github.com/optuna/optuna/pull/4507) does not work properly because a workflow triggered by `pull_request` cannot access secrets. I will use `pull_request_target` instead of it.

## Description of the changes
<!-- Describe the changes in this PR. -->
Use `pull_request_target` as a trigger instead of `pull_request`.
Implemented so that it is triggered only at the moment a PR is labeled `safe-to-run-visual-regression-tests`. This allows that the workflow can only be triggered by PRs that have been identified as safe.