### PR TITLE
Fix alias handler

### DIFF
--- a/optuna/integration/_lightgbm_tuner/alias.py
+++ b/optuna/integration/_lightgbm_tuner/alias.py
@@ -116,17 +116,17 @@ def _handling_alias_metrics(lgbm_params: dict[str, Any]) -> None:
     if "metric" not in lgbm_params.keys():
         return
 
+    if not isinstance(lgbm_params["metric"], (str, Iterable)):
+        raise ValueError(
+            "The `metric` parameter is expected to be a string or an iterable object, but got "
+            f"{type(lgbm_params['metric'])}."
+        )
+
     if isinstance(lgbm_params["metric"], str):
         lgbm_params["metric"] = (
             _ALIAS_METRIC_MAP.get(lgbm_params["metric"]) or lgbm_params["metric"]
         )
         return
-
-    if not isinstance(lgbm_params["metric"], Iterable):
-        raise ValueError(
-            "The `metric` parameter is expected to be a string or an iterable object, but got "
-            f"{type(lgbm_params['metric'])}."
-        )
 
     canonical_metrics = []
     for metric in lgbm_params["metric"]:

--- a/optuna/integration/_lightgbm_tuner/alias.py
+++ b/optuna/integration/_lightgbm_tuner/alias.py
@@ -1,9 +1,10 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
 from typing import Any
-from typing import Dict
-from typing import List  # NOQA
 
 
-_ALIAS_GROUP_LIST: List[Dict[str, Any]] = [
+_ALIAS_GROUP_LIST: list[dict[str, Any]] = [
     {"param_name": "bagging_fraction", "alias_names": ["sub_row", "subsample", "bagging"]},
     {"param_name": "learning_rate", "alias_names": ["shrinkage_rate", "eta"]},
     {
@@ -27,7 +28,7 @@ _ALIAS_GROUP_LIST: List[Dict[str, Any]] = [
 ]
 
 
-def _handling_alias_parameters(lgbm_params: Dict[str, Any]) -> None:
+def _handling_alias_parameters(lgbm_params: dict[str, Any]) -> None:
     """Handling alias parameters."""
 
     for alias_group in _ALIAS_GROUP_LIST:
@@ -40,7 +41,7 @@ def _handling_alias_parameters(lgbm_params: Dict[str, Any]) -> None:
                 del lgbm_params[alias_name]
 
 
-_ALIAS_METRIC_LIST: List[Dict[str, Any]] = [
+_ALIAS_METRIC_LIST: list[dict[str, Any]] = [
     # The list `alias_names` do not include the `metric_name` itself.
     {
         "metric_name": "ndcg",
@@ -103,14 +104,14 @@ _ALIAS_METRIC_LIST: List[Dict[str, Any]] = [
     },
 ]
 
-_ALIAS_METRIC_MAP: Dict[str, str] = {
+_ALIAS_METRIC_MAP: dict[str, str] = {
     alias_name: canonical_metric["metric_name"]
     for canonical_metric in _ALIAS_METRIC_LIST
     for alias_name in canonical_metric["alias_names"]
 }
 
 
-def _handling_alias_metrics(lgbm_params: Dict[str, Any]) -> None:
+def _handling_alias_metrics(lgbm_params: dict[str, Any]) -> None:
     """Handling alias metrics."""
     if "metric" not in lgbm_params.keys():
         return
@@ -121,9 +122,9 @@ def _handling_alias_metrics(lgbm_params: Dict[str, Any]) -> None:
         )
         return
 
-    if not isinstance(lgbm_params["metric"], list):
+    if not isinstance(lgbm_params["metric"], Iterable):
         raise ValueError(
-            "The `metric` parameter is expected to be a list or a string, but got "
+            "The `metric` parameter is expected to be a string or an iterable object, but got "
             f"{type(lgbm_params['metric'])}."
         )
 

--- a/tests/integration_tests/lightgbm_tuner_tests/test_alias.py
+++ b/tests/integration_tests/lightgbm_tuner_tests/test_alias.py
@@ -98,3 +98,8 @@ def test_handling_alias_metrics(aliases: List[str], expect: str) -> None:
         lgbm_params = {}
         _handling_alias_metrics(lgbm_params)
         assert lgbm_params == {}
+
+
+def test_handling_unexpected_alias_metrics() -> None:
+    with pytest.raises(ValueError):
+        _handling_alias_metrics({"metric": "unexpected"})

--- a/tests/integration_tests/lightgbm_tuner_tests/test_alias.py
+++ b/tests/integration_tests/lightgbm_tuner_tests/test_alias.py
@@ -102,4 +102,4 @@ def test_handling_alias_metrics(aliases: List[str], expect: str) -> None:
 
 def test_handling_unexpected_alias_metrics() -> None:
     with pytest.raises(ValueError):
-        _handling_alias_metrics({"metric": "unexpected"})
+        _handling_alias_metrics({"metric": 1})

--- a/tests/integration_tests/lightgbm_tuner_tests/test_alias.py
+++ b/tests/integration_tests/lightgbm_tuner_tests/test_alias.py
@@ -81,6 +81,11 @@ def test_handling_alias_parameter() -> None:
         (["auc_mu"], "auc_mu"),
         (["custom", "none", "null", "na"], "custom"),
         ([], None),  # If "metric" not in lgbm_params.keys(): return None.
+        ([["lambdarank"]], ["ndcg"]),
+        (
+            [["lambdarank", "mean_average_precision", "root_mean_squared_error"]],
+            ["ndcg", "map", "rmse"],
+        ),
     ],
 )
 def test_handling_alias_metrics(aliases: List[str], expect: str) -> None:


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
Currently, `_handling_alias_metrics()` does nothing when `pram["metric"]` is a list, even though its last element is actually used as the objective for optimization. This PR resolve this problem.

## Description of the changes
<!-- Describe the changes in this PR. -->
