### PR TITLE
Renaming CI jobs

### DIFF
--- a/.github/workflows/mac-tests.yml
+++ b/.github/workflows/mac-tests.yml
@@ -1,7 +1,7 @@
 # Run tests on Mac, which are triggered by each master push.
 # Currently, Python3.8 is only used as an environment.
 # This is mainly for the sake of speed.
-name: mac-tests
+name: Mac tests
 
 on:
   push:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,4 +1,4 @@
-name: stale
+name: Stale
 
 on:
   schedule:

--- a/.github/workflows/windows-tests.yml
+++ b/.github/workflows/windows-tests.yml
@@ -1,7 +1,7 @@
 # Run tests on Windows, which are triggered by each master push.
 # Currently, Python3.9 is only used as an environment.
 # This is mainly for the sake of speed.
-name: windows-tests
+name: Windows tests
 
 on:
   push:


### PR DESCRIPTION
## Motivation
Related to #5264

## Description of the changes
Renamed the CI jobs by making changes in the following files:

-  `.github/workflows/mac-tests.yml`
-  `.github/workflows/stale.yml`
-  `.github/workflows/windows-tests.yml`