### PR TITLE
Remove email of authors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,6 @@ readme = "README.md"
 license = {file = "LICENSE"}
 authors = [
   {name = "Takuya Akiba"},
-  {email = "akiba@preferred.jp"}
 ]
 classifiers = [
     "Development Status :: 5 - Production/Stable",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description = "A hyperparameter optimization framework"
 readme = "README.md"
 license = {file = "LICENSE"}
 authors = [
-  {name = "Takuya Akiba"},
+  {name = "Takuya Akiba"}
 ]
 classifiers = [
     "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
## Motivation

Currently, `pyproject.toml` has the author's email.
To encourage the community to engage with the developers through GitHub Issues and Discussions,
we'd like to deprecate the email for feedback and questions.

## Description of the changes

This PR removes the author's email from `pyproject.toml`.
According to the [PEP 621](https://peps.python.org/pep-0621/#authors-maintainers), email seems to be optional.

@iwiwi As the original author, if you have any concerns or comments regarding this change, could you please share them with us?
