### PR TITLE
Fix TensorBoard error on categorical choices of mixed types

### DIFF
--- a/optuna/integration/tensorboard.py
+++ b/optuna/integration/tensorboard.py
@@ -4,11 +4,14 @@ from typing import Dict
 import optuna
 from optuna._experimental import experimental_class
 from optuna._imports import try_import
+from optuna.logging import get_logger
 
 
 with try_import() as _imports:
     from tensorboard.plugins.hparams import api as hp
     import tensorflow as tf
+
+_logger = get_logger(__name__)
 
 
 @experimental_class("2.0.0")
@@ -46,7 +49,11 @@ class TensorBoardCallback:
         for param_name, param_value in trial.params.items():
             if param_name not in self._hp_params:
                 self._add_distributions(trial.distributions)
-            hparams[self._hp_params[param_name]] = param_value
+            param = self._hp_params[param_name]
+            if isinstance(param.domain, hp.Discrete):
+                hparams[param] = param.domain.dtype(param_value)
+            else:
+                hparams[param] = param_value
         run_name = "trial-%d" % trial.number
         run_dir = os.path.join(self._dirname, run_name)
         with tf.summary.create_file_writer(run_dir).as_default():
@@ -74,9 +81,24 @@ class TensorBoardCallback:
                     hp.IntInterval(param_distribution.low, param_distribution.high),
                 )
             elif isinstance(param_distribution, optuna.distributions.CategoricalDistribution):
+                choices = param_distribution.choices
+                dtype = type(choices[0])
+                if any(not isinstance(choice, dtype) for choice in choices):
+                    _logger.warning(
+                        "Choices contains mixed types, which is not supported by TensorBoard."
+                        "Converting all choices to strings."
+                    )
+                    choices = tuple(map(str, choices))
+                elif dtype not in (int, float, bool, str):
+                    _logger.warning(
+                        f"Choices are of type {dtype}, which is not supported by TensorBoard."
+                        "Converting all choices to strings."
+                    )
+                    choices = tuple(map(str, choices))
+
                 self._hp_params[param_name] = hp.HParam(
                     param_name,
-                    hp.Discrete(param_distribution.choices),
+                    hp.Discrete(choices, dtype),
                 )
             else:
                 distribution_list = [

--- a/optuna/integration/tensorboard.py
+++ b/optuna/integration/tensorboard.py
@@ -85,13 +85,13 @@ class TensorBoardCallback:
                 dtype = type(choices[0])
                 if any(not isinstance(choice, dtype) for choice in choices):
                     _logger.warning(
-                        "Choices contains mixed types, which is not supported by TensorBoard."
+                        "Choices contains mixed types, which is not supported by TensorBoard. "
                         "Converting all choices to strings."
                     )
                     choices = tuple(map(str, choices))
                 elif dtype not in (int, float, bool, str):
                     _logger.warning(
-                        f"Choices are of type {dtype}, which is not supported by TensorBoard."
+                        f"Choices are of type {dtype}, which is not supported by TensorBoard. "
                         "Converting all choices to strings."
                     )
                     choices = tuple(map(str, choices))

--- a/optuna/integration/tensorboard.py
+++ b/optuna/integration/tensorboard.py
@@ -98,7 +98,7 @@ class TensorBoardCallback:
 
                 self._hp_params[param_name] = hp.HParam(
                     param_name,
-                    hp.Discrete(choices, dtype),
+                    hp.Discrete(choices),
                 )
             else:
                 distribution_list = [

--- a/tests/integration_tests/test_tensorboard.py
+++ b/tests/integration_tests/test_tensorboard.py
@@ -63,6 +63,36 @@ def test_cast_float() -> None:
     study.optimize(objective, n_trials=1, callbacks=[tbcallback])
 
 
+def test_categorical() -> None:
+    def objective(trial: optuna.trial.Trial) -> float:
+        x = trial.suggest_categorical("x", [1, 2, 3])
+        assert isinstance(x, int)
+        return x
+
+    dirname = tempfile.mkdtemp()
+    metric_name = "target"
+    study_name = "test_tensorboard_integration"
+
+    tbcallback = TensorBoardCallback(dirname, metric_name)
+    study = optuna.create_study(study_name=study_name)
+    study.optimize(objective, n_trials=1, callbacks=[tbcallback])
+
+
+def test_categorical_mixed_types() -> None:
+    def objective(trial: optuna.trial.Trial) -> float:
+        x = trial.suggest_categorical("x", [None, 1, 2, 3, True, "foo"])
+        assert isinstance(x, str)
+        return len(x)
+
+    dirname = tempfile.mkdtemp()
+    metric_name = "target"
+    study_name = "test_tensorboard_integration"
+
+    tbcallback = TensorBoardCallback(dirname, metric_name)
+    study = optuna.create_study(study_name=study_name)
+    study.optimize(objective, n_trials=1, callbacks=[tbcallback])
+
+
 def test_experimental_warning() -> None:
     with pytest.warns(optuna.exceptions.ExperimentalWarning):
         TensorBoardCallback(dirname="", metric_name="")

--- a/tests/integration_tests/test_tensorboard.py
+++ b/tests/integration_tests/test_tensorboard.py
@@ -81,8 +81,8 @@ def test_categorical() -> None:
 def test_categorical_mixed_types() -> None:
     def objective(trial: optuna.trial.Trial) -> float:
         x = trial.suggest_categorical("x", [None, 1, 2, 3, True, "foo"])
-        assert isinstance(x, str)
-        return len(x)
+        assert type(x) in (int, float, bool, str)
+        return len(str(x))
 
     dirname = tempfile.mkdtemp()
     metric_name = "target"

--- a/tests/integration_tests/test_tensorboard.py
+++ b/tests/integration_tests/test_tensorboard.py
@@ -80,9 +80,24 @@ def test_categorical() -> None:
 
 def test_categorical_mixed_types() -> None:
     def objective(trial: optuna.trial.Trial) -> float:
-        x = trial.suggest_categorical("x", [None, 1, 2, 3, True, "foo"])
+        x = trial.suggest_categorical("x", [None, 1, 2, 3.14, True, "foo"])
         assert x is None or isinstance(x, (int, float, bool, str))
         return len(str(x))
+
+    dirname = tempfile.mkdtemp()
+    metric_name = "target"
+    study_name = "test_tensorboard_integration"
+
+    tbcallback = TensorBoardCallback(dirname, metric_name)
+    study = optuna.create_study(study_name=study_name)
+    study.optimize(objective, n_trials=10, callbacks=[tbcallback])
+
+
+def test_categorical_unsupported_types() -> None:
+    def objective(trial: optuna.trial.Trial) -> float:
+        x = trial.suggest_categorical("x", [[1, 2], [3, 4, 5], [6]])
+        assert isinstance(x, list)
+        return len(x)
 
     dirname = tempfile.mkdtemp()
     metric_name = "target"

--- a/tests/integration_tests/test_tensorboard.py
+++ b/tests/integration_tests/test_tensorboard.py
@@ -81,7 +81,7 @@ def test_categorical() -> None:
 def test_categorical_mixed_types() -> None:
     def objective(trial: optuna.trial.Trial) -> float:
         x = trial.suggest_categorical("x", [None, 1, 2, 3, True, "foo"])
-        assert type(x) in (int, float, bool, str)
+        assert x is None or isinstance(x, (int, float, bool, str))
         return len(str(x))
 
     dirname = tempfile.mkdtemp()
@@ -90,7 +90,7 @@ def test_categorical_mixed_types() -> None:
 
     tbcallback = TensorBoardCallback(dirname, metric_name)
     study = optuna.create_study(study_name=study_name)
-    study.optimize(objective, n_trials=1, callbacks=[tbcallback])
+    study.optimize(objective, n_trials=10, callbacks=[tbcallback])
 
 
 def test_experimental_warning() -> None:

--- a/tests/integration_tests/test_tensorboard.py
+++ b/tests/integration_tests/test_tensorboard.py
@@ -95,7 +95,7 @@ def test_categorical_mixed_types() -> None:
 
 def test_categorical_unsupported_types() -> None:
     def objective(trial: optuna.trial.Trial) -> float:
-        x = trial.suggest_categorical("x", [[1, 2], [3, 4, 5], [6]])
+        x = trial.suggest_categorical("x", [[1, 2], [3, 4, 5], [6]])  # type: ignore[list-item]
         assert isinstance(x, list)
         return len(x)
 


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

The current version of TensorBoard integration fails when a choice of categorical distribution is not type of `int`, `float`, `bool`, or `str`. This is caused by a limitation of TensorBoard.

https://github.com/tensorflow/tensorboard/blob/80ccab8c8729ff7f8f5e17c132af808b0efe5f5b/tensorboard/plugins/hparams/summary_v2.py#L477-L499

## Description of the changes
<!-- Describe the changes in this PR. -->

This PR fixes the issue by converting choices to strings when needed.

Fixes #4761.