### PR TITLE
Support `constant_liar` in multi-objective `TPESampler`

### DIFF
--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -646,6 +646,7 @@ def _split_complete_trials_multi_objective(
     n_below: int,
 ) -> tuple[list[FrozenTrial], list[FrozenTrial]]:
     if n_below == 0:
+        # QUESTION: Shall I change it as well??
         return [], []
 
     lvals = np.asarray([trial.values for trial in trials])

--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -642,7 +642,6 @@ def _split_complete_trials_multi_objective(
     n_below: int,
 ) -> tuple[list[FrozenTrial], list[FrozenTrial]]:
     if n_below == 0:
-        # QUESTION: Shall I change it as well??
         return [], []
 
     lvals = np.asarray([trial.values for trial in trials])

--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -206,10 +206,6 @@ class TPESampler(BaseSampler):
                 workers is high.
 
             .. note::
-                This feature can be used for only single-objective optimization; this argument is
-                ignored for multi-objective optimization.
-
-            .. note::
                 Added in v2.8.0 as an experimental feature. The interface may change in newer
                 versions without prior notice. See
                 https://github.com/optuna/optuna/releases/tag/v2.8.0.

--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -437,7 +437,7 @@ class TPESampler(BaseSampler):
     def _sample(
         self, study: Study, trial: FrozenTrial, search_space: Dict[str, BaseDistribution]
     ) -> Dict[str, Any]:
-        if self._constant_liar and not study._is_multi_objective():
+        if self._constant_liar:
             states = [TrialState.COMPLETE, TrialState.PRUNED, TrialState.RUNNING]
         else:
             states = [TrialState.COMPLETE, TrialState.PRUNED]

--- a/tests/samplers_tests/tpe_tests/test_sampler.py
+++ b/tests/samplers_tests/tpe_tests/test_sampler.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import random
 from typing import Callable
 from typing import Dict

--- a/tests/samplers_tests/tpe_tests/test_sampler.py
+++ b/tests/samplers_tests/tpe_tests/test_sampler.py
@@ -1052,7 +1052,8 @@ def test_constant_liar_experimental_warning() -> None:
 
 
 @pytest.mark.parametrize("multivariate", [True, False])
-def test_constant_liar_with_running_trial(multivariate: bool) -> None:
+@pytest.mark.parametrize("multiobjective", [True, False])
+def test_constant_liar_with_running_trial(multivariate: bool, multiobjective: bool) -> None:
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", optuna.exceptions.ExperimentalWarning)
         sampler = TPESampler(multivariate=multivariate, constant_liar=True, n_startup_trials=0)
@@ -1064,7 +1065,7 @@ def test_constant_liar_with_running_trial(multivariate: bool) -> None:
     trial0.suggest_int("x", 0, 10)
     trial0.suggest_float("y", 0, 10)
     trial0.suggest_categorical("z", [0, 1, 2])
-    study.tell(trial0, 0)
+    study.tell(trial0, [0, 0] if multiobjective else 0)
 
     # Add running trials.
     trial1 = study.ask()
@@ -1079,7 +1080,7 @@ def test_constant_liar_with_running_trial(multivariate: bool) -> None:
     trial.suggest_int("x", 0, 10)
     trial.suggest_float("y", 0, 10)
     trial.suggest_categorical("z", [0, 1, 2])
-    study.tell(trial, 0)
+    study.tell(trial, [0, 0] if multiobjective else 0)
 
 
 def test_categorical_distance_func_experimental_warning() -> None:


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

Support `constant_liar` for multi-objective TPE as mentioned in #3565 .

## Description of the changes
<!-- Describe the changes in this PR. -->

As `running_trials` is simply added to `samples_above` in the current implementation, we just need to remove the branching in the if-statement for multi-objective and `constant_liar`.