### PR TITLE
Update pytorch_lightning.py to match PyTorch Lightning new import names

### DIFF
--- a/optuna/integration/pytorch_lightning.py
+++ b/optuna/integration/pytorch_lightning.py
@@ -13,10 +13,10 @@ _INTERMEDIATE_VALUE = "ddp_pl:intermediate_value"
 _PRUNED_KEY = "ddp_pl:pruned"
 
 with optuna._imports.try_import() as _imports:
-    import pytorch_lightning as pl
-    from pytorch_lightning import LightningModule
-    from pytorch_lightning import Trainer
-    from pytorch_lightning.callbacks import Callback
+    import lightning.pytorch as pl
+    from lightning.pytorch import LightningModule
+    from lightning.pytorch import Trainer
+    from lightning.pytorch.callbacks import Callback
 
 if not _imports.is_successful():
     Callback = object  # type: ignore[assignment, misc]  # NOQA[F811]


### PR DESCRIPTION
## Motivation
PyTorch Lightning got a name change in library imports. Therefore the `PyTorchLightningPruningCallback` cannot be imported without the the package `pytorch-lightning`.

This is a fix for the PruningCallback addressed in these issues:
#4935 #4689 #4935 

## Description of the changes
Changed the imports from `pytorch_lightning` to `lightning.pytorch` in `PyTorchLightningPruningCallback`. 