### PR TITLE
Fix type annotation

### DIFF
--- a/optuna/integration/sklearn.py
+++ b/optuna/integration/sklearn.py
@@ -52,7 +52,7 @@ ArrayLikeType = Union[List, np.ndarray, "pd.Series", "spmatrix"]
 OneDimArrayLikeType = Union[List[float], np.ndarray, "pd.Series"]
 TwoDimArrayLikeType = Union[List[List[float]], np.ndarray, "pd.DataFrame", "spmatrix"]
 IterableType = Union[List, "pd.DataFrame", np.ndarray, "pd.Series", "spmatrix", None]
-IndexableType = Union[Iterable, None]
+IndexableType = Optional[Iterable]
 
 _logger = logging.get_logger(__name__)
 

--- a/optuna/integration/sklearn.py
+++ b/optuna/integration/sklearn.py
@@ -48,10 +48,10 @@ with try_import() as _imports:
 if not _imports.is_successful():
     BaseEstimator = object  # NOQA
 
-ArrayLikeType = Union[List, np.ndarray, "pd.Series", spmatrix]
+ArrayLikeType = Union[List, np.ndarray, "pd.Series", "spmatrix"]
 OneDimArrayLikeType = Union[List[float], np.ndarray, "pd.Series"]
-TwoDimArrayLikeType = Union[List[List[float]], np.ndarray, "pd.DataFrame", spmatrix]
-IterableType = Union[List, "pd.DataFrame", np.ndarray, "pd.Series", spmatrix, None]
+TwoDimArrayLikeType = Union[List[List[float]], np.ndarray, "pd.DataFrame", "spmatrix"]
+IterableType = Union[List, "pd.DataFrame", np.ndarray, "pd.Series", "spmatrix", None]
 IndexableType = Union[Iterable, None]
 
 _logger = logging.get_logger(__name__)


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
Pass `spmatrix` as a string, which is used only when type checking.

## Description of the changes
Currently, if you use `OptunaSearchCV` with default dependencies and `scikit-learn`, you will get following error:
```
NameError: name 'spmatrix' is not defined
```
This would be because `import pandas as pd` under `try_import()` context fails and `spmatrix` is left uimported. The error message will not let users know that they need to install `pandas`. With this patch, the error message is going to be as follows:
```
ModuleNotFoundError: No module named 'pandas'
```
