### PR TITLE
Reduce `n_trials` in `test_combination_of_different_distributions_objective`

### DIFF
--- a/tests/samplers_tests/test_samplers.py
+++ b/tests/samplers_tests/test_samplers.py
@@ -922,9 +922,9 @@ def test_combination_of_different_distributions_objective(
         sampler = sampler_class()
 
     study = optuna.study.create_study(sampler=sampler)
-    study.optimize(objective, n_trials=10)
+    study.optimize(objective, n_trials=3)
 
-    assert len(study.trials) == 10
+    assert len(study.trials) == 3
     assert all(t.state == TrialState.COMPLETE for t in study.trials)
 
 


### PR DESCRIPTION
## Motivation
`test_combination_of_different_distributions_objective` takes about 7 minutes in my environment.
This PR reduces `n_trials` and shortens the execution time by about 5 minutes.

## Description of the changes
- reduce `n_trials` in `test_combination_of_different_distributions_objective`