### PR TITLE
Use CPU version of PyTorch in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ COPY . .
 ARG BUILD_TYPE='dev'
 
 RUN if [ "${BUILD_TYPE}" = "dev" ]; then \
-        pip install ${PIP_OPTIONS} -e '.[benchmark, checking, document, integration, optional, test]' -f https://download.pytorch.org/whl/torch_stable.html; \
+        pip install ${PIP_OPTIONS} -e '.[benchmark, checking, document, integration, optional, test]' --extra-index-url https://download.pytorch.org/whl/cpu; \
     else \
         pip install ${PIP_OPTIONS} -e .; \
     fi \


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
Currently the installed PyTorch wheel package in Docker image is different with `tests-integration` action.

* Dockerfile: https://github.com/optuna/optuna/blob/fba23b19ca99702346bec078f3f0bf97eeb07946/Dockerfile#L19
* tests-integration: https://github.com/optuna/optuna/blob/fba23b19ca99702346bec078f3f0bf97eeb07946/.github/workflows/tests-integration.yml#L60


## Description of the changes
<!-- Describe the changes in this PR. -->

Change the PyTorch wheel package installed in Docker image.