### PR TITLE
Generete CLI documentation using sphinx extension

### DIFF
--- a/docs/source/_ext/optunacli/ext.py
+++ b/docs/source/_ext/optunacli/ext.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+from typing import Any
+
+from docutils import nodes
+from docutils.frontend import OptionParser
+from docutils.parsers.rst import Directive
+from docutils.parsers.rst import Parser
+from docutils.parsers.rst.directives import unchanged
+from docutils.statemachine import StringList
+from docutils.utils import new_document
+import sphinx
+
+from optuna.version import __version__
+
+from .parser import parse_parsers
+
+
+def render_list(
+    structured_texts: list[str | nodes.definition], settings: Any = None
+) -> list[nodes.Node]:
+    """
+    Given a list of reStructuredText or MarkDown sections, return a docutils node list
+    """
+    if len(structured_texts) == 0:
+        return []
+    all_subcommands = []
+    for element in structured_texts:
+        if isinstance(element, str):
+            if settings is None:
+                settings = OptionParser(components=(Parser,)).get_default_values()
+            document = new_document(None, settings)
+            Parser().parse(element + "\n", document)
+            all_subcommands += document.children
+        elif isinstance(element, nodes.definition):
+            all_subcommands += element
+
+    return all_subcommands
+
+
+def print_action_groups(data: dict[str, Any], settings: Any = None) -> list[nodes.section]:
+    nodes_list = []
+    for action_group in data["action_groups"]:
+        # Create a new section for each action group, e.g., positional arguments or options.
+        section = nodes.section(ids=[action_group["title"].replace(" ", "-").lower()])
+        section += nodes.title(action_group["title"], action_group["title"])
+
+        # Collect all arguments in the action group except for the ones shared among all
+        # subcommands.
+        arguments = []
+        for action in action_group["actions"]:
+            argument = []
+            if action.get("help"):
+                argument.append(action["help"])
+            if action.get("description"):
+                argument.append(action["description"])
+
+            # Add possible choices and default values as a field list.
+            if action.get("choices"):
+                argument.append(
+                    f"Possible choices: {', '.join(str(choice) for choice in action['choices'])}\n"
+                )
+            default = action.get("default")
+            if default not in ['"==SUPPRESS=="', "==SUPPRESS==", None]:
+                argument.append(f"Default: {default}")
+
+            term = ", ".join(action["prog"])
+            arguments.append(
+                nodes.option_list_item(
+                    "",
+                    nodes.option_group("", nodes.option_string(text=term)),
+                    nodes.description("", *render_list(argument, settings)),
+                )
+            )
+
+        section += nodes.option_list("", *arguments)
+        nodes_list.append(section)
+    return nodes_list
+
+
+def create_section(action: dict[str, Any], title: str | None = None, settings: Any = None):
+    # Create a new section for each action.
+    title = title or action["name"]
+    sections = nodes.section(ids=title)
+    sections += nodes.title(title, title)
+    if action.get("help"):
+        sections += nodes.paragraph(text=action["help"])
+
+    sections += nodes.literal_block(text=action["usage"])
+    for section in print_action_groups(action, settings=settings):
+        sections += section
+
+    return sections
+
+
+class ArgParseDirective(Directive):
+    has_content = True
+    option_spec = dict(
+        deprecated=unchanged,
+    )
+
+    def _nested_parse_paragraph(self, text: str) -> nodes.paragraph:
+        content = nodes.paragraph()
+        self.state.nested_parse(StringList(text.split("\n")), 0, content)
+        return content
+
+    def run(self) -> list[nodes.Node]:
+        # Set deprecated subcommand if specified.
+        self.deprecated = self.options.get("deprecated") or []
+
+        parsed_args = parse_parsers()
+
+        # Add common contents to the document.
+        items = []
+        items.extend(
+            create_section(
+                parsed_args,
+                settings=self.state.document.settings,
+            )
+        )
+        for subcommand in parsed_args["subcommands"]:
+            if subcommand["name"] in self.deprecated:
+                continue
+            items.extend(
+                create_section(
+                    subcommand,
+                    settings=self.state.document.settings,
+                )
+            )
+        return items
+
+
+def setup(app: sphinx.application.Sphinx) -> dict[str, bool | str]:
+    app.add_directive("argparse", ArgParseDirective)
+    return {"parallel_read_safe": True, "version": __version__}

--- a/docs/source/_ext/optunacli/parser.py
+++ b/docs/source/_ext/optunacli/parser.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from argparse import ArgumentParser
+
+from optuna.cli import _get_parser
+
+
+def _format_usage(parser: ArgumentParser) -> str:
+    """Format the usage without any prefixes"""
+    fmt = parser._get_formatter()
+    fmt.add_usage(parser.usage, parser._actions, parser._mutually_exclusive_groups, prefix="")
+    return fmt.format_help().strip()
+
+
+def parse_arguments(parser, shared_actions: set | None = None):
+    """Collect all arguments"""
+    shared_actions = shared_actions or set()
+    ignored_actions = {"==SUPPRESS==", "help"}
+
+    action_groups = []
+    for action_group in parser._action_groups:
+        actions = []
+        for action in action_group._group_actions:
+            # Skip arguments shared among all subcommands.
+            if action.dest in shared_actions or action.dest in ignored_actions:
+                continue
+            action_data = {
+                "name": action.dest,
+                "default": f'"{action.default}"',
+                "help": action.help,
+                "choices": action.choices,
+                "prog": action.option_strings,
+            }
+            actions.append(action_data)
+        # The titles are either 'positional arguments', 'options' or 'shared_actions'
+        # until any custom action group is added.
+        if actions:
+            action_groups.append({"title": action_group.title, "actions": actions})
+    return action_groups
+
+
+def parse_parser(parser: ArgumentParser, shared_actions: set[str]) -> dict:
+    """Parse an ArgumentParser object into a dict."""
+    data = {
+        "name": parser.prog,
+        "description": parser.description,
+        "usage": _format_usage(parser),
+        "prog": parser.prog,
+        "action_groups": parse_arguments(parser, shared_actions=shared_actions),
+    }
+    return data
+
+
+def parse_parsers():
+    "Collect the shared optional arguments among all subcommands."
+    main_parser, parent_parser, command_name_to_subparser = _get_parser()
+
+    # Currently, only unnamed optional arguments are shared among all subcommands.
+    shared_actions = parse_arguments(parent_parser)[0]
+    shared_actions["title"] = "shared options"
+    shared_actions_set = {action["name"] for action in shared_actions["actions"]}
+
+    main_parser.prog = "optuna"
+    parsed_args = parse_parser(main_parser, shared_actions_set)
+    parsed_args["action_groups"].append(shared_actions)
+
+    parsed_args["subcommands"] = []
+    for command_name, subparser in command_name_to_subparser.items():
+        subparser.prog = f"optuna {command_name}"
+        parsed_args["subcommands"].append(parse_parser(subparser, shared_actions_set))
+
+    return parsed_args

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -12,10 +12,10 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-# import os
-# import sys
-# sys.path.insert(0, os.path.abspath('.'))
+import os
+import sys
 
+# sys.path.insert(0, os.path.abspath('.'))
 import warnings
 
 import plotly.io as pio
@@ -23,7 +23,6 @@ from sklearn.exceptions import ConvergenceWarning
 from sphinx_gallery.sorting import FileNameSortKey
 
 import optuna
-
 
 # -- Project information -----------------------------------------------------
 
@@ -45,7 +44,9 @@ release = optuna.version.__version__
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
+sys.path.append(os.path.abspath("./_ext"))
 extensions = [
+    "optunacli.ext",
     "sphinx.ext.autodoc",
     "sphinx.ext.autosummary",
     "sphinx.ext.doctest",

--- a/docs/source/reference/cli.rst
+++ b/docs/source/reference/cli.rst
@@ -5,11 +5,8 @@ optuna.cli
 
 The :mod:`~optuna.cli` module implements Optuna's command-line functionality.
 
-For detail, please see the result of
-
-.. code-block:: console
-
-    $ optuna --help
+.. argparse::
+    :deprecated: study optimize
 
 .. seealso::
     The :ref:`cli` tutorial provides use-cases with examples.

--- a/optuna/cli.py
+++ b/optuna/cli.py
@@ -1029,7 +1029,10 @@ def _add_commands(
     for command_name, command_type in _COMMANDS.items():
         command = command_type()
         subparser = subparsers.add_parser(
-            command_name, parents=[parent_parser], help=inspect.getdoc(command_type)
+            command_name,
+            parents=[parent_parser],
+            help=inspect.getdoc(command_type),
+            description=inspect.getdoc(command_type),
         )
         command.add_arguments(subparser)
         subparser.set_defaults(handler=command.take_action)

--- a/optuna/cli.py
+++ b/optuna/cli.py
@@ -1044,7 +1044,9 @@ def _add_commands(
     return command_name_to_subparser
 
 
-def _get_parser(description: str = "") -> Tuple[ArgumentParser, Dict[str, ArgumentParser]]:
+def _get_parser(
+    description: str = "",
+) -> Tuple[ArgumentParser, ArgumentParser, Dict[str, ArgumentParser]]:
     # Use `parent_parser` is necessary to avoid namespace conflict for -h/--help
     # between `main_parser` and `subparser`.
     parent_parser = ArgumentParser(add_help=False)
@@ -1055,7 +1057,8 @@ def _get_parser(description: str = "") -> Tuple[ArgumentParser, Dict[str, Argume
         "--version", action="version", version="{0} {1}".format("optuna", optuna.__version__)
     )
     command_name_to_subparser = _add_commands(main_parser, parent_parser)
-    return main_parser, command_name_to_subparser
+    # Return parent_parser only for documenting purpose.
+    return main_parser, parent_parser, command_name_to_subparser
 
 
 def _preprocess_argv(argv: List[str]) -> List[str]:
@@ -1107,7 +1110,7 @@ def _set_log_file(args: Namespace) -> None:
 
 
 def main() -> int:
-    main_parser, command_name_to_subparser = _get_parser()
+    main_parser, _, command_name_to_subparser = _get_parser()
 
     argv = sys.argv
     preprocessed_argv = _preprocess_argv(argv)


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
Add documentation of optuna cli based on help message.

## Description of the changes
Add sphinx extension to generate cli document.
This extention generates document by
1. actually creating `ArgumentParser`.
2. extract options shared among all subcomands from parent_parser.
3. extract options of `optuna` command, (only `--version` for now)
4. extract  optional and potitional argument of `optuna XXX` sub commands 
5. parse them into sphinx's `Directive` class.
