### PR TITLE
Support Study Artifacts

### DIFF
--- a/optuna/artifacts/_upload.py
+++ b/optuna/artifacts/_upload.py
@@ -10,8 +10,9 @@ import uuid
 from optuna._experimental import experimental_func
 from optuna.artifacts._protocol import ArtifactStore
 from optuna.storages import BaseStorage
-from optuna.trial._frozen import FrozenTrial
-from optuna.trial._trial import Trial
+from optuna.study import Study
+from optuna.trial import FrozenTrial
+from optuna.trial import Trial
 
 
 ARTIFACTS_ATTR_PREFIX = "artifacts:"
@@ -28,7 +29,7 @@ class ArtifactMeta:
 
 @experimental_func("3.3.0")
 def upload_artifact(
-    trial: Trial | FrozenTrial,
+    study_or_trial: Trial | FrozenTrial | Study,
     file_path: str,
     artifact_store: ArtifactStore,
     *,
@@ -37,8 +38,9 @@ def upload_artifact(
     """Upload an artifact to the artifact store.
 
     Args:
-        trial:
-            A :class:`~optuna.trial.Trial` object, or a :class:`~optuna.trial.FrozenTrial` object.
+        study_or_trial:
+            A :class:`~optuna.trial.Trial` object, a :class:`~optuna.trial.FrozenTrial`, or
+            a :class:`~optuna.study.Study` object.
         file_path:
             A path to the file to be uploaded.
         artifact_store:
@@ -53,17 +55,16 @@ def upload_artifact(
 
     filename = os.path.basename(file_path)
 
-    if isinstance(trial, Trial) and storage is None:
-        storage = trial.storage
+    if isinstance(study_or_trial, Trial) and storage is None:
+        storage = study_or_trial.storage
+    elif isinstance(study_or_trial, Study) and storage is None:
+        storage = study_or_trial._storage
 
     if storage is None:
         raise ValueError("storage is required for FrozenTrial.")
 
-    trial_id = trial._trial_id
     artifact_id = str(uuid.uuid4())
-
     guess_mimetype, guess_encoding = mimetypes.guess_type(filename)
-
     artifact = ArtifactMeta(
         artifact_id=artifact_id,
         filename=filename,
@@ -71,7 +72,12 @@ def upload_artifact(
         encoding=guess_encoding,
     )
     attr_key = ARTIFACTS_ATTR_PREFIX + artifact_id
-    storage.set_trial_system_attr(trial_id, attr_key, json.dumps(asdict(artifact)))
+    if isinstance(study_or_trial, (Trial, FrozenTrial)):
+        trial_id = study_or_trial._trial_id
+        storage.set_trial_system_attr(trial_id, attr_key, json.dumps(asdict(artifact)))
+    else:
+        study_id = study_or_trial._study_id
+        storage.set_study_system_attr(study_id, attr_key, json.dumps(asdict(artifact)))
 
     with open(file_path, "rb") as f:
         artifact_store.write(artifact_id, f)

--- a/tests/artifacts_tests/test_upload_artifact.py
+++ b/tests/artifacts_tests/test_upload_artifact.py
@@ -19,13 +19,14 @@ def artifact_store(tmp_path: pathlib.PurePath, request: pytest.FixtureRequest) -
     assert False, f"Unknown artifact store: {request.param}"
 
 
-def test_upload_artifact(tmp_path: pathlib.PurePath, artifact_store: ArtifactStore) -> None:
+def test_upload_trial_artifact(tmp_path: pathlib.PurePath, artifact_store: ArtifactStore) -> None:
     file_path = str(tmp_path / "dummy.txt")
 
     with open(file_path, "w") as f:
         f.write("foo")
 
-    study = optuna.create_study()
+    storage = optuna.storages.InMemoryStorage()
+    study = optuna.create_study(storage=storage)
 
     trial = study.ask()
 
@@ -38,7 +39,7 @@ def test_upload_artifact(tmp_path: pathlib.PurePath, artifact_store: ArtifactSto
 
     upload_artifact(frozen_trial, file_path, artifact_store, storage=trial.study._storage)
 
-    system_attrs = trial.study._storage.get_trial(frozen_trial._trial_id).system_attrs
+    system_attrs = storage.get_trial_system_attrs(frozen_trial._trial_id)
     artifact_items = [
         ArtifactMeta(**json.loads(val))
         for key, val in system_attrs.items()
@@ -47,6 +48,30 @@ def test_upload_artifact(tmp_path: pathlib.PurePath, artifact_store: ArtifactSto
 
     assert len(artifact_items) == 2
     assert artifact_items[0].artifact_id != artifact_items[1].artifact_id
+    assert artifact_items[0].filename == "dummy.txt"
+    assert artifact_items[0].mimetype == "text/plain"
+    assert artifact_items[0].encoding is None
+
+
+def test_upload_study_artifact(tmp_path: pathlib.PurePath, artifact_store: ArtifactStore) -> None:
+    file_path = str(tmp_path / "dummy.txt")
+
+    with open(file_path, "w") as f:
+        f.write("foo")
+
+    storage = optuna.storages.InMemoryStorage()
+    study = optuna.create_study(storage=storage)
+    artifact_id = upload_artifact(study, file_path, artifact_store)
+
+    system_attrs = storage.get_study_system_attrs(study._study_id)
+    artifact_items = [
+        ArtifactMeta(**json.loads(val))
+        for key, val in system_attrs.items()
+        if key.startswith("artifacts:")
+    ]
+
+    assert len(artifact_items) == 1
+    assert artifact_items[0].artifact_id == artifact_id
     assert artifact_items[0].filename == "dummy.txt"
     assert artifact_items[0].mimetype == "text/plain"
     assert artifact_items[0].encoding is None


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
Currently, artifacts (output files) can only be associated with trials. This PR also allows users to upload an artifact, which is associated with studies.

## Description of the changes
<!-- Describe the changes in this PR. -->
Change `upload_artifact()` function to accept `optuna.Study` as well as trial objects. There is a minor breaking change that the code `upload_artifact(trial=trial, ...)` will be broken. However we discussed it internally and reached the consensus to accept it since this feature is still experimental and has not been promoted at Optuna 3.3 release.
