### PR TITLE
Add constraints support to `_optimization_history_plot`

### DIFF
--- a/optuna/visualization/_optimization_history.py
+++ b/optuna/visualization/_optimization_history.py
@@ -143,7 +143,10 @@ def _get_optimization_history_info_list(
                 values_info = best_values_info
             for n, v, s in zip(trial_numbers, values_info.values, values_info.states):
                 if not math.isinf(v):
-                    values[n].append(v)
+                    if not use_best_value and s == _ValueState.Feasible:
+                        values[n].append(v)
+                    elif use_best_value:
+                        values[n].append(v)
                 states[n].append(s)
         trial_numbers_union: list[int] = []
         value_states: list[_ValueState] = []

--- a/optuna/visualization/_optimization_history.py
+++ b/optuna/visualization/_optimization_history.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 from typing import Callable
 from typing import cast
 from typing import NamedTuple
@@ -8,6 +9,7 @@ from typing import Sequence
 import numpy as np
 
 from optuna.logging import get_logger
+from optuna.samplers._base import _CONSTRAINTS_KEY
 from optuna.study import Study
 from optuna.study._study_direction import StudyDirection
 from optuna.trial import FrozenTrial
@@ -26,6 +28,7 @@ class _ValuesInfo(NamedTuple):
     values: list[float]
     stds: list[float] | None
     label_name: str
+    is_feasibles: list[bool]
 
 
 class _OptimizationHistoryInfo(NamedTuple):
@@ -48,27 +51,44 @@ def _get_optimization_history_info_list(
 
     info_list: list[_OptimizationHistoryInfo] = []
     for study in studies:
-        trials = study.get_trials(states=(TrialState.COMPLETE,))
+        completed_trials = study.get_trials(states=(TrialState.COMPLETE,))
         label_name = target_name if len(studies) == 1 else f"{target_name} of {study.study_name}"
+        values = []
+        is_feasibles = []
+        for trial in completed_trials:
+            has_constraints = _CONSTRAINTS_KEY in trial.system_attrs
+            constraints_value = trial.system_attrs[_CONSTRAINTS_KEY] if has_constraints else [0]
+            is_feasibles.append(all(map(lambda x: x <= 0.0, constraints_value)))
+            if target is not None:
+                values.append(target(trial))
+            else:
+                values.append(cast(float, trial.value))
         if target is not None:
-            values = [target(t) for t in trials]
             # We don't calculate best for user-defined target function since we cannot tell
             # which direction is better.
             best_values_info: _ValuesInfo | None = None
         else:
-            values = [cast(float, t.value) for t in trials]
+            feasible_best_values = []
             if study.direction == StudyDirection.MINIMIZE:
-                best_values = list(np.minimum.accumulate(values))
+                feasible_best_values = [
+                    value if is_feasible else float("inf")
+                    for value, is_feasible in zip(values, is_feasibles)
+                ]
+                best_values = list(np.minimum.accumulate(feasible_best_values))
             else:
-                best_values = list(np.maximum.accumulate(values))
+                feasible_best_values = [
+                    value if is_feasible else -float("inf")
+                    for value, is_feasible in zip(values, is_feasibles)
+                ]
+                best_values = list(np.maximum.accumulate(feasible_best_values))
             best_label_name = (
                 "Best Value" if len(studies) == 1 else f"Best Value of {study.study_name}"
             )
-            best_values_info = _ValuesInfo(best_values, None, best_label_name)
+            best_values_info = _ValuesInfo(best_values, None, best_label_name, is_feasibles)
         info_list.append(
             _OptimizationHistoryInfo(
-                trial_numbers=[t.number for t in trials],
-                values_info=_ValuesInfo(values, None, label_name),
+                trial_numbers=[t.number for t in completed_trials],
+                values_info=_ValuesInfo(values, None, label_name, is_feasibles),
                 best_values_info=best_values_info,
             )
         )
@@ -92,17 +112,38 @@ def _get_optimization_history_info_list(
     def _aggregate(label_name: str, use_best_value: bool) -> tuple[list[int], _ValuesInfo]:
         # Calculate mean and std of values for each trial number.
         values: list[list[float]] = [[] for _ in range(max_num_trial)]
+        is_feasibles: list[list[bool]] = [[] for _ in range(max_num_trial)]
         assert info_list is not None
         for trial_numbers, values_info, best_values_info in info_list:
             if use_best_value:
                 assert best_values_info is not None
                 values_info = best_values_info
-            for trial_number, value in zip(trial_numbers, values_info.values):
-                values[trial_number].append(value)
-        trial_numbers_union = [i for i in range(max_num_trial) if len(values[i]) > 0]
-        value_means = [np.mean(v).item() for v in values if len(v) > 0]
-        value_stds = [np.std(v).item() for v in values if len(v) > 0]
-        return trial_numbers_union, _ValuesInfo(value_means, value_stds, label_name)
+                for trial_number, value, is_feasible in zip(
+                    trial_numbers, values_info.values, values_info.is_feasibles
+                ):
+                    if not math.isinf(value):
+                        values[trial_number].append(value)
+                    is_feasibles[trial_number].append(is_feasible)
+            else:
+                for trial_number, value, is_feasible in zip(
+                    trial_numbers, values_info.values, values_info.is_feasibles
+                ):
+                    if is_feasible and not math.isinf(value):
+                        values[trial_number].append(value)
+                    is_feasibles[trial_number].append(is_feasible)
+        value_feasibles = [any(f) for f in is_feasibles if len(f) > 0]
+        trial_numbers_union = [
+            i for i in range(max_num_trial) if len(values[i]) > 0 and value_feasibles[i]
+        ]
+        value_means = [
+            np.mean(v).item() for v, f in zip(values, value_feasibles) if len(v) > 0 and f
+        ]
+        value_stds = [
+            np.std(v).item() for v, f in zip(values, value_feasibles) if len(v) > 0 and f
+        ]
+        return trial_numbers_union, _ValuesInfo(
+            value_means, value_stds, label_name, value_feasibles
+        )
 
     eb_trial_numbers, eb_values_info = _aggregate(target_name, False)
     eb_best_values_info: _ValuesInfo | None = None
@@ -179,26 +220,51 @@ def _get_optimization_history_plot(
 
     traces = []
     for trial_numbers, values_info, best_values_info in info_list:
+        infeasible_trial_numbers = [
+            number
+            for number, is_feasible in zip(trial_numbers, values_info.is_feasibles)
+            if not is_feasible
+        ]
         if values_info.stds is None:
             error_y = None
+            feasible_trial_numbers = [
+                number
+                for number, is_feasible in zip(trial_numbers, values_info.is_feasibles)
+                if is_feasible
+            ]
+            feasible_trial_values = []
+            for i in feasible_trial_numbers:
+                feasible_trial_values.append(values_info.values[i])
+            infeasible_trial_values = []
+            for i in infeasible_trial_numbers:
+                infeasible_trial_values.append(values_info.values[i])
         else:
+            if False in values_info.is_feasibles:
+                _logger.warning(
+                    "Your study contains infeasible trials. "
+                    "In optimization history plot,"
+                    "error bars are calculated for only feasible trial values."
+                )
             error_y = {"type": "data", "array": values_info.stds, "visible": True}
+            feasible_trial_numbers = trial_numbers
+            feasible_trial_values = values_info.values
+            infeasible_trial_values = []
         traces.append(
             go.Scatter(
-                x=trial_numbers,
-                y=values_info.values,
+                x=feasible_trial_numbers,
+                y=feasible_trial_values,
                 error_y=error_y,
                 mode="markers",
                 name=values_info.label_name,
             )
         )
-
         if best_values_info is not None:
             traces.append(
                 go.Scatter(
                     x=trial_numbers,
                     y=best_values_info.values,
                     name=best_values_info.label_name,
+                    mode="lines",
                 )
             )
             if best_values_info.stds is not None:
@@ -223,5 +289,15 @@ def _get_optimization_history_plot(
                         fillcolor="rgba(255,0,0,0.2)",
                     )
                 )
-
+        traces.append(
+            go.Scatter(
+                x=infeasible_trial_numbers,
+                y=infeasible_trial_values,
+                error_y=error_y,
+                mode="markers",
+                name="Infeasible Trial",
+                marker={"color": "#cccccc"},
+                showlegend=False,
+            )
+        )
     return go.Figure(data=traces, layout=layout)

--- a/tests/visualization_tests/test_optimization_history.py
+++ b/tests/visualization_tests/test_optimization_history.py
@@ -1,12 +1,18 @@
 from __future__ import annotations
 
 from io import BytesIO
+import math
+from typing import Sequence
 
 import numpy as np
 import pytest
 
+from optuna import samplers
+from optuna import TrialPruned
 from optuna.study import create_study
 from optuna.testing.objectives import fail_objective
+from optuna.testing.objectives import pruned_objective
+from optuna.trial import FrozenTrial
 from optuna.trial import Trial
 from optuna.visualization._optimization_history import _get_optimization_history_info_list
 from optuna.visualization._optimization_history import _get_optimization_history_plot
@@ -74,6 +80,27 @@ def test_ignore_failed_trials(direction: str, error_bar: bool) -> None:
     studies = [create_study(direction=direction) for _ in range(10)]
     for study in studies:
         study.optimize(fail_objective, n_trials=1, catch=(ValueError,))
+    info_list = _get_optimization_history_info_list(
+        studies, target=None, target_name="Objective Value", error_bar=error_bar
+    )
+    assert info_list == []
+
+
+@pytest.mark.parametrize("direction", ["minimize", "maximize"])
+@pytest.mark.parametrize("error_bar", [False, True])
+def test_ignore_pruned_trials(direction: str, error_bar: bool) -> None:
+    # Single study.
+    study = create_study(direction=direction)
+    study.optimize(pruned_objective, n_trials=1, catch=(ValueError,))
+    info_list = _get_optimization_history_info_list(
+        study, target=None, target_name="Objective Value", error_bar=error_bar
+    )
+    assert info_list == []
+
+    # Multiple studies.
+    studies = [create_study(direction=direction) for _ in range(10)]
+    for study in studies:
+        study.optimize(pruned_objective, n_trials=1, catch=(ValueError,))
     info_list = _get_optimization_history_info_list(
         studies, target=None, target_name="Objective Value", error_bar=error_bar
     )
@@ -160,6 +187,81 @@ def test_get_optimization_history_info_list_with_multiple_studies(direction: str
                 [0.0, 1.0, 2.0], None, f"{target_name} of {studies[i].study_name}", value_states
             ),
             None,
+        )
+
+
+@pytest.mark.parametrize("direction", ["minimize", "maximize"])
+def test_get_optimization_history_info_list_with_infeasible(direction: str) -> None:
+    target_name = "Target Name"
+
+    def objective(trial: Trial) -> float:
+        if trial.number == 0:
+            trial.set_user_attr("constraint", [0])
+            return 1.0
+        elif trial.number == 1:
+            trial.set_user_attr("constraint", [0])
+            return 2.0
+        elif trial.number == 2:
+            trial.set_user_attr("constraint", [1])
+            return 3.0
+        return 0.0
+
+    def constraints_func(trial: FrozenTrial) -> Sequence[float]:
+        return trial.user_attrs["constraint"]
+
+    sampler = samplers.TPESampler(constraints_func=constraints_func)
+    study = create_study(sampler=sampler, direction=direction)
+    study.optimize(objective, n_trials=3)
+    info_list = _get_optimization_history_info_list(
+        study, target=None, target_name=target_name, error_bar=False
+    )
+
+    best_values = [1.0, 1.0, 1.0] if direction == "minimize" else [1.0, 2.0, 2.0]
+    states = [_ValueState.Feasible, _ValueState.Feasible, _ValueState.Infeasible]
+    assert info_list == [
+        _OptimizationHistoryInfo(
+            [0, 1, 2],
+            _ValuesInfo(
+                [1.0, 2.0, 3.0],
+                None,
+                target_name,
+                states,
+            ),
+            _ValuesInfo(best_values, None, "Best Value", states),
+        )
+    ]
+
+
+@pytest.mark.parametrize("direction", ["minimize", "maximize"])
+def test_get_optimization_history_info_list_with_pruned_trial(direction: str) -> None:
+    target_name = "Target Name"
+
+    def objective(trial: Trial) -> float:
+        if trial.number == 0:
+            return 1.0
+        elif trial.number == 1:
+            return 2.0
+        elif trial.number == 2:
+            raise TrialPruned()
+        return 0.0
+
+    study = create_study(direction=direction)
+    study.optimize(objective, n_trials=3)
+    info_list = _get_optimization_history_info_list(
+        study, target=None, target_name=target_name, error_bar=False
+    )
+
+    assert info_list[0].values_info.states == [
+        _ValueState.Feasible,
+        _ValueState.Feasible,
+        _ValueState.Incomplete,
+    ]
+    assert math.isnan(info_list[0].values_info.values[2])
+    if info_list[0].best_values_info is not None:
+        assert (
+            info_list[0].best_values_info.values == [1.0, 1.0, 1.0]
+            if direction == "minimize"
+            else [1.0, 2.0, 2.0]
         )
 
 

--- a/tests/visualization_tests/test_optimization_history.py
+++ b/tests/visualization_tests/test_optimization_history.py
@@ -103,8 +103,8 @@ def test_get_optimization_history_info_list(direction: str) -> None:
     assert info_list == [
         _OptimizationHistoryInfo(
             [0, 1, 2],
-            _ValuesInfo([1.0, 2.0, 0.0], None, target_name),
-            _ValuesInfo(best_values, None, "Best Value"),
+            _ValuesInfo([1.0, 2.0, 0.0], None, target_name, [True, True, True]),
+            _ValuesInfo(best_values, None, "Best Value", [True, True, True]),
         )
     ]
 
@@ -115,7 +115,7 @@ def test_get_optimization_history_info_list(direction: str) -> None:
     assert info_list == [
         _OptimizationHistoryInfo(
             [0, 1, 2],
-            _ValuesInfo([0.0, 1.0, 2.0], None, target_name),
+            _ValuesInfo([0.0, 1.0, 2.0], None, target_name, [True, True, True]),
             None,
         )
     ]
@@ -127,6 +127,7 @@ def test_get_optimization_history_info_list_with_multiple_studies(direction: str
     base_values = [1.0, 2.0, 0.0]
     base_best_values = [1.0, 1.0, 0.0] if direction == "minimize" else [1.0, 2.0, 2.0]
     target_name = "Target Name"
+    is_feasibles = [True, True, True]
 
     # Test with trials.
     studies = [create_study(direction=direction) for _ in range(n_studies)]
@@ -141,8 +142,10 @@ def test_get_optimization_history_info_list_with_multiple_studies(direction: str
         best_values_i = [v + i for v in base_best_values]
         assert info == _OptimizationHistoryInfo(
             [0, 1, 2],
-            _ValuesInfo(values_i, None, f"{target_name} of {studies[i].study_name}"),
-            _ValuesInfo(best_values_i, None, f"Best Value of {studies[i].study_name}"),
+            _ValuesInfo(values_i, None, f"{target_name} of {studies[i].study_name}", is_feasibles),
+            _ValuesInfo(
+                best_values_i, None, f"Best Value of {studies[i].study_name}", is_feasibles
+            ),
         )
 
     # Test customized target.
@@ -152,7 +155,9 @@ def test_get_optimization_history_info_list_with_multiple_studies(direction: str
     for i, info in enumerate(info_list):
         assert info == _OptimizationHistoryInfo(
             [0, 1, 2],
-            _ValuesInfo([0.0, 1.0, 2.0], None, f"{target_name} of {studies[i].study_name}"),
+            _ValuesInfo(
+                [0.0, 1.0, 2.0], None, f"{target_name} of {studies[i].study_name}", is_feasibles
+            ),
             None,
         )
 
@@ -183,8 +188,8 @@ def test_get_optimization_history_info_list_with_error_bar(direction: str) -> No
     assert info_list == [
         _OptimizationHistoryInfo(
             [0, 1, 2],
-            _ValuesInfo([1.0, 2.0, 0.0], [0.0, 0.0, 0.0], target_name),
-            _ValuesInfo(best_values, [0.0, 0.0, 0.0], "Best Value"),
+            _ValuesInfo([1.0, 2.0, 0.0], [0.0, 0.0, 0.0], target_name, [True, True, True]),
+            _ValuesInfo(best_values, [0.0, 0.0, 0.0], "Best Value", [True, True, True]),
         )
     ]
 
@@ -195,7 +200,7 @@ def test_get_optimization_history_info_list_with_error_bar(direction: str) -> No
     assert info_list == [
         _OptimizationHistoryInfo(
             [0, 1, 2],
-            _ValuesInfo([0.0, 1.0, 2.0], [0.0, 0.0, 0.0], target_name),
+            _ValuesInfo([0.0, 1.0, 2.0], [0.0, 0.0, 0.0], target_name, [True, True, True]),
             None,
         )
     ]
@@ -216,11 +221,12 @@ def test_error_bar_in_optimization_history(direction: str) -> None:
     )
     mean = np.mean(suggested_params).item()
     std = np.std(suggested_params).item()
+    is_feasibles = [True]
     assert info_list == [
         _OptimizationHistoryInfo(
             [0],
-            _ValuesInfo([mean], [std], "Objective Value"),
-            _ValuesInfo([mean], [std], "Best Value"),
+            _ValuesInfo([mean], [std], "Objective Value", is_feasibles),
+            _ValuesInfo([mean], [std], "Best Value", is_feasibles),
         )
     ]
 
@@ -230,41 +236,53 @@ optimization_history_info_lists = [
     [  # Vanilla.
         _OptimizationHistoryInfo(
             [0, 1, 2],
-            _ValuesInfo([1.0, 2.0, 0.0], None, "Dummy"),
+            _ValuesInfo([1.0, 2.0, 0.0], None, "Dummy", [True, True, True]),
+            None,
+        )
+    ],
+    [  # with infeasible trial.
+        _OptimizationHistoryInfo(
+            [0, 1, 2],
+            _ValuesInfo([1.0, 2.0, 0.0], None, "Dummy", [False, False, False]),
             None,
         )
     ],
     [  # Multiple.
         _OptimizationHistoryInfo(
             [0, 1, 2],
-            _ValuesInfo([1.0, 2.0, 0.0], None, "Dummy"),
+            _ValuesInfo([1.0, 2.0, 0.0], None, "Dummy", [True, True, True]),
             None,
         ),
         _OptimizationHistoryInfo(
             [0, 1, 2],
-            _ValuesInfo([1.0, 1.0, 1.0], None, "Dummy"),
+            _ValuesInfo([1.0, 1.0, 1.0], None, "Dummy", [True, True, True]),
+            None,
+        ),
+        _OptimizationHistoryInfo(
+            [0, 1, 2],
+            _ValuesInfo([1.0, 1.0, 1.0], None, "Dummy", [False, False, False]),
             None,
         ),
     ],
     [  # With best values.
         _OptimizationHistoryInfo(
             [0, 1, 2],
-            _ValuesInfo([1.0, 2.0, 0.0], None, "Dummy"),
-            _ValuesInfo([1.0, 1.0, 1.0], None, "Best Value"),
+            _ValuesInfo([1.0, 2.0, 0.0], None, "Dummy", [True, True, True]),
+            _ValuesInfo([1.0, 1.0, 1.0], None, "Best Value", [True, True, True]),
         )
     ],
     [  # With error bar.
         _OptimizationHistoryInfo(
             [0, 1, 2],
-            _ValuesInfo([1.0, 2.0, 0.0], [1.0, 2.0, 0.0], "Dummy"),
+            _ValuesInfo([1.0, 2.0, 0.0], [1.0, 2.0, 0.0], "Dummy", [True, True, True]),
             None,
         )
     ],
     [  # With best values and error bar.
         _OptimizationHistoryInfo(
             [0, 1, 2],
-            _ValuesInfo([1.0, 2.0, 0.0], [1.0, 2.0, 0.0], "Dummy"),
-            _ValuesInfo([1.0, 1.0, 1.0], [1.0, 2.0, 0.0], "Best Value"),
+            _ValuesInfo([1.0, 2.0, 0.0], [1.0, 2.0, 0.0], "Dummy", [True, True, True]),
+            _ValuesInfo([1.0, 1.0, 1.0], [1.0, 2.0, 0.0], "Best Value", [True, True, True]),
         )
     ],
 ]
@@ -280,6 +298,7 @@ def test_get_optimization_history_plot(
     expected_legends = []
     for info in info_list:
         expected_legends.append(info.values_info.label_name)
+        expected_legends.append("Infeasible Trial")
         if info.best_values_info is not None:
             expected_legends.append(info.best_values_info.label_name)
     legends = [scatter.name for scatter in figure.data if scatter.name is not None]

--- a/tests/visualization_tests/test_optimization_history.py
+++ b/tests/visualization_tests/test_optimization_history.py
@@ -103,8 +103,8 @@ def test_get_optimization_history_info_list(direction: str) -> None:
     assert info_list == [
         _OptimizationHistoryInfo(
             [0, 1, 2],
-            _ValuesInfo([1.0, 2.0, 0.0], None, target_name, [True, True, True]),
-            _ValuesInfo(best_values, None, "Best Value", [True, True, True]),
+            _ValuesInfo([1.0, 2.0, 0.0], None, target_name, ["feasible"] * 3),
+            _ValuesInfo(best_values, None, "Best Value", ["feasible"] * 3),
         )
     ]
 
@@ -115,7 +115,7 @@ def test_get_optimization_history_info_list(direction: str) -> None:
     assert info_list == [
         _OptimizationHistoryInfo(
             [0, 1, 2],
-            _ValuesInfo([0.0, 1.0, 2.0], None, target_name, [True, True, True]),
+            _ValuesInfo([0.0, 1.0, 2.0], None, target_name, ["feasible"] * 3),
             None,
         )
     ]
@@ -127,7 +127,7 @@ def test_get_optimization_history_info_list_with_multiple_studies(direction: str
     base_values = [1.0, 2.0, 0.0]
     base_best_values = [1.0, 1.0, 0.0] if direction == "minimize" else [1.0, 2.0, 2.0]
     target_name = "Target Name"
-    is_feasibles = [True, True, True]
+    value_states = ["feasible"] * 3
 
     # Test with trials.
     studies = [create_study(direction=direction) for _ in range(n_studies)]
@@ -142,9 +142,9 @@ def test_get_optimization_history_info_list_with_multiple_studies(direction: str
         best_values_i = [v + i for v in base_best_values]
         assert info == _OptimizationHistoryInfo(
             [0, 1, 2],
-            _ValuesInfo(values_i, None, f"{target_name} of {studies[i].study_name}", is_feasibles),
+            _ValuesInfo(values_i, None, f"{target_name} of {studies[i].study_name}", value_states),
             _ValuesInfo(
-                best_values_i, None, f"Best Value of {studies[i].study_name}", is_feasibles
+                best_values_i, None, f"Best Value of {studies[i].study_name}", value_states
             ),
         )
 
@@ -156,7 +156,7 @@ def test_get_optimization_history_info_list_with_multiple_studies(direction: str
         assert info == _OptimizationHistoryInfo(
             [0, 1, 2],
             _ValuesInfo(
-                [0.0, 1.0, 2.0], None, f"{target_name} of {studies[i].study_name}", is_feasibles
+                [0.0, 1.0, 2.0], None, f"{target_name} of {studies[i].study_name}", value_states
             ),
             None,
         )
@@ -188,8 +188,8 @@ def test_get_optimization_history_info_list_with_error_bar(direction: str) -> No
     assert info_list == [
         _OptimizationHistoryInfo(
             [0, 1, 2],
-            _ValuesInfo([1.0, 2.0, 0.0], [0.0, 0.0, 0.0], target_name, [True, True, True]),
-            _ValuesInfo(best_values, [0.0, 0.0, 0.0], "Best Value", [True, True, True]),
+            _ValuesInfo([1.0, 2.0, 0.0], [0.0, 0.0, 0.0], target_name, ["feasible"] * 3),
+            _ValuesInfo(best_values, [0.0, 0.0, 0.0], "Best Value", ["feasible"] * 3),
         )
     ]
 
@@ -200,7 +200,7 @@ def test_get_optimization_history_info_list_with_error_bar(direction: str) -> No
     assert info_list == [
         _OptimizationHistoryInfo(
             [0, 1, 2],
-            _ValuesInfo([0.0, 1.0, 2.0], [0.0, 0.0, 0.0], target_name, [True, True, True]),
+            _ValuesInfo([0.0, 1.0, 2.0], [0.0, 0.0, 0.0], target_name, ["feasible"] * 3),
             None,
         )
     ]
@@ -221,12 +221,12 @@ def test_error_bar_in_optimization_history(direction: str) -> None:
     )
     mean = np.mean(suggested_params).item()
     std = np.std(suggested_params).item()
-    is_feasibles = [True]
+    value_states = ["feasible"]
     assert info_list == [
         _OptimizationHistoryInfo(
             [0],
-            _ValuesInfo([mean], [std], "Objective Value", is_feasibles),
-            _ValuesInfo([mean], [std], "Best Value", is_feasibles),
+            _ValuesInfo([mean], [std], "Objective Value", value_states),
+            _ValuesInfo([mean], [std], "Best Value", value_states),
         )
     ]
 
@@ -236,53 +236,60 @@ optimization_history_info_lists = [
     [  # Vanilla.
         _OptimizationHistoryInfo(
             [0, 1, 2],
-            _ValuesInfo([1.0, 2.0, 0.0], None, "Dummy", [True, True, True]),
+            _ValuesInfo([1.0, 2.0, 0.0], None, "Dummy", ["feasible"] * 3),
             None,
         )
     ],
     [  # with infeasible trial.
         _OptimizationHistoryInfo(
             [0, 1, 2],
-            _ValuesInfo([1.0, 2.0, 0.0], None, "Dummy", [False, False, False]),
+            _ValuesInfo([1.0, 2.0, 0.0], None, "Dummy", ["infeasible"] * 3),
+            None,
+        )
+    ],
+    [  # with incomplete trial.
+        _OptimizationHistoryInfo(
+            [0, 1, 2],
+            _ValuesInfo([1.0, 2.0, 0.0], None, "Dummy", ["incomplete"] * 3),
             None,
         )
     ],
     [  # Multiple.
         _OptimizationHistoryInfo(
             [0, 1, 2],
-            _ValuesInfo([1.0, 2.0, 0.0], None, "Dummy", [True, True, True]),
+            _ValuesInfo([1.0, 2.0, 0.0], None, "Dummy", ["feasible"] * 3),
             None,
         ),
         _OptimizationHistoryInfo(
             [0, 1, 2],
-            _ValuesInfo([1.0, 1.0, 1.0], None, "Dummy", [True, True, True]),
+            _ValuesInfo([1.0, 1.0, 1.0], None, "Dummy", ["feasible"] * 3),
             None,
         ),
         _OptimizationHistoryInfo(
             [0, 1, 2],
-            _ValuesInfo([1.0, 1.0, 1.0], None, "Dummy", [False, False, False]),
+            _ValuesInfo([1.0, 1.0, 1.0], None, "Dummy", ["infeasible"] * 3),
             None,
         ),
     ],
     [  # With best values.
         _OptimizationHistoryInfo(
             [0, 1, 2],
-            _ValuesInfo([1.0, 2.0, 0.0], None, "Dummy", [True, True, True]),
-            _ValuesInfo([1.0, 1.0, 1.0], None, "Best Value", [True, True, True]),
+            _ValuesInfo([1.0, 2.0, 0.0], None, "Dummy", ["feasible"] * 3),
+            _ValuesInfo([1.0, 1.0, 1.0], None, "Best Value", ["feasible"] * 3),
         )
     ],
     [  # With error bar.
         _OptimizationHistoryInfo(
             [0, 1, 2],
-            _ValuesInfo([1.0, 2.0, 0.0], [1.0, 2.0, 0.0], "Dummy", [True, True, True]),
+            _ValuesInfo([1.0, 2.0, 0.0], [1.0, 2.0, 0.0], "Dummy", ["feasible"] * 3),
             None,
         )
     ],
     [  # With best values and error bar.
         _OptimizationHistoryInfo(
             [0, 1, 2],
-            _ValuesInfo([1.0, 2.0, 0.0], [1.0, 2.0, 0.0], "Dummy", [True, True, True]),
-            _ValuesInfo([1.0, 1.0, 1.0], [1.0, 2.0, 0.0], "Best Value", [True, True, True]),
+            _ValuesInfo([1.0, 2.0, 0.0], [1.0, 2.0, 0.0], "Dummy", ["feasible"] * 3),
+            _ValuesInfo([1.0, 1.0, 1.0], [1.0, 2.0, 0.0], "Best Value", ["feasible"] * 3),
         )
     ],
 ]

--- a/tests/visualization_tests/test_optimization_history.py
+++ b/tests/visualization_tests/test_optimization_history.py
@@ -12,6 +12,7 @@ from optuna.visualization._optimization_history import _get_optimization_history
 from optuna.visualization._optimization_history import _get_optimization_history_plot
 from optuna.visualization._optimization_history import _OptimizationHistoryInfo
 from optuna.visualization._optimization_history import _ValuesInfo
+from optuna.visualization._optimization_history import _ValueState
 
 
 def test_target_is_none_and_study_is_multi_obj() -> None:
@@ -103,8 +104,8 @@ def test_get_optimization_history_info_list(direction: str) -> None:
     assert info_list == [
         _OptimizationHistoryInfo(
             [0, 1, 2],
-            _ValuesInfo([1.0, 2.0, 0.0], None, target_name, ["feasible"] * 3),
-            _ValuesInfo(best_values, None, "Best Value", ["feasible"] * 3),
+            _ValuesInfo([1.0, 2.0, 0.0], None, target_name, [_ValueState.Feasible] * 3),
+            _ValuesInfo(best_values, None, "Best Value", [_ValueState.Feasible] * 3),
         )
     ]
 
@@ -115,7 +116,7 @@ def test_get_optimization_history_info_list(direction: str) -> None:
     assert info_list == [
         _OptimizationHistoryInfo(
             [0, 1, 2],
-            _ValuesInfo([0.0, 1.0, 2.0], None, target_name, ["feasible"] * 3),
+            _ValuesInfo([0.0, 1.0, 2.0], None, target_name, [_ValueState.Feasible] * 3),
             None,
         )
     ]
@@ -127,7 +128,7 @@ def test_get_optimization_history_info_list_with_multiple_studies(direction: str
     base_values = [1.0, 2.0, 0.0]
     base_best_values = [1.0, 1.0, 0.0] if direction == "minimize" else [1.0, 2.0, 2.0]
     target_name = "Target Name"
-    value_states = ["feasible"] * 3
+    value_states = [_ValueState.Feasible] * 3
 
     # Test with trials.
     studies = [create_study(direction=direction) for _ in range(n_studies)]
@@ -188,8 +189,8 @@ def test_get_optimization_history_info_list_with_error_bar(direction: str) -> No
     assert info_list == [
         _OptimizationHistoryInfo(
             [0, 1, 2],
-            _ValuesInfo([1.0, 2.0, 0.0], [0.0, 0.0, 0.0], target_name, ["feasible"] * 3),
-            _ValuesInfo(best_values, [0.0, 0.0, 0.0], "Best Value", ["feasible"] * 3),
+            _ValuesInfo([1.0, 2.0, 0.0], [0.0, 0.0, 0.0], target_name, [_ValueState.Feasible] * 3),
+            _ValuesInfo(best_values, [0.0, 0.0, 0.0], "Best Value", [_ValueState.Feasible] * 3),
         )
     ]
 
@@ -200,7 +201,7 @@ def test_get_optimization_history_info_list_with_error_bar(direction: str) -> No
     assert info_list == [
         _OptimizationHistoryInfo(
             [0, 1, 2],
-            _ValuesInfo([0.0, 1.0, 2.0], [0.0, 0.0, 0.0], target_name, ["feasible"] * 3),
+            _ValuesInfo([0.0, 1.0, 2.0], [0.0, 0.0, 0.0], target_name, [_ValueState.Feasible] * 3),
             None,
         )
     ]
@@ -221,7 +222,7 @@ def test_error_bar_in_optimization_history(direction: str) -> None:
     )
     mean = np.mean(suggested_params).item()
     std = np.std(suggested_params).item()
-    value_states = ["feasible"]
+    value_states = [_ValueState.Feasible]
     assert info_list == [
         _OptimizationHistoryInfo(
             [0],
@@ -236,60 +237,62 @@ optimization_history_info_lists = [
     [  # Vanilla.
         _OptimizationHistoryInfo(
             [0, 1, 2],
-            _ValuesInfo([1.0, 2.0, 0.0], None, "Dummy", ["feasible"] * 3),
+            _ValuesInfo([1.0, 2.0, 0.0], None, "Dummy", [_ValueState.Feasible] * 3),
             None,
         )
     ],
     [  # with infeasible trial.
         _OptimizationHistoryInfo(
             [0, 1, 2],
-            _ValuesInfo([1.0, 2.0, 0.0], None, "Dummy", ["infeasible"] * 3),
+            _ValuesInfo([1.0, 2.0, 0.0], None, "Dummy", [_ValueState.Infeasible] * 3),
             None,
         )
     ],
     [  # with incomplete trial.
         _OptimizationHistoryInfo(
             [0, 1, 2],
-            _ValuesInfo([1.0, 2.0, 0.0], None, "Dummy", ["incomplete"] * 3),
+            _ValuesInfo([1.0, 2.0, 0.0], None, "Dummy", [_ValueState.Incomplete] * 3),
             None,
         )
     ],
     [  # Multiple.
         _OptimizationHistoryInfo(
             [0, 1, 2],
-            _ValuesInfo([1.0, 2.0, 0.0], None, "Dummy", ["feasible"] * 3),
+            _ValuesInfo([1.0, 2.0, 0.0], None, "Dummy", [_ValueState.Feasible] * 3),
             None,
         ),
         _OptimizationHistoryInfo(
             [0, 1, 2],
-            _ValuesInfo([1.0, 1.0, 1.0], None, "Dummy", ["feasible"] * 3),
+            _ValuesInfo([1.0, 1.0, 1.0], None, "Dummy", [_ValueState.Feasible] * 3),
             None,
         ),
         _OptimizationHistoryInfo(
             [0, 1, 2],
-            _ValuesInfo([1.0, 1.0, 1.0], None, "Dummy", ["infeasible"] * 3),
+            _ValuesInfo([1.0, 1.0, 1.0], None, "Dummy", [_ValueState.Infeasible] * 3),
             None,
         ),
     ],
     [  # With best values.
         _OptimizationHistoryInfo(
             [0, 1, 2],
-            _ValuesInfo([1.0, 2.0, 0.0], None, "Dummy", ["feasible"] * 3),
-            _ValuesInfo([1.0, 1.0, 1.0], None, "Best Value", ["feasible"] * 3),
+            _ValuesInfo([1.0, 2.0, 0.0], None, "Dummy", [_ValueState.Feasible] * 3),
+            _ValuesInfo([1.0, 1.0, 1.0], None, "Best Value", [_ValueState.Feasible] * 3),
         )
     ],
     [  # With error bar.
         _OptimizationHistoryInfo(
             [0, 1, 2],
-            _ValuesInfo([1.0, 2.0, 0.0], [1.0, 2.0, 0.0], "Dummy", ["feasible"] * 3),
+            _ValuesInfo([1.0, 2.0, 0.0], [1.0, 2.0, 0.0], "Dummy", [_ValueState.Feasible] * 3),
             None,
         )
     ],
     [  # With best values and error bar.
         _OptimizationHistoryInfo(
             [0, 1, 2],
-            _ValuesInfo([1.0, 2.0, 0.0], [1.0, 2.0, 0.0], "Dummy", ["feasible"] * 3),
-            _ValuesInfo([1.0, 1.0, 1.0], [1.0, 2.0, 0.0], "Best Value", ["feasible"] * 3),
+            _ValuesInfo([1.0, 2.0, 0.0], [1.0, 2.0, 0.0], "Dummy", [_ValueState.Feasible] * 3),
+            _ValuesInfo(
+                [1.0, 1.0, 1.0], [1.0, 2.0, 0.0], "Best Value", [_ValueState.Feasible] * 3
+            ),
         )
     ],
 ]


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
Currently, only the pareto front can visualize the results considering the constraints.
To make it easier to understand the results, we have added an optimized_history_plot to allow plots that consider the constraints.


## Description of the changes
<!-- Describe the changes in this PR. -->

Modified _optimization_history_plot.py to allow plots that reflect constraints.
Tests have been modified accordingly.

An example plot of the modified results is shown below.

```py
def objective(trial: optuna.Trial):
    x = trial.suggest_float("x", -15, 30)
    y = trial.suggest_float("y", -15, 30)
    v0 = 4 * x**2 + 4 * y**2
    trial.set_user_attr("constraint", [1000 - v0])
    return v0
```

![r8MhiXGk](https://github.com/optuna/optuna/assets/23289252/f2421df7-88d5-4abd-9a46-c88146ba9cf5)

When calculating error bars(`plot_optimization_history(study, error_bar=True)`), only feasible trials are included in the calculation. 
Therefore, if an infeasible trial is included, output the following as warnings.
"Your study contains infeasible trials. In optimization history plot,error bars are calculated for only feasible trial values." 

If the constraints are strict, the error bar may not be displayed from about trial number 0 because the first feasible trial is not easily obtained.
The following example uses `trial.set_user_attr("constraint", [1000 - v0, x-10, y-10])`
<img width="2595" alt="Screenshot 2023-07-06 at 23 28 29" src="https://github.com/optuna/optuna/assets/23289252/b7a66c7b-6d72-4f81-ae5a-e5b0f219a113">


