### PR TITLE
Run mlflow with python 3.11

### DIFF
--- a/.github/workflows/tests-integration.yml
+++ b/.github/workflows/tests-integration.yml
@@ -81,7 +81,6 @@ jobs:
             --ignore tests/integration_tests/test_catboost.py \
             --ignore tests/integration_tests/test_fastaiv2.py \
             --ignore tests/integration_tests/test_lightgbm.py \
-            --ignore tests/integration_tests/test_mlflow.py \
             --ignore tests/integration_tests/test_mxnet.py \
             --ignore tests/integration_tests/test_pytorch_distributed.py \
             --ignore tests/integration_tests/test_pytorch_ignite.py \
@@ -109,7 +108,6 @@ jobs:
             --ignore tests/integration_tests/test_catboost.py \
             --ignore tests/integration_tests/test_fastaiv2.py \
             --ignore tests/integration_tests/test_lightgbm.py \
-            --ignore tests/integration_tests/test_mlflow.py \
             --ignore tests/integration_tests/test_mxnet.py \
             --ignore tests/integration_tests/test_pytorch_distributed.py \
             --ignore tests/integration_tests/test_pytorch_ignite.py \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ integration = [
     "distributed",
     "fastai; python_version<'3.11'",
     "lightgbm; python_version<'3.11'",
-    "mlflow; python_version<'3.11'",
+    "mlflow",
     "mxnet; python_version<'3.11'",
     "pandas",
     "pytorch-ignite; python_version<'3.11'",


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
Resolve a sub-task of https://github.com/optuna/optuna/issues/3964. Thanks to the [recent numba release](https://github.com/numba/numba/releases/tag/0.57.0), we can use mlflow with python 3.11.


## Description of the changes
<!-- Describe the changes in this PR. -->

- Remove pytest ignore lines 
- Remove python 3.11 version constraint

Note that shap was also blocked by numba python 3.11 support, but shape doesn't support the latest stable numba according to the [CI error](https://github.com/optuna/optuna/actions/runs/4867973181) and https://github.com/slundberg/shap/issues/2909.


---

The MacOS's integration error will be resolved by https://github.com/optuna/optuna/pull/4646.