### PR TITLE
Remove deprecated `CmaEsSampler` from integration

### DIFF
--- a/optuna/integration/__init__.py
+++ b/optuna/integration/__init__.py
@@ -11,7 +11,7 @@ _import_structure = {
     "catboost": ["CatBoostPruningCallback"],
     "chainer": ["ChainerPruningExtension"],
     "chainermn": ["ChainerMNStudy"],
-    "cma": ["CmaEsSampler", "PyCmaSampler"],
+    "cma": ["PyCmaSampler"],
     "dask": ["DaskStorage"],
     "mlflow": ["MLflowCallback"],
     "wandb": ["WeightsAndBiasesCallback"],
@@ -39,7 +39,6 @@ __all__ = [
     "CatBoostPruningCallback",
     "ChainerPruningExtension",
     "ChainerMNStudy",
-    "CmaEsSampler",
     "PyCmaSampler",
     "DaskStorage",
     "MLflowCallback",
@@ -71,7 +70,6 @@ if TYPE_CHECKING:
     from optuna.integration.catboost import CatBoostPruningCallback
     from optuna.integration.chainer import ChainerPruningExtension
     from optuna.integration.chainermn import ChainerMNStudy
-    from optuna.integration.cma import CmaEsSampler
     from optuna.integration.cma import PyCmaSampler
     from optuna.integration.dask import DaskStorage
     from optuna.integration.fastaiv2 import FastAIPruningCallback

--- a/optuna/integration/cma.py
+++ b/optuna/integration/cma.py
@@ -1,5 +1,4 @@
-from optuna_integration.cma import CmaEsSampler
 from optuna_integration.cma import PyCmaSampler
 
 
-__all__ = ["CmaEsSampler", "PyCmaSampler"]
+__all__ = ["PyCmaSampler"]


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

I want to remove deprecated `CmaEsSampler` from integration. This PR does not affect `sampler/_cmaes.py`.

This PR is related to PR https://github.com/optuna/optuna/pull/1325 .

## Description of the changes
<!-- Describe the changes in this PR. -->

I removed `CmaEsSampler` from integration module.