### PR TITLE
Add lower version constraint for `sphinx_rtd_theme`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,7 @@ document = [
     "sphinx-copybutton",
     "sphinx-gallery",
     "sphinx-plotly-directive",
-    "sphinx_rtd_theme",
+    "sphinx_rtd_theme>=1.2.0",
     "torch",
     "torchaudio",
     "torchvision",


### PR DESCRIPTION
## Motivation
By RTD update (https://github.com/readthedocs/readthedocs.org/pull/10560), `sphinx_rtd_theme` v0.4.3 is used to build the document. It is too old and we need to add lower version constraint.

## Description of the changes
This PR adds lower version constraint for `sphinx_rtd_theme`. I chose v1.2.0 because it is the first version to support Sphinx 6.