### PR TITLE
Rename variables in `plot_timeline` files

### DIFF
--- a/optuna/visualization/_timeline.py
+++ b/optuna/visualization/_timeline.py
@@ -115,34 +115,35 @@ def _is_running_trials_in_study(study: Study, max_run_duration: datetime.timedel
 
 def _get_timeline_info(study: Study) -> _TimelineInfo:
     bars = []
+
     max_datetime = _get_max_datetime_complete(study)
     timedelta_for_small_bar = datetime.timedelta(seconds=1)
-    for t in study.get_trials(deepcopy=False):
-        date_start = t.datetime_start or max_datetime
-        date_complete = (
+    for trial in study.get_trials(deepcopy=False):
+        datetime_start = trial.datetime_start or max_datetime
+        datetime_complete = (
             max_datetime + timedelta_for_small_bar
-            if t.state == TrialState.RUNNING
-            else t.datetime_complete or date_start + timedelta_for_small_bar
+            if trial.state == TrialState.RUNNING
+            else trial.datetime_complete or datetime_start + timedelta_for_small_bar
         )
         infeasible = (
             False
-            if _CONSTRAINTS_KEY not in t.system_attrs
-            else any([x > 0 for x in t.system_attrs[_CONSTRAINTS_KEY]])
+            if _CONSTRAINTS_KEY not in trial.system_attrs
+            else any([x > 0 for x in trial.system_attrs[_CONSTRAINTS_KEY]])
         )
-        if date_complete < date_start:
+        if datetime_complete < datetime_start:
             _logger.warning(
                 (
-                    f"The start and end times for Trial {t.number} seem to be reversed. "
-                    f"The start time is {date_start} and the end time is {date_complete}."
+                    f"The start and end times for Trial {trial.number} seem to be reversed. "
+                    f"The start time is {datetime_start} and the end time is {datetime_complete}."
                 )
             )
         bars.append(
             _TimelineBarInfo(
-                number=t.number,
-                start=date_start,
-                complete=date_complete,
-                state=t.state,
-                hovertext=_make_hovertext(t),
+                number=trial.number,
+                start=datetime_start,
+                complete=datetime_complete,
+                state=trial.state,
+                hovertext=_make_hovertext(trial),
                 infeasible=infeasible,
             )
         )
@@ -163,15 +164,15 @@ def _get_timeline_plot(info: _TimelineInfo) -> "go.Figure":
     }
 
     fig = go.Figure()
-    for s in sorted(TrialState, key=lambda x: x.name):
-        if s.name == "COMPLETE":
-            infeasible_bars = [b for b in info.bars if b.state == s and b.infeasible]
-            feasible_bars = [b for b in info.bars if b.state == s and not b.infeasible]
+    for state in sorted(TrialState, key=lambda x: x.name):
+        if state.name == "COMPLETE":
+            infeasible_bars = [b for b in info.bars if b.state == state and b.infeasible]
+            feasible_bars = [b for b in info.bars if b.state == state and not b.infeasible]
             _plot_bars(infeasible_bars, "#cccccc", "INFEASIBLE", fig)
-            _plot_bars(feasible_bars, _cm[s.name], s.name, fig)
+            _plot_bars(feasible_bars, _cm[state.name], state.name, fig)
         else:
-            bars = [b for b in info.bars if b.state == s]
-            _plot_bars(bars, _cm[s.name], s.name, fig)
+            bars = [b for b in info.bars if b.state == state]
+            _plot_bars(bars, _cm[state.name], state.name, fig)
     fig.update_xaxes(type="date")
     fig.update_layout(
         go.Layout(

--- a/optuna/visualization/matplotlib/_timeline.py
+++ b/optuna/visualization/matplotlib/_timeline.py
@@ -107,11 +107,11 @@ def _get_timeline_plot(info: _TimelineInfo) -> "Axes":
     fig.tight_layout()
 
     assert len(info.bars) > 0
-    start_time = min([b.start for b in info.bars])
-    complete_time = max([b.complete for b in info.bars])
-    margin = (complete_time - start_time) * 0.05
+    first_start_time = min([b.start for b in info.bars])
+    last_complete_time = max([b.complete for b in info.bars])
+    margin = (last_complete_time - first_start_time) * 0.05
 
-    ax.set_xlim(right=complete_time + margin, left=start_time - margin)
+    ax.set_xlim(right=last_complete_time + margin, left=first_start_time - margin)
     ax.yaxis.set_major_locator(matplotlib.ticker.MaxNLocator(integer=True))
     ax.xaxis.set_major_formatter(matplotlib.dates.DateFormatter("%H:%M:%S"))
     plt.gcf().autofmt_xdate()


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

When I read `plot_timeline`, I'm a bit confused, so I'd like to suggest renaming a few variables.
## Description of the changes
<!-- Describe the changes in this PR. -->

- Avoid single character variable names:  `s` and `t`, appearing multiple lines.
    - `s` is used for `TrialState` but `timeline` plot uses `start` or `trial.datetime_start`, so it is a little bit confusing as a shortform of start related variable.
    - Similarly `t` is used for `Trial`, but these functions often use time and datetime.
- Minor suggestion on variable names