### PR TITLE
Remove non oldest and latest Python versions from tests

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -27,8 +27,8 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    # TODO (nzw0301): Remove `exclude` once integration works with Python 3.11.
     # NOTE (nabenabe0928): 3.8 exists for the check of the oldest version with dev.
+    # TODO (nabenabe0928): Remove `exclude` of Python3.8 x non-dev once 3.7 is removed.
     strategy:
       matrix:
         python_version: ['3.7', '3.8', '3.11']
@@ -36,6 +36,8 @@ jobs:
         exclude:
         - python_version: '3.7'
           build_type: 'dev'
+        - python_version: '3.8'
+          build_type: ''
 
     # This action cannot be executed in the forked repository.
     if: github.repository == 'optuna/optuna'

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -30,13 +30,8 @@ jobs:
     # TODO (nzw0301): Remove `exclude` once integration works with Python 3.11.
     strategy:
       matrix:
-        python_version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python_version: ['3.7', '3.11']
         build_type: ['', 'dev']  # "dev" installs all the dependencies including pytest.
-        exclude:
-        - python_version: '3.7'
-          build_type: 'dev'
-        - python_version: '3.11'
-          build_type: 'dev'
 
     # This action cannot be executed in the forked repository.
     if: github.repository == 'optuna/optuna'

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -28,10 +28,14 @@ jobs:
     runs-on: ubuntu-latest
 
     # TODO (nzw0301): Remove `exclude` once integration works with Python 3.11.
+    # NOTE (nabenabe0928): 3.8 exists for the check of the oldest version with dev.
     strategy:
       matrix:
-        python_version: ['3.7', '3.11']
+        python_version: ['3.7', '3.8', '3.11']
         build_type: ['', 'dev']  # "dev" installs all the dependencies including pytest.
+        exclude:
+        - python_version: '3.7'
+          build_type: 'dev'
 
     # This action cannot be executed in the forked repository.
     if: github.repository == 'optuna/optuna'

--- a/.github/workflows/tests-integration.yml
+++ b/.github/workflows/tests-integration.yml
@@ -20,7 +20,15 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.8', '3.11']
+        include:
+          - python-version: '3.8'
+            schedule-only: true
+          - python-version: '3.9'
+            schedule-only: true
+          - python-version: '3.10'
+            schedule-only: true
+          - python-version: '3.11'
+            schedule-only: false
 
     steps:
     - name: Checkout
@@ -73,6 +81,6 @@ jobs:
         pytest tests -m "integration"
         
     - name: Tests
-      if:  ${{ github.event_name != 'schedule' && github.event_name != 'workflow_dispatch' }}
+      if:  ${{ github.event_name != 'schedule' && github.event_name != 'workflow_dispatch' && !matrix.schedule-only }}
       run: |
         pytest tests -m "integration"

--- a/.github/workflows/tests-integration.yml
+++ b/.github/workflows/tests-integration.yml
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.11']
 
     steps:
     - name: Checkout

--- a/.github/workflows/tests-integration.yml
+++ b/.github/workflows/tests-integration.yml
@@ -75,12 +75,8 @@ jobs:
         pip install pipdeptree
         pipdeptree
 
-    - name: Scheduled tests
-      if:  ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
-      run: |
-        pytest tests -m "integration"
-        
-    - name: Tests
-      if:  ${{ github.event_name != 'schedule' && github.event_name != 'workflow_dispatch' && !matrix.schedule-only }}
+    - name: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && 'Scheduled tests' || 'Tests' }}
+      # The first two conditions are for `Scheduled tests` and the last one is for `Tests`
+      if: (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || !matrix.schedule-only)
       run: |
         pytest tests -m "integration"

--- a/.github/workflows/tests-mpi.yml
+++ b/.github/workflows/tests-mpi.yml
@@ -19,7 +19,15 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.8', '3.11']
+        include:
+          - python-version: '3.8'
+            schedule-only: true
+          - python-version: '3.9'
+            schedule-only: true
+          - python-version: '3.10'
+            schedule-only: true
+          - python-version: '3.11'
+            schedule-only: false
 
     steps:
     - name: Checkout
@@ -70,7 +78,21 @@ jobs:
         pip install pipdeptree
         pipdeptree
 
+    - name: Scheduled tests
+      if:  ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+      run: |
+        export OMPI_MCA_rmaps_base_oversubscribe=yes
+
+        # Question(nabenabe0928) Why is Python 3.11 skipped?? We can skip it from `matrix`.
+        if [ ${{ matrix.python-version }} != 3.11 ]; then
+          mpirun -n 2 -- pytest tests/integration_tests/test_pytorch_distributed.py
+        fi
+
+      env:
+        OMP_NUM_THREADS: 1
+
     - name: Tests
+      if:  ${{ github.event_name != 'schedule' && github.event_name != 'workflow_dispatch' && !matrix.schedule-only }}
       run: |
         export OMPI_MCA_rmaps_base_oversubscribe=yes
 

--- a/.github/workflows/tests-mpi.yml
+++ b/.github/workflows/tests-mpi.yml
@@ -19,7 +19,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.11']
 
     steps:
     - name: Checkout

--- a/.github/workflows/tests-mpi.yml
+++ b/.github/workflows/tests-mpi.yml
@@ -78,21 +78,9 @@ jobs:
         pip install pipdeptree
         pipdeptree
 
-    - name: Scheduled tests
-      if:  ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
-      run: |
-        export OMPI_MCA_rmaps_base_oversubscribe=yes
-
-        # Question(nabenabe0928) Why is Python 3.11 skipped?? We can skip it from `matrix`.
-        if [ ${{ matrix.python-version }} != 3.11 ]; then
-          mpirun -n 2 -- pytest tests/integration_tests/test_pytorch_distributed.py
-        fi
-
-      env:
-        OMP_NUM_THREADS: 1
-
-    - name: Tests
-      if:  ${{ github.event_name != 'schedule' && github.event_name != 'workflow_dispatch' && !matrix.schedule-only }}
+    - name: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && 'Scheduled tests' || 'Tests' }}
+      # The first two conditions are for `Scheduled tests` and the last one is for `Tests`
+      if: (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || !matrix.schedule-only)
       run: |
         export OMPI_MCA_rmaps_base_oversubscribe=yes
 

--- a/.github/workflows/tests-storage.yml
+++ b/.github/workflows/tests-storage.yml
@@ -22,7 +22,17 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.7', '3.11']
+        include:
+          - python-version: '3.7'
+            schedule-only: false
+          - python-version: '3.8'
+            schedule-only: true
+          - python-version: '3.9'
+            schedule-only: true
+          - python-version: '3.10'
+            schedule-only: true
+          - python-version: '3.11'
+            schedule-only: false
 
     services:
       mysql:
@@ -106,7 +116,9 @@ jobs:
         pip install pipdeptree
         pipdeptree
 
-    - name: Tests MySQL
+    - name: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && 'Scheduled tests MySQL' || 'Tests MySQL' }}
+      # The first two conditions are for `Scheduled tests` and the last one is for `Tests`
+      if: (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || !matrix.schedule-only)
       run: |
         pytest tests/storages_tests/test_with_server.py
       env:
@@ -114,14 +126,18 @@ jobs:
         OMP_NUM_THREADS: 1
         TEST_DB_URL: mysql+pymysql://user:test@127.0.0.1/optunatest
 
-    - name: Tests PostgreSQL
+    - name: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && 'Scheduled tests PostgreSQL' || 'Tests PostgreSQL' }}
+      # The first two conditions are for `Scheduled tests` and the last one is for `Tests`
+      if: (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || !matrix.schedule-only)
       run: |
         pytest tests/storages_tests/test_with_server.py
       env:
         OMP_NUM_THREADS: 1
         TEST_DB_URL: postgresql+psycopg2://user:test@127.0.0.1/optunatest
 
-    - name: Tests Journal Redis
+    - name: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && 'Scheduled tests Journal Redis' || 'Tests Journal Redis' }}
+      # The first two conditions are for `Scheduled tests` and the last one is for `Tests`
+      if: (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || !matrix.schedule-only)
       run: |
         pytest tests/storages_tests/test_with_server.py
       env:

--- a/.github/workflows/tests-storage.yml
+++ b/.github/workflows/tests-storage.yml
@@ -22,7 +22,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.7', '3.11']
 
     services:
       mysql:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -92,7 +92,7 @@ jobs:
         SQLALCHEMY_WARN_20: 1
 
     - name: Tests
-      if:  ${{ (github.event_name != 'schedule' && github.event_name != 'workflow_dispatch') && !matrix.schedule-only }}
+      if:  ${{ github.event_name != 'schedule' && github.event_name != 'workflow_dispatch' && !matrix.schedule-only }}
       run: |
         pytest tests -m "not integration and not slow"
       env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.7', '3.11']
 
     services:
       redis:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,17 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.7', '3.11']
+        include:
+          - python-version: '3.7'
+            schedule-only: false
+          - python-version: '3.8'
+            schedule-only: true
+          - python-version: '3.9'
+            schedule-only: true
+          - python-version: '3.10'
+            schedule-only: true
+          - python-version: '3.11'
+            schedule-only: false
 
     services:
       redis:
@@ -82,7 +92,7 @@ jobs:
         SQLALCHEMY_WARN_20: 1
 
     - name: Tests
-      if:  ${{ github.event_name != 'schedule' && github.event_name != 'workflow_dispatch' }}
+      if:  ${{ (github.event_name != 'schedule' && github.event_name != 'workflow_dispatch') && !matrix.schedule-only }}
       run: |
         pytest tests -m "not integration and not slow"
       env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -84,16 +84,16 @@ jobs:
         pip install pipdeptree
         pipdeptree
 
-    - name: Scheduled tests
-      if:  ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+    - name: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && 'Scheduled tests' || 'Tests' }}
+      # The first two conditions are for `Scheduled tests` and the last one is for `Tests`
+      if: (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || !matrix.schedule-only)
       run: |
-        pytest tests -m "not integration"
-      env:
-        SQLALCHEMY_WARN_20: 1
-
-    - name: Tests
-      if:  ${{ github.event_name != 'schedule' && github.event_name != 'workflow_dispatch' && !matrix.schedule-only }}
-      run: |
-        pytest tests -m "not integration and not slow"
+        if [ ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') }} ]: then
+          # Scheduled tests
+          pytest tests -m "not integration"
+        else:
+          # Tests
+          pytest tests -m "not integration and not slow"
+        fi
       env:
         SQLALCHEMY_WARN_20: 1


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

As the CI is slow with tests on all the Python versions, I made a change so that the tests will run only on the oldest and the latest supported Python versions.
Note that we still maintain the tests on all the versions for scheduled tests to make sure that Optuna still works on all the versions.


## Description of the changes
<!-- Describe the changes in this PR. -->

More specifically, the changes are:
1. Remove the Python version 3.8, 3.9, 3.10 from tests, and
2. Maintain these versions at least for scheduled tests.