### PR TITLE
Make an option to assume Pareto optimality in WFG

### DIFF
--- a/optuna/_hypervolume/base.py
+++ b/optuna/_hypervolume/base.py
@@ -67,7 +67,7 @@ class BaseHypervolume(abc.ABC):
     @staticmethod
     def _validate(solution_set: np.ndarray, reference_point: np.ndarray) -> None:
         # Validates that all points in the solution set dominate or equal the reference point.
-        if not (solution_set <= reference_point).all():
+        if not np.all(solution_set <= reference_point):
             raise ValueError(
                 "All points must dominate or equal the reference point. "
                 "That is, for all points in the solution_set and the coordinate `i`, "

--- a/optuna/_hypervolume/base.py
+++ b/optuna/_hypervolume/base.py
@@ -42,7 +42,9 @@ class BaseHypervolume(abc.ABC):
             print("Hypervolume of the Pareto solutions is {}.".format(hypervolume))
     """
 
-    def compute(self, solution_set: np.ndarray, reference_point: np.ndarray) -> float:
+    def compute(
+        self, solution_set: np.ndarray, reference_point: np.ndarray, assume_pareto: bool = False
+    ) -> float:
         """Compute the hypervolume for the given solution set and reference point.
 
         .. note::
@@ -55,10 +57,12 @@ class BaseHypervolume(abc.ABC):
                 The solution set which we want to compute the hypervolume.
             reference_point:
                 The reference point to compute the hypervolume.
+            assume_pareto:
+                Whether to assume the solution set is Pareto optimal.
         """
 
         self._validate(solution_set, reference_point)
-        return self._compute(solution_set, reference_point)
+        return self._compute(solution_set, reference_point, assume_pareto)
 
     @staticmethod
     def _validate(solution_set: np.ndarray, reference_point: np.ndarray) -> None:
@@ -71,5 +75,7 @@ class BaseHypervolume(abc.ABC):
             )
 
     @abc.abstractmethod
-    def _compute(self, solution_set: np.ndarray, reference_point: np.ndarray) -> float:
+    def _compute(
+        self, solution_set: np.ndarray, reference_point: np.ndarray, assume_pareto: bool
+    ) -> float:
         raise NotImplementedError

--- a/optuna/_hypervolume/hssp.py
+++ b/optuna/_hypervolume/hssp.py
@@ -20,7 +20,9 @@ def _lazy_contribs_update(
     H(S' v {j}) - H(S'), we start to update from i with a higher upper bound so that we can
     skip more HV calculations.
     """
-    hv_selected = optuna._hypervolume.WFG().compute(selected_vecs[:-1], reference_point)
+    hv_selected = optuna._hypervolume.WFG().compute(
+        selected_vecs[:-1], reference_point, assume_pareto=True
+    )
     max_contrib = 0.0
     index_from_larger_upper_bound_contrib = np.argsort(-contribs)
     for i in index_from_larger_upper_bound_contrib:
@@ -30,7 +32,9 @@ def _lazy_contribs_update(
             continue
 
         selected_vecs[-1] = pareto_loss_values[i].copy()
-        hv_plus = optuna._hypervolume.WFG().compute(selected_vecs, reference_point)
+        hv_plus = optuna._hypervolume.WFG().compute(
+            selected_vecs, reference_point, assume_pareto=True
+        )
         # inf - inf in the contribution calculation is always inf.
         contribs[i] = hv_plus - hv_selected if not np.isinf(hv_plus) else np.inf
         max_contrib = max(contribs[i], max_contrib)

--- a/optuna/_hypervolume/utils.py
+++ b/optuna/_hypervolume/utils.py
@@ -17,9 +17,6 @@ def _compute_2d(sorted_pareto_sols: np.ndarray, reference_point: np.ndarray) -> 
             The reference point to compute the hypervolume.
     """
     assert sorted_pareto_sols.shape[1] == 2 and reference_point.shape[0] == 2
-    if not np.all(np.isfinite(reference_point)):
-        return float("inf")
-
     rect_diag_y = np.append(reference_point[1], sorted_pareto_sols[:-1, 1])
     edge_length_x = reference_point[0] - sorted_pareto_sols[:, 0]
     edge_length_y = rect_diag_y - sorted_pareto_sols[:, 1]

--- a/optuna/_hypervolume/utils.py
+++ b/optuna/_hypervolume/utils.py
@@ -1,29 +1,23 @@
 import numpy as np
 
 
-def _compute_2d(solution_set: np.ndarray, reference_point: np.ndarray) -> float:
+def _compute_2d(sorted_pareto_sols: np.ndarray, reference_point: np.ndarray) -> float:
     """Compute the hypervolume for the two-dimensional space.
 
     This algorithm divides a hypervolume into
     smaller rectangles and sum these areas.
 
     Args:
-        solution_set:
+        sorted_pareto_sols:
             The solution set which we want to compute the hypervolume.
+            Note that this set is assumed to be sorted by the first value and Pareto optimal.
+            As this set is Pareto optimal and sorted by the first order, the second value
+            monotonically decreasing.
         reference_point:
             The reference point to compute the hypervolume.
     """
-    assert solution_set.shape[1] == 2 and reference_point.shape[0] == 2
-    if not np.isfinite(reference_point).all():
-        return float("inf")
-
-    # Ascending order in the 1st objective, and descending order in the 2nd objective.
-    sorted_solution_set = solution_set[np.lexsort((-solution_set[:, 1], solution_set[:, 0]))]
-    reference_points_y = np.append(reference_point[1], sorted_solution_set[:-1, 1])
-    reference_points_y_cummin = np.minimum.accumulate(reference_points_y)
-    mask = sorted_solution_set[:, 1] <= reference_points_y_cummin
-
-    used_solution = sorted_solution_set[mask]
-    edge_length_x = reference_point[0] - used_solution[:, 0]
-    edge_length_y = reference_points_y_cummin[mask] - used_solution[:, 1]
+    assert sorted_pareto_sols.shape[1] == 2 and reference_point.shape[0] == 2
+    rect_diag_y = np.append(reference_point[1], sorted_pareto_sols[:-1, 1])
+    edge_length_x = reference_point[0] - sorted_pareto_sols[:, 0]
+    edge_length_y = rect_diag_y - sorted_pareto_sols[:, 1]
     return edge_length_x @ edge_length_y

--- a/optuna/_hypervolume/wfg.py
+++ b/optuna/_hypervolume/wfg.py
@@ -26,8 +26,8 @@ class WFG(BaseHypervolume):
             return float("inf")
 
         if not assume_pareto:
-            unique_sols = np.unique(solution_set, axis=0)
-            sorted_pareto_sols = unique_sols[_is_pareto_front(unique_sols)]
+            unique_lexsorted_sols = np.unique(solution_set, axis=0)
+            sorted_pareto_sols = unique_lexsorted_sols[_is_pareto_front(unique_lexsorted_sols)]
         else:
             sorted_pareto_sols = solution_set[solution_set[:, 0].argsort()]
 

--- a/optuna/_hypervolume/wfg.py
+++ b/optuna/_hypervolume/wfg.py
@@ -22,7 +22,8 @@ class WFG(BaseHypervolume):
     def _compute(
         self, solution_set: np.ndarray, reference_point: np.ndarray, assume_pareto: bool
     ) -> float:
-        if not np.isfinite(reference_point).all():
+        if not np.all(np.isfinite(reference_point)):
+            # reference_point does not have nan, because BaseHypervolume._validate will filter out.
             return float("inf")
 
         if not assume_pareto:

--- a/tests/hypervolume_tests/test_utils.py
+++ b/tests/hypervolume_tests/test_utils.py
@@ -10,5 +10,7 @@ def test_compute_2d() -> None:
         for i in range(n + 1):
             s = np.vstack((s, np.asarray([i, n - i])))
         np.random.shuffle(s)
-        v = optuna._hypervolume._compute_2d(s, r)
+        on_front = optuna.study._multi_objective._is_pareto_front(s, assume_unique_lexsorted=False)
+        pareto_sols = s[on_front]
+        v = optuna._hypervolume._compute_2d(pareto_sols[np.argsort(pareto_sols[:, 0])], r)
         assert v == n * n - n * (n - 1) // 2

--- a/tests/hypervolume_tests/test_wfg.py
+++ b/tests/hypervolume_tests/test_wfg.py
@@ -4,8 +4,10 @@ import pytest
 import optuna
 
 
-def _shuffle_and_filter_sols(sols: np.ndarray, assume_pareto: bool) -> np.ndarray:
-    np.random.shuffle(sols)
+def _shuffle_and_filter_sols(
+    sols: np.ndarray, assume_pareto: bool, rng: np.random.RandomState
+) -> np.ndarray:
+    rng.shuffle(sols)
     if assume_pareto:
         on_front = optuna.study._multi_objective._is_pareto_front(sols, False)
         sols = sols[on_front]
@@ -14,32 +16,35 @@ def _shuffle_and_filter_sols(sols: np.ndarray, assume_pareto: bool) -> np.ndarra
 
 @pytest.mark.parametrize("assume_pareto", (True, False))
 def test_wfg_2d(assume_pareto: bool) -> None:
+    rng = np.random.RandomState(42)
     for n in range(2, 30):
         r = n * np.ones(2)
         s = np.empty((2 * n + 1, 2), dtype=int)
         s[:n] = np.stack([np.arange(n), np.arange(n)[::-1]], axis=-1)
         s[n:] = np.stack([np.arange(n + 1), np.arange(n + 1)[::-1]], axis=-1)
-        s = _shuffle_and_filter_sols(s, assume_pareto)
+        s = _shuffle_and_filter_sols(s, assume_pareto, rng)
         assert optuna._hypervolume.WFG().compute(s, r, assume_pareto) == n * n - n * (n - 1) // 2
 
 
 @pytest.mark.parametrize("n_objs", list(range(2, 10)))
 @pytest.mark.parametrize("assume_pareto", (True, False))
 def test_wfg_nd(n_objs: int, assume_pareto: bool) -> None:
+    rng = np.random.RandomState(42)
     r = 10 * np.ones(n_objs)
-    s = np.vstack([np.identity(n_objs), np.random.randint(1, 10, size=(10, n_objs))])
-    s = _shuffle_and_filter_sols(s, assume_pareto)
+    s = np.vstack([np.identity(n_objs), rng.randint(1, 10, size=(10, n_objs))])
+    s = _shuffle_and_filter_sols(s, assume_pareto, rng)
     assert optuna._hypervolume.WFG().compute(s, r, assume_pareto) == 10**n_objs - 1
 
 
 @pytest.mark.parametrize("assume_pareto", (True, False))
 def test_wfg_duplicate_points(assume_pareto: bool) -> None:
+    rng = np.random.RandomState(42)
     n = 3
     r = 10 * np.ones(n)
-    s = np.vstack([np.identity(n), np.random.randint(1, 10, size=(10, n))])
+    s = np.vstack([np.identity(n), rng.randint(1, 10, size=(10, n))])
     ground_truth = optuna._hypervolume.WFG().compute(s, r, assume_pareto=False)
     s = np.vstack([s, s[-1]])  # Add an already existing point.
-    s = _shuffle_and_filter_sols(s, assume_pareto)
+    s = _shuffle_and_filter_sols(s, assume_pareto, rng)
     assert optuna._hypervolume.WFG().compute(s, r, assume_pareto) == ground_truth
 
 

--- a/tests/hypervolume_tests/test_wfg.py
+++ b/tests/hypervolume_tests/test_wfg.py
@@ -4,56 +4,47 @@ import pytest
 import optuna
 
 
-def test_wfg_2d() -> None:
+def _shuffle_and_filter_sols(sols: np.ndarray, assume_pareto: bool) -> np.ndarray:
+    np.random.shuffle(sols)
+    if assume_pareto:
+        on_front = optuna.study._multi_objective._is_pareto_front(sols, False)
+        sols = sols[on_front]
+    return sols
+
+
+@pytest.mark.parametrize("assume_pareto", (True, False))
+def test_wfg_2d(assume_pareto: bool) -> None:
     for n in range(2, 30):
         r = n * np.ones(2)
-        s = np.asarray([[n - 1 - i, i] for i in range(n)])
-        for i in range(n + 1):
-            s = np.vstack((s, np.asarray([i, n - i])))
-        np.random.shuffle(s)
-        v = optuna._hypervolume.WFG().compute(s, r)
-        assert v == n * n - n * (n - 1) // 2
+        s = np.empty((2 * n + 1, 2), dtype=int)
+        s[:n, 0] = np.arange(n)
+        s[:n, 1] = np.arange(n)[::-1]
+        s[n:, 0] = np.arange(n + 1)
+        s[n:, 1] = np.arange(n + 1)[::-1]
+        s = _shuffle_and_filter_sols(s, assume_pareto)
+        hv = optuna._hypervolume.WFG().compute(s, r, assume_pareto=assume_pareto)
+        assert hv == n * n - n * (n - 1) // 2
 
 
-def test_wfg_3d() -> None:
+@pytest.mark.parametrize("n_objs", list(range(2, 10)))
+@pytest.mark.parametrize("assume_pareto", (True, False))
+def test_wfg_nd(n_objs: int, assume_pareto: bool) -> None:
+    r = 10 * np.ones(n_objs)
+    s = np.vstack([np.identity(n_objs), np.random.randint(1, 10, size=(10, n_objs))])
+    s = _shuffle_and_filter_sols(s, assume_pareto)
+    hv = optuna._hypervolume.WFG().compute(s, r, assume_pareto=assume_pareto)
+    assert optuna._hypervolume.WFG().compute(s, r, assume_pareto=assume_pareto) == 10**n_objs - 1
+
+
+@pytest.mark.parametrize("assume_pareto", (True, False))
+def test_wfg_duplicate_points(assume_pareto: bool) -> None:
     n = 3
     r = 10 * np.ones(n)
-    s = [np.hstack((np.zeros(i), [1], np.zeros(n - i - 1))) for i in range(n)]
-    for _ in range(10):
-        s.append(np.random.randint(1, 10, size=(n,)))
-    o = np.asarray(s)
-    np.random.shuffle(o)
-    v = optuna._hypervolume.WFG().compute(o, r)
-    assert v == 10**n - 1
-
-
-def test_wfg_nd() -> None:
-    for n in range(2, 10):
-        r = 10 * np.ones(n)
-        s = [np.hstack((np.zeros(i), [1], np.zeros(n - i - 1))) for i in range(n)]
-        for _ in range(10):
-            s.append(np.random.randint(1, 10, size=(n,)))
-        o = np.asarray(s)
-        np.random.shuffle(o)
-        v = optuna._hypervolume.WFG().compute(o, r)
-        assert v == 10**n - 1
-
-
-def test_wfg_duplicate_points() -> None:
-    n = 3
-    r = 10 * np.ones(n)
-    s = [np.hstack((np.zeros(i), [1], np.zeros(n - i - 1))) for i in range(n)]
-    for _ in range(10):
-        s.append(np.random.randint(1, 10, size=(n,)))
-    o = np.asarray(s)
-    v = optuna._hypervolume.WFG().compute(o, r)
-
-    # Add an already existing point.
-    o = np.vstack([o, o[-1]])
-
-    np.random.shuffle(o)
-    v_with_duplicate_point = optuna._hypervolume.WFG().compute(o, r)
-    assert v == v_with_duplicate_point
+    s = np.vstack([np.identity(n), np.random.randint(1, 10, size=(10, n))])
+    ground_truth = optuna._hypervolume.WFG().compute(s, r, assume_pareto=False)
+    s = np.vstack([s, s[-1]])  # Add an already existing point.
+    s = _shuffle_and_filter_sols(s, assume_pareto)
+    assert optuna._hypervolume.WFG().compute(s, r, assume_pareto=assume_pareto) == ground_truth
 
 
 def test_invalid_input() -> None:

--- a/tests/hypervolume_tests/test_wfg.py
+++ b/tests/hypervolume_tests/test_wfg.py
@@ -36,6 +36,24 @@ def test_wfg_nd(n_objs: int, assume_pareto: bool) -> None:
     assert optuna._hypervolume.WFG().compute(s, r, assume_pareto) == 10**n_objs - 1
 
 
+@pytest.mark.parametrize("n_objs", list(range(2, 10)))
+def test_wfg_with_inf(n_objs: int) -> None:
+    s = np.ones((1, n_objs), dtype=float)
+    s[0, n_objs // 2] = np.inf
+    r = 1.1 * s
+    assert optuna._hypervolume.WFG().compute(s, r) == np.inf
+
+
+@pytest.mark.parametrize("n_objs", list(range(2, 10)))
+def test_wfg_with_nan(n_objs: int) -> None:
+    s = np.ones((1, n_objs), dtype=float)
+    s[0, n_objs // 2] = np.inf
+    r = 1.1 * s
+    r[-1] = np.nan
+    with pytest.raises(ValueError):
+        optuna._hypervolume.WFG().compute(s, r)
+
+
 @pytest.mark.parametrize("assume_pareto", (True, False))
 def test_wfg_duplicate_points(assume_pareto: bool) -> None:
     rng = np.random.RandomState(42)

--- a/tests/hypervolume_tests/test_wfg.py
+++ b/tests/hypervolume_tests/test_wfg.py
@@ -17,13 +17,10 @@ def test_wfg_2d(assume_pareto: bool) -> None:
     for n in range(2, 30):
         r = n * np.ones(2)
         s = np.empty((2 * n + 1, 2), dtype=int)
-        s[:n, 0] = np.arange(n)
-        s[:n, 1] = np.arange(n)[::-1]
-        s[n:, 0] = np.arange(n + 1)
-        s[n:, 1] = np.arange(n + 1)[::-1]
+        s[:n] = np.stack([np.arange(n), np.arange(n)[::-1]], axis=-1)
+        s[n:] = np.stack([np.arange(n + 1), np.arange(n + 1)[::-1]], axis=-1)
         s = _shuffle_and_filter_sols(s, assume_pareto)
-        hv = optuna._hypervolume.WFG().compute(s, r, assume_pareto=assume_pareto)
-        assert hv == n * n - n * (n - 1) // 2
+        assert optuna._hypervolume.WFG().compute(s, r, assume_pareto) == n * n - n * (n - 1) // 2
 
 
 @pytest.mark.parametrize("n_objs", list(range(2, 10)))
@@ -32,8 +29,7 @@ def test_wfg_nd(n_objs: int, assume_pareto: bool) -> None:
     r = 10 * np.ones(n_objs)
     s = np.vstack([np.identity(n_objs), np.random.randint(1, 10, size=(10, n_objs))])
     s = _shuffle_and_filter_sols(s, assume_pareto)
-    hv = optuna._hypervolume.WFG().compute(s, r, assume_pareto=assume_pareto)
-    assert optuna._hypervolume.WFG().compute(s, r, assume_pareto=assume_pareto) == 10**n_objs - 1
+    assert optuna._hypervolume.WFG().compute(s, r, assume_pareto) == 10**n_objs - 1
 
 
 @pytest.mark.parametrize("assume_pareto", (True, False))
@@ -44,7 +40,7 @@ def test_wfg_duplicate_points(assume_pareto: bool) -> None:
     ground_truth = optuna._hypervolume.WFG().compute(s, r, assume_pareto=False)
     s = np.vstack([s, s[-1]])  # Add an already existing point.
     s = _shuffle_and_filter_sols(s, assume_pareto)
-    assert optuna._hypervolume.WFG().compute(s, r, assume_pareto=assume_pareto) == ground_truth
+    assert optuna._hypervolume.WFG().compute(s, r, assume_pareto) == ground_truth
 
 
 def test_invalid_input() -> None:


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

As the current `WFG` significantly slows down when `solution_set` is not Pareto optimal, I added a line to make `solution_set` Pareto optimal.

```python
from optuna._hypervolume import WFG


rng = np.random.RandomState(42)
sols = rng.normal(size=(10000, 3)) + 10.0
reference_point = np.max(sols, axis=0) * 1.1
hv = WFG().compute(sols, reference_point)
```

As `is_pareto_front` is not really a cheap operation, I additionally added an option to avoid the function call as well.

## Description of the changes
<!-- Describe the changes in this PR. -->

- Add a line to make `solution_set` Pareto optimal,
- Add an option to avoid the Pareto solution filtering.