### PR TITLE
Upgrade redis version.

### DIFF
--- a/.github/workflows/tests-storage.yml
+++ b/.github/workflows/tests-storage.yml
@@ -53,7 +53,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
       redis:
-        image: redis:6.2.6
+        image: redis:6.2.13
         ports:
           - 6379:6379
 

--- a/.github/workflows/tests-storage.yml
+++ b/.github/workflows/tests-storage.yml
@@ -53,7 +53,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
       redis:
-        image: redis:6.2.13
+        image: redis
         ports:
           - 6379:6379
 


### PR DESCRIPTION
## Motivation
- Redis announced the [security issues](https://redis.com/blog/security-notice-heap-overflow-vulnerabilties/), and I'd like to avoid them by upgrading the software version.
- Redis 6.2.6 was patched at [v8 yesterday](https://github.com/redis-stack/redis-stack/releases/tag/v6.2.6-v8), but the corresponding docker image is not available. The current docker image was released last year ([dockerhub](https://hub.docker.com/layers/library/redis/6.2.6/images/sha256-226cbafc637cd58cf008bf87ec9d1548ad1b672ef4279433495bdff100cdb883?context=explore)).

## Description of the changes
- Upgrade redis in CI from 6.2.6 to 6.2.13