### PR TITLE
Hotfix and run catboost test w/ python 3.11 except for MacOS

### DIFF
--- a/.github/workflows/tests-integration.yml
+++ b/.github/workflows/tests-integration.yml
@@ -78,7 +78,6 @@ jobs:
           pytest tests -m "integration" \
             --ignore tests/integration_tests/test_botorch.py \
             --ignore tests/integration_tests/test_catalyst.py \
-            --ignore tests/integration_tests/test_catboost.py \
             --ignore tests/integration_tests/test_fastaiv2.py \
             --ignore tests/integration_tests/test_lightgbm.py \
             --ignore tests/integration_tests/test_mlflow.py \
@@ -106,7 +105,6 @@ jobs:
           pytest tests -m "integration and not slow" \
             --ignore tests/integration_tests/test_botorch.py \
             --ignore tests/integration_tests/test_catalyst.py \
-            --ignore tests/integration_tests/test_catboost.py \
             --ignore tests/integration_tests/test_fastaiv2.py \
             --ignore tests/integration_tests/test_lightgbm.py \
             --ignore tests/integration_tests/test_mlflow.py \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,7 @@ document = [
 integration = [
     "botorch>=0.4.0; python_version<'3.11'",
     "catalyst>=21.3; python_version<'3.11'",
-    "catboost>=0.26; python_version<'3.11'",
+    "catboost>=0.26",
     "cma",
     "distributed",
     "fastai; python_version<'3.11'",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,8 @@ document = [
 integration = [
     "botorch>=0.4.0; python_version<'3.11'",
     "catalyst>=21.3; python_version<'3.11'",
-    "catboost>=0.26",
+    "catboost>=0.26; sys_platform!='darwin'",
+    "catboost>=0.26,<1.2; sys_platform=='darwin'",
     "cma",
     "distributed",
     "fastai; python_version<'3.11'",


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation

Hotfix and resolve a task in https://github.com/optuna/optuna/issues/3964 thanks to https://github.com/catboost/catboost/releases/tag/v1.2.

## Description of the changes
<!-- Describe the changes in this PR. -->

- Remove pytest ignore lines.
- We cannot install the latest stable catboost to MacOS with Python 3.8 (see https://github.com/catboost/catboost/issues/2371 for more details), so this PR also introduces the upper version constraint of catboost for MacOS.