### PR TITLE
Pin mypy version to 1.6.*

### DIFF
--- a/.github/workflows/checks-integration.yml
+++ b/.github/workflows/checks-integration.yml
@@ -29,7 +29,7 @@ jobs:
         sudo apt-get update
         sudo apt-get -y install openmpi-bin libopenmpi-dev libopenblas-dev
 
-    # TODO(Shinichi): Remove the version constraint on mypy
+    # TODO(Shinichi): Remove the version constraint on mypy.
     - name: Install
       run: |
         python -m pip install -U pip

--- a/.github/workflows/checks-integration.yml
+++ b/.github/workflows/checks-integration.yml
@@ -29,6 +29,7 @@ jobs:
         sudo apt-get update
         sudo apt-get -y install openmpi-bin libopenmpi-dev libopenblas-dev
 
+    # TODO(Shinichi): Remove the version constraint on mypy.
     - name: Install
       run: |
         python -m pip install -U pip

--- a/.github/workflows/checks-integration.yml
+++ b/.github/workflows/checks-integration.yml
@@ -29,7 +29,6 @@ jobs:
         sudo apt-get update
         sudo apt-get -y install openmpi-bin libopenmpi-dev libopenblas-dev
 
-    # TODO(Shinichi): Remove the version constraint on SQLAlchemy
     - name: Install
       run: |
         python -m pip install -U pip

--- a/.github/workflows/checks-integration.yml
+++ b/.github/workflows/checks-integration.yml
@@ -39,6 +39,7 @@ jobs:
         pip install --progress-bar off -U .[test]
         pip install --progress-bar off -U bayesmark
         pip install --progress-bar off -U kurobako
+        pip install --progress-bar off -U "mypy<1.7.0"
 
     - name: Output installed packages
       run: |


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
Temporary fix `Checks(integration)` by adding version specification on `mypy`

## Description of the changes
It appears that `mypy v1.7.0` is causing significant regressions when used in conjunction with `pybind11`, upon which mypy's type inference for torch modules depends. This issue is highlighted in https://github.com/python/mypy/issues/16486. 
This pull request addresses the problem by setting the `mypy` version to `v1.6.*` until the associated bugs are resolved, as `Pytorch` does [here](https://github.com/pytorch/pytorch/blob/fb3bc3949a64fd976f84806077bcc36167618505/.ci/docker/requirements-ci.txt#L78-L79).

## Alternatives 
Add `type:ignore`s and wait for the `warn-unused-ignores` option to detect that the bug has been resolved.