### PR TITLE
Make `ObjectiveFuncType` available externally

### DIFF
--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -46,7 +46,8 @@ if TYPE_CHECKING:
     from optuna.trial import FrozenTrial
     from optuna.trial import Trial
 
-    ObjectiveFuncType = Callable[[Trial], Union[float, Sequence[float]]]
+
+ObjectiveFuncType = Callable[["Trial"], Union[float, Sequence[float]]]
 
 
 _SYSTEM_ATTR_METRIC_NAMES = "study:metric_names"


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

As `ObjectiveFuncType` is used in other modules such as `optuna-integration` and `optuna-examples`, and it is useful for typing anyways, I will make it available again externally.

## Description of the changes
<!-- Describe the changes in this PR. -->

`ObjectiveFuncType` was made available only for type checking in
- https://github.com/optuna/optuna/pull/5391
and I will make it available again.