### PR TITLE
Change arguments of `BaseErrorEvaluator` and classes that inherit from it

### DIFF
--- a/optuna/terminator/terminator.py
+++ b/optuna/terminator/terminator.py
@@ -109,7 +109,9 @@ class Terminator(BaseTerminator):
             trials=study.trials,
             study_direction=study.direction,
         )
-        error = self._error_evaluator.evaluate(study)
+        error = self._error_evaluator.evaluate(
+            trials=study.trials, study_direction=study.direction
+        )
         should_terminate = regret_bound < error
 
         return should_terminate

--- a/tests/terminator_tests/test_erroreval.py
+++ b/tests/terminator_tests/test_erroreval.py
@@ -32,7 +32,7 @@ def test_cross_validation_evaluator() -> None:
     )
 
     evaluator = CrossValidationErrorEvaluator()
-    serror = evaluator.evaluate(study)
+    serror = evaluator.evaluate(study.trials, study.direction)
 
     expected_scale = 1.5
     assert serror == math.sqrt(4.0 * expected_scale)
@@ -47,7 +47,7 @@ def test_cross_validation_evaluator_without_cv_scores() -> None:
 
     evaluator = CrossValidationErrorEvaluator()
     with pytest.raises(ValueError):
-        evaluator.evaluate(study)
+        evaluator.evaluate(study.trials, study.direction)
 
 
 def test_report_cross_validation_scores() -> None:
@@ -79,6 +79,6 @@ def test_static_evaluator() -> None:
     )
 
     evaluator = StaticErrorEvaluator(constant=100.0)
-    serror = evaluator.evaluate(study)
+    serror = evaluator.evaluate(study.trials, study.direction)
 
     assert serror == 100.0

--- a/tests/terminator_tests/test_erroreval.py
+++ b/tests/terminator_tests/test_erroreval.py
@@ -22,12 +22,16 @@ def _create_trial(value: float, cv_scores: list[float]) -> FrozenTrial:
     )
 
 
-def test_cross_validation_evaluator() -> None:
-    study = create_study(direction="minimize")
+@pytest.mark.parametrize("direction", ["minimize", "maximize"])
+def test_cross_validation_evaluator(direction: str) -> None:
+    study = create_study(direction=direction)
+    sign = 1 if direction == "minimize" else -1
     study.add_trials(
         [
-            _create_trial(value=2.0, cv_scores=[1.0, -1.0]),  # Second best trial with 1.0 var.
-            _create_trial(value=1.0, cv_scores=[2.0, -2.0]),  # Best trial with 4.0 var.
+            _create_trial(
+                value=sign * 2.0, cv_scores=[1.0, -1.0]
+            ),  # Second best trial with 1.0 var.
+            _create_trial(value=sign * 1.0, cv_scores=[2.0, -2.0]),  # Best trial with 4.0 var.
         ]
     )
 
@@ -38,8 +42,9 @@ def test_cross_validation_evaluator() -> None:
     assert serror == math.sqrt(4.0 * expected_scale)
 
 
-def test_cross_validation_evaluator_without_cv_scores() -> None:
-    study = create_study(direction="minimize")
+@pytest.mark.parametrize("direction", ["minimize", "maximize"])
+def test_cross_validation_evaluator_without_cv_scores(direction: str) -> None:
+    study = create_study(direction=direction)
     study.add_trial(
         # Note that the CV score is not reported with the system attr.
         create_trial(params={}, distributions={}, value=0.0)
@@ -50,10 +55,11 @@ def test_cross_validation_evaluator_without_cv_scores() -> None:
         evaluator.evaluate(study.trials, study.direction)
 
 
-def test_report_cross_validation_scores() -> None:
+@pytest.mark.parametrize("direction", ["minimize", "maximize"])
+def test_report_cross_validation_scores(direction: str) -> None:
     scores = [1.0, 2.0]
 
-    study = create_study(direction="minimize")
+    study = create_study(direction=direction)
     trial = study.ask()
     report_cross_validation_scores(trial, scores)
     study.tell(trial, 0.0)
@@ -61,17 +67,19 @@ def test_report_cross_validation_scores() -> None:
     assert study.trials[0].system_attrs[_CROSS_VALIDATION_SCORES_KEY] == scores
 
 
-def test_report_cross_validation_scores_with_illegal_scores_length() -> None:
+@pytest.mark.parametrize("direction", ["minimize", "maximize"])
+def test_report_cross_validation_scores_with_illegal_scores_length(direction: str) -> None:
     scores = [1.0]
 
-    study = create_study(direction="minimize")
+    study = create_study(direction=direction)
     trial = study.ask()
     with pytest.raises(ValueError):
         report_cross_validation_scores(trial, scores)
 
 
-def test_static_evaluator() -> None:
-    study = create_study(direction="minimize")
+@pytest.mark.parametrize("direction", ["minimize", "maximize"])
+def test_static_evaluator(direction: str) -> None:
+    study = create_study(direction=direction)
     study.add_trials(
         [
             _create_trial(value=2.0, cv_scores=[1.0, -1.0]),


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
Current `BaseErrorEvaluator` and classes that inherit from it requires `study` for `evaluate` method.
However, the implementation of `evaluate` method does not require `study`, thus we can replace it by list of `trials`.
This change gives some merits.
* This change make  `evaluate` of `BaseErrorEvaluator`  have the same interface of `evaluate` of `BaseImprovementEvaluator`
* We can call `evaluate` method with fewer information

<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

## Description of the changes
Change the argument of  `evaluate` of `BaseErrorEvaluator` to `list[FrozenTrial]` and `StudyDirection` from old argument  `Study`.
<!-- Describe the changes in this PR. -->
