### PR TITLE
Support `JournalFileStorage` and `JournalRedisStorage` on CLI

### DIFF
--- a/optuna/cli.py
+++ b/optuna/cli.py
@@ -21,8 +21,8 @@ from typing import Type
 from typing import Union
 import warnings
 
-import yaml
 import sqlalchemy.exc
+import yaml
 
 import optuna
 from optuna._imports import _LazyImport
@@ -685,7 +685,9 @@ class _StorageUpgrade(_BaseCommand):
     def take_action(self, parsed_args: Namespace) -> int:
         storage_url = _check_storage_url(parsed_args.storage)
         try:
-            storage = RDBStorage(storage_url, skip_compatibility_check=True, skip_table_creation=True)
+            storage = RDBStorage(
+                storage_url, skip_compatibility_check=True, skip_table_creation=True
+            )
         except sqlalchemy.exc.ArgumentError:
             self.logger.info("Invalid RDBStorage URL.")
             return 1

--- a/optuna/cli.py
+++ b/optuna/cli.py
@@ -689,7 +689,7 @@ class _StorageUpgrade(_BaseCommand):
                 storage_url, skip_compatibility_check=True, skip_table_creation=True
             )
         except sqlalchemy.exc.ArgumentError:
-            self.logger.info("Invalid RDBStorage URL.")
+            self.logger.error("Invalid RDBStorage URL.")
             return 1
         current_version = storage.get_current_version()
         head_version = storage.get_head_version()
@@ -940,8 +940,12 @@ def _add_common_arguments(parser: ArgumentParser) -> ArgumentParser:
     parser.add_argument(
         "--storage-class",
         help="Storage class hint (e.g. JournalFileStorage)",
-        type=str,
         default=None,
+        choices=[
+            RDBStorage.__name__,
+            JournalFileStorage.__name__,
+            JournalRedisStorage.__name__,
+        ],
     )
     verbose_group = parser.add_mutually_exclusive_group()
     verbose_group.add_argument(

--- a/optuna/cli.py
+++ b/optuna/cli.py
@@ -22,11 +22,16 @@ from typing import Union
 import warnings
 
 import yaml
+import sqlalchemy.exc
 
 import optuna
 from optuna._imports import _LazyImport
 from optuna.exceptions import CLIUsageError
 from optuna.exceptions import ExperimentalWarning
+from optuna.storages import BaseStorage
+from optuna.storages import JournalFileStorage
+from optuna.storages import JournalRedisStorage
+from optuna.storages import JournalStorage
 from optuna.storages import RDBStorage
 from optuna.trial import TrialState
 
@@ -49,6 +54,27 @@ def _check_storage_url(storage_url: Optional[str]) -> str:
         )
         return env_storage
     raise CLIUsageError("Storage URL is not specified.")
+
+
+def _get_storage(storage_url: Optional[str], storage_class: Optional[str]) -> BaseStorage:
+    storage_url = _check_storage_url(storage_url)
+    if storage_class:
+        if storage_class == JournalRedisStorage.__name__:
+            return JournalStorage(JournalRedisStorage(storage_url))
+        if storage_class == JournalFileStorage.__name__:
+            return JournalStorage(JournalFileStorage(storage_url))
+        if storage_class == RDBStorage.__name__:
+            return RDBStorage(storage_url)
+        raise CLIUsageError("Unsupported storage class")
+
+    if storage_url.startswith("redis"):
+        return JournalStorage(JournalRedisStorage(storage_url))
+    if os.path.isfile(storage_url):
+        return JournalStorage(JournalFileStorage(storage_url))
+    try:
+        return RDBStorage(storage_url)
+    except sqlalchemy.exc.ArgumentError:
+        raise CLIUsageError("Failed to guess storage class from storage_url")
 
 
 def _format_value(value: Any) -> Any:
@@ -293,8 +319,7 @@ class _CreateStudy(_BaseCommand):
         )
 
     def take_action(self, parsed_args: Namespace) -> int:
-        storage_url = _check_storage_url(parsed_args.storage)
-        storage = optuna.storages.get_storage(storage_url)
+        storage = _get_storage(parsed_args.storage, parsed_args.storage_class)
         study_name = optuna.create_study(
             storage=storage,
             study_name=parsed_args.study_name,
@@ -313,8 +338,7 @@ class _DeleteStudy(_BaseCommand):
         parser.add_argument("--study-name", default=None, help="The name of the study to delete.")
 
     def take_action(self, parsed_args: Namespace) -> int:
-        storage_url = _check_storage_url(parsed_args.storage)
-        storage = optuna.storages.get_storage(storage_url)
+        storage = _get_storage(parsed_args.storage, parsed_args.storage_class)
         study_id = storage.get_study_id_from_name(parsed_args.study_name)
         storage.delete_study(study_id)
         return 0
@@ -336,7 +360,7 @@ class _StudySetUserAttribute(_BaseCommand):
         parser.add_argument("--value", required=True, help="Value to be set.")
 
     def take_action(self, parsed_args: Namespace) -> int:
-        storage_url = _check_storage_url(parsed_args.storage)
+        storage = _get_storage(parsed_args.storage, parsed_args.storage_class)
 
         if parsed_args.study and parsed_args.study_name:
             raise ValueError(
@@ -346,9 +370,9 @@ class _StudySetUserAttribute(_BaseCommand):
         elif parsed_args.study:
             message = "The use of `--study` is deprecated. Please use `--study-name` instead."
             warnings.warn(message, FutureWarning)
-            study = optuna.load_study(storage=storage_url, study_name=parsed_args.study)
+            study = optuna.load_study(storage=storage, study_name=parsed_args.study)
         elif parsed_args.study_name:
-            study = optuna.load_study(storage=storage_url, study_name=parsed_args.study_name)
+            study = optuna.load_study(storage=storage, study_name=parsed_args.study_name)
         else:
             raise ValueError("Missing study name. Please use `--study-name`.")
 
@@ -385,8 +409,8 @@ class _Studies(_BaseCommand):
         )
 
     def take_action(self, parsed_args: Namespace) -> int:
-        storage_url = _check_storage_url(parsed_args.storage)
-        summaries = optuna.get_all_study_summaries(storage_url, include_best_trial=False)
+        storage = _get_storage(parsed_args.storage, parsed_args.storage_class)
+        summaries = optuna.get_all_study_summaries(storage, include_best_trial=False)
 
         records = []
         for s in summaries:
@@ -444,8 +468,8 @@ class _Trials(_BaseCommand):
             ExperimentalWarning,
         )
 
-        storage_url = _check_storage_url(parsed_args.storage)
-        study = optuna.load_study(storage=storage_url, study_name=parsed_args.study_name)
+        storage = _get_storage(parsed_args.storage, parsed_args.storage_class)
+        study = optuna.load_study(storage=storage, study_name=parsed_args.study_name)
         attrs = (
             "number",
             "value" if not study._is_multi_objective() else "values",
@@ -494,8 +518,8 @@ class _BestTrial(_BaseCommand):
             ExperimentalWarning,
         )
 
-        storage_url = _check_storage_url(parsed_args.storage)
-        study = optuna.load_study(storage=storage_url, study_name=parsed_args.study_name)
+        storage = _get_storage(parsed_args.storage, parsed_args.storage_class)
+        study = optuna.load_study(storage=storage, study_name=parsed_args.study_name)
         attrs = (
             "number",
             "value" if not study._is_multi_objective() else "values",
@@ -548,8 +572,8 @@ class _BestTrials(_BaseCommand):
             ExperimentalWarning,
         )
 
-        storage_url = _check_storage_url(parsed_args.storage)
-        study = optuna.load_study(storage=storage_url, study_name=parsed_args.study_name)
+        storage = _get_storage(parsed_args.storage, parsed_args.storage_class)
+        study = optuna.load_study(storage=storage, study_name=parsed_args.study_name)
         best_trials = [trial.number for trial in study.best_trials]
         attrs = (
             "number",
@@ -613,7 +637,7 @@ class _StudyOptimize(_BaseCommand):
         )
         warnings.warn(message, FutureWarning)
 
-        storage_url = _check_storage_url(parsed_args.storage)
+        storage = _get_storage(parsed_args.storage, parsed_args.storage_class)
 
         if parsed_args.study and parsed_args.study_name:
             raise ValueError(
@@ -623,9 +647,9 @@ class _StudyOptimize(_BaseCommand):
         elif parsed_args.study:
             message = "The use of `--study` is deprecated. Please use `--study-name` instead."
             warnings.warn(message, FutureWarning)
-            study = optuna.load_study(storage=storage_url, study_name=parsed_args.study)
+            study = optuna.load_study(storage=storage, study_name=parsed_args.study)
         elif parsed_args.study_name:
-            study = optuna.load_study(storage=storage_url, study_name=parsed_args.study_name)
+            study = optuna.load_study(storage=storage, study_name=parsed_args.study_name)
         else:
             raise ValueError("Missing study name. Please use `--study-name`.")
 
@@ -656,14 +680,15 @@ class _StudyOptimize(_BaseCommand):
 
 
 class _StorageUpgrade(_BaseCommand):
-    """Upgrade the schema of a storage."""
+    """Upgrade the schema of an RDB storage."""
 
     def take_action(self, parsed_args: Namespace) -> int:
         storage_url = _check_storage_url(parsed_args.storage)
-        if storage_url.startswith("redis"):
-            self.logger.info("This storage does not support upgrade yet.")
+        try:
+            storage = RDBStorage(storage_url, skip_compatibility_check=True, skip_table_creation=True)
+        except sqlalchemy.exc.ArgumentError:
+            self.logger.info("Invalid RDBStorage URL.")
             return 1
-        storage = RDBStorage(storage_url, skip_compatibility_check=True, skip_table_creation=True)
         current_version = storage.get_current_version()
         head_version = storage.get_head_version()
         known_versions = storage.get_all_versions()
@@ -741,10 +766,10 @@ class _Ask(_BaseCommand):
             ExperimentalWarning,
         )
 
-        storage_url = _check_storage_url(parsed_args.storage)
+        storage = _get_storage(parsed_args.storage, parsed_args.storage_class)
 
         create_study_kwargs = {
-            "storage": storage_url,
+            "storage": storage,
             "study_name": parsed_args.study_name,
             "direction": parsed_args.direction,
             "directions": parsed_args.directions,
@@ -859,10 +884,10 @@ class _Tell(_BaseCommand):
             ExperimentalWarning,
         )
 
-        storage_url = _check_storage_url(parsed_args.storage)
+        storage = _get_storage(parsed_args.storage, parsed_args.storage_class)
 
         study = optuna.load_study(
-            storage=storage_url,
+            storage=storage,
             study_name=parsed_args.study_name,
         )
 
@@ -909,6 +934,12 @@ def _add_common_arguments(parser: ArgumentParser) -> ArgumentParser:
             "DB URL. (e.g. sqlite:///example.db) "
             "Also can be specified via OPTUNA_STORAGE environment variable."
         ),
+    )
+    parser.add_argument(
+        "--storage-class",
+        help="Storage class hint (e.g. JournalFileStorage)",
+        type=str,
+        default=None,
     )
     verbose_group = parser.add_mutually_exclusive_group()
     verbose_group.add_argument(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1122,7 +1122,6 @@ def test_storage_upgrade_command() -> None:
 def test_storage_upgrade_command_with_invalid_url() -> None:
     with StorageSupplier("sqlite") as storage:
         assert isinstance(storage, RDBStorage)
-        storage_url = str(storage.engine.url)
 
         command = ["optuna", "storage", "upgrade", "--storage", "invalid-storage-url"]
         with pytest.raises(CalledProcessError):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,15 +1,19 @@
 from collections import OrderedDict
 import json
 import os
+import platform
 import re
 import subprocess
 from subprocess import CalledProcessError
+import tempfile
 from typing import Any
 from typing import Callable
 from typing import Optional
 from typing import Tuple
+from unittest.mock import MagicMock
 from unittest.mock import patch
 
+import fakeredis
 import numpy as np
 from pandas import Timedelta
 from pandas import Timestamp
@@ -20,6 +24,9 @@ import optuna
 import optuna.cli
 from optuna.exceptions import CLIUsageError
 from optuna.exceptions import ExperimentalWarning
+from optuna.storages import JournalFileStorage
+from optuna.storages import JournalRedisStorage
+from optuna.storages import JournalStorage
 from optuna.storages import RDBStorage
 from optuna.storages._base import DEFAULT_STUDY_NAME_PREFIX
 from optuna.study import StudyDirection
@@ -1049,6 +1056,51 @@ def test_check_storage_url() -> None:
         optuna.cli._check_storage_url(None)
 
 
+@pytest.mark.skipif(platform.system() == "Windows", reason="Skip on Windows")
+@patch("optuna.storages._journal.redis.redis")
+def test_get_storage_without_storage_class(mock_redis: MagicMock) -> None:
+    with tempfile.NamedTemporaryFile(suffix=".db") as fp:
+        storage = optuna.cli._get_storage(f"sqlite:///{fp.name}", storage_class=None)
+        assert isinstance(storage, RDBStorage)
+
+    with tempfile.NamedTemporaryFile(suffix=".log") as fp:
+        storage = optuna.cli._get_storage(fp.name, storage_class=None)
+        assert isinstance(storage, JournalStorage)
+        assert isinstance(storage._backend, JournalFileStorage)
+
+    mock_redis.Redis = fakeredis.FakeRedis
+    storage = optuna.cli._get_storage("redis://localhost:6379", storage_class=None)
+    assert isinstance(storage, JournalStorage)
+    assert isinstance(storage._backend, JournalRedisStorage)
+
+    with pytest.raises(CLIUsageError):
+        optuna.cli._get_storage("./file-not-found.log", storage_class=None)
+
+
+@pytest.mark.skipif(platform.system() == "Windows", reason="Skip on Windows")
+@patch("optuna.storages._journal.redis.redis")
+def test_get_storage_with_storage_class(mock_redis: MagicMock) -> None:
+    with tempfile.NamedTemporaryFile(suffix=".db") as fp:
+        storage = optuna.cli._get_storage(f"sqlite:///{fp.name}", storage_class=None)
+        assert isinstance(storage, RDBStorage)
+
+    with tempfile.NamedTemporaryFile(suffix=".log") as fp:
+        storage = optuna.cli._get_storage(fp.name, storage_class="JournalFileStorage")
+        assert isinstance(storage, JournalStorage)
+        assert isinstance(storage._backend, JournalFileStorage)
+
+    mock_redis.Redis = fakeredis.FakeRedis
+    storage = optuna.cli._get_storage(
+        "redis:///localhost:6379", storage_class="JournalRedisStorage"
+    )
+    assert isinstance(storage, JournalStorage)
+    assert isinstance(storage._backend, JournalRedisStorage)
+
+    with pytest.raises(CLIUsageError):
+        with tempfile.NamedTemporaryFile(suffix=".db") as fp:
+            optuna.cli._get_storage(f"sqlite:///{fp.name}", storage_class="InMemoryStorage")
+
+
 @pytest.mark.skip_coverage
 def test_storage_upgrade_command() -> None:
     with StorageSupplier("sqlite") as storage:
@@ -1064,6 +1116,17 @@ def test_storage_upgrade_command() -> None:
 
         command.extend(["--storage", storage_url])
         subprocess.check_call(command)
+
+
+@pytest.mark.skip_coverage
+def test_storage_upgrade_command_with_invalid_url() -> None:
+    with StorageSupplier("sqlite") as storage:
+        assert isinstance(storage, RDBStorage)
+        storage_url = str(storage.engine.url)
+
+        command = ["optuna", "storage", "upgrade", "--storage", "invalid-storage-url"]
+        with pytest.raises(CalledProcessError):
+            subprocess.check_call(command)
 
 
 @pytest.mark.skip_coverage


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
It's useful to support JournalFileStorage and JournalRedisStorage as requested at https://github.com/optuna/optuna-dashboard/issues/379.

## Description of the changes
<!-- Describe the changes in this PR. -->

Currently Optuna's command line interface only allows specifying RDBStorage, but this PR will also allow specifying JournalFileStorage and JournalRedisStorage as follows.

* `JournalFileStorage` : `optuna create-study --storage ./journal.log`
* `JournalRedisStorage` : `optuna create-study --storage redis://localhost:6379`
* `RDBStorage` : `optuna create-study --storage sqlite://db.sqlite3`

However, such a design may cause following two problems.

1. if there are multiple FileStorage or RedisStorage of the same storage_url format, it is not possible to identify which storage class is used from the `storage_url`.
1. As RedisStorage was removed in Optuna v3.1 and replaced by JournalRedisStorage, it may cause breaking changes to storage classes in the future.

Therefore, this PR introduce the `--storage-class` argument. It is possible to explicitly specify which storage class is to be used, thus solving the above problems.

* `JournalFileStorage` : `optuna create-study --storage ./journal.log --storage-class JournalFileStorage`
* `JournalRedisStorage` : `optuna create-study --storage redis://localhost:6379 --storage-class JournalRedisStorage`
* `RDBStorage` : `optuna create-study --storage sqlite://db.sqlite3 --storage-class RDBStorage`
