### PR TITLE
Fix botorch integration tests

### DIFF
--- a/tests/samplers_tests/test_samplers.py
+++ b/tests/samplers_tests/test_samplers.py
@@ -129,6 +129,10 @@ sampler_class_with_seed: Dict[str, Tuple[Callable[[int], BaseSampler], bool]] = 
 param_sampler_with_seed = []
 param_sampler_name_with_seed = []
 for sampler_name, (sampler_class, integration_flag) in sampler_class_with_seed.items():
+    # TODO(c-bata): Remove this logic after Python 3.7 support is dropped.
+    if sampler_name == "BoTorchSampler" and sys.version_info < (3, 8):
+        continue
+
     if integration_flag:
         param_sampler_with_seed.append(
             pytest.param(sampler_class, id=sampler_name, marks=pytest.mark.integration)


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
After merged #4667, the scheduled ci became being failed as shown below:
https://github.com/optuna/optuna/actions/runs/5449179567/jobs/9913162023

## Description of the changes
<!-- Describe the changes in this PR. -->
Skip BoTorchSampler tests if Python version is 3.7.

```
$docker run -it -v $(pwd):/usr/src python:3.7 bash
...
# pytest -m "integration" ./tests/samplers_tests/test_samplers.py
=============================================================================== test session starts ================================================================================
platform linux -- Python 3.7.17, pytest-7.4.0, pluggy-1.2.0
rootdir: /usr/src
configfile: pyproject.toml
collected 1140 items / 759 deselected / 381 selected

tests/samplers_tests/test_samplers.py .......s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s.................................................................. [ 35%]
.....................s...s...s...................s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s.. [ 80%]
.s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s.............                                                                                                  [100%]

================================================================================= warnings summary =================================================================================
tests/samplers_tests/test_samplers.py::test_combination_of_different_distributions_objective[<lambda>0-<lambda>0-<lambda>7]
  /usr/local/lib/python3.7/site-packages/botorch/optim/initializers.py:212: BadInitialCandidatesWarning: Unable to find non-zero acquisition function values - initial conditions are being selected randomly.
    BadInitialCandidatesWarning,

tests/samplers_tests/test_samplers.py: 608 warnings
  /usr/local/lib/python3.7/site-packages/skopt/space/transformers.py:275: DeprecationWarning: `np.int` is a deprecated alias for the builtin `int`. To silence this warning, use `int` by itself. Doing this will not modify any behavior and is safe. When replacing `np.int`, you may wish to use e.g. `np.int64` or `np.int32` to specify the precision. If you wish to review your current use, check the release note link for additional information.
  Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
    return np.round(X_orig).astype(np.int)

tests/samplers_tests/test_samplers.py: 160 warnings
  /usr/local/lib/python3.7/site-packages/skopt/space/transformers.py:262: DeprecationWarning: `np.int` is a deprecated alias for the builtin `int`. To silence this warning, use `int` by itself. Doing this will not modify any behavior and is safe. When replacing `np.int`, you may wish to use e.g. `np.int64` or `np.int32` to specify the precision. If you wish to review your current use, check the release note link for additional information.
  Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
    return (np.round(X).astype(np.int) - self.low) /\

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
==================================================== 315 passed, 66 skipped, 759 deselected, 769 warnings in 178.76s (0:02:58) =====================================================
```