### PR TITLE
Remove experimental from plot

### DIFF
--- a/optuna/visualization/_hypervolume_history.py
+++ b/optuna/visualization/_hypervolume_history.py
@@ -5,6 +5,7 @@ from typing import NamedTuple
 
 import numpy as np
 
+from optuna._experimental import experimental_func
 from optuna._hypervolume import WFG
 from optuna.logging import get_logger
 from optuna.samplers._base import _CONSTRAINTS_KEY
@@ -27,6 +28,7 @@ class _HypervolumeHistoryInfo(NamedTuple):
     values: list[float]
 
 
+@experimental_func("3.3.0")
 def plot_hypervolume_history(
     study: Study,
     reference_point: Sequence[float],

--- a/optuna/visualization/_hypervolume_history.py
+++ b/optuna/visualization/_hypervolume_history.py
@@ -5,7 +5,6 @@ from typing import NamedTuple
 
 import numpy as np
 
-from optuna._experimental import experimental_func
 from optuna._hypervolume import WFG
 from optuna.logging import get_logger
 from optuna.samplers._base import _CONSTRAINTS_KEY
@@ -28,7 +27,6 @@ class _HypervolumeHistoryInfo(NamedTuple):
     values: list[float]
 
 
-@experimental_func("3.3.0")
 def plot_hypervolume_history(
     study: Study,
     reference_point: Sequence[float],

--- a/optuna/visualization/_rank.py
+++ b/optuna/visualization/_rank.py
@@ -8,7 +8,6 @@ from typing import NamedTuple
 
 import numpy as np
 
-from optuna._experimental import experimental_func
 from optuna.logging import get_logger
 from optuna.samplers._base import _CONSTRAINTS_KEY
 from optuna.study import Study
@@ -64,7 +63,6 @@ class _RankPlotInfo(NamedTuple):
     has_custom_target: bool
 
 
-@experimental_func("3.2.0")
 def plot_rank(
     study: Study,
     params: list[str] | None = None,

--- a/optuna/visualization/_timeline.py
+++ b/optuna/visualization/_timeline.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import datetime
 from typing import NamedTuple
 
-from optuna._experimental import experimental_func
 from optuna.logging import get_logger
 from optuna.samplers._base import _CONSTRAINTS_KEY
 from optuna.study import Study
@@ -31,7 +30,6 @@ class _TimelineInfo(NamedTuple):
     bars: list[_TimelineBarInfo]
 
 
-@experimental_func("3.2.0")
 def plot_timeline(study: Study) -> "go.Figure":
     """Plot the timeline of a study.
 


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

As `plot_rank`, and `plot_timeline` are stable, we remove the experimental label from them.

We do not remove the label from the matplotlib version because the handling of the directory structure for matplotlib could be still under discussion.

For `plot_rank` and `plot_timeline`, I will summarize some discussion points:
- they are often used, so we decided to remove the experimental label,
- the feature of `plot_rank` is similar to that of `plot_contour`, but we decided to keep `plot_rank` as well and we have not seen any problem for a while,
- Although `plot_timeline` may need some additional arguments such as `n_trials`, `head`, and `tail`, we can add such arguments in the future without breaking the compatibility.

For this reason, we decide to remove the experimental label as we will not break the compatibility in the future.

## Description of the changes
<!-- Describe the changes in this PR. -->

Remove the experimental label from the two plot functions mentioned above.
