### PR TITLE
Updated checks.yml

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -24,6 +24,10 @@ jobs:
       with:
         python-version: 3.8
 
+    - uses: psf/black@stable
+      with:
+        src: "./"
+
     - name: Install
       run: |
         python -m pip install -U pip


### PR DESCRIPTION
## Motivation
I encountered a failure with the **black** formatter in **Checks / checks** when I replaced `import List`, etc. with `__future__.annotations`. According to the other's blog post, it seems to be caused by the descriptions in `checks.yml`, so can I make a slight addition?

I'm not sure if it will work.

![スクリーンショット 2024-03-15 19 33 51](https://github.com/optuna/optuna/assets/58361623/18afffa8-3236-4595-bdbb-89a062dbd600)


## Description of the changes
```
 - uses: psf/black@stable
   with:
     src: "./"
```