### PR TITLE
Update the FAQ on reproducible optimization results to remove note on HyperbandPruner

### DIFF
--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -182,8 +182,6 @@ To make the parameters suggested by Optuna reproducible, you can specify a fixed
     study = optuna.create_study(sampler=sampler)
     study.optimize(objective)
 
-To make the pruning by :class:`~optuna.pruners.HyperbandPruner` reproducible, you can specify ``study_name`` of :class:`~optuna.study.Study` and `hash seed <https://docs.python.org/3/using/cmdline.html#envvar-PYTHONHASHSEED>`_.
-
 However, there are two caveats.
 
 First, when optimizing a study in distributed or parallel mode, there is inherent non-determinism.


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
The FAQ contains a note on HyperbandPruner advising setting the python hash seed to ensure reproducible results.
It's in the paragraph after the code block.
It seems like this this is no longer applicable since #4131 and a similar note on in the API docs for HyperbandPruner was removed at that time

## Description of the changes
<!-- Describe the changes in this PR. -->
Remove paragraph
```rst
To make the pruning by :class:`~optuna.pruners.HyperbandPruner` reproducible, you can specify ``study_name`` of :class:`~optuna.study.Study` and `hash seed <https://docs.python.org/3/using/cmdline.html#envvar-PYTHONHASHSEED>`_.
```