### PR TITLE
Refactor TPESampler for more clarity before c-TPE integration

### DIFF
--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -538,7 +538,7 @@ class TPESampler(BaseSampler):
 
         if sample_size != acq_fn_vals.size:
             raise ValueError(
-                "The sizes of `samples` and `acq_fn_vals` must be same , but got "
+                "The sizes of `samples` and `acq_fn_vals` must be same, but got "
                 f"(samples.size, acq_fn_vals.size) = ({sample_size}, {acq_fn_vals.size})."
             )
 

--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -7,7 +7,6 @@ from typing import cast
 from typing import Dict
 from typing import Optional
 from typing import Sequence
-from typing import Union
 import warnings
 
 import numpy as np
@@ -477,58 +476,74 @@ class TPESampler(BaseSampler):
             self._constraints_func is not None,
         )
 
-        below = self._get_internal_repr(below_trials, search_space)
-        above = self._get_internal_repr(above_trials, search_space)
+        mpe_below = self._build_parzen_estimator(
+            study, search_space, below_trials, handle_below=True
+        )
+        mpe_above = self._build_parzen_estimator(study, search_space, above_trials)
 
-        # We then sample by maximizing log likelihood ratio.
-        if study._is_multi_objective():
-            param_mask_below = []
-            for trial in below_trials:
-                param_mask_below.append(
-                    all((param_name in trial.params) for param_name in search_space)
-                )
-            weights_below = _calculate_weights_below_for_multi_objective(
-                study, below_trials, self._constraints_func
-            )[param_mask_below]
-            mpe_below = _ParzenEstimator(
-                below, search_space, self._parzen_estimator_parameters, weights_below
-            )
-        else:
-            mpe_below = _ParzenEstimator(below, search_space, self._parzen_estimator_parameters)
-        mpe_above = _ParzenEstimator(above, search_space, self._parzen_estimator_parameters)
         samples_below = mpe_below.sample(self._rng.rng, self._n_ei_candidates)
-        log_likelihoods_below = mpe_below.log_pdf(samples_below)
-        log_likelihoods_above = mpe_above.log_pdf(samples_below)
-        ret = TPESampler._compare(samples_below, log_likelihoods_below, log_likelihoods_above)
+        acq_fn_vals = self._compute_acquisition_function(samples_below, mpe_below, mpe_above)
+        ret = TPESampler._compare(samples_below, acq_fn_vals)
 
         for param_name, dist in search_space.items():
             ret[param_name] = dist.to_external_repr(ret[param_name])
 
         return ret
 
+    def _build_parzen_estimator(
+        self,
+        study: Study,
+        search_space: dict[str, BaseDistribution],
+        trials: list[FrozenTrial],
+        handle_below: bool = False,
+    ) -> _ParzenEstimator:
+        observations = self._get_internal_repr(trials, search_space)
+        if handle_below and study._is_multi_objective():
+            param_mask_below = []
+            for trial in trials:
+                param_mask_below.append(
+                    all((param_name in trial.params) for param_name in search_space)
+                )
+            weights_below = _calculate_weights_below_for_multi_objective(
+                study, trials, self._constraints_func
+            )[param_mask_below]
+            mpe = _ParzenEstimator(
+                observations, search_space, self._parzen_estimator_parameters, weights_below
+            )
+        else:
+            mpe = _ParzenEstimator(observations, search_space, self._parzen_estimator_parameters)
+
+        return mpe
+
+    def _compute_acquisition_function(
+        self,
+        samples: dict[str, np.ndarray],
+        mpe_below: _ParzenEstimator,
+        mpe_above: _ParzenEstimator,
+    ) -> np.ndarray:
+        log_likelihoods_below = mpe_below.log_pdf(samples)
+        log_likelihoods_above = mpe_above.log_pdf(samples)
+        acq_fn_vals = log_likelihoods_below - log_likelihoods_above
+        return acq_fn_vals
+
     @classmethod
     def _compare(
         cls,
         samples: Dict[str, np.ndarray],
-        log_l: np.ndarray,
-        log_g: np.ndarray,
-    ) -> Dict[str, Union[float, int]]:
+        acq_fn_vals: np.ndarray,
+    ) -> dict[str, int | float]:
         sample_size = next(iter(samples.values())).size
-        if sample_size:
-            score = log_l - log_g
-            if sample_size != score.size:
-                raise ValueError(
-                    "The size of the 'samples' and that of the 'score' "
-                    "should be same. "
-                    "But (samples.size, score.size) = ({}, {})".format(sample_size, score.size)
-                )
-            best = np.argmax(score)
-            return {k: v[best].item() for k, v in samples.items()}
-        else:
+        if sample_size == 0:
+            raise ValueError(f"The size of `samples` must be positive, but got {sample_size}.")
+
+        if sample_size != acq_fn_vals.size:
             raise ValueError(
-                "The size of 'samples' should be more than 0."
-                "But samples.size = {}".format(sample_size)
+                "The sizes of `samples` and `acq_fn_vals` must be same , but got "
+                f"(samples.size, acq_fn_vals.size) = ({sample_size}, {acq_fn_vals.size})."
             )
+
+        best_idx = np.argmax(acq_fn_vals)
+        return {k: v[best_idx].item() for k, v in samples.items()}
 
     @staticmethod
     def hyperopt_parameters() -> Dict[str, Any]:

--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -532,19 +532,20 @@ class TPESampler(BaseSampler):
     def _compare(
         cls,
         samples: Dict[str, np.ndarray],
-        acq_func_vals: np.ndarray,
+        acquisition_func_vals: np.ndarray,
     ) -> dict[str, int | float]:
         sample_size = next(iter(samples.values())).size
         if sample_size == 0:
             raise ValueError(f"The size of `samples` must be positive, but got {sample_size}.")
 
-        if sample_size != acq_func_vals.size:
+        if sample_size != acquisition_func_vals.size:
             raise ValueError(
-                "The sizes of `samples` and `acq_func_vals` must be same, but got "
-                f"(samples.size, acq_func_vals.size) = ({sample_size}, {acq_func_vals.size})."
+                "The sizes of `samples` and `acquisition_func_vals` must be same, but got "
+                "(samples.size, acquisition_func_vals.size) = "
+                f"({sample_size}, {acquisition_func_vals.size})."
             )
 
-        best_idx = np.argmax(acq_func_vals)
+        best_idx = np.argmax(acquisition_func_vals)
         return {k: v[best_idx].item() for k, v in samples.items()}
 
     @staticmethod


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

This PR aims for:
1. making the processing of each part clearer,
2. making the sample method more concise, and
3. making it easier to integrate [c-TPE](https://arxiv.org/abs/2211.14411) afterward.

Note that this PR does not intend to break any behaviors. In other words, this commit should not change any outputs.

## Description of the changes
<!-- Describe the changes in this PR. -->
In this PR, I made the following changes:
1. Separate the process for building a Parzen estimator as a method,
2. Create a method to compute the acquisition function values,
3. Make the role of `_compare` clearer by changing its arguments from log-likelihoods to the acquisition function values.