### PR TITLE
Ignore MXNet test

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -69,7 +69,7 @@ jobs:
         pip install pipdeptree
         pipdeptree
 
-
+    # TODO(Shinichi): Remove the version constraint on MXNet
     - name: Tests
       env:
         OMP_NUM_THREADS: 1
@@ -77,7 +77,9 @@ jobs:
         COVERAGE_PROCESS_START: .coveragerc  # https://coverage.readthedocs.io/en/6.4.1/subprocess.html
         COVERAGE_COVERAGE: yes  # https://github.com/nedbat/coveragepy/blob/65bf33fc03209ffb01bbbc0d900017614645ee7a/coverage/control.py#L255-L261
       run: |
-        coverage run --source=optuna -m pytest tests -m "not skip_coverage and not slow"
+        coverage run \
+        --source=optuna -m pytest tests -m "not skip_coverage and not slow" \
+        --ignore=tests/integration_tests/test_mxnet.py
         coverage combine
         coverage xml
 

--- a/.github/workflows/mac-tests.yml
+++ b/.github/workflows/mac-tests.yml
@@ -130,10 +130,11 @@ jobs:
         pip install pipdeptree
         pipdeptree
 
-
+    # TODO(Shinichi): Remove the version constraint on MXNet
     - name: Tests
       run: |
-        pytest tests -m "integration"
+        pytest tests -m "integration" \
+        --ignore tests/integration_tests/test_mxnet.py
 
       env:
         OMP_NUM_THREADS: 1

--- a/.github/workflows/tests-integration.yml
+++ b/.github/workflows/tests-integration.yml
@@ -71,6 +71,7 @@ jobs:
         pip install pipdeptree
         pipdeptree
 
+    # TODO(Shinichi): Remove the version constraint on MXNet
     - name: Scheduled tests
       if:  ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
       run: |
@@ -88,11 +89,14 @@ jobs:
             --ignore tests/integration_tests/test_tensorboard.py \
             --ignore tests/integration_tests/lightgbm_tuner_tests \
             --ignore tests/importance_tests/test_init.py \
-            --ignore tests/samplers_tests/test_samplers.py
+            --ignore tests/samplers_tests/test_samplers.py \
+            --ignore tests/integration_tests/test_mxnet.py
         else
-          pytest tests -m "integration"
+          pytest tests -m "integration" \
+           --ignore tests/integration_tests/test_mxnet.py
         fi
 
+    # TODO(Shinichi): Remove the version constraint on MXNet
     - name: Tests
       if:  ${{ github.event_name != 'schedule' && github.event_name != 'workflow_dispatch' }}
       run: |
@@ -110,7 +114,9 @@ jobs:
             --ignore tests/integration_tests/test_tensorboard.py \
             --ignore tests/integration_tests/lightgbm_tuner_tests \
             --ignore tests/importance_tests/test_init.py \
-            --ignore tests/samplers_tests/test_samplers.py
+            --ignore tests/samplers_tests/test_samplers.py \
+            --ignore tests/integration_tests/test_mxnet.py
         else
-          pytest tests -m "integration and not slow"
+          pytest tests -m "integration and not slow" \
+          --ignore tests/integration_tests/test_mxnet.py
         fi


### PR DESCRIPTION
## Motivation
Pass CI which runs on PR submission.

## Description of the changes
Ignore test on MXNet since this library used deprecated numpy feature (https://github.com/apache/mxnet/issues/21165) and generates error just by importing MXNet.
See https://github.com/optuna/optuna/actions/runs/5469763066 for more details.

## Alternative
It is also possible to use numpy whose version is lower than 1.24.3 in the integration tests.