### PR TITLE
Return `trials` for above in MO split when n_below=0

### DIFF
--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -646,7 +646,7 @@ def _split_complete_trials_multi_objective(
     n_below: int,
 ) -> tuple[list[FrozenTrial], list[FrozenTrial]]:
     if n_below == 0:
-        return [], []
+        return [], trials
 
     lvals = np.asarray([trial.values for trial in trials])
     for i, direction in enumerate(study.directions):

--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -646,7 +646,7 @@ def _split_complete_trials_multi_objective(
     n_below: int,
 ) -> tuple[list[FrozenTrial], list[FrozenTrial]]:
     if n_below == 0:
-        # The type of trials must be `list`, but not `Sequence`. 
+        # The type of trials must be `list`, but not `Sequence`.
         return [], [t for t in trials]
 
     lvals = np.asarray([trial.values for trial in trials])

--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -647,7 +647,7 @@ def _split_complete_trials_multi_objective(
 ) -> tuple[list[FrozenTrial], list[FrozenTrial]]:
     if n_below == 0:
         # The type of trials must be `list`, but not `Sequence`.
-        return [], [t for t in trials]
+        return [], list(trials)
 
     lvals = np.asarray([trial.values for trial in trials])
     for i, direction in enumerate(study.directions):

--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -646,7 +646,8 @@ def _split_complete_trials_multi_objective(
     n_below: int,
 ) -> tuple[list[FrozenTrial], list[FrozenTrial]]:
     if n_below == 0:
-        return [], trials
+        # The type of trials must be `list`, but not `Sequence`. 
+        return [], [t for t in trials]
 
     lvals = np.asarray([trial.values for trial in trials])
     for i, direction in enumerate(study.directions):


### PR DESCRIPTION
* The last one was returning an empty list, which was incorrect

<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

As the last implementation returns an empty list when `n_below=0` and the union of above and below should be `trials`, I simply return `trials` instead of an empty list. 

## Description of the changes
<!-- Describe the changes in this PR. -->

I replaced `[]` with `trials`.
