### PR TITLE
Remove unnecessary period

### DIFF
--- a/optuna/study/_tell.py
+++ b/optuna/study/_tell.py
@@ -65,15 +65,15 @@ def _check_values_are_feasible(study: "optuna.Study", values: Sequence[float]) -
         try:
             float(v)
         except (ValueError, TypeError):
-            return f"The value {repr(v)} could not be cast to float."
+            return f"The value {repr(v)} could not be cast to float"
 
         if math.isnan(v):
-            return f"The value {v} is not acceptable."
+            return f"The value {v} is not acceptable"
 
     if len(study.directions) != len(values):
         return (
             f"The number of the values {len(values)} did not match the number of the objectives "
-            f"{len(study.directions)}."
+            f"{len(study.directions)}"
         )
 
     return None


### PR DESCRIPTION
## Motivation
Make error log grammatically correct.

## Description of the changes
Currently, error logs from `_check_values_are_feasible()` in `_tell.py` contains unnecessary periods since another period is added when they go through `_log_failed_trial()` in `_optimize.py`. This PR removes those periods in `_tell.py`.

## Minimal Reproducible code
```
import numpy as np

import optuna


def objective(trial):
    x = trial.suggest_int("x", -1, 1)
    return np.nan if x == 0 else "a" if x == -1 else [1, 2]


study = optuna.create_study(sampler=optuna.samplers.BruteForceSampler(seed=1))
study.optimize(objective, n_trials=3)
```