### PR TITLE
Install PyTorch for CPU on CIs

### DIFF
--- a/.github/workflows/checks-integration.yml
+++ b/.github/workflows/checks-integration.yml
@@ -33,10 +33,10 @@ jobs:
     - name: Install
       run: |
         python -m pip install -U pip
-        pip install --progress-bar off -U .[benchmark]
+        pip install --progress-bar off -U .[benchmark] --extra-index-url https://download.pytorch.org/whl/cpu
         pip install --progress-bar off -U .[checking]
         pip install --progress-bar off -U .[integration] --extra-index-url https://download.pytorch.org/whl/cpu
-        pip install --progress-bar off -U .[optional]
+        pip install --progress-bar off -U .[optional] --extra-index-url https://download.pytorch.org/whl/cpu
         pip install --progress-bar off -U .[test]
         pip install --progress-bar off -U bayesmark
         pip install --progress-bar off -U kurobako

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -52,7 +52,7 @@ jobs:
         optuna --version
 
         pip install --progress-bar off .[test]
-        pip install --progress-bar off .[optional]
+        pip install --progress-bar off .[optional] --extra-index-url https://download.pytorch.org/whl/cpu
         pip install --progress-bar off .[integration] --extra-index-url https://download.pytorch.org/whl/cpu
 
         echo 'import coverage; coverage.process_startup()' > sitecustomize.py

--- a/.github/workflows/performance-benchmarks-bayesmark.yml
+++ b/.github/workflows/performance-benchmarks-bayesmark.yml
@@ -59,7 +59,7 @@ jobs:
         python -c 'import optuna'
         optuna --version
 
-        pip install --progress-bar off .[benchmark]
+        pip install --progress-bar off .[benchmark] --extra-index-url https://download.pytorch.org/whl/cpu
         pip install --progress-bar off bayesmark matplotlib pandas
 
     - name: Output installed packages

--- a/.github/workflows/performance-benchmarks-kurobako.yml
+++ b/.github/workflows/performance-benchmarks-kurobako.yml
@@ -72,7 +72,7 @@ jobs:
         python -c 'import optuna'
         optuna --version
 
-        pip install --progress-bar off .[benchmark]
+        pip install --progress-bar off .[benchmark] --extra-index-url https://download.pytorch.org/whl/cpu
 
         pip install --progress-bar off kurobako
 

--- a/.github/workflows/performance-benchmarks-mo-kurobako.yml
+++ b/.github/workflows/performance-benchmarks-mo-kurobako.yml
@@ -64,7 +64,7 @@ jobs:
         python -c 'import optuna'
         optuna --version
 
-        pip install --progress-bar off .[benchmark]
+        pip install --progress-bar off .[benchmark] --extra-index-url https://download.pytorch.org/whl/cpu
 
         pip install --progress-bar off kurobako
 

--- a/.github/workflows/speed-benchmarks.yml
+++ b/.github/workflows/speed-benchmarks.yml
@@ -40,7 +40,7 @@ jobs:
         python -c 'import optuna'
         optuna --version
 
-        pip install --progress-bar off .[benchmark]
+        pip install --progress-bar off .[benchmark] --extra-index-url https://download.pytorch.org/whl/cpu
         asv machine --yes
 
     - name: Output installed packages

--- a/.github/workflows/sphinx-build.yml
+++ b/.github/workflows/sphinx-build.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Install Dependencies
       run: |
         python -m pip install -U pip
-        pip install --progress-bar off -U .[document]
+        pip install --progress-bar off -U .[document] --extra-index-url https://download.pytorch.org/whl/cpu
 
     - name: Output installed packages
       run: |
@@ -91,7 +91,7 @@ jobs:
     - name: Install Dependencies
       run: |
         python -m pip install -U pip
-        pip install --progress-bar off -U .[document]
+        pip install --progress-bar off -U .[document] --extra-index-url https://download.pytorch.org/whl/cpu
 
     - name: Output installed packages
       run: |

--- a/.github/workflows/tests-integration.yml
+++ b/.github/workflows/tests-integration.yml
@@ -56,7 +56,7 @@ jobs:
         optuna --version
 
         pip install --progress-bar off .[test]
-        pip install --progress-bar off .[optional]
+        pip install --progress-bar off .[optional] --extra-index-url https://download.pytorch.org/whl/cpu
         pip install --progress-bar off .[integration] --extra-index-url https://download.pytorch.org/whl/cpu
 
     - name: Output installed packages

--- a/.github/workflows/tests-mpi.yml
+++ b/.github/workflows/tests-mpi.yml
@@ -55,7 +55,7 @@ jobs:
         optuna --version
 
         pip install --progress-bar off .[test]
-        pip install --progress-bar off .[optional]
+        pip install --progress-bar off .[optional] --extra-index-url https://download.pytorch.org/whl/cpu
 
         # TODO(not522): Remove this line when torchmetrics can be installed with extra-index-url
         pip install --progress-bar off torchmetrics

--- a/.github/workflows/tests-storage.yml
+++ b/.github/workflows/tests-storage.yml
@@ -92,7 +92,7 @@ jobs:
         optuna --version
 
         pip install --progress-bar off .[test]
-        pip install --progress-bar off .[optional]
+        pip install --progress-bar off .[optional] --extra-index-url https://download.pytorch.org/whl/cpu
 
     - name: Install DB bindings
       run: |

--- a/.github/workflows/tests-with-minimum-versions.yml
+++ b/.github/workflows/tests-with-minimum-versions.yml
@@ -64,7 +64,7 @@ jobs:
         optuna --version
 
         pip install --progress-bar off .[test]
-        pip install --progress-bar off .[optional]
+        pip install --progress-bar off .[optional] --extra-index-url https://download.pytorch.org/whl/cpu
 
     - name: Install dependencies with minimum versions
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -64,7 +64,7 @@ jobs:
         optuna --version
 
         pip install --progress-bar off .[test]
-        pip install --progress-bar off .[optional]
+        pip install --progress-bar off .[optional] --extra-index-url https://download.pytorch.org/whl/cpu
 
     - name: Output installed packages
       run: |


### PR DESCRIPTION
## Motivation
PyPI's PyTorch installs CUDA-related libraries, which waste disk space. It may result CI fails. `--extra-index-url https://download.pytorch.org/whl/cpu` prevents it.


## Description of the changes
Install PyTorch for CPU on CIs.