### PR TITLE
Replace Duplicate Code in `PyTorchLightningPruningCallback`

### DIFF
--- a/optuna/integration/pytorch_lightning.py
+++ b/optuna/integration/pytorch_lightning.py
@@ -119,9 +119,7 @@ class PyTorchLightningPruningCallback(Callback):
             should_stop = self._trial.should_prune()
 
             # Update intermediate value in the storage.
-            _trial_id = self._trial._trial_id
-            _study = self._trial.study
-            _trial_system_attrs = _study._storage.get_trial_system_attrs(_trial_id)
+            _trial_system_attrs = self._trial.system_attrs
             intermediate_values = _trial_system_attrs.get(_INTERMEDIATE_VALUE)
             intermediate_values[epoch] = current_score.item()  # type: ignore[index]
             self._trial.set_system_attr(_INTERMEDIATE_VALUE, intermediate_values)


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
Current implementation of `PyTorchLightningPruningCallback` involves a few duplicate code when dealing with a `trial`'s `system_attr`. Specifically, access and modification of a `trial`'s `system_attr` is done by explicitly accessing the attributes of the `trial`. However, the same could be done by simply accessing `trial.system_attrs` and `trial.set_system_attr`. This pull request resolves this duplicate implementation, and consequently hides the inner implementation of `trial`, while also improving readability.

## Description of the changes
<!-- Describe the changes in this PR. -->
1. Replace `self._trial.storage.set_trial_system_attr` calls with `self._trial.set_system_attr` calls.
2. Replace current `_trial_system_attrs` access with direct access to `self._trial.system_attrs`.