### PR TITLE
Update links to papers

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ For general guidelines on how to contribute to the project, take a look at [CONT
 
 ## Reference
 
-If you use Optuna in one of your research projects, please cite [our KDD paper](https://arxiv.org/abs/1907.10902) "Optuna: A Next-generation Hyperparameter Optimization Framework":
+If you use Optuna in one of your research projects, please cite [our KDD paper](https://doi.org/10.1145/3292500.3330701) "Optuna: A Next-generation Hyperparameter Optimization Framework":
 
 <details open>
 <summary>BibTeX</summary>

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -104,7 +104,7 @@ Reference
 
 Takuya Akiba, Shotaro Sano, Toshihiko Yanase, Takeru Ohta, and Masanori
 Koyama. 2019. Optuna: A Next-generation Hyperparameter Optimization
-Framework. In KDD (`arXiv <https://arxiv.org/abs/1907.10902>`__).
+Framework. In KDD (`paper <https://doi.org/10.1145/3292500.3330701>`__).
 
 .. toctree::
    :maxdepth: 2

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -104,7 +104,7 @@ Reference
 
 Takuya Akiba, Shotaro Sano, Toshihiko Yanase, Takeru Ohta, and Masanori
 Koyama. 2019. Optuna: A Next-generation Hyperparameter Optimization
-Framework. In KDD (`paper <https://doi.org/10.1145/3292500.3330701>`__).
+Framework. In KDD (`arXiv <https://arxiv.org/abs/1907.10902>`__).
 
 .. toctree::
    :maxdepth: 2

--- a/optuna/_hypervolume/hssp.py
+++ b/optuna/_hypervolume/hssp.py
@@ -19,7 +19,7 @@ def _solve_hssp(
     paper:
 
     - `Greedy Hypervolume Subset Selection in Low Dimensions
-       <https://ieeexplore.ieee.org/document/7570501>`_
+       <https://doi.org/10.1162/EVCO_a_00188>`_
     """
     selected_vecs: List[np.ndarray] = []
     selected_indices: List[int] = []

--- a/optuna/multi_objective/samplers/_nsga2.py
+++ b/optuna/multi_objective/samplers/_nsga2.py
@@ -34,7 +34,7 @@ class NSGAIIMultiObjectiveSampler(BaseMultiObjectiveSampler):
     For further information about NSGA-II, please refer to the following paper:
 
     - `A fast and elitist multiobjective genetic algorithm: NSGA-II
-      <https://ieeexplore.ieee.org/document/996017>`_
+      <https://doi.org/10.1109/4235.996017>`_
 
     Args:
         population_size:

--- a/optuna/pruners/_successive_halving.py
+++ b/optuna/pruners/_successive_halving.py
@@ -12,10 +12,11 @@ from optuna.trial._state import TrialState
 class SuccessiveHalvingPruner(BasePruner):
     """Pruner using Asynchronous Successive Halving Algorithm.
 
-    `Successive Halving <https://arxiv.org/abs/1502.07943>`_ is a bandit-based algorithm to
-    identify the best one among multiple configurations. This class implements an asynchronous
-    version of Successive Halving. Please refer to the paper of
-    `Asynchronous Successive Halving <http://arxiv.org/abs/1810.05934>`_ for detailed descriptions.
+    `Successive Halving <https://proceedings.mlr.press/v51/jamieson16.html>`_ is a bandit-based
+    algorithm to identify the best one among multiple configurations. This class implements an
+    asynchronous version of Successive Halving. Please refer to the paper of
+    `Asynchronous Successive Halving <https://proceedings.mlsys.org/paper_files/paper/2020/file/
+    a06f20b349c6cf09a6b171c71b88bbfc-Paper.pdf>`_ for detailed descriptions.
 
     Note that, this class does not take care of the parameter for the maximum
     resource, referred to as :math:`R` in the paper. The maximum resource allocated to a trial is
@@ -70,8 +71,9 @@ class SuccessiveHalvingPruner(BasePruner):
     Args:
         min_resource:
             A parameter for specifying the minimum resource allocated to a trial
-            (in the `paper <http://arxiv.org/abs/1810.05934>`_ this parameter is
-            referred to as :math:`r`).
+            (in the `paper <https://proceedings.mlsys.org/paper_files/paper/2020/file/
+            a06f20b349c6cf09a6b171c71b88bbfc-Paper.pdf>`_ this parameter is referred to as
+            :math:`r`).
             This parameter defaults to 'auto' where the value is determined based on a heuristic
             that looks at the number of required steps for the first trial to complete.
 
@@ -96,13 +98,15 @@ class SuccessiveHalvingPruner(BasePruner):
                 manually specify the minimum possible step to ``min_resource``.
         reduction_factor:
             A parameter for specifying reduction factor of promotable trials
-            (in the `paper <http://arxiv.org/abs/1810.05934>`_ this parameter is
+            (in the `paper <https://proceedings.mlsys.org/paper_files/paper/2020/file/
+            a06f20b349c6cf09a6b171c71b88bbfc-Paper.pdf>`_ this parameter is
             referred to as :math:`\\eta`).  At the completion point of each rung,
             about :math:`{1 \\over \\mathsf{reduction}\\_\\mathsf{factor}}`
             trials will be promoted.
         min_early_stopping_rate:
             A parameter for specifying the minimum early-stopping rate
-            (in the `paper <http://arxiv.org/abs/1810.05934>`_ this parameter is
+            (in the `paper <https://proceedings.mlsys.org/paper_files/paper/2020/file/
+            a06f20b349c6cf09a6b171c71b88bbfc-Paper.pdf>`_ this parameter is
             referred to as :math:`s`).
         bootstrap_count:
             Minimum number of trials that need to complete a rung before any trial

--- a/optuna/samplers/_cmaes.py
+++ b/optuna/samplers/_cmaes.py
@@ -101,7 +101,7 @@ class CmaEsSampler(BaseSampler):
       size. In Proceedings of the IEEE Congress on Evolutionary Computation (CEC 2005),
       pages 1769–1776. IEEE Press, 2005. <https://doi.org/10.1109/CEC.2005.1554902>`_
     - `N. Hansen. Benchmarking a BI-Population CMA-ES on the BBOB-2009 Function Testbed.
-      GECCO Workshop, 2009. <https://dl.acm.org/doi/10.1145/1570256.1570333>`_
+      GECCO Workshop, 2009. <https://doi.org/10.1145/1570256.1570333>`_
     - `Raymond Ros, Nikolaus Hansen. A Simple Modification in CMA-ES Achieving Linear Time and
       Space Complexity. 10th International Conference on Parallel Problem Solving From Nature,
       Sep 2008, Dortmund, Germany. inria-00287367. <https://doi.org/10.1007/978-3-540-87700-4_30>`_

--- a/optuna/samplers/_cmaes.py
+++ b/optuna/samplers/_cmaes.py
@@ -99,24 +99,21 @@ class CmaEsSampler(BaseSampler):
       <https://arxiv.org/abs/1604.00772>`_
     - `A. Auger and N. Hansen. A restart CMA evolution strategy with increasing population
       size. In Proceedings of the IEEE Congress on Evolutionary Computation (CEC 2005),
-      pages 1769–1776. IEEE Press, 2005.
-      <http://www.cmap.polytechnique.fr/~nikolaus.hansen/cec2005ipopcmaes.pdf>`_
+      pages 1769–1776. IEEE Press, 2005. <https://doi.org/10.1109/CEC.2005.1554902>`_
     - `N. Hansen. Benchmarking a BI-Population CMA-ES on the BBOB-2009 Function Testbed.
-      GECCO Workshop, 2009.
-      <https://dl.acm.org/doi/10.1145/1570256.1570333>`_
+      GECCO Workshop, 2009. <https://dl.acm.org/doi/10.1145/1570256.1570333>`_
     - `Raymond Ros, Nikolaus Hansen. A Simple Modification in CMA-ES Achieving Linear Time and
       Space Complexity. 10th International Conference on Parallel Problem Solving From Nature,
-      Sep 2008, Dortmund, Germany. inria-00287367.
-      <https://hal.inria.fr/inria-00287367/document>`_
+      Sep 2008, Dortmund, Germany. inria-00287367. <https://doi.org/10.1007/978-3-540-87700-4_30>`_
     - `Masahiro Nomura, Shuhei Watanabe, Youhei Akimoto, Yoshihiko Ozaki, Masaki Onishi.
       Warm Starting CMA-ES for Hyperparameter Optimization, AAAI. 2021.
-      <https://arxiv.org/abs/2012.06932>`_
+      <https://doi.org/10.1609/aaai.v35i10.17109>`_
     - `R. Hamano, S. Saito, M. Nomura, S. Shirakawa. CMA-ES with Margin: Lower-Bounding Marginal
       Probability for Mixed-Integer Black-Box Optimization, GECCO. 2022.
-      <https://arxiv.org/abs/2205.13482>`_
+      <https://doi.org/10.1145/3512290.3528827>`_
     - `M. Nomura, Y. Akimoto, I. Ono. CMA-ES with Learning Rate Adaptation: Can CMA-ES with
       Default Population Size Solve Multimodal and Noisy Problems?, GECCO. 2023.
-      <https://arxiv.org/abs/2304.03473>`_
+      <https://doi.org/10.1145/3583131.3590358>`_
 
     .. seealso::
         You can also use :class:`optuna.integration.PyCmaSampler` which is a sampler using cma

--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -160,7 +160,7 @@ class TPESampler(BaseSampler):
                 <https://papers.nips.cc/paper/4443-algorithms-for-hyper-parameter-optimization.pdf>`_
                 ). The weights of good trials, i.e., trials to construct `l(x)`, are computed by a
                 rule based on the hypervolume contribution proposed in the `paper of MOTPE
-                <https://doi.org/10.1145/3377930.3389817>`_.
+                <https://doi.org/10.1613/jair.1.13188>`_.
         seed:
             Seed for random number generator.
         multivariate:

--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -79,7 +79,7 @@ class TPESampler(BaseSampler):
     For multi-objective TPE (MOTPE), please refer to the following papers:
 
     - `Multiobjective Tree-Structured Parzen Estimator for Computationally Expensive Optimization
-      Problems <https://dl.acm.org/doi/10.1145/3377930.3389817>`_
+      Problems <https://doi.org/10.1145/3377930.3389817>`_
     - `Multiobjective Tree-Structured Parzen Estimator <https://doi.org/10.1613/jair.1.13188>`_
 
     Example:
@@ -160,7 +160,7 @@ class TPESampler(BaseSampler):
                 <https://papers.nips.cc/paper/4443-algorithms-for-hyper-parameter-optimization.pdf>`_
                 ). The weights of good trials, i.e., trials to construct `l(x)`, are computed by a
                 rule based on the hypervolume contribution proposed in the `paper of MOTPE
-                <https://dl.acm.org/doi/10.1145/3377930.3389817>`_.
+                <https://doi.org/10.1145/3377930.3389817>`_.
         seed:
             Seed for random number generator.
         multivariate:

--- a/optuna/samplers/nsgaii/_crossovers/_blxalpha.py
+++ b/optuna/samplers/nsgaii/_crossovers/_blxalpha.py
@@ -15,7 +15,7 @@ class BLXAlphaCrossover(BaseCrossover):
 
     - `Eshelman, L. and J. D. Schaffer.
       Real-Coded Genetic Algorithms and Interval-Schemata. FOGA (1992).
-      <https://www.sciencedirect.com/science/article/abs/pii/B9780080948324500180>`_
+      <https://doi.org/10.1016/B978-0-08-094832-4.50018-0>`_
 
     Args:
         alpha:

--- a/optuna/samplers/nsgaii/_crossovers/_blxalpha.py
+++ b/optuna/samplers/nsgaii/_crossovers/_blxalpha.py
@@ -34,7 +34,7 @@ class BLXAlphaCrossover(BaseCrossover):
         study: Study,
         search_space_bounds: np.ndarray,
     ) -> np.ndarray:
-        # http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.465.6900&rep=rep1&type=pdf
+        # https://doi.org/10.1109/CEC.2001.934452
         # Section 2 Crossover Operators for RCGA 2.1 Blend Crossover
 
         parents_min = parents_params.min(axis=0)

--- a/optuna/samplers/nsgaii/_crossovers/_undx.py
+++ b/optuna/samplers/nsgaii/_crossovers/_undx.py
@@ -19,7 +19,7 @@ class UNDXCrossover(BaseCrossover):
       for real-coded genetic algorithms,
       Proceedings of the 1999 Congress on Evolutionary Computation-CEC99
       (Cat. No. 99TH8406), 1999, pp. 1581-1588 Vol. 2
-      <https://ieeexplore.ieee.org/document/782672>`_
+      <https://doi.org/10.1109/CEC.1999.782672>`_
 
     Args:
         sigma_xi:
@@ -69,7 +69,7 @@ class UNDXCrossover(BaseCrossover):
         study: Study,
         search_space_bounds: np.ndarray,
     ) -> np.ndarray:
-        # https://ieeexplore.ieee.org/document/782672
+        # https://doi.org/10.1109/CEC.1999.782672
         # Section 2 Unimodal Normal Distribution Crossover
         n = len(search_space_bounds)
         xp = (parents_params[0] + parents_params[1]) / 2  # Section 2 (2).

--- a/optuna/samplers/nsgaii/_crossovers/_vsbx.py
+++ b/optuna/samplers/nsgaii/_crossovers/_vsbx.py
@@ -39,7 +39,7 @@ class VSBXCrossover(BaseCrossover):
         study: Study,
         search_space_bounds: np.ndarray,
     ) -> np.ndarray:
-        # https://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.422.952&rep=rep1&type=pdf
+        # https://doi.org/10.1007/3-540-45105-6_86
         # Section 3.2 Crossover Schemes (vSBX)
         if self._eta is None:
             eta = 20.0 if study._is_multi_objective() else 2.0

--- a/optuna/samplers/nsgaii/_crossovers/_vsbx.py
+++ b/optuna/samplers/nsgaii/_crossovers/_vsbx.py
@@ -18,7 +18,7 @@ class VSBXCrossover(BaseCrossover):
     - `Pedro J. Ballester, Jonathan N. Carter.
       Real-Parameter Genetic Algorithms for Finding Multiple Optimal Solutions
       in Multi-modal Optimization. GECCO 2003: 706-717
-      <https://link.springer.com/chapter/10.1007/3-540-45105-6_86>`_
+      <https://doi.org/10.1007/3-540-45105-6_86>`_
 
     Args:
         eta:

--- a/optuna/samplers/nsgaii/_sampler.py
+++ b/optuna/samplers/nsgaii/_sampler.py
@@ -40,7 +40,7 @@ class NSGAIISampler(BaseSampler):
     For further information about NSGA-II, please refer to the following paper:
 
     - `A fast and elitist multiobjective genetic algorithm: NSGA-II
-      <https://ieeexplore.ieee.org/document/996017>`_
+      <https://doi.org/10.1109/4235.996017>`_
 
     Args:
         population_size:

--- a/optuna/terminator/terminator.py
+++ b/optuna/terminator/terminator.py
@@ -34,7 +34,7 @@ class Terminator(BaseTerminator):
     For further information about the algorithm, please refer to the following paper:
 
     - `A. Makarova et al. Automatic termination for hyperparameter optimization.
-      <https://arxiv.org/abs/2104.08166>`_
+      <https://proceedings.mlr.press/v188/makarova22a.html>`_
 
     Args:
         improvement_evaluator:

--- a/optuna/visualization/_edf.py
+++ b/optuna/visualization/_edf.py
@@ -49,7 +49,8 @@ def plot_edf(
 
         EDF is useful to analyze and improve search spaces.
         For instance, you can see a practical use case of EDF in the paper
-        `Designing Network Design Spaces <https://arxiv.org/abs/2003.13678>`_.
+        `Designing Network Design Spaces
+        <https://doi.ieeecomputersociety.org/10.1109/CVPR42600.2020.01044>`_.
 
     .. note::
 


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
Correctly link to papers from our documents (replace links to preprint with journals or conference) and use DOI link as much as possible to progress https://github.com/optuna/optuna/issues/4682



## Description of the changes
Some citations to papers in the documents are not properly linked; for example, some of them are linked to arXiv even if the paper is accepted to a journal or conference. Additionally, some papers are linked to a DOI domain URL, while others are linked to a publisher domain. This pull request updates those links to ensure consistency throughout the documents.
Please note that the URL update in https://github.com/optuna/optuna/commit/6808c869771e8c09e2deba4d5a83a69048cc6bf7 might be incorrect, as these URLs are unavailable. I inferred the correct paper based on the context.