### PR TITLE
Suppress warnings from `numpy` in hypervolume computation

### DIFF
--- a/optuna/_hypervolume/hssp.py
+++ b/optuna/_hypervolume/hssp.py
@@ -45,8 +45,7 @@ def _solve_hssp_on_unique_loss_vals(
     reference_point: np.ndarray,
 ) -> np.ndarray:
     with np.errstate(invalid="ignore"):
-        distance_from_reference_point = reference_point - rank_i_loss_vals
-    assert not np.any(distance_from_reference_point <= 0)
+        diff_of_loss_vals_and_ref_point = reference_point - rank_i_loss_vals
     assert subset_size <= rank_i_indices.size
     n_objectives = reference_point.size
     contribs = np.prod(distance_from_reference_point, axis=-1)

--- a/optuna/_hypervolume/hssp.py
+++ b/optuna/_hypervolume/hssp.py
@@ -44,6 +44,8 @@ def _solve_hssp_on_unique_loss_vals(
     subset_size: int,
     reference_point: np.ndarray,
 ) -> np.ndarray:
+    if not np.isfinite(reference_point).all():
+        return rank_i_indices[list(range(subset_size))]
     with np.errstate(invalid="ignore"):
         diff_of_loss_vals_and_ref_point = reference_point - rank_i_loss_vals
     assert subset_size <= rank_i_indices.size

--- a/optuna/_hypervolume/hssp.py
+++ b/optuna/_hypervolume/hssp.py
@@ -48,7 +48,7 @@ def _solve_hssp_on_unique_loss_vals(
         diff_of_loss_vals_and_ref_point = reference_point - rank_i_loss_vals
     assert subset_size <= rank_i_indices.size
     n_objectives = reference_point.size
-    contribs = np.prod(distance_from_reference_point, axis=-1)
+    contribs = np.prod(diff_of_loss_vals_and_ref_point, axis=-1)
     selected_indices = np.zeros(subset_size, dtype=int)
     selected_vecs = np.empty((subset_size, n_objectives))
     indices = np.arange(rank_i_loss_vals.shape[0], dtype=int)

--- a/optuna/_hypervolume/hssp.py
+++ b/optuna/_hypervolume/hssp.py
@@ -44,7 +44,7 @@ def _solve_hssp_on_unique_loss_vals(
     subset_size: int,
     reference_point: np.ndarray,
 ) -> np.ndarray:
-    with np.errstate(invalid='ignore'):
+    with np.errstate(invalid="ignore"):
         distance_from_reference_point = reference_point - rank_i_loss_vals
     assert not np.any(distance_from_reference_point <= 0)
     assert subset_size <= rank_i_indices.size

--- a/optuna/_hypervolume/hssp.py
+++ b/optuna/_hypervolume/hssp.py
@@ -44,10 +44,12 @@ def _solve_hssp_on_unique_loss_vals(
     subset_size: int,
     reference_point: np.ndarray,
 ) -> np.ndarray:
-    assert not np.any(reference_point - rank_i_loss_vals <= 0)
+    with np.errstate(invalid='ignore'):
+        distance_from_reference_point = reference_point - rank_i_loss_vals
+    assert not np.any(distance_from_reference_point <= 0)
     assert subset_size <= rank_i_indices.size
     n_objectives = reference_point.size
-    contribs = np.prod(reference_point - rank_i_loss_vals, axis=-1)
+    contribs = np.prod(distance_from_reference_point, axis=-1)
     selected_indices = np.zeros(subset_size, dtype=int)
     selected_vecs = np.empty((subset_size, n_objectives))
     indices = np.arange(rank_i_loss_vals.shape[0], dtype=int)

--- a/optuna/_hypervolume/hssp.py
+++ b/optuna/_hypervolume/hssp.py
@@ -46,8 +46,7 @@ def _solve_hssp_on_unique_loss_vals(
 ) -> np.ndarray:
     if not np.isfinite(reference_point).all():
         return rank_i_indices[list(range(subset_size))]
-    with np.errstate(invalid="ignore"):
-        diff_of_loss_vals_and_ref_point = reference_point - rank_i_loss_vals
+    diff_of_loss_vals_and_ref_point = reference_point - rank_i_loss_vals
     assert subset_size <= rank_i_indices.size
     n_objectives = reference_point.size
     contribs = np.prod(diff_of_loss_vals_and_ref_point, axis=-1)

--- a/optuna/_hypervolume/hssp.py
+++ b/optuna/_hypervolume/hssp.py
@@ -45,7 +45,7 @@ def _solve_hssp_on_unique_loss_vals(
     reference_point: np.ndarray,
 ) -> np.ndarray:
     if not np.isfinite(reference_point).all():
-        return rank_i_indices[list(range(subset_size))]
+        return rank_i_indices[:subset_size]
     diff_of_loss_vals_and_ref_point = reference_point - rank_i_loss_vals
     assert subset_size <= rank_i_indices.size
     n_objectives = reference_point.size

--- a/optuna/_hypervolume/utils.py
+++ b/optuna/_hypervolume/utils.py
@@ -27,6 +27,8 @@ def _compute_2d(solution_set: np.ndarray, reference_point: np.ndarray) -> float:
             The reference point to compute the hypervolume.
     """
     assert solution_set.shape[1] == 2 and reference_point.shape[0] == 2
+    if not np.isfinite(reference_point).all():
+        return float("inf")
 
     # Ascending order in the 1st objective, and descending order in the 2nd objective.
     sorted_solution_set = solution_set[np.lexsort((-solution_set[:, 1], solution_set[:, 0]))]

--- a/optuna/_hypervolume/utils.py
+++ b/optuna/_hypervolume/utils.py
@@ -37,7 +37,6 @@ def _compute_2d(solution_set: np.ndarray, reference_point: np.ndarray) -> float:
     mask = sorted_solution_set[:, 1] <= reference_points_y_cummin
 
     used_solution = sorted_solution_set[mask]
-    with np.errstate(invalid="ignore"):
-        edge_length_x = reference_point[0] - used_solution[:, 0]
-        edge_length_y = reference_points_y_cummin[mask] - used_solution[:, 1]
+    edge_length_x = reference_point[0] - used_solution[:, 0]
+    edge_length_y = reference_points_y_cummin[mask] - used_solution[:, 1]
     return edge_length_x @ edge_length_y

--- a/optuna/_hypervolume/utils.py
+++ b/optuna/_hypervolume/utils.py
@@ -35,6 +35,7 @@ def _compute_2d(solution_set: np.ndarray, reference_point: np.ndarray) -> float:
     mask = sorted_solution_set[:, 1] <= reference_points_y_cummin
 
     used_solution = sorted_solution_set[mask]
-    edge_length_x = reference_point[0] - used_solution[:, 0]
-    edge_length_y = reference_points_y_cummin[mask] - used_solution[:, 1]
+    with np.errstate(invalid='ignore'):
+        edge_length_x = reference_point[0] - used_solution[:, 0]
+        edge_length_y = reference_points_y_cummin[mask] - used_solution[:, 1]
     return edge_length_x @ edge_length_y

--- a/optuna/_hypervolume/utils.py
+++ b/optuna/_hypervolume/utils.py
@@ -35,7 +35,7 @@ def _compute_2d(solution_set: np.ndarray, reference_point: np.ndarray) -> float:
     mask = sorted_solution_set[:, 1] <= reference_points_y_cummin
 
     used_solution = sorted_solution_set[mask]
-    with np.errstate(invalid='ignore'):
+    with np.errstate(invalid="ignore"):
         edge_length_x = reference_point[0] - used_solution[:, 0]
         edge_length_y = reference_points_y_cummin[mask] - used_solution[:, 1]
     return edge_length_x @ edge_length_y

--- a/optuna/_hypervolume/wfg.py
+++ b/optuna/_hypervolume/wfg.py
@@ -20,6 +20,8 @@ class WFG(BaseHypervolume):
         self._reference_point: Optional[np.ndarray] = None
 
     def _compute(self, solution_set: np.ndarray, reference_point: np.ndarray) -> float:
+        if not np.isfinite(reference_point).all():
+            return float("inf")
         self._reference_point = reference_point.astype(np.float64)
         return self._compute_rec(solution_set.astype(np.float64))
 

--- a/tests/hypervolume_tests/test_hssp.py
+++ b/tests/hypervolume_tests/test_hssp.py
@@ -34,7 +34,6 @@ def test_solve_hssp(dim: int) -> None:
         assert approx / truth > 0.6321  # 1 - 1/e
 
 
-@pytest.mark.filterwarnings("ignore::RuntimeWarning")
 def test_solve_hssp_infinite_loss() -> None:
     rng = np.random.RandomState(128)
 
@@ -53,7 +52,6 @@ def test_solve_hssp_infinite_loss() -> None:
         assert np.isinf(approx)
 
 
-@pytest.mark.filterwarnings("ignore::RuntimeWarning")
 def test_solve_hssp_duplicated_infinite_loss() -> None:
     test_case = np.array([[np.inf, 0, 0], [np.inf, 0, 0], [0, np.inf, 0], [0, 0, np.inf]])
     r = np.full(3, np.inf)

--- a/tests/hypervolume_tests/test_hssp.py
+++ b/tests/hypervolume_tests/test_hssp.py
@@ -1,4 +1,5 @@
 import itertools
+import math
 from typing import Tuple
 
 import numpy as np
@@ -11,11 +12,14 @@ def _compute_hssp_truth_and_approx(test_case: np.ndarray, subset_size: int) -> T
     r = 1.1 * np.max(test_case, axis=0)
     truth = 0.0
     for subset in itertools.permutations(test_case, subset_size):
-        truth = max(truth, optuna._hypervolume.WFG().compute(np.asarray(subset), r))
+        hv = optuna._hypervolume.WFG().compute(np.asarray(subset), r)
+        assert not math.isnan(hv)
+        truth = max(truth, hv)
     indices = optuna._hypervolume.hssp._solve_hssp(
         test_case, np.arange(len(test_case)), subset_size, r
     )
     approx = optuna._hypervolume.WFG().compute(test_case[indices], r)
+    assert not math.isnan(approx)
     return truth, approx
 
 
@@ -35,19 +39,13 @@ def test_solve_hssp_infinite_loss() -> None:
     rng = np.random.RandomState(128)
 
     subset_size = 4
-    test_case = rng.rand(9, 2)
-    test_case[-1].fill(float("inf"))
-    truth, approx = _compute_hssp_truth_and_approx(test_case, subset_size)
-    assert np.isinf(truth)
-    assert np.isinf(approx)
-
-    test_case = rng.rand(9, 3)
-    test_case[-1].fill(float("inf"))
-    truth, approx = _compute_hssp_truth_and_approx(test_case, subset_size)
-    assert truth == 0
-    assert np.isnan(approx)
-
     for dim in range(2, 4):
+        test_case = rng.rand(9, dim)
+        test_case[-1].fill(float("inf"))
+        truth, approx = _compute_hssp_truth_and_approx(test_case, subset_size)
+        assert np.isinf(truth)
+        assert np.isinf(approx)
+
         test_case = rng.rand(9, dim)
         test_case[-1].fill(-float("inf"))
         truth, approx = _compute_hssp_truth_and_approx(test_case, subset_size)


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

I want to reduce warning `RuntimeWarning: invalid value encountered in subtract` in unittests.
Related to issue https://github.com/optuna/optuna/issues/3815 .

## Description of the changes
<!-- Describe the changes in this PR. -->

I applied `with np.errstate(invalid='ignore'):` to minimum extent necessary and suppressed warnings.