### PR TITLE
Checkout PR head instead of `master` of `optuna/optuna` in visual regression tests

### DIFF
--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
 
     - uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
 
     - uses: actions/setup-python@v4
       with:


### PR DESCRIPTION
## Motivation

Currently, the `visual-regression.yml` CI jobs check out the `master` of `optuna/optuna` instead of the head of PR. This issue was originally found at [`optuna/optuna-visualization-regression-tests`](https://github.com/optuna/optuna-visualization-regression-tests), so see https://github.com/optuna/optuna-visualization-regression-tests/pull/10 for details.

## Description of the changes

- Set ref of actions/checkout to `github.event.pull_request.head.sha`
  - The variable can be seen in https://securitylab.github.com/research/github-actions-preventing-pwn-requests/