### PR TITLE
Avoid deepcopy in `optuna.visualization.plot_timeline`.

### DIFF
--- a/optuna/visualization/_timeline.py
+++ b/optuna/visualization/_timeline.py
@@ -79,7 +79,7 @@ def plot_timeline(study: Study) -> "go.Figure":
 
 def _get_timeline_info(study: Study) -> _TimelineInfo:
     bars = []
-    for t in study.get_trials():
+    for t in study.get_trials(deepcopy=False):
         date_complete = t.datetime_complete or datetime.datetime.now()
         date_start = t.datetime_start or date_complete
         if date_complete < date_start:


### PR DESCRIPTION
## Motivation

The title explains the change.
(I'd like to check the behavior of visual regression tests in this PR.)

## Description of the changes

- Add `deepcopy=False` to `study.get_trials` since `plot_timeline` does not update trials.