### PR TITLE
Install `test` in `checks-integration` CI

### DIFF
--- a/.github/workflows/checks-integration.yml
+++ b/.github/workflows/checks-integration.yml
@@ -34,10 +34,11 @@ jobs:
     - name: Install
       run: |
         python -m pip install -U pip
-        pip install --progress-bar off -U .[checking]
-        pip install --progress-bar off -U .[optional]
-        pip install --progress-bar off -U .[integration] --extra-index-url https://download.pytorch.org/whl/cpu
         pip install --progress-bar off -U .[benchmark]
+        pip install --progress-bar off -U .[checking]
+        pip install --progress-bar off -U .[integration] --extra-index-url https://download.pytorch.org/whl/cpu
+        pip install --progress-bar off -U .[optional]
+        pip install --progress-bar off -U .[test]
         pip install --progress-bar off -U bayesmark
         pip install --progress-bar off -U kurobako
         pip install "sqlalchemy<2.0.0"

--- a/optuna/testing/storages.py
+++ b/optuna/testing/storages.py
@@ -84,7 +84,7 @@ class StorageSupplier:
         elif self.storage_specifier == "journal_redis":
             journal_redis_storage = optuna.storages.JournalRedisStorage("redis://localhost")
             journal_redis_storage._redis = self.extra_args.get(
-                "redis", fakeredis.FakeStrictRedis()
+                "redis", fakeredis.FakeStrictRedis()  # type: ignore[no-untyped-call]
             )
             return optuna.storages.JournalStorage(journal_redis_storage)
         elif "journal" in self.storage_specifier:

--- a/tests/storages_tests/test_journal.py
+++ b/tests/storages_tests/test_journal.py
@@ -10,7 +10,7 @@ from typing import Type
 from unittest import mock
 
 import _pytest.capture
-import fakeredis
+from fakeredis import FakeStrictRedis
 import pytest
 
 import optuna
@@ -59,7 +59,7 @@ class JournalLogStorageSupplier:
             journal_redis_storage = optuna.storages.JournalRedisStorage(
                 "redis://localhost", use_cluster
             )
-            journal_redis_storage._redis = fakeredis.FakeStrictRedis()
+            journal_redis_storage._redis = FakeStrictRedis()  # type: ignore[no-untyped-call]
             return journal_redis_storage
         else:
             raise RuntimeError("Unknown log storage type: {}".format(self.storage_type))


### PR DESCRIPTION
## Motivation
`mypy` raises errors in my environment.

## Description of the changes
- Install `test` in `checks-integration` CI
- Add `type: ignore[no-untyped-call]` for `FakeStrictRedis`