### PR TITLE
Fix `ImportError` for `botorch<=0.4.0`

### DIFF
--- a/optuna/integration/botorch.py
+++ b/optuna/integration/botorch.py
@@ -8,7 +8,7 @@ from typing import Union
 import warnings
 
 import numpy
-from pkg_resources import parse_version
+from packaging import version
 
 from optuna import logging
 from optuna._experimental import experimental_class
@@ -39,7 +39,7 @@ with try_import() as _imports:
     from botorch.sampling import SobolQMCNormalSampler
     import botorch.version
 
-    if parse_version(botorch.version.version) < parse_version("0.8.0"):
+    if version.parse(botorch.version.version) < version.parse("0.8.0"):
         from botorch.fit import fit_gpytorch_model as fit_gpytorch_mll
 
         def _get_sobol_qmc_normal_sampler(num_samples: int) -> SobolQMCNormalSampler:

--- a/optuna/integration/botorch.py
+++ b/optuna/integration/botorch.py
@@ -8,6 +8,7 @@ from typing import Union
 import warnings
 
 import numpy
+from pkg_resources import parse_version
 
 from optuna import logging
 from optuna._experimental import experimental_class
@@ -38,7 +39,7 @@ with try_import() as _imports:
     from botorch.sampling import SobolQMCNormalSampler
     import botorch.version
 
-    if botorch.version.version_tuple < (0, 8, 0):
+    if parse_version(botorch.version.version) < parse_version("0.8.0"):
         from botorch.fit import fit_gpytorch_model as fit_gpytorch_mll
 
         def _get_sobol_qmc_normal_sampler(num_samples: int) -> SobolQMCNormalSampler:


### PR DESCRIPTION
## Motivation
`botorch.version.version_tuple` was introduced in BoTorch v0.5.0. If BoTorch v0.4.0 is installed, `from optuna.integration import BoTorchSampler` raises an incomprehensible exception.

```
$ python -c "from optuna.integration import BoTorchSampler"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
ImportError: cannot import name 'BoTorchSampler' from 'optuna.integration' (unknown location)
```

## Description of the changes
Use ~`pkg_resources.parse_version`~ `packaging.version` instead of `version_tuple`