### PR TITLE
Fix `fail_stale_trials` with race condition

### DIFF
--- a/optuna/storages/_heartbeat.py
+++ b/optuna/storages/_heartbeat.py
@@ -166,8 +166,12 @@ def fail_stale_trials(study: "optuna.Study") -> None:
 
     failed_trial_ids = []
     for trial_id in storage._get_stale_trial_ids(study._study_id):
-        if storage.set_trial_state_values(trial_id, state=TrialState.FAIL):
-            failed_trial_ids.append(trial_id)
+        try:
+            if storage.set_trial_state_values(trial_id, state=TrialState.FAIL):
+                failed_trial_ids.append(trial_id)
+        except RuntimeError:
+            # If another process fails the trial, the storage raises RuntimeError.
+            pass
 
     failed_trial_callback = storage.get_failed_trial_callback()
     if failed_trial_callback is not None:


### PR DESCRIPTION
## Motivation
Fix #4862.
If another process fails the trial, the storage raises `RuntimeError`. This behavior is described in [the document of `set_trial_state_values`](https://optuna.readthedocs.io/en/stable/reference/generated/optuna.storages.RDBStorage.html#optuna.storages.RDBStorage.set_trial_state_values).

## Description of the changes
- Add try-except for race condition
