### PR TITLE
Fix inconsistencies between terminator and terminator visualization i…

### DIFF
--- a/optuna/visualization/_terminator_improvement.py
+++ b/optuna/visualization/_terminator_improvement.py
@@ -12,6 +12,8 @@ from optuna.terminator import BaseErrorEvaluator
 from optuna.terminator import BaseImprovementEvaluator
 from optuna.terminator import CrossValidationErrorEvaluator
 from optuna.terminator import RegretBoundEvaluator
+from optuna.terminator.erroreval import StaticErrorEvaluator
+from optuna.terminator.improvement.evaluator import BestValueStagnationEvaluator
 from optuna.terminator.improvement.evaluator import DEFAULT_MIN_N_TRIALS
 from optuna.visualization._plotly_imports import _imports
 
@@ -128,7 +130,10 @@ def _get_improvement_info(
     if improvement_evaluator is None:
         improvement_evaluator = RegretBoundEvaluator()
     if error_evaluator is None:
-        error_evaluator = CrossValidationErrorEvaluator()
+        if isinstance(improvement_evaluator, BestValueStagnationEvaluator):
+            error_evaluator = StaticErrorEvaluator(constant=0)
+        else:
+            error_evaluator = CrossValidationErrorEvaluator()
 
     trial_numbers = []
     completed_trials = []


### PR DESCRIPTION
Hi!

The goal of this pull request is to answer issue #5073 

## Motivation
As mentioned in the issue, the objective is to harmonize the `plot_terminator_improvement` function and `Terminator` class when initializing the `error_evaluator` object. 

## Description of the changes
It adds a similar logic to the initialization of the `error_evaluator` for `plot_terminator_improvement` so that it reflects what the `Terminator` class does.

## Suggestions
Currently, I replicated the logic in `plot_terminator_improvement`. Should I factorize that code with that of the `Terminator` class so that when updated, we do not risk creating the same discrepancy in the future? 

I could add a static method to Terminator to initialize `error_evaluator`. What do you think? That way, I could also add a unit test more easily.
