### PR TITLE
Fix `Any` with `float` in `_TreeNode.children`

### DIFF
--- a/optuna/samplers/_brute_force.py
+++ b/optuna/samplers/_brute_force.py
@@ -33,9 +33,9 @@ class _TreeNode:
     # 3. Normal node. It has a param_name and non-empty children.
 
     param_name: Optional[str] = None
-    children: Optional[Dict[Any, "_TreeNode"]] = None
+    children: Optional[Dict[float, "_TreeNode"]] = None
 
-    def expand(self, param_name: Optional[str], search_space: Iterable[Any]) -> None:
+    def expand(self, param_name: Optional[str], search_space: Iterable[float]) -> None:
         # If the node is unexpanded, expand it.
         # Otherwise, check if the node is compatible with the given search space.
         if self.children is None:
@@ -54,7 +54,7 @@ class _TreeNode:
         self.expand(None, [])
 
     def add_path(
-        self, params_and_search_spaces: Iterable[Tuple[str, Iterable[Any], Any]]
+        self, params_and_search_spaces: Iterable[Tuple[str, Iterable[float], Any]]
     ) -> Optional["_TreeNode"]:
         # Add a path (i.e. a list of suggested parameters in one trial) to the tree.
         current_node = self

--- a/optuna/samplers/_brute_force.py
+++ b/optuna/samplers/_brute_force.py
@@ -54,7 +54,7 @@ class _TreeNode:
         self.expand(None, [])
 
     def add_path(
-        self, params_and_search_spaces: Iterable[Tuple[str, Iterable[float], Any]]
+        self, params_and_search_spaces: Iterable[Tuple[str, Iterable[float], float]]
     ) -> Optional["_TreeNode"]:
         # Add a path (i.e. a list of suggested parameters in one trial) to the tree.
         current_node = self
@@ -74,7 +74,7 @@ class _TreeNode:
             else sum(child.count_unexpanded() for child in self.children.values())
         )
 
-    def sample_child(self, rng: np.random.RandomState) -> Any:
+    def sample_child(self, rng: np.random.RandomState) -> float:
         assert self.children is not None
         # Sample an unexpanded node in the subtree uniformly, and return the first
         # parameter value in the path to the node.
@@ -240,7 +240,7 @@ class BruteForceSampler(BaseSampler):
             study.stop()
 
 
-def _enumerate_candidates(param_distribution: BaseDistribution) -> Sequence[Any]:
+def _enumerate_candidates(param_distribution: BaseDistribution) -> Sequence[float]:
     if isinstance(param_distribution, FloatDistribution):
         if param_distribution.step is None:
             raise ValueError(


### PR DESCRIPTION
## Motivation

Fix typing of `_TreeNode.children` in `_brute_force.py` as described in #5034 . Additional changes have been applied to keep type hinting consistent.

## Description of the changes

* Change `Optional[Dict[Any, "_TreeNode"]]` to `Optional[Dict[float, "_TreeNode"]]`
* Change **search_space** in `expand` to `Iterable[float]`3
* Change **params_and_search_spaces** in `add_path` to `Iterable[Tuple[str, Iterable[float], float]] `
* Change return type of `sample_child` to `float`
* Change return type of `_enumerate_candidates` to `Sequence[float]`

Changes have been checked with `./formats.sh`.

Resolves: #5034
