### PR TITLE
Add `lightning_logs` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,3 +124,6 @@ docs/source/tutorial/
 
 # Dask
 dask-worker-space/
+
+# PyTorch Lightning
+lightning_logs/

--- a/optuna/samplers/_search_space/intersection.py
+++ b/optuna/samplers/_search_space/intersection.py
@@ -12,7 +12,7 @@ from optuna.study import Study
 
 @deprecated_class(
     "3.2.0",
-    "6.0.0",
+    "4.0.0",
     name="optuna.samplers.IntersectionSearchSpace",
     text="Please use optuna.search_space.IntersectionSearchSpace instead.",
 )
@@ -108,7 +108,7 @@ class IntersectionSearchSpace:
 
 @deprecated_func(
     "3.2.0",
-    "6.0.0",
+    "4.0.0",
     name="optuna.samplers.intersection_search_space",
     text="Please use optuna.search_space.intersection_search_space instead.",
 )


### PR DESCRIPTION
## Motivation
PyTorch Lightning uses `lightning_logs` as the logging directory.

## Description of the changes
Add `lightning_logs` to `.gitignore`