### PR TITLE
Update `optional-dependencies` and document deselecting integration tests in `CONTRIBUTING.md`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -139,11 +139,11 @@ unit tests are stored under the [tests directory](./tests).
 
 Please install some required packages at first.
 ```bash
-# Install required packages to test all modules without visualization and integration modules.
-pip install ".[test]"
+# Install required packages to test all modules without integration modules.
+pip install ".[test,optional]"
 
-# Install required packages to test all modules including visualization and integration modules.
-pip install ".[optional,integration]" -f https://download.pytorch.org/whl/torch_stable.html
+# Install required packages to test all modules including integration modules.
+pip install ".[integration]" -f https://download.pytorch.org/whl/torch_stable.html
 ```
 
 You can run your tests as follows:
@@ -151,6 +151,9 @@ You can run your tests as follows:
 ```bash
 # Run all the unit tests.
 pytest
+
+# Run all the unit tests without integrations.
+pytest -m "not integration"
 
 # Run all the unit tests defined in the specified test file.
 pytest tests/${TARGET_TEST_FILE_NAME}


### PR DESCRIPTION
## Motivation
This PR adds documentation for useful `pytest` option.

## Description of the changes
- Update `optional-dependencies` in `CONTRIBUTING.md`
- Document deselecting integration tests