### PR TITLE
Fix Tests (MPI) CI

### DIFF
--- a/.github/workflows/tests-mpi.yml
+++ b/.github/workflows/tests-mpi.yml
@@ -56,6 +56,10 @@ jobs:
 
         pip install --progress-bar off .[test]
         pip install --progress-bar off .[optional]
+
+        # TODO(not522): Remove this line when torchmetrics can be installed with extra-index-url
+        pip install --progress-bar off torchmetrics
+
         pip install --progress-bar off .[integration] --extra-index-url https://download.pytorch.org/whl/cpu
 
     - name: Output installed packages


### PR DESCRIPTION
## Motivation
CI fails because `torchmetrics` cannot be installed from `https://download.pytorch.org/whl/cpu`.

## Description of the changes
Install `torchmetrics` from PyPI before other integration libraries.