### PR TITLE
Add docstring for the `Terminator` class

### DIFF
--- a/optuna/terminator/terminator.py
+++ b/optuna/terminator/terminator.py
@@ -19,6 +19,73 @@ class BaseTerminator(metaclass=abc.ABCMeta):
 
 @experimental_class("3.2.0")
 class Terminator(BaseTerminator):
+    """Automatic stopping mechanism for Optuna studies
+
+    This class implements an automatic stopping mechanism for Optuna studies, aiming to prevent
+    unnecessary computation. The study is terminated when the statistical error, e.g. 
+    cross-validation error, exceeds the room left for optimization.
+
+    For further information about the algorithm, please refer to the following paper:
+
+    - `A. Makarova et al. Automatic termination for hyperparameter optimization.
+      <https://arxiv.org/abs/2104.08166>`_
+
+    Args:
+        improvement_evaluator:
+            An evaluator object for assessing the room left for optimization. Defaults to a
+            :class:`~optuna.terminator.improvement.evaluator.RegretBoundEvaluator` object.
+        error_evaluator:
+            An evaluator for calculating the statistical error, e.g. cross-validation error.
+            Defaults to a :class:`~optuna.terminator.erroreval.CrossValidationErrorEvaluator`
+            object.
+        min_n_trials:
+            The minimum number of trials before termination is considered. Defaults to ``20``.
+
+    Raises:
+        ValueError: If ``min_n_trials`` is not a positive integer.
+
+    Example:
+        from sklearn.datasets import load_wine
+        from sklearn.ensemble import RandomForestClassifier
+        from sklearn.model_selection import cross_val_score
+        from sklearn.model_selection import KFold
+
+        import optuna
+        from optuna.terminator.terminator import Terminator
+        from optuna.terminator.serror import report_cross_validation_scores
+
+
+        study = optuna.create_study(direction="maximize")
+        terminator = Terminator()
+        min_n_trials = 20
+
+        while True:
+            trial = study.ask()
+
+            X, y = load_wine(return_X_y=True)
+
+            clf = RandomForestClassifier(
+                max_depth=trial.suggest_int("max_depth", 2, 32),
+                min_samples_split=trial.suggest_float("min_samples_split", 0, 1),
+                criterion=trial.suggest_categorical("criterion", ("gini", "entropy")),
+            )
+
+            scores = cross_val_score(clf, X, y, cv=KFold(n_splits=5, shuffle=True))
+            report_cross_validation_scores(trial, scores)
+
+            value = scores.mean()
+            print(f"Trial #{trial.number} finished with value {value}.")
+            study.tell(trial, value)
+
+            if trial.number > min_n_trials and terminator.should_terminate(study):
+                print("Terminated by Optuna Terminator!")
+                break
+
+    .. seealso::
+        Please refer to :class:`~optuna.terminator.callbacks.TerminationCallback` for to use the
+        terminator mechanism with the :func:`~optuna.study.Study.optimize` method.
+    """
+
     def __init__(
         self,
         improvement_evaluator: Optional[BaseImprovementEvaluator] = None,

--- a/optuna/terminator/terminator.py
+++ b/optuna/terminator/terminator.py
@@ -22,7 +22,7 @@ class Terminator(BaseTerminator):
     """Automatic stopping mechanism for Optuna studies
 
     This class implements an automatic stopping mechanism for Optuna studies, aiming to prevent
-    unnecessary computation. The study is terminated when the statistical error, e.g. 
+    unnecessary computation. The study is terminated when the statistical error, e.g.
     cross-validation error, exceeds the room left for optimization.
 
     For further information about the algorithm, please refer to the following paper:


### PR DESCRIPTION
This is a follow-up PR of #4405, adding the docstring of the `Terminator` class.