### PR TITLE
Install `benchmark`, `optional`, and `test` in dev Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ COPY . .
 ARG BUILD_TYPE='dev'
 
 RUN if [ "${BUILD_TYPE}" = "dev" ]; then \
-        pip install ${PIP_OPTIONS} -e '.[checking, document, integration]' -f https://download.pytorch.org/whl/torch_stable.html; \
+        pip install ${PIP_OPTIONS} -e '.[benchmark, checking, document, integration, optional, test]' -f https://download.pytorch.org/whl/torch_stable.html; \
     else \
         pip install ${PIP_OPTIONS} -e .; \
     fi \


### PR DESCRIPTION
## Motivation
For development purposes, `benchmark`, `optional`, and `test` should be installed in Docker image.

## Description of the changes
Install `benchmark`, `optional`, and `test` in dev Docker image