### PR TITLE
Make Methods section hidden from Artifact Docs

### DIFF
--- a/docs/source/reference/artifacts.rst
+++ b/docs/source/reference/artifacts.rst
@@ -5,12 +5,16 @@ optuna.artifacts
 
 The :mod:`~optuna.artifacts` module provides the way to manage artifacts (output files) in Optuna.
 
-.. autosummary::
-   :toctree: generated/
-   :nosignatures:
+.. autoclass:: optuna.artifacts.FileSystemArtifactStore
+   :no-members:
 
-   optuna.artifacts.FileSystemArtifactStore
-   optuna.artifacts.Boto3ArtifactStore
-   optuna.artifacts.GCSArtifactStore
-   optuna.artifacts.Backoff
-   optuna.artifacts.upload_artifact
+.. autoclass:: optuna.artifacts.Boto3ArtifactStore
+   :no-members:
+
+.. autoclass:: optuna.artifacts.GCSArtifactStore
+   :no-members:
+
+.. autoclass:: optuna.artifacts.Backoff
+   :no-members:
+
+.. autofunction:: optuna.artifacts.upload_artifact


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
At present, the methods within the artifact stores lack docstrings. Consequently, the "Methods" section appears empty:
https://optuna.readthedocs.io/en/stable/reference/generated/optuna.artifacts.FileSystemArtifactStore.html

## Description of the changes
<!-- Describe the changes in this PR. -->
The "Methods" section will be hidden from the artifact documentation.