### PR TITLE
Replace lightgbm with PyTorch-based example to remove lightgbm dependency in visualization tutorial

### DIFF
--- a/tutorial/10_key_features/005_visualization.py
+++ b/tutorial/10_key_features/005_visualization.py
@@ -105,6 +105,7 @@ def eval_model(model, valid_loader):
 
     return accuracy
 
+
 ###################################################################################################
 # Define the objective function.
 def objective(trial):

--- a/tutorial/10_key_features/005_visualization.py
+++ b/tutorial/10_key_features/005_visualization.py
@@ -54,7 +54,7 @@ from optuna.visualization import plot_slice
 from optuna.visualization import plot_timeline
 
 
-SEED = 42
+SEED = 13
 torch.manual_seed(SEED)
 
 DEVICE = torch.device("cuda") if torch.cuda.is_available() else torch.device("cpu")


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

Resolve #5255

## Description of the changes
<!-- Describe the changes in this PR. -->

1. Replace the existing example using lightgbm with PyTorch since Optuna is a part of PyTorch ecosystem. 
The newly added PyTorch example comes from the multi-objective tutorial page: [Multi-objective Optimization with Optuna](https://optuna.readthedocs.io/en/stable/tutorial/20_recipes/002_multi_objective.html). I've removed a few hyperparameters so as not to make the figure less clear due to overlapping text. 
2. Revert the removal of two sections by #5249



