### PR TITLE
Get `system_attrs` lazily for samplers and pruners

### DIFF
--- a/optuna/trial/_trial.py
+++ b/optuna/trial/_trial.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+from collections import UserDict
 import copy
 import datetime
 from typing import Any
@@ -59,6 +62,7 @@ class Trial(BaseTrial):
             study, self._cached_frozen_trial
         )
         self._relative_params: Optional[Dict[str, Any]] = None
+        self._fixed_params = self._cached_frozen_trial.system_attrs.get("fixed_params", [])
 
     @property
     def relative_params(self) -> Dict[str, Any]:
@@ -528,7 +532,7 @@ class Trial(BaseTrial):
                 "Trial.should_prune is not supported for multi-objective optimization."
             )
 
-        trial = copy.deepcopy(self._get_latest_trial())
+        trial = self._get_latest_trial()
         return self.study.pruner.prune(self.study, trial)
 
     def set_user_attr(self, key: str, value: Any) -> None:
@@ -618,7 +622,7 @@ class Trial(BaseTrial):
             param_value = trial.params[name]
         else:
             if self._is_fixed_param(name, distribution):
-                param_value = trial.system_attrs["fixed_params"][name]
+                param_value = self._fixed_params[name]
             elif distribution.single():
                 param_value = distributions._get_single_value(distribution)
             elif self._is_relative_param(name, distribution):
@@ -638,14 +642,10 @@ class Trial(BaseTrial):
         return param_value
 
     def _is_fixed_param(self, name: str, distribution: BaseDistribution) -> bool:
-        system_attrs = self._cached_frozen_trial.system_attrs
-        if "fixed_params" not in system_attrs:
+        if name not in self._fixed_params:
             return False
 
-        if name not in system_attrs["fixed_params"]:
-            return False
-
-        param_value = system_attrs["fixed_params"][name]
+        param_value = self._fixed_params[name]
         param_value_in_internal_repr = distribution.to_internal_repr(param_value)
 
         contained = distribution._contains(param_value_in_internal_repr)
@@ -688,10 +688,12 @@ class Trial(BaseTrial):
             )
 
     def _get_latest_trial(self) -> FrozenTrial:
-        # TODO(eukaryo): Remove this method after `system_attrs` property is deprecated.
-        system_attrs = copy.deepcopy(self.storage.get_trial_system_attrs(self._trial_id))
-        self._cached_frozen_trial.system_attrs = system_attrs
-        return self._cached_frozen_trial
+        # TODO(eukaryo): Remove this method after `system_attrs` property is removed.
+        latest_trial = copy.deepcopy(self._cached_frozen_trial)
+        latest_trial.system_attrs = _LazyTrialSystemAttrs(  # type: ignore[assignment]
+            self._trial_id, self.storage
+        )
+        return latest_trial
 
     @property
     def params(self) -> Dict[str, Any]:
@@ -752,3 +754,18 @@ class Trial(BaseTrial):
         """
 
         return self._cached_frozen_trial.number
+
+
+class _LazyTrialSystemAttrs(UserDict):
+    def __init__(self, trial_id: int, storage: optuna.storages.BaseStorage) -> None:
+        super().__init__()
+        self._trial_id = trial_id
+        self._storage = storage
+        self._initialized = False
+
+    def __getattribute__(self, key: str) -> Any:
+        if key == "data":
+            if not self._initialized:
+                self._initialized = True
+                super().update(self._storage.get_trial_system_attrs(self._trial_id))
+        return super().__getattribute__(key)

--- a/tests/trial_tests/test_trial.py
+++ b/tests/trial_tests/test_trial.py
@@ -678,3 +678,35 @@ def test_persisted_param() -> None:
         study = load_study(storage=storage, study_name=study_name)
 
         assert all("x" in t.params for t in study.trials)
+
+
+@pytest.mark.parametrize("storage_mode", STORAGE_MODES)
+def test_lazy_trial_system_attrs(storage_mode: str) -> None:
+    with StorageSupplier(storage_mode) as storage:
+        study = optuna.create_study(storage=storage)
+        trial = study.ask()
+        storage.set_trial_system_attr(trial._trial_id, "int", 0)
+        storage.set_trial_system_attr(trial._trial_id, "str", "A")
+
+        # _LazyTrialSystemAttrs gets attrs the first time it is needed.
+        # Then, we create the instance for each method, and test the first and second use.
+
+        system_attrs = optuna.trial._trial._LazyTrialSystemAttrs(trial._trial_id, storage)
+        assert system_attrs == {"int": 0, "str": "A"}  # type: ignore[comparison-overlap]
+        assert system_attrs == {"int": 0, "str": "A"}  # type: ignore[comparison-overlap]
+
+        system_attrs = optuna.trial._trial._LazyTrialSystemAttrs(trial._trial_id, storage)
+        assert len(system_attrs) == 2
+        assert len(system_attrs) == 2
+
+        system_attrs = optuna.trial._trial._LazyTrialSystemAttrs(trial._trial_id, storage)
+        assert set(system_attrs.keys()) == {"int", "str"}
+        assert set(system_attrs.keys()) == {"int", "str"}
+
+        system_attrs = optuna.trial._trial._LazyTrialSystemAttrs(trial._trial_id, storage)
+        assert set(system_attrs.values()) == {0, "A"}
+        assert set(system_attrs.values()) == {0, "A"}
+
+        system_attrs = optuna.trial._trial._LazyTrialSystemAttrs(trial._trial_id, storage)
+        assert set(system_attrs.items()) == {("int", 0), ("str", "A")}
+        assert set(system_attrs.items()) == {("int", 0), ("str", "A")}


### PR DESCRIPTION
## Motivation
This is part of the work to deprecate `_CachedStorage`.

When directly using `RDBStorage`, `_get_latest_trial` is a bottleneck because it reads `system_attrs` from the remote storage.

## Description of the changes
Getting `system_attrs` lazily. This change eliminates access to remote storage for `system_attrs` by samplers and pruners except `GridSampler`, `SuccessiveHalvingPruner`, and `HyperbandPruner`.