### PR TITLE
Fix targets of `black` and `isort` in `formats.sh`

### DIFF
--- a/formats.sh
+++ b/formats.sh
@@ -50,7 +50,7 @@ res_black=$(black $target --check --diff 2>&1)
 if [ $? -eq 1 ] ; then
   if [ $update -eq 1 ] ; then
     echo "black failed. The code will be formatted by black."
-    black .
+    black $target
   else
     echo "$res_black"
     echo "black failed."
@@ -87,7 +87,7 @@ res_isort=$(isort $target --check 2>&1)
 if [ $? -eq 1 ] ; then
   if [ $update -eq 1 ] ; then
     echo "isort failed. The code will be formatted by isort."
-    isort .
+    isort $target
   else
     echo "$res_isort"
     echo "isort failed."


### PR DESCRIPTION
## Motivation
`black` and `isort` in `formats.sh` wrongly reformat all files.

## Description of the changes
Specify the targets of `black` and `isort`.