### PR TITLE
Check whether the study is multi-objective in `sample_independent` of `GPSampler`

### DIFF
--- a/optuna/samplers/_gp/sampler.py
+++ b/optuna/samplers/_gp/sampler.py
@@ -206,6 +206,7 @@ class GPSampler(BaseSampler):
         param_name: str,
         param_distribution: BaseDistribution,
     ) -> Any:
+        self._raise_error_if_multi_objective(study)
         return self._independent_sampler.sample_independent(
             study, trial, param_name, param_distribution
         )


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

`GPSampler` does not currently support multi-objective optimization as well as `CmaEsSampler`.

`CmaEsSampler` checks if the study is multi-objective in both `sample_relative` ([code](https://github.com/optuna/optuna/blob/39f83f7eda0979af27d5e9dd6acc7a08fa1c63ec/optuna/samplers/_cmaes.py#L388)) and `sample_independent` ([code](https://github.com/optuna/optuna/blob/39f83f7eda0979af27d5e9dd6acc7a08fa1c63ec/optuna/samplers/_cmaes.py#L733)).

On the other hand, `GPSampler` checks it only in `sample_relative` ([code](https://github.com/optuna/optuna/blob/39f83f7eda0979af27d5e9dd6acc7a08fa1c63ec/optuna/samplers/_gp/sampler.py#L137)).

## Description of the changes
<!-- Describe the changes in this PR. -->

I added code to check if the study is multi-objective in `sample_independent` of `GPSampler`.
