### PR TITLE
Add `_split_trials` instead of `_get_observation_pairs` and `_split_observation_pairs`

### DIFF
--- a/tests/samplers_tests/tpe_tests/test_multi_objective_sampler.py
+++ b/tests/samplers_tests/tpe_tests/test_multi_objective_sampler.py
@@ -3,7 +3,6 @@ from typing import Callable
 from typing import Dict
 from typing import List
 from typing import Optional
-from typing import Tuple
 from typing import Union
 from unittest.mock import patch
 from unittest.mock import PropertyMock
@@ -305,93 +304,37 @@ def test_multi_objective_sample_independent_ignored_states() -> None:
     assert len(set(suggestions)) == 1
 
 
-@pytest.mark.parametrize("int_value", [-5, 5, 0])
-@pytest.mark.parametrize(
-    "categorical_value", [1, 0.0, "A", None, True, float("inf"), float("nan")]
-)
-@pytest.mark.parametrize("objective_value", [-5.0, 5.0, 0.0, -float("inf"), float("inf")])
-@pytest.mark.parametrize("multivariate", [True, False])
-@pytest.mark.parametrize("constant_liar", [True, False])
-@pytest.mark.filterwarnings("ignore::optuna.exceptions.ExperimentalWarning")
-def test_multi_objective_get_observation_pairs(
-    int_value: int,
-    categorical_value: optuna.distributions.CategoricalChoiceType,
-    objective_value: float,
-    multivariate: bool,
-    constant_liar: bool,
-) -> None:
-    def objective(trial: optuna.trial.Trial) -> Tuple[float, float]:
-        trial.suggest_int("x", int_value, int_value)
-        trial.suggest_categorical("y", [categorical_value])
-        return objective_value, objective_value
+@pytest.mark.parametrize("direction0", ["minimize", "maximize"])
+@pytest.mark.parametrize("direction1", ["minimize", "maximize"])
+def test_split_complete_trials_multi_objective(direction0: str, direction1: str) -> None:
+    study = optuna.create_study(directions=(direction0, direction1))
 
-    sampler = TPESampler(seed=0, multivariate=multivariate, constant_liar=constant_liar)
-    study = optuna.create_study(directions=["minimize", "maximize"], sampler=sampler)
-    study.optimize(objective, n_trials=2)
-    study.add_trial(
-        optuna.create_trial(
-            state=optuna.trial.TrialState.RUNNING,
-            params={"x": int_value, "y": categorical_value},
-            distributions={
-                "x": optuna.distributions.IntDistribution(int_value, int_value),
-                "y": optuna.distributions.CategoricalDistribution([categorical_value]),
-            },
+    for values in ([-2.0, -1.0], [3.0, 3.0], [0.0, 1.0], [-1.0, 0.0]):
+        value0, value1 = values
+        if direction0 == "maximize":
+            value0 = -value0
+        if direction1 == "maximize":
+            value1 = -value1
+        study.add_trial(
+            optuna.create_trial(
+                state=optuna.trial.TrialState.COMPLETE,
+                values=(value0, value1),
+                params={"x": 0},
+                distributions={"x": optuna.distributions.FloatDistribution(-1.0, 1.0)},
+            )
         )
-    )
 
-    states = [optuna.trial.TrialState.COMPLETE, optuna.trial.TrialState.PRUNED]
-    assert _tpe.sampler._get_observation_pairs(study, study.get_trials(states=states)) == (
-        [(-float("inf"), [objective_value, -objective_value]) for _ in range(2)],
-        None,
-    )
-
-
-@pytest.mark.parametrize("constraint_value", [-2, 2])
-def test_multi_objective_get_observation_pairs_constrained(constraint_value: int) -> None:
-    def objective(trial: optuna.trial.Trial) -> Tuple[float, float]:
-        trial.suggest_int("x", 5, 5)
-        trial.set_user_attr("constraint", (constraint_value, -1))
-        return 5.0, 5.0
-
-    sampler = TPESampler(constraints_func=lambda trial: trial.user_attrs["constraint"], seed=0)
-    study = optuna.create_study(directions=["minimize", "maximize"], sampler=sampler)
-    study.optimize(objective, n_trials=5)
-
-    violations = [max(0, constraint_value) for _ in range(5)]
-    states = (optuna.trial.TrialState.COMPLETE, optuna.trial.TrialState.PRUNED)
-    assert _tpe.sampler._get_observation_pairs(
-        study, study.get_trials(states=states), constraints_enabled=True
-    ) == (
-        [(-float("inf"), [5.0, -5.0]) for _ in range(5)],
-        violations,
-    )
-
-
-def test_multi_objective_split_observation_pairs() -> None:
-    indices_below, indices_above = _tpe.sampler._split_observation_pairs(
-        [
-            (-float("inf"), [-2.0, -1.0]),
-            (-float("inf"), [3.0, 3.0]),
-            (-float("inf"), [0.0, 1.0]),
-            (-float("inf"), [-1.0, 0.0]),
-        ],
+    below_trials = _tpe.sampler._split_complete_trials_multi_objective(
+        study.trials,
+        study,
         2,
-        None,
     )
-    assert list(indices_below) == [0, 3]
-    assert list(indices_above) == [1, 2]
+    assert [trial.number for trial in below_trials] == [0, 3]
 
 
-def test_multi_objective_split_observation_pairs_with_all_indices_below() -> None:
-    indices_below, indices_above = _tpe.sampler._split_observation_pairs(
-        [
-            (-float("inf"), [1.0, 1.0]),
-        ],
-        1,
-        None,
-    )
-    assert list(indices_below) == [0]
-    assert list(indices_above) == []
+def test_split_complete_trials_multi_objective_empty() -> None:
+    study = optuna.create_study(directions=("minimize", "minimize"))
+    _tpe.sampler._split_complete_trials_multi_objective([], study, 0) == []
 
 
 def test_calculate_nondomination_rank() -> None:

--- a/tests/samplers_tests/tpe_tests/test_multi_objective_sampler.py
+++ b/tests/samplers_tests/tpe_tests/test_multi_objective_sampler.py
@@ -335,7 +335,7 @@ def test_split_complete_trials_multi_objective(direction0: str, direction1: str)
 
 def test_split_complete_trials_multi_objective_empty() -> None:
     study = optuna.create_study(directions=("minimize", "minimize"))
-    _tpe.sampler._split_complete_trials_multi_objective([], study, 0) == ([], [])
+    assert _tpe.sampler._split_complete_trials_multi_objective([], study, 0) == ([], [])
 
 
 def test_calculate_nondomination_rank() -> None:

--- a/tests/samplers_tests/tpe_tests/test_multi_objective_sampler.py
+++ b/tests/samplers_tests/tpe_tests/test_multi_objective_sampler.py
@@ -324,17 +324,18 @@ def test_split_complete_trials_multi_objective(direction0: str, direction1: str)
             )
         )
 
-    below_trials = _tpe.sampler._split_complete_trials_multi_objective(
+    below_trials, above_trials = _tpe.sampler._split_complete_trials_multi_objective(
         study.trials,
         study,
         2,
     )
     assert [trial.number for trial in below_trials] == [0, 3]
+    assert [trial.number for trial in above_trials] == [1, 2]
 
 
 def test_split_complete_trials_multi_objective_empty() -> None:
     study = optuna.create_study(directions=("minimize", "minimize"))
-    _tpe.sampler._split_complete_trials_multi_objective([], study, 0) == []
+    _tpe.sampler._split_complete_trials_multi_objective([], study, 0) == ([], [])
 
 
 def test_calculate_nondomination_rank() -> None:

--- a/tests/samplers_tests/tpe_tests/test_sampler.py
+++ b/tests/samplers_tests/tpe_tests/test_sampler.py
@@ -832,17 +832,18 @@ def test_split_complete_trials_single_objective(direction: str) -> None:
         )
 
     for n_below in range(len(study.trials) + 1):
-        below_trials = _tpe.sampler._split_complete_trials_single_objective(
+        below_trials, above_trials = _tpe.sampler._split_complete_trials_single_objective(
             study.trials,
             study,
             n_below,
         )
         assert [trial.number for trial in below_trials] == list(range(n_below))
+        assert [trial.number for trial in above_trials] == list(range(n_below, len(study.trials)))
 
 
 def test_split_complete_trials_single_objective_empty() -> None:
     study = optuna.create_study()
-    _tpe.sampler._split_complete_trials_single_objective([], study, 0) == []
+    _tpe.sampler._split_complete_trials_single_objective([], study, 0) == ([], [])
 
 
 @pytest.mark.parametrize("direction", ["minimize", "maximize"])
@@ -869,17 +870,18 @@ def test_split_pruned_trials(direction: str) -> None:
     )
 
     for n_below in range(len(study.trials) + 1):
-        below_trials = _tpe.sampler._split_pruned_trials(
+        below_trials, above_trials = _tpe.sampler._split_pruned_trials(
             study.trials,
             study,
             n_below,
         )
         assert [trial.number for trial in below_trials] == list(range(n_below))
+        assert [trial.number for trial in above_trials] == list(range(n_below, len(study.trials)))
 
 
 def test_split_pruned_trials_empty() -> None:
     study = optuna.create_study()
-    _tpe.sampler._split_pruned_trials([], study, 0) == []
+    _tpe.sampler._split_pruned_trials([], study, 0) == ([], [])
 
 
 @pytest.mark.parametrize("direction", ["minimize", "maximize"])
@@ -898,12 +900,13 @@ def test_split_infeasible_trials(direction: str) -> None:
         )
 
     for n_below in range(len(study.trials) + 1):
-        below_trials = _tpe.sampler._split_infeasible_trials(study.trials, n_below)
+        below_trials, above_trials = _tpe.sampler._split_infeasible_trials(study.trials, n_below)
         assert [trial.number for trial in below_trials] == list(range(n_below))
+        assert [trial.number for trial in above_trials] == list(range(n_below, len(study.trials)))
 
 
 def test_split_infeasible_trials_empty() -> None:
-    _tpe.sampler._split_infeasible_trials([], 0) == []
+    _tpe.sampler._split_infeasible_trials([], 0) == ([], [])
 
 
 def frozen_trial_factory(

--- a/tests/samplers_tests/tpe_tests/test_sampler.py
+++ b/tests/samplers_tests/tpe_tests/test_sampler.py
@@ -843,7 +843,7 @@ def test_split_complete_trials_single_objective(direction: str) -> None:
 
 def test_split_complete_trials_single_objective_empty() -> None:
     study = optuna.create_study()
-    _tpe.sampler._split_complete_trials_single_objective([], study, 0) == ([], [])
+    assert _tpe.sampler._split_complete_trials_single_objective([], study, 0) == ([], [])
 
 
 @pytest.mark.parametrize("direction", ["minimize", "maximize"])
@@ -881,7 +881,7 @@ def test_split_pruned_trials(direction: str) -> None:
 
 def test_split_pruned_trials_empty() -> None:
     study = optuna.create_study()
-    _tpe.sampler._split_pruned_trials([], study, 0) == ([], [])
+    assert _tpe.sampler._split_pruned_trials([], study, 0) == ([], [])
 
 
 @pytest.mark.parametrize("direction", ["minimize", "maximize"])
@@ -906,7 +906,7 @@ def test_split_infeasible_trials(direction: str) -> None:
 
 
 def test_split_infeasible_trials_empty() -> None:
-    _tpe.sampler._split_infeasible_trials([], 0) == ([], [])
+    assert _tpe.sampler._split_infeasible_trials([], 0) == ([], [])
 
 
 def frozen_trial_factory(

--- a/tests/samplers_tests/tpe_tests/test_sampler.py
+++ b/tests/samplers_tests/tpe_tests/test_sampler.py
@@ -1,9 +1,7 @@
 import random
 from typing import Callable
 from typing import Dict
-from typing import List
 from typing import Optional
-from typing import Sequence
 from typing import Union
 from unittest.mock import Mock
 from unittest.mock import patch
@@ -15,7 +13,6 @@ import pytest
 
 import optuna
 from optuna import distributions
-from optuna import TrialPruned
 from optuna.samplers import _tpe
 from optuna.samplers import TPESampler
 from optuna.samplers._base import _CONSTRAINTS_KEY
@@ -723,167 +720,9 @@ def test_constrained_sample_independent_zero_startup() -> None:
 
 
 @pytest.mark.parametrize("direction", ["minimize", "maximize"])
-@pytest.mark.parametrize(
-    "constraints_enabled, constraints_func, expected_violations",
-    [
-        (False, None, None),
-        (True, lambda trial: [(-1, -1), (0, -1), (1, -1), (2, -1)][trial.number], [0, 0, 1, 2]),
-    ],
-)
-def test_get_observation_pairs(
-    direction: str,
-    constraints_enabled: bool,
-    constraints_func: Optional[Callable[[optuna.trial.FrozenTrial], Sequence[float]]],
-    expected_violations: List[float],
-) -> None:
-    def objective(trial: Trial) -> float:
-        x = trial.suggest_int("x", 5, 5)
-        z = trial.suggest_categorical("z", [None])
-        if trial.number == 0:
-            return x * int(z is None)
-        elif trial.number == 1:
-            trial.report(1, 4)
-            trial.report(2, 7)
-            raise TrialPruned()
-        elif trial.number == 2:
-            trial.report(float("nan"), 3)
-            raise TrialPruned()
-        elif trial.number == 3:
-            raise TrialPruned()
-        else:
-            raise RuntimeError()
-
-    sampler = TPESampler(constraints_func=constraints_func)
-    study = optuna.create_study(direction=direction, sampler=sampler)
-    study.optimize(objective, n_trials=5, catch=(RuntimeError,))
-
-    sign = 1 if direction == "minimize" else -1
-    scores = [
-        (-float("inf"), [sign * 5.0]),  # COMPLETE
-        (-7, [sign * 2]),  # PRUNED (with intermediate values)
-        (-3, [float("inf")]),  # PRUNED (with a NaN intermediate value; it's treated as infinity)
-        (1, [sign * 0.0]),  # PRUNED (without intermediate values)
-    ]
-    states = (optuna.trial.TrialState.COMPLETE, optuna.trial.TrialState.PRUNED)
-    assert _tpe.sampler._get_observation_pairs(
-        study, study.get_trials(states=states), constraints_enabled=constraints_enabled
-    ) == (
-        scores,
-        expected_violations,
-    )
-
-
-@pytest.mark.parametrize("direction", ["minimize", "maximize"])
-@pytest.mark.parametrize(
-    "constraints_enabled, constraints_func, expected_violations",
-    [
-        (False, None, None),
-        (True, lambda trial: [(-1, -1), (0, -1), (1, -1), (2, -1)][trial.number], [0, 0, 1, 2]),
-    ],
-)
-def test_get_observation_pairs_multi(
-    direction: str,
-    constraints_enabled: bool,
-    constraints_func: Optional[Callable[[optuna.trial.FrozenTrial], Sequence[float]]],
-    expected_violations: List[float],
-) -> None:
-    def objective(trial: Trial) -> float:
-        x = trial.suggest_int("x", 5, 5)
-        y = trial.suggest_int("y", 6, 6)
-        if trial.number == 0:
-            return x + y
-        elif trial.number == 1:
-            trial.report(1, 4)
-            trial.report(2, 7)
-            raise TrialPruned()
-        elif trial.number == 2:
-            trial.report(float("nan"), 3)
-            raise TrialPruned()
-        elif trial.number == 3:
-            raise TrialPruned()
-        else:
-            raise RuntimeError()
-
-    sampler = TPESampler(constraints_func=constraints_func)
-    study = optuna.create_study(direction=direction, sampler=sampler)
-    study.optimize(objective, n_trials=5, catch=(RuntimeError,))
-
-    sign = 1 if direction == "minimize" else -1
-    states = (optuna.trial.TrialState.COMPLETE, optuna.trial.TrialState.PRUNED)
-    assert _tpe.sampler._get_observation_pairs(
-        study, study.get_trials(states=states), constraints_enabled=constraints_enabled
-    ) == (
-        [
-            (-float("inf"), [sign * 11.0]),  # COMPLETE
-            (-7, [sign * 2]),  # PRUNED (with intermediate values)
-            (
-                -3,
-                [float("inf")],
-            ),  # PRUNED (with a NaN intermediate value; it's treated as infinity)
-            (1, [sign * 0.0]),  # PRUNED (without intermediate values)
-        ],
-        expected_violations,
-    )
-
-
-def test_split_observation_pairs() -> None:
-    indices_below, indices_above = _tpe.sampler._split_observation_pairs(
-        [
-            (-7, [-2]),  # PRUNED (with intermediate values)
-            (float("inf"), [0.0]),  # PRUNED (without intermediate values)
-            (
-                -3,
-                [float("inf")],
-            ),  # PRUNED (with a NaN intermediate value; it's treated as infinity)
-            (-float("inf"), [-5.0]),  # COMPLETE
-        ],
-        2,
-        None,
-    )
-    assert list(indices_below) == [0, 3]
-    assert list(indices_above) == [1, 2]
-
-
-def test_split_observation_pairs_with_constraints_below_all_feasible() -> None:
-    indices_below, indices_above = _tpe.sampler._split_observation_pairs(
-        [
-            (-7, [-2]),  # PRUNED (with intermediate values)
-            (float("inf"), [0.0]),  # PRUNED (without intermediate values)
-            (
-                -3,
-                [float("inf")],
-            ),  # PRUNED (with a NaN intermediate value; it's treated as infinity)
-            (-float("inf"), [-5.0]),  # COMPLETE
-        ],
-        1,
-        [1, 0, 0, 2],
-    )
-    assert list(indices_below) == [2]
-    assert list(indices_above) == [0, 1, 3]
-
-
-def test_split_observation_pairs_with_constraints_below_include_infeasible() -> None:
-    indices_below, indices_above = _tpe.sampler._split_observation_pairs(
-        [
-            (-7, [-2]),  # PRUNED (with intermediate values)
-            (float("inf"), [0.0]),  # PRUNED (without intermediate values)
-            (
-                -3,
-                [float("inf")],
-            ),  # PRUNED (with a NaN intermediate value; it's treated as infinity)
-            (-float("inf"), [-5.0]),  # COMPLETE
-        ],
-        3,
-        [1, 0, 0, 2],
-    )
-    assert list(indices_below) == [0, 1, 2]
-    assert list(indices_above) == [3]
-
-
-@pytest.mark.parametrize("direction", ["minimize", "maximize"])
 @pytest.mark.parametrize("constant_liar", [True, False])
 @pytest.mark.parametrize("constraints", [True, False])
-def test_split_order(direction: str, constant_liar: bool, constraints: bool) -> None:
+def test_split_trials(direction: str, constant_liar: bool, constraints: bool) -> None:
     study = optuna.create_study(direction=direction)
 
     for value in [-float("inf"), 0, 1, float("inf")]:
@@ -919,7 +758,7 @@ def test_split_order(direction: str, constant_liar: bool, constraints: bool) -> 
     )
 
     if constraints:
-        for value in [1, 2]:
+        for value in [1, 2, float("inf")]:
             study.add_trial(
                 optuna.create_trial(
                     state=optuna.trial.TrialState.COMPLETE,
@@ -939,6 +778,18 @@ def test_split_order(direction: str, constant_liar: bool, constraints: bool) -> 
         )
     )
 
+    study.add_trial(
+        optuna.create_trial(
+            state=optuna.trial.TrialState.FAIL,
+        )
+    )
+
+    study.add_trial(
+        optuna.create_trial(
+            state=optuna.trial.TrialState.WAITING,
+        )
+    )
+
     if constant_liar:
         states = [
             optuna.trial.TrialState.COMPLETE,
@@ -948,24 +799,111 @@ def test_split_order(direction: str, constant_liar: bool, constraints: bool) -> 
     else:
         states = [optuna.trial.TrialState.COMPLETE, optuna.trial.TrialState.PRUNED]
 
-    scores, violations = _tpe.sampler._get_observation_pairs(
-        study,
-        study.get_trials(states=states),
-        constraints,
+    trials = study.get_trials(states=states)
+    finished_trials = study.get_trials(
+        states=(optuna.trial.TrialState.COMPLETE, optuna.trial.TrialState.PRUNED)
+    )
+    for n_below in range(len(finished_trials) + 1):
+        below_trials, above_trials = _tpe.sampler._split_trials(
+            study,
+            trials,
+            n_below,
+            constraints,
+        )
+
+        below_trial_numbers = [trial.number for trial in below_trials]
+        assert below_trial_numbers == list(range(n_below))
+        above_trial_numbers = [trial.number for trial in above_trials]
+        assert above_trial_numbers == list(range(n_below, len(trials)))
+
+
+@pytest.mark.parametrize("direction", ["minimize", "maximize"])
+def test_split_complete_trials_single_objective(direction: str) -> None:
+    study = optuna.create_study(direction=direction)
+
+    for value in [-float("inf"), 0, 1, float("inf")]:
+        study.add_trial(
+            optuna.create_trial(
+                state=optuna.trial.TrialState.COMPLETE,
+                value=(value if direction == "minimize" else -value),
+                params={"x": 0},
+                distributions={"x": optuna.distributions.FloatDistribution(-1.0, 1.0)},
+            )
+        )
+
+    for n_below in range(len(study.trials) + 1):
+        below_trials = _tpe.sampler._split_complete_trials_single_objective(
+            study.trials,
+            study,
+            n_below,
+        )
+        assert [trial.number for trial in below_trials] == list(range(n_below))
+
+
+def test_split_complete_trials_single_objective_empty() -> None:
+    study = optuna.create_study()
+    _tpe.sampler._split_complete_trials_single_objective([], study, 0) == []
+
+
+@pytest.mark.parametrize("direction", ["minimize", "maximize"])
+def test_split_pruned_trials(direction: str) -> None:
+    study = optuna.create_study(direction=direction)
+
+    for step in [2, 1]:
+        for value in [-float("inf"), 0, 1, float("inf"), float("nan")]:
+            study.add_trial(
+                optuna.create_trial(
+                    state=optuna.trial.TrialState.PRUNED,
+                    params={"x": 0},
+                    distributions={"x": optuna.distributions.FloatDistribution(-1.0, 1.0)},
+                    intermediate_values={step: (value if direction == "minimize" else -value)},
+                )
+            )
+
+    study.add_trial(
+        optuna.create_trial(
+            state=optuna.trial.TrialState.PRUNED,
+            params={"x": 0},
+            distributions={"x": optuna.distributions.FloatDistribution(-1.0, 1.0)},
+        )
     )
 
-    assert len(scores) == len(study.get_trials(states=states))
-    if constraints:
-        assert violations is not None
-        assert len(violations) == len(study.get_trials(states=states))
-    else:
-        assert violations is None
-
-    for gamma in range(1, len(scores)):
-        indices_below, indices_above = _tpe.sampler._split_observation_pairs(
-            scores, gamma, violations
+    for n_below in range(len(study.trials) + 1):
+        below_trials = _tpe.sampler._split_pruned_trials(
+            study.trials,
+            study,
+            n_below,
         )
-        assert np.max(indices_below) < np.min(indices_above)
+        assert [trial.number for trial in below_trials] == list(range(n_below))
+
+
+def test_split_pruned_trials_empty() -> None:
+    study = optuna.create_study()
+    _tpe.sampler._split_pruned_trials([], study, 0) == []
+
+
+@pytest.mark.parametrize("direction", ["minimize", "maximize"])
+def test_split_infeasible_trials(direction: str) -> None:
+    study = optuna.create_study(direction=direction)
+
+    for value in [1, 2, float("inf")]:
+        study.add_trial(
+            optuna.create_trial(
+                state=optuna.trial.TrialState.COMPLETE,
+                value=0,
+                params={"x": 0},
+                distributions={"x": optuna.distributions.FloatDistribution(-1.0, 1.0)},
+                system_attrs={_CONSTRAINTS_KEY: [value]},
+            )
+        )
+
+    for n_below in range(len(study.trials) + 1):
+        below_trials = _tpe.sampler._split_infeasible_trials(study.trials, n_below)
+        assert [trial.number for trial in below_trials] == list(range(n_below))
+
+
+def test_split_infeasible_trials_empty() -> None:
+    _tpe.sampler._split_infeasible_trials([], 0) == []
 
 
 def frozen_trial_factory(
@@ -1103,38 +1041,6 @@ def test_invalid_multivariate_and_group() -> None:
 def test_group_experimental_warning() -> None:
     with pytest.warns(optuna.exceptions.ExperimentalWarning):
         _ = TPESampler(multivariate=True, group=True)
-
-
-@pytest.mark.parametrize("direction", ["minimize", "maximize"])
-def test_constant_liar_observation_pairs(direction: str) -> None:
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", optuna.exceptions.ExperimentalWarning)
-        sampler = TPESampler(constant_liar=True)
-
-    study = optuna.create_study(sampler=sampler, direction=direction)
-
-    trial = study.ask()
-    trial.suggest_int("x", 2, 2)
-
-    assert (
-        len(study.trials) == 1 and study.trials[0].state == optuna.trial.TrialState.RUNNING
-    ), "Precondition"
-
-    # The value of the constant liar should be penalizing, i.e. `float("inf")` during minimization
-    # and `-float("inf")` during maximization.
-    expected_values = [(float("inf"), [float("inf") * (-1 if direction == "maximize" else 1)])]
-
-    states = [optuna.trial.TrialState.COMPLETE, optuna.trial.TrialState.PRUNED]
-    assert _tpe.sampler._get_observation_pairs(study, study.get_trials(states=states)) == (
-        [],
-        None,
-    )
-
-    states.append(optuna.trial.TrialState.RUNNING)
-    assert _tpe.sampler._get_observation_pairs(study, study.get_trials(states=states)) == (
-        expected_values,
-        None,
-    )
 
 
 def test_constant_liar_experimental_warning() -> None:


### PR DESCRIPTION
## Motivation
This is part of a series of `TPESampler` refactorings. ref: #4773 
This PR introduces `_split_trials`, which directly splits the trials for below and above. `_split_trials` lists trials according to states and calls `_split_complete_trials`, `_split_pruned_trials`, or `_split_infeasible_trials`.

## Description of the changes
- Add `_split_trials` instead of `_get_observation_pairs` and `_split_observation_pairs`
- Modify tests