### PR TITLE
Add support for `distributed>=2023.3.2`

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -42,7 +42,7 @@ jobs:
         sudo apt-get update
         sudo apt-get -y install openmpi-bin libopenmpi-dev libopenblas-dev
 
-    # TODO(Shinichi): Remove the version constraint on PyTorch Lightning and Distributed
+    # TODO(Shinichi): Remove the version constraint on PyTorch Lightning
     - name: Install
       run: |
         python -m pip install --upgrade pip
@@ -56,7 +56,6 @@ jobs:
         pip install --progress-bar off .[optional]
         pip install --progress-bar off .[integration] --extra-index-url https://download.pytorch.org/whl/cpu
         pip install "pytorch-lightning<2.0.0"
-        pip install "distributed<2023.3.2"
 
         echo 'import coverage; coverage.process_startup()' > sitecustomize.py
 

--- a/.github/workflows/mac-tests.yml
+++ b/.github/workflows/mac-tests.yml
@@ -98,7 +98,7 @@ jobs:
         brew install open-mpi
         brew install openblas
 
-    # TODO(Shinichi): Remove the version constraint on PyTorch Lightning and Distributed
+    # TODO(Shinichi): Remove the version constraint on PyTorch Lightning
     - name: Install
       run: |
         python -m pip install --upgrade pip
@@ -112,7 +112,6 @@ jobs:
         pip install --progress-bar off .[optional]
         pip install --progress-bar off .[integration]
         pip install "pytorch-lightning<2.0.0"
-        pip install "distributed<2023.3.2"
 
     - name: Output installed packages
       run: |

--- a/.github/workflows/tests-integration.yml
+++ b/.github/workflows/tests-integration.yml
@@ -46,7 +46,7 @@ jobs:
         sudo apt-get update
         sudo apt-get -y install openmpi-bin libopenmpi-dev libopenblas-dev
 
-    # TODO(Shinichi): Remove the version constraint on PyTorch Lightning and Distributed
+    # TODO(Shinichi): Remove the version constraint on PyTorch Lightning
     - name: Install
       run: |
         python -m pip install --upgrade pip
@@ -60,7 +60,6 @@ jobs:
         pip install --progress-bar off .[optional]
         pip install --progress-bar off .[integration] --extra-index-url https://download.pytorch.org/whl/cpu
         pip install "pytorch-lightning<2.0.0"
-        pip install "distributed<2023.3.2"
 
     - name: Output installed packages
       run: |

--- a/optuna/integration/dask.py
+++ b/optuna/integration/dask.py
@@ -443,6 +443,11 @@ class DaskStorage(BaseStorage):
             Dask ``Client`` to connect to. If not provided, will attempt to find an
             existing ``Client``.
 
+        register:
+            Whether or not to register this storage instance with the cluster scheduler.
+            Most common usage of this storage class will not need to specify this argument.
+            Defaults to ``True``.
+
     """
 
     def __init__(

--- a/optuna/integration/dask.py
+++ b/optuna/integration/dask.py
@@ -471,7 +471,7 @@ class DaskStorage(BaseStorage):
                 )
 
     @property
-    def client(self):
+    def client(self) -> "distributed.Client":
         if not self._client:
             self._client = get_client()
         return self._client


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

There was a recent change in `distributed` that caused the Dask integration here to break (apologies for this breakage). As a temporary remediation, a version restriction on `distributed` was added in https://github.com/optuna/optuna/pull/4545. This PR adds support for `distributed>=2023.3.2` and removes those version restrictions. 

Closes https://github.com/optuna/optuna/issues/4553

## Description of the changes
<!-- Describe the changes in this PR. -->

This PR adds support for `distributed>=2023.3.2` to the Dask integration. Note, the changes here are backwards compatible (I've confirmed locally that tests pass with `dask` and `distributed` 2023.3.0)

cc @toshihikoyanase