### PR TITLE
Add pareto front display example: 2D-plot from 3D-optimization including crop the scale

### DIFF
--- a/optuna/visualization/_pareto_front.py
+++ b/optuna/visualization/_pareto_front.py
@@ -136,7 +136,7 @@ def plot_pareto_front(
             import optuna
 
             def objective(trial):
-                value_a = trial.suggest_int("a", 0,100)
+                value_a = trial.suggest_int("a", 0, 100)
                 value_b = trial.suggest_int("b", 0, 100)
 
                 v0 = value_a ** 2

--- a/optuna/visualization/_pareto_front.py
+++ b/optuna/visualization/_pareto_front.py
@@ -154,12 +154,6 @@ def plot_pareto_front(
                                                          t.values[1]), \
                                                          target_names=["volume", "loss"])
 
-            # Use this line of code instead the above one to add some limitations,
-            # e.g. only plot values if the 3rd (non-displayed) dimension is below 100:
-            # fig = optuna.visualization.plot_pareto_front(study, targets=lambda t: (t.values[0] \
-            #                                              if t.values[2] < 100 else None,
-            #                                              t.values[1]), \
-            #                                              target_names=["volume", "loss"])
 
             fig.show()
     """

--- a/optuna/visualization/_pareto_front.py
+++ b/optuna/visualization/_pareto_front.py
@@ -140,7 +140,7 @@ def plot_pareto_front(
                 value_b = trial.suggest_int("b", 0, 100)
 
                 v0 = value_a ** 2
-                v1 = value_b **2
+                v1 = value_b ** 2
                 v2 = value_a + value_b
 
                 return v0, v1, v2

--- a/optuna/visualization/_pareto_front.py
+++ b/optuna/visualization/_pareto_front.py
@@ -79,7 +79,6 @@ def plot_pareto_front(
         of a 3-dimensional study.
         This example is scalable, e.g., for plotting a 2- or 3-dimensional Pareto front
         of a 4-dimensional study and so on.
-        The example also contains the option to crop the displayed scale.
 
         .. plotly::
 

--- a/optuna/visualization/_pareto_front.py
+++ b/optuna/visualization/_pareto_front.py
@@ -150,9 +150,11 @@ def plot_pareto_front(
 
             study.optimize(objective, n_trials=100)
 
-            fig = optuna.visualization.plot_pareto_front(study, targets=lambda t: (t.values[0], \
-                                                         t.values[1]), \
-                                                         target_names=["volume", "loss"])
+            fig = optuna.visualization.plot_pareto_front(
+                study, 
+                targets=lambda t: (t.values[0], t.values[1]), 
+                target_names=["Objective 0", "Objective 1"],
+            )
 
 
             fig.show()

--- a/optuna/visualization/_pareto_front.py
+++ b/optuna/visualization/_pareto_front.py
@@ -125,8 +125,10 @@ def plot_pareto_front(
 
     Example:
 
-        The following code snippet shows how to plot a 2-dimensional Pareto front of a 3-dimensional study.
-        This example is scalable e.g. for plotting a 2- or 3-dimensional Pareto front of a 4-dimensional study and so on.
+        The following code snippet shows how to plot a 2-dimensional Pareto front
+        of a 3-dimensional study.
+        This example is scalable, e.g., for plotting a 2- or 3-dimensional Pareto front
+        of a 4-dimensional study and so on.
         The example also contains the option to crop the displayed scale.
 
         .. plotly::
@@ -148,10 +150,16 @@ def plot_pareto_front(
 
             study.optimize(objective, n_trials=100)
 
-            fig = optuna.visualization.plot_pareto_front(study, targets=lambda t: (t.values[0], t.values[1]), target_names=["volume", "loss"])
+            fig = optuna.visualization.plot_pareto_front(study, targets=lambda t: (t.values[0], \
+                                                         t.values[1]), \
+                                                         target_names=["volume", "loss"])
 
-            # Use this line of code instead the above one to add some limitations, e.g. only plot values if the 3rd (non-displayed) dimension is below 100:
-            # fig = optuna.visualization.plot_pareto_front(study, targets=lambda t: (t.values[0] if t.values[2] < 100 else None, t.values[1]), target_names=["volume", "loss"])
+            # Use this line of code instead the above one to add some limitations,
+            # e.g. only plot values if the 3rd (non-displayed) dimension is below 100:
+            # fig = optuna.visualization.plot_pareto_front(study, targets=lambda t: (t.values[0] \
+            #                                              if t.values[2] < 100 else None,
+            #                                              t.values[1]), \
+            #                                              target_names=["volume", "loss"])
 
             fig.show()
     """

--- a/optuna/visualization/_pareto_front.py
+++ b/optuna/visualization/_pareto_front.py
@@ -121,6 +121,39 @@ def plot_pareto_front(
 
     Returns:
         A :class:`plotly.graph_objs.Figure` object.
+        
+        
+    Example:
+
+        The following code snippet shows how to plot a 2-dimensional Pareto front of a 3-dimensional study.
+        This example is scalable e.g. for plotting a 2- or 3-dimensional Pareto front of a 4-dimensional study and so on.
+        The example also contains the option to crop the displayed scale.
+
+        .. plotly::
+
+            import optuna
+
+            def objective(trial):
+                value_a = trial.suggest_int("a", 0,100)
+                value_b = trial.suggest_int("b", 0, 100)
+
+                v0 = value_a ** 2
+                v1 = value_b **2
+                v2 = value_a + value_b
+
+                return v0, v1, v2
+
+            study = optuna.create_study(directions=["minimize", "minimize", "minimize"],
+                            sampler=optuna.samplers.NSGAIISampler())
+
+            study.optimize(objective, n_trials=100)
+
+            fig = optuna.visualization.plot_pareto_front(study, targets=lambda t: (t.values[0], t.values[1]), target_names=["volume", "loss"])
+
+            # Use this line of code instead the above one to add some limitations, e.g. only plot values if the 3rd (non-displayed) dimension is below 100:
+            # fig = optuna.visualization.plot_pareto_front(study, targets=lambda t: (t.values[0] if t.values[2] < 100 else None, t.values[1]), target_names=["volume", "loss"])
+            
+            fig.show()
     """
 
     _imports.check()

--- a/optuna/visualization/_pareto_front.py
+++ b/optuna/visualization/_pareto_front.py
@@ -86,12 +86,11 @@ def plot_pareto_front(
             import optuna
 
             def objective(trial):
-                value_a = trial.suggest_int("a", 0, 100)
-                value_b = trial.suggest_int("b", 0, 100)
-
-                v0 = value_a ** 2
-                v1 = value_b ** 2
-                v2 = value_a + value_b
+                x = trial.suggest_float("x", 0, 5)
+                y = trial.suggest_float("y", 0, 3)
+                v0 = 5 * x ** 2 + 3 * y ** 2
+                v1 = (x - 10) ** 2 + (y - 10) ** 2
+                v2 = x + y
 
                 return v0, v1, v2
 

--- a/optuna/visualization/_pareto_front.py
+++ b/optuna/visualization/_pareto_front.py
@@ -121,8 +121,8 @@ def plot_pareto_front(
 
     Returns:
         A :class:`plotly.graph_objs.Figure` object.
-        
-        
+
+
     Example:
 
         The following code snippet shows how to plot a 2-dimensional Pareto front of a 3-dimensional study.
@@ -152,7 +152,7 @@ def plot_pareto_front(
 
             # Use this line of code instead the above one to add some limitations, e.g. only plot values if the 3rd (non-displayed) dimension is below 100:
             # fig = optuna.visualization.plot_pareto_front(study, targets=lambda t: (t.values[0] if t.values[2] < 100 else None, t.values[1]), target_names=["volume", "loss"])
-            
+
             fig.show()
     """
 

--- a/optuna/visualization/_pareto_front.py
+++ b/optuna/visualization/_pareto_front.py
@@ -73,6 +73,40 @@ def plot_pareto_front(
             fig = optuna.visualization.plot_pareto_front(study)
             fig.show()
 
+    Example:
+
+        The following code snippet shows how to plot a 2-dimensional Pareto front
+        of a 3-dimensional study.
+        This example is scalable, e.g., for plotting a 2- or 3-dimensional Pareto front
+        of a 4-dimensional study and so on.
+        The example also contains the option to crop the displayed scale.
+
+        .. plotly::
+
+            import optuna
+
+            def objective(trial):
+                value_a = trial.suggest_int("a", 0, 100)
+                value_b = trial.suggest_int("b", 0, 100)
+
+                v0 = value_a ** 2
+                v1 = value_b ** 2
+                v2 = value_a + value_b
+
+                return v0, v1, v2
+
+            study = optuna.create_study(directions=["minimize", "minimize", "minimize"])
+
+            study.optimize(objective, n_trials=100)
+
+            fig = optuna.visualization.plot_pareto_front(
+                study,
+                targets=lambda t: (t.values[0], t.values[1]),
+                target_names=["Objective 0", "Objective 1"],
+            )
+
+            fig.show()
+
     Args:
         study:
             A :class:`~optuna.study.Study` object whose trials are plotted for their objective
@@ -121,43 +155,6 @@ def plot_pareto_front(
 
     Returns:
         A :class:`plotly.graph_objs.Figure` object.
-
-
-    Example:
-
-        The following code snippet shows how to plot a 2-dimensional Pareto front
-        of a 3-dimensional study.
-        This example is scalable, e.g., for plotting a 2- or 3-dimensional Pareto front
-        of a 4-dimensional study and so on.
-        The example also contains the option to crop the displayed scale.
-
-        .. plotly::
-
-            import optuna
-
-            def objective(trial):
-                value_a = trial.suggest_int("a", 0, 100)
-                value_b = trial.suggest_int("b", 0, 100)
-
-                v0 = value_a ** 2
-                v1 = value_b ** 2
-                v2 = value_a + value_b
-
-                return v0, v1, v2
-
-            study = optuna.create_study(directions=["minimize", "minimize", "minimize"],
-                            sampler=optuna.samplers.NSGAIISampler())
-
-            study.optimize(objective, n_trials=100)
-
-            fig = optuna.visualization.plot_pareto_front(
-                study, 
-                targets=lambda t: (t.values[0], t.values[1]), 
-                target_names=["Objective 0", "Objective 1"],
-            )
-
-
-            fig.show()
     """
 
     _imports.check()


### PR DESCRIPTION
## Motivation
As it is hard to understand how to use the `targets`-key inside `plot_pareto_front`, here is an example how to use this code.

## Description of the changes
Added example.
