### PR TITLE
Fix tests with MPI

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -85,7 +85,7 @@ jobs:
         COVERAGE_COVERAGE: yes
       run: |
         export OMPI_MCA_rmaps_base_oversubscribe=yes
-        mpirun -n 2 -- coverage run -m pytest tests/integration_tests/test_pytorch_distributed.py
+        mpirun -n 2 coverage run -m pytest tests/integration_tests/test_pytorch_distributed.py
         coverage combine --append
         coverage xml
 

--- a/.github/workflows/mac-tests.yml
+++ b/.github/workflows/mac-tests.yml
@@ -133,6 +133,6 @@ jobs:
     - name: Tests MPI
       run: |
         export OMPI_MCA_rmaps_base_oversubscribe=yes
-        mpirun -n 2 -- pytest tests/integration_tests/test_pytorch_distributed.py
+        mpirun -n 2 pytest -- tests/integration_tests/test_pytorch_distributed.py
       env:
         OMP_NUM_THREADS: 1

--- a/.github/workflows/tests-mpi.yml
+++ b/.github/workflows/tests-mpi.yml
@@ -81,7 +81,7 @@ jobs:
     - name: Tests
       run: |
         export OMPI_MCA_rmaps_base_oversubscribe=yes
-        mpirun -n 2 -- pytest tests/integration_tests/test_pytorch_distributed.py
+        mpirun -n 2 pytest -- tests/integration_tests/test_pytorch_distributed.py
 
       env:
         OMP_NUM_THREADS: 1


### PR DESCRIPTION
## Motivation
The `tests-integration-mac` CI has failed due to an OpenMPI update.
I think that `pytest` should be placed before `--`.

## Description of the changes
- Fix the order of args in CIs.
