### PR TITLE
Fix `average_is_best` implementation in `WilcoxonPruner`

### DIFF
--- a/optuna/pruners/_wilcoxon.py
+++ b/optuna/pruners/_wilcoxon.py
@@ -198,10 +198,14 @@ class WilcoxonPruner(BasePruner):
 
         if study.direction == StudyDirection.MAXIMIZE:
             alt = "less"
-            average_is_best = sum(best_step_values) / len(best_step_values) <= sum(step_values) / len(step_values)
+            average_is_best = sum(best_step_values) / len(best_step_values) <= sum(
+                step_values
+            ) / len(step_values)
         else:
             alt = "greater"
-            average_is_best = sum(best_step_values) / len(best_step_values) >= sum(step_values) / len(step_values)
+            average_is_best = sum(best_step_values) / len(best_step_values) >= sum(
+                step_values
+            ) / len(step_values)
 
         # We use zsplit to avoid the problem when all values are zero.
         p = ss.wilcoxon(diff_values, alternative=alt, zero_method="zsplit").pvalue

--- a/optuna/pruners/_wilcoxon.py
+++ b/optuna/pruners/_wilcoxon.py
@@ -198,10 +198,10 @@ class WilcoxonPruner(BasePruner):
 
         if study.direction == StudyDirection.MAXIMIZE:
             alt = "less"
-            average_is_best = best_trial.value <= sum(step_values) / len(step_values)
+            average_is_best = sum(best_step_values) / len(best_step_values) <= sum(step_values) / len(step_values)
         else:
             alt = "greater"
-            average_is_best = best_trial.value >= sum(step_values) / len(step_values)
+            average_is_best = sum(best_step_values) / len(best_step_values) >= sum(step_values) / len(step_values)
 
         # We use zsplit to avoid the problem when all values are zero.
         p = ss.wilcoxon(diff_values, alternative=alt, zero_method="zsplit").pvalue


### PR DESCRIPTION

## Motivation
Since we cannot assume that the objective value is the mean of all steps when using WilcoxonPruner, we must compare average with explicitly computed average.

