### PR TITLE
Downgrade kaleido to 0.1.0post1 for fixing Windows CI.

### DIFF
--- a/.github/workflows/windows-tests.yml
+++ b/.github/workflows/windows-tests.yml
@@ -52,6 +52,7 @@ jobs:
         pip install --progress-bar off .[test]
         pip install --progress-bar off .[optional]
         pip install PyQt6 # Install PyQT for using QtAgg as matplotlib backend.
+        pip install "kaleido<=0.1.0"  # TODO(HideakiImamura): Remove this after fixing https://github.com/plotly/Kaleido/issues/110
 
     - name: Output installed packages
       run: |

--- a/.github/workflows/windows-tests.yml
+++ b/.github/workflows/windows-tests.yml
@@ -52,7 +52,7 @@ jobs:
         pip install --progress-bar off .[test]
         pip install --progress-bar off .[optional]
         pip install PyQt6 # Install PyQT for using QtAgg as matplotlib backend.
-        pip install "kaleido<=0.1.0"  # TODO(HideakiImamura): Remove this after fixing https://github.com/plotly/Kaleido/issues/110
+        pip install "kaleido<=0.1.0post1"  # TODO(HideakiImamura): Remove this after fixing https://github.com/plotly/Kaleido/issues/110
 
     - name: Output installed packages
       run: |


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
Hotfix for https://github.com/optuna/optuna/issues/5099

## Description of the changes
<!-- Describe the changes in this PR. -->

According to some comments in https://github.com/plotly/Kaleido/issues/110, I downgrade the kaleido to 0.1.0post1 for the Windows CI.
