### PR TITLE
Support constraints plot_rank

### DIFF
--- a/optuna/visualization/_rank.py
+++ b/optuna/visualization/_rank.py
@@ -294,7 +294,7 @@ def _get_rank_subplot(
         x=info.xs,
         y=info.ys,
         marker={
-            "color": info.colors,
+            "color": list(map(plotly.colors.label_rgb, info.colors)),
             "cmin": 0,
             "cmax": 1,
             "line": {"width": 0.5, "color": "Grey"},

--- a/optuna/visualization/_rank.py
+++ b/optuna/visualization/_rank.py
@@ -82,10 +82,18 @@ def plot_rank(
             def objective(trial):
                 x = trial.suggest_float("x", -100, 100)
                 y = trial.suggest_categorical("y", [-1, 0, 1])
+
+                c0 = 400 - (x + y)**2
+                trial.set_user_attr("constraint", [c0])
+
                 return x ** 2 + y
 
 
-            sampler = optuna.samplers.TPESampler(seed=10)
+            def constraints(trial):
+                return trial.user_attrs["constraint"]
+
+
+            sampler = optuna.samplers.TPESampler(seed=10, constraints_func=constraints)
             study = optuna.create_study(sampler=sampler)
             study.optimize(objective, n_trials=30)
 

--- a/optuna/visualization/_rank.py
+++ b/optuna/visualization/_rank.py
@@ -204,9 +204,7 @@ def _get_rank_subplot_info(
         if constraints is not None and any([x > 0.0 for x in constraints]):
             infeasible_trial_ids.append(i)
 
-    colors[infeasible_trial_ids] = plotly.colors.unconvert_from_RGB_255(
-        (plotly.colors.hex_to_rgb("#cccccc"))
-    )
+    colors[infeasible_trial_ids] = plotly.colors.hex_to_rgb("#cccccc")
 
     filtered_ids = [
         i
@@ -295,8 +293,6 @@ def _get_rank_subplot(
         y=info.ys,
         marker={
             "color": list(map(plotly.colors.label_rgb, info.colors)),
-            "cmin": 0,
-            "cmax": 1,
             "line": {"width": 0.5, "color": "Grey"},
         },
         mode="markers",
@@ -420,11 +416,5 @@ def _convert_color_idxs_to_scaled_rgb_colors(color_idxs: np.ndarray) -> np.ndarr
     colormap = "RdYlBu_r"
     # sample_colorscale requires plotly >= 5.0.0.
     labeled_colors = plotly.colors.sample_colorscale(colormap, color_idxs)
-    scaled_rgb_colors = np.array(
-        [
-            plotly.colors.unconvert_from_RGB_255(plotly.colors.unlabel_rgb(cl))
-            for cl in labeled_colors
-        ]
-    )
-
-    return scaled_rgb_colors.reshape(-1, 3)
+    scaled_rgb_colors = np.array([plotly.colors.unlabel_rgb(cl) for cl in labeled_colors])
+    return scaled_rgb_colors

--- a/optuna/visualization/_rank.py
+++ b/optuna/visualization/_rank.py
@@ -10,6 +10,7 @@ import numpy as np
 
 from optuna._experimental import experimental_func
 from optuna.logging import get_logger
+from optuna.samplers._base import _CONSTRAINTS_KEY
 from optuna.study import Study
 from optuna.trial import FrozenTrial
 from optuna.trial import TrialState
@@ -196,6 +197,16 @@ def _get_rank_subplot_info(
 ) -> _RankSubplotInfo:
     xaxis = _get_axis_info(trials, x_param)
     yaxis = _get_axis_info(trials, y_param)
+
+    infeasible_trial_ids = []
+    for i in range(len(trials)):
+        constraints = trials[i].system_attrs.get(_CONSTRAINTS_KEY)
+        if constraints is not None and any([x > 0.0 for x in constraints]):
+            infeasible_trial_ids.append(i)
+
+    colors[infeasible_trial_ids] = plotly.colors.unconvert_from_RGB_255(
+        (plotly.colors.hex_to_rgb("#cccccc"))
+    )
 
     filtered_ids = [
         i

--- a/optuna/visualization/matplotlib/_rank.py
+++ b/optuna/visualization/matplotlib/_rank.py
@@ -126,7 +126,8 @@ def _get_rank_plot(
 
     tick_info = _get_tick_info(info.zs)
 
-    cbar = fig.colorbar(pc, ax=axs, ticks=tick_info.coloridxs, cmap=plt.get_cmap("RdYlBu_r"))
+    pc.set_cmap(plt.get_cmap("RdYlBu_r"))
+    cbar = fig.colorbar(pc, ax=axs, ticks=tick_info.coloridxs)
     cbar.ax.set_yticklabels(tick_info.text)
     cbar.outline.set_edgecolor("gray")
     return axs

--- a/optuna/visualization/matplotlib/_rank.py
+++ b/optuna/visualization/matplotlib/_rank.py
@@ -54,10 +54,18 @@ def plot_rank(
             def objective(trial):
                 x = trial.suggest_float("x", -100, 100)
                 y = trial.suggest_categorical("y", [-1, 0, 1])
+
+                c0 = 400 - (x + y)**2
+                trial.set_user_attr("constraint", [c0])
+
                 return x ** 2 + y
 
 
-            sampler = optuna.samplers.TPESampler(seed=10)
+            def constraints(trial):
+                return trial.user_attrs["constraint"]
+
+
+            sampler = optuna.samplers.TPESampler(seed=10, constraints_func=constraints)
             study = optuna.create_study(sampler=sampler)
             study.optimize(objective, n_trials=30)
 

--- a/optuna/visualization/matplotlib/_rank.py
+++ b/optuna/visualization/matplotlib/_rank.py
@@ -152,4 +152,4 @@ def _add_rank_subplot(
     if info.yaxis.is_log:
         ax.set_yscale("log")
 
-    return ax.scatter(x=info.xs, y=info.ys, c=info.colors, edgecolors="grey")
+    return ax.scatter(x=info.xs, y=info.ys, c=info.colors / 255, edgecolors="grey")

--- a/optuna/visualization/matplotlib/_rank.py
+++ b/optuna/visualization/matplotlib/_rank.py
@@ -151,6 +151,4 @@ def _add_rank_subplot(
     if info.yaxis.is_log:
         ax.set_yscale("log")
 
-    return ax.scatter(
-        x=info.xs, y=info.ys, c=info.color_idxs, cmap=plt.get_cmap("RdYlBu_r"), edgecolors="grey"
-    )
+    return ax.scatter(x=info.xs, y=info.ys, c=info.colors, edgecolors="grey")

--- a/tests/visualization_tests/test_rank.py
+++ b/tests/visualization_tests/test_rank.py
@@ -133,8 +133,6 @@ def _named_tuple_equal(t1: Any, t2: Any) -> bool:
             return False
         for x, y in zip(t1, t2):
             if not _named_tuple_equal(x, y):
-                print(t1)
-                print(t2)
                 return False
         return True
     else:

--- a/tests/visualization_tests/test_rank.py
+++ b/tests/visualization_tests/test_rank.py
@@ -696,8 +696,8 @@ def test_get_order_with_same_order_averaging() -> None:
 def test_convert_color_idxs_to_scaled_rgb_colors() -> None:
     x1 = np.array([0.1, 0.2])
     result1 = _convert_color_idxs_to_scaled_rgb_colors(x1)
-    assert result1.shape == (2, 3)
+    np.testing.assert_array_equal(result1, [[69, 117, 180], [116, 173, 209]])
 
     x2 = np.array([])
     result2 = _convert_color_idxs_to_scaled_rgb_colors(x2)
-    assert result2.shape == (0,)
+    np.testing.assert_array_equal(result2, [])

--- a/tests/visualization_tests/test_rank.py
+++ b/tests/visualization_tests/test_rank.py
@@ -133,6 +133,8 @@ def _named_tuple_equal(t1: Any, t2: Any) -> bool:
             return False
         for x, y in zip(t1, t2):
             if not _named_tuple_equal(x, y):
+                print(t1)
+                print(t2)
                 return False
         return True
     else:
@@ -355,7 +357,9 @@ def test_generate_rank_plot_for_no_plots(params: list[str]) -> None:
                         ys=[],
                         trials=[],
                         zs=np.array([]),
-                        colors=_convert_color_idxs_to_scaled_rgb_colors(np.array([])),
+                        colors=_convert_color_idxs_to_scaled_rgb_colors(np.array([])).reshape(
+                            -1, 3
+                        ),
                     )
                 ]
             ],
@@ -657,7 +661,7 @@ def test_generate_rank_info_with_constraints() -> None:
     study = _create_study_with_constraints()
     info = _get_rank_info(study, params=None, target=None, target_name="Objective Value")
     expected_color = _convert_color_idxs_to_scaled_rgb_colors(np.array([0.0, 1.0]))
-    expected_color[1] = [0.8, 0.8, 0.8]
+    expected_color[1] = [204, 204, 204]
 
     assert _named_tuple_equal(
         info,
@@ -696,4 +700,4 @@ def test_convert_color_idxs_to_scaled_rgb_colors() -> None:
 
     x2 = np.array([])
     result2 = _convert_color_idxs_to_scaled_rgb_colors(x2)
-    assert result2.shape == (0, 3)
+    assert result2.shape == (0,)

--- a/tests/visualization_tests/test_rank.py
+++ b/tests/visualization_tests/test_rank.py
@@ -19,6 +19,7 @@ from optuna.trial import create_trial
 from optuna.visualization import plot_rank as plotly_plot_rank
 from optuna.visualization._plotly_imports import go
 from optuna.visualization._rank import _AxisInfo
+from optuna.visualization._rank import _convert_color_idxs_to_scaled_rgb_colors
 from optuna.visualization._rank import _get_order_with_same_order_averaging
 from optuna.visualization._rank import _get_rank_info
 from optuna.visualization._rank import _RankPlotInfo
@@ -226,13 +227,13 @@ def test_get_rank_info_2_params() -> None:
                         ys=[2.0, 1.0],
                         trials=[study.trials[0], study.trials[2]],
                         zs=np.array([0.0, 1.0]),
-                        color_idxs=np.array([0.0, 0.5]),
+                        colors=_convert_color_idxs_to_scaled_rgb_colors(np.array([0.0, 0.5])),
                     )
                 ]
             ],
             target_name="Objective Value",
             zs=np.array([0.0, 2.0, 1.0]),
-            color_idxs=np.array([0.0, 1.0, 0.5]),
+            colors=_convert_color_idxs_to_scaled_rgb_colors(np.array([0.0, 1.0, 0.5])),
             has_custom_target=False,
         ),
     )
@@ -326,13 +327,13 @@ def test_generate_rank_plot_for_no_plots(params: list[str]) -> None:
                         ys=[],
                         trials=[],
                         zs=np.array([]),
-                        color_idxs=np.array([]),
+                        colors=_convert_color_idxs_to_scaled_rgb_colors(np.array([])),
                     )
                 ]
             ],
             target_name="Objective Value",
             zs=np.array([0.0, 2.0]),
-            color_idxs=np.array([0.0, 1.0]),
+            colors=_convert_color_idxs_to_scaled_rgb_colors(np.array([0.0, 1.0])),
             has_custom_target=False,
         ),
     )
@@ -393,13 +394,13 @@ def test_generate_rank_plot_for_few_observations(params: list[str]) -> None:
                         ys=[study.get_trials()[0].params[params[1]]],
                         trials=[study.get_trials()[0]],
                         zs=np.array([0.0]),
-                        color_idxs=np.array([0.0]),
+                        colors=_convert_color_idxs_to_scaled_rgb_colors(np.array([0.0])),
                     )
                 ]
             ],
             target_name="Objective Value",
             zs=np.array([0.0, 2.0]),
-            color_idxs=np.array([0.0, 1.0]),
+            colors=_convert_color_idxs_to_scaled_rgb_colors(np.array([0.0, 1.0])),
             has_custom_target=False,
         ),
     )
@@ -432,13 +433,13 @@ def test_get_rank_info_log_scale_and_str_category_2_params() -> None:
                         ys=["101", "100"],
                         trials=[study.trials[0], study.trials[1]],
                         zs=np.array([0.0, 1.0]),
-                        color_idxs=np.array([0.0, 1.0]),
+                        colors=_convert_color_idxs_to_scaled_rgb_colors(np.array([0.0, 1.0])),
                     )
                 ]
             ],
             target_name="Objective Value",
             zs=np.array([0.0, 1.0]),
-            color_idxs=np.array([0.0, 1.0]),
+            colors=_convert_color_idxs_to_scaled_rgb_colors(np.array([0.0, 1.0])),
             has_custom_target=False,
         ),
     )
@@ -461,7 +462,7 @@ def test_get_rank_info_log_scale_and_str_category_more_than_2_params() -> None:
 
     param_values = {"param_a": [1e-6, 1e-5], "param_b": ["101", "100"], "param_c": ["one", "two"]}
     zs = np.array([0.0, 1.0])
-    color_idxs = np.array([0.0, 1.0])
+    colors = _convert_color_idxs_to_scaled_rgb_colors(np.array([0.0, 1.0]))
 
     def _check_axis(axis: _AxisInfo, name: str) -> None:
         assert axis.name == name
@@ -481,11 +482,11 @@ def test_get_rank_info_log_scale_and_str_category_more_than_2_params() -> None:
             assert info.sub_plot_infos[yi][xi].ys == param_values[y_param]
             assert info.sub_plot_infos[yi][xi].trials == study.trials
             assert np.all(info.sub_plot_infos[yi][xi].zs == zs)
-            assert np.all(info.sub_plot_infos[yi][xi].color_idxs == color_idxs)
+            assert np.all(info.sub_plot_infos[yi][xi].colors == colors)
 
     info.target_name == "Objective Value"
     assert np.all(info.zs == zs)
-    assert np.all(info.color_idxs == color_idxs)
+    assert np.all(info.colors == colors)
     assert not info.has_custom_target
 
 
@@ -515,13 +516,13 @@ def test_get_rank_info_mixture_category_types() -> None:
                         ys=[101, 102.0],
                         trials=study.trials,
                         zs=np.array([0.0, 0.5]),
-                        color_idxs=np.array([0.0, 1.0]),
+                        colors=_convert_color_idxs_to_scaled_rgb_colors(np.array([0.0, 1.0])),
                     )
                 ]
             ],
             target_name="Objective Value",
             zs=np.array([0.0, 0.5]),
-            color_idxs=np.array([0.0, 1.0]),
+            colors=_convert_color_idxs_to_scaled_rgb_colors(np.array([0.0, 1.0])),
             has_custom_target=False,
         ),
     )
@@ -534,7 +535,11 @@ def test_get_rank_info_nonfinite(value: float) -> None:
         study, params=["param_b", "param_d"], target=None, target_name="Objective Value"
     )
 
-    color_idxs = np.array([0.0, 1.0, 0.5]) if value == float("-inf") else np.array([1.0, 0.5, 0.0])
+    colors = (
+        _convert_color_idxs_to_scaled_rgb_colors(np.array([0.0, 1.0, 0.5]))
+        if value == float("-inf")
+        else _convert_color_idxs_to_scaled_rgb_colors(np.array([1.0, 0.5, 0.0]))
+    )
     assert _named_tuple_equal(
         info,
         _RankPlotInfo(
@@ -558,13 +563,13 @@ def test_get_rank_info_nonfinite(value: float) -> None:
                         ys=[4.0, 4.0, 2.0],
                         trials=study.trials,
                         zs=np.array([value, 2.0, 1.0]),
-                        color_idxs=color_idxs,
+                        colors=colors,
                     )
                 ]
             ],
             target_name="Objective Value",
             zs=np.array([value, 2.0, 1.0]),
-            color_idxs=color_idxs,
+            colors=colors,
             has_custom_target=False,
         ),
     )
@@ -580,7 +585,11 @@ def test_get_rank_info_nonfinite_multiobjective(objective: int, value: float) ->
         target=lambda t: t.values[objective],
         target_name="Target Name",
     )
-    color_idxs = np.array([0.0, 1.0, 0.5]) if value == float("-inf") else np.array([1.0, 0.5, 0.0])
+    colors = (
+        _convert_color_idxs_to_scaled_rgb_colors(np.array([0.0, 1.0, 0.5]))
+        if value == float("-inf")
+        else _convert_color_idxs_to_scaled_rgb_colors(np.array([1.0, 0.5, 0.0]))
+    )
     assert _named_tuple_equal(
         info,
         _RankPlotInfo(
@@ -604,13 +613,13 @@ def test_get_rank_info_nonfinite_multiobjective(objective: int, value: float) ->
                         ys=[4.0, 4.0, 2.0],
                         trials=study.trials,
                         zs=np.array([value, 2.0, 1.0]),
-                        color_idxs=color_idxs,
+                        colors=colors,
                     )
                 ]
             ],
             target_name="Target Name",
             zs=np.array([value, 2.0, 1.0]),
-            color_idxs=color_idxs,
+            colors=colors,
             has_custom_target=True,
         ),
     )
@@ -619,3 +628,13 @@ def test_get_rank_info_nonfinite_multiobjective(objective: int, value: float) ->
 def test_get_order_with_same_order_averaging() -> None:
     x = np.array([6.0, 2.0, 3.0, 1.0, 4.5, 4.5, 8.0, 8.0, 0.0, 8.0])
     assert np.all(x == _get_order_with_same_order_averaging(x))
+
+
+def test_convert_color_idxs_to_scaled_rgb_colors() -> None:
+    x1 = np.array([0.1, 0.2])
+    result1 = _convert_color_idxs_to_scaled_rgb_colors(x1)
+    assert result1.shape == (2, 3)
+
+    x2 = np.array([])
+    result2 = _convert_color_idxs_to_scaled_rgb_colors(x2)
+    assert result2.shape == (0, 3)


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

#4832 

Supports `plot_rank` visualization for Infeasible trials to be displayed in `#CCCCCC` color.

## Description of the changes
<!-- Describe the changes in this PR. -->

- [f10a978](https://github.com/optuna/optuna/pull/4899/commits/f10a97875735d99a9d905497b701888608fc6c54): refactor to pass each color as rgb(numpy array with 0 ~ 1).
- [07092ba](https://github.com/optuna/optuna/pull/4899/commits/07092ba7c24619081c426e67e4310d5173d99c74): infeasible trials visualization support.
