### PR TITLE
Add `metric_names` getter to study

### DIFF
--- a/optuna/study/_dataframe.py
+++ b/optuna/study/_dataframe.py
@@ -8,7 +8,6 @@ from typing import Tuple
 
 import optuna
 from optuna._imports import try_import
-from optuna.study.study import _SYSTEM_ATTR_METRIC_NAMES
 from optuna.trial._state import TrialState
 
 
@@ -41,9 +40,7 @@ def _create_records_and_aggregate_column(
     column_agg: DefaultDict[str, Set] = collections.defaultdict(set)
     non_nested_attr = ""
 
-    metric_names = study._storage.get_study_system_attrs(study._study_id).get(
-        _SYSTEM_ATTR_METRIC_NAMES
-    )
+    metric_names = study.metric_names
 
     records = []
     for trial in study.get_trials(deepcopy=False):

--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -1088,9 +1088,7 @@ class Study:
         if not _logger.isEnabledFor(logging.INFO):
             return
 
-        metric_names = self._storage.get_study_system_attrs(self._study_id).get(
-            _SYSTEM_ATTR_METRIC_NAMES
-        )
+        metric_names = self.metric_names
 
         if len(trial.values) > 1:
             trial_values: list[float] | dict[str, float]

--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -333,6 +333,19 @@ class Study:
 
         return copy.deepcopy(self._storage.get_study_system_attrs(self._study_id))
 
+    @property
+    @experimental_func("3.4.0")
+    def metric_names(self) -> list[str] | None:
+        """Return metric names.
+
+        .. note::
+            Use :meth:`~optuna.study.Study.set_metric_names` to set the metric names first.
+
+        Returns:
+            A list with names for each dimension of the returned values of the objective function.
+        """
+        return self._storage.get_study_system_attrs(self._study_id).get(_SYSTEM_ATTR_METRIC_NAMES)
+
     def optimize(
         self,
         func: ObjectiveFuncType,

--- a/optuna/visualization/_pareto_front.py
+++ b/optuna/visualization/_pareto_front.py
@@ -11,7 +11,6 @@ import optuna
 from optuna.exceptions import ExperimentalWarning
 from optuna.study import Study
 from optuna.study._multi_objective import _get_pareto_front_trials_by_trials
-from optuna.study.study import _SYSTEM_ATTR_METRIC_NAMES
 from optuna.trial import FrozenTrial
 from optuna.trial import TrialState
 from optuna.visualization._plotly_imports import _imports
@@ -343,9 +342,7 @@ def _get_pareto_front_info(
         )
 
     if target_names is None:
-        metric_names = study._storage.get_study_system_attrs(study._study_id).get(
-            _SYSTEM_ATTR_METRIC_NAMES
-        )
+        metric_names = study.metric_names
         if metric_names is None:
             target_names = [f"Objective {i}" for i in range(n_targets)]
         else:

--- a/tests/study_tests/test_study.py
+++ b/tests/study_tests/test_study.py
@@ -1601,3 +1601,18 @@ def test_set_invalid_metric_names() -> None:
     study = create_study(directions=["minimize", "minimize"])
     with pytest.raises(ValueError):
         study.set_metric_names(metric_names)
+
+
+def test_get_metric_names() -> None:
+    study = create_study()
+    assert study.metric_names is None
+    study.set_metric_names(["v0"])
+    assert study.metric_names == ["v0"]
+    study.set_metric_names(["v1"])
+    assert study.metric_names == ["v1"]
+
+
+def test_get_metric_names_experimental_warning() -> None:
+    study = create_study()
+    with pytest.warns(ExperimentalWarning):
+        study.metric_names


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
This PR complements `study.set_metric_names` with getter attribute. Ref https://github.com/optuna/optuna/issues/4895#issuecomment-1711283435

Initially I've implemented this as a cached property (#4928), but due to amount of workarounds needed to make it work with Python 3.7, I've ultimately decided to go with simple uncached  version instead. This should still be fine, as I expect this is read-once kind of attribute for most of the users. Adding the cache back (in nice `cached_property` form from 093a4c6e298bf991b280f8d2e6a209e8417d2e0c) can be left as a possible enhancement after Python 3.7 is dropped.  

## Description of the changes
<!-- Describe the changes in this PR. -->
* Added metric_names attribute to study.
* Library code that was previously querying storage for metric names is now using the new attribute.
* Added tests