### PR TITLE
Improve visiblity of infeasible trials in `plot_contour`

### DIFF
--- a/optuna/visualization/_contour.py
+++ b/optuna/visualization/_contour.py
@@ -249,7 +249,7 @@ def _get_contour_subplot(
 
 
 def _create_scatter(x: list[Any], y: list[Any], is_feasible: bool) -> Scatter:
-    edge_color = "Gray" if is_feasible else "#cccccc"
+    edge_color = "Gray"
     marker_color = "black" if is_feasible else "#cccccc"
     name = "Feasible Trial" if is_feasible else "Infeasible Trial"
     return go.Scatter(

--- a/optuna/visualization/matplotlib/_contour.py
+++ b/optuna/visualization/matplotlib/_contour.py
@@ -332,7 +332,7 @@ def _generate_contour_subplot(info: _SubContourInfo, ax: "Axes", cmap: "Colormap
                 marker="o",
                 c="#cccccc",
                 s=20,
-                edgecolors="#cccccc",
+                edgecolors="grey",
                 linewidth=2.0,
             )
 


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

In `plot_contour`, the background of bad values is white. In constrained optimization, the figure is less visible now, because infeasible trials are painted in one color, `'#cccccc'`.

## Description of the changes
<!-- Describe the changes in this PR. -->
In `plot_contour`, the outline of the points of infeasible trials were changed from `'#cccccc'` to `'gray'` to improve the visiblity. This is a reimport from the implementation in Optuna Dashboard.

This PR could also be positioned as a follow-up to [Issue#4829](https://github.com/optuna/optuna/issues/4829).