### PR TITLE
Fix the build on Read the Docs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,6 +4,12 @@
 # Required
 version: 2
 
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: docs/source/conf.py
@@ -15,7 +21,6 @@ formats: all
 python:
   # `sphinx` requires either Python >= 3.8 or `typed-ast` to reflect type comments 
   # in the documentation. See: https://github.com/sphinx-doc/sphinx/pull/6984
-  version: 3.8
   install:
     - method: pip
       path: .


### PR DESCRIPTION
## Motivation
The build on Read the Docs failed because urllib3 v2.0.2 released. See https://github.com/readthedocs/readthedocs.org/issues/10290.

## Description of the changes
Fix `.readthedocs.yml` according to https://github.com/readthedocs/readthedocs.org/issues/10290 and https://docs.readthedocs.io/en/stable/config-file/v2.html.
