### PR TITLE
Replace `hacking` with `flake8`

### DIFF
--- a/formats.sh
+++ b/formats.sh
@@ -15,7 +15,7 @@ if [ $? -eq 1 ] ; then
 fi
 command -v flake8 &> /dev/null
 if [ $? -eq 1 ] ; then
-  missing_dependencies+=(hacking)
+  missing_dependencies+=(flake8)
 fi
 command -v isort &> /dev/null
 if [ $? -eq 1 ] ; then

--- a/optuna/_hypervolume/hssp.py
+++ b/optuna/_hypervolume/hssp.py
@@ -21,8 +21,8 @@ def _solve_hssp(
     - `Greedy Hypervolume Subset Selection in Low Dimensions
        <https://ieeexplore.ieee.org/document/7570501>`_
     """
-    selected_vecs = []  # type: List[np.ndarray]
-    selected_indices = []  # type: List[int]
+    selected_vecs: List[np.ndarray] = []
+    selected_indices: List[int] = []
     contributions = [
         optuna._hypervolume.WFG().compute(np.asarray([v]), reference_point)
         for v in rank_i_loss_vals

--- a/optuna/samplers/nsgaii/_crossovers/_vsbx.py
+++ b/optuna/samplers/nsgaii/_crossovers/_vsbx.py
@@ -9,7 +9,8 @@ from optuna.study import Study
 
 @experimental_class("3.0.0")
 class VSBXCrossover(BaseCrossover):
-    """Modified Simulated Binary Crossover operation used by :class:`~optuna.samplers.NSGAIISampler`.
+    """Modified Simulated Binary Crossover operation used by
+    :class:`~optuna.samplers.NSGAIISampler`.
 
     vSBX generates child individuals without excluding any region of the parameter space,
     while maintaining the excellent properties of SBX.

--- a/optuna/storages/_in_memory.py
+++ b/optuna/storages/_in_memory.py
@@ -362,10 +362,9 @@ class InMemoryStorage(BaseStorage):
         with self._lock:
             self._check_study_id(study_id)
 
-            trials = self._studies[
+            trials: Union[List[FrozenTrial], Iterator[FrozenTrial]] = self._studies[
                 study_id
-            ].trials  # type: Union[List[FrozenTrial], Iterator[FrozenTrial]]
-
+            ].trials
             if states is not None:
                 trials = filter(lambda t: t.state in states, trials)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ benchmark = [
 checking = [
     "black",
     "blackdoc",
+    "flake8",
     "isort",
     "mypy",
     "types-PyYAML",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,6 @@ benchmark = [
 checking = [
     "black",
     "blackdoc",
-    "hacking",
     "isort",
     "mypy",
     "types-PyYAML",

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,10 +2,7 @@
 [flake8]
 ignore =
     E203,
-    W503,
-    # Ignore H306 for `hacking` to be compatible with `isort`:
-    # https://docs.openstack.org/hacking/latest/user/hacking.html#imports
-    H306
+    W503
 max-line-length = 99
 statistics = True
 exclude = .venv,venv,build,tutorial,.asv

--- a/tests/multi_objective_tests/samplers_tests/test_motpe.py
+++ b/tests/multi_objective_tests/samplers_tests/test_motpe.py
@@ -13,7 +13,7 @@ from optuna.samplers import MOTPESampler
 
 class MockSystemAttr:
     def __init__(self) -> None:
-        self.value = {}  # type: Dict[str, dict]
+        self.value: Dict[str, dict] = {}
 
     def set_trial_system_attr(self, _: int, key: str, value: dict) -> None:
         self.value[key] = value

--- a/tests/samplers_tests/tpe_tests/test_multi_objective_sampler.py
+++ b/tests/samplers_tests/tpe_tests/test_multi_objective_sampler.py
@@ -18,7 +18,7 @@ from optuna.samplers import TPESampler
 
 class MockSystemAttr:
     def __init__(self) -> None:
-        self.value = {}  # type: Dict[str, dict]
+        self.value: Dict[str, dict] = {}
 
     def set_trial_system_attr(self, _: int, key: str, value: dict) -> None:
         self.value[key] = value


### PR DESCRIPTION
## Motivation
"hacking" flake8 extension depends on `flake8 ~= 4.0.0` while latest version is
`6.0.0`. Due to this fixed version of flake8, latest flake8 linting fails on optuna
master branch.

## Description of the changes
- Drop `hacking`.
- Fix lint errors.
