### PR TITLE
Add mimetype input

### DIFF
--- a/optuna/artifacts/_upload.py
+++ b/optuna/artifacts/_upload.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 import json
 import mimetypes
 import os
+from typing import Optional
 import uuid
 
 from optuna._experimental import experimental_func
@@ -33,6 +34,8 @@ def upload_artifact(
     artifact_store: ArtifactStore,
     *,
     storage: BaseStorage | None = None,
+    mimetype: Optional[str] = None,
+    encoding: Optional[str] = None,
 ) -> str:
     """Upload an artifact to the artifact store.
 
@@ -67,8 +70,8 @@ def upload_artifact(
     artifact = ArtifactMeta(
         artifact_id=artifact_id,
         filename=filename,
-        mimetype=guess_mimetype or DEFAULT_MIME_TYPE,
-        encoding=guess_encoding,
+        mimetype=mimetype or guess_mimetype or DEFAULT_MIME_TYPE,
+        encoding=encoding or guess_encoding,
     )
     attr_key = ARTIFACTS_ATTR_PREFIX + artifact_id
     storage.set_trial_system_attr(trial_id, attr_key, json.dumps(asdict(artifact)))

--- a/optuna/artifacts/_upload.py
+++ b/optuna/artifacts/_upload.py
@@ -55,8 +55,8 @@ def upload_artifact(
             A MIME type of the artifact. If not specified, the MIME type is guessed from the file
             extension.
         encoding:
-            An encoding of the artifact. If not specified, the encoding is guessed from the file
-            extension.
+            An encoding of the artifact, which is suitable for use as a ``Content-Encoding``
+            header (e.g. gzip). If not specified, the encoding is guessed from the file extension.
 
     Returns:
         An artifact ID.

--- a/optuna/artifacts/_upload.py
+++ b/optuna/artifacts/_upload.py
@@ -49,6 +49,12 @@ def upload_artifact(
         storage:
             A storage object. If trial is not a :class:`~optuna.trial.Trial` object, this argument
             is required.
+        mimetype:
+            A MIME type of the artifact. If not specified, the MIME type is guessed from the file
+            extension.
+        encoding:
+            An encoding of the artifact. If not specified, the encoding is guessed from the file
+            extension.
 
     Returns:
         An artifact ID.

--- a/optuna/artifacts/_upload.py
+++ b/optuna/artifacts/_upload.py
@@ -5,7 +5,6 @@ from dataclasses import dataclass
 import json
 import mimetypes
 import os
-from typing import Optional
 import uuid
 
 from optuna._experimental import experimental_func
@@ -35,8 +34,8 @@ def upload_artifact(
     artifact_store: ArtifactStore,
     *,
     storage: BaseStorage | None = None,
-    mimetype: Optional[str] = None,
-    encoding: Optional[str] = None,
+    mimetype: str | None = None,
+    encoding: str | None = None,
 ) -> str:
     """Upload an artifact to the artifact store.
 

--- a/tests/artifacts_tests/test_upload_artifact.py
+++ b/tests/artifacts_tests/test_upload_artifact.py
@@ -50,3 +50,38 @@ def test_upload_artifact(tmp_path: pathlib.PurePath, artifact_store: ArtifactSto
     assert artifact_items[0].filename == "dummy.txt"
     assert artifact_items[0].mimetype == "text/plain"
     assert artifact_items[0].encoding is None
+
+
+def test_upload_artifact_with_mimetype(
+    tmp_path: pathlib.PurePath, artifact_store: ArtifactStore
+) -> None:
+    file_path = str(tmp_path / "dummy.obj")
+
+    with open(file_path, "w") as f:
+        f.write("foo")
+
+    study = optuna.create_study()
+
+    trial = study.ask()
+
+    upload_artifact(trial, file_path, artifact_store, mimetype="model/obj", encoding="utf-8")
+
+    frozen_trial = study._storage.get_trial(trial._trial_id)
+
+    with pytest.raises(ValueError):
+        upload_artifact(frozen_trial, file_path, artifact_store)
+
+    upload_artifact(frozen_trial, file_path, artifact_store, storage=trial.study._storage)
+
+    system_attrs = trial.study._storage.get_trial(frozen_trial._trial_id).system_attrs
+    artifact_items = [
+        ArtifactMeta(**json.loads(val))
+        for key, val in system_attrs.items()
+        if key.startswith("artifacts:")
+    ]
+
+    assert len(artifact_items) == 2
+    assert artifact_items[0].artifact_id != artifact_items[1].artifact_id
+    assert artifact_items[0].filename == "dummy.obj"
+    assert artifact_items[0].mimetype == "model/obj"
+    assert artifact_items[0].encoding == "utf-8"


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

Support for displaying 3d models in https://github.com/optuna/optuna-dashboard/pull/552
I am considering increasing the number of supported 3D file types.

Added an option to specify directly the mimetype of the 3d model file, since it is not always expected to be appropriate using the guess function.

For example, ".obj" file, which is one of the extensions of a 3D model, will be `application/x-tgif` in one environment, but `model/obj` in another environment.

This is because the function mimetypes.guess_type gets mimetype information from OS-dependent files. (I suspect this is due to the use of [knownfiles](https://github.com/python/cpython/blob/63a7f7765c6e9c1c9b93b7692e828ecf7bbd3bb9/Lib/mimetypes.py#L48) .)

## Description of the changes
<!-- Describe the changes in this PR. -->

The implementation was made the same as the [optuna dashboard implementation](https://github.com/optuna/optuna-dashboard/blob/941f926abdcff1fa7f9377cb8ce07937161f998f/optuna_dashboard/artifact/_backend.py#L142).