### PR TITLE
Use shallow copy in `_get_latest_trial`

### DIFF
--- a/optuna/trial/_trial.py
+++ b/optuna/trial/_trial.py
@@ -687,7 +687,7 @@ class Trial(BaseTrial):
 
     def _get_latest_trial(self) -> FrozenTrial:
         # TODO(eukaryo): Remove this method after `system_attrs` property is removed.
-        latest_trial = copy.deepcopy(self._cached_frozen_trial)
+        latest_trial = copy.copy(self._cached_frozen_trial)
         latest_trial.system_attrs = _LazyTrialSystemAttrs(  # type: ignore[assignment]
             self._trial_id, self.storage
         )


### PR DESCRIPTION
## Motivation
The deep copy in `_get_latest_trial` takes a long time when the parameters are many. This PR changes it to the shallow copy. 

The returned `FrozenTrial` is passed to samplers and pruners, but they must not modify the trial object. This behavior is described in the base classes.
https://github.com/optuna/optuna/blob/b00caef6ad0ee87304952e8c6a261d7418e9a087/optuna/samplers/_base.py#L136-L138

### benchmark

```python
import optuna

def objective(trial):
    return sum([trial.suggest_float(f"x_{i}", -100, 100) ** 2 for i in range(1000)])

study = optuna.create_study(sampler=optuna.samplers.RandomSampler(seed=42))
study.optimize(objective, n_trials=10)
```

- master

```
real	1m16.989s
user	1m15.750s
sys	0m0.710s
```

- PR

```
real	0m2.370s
user	0m2.277s
sys	0m0.307s
```

## Description of the changes
- Use shallow copy in `_get_latest_trial`