### PR TITLE
Remove _study_id parameter from Trial class

### DIFF
--- a/optuna/trial/_trial.py
+++ b/optuna/trial/_trial.py
@@ -51,8 +51,6 @@ class Trial(BaseTrial):
         self.study = study
         self._trial_id = trial_id
 
-        # TODO(Yanase): Remove _study_id attribute, and use study._study_id instead.
-        self._study_id = self.study._study_id
         self.storage = self.study._storage
 
         self._cached_frozen_trial = self.storage.get_trial(self._trial_id)

--- a/tests/trial_tests/test_trial.py
+++ b/tests/trial_tests/test_trial.py
@@ -613,13 +613,6 @@ def test_report_warning() -> None:
         trial.report(1, 1)
 
 
-def test_study_id() -> None:
-    study = create_study()
-    trial = Trial(study, study._storage.create_new_trial(study._study_id))
-
-    assert trial._study_id == trial.study._study_id
-
-
 def test_suggest_with_multi_objectives() -> None:
     study = create_study(directions=["maximize", "maximize"])
 


### PR DESCRIPTION
## Motivation
Referencing issue optuna/optuna#4678
All uses of `trial._study_id` were removed in optuna/optuna-dashboard/pull/463, which was merged into the main optuna repository.

## Description of the changes
Remove the `_study_id` parameter from the Trial class, and remove the test that checks the `_study_id` parameter was always the same as `study._study_id`.
