### PR TITLE
[bug] Fix an error that does not consider min_child_samples

### DIFF
--- a/optuna/integration/_lightgbm_tuner/alias.py
+++ b/optuna/integration/_lightgbm_tuner/alias.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 from typing import Any
+import warnings
 
 
 _ALIAS_GROUP_LIST: list[dict[str, Any]] = [
@@ -43,11 +44,20 @@ def _handling_alias_parameters(lgbm_params: dict[str, Any]) -> None:
     for alias_group in _ALIAS_GROUP_LIST:
         param_name = alias_group["param_name"]
         alias_names = alias_group["alias_names"]
+        duplicated_alias: dict[str, Any] = {}
 
         for alias_name in alias_names:
             if alias_name in lgbm_params:
+                duplicated_alias[alias_name] = lgbm_params[alias_name]
                 lgbm_params[param_name] = lgbm_params[alias_name]
                 del lgbm_params[alias_name]
+
+        if len(duplicated_alias) > 1:
+            msg = (
+                f"{param_name} in param detected multiple identical aliases {duplicated_alias}, "
+                f"but we use {param_name}={lgbm_params[param_name]}."
+            )
+            warnings.warn(msg)
 
 
 _ALIAS_METRIC_LIST: list[dict[str, Any]] = [

--- a/optuna/integration/_lightgbm_tuner/alias.py
+++ b/optuna/integration/_lightgbm_tuner/alias.py
@@ -8,8 +8,8 @@ _ALIAS_GROUP_LIST: list[dict[str, Any]] = [
     {"param_name": "bagging_fraction", "alias_names": ["sub_row", "subsample", "bagging"]},
     {"param_name": "learning_rate", "alias_names": ["shrinkage_rate", "eta"]},
     {
-        "param_name": "min_data_in_leaf",
-        "alias_names": ["min_data_per_leaf", "min_data", "min_child_samples", "min_samples_leaf"],
+        "param_name": "min_child_samples",
+        "alias_names": ["min_data_per_leaf", "min_data", "min_data_in_leaf", "min_samples_leaf"],
     },
     {
         "param_name": "min_sum_hessian_in_leaf",

--- a/optuna/integration/_lightgbm_tuner/alias.py
+++ b/optuna/integration/_lightgbm_tuner/alias.py
@@ -9,7 +9,7 @@ _ALIAS_GROUP_LIST: list[dict[str, Any]] = [
     {"param_name": "learning_rate", "alias_names": ["shrinkage_rate", "eta"]},
     {
         "param_name": "min_data_in_leaf",
-        "alias_names": ["min_data_per_leaf", "min_data", "min_child_samples"],
+        "alias_names": ["min_data_per_leaf", "min_data", "min_child_samples", "min_samples_leaf"],
     },
     {
         "param_name": "min_sum_hessian_in_leaf",
@@ -20,10 +20,19 @@ _ALIAS_GROUP_LIST: list[dict[str, Any]] = [
             "min_child_weight",
         ],
     },
+    {
+        "param_name": "num_leaves",
+        "alias_names": [
+            "num_leaf",
+            "max_leaves",
+            "max_leaf",
+            "max_leaf_nodes",
+        ],
+    },
     {"param_name": "bagging_freq", "alias_names": ["subsample_freq"]},
     {"param_name": "feature_fraction", "alias_names": ["sub_feature", "colsample_bytree"]},
-    {"param_name": "lambda_l1", "alias_names": ["reg_alpha"]},
-    {"param_name": "lambda_l2", "alias_names": ["reg_lambda", "lambda"]},
+    {"param_name": "lambda_l1", "alias_names": ["reg_alpha", "l1_regularization"]},
+    {"param_name": "lambda_l2", "alias_names": ["reg_lambda", "lambda", "l2_regularization"]},
     {"param_name": "min_gain_to_split", "alias_names": ["min_split_gain"]},
 ]
 

--- a/optuna/integration/_lightgbm_tuner/optimize.py
+++ b/optuna/integration/_lightgbm_tuner/optimize.py
@@ -57,7 +57,7 @@ _DEFAULT_LIGHTGBM_PARAMETERS = {
     "feature_fraction": 1.0,
     "bagging_fraction": 1.0,
     "bagging_freq": 0,
-    "min_data_in_leaf": 20,
+    "min_child_samples": 20,
 }
 
 _logger = optuna.logging.get_logger(__name__)
@@ -215,11 +215,11 @@ class _OptunaObjective(_BaseTuner):
             self.lgbm_params["bagging_fraction"] = param_value
         if "bagging_freq" in self.target_param_names:
             self.lgbm_params["bagging_freq"] = trial.suggest_int("bagging_freq", 1, 7)
-        if "min_data_in_leaf" in self.target_param_names:
-            # `GridSampler` is used for sampling min_data_in_leaf value.
+        if "min_child_samples" in self.target_param_names:
+            # `GridSampler` is used for sampling min_child_samples value.
             # The value 1.0 for the hyperparameter is always sampled.
-            param_value = trial.suggest_int("min_data_in_leaf", 5, 100)
-            self.lgbm_params["min_data_in_leaf"] = param_value
+            param_value = trial.suggest_int("min_child_samples", 5, 100)
+            self.lgbm_params["min_child_samples"] = param_value
 
     def _copy_valid_sets(self, valid_sets: "VALID_SET_TYPE") -> "VALID_SET_TYPE":
         if isinstance(valid_sets, list):
@@ -394,12 +394,12 @@ class _LightGBMBaseTuner(_BaseTuner):
         self._model_dir = model_dir
         self._optuna_seed = optuna_seed
 
-        # Should not alter data since `min_data_in_leaf` is tuned.
+        # Should not alter data since `min_child_samples` is tuned.
         # https://lightgbm.readthedocs.io/en/latest/Parameters.html#feature_pre_filter
         if self.lgbm_params.get("feature_pre_filter", False):
             warnings.warn(
                 "feature_pre_filter is given as True but will be set to False. This is required "
-                "for the tuner to tune min_data_in_leaf."
+                "for the tuner to tune min_child_samples."
             )
         self.lgbm_params["feature_pre_filter"] = False
 
@@ -556,11 +556,11 @@ class _LightGBMBaseTuner(_BaseTuner):
         )
 
     def tune_min_data_in_leaf(self) -> None:
-        param_name = "min_data_in_leaf"
+        param_name = "min_child_samples"
         param_values = [5, 10, 25, 50, 100]
 
         sampler = optuna.samplers.GridSampler({param_name: param_values}, seed=self._optuna_seed)
-        self._tune_params([param_name], len(param_values), sampler, "min_data_in_leaf")
+        self._tune_params([param_name], len(param_values), sampler, "min_child_samples")
 
     def _tune_params(
         self,
@@ -678,7 +678,7 @@ class LightGBMTuner(_LightGBMBaseTuner):
 
     It optimizes the following hyperparameters in a stepwise manner:
     ``lambda_l1``, ``lambda_l2``, ``num_leaves``, ``feature_fraction``, ``bagging_fraction``,
-    ``bagging_freq`` and ``min_data_in_leaf``.
+    ``bagging_freq`` and ``min_child_samples``.
 
     You can find the details of the algorithm and benchmark results in `this blog article <https:/
     /medium.com/optuna/lightgbm-tuner-new-optuna-integration-for-hyperparameter-optimization-8b709

--- a/optuna/integration/_lightgbm_tuner/optimize.py
+++ b/optuna/integration/_lightgbm_tuner/optimize.py
@@ -57,7 +57,7 @@ _DEFAULT_LIGHTGBM_PARAMETERS = {
     "feature_fraction": 1.0,
     "bagging_fraction": 1.0,
     "bagging_freq": 0,
-    "min_child_samples": 20,
+    "min_data_in_leaf": 20,
 }
 
 _logger = optuna.logging.get_logger(__name__)
@@ -215,11 +215,11 @@ class _OptunaObjective(_BaseTuner):
             self.lgbm_params["bagging_fraction"] = param_value
         if "bagging_freq" in self.target_param_names:
             self.lgbm_params["bagging_freq"] = trial.suggest_int("bagging_freq", 1, 7)
-        if "min_child_samples" in self.target_param_names:
-            # `GridSampler` is used for sampling min_child_samples value.
+        if "min_data_in_leaf" in self.target_param_names:
+            # `GridSampler` is used for sampling min_data_in_leaf value.
             # The value 1.0 for the hyperparameter is always sampled.
-            param_value = trial.suggest_int("min_child_samples", 5, 100)
-            self.lgbm_params["min_child_samples"] = param_value
+            param_value = trial.suggest_int("min_data_in_leaf", 5, 100)
+            self.lgbm_params["min_data_in_leaf"] = param_value
 
     def _copy_valid_sets(self, valid_sets: "VALID_SET_TYPE") -> "VALID_SET_TYPE":
         if isinstance(valid_sets, list):
@@ -556,7 +556,7 @@ class _LightGBMBaseTuner(_BaseTuner):
         )
 
     def tune_min_data_in_leaf(self) -> None:
-        param_name = "min_child_samples"
+        param_name = "min_data_in_leaf"
         param_values = [5, 10, 25, 50, 100]
 
         sampler = optuna.samplers.GridSampler({param_name: param_values}, seed=self._optuna_seed)
@@ -678,7 +678,7 @@ class LightGBMTuner(_LightGBMBaseTuner):
 
     It optimizes the following hyperparameters in a stepwise manner:
     ``lambda_l1``, ``lambda_l2``, ``num_leaves``, ``feature_fraction``, ``bagging_fraction``,
-    ``bagging_freq`` and ``min_child_samples``.
+    ``bagging_freq`` and ``min_data_in_leaf``.
 
     You can find the details of the algorithm and benchmark results in `this blog article <https:/
     /medium.com/optuna/lightgbm-tuner-new-optuna-integration-for-hyperparameter-optimization-8b709

--- a/tests/integration_tests/lightgbm_tuner_tests/test_alias.py
+++ b/tests/integration_tests/lightgbm_tuner_tests/test_alias.py
@@ -37,8 +37,33 @@ def test_handling_alias_parameter() -> None:
     }
     _handling_alias_parameters(params)
     assert "min_data" not in params
-    assert "min_data_in_leaf" in params
-    assert params["min_data_in_leaf"] == 0.2
+    assert "min_child_samples" in params
+    assert params["min_child_samples"] == 0.2
+
+
+def test_handling_alias_parameter_duplication() -> None:
+    params = {
+        "num_boost_round": 5,
+        "early_stopping_rounds": 2,
+        "min_data": 0.2,
+        "min_child_samples": 0.3,
+        "l1_regularization": 0.0,
+        "l2_regularization": 0.0,
+        "reg_alpha": 0.0,
+        "reg_lambda": 0.0,
+    }
+    _handling_alias_parameters(params)
+    # Here are the main alias names
+    assert "min_child_samples" in params
+    assert "lambda_l1" in params
+    assert "lambda_l2" in params
+
+    # None of them are the main alias names
+    assert "min_data" not in params
+    assert "l1_regularization" not in params
+    assert "l2_regularization" not in params
+    assert "reg_alpha" not in params
+    assert "reg_lambda" not in params
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

In this PR, I address a minor bug in LightGBMTuner.
The problem is that while LightGBMTuner optimizes `min_child_samples`, `min_data_in_leaf` can also be set as a default parameter.
Hence, we are not sure which parameter is used by the resulting LightGBM. 
Note that `min_child_samples` and `min_data_in_leaf` are identical parameters.
Please check [the original documentation](https://lightgbm.readthedocs.io/en/latest/Parameters.html#min_data_in_leaf).

For example, the following codeblock may cause the exact issue given a sufficient amount of time.

```python
import numpy as np

from optuna.integration import lightgbm as optuna_lgb


X = np.arange(100)
train_set = optuna_lgb.Dataset(X[:80][:, None], X[:80])
valid_sets = optuna_lgb.Dataset(X[80:][:, None], X[80:])
opt = optuna_lgb.train(
    params={
        "objective": "regression",
        "metric": "rmse",
        # Users can specify min_data_in_leaf, i.e. min_child_samples, as a fixed parameter
        "min_data_in_leaf": 30
    },
    train_set=train_set,
    valid_sets=valid_sets,
    num_boost_round=1,  # I used a very small number for a quick test
)
```

Besides this change, I added the aliases specified in the latest `lightgbm` to `_ALIAS_GROUP_LIST` so that users can also use these parameters and they will not be mixed up as discussed above.

With the example above and the current version, we get `params` like below:

```
{'objective': 'regression', 'metric': 'rmse', 'min_data_in_leaf': 30, 'feature_pre_filter': False, 'lambda_l1': 0.0, 'lambda_l2': 0.0, 'num_leaves': 31, 'feature_fraction': 1.0, 'bagging_fraction': 1.0, 'bagging_freq': 0, 'min_child_samples': 100}
{'objective': 'regression', 'metric': 'rmse', 'min_data_in_leaf': 30, 'feature_pre_filter': False, 'lambda_l1': 0.0, 'lambda_l2': 0.0, 'num_leaves': 31, 'feature_fraction': 1.0, 'bagging_fraction': 1.0, 'bagging_freq': 0, 'min_child_samples': 25}
{'objective': 'regression', 'metric': 'rmse', 'min_data_in_leaf': 30, 'feature_pre_filter': False, 'lambda_l1': 0.0, 'lambda_l2': 0.0, 'num_leaves': 31, 'feature_fraction': 1.0, 'bagging_fraction': 1.0, 'bagging_freq': 0, 'min_child_samples': 10}
{'objective': 'regression', 'metric': 'rmse', 'min_data_in_leaf': 30, 'feature_pre_filter': False, 'lambda_l1': 0.0, 'lambda_l2': 0.0, 'num_leaves': 31, 'feature_fraction': 1.0, 'bagging_fraction': 1.0, 'bagging_freq': 0, 'min_child_samples': 5}
```

After the modification in this PR, we get `params` like below:

```
{'objective': 'regression', 'metric': 'rmse', 'min_data_in_leaf': 30, 'feature_pre_filter': False, 'lambda_l1': 0.0, 'lambda_l2': 0.0, 'num_leaves': 31, 'feature_fraction': 1.0, 'bagging_fraction': 1.0, 'bagging_freq': 0}
{'objective': 'regression', 'metric': 'rmse', 'min_data_in_leaf': 50, 'feature_pre_filter': False, 'lambda_l1': 0.0, 'lambda_l2': 0.0, 'num_leaves': 31, 'feature_fraction': 1.0, 'bagging_fraction': 1.0, 'bagging_freq': 0}
{'objective': 'regression', 'metric': 'rmse', 'min_data_in_leaf': 10, 'feature_pre_filter': False, 'lambda_l1': 0.0, 'lambda_l2': 0.0, 'num_leaves': 31, 'feature_fraction': 1.0, 'bagging_fraction': 1.0, 'bagging_freq': 0}
{'objective': 'regression', 'metric': 'rmse', 'min_data_in_leaf': 5, 'feature_pre_filter': False, 'lambda_l1': 0.0, 'lambda_l2': 0.0, 'num_leaves': 31, 'feature_fraction': 1.0, 'bagging_fraction': 1.0, 'bagging_freq': 0}

```

The difference is whether we allow identical parameters to coexist or not. (The first example does, but the second example does not)