### PR TITLE
Make `LightGBMTuner` reproducible

### DIFF
--- a/optuna/integration/_lightgbm_tuner/optimize.py
+++ b/optuna/integration/_lightgbm_tuner/optimize.py
@@ -557,7 +557,7 @@ class _LightGBMBaseTuner(_BaseTuner):
         param_name = "feature_fraction"
         param_values = np.linspace(0.4, 1.0, n_trials).tolist()
 
-        sampler = optuna.samplers.GridSampler({param_name: param_values})
+        sampler = optuna.samplers.GridSampler({param_name: param_values}, seed=self._optuna_seed)
         self._tune_params([param_name], len(param_values), sampler, "feature_fraction")
 
     def tune_num_leaves(self, n_trials: int = 20) -> None:
@@ -584,7 +584,7 @@ class _LightGBMBaseTuner(_BaseTuner):
         ).tolist()
         param_values = [val for val in param_values if val >= 0.4 and val <= 1.0]
 
-        sampler = optuna.samplers.GridSampler({param_name: param_values})
+        sampler = optuna.samplers.GridSampler({param_name: param_values}, seed=self._optuna_seed)
         self._tune_params([param_name], len(param_values), sampler, "feature_fraction_stage2")
 
     def tune_regularization_factors(self, n_trials: int = 20) -> None:
@@ -599,7 +599,7 @@ class _LightGBMBaseTuner(_BaseTuner):
         param_name = "min_child_samples"
         param_values = [5, 10, 25, 50, 100]
 
-        sampler = optuna.samplers.GridSampler({param_name: param_values})
+        sampler = optuna.samplers.GridSampler({param_name: param_values}, seed=self._optuna_seed)
         self._tune_params([param_name], len(param_values), sampler, "min_data_in_leaf")
 
     def _tune_params(

--- a/tests/integration_tests/lightgbm_tuner_tests/test_optimize.py
+++ b/tests/integration_tests/lightgbm_tuner_tests/test_optimize.py
@@ -762,6 +762,13 @@ class TestLightGBMTuner:
 
         assert best_score_second_try == best_score_first_try
 
+        first_try_trials = tuner_first_try.study.trials
+        second_try_trials = tuner_second_try.study.trials
+        assert len(first_try_trials) == len(second_try_trials)
+        for first_trial, second_trial in zip(first_try_trials, second_try_trials):
+            assert first_trial.value == second_trial.value
+            assert first_trial.params == second_trial.params
+
 
 class TestLightGBMTunerCV:
     def _get_tunercv_object(
@@ -1077,3 +1084,10 @@ class TestLightGBMTunerCV:
         best_score_second_try = tuner_second_try.best_score
 
         assert best_score_second_try == best_score_first_try
+
+        first_try_trials = tuner_first_try.study.trials
+        second_try_trials = tuner_second_try.study.trials
+        assert len(first_try_trials) == len(second_try_trials)
+        for first_trial, second_trial in zip(first_try_trials, second_try_trials):
+            assert first_trial.value == second_trial.value
+            assert first_trial.params == second_trial.params


### PR DESCRIPTION
## Motivation
`LightGBMTuner` is not reproducible because the order of trials is shuffled by `GridSampler`.
This PR will fix the CI of #4752.

## Description of the changes
- Make `LightGBMTuner` reproducible by fixing seed of `GridSampler`
- Add tests to check suggested parameters