### PR TITLE
Fix `logpdf` for scaled `truncnorm`

### DIFF
--- a/optuna/samplers/_tpe/_truncnorm.py
+++ b/optuna/samplers/_tpe/_truncnorm.py
@@ -226,7 +226,7 @@ def logpdf(
 
     x, a, b = np.atleast_1d(x, a, b)
 
-    out = _norm_logpdf(x) - _log_gauss_mass(a, b)
+    out = _norm_logpdf(x) - _log_gauss_mass(a, b) - np.log(scale)
 
     x, a, b = np.broadcast_arrays(x, a, b)
     out[(x < a) | (b < x)] = -np.inf

--- a/tests/samplers_tests/tpe_tests/test_truncnorm.py
+++ b/tests/samplers_tests/tpe_tests/test_truncnorm.py
@@ -35,12 +35,14 @@ def test_ppf(a: float, b: float) -> None:
     "a,b",
     [(-np.inf, np.inf), (-10, +10), (-1, +1), (-1e-3, +1e-3), (10, 100), (-100, -10), (0, 0)],
 )
-def test_logpdf(a: float, b: float) -> None:
+@pytest.mark.parametrize("loc", [-10, 0, 10])
+@pytest.mark.parametrize("scale", [0.1, 1, 10])
+def test_logpdf(a: float, b: float, loc: float, scale: float) -> None:
     for x in np.concatenate(
         [np.linspace(np.max([a, -100]), np.min([b, 100]), num=1000), np.array([-2000.0, +2000.0])]
     ):
-        assert truncnorm_ours.logpdf(x, a, b) == pytest.approx(
-            truncnorm_scipy.logpdf(x, a, b), nan_ok=True
+        assert truncnorm_ours.logpdf(x, a, b, loc, scale) == pytest.approx(
+            truncnorm_scipy.logpdf(x, a, b, loc, scale), nan_ok=True
         ), f"logpdf(x={x}, a={a}, b={b})"
 
 


### PR DESCRIPTION
## Motivation
Fix #5109. The calculation results should be shifted by log(scale).

## Description of the changes
- Fix the calculation of `logpdf` for scaled `truncnorm`.