### PR TITLE
Skip slow integration tests

### DIFF
--- a/.github/workflows/tests-integration.yml
+++ b/.github/workflows/tests-integration.yml
@@ -75,4 +75,4 @@ jobs:
     - name: Tests
       if:  ${{ github.event_name != 'schedule' && github.event_name != 'workflow_dispatch' }}
       run: |
-        pytest tests -m "integration"
+        pytest tests -m "integration and not slow"


### PR DESCRIPTION
## Motivation

Unintentionally, integration tests marked as `slow` are running in CI for PR. This bug was introduced in #4820.

## Description of the changes
This PR makes CI skip slow integration tests.