### PR TITLE
Make BruteForceSampler consider failed trials

### DIFF
--- a/optuna/samplers/_brute_force.py
+++ b/optuna/samplers/_brute_force.py
@@ -187,6 +187,7 @@ class BruteForceSampler(BaseSampler):
                 TrialState.COMPLETE,
                 TrialState.PRUNED,
                 TrialState.RUNNING,
+                TrialState.FAIL,
             ),
         )
         tree = self._build_tree((t for t in trials if t.number != trial.number), trial.params)
@@ -210,6 +211,7 @@ class BruteForceSampler(BaseSampler):
                 TrialState.COMPLETE,
                 TrialState.PRUNED,
                 TrialState.RUNNING,
+                TrialState.FAIL,
             ),
         )
         tree = self._build_tree(

--- a/tests/samplers_tests/test_brute_force.py
+++ b/tests/samplers_tests/test_brute_force.py
@@ -287,5 +287,6 @@ def test_study_optimize_with_failed_trials() -> None:
 
     expected_suggested_values = [{"x": i} for i in range(100)]
     all_suggested_values = [t.params for t in study.trials]
+    assert len(all_suggested_values) == len(expected_suggested_values)
     for a in expected_suggested_values:
         assert a in all_suggested_values

--- a/tests/samplers_tests/test_brute_force.py
+++ b/tests/samplers_tests/test_brute_force.py
@@ -275,3 +275,18 @@ def test_study_optimize_with_nonconstant_search_space() -> None:
     )
     with pytest.raises(ValueError):
         study.optimize(objective_decreasing_variable, n_trials=10)
+
+
+def test_study_optimize_with_failed_trials() -> None:
+    def objective(trial: Trial) -> float:
+        x = trial.suggest_int("x", 0, 99)
+        return np.nan
+
+    study = optuna.create_study(sampler=samplers.BruteForceSampler())
+    study.optimize(objective, n_trials=100)
+
+    expected_suggested_values = [{"x": i} for i in range(100)]
+    all_suggested_values = [t.params for t in study.trials]
+    for a in expected_suggested_values:
+        assert a in all_suggested_values
+    

--- a/tests/samplers_tests/test_brute_force.py
+++ b/tests/samplers_tests/test_brute_force.py
@@ -289,4 +289,3 @@ def test_study_optimize_with_failed_trials() -> None:
     all_suggested_values = [t.params for t in study.trials]
     for a in expected_suggested_values:
         assert a in all_suggested_values
-    

--- a/tests/samplers_tests/test_brute_force.py
+++ b/tests/samplers_tests/test_brute_force.py
@@ -279,7 +279,7 @@ def test_study_optimize_with_nonconstant_search_space() -> None:
 
 def test_study_optimize_with_failed_trials() -> None:
     def objective(trial: Trial) -> float:
-        x = trial.suggest_int("x", 0, 99)
+        x = trial.suggest_int("x", 0, 99)  # NOQA[F811]
         return np.nan
 
     study = optuna.create_study(sampler=samplers.BruteForceSampler())


### PR DESCRIPTION
## Motivation
Ensure consistent behaviors for failed trials of both`BruteForceSampler` and `GridSampler`.
The following is minimum reproducible code to make `BruteForceSampler` sample the same parameters multiple times.
```
import optuna


def objective(trial):
    x = trial.suggest_int("x", 0, 1)
    return [0, 1] if x else "a"


study = optuna.create_study(sampler=optuna.samplers.BruteForceSampler(seed=0))
study.optimize(objective, n_trials=2)

```

## Description of the changes
Consider trials in `TrialState.FAIL` as finished trials.