### PR TITLE
Use lazy random state in samplers

### DIFF
--- a/optuna/multi_objective/samplers/_nsga2.py
+++ b/optuna/multi_objective/samplers/_nsga2.py
@@ -17,6 +17,7 @@ from optuna import multi_objective
 from optuna._deprecated import deprecated_class
 from optuna.distributions import BaseDistribution
 from optuna.multi_objective.samplers import BaseMultiObjectiveSampler
+from optuna.samplers._lazy_random_sate import LazyRandomState
 
 
 # Define key names of `Trial.system_attrs`.
@@ -90,11 +91,11 @@ class NSGAIIMultiObjectiveSampler(BaseMultiObjectiveSampler):
         self._crossover_prob = crossover_prob
         self._swapping_prob = swapping_prob
         self._random_sampler = multi_objective.samplers.RandomMultiObjectiveSampler(seed=seed)
-        self._rng = np.random.RandomState(seed)
+        self._rng = LazyRandomState(seed)
 
     def reseed_rng(self) -> None:
         self._random_sampler.reseed_rng()
-        self._rng.seed()
+        self._rng.rng.seed()
 
     def infer_relative_search_space(
         self,
@@ -117,7 +118,7 @@ class NSGAIIMultiObjectiveSampler(BaseMultiObjectiveSampler):
 
         if parent_generation >= 0:
             p0 = self._select_parent(study, parent_population)
-            if self._rng.rand() < self._crossover_prob:
+            if self._rng.rng.rand() < self._crossover_prob:
                 p1 = self._select_parent(
                     study, [t for t in parent_population if t._trial_id != p0._trial_id]
                 )
@@ -148,7 +149,7 @@ class NSGAIIMultiObjectiveSampler(BaseMultiObjectiveSampler):
 
         param = p0.params.get(param_name, None)
         parent_params_len = len(p0.params)
-        if param is None or self._rng.rand() < self._swapping_prob:
+        if param is None or self._rng.rng.rand() < self._swapping_prob:
             param = p1.params.get(param_name, None)
             parent_params_len = len(p1.params)
 
@@ -156,7 +157,7 @@ class NSGAIIMultiObjectiveSampler(BaseMultiObjectiveSampler):
         if mutation_prob is None:
             mutation_prob = 1.0 / max(1.0, parent_params_len)
 
-        if param is None or self._rng.rand() < mutation_prob:
+        if param is None or self._rng.rng.rand() < mutation_prob:
             return self._random_sampler.sample_independent(
                 study, trial, param_name, param_distribution
             )
@@ -267,8 +268,8 @@ class NSGAIIMultiObjectiveSampler(BaseMultiObjectiveSampler):
     ) -> "multi_objective.trial.FrozenMultiObjectiveTrial":
         # TODO(ohta): Consider to allow users to specify the number of parent candidates.
         population_size = len(population)
-        candidate0 = population[self._rng.choice(population_size)]
-        candidate1 = population[self._rng.choice(population_size)]
+        candidate0 = population[self._rng.rng.choice(population_size)]
+        candidate1 = population[self._rng.rng.choice(population_size)]
 
         # TODO(ohta): Consider crowding distance.
         if candidate0._dominates(candidate1, study.directions):

--- a/optuna/multi_objective/samplers/_nsga2.py
+++ b/optuna/multi_objective/samplers/_nsga2.py
@@ -10,14 +10,12 @@ from typing import Optional
 from typing import Sequence
 from typing import Tuple
 
-import numpy as np
-
 import optuna
 from optuna import multi_objective
 from optuna._deprecated import deprecated_class
 from optuna.distributions import BaseDistribution
 from optuna.multi_objective.samplers import BaseMultiObjectiveSampler
-from optuna.samplers._lazy_random_sate import LazyRandomState
+from optuna.samplers._lazy_random_state import LazyRandomState
 
 
 # Define key names of `Trial.system_attrs`.

--- a/optuna/samplers/_brute_force.py
+++ b/optuna/samplers/_brute_force.py
@@ -20,6 +20,7 @@ from optuna.study import Study
 from optuna.trial import create_trial
 from optuna.trial import FrozenTrial
 from optuna.trial import TrialState
+from optuna.samplers._lazy_random_sate import LazyRandomState
 
 
 @dataclass
@@ -130,7 +131,7 @@ class BruteForceSampler(BaseSampler):
     """
 
     def __init__(self, seed: Optional[int] = None) -> None:
-        self._rng = np.random.RandomState(seed)
+        self._rng = LazyRandomState(seed)
 
     def infer_relative_search_space(
         self, study: Study, trial: FrozenTrial
@@ -194,9 +195,9 @@ class BruteForceSampler(BaseSampler):
         candidates = _enumerate_candidates(param_distribution)
         tree.expand(param_name, candidates)
         if tree.count_unexpanded() == 0:
-            return param_distribution.to_external_repr(self._rng.choice(candidates))
+            return param_distribution.to_external_repr(self._rng.rng.choice(candidates))
         else:
-            return param_distribution.to_external_repr(tree.sample_child(self._rng))
+            return param_distribution.to_external_repr(tree.sample_child(self._rng.rng))
 
     def after_trial(
         self,

--- a/optuna/samplers/_brute_force.py
+++ b/optuna/samplers/_brute_force.py
@@ -16,11 +16,11 @@ from optuna.distributions import CategoricalDistribution
 from optuna.distributions import FloatDistribution
 from optuna.distributions import IntDistribution
 from optuna.samplers import BaseSampler
+from optuna.samplers._lazy_random_state import LazyRandomState
 from optuna.study import Study
 from optuna.trial import create_trial
 from optuna.trial import FrozenTrial
 from optuna.trial import TrialState
-from optuna.samplers._lazy_random_sate import LazyRandomState
 
 
 @dataclass

--- a/optuna/samplers/_cmaes.py
+++ b/optuna/samplers/_cmaes.py
@@ -31,6 +31,7 @@ from optuna.search_space import IntersectionSearchSpace
 from optuna.study._study_direction import StudyDirection
 from optuna.trial import FrozenTrial
 from optuna.trial import TrialState
+from optuna.samplers._lazy_random_sate import LazyRandomState
 
 
 if TYPE_CHECKING:
@@ -272,7 +273,7 @@ class CmaEsSampler(BaseSampler):
         self._independent_sampler = independent_sampler or optuna.samplers.RandomSampler(seed=seed)
         self._n_startup_trials = n_startup_trials
         self._warn_independent_sampling = warn_independent_sampling
-        self._cma_rng = np.random.RandomState(seed)
+        self._cma_rng = LazyRandomState(seed)
         self._search_space = IntersectionSearchSpace()
         self._consider_pruned_trials = consider_pruned_trials
         self._restart_strategy = restart_strategy
@@ -496,7 +497,7 @@ class CmaEsSampler(BaseSampler):
                     popsize_multiplier = self._inc_popsize**n_restarts_with_large
                     popsize = math.floor(
                         self._initial_popsize
-                        * popsize_multiplier ** (self._cma_rng.uniform() ** 2)
+                        * popsize_multiplier ** (self._cma_rng.rng.uniform() ** 2)
                     )
                 else:
                     poptype = "large"
@@ -514,7 +515,7 @@ class CmaEsSampler(BaseSampler):
                 study._storage.set_trial_system_attr(trial._trial_id, key, optimizer_attrs[key])
 
         # Caution: optimizer should update its seed value.
-        seed = self._cma_rng.randint(1, 2**16) + trial.number
+        seed = self._cma_rng.rng.randint(1, 2**16) + trial.number
         optimizer._rng.seed(seed)
         if isinstance(optimizer, cmaes.CMAwM):
             params, x_for_tell = optimizer.ask()
@@ -644,7 +645,7 @@ class CmaEsSampler(BaseSampler):
 
         if self._source_trials is None:
             if randomize_start_point:
-                mean = lower_bounds + (upper_bounds - lower_bounds) * self._cma_rng.rand(
+                mean = lower_bounds + (upper_bounds - lower_bounds) * self._cma_rng.rng.rand(
                     n_dimension
                 )
             elif self._x0 is None:
@@ -686,7 +687,7 @@ class CmaEsSampler(BaseSampler):
                 mean=mean,
                 sigma=sigma0,
                 bounds=trans.bounds,
-                seed=self._cma_rng.randint(1, 2**31 - 2),
+                seed=self._cma_rng.rng.randint(1, 2**31 - 2),
                 n_max_resampling=10 * n_dimension,
                 population_size=population_size,
             )
@@ -709,7 +710,7 @@ class CmaEsSampler(BaseSampler):
                 bounds=trans.bounds,
                 steps=steps,
                 cov=cov,
-                seed=self._cma_rng.randint(1, 2**31 - 2),
+                seed=self._cma_rng.rng.randint(1, 2**31 - 2),
                 n_max_resampling=10 * n_dimension,
                 population_size=population_size,
             )
@@ -719,7 +720,7 @@ class CmaEsSampler(BaseSampler):
             sigma=sigma0,
             cov=cov,
             bounds=trans.bounds,
-            seed=self._cma_rng.randint(1, 2**31 - 2),
+            seed=self._cma_rng.rng.randint(1, 2**31 - 2),
             n_max_resampling=10 * n_dimension,
             population_size=population_size,
             lr_adapt=self._lr_adapt,

--- a/optuna/samplers/_cmaes.py
+++ b/optuna/samplers/_cmaes.py
@@ -27,11 +27,11 @@ from optuna.distributions import FloatDistribution
 from optuna.distributions import IntDistribution
 from optuna.exceptions import ExperimentalWarning
 from optuna.samplers import BaseSampler
+from optuna.samplers._lazy_random_state import LazyRandomState
 from optuna.search_space import IntersectionSearchSpace
 from optuna.study._study_direction import StudyDirection
 from optuna.trial import FrozenTrial
 from optuna.trial import TrialState
-from optuna.samplers._lazy_random_sate import LazyRandomState
 
 
 if TYPE_CHECKING:

--- a/optuna/samplers/_nsgaiii.py
+++ b/optuna/samplers/_nsgaiii.py
@@ -27,6 +27,7 @@ from optuna.study import Study
 from optuna.study._multi_objective import _dominates
 from optuna.trial import FrozenTrial
 from optuna.trial import TrialState
+from optuna.samplers._lazy_random_sate import LazyRandomState
 
 
 # Define key names of `Trial.system_attrs`.
@@ -121,7 +122,7 @@ class NSGAIIISampler(BaseSampler):
 
         self._population_size = population_size
         self._random_sampler = RandomSampler(seed=seed)
-        self._rng = np.random.RandomState(seed)
+        self._rng = LazyRandomState(seed)
         self._constraints_func = constraints_func
         self._reference_points = reference_points
         self._dividing_parameter = dividing_parameter
@@ -143,7 +144,7 @@ class NSGAIIISampler(BaseSampler):
 
     def reseed_rng(self) -> None:
         self._random_sampler.reseed_rng()
-        self._rng.seed()
+        self._rng.rng.seed()
 
     def infer_relative_search_space(
         self, study: Study, trial: FrozenTrial
@@ -309,7 +310,7 @@ class NSGAIIISampler(BaseSampler):
                     population,
                     closest_reference_points,
                     distance_reference_points,
-                    self._rng,
+                    self._rng.rng,
                 )
                 elite_population.extend(additional_elite_population)
                 break

--- a/optuna/samplers/_nsgaiii.py
+++ b/optuna/samplers/_nsgaiii.py
@@ -14,6 +14,7 @@ import optuna
 from optuna._experimental import experimental_class
 from optuna.distributions import BaseDistribution
 from optuna.samplers._base import BaseSampler
+from optuna.samplers._lazy_random_state import LazyRandomState
 from optuna.samplers._random import RandomSampler
 from optuna.samplers.nsgaii._after_trial_strategy import NSGAIIAfterTrialStrategy
 from optuna.samplers.nsgaii._child_generation_strategy import NSGAIIChildGenerationStrategy
@@ -27,7 +28,6 @@ from optuna.study import Study
 from optuna.study._multi_objective import _dominates
 from optuna.trial import FrozenTrial
 from optuna.trial import TrialState
-from optuna.samplers._lazy_random_sate import LazyRandomState
 
 
 # Define key names of `Trial.system_attrs`.

--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -22,6 +22,7 @@ from optuna.logging import get_logger
 from optuna.samplers._base import _CONSTRAINTS_KEY
 from optuna.samplers._base import _process_constraints_after_trial
 from optuna.samplers._base import BaseSampler
+from optuna.samplers._lazy_random_state import LazyRandomState
 from optuna.samplers._random import RandomSampler
 from optuna.samplers._tpe.parzen_estimator import _ParzenEstimator
 from optuna.samplers._tpe.parzen_estimator import _ParzenEstimatorParameters
@@ -32,7 +33,7 @@ from optuna.study import Study
 from optuna.study._study_direction import StudyDirection
 from optuna.trial import FrozenTrial
 from optuna.trial import TrialState
-from optuna.samplers._lazy_random_sate import LazyRandomState
+
 
 EPS = 1e-12
 _logger = get_logger(__name__)

--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -32,7 +32,7 @@ from optuna.study import Study
 from optuna.study._study_direction import StudyDirection
 from optuna.trial import FrozenTrial
 from optuna.trial import TrialState
-
+from optuna.samplers._lazy_random_sate import LazyRandomState
 
 EPS = 1e-12
 _logger = get_logger(__name__)
@@ -280,7 +280,7 @@ class TPESampler(BaseSampler):
         self._gamma = gamma
 
         self._warn_independent_sampling = warn_independent_sampling
-        self._rng = np.random.RandomState(seed)
+        self._rng = LazyRandomState(seed)
         self._random_sampler = RandomSampler(seed=seed)
 
         self._multivariate = multivariate
@@ -332,7 +332,7 @@ class TPESampler(BaseSampler):
             )
 
     def reseed_rng(self) -> None:
-        self._rng.seed()
+        self._rng.rng.seed()
         self._random_sampler.reseed_rng()
 
     def infer_relative_search_space(
@@ -476,7 +476,7 @@ class TPESampler(BaseSampler):
         else:
             mpe_below = _ParzenEstimator(below, search_space, self._parzen_estimator_parameters)
         mpe_above = _ParzenEstimator(above, search_space, self._parzen_estimator_parameters)
-        samples_below = mpe_below.sample(self._rng, self._n_ei_candidates)
+        samples_below = mpe_below.sample(self._rng.rng, self._n_ei_candidates)
         log_likelihoods_below = mpe_below.log_pdf(samples_below)
         log_likelihoods_above = mpe_above.log_pdf(samples_below)
         ret = TPESampler._compare(samples_below, log_likelihoods_below, log_likelihoods_above)

--- a/optuna/samplers/nsgaii/_child_generation_strategy.py
+++ b/optuna/samplers/nsgaii/_child_generation_strategy.py
@@ -4,16 +4,14 @@ from collections.abc import Callable
 from collections.abc import Sequence
 from typing import Any
 
-import numpy as np
-
 from optuna.distributions import BaseDistribution
+from optuna.samplers._lazy_random_state import LazyRandomState
 from optuna.samplers.nsgaii._crossover import perform_crossover
 from optuna.samplers.nsgaii._crossovers._base import BaseCrossover
 from optuna.samplers.nsgaii._dominates import _constrained_dominates
 from optuna.study import Study
 from optuna.study._multi_objective import _dominates
 from optuna.trial import FrozenTrial
-from optuna.samplers._lazy_random_sate import LazyRandomState
 
 
 class NSGAIIChildGenerationStrategy:

--- a/optuna/samplers/nsgaii/_sampler.py
+++ b/optuna/samplers/nsgaii/_sampler.py
@@ -25,6 +25,7 @@ from optuna.search_space import IntersectionSearchSpace
 from optuna.study import Study
 from optuna.trial import FrozenTrial
 from optuna.trial import TrialState
+from optuna.samplers._lazy_random_sate import LazyRandomState
 
 
 # Define key names of `Trial.system_attrs`.
@@ -205,7 +206,7 @@ class NSGAIISampler(BaseSampler):
 
         self._population_size = population_size
         self._random_sampler = RandomSampler(seed=seed)
-        self._rng = np.random.RandomState(seed)
+        self._rng = LazyRandomState(seed)
         self._constraints_func = constraints_func
         self._search_space = IntersectionSearchSpace()
 
@@ -232,7 +233,7 @@ class NSGAIISampler(BaseSampler):
 
     def reseed_rng(self) -> None:
         self._random_sampler.reseed_rng()
-        self._rng.seed()
+        self._rng.rng.seed()
 
     def infer_relative_search_space(
         self, study: Study, trial: FrozenTrial

--- a/optuna/samplers/nsgaii/_sampler.py
+++ b/optuna/samplers/nsgaii/_sampler.py
@@ -7,12 +7,11 @@ import hashlib
 from typing import Any
 import warnings
 
-import numpy as np
-
 import optuna
 from optuna.distributions import BaseDistribution
 from optuna.exceptions import ExperimentalWarning
 from optuna.samplers._base import BaseSampler
+from optuna.samplers._lazy_random_state import LazyRandomState
 from optuna.samplers._random import RandomSampler
 from optuna.samplers.nsgaii._after_trial_strategy import NSGAIIAfterTrialStrategy
 from optuna.samplers.nsgaii._child_generation_strategy import NSGAIIChildGenerationStrategy
@@ -25,7 +24,6 @@ from optuna.search_space import IntersectionSearchSpace
 from optuna.study import Study
 from optuna.trial import FrozenTrial
 from optuna.trial import TrialState
-from optuna.samplers._lazy_random_sate import LazyRandomState
 
 
 # Define key names of `Trial.system_attrs`.

--- a/tests/multi_objective_tests/samplers_tests/test_motpe.py
+++ b/tests/multi_objective_tests/samplers_tests/test_motpe.py
@@ -22,14 +22,14 @@ class MockSystemAttr:
 @pytest.mark.filterwarnings("ignore::FutureWarning")
 def test_reseed_rng() -> None:
     sampler = MOTPEMultiObjectiveSampler()
-    original_random_state = sampler._motpe_sampler._rng.get_state()
+    original_random_state = sampler._motpe_sampler._rng.rng.get_state()
 
     with patch.object(
         sampler._motpe_sampler, "reseed_rng", wraps=sampler._motpe_sampler.reseed_rng
     ) as mock_object:
         sampler.reseed_rng()
         assert mock_object.call_count == 1
-    assert str(original_random_state) != str(sampler._motpe_sampler._rng.get_state())
+    assert str(original_random_state) != str(sampler._motpe_sampler._rng.rng.get_state())
 
 
 @pytest.mark.filterwarnings("ignore::FutureWarning")

--- a/tests/multi_objective_tests/samplers_tests/test_nsga2.py
+++ b/tests/multi_objective_tests/samplers_tests/test_nsga2.py
@@ -193,7 +193,7 @@ def test_study_system_attr_for_population_cache() -> None:
 
 def test_reseed_rng() -> None:
     sampler = multi_objective.samplers.NSGAIIMultiObjectiveSampler(population_size=10)
-    original_random_state = sampler._rng.get_state()
+    original_random_state = sampler._rng.rng.get_state()
     original_random_sampler_random_state = sampler._random_sampler._sampler._rng.rng.get_state()
 
     with patch.object(
@@ -201,7 +201,7 @@ def test_reseed_rng() -> None:
     ) as mock_object:
         sampler.reseed_rng()
         assert mock_object.call_count == 1
-    assert str(original_random_state) != str(sampler._rng.get_state())
+    assert str(original_random_state) != str(sampler._rng.rng.get_state())
     assert str(original_random_sampler_random_state) != str(
         sampler._random_sampler._sampler._rng.rng.get_state()
     )

--- a/tests/samplers_tests/test_nsgaiii.py
+++ b/tests/samplers_tests/test_nsgaiii.py
@@ -607,7 +607,7 @@ def test_niching(
             population,
             np.array(closest_reference_points),
             np.array(distance_reference_points),
-            sampler._rng,
+            sampler._rng.rng,
         )
     ]
     expected_additional_elite_population = [

--- a/tests/samplers_tests/test_nsgaiii.py
+++ b/tests/samplers_tests/test_nsgaiii.py
@@ -628,5 +628,5 @@ def test_niching_unexpected_target_population_size() -> None:
             population,
             np.array([0]),
             np.array([0.0]),
-            sampler._rng,
+            sampler._rng.rng,
         )

--- a/tests/samplers_tests/test_samplers.py
+++ b/tests/samplers_tests/test_samplers.py
@@ -170,24 +170,14 @@ def test_sampler_reseed_rng(
 
     sampler = sampler_class()
 
-    rng_name = _extract_attr_name_from_sampler_by_cls(sampler, np.random.RandomState)
-    using_lazy_rng = False
-    if rng_name is None:
-        rng_name = _extract_attr_name_from_sampler_by_cls(sampler, LazyRandomState)
-        using_lazy_rng = rng_name is not None
+    rng_name = _extract_attr_name_from_sampler_by_cls(sampler, LazyRandomState)
     has_rng = rng_name is not None
     assert expected_has_rng == has_rng
     if has_rng:
         rng_name = str(rng_name)
-        if using_lazy_rng:
-            original_random_state = sampler.__dict__[rng_name].rng.get_state()
-        else:
-            original_random_state = sampler.__dict__[rng_name].get_state()
+        original_random_state = sampler.__dict__[rng_name].rng.get_state()
         sampler.reseed_rng()
-        if using_lazy_rng:
-            random_state = sampler.__dict__[rng_name].rng.get_state()
-        else:
-            random_state = sampler.__dict__[rng_name].get_state()
+        random_state = sampler.__dict__[rng_name].rng.get_state()
         if not isinstance(sampler, optuna.samplers.CmaEsSampler):
             assert str(original_random_state) != str(random_state)
         else:
@@ -201,25 +191,10 @@ def test_sampler_reseed_rng(
     if has_another_sampler:
         had_sampler_name = str(had_sampler_name)
         had_sampler = sampler.__dict__[had_sampler_name]
-        had_sampler_rng_name = _extract_attr_name_from_sampler_by_cls(
-            had_sampler, np.random.RandomState
-        )
-        using_lazy_rng = False
-        if had_sampler_rng_name is None:
-            had_sampler_rng_name = _extract_attr_name_from_sampler_by_cls(
-                had_sampler, LazyRandomState
-            )
-            assert had_sampler_rng_name is not None
-            using_lazy_rng = True
-        if using_lazy_rng:
-            original_had_sampler_random_state = had_sampler.__dict__[
-                had_sampler_rng_name
-            ].rng.get_state()
-        else:
-            original_had_sampler_random_state = had_sampler.__dict__[
-                had_sampler_rng_name
-            ].get_state()
-
+        had_sampler_rng_name = _extract_attr_name_from_sampler_by_cls(had_sampler, LazyRandomState)
+        original_had_sampler_random_state = had_sampler.__dict__[
+            had_sampler_rng_name
+        ].rng.get_state()
         with patch.object(
             had_sampler,
             "reseed_rng",
@@ -229,10 +204,7 @@ def test_sampler_reseed_rng(
             assert mock_object.call_count == 1
 
         had_sampler = sampler.__dict__[had_sampler_name]
-        if using_lazy_rng:
-            had_sampler_random_state = had_sampler.__dict__[had_sampler_rng_name].rng.get_state()
-        else:
-            had_sampler_random_state = had_sampler.__dict__[had_sampler_rng_name].get_state()
+        had_sampler_random_state = had_sampler.__dict__[had_sampler_rng_name].rng.get_state()
         assert str(original_had_sampler_random_state) != str(had_sampler_random_state)
 
 


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

This PR should be merged after https://github.com/optuna/optuna/pull/4970
The PR solves https://github.com/optuna/optuna/issues/4604

I modify that Samplers use `LazyRandomState`


## Description of the changes
<!-- Describe the changes in this PR. -->

use `LazyRandomState` in following Samplers

* `NSGAIIMultiObjectiveSampler` and `NSGAIIChildGenerationStrategy`
* `BruteForceSampler`  
* `CmaEsSampler` 
* `NSGAIIISampler`
* `TPESampler`
* `NSGAIISampler`

