### PR TITLE
Add `metric_names` getter to study

### DIFF
--- a/optuna/study/_dataframe.py
+++ b/optuna/study/_dataframe.py
@@ -58,7 +58,7 @@ def _create_records_and_aggregate_column(
                 iterator = (
                     enumerate(trial_values)
                     if study.metric_names is None
-                    else zip(study.metric_names, trial_values)
+                    else zip(study.metric_names, trial_values)  # type: ignore
                 )
                 for nested_attr, nested_value in iterator:
                     record[(df_column, nested_attr)] = nested_value
@@ -69,7 +69,9 @@ def _create_records_and_aggregate_column(
                     column_agg[attr].add((df_column, nested_attr))
             elif attr == "value":
                 nested_attr = (
-                    non_nested_attr if study.metric_names is None else study.metric_names[0]
+                    non_nested_attr
+                    if study.metric_names is None
+                    else study.metric_names[0]  # type: ignore
                 )
                 record[(df_column, nested_attr)] = value
                 column_agg[attr].add((df_column, nested_attr))

--- a/optuna/study/_dataframe.py
+++ b/optuna/study/_dataframe.py
@@ -8,7 +8,6 @@ from typing import Tuple
 
 import optuna
 from optuna._imports import try_import
-from optuna.study.study import _SYSTEM_ATTR_METRIC_NAMES
 from optuna.trial._state import TrialState
 
 
@@ -41,10 +40,6 @@ def _create_records_and_aggregate_column(
     column_agg: DefaultDict[str, Set] = collections.defaultdict(set)
     non_nested_attr = ""
 
-    metric_names = study._storage.get_study_system_attrs(study._study_id).get(
-        _SYSTEM_ATTR_METRIC_NAMES
-    )
-
     records = []
     for trial in study.get_trials(deepcopy=False):
         record = {}
@@ -62,8 +57,8 @@ def _create_records_and_aggregate_column(
                 trial_values = [None] * len(study.directions) if value is None else value
                 iterator = (
                     enumerate(trial_values)
-                    if metric_names is None
-                    else zip(metric_names, trial_values)
+                    if study.metric_names is None
+                    else zip(study.metric_names, trial_values)
                 )
                 for nested_attr, nested_value in iterator:
                     record[(df_column, nested_attr)] = nested_value
@@ -73,7 +68,9 @@ def _create_records_and_aggregate_column(
                     record[(df_column, nested_attr)] = nested_value
                     column_agg[attr].add((df_column, nested_attr))
             elif attr == "value":
-                nested_attr = non_nested_attr if metric_names is None else metric_names[0]
+                nested_attr = (
+                    non_nested_attr if study.metric_names is None else study.metric_names[0]
+                )
                 record[(df_column, nested_attr)] = value
                 column_agg[attr].add((df_column, nested_attr))
             else:

--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -223,7 +223,7 @@ class Study:
         return self.get_trials(deepcopy=True, states=None)
 
     @property
-    @lru_cache  # TODO(xadrianzetx): Switch to @cached_property after Python 3.7 is dropped.
+    @lru_cache()  # TODO(xadrianzetx): Switch to @cached_property after Python 3.7 is dropped.
     @experimental_func("3.4.0")
     def metric_names(self) -> list[str] | None:
         """Return metric names.

--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -4,6 +4,7 @@ from collections.abc import Container
 from collections.abc import Iterable
 from collections.abc import Mapping
 import copy
+from functools import cached_property
 from numbers import Real
 import threading
 from typing import Any
@@ -220,6 +221,19 @@ class Study:
         """
 
         return self.get_trials(deepcopy=True, states=None)
+
+    @cached_property
+    @experimental_func("3.4.0")
+    def metric_names(self) -> list[str] | None:
+        """Return metric names.
+
+        .. note::
+            Use :meth:`~optuna.study.Study.set_metric_names` to set the metric names first.
+
+        Returns:
+            A list with names for each dimension of the returned values of the objective function.
+        """
+        return self._storage.get_study_system_attrs(self._study_id).get(_SYSTEM_ATTR_METRIC_NAMES)
 
     def get_trials(
         self,
@@ -1004,6 +1018,9 @@ class Study:
         """
         if len(self.directions) != len(metric_names):
             raise ValueError("The number of objectives must match the length of the metric names.")
+
+        if "metric_names" in self.__dict__:
+            del self.metric_names
 
         self._storage.set_study_system_attr(
             self._study_id, _SYSTEM_ATTR_METRIC_NAMES, metric_names

--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -1092,16 +1092,14 @@ class Study:
         if not _logger.isEnabledFor(logging.INFO):
             return
 
-        metric_names = self._storage.get_study_system_attrs(self._study_id).get(
-            _SYSTEM_ATTR_METRIC_NAMES
-        )
-
         if len(trial.values) > 1:
             trial_values: list[float] | dict[str, float]
-            if metric_names is None:
+            if self.metric_names is None:
                 trial_values = trial.values
             else:
-                trial_values = {name: value for name, value in zip(metric_names, trial.values)}
+                trial_values = {
+                    name: value for name, value in zip(self.metric_names, trial.values)
+                }
             _logger.info(
                 "Trial {} finished with values: {} and parameters: {}. ".format(
                     trial.number, trial_values, trial.params
@@ -1110,10 +1108,10 @@ class Study:
         elif len(trial.values) == 1:
             best_trial = self.best_trial
             trial_value: float | dict[str, float]
-            if metric_names is None:
+            if self.metric_names is None:
                 trial_value = trial.values[0]
             else:
-                trial_value = {metric_names[0]: trial.values[0]}
+                trial_value = {self.metric_names[0]: trial.values[0]}
             _logger.info(
                 "Trial {} finished with value: {} and parameters: {}. "
                 "Best is trial {} with value: {}.".format(

--- a/optuna/visualization/_pareto_front.py
+++ b/optuna/visualization/_pareto_front.py
@@ -345,7 +345,7 @@ def _get_pareto_front_info(
         if study.metric_names is None:
             target_names = [f"Objective {i}" for i in range(n_targets)]
         else:
-            target_names = study.metric_names
+            target_names = study.metric_names  # type: ignore
     elif len(target_names) != n_targets:
         raise ValueError(f"The length of `target_names` is supposed to be {n_targets}.")
 
@@ -372,7 +372,7 @@ def _get_pareto_front_info(
 
     return _ParetoFrontInfo(
         n_targets=n_targets,
-        target_names=target_names,
+        target_names=target_names,  # type: ignore
         best_trials_with_values=best_trials_with_values,
         non_best_trials_with_values=non_best_trials_with_values,
         infeasible_trials_with_values=infeasible_trials_with_values,

--- a/optuna/visualization/_pareto_front.py
+++ b/optuna/visualization/_pareto_front.py
@@ -11,7 +11,6 @@ import optuna
 from optuna.exceptions import ExperimentalWarning
 from optuna.study import Study
 from optuna.study._multi_objective import _get_pareto_front_trials_by_trials
-from optuna.study.study import _SYSTEM_ATTR_METRIC_NAMES
 from optuna.trial import FrozenTrial
 from optuna.trial import TrialState
 from optuna.visualization._plotly_imports import _imports
@@ -343,13 +342,10 @@ def _get_pareto_front_info(
         )
 
     if target_names is None:
-        metric_names = study._storage.get_study_system_attrs(study._study_id).get(
-            _SYSTEM_ATTR_METRIC_NAMES
-        )
-        if metric_names is None:
+        if study.metric_names is None:
             target_names = [f"Objective {i}" for i in range(n_targets)]
         else:
-            target_names = metric_names
+            target_names = study.metric_names
     elif len(target_names) != n_targets:
         raise ValueError(f"The length of `target_names` is supposed to be {n_targets}.")
 

--- a/tests/study_tests/test_study.py
+++ b/tests/study_tests/test_study.py
@@ -1601,3 +1601,18 @@ def test_set_invalid_metric_names() -> None:
     study = create_study(directions=["minimize", "minimize"])
     with pytest.raises(ValueError):
         study.set_metric_names(metric_names)
+
+
+def test_get_metric_names() -> None:
+    study = create_study()
+    assert study.metric_names is None
+    study.set_metric_names(["v0"])
+    assert study.metric_names == ["v0"]
+    study.set_metric_names(["v1"])
+    assert study.metric_names == ["v1"]
+
+
+def test_get_metric_names_experimental_warning() -> None:
+    study = create_study()
+    with pytest.warns(ExperimentalWarning):
+        study.metric_names


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
This PR complements `study.set_metric_names` with cached getter attribute.

Note: Unfortunately, Python 3.7 does not support `cached_property` decorator (initial implementation from 093a4c6e298bf991b280f8d2e6a209e8417d2e0c), so for the time being we have to use rather nasty workaround (at least from typing perspective). Alternatively, we can use non-cached version and leave the improvements until after 3.7 is dropped.

## Description of the changes
<!-- Describe the changes in this PR. -->
* Added `metric_names` attribute to study.
* Library code that was previously querying storage for metric names is now using the new attribute.
* Added tests
