### PR TITLE
Use vectorization for categorical distance

### DIFF
--- a/optuna/samplers/_tpe/parzen_estimator.py
+++ b/optuna/samplers/_tpe/parzen_estimator.py
@@ -187,19 +187,19 @@ class _ParzenEstimator:
     ) -> _BatchedDistributions:
         choices = search_space.choices
         n_choices = len(choices)
-        n_kernels = len(observations) + (parameters.consider_prior or len(observations) == 0)
+        if len(observations) == 0:
+            return _BatchedCategoricalDistributions(
+                weights=np.full((1, n_choices), fill_value=1.0 / n_choices)
+            )
 
+        n_kernels = len(observations) + parameters.consider_prior
         assert parameters.prior_weight is not None
         weights = np.full(
             shape=(n_kernels, n_choices),
             fill_value=parameters.prior_weight / n_kernels,
         )
-
         observed_indices = observations.astype(int)
-        if len(observed_indices) == 0:
-            # Do nothing.
-            pass
-        elif param_name in parameters.categorical_distance_func:
+        if param_name in parameters.categorical_distance_func:
             # TODO(nabenabe0928): Think about how to handle combinatorial explosion.
             # The time complexity is O(n_choices * used_indices.size), so n_choices cannot be huge.
             used_indices, rev_indices = np.unique(observed_indices, return_inverse=True)

--- a/optuna/samplers/_tpe/parzen_estimator.py
+++ b/optuna/samplers/_tpe/parzen_estimator.py
@@ -205,10 +205,9 @@ class _ParzenEstimator:
             used_indices, rev_indices = np.unique(observed_indices, return_inverse=True)
             dist_func = parameters.categorical_distance_func[param_name]
             dists = np.array([[dist_func(choices[i], c) for c in choices] for i in used_indices])
-            max_dists = np.max(dists, axis=1)
             coef = np.log(n_kernels / parameters.prior_weight) * np.log(n_choices) / np.log(6)
-            categorical_weights = np.exp(-((dists / max_dists[:, np.newaxis]) ** 2) * coef)
-            weights[: len(observed_indices)] = categorical_weights[rev_indices]
+            cat_weights = np.exp(-((dists / np.max(dists, axis=1)[:, np.newaxis]) ** 2) * coef)
+            weights[: len(observed_indices)] = cat_weights[rev_indices]
         else:
             weights[np.arange(len(observed_indices)), observed_indices] += 1
 

--- a/optuna/samplers/_tpe/parzen_estimator.py
+++ b/optuna/samplers/_tpe/parzen_estimator.py
@@ -187,7 +187,7 @@ class _ParzenEstimator:
     ) -> _BatchedDistributions:
         choices = search_space.choices
         n_choices = len(choices)
-        n_samples = len(observations) + (parameters.consider_prior or len(observations) == 0)
+        n_samples = observations.size + (parameters.consider_prior or observations.size == 0)
 
         assert parameters.prior_weight is not None
         weights = np.full(
@@ -195,16 +195,20 @@ class _ParzenEstimator:
             fill_value=parameters.prior_weight / n_samples,
         )
 
+        observed_indices = observations.astype(int)
         if param_name in parameters.categorical_distance_func:
+            # TODO(nabenabe0928): Think about how to handle combinatorial explosion.
+            # The time complexity is O(n_choices * used_indices.size), so n_choices cannot be huge.
+            used_indices, rev_indices = np.unique(observed_indices, return_inverse=True)
             dist_func = parameters.categorical_distance_func[param_name]
-            dists = np.array([[dist_func(c1, c2) for c1 in choices] for c2 in choices])
+            dists = np.array([[dist_func(choices[i], c) for c in choices] for i in used_indices])
             max_dists = np.max(dists, axis=1)
             coef = np.log(n_samples / parameters.prior_weight) * np.log(n_choices) / np.log(6)
             categorical_weights = np.exp(-dists / max_dists[:, np.newaxis] * coef)
             categorical_weights /= np.sum(categorical_weights, axis=1, keepdims=True)
-            weights = categorical_weights[observations.astype(int)]
+            weights = categorical_weights[rev_indices]
         else:
-            weights[np.arange(len(observations)), observations.astype(int)] += 1
+            weights[np.arange(observed_indices.size), observed_indices] += 1
 
         weights /= weights.sum(axis=1, keepdims=True)
         return _BatchedCategoricalDistributions(weights)

--- a/optuna/samplers/_tpe/parzen_estimator.py
+++ b/optuna/samplers/_tpe/parzen_estimator.py
@@ -196,7 +196,10 @@ class _ParzenEstimator:
         )
 
         observed_indices = observations.astype(int)
-        if param_name in parameters.categorical_distance_func:
+        if observed_indices.size == 0:
+            # Do nothing.
+            pass
+        elif param_name in parameters.categorical_distance_func:
             # TODO(nabenabe0928): Think about how to handle combinatorial explosion.
             # The time complexity is O(n_choices * used_indices.size), so n_choices cannot be huge.
             used_indices, rev_indices = np.unique(observed_indices, return_inverse=True)

--- a/optuna/samplers/_tpe/parzen_estimator.py
+++ b/optuna/samplers/_tpe/parzen_estimator.py
@@ -208,7 +208,7 @@ class _ParzenEstimator:
             max_dists = np.max(dists, axis=1)
             coef = np.log(n_samples / parameters.prior_weight) * np.log(n_choices) / np.log(6)
             categorical_weights = np.exp(-((dists / max_dists[:, np.newaxis]) ** 2) * coef)
-            weights[:-1] = categorical_weights[rev_indices]
+            weights[: observed_indices.size] = categorical_weights[rev_indices]
         else:
             weights[np.arange(observed_indices.size), observed_indices] += 1
 

--- a/optuna/samplers/_tpe/parzen_estimator.py
+++ b/optuna/samplers/_tpe/parzen_estimator.py
@@ -204,9 +204,8 @@ class _ParzenEstimator:
             dists = np.array([[dist_func(choices[i], c) for c in choices] for i in used_indices])
             max_dists = np.max(dists, axis=1)
             coef = np.log(n_samples / parameters.prior_weight) * np.log(n_choices) / np.log(6)
-            categorical_weights = np.exp(-dists / max_dists[:, np.newaxis] * coef)
-            categorical_weights /= np.sum(categorical_weights, axis=1, keepdims=True)
-            weights = categorical_weights[rev_indices]
+            categorical_weights = np.exp(-((dists / max_dists[:, np.newaxis]) ** 2) * coef)
+            weights[:-1] = categorical_weights[rev_indices]
         else:
             weights[np.arange(observed_indices.size), observed_indices] += 1
 


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

As the current implementation for the categorical distance is not vectorized, I modified it to the vectorized version for a quicker runtime.

Furthermore, I reuse some results to reduce the computational overheads as well.

## Description of the changes
<!-- Describe the changes in this PR. -->

The changes are to:
1. vectorize the computation, and
2. avoid the re-computation of some coefficients and distances. 

## Benchmarking Results

As the time complexity of the new algorithm is `O(n_trials + n_choices * n_unique_occurrences)` while that of the old one is `O(n_trials * n_choices)`, the new algorithm is quicker in all the instances listed in the table.
Plus, all the instances passed `assert np.allclose(res_old, res_new)`.

```python
from __future__ import annotations

import itertools
import string
import time

import numpy as np

from optuna.distributions import CategoricalDistribution


def old_version(
    observations: np.ndarray,
    choices: list[str],
    consider_prior: bool,
    prior_weight: float,
    dist_func,
) -> np.ndarray:
    n_samples = observations.size + (consider_prior or observations.size == 0)
    n_choices = len(choices)
    weights = np.full(
        shape=(n_samples, n_choices),
        fill_value=prior_weight / n_samples,
    )

    for i, observation in enumerate(observations.astype(int)):
        dists = [
            dist_func(choices[observation], choices[j])
            for j in range(len(choices))
        ]
        exponent = -(
            (np.array(dists) / max(dists)) ** 2
            * np.log((len(observations) + consider_prior) / prior_weight)
            * (np.log(len(choices)) / np.log(6))
        )
        weights[i] = np.exp(exponent)

    return weights


def new_version(
    observations: np.ndarray,
    choices: list[str],
    consider_prior: bool,
    prior_weight: float,
    dist_func,
) -> np.ndarray:
    n_samples = observations.size + (consider_prior or observations.size == 0)
    n_choices = len(choices)
    weights = np.full(
        shape=(n_samples, n_choices),
        fill_value=prior_weight / n_samples,
    )

    observed_indices = observations.astype(int)
    used_indices, rev_indices = np.unique(observed_indices, return_inverse=True)
    dists = np.array([[dist_func(choices[i], c) for c in choices] for i in used_indices])
    max_dists = np.max(dists, axis=1)
    coef = np.log(n_samples / prior_weight) * np.log(n_choices) / np.log(6)
    categorical_weights = np.exp(-((dists / max_dists[:, np.newaxis]) ** 2) * coef)
    weights[: observed_indices.size] = categorical_weights[rev_indices]
    return weights


def dist_func(s1: str, s2: str) -> float:
    return sum(c1 != c2 for c1, c2 in zip(s1, s2))


alphabets = list(string.ascii_lowercase)

for n_chars in range(1, 4):
    choices = ["".join(it) for it in itertools.product(*[alphabets] * n_chars)]
    for size in [100, 1000, 10000]:
        print(f"{n_chars=},{size=}")
        rng = np.random.RandomState(42)
        observations = rng.choice(len(choices), size=size)
        start = time.time()
        res_old = old_version(observations, choices, consider_prior=True, prior_weight=1.0, dist_func=dist_func)
        print(f"Old version took {(time.time() - start) * 1000:.3f}[ms]")
        start = time.time()
        res_new = new_version(observations, choices, consider_prior=True, prior_weight=1.0, dist_func=dist_func)
        print(f"New version took {(time.time() - start) * 1000:.3f}[ms]")
        assert np.allclose(res_old, res_new)
```

||Old|New|
|:--:|:--:|:--:|
|n_chars=1,size=100|2.1|0.4|
|n_chars=1,size=1000|12.4|0.4|
|n_chars=1,size=10000|128.6|1.8|
|n_chars=2,size=100|22.2|20.3|
|n_chars=2,size=1000|229.4|107.5|
|n_chars=2,size=10000|2320.8|162.2|
|n_chars=3,size=100|656.8|618.2|
|n_chars=3,size=1000|6699.5|6193.8|
|n_chars=3,size=10000|77744.1|56137.2|
