### PR TITLE
Faster implementation of fANOVA

### DIFF
--- a/optuna/importance/_fanova/_tree.py
+++ b/optuna/importance/_fanova/_tree.py
@@ -123,6 +123,7 @@ class _FanovaTree:
                     continue
 
                 # If subtree starting from node splits on an active feature, push both child nodes.
+                # Here, we use `any` for list because `ndarray.any` is slow.
                 if any(self._subtree_active_features[node_index][active_features].tolist()):
                     for child_node_index in self._get_node_children(node_index):
                         active_nodes.append(child_node_index)

--- a/optuna/importance/_fanova/_tree.py
+++ b/optuna/importance/_fanova/_tree.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from functools import lru_cache
 import itertools
 from typing import List
@@ -134,11 +136,7 @@ class _FanovaTree:
         statistics = self._statistics[node_indices]
         values = statistics[:, 0]
         weights = statistics[:, 1]
-        active_features_cardinalities = numpy.asarray(active_leaf_search_spaces)
-        active_features_cardinalities = (
-            active_features_cardinalities[:, :, 1] - active_features_cardinalities[:, :, 0]
-        )
-        active_features_cardinalities = numpy.prod(active_features_cardinalities, axis=1)
+        active_features_cardinalities = _get_cardinality_batched(active_leaf_search_spaces)
         weights = weights / active_features_cardinalities
 
         value = numpy.average(values, weights=weights)
@@ -307,6 +305,11 @@ class _FanovaTree:
 
 def _get_cardinality(search_spaces: numpy.ndarray) -> float:
     return numpy.prod(search_spaces[:, 1] - search_spaces[:, 0])
+
+
+def _get_cardinality_batched(search_spaces_list: list[numpy.ndarray]) -> float:
+    search_spaces = numpy.asarray(search_spaces_list)
+    return numpy.prod(search_spaces[:, :, 1] - search_spaces[:, :, 0], axis=1)
 
 
 def _get_subspaces(


### PR DESCRIPTION
## Motivation
This PR refactors the implementation of `FanovaImportanceEvaluator` to improve speed.

## Description of the changes
- Adding `lru_cache` to node information getters
- Discarding NumPy's `any`
- Reducing the number of cardinality calculations

## Benchmark
I ran a benchmark using the optuna-fast-fanova's script. https://github.com/optuna/optuna-fast-fanova/blob/main/tools/benchmark.py

| n_trials | n_params | n_trees | Optuna (master) | Optuna (PR) | optuna-fast-fanova |
| -------- | -------- | ------- | --------------- | ------------------ | ------------------ |
| 100 | 2 | 64 | 1.219s | 0.844s (-30.8%) | 0.111s (-90.9%) |
| 100 | 8 | 64 | 1.611s | 1.031s (-36.0%) | 0.170s (-89.5%) |
| 100 | 32 | 64 | 1.763s | 1.245s (-29.4%) | 0.438s (-75.2%) |
| 1000 | 2 | 64 | 51.800s | 24.699s (-52.3%) | 1.359s (-97.4%) |
| 1000 | 8 | 64 | 79.404s | 34.244s (-56.9%) | 2.342s (-97.0%) |
| 1000 | 32 | 64 | 58.464s | 26.081s (-55.4%) | 3.464s (-94.1%) |


