### PR TITLE
Fix JSONDecodeError in JournalStorage

### DIFF
--- a/optuna/storages/_journal/file.py
+++ b/optuna/storages/_journal/file.py
@@ -190,7 +190,6 @@ class JournalFileStorage(BaseJournalLogStorage):
                     "\r",
                     "\r\n",
                 ]:  # to avoid json.loads(<line separator>)
-                    print('bang!')
                     continue
                 try:
                     logs.append(json.loads(line))

--- a/optuna/storages/_journal/file.py
+++ b/optuna/storages/_journal/file.py
@@ -11,7 +11,6 @@ from typing import List
 from typing import Optional
 import uuid
 
-from optuna.exceptions import StorageInternalError
 from optuna.storages._journal.base import BaseJournalLogStorage
 
 
@@ -191,7 +190,7 @@ class JournalFileStorage(BaseJournalLogStorage):
 
                 # Ensure that each line ends with line separators (\n, \r\n)
                 if not line.endswith(b"\n") and not line.endswith(b"\r\n"):
-                    last_decode_error = StorageInternalError("Invalid log format.")
+                    last_decode_error = ValueError("Invalid log format.")
                     del self._log_number_offset[log_number + 1]
                     continue
                 try:

--- a/optuna/storages/_journal/file.py
+++ b/optuna/storages/_journal/file.py
@@ -172,11 +172,15 @@ class JournalFileStorage(BaseJournalLogStorage):
                 remaining_log_size -= self._log_number_offset[log_number_from]
 
             last_decode_error = None
-            for log_number, line in enumerate(f, start=log_number_start):
+            log_number = log_number_start
+            for line in f:
                 if last_decode_error is not None:
                     raise last_decode_error
                 byte_len = len(line)
                 remaining_log_size -= byte_len
+                if line in b"\r\n":  # to avoid json.loads(<line separator>)
+                    self._log_number_offset[log_number] += byte_len
+                    continue
                 if remaining_log_size < 0:
                     break
                 if log_number + 1 not in self._log_number_offset:
@@ -185,8 +189,6 @@ class JournalFileStorage(BaseJournalLogStorage):
                     )
                 if log_number < log_number_from:
                     continue
-                if line in b"\r\n":  # to avoid json.loads(<line separator>)
-                    continue
                 try:
                     logs.append(json.loads(line))
                 except json.JSONDecodeError as err:
@@ -194,6 +196,7 @@ class JournalFileStorage(BaseJournalLogStorage):
                     del self._log_number_offset[log_number + 1]
                 if remaining_log_size == 0:
                     break
+                log_number += 1
             return logs
 
     def append_logs(self, logs: List[Dict[str, Any]]) -> None:

--- a/optuna/storages/_journal/file.py
+++ b/optuna/storages/_journal/file.py
@@ -185,11 +185,7 @@ class JournalFileStorage(BaseJournalLogStorage):
                     )
                 if log_number < log_number_from:
                     continue
-                if line.decode("utf-8") in [
-                    "\n",
-                    "\r",
-                    "\r\n",
-                ]:  # to avoid json.loads(<line separator>)
+                if line in b"\r\n":  # to avoid json.loads(<line separator>)
                     continue
                 try:
                     logs.append(json.loads(line))

--- a/optuna/storages/_journal/file.py
+++ b/optuna/storages/_journal/file.py
@@ -165,7 +165,7 @@ class JournalFileStorage(BaseJournalLogStorage):
     def read_logs(self, log_number_from: int) -> List[Dict[str, Any]]:
         logs = []
         with open(self._file_path, "rb") as f:
-            # Maintain remaining_log_size to allow writing by another process while reading the log.
+            # Maintain remaining_log_size to allow writing by another process while reading the log
             remaining_log_size = os.stat(self._file_path).st_size
             log_number_start = 0
             if log_number_from in self._log_number_offset:
@@ -189,8 +189,8 @@ class JournalFileStorage(BaseJournalLogStorage):
                         self._log_number_offset[log_number] + byte_len
                     )
 
-                # Ensure that each line ends with line separators (\n, \r\n).
-                if not line.endswith(b'\n') and not line.endswith(b'\r\n'):
+                # Ensure that each line ends with line separators (\n, \r\n)
+                if not line.endswith(b"\n") and not line.endswith(b"\r\n"):
                     last_decode_error = StorageInternalError("Invalid log format.")
                     del self._log_number_offset[log_number + 1]
                     continue

--- a/optuna/storages/_journal/file.py
+++ b/optuna/storages/_journal/file.py
@@ -188,7 +188,7 @@ class JournalFileStorage(BaseJournalLogStorage):
                     continue
 
                 # Ensure that each line ends with line separators (\n, \r\n)
-                if not line.endswith(b"\n") and not line.endswith(b"\r\n"):
+                if not line.endswith(b"\n"):
                     last_decode_error = ValueError("Invalid log format.")
                     del self._log_number_offset[log_number + 1]
                     continue

--- a/optuna/storages/_journal/file.py
+++ b/optuna/storages/_journal/file.py
@@ -188,7 +188,7 @@ class JournalFileStorage(BaseJournalLogStorage):
                     continue
 
                 # Ensure that each line ends with line separators (\n, \r\n)
-                if not line.endswith(b"\n"):
+                if not line.endswith(os.linesep.encode()):
                     last_decode_error = ValueError("Invalid log format.")
                     del self._log_number_offset[log_number + 1]
                     continue

--- a/optuna/storages/_journal/file.py
+++ b/optuna/storages/_journal/file.py
@@ -174,9 +174,6 @@ class JournalFileStorage(BaseJournalLogStorage):
 
             last_decode_error = None
             for log_number, line in enumerate(f, start=log_number_start):
-                if log_number < log_number_from:
-                    continue
-
                 byte_len = len(line)
                 remaining_log_size -= byte_len
                 if remaining_log_size < 0:
@@ -187,6 +184,8 @@ class JournalFileStorage(BaseJournalLogStorage):
                     self._log_number_offset[log_number + 1] = (
                         self._log_number_offset[log_number] + byte_len
                     )
+                if log_number < log_number_from:
+                    continue
 
                 # Ensure that each line ends with line separators (\n, \r\n)
                 if not line.endswith(b"\n") and not line.endswith(b"\r\n"):

--- a/optuna/storages/_journal/file.py
+++ b/optuna/storages/_journal/file.py
@@ -185,7 +185,12 @@ class JournalFileStorage(BaseJournalLogStorage):
                     )
                 if log_number < log_number_from:
                     continue
-                if line == os.linesep.encode("utf-8"):  # to avoid json.loads('\n')
+                if line.decode("utf-8") in [
+                    "\n",
+                    "\r",
+                    "\r\n",
+                ]:  # to avoid json.loads(<line separator>)
+                    print('bang!')
                     continue
                 try:
                     logs.append(json.loads(line))

--- a/optuna/storages/_journal/file.py
+++ b/optuna/storages/_journal/file.py
@@ -188,7 +188,7 @@ class JournalFileStorage(BaseJournalLogStorage):
                     continue
 
                 # Ensure that each line ends with line separators (\n, \r\n)
-                if not line.endswith(os.linesep.encode()):
+                if not line.endswith(b"\n"):
                     last_decode_error = ValueError("Invalid log format.")
                     del self._log_number_offset[log_number + 1]
                     continue

--- a/optuna/storages/_journal/file.py
+++ b/optuna/storages/_journal/file.py
@@ -164,28 +164,36 @@ class JournalFileStorage(BaseJournalLogStorage):
     def read_logs(self, log_number_from: int) -> List[Dict[str, Any]]:
         logs = []
         with open(self._file_path, "rb") as f:
+            remaining_log_size = os.stat(self._file_path).st_size
             log_number_start = 0
             if log_number_from in self._log_number_offset:
                 f.seek(self._log_number_offset[log_number_from])
                 log_number_start = log_number_from
+                remaining_log_size -= self._log_number_offset[log_number_from]
 
             last_decode_error = None
             for log_number, line in enumerate(f, start=log_number_start):
                 if last_decode_error is not None:
                     raise last_decode_error
+                byte_len = len(line)
+                remaining_log_size -= byte_len
+                if remaining_log_size < 0:
+                    break
                 if log_number + 1 not in self._log_number_offset:
-                    byte_len = len(line)
                     self._log_number_offset[log_number + 1] = (
                         self._log_number_offset[log_number] + byte_len
                     )
                 if log_number < log_number_from:
+                    continue
+                if line == os.linesep.encode("utf-8"):  # to avoid json.loads('\n')
                     continue
                 try:
                     logs.append(json.loads(line))
                 except json.JSONDecodeError as err:
                     last_decode_error = err
                     del self._log_number_offset[log_number + 1]
-
+                if remaining_log_size == 0:
+                    break
             return logs
 
     def append_logs(self, logs: List[Dict[str, Any]]) -> None:


### PR DESCRIPTION
## Motivation
- Fix JSONDecodeError in JournalStorage #5138

## Description of the changes
- Maintain `remaining_log_size` to allow writing by another process while reading the log.