### PR TITLE
Pin the version of PyQt6-Qt6

### DIFF
--- a/.github/workflows/windows-tests.yml
+++ b/.github/workflows/windows-tests.yml
@@ -52,6 +52,8 @@ jobs:
         pip install --progress-bar off .[test]
         pip install --progress-bar off .[optional]
         pip install PyQt6 # Install PyQT for using QtAgg as matplotlib backend.
+        # TODO(not522): Remove the version constraint.
+        pip install "PyQt6-Qt6<=6.6.0"
         pip install "kaleido<=0.1.0post1"  # TODO(HideakiImamura): Remove this after fixing https://github.com/plotly/Kaleido/issues/110
 
     - name: Output installed packages


### PR DESCRIPTION
## Motivation
The windows-tests CI has been failed because of the PyQt6-Qt6 v6.6.1 release. (The same problem was reported in matplotlib. https://github.com/matplotlib/matplotlib/pull/27412)

## Description of the changes
- Pin the version of PyQt6-Qt6 below 6.6.1