### PR TITLE
Implement `get_all_study_names()`

### DIFF
--- a/docs/source/reference/optuna.rst
+++ b/docs/source/reference/optuna.rst
@@ -13,5 +13,6 @@ The :mod:`optuna` module is primarily used as an alias for basic Optuna function
    optuna.load_study
    optuna.delete_study
    optuna.copy_study
+   optuna.get_all_study_names
    optuna.get_all_study_summaries
    optuna.TrialPruned

--- a/docs/source/reference/study.rst
+++ b/docs/source/reference/study.rst
@@ -14,6 +14,7 @@ The :mod:`~optuna.study` module implements the :class:`~optuna.study.Study` obje
    optuna.study.load_study
    optuna.study.delete_study
    optuna.study.copy_study
+   optuna.study.get_all_study_names
    optuna.study.get_all_study_summaries
    optuna.study.MaxTrialsCallback
    optuna.study.StudyDirection

--- a/optuna/__init__.py
+++ b/optuna/__init__.py
@@ -15,6 +15,7 @@ from optuna.exceptions import TrialPruned
 from optuna.study import copy_study
 from optuna.study import create_study
 from optuna.study import delete_study
+from optuna.study import get_all_study_names
 from optuna.study import get_all_study_summaries
 from optuna.study import load_study
 from optuna.study import Study
@@ -35,6 +36,7 @@ __all__ = [
     "delete_study",
     "distributions",
     "exceptions",
+    "get_all_study_names",
     "get_all_study_summaries",
     "importance",
     "integration",

--- a/optuna/study/__init__.py
+++ b/optuna/study/__init__.py
@@ -4,6 +4,7 @@ from optuna.study._study_summary import StudySummary
 from optuna.study.study import copy_study
 from optuna.study.study import create_study
 from optuna.study.study import delete_study
+from optuna.study.study import get_all_study_names
 from optuna.study.study import get_all_study_summaries
 from optuna.study.study import load_study
 from optuna.study.study import Study
@@ -16,6 +17,7 @@ __all__ = [
     "copy_study",
     "create_study",
     "delete_study",
+    "get_all_study_names",
     "get_all_study_summaries",
     "load_study",
     "Study",

--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -1328,13 +1328,13 @@ def load_study(
 
     """
     if study_name is None:
-        study_summaries = get_all_study_summaries(storage)
-        if len(study_summaries) != 1:
+        study_names = get_all_study_names(storage)
+        if len(study_names) != 1:
             raise ValueError(
                 f"Could not determine the study name since the storage {storage} does not "
                 "contain exactly 1 study. Specify `study_name`."
             )
-        study_name = study_summaries[0].study_name
+        study_name = study_names[0]
         _logger.info(
             f"Study name was omitted but trying to load '{study_name}' because that was the only "
             "study found in the storage."

--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -1602,3 +1602,57 @@ def get_all_study_summaries(
         )
 
     return study_summaries
+
+
+def get_all_study_names(storage: Union[str, storages.BaseStorage]) -> List[str]:
+    """Get all study names stored in a specified storage.
+
+    Example:
+
+        .. testsetup::
+
+            import os
+
+            if os.path.exists("example.db"):
+                raise RuntimeError("'example.db' already exists. Please remove it.")
+
+        .. testcode::
+
+            import optuna
+
+
+            def objective(trial):
+                x = trial.suggest_float("x", -10, 10)
+                return (x - 2) ** 2
+
+
+            study = optuna.create_study(study_name="example-study", storage="sqlite:///example.db")
+            study.optimize(objective, n_trials=3)
+
+            study_names = optuna.study.get_all_study_names(storage="sqlite:///example.db")
+            assert len(study_names) == 1
+
+            assert study_names[0] == "example-study"
+
+        .. testcleanup::
+
+            os.remove("example.db")
+
+    Args:
+        storage:
+            Database URL such as ``sqlite:///example.db``. Please see also the documentation of
+            :func:`~optuna.study.create_study` for further details.
+
+    Returns:
+        List of all study names in the storage.
+
+    See also:
+        :func:`optuna.get_all_study_names` is an alias of
+        :func:`optuna.study.get_all_study_names`.
+
+    """
+
+    storage = storages.get_storage(storage)
+    study_names = [study.study_name for study in storage.get_all_studies()]
+
+    return study_names

--- a/tests/study_tests/test_study.py
+++ b/tests/study_tests/test_study.py
@@ -24,6 +24,7 @@ from optuna import create_study
 from optuna import create_trial
 from optuna import delete_study
 from optuna import distributions
+from optuna import get_all_study_names
 from optuna import get_all_study_summaries
 from optuna import load_study
 from optuna import logging
@@ -315,6 +316,19 @@ def test_get_all_study_summaries_with_no_trials(storage_mode: str) -> None:
         assert summary.study_name == study.study_name
         assert summary.n_trials == 0
         assert summary.datetime_start is None
+
+
+@pytest.mark.parametrize("storage_mode", STORAGE_MODES)
+def test_get_all_study_names(storage_mode: str) -> None:
+    with StorageSupplier(storage_mode) as storage:
+        n_studies = 5
+
+        studies = [create_study(storage=storage) for _ in range(n_studies)]
+        study_names = get_all_study_names(storage)
+
+        assert len(study_names) == n_studies
+        for study, study_name in zip(studies, study_names):
+            assert study_name == study.study_name
 
 
 def test_study_pickle() -> None:

--- a/tests/study_tests/test_study.py
+++ b/tests/study_tests/test_study.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from concurrent.futures import as_completed
 from concurrent.futures import ThreadPoolExecutor
 import copy
@@ -8,10 +10,6 @@ import threading
 import time
 from typing import Any
 from typing import Callable
-from typing import Dict
-from typing import List
-from typing import Optional
-from typing import Union
 from unittest.mock import Mock
 from unittest.mock import patch
 import uuid
@@ -53,7 +51,7 @@ def func(trial: Trial) -> float:
 
 
 class Func:
-    def __init__(self, sleep_sec: Optional[float] = None) -> None:
+    def __init__(self, sleep_sec: float | None = None) -> None:
         self.n_calls = 0
         self.sleep_sec = sleep_sec
         self.lock = threading.Lock()
@@ -71,11 +69,11 @@ class Func:
         return value
 
 
-def check_params(params: Dict[str, Any]) -> None:
+def check_params(params: dict[str, Any]) -> None:
     assert sorted(params.keys()) == ["x", "y", "z"]
 
 
-def check_value(value: Optional[float]) -> None:
+def check_value(value: float | None) -> None:
     assert isinstance(value, float)
     assert -1.0 <= value <= 12.0**2 + 5.0**2 + 1.0
 
@@ -731,7 +729,7 @@ def test_enqueue_trial_skips_existing_waiting(storage_mode: str) -> None:
     "new_params", [{"x": -5, "y": 5, "z": 5}, {"x": -5}, {"x": -5, "z": 5}, {"x": -5, "y": 6}]
 )
 def test_enqueue_trial_skip_existing_allows_unfixed(
-    storage_mode: str, new_params: Dict[str, int]
+    storage_mode: str, new_params: dict[str, int]
 ) -> None:
     with StorageSupplier(storage_mode) as storage:
         study = create_study(storage=storage)
@@ -1143,7 +1141,7 @@ def test_optimize_with_multi_objectives(n_objectives: int) -> None:
     directions = ["minimize" for _ in range(n_objectives)]
     study = create_study(directions=directions)
 
-    def objective(trial: Trial) -> List[float]:
+    def objective(trial: Trial) -> list[float]:
         return [trial.suggest_float("v{}".format(i), 0, 5) for i in range(n_objectives)]
 
     study.optimize(objective, n_trials=10)
@@ -1168,7 +1166,7 @@ def test_wrong_n_objectives() -> None:
     directions = ["minimize" for _ in range(n_objectives)]
     study = create_study(directions=directions)
 
-    def objective(trial: Trial) -> List[float]:
+    def objective(trial: Trial) -> list[float]:
         return [trial.suggest_float("v{}".format(i), 0, 5) for i in range(n_objectives + 1)]
 
     study.optimize(objective, n_trials=10)
@@ -1525,7 +1523,7 @@ def test_study_summary_datetime_start_calculation(storage_mode: str) -> None:
         assert summaries[0].datetime_start is not None
 
 
-def _process_tell(study: Study, trial: Union[Trial, int], values: float) -> None:
+def _process_tell(study: Study, trial: Trial | int, values: float) -> None:
     study.tell(trial, values)
 
 


### PR DESCRIPTION
## Motivation
Currently, we only have `get_study_summaries()` to retrieve all study names from storage, and it is performing too slowly for the intended use. This PR introduces `get_study_names()`, specifically designed for faster retrieval of study names compared to `get_study_summaries()`.

## Description of the changes
- Implements `get_study_names()` based on the existing `get_study_summaries()` function.
- Adds tests for `get_study_names()`.
- Updates type annotations in `optuna/study/study.py` and `tests/study_tests/test_study.py`.