### PR TITLE
Replace deprecated botorch method to remove warning

### DIFF
--- a/optuna/terminator/improvement/gp/botorch.py
+++ b/optuna/terminator/improvement/gp/botorch.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Optional
 
 import numpy as np
+from packaging import version
 
 from optuna._imports import try_import
 from optuna.distributions import _is_distribution_log
@@ -16,15 +17,20 @@ from optuna.trial._state import TrialState
 
 
 with try_import() as _imports:
-    from botorch.fit import fit_gpytorch_model
+    import botorch
     from botorch.models import SingleTaskGP
     from botorch.models.transforms import Normalize
     from botorch.models.transforms import Standardize
     import gpytorch
     import torch
 
+    if version.parse(botorch.version.version) < version.parse("0.8.0"):
+        from botorch.fit import fit_gpytorch_model as fit_gpytorch_mll
+    else:
+        from botorch.fit import fit_gpytorch_mll
+
 __all__ = [
-    "fit_gpytorch_model",
+    "fit_gpytorch_mll",
     "SingleTaskGP",
     "Normalize",
     "Standardize",
@@ -61,7 +67,7 @@ class _BoTorchGaussianProcess(BaseGaussianProcess):
 
         mll = gpytorch.mlls.ExactMarginalLogLikelihood(self._gp.likelihood, self._gp)
 
-        fit_gpytorch_model(mll)
+        fit_gpytorch_mll(mll)
 
     def predict_mean_std(
         self,


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

Resolve #4939

## Description of the changes
<!-- Describe the changes in this PR. -->

- By the same as botorch interaction, https://github.com/optuna/optuna/blob/a920a91e4e5a32ade707f3e9819fff0f96cc7946/optuna/integration/botorch.py#L42-L52 add version condition to import the fitting method
- Replace the corresponding warning method with new one.