### PR TITLE
Unify the implementation of `_create_frozen_trial()` under `testing` module

### DIFF
--- a/optuna/testing/trials.py
+++ b/optuna/testing/trials.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+import optuna
+from optuna.distributions import BaseDistribution
+from optuna.samplers._base import _CONSTRAINTS_KEY
+from optuna.trial import FrozenTrial
+from optuna.trial import TrialState
+
+
+def _create_frozen_trial(
+    number: int = 0,
+    values: Sequence[float] | None = None,
+    constraints: Sequence[float] | None = None,
+    params: dict[str, Any] | None = None,
+    param_distributions: dict[str, BaseDistribution] | None = None,
+    state: TrialState = TrialState.COMPLETE,
+) -> optuna.trial.FrozenTrial:
+    return FrozenTrial(
+        number=number,
+        value=1.0 if values is None else None,
+        values=values,
+        state=state,
+        user_attrs={},
+        system_attrs={} if constraints is None else {_CONSTRAINTS_KEY: list(constraints)},
+        params=params or {},
+        distributions=param_distributions or {},
+        intermediate_values={},
+        datetime_start=None,
+        datetime_complete=None,
+        trial_id=number,
+    )


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
Resolve this todo comment and unify the implementation of the same name function.
https://github.com/optuna/optuna/blob/d430a23d36489e19c0d8306be80486b922da4807/tests/samplers_tests/test_nsgaii.py#L578

## Description of the changes
Implement `testing._create_frozen_trial()`, which behaves exactly the same as `test_cma._create_frozen_trial()` and `test_nsgaii._create_frozen_trial()` except the order of the positional arguments, and use it instead of `_create_frozen_trial()` in each test module.
