### PR TITLE
Remove `MOTPESampler` from `index.rst` file

### DIFF
--- a/docs/source/reference/samplers/index.rst
+++ b/docs/source/reference/samplers/index.rst
@@ -84,7 +84,6 @@ The :mod:`~optuna.samplers` module defines a base class for parameter sampling a
     optuna.samplers.PartialFixedSampler
     optuna.samplers.NSGAIISampler
     optuna.samplers.NSGAIIISampler
-    optuna.samplers.MOTPESampler
     optuna.samplers.QMCSampler
     optuna.samplers.BruteForceSampler
     optuna.samplers.IntersectionSearchSpace


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
Resolved Issue #5072 

## Description of the changes
<!-- Describe the changes in this PR. -->
As the issue #5072 says that `optuna.samplers.MOTPESampler` is deprecated from v2.9.0, therefore removal of it from the documentation is needed to avoid misunderstanding.
I have removed the line `optuna.samplers.MOTPESampler` from `index.rst` file present in `doc\source\reference\samplers` directive.
