### PR TITLE
Refactor _grid.py

### DIFF
--- a/optuna/samplers/_grid.py
+++ b/optuna/samplers/_grid.py
@@ -129,13 +129,13 @@ class GridSampler(BaseSampler):
         if "grid_id" in trial.system_attrs or "fixed_params" in trial.system_attrs:
             return
 
-        if 0 <= trial._trial_id and trial._trial_id < self._n_min_trials:
+        if 0 <= trial.number and trial.number < self._n_min_trials:
             study._storage.set_trial_system_attr(
                 trial._trial_id, "search_space", self._search_space
             )
 
-            # Here we assume that _trial_id is unique even in a parallel distributed environment.
-            study._storage.set_trial_system_attr(trial._trial_id, "grid_id", trial._trial_id)
+            # Here we assume that trial.number is unique even in an arbitrary environment.
+            study._storage.set_trial_system_attr(trial._trial_id, "grid_id", trial.number)
             return
 
         target_grids = self._get_unvisited_grid_ids(study)

--- a/optuna/samplers/_grid.py
+++ b/optuna/samplers/_grid.py
@@ -133,8 +133,6 @@ class GridSampler(BaseSampler):
             study._storage.set_trial_system_attr(
                 trial._trial_id, "search_space", self._search_space
             )
-
-            # Here we assume that trial.number is unique even in an arbitrary environment.
             study._storage.set_trial_system_attr(trial._trial_id, "grid_id", trial.number)
             return
 


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

I want to refactor and speed-up the grid-sampler.

## Description of the changes
<!-- Describe the changes in this PR. -->

- I utilized `before_trial`. Codes in `infer_relative_search_space` were moved into `before_trial`.
- For the first N trials, the pre-shuffled `_all_grids` were to be executed in order, based on ~`_trial_id`~`trial.number`.
  - This change reduces the number of calls of `_get_unvisited_grid_ids` function, which is heavy and tends to output the same parameters multiple times.
  - This change may resolve or mitigate https://github.com/optuna/optuna/issues/4627 .
