### PR TITLE
Remove Python 3.7 from the development docker image build

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -30,7 +30,7 @@ jobs:
     # TODO (nzw0301): Remove `exclude` once integration works with Python 3.11.
     strategy:
       matrix:
-        python_version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python_version: ['3.8', '3.9', '3.10', '3.11']
         build_type: ['', 'dev']  # "dev" installs all the dependencies including pytest.
         exclude:
         - python_version: '3.11'

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -30,9 +30,11 @@ jobs:
     # TODO (nzw0301): Remove `exclude` once integration works with Python 3.11.
     strategy:
       matrix:
-        python_version: ['3.8', '3.9', '3.10', '3.11']
+        python_version: ['3.7', '3.8', '3.9', '3.10', '3.11']
         build_type: ['', 'dev']  # "dev" installs all the dependencies including pytest.
         exclude:
+        - python_version: '3.7'
+          build_type: 'dev'
         - python_version: '3.11'
           build_type: 'dev'
 


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
Python 3.7 is EOL. This PR removes it from the development docker image build.

## Description of the changes
<!-- Describe the changes in this PR. -->
Remove Python 3.7 from the development docker image build
