### PR TITLE
FileStorage: enable loading of read-only files

### DIFF
--- a/optuna/storages/_journal/file.py
+++ b/optuna/storages/_journal/file.py
@@ -157,7 +157,8 @@ class JournalFileStorage(BaseJournalLogStorage):
     def __init__(self, file_path: str, lock_obj: Optional[JournalFileBaseLock] = None) -> None:
         self._file_path: str = file_path
         self._lock = lock_obj or JournalFileSymlinkLock(self._file_path)
-        open(self._file_path, "ab").close()  # Create a file if it does not exist
+        if not os.path.exists(self._file_path):
+            open(self._file_path, "ab").close()  # Create a file if it does not exist
         self._log_number_offset: Dict[int, int] = {0: 0}
 
     def read_logs(self, log_number_from: int) -> List[Dict[str, Any]]:


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
In FileStorage initialization, current logic attempts to create a file (in append mode) even if it exists already. When trying to access a read-only file that results in a permission error even though no modification of the file is intended.
I came upon that problem when trying to load/display an existing study to which I had only read-only access.

## Description of the changes
<!-- Describe the changes in this PR. -->
If the file exists, do not attempt to create it.