### PR TITLE
Add hypervolume history plot for plotly backend.

### DIFF
--- a/docs/source/reference/visualization/index.rst
+++ b/docs/source/reference/visualization/index.rst
@@ -8,7 +8,7 @@ The :mod:`~optuna.visualization` module provides utility functions for plotting 
 .. note::
     In the :mod:`optuna.visualization` module, the following functions use plotly to create figures, but `JupyterLab`_ cannot
     render them by default. Please follow this `installation guide`_ to show figures in
-    `JupyterLab`_. 
+    `JupyterLab`_.
 .. note::
     The :func:`~optuna.visualization.plot_param_importances` requires the Python package of `scikit-learn <https://github.com/scikit-learn/scikit-learn>`_.
 
@@ -21,6 +21,7 @@ The :mod:`~optuna.visualization` module provides utility functions for plotting 
 
    optuna.visualization.plot_contour
    optuna.visualization.plot_edf
+   optuna.visualization.plot_hypervolume_history
    optuna.visualization.plot_intermediate_values
    optuna.visualization.plot_optimization_history
    optuna.visualization.plot_parallel_coordinate

--- a/optuna/visualization/__init__.py
+++ b/optuna/visualization/__init__.py
@@ -1,6 +1,7 @@
 from optuna.visualization import matplotlib
 from optuna.visualization._contour import plot_contour
 from optuna.visualization._edf import plot_edf
+from optuna.visualization._hypervolume_history import plot_hypervolume_history
 from optuna.visualization._intermediate_values import plot_intermediate_values
 from optuna.visualization._optimization_history import plot_optimization_history
 from optuna.visualization._parallel_coordinate import plot_parallel_coordinate
@@ -18,6 +19,7 @@ __all__ = [
     "matplotlib",
     "plot_contour",
     "plot_edf",
+    "plot_hypervolume_history",
     "plot_intermediate_values",
     "plot_optimization_history",
     "plot_parallel_coordinate",

--- a/optuna/visualization/_hypervolume_history.py
+++ b/optuna/visualization/_hypervolume_history.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import NamedTuple
 from typing import Sequence
 

--- a/optuna/visualization/_hypervolume_history.py
+++ b/optuna/visualization/_hypervolume_history.py
@@ -1,0 +1,92 @@
+from typing import Sequence
+
+import numpy as np
+
+from optuna._experimental import experimental_func
+from optuna.study import Study
+from optuna.visualization._plotly_imports import _imports
+from optuna.visualization.matplotlib._hypervolume_history import _get_hypervolume_history_info
+from optuna.visualization.matplotlib._hypervolume_history import _HypervolumeHistoryInfo
+
+
+if _imports.is_successful():
+    from optuna.visualization._plotly_imports import go
+
+
+@experimental_func("3.3.0")
+def plot_hypervolume_history(
+    study: Study,
+    reference_point: Sequence[float],
+) -> "go.Figure":
+    """Plot hypervolume history of all trials in a study.
+
+    Example:
+
+        The following code snippet shows how to plot optimization history.
+
+        .. plotly::
+
+            import optuna
+
+
+            def objective(trial):
+                x = trial.suggest_float("x", 0, 5)
+                y = trial.suggest_float("y", 0, 3)
+
+                v0 = 4 * x ** 2 + 4 * y ** 2
+                v1 = (x - 5) ** 2 + (y - 5) ** 2
+                return v0, v1
+
+
+            study = optuna.create_study(directions=["minimize", "minimize"])
+            study.optimize(objective, n_trials=50)
+
+            reference_point=[100., 50.]
+            fig = optuna.visualization.plot_hypervolume_history(study, reference_point)
+            fig.show()
+
+    Args:
+        study:
+            A :class:`~optuna.study.Study` object whose trials are plotted for their hypervolumes.
+           ``study.n_objectives`` must be 2 or more.
+
+        reference_point:
+            A reference point to use for hypervolume computation.
+            The dimension of the reference point must be the same as the number of objectives.
+
+    Returns:
+        A :class:`plotly.graph_objs.Figure` object.
+    """
+
+    _imports.check()
+
+    if not study._is_multi_objective():
+        raise ValueError(
+            "Study must be multi-objective. For single-objective optimization, "
+            "please use plot_optimization_history instead."
+        )
+
+    if len(reference_point) != len(study.directions):
+        raise ValueError(
+            "The dimension of the reference point must be the same as the number of objectives."
+        )
+
+    info = _get_hypervolume_history_info(study, np.asarray(reference_point, dtype=np.float64))
+    return _get_hypervolume_history_plot(info)
+
+
+def _get_hypervolume_history_plot(
+    info: _HypervolumeHistoryInfo,
+) -> "go.Figure":
+    layout = go.Layout(
+        title="Hypervolume History Plot",
+        xaxis={"title": "Trial"},
+        yaxis={"title": "Hypervolume"},
+    )
+
+    data = go.Scatter(
+        x=info.trial_numbers,
+        y=info.values,
+        mode="lines+markers",
+    )
+    return go.Figure(data=data, layout=layout)

--- a/optuna/visualization/_hypervolume_history.py
+++ b/optuna/visualization/_hypervolume_history.py
@@ -1,16 +1,28 @@
+from typing import NamedTuple
 from typing import Sequence
 
 import numpy as np
 
 from optuna._experimental import experimental_func
+from optuna._hypervolume import WFG
+from optuna.logging import get_logger
+from optuna.samplers._base import _CONSTRAINTS_KEY
 from optuna.study import Study
+from optuna.study._multi_objective import _get_pareto_front_trials_by_trials
+from optuna.study._study_direction import StudyDirection
+from optuna.trial import TrialState
 from optuna.visualization._plotly_imports import _imports
-from optuna.visualization.matplotlib._hypervolume_history import _get_hypervolume_history_info
-from optuna.visualization.matplotlib._hypervolume_history import _HypervolumeHistoryInfo
 
 
 if _imports.is_successful():
     from optuna.visualization._plotly_imports import go
+
+_logger = get_logger(__name__)
+
+
+class _HypervolumeHistoryInfo(NamedTuple):
+    trial_numbers: list[int]
+    values: list[float]
 
 
 @experimental_func("3.3.0")
@@ -90,3 +102,54 @@ def _get_hypervolume_history_plot(
         mode="lines+markers",
     )
     return go.Figure(data=data, layout=layout)
+
+
+def _get_hypervolume_history_info(
+    study: Study,
+    reference_point: np.ndarray,
+) -> _HypervolumeHistoryInfo:
+    completed_trials = study.get_trials(deepcopy=False, states=(TrialState.COMPLETE,))
+
+    if len(completed_trials) == 0:
+        _logger.warning("Your study does not have any completed trials.")
+
+    # Only feasible trials are considered in hypervolume computation.
+    trial_numbers = []
+    best_trials_history = []
+    feasible_trials = []
+    for trial in completed_trials:
+        has_constraints = _CONSTRAINTS_KEY in trial.system_attrs
+        if has_constraints:
+            constraints_values = trial.system_attrs[_CONSTRAINTS_KEY]
+            if all(map(lambda x: x <= 0.0, constraints_values)):
+                feasible_trials.append(trial)
+        else:
+            feasible_trials.append(trial)
+
+        trial_numbers.append(trial.number)
+        best_trials_history.append(
+            _get_pareto_front_trials_by_trials(feasible_trials, study.directions)
+        )
+
+    if len(feasible_trials) == 0:
+        _logger.warning("Your study does not have any feasible trials.")
+
+    # Our hypervolume computation module assumes that all objectives are minimized.
+    # Here we transform the objective values and the reference point.
+    signs = np.asarray([1 if d == StudyDirection.MINIMIZE else -1 for d in study.directions])
+    minimization_reference_point = signs * reference_point
+    values = []
+    for best_trials in best_trials_history:
+        solution_set = np.asarray(
+            list(
+                filter(
+                    lambda v: (v <= minimization_reference_point).all(),
+                    [signs * trial.values for trial in best_trials],
+                )
+            )
+        )
+        hypervolume = 0.0
+        if solution_set.size > 0:
+            hypervolume = WFG().compute(solution_set, minimization_reference_point)
+        values.append(hypervolume)
+    return _HypervolumeHistoryInfo(trial_numbers, values)

--- a/tests/visualization_tests/test_hypervolume_history.py
+++ b/tests/visualization_tests/test_hypervolume_history.py
@@ -7,8 +7,8 @@ from optuna.samplers import NSGAIISampler
 from optuna.study import create_study
 from optuna.trial import FrozenTrial
 from optuna.trial import Trial
-from optuna.visualization.matplotlib._hypervolume_history import _get_hypervolume_history_info
-from optuna.visualization.matplotlib._hypervolume_history import _HypervolumeHistoryInfo
+from optuna.visualization._hypervolume_history import _get_hypervolume_history_info
+from optuna.visualization._hypervolume_history import _HypervolumeHistoryInfo
 
 
 @pytest.mark.parametrize(
@@ -52,7 +52,6 @@ def test_get_optimization_history_info(directions: str) -> None:
 
     reference_point = np.asarray(signs)
     info = _get_hypervolume_history_info(study, reference_point)
-
     assert info == _HypervolumeHistoryInfo(
-        trial_numbers=[0, 1, 2, 3, 4, 5], values=[0, 0.0625, 0.0625, 0.25, 0.3125, 1.0]
+        trial_numbers=[0, 1, 2, 3, 4, 5], values=[0.0, 0.0625, 0.0625, 0.25, 0.3125, 1.0]
     )


### PR DESCRIPTION
## Motivation
This PR implements a hypervolume history plot function for the plotly backend.
This is a follow-up for #4748 that introduced the matplotlib version.

## Description of the changes
- Add _hypervolume_history.py to optuna.visualization

## Demo
<img src="https://github.com/optuna/optuna/assets/30489874/aaaa3ca7-6d97-4ebe-9dc5-88088a47d462" width="75%">