### PR TITLE
Fix speed-benchmarks CI

### DIFF
--- a/asv.conf.json
+++ b/asv.conf.json
@@ -29,7 +29,8 @@
     // ],
     "build_command": [
         "python -m pip install build wheel",
-        "python -m build --wheel -o {build_cache_dir} {build_dir}"
+        "python -m build --wheel -o {build_cache_dir} {build_dir}",
+        "python -m pip install .[optional,test]"
     ],
 
     // List of branches to benchmark. If not provided, defaults to "master"
@@ -75,10 +76,8 @@
     // pip (with all the conda available packages installed first,
     // followed by the pip installed packages).
     //
-    "matrix": {
-        "pip+fakeredis": [""],
-        "pip+pytest": [""],
-    },
+    // "matrix": {
+    // },
 
     // Combinations of libraries/python versions can be excluded/included
     // from the set to test. Each entry is a dictionary containing additional


### PR DESCRIPTION
## Motivation
Fix CI fail due to `cmaes` becoming optional. ref: https://github.com/optuna/optuna/pull/4901
I checked the CI in my fork repository. https://github.com/not522/optuna/actions/runs/6116773398

## Description of the changes
Install `optional` and `test` in `build_command`.
