### PR TITLE
Use `ExpectedHypervolumeImprovement` candidates function for `BotorchSampler`

### DIFF
--- a/docs/source/reference/integration.rst
+++ b/docs/source/reference/integration.rst
@@ -26,6 +26,7 @@ BoTorch
    :nosignatures:
 
    optuna.integration.BoTorchSampler
+   optuna.integration.botorch.ehvi_candidates_func
    optuna.integration.botorch.logei_candidates_func
    optuna.integration.botorch.qei_candidates_func
    optuna.integration.botorch.qnei_candidates_func

--- a/optuna/integration/botorch.py
+++ b/optuna/integration/botorch.py
@@ -421,6 +421,7 @@ def qehvi_candidates_func(
 
     return candidates
 
+
 @experimental_func("3.5.0")
 def ehvi_candidates_func(
     train_x: "torch.Tensor",

--- a/optuna/integration/botorch.py
+++ b/optuna/integration/botorch.py
@@ -708,7 +708,7 @@ class BoTorchSampler(BaseSampler):
             If the number of objectives is either two or three, Quasi MC-based
             batch Expected Hypervolume Improvement (qEHVI) is used. Otherwise, for a larger number
             of objectives, analytic Expected Hypervolume Improvement is used if no constraints
-            are specified, or the faster Quasi MC-based extended ParEGO (qParEGO) is used if 
+            are specified, or the faster Quasi MC-based extended ParEGO (qParEGO) is used if
             constraints are present.
 
             The function should assume *maximization* of the objective.

--- a/optuna/integration/botorch.py
+++ b/optuna/integration/botorch.py
@@ -452,8 +452,8 @@ def ehvi_candidates_func(
     fit_gpytorch_mll(mll)
 
     # Approximate box decomposition similar to Ax when the number of objectives is large.
-    # https://github.com/facebook/Ax/blob/master/ax/models/torch/botorch_moo_defaults
-    if n_objectives > 2:
+    # https://github.com/pytorch/botorch/blob/36d09a4297c2a0ff385077b7fcdd5a9d308e40cc/botorch/acquisition/multi_objective/utils.py#L46-L63
+    if n_objectives > 4:
         alpha = 10 ** (-8 + n_objectives)
     else:
         alpha = 0.0

--- a/optuna/integration/botorch.py
+++ b/optuna/integration/botorch.py
@@ -384,7 +384,7 @@ def qehvi_candidates_func(
     fit_gpytorch_mll(mll)
 
     # Approximate box decomposition similar to Ax when the number of objectives is large.
-    # https://github.com/facebook/Ax/blob/master/ax/models/torch/botorch_moo_defaults
+    # https://github.com/pytorch/botorch/blob/36d09a4297c2a0ff385077b7fcdd5a9d308e40cc/botorch/acquisition/multi_objective/utils.py#L46-L63
     if n_objectives > 2:
         alpha = 10 ** (-8 + n_objectives)
     else:
@@ -432,7 +432,7 @@ def ehvi_candidates_func(
 ) -> "torch.Tensor":
     """Expected Hypervolume Improvement (EHVI).
 
-    The default value of ``candidates_func`` in class:`~optuna.integration.BoTorchSampler`
+    The default value of ``candidates_func`` in :class:`~optuna.integration.BoTorchSampler`
     with multi-objective optimization without constraints.
 
     .. seealso::
@@ -532,7 +532,7 @@ def qnehvi_candidates_func(
     fit_gpytorch_mll(mll)
 
     # Approximate box decomposition similar to Ax when the number of objectives is large.
-    # https://github.com/facebook/Ax/blob/master/ax/models/torch/botorch_moo_defaults
+    # https://github.com/pytorch/botorch/blob/36d09a4297c2a0ff385077b7fcdd5a9d308e40cc/botorch/acquisition/multi_objective/utils.py#L46-L63
     if n_objectives > 2:
         alpha = 10 ** (-8 + n_objectives)
     else:
@@ -706,8 +706,10 @@ class BoTorchSampler(BaseSampler):
             is used. If constraints are specified, quasi MC-based batch Expected Improvement
             (qEI) is used.
             If the number of objectives is either two or three, Quasi MC-based
-            batch Expected Hypervolume Improvement (qEHVI) is used. Otherwise, for larger number
-            of objectives, the faster Quasi MC-based extended ParEGO (qParEGO) is used.
+            batch Expected Hypervolume Improvement (qEHVI) is used. Otherwise, for a larger number
+            of objectives, analytic Expected Hypervolume Improvement is used if no constraints
+            are specified, or the faster Quasi MC-based extended ParEGO (qParEGO) is used if 
+            constraints are present.
 
             The function should assume *maximization* of the objective.
 

--- a/tests/integration_tests/test_botorch.py
+++ b/tests/integration_tests/test_botorch.py
@@ -55,7 +55,7 @@ def test_botorch_candidates_func_none(n_objectives: int) -> None:
     elif n_objectives == 2:
         assert sampler._candidates_func is integration.botorch.qehvi_candidates_func
     elif n_objectives == 4:
-        assert sampler._candidates_func is integration.botorch.qparego_candidates_func
+        assert sampler._candidates_func is integration.botorch.ehvi_candidates_func
     else:
         assert False, "Should not reach."
 

--- a/tests/integration_tests/test_botorch.py
+++ b/tests/integration_tests/test_botorch.py
@@ -95,7 +95,7 @@ def test_botorch_candidates_func() -> None:
     "candidates_func, n_objectives",
     [
         (integration.botorch.ehvi_candidates_func, 4),
-        (integration.botorch.ehvi_candidates_func, 5), # alpha > 0
+        (integration.botorch.ehvi_candidates_func, 5),  # alpha > 0
         (integration.botorch.logei_candidates_func, 1),
         (integration.botorch.qei_candidates_func, 1),
         (integration.botorch.qnei_candidates_func, 1),

--- a/tests/integration_tests/test_botorch.py
+++ b/tests/integration_tests/test_botorch.py
@@ -95,6 +95,7 @@ def test_botorch_candidates_func() -> None:
     "candidates_func, n_objectives",
     [
         (integration.botorch.ehvi_candidates_func, 4),
+        (integration.botorch.ehvi_candidates_func, 5), # alpha > 0
         (integration.botorch.logei_candidates_func, 1),
         (integration.botorch.qei_candidates_func, 1),
         (integration.botorch.qnei_candidates_func, 1),

--- a/tests/integration_tests/test_botorch.py
+++ b/tests/integration_tests/test_botorch.py
@@ -94,6 +94,7 @@ def test_botorch_candidates_func() -> None:
 @pytest.mark.parametrize(
     "candidates_func, n_objectives",
     [
+        (integration.botorch.ehvi_candidates_func, 4),
         (integration.botorch.logei_candidates_func, 1),
         (integration.botorch.qei_candidates_func, 1),
         (integration.botorch.qnei_candidates_func, 1),


### PR DESCRIPTION
## Motivation
Resolve #4960 

## Description of the changes
- Add ehvi_candidates_func
- Use ehvi_candidates_func as default when we have multiple objectives, but no constraints and no running/pending trials
- Modify tests

Limitations:
- Constraints are not supported
- X_pending is not supported