### PR TITLE
Remove dependency on  `codecov` 

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -11,6 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+
   coverage:
     runs-on: ubuntu-latest
 
@@ -55,7 +56,6 @@ jobs:
         pip install --progress-bar off .[optional]
         pip install --progress-bar off .[integration] --extra-index-url https://download.pytorch.org/whl/cpu
         pip install "pytorch-lightning<2.0.0"
-        pip install coverage
 
         echo 'import coverage; coverage.process_startup()' > sitecustomize.py
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -11,7 +11,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-
   coverage:
     runs-on: ubuntu-latest
 
@@ -56,6 +55,7 @@ jobs:
         pip install --progress-bar off .[optional]
         pip install --progress-bar off .[integration] --extra-index-url https://download.pytorch.org/whl/cpu
         pip install "pytorch-lightning<2.0.0"
+        pip install coverage
 
         echo 'import coverage; coverage.process_startup()' > sitecustomize.py
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,7 +120,6 @@ optional = [
     # optuna/visualization/param_importances.py.
 ]
 test = [
-    "codecov",
     "fakeredis[lua]",
     "kaleido",
     "pytest",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,6 +120,7 @@ optional = [
     # optuna/visualization/param_importances.py.
 ]
 test = [
+    "coverage",
     "fakeredis[lua]",
     "kaleido",
     "pytest",


### PR DESCRIPTION
## Motivation
Remove dependency on `codecov`, which was suddenly removed from PyPI (See this [blog post](https://about.codecov.io/blog/message-regarding-the-pypi-package/)) and is blocking code tests.
## Description of the changes
- Remove `codecov` from `pyproject.toml`
- Install `coverage` in `Coverrage` CI