### PR TITLE
allow XGBoostPruningCallback for xgboost >= 2.0.0

### DIFF
--- a/optuna/integration/xgboost.py
+++ b/optuna/integration/xgboost.py
@@ -11,7 +11,7 @@ with optuna._imports.try_import() as _imports:
     xgboost_version = xgb.__version__.split(".")
     xgboost_major_version = int(xgboost_version[0])
     xgboost_minor_version = int(xgboost_version[1])
-    use_callback_cls = xgboost_major_version >= 1 and xgboost_minor_version >= 3
+    use_callback_cls = (xgboost_major_version >= 1 and xgboost_minor_version >= 3) or xgboost_major_version >= 2
 
 _doc = """Callback for XGBoost to prune unpromising trials.
 


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation

When I tried to use `XGBoostPruningCallback` in the following example
```
        pruning_callback = optuna.integration.XGBoostPruningCallback(
            trial, f"validation-{self.eval_metric}")
        boost = xgboost.train(self.params, dtrain,
                              num_boost_round=num_boost_round,
                              early_stopping_rounds=50, verbose_eval=False,
                              evals=[(dvalid, 'validation')],
                              callbacks=[pruning_callback])
```
I got the following error with xgboost 2.0.0
```
raise TypeError("callback must be an instance of `TrainingCallback`.")
```
I think this is due to not having a check on if xgboost's major version is greater than or equal to 2. 
## Description of the changes
Consider the import to xgboost successful when major version of xgboost >= 2
