### PR TITLE
Handle deprecated argument `early_stopping_rounds`

### DIFF
--- a/optuna/integration/_lightgbm_tuner/optimize.py
+++ b/optuna/integration/_lightgbm_tuner/optimize.py
@@ -372,6 +372,11 @@ class _LightGBMBaseTuner(_BaseTuner):
         # Handling alias metrics.
         _handling_alias_metrics(params)
 
+        if early_stopping_rounds is not None:
+            if callbacks is None:
+                callbacks = []
+            callbacks.append(lgb.early_stopping(stopping_rounds=early_stopping_rounds))
+
         args = [params, train_set]
         kwargs: Dict[str, Any] = dict(
             num_boost_round=num_boost_round,
@@ -379,7 +384,6 @@ class _LightGBMBaseTuner(_BaseTuner):
             feval=feval,
             feature_name=feature_name,
             categorical_feature=categorical_feature,
-            early_stopping_rounds=early_stopping_rounds,
             verbose_eval=verbose_eval,
             callbacks=callbacks,
             time_budget=time_budget,


### PR DESCRIPTION
## Motivation
The argument `early_stopping_rounds` is deprecated in https://github.com/microsoft/LightGBM/pull/4574 and has been already removed in the latest version by https://github.com/microsoft/LightGBM/pull/4908. Our integration uses this argument and currently warned in the `Test(integration)` as follows.
https://github.com/optuna/optuna/actions/runs/5274281893/jobs/9538592552?pr=4746#step:10:167
This PR resolves the warnings while preserving backward compatibility with `LightGBM<4.0.0`.


## Description of the changes
Generate a callback `early_stopping()` according to the given `early_stopping_rounds` and pass to `LightGBM` side. Note that `early_stopping()` is added in the very early stage (https://github.com/microsoft/LightGBM/pull/131) and therefore this change does not break backward compatibility at least with documented version (`LightGBM >=v3.2.1`).
