### PR TITLE
Support infeasible coloring for plot_timeline

### DIFF
--- a/optuna/visualization/matplotlib/_timeline.py
+++ b/optuna/visualization/matplotlib/_timeline.py
@@ -2,7 +2,8 @@ from optuna._experimental import experimental_func
 from optuna.study import Study
 from optuna.trial import TrialState
 from optuna.visualization._timeline import _get_timeline_info
-from optuna.visualization._timeline import _TimelineInfo, _TimelineBarInfo
+from optuna.visualization._timeline import _TimelineBarInfo
+from optuna.visualization._timeline import _TimelineInfo
 from optuna.visualization.matplotlib._matplotlib_imports import _imports
 
 
@@ -64,7 +65,10 @@ def plot_timeline(study: Study) -> "Axes":
 
 
 def _get_state_name(bar_info: _TimelineBarInfo) -> str:
-    return bar_info.state.name if bar_info.infeasible else _INFEASIBLE_KEY
+    if bar_info.state == TrialState.COMPLETE and bar_info.infeasible:
+        return _INFEASIBLE_KEY
+    else:
+        return bar_info.state.name
 
 
 def _get_timeline_plot(info: _TimelineInfo) -> "Axes":
@@ -72,7 +76,7 @@ def _get_timeline_plot(info: _TimelineInfo) -> "Axes":
         TrialState.COMPLETE.name: "tab:blue",
         TrialState.FAIL.name: "tab:red",
         TrialState.PRUNED.name: "tab:orange",
-        _INFEASIBLE_KEY: "tab:brown",
+        _INFEASIBLE_KEY: "#CCCCCC",
         TrialState.RUNNING.name: "tab:green",
         TrialState.WAITING.name: "tab:gray",
     }

--- a/optuna/visualization/matplotlib/_timeline.py
+++ b/optuna/visualization/matplotlib/_timeline.py
@@ -101,7 +101,7 @@ def _get_timeline_plot(info: _TimelineInfo) -> "Axes":
     # However, the legend depicts only types present in the arguments.
     legend_handles = []
     for state_name, color in _cm.items():
-        if any(_get_state_name(b) == state_name for b in info.bars) > 0:
+        if any(_get_state_name(b) == state_name for b in info.bars):
             legend_handles.append(matplotlib.patches.Patch(color=color, label=state_name))
     ax.legend(handles=legend_handles, loc="upper left", bbox_to_anchor=(1.05, 1.0))
     fig.tight_layout()


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

This PR is to address [issue#4834](https://github.com/optuna/optuna/issues/4834).
Currently, we cannot see the difference between feasible and infeasible trials in `plot_timeline`, but we add functionality to differentiate the color for them.

## Description of the changes

I made the following changes:
1. Differentiate the color for infeasible trials in the timeline plot, and
2. Make the color of infeasible trial `#CCCCCC`.