### PR TITLE
Delete `import Rectangle` in `visualization/matplotlib`

### DIFF
--- a/optuna/visualization/matplotlib/_matplotlib_imports.py
+++ b/optuna/visualization/matplotlib/_matplotlib_imports.py
@@ -13,7 +13,6 @@ with try_import() as _imports:
     from matplotlib.collections import PathCollection
     from matplotlib.colors import Colormap
     from matplotlib.contour import ContourSet
-    from matplotlib.patches import Rectangle
 
     # TODO(ytknzw): Set precise version.
     if version.parse(matplotlib_version) < version.parse("3.0.0"):
@@ -35,5 +34,4 @@ __all__ = [
     "PathCollection",
     "Colormap",
     "ContourSet",
-    "Rectangle",
 ]


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

In `optuna/visualization/matplotlib/_matplotlib_imports.py`, `Rectangle` is imported but not used.

## Description of the changes
<!-- Describe the changes in this PR. -->

Delete codes to import `Rectangle` in `visualization/matplotlib`.