### PR TITLE
Display all objectives on hyperparameter importances plot

### DIFF
--- a/optuna/visualization/_param_importances.py
+++ b/optuna/visualization/_param_importances.py
@@ -124,7 +124,7 @@ def plot_param_importances(
             is :obj:`None`.
 
             .. note::
-                This argument can be used to specify which objective to plot if ``study``is being
+                This argument can be used to specify which objective to plot if ``study`` is being
                 used for multi-objective optimization. For example, to get only the hyperparameter
                 importance of the first objective, use ``target=lambda t: t.values[0]`` for the
                 target parameter.

--- a/optuna/visualization/_param_importances.py
+++ b/optuna/visualization/_param_importances.py
@@ -122,13 +122,16 @@ def plot_param_importances(
         target:
             A function to specify the value to display. If it is :obj:`None` and ``study`` is being
             used for single-objective optimization, the objective values are plotted.
+            For multi-objective optimization, all objectives will be plotted if ``target``
+            is :obj:`None`.
 
             .. note::
-                Specify this argument if ``study`` is being used for multi-objective
-                optimization. For example, to get the hyperparameter importance of the first
-                objective, use ``target=lambda t: t.values[0]`` for the target parameter.
+                This argument can be used to specify which objective to plot if ``study``is being
+                used for multi-objective optimization. For example, to get only the hyperparameter
+                importance of the first objective, use ``target=lambda t: t.values[0]`` for the
+                target parameter.
         target_name:
-            Target's name to display on the axis label.
+            Target's name to display on the legend.
 
     Returns:
         A :class:`plotly.graph_objs.Figure` object.
@@ -136,42 +139,55 @@ def plot_param_importances(
 
     _imports.check()
 
-    importances_info = _get_importances_info(study, evaluator, params, target, target_name)
-    hover_template = _get_hover_template(importances_info, study)
-    return _get_importances_plot(importances_info, hover_template)
+    if target or not study._is_multi_objective():
+        importances_infos: tuple[_ImportancesInfo, ...] = (
+            _get_importances_info(
+                study, evaluator, params, target=target, target_name=target_name
+            ),
+        )
+
+    else:
+        n_objectives = len(study.directions)
+        importances_infos = tuple(
+            _get_importances_info(
+                study,
+                evaluator,
+                params,
+                target=lambda t: t.values[objective_id],
+                target_name=f"{target_name} {objective_id}",
+            )
+            for objective_id in range(n_objectives)
+        )
+
+    return _get_importances_plot(importances_infos, study)
 
 
-def _get_importances_plot(info: _ImportancesInfo, hover_template: list[str]) -> "go.Figure":
+def _get_importances_plot(infos: tuple[_ImportancesInfo, ...], study: Study) -> "go.Figure":
     layout = go.Layout(
         title="Hyperparameter Importances",
-        xaxis={"title": f"Importance for {info.target_name}"},
+        xaxis={"title": "Hyperparameter Importance"},
         yaxis={"title": "Hyperparameter"},
-        showlegend=False,
     )
 
-    param_names = info.param_names
-    importance_values = info.importance_values
+    data: list[go.Bar] = []
+    for info in infos:
+        if not info.importance_values:
+            continue
 
-    if len(importance_values) == 0:
-        return go.Figure(data=[], layout=layout)
-
-    fig = go.Figure(
-        data=[
+        data.append(
             go.Bar(
-                x=importance_values,
-                y=param_names,
+                x=info.importance_values,
+                y=info.param_names,
+                name=info.target_name,
                 text=info.importance_labels,
                 textposition="outside",
                 cliponaxis=False,  # Ensure text is not clipped.
-                hovertemplate=hover_template,
-                marker_color=plotly.colors.sequential.Blues[-4],
+                hovertemplate=_get_hover_template(info, study),
                 orientation="h",
             )
-        ],
-        layout=layout,
-    )
+        )
 
-    return fig
+    return go.Figure(data, layout)
 
 
 def _get_distribution(param_name: str, study: Study) -> BaseDistribution:

--- a/optuna/visualization/_param_importances.py
+++ b/optuna/visualization/_param_importances.py
@@ -16,8 +16,6 @@ from optuna.visualization._utils import _filter_nonfinite
 
 
 if _imports.is_successful():
-    import plotly
-
     from optuna.visualization._plotly_imports import go
 
 

--- a/optuna/visualization/matplotlib/_matplotlib_imports.py
+++ b/optuna/visualization/matplotlib/_matplotlib_imports.py
@@ -13,6 +13,7 @@ with try_import() as _imports:
     from matplotlib.collections import PathCollection
     from matplotlib.colors import Colormap
     from matplotlib.contour import ContourSet
+    from matplotlib.figure import Figure
 
     # TODO(ytknzw): Set precise version.
     if version.parse(matplotlib_version) < version.parse("3.0.0"):
@@ -34,4 +35,5 @@ __all__ = [
     "PathCollection",
     "Colormap",
     "ContourSet",
+    "Figure",
 ]

--- a/optuna/visualization/matplotlib/_param_importances.py
+++ b/optuna/visualization/matplotlib/_param_importances.py
@@ -146,7 +146,7 @@ def _get_importances_plot(infos: tuple[_ImportancesInfo, ...]) -> "Axes":
         _set_bar_labels(info, fig, ax, offset)
         ax.set_yticks(pos + offset / 2, param_names)
 
-    fig.legend(loc="outside upper right")
+    ax.legend(loc="best")
     return ax
 
 

--- a/optuna/visualization/matplotlib/_param_importances.py
+++ b/optuna/visualization/matplotlib/_param_importances.py
@@ -16,6 +16,7 @@ from optuna.visualization.matplotlib._matplotlib_imports import _imports
 
 if _imports.is_successful():
     from optuna.visualization.matplotlib._matplotlib_imports import Axes
+    from optuna.visualization.matplotlib._matplotlib_imports import Figure
     from optuna.visualization.matplotlib._matplotlib_imports import plt
 
 
@@ -76,11 +77,14 @@ def plot_param_importances(
         target:
             A function to specify the value to display. If it is :obj:`None` and ``study`` is being
             used for single-objective optimization, the objective values are plotted.
+            For multi-objective optimization, all objectives will be plotted if ``target``
+            is :obj:`None`.
 
             .. note::
-                Specify this argument if ``study`` is being used for multi-objective
-                optimization. For example, to get the hyperparameter importance of the first
-                objective, use ``target=lambda t: t.values[0]`` for the target parameter.
+                This argument can be used to specify which objective to plot if ``study``is being
+                used for multi-objective optimization. For example, to get only the hyperparameter
+                importance of the first objective, use ``target=lambda t: t.values[0]`` for the
+                target parameter.
         target_name:
             Target's name to display on the axis label.
 
@@ -90,37 +94,66 @@ def plot_param_importances(
 
     _imports.check()
 
-    importances_info = _get_importances_info(study, evaluator, params, target, target_name)
-    return _get_importances_plot(importances_info)
+    if target or not study._is_multi_objective():
+        importances_infos: tuple[_ImportancesInfo, ...] = (
+            _get_importances_info(study, evaluator, params, target, target_name),
+        )
+
+    else:
+        n_objectives = len(study.directions)
+        importances_infos = tuple(
+            _get_importances_info(
+                study,
+                evaluator,
+                params,
+                target=lambda t: t.values[objective_id],
+                target_name=f"{target_name} {objective_id}",
+            )
+            for objective_id in range(n_objectives)
+        )
+
+    return _get_importances_plot(importances_infos)
 
 
-def _get_importances_plot(info: _ImportancesInfo) -> "Axes":
+def _get_importances_plot(infos: tuple[_ImportancesInfo, ...]) -> "Axes":
     # Set up the graph style.
     plt.style.use("ggplot")  # Use ggplot style sheet for similar outputs to plotly.
     fig, ax = plt.subplots()
-    ax.set_title("Hyperparameter Importances")
-    ax.set_xlabel(f"Importance for {info.target_name}")
+    ax.set_title("Hyperparameter Importances", loc="left")
+    ax.set_xlabel("Hyperparameter Importance")
     ax.set_ylabel("Hyperparameter")
+    height = 0.8 / len(infos)  # Default height split between objectives.
 
-    param_names = info.param_names
-    pos = np.arange(len(param_names))
-    importance_values = info.importance_values
+    for objective_id, info in enumerate(infos):
+        param_names = info.param_names
+        pos = np.arange(len(param_names))
+        offset = height * objective_id
+        importance_values = info.importance_values
 
-    if len(importance_values) == 0:
-        return ax
+        if not importance_values:
+            continue
 
-    # Draw horizontal bars.
-    ax.barh(
-        pos,
-        importance_values,
-        align="center",
-        color=plt.get_cmap("tab20c")(0),
-        tick_label=param_names,
-    )
+        # Draw horizontal bars.
+        ax.barh(
+            pos + offset,
+            importance_values,
+            height=height,
+            align="center",
+            label=info.target_name,
+            color=plt.get_cmap("tab20c")(objective_id),
+        )
 
+        _set_bar_labels(info, fig, ax, offset)
+        ax.set_yticks(pos + offset / 2, param_names)
+
+    fig.legend(loc="outside upper right")
+    return ax
+
+
+def _set_bar_labels(info: _ImportancesInfo, fig: "Figure", ax: "Axes", offset: float) -> None:
     renderer = fig.canvas.get_renderer()
-    for idx, (val, label) in enumerate(zip(importance_values, info.importance_labels)):
-        text = ax.text(val, idx, label, va="center")
+    for idx, (val, label) in enumerate(zip(info.importance_values, info.importance_labels)):
+        text = ax.text(val, idx + offset, label, va="center")
 
         # Sometimes horizontal axis needs to be re-scaled
         # to avoid text going over plot area.
@@ -131,5 +164,3 @@ def _get_importances_plot(info: _ImportancesInfo) -> "Axes":
 
         if bbox_xmax > plot_xmax:
             ax.set_xlim(xmax=AXES_PADDING_RATIO * bbox_xmax)
-
-    return ax

--- a/optuna/visualization/matplotlib/_param_importances.py
+++ b/optuna/visualization/matplotlib/_param_importances.py
@@ -81,7 +81,7 @@ def plot_param_importances(
             is :obj:`None`.
 
             .. note::
-                This argument can be used to specify which objective to plot if ``study``is being
+                This argument can be used to specify which objective to plot if ``study`` is being
                 used for multi-objective optimization. For example, to get only the hyperparameter
                 importance of the first objective, use ``target=lambda t: t.values[0]`` for the
                 target parameter.

--- a/tests/visualization_tests/test_param_importances.py
+++ b/tests/visualization_tests/test_param_importances.py
@@ -55,7 +55,7 @@ def test_plot_param_importances_customized_target_name(
     if isinstance(figure, go.Figure):
         assert figure.layout.xaxis.title.text == "Hyperparameter Importance"
     elif isinstance(figure, Axes):
-        assert figure.figure.axes[0].get_xlabel() == "Importance for Target Name"
+        assert figure.figure.axes[0].get_xlabel() == "Hyperparameter Importance"
 
 
 @parametrize_plot_param_importances

--- a/tests/visualization_tests/test_param_importances.py
+++ b/tests/visualization_tests/test_param_importances.py
@@ -53,7 +53,7 @@ def test_plot_param_importances_customized_target_name(
     study = prepare_study_with_trials()
     figure = plot_param_importances(study, params=params, target_name="Target Name")
     if isinstance(figure, go.Figure):
-        assert figure.layout.xaxis.title.text == "Importance for Target Name"
+        assert figure.layout.xaxis.title.text == "Hyperparameter Importance"
     elif isinstance(figure, Axes):
         assert figure.figure.axes[0].get_xlabel() == "Importance for Target Name"
 

--- a/tests/visualization_tests/test_param_importances.py
+++ b/tests/visualization_tests/test_param_importances.py
@@ -37,6 +37,16 @@ def _create_study_with_failed_trial() -> Study:
     return study
 
 
+def _create_multiobjective_study_with_failed_trial() -> Study:
+    study = create_study(directions=["minimize", "minimize"])
+    study.optimize(fail_objective, n_trials=1, catch=(ValueError,))
+    return study
+
+
+def _create_multiobjective_study() -> Study:
+    return prepare_study_with_trials(n_objectives=2)
+
+
 def test_target_is_none_and_study_is_multi_obj() -> None:
     study = create_study(directions=["minimize", "minimize"])
     with pytest.raises(ValueError):
@@ -59,11 +69,27 @@ def test_plot_param_importances_customized_target_name(
 
 
 @parametrize_plot_param_importances
+def test_plot_param_importances_multiobjective_all_objectives_displayed(
+    plot_param_importances: Callable[..., Any]
+) -> None:
+    n_objectives = 2
+    params = ["param_a"]
+    study = prepare_study_with_trials(n_objectives)
+    figure = plot_param_importances(study, params=params)
+    if isinstance(figure, go.Figure):
+        assert len(figure.data) == n_objectives
+    elif isinstance(figure, Axes):
+        assert len(figure.patches) == n_objectives * len(params)
+
+
+@parametrize_plot_param_importances
 @pytest.mark.parametrize(
     "specific_create_study",
     [
         create_study,
+        _create_multiobjective_study,
         _create_study_with_failed_trial,
+        _create_multiobjective_study_with_failed_trial,
         prepare_study_with_trials,
     ],
 )


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
This PR introduces support for multi-objective optimization in hyperparameter importances plots by making them display importances of all objectives on a single plot if no target function was specified. Implementation follows the idea from [optuna-dashboard](https://github.com/optuna/optuna-dashboard/blob/d9b096df0fe5cd84f6efc2e3fbeb554c39cf2a94/optuna_dashboard/_app.py#L225-L243), providing multi-objective support in the visualization layer by dynamically generated target functions. This means no changes were made to the evaluators, which will still rise exceptions if study is being used for multi-objective optimization without a target function.

Closes #4437.

## Description of the changes
<!-- Describe the changes in this PR. -->
* [x] Add multi-objective support to the Plotly version of hyperparam importances plot.
* [x] Add multi-objective support to the Matplotlib version of hyperparam importances plot.
* [x] Add test cases.
* [ ] Update [regression tests](https://github.com/optuna/optuna-visualization-regression-tests) (follow-up).

## Examples
![Screenshot from 2023-08-12 20-33-05](https://github.com/optuna/optuna/assets/37713008/5e22460f-4895-4557-99f1-89516c5ecaf8)

![Screenshot from 2023-08-13 12-52-43](https://github.com/optuna/optuna/assets/37713008/699f803d-81fe-4e21-ae5b-e6270a065cb4)



