### PR TITLE
Use newer docker image to resolve the failed docsbuild 

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,4 @@
+version: 2
+
+build:
+  os: ubuntu-22.04

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,4 +1,16 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
 version: 2
 
+# Set the version of Python and other tools you might need
 build:
   os: ubuntu-22.04
+  tools:
+    python: "3.8"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/source/conf.py


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

Due to the [major version update of `urllib3`](https://urllib3.readthedocs.io/en/stable/v2-migration-guide.html#what-are-the-important-changes), the build of readthedocs has failed, see https://readthedocs.org/projects/optuna/builds/20496423/ for the error message.

## Description of the changes
<!-- Describe the changes in this PR. -->

Apply the suggested approach proposed in the readthedocs repo, https://github.com/readthedocs/readthedocs.org/issues/10290#issuecomment-1535120995.