### PR TITLE
add `optuna.integration.botorch.qnei_candidates_func`

### DIFF
--- a/docs/source/reference/integration.rst
+++ b/docs/source/reference/integration.rst
@@ -27,6 +27,7 @@ BoTorch
 
    optuna.integration.BoTorchSampler
    optuna.integration.botorch.qei_candidates_func
+   optuna.integration.botorch.qnei_candidates_func
    optuna.integration.botorch.qehvi_candidates_func
    optuna.integration.botorch.qnehvi_candidates_func
    optuna.integration.botorch.qparego_candidates_func

--- a/optuna/integration/botorch.py
+++ b/optuna/integration/botorch.py
@@ -28,7 +28,7 @@ from optuna.trial import TrialState
 
 
 with try_import() as _imports:
-    from botorch.acquisition.monte_carlo import qExpectedImprovement
+    from botorch.acquisition.monte_carlo import qExpectedImprovement, qNoisyExpectedImprovement
     from botorch.acquisition.multi_objective import monte_carlo
     from botorch.acquisition.multi_objective.objective import IdentityMCMultiOutputObjective
     from botorch.acquisition.objective import ConstrainedMCObjective
@@ -173,6 +173,86 @@ def qei_candidates_func(
     return candidates
 
 
+@experimental_func("3.3.0")
+def qnei_candidates_func(
+    train_x: "torch.Tensor",
+    train_obj: "torch.Tensor",
+    train_con: Optional["torch.Tensor"],
+    bounds: "torch.Tensor",
+    pending_x: Optional["torch.Tensor"],
+) -> "torch.Tensor":
+    """Quasi MC-based batch Noisy Expected Improvement (qNEI).
+
+    This function may perform better than qEI (`qei_candidates_func`) when
+    the evaluated values of objective function are noisy.
+
+    .. seealso::
+        :func:`~optuna.integration.botorch.qei_candidates_func` for argument and return value
+        descriptions.
+    """
+    if train_obj.size(-1) != 1:
+        raise ValueError("Objective may only contain single values with qNEI.")
+    if train_con is not None:
+        train_y = torch.cat([train_obj, train_con], dim=-1)
+
+        is_feas = (train_con <= 0).all(dim=-1)
+        train_obj_feas = train_obj[is_feas]
+
+        if train_obj_feas.numel() == 0:
+            # TODO(hvy): Do not use 0 as the best observation.
+            _logger.warning(
+                "No objective values are feasible. Using 0 as the best objective in qNEI."
+            )
+            best_f = torch.zeros(())
+        else:
+            best_f = train_obj_feas.max()
+
+        n_constraints = train_con.size(1)
+        objective = ConstrainedMCObjective(
+            objective=lambda Z: Z[..., 0],
+            constraints=[
+                (lambda Z, i=i: Z[..., -n_constraints + i]) for i in range(n_constraints)
+            ],
+        )
+    else:
+        train_y = train_obj
+
+        objective = None  # Using the default identity objective.
+
+    train_x = normalize(train_x, bounds=bounds)
+    if pending_x is not None:
+        pending_x = normalize(pending_x, bounds=bounds)
+
+    model = SingleTaskGP(train_x, train_y, outcome_transform=Standardize(m=train_y.size(-1)))
+    mll = ExactMarginalLogLikelihood(model.likelihood, model)
+    fit_gpytorch_mll(mll)
+
+    acqf = qNoisyExpectedImprovement(
+        model=model,
+        X_baseline=train_x,
+        sampler=_get_sobol_qmc_normal_sampler(256),
+        objective=objective,
+        X_pending=pending_x,
+    )
+
+    standard_bounds = torch.zeros_like(bounds)
+    standard_bounds[1] = 1
+
+    candidates, _ = optimize_acqf(
+        acq_function=acqf,
+        bounds=standard_bounds,
+        q=1,
+        num_restarts=10,
+        raw_samples=512,
+        options={"batch_limit": 5, "maxiter": 200},
+        sequential=True,
+    )
+
+    candidates = unnormalize(candidates.detach(), bounds=bounds)
+
+    return candidates
+
+
 @experimental_func("2.4.0")
 def qehvi_candidates_func(
     train_x: "torch.Tensor",
@@ -268,7 +348,7 @@ def qnehvi_candidates_func(
     bounds: "torch.Tensor",
     pending_x: Optional["torch.Tensor"],
 ) -> "torch.Tensor":
-    """Quasi MC-based batch Expected Noisy Hypervolume Improvement (qNEHVI).
+    """Quasi MC-based batch Noisy Expected Hypervolume Improvement (qNEHVI).
 
     According to Botorch/Ax documentation,
     this function may perform better than qEHVI (`qehvi_candidates_func`).

--- a/optuna/integration/botorch.py
+++ b/optuna/integration/botorch.py
@@ -28,7 +28,8 @@ from optuna.trial import TrialState
 
 
 with try_import() as _imports:
-    from botorch.acquisition.monte_carlo import qExpectedImprovement, qNoisyExpectedImprovement
+    from botorch.acquisition.monte_carlo import qExpectedImprovement
+    from botorch.acquisition.monte_carlo import qNoisyExpectedImprovement
     from botorch.acquisition.multi_objective import monte_carlo
     from botorch.acquisition.multi_objective.objective import IdentityMCMultiOutputObjective
     from botorch.acquisition.objective import ConstrainedMCObjective
@@ -194,18 +195,6 @@ def qnei_candidates_func(
         raise ValueError("Objective may only contain single values with qNEI.")
     if train_con is not None:
         train_y = torch.cat([train_obj, train_con], dim=-1)
-
-        is_feas = (train_con <= 0).all(dim=-1)
-        train_obj_feas = train_obj[is_feas]
-
-        if train_obj_feas.numel() == 0:
-            # TODO(hvy): Do not use 0 as the best observation.
-            _logger.warning(
-                "No objective values are feasible. Using 0 as the best objective in qNEI."
-            )
-            best_f = torch.zeros(())
-        else:
-            best_f = train_obj_feas.max()
 
         n_constraints = train_con.size(1)
         objective = ConstrainedMCObjective(

--- a/tests/integration_tests/test_botorch.py
+++ b/tests/integration_tests/test_botorch.py
@@ -90,6 +90,7 @@ def test_botorch_candidates_func() -> None:
     "candidates_func, n_objectives",
     [
         (integration.botorch.qei_candidates_func, 1),
+        (integration.botorch.qnei_candidates_func, 1),
         (integration.botorch.qehvi_candidates_func, 2),
         (integration.botorch.qparego_candidates_func, 4),
         (integration.botorch.qnehvi_candidates_func, 2),


### PR DESCRIPTION
## Motivation

#4739.

## Description of the changes

Add a new acquisition function `qnei_candidates_func` that complements the existing `qnehvi_candidates_func`, which is a multi-objective version of it (but it is strictly multi-objective and therefore does not cover the single objective case.) 

This PR will let users to take advantage of the noisy surrogate model in BO for a single objective case. For more details, 
please refer to #4739. 