### PR TITLE
[Backport] Fix `average_is_best` implementation in `WilcoxonPruner`

### DIFF
--- a/optuna/pruners/_wilcoxon.py
+++ b/optuna/pruners/_wilcoxon.py
@@ -189,10 +189,14 @@ class WilcoxonPruner(BasePruner):
 
         if study.direction == StudyDirection.MAXIMIZE:
             alt = "less"
-            average_is_best = best_trial.value <= sum(step_values) / len(step_values)
+            average_is_best = sum(best_step_values) / len(best_step_values) <= sum(
+                step_values
+            ) / len(step_values)
         else:
             alt = "greater"
-            average_is_best = best_trial.value >= sum(step_values) / len(step_values)
+            average_is_best = sum(best_step_values) / len(best_step_values) >= sum(
+                step_values
+            ) / len(step_values)
 
         # We use zsplit to avoid the problem when all values are zero.
         p = ss.wilcoxon(diff_values, alternative=alt, zero_method="zsplit").pvalue


### PR DESCRIPTION
Fix `average_is_best` implementation in `WilcoxonPruner`

<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
I want to backport PR#5366 to release-v3.6.1 branch.
## Description of the changes
<!-- Describe the changes in this PR. -->
