### PR TITLE
Add artifact middleware for exponential backoff retries

### DIFF
--- a/docs/source/reference/artifacts.rst
+++ b/docs/source/reference/artifacts.rst
@@ -11,4 +11,5 @@ The :mod:`~optuna.artifacts` module provides the way to manage artifacts (output
 
    optuna.artifacts.FileSystemArtifactStore
    optuna.artifacts.Boto3ArtifactStore
+   optuna.artifacts.Backoff
    optuna.artifacts.upload_artifact

--- a/optuna/artifacts/__init__.py
+++ b/optuna/artifacts/__init__.py
@@ -1,3 +1,4 @@
+from optuna.artifacts._backoff import Backoff
 from optuna.artifacts._boto3 import Boto3ArtifactStore
 from optuna.artifacts._filesystem import FileSystemArtifactStore
 from optuna.artifacts._upload import upload_artifact
@@ -6,5 +7,6 @@ from optuna.artifacts._upload import upload_artifact
 __all__ = [
     "FileSystemArtifactStore",
     "Boto3ArtifactStore",
+    "Backoff",
     "upload_artifact",
 ]

--- a/optuna/artifacts/_backoff.py
+++ b/optuna/artifacts/_backoff.py
@@ -22,20 +22,20 @@ class Backoff:
     Example:
        .. code-block:: python
 
-          import optuna
-          from optuna.artifacts import upload_artifact
-          from optuna.artifacts import Boto3ArtifactStore
-          from optuna.artifacts import Backoff
+           import optuna
+           from optuna.artifacts import upload_artifact
+           from optuna.artifacts import Boto3ArtifactStore
+           from optuna.artifacts import Backoff
 
 
-          artifact_store = Backoff(Boto3ArtifactStore("my-bucket"))
+           artifact_store = Backoff(Boto3ArtifactStore("my-bucket"))
 
 
-          def objective(trial: optuna.Trial) -> float:
-              ... = trial.suggest_float("x", -10, 10)
-              file_path = generate_example(...)
-              upload_artifact(trial, file_path, artifact_store)
-              return ...
+           def objective(trial: optuna.Trial) -> float:
+               ... = trial.suggest_float("x", -10, 10)
+               file_path = generate_example(...)
+               upload_artifact(trial, file_path, artifact_store)
+               return ...
     """
 
     def __init__(

--- a/optuna/artifacts/_backoff.py
+++ b/optuna/artifacts/_backoff.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import logging
+import time
+from typing import TYPE_CHECKING
+
+from optuna.artifacts.exceptions import ArtifactNotFound
+
+
+_logger = logging.getLogger(__name__)
+
+
+if TYPE_CHECKING:
+    from typing import BinaryIO
+
+    from ._protocol import ArtifactStore
+
+
+class Backoff:
+    """An artifact store's middleware for exponential backoff.
+
+    Example:
+       .. code-block:: python
+
+          import optuna
+          from optuna.artifacts import upload_artifact
+          from optuna.artifacts import Boto3ArtifactStore
+          from optuna.artifacts import Backoff
+
+
+          artifact_store = Backoff(Boto3ArtifactStore("my-bucket"))
+
+
+          def objective(trial: optuna.Trial) -> float:
+              ... = trial.suggest_float("x", -10, 10)
+              file_path = generate_example(...)
+              upload_artifact(trial, file_path, artifact_store)
+              return ...
+    """
+
+    def __init__(
+        self,
+        backend: ArtifactStore,
+        *,
+        max_retries: int = 10,
+        multiplier: float = 2,
+        min_delay: float = 0.1,
+        max_delay: float = 30,
+    ) -> None:
+        # Default sleep seconds:
+        # 0.1, 0.2, 0.4, 0.8, 1.6, 3.2, 6.4, 12.8, 25.6, 30
+        self._backend = backend
+        assert max_retries > 0
+        assert multiplier > 0
+        assert min_delay > 0
+        assert max_delay > min_delay
+        self._max_retries = max_retries
+        self._multiplier = multiplier
+        self._min_delay = min_delay
+        self._max_delay = max_delay
+
+    def _get_sleep_secs(self, n_retry: int) -> float:
+        return min(self._min_delay * self._multiplier**n_retry, self._max_delay)
+
+    def open_reader(self, artifact_id: str) -> BinaryIO:
+        for i in range(self._max_retries):
+            try:
+                return self._backend.open_reader(artifact_id)
+            except ArtifactNotFound:
+                raise
+            except Exception as e:
+                if i == self._max_retries - 1:
+                    raise
+                else:
+                    _logger.error(f"Failed to open artifact={artifact_id} n_retry={i}", exc_info=e)
+            time.sleep(self._get_sleep_secs(i))
+        assert False, "must not reach here"
+
+    def write(self, artifact_id: str, content_body: BinaryIO) -> None:
+        for i in range(self._max_retries):
+            try:
+                self._backend.write(artifact_id, content_body)
+                break
+            except ArtifactNotFound:
+                raise
+            except Exception as e:
+                if i == self._max_retries - 1:
+                    raise
+                else:
+                    _logger.error(f"Failed to open artifact={artifact_id} n_retry={i}", exc_info=e)
+            content_body.seek(0)
+            time.sleep(self._get_sleep_secs(i))
+
+    def remove(self, artifact_id: str) -> None:
+        for i in range(self._max_retries):
+            try:
+                self._backend.remove(artifact_id)
+            except ArtifactNotFound:
+                raise
+            except Exception as e:
+                if i == self._max_retries - 1:
+                    raise
+                else:
+                    _logger.error(f"Failed to delete artifact={artifact_id}", exc_info=e)
+            time.sleep(self._get_sleep_secs(i))
+
+
+if TYPE_CHECKING:
+    # A mypy-runtime assertion to ensure that the Backoff middleware implements
+    # all abstract methods in ArtifactStore.
+    from . import FileSystemArtifactStore
+
+    _: ArtifactStore = Backoff(FileSystemArtifactStore("."))

--- a/tests/artifacts_tests/stubs.py
+++ b/tests/artifacts_tests/stubs.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import copy
+import io
+import shutil
+import threading
+from typing import TYPE_CHECKING
+
+from optuna.artifacts.exceptions import ArtifactNotFound
+
+
+if TYPE_CHECKING:
+    from typing import BinaryIO
+
+
+class FailArtifactStore:
+    def open_reader(self, artifact_id: str) -> BinaryIO:
+        raise Exception("something error raised")
+
+    def write(self, artifact_id: str, content_body: BinaryIO) -> None:
+        raise Exception("something error raised")
+
+    def remove(self, artifact_id: str) -> None:
+        raise Exception("something error raised")
+
+
+class InMemoryArtifactStore:
+    def __init__(self) -> None:
+        self._data: dict[str, io.BytesIO] = {}
+        self._lock = threading.Lock()
+
+    def open_reader(self, artifact_id: str) -> BinaryIO:
+        with self._lock:
+            data = self._data.get(artifact_id)
+            if data is None:
+                raise ArtifactNotFound("not found")
+            return copy.deepcopy(data)
+
+    def write(self, artifact_id: str, content_body: BinaryIO) -> None:
+        buf = io.BytesIO()
+        shutil.copyfileobj(content_body, buf)
+        buf.seek(0)
+        with self._lock:
+            self._data[artifact_id] = buf
+
+    def remove(self, artifact_id: str) -> None:
+        with self._lock:
+            if artifact_id not in self._data:
+                raise ArtifactNotFound("not found")
+            del self._data[artifact_id]
+
+
+if TYPE_CHECKING:
+    from optuna.artifacts._protocol import ArtifactStore
+
+    _fail: ArtifactStore = FailArtifactStore()
+    _inmemory: ArtifactStore = InMemoryArtifactStore()

--- a/tests/artifacts_tests/test_backoff.py
+++ b/tests/artifacts_tests/test_backoff.py
@@ -1,0 +1,35 @@
+import io
+import uuid
+
+from optuna.artifacts import Backoff
+
+from .stubs import FailArtifactStore
+from .stubs import InMemoryArtifactStore
+
+
+def test_backoff_time() -> None:
+    backend = Backoff(
+        backend=FailArtifactStore(),
+        min_delay=0.1,
+        multiplier=10,
+        max_delay=10,
+    )
+    assert backend._get_sleep_secs(0) == 0.1
+    assert backend._get_sleep_secs(1) == 1
+    assert backend._get_sleep_secs(2) == 10
+
+
+def test_read_and_write() -> None:
+    artifact_id = f"test-{uuid.uuid4()}"
+    dummy_content = b"Hello World"
+
+    backend = Backoff(
+        backend=InMemoryArtifactStore(),
+        min_delay=0.1,
+        multiplier=10,
+        max_delay=10,
+    )
+    backend.write(artifact_id, io.BytesIO(dummy_content))
+    with backend.open_reader(artifact_id) as f:
+        actual = f.read()
+    assert actual == dummy_content


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
Porting a `Backoff` middleware since it's useful when backends are unstable.
https://optuna-dashboard.readthedocs.io/en/latest/_generated/optuna_dashboard.artifact.backoff.Backoff.html#optuna_dashboard.artifact.backoff.Backoff

## Description of the changes
<!-- Describe the changes in this PR. -->
`Backoff` class is an artifact store's middleware enabling exponential backoff retries.

```Python
from optuna.artifacts import Boto3ArtifactStore
from optuna.artifacts import Backoff

artifact_store = Backoff(Boto3ArtifactStore("my-bucket"))
```