### PR TITLE
Allow users to modify categorical distance more easily

### DIFF
--- a/optuna/samplers/_tpe/parzen_estimator.py
+++ b/optuna/samplers/_tpe/parzen_estimator.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
 from typing import Callable
 from typing import Dict
 from typing import NamedTuple
@@ -178,6 +179,26 @@ class _ParzenEstimator:
                 transformed_observations, low, high, step, parameters
             )
 
+    @staticmethod
+    def _calculate_categorical_weights_by_categorical_distance(
+        param_name: str,
+        weights: np.ndarray,
+        observed_indices: np.ndarray,
+        choices: Sequence[CategoricalChoiceType],
+        parameters: _ParzenEstimatorParameters,
+    ) -> np.ndarray:
+        n_kernels, n_choices = weights.shape
+        assert parameters.prior_weight is not None
+        # TODO(nabenabe0928): Think about how to handle combinatorial explosion.
+        # The time complexity is O(n_choices * used_indices.size), so n_choices cannot be huge.
+        used_indices, rev_indices = np.unique(observed_indices, return_inverse=True)
+        dist_func = parameters.categorical_distance_func[param_name]
+        dists = np.array([[dist_func(choices[i], c) for c in choices] for i in used_indices])
+        coef = np.log(n_kernels / parameters.prior_weight) * np.log(n_choices) / np.log(6)
+        cat_weights = np.exp(-((dists / np.max(dists, axis=1)[:, np.newaxis]) ** 2) * coef)
+        weights[: len(observed_indices)] = cat_weights[rev_indices]
+        return weights
+
     def _calculate_categorical_distributions(
         self,
         observations: np.ndarray,
@@ -200,14 +221,13 @@ class _ParzenEstimator:
         )
         observed_indices = observations.astype(int)
         if param_name in parameters.categorical_distance_func:
-            # TODO(nabenabe0928): Think about how to handle combinatorial explosion.
-            # The time complexity is O(n_choices * used_indices.size), so n_choices cannot be huge.
-            used_indices, rev_indices = np.unique(observed_indices, return_inverse=True)
-            dist_func = parameters.categorical_distance_func[param_name]
-            dists = np.array([[dist_func(choices[i], c) for c in choices] for i in used_indices])
-            coef = np.log(n_kernels / parameters.prior_weight) * np.log(n_choices) / np.log(6)
-            cat_weights = np.exp(-((dists / np.max(dists, axis=1)[:, np.newaxis]) ** 2) * coef)
-            weights[: len(observed_indices)] = cat_weights[rev_indices]
+            weights = self._calculate_categorical_weights_by_categorical_distance(
+                param_name=param_name,
+                weights=weights,
+                observed_indices=observed_indices,
+                choices=choices,
+                parameters=parameters,
+            )
         else:
             weights[np.arange(len(observed_indices)), observed_indices] += 1
 

--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -318,6 +318,7 @@ class TPESampler(BaseSampler):
         self._search_space = IntersectionSearchSpace(include_pruned=True)
         self._constant_liar = constant_liar
         self._constraints_func = constraints_func
+        self._parzen_estimator_cls = _ParzenEstimator
 
         if multivariate:
             warnings.warn(
@@ -514,12 +515,17 @@ class TPESampler(BaseSampler):
             weights_below = _calculate_weights_below_for_multi_objective(
                 study, trials, self._constraints_func
             )[param_mask_below]
-            mpe = _ParzenEstimator(
+            mpe = self._parzen_estimator_cls(
                 observations, search_space, self._parzen_estimator_parameters, weights_below
             )
         else:
-            mpe = _ParzenEstimator(observations, search_space, self._parzen_estimator_parameters)
+            mpe = self._parzen_estimator_cls(
+                observations, search_space, self._parzen_estimator_parameters
+            )
 
+        assert isinstance(
+            mpe, _ParzenEstimator
+        ), "_parzen_estimator_cls must override _ParzenEstimator"
         return mpe
 
     def _compute_acquisition_func(

--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -524,9 +524,9 @@ class TPESampler(BaseSampler):
                 observations, search_space, self._parzen_estimator_parameters
             )
 
-        assert isinstance(
-            mpe, _ParzenEstimator
-        ), "_parzen_estimator_cls must override _ParzenEstimator"
+        if not isinstance(mpe, _ParzenEstimator):
+            raise RuntimeError("_parzen_estimator_cls must override _ParzenEstimator.")
+
         return mpe
 
     def _compute_acquisition_func(

--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -318,6 +318,7 @@ class TPESampler(BaseSampler):
         self._search_space = IntersectionSearchSpace(include_pruned=True)
         self._constant_liar = constant_liar
         self._constraints_func = constraints_func
+        # NOTE(nabenabe0928): Users can overwrite _ParzenEstimator to customize the TPE behavior.
         self._parzen_estimator_cls = _ParzenEstimator
 
         if multivariate:


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

Categorical distance was recently supported by Optuna, but its speed is not really quick when there are many categorical choices.

This PR aims to alleviate this situation by letting users to customize the categorical distance part directly.
The customization is especially beneficial when the distance calculations can be performed in the NumPy vectorization.

To see the batch effect, we use the following common code:

<details>
<summary>Common Code</summary>

```python
from __future__ import annotations

import itertools

import numpy as np

from numba import njit


@njit()
def calculate_distances(vecs: np.ndarray) -> np.ndarray:
    # NOTE: NumPy implementation requires the memory complexity of O(DN**2).
    # This function requires the memory complexity of only O(N**2).
    (N, D) = vecs.shape
    distances = np.zeros((N, N), dtype=np.float32)
    for i in range(N - 1):
        for j in range(i + 1, N):
            for d in range(D):
                distances[i, j] += (vecs[i, d] - vecs[j, d]) ** 2

            distances[i, j] = np.sqrt(distances[i, j])
            distances[j, i] = distances[i, j]

    return distances


class ProbabilitiesOnDiscreteSimplex:
    def __init__(self, n_choices: int, denominator: int):
        assert n_choices <= 10, f"n_choices>=11 is too large to handle with categorical distance."
        _prob_vecs: list[float] = []
        for comb in itertools.combinations(range(n_choices + denominator - 1), n_choices - 1):
            partitions = np.array([-1] + list(comb) + [n_choices + denominator - 1])
            counts = partitions[1:] - partitions[:-1] - 1
            assert np.all(counts >= 0) and np.sum(counts) == denominator
            _prob_vecs.append(counts / denominator)

        self._prob_vecs = np.asarray(_prob_vecs, dtype=np.float32)
        self._distances = calculate_distances(self._prob_vecs)
        self._n_grids = len(self._prob_vecs)

    @property
    def n_grids(self) -> int:
        return self._n_grids

    def distance(self, i1: int, i2: int) -> float:
        return self._distances[i1, i2]

    def distance_for_indices(self, indices: np.ndarray) -> np.ndarray:
        return self._distances[indices]


def objective(trial: optuna.Trial, prob_on_simplex: ProbabilitiesOnDiscreteSimplex) -> float:
    assign_indices = np.arange(prob_on_simplex.n_grids).tolist()
    assign_index = trial.suggest_categorical("assign_index", choices=assign_indices)
    assign_ratios = prob_on_simplex._prob_vecs[assign_index]
    return np.var(assign_ratios)
```

</details>

The current implementation requires users to modify in this way::

<details>
<summary>Current Possible Modification</summary>

```python
import optuna
from optuna.samplers import _tpe


class QuickParzenEstimator(_tpe.parzen_estimator._ParzenEstimator):
    def _calculate_categorical_distributions(
        self,
        observations: np.ndarray,
        param_name: str,
        search_space: optuna.distributions.CategoricalDistribution,
        parameters: _tpe.parzen_estimator._ParzenEstimatorParameters,
    ) -> _tpe.probability_distributions._BatchedDistributions:
        choices = search_space.choices
        n_choices = len(choices)
        if len(observations) == 0:
            return _tpe.probability_distributions_BatchedCategoricalDistributions(
                weights=np.full((1, n_choices), fill_value=1.0 / n_choices)
            )

        n_kernels = len(observations) + parameters.consider_prior
        assert parameters.prior_weight is not None
        weights = np.full(
            shape=(n_kernels, n_choices), fill_value=parameters.prior_weight / n_kernels
        )
        observed_indices = observations.astype(int)
        if param_name in parameters.categorical_distance_func:
            used_indices, rev_indices = np.unique(observed_indices, return_inverse=True)
            dists = parameters.categorical_distance_func[param_name](used_indices)
            coef = np.log(n_kernels / parameters.prior_weight) * np.log(n_choices) / np.log(6)
            # NOTE: The max distance of `ProbabilitiesOnDiscreteSimplex` is sqrt(2).
            cat_weights = np.exp(-((dists / np.sqrt(2)) ** 2) * coef)
            weights[: len(observed_indices)] = cat_weights[rev_indices]
        else:
            weights[np.arange(len(observed_indices)), observed_indices] += 1

        weights /= weights.sum(axis=1, keepdims=True)
        return _tpe.probability_distributions._BatchedCategoricalDistributions(weights)


class QuickMetricTPESampler(optuna.samplers.TPESampler):
    def _build_parzen_estimator(
        self,
        study: optuna.Study,
        search_space: dict[str, optuna.distributions.BaseDistribution],
        trials: list[optuna.FrozenTrial],
        handle_below: bool,
    ) -> optuna._ParzenEstimator:
        # Use only the recent 100 trials.
        observations = self._get_internal_repr(trials, search_space)
        if handle_below and study._is_multi_objective():
            param_mask_below = []
            for trial in trials:
                param_mask_below.append(
                    all((param_name in trial.params) for param_name in search_space)
                )
            weights_below = _tpe.sampler._calculate_weights_below_for_multi_objective(
                study, trials, self._constraints_func
            )[param_mask_below]
            mpe = QuickParzenEstimator(
                observations, search_space, self._parzen_estimator_parameters, weights_below
            )
        else:
            mpe = QuickParzenEstimator(
                observations, search_space, self._parzen_estimator_parameters
            )

        return mpe


prob_on_simplex = ProbabilitiesOnDiscreteSimplex(n_choices=9, denominator=8)
sampler = QuickMetricTPESampler(
    multivariate=True,
    categorical_distance_func={"assign_index": prob_on_simplex.distance_for_indices},
)
study = optuna.create_study(sampler=sampler)
study.optimize(lambda trial: objective(trial, prob_on_simplex), n_trials=300)
```

</details>

With this PR, we can override in this way:

<details>
<summary>New Possible Modification</summary>

```python
import optuna
from optuna.samplers import _tpe


class QuickParzenEstimator(_tpe.parzen_estimator._ParzenEstimator):
    @staticmethod
    def _calculate_categorical_weights_by_categorical_distance(
        dist_func: Callable[[np.ndarray], np.ndarray],
        used_indices: np.ndarray,
        choices: Sequence[CategoricalChoiceType],
        coef: float,
    ) -> np.ndarray:
        dists = dist_func(used_indices)
        # NOTE: The max distance of `ProbabilitiesOnDiscreteSimplex` is sqrt(2).
        cat_weights = np.exp(-((dists / np.sqrt(2)) ** 2) * coef)
        return cat_weights


prob_on_simplex = ProbabilitiesOnDiscreteSimplex(n_choices=9, denominator=8)
sampler = optuna.samplers.TPESampler(
    multivariate=True,
    categorical_distance_func={"assign_index": prob_on_simplex.distance_for_indices},
)
sampler._parzen_estimator_cls = QuickParzenEstimator
study = optuna.create_study(sampler=sampler)
study.optimize(lambda trial: objective(trial, prob_on_simplex), n_trials=300)
```
</details>

The benchmarking depends on the PR below:
- https://github.com/optuna/optuna/pull/5400

So note that the current branch itself does not achieve the following results (the unit is second):

|n_trials|With Modification|Without Modification|
|:--:|:--:|:--:|
|100|7|15|
|200|15|52|
|300|24|109|

## Description of the changes
<!-- Describe the changes in this PR. -->

The changes are the following:
- the separation of the part of categorical distance calculation as a method, and
- create an attribute of `parzen_estimator_cls` in `TPESampler` so that users can overwrite the `ParzenEstimator` class.

By integrating these changes, users can enjoy significant speed up in categorical distance without breaking the current Optuna interface.
