### PR TITLE
Prefer last trials for best trial

### DIFF
--- a/optuna/storages/_rdb/models.py
+++ b/optuna/storages/_rdb/models.py
@@ -206,6 +206,7 @@ class TrialModel(BaseModel):
                     )
                 ),
                 desc(TrialValueModel.value),
+                desc(cls.trial_id),
             )
             .limit(1)
             .one_or_none()
@@ -232,6 +233,7 @@ class TrialModel(BaseModel):
                     )
                 ),
                 asc(TrialValueModel.value),
+                desc(cls.trial_id),
             )
             .limit(1)
             .one_or_none()


### PR DESCRIPTION
## Motivation
Currently, when there are trials with same best value, Optuna selects the first trial to be best trial. This can happen when the value space is quite discrete and the hyperparameter change rarely affects the value.

In my experience though, the first best trials could have been a fluke specially when it came from the first few trials, when Optuna should still be exploring or warming up. Meanwhile the actual best trials are among the last trials (with same best value) after Optuna has exploited enough. So I think it's better to use the last best trial.

## Description of the changes
When selecting best trial, order the trials by trial id descending after the value.