### PR TITLE
Remove experimental_func from metric_names property

### DIFF
--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -334,7 +334,6 @@ class Study:
         return copy.deepcopy(self._storage.get_study_system_attrs(self._study_id))
 
     @property
-    @experimental_func("3.4.0")
     def metric_names(self) -> list[str] | None:
         """Return metric names.
 

--- a/tests/study_tests/test_study.py
+++ b/tests/study_tests/test_study.py
@@ -1610,9 +1610,3 @@ def test_get_metric_names() -> None:
     assert study.metric_names == ["v0"]
     study.set_metric_names(["v1"])
     assert study.metric_names == ["v1"]
-
-
-def test_get_metric_names_experimental_warning() -> None:
-    study = create_study()
-    with pytest.warns(ExperimentalWarning):
-        study.metric_names


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

As described in #4979, we see too many `metric_names is experimental` warning. We don't want to see this warning when we don't use `metric_names`

## Description of the changes

To reduce this kind of warnings, we just remove `@experimental_class` from the `metric_names` property. `set_metric_names` is still marked as experimental and the warning will be shown when we attempt to set `metric_names`.

<!-- Describe the changes in this PR. -->
