### PR TITLE
Fix `_normalize_value` for incomplete trials

### DIFF
--- a/optuna/study/_multi_objective.py
+++ b/optuna/study/_multi_objective.py
@@ -259,7 +259,7 @@ def _dominates(
 
 def _normalize_value(value: None | float, direction: StudyDirection) -> float:
     if value is None:
-        value = float("inf")
+        return float("inf")
 
     if direction is StudyDirection.MAXIMIZE:
         value = -value

--- a/tests/study_tests/test_multi_objective.py
+++ b/tests/study_tests/test_multi_objective.py
@@ -6,6 +6,7 @@ import pytest
 from optuna.study import StudyDirection
 from optuna.study._multi_objective import _dominates
 from optuna.study._multi_objective import _fast_non_dominated_sort
+from optuna.study._multi_objective import _normalize_value
 from optuna.trial import create_trial
 from optuna.trial import TrialState
 
@@ -161,3 +162,10 @@ def test_fast_non_dominated_sort_invalid() -> None:
         _fast_non_dominated_sort(
             np.array([[1.0, 2.0], [3.0, 4.0]]), penalty=np.array([1.0, 2.0, 3.0])
         )
+
+
+def test_normalize_value() -> None:
+    assert _normalize_value(1.0, StudyDirection.MINIMIZE) == 1.0
+    assert _normalize_value(1.0, StudyDirection.MAXIMIZE) == -1.0
+    assert _normalize_value(None, StudyDirection.MINIMIZE) == float("inf")
+    assert _normalize_value(None, StudyDirection.MAXIMIZE) == float("inf")


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
`_normalize_value` should return infinity value for incomplete trials. It seems unused in the current implementation, but I want to fix it to eliminate the possibility of bugs occurring in the future.

## Description of the changes
<!-- Describe the changes in this PR. -->
- Return `float("inf")` for `None` value.
- Add a test.