### PR TITLE
Pin `Distributed` version

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -42,7 +42,7 @@ jobs:
         sudo apt-get update
         sudo apt-get -y install openmpi-bin libopenmpi-dev libopenblas-dev
 
-    # TODO(Shinichi): Remove the version constraint on PyTorch Lightning
+    # TODO(Shinichi): Remove the version constraint on PyTorch Lightning and Distributed
     - name: Install
       run: |
         python -m pip install --upgrade pip
@@ -56,6 +56,7 @@ jobs:
         pip install --progress-bar off .[optional]
         pip install --progress-bar off .[integration] --extra-index-url https://download.pytorch.org/whl/cpu
         pip install "pytorch-lightning<2.0.0"
+        pip install "distributed<2023.3.2"
 
         echo 'import coverage; coverage.process_startup()' > sitecustomize.py
 

--- a/.github/workflows/mac-tests.yml
+++ b/.github/workflows/mac-tests.yml
@@ -99,7 +99,7 @@ jobs:
         brew install open-mpi
         brew install openblas
 
-    # TODO(Shinichi): Remove the version constraint on PyTorch Lightning
+    # TODO(Shinichi): Remove the version constraint on PyTorch Lightning and Distributed
     - name: Install
       run: |
         python -m pip install --upgrade pip
@@ -113,6 +113,7 @@ jobs:
         pip install --progress-bar off .[optional]
         pip install --progress-bar off .[integration]
         pip install "pytorch-lightning<2.0.0"
+        pip install "distributed<2023.3.2"
 
     - name: Output installed packages
       run: |

--- a/.github/workflows/tests-integration.yml
+++ b/.github/workflows/tests-integration.yml
@@ -46,7 +46,7 @@ jobs:
         sudo apt-get update
         sudo apt-get -y install openmpi-bin libopenmpi-dev libopenblas-dev
 
-    # TODO(Shinichi): Remove the version constraint on PyTorch Lightning
+    # TODO(Shinichi): Remove the version constraint on PyTorch Lightning and Distributed
     - name: Install
       run: |
         python -m pip install --upgrade pip
@@ -60,6 +60,7 @@ jobs:
         pip install --progress-bar off .[optional]
         pip install --progress-bar off .[integration] --extra-index-url https://download.pytorch.org/whl/cpu
         pip install "pytorch-lightning<2.0.0"
+        pip install "distributed<2023.3.2"
 
     - name: Output installed packages
       run: |


### PR DESCRIPTION
## Motivation
Temporary fix current CI failure of `coverage`,  `tests-integration`,  `tests-integration-mac`.
See  https://github.com/optuna/optuna/actions/runs/4522852086, https://github.com/optuna/optuna/actions/runs/4522852081, and https://github.com/optuna/optuna/actions/runs/4522852085.


## Description of the changes
Restrict `Distributed` version under 2023.3.2, which was released from PyPI since March 25th.
