### PR TITLE
Make positional args to kwargs in suggest_int

### DIFF
--- a/optuna/_convert_positional_args.py
+++ b/optuna/_convert_positional_args.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 from collections.abc import Callable
 from collections.abc import Sequence
 from functools import wraps
-from inspect import signature
 from inspect import Parameter
+from inspect import signature
 from typing import Any
 from typing import TYPE_CHECKING
 from typing import TypeVar
@@ -21,17 +21,15 @@ if TYPE_CHECKING:
 def _get_positional_arg_names(func: "Callable[_P, _T]") -> list[str]:
     params = signature(func).parameters
     positional_arg_names = [
-        name for name, p in params.items()
+        name
+        for name, p in params.items()
         if p.default == Parameter.empty and p.kind == p.POSITIONAL_OR_KEYWORD
     ]
     return positional_arg_names
 
 
 def _infer_given_args(previous_positional_arg_names: Sequence[str], *args: Any) -> dict[str, Any]:
-    inferred_args = {
-        arg_name: val
-        for val, arg_name in zip(args, previous_positional_arg_names)
-    }
+    inferred_args = {arg_name: val for val, arg_name in zip(args, previous_positional_arg_names)}
     return inferred_args
 
 

--- a/optuna/_convert_positional_args.py
+++ b/optuna/_convert_positional_args.py
@@ -59,8 +59,7 @@ def convert_positional_args(
                 kwargs_expected = set(inferred_args) - set(positional_arg_names)
                 warnings.warn(
                     f"{func.__name__}() got {kwargs_expected} as positional arguments "
-                    "but they were expected to be given as keyword arguments."
-                    " See https://github.com/optuna/optuna/issues/3324 for details.",
+                    "but they were expected to be given as keyword arguments.",
                     FutureWarning,
                     stacklevel=warning_stacklevel,
                 )

--- a/optuna/_convert_positional_args.py
+++ b/optuna/_convert_positional_args.py
@@ -50,6 +50,7 @@ def convert_positional_args(
                     f" arguments but {len(args)} were given."
                 )
 
+            sig = signature(func).parameters
             for val, arg_name in zip(args, previous_positional_arg_names):
                 # When specifying a positional argument that is not located at the end of args as
                 # a keyword argument, raise TypeError as follows by imitating the Python standard
@@ -58,6 +59,15 @@ def convert_positional_args(
                     raise TypeError(
                         f"{func.__name__}() got multiple values for argument '{arg_name}'."
                     )
+
+                if sig[arg_name].kind == sig[arg_name].KEYWORD_ONLY:
+                    warnings.warn(
+                        f"{func.__name__}() takes '{arg_name}' as a keyword argument"
+                        " but it was given as a positional argument.",
+                        FutureWarning,
+                        stacklevel=warning_stacklevel,
+                    )
+
                 kwargs[arg_name] = val
 
             return func(**kwargs)

--- a/optuna/multi_objective/trial.py
+++ b/optuna/multi_objective/trial.py
@@ -8,12 +8,14 @@ from typing import Sequence
 from typing import Union
 
 from optuna import multi_objective
+from optuna._convert_positional_args import convert_positional_args
 from optuna._deprecated import deprecated_class
 from optuna.distributions import BaseDistribution
 from optuna.study._study_direction import StudyDirection
 from optuna.trial import FrozenTrial
 from optuna.trial import Trial
 from optuna.trial import TrialState
+from optuna.trial._base import _SUGGEST_INT_POSITIONAL_ARGS
 
 
 CategoricalChoiceType = Union[None, bool, int, float, str]
@@ -87,7 +89,10 @@ class MultiObjectiveTrial:
 
         return self._trial.suggest_discrete_uniform(name, low, high, q)
 
-    def suggest_int(self, name: str, low: int, high: int, step: int = 1, log: bool = False) -> int:
+    @convert_positional_args(previous_positional_arg_names=_SUGGEST_INT_POSITIONAL_ARGS)
+    def suggest_int(
+        self, name: str, low: int, high: int, *, step: int = 1, log: bool = False
+    ) -> int:
         """Suggest a value for the integer parameter.
 
         Please refer to the documentation of :func:`optuna.trial.Trial.suggest_int`

--- a/optuna/trial/_base.py
+++ b/optuna/trial/_base.py
@@ -11,6 +11,9 @@ from optuna.distributions import BaseDistribution
 from optuna.distributions import CategoricalChoiceType
 
 
+_SUGGEST_INT_POSITIONAL_ARGS = ["self", "name", "low", "high", "step", "log"]
+
+
 class BaseTrial(abc.ABC):
     """Base class for trials.
 
@@ -45,7 +48,9 @@ class BaseTrial(abc.ABC):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def suggest_int(self, name: str, low: int, high: int, step: int = 1, log: bool = False) -> int:
+    def suggest_int(
+        self, name: str, low: int, high: int, *, step: int = 1, log: bool = False
+    ) -> int:
         raise NotImplementedError
 
     @overload

--- a/optuna/trial/_fixed.py
+++ b/optuna/trial/_fixed.py
@@ -7,12 +7,14 @@ from typing import Sequence
 import warnings
 
 from optuna import distributions
+from optuna._convert_positional_args import convert_positional_args
 from optuna._deprecated import deprecated_func
 from optuna.distributions import BaseDistribution
 from optuna.distributions import CategoricalChoiceType
 from optuna.distributions import CategoricalDistribution
 from optuna.distributions import FloatDistribution
 from optuna.distributions import IntDistribution
+from optuna.trial._base import _SUGGEST_INT_POSITIONAL_ARGS
 from optuna.trial._base import BaseTrial
 
 
@@ -89,7 +91,10 @@ class FixedTrial(BaseTrial):
     def suggest_discrete_uniform(self, name: str, low: float, high: float, q: float) -> float:
         return self.suggest_float(name, low, high, step=q)
 
-    def suggest_int(self, name: str, low: int, high: int, step: int = 1, log: bool = False) -> int:
+    @convert_positional_args(previous_positional_arg_names=_SUGGEST_INT_POSITIONAL_ARGS)
+    def suggest_int(
+        self, name: str, low: int, high: int, *, step: int = 1, log: bool = False
+    ) -> int:
         return int(self._suggest(name, IntDistribution(low, high, log=log, step=step)))
 
     @overload

--- a/optuna/trial/_frozen.py
+++ b/optuna/trial/_frozen.py
@@ -11,6 +11,7 @@ import warnings
 
 from optuna import distributions
 from optuna import logging
+from optuna._convert_positional_args import convert_positional_args
 from optuna._deprecated import deprecated_func
 from optuna._typing import JSONSerializable
 from optuna.distributions import _convert_old_distribution_to_new_distribution
@@ -19,6 +20,7 @@ from optuna.distributions import CategoricalChoiceType
 from optuna.distributions import CategoricalDistribution
 from optuna.distributions import FloatDistribution
 from optuna.distributions import IntDistribution
+from optuna.trial._base import _SUGGEST_INT_POSITIONAL_ARGS
 from optuna.trial._base import BaseTrial
 from optuna.trial._state import TrialState
 
@@ -225,7 +227,10 @@ class FrozenTrial(BaseTrial):
     def suggest_discrete_uniform(self, name: str, low: float, high: float, q: float) -> float:
         return self.suggest_float(name, low, high, step=q)
 
-    def suggest_int(self, name: str, low: int, high: int, step: int = 1, log: bool = False) -> int:
+    @convert_positional_args(previous_positional_arg_names=_SUGGEST_INT_POSITIONAL_ARGS)
+    def suggest_int(
+        self, name: str, low: int, high: int, *, step: int = 1, log: bool = False
+    ) -> int:
         return int(self._suggest(name, IntDistribution(low, high, log=log, step=step)))
 
     @overload

--- a/optuna/trial/_trial.py
+++ b/optuna/trial/_trial.py
@@ -14,6 +14,7 @@ import optuna
 from optuna import distributions
 from optuna import logging
 from optuna import pruners
+from optuna._convert_positional_args import convert_positional_args
 from optuna._deprecated import deprecated_func
 from optuna.distributions import BaseDistribution
 from optuna.distributions import CategoricalChoiceType
@@ -21,6 +22,7 @@ from optuna.distributions import CategoricalDistribution
 from optuna.distributions import FloatDistribution
 from optuna.distributions import IntDistribution
 from optuna.trial import FrozenTrial
+from optuna.trial._base import _SUGGEST_INT_POSITIONAL_ARGS
 from optuna.trial._base import BaseTrial
 
 
@@ -235,7 +237,10 @@ class Trial(BaseTrial):
 
         return self.suggest_float(name, low, high, step=q)
 
-    def suggest_int(self, name: str, low: int, high: int, step: int = 1, log: bool = False) -> int:
+    @convert_positional_args(previous_positional_arg_names=_SUGGEST_INT_POSITIONAL_ARGS)
+    def suggest_int(
+        self, name: str, low: int, high: int, *, step: int = 1, log: bool = False
+    ) -> int:
         """Suggest a value for the integer parameter.
 
         The value is sampled from the integers in :math:`[\\mathsf{low}, \\mathsf{high}]`.

--- a/tests/multi_objective_tests/test_trial.py
+++ b/tests/multi_objective_tests/test_trial.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import datetime
 from typing import List
 from typing import Tuple
@@ -205,3 +207,13 @@ def test_dominates() -> None:
             else:
                 # If `t1` isn't COMPLETE, it doesn't dominate others.
                 assert not t1._dominates(t0, directions)
+
+
+@pytest.mark.parametrize("positional_args_names", [[], ["step"], ["step", "log"]])
+def test_suggest_int_positional_args(positional_args_names: list[str]) -> None:
+    # If log is specified as positional, step must also be provided as positional.
+    study = optuna.multi_objective.create_study(["maximize"])
+    kwargs = dict(step=1, log=False)
+    args = [kwargs[name] for name in positional_args_names]
+    # No error should not be raised even if the coding style is old.
+    study.optimize(lambda trial: [trial.suggest_int("x", -1, 1, *args)], n_trials=1)

--- a/tests/test_convert_positional_args.py
+++ b/tests/test_convert_positional_args.py
@@ -38,8 +38,8 @@ def test_convert_positional_args_future_warning() -> None:
     count_give_kwargs = 0
     for warn in record.list:
         msg = warn.message.args[0]
-        count_give_all += ("give all" in msg)
-        count_give_kwargs += ("as a keyword argument" in msg)
+        count_give_all += "give all" in msg
+        count_give_kwargs += "as a keyword argument" in msg
         assert isinstance(warn.message, FutureWarning)
         assert _sample_func.__name__ in str(warn.message)
 

--- a/tests/test_convert_positional_args.py
+++ b/tests/test_convert_positional_args.py
@@ -10,6 +10,12 @@ def _sample_func(*, a: int, b: int, c: int) -> int:
     return a + b + c
 
 
+class _SimpleClass:
+    @convert_positional_args(previous_positional_arg_names=["self", "a", "b"])
+    def simple_method(self, a: int, *, b: int, c: int = 1) -> None:
+        pass
+
+
 def test_convert_positional_args_decorator() -> None:
     previous_positional_arg_names: List[str] = []
     decorator_converter = convert_positional_args(
@@ -18,6 +24,19 @@ def test_convert_positional_args_decorator() -> None:
 
     decorated_func = decorator_converter(_sample_func)
     assert decorated_func.__name__ == _sample_func.__name__
+
+
+def test_convert_positional_args_future_warning_for_methods() -> None:
+    simple_class = _SimpleClass()
+    with pytest.warns(FutureWarning) as record:
+        simple_class.simple_method(1, 2, c=3)  # type: ignore
+        simple_class.simple_method(1, b=2, c=3)  # No warning.
+        simple_class.simple_method(a=1, b=2, c=3)  # No warning.
+
+    assert len(record) == 1
+    for warn in record.list:
+        assert isinstance(warn.message, FutureWarning)
+        assert "simple_method" in str(warn.message)
 
 
 def test_convert_positional_args_future_warning() -> None:

--- a/tests/test_convert_positional_args.py
+++ b/tests/test_convert_positional_args.py
@@ -33,10 +33,18 @@ def test_convert_positional_args_future_warning() -> None:
         decorated_func(1, b=2, c=3)  # type: ignore
         decorated_func(a=1, b=2, c=3)  # No warning.
 
-    assert len(record) == 2
+    assert len(record) == 5
+    count_give_all = 0
+    count_give_kwargs = 0
     for warn in record.list:
+        msg = warn.message.args[0]
+        count_give_all += ("give all" in msg)
+        count_give_kwargs += ("as a keyword argument" in msg)
         assert isinstance(warn.message, FutureWarning)
         assert _sample_func.__name__ in str(warn.message)
+
+    assert count_give_all == 2
+    assert count_give_kwargs == 3
 
 
 def test_convert_positional_args_mypy_type_inference() -> None:

--- a/tests/test_convert_positional_args.py
+++ b/tests/test_convert_positional_args.py
@@ -33,18 +33,10 @@ def test_convert_positional_args_future_warning() -> None:
         decorated_func(1, b=2, c=3)  # type: ignore
         decorated_func(a=1, b=2, c=3)  # No warning.
 
-    assert len(record) == 5
-    count_give_all = 0
-    count_give_kwargs = 0
+    assert len(record) == 2
     for warn in record.list:
-        msg = warn.message.args[0]
-        count_give_all += "give all" in msg
-        count_give_kwargs += "as a keyword argument" in msg
         assert isinstance(warn.message, FutureWarning)
         assert _sample_func.__name__ in str(warn.message)
-
-    assert count_give_all == 2
-    assert count_give_kwargs == 3
 
 
 def test_convert_positional_args_mypy_type_inference() -> None:
@@ -113,4 +105,4 @@ def test_convert_positional_args_invalid_positional_args() -> None:
 
         with pytest.raises(TypeError) as record:
             decorated_func(1, 3, b=2)  # type: ignore
-        assert str(record.value) == "_sample_func() got multiple values for argument 'b'."
+        assert str(record.value) == "_sample_func() got multiple values for arguments {'b'}."

--- a/tests/trial_tests/test_fixed.py
+++ b/tests/trial_tests/test_fixed.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+import pytest
+
 from optuna.trial import FixedTrial
 
 
@@ -8,6 +12,17 @@ def test_params() -> None:
 
     assert trial.suggest_float("x", 0, 10) == 1
     assert trial.params == params
+
+
+@pytest.mark.parametrize("positional_args_names", [[], ["step"], ["step", "log"]])
+def test_suggest_int_positional_args(positional_args_names: list[str]) -> None:
+    # If log is specified as positional, step must also be provided as positional.
+    params = {"x": 1}
+    trial = FixedTrial(params)
+    kwargs = dict(step=1, log=False)
+    args = [kwargs[name] for name in positional_args_names]
+    # No error should not be raised even if the coding style is old.
+    trial.suggest_int("x", -1, 1, *args)
 
 
 def test_number() -> None:

--- a/tests/trial_tests/test_frozen.py
+++ b/tests/trial_tests/test_frozen.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import copy
 import datetime
 from typing import Any
@@ -11,6 +13,7 @@ import pytest
 from optuna import create_study
 from optuna.distributions import BaseDistribution
 from optuna.distributions import FloatDistribution
+from optuna.distributions import IntDistribution
 from optuna.testing.storages import STORAGE_MODES
 from optuna.testing.storages import StorageSupplier
 import optuna.trial
@@ -385,3 +388,26 @@ def test_create_trial_distribution_conversion_noop() -> None:
 
     # Check fixed_distributions doesn't change.
     assert trial.distributions == fixed_distributions
+
+
+@pytest.mark.parametrize("positional_args_names", [[], ["step"], ["step", "log"]])
+def test_suggest_int_positional_args(positional_args_names: list[str]) -> None:
+    # If log is specified as positional, step must also be provided as positional.
+    trial = FrozenTrial(
+        number=0,
+        trial_id=0,
+        state=TrialState.COMPLETE,
+        value=0.0,
+        values=None,
+        datetime_start=datetime.datetime.now(),
+        datetime_complete=datetime.datetime.now(),
+        params={"x": 1},
+        distributions={"x": IntDistribution(-1, 1)},
+        user_attrs={},
+        system_attrs={},
+        intermediate_values={},
+    )
+    kwargs = dict(step=1, log=False)
+    args = [kwargs[name] for name in positional_args_names]
+    # No error should not be raised even if the coding style is old.
+    trial.suggest_int("x", -1, 1, *args)

--- a/tests/trial_tests/test_trial.py
+++ b/tests/trial_tests/test_trial.py
@@ -709,7 +709,7 @@ def test_lazy_trial_system_attrs(storage_mode: str) -> None:
 
 
 @pytest.mark.parametrize("positional_args_names", [[], ["step"], ["step", "log"]])
-def test_suggest_int_positional_args(positional_args_names: list[str]):
+def test_suggest_int_positional_args(positional_args_names: list[str]) -> None:
     # If log is specified as positional, step must also be provided as positional.
     study = optuna.create_study()
     trial = study.ask()

--- a/tests/trial_tests/test_trial.py
+++ b/tests/trial_tests/test_trial.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import datetime
 import math
 from typing import Any
@@ -704,3 +706,14 @@ def test_lazy_trial_system_attrs(storage_mode: str) -> None:
         system_attrs = _LazyTrialSystemAttrs(trial._trial_id, storage)
         assert set(system_attrs.items()) == {("int", 0), ("str", "A")}
         assert set(system_attrs.items()) == {("int", 0), ("str", "A")}
+
+
+@pytest.mark.parametrize("positional_args_names", [[], ["step"], ["step", "log"]])
+def test_suggest_int_positional_args(positional_args_names: list[str]):
+    # If log is specified as positional, step must also be provided as positional.
+    study = optuna.create_study()
+    trial = study.ask()
+    kwargs = dict(step=1, log=False)
+    args = [kwargs[name] for name in positional_args_names]
+    # No error should not be raised even if the coding style is old.
+    trial.suggest_int("x", -1, 1, *args)

--- a/tests/trial_tests/test_trial.py
+++ b/tests/trial_tests/test_trial.py
@@ -128,11 +128,11 @@ def test_check_distribution_suggest_discrete_uniform(storage_mode: str) -> None:
         assert len([r for r in record if r.category != FutureWarning]) == 1
 
         with pytest.raises(ValueError):
-            trial.suggest_int("x", 10, 20, 2)
+            trial.suggest_int("x", 10, 20, step=2)
 
         trial = Trial(study, study._storage.create_new_trial(study._study_id))
         with pytest.raises(ValueError):
-            trial.suggest_int("x", 10, 20, 2)
+            trial.suggest_int("x", 10, 20, step=2)
 
 
 @pytest.mark.parametrize("storage_mode", STORAGE_MODES)


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

As `suggest_float` has `*` before `steps` and `log` so that users need to pass them as `kwargs`, I applied the same to `suggest_int`.

## Description of the changes
<!-- Describe the changes in this PR. -->

I made the following changes:
1. Change `suggest_int(name, low, high, step, log)` into `suggest_int(name, low, high, *, step, log)` to strengthen the future safety, and
2. Wrap `suggest_int` with `convert_positional_args` for now to avoid breaking changes.