### PR TITLE
Change n_objectives condition to be greater than 4 in candidates functions

### DIFF
--- a/optuna/integration/botorch.py
+++ b/optuna/integration/botorch.py
@@ -385,7 +385,7 @@ def qehvi_candidates_func(
 
     # Approximate box decomposition similar to Ax when the number of objectives is large.
     # https://github.com/pytorch/botorch/blob/36d09a4297c2a0ff385077b7fcdd5a9d308e40cc/botorch/acquisition/multi_objective/utils.py#L46-L63
-    if n_objectives > 2:
+    if n_objectives > 4:
         alpha = 10 ** (-8 + n_objectives)
     else:
         alpha = 0.0
@@ -533,7 +533,7 @@ def qnehvi_candidates_func(
 
     # Approximate box decomposition similar to Ax when the number of objectives is large.
     # https://github.com/pytorch/botorch/blob/36d09a4297c2a0ff385077b7fcdd5a9d308e40cc/botorch/acquisition/multi_objective/utils.py#L46-L63
-    if n_objectives > 2:
+    if n_objectives > 4:
         alpha = 10 ** (-8 + n_objectives)
     else:
         alpha = 0.0

--- a/tests/integration_tests/test_botorch.py
+++ b/tests/integration_tests/test_botorch.py
@@ -100,9 +100,10 @@ def test_botorch_candidates_func() -> None:
         (integration.botorch.qei_candidates_func, 1),
         (integration.botorch.qnei_candidates_func, 1),
         (integration.botorch.qehvi_candidates_func, 2),
+        (integration.botorch.qehvi_candidates_func, 7),  # alpha > 0
         (integration.botorch.qparego_candidates_func, 4),
         (integration.botorch.qnehvi_candidates_func, 2),
-        (integration.botorch.qnehvi_candidates_func, 3),  # alpha > 0
+        (integration.botorch.qnehvi_candidates_func, 6),  # alpha > 0
     ],
 )
 def test_botorch_specify_candidates_func(candidates_func: Any, n_objectives: int) -> None:


### PR DESCRIPTION
## Motivation
Refs #5087

## Description of the changes
Follow-up to PR #4960, in which it was pointed out the documentation has changed re. the number of objectives required to set a non-zero alpha. Tests are amended accordingly.
