### PR TITLE
Fix checks integration

### DIFF
--- a/tests/integration_tests/test_pytorch_distributed.py
+++ b/tests/integration_tests/test_pytorch_distributed.py
@@ -37,12 +37,12 @@ def init_process_group() -> None:
     os.environ["MASTER_ADDR"] = "127.0.0.1"
     os.environ["MASTER_PORT"] = "20000"
 
-    dist.init_process_group("gloo", timeout=datetime.timedelta(seconds=15))  # type: ignore
+    dist.init_process_group("gloo", timeout=datetime.timedelta(seconds=15))
 
 
 def test_torch_distributed_trial_experimental_warning() -> None:
     with pytest.warns(optuna.exceptions.ExperimentalWarning):
-        if dist.get_rank() == 0:  # type: ignore
+        if dist.get_rank() == 0:
             study = optuna.create_study()
             TorchDistributedTrial(study.ask())
         else:
@@ -52,7 +52,7 @@ def test_torch_distributed_trial_experimental_warning() -> None:
 @pytest.mark.filterwarnings("ignore::optuna.exceptions.ExperimentalWarning")
 def test_torch_distributed_trial_invalid_argument() -> None:
     with pytest.raises(ValueError):
-        if dist.get_rank() == 0:  # type: ignore
+        if dist.get_rank() == 0:
             TorchDistributedTrial(None)
         else:
             study = optuna.create_study()
@@ -63,7 +63,7 @@ def test_torch_distributed_trial_invalid_argument() -> None:
 @pytest.mark.parametrize("storage_mode", STORAGE_MODES)
 def test_suggest_float(storage_mode: str) -> None:
     with StorageSupplier(storage_mode) as storage:
-        if dist.get_rank() == 0:  # type: ignore
+        if dist.get_rank() == 0:
             study = optuna.create_study(storage=storage)
             trial = TorchDistributedTrial(study.ask())
         else:
@@ -81,7 +81,7 @@ def test_suggest_float(storage_mode: str) -> None:
 @pytest.mark.parametrize("storage_mode", STORAGE_MODES)
 def test_suggest_uniform(storage_mode: str) -> None:
     with StorageSupplier(storage_mode) as storage:
-        if dist.get_rank() == 0:  # type: ignore
+        if dist.get_rank() == 0:
             study = optuna.create_study(storage=storage)
             trial = TorchDistributedTrial(study.ask())
         else:
@@ -99,7 +99,7 @@ def test_suggest_uniform(storage_mode: str) -> None:
 @pytest.mark.parametrize("storage_mode", STORAGE_MODES)
 def test_suggest_loguniform(storage_mode: str) -> None:
     with StorageSupplier(storage_mode) as storage:
-        if dist.get_rank() == 0:  # type: ignore
+        if dist.get_rank() == 0:
             study = optuna.create_study(storage=storage)
             trial = TorchDistributedTrial(study.ask())
         else:
@@ -117,7 +117,7 @@ def test_suggest_loguniform(storage_mode: str) -> None:
 @pytest.mark.parametrize("storage_mode", STORAGE_MODES)
 def test_suggest_discrete_uniform(storage_mode: str) -> None:
     with StorageSupplier(storage_mode) as storage:
-        if dist.get_rank() == 0:  # type: ignore
+        if dist.get_rank() == 0:
             study = optuna.create_study(storage=storage)
             trial = TorchDistributedTrial(study.ask())
         else:
@@ -135,7 +135,7 @@ def test_suggest_discrete_uniform(storage_mode: str) -> None:
 @pytest.mark.parametrize("storage_mode", STORAGE_MODES)
 def test_suggest_int(storage_mode: str) -> None:
     with StorageSupplier(storage_mode) as storage:
-        if dist.get_rank() == 0:  # type: ignore
+        if dist.get_rank() == 0:
             study = optuna.create_study(storage=storage)
             trial = TorchDistributedTrial(study.ask())
         else:
@@ -152,7 +152,7 @@ def test_suggest_int(storage_mode: str) -> None:
 @pytest.mark.parametrize("storage_mode", STORAGE_MODES)
 def test_suggest_categorical(storage_mode: str) -> None:
     with StorageSupplier(storage_mode) as storage:
-        if dist.get_rank() == 0:  # type: ignore
+        if dist.get_rank() == 0:
             study = optuna.create_study(storage=storage)
             trial = TorchDistributedTrial(study.ask())
         else:
@@ -170,7 +170,7 @@ def test_suggest_categorical(storage_mode: str) -> None:
 def test_report(storage_mode: str) -> None:
     with StorageSupplier(storage_mode) as storage:
         study: Optional[optuna.study.Study] = None
-        if dist.get_rank() == 0:  # type: ignore
+        if dist.get_rank() == 0:
             study = optuna.create_study(storage=storage)
             trial = TorchDistributedTrial(study.ask())
         else:
@@ -178,7 +178,7 @@ def test_report(storage_mode: str) -> None:
 
         trial.report(1, 0)
 
-        if dist.get_rank() == 0:  # type: ignore
+        if dist.get_rank() == 0:
             assert study is not None
             study.trials[0].intermediate_values[0] == 1
 
@@ -188,7 +188,7 @@ def test_report(storage_mode: str) -> None:
 def test_report_nan(storage_mode: str) -> None:
     with StorageSupplier(storage_mode) as storage:
         study: Optional[optuna.study.Study] = None
-        if dist.get_rank() == 0:  # type: ignore
+        if dist.get_rank() == 0:
             study = optuna.create_study(storage=storage)
             trial = TorchDistributedTrial(study.ask())
         else:
@@ -197,7 +197,7 @@ def test_report_nan(storage_mode: str) -> None:
         with pytest.raises(TypeError):
             trial.report("abc", 0)  # type: ignore
 
-        if dist.get_rank() == 0:  # type: ignore
+        if dist.get_rank() == 0:
             assert study is not None
             assert len(study.trials[0].intermediate_values) == 0
 
@@ -207,7 +207,7 @@ def test_report_nan(storage_mode: str) -> None:
 @pytest.mark.parametrize("is_pruning", [False, True])
 def test_should_prune(storage_mode: str, is_pruning: bool) -> None:
     with StorageSupplier(storage_mode) as storage:
-        if dist.get_rank() == 0:  # type: ignore
+        if dist.get_rank() == 0:
             study = optuna.create_study(storage=storage, pruner=DeterministicPruner(is_pruning))
             trial = TorchDistributedTrial(study.ask())
         else:
@@ -221,7 +221,7 @@ def test_should_prune(storage_mode: str, is_pruning: bool) -> None:
 @pytest.mark.parametrize("storage_mode", STORAGE_MODES)
 def test_user_attrs(storage_mode: str) -> None:
     with StorageSupplier(storage_mode) as storage:
-        if dist.get_rank() == 0:  # type: ignore
+        if dist.get_rank() == 0:
             study = optuna.create_study(storage=storage)
             trial = TorchDistributedTrial(study.ask())
         else:
@@ -237,7 +237,7 @@ def test_user_attrs(storage_mode: str) -> None:
 @pytest.mark.filterwarnings("ignore::optuna.exceptions.ExperimentalWarning")
 def test_user_attrs_with_exception() -> None:
     with StorageSupplier("sqlite") as storage:
-        if dist.get_rank() == 0:  # type: ignore
+        if dist.get_rank() == 0:
             study = optuna.create_study(storage=storage)
             trial = TorchDistributedTrial(study.ask())
         else:
@@ -251,7 +251,7 @@ def test_user_attrs_with_exception() -> None:
 @pytest.mark.parametrize("storage_mode", STORAGE_MODES)
 def test_number(storage_mode: str) -> None:
     with StorageSupplier(storage_mode) as storage:
-        if dist.get_rank() == 0:  # type: ignore
+        if dist.get_rank() == 0:
             study = optuna.create_study(storage=storage)
             trial = TorchDistributedTrial(study.ask())
         else:
@@ -264,7 +264,7 @@ def test_number(storage_mode: str) -> None:
 @pytest.mark.parametrize("storage_mode", STORAGE_MODES)
 def test_datetime_start(storage_mode: str) -> None:
     with StorageSupplier(storage_mode) as storage:
-        if dist.get_rank() == 0:  # type: ignore
+        if dist.get_rank() == 0:
             study = optuna.create_study(storage=storage)
             trial = TorchDistributedTrial(study.ask())
         else:
@@ -277,7 +277,7 @@ def test_datetime_start(storage_mode: str) -> None:
 @pytest.mark.parametrize("storage_mode", STORAGE_MODES)
 def test_params(storage_mode: str) -> None:
     with StorageSupplier(storage_mode) as storage:
-        if dist.get_rank() == 0:  # type: ignore
+        if dist.get_rank() == 0:
             study = optuna.create_study(storage=storage)
             trial = TorchDistributedTrial(study.ask())
         else:
@@ -297,7 +297,7 @@ def test_params(storage_mode: str) -> None:
 @pytest.mark.parametrize("storage_mode", STORAGE_MODES)
 def test_distributions(storage_mode: str) -> None:
     with StorageSupplier(storage_mode) as storage:
-        if dist.get_rank() == 0:  # type: ignore
+        if dist.get_rank() == 0:
             study = optuna.create_study(storage=storage)
             trial = TorchDistributedTrial(study.ask())
         else:
@@ -324,7 +324,7 @@ def test_distributions(storage_mode: str) -> None:
 def test_updates_properties(storage_mode: str) -> None:
     """Check for any distributed deadlock following a property read."""
     with StorageSupplier(storage_mode) as storage:
-        if dist.get_rank() == 0:  # type: ignore
+        if dist.get_rank() == 0:
             study = optuna.create_study(storage=storage)
             trial = TorchDistributedTrial(study.ask())
         else:
@@ -341,13 +341,13 @@ def test_updates_properties(storage_mode: str) -> None:
         ]
 
         # Rank 0 can read properties without deadlock.
-        if dist.get_rank() == 0:  # type: ignore
+        if dist.get_rank() == 0:
             [getattr(trial, p) for p in property_names]
 
         dist.barrier()  # type: ignore
 
         # Same with rank 1.
-        if dist.get_rank() == 1:  # type: ignore
+        if dist.get_rank() == 1:
             [getattr(trial, p) for p in property_names]
 
         dist.barrier()  # type: ignore

--- a/tests/integration_tests/test_pytorch_distributed.py
+++ b/tests/integration_tests/test_pytorch_distributed.py
@@ -195,7 +195,7 @@ def test_report_nan(storage_mode: str) -> None:
             trial = TorchDistributedTrial(None)
 
         with pytest.raises(TypeError):
-            trial.report("abc", 0)  # type: ignore
+            trial.report("abc", 0)  # type: ignore[arg-type]
 
         if dist.get_rank() == 0:
             assert study is not None
@@ -344,10 +344,10 @@ def test_updates_properties(storage_mode: str) -> None:
         if dist.get_rank() == 0:
             [getattr(trial, p) for p in property_names]
 
-        dist.barrier()  # type: ignore
+        dist.barrier()  # type: ignore[no-untyped-call]
 
         # Same with rank 1.
         if dist.get_rank() == 1:
             [getattr(trial, p) for p in property_names]
 
-        dist.barrier()  # type: ignore
+        dist.barrier()  # type: ignore[no-untyped-call]


### PR DESCRIPTION
## Motivation
Resolve current failure of `Checks(Integration)`

## Description of the changes
Mypy type annotations are added to some functions in `torch.distributed` since `torch==1.11.0` `torch==2.0.0` and some `type:ignore`s became unnecessary after https://github.com/optuna/optuna/pull/4585 is merged. For more details, see the history of https://github.com/pytorch/pytorch/blob/main/torch/distributed/distributed_c10d.py

- removes unnecessary `type:ignore`s
- specifies error code for `type:ignore` in `test_pytorch_distributed.py`
