### PR TITLE
Fix a logic for invalidating the cache in `CachedStorage`

### DIFF
--- a/optuna/storages/_cached_storage.py
+++ b/optuna/storages/_cached_storage.py
@@ -107,12 +107,12 @@ class _CachedStorage(BaseStorage, BaseHeartbeat):
     def delete_study(self, study_id: int) -> None:
         with self._lock:
             if study_id in self._studies:
-                for trial_id in self._studies[study_id].trials:
+                for trial_number in self._studies[study_id].trials:
+                    trial_id = self._study_id_and_number_to_trial_id.get((study_id, trial_number))
                     if trial_id in self._trial_id_to_study_id_and_number:
-                        del self._study_id_and_number_to_trial_id[
-                            self._trial_id_to_study_id_and_number[trial_id]
-                        ]
                         del self._trial_id_to_study_id_and_number[trial_id]
+                    if (study_id, trial_number) in self._study_id_and_number_to_trial_id:
+                        del self._study_id_and_number_to_trial_id[(study_id, trial_number)]
                 del self._studies[study_id]
 
         self._backend.delete_study(study_id)


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
While reviewing #4631, I found a bug in CachedStorage's delete_study method.
I will make this PR ready for review after #4631 is merged.

## Description of the changes
<!-- Describe the changes in this PR. -->
Added a test case and fixed a logic for invalidating the cache. See https://github.com/optuna/optuna/commit/56808981f5dabe2bd10fc51e24d0e605bb6a53c2 for details.