### PR TITLE
Replaced `import List`, `import Union`  with `__future__.annotations`

### DIFF
--- a/optuna/pruners/_hyperband.py
+++ b/optuna/pruners/_hyperband.py
@@ -1,9 +1,9 @@
+from __future__ import annotations
+
 import binascii
 import math
 from typing import Container
-from typing import List
 from typing import Optional
-from typing import Union
 
 import optuna
 from optuna import logging
@@ -139,18 +139,18 @@ class HyperbandPruner(BasePruner):
     def __init__(
         self,
         min_resource: int = 1,
-        max_resource: Union[str, int] = "auto",
+        max_resource: str|int = "auto",
         reduction_factor: int = 3,
         bootstrap_count: int = 0,
     ) -> None:
         self._min_resource = min_resource
         self._max_resource = max_resource
         self._reduction_factor = reduction_factor
-        self._pruners: List[SuccessiveHalvingPruner] = []
+        self._pruners: list[SuccessiveHalvingPruner] = []
         self._bootstrap_count = bootstrap_count
         self._total_trial_allocation_budget = 0
-        self._trial_allocation_budgets: List[int] = []
-        self._n_brackets: Optional[int] = None
+        self._trial_allocation_budgets: list[int] = []
+        self._n_brackets: int|None = None
 
         if not isinstance(self._max_resource, int) and self._max_resource != "auto":
             raise ValueError(
@@ -297,7 +297,7 @@ class HyperbandPruner(BasePruner):
                 self,
                 deepcopy: bool = True,
                 states: Optional[Container[TrialState]] = None,
-            ) -> List["optuna.trial.FrozenTrial"]:
+            ) -> list["optuna.trial.FrozenTrial"]:
                 trials = super()._get_trials(deepcopy=deepcopy, states=states)
                 pruner = self.pruner
                 assert isinstance(pruner, HyperbandPruner)


### PR DESCRIPTION
## Motivation
I want to contribute to Optuna's OSS development and decided to work on the `contribution-welcome` tasks on a trial basis.

Among them, #4508 looks a simple task to just add `__future__.annotations` and change the notation of `List`, `Tuple`, `Dict`, `Optional`, and `Union`, so I've committed it.

## Description of the changes
Added:
`from __future__ import annotations`

Deleted:
`from typing import List`
`from typing import Union`

Changed:
`List`; 3 places
`Union`; 1 place
`Optional`; 1 place

*To avoid **Checks / checks** failure, which was not successful in the previous pull request, I've installed a formatter related plugin that complied with black, flakes8.
