### PR TITLE
Add a version constraint for Torch

### DIFF
--- a/.github/workflows/windows-tests.yml
+++ b/.github/workflows/windows-tests.yml
@@ -118,6 +118,8 @@ jobs:
         pip install --progress-bar off .[optional]
         pip install --progress-bar off .[integration]
         pip install "distributed<2023.3.2"
+        # TODO(nabenabe0928): Remove the version constraint on Torch.
+        pip install "torch<2.2.0"
 
     - name: Output installed packages
       run: |

--- a/.github/workflows/windows-tests.yml
+++ b/.github/workflows/windows-tests.yml
@@ -121,8 +121,8 @@ jobs:
 
         # TODO(nabenabe0928): Remove the version constraint on Torch.
         pip install "torch<2.2.0"
+        pip install "torchaudio<2.2.0"
         pip install "torchvision<0.17.0"
-        pip install "lightning<2.1.4"
 
     - name: Output installed packages
       run: |

--- a/.github/workflows/windows-tests.yml
+++ b/.github/workflows/windows-tests.yml
@@ -118,8 +118,11 @@ jobs:
         pip install --progress-bar off .[optional]
         pip install --progress-bar off .[integration]
         pip install "distributed<2023.3.2"
+
         # TODO(nabenabe0928): Remove the version constraint on Torch.
         pip install "torch<2.2.0"
+        pip install "torchvision<0.17.0"
+        pip install "lightning<2.1.4"
 
     - name: Output installed packages
       run: |


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

As Windows test fails now due to torch==2.2.0 ([issue](https://github.com/pytorch/pytorch/issues/118737)), I fix this problem by introducing the version constraint. 

## Description of the changes
<!-- Describe the changes in this PR. -->

I added the version constraint of `torch<2.2.0`.
