### PR TITLE
[HOT FIX] Fix mypy error in CI

### DIFF
--- a/optuna/importance/_fanova/_tree.py
+++ b/optuna/importance/_fanova/_tree.py
@@ -53,11 +53,11 @@ class _FanovaTree:
 
         # For each midpoint along the given dimensions, traverse this tree to compute the
         # marginal predictions.
-        midpoints = [self._split_midpoints[f] for f in features]
-        sizes = [self._split_sizes[f] for f in features]
+        selected_midpoints = [self._split_midpoints[f] for f in features]
+        selected_sizes = [self._split_sizes[f] for f in features]
 
-        product_midpoints = itertools.product(*midpoints)
-        product_sizes = itertools.product(*sizes)
+        product_midpoints = itertools.product(*selected_midpoints)
+        product_sizes = itertools.product(*selected_sizes)
 
         sample = numpy.full(self._n_features, fill_value=numpy.nan, dtype=numpy.float64)
 


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
Fix mypy error in `Checks`


## Description of the changes
As Mypy v1.7.0 is released some type inferences are failing in python 3.8. 
This PR renames duplicated variable with different types in `importance/_fanova/_tree.py`

## Alternatives
Updating python version for mypy check to 3.9 also resolves the CI errors, including `Check(integration)`, though they have not officially stopped supporting python 3.8.