### PR TITLE
Separate after_trial strategy

### DIFF
--- a/optuna/samplers/_nsgaiii.py
+++ b/optuna/samplers/_nsgaiii.py
@@ -359,7 +359,7 @@ class NSGAIIISampler(BaseSampler):
         values: Sequence[float] | None,
     ) -> None:
         assert state in [TrialState.COMPLETE, TrialState.FAIL, TrialState.PRUNED]
-        self._after_trial_strategy.after_trial(study, trial, state, values)
+        self._after_trial_strategy(study, trial, state, values)
         self._random_sampler.after_trial(study, trial, state, values)
 
 

--- a/optuna/samplers/_nsgaiii.py
+++ b/optuna/samplers/_nsgaiii.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
 from collections import defaultdict
+from collections.abc import Callable
+from collections.abc import Sequence
 import hashlib
 import itertools
 import math
 from typing import Any
-from typing import Callable
-from typing import Sequence
 import warnings
 
 import numpy as np
@@ -15,10 +15,10 @@ import optuna
 from optuna._experimental import experimental_class
 from optuna.distributions import BaseDistribution
 from optuna.exceptions import ExperimentalWarning
-from optuna.samplers._base import _process_constraints_after_trial
 from optuna.samplers._base import BaseSampler
 from optuna.samplers._random import RandomSampler
 from optuna.samplers._search_space import IntersectionSearchSpace
+from optuna.samplers.nsgaii._after_trial_strategy import NSGAIIAfterTrialStrategy
 from optuna.samplers.nsgaii._crossover import perform_crossover
 from optuna.samplers.nsgaii._crossovers._base import BaseCrossover
 from optuna.samplers.nsgaii._crossovers._uniform import UniformCrossover
@@ -85,6 +85,10 @@ class NSGAIIISampler(BaseSampler):
         swapping_prob: float = 0.5,
         seed: int | None = None,
         constraints_func: Callable[[FrozenTrial], Sequence[float]] | None = None,
+        after_trial_strategy: Callable[
+            [Study, FrozenTrial, TrialState, Sequence[float] | None], None
+        ]
+        | None = None,
         reference_points: np.ndarray | None = None,
         dividing_parameter: int = 3,
     ) -> None:
@@ -141,6 +145,9 @@ class NSGAIIISampler(BaseSampler):
         self._reference_points = reference_points
         self._dividing_parameter = dividing_parameter
         self._search_space = IntersectionSearchSpace()
+        self._after_trial_strategy = after_trial_strategy or NSGAIIAfterTrialStrategy(
+            constraints_func=constraints_func
+        )
 
     def reseed_rng(self) -> None:
         self._random_sampler.reseed_rng()
@@ -352,8 +359,7 @@ class NSGAIIISampler(BaseSampler):
         values: Sequence[float] | None,
     ) -> None:
         assert state in [TrialState.COMPLETE, TrialState.FAIL, TrialState.PRUNED]
-        if self._constraints_func is not None:
-            _process_constraints_after_trial(self._constraints_func, study, trial, state)
+        self._after_trial_strategy.after_trial(study, trial, state, values)
         self._random_sampler.after_trial(study, trial, state, values)
 
 

--- a/optuna/samplers/nsgaii/_after_trial_strategy.py
+++ b/optuna/samplers/nsgaii/_after_trial_strategy.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from collections.abc import Sequence
+
+from optuna.samplers._base import _process_constraints_after_trial
+from optuna.study import Study
+from optuna.trial import FrozenTrial
+from optuna.trial import TrialState
+
+
+class NSGAIIAfterTrialStrategy:
+    def __init__(
+        self, *, constraints_func: Callable[[FrozenTrial], Sequence[float]] | None = None
+    ) -> None:
+        self._constraints_func = constraints_func
+
+    def after_trial(
+        self,
+        study: Study,
+        trial: FrozenTrial,
+        state: TrialState,
+        values: Sequence[float] | None = None,
+    ) -> None:
+        if self._constraints_func is not None:
+            _process_constraints_after_trial(self._constraints_func, study, trial, state)

--- a/optuna/samplers/nsgaii/_after_trial_strategy.py
+++ b/optuna/samplers/nsgaii/_after_trial_strategy.py
@@ -22,5 +22,10 @@ class NSGAIIAfterTrialStrategy:
         state: TrialState,
         values: Sequence[float] | None = None,
     ) -> None:
+        """Carry out the after trial process of default NSGA-II.
+
+        This method is called after each trial of the study, examines whether the trial result is
+        valid in terms of constraints, and store the results in system_attrs of the study.
+        """
         if self._constraints_func is not None:
             _process_constraints_after_trial(self._constraints_func, study, trial, state)

--- a/optuna/samplers/nsgaii/_after_trial_strategy.py
+++ b/optuna/samplers/nsgaii/_after_trial_strategy.py
@@ -15,7 +15,7 @@ class NSGAIIAfterTrialStrategy:
     ) -> None:
         self._constraints_func = constraints_func
 
-    def after_trial(
+    def __call__(
         self,
         study: Study,
         trial: FrozenTrial,

--- a/optuna/samplers/nsgaii/_sampler.py
+++ b/optuna/samplers/nsgaii/_sampler.py
@@ -362,7 +362,7 @@ class NSGAIISampler(BaseSampler):
         values: Optional[Sequence[float]],
     ) -> None:
         assert state in [TrialState.COMPLETE, TrialState.FAIL, TrialState.PRUNED]
-        self._after_trial_strategy.after_trial(study, trial, state, values)
+        self._after_trial_strategy(study, trial, state, values)
         self._random_sampler.after_trial(study, trial, state, values)
 
 

--- a/optuna/samplers/nsgaii/_sampler.py
+++ b/optuna/samplers/nsgaii/_sampler.py
@@ -110,6 +110,9 @@ class NSGAIISampler(BaseSampler):
                 versions without prior notice. See
                 https://github.com/optuna/optuna/releases/tag/v2.5.0.
 
+        after_trial_strategy:
+            A process to be conducted after each trial. Defaults to
+            :class:`~optuna.samplers.nsgaii._after_trial_strategy.NSGAIIAfterTrialStrategy`.
     """
 
     def __init__(

--- a/tests/samplers_tests/test_nsgaii.py
+++ b/tests/samplers_tests/test_nsgaii.py
@@ -1,13 +1,9 @@
 from collections import Counter
+from collections.abc import Callable
+from collections.abc import Sequence
 import copy
 import itertools
 from typing import Any
-from typing import Callable
-from typing import Dict
-from typing import List
-from typing import Optional
-from typing import Sequence
-from typing import Tuple
 from unittest.mock import Mock
 from unittest.mock import patch
 import warnings
@@ -117,7 +113,7 @@ def test_swapping_prob() -> None:
 
 
 @pytest.mark.parametrize("choices", [[-1, 0, 1], [True, False]])
-def test_crossover_casting(choices: List[Any]) -> None:
+def test_crossover_casting(choices: list[Any]) -> None:
     str_choices = list(map(str, choices))
 
     def objective(trial: optuna.Trial) -> Sequence[float]:
@@ -215,7 +211,7 @@ def test_constraints_func_nan() -> None:
     ],
 )
 def test_constrained_dominates_feasible_vs_feasible(
-    direction1: StudyDirection, direction2: StudyDirection, constraints_list: List[List[float]]
+    direction1: StudyDirection, direction2: StudyDirection, constraints_list: list[list[float]]
 ) -> None:
     directions = [direction1, direction2]
     # Check all pairs of trials consisting of these values, i.e.,
@@ -297,7 +293,7 @@ def test_constrained_dominates_infeasible_vs_infeasible(direction: StudyDirectio
     #
 
     # Check all pairs of these constraints.
-    constraints_infeasible_sorted: List[List[List[float]]]
+    constraints_infeasible_sorted: list[list[list[float]]]
     constraints_infeasible_sorted = [
         # These constraints have violation 1.
         [[1, -inf], [1, -1], [1, 0], [0, 1], [-1, 1], [-inf, 1]],
@@ -347,9 +343,9 @@ def test_constrained_dominates_infeasible_vs_infeasible(direction: StudyDirectio
 
 
 def _assert_population_per_rank(
-    trials: List[FrozenTrial],
-    direction: List[StudyDirection],
-    population_per_rank: List[List[FrozenTrial]],
+    trials: list[FrozenTrial],
+    direction: list[StudyDirection],
+    population_per_rank: list[list[FrozenTrial]],
 ) -> None:
     # Check that the number of trials do not change.
     flattened = [trial for rank in population_per_rank for trial in rank]
@@ -428,7 +424,7 @@ def test_fast_non_dominated_sort_with_nan_constraint() -> None:
     ],
 )
 def test_fast_non_dominated_sort_missing_constraint_values(
-    values_and_constraints: List[Tuple[List[float], List[float]]]
+    values_and_constraints: list[tuple[list[float], list[float]]]
 ) -> None:
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", optuna.exceptions.ExperimentalWarning)
@@ -451,7 +447,7 @@ def test_fast_non_dominated_sort_empty(n_dims: int) -> None:
     for directions in itertools.product(
         [StudyDirection.MINIMIZE, StudyDirection.MAXIMIZE], repeat=n_dims
     ):
-        trials: List[FrozenTrial] = []
+        trials: list[FrozenTrial] = []
         population_per_rank = _fast_non_dominated_sort(trials, list(directions))
         assert population_per_rank == []
 
@@ -484,7 +480,7 @@ def test_fast_non_dominated_sort_empty(n_dims: int) -> None:
         ),
     ],
 )
-def test_calc_crowding_distance(values: List[List[float]], expected_dist: List[float]) -> None:
+def test_calc_crowding_distance(values: list[list[float]], expected_dist: list[float]) -> None:
     trials = [_create_frozen_trial(i, value) for i, value in enumerate(values)]
     crowding_dist = optuna.samplers.nsgaii._sampler._calc_crowding_distance(trials)
     for i in range(len(trials)):
@@ -501,7 +497,7 @@ def test_calc_crowding_distance(values: List[List[float]], expected_dist: List[f
         [[float("-inf")], [1], [2]],
     ],
 )
-def test_crowding_distance_sort(values: List[List[float]]) -> None:
+def test_crowding_distance_sort(values: list[list[float]]) -> None:
     """Checks that trials are sorted by the values of `_calc_crowding_distance`."""
     trials = [_create_frozen_trial(i, value) for i, value in enumerate(values)]
     crowding_dist = optuna.samplers.nsgaii._sampler._calc_crowding_distance(trials)
@@ -516,7 +512,7 @@ def test_study_system_attr_for_population_cache() -> None:
 
     def get_cached_entries(
         study: optuna.study.Study,
-    ) -> List[Tuple[int, List[int]]]:
+    ) -> list[tuple[int, list[int]]]:
         study_system_attrs = study._storage.get_study_system_attrs(study._study_id)
         return [
             v
@@ -548,7 +544,7 @@ def test_constraints_func_experimental_warning() -> None:
 
 # TODO(ohta): Consider to move this utility function to `optuna.testing` module.
 def _create_frozen_trial(
-    number: int, values: Sequence[float], constraints: Optional[Sequence[float]] = None
+    number: int, values: Sequence[float], constraints: Sequence[float] | None = None
 ) -> optuna.trial.FrozenTrial:
     trial = optuna.trial.create_trial(
         state=optuna.trial.TrialState.COMPLETE,
@@ -657,7 +653,7 @@ def test_crossover_numerical_distribution(crossover: BaseCrossover) -> None:
 
 
 def test_crossover_inlined_categorical_distribution() -> None:
-    search_space: Dict[str, BaseDistribution] = {
+    search_space: dict[str, BaseDistribution] = {
         "x": CategoricalDistribution(choices=["a", "c"]),
         "y": CategoricalDistribution(choices=["b", "d"]),
     }
@@ -731,7 +727,7 @@ def test_crossover_deterministic(
     crossover: BaseCrossover, rand_value: float, expected_params: np.ndarray
 ) -> None:
     study = optuna.study.create_study()
-    search_space: Dict[str, BaseDistribution] = {
+    search_space: dict[str, BaseDistribution] = {
         "x": FloatDistribution(1, 10),
         "y": FloatDistribution(1, 10),
     }

--- a/tests/samplers_tests/test_nsgaii.py
+++ b/tests/samplers_tests/test_nsgaii.py
@@ -450,7 +450,7 @@ def test_fast_non_dominated_sort_empty(n_dims: int) -> None:
     for directions in itertools.product(
         [StudyDirection.MINIMIZE, StudyDirection.MAXIMIZE], repeat=n_dims
     ):
-        trials: List[FrozenTrial] = []
+        trials: list[FrozenTrial] = []
         population_per_rank = _fast_non_dominated_sort(trials, list(directions), _dominates)
         assert population_per_rank == []
 

--- a/tests/samplers_tests/test_nsgaii.py
+++ b/tests/samplers_tests/test_nsgaii.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections import Counter
 from collections.abc import Callable
 from collections.abc import Sequence

--- a/tests/samplers_tests/test_samplers.py
+++ b/tests/samplers_tests/test_samplers.py
@@ -1,16 +1,13 @@
+from __future__ import annotations
+
 from collections import OrderedDict
+from collections.abc import Callable
+from collections.abc import Sequence
 import multiprocessing
 from multiprocessing.managers import DictProxy
 import os
 import pickle
 from typing import Any
-from typing import Callable
-from typing import Dict
-from typing import List
-from typing import Optional
-from typing import Sequence
-from typing import Tuple
-from typing import Union
 from unittest.mock import patch
 import warnings
 
@@ -91,7 +88,7 @@ parametrize_multi_objective_sampler = pytest.mark.parametrize(
         ),
     ],
 )
-sampler_class_with_seed: Dict[str, Tuple[Callable[[int], BaseSampler], bool]] = {
+sampler_class_with_seed: dict[str, tuple[Callable[[int], BaseSampler], bool]] = {
     "RandomSampler": (lambda seed: optuna.samplers.RandomSampler(seed=seed), False),
     "TPESampler": (lambda seed: optuna.samplers.TPESampler(seed=seed), False),
     "multivariate TPESampler": (
@@ -174,7 +171,7 @@ def test_sampler_reseed_rng(
     expected_has_rng: bool,
     expected_has_another_sampler: bool,
 ) -> None:
-    def _extract_attr_name_from_sampler_by_cls(sampler: BaseSampler, cls: Any) -> Optional[str]:
+    def _extract_attr_name_from_sampler_by_cls(sampler: BaseSampler, cls: Any) -> str | None:
         for name, attr in sampler.__dict__.items():
             if isinstance(attr, cls):
                 return name
@@ -271,7 +268,7 @@ def test_raise_error_for_samplers_during_multi_objectives(
 
 
 @pytest.mark.parametrize("seed", [None, 0, 169208])
-def test_pickle_random_sampler(seed: Optional[int]) -> None:
+def test_pickle_random_sampler(seed: int | None) -> None:
     sampler = optuna.samplers.RandomSampler(seed)
     restored_sampler = pickle.loads(pickle.dumps(sampler))
     assert sampler._rng.bytes(10) == restored_sampler._rng.bytes(10)
@@ -395,12 +392,12 @@ def test_sample_relative_numerical(
     x_distribution: BaseDistribution,
     y_distribution: BaseDistribution,
 ) -> None:
-    search_space: Dict[str, BaseDistribution] = OrderedDict(x=x_distribution, y=y_distribution)
+    search_space: dict[str, BaseDistribution] = OrderedDict(x=x_distribution, y=y_distribution)
     study = optuna.study.create_study(sampler=relative_sampler_class())
     trial = study.ask(search_space)
     study.tell(trial, sum(trial.params.values()))
 
-    def sample() -> List[Union[int, float]]:
+    def sample() -> list[int | float]:
         params = study.sampler.sample_relative(study, _create_new_trial(study), search_space)
         return [params[name] for name in search_space]
 
@@ -426,14 +423,14 @@ def test_sample_relative_numerical(
 
 @parametrize_relative_sampler
 def test_sample_relative_categorical(relative_sampler_class: Callable[[], BaseSampler]) -> None:
-    search_space: Dict[str, BaseDistribution] = OrderedDict(
+    search_space: dict[str, BaseDistribution] = OrderedDict(
         x=CategoricalDistribution([1, 10, 100]), y=CategoricalDistribution([-1, -10, -100])
     )
     study = optuna.study.create_study(sampler=relative_sampler_class())
     trial = study.ask(search_space)
     study.tell(trial, sum(trial.params.values()))
 
-    def sample() -> List[float]:
+    def sample() -> list[float]:
         params = study.sampler.sample_relative(study, _create_new_trial(study), search_space)
         return [params[name] for name in search_space]
 
@@ -461,14 +458,14 @@ def test_sample_relative_categorical(relative_sampler_class: Callable[[], BaseSa
 def test_sample_relative_mixed(
     relative_sampler_class: Callable[[], BaseSampler], x_distribution: BaseDistribution
 ) -> None:
-    search_space: Dict[str, BaseDistribution] = OrderedDict(
+    search_space: dict[str, BaseDistribution] = OrderedDict(
         x=x_distribution, y=CategoricalDistribution([-1, -10, -100])
     )
     study = optuna.study.create_study(sampler=relative_sampler_class())
     trial = study.ask(search_space)
     study.tell(trial, sum(trial.params.values()))
 
-    def sample() -> List[float]:
+    def sample() -> list[float]:
         params = study.sampler.sample_relative(study, _create_new_trial(study), search_space)
         return [params[name] for name in search_space]
 
@@ -541,8 +538,8 @@ def _create_new_trial(study: Study) -> FrozenTrial:
 class FixedSampler(BaseSampler):
     def __init__(
         self,
-        relative_search_space: Dict[str, BaseDistribution],
-        relative_params: Dict[str, Any],
+        relative_search_space: dict[str, BaseDistribution],
+        relative_params: dict[str, Any],
         unknown_param_value: Any,
     ) -> None:
         self.relative_search_space = relative_search_space
@@ -551,12 +548,12 @@ class FixedSampler(BaseSampler):
 
     def infer_relative_search_space(
         self, study: Study, trial: FrozenTrial
-    ) -> Dict[str, BaseDistribution]:
+    ) -> dict[str, BaseDistribution]:
         return self.relative_search_space
 
     def sample_relative(
-        self, study: Study, trial: FrozenTrial, search_space: Dict[str, BaseDistribution]
-    ) -> Dict[str, Any]:
+        self, study: Study, trial: FrozenTrial, search_space: dict[str, BaseDistribution]
+    ) -> dict[str, Any]:
         return self.relative_params
 
     def sample_independent(
@@ -570,7 +567,7 @@ class FixedSampler(BaseSampler):
 
 
 def test_sample_relative() -> None:
-    relative_search_space: Dict[str, BaseDistribution] = {
+    relative_search_space: dict[str, BaseDistribution] = {
         "a": FloatDistribution(low=0, high=5),
         "b": CategoricalDistribution(choices=("foo", "bar", "baz")),
         "c": IntDistribution(low=20, high=50),  # Not exist in `relative_params`.
@@ -703,7 +700,7 @@ def test_after_trial() -> None:
             study: Study,
             trial: FrozenTrial,
             state: TrialState,
-            values: Optional[Sequence[float]],
+            values: Sequence[float] | None,
         ) -> None:
             assert len(study.trials) - 1 == trial.number
             assert trial.state == TrialState.RUNNING
@@ -732,7 +729,7 @@ def test_after_trial_pruning() -> None:
             study: Study,
             trial: FrozenTrial,
             state: TrialState,
-            values: Optional[Sequence[float]],
+            values: Sequence[float] | None,
         ) -> None:
             assert len(study.trials) - 1 == trial.number
             assert trial.state == TrialState.RUNNING
@@ -760,7 +757,7 @@ def test_after_trial_failing() -> None:
             study: Study,
             trial: FrozenTrial,
             state: TrialState,
-            values: Optional[Sequence[float]],
+            values: Sequence[float] | None,
         ) -> None:
             assert len(study.trials) - 1 == trial.number
             assert trial.state == TrialState.RUNNING
@@ -790,7 +787,7 @@ def test_after_trial_failing_in_after_trial() -> None:
             study: Study,
             trial: FrozenTrial,
             state: TrialState,
-            values: Optional[Sequence[float]],
+            values: Sequence[float] | None,
         ) -> None:
             nonlocal n_calls
             n_calls += 1
@@ -827,7 +824,7 @@ def test_after_trial_with_study_tell() -> None:
             study: Study,
             trial: FrozenTrial,
             state: TrialState,
-            values: Optional[Sequence[float]],
+            values: Sequence[float] | None,
         ) -> None:
             nonlocal n_calls
             n_calls += 1


### PR DESCRIPTION
## Motivation
Progress v3.3 task to make `NSGAII Sampler` loose coupled.

## Description of the changes
Add `after_trial_strategy` argument to the constructor if `NSGAIISampler` and `NSGAIIISampler` and separate the after_trial process so that users can customize `after_trial()`.
