### PR TITLE
Restrict numpy version < 1.24

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -42,6 +42,7 @@ jobs:
         sudo apt-get update
         sudo apt-get -y install openmpi-bin libopenmpi-dev libopenblas-dev
 
+    # TODO(Shinichi): Remove the version constraint on Numpy
     # TODO(Shinichi): Remove the version constraint on PyTorch Lightning
     # TODO(c-bata): Remove the version constraint on fakeredis
     - name: Install
@@ -56,6 +57,7 @@ jobs:
         pip install --progress-bar off .[test]
         pip install --progress-bar off .[optional]
         pip install --progress-bar off .[integration] --extra-index-url https://download.pytorch.org/whl/cpu
+        pip install "numpy<1.24.0"
         pip install "pytorch-lightning<2.0.0"
         pip install "fakeredis<2.11.1"
 

--- a/.github/workflows/mac-tests.yml
+++ b/.github/workflows/mac-tests.yml
@@ -105,6 +105,7 @@ jobs:
         brew install open-mpi
         brew install openblas
 
+    # TODO(Shinichi): Remove the version constraint on Numpy
     # TODO(Shinichi): Remove the version constraint on PyTorch Lightning
     # TODO(c-bata): Remove the version constraint on fakeredis
     - name: Install
@@ -119,6 +120,7 @@ jobs:
         pip install --progress-bar off .[test]
         pip install --progress-bar off .[optional]
         pip install --progress-bar off .[integration]
+        pip install "numpy<1.24.0"
         pip install "pytorch-lightning<2.0.0"
         pip install "fakeredis<2.11.1"
 

--- a/.github/workflows/tests-integration.yml
+++ b/.github/workflows/tests-integration.yml
@@ -46,6 +46,7 @@ jobs:
         sudo apt-get update
         sudo apt-get -y install openmpi-bin libopenmpi-dev libopenblas-dev
 
+    # TODO(Shinichi): Remove the version constraint on Numpy
     # TODO(Shinichi): Remove the version constraint on PyTorch Lightning
     # TODO(c-bata): Remove the version constraint on fakeredis
     - name: Install
@@ -60,6 +61,7 @@ jobs:
         pip install --progress-bar off .[test]
         pip install --progress-bar off .[optional]
         pip install --progress-bar off .[integration] --extra-index-url https://download.pytorch.org/whl/cpu
+        pip install "numpy<1.24.0"
         pip install "pytorch-lightning<2.0.0"
         pip install "fakeredis<2.11.1"
 

--- a/.github/workflows/windows-tests.yml
+++ b/.github/workflows/windows-tests.yml
@@ -109,6 +109,7 @@ jobs:
       with:
         mpi: "msmpi"
 
+    # TODO(Shinichi): Remove the version constraint on Numpy
     # TODO(Shinichi): Remove the version constraint on PyTorch Lightning
     # TODO(c-bata): Remove the version constraint on fakeredis
     - name: Install
@@ -122,6 +123,7 @@ jobs:
         pip install --progress-bar off .[test]
         pip install --progress-bar off .[optional]
         pip install --progress-bar off .[integration]
+        pip install "numpy<1.24.0"
         pip install "pytorch-lightning<2.0.0"
         pip install "distributed<2023.3.2"
         pip install "fakeredis<2.11.1"


### PR DESCRIPTION
## Motivation
Pass CI which runs on PR submission.

## Description of the changes
Fix `numpy` version smaller than `1.24.0`, which return error with `np.bool` and `np.int`.
Some libraries, such as MXNet, scikit-optimize and shap uses these deprecated numpy feature and incompatible with `numpy>=1.24.0`.
