### PR TITLE
Remove the skip of Python 3.11 in `tests-mpi`

### DIFF
--- a/.github/workflows/tests-mpi.yml
+++ b/.github/workflows/tests-mpi.yml
@@ -90,10 +90,7 @@ jobs:
     - name: Tests
       run: |
         export OMPI_MCA_rmaps_base_oversubscribe=yes
-
-        if [ ${{ matrix.python-version }} != 3.11 ]; then
-          mpirun -n 2 -- pytest tests/integration_tests/test_pytorch_distributed.py
-        fi
+        mpirun -n 2 -- pytest tests/integration_tests/test_pytorch_distributed.py
 
       env:
         OMP_NUM_THREADS: 1


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

As we can now run `tests-mpi` on Python 3.11, I removed the skip for this.

## Description of the changes
<!-- Describe the changes in this PR. -->

Removed the skip of Python 3.11 in `tests-mpi`.