### PR TITLE
Install ninja in Mac CI for catboost 1.2 or higher

### DIFF
--- a/.github/workflows/mac-tests.yml
+++ b/.github/workflows/mac-tests.yml
@@ -102,6 +102,7 @@ jobs:
     - name: Setup mac environment
       run: |
         brew install libomp
+        brew install ninja
         brew install open-mpi
         brew install openblas
 


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

Resolve the CI failure on the latest master branch with Mac.

According to the [CI error](https://github.com/optuna/optuna/actions/runs/4877311719/jobs/8701825683), the integration job with MacOS failed with the following message.  

>       CMake Error: CMake was unable to find a build program corresponding to "Ninja".  CMAKE_MAKE_PROGRAM is not set.  You probably need to select a different build tool.

As related info, the latest stable catboost (v1.2) has switched the default build tool to CMake from Yandex's build tool., https://github.com/catboost/catboost/releases/tag/v1.2

> CatBoost's build system has been switched from Ya Make (Yandex's build system) to [CMake](https://cmake.org/). This means more transparency in the build process and more familiar tools for Open Source developers.


## Description of the changes
<!-- Describe the changes in this PR. -->

This PR proposes installing the missing `ninja` via `brew`.