### PR TITLE
Separate dominate function from `_fast_non_dominated_sort()`

### DIFF
--- a/optuna/samplers/_nsgaiii.py
+++ b/optuna/samplers/_nsgaiii.py
@@ -24,6 +24,7 @@ from optuna.samplers.nsgaii._crossovers._base import BaseCrossover
 from optuna.samplers.nsgaii._crossovers._uniform import UniformCrossover
 from optuna.samplers.nsgaii._sampler import _constrained_dominates
 from optuna.samplers.nsgaii._sampler import _fast_non_dominated_sort
+from optuna.samplers.nsgaii._sampler import _validate_constraints
 from optuna.study import Study
 from optuna.study._multi_objective import _dominates
 from optuna.trial import FrozenTrial
@@ -299,6 +300,8 @@ class NSGAIIISampler(BaseSampler):
     def _select_elite_population(
         self, study: Study, population: list[FrozenTrial]
     ) -> list[FrozenTrial]:
+        _validate_constraints(population, self._constraints_func)
+
         dominates = _dominates if self._constraints_func is None else _constrained_dominates
         population_per_rank = _fast_non_dominated_sort(population, study.directions, dominates)
         elite_population: list[FrozenTrial] = []

--- a/optuna/samplers/_nsgaiii.py
+++ b/optuna/samplers/_nsgaiii.py
@@ -299,10 +299,9 @@ class NSGAIIISampler(BaseSampler):
     def _select_elite_population(
         self, study: Study, population: list[FrozenTrial]
     ) -> list[FrozenTrial]:
+        dominates = _dominates if self._constraints_func is None else _constrained_dominates
+        population_per_rank = _fast_non_dominated_sort(population, study.directions, dominates)
         elite_population: list[FrozenTrial] = []
-        population_per_rank = _fast_non_dominated_sort(
-            population, study.directions, self._constraints_func
-        )
         for population in population_per_rank:
             if len(elite_population) + len(population) < self._population_size:
                 elite_population.extend(population)

--- a/optuna/samplers/nsgaii/_sampler.py
+++ b/optuna/samplers/nsgaii/_sampler.py
@@ -330,8 +330,9 @@ class NSGAIISampler(BaseSampler):
     def _select_elite_population(
         self, study: Study, population: List[FrozenTrial]
     ) -> List[FrozenTrial]:
+        _validate_constraints(population, self._constraints_func)
+
         dominates = _dominates if self._constraints_func is None else _constrained_dominates
-        _validate_constraints(population, dominates)
         population_per_rank = _fast_non_dominated_sort(population, study.directions, dominates)
 
         elite_population: List[FrozenTrial] = []

--- a/tests/samplers_tests/test_nsgaii.py
+++ b/tests/samplers_tests/test_nsgaii.py
@@ -406,7 +406,6 @@ def test_fast_non_dominated_sort_with_constraints() -> None:
 
 
 def test_validate_constraints() -> None:
-    directions = [StudyDirection.MINIMIZE, StudyDirection.MINIMIZE]
     with pytest.raises(ValueError):
         _validate_constraints(
             [_create_frozen_trial(0, [1], [0, float("nan")])],

--- a/tests/samplers_tests/test_nsgaii.py
+++ b/tests/samplers_tests/test_nsgaii.py
@@ -34,6 +34,7 @@ from optuna.samplers.nsgaii import VSBXCrossover
 from optuna.samplers.nsgaii._crossover import _inlined_categorical_uniform_crossover
 from optuna.samplers.nsgaii._sampler import _constrained_dominates
 from optuna.samplers.nsgaii._sampler import _fast_non_dominated_sort
+from optuna.samplers.nsgaii._sampler import _validate_constraints
 from optuna.study._multi_objective import _dominates
 from optuna.study._study_direction import StudyDirection
 from optuna.trial import FrozenTrial
@@ -382,7 +383,7 @@ def test_fast_non_dominated_sort_no_constraints(
     values = [[v1, v2] for v1 in value_list for v2 in value_list]
 
     trials = [_create_frozen_trial(i, v) for i, v in enumerate(values)]
-    population_per_rank = _fast_non_dominated_sort(copy.copy(trials), directions)
+    population_per_rank = _fast_non_dominated_sort(copy.copy(trials), directions, _dominates)
     _assert_population_per_rank(trials, directions, population_per_rank)
 
 
@@ -399,17 +400,16 @@ def test_fast_non_dominated_sort_with_constraints() -> None:
     ]
     directions = [StudyDirection.MINIMIZE, StudyDirection.MAXIMIZE]
     population_per_rank = _fast_non_dominated_sort(
-        copy.copy(trials), directions, constraints_func=lambda _: [0]
+        copy.copy(trials), directions, _constrained_dominates
     )
     _assert_population_per_rank(trials, directions, population_per_rank)
 
 
-def test_fast_non_dominated_sort_with_nan_constraint() -> None:
+def test_validate_constraints() -> None:
     directions = [StudyDirection.MINIMIZE, StudyDirection.MINIMIZE]
     with pytest.raises(ValueError):
-        _fast_non_dominated_sort(
+        _validate_constraints(
             [_create_frozen_trial(0, [1], [0, float("nan")])],
-            directions,
             constraints_func=lambda _: [0],
         )
 
@@ -441,7 +441,7 @@ def test_fast_non_dominated_sort_missing_constraint_values(
 
         with pytest.warns(UserWarning):
             population_per_rank = _fast_non_dominated_sort(
-                copy.copy(trials), list(directions), constraints_func=lambda _: [0]
+                copy.copy(trials), list(directions), _constrained_dominates
             )
         _assert_population_per_rank(trials, list(directions), population_per_rank)
 
@@ -452,7 +452,7 @@ def test_fast_non_dominated_sort_empty(n_dims: int) -> None:
         [StudyDirection.MINIMIZE, StudyDirection.MAXIMIZE], repeat=n_dims
     ):
         trials: List[FrozenTrial] = []
-        population_per_rank = _fast_non_dominated_sort(trials, list(directions))
+        population_per_rank = _fast_non_dominated_sort(trials, list(directions), _dominates)
         assert population_per_rank == []
 
 


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
Progress v3.3 task to make `NSGAII Sampler` loose coupled.

## Description of the changes
Change one of the arguments of `_fast_non_dominated_sort`, from `constraints_func` to `dominate` so that users (currently sampler) can customize dominate functions.
