### PR TITLE
Fix trial validation

### DIFF
--- a/optuna/trial/_frozen.py
+++ b/optuna/trial/_frozen.py
@@ -322,11 +322,8 @@ class FrozenTrial(BaseTrial):
                     "`datetime_complete` is supposed to be None for an unfinished trial."
                 )
 
-        if self.state in (TrialState.PRUNED, TrialState.FAIL) and self._values is not None:
-            raise ValueError(
-                f"values should be None for a trial with state {self.state}, "
-                f"but got {self._values}."
-            )
+        if self.state == TrialState.FAIL and self._values is not None:
+            raise ValueError(f"values should be None for a failed trial, but got {self._values}.")
         if self.state == TrialState.COMPLETE:
             if self._values is None:
                 raise ValueError("values should be set for a complete trial.")

--- a/tests/trial_tests/test_frozen.py
+++ b/tests/trial_tests/test_frozen.py
@@ -145,13 +145,12 @@ def test_validate() -> None:
         with pytest.raises(ValueError):
             invalid_trial._validate()
 
-    # Invalid: `state` is `PRUNED` or `FAIL`, and `value` is set.
-    for state in [TrialState.PRUNED, TrialState.FAIL]:
-        invalid_trial = copy.copy(valid_trial)
-        invalid_trial.state = state
-        invalid_trial.value = 1.0
-        with pytest.raises(ValueError):
-            invalid_trial._validate()
+    # Invalid: `state` is `FAIL`, and `value` is set.
+    invalid_trial = copy.copy(valid_trial)
+    invalid_trial.state = TrialState.FAIL
+    invalid_trial.value = 1.0
+    with pytest.raises(ValueError):
+        invalid_trial._validate()
 
     # Invalid: `state` is `COMPLETE` and `value` is not set.
     invalid_trial = copy.copy(valid_trial)


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
#5211 introduced a bug that enforced all `PRUNED` trials to have `None` value. In https://github.com/optuna/optuna/blob/f831ee677db1b32289825e5c13577ae969705879/optuna/study/_tell.py#L136-L146, pruned trials have the value of the last intermediate value (if it exists and it is acceptable as an objective value). 

## Description of the changes
Remove validation of `value` on `PRUNED` trials.
