### PR TITLE
Fix heartbeat for race condition

### DIFF
--- a/optuna/storages/_rdb/storage.py
+++ b/optuna/storages/_rdb/storage.py
@@ -4,6 +4,7 @@ from collections import defaultdict
 from contextlib import contextmanager
 import copy
 from datetime import datetime
+from datetime import timedelta
 import json
 import logging
 import os
@@ -1010,7 +1011,7 @@ class RDBStorage(BaseStorage, BaseHeartbeat):
                     continue
                 assert len(trial.heartbeats) == 1
                 heartbeat = trial.heartbeats[0].heartbeat
-                if (current_heartbeat - heartbeat).seconds > grace_period:
+                if current_heartbeat - heartbeat > timedelta(seconds=grace_period):
                     stale_trial_ids.append(trial.trial_id)
 
         return stale_trial_ids


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
The current heartbeat implementation has a bug when it comes to race conditions. If the heartbeat value is updated between getting the current time and getting the heartbeat value, the time difference will be negative and the `.seconds` value will be 86399. (ref: https://docs.python.org/3/library/datetime.html#datetime.timedelta)

I have checked this bug using the following code and modification.

```python
import random
import time
import optuna

def objective(trial):
    time.sleep(random.randrange(5))
    return 0

storage = optuna.storages.RDBStorage(url="sqlite:///tmp.db", heartbeat_interval=1, grace_period=2)
study = optuna.create_study(storage=storage)
study.optimize(objective, n_trials=100, n_jobs=2)
```

```
$ git diff
diff --git a/optuna/storages/_rdb/storage.py b/optuna/storages/_rdb/storage.py
index 5a225aa10..497b7f6de 100644
--- a/optuna/storages/_rdb/storage.py
+++ b/optuna/storages/_rdb/storage.py
@@ -998,6 +998,9 @@ class RDBStorage(BaseStorage, BaseHeartbeat):
             # https://github.com/optuna/optuna/pull/2190#issuecomment-766605088 for details
             current_heartbeat = current_heartbeat.replace(tzinfo=None)
 
+            import random
+            import time
+            time.sleep(random.randrange(5))
             running_trials = (
                 session.query(models.TrialModel)
                 .options(sqlalchemy_orm.selectinload(models.TrialModel.heartbeats))
```

## Description of the changes
<!-- Describe the changes in this PR. -->
Comparison between timedelta objects instead of seconds.
