### PR TITLE
Report CV scores from within OptunaSearchCV

### DIFF
--- a/optuna/integration/sklearn.py
+++ b/optuna/integration/sklearn.py
@@ -24,6 +24,7 @@ from optuna._experimental import experimental_class
 from optuna._imports import try_import
 from optuna.distributions import _convert_old_distribution_to_new_distribution
 from optuna.study import StudyDirection
+from optuna.terminator import report_cross_validation_scores
 from optuna.trial import FrozenTrial
 from optuna.trial import Trial
 
@@ -242,6 +243,7 @@ class _Objective:
                 }
 
         self._store_scores(trial, scores)
+        report_cross_validation_scores(trial, scores["test_score"])
 
         return trial.user_attrs["mean_test_score"]
 

--- a/optuna/integration/sklearn.py
+++ b/optuna/integration/sklearn.py
@@ -243,7 +243,10 @@ class _Objective:
                 }
 
         self._store_scores(trial, scores)
-        report_cross_validation_scores(trial, scores["test_score"])
+        test_scores = (
+            scores if isinstance(scores["test_score"], list) else scores["test_score"].tolist()
+        )
+        report_cross_validation_scores(trial, test_scores)
 
         return trial.user_attrs["mean_test_score"]
 

--- a/optuna/integration/sklearn.py
+++ b/optuna/integration/sklearn.py
@@ -243,10 +243,10 @@ class _Objective:
                 }
 
         self._store_scores(trial, scores)
-        test_scores = (
-            scores if isinstance(scores["test_score"], list) else scores["test_score"].tolist()
-        )
-        report_cross_validation_scores(trial, test_scores)
+
+        test_scores = scores["test_score"]
+        scores_list = test_scores if isinstance(test_scores, list) else test_scores.tolist()
+        report_cross_validation_scores(trial, scores_list)
 
         return trial.user_attrs["mean_test_score"]
 

--- a/tests/integration_tests/test_sklearn.py
+++ b/tests/integration_tests/test_sklearn.py
@@ -419,7 +419,7 @@ def test_terminator_cv_score_reporting(mock: MagicMock) -> None:
     scores = {
         "fit_time": np.array([2.01, 1.78, 3.22]),
         "score_time": np.array([0.33, 0.35, 0.48]),
-        "test_score": np.array([0.04, 2.0, 1.5]),
+        "test_score": np.array([0.04, 0.80, 0.70]),
     }
     mock.return_value = scores
 

--- a/tests/integration_tests/test_sklearn.py
+++ b/tests/integration_tests/test_sklearn.py
@@ -380,10 +380,7 @@ def test_optuna_search_convert_deprecated_distribution() -> None:
     assert optuna_search.param_distributions == expected_param_dist
 
 
-@patch("optuna.integration.sklearn.report_cross_validation_scores")
-def test_callbacks(mock: MagicMock) -> None:
-    mock.return_value = None
-
+def test_callbacks() -> None:
     callbacks = []
 
     for _ in range(2):


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
Refs #4958 

## Description of the changes
Call report_cross_validation_scores from within OptunaSearchCV, so that if we pass in a terminator callback (e.g. using CrossValidationErrorEvaluator), we can use the scores to determine whether to terminate the study.

Tested with the following adapted sample code:

```
import optuna
from sklearn.datasets import load_iris
from sklearn.svm import SVC
from optuna.terminator import TerminatorCallback, Terminator, CrossValidationErrorEvaluator

clf = SVC(gamma="auto")
param_distributions = {
    "C": optuna.distributions.FloatDistribution(1e-10, 1e10, log=True)
}
terminator = TerminatorCallback(terminator=Terminator(error_evaluator=CrossValidationErrorEvaluator(), min_n_trials=4))
optuna_search = optuna.integration.OptunaSearchCV(clf, param_distributions, callbacks=[terminator])
X, y = load_iris(return_X_y=True)
optuna_search.fit(X, y)
```
