### PR TITLE
Fix typo for progress bar in documentation

### DIFF
--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -438,7 +438,7 @@ class Study:
             show_progress_bar:
                 Flag to show progress bars or not. To disable progress bar, set this :obj:`False`.
                 Currently, progress bar is experimental feature and disabled
-                when ``n_trials`` is :obj:`None`, ``timeout`` not is :obj:`None`, and
+                when ``n_trials`` is :obj:`None`, ``timeout`` is not :obj:`None`, and
                 ``n_jobs`` :math:`\\ne 1`.
 
         Raises:


### PR DESCRIPTION
Fix typo: `not is` -> `is not`
