### PR TITLE
Add introduction of `optuna-fast-fanova` in documents

### DIFF
--- a/docs/source/reference/importance.rst
+++ b/docs/source/reference/importance.rst
@@ -5,6 +5,12 @@ optuna.importance
 
 The :mod:`~optuna.importance` module provides functionality for evaluating hyperparameter importances based on completed trials in a given study. The utility function :func:`~optuna.importance.get_param_importances` takes a :class:`~optuna.study.Study` and optional evaluator as two of its inputs. The evaluator must derive from :class:`~optuna.importance.BaseImportanceEvaluator`, and is initialized as a :class:`~optuna.importance.FanovaImportanceEvaluator` by default when not passed in. Users implementing custom evaluators should refer to either :class:`~optuna.importance.FanovaImportanceEvaluator` or :class:`~optuna.importance.MeanDecreaseImpurityImportanceEvaluator` as a guide, paying close attention to the format of the return value from the Evaluator's ``evaluate`` function.
 
+.. note::
+
+   :class:`~optuna.importance.FanovaImportanceEvaluator` takes over 1 minute when given a study that contains 1000+ trials.
+   We published `optuna-fast-fanova <https://github.com/optuna/optuna-fast-fanova>`_ library,
+   that is a Cython accelerated fANOVA implementation. By using it, you can get hyperparameter
+   importances within a few seconds.
 
 .. autosummary::
    :toctree: generated/

--- a/optuna/importance/__init__.py
+++ b/optuna/importance/__init__.py
@@ -65,10 +65,11 @@ def get_param_importances(
             :class:`~optuna.importance.FanovaImportanceEvaluator`.
 
             .. note::
-                This class takes over 1 minute when given a study that contains 1000+ trials.
-                We published `optuna-fast-fanova <https://github.com/optuna/optuna-fast-fanova>`_ library,
-                that is a Cython accelerated fANOVA implementation. By using it, you can get hyperparameter
-                importances within a few seconds.
+                :class:`~optuna.importance.FanovaImportanceEvaluator` takes over 1 minute
+                when given a study that contains 1000+ trials. We published
+                `optuna-fast-fanova <https://github.com/optuna/optuna-fast-fanova>`_ library,
+                that is a Cython accelerated fANOVA implementation.
+                By using it, you can get hyperparameter importances within a few seconds.
 
         params:
             A list of names of parameters to assess.

--- a/optuna/importance/__init__.py
+++ b/optuna/importance/__init__.py
@@ -63,6 +63,13 @@ def get_param_importances(
             assessment on.
             Defaults to
             :class:`~optuna.importance.FanovaImportanceEvaluator`.
+
+            .. note::
+                This class takes over 1 minute when given a study that contains 1000+ trials.
+                We published `optuna-fast-fanova <https://github.com/optuna/optuna-fast-fanova>`_ library,
+                that is a Cython accelerated fANOVA implementation. By using it, you can get hyperparameter
+                importances within a few seconds.
+
         params:
             A list of names of parameters to assess.
             If :obj:`None`, all parameters that are present in all of the completed trials are

--- a/optuna/visualization/_param_importances.py
+++ b/optuna/visualization/_param_importances.py
@@ -113,6 +113,13 @@ def plot_param_importances(
             assessment on.
             Defaults to
             :class:`~optuna.importance.FanovaImportanceEvaluator`.
+
+            .. note::
+                This class takes over 1 minute when given a study that contains 1000+ trials.
+                We published `optuna-fast-fanova <https://github.com/optuna/optuna-fast-fanova>`_ library,
+                that is a Cython accelerated fANOVA implementation. By using it, you can get hyperparameter
+                importances within a few seconds.
+
         params:
             A list of names of parameters to assess.
             If :obj:`None`, all parameters that are present in all of the completed trials are

--- a/optuna/visualization/_param_importances.py
+++ b/optuna/visualization/_param_importances.py
@@ -115,10 +115,11 @@ def plot_param_importances(
             :class:`~optuna.importance.FanovaImportanceEvaluator`.
 
             .. note::
-                This class takes over 1 minute when given a study that contains 1000+ trials.
-                We published `optuna-fast-fanova <https://github.com/optuna/optuna-fast-fanova>`_ library,
-                that is a Cython accelerated fANOVA implementation. By using it, you can get hyperparameter
-                importances within a few seconds.
+                :class:`~optuna.importance.FanovaImportanceEvaluator` takes over 1 minute
+                when given a study that contains 1000+ trials. We published
+                `optuna-fast-fanova <https://github.com/optuna/optuna-fast-fanova>`_ library,
+                that is a Cython accelerated fANOVA implementation.
+                By using it, you can get hyperparameter importances within a few seconds.
 
         params:
             A list of names of parameters to assess.


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
Some users worried about the slow computation of fANOVA importance evaluator.
https://github.com/optuna/optuna/issues/4888

We have [optuna-fast-fanova](https://github.com/optuna/optuna-fast-fanova) as a solution of this problem, but it is not well introduced in optuna document.

<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

## Description of the changes
Add introduction of optuna-fast-fanova as NOTE to below 3 documents.
* The toppage of optuna.importance
* The page of optuna.get_param_importance
* The page of optuna.visualization.plot_param_importance
<!-- Describe the changes in this PR. -->
