### PR TITLE
Make test order deterministic for `pytest-xdist`

### DIFF
--- a/tests/storages_tests/test_journal.py
+++ b/tests/storages_tests/test_journal.py
@@ -23,19 +23,14 @@ from optuna.testing.storages import StorageSupplier
 from optuna.testing.tempfile_pool import NamedTemporaryFilePool
 
 
-LOG_STORAGE = {
+LOG_STORAGE = [
     "file_with_open_lock",
     "file_with_link_lock",
     "redis_default",
     "redis_with_use_cluster",
-}
+]
 
-LOG_STORAGE_SUPPORTING_SNAPSHOT = {
-    "redis_default",
-    "redis_with_use_cluster",
-}
-
-JOURNAL_STORAGE_SUPPORTING_SNAPSHOT = {"journal_redis"}
+JOURNAL_STORAGE_SUPPORTING_SNAPSHOT = ["journal_redis"]
 
 
 class JournalLogStorageSupplier:


### PR DESCRIPTION
## Motivation
`pytest-xdist` is useful for parallelizing tests and reducing execution time, but Optuna's tests result in errors because the order is not deterministic. This PR fixes this error. After merging this PR, `pytest -m "not integration" -n auto` will succeed.

## Description of the changes
Make test order deterministic.
