### PR TITLE
Make `plot_contour` faster

### DIFF
--- a/optuna/visualization/_contour.py
+++ b/optuna/visualization/_contour.py
@@ -17,7 +17,7 @@ from optuna.visualization._utils import _filter_nonfinite
 from optuna.visualization._utils import _is_log_scale
 from optuna.visualization._utils import _is_numerical
 from optuna.visualization._utils import _is_reverse_scale
-
+import numpy as np
 
 if _imports.is_successful():
     from optuna.visualization._plotly_imports import Contour
@@ -218,12 +218,12 @@ def _get_contour_subplot(
                 infeasible.x.append(x_value)
                 infeasible.y.append(y_value)
 
-    z_values = [
-        [float("nan") for _ in range(len(info.xaxis.indices))]
-        for _ in range(len(info.yaxis.indices))
-    ]
-    for (x_i, y_i), z_value in info.z_values.items():
-        z_values[y_i][x_i] = z_value
+    z_values = np.full((len(info.xaxis.indices), len(info.yaxis.indices)), np.nan)
+
+    xys = np.array(list(info.z_values.keys()))
+    zs = np.array(list(info.z_values.values()))
+
+    z_values[xys[:, 0], xys[:, 1]] = zs
 
     if len(x_indices) < 2 or len(y_indices) < 2:
         return go.Contour(), go.Scatter(), go.Scatter()

--- a/optuna/visualization/_contour.py
+++ b/optuna/visualization/_contour.py
@@ -220,7 +220,7 @@ def _get_contour_subplot(
                 infeasible.x.append(x_value)
                 infeasible.y.append(y_value)
 
-    z_values = np.full((len(info.xaxis.indices), len(info.yaxis.indices)), np.nan)
+    z_values = np.full((len(y_indices), len(x_indices)), np.nan)
 
     xys = np.array(list(info.z_values.keys()))
     zs = np.array(list(info.z_values.values()))

--- a/optuna/visualization/_contour.py
+++ b/optuna/visualization/_contour.py
@@ -225,7 +225,7 @@ def _get_contour_subplot(
     xys = np.array(list(info.z_values.keys()))
     zs = np.array(list(info.z_values.values()))
 
-    z_values[xys[:, 0], xys[:, 1]] = zs
+    z_values[xys[:, 1], xys[:, 0]] = zs
 
     if len(x_indices) < 2 or len(y_indices) < 2:
         return go.Contour(), go.Scatter(), go.Scatter()

--- a/optuna/visualization/_contour.py
+++ b/optuna/visualization/_contour.py
@@ -5,6 +5,8 @@ from typing import Any
 from typing import Callable
 from typing import NamedTuple
 
+import numpy as np
+
 from optuna.logging import get_logger
 from optuna.samplers._base import _CONSTRAINTS_KEY
 from optuna.study import Study
@@ -17,7 +19,7 @@ from optuna.visualization._utils import _filter_nonfinite
 from optuna.visualization._utils import _is_log_scale
 from optuna.visualization._utils import _is_numerical
 from optuna.visualization._utils import _is_reverse_scale
-import numpy as np
+
 
 if _imports.is_successful():
     from optuna.visualization._plotly_imports import Contour


### PR DESCRIPTION
## Motivation
`plot_contour` is very slow because it is currently not using `numpy`. I used `numpy` to speed up.

## Description of the changes
Use `numpy`.

I tested the change with the following benchmark.

```
import optuna
study = optuna.create_study()
study.optimize(lambda t: sum(t.suggest_float(f"x{i}", 0, 1) for i in range(10)), n_trials=1000)

fig = optuna.visualization.plot_contour(study)
```

Before: 3min 9.4secs
After: 3.6secs