### PR TITLE
Remove unused `type: ignore`

### DIFF
--- a/optuna/integration/pytorch_distributed.py
+++ b/optuna/integration/pytorch_distributed.py
@@ -126,9 +126,7 @@ class TorchDistributedTrial(optuna.trial.BaseTrial):
                     raise RuntimeError("torch distributed is not initialized.")
                 default_pg: "ProcessGroup" = dist.group.WORLD
                 if dist.get_backend(default_pg) == "nccl":
-                    new_group: "ProcessGroup" = dist.new_group(  # type: ignore[no-untyped-call]
-                        backend="gloo"
-                    )
+                    new_group: "ProcessGroup" = dist.new_group(backend="gloo")
                     _g_pg = new_group
                 else:
                     _g_pg = default_pg

--- a/tests/integration_tests/test_pytorch_distributed.py
+++ b/tests/integration_tests/test_pytorch_distributed.py
@@ -344,13 +344,13 @@ def test_updates_properties(storage_mode: str) -> None:
         if dist.get_rank() == 0:
             [getattr(trial, p) for p in property_names]
 
-        dist.barrier()  # type: ignore[no-untyped-call]
+        dist.barrier()
 
         # Same with rank 1.
         if dist.get_rank() == 1:
             [getattr(trial, p) for p in property_names]
 
-        dist.barrier()  # type: ignore[no-untyped-call]
+        dist.barrier()
 
 
 @pytest.mark.filterwarnings("ignore::optuna.exceptions.ExperimentalWarning")


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
Fix `Checks (integration)`

## Description of the changes
As of the release of torch 2.1.0, some functions in `torch.distributed` have been newly type annotated. This PR removes the `type: ignore` comments for those previously untyped functions.
