### PR TITLE
Update link to reference

### DIFF
--- a/optuna/integration/fastaiv1.py
+++ b/optuna/integration/fastaiv1.py
@@ -50,7 +50,7 @@ class FastAIV1PruningCallback(TrackerCallback):
 
     Args:
         learn:
-            `fastai.basic_train.Learner <https://docs.fast.ai/basic_train.html#Learner>`_.
+            `fastai.basic_train.Learner <https://fastai1.fast.ai/basic_train.html#Learner>`_.
         trial:
             A :class:`~optuna.trial.Trial` corresponding to the current
             evaluation of the objective function.


### PR DESCRIPTION
## Motivation
Update expired link.

## Description of the changes
Link to `fastai.basic_train.Learner` in the docstring of `FastAIV1PruningCallback` is expired. This PR updates the link to be properly connected.