### PR TITLE
Fix Wilcoxon pruner bug when `best_trial` has no intermediate value

### DIFF
--- a/optuna/pruners/_wilcoxon.py
+++ b/optuna/pruners/_wilcoxon.py
@@ -154,6 +154,11 @@ class WilcoxonPruner(BasePruner):
             return False
 
         if len(best_trial.intermediate_values) == 0:
+            warnings.warn(
+                "The best trial has no intermediate values so WilcoxonPruner cannot prune trials."
+                "If you have added the best trial with Study.add_trial, please consider setting "
+                "intermediate_values argument."
+            )
             return False
 
         best_steps, best_step_values = np.array(list(best_trial.intermediate_values.items())).T

--- a/optuna/pruners/_wilcoxon.py
+++ b/optuna/pruners/_wilcoxon.py
@@ -152,6 +152,9 @@ class WilcoxonPruner(BasePruner):
             best_trial = study.best_trial
         except ValueError:
             return False
+        
+        if len(best_trial.intermediate_values) == 0:
+            return False
 
         best_steps, best_step_values = np.array(list(best_trial.intermediate_values.items())).T
 

--- a/optuna/pruners/_wilcoxon.py
+++ b/optuna/pruners/_wilcoxon.py
@@ -152,7 +152,7 @@ class WilcoxonPruner(BasePruner):
             best_trial = study.best_trial
         except ValueError:
             return False
-        
+
         if len(best_trial.intermediate_values) == 0:
             return False
 

--- a/optuna/pruners/_wilcoxon.py
+++ b/optuna/pruners/_wilcoxon.py
@@ -155,7 +155,7 @@ class WilcoxonPruner(BasePruner):
 
         if len(best_trial.intermediate_values) == 0:
             warnings.warn(
-                "The best trial has no intermediate values so WilcoxonPruner cannot prune trials."
+                "The best trial has no intermediate values so WilcoxonPruner cannot prune trials. "
                 "If you have added the best trial with Study.add_trial, please consider setting "
                 "intermediate_values argument."
             )

--- a/tests/pruners_tests/test_wilcoxon.py
+++ b/tests/pruners_tests/test_wilcoxon.py
@@ -45,7 +45,6 @@ def test_wilcoxon_pruner_when_best_trial_has_no_intermediate_value() -> None:
     assert not trial.should_prune()
 
 
-
 @pytest.mark.parametrize(
     "p_threshold,step_values,expected_should_prune",
     [

--- a/tests/pruners_tests/test_wilcoxon.py
+++ b/tests/pruners_tests/test_wilcoxon.py
@@ -31,6 +31,21 @@ def test_wilcoxon_pruner_first_trial() -> None:
     assert not trial.should_prune()
 
 
+def test_wilcoxon_pruner_when_best_trial_has_no_intermediate_value() -> None:
+    # A pruner is not activated at a first trial.
+    pruner = optuna.pruners.WilcoxonPruner()
+    study = optuna.study.create_study(pruner=pruner)
+    trial = study.ask()
+    study.tell(trial, 10)
+    trial = study.ask()
+    assert not trial.should_prune()
+    trial.report(1, 1)
+    assert not trial.should_prune()
+    trial.report(2, 2)
+    assert not trial.should_prune()
+
+
+
 @pytest.mark.parametrize(
     "p_threshold,step_values,expected_should_prune",
     [


### PR DESCRIPTION

## Motivation
WilcoxonPruner raises error at line
```python
best_steps, best_step_values = np.array(list(best_trial.intermediate_values.items())).T
```
when intermediate_values is empty.

## Description of the changes
Add a conditional.
