### PR TITLE
Mention a pruner instance is not stored in a storage in resuming tutorial

### DIFF
--- a/tutorial/20_recipes/001_rdb.py
+++ b/tutorial/20_recipes/001_rdb.py
@@ -55,7 +55,8 @@ study = optuna.create_study(study_name=study_name, storage=storage_name, load_if
 study.optimize(objective, n_trials=3)
 
 ###################################################################################################
-# Note that the storage doesn't store the state of the instance of :mod:`~optuna.samplers`.
+# Note that the storage doesn't store the state of the instance of :mod:`~optuna.samplers`
+# and :mod:`~optuna.pruners`.
 # When we resume a study with a sampler whose ``seed`` argument is specified for
 # reproducibility, you need to restore the sampler with using ``pickle`` as follows::
 #


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

The current tutorial only mentions a sampler instance is not stored in the storage. In my understanding, a pruner instance has the same situation. It would be nice to clarify this in the tutorial. 

A user actually confused this behaviour as mentioned in https://github.com/optuna/optuna/discussions/4883.

## Description of the changes
<!-- Describe the changes in this PR. -->

Add a few words to mention pruner instance is not saved in the storage.
