### PR TITLE
Make HV calculations in HSSP lazy to speed up

### DIFF
--- a/optuna/_hypervolume/hssp.py
+++ b/optuna/_hypervolume/hssp.py
@@ -30,13 +30,14 @@ def _solve_hssp(
         max_index = int(np.argmax(contribs))
         selected_indices[k] = indices[max_index]
         selected_vecs[k] = rank_i_loss_vals[indices[max_index]].copy()
-        keep = contribs >= 0.0
+        keep = np.ones(contribs.size, dtype=bool)
+        keep[max_index] = False
         contribs = contribs[keep]
         indices = indices[keep]
         if k == subset_size - 1:
             break
 
-        hv_selected = optuna._hypervolume.WFG().compute(selected_vecs[:k + 1], reference_point)
+        hv_selected = optuna._hypervolume.WFG().compute(selected_vecs[: k + 1], reference_point)
         max_contrib = 0.0
         index_from_larger_contrib = np.argsort(-contribs)
         for i in index_from_larger_contrib:
@@ -46,7 +47,7 @@ def _solve_hssp(
                 continue
 
             selected_vecs[k + 1] = rank_i_loss_vals[indices[i]].copy()
-            hv_plus = optuna._hypervolume.WFG().compute(selected_vecs[:k + 2], reference_point)
+            hv_plus = optuna._hypervolume.WFG().compute(selected_vecs[: k + 2], reference_point)
             contribs[i] = hv_plus - hv_selected
             max_contrib = max(contribs[i], max_contrib)
 

--- a/optuna/_hypervolume/hssp.py
+++ b/optuna/_hypervolume/hssp.py
@@ -5,6 +5,39 @@ import numpy as np
 import optuna
 
 
+def _lazy_contribs_update(
+    contribs: np.ndarray,
+    pareto_loss_values: np.ndarray,
+    selected_vecs: np.ndarray,
+    reference_point: np.ndarray,
+) -> np.ndarray:
+    """Lazy update the hypervolume contributions.
+
+    S=selected_indices \ {indices[max_index]}, T=selected_indices, and S' is a subset of S.
+    As we would like to know argmax H(T v {i}) in the next iteration, we can skip HV
+    calculations for j if H(T v {i}) - H(T) > H(S' v {j}) - H(S') >= H(T v {j}) - H(T).
+    We used the submodularity for the inequality above. As the upper bound of contribs[i] is
+    H(S' v {j}) - H(S'), we start to update from i with a higher upper bound so that we can
+    skip more HV calculations.
+    """
+    hv_selected = optuna._hypervolume.WFG().compute(selected_vecs[:-1], reference_point)
+    max_contrib = 0.0
+    index_from_larger_upper_bound_contrib = np.argsort(-contribs)
+    for i in index_from_larger_upper_bound_contrib:
+        if contribs[i] < max_contrib:
+            # Lazy evaluation to reduce HV calculations.
+            # If contribs[i] will not be the maximum next, it is unnecessary to compute it.
+            continue
+
+        selected_vecs[-1] = pareto_loss_values[i].copy()
+        hv_plus = optuna._hypervolume.WFG().compute(selected_vecs, reference_point)
+        # inf - inf in the contribution calculation is always inf.
+        contribs[i] = hv_plus - hv_selected if not np.isinf(hv_plus) else np.inf
+        max_contrib = max(contribs[i], max_contrib)
+
+    return contribs
+
+
 def _solve_hssp(
     rank_i_loss_vals: np.ndarray,
     rank_i_indices: np.ndarray,
@@ -33,33 +66,17 @@ def _solve_hssp(
     for k in range(subset_size):
         max_index = int(np.argmax(contribs))
         selected_indices[k] = indices[max_index]
-        selected_vecs[k] = rank_i_loss_vals[indices[max_index]].copy()
+        selected_vecs[k] = rank_i_loss_vals[max_index].copy()
         keep = np.ones(contribs.size, dtype=bool)
         keep[max_index] = False
         contribs = contribs[keep]
         indices = indices[keep]
+        rank_i_loss_vals = rank_i_loss_vals[keep]
         if k == subset_size - 1:
             break
 
-        hv_selected = optuna._hypervolume.WFG().compute(selected_vecs[: k + 1], reference_point)
-        max_contrib = 0.0
-        # S=selected_indices \ {indices[max_index]}, T=selected_indices, and S' is a subset of S.
-        # As we would like to know argmax H(T v {i}) in the next iteration, we can skip HV
-        # calculations for j if H(T v {i}) - H(T) > H(S' v {j}) - H(S') >= H(T v {j}) - H(T).
-        # We used the submodularity for the inequality above. As the upper bound of contribs[i] is
-        # H(S' v {j}) - H(S'), we start to update from i with a higher upper bound so that we can
-        # skip more HV calculations.
-        index_from_larger_upper_bound_contrib = np.argsort(-contribs)
-        for i in index_from_larger_upper_bound_contrib:
-            if contribs[i] < max_contrib:
-                # Lazy evaluation to reduce HV calculations.
-                # If contribs[i] will not be the maximum next, it is unnecessary to compute it.
-                continue
-
-            selected_vecs[k + 1] = rank_i_loss_vals[indices[i]].copy()
-            hv_plus = optuna._hypervolume.WFG().compute(selected_vecs[: k + 2], reference_point)
-            # inf - inf in the contribution calculation is always inf.
-            contribs[i] = hv_plus - hv_selected if not np.isinf(hv_plus) else np.inf
-            max_contrib = max(contribs[i], max_contrib)
+        contribs = _lazy_contribs_update(
+            contribs, rank_i_loss_vals, selected_vecs[: k + 2], reference_point
+        )
 
     return rank_i_indices[selected_indices]

--- a/optuna/_hypervolume/hssp.py
+++ b/optuna/_hypervolume/hssp.py
@@ -13,7 +13,7 @@ def _lazy_contribs_update(
 ) -> np.ndarray:
     """Lazy update the hypervolume contributions.
 
-    S=selected_indices \ {indices[max_index]}, T=selected_indices, and S' is a subset of S.
+    S=selected_indices - {indices[max_index]}, T=selected_indices, and S' is a subset of S.
     As we would like to know argmax H(T v {i}) in the next iteration, we can skip HV
     calculations for j if H(T v {i}) - H(T) > H(S' v {j}) - H(S') >= H(T v {j}) - H(T).
     We used the submodularity for the inequality above. As the upper bound of contribs[i] is

--- a/optuna/_hypervolume/hssp.py
+++ b/optuna/_hypervolume/hssp.py
@@ -58,30 +58,26 @@ def _solve_hssp(
         return rank_i_indices
 
     assert not np.any(reference_point - rank_i_loss_vals <= 0)
-    # Take unique to avoid a duplication error in case rank_i_loss_vals has `inf`or `-inf`.
-    rank_i_unique_loss_vals, indices_of_unique_loss_vals = np.unique(
-        rank_i_loss_vals, return_index=True, axis=0
-    )
     n_objectives = reference_point.size
-    contribs = np.prod(reference_point - rank_i_unique_loss_vals, axis=-1)
+    contribs = np.prod(reference_point - rank_i_loss_vals, axis=-1)
     selected_indices = np.zeros(subset_size, dtype=int)
     selected_vecs = np.empty((subset_size, n_objectives))
-    indices = np.arange(rank_i_unique_loss_vals.shape[0], dtype=int)
+    indices = np.arange(rank_i_loss_vals.shape[0], dtype=int)
     for k in range(subset_size):
         max_index = int(np.argmax(contribs))
         selected_indices[k] = indices[max_index]
-        selected_vecs[k] = rank_i_unique_loss_vals[max_index].copy()
+        selected_vecs[k] = rank_i_loss_vals[max_index].copy()
         keep = np.ones(contribs.size, dtype=bool)
         keep[max_index] = False
         contribs = contribs[keep]
         indices = indices[keep]
-        rank_i_unique_loss_vals = rank_i_unique_loss_vals[keep]
+        rank_i_loss_vals = rank_i_loss_vals[keep]
         if k == subset_size - 1:
             # We do not need to update contribs at the last iteration.
             break
 
         contribs = _lazy_contribs_update(
-            contribs, rank_i_unique_loss_vals, selected_vecs[: k + 2], reference_point
+            contribs, rank_i_loss_vals, selected_vecs[: k + 2], reference_point
         )
 
-    return rank_i_indices[indices_of_unique_loss_vals[selected_indices]]
+    return rank_i_indices[selected_indices]

--- a/optuna/_hypervolume/hssp.py
+++ b/optuna/_hypervolume/hssp.py
@@ -21,7 +21,8 @@ def _solve_hssp(
     - `Greedy Hypervolume Subset Selection in Low Dimensions
        <https://doi.org/10.1162/EVCO_a_00188>`_
     """
-    assert np.all(reference_point - rank_i_loss_vals >= 0)
+    assert subset_size != rank_i_indices.size
+    assert not np.any(reference_point - rank_i_loss_vals < 0)
     n_objectives = reference_point.size
     contribs = np.prod(reference_point - rank_i_loss_vals, axis=-1)
     selected_indices = np.zeros(subset_size, dtype=int)
@@ -54,7 +55,8 @@ def _solve_hssp(
 
             selected_vecs[k + 1] = rank_i_loss_vals[indices[i]].copy()
             hv_plus = optuna._hypervolume.WFG().compute(selected_vecs[: k + 2], reference_point)
-            contribs[i] = hv_plus - hv_selected
+            # inf - inf in the contribution calculation is always inf.
+            contribs[i] = hv_plus - hv_selected if not np.isinf(hv_plus) else np.inf
             max_contrib = max(contribs[i], max_contrib)
 
     return rank_i_indices[selected_indices]

--- a/optuna/_hypervolume/hssp.py
+++ b/optuna/_hypervolume/hssp.py
@@ -45,7 +45,7 @@ def _solve_hssp_on_unique_loss_vals(
     reference_point: np.ndarray,
 ) -> np.ndarray:
     assert not np.any(reference_point - rank_i_loss_vals <= 0)
-    assert subset_size < rank_i_indices.size
+    assert subset_size <= rank_i_indices.size
     n_objectives = reference_point.size
     contribs = np.prod(reference_point - rank_i_loss_vals, axis=-1)
     selected_indices = np.zeros(subset_size, dtype=int)

--- a/optuna/_hypervolume/hssp.py
+++ b/optuna/_hypervolume/hssp.py
@@ -57,7 +57,7 @@ def _solve_hssp(
     if subset_size == rank_i_indices.size:
         return rank_i_indices
 
-    assert not np.any(reference_point - rank_i_loss_vals < 0)
+    assert not np.any(reference_point - rank_i_loss_vals <= 0)
     n_objectives = reference_point.size
     contribs = np.prod(reference_point - rank_i_loss_vals, axis=-1)
     selected_indices = np.zeros(subset_size, dtype=int)
@@ -73,6 +73,7 @@ def _solve_hssp(
         indices = indices[keep]
         rank_i_loss_vals = rank_i_loss_vals[keep]
         if k == subset_size - 1:
+            # We do not need to update contribs at the last iteration.
             break
 
         contribs = _lazy_contribs_update(

--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -703,8 +703,6 @@ def _split_complete_trials_multi_objective(
     # Hypervolume subset selection problem (HSSP)-based selection
     subset_size = n_below - last_idx
     if subset_size > 0:
-        # TODO(nabenabe0928): Do not call HSSP if subset_size == rank_i_indices.size.
-        # TODO(nabenabe0928): Do not call HSSP if reference_point include `inf` or `nan`.
         rank_i_lvals = lvals[nondomination_ranks == i]
         rank_i_indices = indices[nondomination_ranks == i]
         worst_point = np.max(rank_i_lvals, axis=0)

--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -703,6 +703,8 @@ def _split_complete_trials_multi_objective(
     # Hypervolume subset selection problem (HSSP)-based selection
     subset_size = n_below - last_idx
     if subset_size > 0:
+        # TODO(nabenabe0928): Do not call HSSP if subset_size == rank_i_indices.size.
+        # TODO(nabenabe0928): Do not call HSSP if reference_point include `inf` or `nan`.
         rank_i_lvals = lvals[nondomination_ranks == i]
         rank_i_indices = indices[nondomination_ranks == i]
         worst_point = np.max(rank_i_lvals, axis=0)

--- a/tests/hypervolume_tests/test_hssp.py
+++ b/tests/hypervolume_tests/test_hssp.py
@@ -53,3 +53,13 @@ def test_solve_hssp_infinite_loss() -> None:
         truth, approx = _compute_hssp_truth_and_approx(test_case, subset_size)
         assert np.isinf(truth)
         assert np.isinf(approx)
+
+
+@pytest.mark.filterwarnings("ignore::RuntimeWarning")
+def test_solve_hssp_duplicated_infinite_loss() -> None:
+    test_case = np.array([[np.inf, 0, 0], [np.inf, 0, 0], [0, np.inf, 0], [0, 0, np.inf]])
+    r = np.full(3, np.inf)
+    res = optuna._hypervolume._solve_hssp(
+        rank_i_loss_vals=test_case, rank_i_indices=np.arange(4), subset_size=2, reference_point=r
+    )
+    assert (0 not in res) or (1 not in res)


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

As the HSSP for more than two objectives is still very slow, I introduce a lazy evaluation of HV calculations.
This PR relates to the following issue:
- https://github.com/optuna/optuna/issues/5285

## Description of the changes
<!-- Describe the changes in this PR. -->

This PR speeds up HSSP by using the following property:
- contributions for each point can always be calculated by an HV calculation,
- it is unnecessary to calculate HVs if we already know they will not be the maximum contribution in the next iteration, and
- we update the hypervolume from the ones with higher upper bound based on the submodularity.

The new algorithm does not change the output of this function, so the results obtained by TPESampler will also be preserved after this PR is merged. 

## Mathematical Background for Submodularity

When we define $S \subseteq T \subseteq [N] \coloneqq \\{1,2,...,N\\}$ and the hypervolume measure as $H(S)$, the hypervolume measure is known to have the submodularity, i.e. $H(S \cup \\{i\\}) - H(S) \geq H(T \cup \\{i\\}) - H(T)$ holds for $i \in [N] \setminus T$.

At each iteration, we pick an index of a point $i \in \max_{i^\prime \in [N] \setminus S} H(S \cup \\{i^\prime\\}) - H(S)$ and increment $S$ to $T \coloneqq S \cup \\{i\\}$, the problem here is that the calculation of $H(S \cup \\{i^\prime\\})$ is expensive and we would like to avoid unnecessary calculations as much as possible.

Once we start to calculate, every single $H(S \cup \\{i\\})$ for each $i$ will be recorded every time they are calculated for some $S^\prime \subseteq S \subseteq [N]$.
However, if there exists an index $i \in [N] \setminus S$ such that $H(S \cup \\{i\\}) - H(S) \geq H(S^\prime \cup \\{j\\}) - H(S^\prime) \geq H(S \cup \\{j\\}) - H(S)$ for $j \in [N] \setminus S$, it is unnecessary to calculate $H(S \cup \\{j\\})$ for now.
In principle, we can skip some calculations based on the submodularity as discussed above.

Furthermore, we start to calculate $H(S \cup \\{i\\})$ with $i$ that has a larger upper bound $H(S^\prime \cup \\{i\\})$ because we are likely to end up skipping more calculations.