### PR TITLE
Follow up separation of after trial strategy

### DIFF
--- a/optuna/samplers/_nsgaiii.py
+++ b/optuna/samplers/_nsgaiii.py
@@ -118,6 +118,12 @@ class NSGAIIISampler(BaseSampler):
                 " The interface can change in the future.",
                 ExperimentalWarning,
             )
+        if after_trial_strategy is not None:
+            warnings.warn(
+                "The after_trial_strategy option is an experimental feature."
+                " The interface can change in the future.",
+                ExperimentalWarning,
+            )
 
         if crossover is None:
             crossover = UniformCrossover(swapping_prob)

--- a/optuna/samplers/_nsgaiii.py
+++ b/optuna/samplers/_nsgaiii.py
@@ -77,6 +77,7 @@ class NSGAIIISampler(BaseSampler):
 
     def __init__(
         self,
+        *,
         population_size: int = 50,
         mutation_prob: float | None = None,
         crossover: BaseCrossover | None = None,

--- a/optuna/samplers/_nsgaiii.py
+++ b/optuna/samplers/_nsgaiii.py
@@ -86,12 +86,12 @@ class NSGAIIISampler(BaseSampler):
         swapping_prob: float = 0.5,
         seed: int | None = None,
         constraints_func: Callable[[FrozenTrial], Sequence[float]] | None = None,
+        reference_points: np.ndarray | None = None,
+        dividing_parameter: int = 3,
         after_trial_strategy: Callable[
             [Study, FrozenTrial, TrialState, Sequence[float] | None], None
         ]
         | None = None,
-        reference_points: np.ndarray | None = None,
-        dividing_parameter: int = 3,
     ) -> None:
         # TODO(ohta): Reconsider the default value of each parameter.
 

--- a/optuna/samplers/_nsgaiii.py
+++ b/optuna/samplers/_nsgaiii.py
@@ -7,14 +7,12 @@ import hashlib
 import itertools
 import math
 from typing import Any
-import warnings
 
 import numpy as np
 
 import optuna
 from optuna._experimental import experimental_class
 from optuna.distributions import BaseDistribution
-from optuna.exceptions import ExperimentalWarning
 from optuna.samplers._base import BaseSampler
 from optuna.samplers._random import RandomSampler
 from optuna.samplers._search_space import IntersectionSearchSpace
@@ -111,19 +109,6 @@ class NSGAIIISampler(BaseSampler):
 
         if not (0.0 <= swapping_prob <= 1.0):
             raise ValueError("`swapping_prob` must be a float value within the range [0.0, 1.0].")
-
-        if constraints_func is not None:
-            warnings.warn(
-                "The constraints_func option is an experimental feature."
-                " The interface can change in the future.",
-                ExperimentalWarning,
-            )
-        if after_trial_strategy is not None:
-            warnings.warn(
-                "The after_trial_strategy option is an experimental feature."
-                " The interface can change in the future.",
-                ExperimentalWarning,
-            )
 
         if crossover is None:
             crossover = UniformCrossover(swapping_prob)

--- a/optuna/samplers/nsgaii/_sampler.py
+++ b/optuna/samplers/nsgaii/_sampler.py
@@ -155,6 +155,12 @@ class NSGAIISampler(BaseSampler):
                 " The interface can change in the future.",
                 ExperimentalWarning,
             )
+        if after_trial_strategy is not None:
+            warnings.warn(
+                "The after_trial_strategy option is an experimental feature."
+                " The interface can change in the future.",
+                ExperimentalWarning,
+            )
 
         if crossover is None:
             crossover = UniformCrossover(swapping_prob)

--- a/tests/samplers_tests/test_nsgaii.py
+++ b/tests/samplers_tests/test_nsgaii.py
@@ -545,6 +545,11 @@ def test_constraints_func_experimental_warning() -> None:
         NSGAIISampler(constraints_func=lambda _: [0])
 
 
+def test_after_trial_strategy_experimental_warning() -> None:
+    with pytest.warns(optuna.exceptions.ExperimentalWarning):
+        NSGAIISampler(after_trial_strategy=lambda study, trial, state, value: None)
+
+
 # TODO(ohta): Consider to move this utility function to `optuna.testing` module.
 def _create_frozen_trial(
     number: int, values: Sequence[float], constraints: Sequence[float] | None = None

--- a/tests/samplers_tests/test_nsgaiii.py
+++ b/tests/samplers_tests/test_nsgaiii.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections import Counter
 from typing import Sequence
+from unittest.mock import MagicMock
 from unittest.mock import patch
 import warnings
 
@@ -26,6 +27,7 @@ from optuna.samplers.nsgaii import SPXCrossover
 from optuna.samplers.nsgaii import UNDXCrossover
 from optuna.samplers.nsgaii import UniformCrossover
 from optuna.samplers.nsgaii import VSBXCrossover
+from optuna.samplers.nsgaii._after_trial_strategy import NSGAIIAfterTrialStrategy
 from optuna.trial import create_trial
 from optuna.trial import FrozenTrial
 
@@ -218,6 +220,34 @@ def test_call_after_trial_of_random_sampler() -> None:
     ) as mock_object:
         study.optimize(lambda _: 1.0, n_trials=1)
         assert mock_object.call_count == 1
+
+
+def test_call_after_trial_of_after_trial_strategy() -> None:
+    sampler = NSGAIIISampler()
+    study = optuna.create_study(sampler=sampler)
+    with patch.object(sampler, "_after_trial_strategy") as mock_object:
+        study.optimize(lambda _: 1.0, n_trials=1)
+        assert mock_object.call_count == 1
+
+
+@patch("optuna.samplers.nsgaii._after_trial_strategy._process_constraints_after_trial")
+def test_nsgaii_after_trial_strategy(mock_func: MagicMock) -> None:
+    def constraints_func(_: FrozenTrial) -> Sequence[float]:
+        return (float("nan"),)
+
+    state = optuna.trial.TrialState.FAIL
+    study = optuna.create_study()
+    trial = optuna.trial.create_trial(state=state)
+
+    after_trial_strategy_without_constrains = NSGAIIAfterTrialStrategy()
+    after_trial_strategy_without_constrains(study, trial, state)
+    assert mock_func.call_count == 0
+
+    after_trial_strategy_with_constrains = NSGAIIAfterTrialStrategy(
+        constraints_func=constraints_func
+    )
+    after_trial_strategy_with_constrains(study, trial, state)
+    assert mock_func.call_count == 1
 
 
 parametrize_crossover_population = pytest.mark.parametrize(

--- a/tests/samplers_tests/test_nsgaiii.py
+++ b/tests/samplers_tests/test_nsgaiii.py
@@ -205,6 +205,11 @@ def test_constraints_func_experimental_warning() -> None:
         NSGAIIISampler(constraints_func=lambda _: [0])
 
 
+def test_after_trial_strategy_experimental_warning() -> None:
+    with pytest.warns(optuna.exceptions.ExperimentalWarning):
+        NSGAIIISampler(after_trial_strategy=lambda study, trial, state, value: None)
+
+
 def test_call_after_trial_of_random_sampler() -> None:
     sampler = NSGAIIISampler()
     study = optuna.create_study(sampler=sampler)


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
Follow up https://github.com/optuna/optuna/pull/4760
## Description of the changes
- Rearrange the order of the arguments of `NSGAIIISampler` constructor.
- Make `NSGAIISampler` and `NSGAIIISampler` return `ExperimentalWarning` when `after_trial_strategy` is given in initialization.
- Add test for `after_trial_strategy` of `NSGAIIISampler`.