### PR TITLE
add hint how to customize plotly figures generated by optuna

### DIFF
--- a/optuna/visualization/_pareto_front.py
+++ b/optuna/visualization/_pareto_front.py
@@ -72,6 +72,9 @@ def plot_pareto_front(
 
             fig = optuna.visualization.plot_pareto_front(study)
             fig.show()
+            
+        .. seealso::
+	        To customize the generated diagram afterwards (change title, ...), use the function 'update_layout()' of plotly. See https://plotly.com/python/reference/layout/.
 
     Example:
 

--- a/optuna/visualization/_pareto_front.py
+++ b/optuna/visualization/_pareto_front.py
@@ -72,7 +72,7 @@ def plot_pareto_front(
 
             fig = optuna.visualization.plot_pareto_front(study)
             fig.show()
-            
+
         .. seealso::
             To customize the generated diagram afterwards (change title, ...), use the function 'update_layout()' of plotly. See https://plotly.com/python/reference/layout/.
 

--- a/optuna/visualization/_pareto_front.py
+++ b/optuna/visualization/_pareto_front.py
@@ -74,7 +74,7 @@ def plot_pareto_front(
             fig.show()
             
         .. seealso::
-	        To customize the generated diagram afterwards (change title, ...), use the function 'update_layout()' of plotly. See https://plotly.com/python/reference/layout/.
+            To customize the generated diagram afterwards (change title, ...), use the function 'update_layout()' of plotly. See https://plotly.com/python/reference/layout/.
 
     Example:
 

--- a/optuna/visualization/_pareto_front.py
+++ b/optuna/visualization/_pareto_front.py
@@ -74,7 +74,7 @@ def plot_pareto_front(
             fig.show()
 
         .. seealso::
-            To customize the generated diagram afterwards (change title, ...), use the 
+            To customize the generated diagram afterwards (change title, ...), use the
             function 'update_layout()' of plotly. See https://plotly.com/python/reference/layout/.
 
     Example:

--- a/optuna/visualization/_pareto_front.py
+++ b/optuna/visualization/_pareto_front.py
@@ -74,7 +74,8 @@ def plot_pareto_front(
             fig.show()
 
         .. seealso::
-            To customize the generated diagram afterwards (change title, ...), use the function 'update_layout()' of plotly. See https://plotly.com/python/reference/layout/.
+            To customize the generated diagram afterwards (change title, ...), use the 
+            function 'update_layout()' of plotly. See https://plotly.com/python/reference/layout/.
 
     Example:
 

--- a/optuna/visualization/_pareto_front.py
+++ b/optuna/visualization/_pareto_front.py
@@ -75,7 +75,7 @@ def plot_pareto_front(
 
         .. seealso::
             To customize the generated diagram afterwards (change title, ...), use the
-            function 'update_layout()' of plotly. See https://plotly.com/python/reference/layout/.
+            function ``update_layout()`` of plotly. See https://plotly.com/python/reference/layout/.
 
     Example:
 

--- a/optuna/visualization/_pareto_front.py
+++ b/optuna/visualization/_pareto_front.py
@@ -75,7 +75,8 @@ def plot_pareto_front(
 
         .. seealso::
             To customize the generated diagram afterwards (change title, ...), use the
-            function ``update_layout()`` of plotly. See https://plotly.com/python/reference/layout/.
+            function ``update_layout()`` of plotly.
+            See https://plotly.com/python/reference/layout/.
 
     Example:
 


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
When using a plotly graph generated by optuna, it is not possible to change things according to the layout. E.g. it is not possible to choose a title for your graph. Some people like to use this functionality and might search a long time how to do this.

## Description of the changes
I have added a small hintbox to the `plot_pareto_front()` function documentation which links to the plotly `update_layout()` method.
