### PR TITLE
Make 2d HV computation twice faster

### DIFF
--- a/optuna/_hypervolume/utils.py
+++ b/optuna/_hypervolume/utils.py
@@ -27,19 +27,13 @@ def _compute_2d(solution_set: np.ndarray, reference_point: np.ndarray) -> float:
             The reference point to compute the hypervolume.
     """
 
+    # Descending order in the 1st objective, and ascending order in the 2nd objective.
     sorted_solution_set = solution_set[np.lexsort((-solution_set[:, 1], solution_set[:, 0]))]
+    reference_points_y = np.append(reference_point[1], sorted_solution_set[:-1, 1])
+    reference_points_y_cummin = np.minimum.accumulate(reference_points_y)
+    mask = sorted_solution_set[:, 1] <= reference_points_y_cummin
 
-    hypervolume = 0.0
-    for solution in sorted_solution_set:
-        if reference_point[1] < solution[1]:
-            continue
-
-        # Compute an area of a rectangle with reference_point
-        # and one point in solution_sets as diagonals.
-        hypervolume += _compute_2points_volume(reference_point, solution)
-
-        # Update a reference_point to create a new hypervolume that
-        # exclude a rectangle from the current hypervolume
-        reference_point[1] = solution[1]
-
-    return hypervolume
+    used_solution = sorted_solution_set[mask]
+    edge_length_x = reference_point[0] - used_solution[:, 0]
+    edge_length_y = reference_points_y_cummin[mask] - used_solution[:, 1]
+    return edge_length_x @ edge_length_y

--- a/optuna/_hypervolume/utils.py
+++ b/optuna/_hypervolume/utils.py
@@ -34,6 +34,6 @@ def _compute_2d(solution_set: np.ndarray, reference_point: np.ndarray) -> float:
     mask = sorted_solution_set[:, 1] <= reference_points_y_cummin
 
     used_solution = sorted_solution_set[mask]
-    edge_length_x = np.abs(reference_point[0] - used_solution[:, 0])
-    edge_length_y = np.abs(reference_points_y_cummin[mask] - used_solution[:, 1])
+    edge_length_x = reference_point[0] - used_solution[:, 0]
+    edge_length_y = reference_points_y_cummin[mask] - used_solution[:, 1]
     return edge_length_x @ edge_length_y

--- a/optuna/_hypervolume/utils.py
+++ b/optuna/_hypervolume/utils.py
@@ -26,6 +26,7 @@ def _compute_2d(solution_set: np.ndarray, reference_point: np.ndarray) -> float:
         reference_point:
             The reference point to compute the hypervolume.
     """
+    assert solution_set.shape[1] == 2 and reference_point.shape[0] == 2
 
     # Ascending order in the 1st objective, and descending order in the 2nd objective.
     sorted_solution_set = solution_set[np.lexsort((-solution_set[:, 1], solution_set[:, 0]))]

--- a/optuna/_hypervolume/utils.py
+++ b/optuna/_hypervolume/utils.py
@@ -27,7 +27,7 @@ def _compute_2d(solution_set: np.ndarray, reference_point: np.ndarray) -> float:
             The reference point to compute the hypervolume.
     """
 
-    # Descending order in the 1st objective, and ascending order in the 2nd objective.
+    # Ascending order in the 1st objective, and descending order in the 2nd objective.
     sorted_solution_set = solution_set[np.lexsort((-solution_set[:, 1], solution_set[:, 0]))]
     reference_points_y = np.append(reference_point[1], sorted_solution_set[:-1, 1])
     reference_points_y_cummin = np.minimum.accumulate(reference_points_y)

--- a/optuna/_hypervolume/utils.py
+++ b/optuna/_hypervolume/utils.py
@@ -36,4 +36,6 @@ def _compute_2d(solution_set: np.ndarray, reference_point: np.ndarray) -> float:
     used_solution = sorted_solution_set[mask]
     edge_length_x = reference_point[0] - used_solution[:, 0]
     edge_length_y = reference_points_y_cummin[mask] - used_solution[:, 1]
-    return edge_length_x @ edge_length_y
+    volume = edge_length_x @ edge_length_y
+    assert volume >= 0, "Hypervolume must be non negative."
+    return volume

--- a/optuna/_hypervolume/utils.py
+++ b/optuna/_hypervolume/utils.py
@@ -34,8 +34,6 @@ def _compute_2d(solution_set: np.ndarray, reference_point: np.ndarray) -> float:
     mask = sorted_solution_set[:, 1] <= reference_points_y_cummin
 
     used_solution = sorted_solution_set[mask]
-    edge_length_x = reference_point[0] - used_solution[:, 0]
-    edge_length_y = reference_points_y_cummin[mask] - used_solution[:, 1]
-    volume = edge_length_x @ edge_length_y
-    assert volume >= 0, "Hypervolume must be non negative."
-    return volume
+    edge_length_x = np.abs(reference_point[0] - used_solution[:, 0])
+    edge_length_y = np.abs(reference_points_y_cummin[mask] - used_solution[:, 1])
+    return edge_length_x @ edge_length_y


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

# Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

As MOTPE is still not quick, I replaced the current Hypervolume 2d computation with numpy vectorization.
By using vectorization, we get a significant speedup.
My implementation halves the runtime for the 2d MOTPE experiment below.

This PR partially relates to:
- https://github.com/optuna/optuna/issues/5203

# Description of the changes
<!-- Describe the changes in this PR. -->

I simply replaced the current implementation with the equivalent vectorization implementation.

# Benchmark

<details>

<summary>Benchmark Code</summary>

```python
from __future__ import annotations

import time

import optuna


def objective2d(trial: optuna.Trial) -> tuple[float, float]:
    x = trial.suggest_float("x", -5, 5)
    y = trial.suggest_float("y", -5, 5)
    return x ** 2 + y ** 2, (x - 2) ** 2 + (y - 2) ** 2


def objective3d(trial: optuna.Trial) -> tuple[float, float]:
    x = trial.suggest_float("x", -5, 5)
    y = trial.suggest_float("y", -5, 5)
    return x ** 2 + y ** 2, (x - 2) ** 2 + (y - 2) ** 2, (x + 2) ** 2 + (y + 2) ** 2


if __name__ == "__main__":
    start = time.time()
    optuna.logging.set_verbosity(optuna.logging.CRITICAL)
    n_trials = 1000
    sampler = optuna.samplers.TPESampler(seed=42)
    study = optuna.create_study(sampler=sampler, directions=["minimize"]*2)
    study.optimize(objective2d, n_trials=n_trials)
    print(f"n_obj=2, {study.sampler}", time.time() - start)
```

</details>

This PR finishes it in about 80 seconds while the original one takes 170 seconds in my local environment.

# Verification

To verify the new implementation, I compared the numerical outputs with the original implementation and my implementation passed the pure comparison with the original implementation.

<details>
<summary>Verification Code</summary>

```python
import time

import numpy as np


def _compute_2points_volume(point1: np.ndarray, point2: np.ndarray) -> float:
    """Compute the hypervolume of the hypercube, whose diagonal endpoints are given 2 points.

    Args:
        point1:
            The first endpoint of the hypercube's diagonal.
        point2:
            The second endpoint of the hypercube's diagonal.
    """

    return float(np.abs(np.prod(point1 - point2)))


def original(solution_set: np.ndarray, reference_point: np.ndarray) -> float:
    """Compute the hypervolume for the two-dimensional space.

    This algorithm divides a hypervolume into
    smaller rectangles and sum these areas.

    Args:
        solution_set:
            The solution set which we want to compute the hypervolume.
        reference_point:
            The reference point to compute the hypervolume.
    """

    sorted_solution_set = solution_set[np.lexsort((-solution_set[:, 1], solution_set[:, 0]))]

    hypervolume = 0.0
    for solution in sorted_solution_set:
        if reference_point[1] < solution[1]:
            continue

        # Compute an area of a rectangle with reference_point
        # and one point in solution_sets as diagonals.
        hypervolume += _compute_2points_volume(reference_point, solution)

        # Update a reference_point to create a new hypervolume that
        # exclude a rectangle from the current hypervolume
        reference_point[1] = solution[1]

    return hypervolume


def this_pr(solution_set: np.ndarray, reference_point: np.ndarray) -> float:
    """Compute the hypervolume for the two-dimensional space.

    This algorithm divides a hypervolume into
    smaller rectangles and sum these areas.

    Args:
        solution_set:
            The solution set which we want to compute the hypervolume.
        reference_point:
            The reference point to compute the hypervolume.
    """
    # Descending order in the 1st objective, and ascending order in the 2nd objective.
    sorted_solution_set = solution_set[np.lexsort((-solution_set[:, 1], solution_set[:, 0]))]
    reference_points_y = np.append(reference_point[1], sorted_solution_set[:-1, 1])
    reference_points_y_cummin = np.minimum.accumulate(reference_points_y)
    mask = sorted_solution_set[:, 1] <= reference_points_y_cummin

    used_solution = sorted_solution_set[mask]
    edge_length_x = reference_point[0] - used_solution[:, 0]
    edge_length_y = reference_points_y_cummin[mask] - used_solution[:, 1]
    return edge_length_x @ edge_length_y


if __name__ == "__main__":
    rng = np.random.RandomState(42)
    for _ in range(30):
        x = rng.normal(size=(100000, 2))
        reference_point = np.max(x, axis=0) * 1.1
        start = time.time()
        ans = original(x.copy(), reference_point.copy())
        print("Original", time.time() - start)
        start = time.time()
        output = this_pr(x.copy(), reference_point.copy())
        print("This PR", time.time() - start)
        assert np.isclose(ans, output), f"{ans=}, {output=}"
```
</details>