### PR TITLE
Add UCB for `optuna._gp`

### DIFF
--- a/optuna/_gp/acqf.py
+++ b/optuna/_gp/acqf.py
@@ -58,6 +58,7 @@ def ucb(mean: torch.Tensor, var: torch.Tensor, beta: float) -> torch.Tensor:
 
 
 # TODO(contramundum53): consider abstraction for acquisition functions.
+# NOTE: Acquisition function is not class on purpose to integrate numba in the future.
 class AcquisitionFunctionType(IntEnum):
     LOG_EI = 0
     UCB = 1

--- a/optuna/_gp/acqf.py
+++ b/optuna/_gp/acqf.py
@@ -120,7 +120,7 @@ def eval_acqf(acqf_params: AcquisitionFunctionParams, x: torch.Tensor) -> torch.
     if acqf_params.acqf_type == AcquisitionFunctionType.LOG_EI:
         return logei(mean=mean, var=var + acqf_params.acqf_stabilizing_noise, f0=acqf_params.max_Y)
     elif acqf_params.acqf_type == AcquisitionFunctionType.UCB:
-        assert acqf_params.beta is not None
+        assert acqf_params.beta is not None, "beta must be given to UCB."
         return ucb(mean=mean, var=var, beta=acqf_params.beta)
     else:
         assert False, "Unknown acquisition function type."

--- a/optuna/_gp/acqf.py
+++ b/optuna/_gp/acqf.py
@@ -122,7 +122,7 @@ def eval_acqf(acqf_params: AcquisitionFunctionParams, x: torch.Tensor) -> torch.
         assert acqf_params.beta is not None
         return ucb(mean=mean, var=var, beta=acqf_params.beta)
     else:
-        assert False  # Unknown acquisition function type.
+        assert False, "Unknown acquisition function type."
 
 
 def eval_acqf_no_grad(acqf_params: AcquisitionFunctionParams, x: np.ndarray) -> np.ndarray:

--- a/optuna/_gp/gp.py
+++ b/optuna/_gp/gp.py
@@ -146,7 +146,7 @@ def fit_kernel_params(
     Y: np.ndarray,  # [len(trials)]
     is_categorical: np.ndarray,  # [len(params)]
     log_prior: Callable[[KernelParamsTensor], torch.Tensor],
-    minimum_noise: float = 0.0,
+    minimum_noise: float,
     initial_kernel_params: KernelParamsTensor | None = None,
 ) -> KernelParamsTensor:
     n_params = X.shape[1]

--- a/optuna/_gp/gp.py
+++ b/optuna/_gp/gp.py
@@ -106,7 +106,7 @@ def posterior(
 ) -> tuple[torch.Tensor, torch.Tensor]:  # (mean: [(batch,)], var: [(batch,)])
     cov_fx_fX = kernel(is_categorical, kernel_params, x[..., None, :], X)[..., 0, :]
     cov_fx_fx = kernel_at_zero_distance(kernel_params)
-    
+
     # mean = cov_fx_fX @ inv(cov_fX_fX + noise * I) @ Y
     # var = cov_fx_fx - cov_fx_fX @ inv(cov_fX_fX + noise * I) @ cov_fx_fX.T
     mean = cov_fx_fX @ cov_Y_Y_inv_Y  # [batch]

--- a/optuna/_gp/gp.py
+++ b/optuna/_gp/gp.py
@@ -97,14 +97,18 @@ def kernel_at_zero_distance(
 
 
 def posterior(
+    kernel_params: KernelParamsTensor,
+    X: torch.Tensor,  # [len(trials), len(params)]
+    is_categorical: torch.Tensor,  # bool[len(params)]
     cov_Y_Y_inv: torch.Tensor,  # [len(trials), len(trials)]
     cov_Y_Y_inv_Y: torch.Tensor,  # [len(trials)]
-    cov_fx_fX: torch.Tensor,  # [(batch,) len(trials)]
-    cov_fx_fx: torch.Tensor,  # Scalar or [(batch,)]
-) -> tuple[torch.Tensor, torch.Tensor]:  # [(batch,)], [(batch,)]
+    x: torch.Tensor,  # [(batch,) len(params)]
+) -> tuple[torch.Tensor, torch.Tensor]:  # (mean: [(batch,)], var: [(batch,)])
+    cov_fx_fX = kernel(is_categorical, kernel_params, x[..., None, :], X)[..., 0, :]
+    cov_fx_fx = kernel_at_zero_distance(kernel_params)
+    
     # mean = cov_fx_fX @ inv(cov_fX_fX + noise * I) @ Y
     # var = cov_fx_fx - cov_fx_fX @ inv(cov_fX_fX + noise * I) @ cov_fx_fX.T
-
     mean = cov_fx_fX @ cov_Y_Y_inv_Y  # [batch]
     var = cov_fx_fx - (cov_fx_fX * (cov_fx_fX @ cov_Y_Y_inv)).sum(dim=-1)  # [batch]
     # We need to clamp the variance to avoid negative values due to numerical errors.

--- a/optuna/samplers/_gp/sampler.py
+++ b/optuna/samplers/_gp/sampler.py
@@ -172,6 +172,7 @@ class GPSampler(BaseSampler):
         self._kernel_params_cache = kernel_params
 
         acqf_params = acqf.create_acqf_params(
+            acqf_type=acqf.AcquisitionFunctionType.LOG_EI,
             kernel_params=kernel_params,
             search_space=internal_search_space,
             X=normalized_params,

--- a/tests/gp_tests/test_acqf.py
+++ b/tests/gp_tests/test_acqf.py
@@ -22,7 +22,7 @@ from optuna._gp.search_space import SearchSpace
 @pytest.mark.parametrize(
     "x", [np.array([0.15, 0.12]), np.array([[0.15, 0.12], [0.0, 1.0]])]  # unbatched  # batched
 )
-def test_posterior_and_eval_acqf(
+def test_eval_acqf(
     acqf_type: AcquisitionFunctionType,
     beta: float | None,
     x: np.ndarray,

--- a/tests/gp_tests/test_acqf.py
+++ b/tests/gp_tests/test_acqf.py
@@ -2,7 +2,13 @@ from __future__ import annotations
 
 import numpy as np
 import pytest
-import torch
+
+
+# TODO(contramundum53): Remove this block after torch supports Python 3.12.
+try:
+    import torch
+except ImportError:
+    pytest.skip()
 
 from optuna._gp.acqf import AcquisitionFunctionType
 from optuna._gp.acqf import create_acqf_params
@@ -10,7 +16,7 @@ from optuna._gp.acqf import eval_acqf
 from optuna._gp.gp import KernelParamsTensor
 from optuna._gp.search_space import ScaleType
 from optuna._gp.search_space import SearchSpace
-import sys
+
 
 @pytest.mark.parametrize(
     "acqf_type, beta",
@@ -21,10 +27,6 @@ import sys
 )
 @pytest.mark.parametrize(
     "x", [np.array([0.15, 0.12]), np.array([[0.15, 0.12], [0.0, 1.0]])]  # unbatched  # batched
-)
-@pytest.mark.skipif(
-    sys.version_info >= (3, 12),
-    reason="PyTorch does not support Python 3.12 yet.",
 )
 def test_eval_acqf(
     acqf_type: AcquisitionFunctionType,

--- a/tests/gp_tests/test_acqf.py
+++ b/tests/gp_tests/test_acqf.py
@@ -1,14 +1,16 @@
 from __future__ import annotations
 
+import sys
+
 import numpy as np
 import pytest
 
 
 # TODO(contramundum53): Remove this block after torch supports Python 3.12.
-try:
-    import torch
-except ImportError:
-    pytest.skip()
+if sys.version_info >= (3, 12):
+    pytest.skip("PyTorch does not support python 3.12.", allow_module_level=True)
+
+import torch
 
 from optuna._gp.acqf import AcquisitionFunctionType
 from optuna._gp.acqf import create_acqf_params

--- a/tests/gp_tests/test_acqf.py
+++ b/tests/gp_tests/test_acqf.py
@@ -1,0 +1,103 @@
+from optuna._gp.gp import KernelParamsTensor, kernel, posterior
+from optuna._gp.acqf import AcquisitionFunctionType, eval_acqf, AcquisitionFunctionParams, create_acqf_params
+from optuna._gp.search_space import SearchSpace, ScaleType
+import numpy as np
+import pytest
+
+from botorch.models.model import Model
+from botorch.models import SingleTaskGP
+from gpytorch.kernels import MaternKernel, ScaleKernel
+from gpytorch.likelihoods import GaussianLikelihood
+from gpytorch.likelihoods.noise_models import HomoskedasticNoise
+from gpytorch.means import ZeroMean
+from botorch.acquisition.analytic import LogExpectedImprovement, UpperConfidenceBound
+from typing import Callable, Any
+import torch
+
+@pytest.mark.parametrize(
+    "acqf_type, beta, botorch_acqf_gen",
+    [
+        (AcquisitionFunctionType.LOG_EI, None, lambda model, acqf_params: LogExpectedImprovement(model, best_f=acqf_params.max_Y)),
+        (AcquisitionFunctionType.UCB, 2.0, lambda model, acqf_params: UpperConfidenceBound(model, beta=acqf_params.beta))
+    ]
+)
+@pytest.mark.parametrize("x",[
+    np.array([0.15, 0.12]),  # unbatched
+    np.array([[0.15, 0.12], [0.0, 1.0]])  # batched
+])
+def test_posterior_and_eval_acqf(acqf_type: AcquisitionFunctionType, beta: float | None, botorch_acqf_gen: Callable[[Model, AcquisitionFunctionParams], Any], x: np.ndarray) -> None:
+
+    n_dims = 2
+    X = np.array([[0.1, 0.2], [0.2, 0.3], [0.3, 0.1]])
+    Y = np.array([1.0, 2.0, 3.0])
+    kernel_params = KernelParamsTensor(
+        inverse_squared_lengthscales=torch.tensor([2.0, 3.0], dtype=torch.float64),
+        kernel_scale=torch.tensor(4.0, dtype=torch.float64),
+        noise_var=torch.tensor(0.1, dtype=torch.float64),
+    )
+    search_space = SearchSpace(
+        scale_types=np.full(n_dims, ScaleType.LINEAR), 
+        bounds=np.array([[0.0, 1.0] * n_dims]), 
+        steps=np.zeros(n_dims)
+    )
+
+
+    acqf_params = create_acqf_params(
+        acqf_type=acqf_type,
+        kernel_params=kernel_params,
+        search_space=search_space,
+        X=X,
+        Y=Y,
+        beta=beta,
+        acqf_stabilizing_noise=0.0,
+    )
+
+    x_tensor = torch.from_numpy(x)
+    x_tensor.requires_grad_(True)
+
+    prior_cov_fX_fX = kernel(torch.zeros(n_dims, dtype=torch.bool), kernel_params, torch.from_numpy(X), torch.from_numpy(X))
+    posterior_mean_fx, posterior_var_fx = posterior(kernel_params, torch.from_numpy(X), torch.zeros(n_dims, dtype=torch.bool), acqf_params.cov_Y_Y_inv, acqf_params.cov_Y_Y_inv_Y, torch.from_numpy(x))
+
+    acqf_value = eval_acqf(acqf_params, x_tensor)
+    acqf_value.sum().backward()
+    acqf_grad = x_tensor.grad
+    assert acqf_grad is not None
+
+
+    gpytorch_likelihood = GaussianLikelihood()
+    gpytorch_likelihood.noise_covar.noise = kernel_params.noise_var
+    matern_kernel = MaternKernel(nu=2.5, ard_num_dims=n_dims)
+    matern_kernel.lengthscale = kernel_params.inverse_squared_lengthscales.rsqrt()
+    covar_module = ScaleKernel(matern_kernel)
+    covar_module.outputscale = kernel_params.kernel_scale
+
+    botorch_model = SingleTaskGP(
+        train_X = torch.from_numpy(X),
+        train_Y = torch.from_numpy(Y)[:, None],
+        likelihood=gpytorch_likelihood,
+        covar_module=covar_module,
+        mean_module=ZeroMean(),
+    )
+    botorch_prior_fX = botorch_model(torch.from_numpy(X))
+    assert torch.allclose(botorch_prior_fX.covariance_matrix, prior_cov_fX_fX)
+
+    botorch_model.eval()
+
+    botorch_acqf = botorch_acqf_gen(botorch_model, acqf_params)
+
+    x_tensor = torch.from_numpy(x)
+    x_tensor.requires_grad_(True)
+    botorch_posterior_fx = botorch_model.posterior(x_tensor[..., None, :])
+    assert torch.allclose(posterior_mean_fx, botorch_posterior_fx.mean[..., 0, 0])
+    assert torch.allclose(posterior_var_fx, botorch_posterior_fx.variance[..., 0, 0])
+
+    botorch_acqf_value = botorch_acqf(x_tensor[..., None, :])
+    botorch_acqf_value.sum().backward()
+    botorch_acqf_grad = x_tensor.grad
+    assert botorch_acqf_grad is not None
+    assert torch.allclose(acqf_value, botorch_acqf_value)
+    assert torch.allclose(acqf_grad, botorch_acqf_grad)
+
+
+
+

--- a/tests/gp_tests/test_acqf.py
+++ b/tests/gp_tests/test_acqf.py
@@ -10,7 +10,7 @@ from optuna._gp.acqf import eval_acqf
 from optuna._gp.gp import KernelParamsTensor
 from optuna._gp.search_space import ScaleType
 from optuna._gp.search_space import SearchSpace
-
+import sys
 
 @pytest.mark.parametrize(
     "acqf_type, beta",
@@ -21,6 +21,10 @@ from optuna._gp.search_space import SearchSpace
 )
 @pytest.mark.parametrize(
     "x", [np.array([0.15, 0.12]), np.array([[0.15, 0.12], [0.0, 1.0]])]  # unbatched  # batched
+)
+@pytest.mark.skipif(
+    sys.version_info >= (3, 12),
+    reason="PyTorch does not support Python 3.12 yet.",
 )
 def test_eval_acqf(
     acqf_type: AcquisitionFunctionType,


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
`optuna.terminator` uses UCB. We implement UCB in `optuna._gp` so that we can implement the backend of `optuna.terminator` with `optuna._gp`, essentially removing the dependency on BoTorch from Optuna.

## Description of the changes
* Implement UCB in `optuna._gp`
* Add test that compares the values with BoTorch

#5185 must be merged first.
