### PR TITLE
Add workflow matrices for the tests to reduce GitHub check runtime

### DIFF
--- a/.github/workflows/tests-integration.yml
+++ b/.github/workflows/tests-integration.yml
@@ -22,11 +22,11 @@ jobs:
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.11']
         should-skip:
-          - ${{ (github.event_name != 'schedule' && github.event_name != 'workflow_dispatch') }}
+          - ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && 'Scheduled' || 'PR' }}
         exclude:
-          - should-skip: true
+          - should-skip: "PR"
             python-version: "3.9"
-          - should-skip: true
+          - should-skip: "PR"
             python-version: "3.10"
 
     steps:

--- a/.github/workflows/tests-integration.yml
+++ b/.github/workflows/tests-integration.yml
@@ -14,29 +14,20 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  define-matrix:
-    runs-on: ubuntu-latest
-    outputs:
-      matrix: ${{ steps.set-matrix.outputs.matrix }}
-    steps:
-    - name: Define workflow matrix
-      id: set-matrix
-      run: |
-        if [ "${{ github.event_name }}" = "schedule" ] || [ "${{ github.event_name }}" = "workflow_dispatch" ] ; then
-          echo "Schedule tests (run all the versions)"
-          echo "matrix={\"python-version\":[\"3.8\", \"3.9\", \"3.10\", \"3.11\"]}" >> $GITHUB_OUTPUT
-        else
-          echo "PR push tests (run only the oldest and the latest versions)"
-          echo "matrix={\"python-version\":[\"3.8\", \"3.11\"]}" >> $GITHUB_OUTPUT
-        fi
-
   tests-integration:
     if: (github.event_name == 'schedule' && github.repository == 'optuna/optuna') || (github.event_name != 'schedule')
-    needs: define-matrix
     runs-on: ubuntu-latest
 
     strategy:
-      matrix: ${{fromJson(needs.define-matrix.outputs.matrix)}}
+      matrix:
+        python-version: ['3.8', '3.9', '3.10', '3.11']
+        should-skip:
+          - ${{ (github.event_name != 'schedule' && github.event_name != 'workflow_dispatch') }}
+        exclude:
+          - should-skip: true
+            python-version: "3.9"
+          - should-skip: true
+            python-version: "3.10"
 
     steps:
     - name: Checkout

--- a/.github/workflows/tests-integration.yml
+++ b/.github/workflows/tests-integration.yml
@@ -14,13 +14,29 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  define-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+    - name: Define workflow matrix
+      id: set-matrix
+      run: |
+        if [ "${{ github.event_name }}" = "schedule" ] || [ "${{ github.event_name }}" = "workflow_dispatch" ] ; then
+          echo "Schedule tests (run all the versions)"
+          echo "matrix={\"python-version\":[\"3.8\", \"3.9\", \"3.10\", \"3.11\"]}" >> $GITHUB_OUTPUT
+        else
+          echo "PR push tests (run only the oldest and the latest versions)"
+          echo "matrix={\"python-version\":[\"3.8\", \"3.11\"]}" >> $GITHUB_OUTPUT
+        fi
+
   tests-integration:
     if: (github.event_name == 'schedule' && github.repository == 'optuna/optuna') || (github.event_name != 'schedule')
+    needs: define-matrix
     runs-on: ubuntu-latest
 
     strategy:
-      matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+      matrix: ${{fromJson(needs.define-matrix.outputs.matrix)}}
 
     steps:
     - name: Checkout

--- a/.github/workflows/tests-integration.yml
+++ b/.github/workflows/tests-integration.yml
@@ -22,11 +22,11 @@ jobs:
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.11']
         should-skip:
-          - ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && 'Scheduled' || 'PR' }}
+          - ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && 'Scheduled' || '' }}
         exclude:
-          - should-skip: "PR"
+          - should-skip: ""
             python-version: "3.9"
-          - should-skip: "PR"
+          - should-skip: ""
             python-version: "3.10"
 
     steps:

--- a/.github/workflows/tests-mpi.yml
+++ b/.github/workflows/tests-mpi.yml
@@ -90,10 +90,7 @@ jobs:
     - name: Tests
       run: |
         export OMPI_MCA_rmaps_base_oversubscribe=yes
-
-        if [ ${{ matrix.python-version }} != 3.11 ]; then
-          mpirun -n 2 -- pytest tests/integration_tests/test_pytorch_distributed.py
-        fi
+        mpirun -n 2 -- pytest tests/integration_tests/test_pytorch_distributed.py
 
       env:
         OMP_NUM_THREADS: 1

--- a/.github/workflows/tests-mpi.yml
+++ b/.github/workflows/tests-mpi.yml
@@ -22,11 +22,11 @@ jobs:
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.11']
         should-skip:
-          - ${{ (github.event_name != 'schedule' && github.event_name != 'workflow_dispatch') }}
+          - ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && 'Scheduled' || 'PR' }}
         exclude:
-          - should-skip: true
+          - should-skip: "PR"
             python-version: "3.9"
-          - should-skip: true
+          - should-skip: "PR"
             python-version: "3.10"
 
     steps:

--- a/.github/workflows/tests-mpi.yml
+++ b/.github/workflows/tests-mpi.yml
@@ -14,29 +14,20 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  define-matrix:
-    runs-on: ubuntu-latest
-    outputs:
-      matrix: ${{ steps.set-matrix.outputs.matrix }}
-    steps:
-    - name: Define workflow matrix
-      id: set-matrix
-      run: |
-        if [ "${{ github.event_name }}" = "schedule" ] || [ "${{ github.event_name }}" = "workflow_dispatch" ] ; then
-          echo "Schedule tests (run all the versions)"
-          echo "matrix={\"python-version\":[\"3.8\", \"3.9\", \"3.10\", \"3.11\"]}" >> $GITHUB_OUTPUT
-        else
-          echo "PR push tests (run only the oldest and the latest versions)"
-          echo "matrix={\"python-version\":[\"3.8\", \"3.11\"]}" >> $GITHUB_OUTPUT
-        fi
-
   tests-mpi:
     if: (github.event_name == 'schedule' && github.repository == 'optuna/optuna') || (github.event_name != 'schedule')
-    needs: define-matrix
     runs-on: ubuntu-latest
 
     strategy:
-      matrix: ${{fromJson(needs.define-matrix.outputs.matrix)}}
+      matrix:
+        python-version: ['3.8', '3.9', '3.10', '3.11']
+        should-skip:
+          - ${{ (github.event_name != 'schedule' && github.event_name != 'workflow_dispatch') }}
+        exclude:
+          - should-skip: true
+            python-version: "3.9"
+          - should-skip: true
+            python-version: "3.10"
 
     steps:
     - name: Checkout

--- a/.github/workflows/tests-mpi.yml
+++ b/.github/workflows/tests-mpi.yml
@@ -90,7 +90,10 @@ jobs:
     - name: Tests
       run: |
         export OMPI_MCA_rmaps_base_oversubscribe=yes
-        mpirun -n 2 -- pytest tests/integration_tests/test_pytorch_distributed.py
+
+        if [ ${{ matrix.python-version }} != 3.11 ]; then
+          mpirun -n 2 -- pytest tests/integration_tests/test_pytorch_distributed.py
+        fi
 
       env:
         OMP_NUM_THREADS: 1

--- a/.github/workflows/tests-mpi.yml
+++ b/.github/workflows/tests-mpi.yml
@@ -22,11 +22,11 @@ jobs:
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.11']
         should-skip:
-          - ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && 'Scheduled' || 'PR' }}
+          - ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && 'Scheduled' || '' }}
         exclude:
-          - should-skip: "PR"
+          - should-skip: ""
             python-version: "3.9"
-          - should-skip: "PR"
+          - should-skip: ""
             python-version: "3.10"
 
     steps:

--- a/.github/workflows/tests-storage.yml
+++ b/.github/workflows/tests-storage.yml
@@ -25,13 +25,13 @@ jobs:
       matrix:
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
         should-skip:
-          - ${{ (github.event_name != 'schedule' && github.event_name != 'workflow_dispatch') }}
+          - ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && 'Scheduled' || 'PR' }}
         exclude:
-          - should-skip: true
+          - should-skip: "PR"
             python-version: "3.8"
-          - should-skip: true
+          - should-skip: "PR"
             python-version: "3.9"
-          - should-skip: true
+          - should-skip: "PR"
             python-version: "3.10"
 
     services:

--- a/.github/workflows/tests-storage.yml
+++ b/.github/workflows/tests-storage.yml
@@ -25,13 +25,13 @@ jobs:
       matrix:
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
         should-skip:
-          - ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && 'Scheduled' || 'PR' }}
+          - ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && 'Scheduled' || '' }}
         exclude:
-          - should-skip: "PR"
+          - should-skip: ""
             python-version: "3.8"
-          - should-skip: "PR"
+          - should-skip: ""
             python-version: "3.9"
-          - should-skip: "PR"
+          - should-skip: ""
             python-version: "3.10"
 
     services:

--- a/.github/workflows/tests-storage.yml
+++ b/.github/workflows/tests-storage.yml
@@ -13,16 +13,32 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  define-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+    - name: Define workflow matrix
+      id: set-matrix
+      run: |
+        if [ "${{ github.event_name }}" = "schedule" ] || [ "${{ github.event_name }}" = "workflow_dispatch" ] ; then
+          echo "Schedule tests (run all the versions)"
+          echo "matrix={\"python-version\":[\"3.7\", \"3.8\", \"3.9\", \"3.10\", \"3.11\"]}" >> $GITHUB_OUTPUT
+        else
+          echo "PR push tests (run only the oldest and the latest versions)"
+          echo "matrix={\"python-version\":[\"3.7\", \"3.11\"]}" >> $GITHUB_OUTPUT
+        fi
+
   # TODO(masap): Modify job name to "tests-storage-with-server" because this test is not only for
   # RDB. Since current name "tests-rdbstorage" is required in the Branch protection rules, you
   # need to modify the Branch protection rules as well.
   tests-rdbstorage:
     if: (github.event_name == 'schedule' && github.repository == 'optuna/optuna') || (github.event_name != 'schedule')
+    needs: define-matrix
     runs-on: ubuntu-latest
 
     strategy:
-      matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+      matrix: ${{fromJson(needs.define-matrix.outputs.matrix)}}
 
     services:
       mysql:

--- a/.github/workflows/tests-storage.yml
+++ b/.github/workflows/tests-storage.yml
@@ -1,6 +1,7 @@
 name: Tests (Storage with server)
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - master

--- a/.github/workflows/tests-storage.yml
+++ b/.github/workflows/tests-storage.yml
@@ -13,32 +13,25 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  define-matrix:
-    runs-on: ubuntu-latest
-    outputs:
-      matrix: ${{ steps.set-matrix.outputs.matrix }}
-    steps:
-    - name: Define workflow matrix
-      id: set-matrix
-      run: |
-        if [ "${{ github.event_name }}" = "schedule" ] || [ "${{ github.event_name }}" = "workflow_dispatch" ] ; then
-          echo "Schedule tests (run all the versions)"
-          echo "matrix={\"python-version\":[\"3.7\", \"3.8\", \"3.9\", \"3.10\", \"3.11\"]}" >> $GITHUB_OUTPUT
-        else
-          echo "PR push tests (run only the oldest and the latest versions)"
-          echo "matrix={\"python-version\":[\"3.7\", \"3.11\"]}" >> $GITHUB_OUTPUT
-        fi
-
   # TODO(masap): Modify job name to "tests-storage-with-server" because this test is not only for
   # RDB. Since current name "tests-rdbstorage" is required in the Branch protection rules, you
   # need to modify the Branch protection rules as well.
   tests-rdbstorage:
     if: (github.event_name == 'schedule' && github.repository == 'optuna/optuna') || (github.event_name != 'schedule')
-    needs: define-matrix
     runs-on: ubuntu-latest
 
     strategy:
-      matrix: ${{fromJson(needs.define-matrix.outputs.matrix)}}
+      matrix:
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        should-skip:
+          - ${{ (github.event_name != 'schedule' && github.event_name != 'workflow_dispatch') }}
+        exclude:
+          - should-skip: true
+            python-version: "3.8"
+          - should-skip: true
+            python-version: "3.9"
+          - should-skip: true
+            python-version: "3.10"
 
     services:
       mysql:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,6 @@ jobs:
           echo "matrix={\"python-version\":[\"3.7\", \"3.8\", \"3.9\", \"3.10\", \"3.11\", \"3.12\"]}" >> $GITHUB_OUTPUT
         else
           echo "PR push tests (run only the oldest and the latest versions)"
-          # QUESTION: Shall I run 3.11 as well because BoTorch will not be tested on 3.12 right now? 
           echo "matrix={\"python-version\":[\"3.7\", \"3.12\"]}" >> $GITHUB_OUTPUT
         fi
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,8 +37,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
-      matrix:
-        python-version: ${{fromJson(needs.define-matrix.outputs.matrix)}}
+      matrix: ${{fromJson(needs.define-matrix.outputs.matrix)}}
 
     services:
       redis:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,15 +22,15 @@ jobs:
       matrix:
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
         should-skip:
-          - ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && 'Scheduled' || 'PR' }}
+          - ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && 'Scheduled' || '' }}
         exclude:
-          - should-skip: "PR"
+          - should-skip: ""
             python-version: "3.8"
-          - should-skip: "PR"
+          - should-skip: ""
             python-version: "3.9"
-          - should-skip: "PR"
+          - should-skip: ""
             python-version: "3.10"
-          - should-skip: "PR"
+          - should-skip: ""
             python-version: "3.11"
 
     services:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,13 +14,31 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  define-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+    - name: Define workflow matrix
+      id: set-matrix
+      run: |
+        if [ "${{ github.event_name }}" = "schedule" ] || [ "${{ github.event_name }}" = "workflow_dispatch" ] ; then
+          echo "Schedule tests (run all the versions)"
+          echo "matrix={\"python-version\":[\"3.7\", \"3.8\", \"3.9\", \"3.10\", \"3.11\", \"3.12\"]}" >> $GITHUB_OUTPUT
+        else
+          echo "PR push tests (run only the oldest and the latest versions)"
+          # QUESTION: Shall I run 3.11 as well because BoTorch will not be tested on 3.12 right now? 
+          echo "matrix={\"python-version\":[\"3.7\", \"3.12\"]}" >> $GITHUB_OUTPUT
+        fi
+
   tests:
     if: (github.event_name == 'schedule' && github.repository == 'optuna/optuna') || (github.event_name != 'schedule')
+    needs: define-matrix
     runs-on: ubuntu-latest
 
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ${{fromJson(needs.define-matrix.outputs.matrix)}}
 
     services:
       redis:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,15 +22,15 @@ jobs:
       matrix:
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
         should-skip:
-          - ${{ (github.event_name != 'schedule' && github.event_name != 'workflow_dispatch') }}
+          - ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && 'Scheduled' || 'PR' }}
         exclude:
-          - should-skip: true
+          - should-skip: "PR"
             python-version: "3.8"
-          - should-skip: true
+          - should-skip: "PR"
             python-version: "3.9"
-          - should-skip: true
+          - should-skip: "PR"
             python-version: "3.10"
-          - should-skip: true
+          - should-skip: "PR"
             python-version: "3.11"
 
     services:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,29 +14,24 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  define-matrix:
-    runs-on: ubuntu-latest
-    outputs:
-      matrix: ${{ steps.set-matrix.outputs.matrix }}
-    steps:
-    - name: Define workflow matrix
-      id: set-matrix
-      run: |
-        if [ "${{ github.event_name }}" = "schedule" ] || [ "${{ github.event_name }}" = "workflow_dispatch" ] ; then
-          echo "Schedule tests (run all the versions)"
-          echo "matrix={\"python-version\":[\"3.7\", \"3.8\", \"3.9\", \"3.10\", \"3.11\", \"3.12\"]}" >> $GITHUB_OUTPUT
-        else
-          echo "PR push tests (run only the oldest and the latest versions)"
-          echo "matrix={\"python-version\":[\"3.7\", \"3.12\"]}" >> $GITHUB_OUTPUT
-        fi
-
   tests:
     if: (github.event_name == 'schedule' && github.repository == 'optuna/optuna') || (github.event_name != 'schedule')
-    needs: define-matrix
     runs-on: ubuntu-latest
 
     strategy:
-      matrix: ${{fromJson(needs.define-matrix.outputs.matrix)}}
+      matrix:
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
+        should-skip:
+          - ${{ (github.event_name != 'schedule' && github.event_name != 'workflow_dispatch') }}
+        exclude:
+          - should-skip: true
+            python-version: "3.8"
+          - should-skip: true
+            python-version: "3.9"
+          - should-skip: true
+            python-version: "3.10"
+          - should-skip: true
+            python-version: "3.11"
 
     services:
       redis:


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

As the CI is slow with tests on all the Python versions, I made changes so that the tests will run only on the oldest and the latest supported Python versions.
For the first step, I applied the similar change to tests mpi in [PR#5067](https://github.com/optuna/optuna/pull/5067), which is not one of the required tests.
In this PR, I further change the other tests to reduce the runtime.
Note that these changes require modifying the requirements of CI.

## Description of the changes
<!-- Describe the changes in this PR. -->

More specifically, the changes are:
1. Remove the Python versions 3.9, 3.10 from tests-integration,
2. Remove the Python versions 3.8, 3.9, 3.10 from tests-storage, and
3. Remove the Python versions 3.8, 3.9, 3.10, 3.11 from tests.
