### PR TITLE
adding link for module's example to documetation for the optuna.terminator module

### DIFF
--- a/docs/source/reference/terminator.rst
+++ b/docs/source/reference/terminator.rst
@@ -19,3 +19,5 @@ The :mod:`~optuna.terminator` module implements a mechanism for automatically te
    optuna.terminator.StaticErrorEvaluator
    optuna.terminator.TerminatorCallback
    optuna.terminator.report_cross_validation_scores
+
+   For an example of using the `optuna.terminator` module, please refer to [this link](https://github.com/optuna/optuna-examples/tree/main/terminator).

--- a/docs/source/reference/terminator.rst
+++ b/docs/source/reference/terminator.rst
@@ -20,4 +20,4 @@ The :mod:`~optuna.terminator` module implements a mechanism for automatically te
    optuna.terminator.TerminatorCallback
    optuna.terminator.report_cross_validation_scores
 
-For an example of using the this module, please refer to `this example <https://github.com/optuna/optuna-examples/tree/main/terminator>`_.
+For an example of using this module, please refer to `this example <https://github.com/optuna/optuna-examples/tree/main/terminator>`_.

--- a/docs/source/reference/terminator.rst
+++ b/docs/source/reference/terminator.rst
@@ -20,4 +20,9 @@ The :mod:`~optuna.terminator` module implements a mechanism for automatically te
    optuna.terminator.TerminatorCallback
    optuna.terminator.report_cross_validation_scores
 
-   For an example of using the `optuna.terminator` module, please refer to [this link](https://github.com/optuna/optuna-examples/tree/main/terminator).
+For an example of using the `optuna.terminator` module, please refer to `this link <https://github.com/optuna/optuna-examples/tree/main/terminator>`_.
+
+.. seealso::
+   :ref:`terminator_example` tutorial provides an example of using the `optuna.terminator` module.
+
+.. _terminator_example: https://github.com/optuna/optuna-examples/tree/main/terminator

--- a/docs/source/reference/terminator.rst
+++ b/docs/source/reference/terminator.rst
@@ -20,9 +20,4 @@ The :mod:`~optuna.terminator` module implements a mechanism for automatically te
    optuna.terminator.TerminatorCallback
    optuna.terminator.report_cross_validation_scores
 
-For an example of using the `optuna.terminator` module, please refer to `this link <https://github.com/optuna/optuna-examples/tree/main/terminator>`_.
-
-.. seealso::
-   :ref:`terminator_example` tutorial provides an example of using the `optuna.terminator` module.
-
-.. _terminator_example: https://github.com/optuna/optuna-examples/tree/main/terminator
+For an example of using the this module, please refer to `this example <https://github.com/optuna/optuna-examples/tree/main/terminator>`_.


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

## Description of the changes
I added link for module's example to [documentation](https://optuna.readthedocs.io/en/stable/reference/terminator.html) for the optuna.terminator module as mentioned in the issue (https://github.com/optuna/optuna/issues/5204)
