### PR TITLE
support constraints in plot contour

### DIFF
--- a/optuna/visualization/_contour.py
+++ b/optuna/visualization/_contour.py
@@ -243,16 +243,21 @@ def _get_contour_subplot(
 
     return (
         contour,
-        _create_scatter(feasible.x, feasible.y, "black"),
-        _create_scatter(infeasible.x, infeasible.y, "#cccccc"),
+        _create_scatter(feasible.x, feasible.y, is_feasible=True),
+        _create_scatter(infeasible.x, infeasible.y, is_feasible=False),
     )
 
 
-def _create_scatter(x: list[Any], y: list[Any], marker_color: str) -> Scatter:
+def _create_scatter(x: list[Any], y: list[Any], is_feasible: bool) -> Scatter:
+    edge_color = "Gray" if is_feasible else "#cccccc"
+    marker_color = "black" if is_feasible else "#cccccc"
     return go.Scatter(
         x=x,
         y=y,
-        marker={"line": {"width": 2.0, "color": "Grey"}, "color": marker_color},
+        marker={
+            "line": {"width": 2.0, "color": edge_color},
+            "color": marker_color,
+        },
         mode="markers",
         name="Infeasible Trial",
         showlegend=False,

--- a/optuna/visualization/_contour.py
+++ b/optuna/visualization/_contour.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import math
+from typing import Any
 from typing import Callable
 from typing import NamedTuple
 
 from optuna.logging import get_logger
+from optuna.samplers._base import _CONSTRAINTS_KEY
 from optuna.study import Study
 from optuna.study import StudyDirection
 from optuna.trial import FrozenTrial
@@ -43,6 +45,7 @@ class _SubContourInfo(NamedTuple):
     xaxis: _AxisInfo
     yaxis: _AxisInfo
     z_values: dict[tuple[int, int], float]
+    constraints: list[bool]
 
 
 class _ContourInfo(NamedTuple):
@@ -50,6 +53,11 @@ class _ContourInfo(NamedTuple):
     sub_plot_infos: list[list[_SubContourInfo]]
     reverse_scale: bool
     target_name: str
+
+
+class _PlotValues(NamedTuple):
+    x: list[Any]
+    y: list[Any]
 
 
 def plot_contour(
@@ -194,15 +202,22 @@ def _get_contour_subplot(
     info: _SubContourInfo,
     reverse_scale: bool,
     target_name: str = "Objective Value",
-) -> tuple["Contour", "Scatter"]:
+) -> tuple["Contour", "Scatter", "Scatter"]:
     x_indices = info.xaxis.indices
     y_indices = info.yaxis.indices
-    x_values = []
-    y_values = []
-    for x_value, y_value in zip(info.xaxis.values, info.yaxis.values):
+
+    feasible = _PlotValues([], [])
+    infeasible = _PlotValues([], [])
+
+    for x_value, y_value, c in zip(info.xaxis.values, info.yaxis.values, info.constraints):
         if x_value is not None and y_value is not None:
-            x_values.append(x_value)
-            y_values.append(y_value)
+            if c:
+                feasible.x.append(x_value)
+                feasible.y.append(y_value)
+            else:
+                infeasible.x.append(x_value)
+                infeasible.y.append(y_value)
+
     z_values = [
         [float("nan") for _ in range(len(info.xaxis.indices))]
         for _ in range(len(info.yaxis.indices))
@@ -211,7 +226,7 @@ def _get_contour_subplot(
         z_values[y_i][x_i] = z_value
 
     if len(x_indices) < 2 or len(y_indices) < 2:
-        return go.Contour(), go.Scatter()
+        return go.Contour(), go.Scatter(), go.Scatter()
 
     contour = go.Contour(
         x=x_indices,
@@ -226,15 +241,22 @@ def _get_contour_subplot(
         reversescale=reverse_scale,
     )
 
-    scatter = go.Scatter(
-        x=x_values,
-        y=y_values,
-        marker={"line": {"width": 2.0, "color": "Grey"}, "color": "black"},
-        mode="markers",
-        showlegend=False,
+    return (
+        contour,
+        _create_scatter(feasible.x, feasible.y, "black"),
+        _create_scatter(infeasible.x, infeasible.y, "#cccccc"),
     )
 
-    return contour, scatter
+
+def _create_scatter(x: list[Any], y: list[Any], marker_color: str) -> Scatter:
+    return go.Scatter(
+        x=x,
+        y=y,
+        marker={"line": {"width": 2.0, "color": "Grey"}, "color": marker_color},
+        mode="markers",
+        name="Infeasible Trial",
+        showlegend=False,
+    )
 
 
 def _get_contour_info(
@@ -337,7 +359,17 @@ def _get_contour_subplot_info(
                 else max(existing, value)
             )
 
-    return _SubContourInfo(xaxis=xaxis, yaxis=yaxis, z_values=z_values)
+    return _SubContourInfo(
+        xaxis=xaxis,
+        yaxis=yaxis,
+        z_values=z_values,
+        constraints=[_satisfy_constraints(t) for t in trials],
+    )
+
+
+def _satisfy_constraints(trial: FrozenTrial) -> bool:
+    constraints = trial.system_attrs.get(_CONSTRAINTS_KEY)
+    return constraints is None or all([x <= 0.0 for x in constraints])
 
 
 def _get_axis_info(trials: list[FrozenTrial], param_name: str) -> _AxisInfo:

--- a/optuna/visualization/_contour.py
+++ b/optuna/visualization/_contour.py
@@ -251,6 +251,7 @@ def _get_contour_subplot(
 def _create_scatter(x: list[Any], y: list[Any], is_feasible: bool) -> Scatter:
     edge_color = "Gray" if is_feasible else "#cccccc"
     marker_color = "black" if is_feasible else "#cccccc"
+    name = "Feasible Trial" if is_feasible else "Infeasible Trial"
     return go.Scatter(
         x=x,
         y=y,
@@ -259,7 +260,7 @@ def _create_scatter(x: list[Any], y: list[Any], is_feasible: bool) -> Scatter:
             "color": marker_color,
         },
         mode="markers",
-        name="Infeasible Trial",
+        name=name,
         showlegend=False,
     )
 

--- a/optuna/visualization/_contour.py
+++ b/optuna/visualization/_contour.py
@@ -45,7 +45,7 @@ class _SubContourInfo(NamedTuple):
     xaxis: _AxisInfo
     yaxis: _AxisInfo
     z_values: dict[tuple[int, int], float]
-    constraints: list[bool]
+    constraints: list[bool] = []
 
 
 class _ContourInfo(NamedTuple):

--- a/optuna/visualization/matplotlib/_contour.py
+++ b/optuna/visualization/matplotlib/_contour.py
@@ -204,7 +204,17 @@ def _calculate_griddata(
 
     # Return empty values when x or y has no value.
     if len(x_values) == 0 or len(y_values) == 0:
-        return np.array([]), np.array([]), np.array([]), [], [], [], [], _PlotValues([], []), _PlotValues([], [])
+        return (
+            np.array([]),
+            np.array([]),
+            np.array([]),
+            [],
+            [],
+            [],
+            [],
+            _PlotValues([], []),
+            _PlotValues([], []),
+        )
 
     def _calculate_axis_data(
         axis: _AxisInfo,

--- a/optuna/visualization/matplotlib/_contour.py
+++ b/optuna/visualization/matplotlib/_contour.py
@@ -204,7 +204,7 @@ def _calculate_griddata(
 
     # Return empty values when x or y has no value.
     if len(x_values) == 0 or len(y_values) == 0:
-        return np.array([]), np.array([]), np.array([]), [], [], [], [], [], []
+        return np.array([]), np.array([]), np.array([]), [], [], [], [], _PlotValues([], []), _PlotValues([], [])
 
     def _calculate_axis_data(
         axis: _AxisInfo,

--- a/optuna/visualization/matplotlib/_contour.py
+++ b/optuna/visualization/matplotlib/_contour.py
@@ -13,6 +13,7 @@ from optuna.trial import FrozenTrial
 from optuna.visualization._contour import _AxisInfo
 from optuna.visualization._contour import _ContourInfo
 from optuna.visualization._contour import _get_contour_info
+from optuna.visualization._contour import _PlotValues
 from optuna.visualization._contour import _SubContourInfo
 from optuna.visualization.matplotlib._matplotlib_imports import _imports
 
@@ -174,9 +175,7 @@ class _LabelEncoder:
 
 
 def _calculate_griddata(
-    xaxis: _AxisInfo,
-    yaxis: _AxisInfo,
-    z_values_dict: dict[tuple[int, int], float],
+    info: _SubContourInfo,
 ) -> tuple[
     np.ndarray,
     np.ndarray,
@@ -185,9 +184,13 @@ def _calculate_griddata(
     list[str],
     list[int],
     list[str],
-    list[int | float],
-    list[int | float],
+    _PlotValues,
+    _PlotValues,
 ]:
+    xaxis = info.xaxis
+    yaxis = info.yaxis
+    z_values_dict = info.z_values
+
     x_values = []
     y_values = []
     z_values = []
@@ -244,6 +247,18 @@ def _calculate_griddata(
         zmap = _create_zmap(transformed_x_values, transformed_y_values, z_values, xi, yi)
         zi = _interpolate_zmap(zmap, CONTOUR_POINT_NUM)
 
+    # categorize by constraints
+    feasible = _PlotValues([], [])
+    infeasible = _PlotValues([], [])
+
+    for x_value, y_value, c in zip(transformed_x_values, transformed_y_values, info.constraints):
+        if c:
+            feasible.x.append(x_value)
+            feasible.y.append(y_value)
+        else:
+            infeasible.x.append(x_value)
+            infeasible.y.append(y_value)
+
     return (
         xi,
         yi,
@@ -252,8 +267,8 @@ def _calculate_griddata(
         cat_param_labels_x,
         cat_param_pos_y,
         cat_param_labels_y,
-        transformed_x_values,
-        transformed_y_values,
+        feasible,
+        infeasible,
     )
 
 
@@ -278,9 +293,9 @@ def _generate_contour_subplot(info: _SubContourInfo, ax: "Axes", cmap: "Colormap
         x_cat_param_label,
         y_cat_param_pos,
         y_cat_param_label,
-        x_values,
-        y_values,
-    ) = _calculate_griddata(info.xaxis, info.yaxis, info.z_values)
+        feasible_plot_values,
+        infeasible_plot_values,
+    ) = _calculate_griddata(info)
     cs = None
     if len(zi) > 0:
         if info.xaxis.is_log:
@@ -293,14 +308,24 @@ def _generate_contour_subplot(info: _SubContourInfo, ax: "Axes", cmap: "Colormap
             cs = ax.contourf(xi, yi, zi, 15, cmap=cmap.reversed())
             # Plot data points.
             ax.scatter(
-                x_values,
-                y_values,
+                feasible_plot_values.x,
+                feasible_plot_values.y,
                 marker="o",
                 c="black",
                 s=20,
                 edgecolors="grey",
                 linewidth=2.0,
             )
+            ax.scatter(
+                infeasible_plot_values.x,
+                infeasible_plot_values.y,
+                marker="o",
+                c="#cccccc",
+                s=20,
+                edgecolors="grey",
+                linewidth=2.0,
+            )
+
     if info.xaxis.is_cat:
         ax.set_xticks(x_cat_param_pos)
         ax.set_xticklabels(x_cat_param_label)

--- a/optuna/visualization/matplotlib/_contour.py
+++ b/optuna/visualization/matplotlib/_contour.py
@@ -322,7 +322,7 @@ def _generate_contour_subplot(info: _SubContourInfo, ax: "Axes", cmap: "Colormap
                 marker="o",
                 c="#cccccc",
                 s=20,
-                edgecolors="grey",
+                edgecolors="#cccccc",
                 linewidth=2.0,
             )
 

--- a/tests/visualization_tests/test_contour.py
+++ b/tests/visualization_tests/test_contour.py
@@ -256,6 +256,7 @@ def test_get_contour_info_2_params() -> None:
                         values=[2.0, 0.0, 1.0],
                     ),
                     z_values={(1, 3): 0.0, (2, 2): 1.0},
+                    constraints=[True, True, True],
                 )
             ]
         ],
@@ -277,7 +278,7 @@ def test_get_contour_info_more_than_2_params(params: list[str] | None) -> None:
     n_params = len(params) if params is not None else 4
     info = _get_contour_info(study, params=params)
     assert len(info.sorted_params) == n_params
-    assert np.shape(np.asarray(info.sub_plot_infos, dtype=object)) == (n_params, n_params, 3)
+    assert np.shape(np.asarray(info.sub_plot_infos, dtype=object)) == (n_params, n_params, 4)
 
 
 @pytest.mark.parametrize(
@@ -294,7 +295,7 @@ def test_get_contour_info_customized_target(params: list[str]) -> None:
     )
     n_params = len(params)
     assert len(info.sorted_params) == n_params
-    plot_shape = (1, 1, 3) if n_params == 2 else (n_params, n_params, 3)
+    plot_shape = (1, 1, 4) if n_params == 2 else (n_params, n_params, 4)
     assert np.shape(np.asarray(info.sub_plot_infos, dtype=object)) == plot_shape
 
 
@@ -348,6 +349,7 @@ def test_generate_contour_plot_for_few_observations(params: list[str]) -> None:
                         values=[2.0, 0.0],
                     ),
                     z_values={},
+                    constraints=[],
                 )
             ]
         ],
@@ -382,6 +384,7 @@ def test_get_contour_info_log_scale_and_str_category_2_params() -> None:
                         values=["101", "100"],
                     ),
                     z_values={(1, 1): 0.0, (2, 0): 1.0},
+                    constraints=[True, True],
                 )
             ]
         ],
@@ -396,7 +399,7 @@ def test_get_contour_info_log_scale_and_str_category_more_than_2_params() -> Non
     info = _get_contour_info(study)
     params = ["param_a", "param_b", "param_c"]
     assert info.sorted_params == params
-    assert np.shape(np.asarray(info.sub_plot_infos, dtype=object)) == (3, 3, 3)
+    assert np.shape(np.asarray(info.sub_plot_infos, dtype=object)) == (3, 3, 4)
     ranges = {
         "param_a": (math.pow(10, -6.05), math.pow(10, -4.95)),
         "param_b": (-0.05, 1.05),
@@ -466,6 +469,7 @@ def test_get_contour_info_mixture_category_types() -> None:
                         values=[101.0, 102.0],
                     ),
                     z_values={(0, 2): 0.5, (1, 1): 0.0},
+                    constraints=[True, True],
                 )
             ]
         ],
@@ -500,6 +504,7 @@ def test_get_contour_info_nonfinite_removed(value: float) -> None:
                         values=[4.0, 2.0],
                     ),
                     z_values={(1, 2): 2.0, (2, 1): 1.0},
+                    constraints=[True, True],
                 )
             ]
         ],
@@ -540,6 +545,7 @@ def test_get_contour_info_nonfinite_multiobjective(objective: int, value: float)
                         values=[4.0, 2.0],
                     ),
                     z_values={(1, 2): 2.0, (2, 1): 1.0},
+                    constraints=[True, True],
                 )
             ]
         ],
@@ -574,6 +580,7 @@ def test_get_contour_info_overlapping_params(direction: str, expected: float) ->
                         values=["101", "101", "100"],
                     ),
                     z_values={(1, 1): expected, (2, 0): 1.0},
+                    constraints=[True, True, True],
                 )
             ]
         ],


### PR DESCRIPTION
## Motivation
https://github.com/optuna/optuna/issues/4829
Make `plot_contour` plots support optimization with constraints

## Description of the changes
show feasible or infeasible plots by changing marker color
 
![スクリーンショット 2023-09-30 15 04 53](https://github.com/y-kamiya/optuna/assets/1647260/10867f07-a92c-4ca8-b23a-6f0ed457a127)

sample code to show plots above
```
import optuna
from optuna.samplers._base import _CONSTRAINTS_KEY

def objective(trial):
    x = trial.suggest_float("x", -100, 100)
    y = trial.suggest_categorical("y", [-1, 0, 1])
    trial.set_user_attr(_CONSTRAINTS_KEY, [y])
    return x ** 2 + y

def constraints(trial):
    return trial.user_attrs[_CONSTRAINTS_KEY]

sampler = optuna.samplers.TPESampler(seed=10, constraints_func=constraints)
study = optuna.create_study(sampler=sampler)
study.optimize(objective, n_trials=30)

fig = optuna.visualization.plot_contour(study, params=["x", "y"])
fig.show()
```