### PR TITLE
Support `asv` 0.6.0

### DIFF
--- a/.github/workflows/speed-benchmarks.yml
+++ b/.github/workflows/speed-benchmarks.yml
@@ -53,4 +53,4 @@ jobs:
 
     - name: Speed benchmarks
       run: |
-        asv run --strict
+        asv run

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -76,8 +76,8 @@
     // followed by the pip installed packages).
     //
     "matrix": {
-        "fakeredis": [""],
-        "pytest": [""],
+        "pip+fakeredis": [""],
+        "pip+pytest": [""],
     },
 
     // Combinations of libraries/python versions can be excluded/included


### PR DESCRIPTION
## Motivation
Speed benchmark CI has been failed because asv 0.6.0 was released. Change log is here. https://github.com/airspeed-velocity/asv/blob/master/CHANGES.rst#060-2023-08-20

## Description of the changes
- Remove `--strict` option
- Add `pip+` prefix (I'm not sure this is the intended behavior, but it seems necessary in asv 0.6.0.)

I have confirmed the change on my fork repository. https://github.com/not522/optuna/actions/runs/5961145531/job/16169802756
