### PR TITLE
Ensure that the plotly version of timeline plot draws a legend even if all TrialStates are the same.

### DIFF
--- a/optuna/visualization/_timeline.py
+++ b/optuna/visualization/_timeline.py
@@ -140,4 +140,5 @@ def _get_timeline_plot(info: _TimelineInfo) -> "go.Figure":
             yaxis={"title": "Trial"},
         )
     )
+    fig.update_layout(showlegend=True)  # Draw a legend even if all TrialStates are the same.
     return fig


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

I found that if all `TrialStates` are `COMPLETED`, the matplotlib version of timeline plot displays the legend, but the plotly version does not unless explicitly indicated.  I want to make the behavior of both versions the same.

## Description of the changes
<!-- Describe the changes in this PR. -->
Added explicit indication to always display legend(s).

||plotly|matplotlib|
|---|---|---|
|before|  ![test-fig-plotly-old-1state](https://user-images.githubusercontent.com/22315555/234389663-c81905cf-2a69-4b74-b0a6-cee34637a97a.png) | ![test-fig-matplotlib-old-1state](https://user-images.githubusercontent.com/22315555/234389589-235eee01-631c-40f3-ad13-9d7e68d13a0a.png) |
|after|![test-fig-plotly-new-1state](https://user-images.githubusercontent.com/22315555/234390409-104f58d8-711f-45f0-892e-0db81a0a25f3.png)|![test-fig-matplotlib-new-1state](https://user-images.githubusercontent.com/22315555/234390366-538b60ea-f613-41ff-bc71-a36c647a7b64.png)|
|after|![test-fig-plotly-new-3states](https://user-images.githubusercontent.com/22315555/234390626-9436a080-94d9-46c2-9f19-759c12e114d3.png)|![test-fig-matplotlib-new-3states](https://user-images.githubusercontent.com/22315555/234390590-fad60224-4b8a-46e5-a2e6-3489ab1c357d.png)|

The last row is provided to confirm that this PR does not cause degradation.
