### PR TITLE
[bug] Fix BruteForceSampler crashes when used with n_jobs

### DIFF
--- a/optuna/samplers/_brute_force.py
+++ b/optuna/samplers/_brute_force.py
@@ -170,9 +170,9 @@ class BruteForceSampler(BaseSampler):
                     incomplete_leaves.append(leaf)
 
         # Add all incomplete leaf nodes at the end because they may not have complete search space.
-        for leaf in incomplete_leaves:
-            if leaf.children is None:
-                leaf.set_leaf()
+        # for leaf in incomplete_leaves:
+        #     if leaf.children is None:
+        #         leaf.set_leaf()
         return tree
 
     def sample_independent(


### PR DESCRIPTION
Fixes optuna/optuna#4948


Steps to reproduce the error:
```
import time
import optuna

def objective(trial):
    time.sleep(1)
    return trial.suggest_int("x", 0, 9)

sampler = optuna.samplers.BruteForceSampler()
study = optuna.create_study(sampler=sampler)

study.optimize(objective, n_jobs=2)
```

The error occurred because the `tree` was not correctly initialized. When multi-threading was enabled (`n_jobs=2`), the root node was initialized as a leaf `children={}` and thus never expanded:

```
A tree node has three states:
- 1. Unexpanded. This is represented by children=None.
- 2. Leaf. This is represented by children={} and param_name=None.
- 3. Normal node. It has a param_name and non-empty children.
```

[Source Code](https://github.com/optuna/optuna/blob/1b0b22a957e49c4c920615a763cf6a542f36994d/optuna/samplers/_brute_force.py#L194C1-L196C44)

```
tree = self._build_tree((t for t in trials if t.number != trial.number), trial.params)
candidates = _enumerate_candidates(param_distribution)
tree.expand(param_name, candidates)
```

Before the fix:
```
[I 2023-10-06 14:05:26,643] A new study created in RDB with name: no-name-01adf7e6-3b87-4b9a-81cf-328eabfbbc1e
[W 2023-10-06 14:05:27,731] Trial 1 failed with parameters: {} because of the following error: ValueError('param_name mismatch: None != x').
ValueError: param_name mismatch: None != x
[W 2023-10-06 14:05:27,742] Trial 1 failed with value None.
[W 2023-10-06 14:05:27,754] Trial 0 failed with parameters: {} because of the following error: ValueError('param_name mismatch: None != x').
ValueError: param_name mismatch: None != x
[W 2023-10-06 14:05:27,759] Trial 0 failed with value None.
ValueError: param_name mismatch: None != x
PS F:\optuna> 
```

After the fix:
```
[I 2023-10-06 14:03:19,308] A new study created in RDB with name: no-name-1df08752-3fff-4b37-9259-f045aa79ac60
[I 2023-10-06 14:03:20,422] Trial 1 finished with value: 9.0 and parameters: {'x': 9}. Best is trial 1 with value: 9.0.
[I 2023-10-06 14:03:20,488] Trial 0 finished with value: 3.0 and parameters: {'x': 3}. Best is trial 0 with value: 3.0.
[I 2023-10-06 14:03:21,635] Trial 3 finished with value: 5.0 and parameters: {'x': 5}. Best is trial 0 with value: 3.0.
[I 2023-10-06 14:03:21,652] Trial 2 finished with value: 6.0 and parameters: {'x': 6}. Best is trial 0 with value: 3.0.   
[I 2023-10-06 14:03:22,733] Trial 4 finished with value: 0.0 and parameters: {'x': 0}. Best is trial 4 with value: 0.0.
[I 2023-10-06 14:03:22,804] Trial 5 finished with value: 0.0 and parameters: {'x': 0}. Best is trial 4 with value: 0.0.
[I 2023-10-06 14:03:23,791] Trial 6 finished with value: 1.0 and parameters: {'x': 1}. Best is trial 4 with value: 0.0.
[I 2023-10-06 14:03:23,893] Trial 7 finished with value: 8.0 and parameters: {'x': 8}. Best is trial 4 with value: 0.0.
[I 2023-10-06 14:03:24,857] Trial 8 finished with value: 4.0 and parameters: {'x': 4}. Best is trial 4 with value: 0.0.
[I 2023-10-06 14:03:24,971] Trial 9 finished with value: 7.0 and parameters: {'x': 7}. Best is trial 4 with value: 0.0.
[I 2023-10-06 14:03:25,916] Trial 10 finished with value: 2.0 and parameters: {'x': 2}. Best is trial 4 with value: 0.0.
[I 2023-10-06 14:03:26,040] Trial 11 finished with value: 1.0 and parameters: {'x': 1}. Best is trial 4 with value: 0.0.
PS F:\optuna> 
```