### PR TITLE
Adapt tests to backward-incompatible changes in moto 5.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,7 +122,7 @@ test = [
     "coverage",
     "fakeredis[lua]",
     "kaleido",
-    "moto>=5.0.0",
+    "moto",
     "pytest",
     "scipy>=1.9.2; python_version>='3.8'",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,7 +122,7 @@ test = [
     "coverage",
     "fakeredis[lua]",
     "kaleido",
-    "moto",
+    "moto>=5.0.0",
     "pytest",
     "scipy>=1.9.2; python_version>='3.8'",
 ]

--- a/tests/artifacts_tests/test_boto3.py
+++ b/tests/artifacts_tests/test_boto3.py
@@ -4,17 +4,16 @@ import io
 from typing import TYPE_CHECKING
 
 import boto3
-
-try:
-    from moto import mock_aws
-except ImportError:
-    from moto import mock_s3 as mock_aws
-
 import pytest
 
 from optuna.artifacts import Boto3ArtifactStore
 from optuna.artifacts.exceptions import ArtifactNotFound
 
+
+try:
+    from moto import mock_aws
+except ImportError:
+    from moto import mock_s3 as mock_aws
 
 if TYPE_CHECKING:
     from collections.abc import Iterator

--- a/tests/artifacts_tests/test_boto3.py
+++ b/tests/artifacts_tests/test_boto3.py
@@ -4,7 +4,7 @@ import io
 from typing import TYPE_CHECKING
 
 import boto3
-from moto import mock_s3
+from moto import mock_aws
 import pytest
 
 from optuna.artifacts import Boto3ArtifactStore
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 
 @pytest.fixture()
 def init_mock_client() -> Iterator[tuple[str, S3Client]]:
-    with mock_s3():
+    with mock_aws():
         # Runs before each test
         bucket_name = "moto-bucket"
         s3_client = boto3.client("s3")

--- a/tests/artifacts_tests/test_boto3.py
+++ b/tests/artifacts_tests/test_boto3.py
@@ -4,7 +4,12 @@ import io
 from typing import TYPE_CHECKING
 
 import boto3
-from moto import mock_aws
+
+try:
+    from moto import mock_aws
+except ImportError:
+    from moto import mock_s3 as mock_aws
+
 import pytest
 
 from optuna.artifacts import Boto3ArtifactStore


### PR DESCRIPTION
## Motivation

I forked Optuna and ran tests about 4 hours ago, right after `moto` [issued their new backward-incompatible release](https://github.com/getmoto/moto/releases/tag/5.0.0). 

As a consequence, one of the tests failed. Additionally, `pyproject.toml` has no version constraint for `moto` therefore, tests will fail for all new repo clones or package upgrades (as well as CI/CD unless dependencies are cached between runs). 

Edit: As mentioned by @nzw0301 `moto=5.0.0` does not support python `3.7` anymore; therefore, I've changed the approach and do not require any specific version of `moto` but instead handle the `ImportError`.

## Description of the changes

Hopefully, the fix is trivial: 
- I've replaced the imported decorator name `mock_s3` with `mock_aws`. When the import fails, retreat to `mock_s3`
- ~Added version constraint to `pyproject.toml`~

