### PR TITLE
Fix index of `n_retries += 1` in `RDBStorage`

### DIFF
--- a/optuna/storages/_rdb/storage.py
+++ b/optuna/storages/_rdb/storage.py
@@ -459,7 +459,7 @@ class RDBStorage(BaseStorage, BaseHeartbeat):
                     if n_retries > 2:
                         raise
 
-            n_retries += 1
+                n_retries += 1
 
             if template_trial:
                 frozen = copy.deepcopy(template_trial)


### PR DESCRIPTION
## Motivation
The index of `n_retries += 1` is wrong, and as a result `n_retries` does not do anything. This bug was introduced in #2345.

## Description of the changes
Fix the index.
