### PR TITLE
Remove MOTPESampler from the doc because it is deprecated

### DIFF
--- a/optuna/multi_objective/samplers/_motpe.py
+++ b/optuna/multi_objective/samplers/_motpe.py
@@ -28,6 +28,28 @@ class MOTPEMultiObjectiveSampler(BaseMultiObjectiveSampler):
 
     This sampler is a multiobjective version of :class:`~optuna.samplers.TPESampler`.
 
+    .. note::
+        For `v2.9.0 <https://github.com/optuna/optuna/releases/tag/v2.9.0>`_ or later,
+        MOTPEMultiObjectiveSampler is deprecated and :class:`~optuna.samplers.TPESampler` should be
+        used instead. The following code shows how you run TPESampler on a multi-objective task:
+
+        .. testcode::
+
+            import optuna
+
+            def objective(trial):
+                x = trial.suggest_float("x", -100, 100)
+                y = trial.suggest_categorical("y", [-1, 0, 1])
+                f1 = x**2 + y
+                f2 = -((x - 2) ** 2 + y)
+                return f1, f2
+
+
+            # We minimize the first objective and the second objective.
+            sampler = optuna.samplers.TPESampler()
+            study = optuna.create_study(directions=["minimize", "maximize"], sampler=sampler)
+            study.optimize(objective, n_trials=100)
+
     For further information about MOTPE algorithm, please refer to the following paper:
 
     - `Multiobjective tree-structured parzen estimator for computationally expensive optimization

--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -74,11 +74,16 @@ class TPESampler(BaseSampler):
       <https://papers.nips.cc/paper/4443-algorithms-for-hyper-parameter-optimization.pdf>`_
     - `Making a Science of Model Search: Hyperparameter Optimization in Hundreds of
       Dimensions for Vision Architectures <http://proceedings.mlr.press/v28/bergstra13.pdf>`_
-    - `Multiobjective tree-structured parzen estimator for computationally expensive optimization
-      problems <https://dl.acm.org/doi/10.1145/3377930.3389817>`_
+    - `Tree-Structured Parzen Estimator: Understanding Its Algorithm Components and Their Roles for
+      Better Empirical Performance <https://arxiv.org/abs/2304.11127>`_
+
+    For multi-objective TPE (MOTPE), please refer to the following papers:
+    - `Multiobjective Tree-Structured Parzen Estimator for Computationally Expensive Optimization
+      Problems <https://dl.acm.org/doi/10.1145/3377930.3389817>`_
     - `Multiobjective Tree-Structured Parzen Estimator <https://doi.org/10.1613/jair.1.13188>`_
 
     Example:
+        An example of a single-objective optimization is as follows:
 
         .. testcode::
 
@@ -93,6 +98,28 @@ class TPESampler(BaseSampler):
 
             study = optuna.create_study(sampler=TPESampler())
             study.optimize(objective, n_trials=10)
+
+    .. note::
+        For `v2.9.0 <https://github.com/optuna/optuna/releases/tag/v2.9.0>`_ or later,
+        :class:`~optuna.samplers.MOTPESampler` is deprecated and TPESampler should be used instead.
+        The following code shows how you run TPESampler on a multi-objective task:
+
+        .. testcode::
+
+            import optuna
+
+            def objective(trial):
+                x = trial.suggest_float("x", -100, 100)
+                y = trial.suggest_categorical("y", [-1, 0, 1])
+                f1 = x**2 + y
+                f2 = -((x - 2) ** 2 + y)
+                return f1, f2
+
+
+            # We minimize the first objective and the second objective.
+            sampler = optuna.samplers.TPESampler()
+            study = optuna.create_study(directions=["minimize", "maximize"], sampler=sampler)
+            study.optimize(objective, n_trials=100)
 
     Args:
         consider_prior:


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

Since `MOTPESampler` has been already deprecated and `TPESampler` directly supports multi-objective optimization after v2.9.0, we decided to remove the documentation of `MOTPESampler` and add supplementary information for it to `TPESampler`.

## Description of the changes
<!-- Describe the changes in this PR. -->
- Add a guide to `TPESamper` doc and its alternative coding using `TPESampler` in the `MOTPESampler` doc,
- Divide the references for `MOTPE` so that the new reference self-explains the information source for both, and
- Add a code example of multi-objective optimization using `TPESampler` to the `TPESampler` doc. 