### PR TITLE
Drop Python 3.7 on `tests-mpi`

### DIFF
--- a/.github/workflows/tests-mpi.yml
+++ b/.github/workflows/tests-mpi.yml
@@ -19,7 +19,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
 
     steps:
     - name: Checkout


### PR DESCRIPTION
## Motivation
Python 3.7 support for integrations is already dropped. #4586
Tests (MPI) failed in Python 3.7 and it only tests PyTorch Distributed integration. So this PR removes the support.

## Description of the changes
Drop Python 3.7 support on `tests-mpi`.
