### PR TITLE
Added support for `tuple` to `CategoricalChoiceType` and `CategoricalDistribution`

### DIFF
--- a/optuna/distributions.py
+++ b/optuna/distributions.py
@@ -6,6 +6,7 @@ from numbers import Real
 from typing import Any
 from typing import cast
 from typing import Dict
+from typing import List
 from typing import Sequence
 from typing import Tuple
 from typing import Union
@@ -25,7 +26,7 @@ ConvertableChoiceType = Union[
     float,
     str,
     Tuple["ConvertableChoiceType", ...],
-    list["ConvertableChoiceType"],
+    List["ConvertableChoiceType"],
 ]
 
 
@@ -597,7 +598,9 @@ DISTRIBUTION_CLASSES = (
 )
 
 
-def _to_categorical_choices(choice: ConvertableChoiceType) -> CategoricalChoiceType:
+def _to_categorical_choices(
+    choice: ConvertableChoiceType,
+) -> CategoricalChoiceType:
     if choice is None or isinstance(choice, (bool, int, float, str)):
         return choice
     if isinstance(choice, (tuple, list)):
@@ -623,8 +626,8 @@ def json_to_distribution(json_str: str) -> BaseDistribution:
 
     if "name" in json_dict:
         if json_dict["name"] == CategoricalDistribution.__name__:
-            json_dict["attributes"]["choices"] = _to_categorical_choices(
-                json_dict["attributes"]["choices"]
+            json_dict["attributes"]["choices"] = tuple(
+                _to_categorical_choices(value) for value in json_dict["attributes"]["choices"]
             )
 
         for cls in DISTRIBUTION_CLASSES:
@@ -636,7 +639,9 @@ def json_to_distribution(json_str: str) -> BaseDistribution:
     else:
         # Deserialize a distribution from an abbreviated format.
         if json_dict["type"] == "categorical":
-            return CategoricalDistribution(_to_categorical_choices(json_dict["choices"]))
+            return CategoricalDistribution(
+                tuple(_to_categorical_choices(value) for value in json_dict["choices"])
+            )
         elif json_dict["type"] in ("float", "int"):
             low = json_dict["low"]
             high = json_dict["high"]

--- a/optuna/integration/pytorch_distributed.py
+++ b/optuna/integration/pytorch_distributed.py
@@ -7,6 +7,7 @@ from typing import Dict
 from typing import Optional
 from typing import overload
 from typing import Sequence
+from typing import Tuple
 from typing import TYPE_CHECKING
 from typing import TypeVar
 
@@ -207,6 +208,12 @@ class TorchDistributedTrial(optuna.trial.BaseTrial):
 
     @overload
     def suggest_categorical(self, name: str, choices: Sequence[str]) -> str:
+        ...
+
+    @overload
+    def suggest_categorical(
+        self, name: str, choices: Sequence[Tuple[CategoricalChoiceType, ...]]
+    ) -> Tuple[CategoricalChoiceType, ...]:
         ...
 
     @overload

--- a/optuna/multi_objective/trial.py
+++ b/optuna/multi_objective/trial.py
@@ -5,18 +5,16 @@ from typing import List
 from typing import Optional
 from typing import overload
 from typing import Sequence
-from typing import Union
+from typing import Tuple
 
 from optuna import multi_objective
 from optuna._deprecated import deprecated_class
 from optuna.distributions import BaseDistribution
+from optuna.distributions import CategoricalChoiceType
 from optuna.study._study_direction import StudyDirection
 from optuna.trial import FrozenTrial
 from optuna.trial import Trial
 from optuna.trial import TrialState
-
-
-CategoricalChoiceType = Union[None, bool, int, float, str]
 
 
 @deprecated_class("2.4.0", "4.0.0")
@@ -114,6 +112,12 @@ class MultiObjectiveTrial:
 
     @overload
     def suggest_categorical(self, name: str, choices: Sequence[str]) -> str:
+        ...
+
+    @overload
+    def suggest_categorical(
+        self, name: str, choices: Sequence[Tuple[CategoricalChoiceType, ...]]
+    ) -> Tuple[CategoricalChoiceType, ...]:
         ...
 
     @overload

--- a/optuna/samplers/_grid.py
+++ b/optuna/samplers/_grid.py
@@ -220,10 +220,15 @@ class GridSampler(BaseSampler):
         if param_value is None or isinstance(param_value, (str, int, float, bool)):
             return
 
+        if isinstance(param_value, tuple):
+            for value in param_value:
+                GridSampler._check_value(param_name, value)
+            return
+
         message = (
             "{} contains a value with the type of {}, which is not supported by "
-            "`GridSampler`. Please make sure a value is `str`, `int`, `float`, `bool`"
-            " or `None` for persistent storage.".format(param_name, type(param_value))
+            "`GridSampler`. Please make sure a value is `str`, `int`, `float`, `bool`, "
+            "`tuple` or `None` for persistent storage.".format(param_name, type(param_value))
         )
         warnings.warn(message)
 

--- a/optuna/trial/_base.py
+++ b/optuna/trial/_base.py
@@ -5,6 +5,7 @@ from typing import Dict
 from typing import Optional
 from typing import overload
 from typing import Sequence
+from typing import Tuple
 
 from optuna._deprecated import deprecated_func
 from optuna.distributions import BaseDistribution
@@ -71,6 +72,13 @@ class BaseTrial(abc.ABC):
     @overload
     @abc.abstractmethod
     def suggest_categorical(self, name: str, choices: Sequence[str]) -> str:
+        ...
+
+    @overload
+    @abc.abstractmethod
+    def suggest_categorical(
+        self, name: str, choices: Sequence[Tuple[CategoricalChoiceType, ...]]
+    ) -> Tuple[CategoricalChoiceType, ...]:
         ...
 
     @overload

--- a/optuna/trial/_fixed.py
+++ b/optuna/trial/_fixed.py
@@ -4,6 +4,7 @@ from typing import Dict
 from typing import Optional
 from typing import overload
 from typing import Sequence
+from typing import Tuple
 import warnings
 
 from optuna import distributions
@@ -110,6 +111,12 @@ class FixedTrial(BaseTrial):
 
     @overload
     def suggest_categorical(self, name: str, choices: Sequence[str]) -> str:
+        ...
+
+    @overload
+    def suggest_categorical(
+        self, name: str, choices: Sequence[Tuple[CategoricalChoiceType, ...]]
+    ) -> Tuple[CategoricalChoiceType, ...]:
         ...
 
     @overload

--- a/optuna/trial/_frozen.py
+++ b/optuna/trial/_frozen.py
@@ -7,6 +7,7 @@ from typing import Mapping
 from typing import Optional
 from typing import overload
 from typing import Sequence
+from typing import Tuple
 import warnings
 
 from optuna import distributions
@@ -246,6 +247,12 @@ class FrozenTrial(BaseTrial):
 
     @overload
     def suggest_categorical(self, name: str, choices: Sequence[str]) -> str:
+        ...
+
+    @overload
+    def suggest_categorical(
+        self, name: str, choices: Sequence[Tuple[CategoricalChoiceType, ...]]
+    ) -> Tuple[CategoricalChoiceType, ...]:
         ...
 
     @overload

--- a/optuna/trial/_trial.py
+++ b/optuna/trial/_trial.py
@@ -8,6 +8,7 @@ from typing import Dict
 from typing import Optional
 from typing import overload
 from typing import Sequence
+from typing import Tuple
 import warnings
 
 import optuna
@@ -340,6 +341,12 @@ class Trial(BaseTrial):
 
     @overload
     def suggest_categorical(self, name: str, choices: Sequence[str]) -> str:
+        ...
+
+    @overload
+    def suggest_categorical(
+        self, name: str, choices: Sequence[Tuple[CategoricalChoiceType, ...]]
+    ) -> Tuple[CategoricalChoiceType, ...]:
         ...
 
     @overload

--- a/tests/integration_tests/test_tensorboard.py
+++ b/tests/integration_tests/test_tensorboard.py
@@ -80,8 +80,8 @@ def test_categorical() -> None:
 
 def test_categorical_mixed_types() -> None:
     def objective(trial: optuna.trial.Trial) -> float:
-        x = trial.suggest_categorical("x", [None, 1, 2, 3.14, True, "foo"])
-        assert x is None or isinstance(x, (int, float, bool, str))
+        x = trial.suggest_categorical("x", [None, 1, 2, 3.14, True, "foo", ("foo", "bar")])
+        assert x is None or isinstance(x, (int, float, bool, str, tuple))
         return len(str(x))
 
     dirname = tempfile.mkdtemp()

--- a/tests/samplers_tests/test_grid.py
+++ b/tests/samplers_tests/test_grid.py
@@ -23,7 +23,7 @@ def test_study_optimize_with_single_search_space() -> None:
     def objective(trial: Trial) -> float:
         a = trial.suggest_int("a", 0, 100)
         b = trial.suggest_float("b", -0.1, 0.1)
-        c = trial.suggest_categorical("c", ("x", "y", None, 1, 2.0))
+        c = trial.suggest_categorical("c", ("x", "y", None, 1, 2.0, ("a", "b")))
         d = trial.suggest_float("d", -5, 5, step=1)
         e = trial.suggest_float("e", 0.0001, 1, log=True)
 
@@ -35,7 +35,7 @@ def test_study_optimize_with_single_search_space() -> None:
     # Test that all combinations of the grid is sampled.
     search_space = {
         "b": np.arange(-0.1, 0.1, 0.05),
-        "c": ("x", "y", None, 1, 2.0),
+        "c": ("x", "y", None, 1, 2.0, ("a", "b")),
         "d": [-5.0, 5.0],
         "e": [0.1],
         "a": list(range(0, 100, 20)),

--- a/tests/samplers_tests/test_samplers.py
+++ b/tests/samplers_tests/test_samplers.py
@@ -323,7 +323,7 @@ def test_int(sampler_class: Callable[[], BaseSampler], distribution: IntDistribu
 
 
 @parametrize_sampler
-@pytest.mark.parametrize("choices", [(1, 2, 3), ("a", "b", "c"), (1, "a")])
+@pytest.mark.parametrize("choices", [(1, 2, 3), ("a", "b", "c"), (1, "a"), ((1, 2), (1, 3))])
 def test_categorical(
     sampler_class: Callable[[], BaseSampler], choices: Sequence[CategoricalChoiceType]
 ) -> None:

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -30,7 +30,9 @@ EXAMPLE_DISTRIBUTIONS: Dict[str, Any] = {
     "c1": distributions.CategoricalDistribution(choices=_choices),
     "c2": distributions.CategoricalDistribution(choices=("Roppongi", "Azabu")),
     "c3": distributions.CategoricalDistribution(choices=["Roppongi", "Azabu"]),
-    "c4": distributions.CategoricalDistribution(choices=[("src",), ("dst",), ("src", "dst")]),
+    "c4": distributions.CategoricalDistribution(
+        choices=[("foo",), ("foo", "bar"), ("foo", ("foo", "bar"))]
+    ),
 }
 
 EXAMPLE_JSONS = {
@@ -54,7 +56,7 @@ EXAMPLE_JSONS = {
     "c2": '{"name": "CategoricalDistribution", "attributes": {"choices": ["Roppongi", "Azabu"]}}',
     "c3": '{"name": "CategoricalDistribution", "attributes": {"choices": ["Roppongi", "Azabu"]}}',
     "c4": '{"name": "CategoricalDistribution", '
-    '"attributes": {"choices": [["src"], ["dst"], ["src", "dst"]]}}',
+    '"attributes": {"choices": [["foo"], ["foo", "bar"], ["foo", ["foo", "bar"]]]}}',
 }
 
 EXAMPLE_ABBREVIATED_JSONS = {
@@ -71,7 +73,7 @@ EXAMPLE_ABBREVIATED_JSONS = {
     "c1": f'{{"type": "categorical", "choices": {_choices_json}}}',
     "c2": '{"type": "categorical", "choices": ["Roppongi", "Azabu"]}',
     "c3": '{"type": "categorical", "choices": ["Roppongi", "Azabu"]}',
-    "c4": '{"type": "categorical", "choices": [["src"], ["dst"], ["src", "dst"]]}',
+    "c4": '{"type": "categorical", "choices": [["foo"], ["foo", "bar"], ["foo", ["foo", "bar"]]]}',
 }
 
 
@@ -611,3 +613,8 @@ def test_is_distribution_log() -> None:
 
     cd = distributions.CategoricalDistribution(choices=["a", "b", "c"])
     assert not distributions._is_distribution_log(cd)
+
+
+def test_to_categorical_choices_error() -> None:
+    with pytest.raises(ValueError):
+        distributions._to_categorical_choices([set()])

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -617,4 +617,4 @@ def test_is_distribution_log() -> None:
 
 def test_to_categorical_choices_error() -> None:
     with pytest.raises(ValueError):
-        distributions._to_categorical_choices([set()])
+        distributions._to_categorical_choices([set()])  # type: ignore

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -30,6 +30,7 @@ EXAMPLE_DISTRIBUTIONS: Dict[str, Any] = {
     "c1": distributions.CategoricalDistribution(choices=_choices),
     "c2": distributions.CategoricalDistribution(choices=("Roppongi", "Azabu")),
     "c3": distributions.CategoricalDistribution(choices=["Roppongi", "Azabu"]),
+    "c4": distributions.CategoricalDistribution(choices=[("src",), ("dst",), ("src", "dst")]),
 }
 
 EXAMPLE_JSONS = {
@@ -52,6 +53,8 @@ EXAMPLE_JSONS = {
     "c1": f'{{"name": "CategoricalDistribution", "attributes": {{"choices": {_choices_json}}}}}',
     "c2": '{"name": "CategoricalDistribution", "attributes": {"choices": ["Roppongi", "Azabu"]}}',
     "c3": '{"name": "CategoricalDistribution", "attributes": {"choices": ["Roppongi", "Azabu"]}}',
+    "c4": '{"name": "CategoricalDistribution", '
+    '"attributes": {"choices": [["src"], ["dst"], ["src", "dst"]]}}',
 }
 
 EXAMPLE_ABBREVIATED_JSONS = {
@@ -68,6 +71,7 @@ EXAMPLE_ABBREVIATED_JSONS = {
     "c1": f'{{"type": "categorical", "choices": {_choices_json}}}',
     "c2": '{"type": "categorical", "choices": ["Roppongi", "Azabu"]}',
     "c3": '{"type": "categorical", "choices": ["Roppongi", "Azabu"]}',
+    "c4": '{"type": "categorical", "choices": [["src"], ["dst"], ["src", "dst"]]}',
 }
 
 


### PR DESCRIPTION
## Motivation
Optuna currently does not support sequences as a type for categorical parameters. This was a feature suggested to improve Optuna's flexibility in https://github.com/optuna/optuna/issues/5061 and caused problems with the dashboard as well, as indicated in https://github.com/optuna/optuna-dashboard/issues/665.

## Description of the changes
`tuple` was added as an allowed type for `CategoricalChoiceType`, with the additional requirement that the elements of the `tuple` are also of type `CategoricalChoiceType`.
The initialization of `CategoricalDistribution` was changed accordingly, as well as its DocStrings.
A new test case (or a parameter to an already existing test case) was added to also test this functionality.

How this works internally with JSON serialization, is that tuples are formatted as lists in JSON. When reading, they hence are lists, but they are converted to tuples in `json_to_distribution`.

This issue solves https://github.com/optuna/optuna/issues/5061 and https://github.com/optuna/optuna-dashboard/issues/665

Since you might wonder how this works downstream in the dashboard, it works excellent as visualized below!
![image](https://github.com/optuna/optuna/assets/32361020/05d3b7ea-ca77-4d82-9a8d-1003f694c050)

