### PR TITLE
Enhance speed benchmark for storages

### DIFF
--- a/benchmarks/asv/optimize.py
+++ b/benchmarks/asv/optimize.py
@@ -63,7 +63,11 @@ class OptimizeSuite:
         "inmemory, tpe, 1000",
         "inmemory, cmaes, 1000",
         "sqlite, random, 1000",
-        "cached_sqlite, random, 1000",
+        "sqlite, tpe, 1000",
+        "sqlite, cmaes, 1000",
+        "journal, random, 1000",
+        "journal, tpe, 1000",
+        "journal, cmaes, 1000",
     )
     param_names = ["storage, sampler, n_trials"]
     timeout = 600


### PR DESCRIPTION
## Motivation
This is a part of #4500.

The current speed benchmark CI does not measure the performance of storages enough.

## Description of the changes
- Add benchmark for `RDBStorage` with `TPESampler` and `CmaEsSampler`
- Add benchmark for `JournalStorage`