### PR TITLE
Delete Python 3.7 Docker image for dev

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -33,6 +33,8 @@ jobs:
         python_version: ['3.7', '3.8', '3.9', '3.10', '3.11']
         build_type: ['', 'dev']  # "dev" installs all the dependencies including pytest.
         exclude:
+        - python_version: '3.7'
+          build_type: 'dev'
         - python_version: '3.11'
           build_type: 'dev'
 


### PR DESCRIPTION
## Motivation
Recently, CI takes a very long time for `dockerimage(3.7, dev)`.

## Description of the changes
Stop to build the Docker image with Python 3.7 for development.