### PR TITLE
Remove `study.n_objectives` from document

### DIFF
--- a/optuna/visualization/_hypervolume_history.py
+++ b/optuna/visualization/_hypervolume_history.py
@@ -63,7 +63,7 @@ def plot_hypervolume_history(
     Args:
         study:
             A :class:`~optuna.study.Study` object whose trials are plotted for their hypervolumes.
-           ``study.n_objectives`` must be 2 or more.
+            The number of objectives must be 2 or more.
 
         reference_point:
             A reference point to use for hypervolume computation.

--- a/optuna/visualization/_pareto_front.py
+++ b/optuna/visualization/_pareto_front.py
@@ -108,7 +108,7 @@ def plot_pareto_front(
     Args:
         study:
             A :class:`~optuna.study.Study` object whose trials are plotted for their objective
-            values. ``study.n_objectives`` must be either 2 or 3 when ``targets`` is :obj:`None`.
+            values. The number of objectives must be either 2 or 3 when ``targets`` is :obj:`None`.
         target_names:
             Objective name list used as the axis titles. If :obj:`None` is specified,
             "Objective {objective_index}" is used instead. If ``targets`` is specified

--- a/optuna/visualization/matplotlib/_hypervolume_history.py
+++ b/optuna/visualization/matplotlib/_hypervolume_history.py
@@ -56,7 +56,7 @@ def plot_hypervolume_history(
     Args:
         study:
             A :class:`~optuna.study.Study` object whose trials are plotted for their hypervolumes.
-           ``study.n_objectives`` must be 2 or more.
+            The number of objectives must be 2 or more.
 
         reference_point:
             A reference point to use for hypervolume computation.

--- a/optuna/visualization/matplotlib/_pareto_front.py
+++ b/optuna/visualization/matplotlib/_pareto_front.py
@@ -89,7 +89,7 @@ def plot_pareto_front(
             The argument to this function is :class:`~optuna.trial.FrozenTrial`.
             ``targets`` must be :obj:`None` or return 2 or 3 values.
             ``axis_order`` and ``targets`` cannot be used at the same time.
-            If ``study.n_objectives`` is neither 2 nor 3, ``targets`` must be specified.
+            If the number of objectives is neither 2 nor 3, ``targets`` must be specified.
 
             .. note::
                 Added in v3.0.0 as an experimental feature. The interface may change in newer


### PR DESCRIPTION
## Motivation
`Study` does not have `n_objectives`. It was inadvertently brought in from the `multi_objective` submodule.

## Description of the changes
Replace `study.n_objectives` with "the number of objectives".