### PR TITLE
Raise TypeError if params is not a dict in enqueue_trial

### DIFF
--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -854,6 +854,9 @@ class Study:
             hyperparameters manually.
         """
 
+        if not isinstance(params, dict):
+            raise TypeError("params must be a dictionary.")
+
         if skip_if_exists and self._should_skip_enqueue(params):
             _logger.info(f"Trial with params {params} already exists. Skipping enqueue.")
             return

--- a/tests/study_tests/test_study.py
+++ b/tests/study_tests/test_study.py
@@ -644,6 +644,16 @@ def test_enqueue_trial_properly_sets_user_attr(storage_mode: str) -> None:
 
 
 @pytest.mark.parametrize("storage_mode", STORAGE_MODES)
+def test_enqueue_trial_with_non_dict_parameters(storage_mode: str) -> None:
+    with StorageSupplier(storage_mode) as storage:
+        study = create_study(storage=storage)
+        assert len(study.trials) == 0
+
+        with pytest.raises(TypeError):
+            study.enqueue_trial(params=[17, 12])  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("storage_mode", STORAGE_MODES)
 def test_enqueue_trial_with_out_of_range_parameters(storage_mode: str) -> None:
     fixed_value = 11
 


### PR DESCRIPTION
## Motivation
Refs #5113, as well as https://github.com/optuna/optuna-dashboard/issues/679


## Description of the changes
The `params` parameter of `enqueue_trial` is expected to be a dictionary, so raise a `TypeError` if this is not the case.
Test case added for coverage