### PR TITLE
Refactor `_normalize_objective_values` in NSGA3 to supress RuntimeWarning

### DIFF
--- a/optuna/samplers/_nsgaiii/_elite_population_selection_strategy.py
+++ b/optuna/samplers/_nsgaiii/_elite_population_selection_strategy.py
@@ -191,7 +191,8 @@ def _normalize_objective_values(objective_matrix: np.ndarray) -> np.ndarray:
     ):
         intercepts_inv = np.linalg.solve(extreme_points, np.ones(n_objectives))
     else:
-        intercepts_inv = 1 / np.max(objective_matrix, axis=0)
+        intercepts = np.max(objective_matrix, axis=0)
+        intercepts_inv = 1 / np.where(intercepts == 0, 1, intercepts)
     objective_matrix *= np.where(np.isfinite(intercepts_inv), intercepts_inv, 1)
 
     return objective_matrix


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

I want to supress `RuntimeWarning: divide by zero encountered in divide` which occurs in testing `tests/samplers_tests/test_nsgaiii.py`, without making any change in behaviour of code.

## Description of the changes
<!-- Describe the changes in this PR. -->

Replaced zeros in the denominator array with ones.