### PR TITLE
Fix `_split_trials` of `TPESampler` for constrained optimization with constant liar

### DIFF
--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -620,14 +620,16 @@ def _split_trials(
     infeasible_trials = []
 
     for trial in trials:
-        if constraints_enabled and _get_infeasible_trial_score(trial) > 0:
+        if trial.state == TrialState.RUNNING:
+            # We should check if the trial is RUNNING before the feasibility check
+            # because its constraint values have not yet been set.
+            running_trials.append(trial)
+        elif constraints_enabled and _get_infeasible_trial_score(trial) > 0:
             infeasible_trials.append(trial)
         elif trial.state == TrialState.COMPLETE:
             complete_trials.append(trial)
         elif trial.state == TrialState.PRUNED:
             pruned_trials.append(trial)
-        elif trial.state == TrialState.RUNNING:
-            running_trials.append(trial)
         else:
             assert False
 

--- a/tests/samplers_tests/tpe_tests/test_sampler.py
+++ b/tests/samplers_tests/tpe_tests/test_sampler.py
@@ -776,7 +776,6 @@ def test_split_trials(direction: str, constant_liar: bool, constraints: bool) ->
             state=optuna.trial.TrialState.RUNNING,
             params={"x": 0},
             distributions={"x": optuna.distributions.FloatDistribution(-1.0, 1.0)},
-            system_attrs={_CONSTRAINTS_KEY: [-1]},
         )
     )
 


### PR DESCRIPTION
## Motivation
Fix #5291.
The constraint values are set in `after_trial`, then `RUNNING` trials don't have them. It causes unexpected warnings (#5291).

## Description of the changes
Fix  `_split_trials` to check if the state of the trial is `RUNNING` before the feasibility check.