### PR TITLE
Support flake8 6.1.0

### DIFF
--- a/tests/integration_tests/test_sklearn.py
+++ b/tests/integration_tests/test_sklearn.py
@@ -94,9 +94,9 @@ def test_optuna_search_properties() -> None:
     optuna_search.set_user_attr("dataset", "blobs")
 
     assert optuna_search._estimator_type == "classifier"
-    assert type(optuna_search.best_index_) == int
-    assert type(optuna_search.best_params_) == dict
-    assert type(optuna_search.cv_results_) == dict
+    assert isinstance(optuna_search.best_index_, int)
+    assert isinstance(optuna_search.best_params_, dict)
+    assert isinstance(optuna_search.cv_results_, dict)
     for cv_result_list_ in optuna_search.cv_results_.values():
         assert len(cv_result_list_) == optuna_search.n_trials_
     assert optuna_search.best_score_ is not None

--- a/tests/samplers_tests/tpe_tests/test_parzen_estimator.py
+++ b/tests/samplers_tests/tpe_tests/test_parzen_estimator.py
@@ -20,7 +20,7 @@ def assert_distribution_almost_equal(
 ) -> None:
     np.testing.assert_almost_equal(d1.weights, d2.weights)
     for d1_, d2_ in zip(d1.distributions, d2.distributions):
-        assert type(d1_) == type(d2_)
+        assert type(d1_) is type(d2_)
         for field1, field2 in zip(d1_, d2_):
             np.testing.assert_almost_equal(np.array(field1), np.array(field2))
 


### PR DESCRIPTION
## Motivation
The flake8 6.1.0 release causes Checks CI to fail.

## Description of the changes
> E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`