### PR TITLE
Fix numpy duplication warning

### DIFF
--- a/optuna/importance/_fanova/_tree.py
+++ b/optuna/importance/_fanova/_tree.py
@@ -267,7 +267,7 @@ class _FanovaTree:
     def _get_node_value(self, node_index: int) -> float:
         # self._tree.value: sklearn.tree._tree.Tree.value has
         # the shape (node_count, n_outputs, max_n_classes)
-        return float(self._tree.value[node_index][0][0])
+        return float(self._tree.value[node_index].reshape(-1)[0])
 
     @lru_cache(maxsize=None)
     def _get_node_split_threshold(self, node_index: int) -> float:

--- a/optuna/importance/_fanova/_tree.py
+++ b/optuna/importance/_fanova/_tree.py
@@ -265,7 +265,7 @@ class _FanovaTree:
 
     @lru_cache(maxsize=None)
     def _get_node_value(self, node_index: int) -> float:
-        return float(self._tree.value[node_index])
+        return float(self._tree.value[node_index].reshape(-1)[0])
 
     @lru_cache(maxsize=None)
     def _get_node_split_threshold(self, node_index: int) -> float:

--- a/optuna/importance/_fanova/_tree.py
+++ b/optuna/importance/_fanova/_tree.py
@@ -265,7 +265,9 @@ class _FanovaTree:
 
     @lru_cache(maxsize=None)
     def _get_node_value(self, node_index: int) -> float:
-        return float(self._tree.value[node_index].reshape(-1)[0])
+        # self._tree.value: sklearn.tree._tree.Tree.value has
+        # the shape [node_count, n_outputs, max_n_classes]
+        return float(self._tree.value[node_index][0][0])
 
     @lru_cache(maxsize=None)
     def _get_node_split_threshold(self, node_index: int) -> float:

--- a/optuna/importance/_fanova/_tree.py
+++ b/optuna/importance/_fanova/_tree.py
@@ -266,7 +266,7 @@ class _FanovaTree:
     @lru_cache(maxsize=None)
     def _get_node_value(self, node_index: int) -> float:
         # self._tree.value: sklearn.tree._tree.Tree.value has
-        # the shape [node_count, n_outputs, max_n_classes]
+        # the shape (node_count, n_outputs, max_n_classes)
         return float(self._tree.value[node_index][0][0])
 
     @lru_cache(maxsize=None)

--- a/optuna/terminator/improvement/gp/botorch.py
+++ b/optuna/terminator/improvement/gp/botorch.py
@@ -77,7 +77,7 @@ class _BoTorchGaussianProcess(BaseGaussianProcess):
             variance = posterior.variance
             std = variance.sqrt()
 
-        return mean.detach().numpy(), std.detach().numpy()
+        return mean.detach().numpy().squeeze(-1), std.detach().numpy().squeeze(-1)
 
 
 def _convert_trials_to_tensors(trials: list[FrozenTrial]) -> tuple[torch.Tensor, torch.Tensor]:

--- a/tests/importance_tests/fanova_tests/test_tree.py
+++ b/tests/importance_tests/fanova_tests/test_tree.py
@@ -18,7 +18,7 @@ def tree() -> _FanovaTree:
     sklearn_tree.feature = [1, 2, -1, -1, -1]
     sklearn_tree.children_left = [1, 2, -1, -1, -1]
     sklearn_tree.children_right = [4, 3, -1, -1, -1]
-    sklearn_tree.value = [numpy.array([[[val]]]) for val in [-1.0, -1.0, 0.1, 0.2, 0.5]]
+    sklearn_tree.value = numpy.array([[[-1.0, -1.0, 0.1, 0.2, 0.5]]])
     sklearn_tree.threshold = [0.5, 1.5, -1.0, -1.0, -1.0]
 
     search_spaces = numpy.array([[0.0, 1.0], [0.0, 1.0], [0.0, 2.0]])

--- a/tests/importance_tests/fanova_tests/test_tree.py
+++ b/tests/importance_tests/fanova_tests/test_tree.py
@@ -11,14 +11,14 @@ from optuna.importance._fanova._tree import _FanovaTree
 
 
 @pytest.fixture
-def tree() -> _FanovaTrTee:
+def tree() -> _FanovaTree:
     sklearn_tree = Mock()
     sklearn_tree.n_features = 3
     sklearn_tree.node_count = 5
     sklearn_tree.feature = [1, 2, -1, -1, -1]
     sklearn_tree.children_left = [1, 2, -1, -1, -1]
     sklearn_tree.children_right = [4, 3, -1, -1, -1]
-    # value is of shape (node_count, n_output, max_n_classes)
+    # value has the shape (node_count, n_output, max_n_classes)
     sklearn_tree.value = numpy.array([[[-1.0]], [[-1.0]], [[0.1]], [[0.2]], [[0.5]]])
     sklearn_tree.threshold = [0.5, 1.5, -1.0, -1.0, -1.0]
 

--- a/tests/importance_tests/fanova_tests/test_tree.py
+++ b/tests/importance_tests/fanova_tests/test_tree.py
@@ -18,7 +18,7 @@ def tree() -> _FanovaTree:
     sklearn_tree.feature = [1, 2, -1, -1, -1]
     sklearn_tree.children_left = [1, 2, -1, -1, -1]
     sklearn_tree.children_right = [4, 3, -1, -1, -1]
-    sklearn_tree.value = [-1.0, -1.0, 0.1, 0.2, 0.5]
+    sklearn_tree.value = [numpy.array([[[val]]]) for val in [-1.0, -1.0, 0.1, 0.2, 0.5]]
     sklearn_tree.threshold = [0.5, 1.5, -1.0, -1.0, -1.0]
 
     search_spaces = numpy.array([[0.0, 1.0], [0.0, 1.0], [0.0, 2.0]])

--- a/tests/importance_tests/fanova_tests/test_tree.py
+++ b/tests/importance_tests/fanova_tests/test_tree.py
@@ -11,14 +11,15 @@ from optuna.importance._fanova._tree import _FanovaTree
 
 
 @pytest.fixture
-def tree() -> _FanovaTree:
+def tree() -> _FanovaTrTee:
     sklearn_tree = Mock()
     sklearn_tree.n_features = 3
     sklearn_tree.node_count = 5
     sklearn_tree.feature = [1, 2, -1, -1, -1]
     sklearn_tree.children_left = [1, 2, -1, -1, -1]
     sklearn_tree.children_right = [4, 3, -1, -1, -1]
-    sklearn_tree.value = numpy.array([[[-1.0, -1.0, 0.1, 0.2, 0.5]]])
+    # value is of shape (node_count, n_output, max_n_classes)
+    sklearn_tree.value = numpy.array([[[-1.0]], [[-1.0]], [[0.1]], [[0.2]], [[0.5]]])
     sklearn_tree.threshold = [0.5, 1.5, -1.0, -1.0, -1.0]
 
     search_spaces = numpy.array([[0.0, 1.0], [0.0, 1.0], [0.0, 2.0]])

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -197,8 +197,7 @@ def test_check_distribution_compatibility() -> None:
 
 
 @pytest.mark.parametrize(
-    "value", (0, 1, 4, 10, 11, 1.1, "1", "1.1", "-1.0", True, False, np.ones(1), np.array([1.1]))
-)
+    "value", (0, 1, 4, 10, 11, 1.1, "1", "1.1", "-1.0", True, False))
 def test_int_internal_representation(value: Any) -> None:
     i = distributions.IntDistribution(low=1, high=10)
 
@@ -231,7 +230,7 @@ def test_int_internal_representation_error(value: Any, kwargs: Dict[str, Any]) -
 
 @pytest.mark.parametrize(
     "value",
-    (1.99, 2.0, 4.5, 7, 7.1, 1, "1", "1.1", "-1.0", True, False, np.ones(1), np.array([1.1])),
+    (1.99, 2.0, 4.5, 7, 7.1, 1, "1", "1.1", "-1.0", True, False),
 )
 def test_float_internal_representation(value: Any) -> None:
     f = distributions.FloatDistribution(low=2.0, high=7.0)

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -196,8 +196,7 @@ def test_check_distribution_compatibility() -> None:
     )
 
 
-@pytest.mark.parametrize(
-    "value", (0, 1, 4, 10, 11, 1.1, "1", "1.1", "-1.0", True, False))
+@pytest.mark.parametrize("value", (0, 1, 4, 10, 11, 1.1, "1", "1.1", "-1.0", True, False))
 def test_int_internal_representation(value: Any) -> None:
     i = distributions.IntDistribution(low=1, high=10)
 


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
This PR fixes `test` warning from NumPy (#4938)

## Description of the changes
<!-- Describe the changes in this PR. -->
I forced to squeeze the scalar value from `numpy.ndarray` when `numpy.ndarray` is converted into scalar values in some unit tests.