### PR TITLE
Solve issue #4557 - error_score

### DIFF
--- a/optuna/integration/sklearn.py
+++ b/optuna/integration/sklearn.py
@@ -897,8 +897,6 @@ class OptunaSearchCV(BaseEstimator):
             callbacks=self.callbacks,
         )
 
-        self.study_.best_params
-
         _logger.info("Finished hyperparemeter search!")
 
         if self.refit:

--- a/optuna/integration/sklearn.py
+++ b/optuna/integration/sklearn.py
@@ -231,7 +231,9 @@ class _Objective:
                 n_splits = self.cv.get_n_splits(self.X, self.y, self.groups)
                 fit_time = np.array([np.nan] * n_splits)
                 score_time = np.array([np.nan] * n_splits)
-                test_score = np.array([self.error_score] * n_splits)
+                test_score = np.array(
+                    [self.error_score if self.error_score is not None else np.nan] * n_splits
+                )
 
                 scores = {
                     "fit_time": fit_time,

--- a/optuna/integration/sklearn.py
+++ b/optuna/integration/sklearn.py
@@ -227,7 +227,7 @@ class _Objective:
                     return_train_score=self.return_train_score,
                     scoring=self.scoring,
                 )
-            except:
+            except ValueError:
                 n_splits = self.cv.get_n_splits(self.X, self.y, self.groups)
                 fit_time = np.array([np.nan] * n_splits)
                 score_time = np.array([np.nan] * n_splits)

--- a/optuna/integration/sklearn.py
+++ b/optuna/integration/sklearn.py
@@ -215,17 +215,29 @@ class _Objective:
         if self.enable_pruning:
             scores = self._cross_validate_with_pruning(trial, estimator)
         else:
-            scores = cross_validate(
-                estimator,
-                self.X,
-                self.y,
-                cv=self.cv,
-                error_score=self.error_score,
-                fit_params=self.fit_params,
-                groups=self.groups,
-                return_train_score=self.return_train_score,
-                scoring=self.scoring,
-            )
+            try:
+                scores = cross_validate(
+                    estimator,
+                    self.X,
+                    self.y,
+                    cv=self.cv,
+                    error_score=self.error_score,
+                    fit_params=self.fit_params,
+                    groups=self.groups,
+                    return_train_score=self.return_train_score,
+                    scoring=self.scoring,
+                )
+            except:
+                n_splits = self.cv.get_n_splits(self.X, self.y, self.groups)
+                fit_time = np.array([np.nan] * n_splits)
+                score_time = np.array([np.nan] * n_splits)
+                test_score = np.array([np.nan] * n_splits)
+
+                scores = {
+                    "fit_time": fit_time,
+                    "score_time": score_time,
+                    "test_score": test_score,
+                }
 
         self._store_scores(trial, scores)
 

--- a/optuna/integration/sklearn.py
+++ b/optuna/integration/sklearn.py
@@ -888,7 +888,7 @@ class OptunaSearchCV(BaseEstimator):
             "Searching the best hyperparameters using {} "
             "samples...".format(_num_samples(self.sample_indices_))
         )
-
+        
         self.study_.optimize(
             objective,
             n_jobs=self.n_jobs,
@@ -897,6 +897,8 @@ class OptunaSearchCV(BaseEstimator):
             callbacks=self.callbacks,
         )
 
+        _logger.info(f"best_params:{self.study_.best_params}")
+        
         _logger.info("Finished hyperparemeter search!")
 
         if self.refit:

--- a/optuna/integration/sklearn.py
+++ b/optuna/integration/sklearn.py
@@ -888,7 +888,7 @@ class OptunaSearchCV(BaseEstimator):
             "Searching the best hyperparameters using {} "
             "samples...".format(_num_samples(self.sample_indices_))
         )
-        
+
         self.study_.optimize(
             objective,
             n_jobs=self.n_jobs,
@@ -900,7 +900,6 @@ class OptunaSearchCV(BaseEstimator):
         _logger.info(f"best_params:{self.study_.best_params}")
 
         _logger.info("Finished hyperparemeter search!")
-
 
         if self.refit:
             self._refit(X, y, **fit_params)

--- a/optuna/integration/sklearn.py
+++ b/optuna/integration/sklearn.py
@@ -231,7 +231,7 @@ class _Objective:
                 n_splits = self.cv.get_n_splits(self.X, self.y, self.groups)
                 fit_time = np.array([np.nan] * n_splits)
                 score_time = np.array([np.nan] * n_splits)
-                test_score = np.array([np.nan] * n_splits)
+                test_score = np.array([self.error_score] * n_splits)
 
                 scores = {
                     "fit_time": fit_time,

--- a/optuna/integration/sklearn.py
+++ b/optuna/integration/sklearn.py
@@ -898,8 +898,9 @@ class OptunaSearchCV(BaseEstimator):
         )
 
         _logger.info(f"best_params:{self.study_.best_params}")
-        
+
         _logger.info("Finished hyperparemeter search!")
+
 
         if self.refit:
             self._refit(X, y, **fit_params)

--- a/optuna/integration/sklearn.py
+++ b/optuna/integration/sklearn.py
@@ -897,7 +897,7 @@ class OptunaSearchCV(BaseEstimator):
             callbacks=self.callbacks,
         )
 
-        _logger.info(f"best_params:{self.study_.best_params}")
+        self.study_.best_params
 
         _logger.info("Finished hyperparemeter search!")
 

--- a/tests/integration_tests/test_sklearn.py
+++ b/tests/integration_tests/test_sklearn.py
@@ -325,7 +325,6 @@ def test_objective_error_score_invalid() -> None:
 def test_objective_error_score_nan_regression(param_dist: dict, expect: bool) -> None:
     X, y = make_regression(n_samples=100, n_features=10)
     est = DecisionTreeRegressor()
-    study = create_study()
     optuna_search = integration.OptunaSearchCV(
         est,
         param_dist,

--- a/tests/integration_tests/test_sklearn.py
+++ b/tests/integration_tests/test_sklearn.py
@@ -317,7 +317,7 @@ def test_objective_error_score_invalid() -> None:
     "param_dist, expect",
     [
         ({"max_depth": distributions.IntDistribution(0, 1)}, False),
-        ({"max_depth": distributions.IntDistribution(0, 0)}, True),
+        ({"max_depth": distributions.FloatDistribution(0, 1)}, True),
     ],
 )
 @pytest.mark.filterwarnings("ignore::RuntimeWarning")

--- a/tests/integration_tests/test_sklearn.py
+++ b/tests/integration_tests/test_sklearn.py
@@ -317,7 +317,7 @@ def test_objective_error_score_invalid() -> None:
     "param_dist, expect",
     [
         ({"max_depth": distributions.IntDistribution(0, 1)}, False),
-        ({"max_depth": distributions.IntDistribution(0, 0)}, True),
+        ({"max_depth": distributions.IntDistribution(-1, -1)}, True),
     ],
 )
 @pytest.mark.filterwarnings("ignore::RuntimeWarning")

--- a/tests/integration_tests/test_sklearn.py
+++ b/tests/integration_tests/test_sklearn.py
@@ -316,7 +316,7 @@ def test_objective_error_score_invalid() -> None:
     "param_dist, expect",
     [
         ({"max_depth": distributions.IntDistribution(1, 10)}, False),
-        ({"max_depth": distributions.FloatDistribution(1, 10)}, True),
+        ({"max_depth": distributions.IntDistribution(0, 0)}, True),
     ],
 )
 @pytest.mark.filterwarnings("ignore::RuntimeWarning")

--- a/tests/integration_tests/test_sklearn.py
+++ b/tests/integration_tests/test_sklearn.py
@@ -4,9 +4,9 @@ import warnings
 import numpy as np
 import pytest
 import scipy as sp
-from sklearn.decomposition import PCA
 from sklearn.datasets import make_blobs
 from sklearn.datasets import make_regression
+from sklearn.decomposition import PCA
 from sklearn.exceptions import ConvergenceWarning
 from sklearn.exceptions import NotFittedError
 from sklearn.linear_model import LogisticRegression

--- a/tests/integration_tests/test_sklearn.py
+++ b/tests/integration_tests/test_sklearn.py
@@ -306,7 +306,7 @@ def test_objective_error_score_invalid() -> None:
     "param_dist, expect",
     [
         ({"n_components": IntDistribution(5, 10)}, False),
-        ({"n_components": IntDistribution(5, 20)}, False),
+        ({"n_components": IntDistribution(0, 0)}, True),
     ],
 )
 @pytest.mark.filterwarnings("ignore::RuntimeWarning")

--- a/tests/integration_tests/test_sklearn.py
+++ b/tests/integration_tests/test_sklearn.py
@@ -317,7 +317,7 @@ def test_objective_error_score_invalid() -> None:
     "param_dist, expect",
     [
         ({"max_depth": distributions.IntDistribution(0, 1)}, False),
-        ({"max_depth": distributions.FloatDistribution(0, 1)}, True),
+        ({"max_depth": distributions.IntDistribution(0, 0)}, True),
     ],
 )
 @pytest.mark.filterwarnings("ignore::RuntimeWarning")

--- a/tests/integration_tests/test_sklearn.py
+++ b/tests/integration_tests/test_sklearn.py
@@ -271,8 +271,7 @@ def test_objective_error_score_nan() -> None:
     )
 
     with pytest.raises(
-        ValueError,
-        match="This SGDClassifier estimator requires y to be passed, but the target y is None.",
+        ValueError
     ):
         optuna_search.fit(X)
 

--- a/tests/integration_tests/test_sklearn.py
+++ b/tests/integration_tests/test_sklearn.py
@@ -16,7 +16,7 @@ from sklearn.neighbors import KernelDensity
 
 from optuna import distributions
 from optuna import integration
-from optuna.distributions import IntDistribution
+from optuna.distributions import IntDistribution, FloatDistribution
 from optuna.study import create_study
 
 

--- a/tests/integration_tests/test_sklearn.py
+++ b/tests/integration_tests/test_sklearn.py
@@ -16,6 +16,7 @@ from sklearn.tree import DecisionTreeRegressor
 
 from optuna import distributions
 from optuna import integration
+from optuna.samplers import BruteForceSampler
 from optuna.study import create_study
 
 

--- a/tests/integration_tests/test_sklearn.py
+++ b/tests/integration_tests/test_sklearn.py
@@ -309,7 +309,6 @@ def test_objective_error_score_invalid() -> None:
         ({"n_components": IntDistribution(5, 10)}, False),
         ({"n_components": IntDistribution(5, 20)}, False),
         ({"n_components": IntDistribution(15, 20)}, True),
-        ({"n_components": FloatDistribution(5, 10)}, True),
     ],
 )
 @pytest.mark.filterwarnings("ignore::RuntimeWarning")

--- a/tests/integration_tests/test_sklearn.py
+++ b/tests/integration_tests/test_sklearn.py
@@ -1,24 +1,18 @@
-from unittest.mock import MagicMock
 import warnings
+from unittest.mock import MagicMock
 
 import numpy as np
 import pytest
 import scipy as sp
-from sklearn.tree import DecisionTreeRegressor
-from sklearn.datasets import make_blobs
-from sklearn.datasets import make_regression
-from sklearn.decomposition import PCA
-from sklearn.exceptions import ConvergenceWarning
-from sklearn.exceptions import NotFittedError
-from sklearn.linear_model import LogisticRegression
-from sklearn.linear_model import SGDClassifier
-from sklearn.neighbors import KernelDensity
-
-from optuna import distributions
-from optuna import integration
-from optuna.distributions import IntDistribution, FloatDistribution
+from optuna import distributions, integration
+from optuna.distributions import FloatDistribution, IntDistribution
 from optuna.study import create_study
-
+from sklearn.datasets import make_blobs, make_regression
+from sklearn.decomposition import PCA
+from sklearn.exceptions import ConvergenceWarning, NotFittedError
+from sklearn.linear_model import LogisticRegression, SGDClassifier
+from sklearn.neighbors import KernelDensity
+from sklearn.tree import DecisionTreeRegressor
 
 pytestmark = pytest.mark.integration
 
@@ -86,7 +80,12 @@ def test_optuna_search_properties() -> None:
     param_dist = {"C": distributions.FloatDistribution(1e-04, 1e03, log=True)}
 
     optuna_search = integration.OptunaSearchCV(
-        est, param_dist, cv=3, error_score="raise", random_state=0, return_train_score=True
+        est,
+        param_dist,
+        cv=3,
+        error_score="raise",
+        random_state=0,
+        return_train_score=True,
     )
     optuna_search.fit(X, y)
     optuna_search.set_user_attr("dataset", "blobs")
@@ -195,7 +194,13 @@ def test_optuna_search_study_with_minimize() -> None:
     est = KernelDensity()
     study = create_study(direction="minimize")
     optuna_search = integration.OptunaSearchCV(
-        est, {}, cv=3, error_score="raise", random_state=0, return_train_score=True, study=study
+        est,
+        {},
+        cv=3,
+        error_score="raise",
+        random_state=0,
+        return_train_score=True,
+        study=study,
     )
 
     with pytest.raises(ValueError, match="direction of study must be 'maximize'."):

--- a/tests/integration_tests/test_sklearn.py
+++ b/tests/integration_tests/test_sklearn.py
@@ -5,18 +5,15 @@ import numpy as np
 import pytest
 import scipy as sp
 from sklearn.datasets import make_blobs
-from sklearn.datasets import make_regression
 from sklearn.decomposition import PCA
 from sklearn.exceptions import ConvergenceWarning
 from sklearn.exceptions import NotFittedError
 from sklearn.linear_model import LogisticRegression
 from sklearn.linear_model import SGDClassifier
 from sklearn.neighbors import KernelDensity
-from sklearn.tree import DecisionTreeRegressor
 
 from optuna import distributions
 from optuna import integration
-from optuna.samplers import BruteForceSampler
 from optuna.study import create_study
 
 
@@ -86,12 +83,7 @@ def test_optuna_search_properties() -> None:
     param_dist = {"C": distributions.FloatDistribution(1e-04, 1e03, log=True)}
 
     optuna_search = integration.OptunaSearchCV(
-        est,
-        param_dist,
-        cv=3,
-        error_score="raise",
-        random_state=0,
-        return_train_score=True,
+        est, param_dist, cv=3, error_score="raise", random_state=0, return_train_score=True
     )
     optuna_search.fit(X, y)
     optuna_search.set_user_attr("dataset", "blobs")
@@ -200,13 +192,7 @@ def test_optuna_search_study_with_minimize() -> None:
     est = KernelDensity()
     study = create_study(direction="minimize")
     optuna_search = integration.OptunaSearchCV(
-        est,
-        {},
-        cv=3,
-        error_score="raise",
-        random_state=0,
-        return_train_score=True,
-        study=study,
+        est, {}, cv=3, error_score="raise", random_state=0, return_train_score=True, study=study
     )
 
     with pytest.raises(ValueError, match="direction of study must be 'maximize'."):
@@ -281,7 +267,10 @@ def test_objective_error_score_nan() -> None:
         return_train_score=True,
     )
 
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError,
+        match="This SGDClassifier estimator requires y to be passed, but the target y is None.",
+    ):
         optuna_search.fit(X)
 
     for trial in optuna_search.study_.get_trials():

--- a/tests/integration_tests/test_sklearn.py
+++ b/tests/integration_tests/test_sklearn.py
@@ -335,7 +335,6 @@ def test_objective_error_score_nan_regression(param_dist: dict, expect: bool) ->
     if expect:
         with pytest.raises(ValueError):
             optuna_search.fit(X, y)
-
     else:
         optuna_search.fit(X, y)
 

--- a/tests/integration_tests/test_sklearn.py
+++ b/tests/integration_tests/test_sklearn.py
@@ -316,7 +316,7 @@ def test_objective_error_score_invalid() -> None:
 @pytest.mark.parametrize(
     "param_dist, expect",
     [
-        ({"max_depth": distributions.IntDistribution(1, 10)}, False),
+        ({"max_depth": distributions.IntDistribution(0, 1)}, False),
         ({"max_depth": distributions.IntDistribution(0, 0)}, True),
     ],
 )
@@ -325,12 +325,11 @@ def test_objective_error_score_invalid() -> None:
 def test_objective_error_score_nan_regression(param_dist: dict, expect: bool) -> None:
     X, y = make_regression(n_samples=100, n_features=10)
     est = DecisionTreeRegressor()
+    study = optuna.create_study()
     optuna_search = integration.OptunaSearchCV(
         est,
         param_dist,
-        cv=3,
-        error_score=np.nan,
-        random_state=0,
+        study=create_study(sampler=BruteForceSampler(), direction="maximize"),
     )
 
     if expect:

--- a/tests/integration_tests/test_sklearn.py
+++ b/tests/integration_tests/test_sklearn.py
@@ -5,7 +5,6 @@ import numpy as np
 import pytest
 import scipy as sp
 from optuna import distributions, integration
-from optuna.distributions import FloatDistribution, IntDistribution
 from optuna.study import create_study
 from sklearn.datasets import make_blobs, make_regression
 from sklearn.decomposition import PCA
@@ -310,8 +309,8 @@ def test_objective_error_score_invalid() -> None:
 @pytest.mark.parametrize(
     "param_dist, expect",
     [
-        ({"max_depth": IntDistribution(1, 10)}, False),
-        ({"max_depth": FloatDistribution(1, 10)}, True),
+        ({"max_depth": distributions.IntDistribution(1, 10)}, False),
+        ({"max_depth": distributions.FloatDistribution(1, 10)}, True),
     ],
 )
 @pytest.mark.filterwarnings("ignore::RuntimeWarning")

--- a/tests/integration_tests/test_sklearn.py
+++ b/tests/integration_tests/test_sklearn.py
@@ -19,7 +19,6 @@ from optuna.study import create_study
 from optuna.distributions import IntDistribution, FloatDistribution
 
 
-
 pytestmark = pytest.mark.integration
 
 
@@ -270,9 +269,7 @@ def test_objective_error_score_nan() -> None:
         return_train_score=True,
     )
 
-    with pytest.raises(
-        ValueError
-    ):
+    with pytest.raises(ValueError):
         optuna_search.fit(X)
 
     for trial in optuna_search.study_.get_trials():
@@ -303,6 +300,7 @@ def test_objective_error_score_invalid() -> None:
     with pytest.raises(ValueError, match="error_score must be 'raise' or numeric."):
         optuna_search.fit(X)
 
+
 @pytest.mark.parametrize(
     "param_dist, expect",
     [
@@ -331,7 +329,7 @@ def test_objective_error_score_nan_regression(param_dist: dict, expect: bool) ->
 
     else:
         optuna_search.fit(X, y)
-        
+
 
 # TODO(himkt): Remove this method with the deletion of deprecated distributions.
 # https://github.com/optuna/optuna/issues/2941

--- a/tests/integration_tests/test_sklearn.py
+++ b/tests/integration_tests/test_sklearn.py
@@ -325,7 +325,7 @@ def test_objective_error_score_invalid() -> None:
 def test_objective_error_score_nan_regression(param_dist: dict, expect: bool) -> None:
     X, y = make_regression(n_samples=100, n_features=10)
     est = DecisionTreeRegressor()
-    study = optuna.create_study()
+    study = create_study()
     optuna_search = integration.OptunaSearchCV(
         est,
         param_dist,

--- a/tests/integration_tests/test_sklearn.py
+++ b/tests/integration_tests/test_sklearn.py
@@ -4,7 +4,7 @@ import warnings
 import numpy as np
 import pytest
 import scipy as sp
-from sklearn.cross_decomposition import PLSRegression
+from sklearn.tree import DecisionTreeRegressor
 from sklearn.datasets import make_blobs
 from sklearn.datasets import make_regression
 from sklearn.decomposition import PCA
@@ -305,15 +305,15 @@ def test_objective_error_score_invalid() -> None:
 @pytest.mark.parametrize(
     "param_dist, expect",
     [
-        ({"n_components": IntDistribution(5, 10)}, False),
-        ({"n_components": IntDistribution(0, 0)}, True),
+        ({"max_depth": IntDistribution(5, 10)}, False),
+        ({"max_depth": FloatDistribution(5, 10)}, True),
     ],
 )
 @pytest.mark.filterwarnings("ignore::RuntimeWarning")
 @pytest.mark.filterwarnings("ignore::UserWarning")
 def test_objective_error_score_nan_regression(param_dist: dict, expect: bool) -> None:
     X, y = make_regression(n_samples=100, n_features=10)
-    est = PLSRegression()
+    est = DecisionTreeRegressor()
     optuna_search = integration.OptunaSearchCV(
         est,
         param_dist,

--- a/tests/integration_tests/test_sklearn.py
+++ b/tests/integration_tests/test_sklearn.py
@@ -307,7 +307,6 @@ def test_objective_error_score_invalid() -> None:
     [
         ({"n_components": IntDistribution(5, 10)}, False),
         ({"n_components": IntDistribution(5, 20)}, False),
-        ({"n_components": IntDistribution(15, 20)}, True),
     ],
 )
 @pytest.mark.filterwarnings("ignore::RuntimeWarning")

--- a/tests/integration_tests/test_sklearn.py
+++ b/tests/integration_tests/test_sklearn.py
@@ -313,31 +313,6 @@ def test_objective_error_score_invalid() -> None:
         optuna_search.fit(X)
 
 
-@pytest.mark.parametrize(
-    "param_dist, expect",
-    [
-        ({"max_depth": distributions.IntDistribution(0, 1)}, False),
-        ({"max_depth": distributions.IntDistribution(-1, -1)}, True),
-    ],
-)
-@pytest.mark.filterwarnings("ignore::RuntimeWarning")
-@pytest.mark.filterwarnings("ignore::UserWarning")
-def test_objective_error_score_nan_regression(param_dist: dict, expect: bool) -> None:
-    X, y = make_regression(n_samples=100, n_features=10)
-    est = DecisionTreeRegressor()
-    optuna_search = integration.OptunaSearchCV(
-        est,
-        param_dist,
-        study=create_study(sampler=BruteForceSampler(), direction="maximize"),
-    )
-
-    if expect:
-        with pytest.raises(ValueError):
-            optuna_search.fit(X, y)
-    else:
-        optuna_search.fit(X, y)
-
-
 # TODO(himkt): Remove this method with the deletion of deprecated distributions.
 # https://github.com/optuna/optuna/issues/2941
 @pytest.mark.filterwarnings("ignore::FutureWarning")

--- a/tests/integration_tests/test_sklearn.py
+++ b/tests/integration_tests/test_sklearn.py
@@ -1,17 +1,26 @@
-import warnings
 from unittest.mock import MagicMock
+import warnings
 
 import numpy as np
 import pytest
 import scipy as sp
-from optuna import distributions, integration
-from optuna.study import create_study
-from sklearn.datasets import make_blobs, make_regression
 from sklearn.decomposition import PCA
-from sklearn.exceptions import ConvergenceWarning, NotFittedError
-from sklearn.linear_model import LogisticRegression, SGDClassifier
+from sklearn.datasets import make_blobs
+from sklearn.datasets import make_regression
+from sklearn.exceptions import ConvergenceWarning
+from sklearn.exceptions import  NotFittedError
+from sklearn.linear_model import LogisticRegression
+from sklearn.linear_model import SGDClassifier
 from sklearn.neighbors import KernelDensity
 from sklearn.tree import DecisionTreeRegressor
+
+from optuna import distributions
+from optuna import integration
+from optuna.study import create_study
+
+
+pytestmark = pytest.mark.integration
+
 
 pytestmark = pytest.mark.integration
 

--- a/tests/integration_tests/test_sklearn.py
+++ b/tests/integration_tests/test_sklearn.py
@@ -310,8 +310,8 @@ def test_objective_error_score_invalid() -> None:
 @pytest.mark.parametrize(
     "param_dist, expect",
     [
-        ({"max_depth": IntDistribution(5, 10)}, False),
-        ({"max_depth": FloatDistribution(5, 10)}, True),
+        ({"max_depth": IntDistribution(1, 10)}, False),
+        ({"max_depth": FloatDistribution(1, 10)}, True),
     ],
 )
 @pytest.mark.filterwarnings("ignore::RuntimeWarning")

--- a/tests/integration_tests/test_sklearn.py
+++ b/tests/integration_tests/test_sklearn.py
@@ -16,7 +16,6 @@ from sklearn.neighbors import KernelDensity
 
 from optuna import distributions
 from optuna import integration
-from optuna.distributions import FloatDistribution
 from optuna.distributions import IntDistribution
 from optuna.study import create_study
 

--- a/tests/integration_tests/test_sklearn.py
+++ b/tests/integration_tests/test_sklearn.py
@@ -8,7 +8,7 @@ from sklearn.decomposition import PCA
 from sklearn.datasets import make_blobs
 from sklearn.datasets import make_regression
 from sklearn.exceptions import ConvergenceWarning
-from sklearn.exceptions import  NotFittedError
+from sklearn.exceptions import NotFittedError
 from sklearn.linear_model import LogisticRegression
 from sklearn.linear_model import SGDClassifier
 from sklearn.neighbors import KernelDensity
@@ -17,9 +17,6 @@ from sklearn.tree import DecisionTreeRegressor
 from optuna import distributions
 from optuna import integration
 from optuna.study import create_study
-
-
-pytestmark = pytest.mark.integration
 
 
 pytestmark = pytest.mark.integration

--- a/tests/integration_tests/test_sklearn.py
+++ b/tests/integration_tests/test_sklearn.py
@@ -4,19 +4,21 @@ import warnings
 import numpy as np
 import pytest
 import scipy as sp
-from sklearn.datasets import make_blobs, make_regression
+from sklearn.cross_decomposition import PLSRegression
+from sklearn.datasets import make_blobs
+from sklearn.datasets import make_regression
 from sklearn.decomposition import PCA
 from sklearn.exceptions import ConvergenceWarning
 from sklearn.exceptions import NotFittedError
 from sklearn.linear_model import LogisticRegression
 from sklearn.linear_model import SGDClassifier
 from sklearn.neighbors import KernelDensity
-from sklearn.cross_decomposition import PLSRegression
 
 from optuna import distributions
 from optuna import integration
+from optuna.distributions import FloatDistribution
+from optuna.distributions import IntDistribution
 from optuna.study import create_study
-from optuna.distributions import IntDistribution, FloatDistribution
 
 
 pytestmark = pytest.mark.integration


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
solve https://github.com/optuna/optuna/issues/4557#issue-1646828230
## Description of the changes
<!-- Describe the changes in this PR. -->

The current implementation passes self.error_score to cross_validate.
When error_score is np.nan, sklearn's _warn_or_raise_about_fit_failures determines whether all fits succeed. This is a judgment whether **all fits in each trial** of OptunaSearchCV were successful.
However, it should be judged whether **all fits in all trials** of OptunaSearchCV were successful, 
that's why the current implementation is wrong.

Therefore, by setting np.nan in scores when cross_validate fails, we can realized the desired function.
