### PR TITLE
Call internal sampler's `before_trial`

### DIFF
--- a/optuna/integration/botorch.py
+++ b/optuna/integration/botorch.py
@@ -883,6 +883,9 @@ class BoTorchSampler(BaseSampler):
         if self._seed is not None:
             self._seed = numpy.random.RandomState().randint(numpy.iinfo(numpy.int32).max)
 
+    def before_trial(self, study: Study, trial: FrozenTrial) -> None:
+        self._independent_sampler.before_trial(study, trial)
+
     def after_trial(
         self,
         study: Study,

--- a/optuna/integration/cma.py
+++ b/optuna/integration/cma.py
@@ -291,6 +291,9 @@ class PyCmaSampler(BaseSampler):
             )
         )
 
+    def before_trial(self, study: Study, trial: FrozenTrial) -> None:
+        self._independent_sampler.before_trial(study, trial)
+
     def after_trial(
         self,
         study: Study,

--- a/optuna/samplers/_cmaes.py
+++ b/optuna/samplers/_cmaes.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import copy
 import math
 import pickle
@@ -778,6 +780,9 @@ class CmaEsSampler(BaseSampler):
     ) -> List[FrozenTrial]:
         generation_attr_key = self._attr_keys.generation(n_restarts)
         return [t for t in trials if generation == t.system_attrs.get(generation_attr_key, -1)]
+
+    def before_trial(self, study: optuna.Study, trial: FrozenTrial) -> None:
+        self._independent_sampler.before_trial(study, trial)
 
     def after_trial(
         self,

--- a/optuna/samplers/_nsgaiii.py
+++ b/optuna/samplers/_nsgaiii.py
@@ -315,6 +315,9 @@ class NSGAIIISampler(BaseSampler):
                 break
         return elite_population
 
+    def before_trial(self, study: Study, trial: FrozenTrial) -> None:
+        self._random_sampler.before_trial(study, trial)
+
     def after_trial(
         self,
         study: Study,

--- a/optuna/samplers/_partial_fixed.py
+++ b/optuna/samplers/_partial_fixed.py
@@ -106,6 +106,9 @@ class PartialFixedSampler(BaseSampler):
                 )
             return param_value
 
+    def before_trial(self, study: Study, trial: FrozenTrial) -> None:
+        self._base_sampler.before_trial(study, trial)
+
     def after_trial(
         self,
         study: Study,

--- a/optuna/samplers/_qmc.py
+++ b/optuna/samplers/_qmc.py
@@ -249,6 +249,9 @@ class QMCSampler(BaseSampler):
         sample = trans.bounds[:, 0] + sample * (trans.bounds[:, 1] - trans.bounds[:, 0])
         return trans.untransform(sample[0, :])
 
+    def before_trial(self, study: Study, trial: FrozenTrial) -> None:
+        self._independent_sampler.before_trial(study, trial)
+
     def after_trial(
         self,
         study: "optuna.Study",

--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -528,6 +528,9 @@ class TPESampler(BaseSampler):
             "weights": default_weights,
         }
 
+    def before_trial(self, study: Study, trial: FrozenTrial) -> None:
+        self._random_sampler.before_trial(study, trial)
+
     def after_trial(
         self,
         study: Study,

--- a/optuna/samplers/nsgaii/_sampler.py
+++ b/optuna/samplers/nsgaii/_sampler.py
@@ -355,6 +355,9 @@ class NSGAIISampler(BaseSampler):
 
         return parent_generation, parent_population
 
+    def before_trial(self, study: Study, trial: FrozenTrial) -> None:
+        self._random_sampler.before_trial(study, trial)
+
     def after_trial(
         self,
         study: Study,


### PR DESCRIPTION
## Motivation
Follow up #4825.
When the `before_trial` of the internal sampler is changed, this PR ensures that it is reflected correctly.

## Description of the changes
Call internal sampler's `before_trial`.
