### PR TITLE
Allow user-defined objective names in hyperparameter importance plots

### DIFF
--- a/optuna/visualization/matplotlib/_param_importances.py
+++ b/optuna/visualization/matplotlib/_param_importances.py
@@ -9,7 +9,7 @@ from optuna.importance._base import BaseImportanceEvaluator
 from optuna.logging import get_logger
 from optuna.study import Study
 from optuna.trial import FrozenTrial
-from optuna.visualization._param_importances import _get_importances_info
+from optuna.visualization._param_importances import _get_importances_infos
 from optuna.visualization._param_importances import _ImportancesInfo
 from optuna.visualization.matplotlib._matplotlib_imports import _imports
 
@@ -86,32 +86,16 @@ def plot_param_importances(
                 importance of the first objective, use ``target=lambda t: t.values[0]`` for the
                 target parameter.
         target_name:
-            Target's name to display on the axis label.
+            Target's name to display on the axis label. Names set via
+            :meth:`~optuna.study.Study.set_metric_names` will be used if ``target`` is :obj:`None`,
+            overriding this argument.
 
     Returns:
         A :class:`matplotlib.axes.Axes` object.
     """
 
     _imports.check()
-
-    if target or not study._is_multi_objective():
-        importances_infos: tuple[_ImportancesInfo, ...] = (
-            _get_importances_info(study, evaluator, params, target, target_name),
-        )
-
-    else:
-        n_objectives = len(study.directions)
-        importances_infos = tuple(
-            _get_importances_info(
-                study,
-                evaluator,
-                params,
-                target=lambda t: t.values[objective_id],
-                target_name=f"{target_name} {objective_id}",
-            )
-            for objective_id in range(n_objectives)
-        )
-
+    importances_infos = _get_importances_infos(study, evaluator, params, target, target_name)
     return _get_importances_plot(importances_infos)
 
 

--- a/tests/visualization_tests/test_param_importances.py
+++ b/tests/visualization_tests/test_param_importances.py
@@ -149,12 +149,30 @@ def test_get_param_importances_infos_custom_objective_names(
 ) -> None:
     study = specific_create_study()
     study.set_metric_names(objective_names)
-    n_objectives = len(study.directions)
 
     infos = _get_importances_infos(
         study, evaluator=None, params=["param_a"], target=None, target_name="Objective Value"
     )
-    assert len(infos) == n_objectives
+    assert len(infos) == len(study.directions)
+    assert all(info.target_name == expected for info, expected in zip(infos, objective_names))
+
+
+@pytest.mark.parametrize(
+    "specific_create_study,objective_names",
+    [
+        (create_study, ["Objective Value"]),
+        (_create_multiobjective_study, ["Objective Value 0", "Objective Value 1"]),
+    ],
+)
+def test_get_param_importances_infos_default_objective_names(
+    specific_create_study: Callable[[], Study], objective_names: list[str]
+) -> None:
+    study = specific_create_study()
+
+    infos = _get_importances_infos(
+        study, evaluator=None, params=["param_a"], target=None, target_name="Objective Value"
+    )
+    assert len(infos) == len(study.directions)
     assert all(info.target_name == expected for info, expected in zip(infos, objective_names))
 
 

--- a/tests/visualization_tests/test_param_importances.py
+++ b/tests/visualization_tests/test_param_importances.py
@@ -19,6 +19,7 @@ from optuna.trial import create_trial
 from optuna.trial import Trial
 from optuna.visualization import plot_param_importances as plotly_plot_param_importances
 from optuna.visualization._param_importances import _get_importances_info
+from optuna.visualization._param_importances import _get_importances_infos
 from optuna.visualization._param_importances import _ImportancesInfo
 from optuna.visualization._plotly_imports import go
 from optuna.visualization.matplotlib import plot_param_importances as plt_plot_param_importances
@@ -137,6 +138,24 @@ def test_get_param_importances_info_empty(
     assert info == _ImportancesInfo(
         importance_values=[], param_names=[], importance_labels=[], target_name="Objective Value"
     )
+
+
+@pytest.mark.parametrize(
+    "specific_create_study,objective_names",
+    [(create_study, ["Foo"]), (_create_multiobjective_study, ["Foo", "Bar"])],
+)
+def test_get_param_importances_infos_custom_objective_names(
+    specific_create_study: Callable[[], Study], objective_names: list[str]
+) -> None:
+    study = specific_create_study()
+    study.set_metric_names(objective_names)
+    n_objectives = len(study.directions)
+
+    infos = _get_importances_infos(
+        study, evaluator=None, params=["param_a"], target=None, target_name="Objective Value"
+    )
+    assert len(infos) == n_objectives
+    assert all(info.target_name == expected for info, expected in zip(infos, objective_names))
 
 
 def test_switch_label_when_param_insignificant() -> None:


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
Closes #4895. Names can be specified via `optuna.study.Study.set_metric_names`. Additionally, `_get_importances_infos` has been factored out to DRY the code a bit.


## Description of the changes
<!-- Describe the changes in this PR. -->
* Use `study.metric_names` in `plot_param_importances` to derive custom objective names.
* Factored out `_get_importances_infos` to DRY the code.
* Added a test case.

## Examples
![Screenshot from 2023-10-01 13-51-30](https://github.com/optuna/optuna/assets/37713008/25dd2b35-c5d6-44eb-85ea-48c4a3c66b28)

![Screenshot from 2023-10-01 13-50-47](https://github.com/optuna/optuna/assets/37713008/44090ef6-e1f1-442a-9dcb-9ae11d50dcb5)