### PR TITLE
Fix `test_log_gass_mass` with SciPy 1.11.0

### DIFF
--- a/tests/samplers_tests/tpe_tests/test_truncnorm.py
+++ b/tests/samplers_tests/tpe_tests/test_truncnorm.py
@@ -60,5 +60,5 @@ def test_log_gass_mass(a: float, b: float) -> None:
         [np.linspace(0, 1, num=100), np.array([sys.float_info.min, 1 - sys.float_info.epsilon])]
     ):
         assert truncnorm_ours._log_gauss_mass(np.array([a]), np.array([b])) == pytest.approx(
-            _log_gauss_mass_scipy(a, b), nan_ok=True
+            np.atleast_1d(_log_gauss_mass_scipy(a, b)), nan_ok=True
         ), f"_log_gauss_mass(x={x}, a={a}, b={b})"


### PR DESCRIPTION
## Motivation
With the release of SciPy 1.11.0, the return value shape of `_log_gauss_mass` has changed.

## Description of the changes
- Add `atleast_1d` to fix `test_log_gass_mass` with SciPy 1.11.0