### PR TITLE
Remove `ordered_dict` argument from `IntersectionSearchSpace`

### DIFF
--- a/optuna/importance/_base.py
+++ b/optuna/importance/_base.py
@@ -71,7 +71,7 @@ def _get_distributions(study: Study, params: Optional[List[str]]) -> Dict[str, B
     _check_evaluate_args(completed_trials, params)
 
     if params is None:
-        return intersection_search_space(study.get_trials(deepcopy=False), ordered_dict=True)
+        return intersection_search_space(study.get_trials(deepcopy=False))
 
     # New temporary required to pass mypy. Seems like a bug.
     params_not_none = params

--- a/optuna/integration/botorch.py
+++ b/optuna/integration/botorch.py
@@ -721,7 +721,7 @@ class BoTorchSampler(BaseSampler):
             raise RuntimeError("BoTorchSampler cannot handle multiple studies.")
 
         search_space: Dict[str, BaseDistribution] = {}
-        for name, distribution in self._search_space.calculate(study, ordered_dict=True).items():
+        for name, distribution in self._search_space.calculate(study).items():
             if distribution.single():
                 # built-in `candidates_func` cannot handle distributions that contain just a
                 # single value, so we skip them. Note that the parameter values for such

--- a/optuna/search_space/intersection.py
+++ b/optuna/search_space/intersection.py
@@ -76,21 +76,17 @@ class IntersectionSearchSpace:
 
         self._include_pruned = include_pruned
 
-    def calculate(self, study: Study, ordered_dict: bool = False) -> Dict[str, BaseDistribution]:
+    def calculate(self, study: Study) -> Dict[str, BaseDistribution]:
         """Returns the intersection search space of the :class:`~optuna.study.Study`.
 
         Args:
             study:
                 A study with completed trials. The same study must be passed for one instance
                 of this class through its lifetime.
-            ordered_dict:
-                A boolean flag determining the return type.
-                If :obj:`False`, the returned object will be a :obj:`dict`.
-                If :obj:`True`, the returned object will be a :obj:`dict` sorted by keys, i.e.
-                parameter names.
 
         Returns:
-            A dictionary containing the parameter names and parameter's distributions.
+            A dictionary containing the parameter names and parameter's distributions sorted by
+            parameter names.
         """
 
         if self._study_id is None:
@@ -108,16 +104,12 @@ class IntersectionSearchSpace:
             self._cached_trial_number,
         )
         search_space = self._search_space or {}
-
-        if ordered_dict:
-            search_space = dict(sorted(search_space.items(), key=lambda x: x[0]))
-
+        search_space = dict(sorted(search_space.items(), key=lambda x: x[0]))
         return copy.deepcopy(search_space)
 
 
 def intersection_search_space(
     trials: list[optuna.trial.FrozenTrial],
-    ordered_dict: bool = False,
     include_pruned: bool = False,
 ) -> Dict[str, BaseDistribution]:
     """Return the intersection search space of the given trials.
@@ -136,22 +128,15 @@ def intersection_search_space(
     Args:
         trials:
             A list of trials.
-        ordered_dict:
-            A boolean flag determining the return type.
-            If :obj:`False`, the returned object will be a :obj:`dict`.
-            If :obj:`True`, the returned object will be a :obj:`dict` sorted by keys, i.e.
-            parameter names.
         include_pruned:
             Whether pruned trials should be included in the search space.
 
     Returns:
-        A dictionary containing the parameter names and parameter's distributions.
+        A dictionary containing the parameter names and parameter's distributions sorted by
+        parameter names.
     """
 
     search_space, _ = _calculate(trials, include_pruned)
     search_space = search_space or {}
-
-    if ordered_dict:
-        search_space = dict(sorted(search_space.items(), key=lambda x: x[0]))
-
+    search_space = dict(sorted(search_space.items(), key=lambda x: x[0]))
     return search_space

--- a/optuna/terminator/improvement/_preprocessing.py
+++ b/optuna/terminator/improvement/_preprocessing.py
@@ -207,7 +207,7 @@ class AddRandomInputs(BasePreprocessing):
         trials: List[optuna.trial.FrozenTrial],
         study_direction: Optional[optuna.study.StudyDirection],
     ) -> List[optuna.trial.FrozenTrial]:
-        search_space = intersection_search_space(trials, ordered_dict=True)
+        search_space = intersection_search_space(trials)
 
         additional_trials = []
         for _ in range(self._n_additional_trials):

--- a/optuna/terminator/improvement/evaluator.py
+++ b/optuna/terminator/improvement/evaluator.py
@@ -96,7 +96,7 @@ class RegretBoundEvaluator(BaseImprovementEvaluator):
         trials: List[FrozenTrial],
         study_direction: StudyDirection,
     ) -> float:
-        search_space = intersection_search_space(trials, ordered_dict=True)
+        search_space = intersection_search_space(trials)
         self._validate_input(trials, search_space)
 
         fit_trials = self.get_preprocessing().apply(trials, study_direction)

--- a/optuna/terminator/improvement/gp/botorch.py
+++ b/optuna/terminator/improvement/gp/botorch.py
@@ -89,7 +89,7 @@ def _convert_trials_to_tensors(trials: list[FrozenTrial]) -> tuple[torch.Tensor,
     - the state is COMPLETE for any trial;
     - direction is MINIMIZE for any trial.
     """
-    search_space = intersection_search_space(trials, ordered_dict=True)
+    search_space = intersection_search_space(trials)
     sorted_params = sorted(search_space.keys())
 
     x = []

--- a/tests/search_space_tests/test_intersection.py
+++ b/tests/search_space_tests/test_intersection.py
@@ -39,16 +39,8 @@ def test_intersection_search_space() -> None:
         study.get_trials(deepcopy=False)
     )
 
-    # Returning sorted `dict`.
-    assert search_space.calculate(study, ordered_dict=True) == dict(
-        [
-            ("x", IntDistribution(low=0, high=10)),
-            ("y", FloatDistribution(low=-3, high=3)),
-        ]
-    )
-    assert search_space.calculate(study, ordered_dict=True) == intersection_search_space(
-        study.get_trials(deepcopy=False), ordered_dict=True
-    )
+    # Returned dict is sorted by parameter names.
+    assert list(search_space.calculate(study).keys()) == ["x", "y"]
 
     # Second trial (only 'y' parameter is suggested in this trial).
     study.optimize(lambda t: t.suggest_float("y", -3, 3), n_trials=1)


### PR DESCRIPTION
## Motivation
By #4838, `OrderedDict` is removed from Optuna's code. Therefore the `ordered_dict` argument is now inappropriate.

## Description of the changes
This PR removes the `ordered_dict` argument and makes the returned dict always sorted.
