### PR TITLE
Speed up `logpdf` in `_truncnorm.py`

### DIFF
--- a/optuna/samplers/_tpe/_truncnorm.py
+++ b/optuna/samplers/_tpe/_truncnorm.py
@@ -225,10 +225,10 @@ def logpdf(
     x = (x - loc) / scale
 
     x, a, b = np.atleast_1d(x, a, b)
-    x, a, b = np.broadcast_arrays(x, a, b)
 
     out = _norm_logpdf(x) - _log_gauss_mass(a, b)
 
+    x, a, b = np.broadcast_arrays(x, a, b)
     out[(x < a) | (b < x)] = -np.inf
     out[a == b] = math.nan
 


### PR DESCRIPTION
## Motivation
The shapes of `a` and `b` in `logpdf` is `(1, n_below or n_above)`, but broadcasted them are `(n_ei_candidates, n_below or n_above)`. Calculating `_log_gauss_mass` before broadcast makes it faster.

----

```python
import optuna

def objective(trial):
    return sum([trial.suggest_float(f"x_{i}", -100, 100) ** 2 for i in range(10)])

study = optuna.create_study()
study.optimize(objective, n_trials=1000)
```

- master
```
$ time python bench.py
real	1m11.063s
user	1m9.636s
sys	0m1.247s
```

- PR
```
$ time python bench.py
real	1m2.653s
user	1m1.911s
sys	0m0.533s
```

## Description of the changes
- Call `_log_gauss_mass` before broadcast
