### PR TITLE
Pin sphinx version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ document = [
     "plotly>=4.9.0",  # optuna/visualization.
     "scikit-learn",
     "scikit-optimize",
-    "sphinx",
+    "sphinx<7",
     "sphinx-copybutton",
     "sphinx-gallery",
     "sphinx-plotly-directive",


### PR DESCRIPTION
## Motivation
Temporally fix `docs/readthedocs.org:optuna`

## Description of the changes
Currently [`sphinx_rtd_theme`](https://github.com/readthedocs/sphinx_rtd_theme) does not support `sphinx>=7` as mentioned in https://github.com/readthedocs/sphinx_rtd_theme/issues/1463. This PR pins the version of `sphinx` under 7 to pass the CI until the issue is resolved. 
Note that pinning the version in `pyproject.toml` is the recommended way to specify `sphinx` version (See [here](https://docs.readthedocs.io/en/stable/config-file/v2.html#sphinx)).