### PR TITLE
Guarantee `weights_below` to be finite in MOTPE

### DIFF
--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -516,8 +516,7 @@ class TPESampler(BaseSampler):
             weights_below = _calculate_weights_below_for_multi_objective(
                 study, trials, self._constraints_func
             )[param_mask_below]
-            if not np.isfinite(weights_below).all():
-                weights_below = np.clip(1.0 - np.isfinite(weights_below), EPS, 1.0)
+            assert np.isfinite(weights_below).all()
             mpe = self._parzen_estimator_cls(
                 observations, search_space, self._parzen_estimator_parameters, weights_below
             )

--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -516,6 +516,8 @@ class TPESampler(BaseSampler):
             weights_below = _calculate_weights_below_for_multi_objective(
                 study, trials, self._constraints_func
             )[param_mask_below]
+            if not np.isfinite(weights_below.sum()):
+                weights_below = np.ones_like(weights_below)
             mpe = self._parzen_estimator_cls(
                 observations, search_space, self._parzen_estimator_parameters, weights_below
             )

--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -516,8 +516,8 @@ class TPESampler(BaseSampler):
             weights_below = _calculate_weights_below_for_multi_objective(
                 study, trials, self._constraints_func
             )[param_mask_below]
-            if not np.isfinite(weights_below.sum()):
-                weights_below = np.ones_like(weights_below)
+            if not np.isfinite(weights_below).all():
+                weights_below = 1.0 - np.isfinite(weights_below)
             mpe = self._parzen_estimator_cls(
                 observations, search_space, self._parzen_estimator_parameters, weights_below
             )
@@ -816,8 +816,7 @@ def _calculate_weights_below_for_multi_objective(
         contributions = np.asarray(
             [hv - WFG().compute(lvals[indices_mat[i]], reference_point) for i in range(n_below)]
         )
-        contributions += EPS
-        weights_below = np.clip(contributions / np.max(contributions), 0, 1)
+        weights_below = np.clip(contributions / np.max(contributions), EPS, 1)
 
     # For now, EPS weight is assigned to infeasible trials.
     weights_below_all = np.full(len(below_trials), EPS)

--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -816,7 +816,7 @@ def _calculate_weights_below_for_multi_objective(
             [hv - WFG().compute(lvals[indices_mat[i]], reference_point) for i in range(n_below)]
         )
         contributions[np.isnan(contributions)] = np.inf
-        max_contribution = np.max(contributions)
+        max_contribution = np.maximum(np.max(contributions), EPS)
         if not np.isfinite(max_contribution):
             weights_below = np.ones_like(contributions, dtype=float)
             weights_below[np.isfinite(contributions)] = EPS

--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -819,6 +819,7 @@ def _calculate_weights_below_for_multi_objective(
         max_contribution = np.maximum(np.max(contributions), EPS)
         if not np.isfinite(max_contribution):
             weights_below = np.ones_like(contributions, dtype=float)
+            # TODO(nabenabe0928): Make the weights for non Pareto solutions to zero.
             weights_below[np.isfinite(contributions)] = EPS
         else:
             weights_below = np.clip(contributions / max_contribution, EPS, 1)

--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -816,8 +816,13 @@ def _calculate_weights_below_for_multi_objective(
         contributions = np.asarray(
             [hv - WFG().compute(lvals[indices_mat[i]], reference_point) for i in range(n_below)]
         )
-        contributions = np.clip(contributions, EPS, None)
-        weights_below = np.clip(contributions / np.max(contributions), EPS, 1.0)
+        contributions[np.isnan(contributions)] = np.inf
+        max_contribution = np.max(contributions)
+        if not np.isfinite(max_contribution):
+            weights_below = np.ones_like(contributions, dtype=float)
+            weights_below[np.isfinite(contributions)] = EPS
+        else:
+            weights_below = np.clip(contributions / max_contribution, EPS, 1)
 
     # For now, EPS weight is assigned to infeasible trials.
     weights_below_all = np.full(len(below_trials), EPS)

--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -517,7 +517,7 @@ class TPESampler(BaseSampler):
                 study, trials, self._constraints_func
             )[param_mask_below]
             if not np.isfinite(weights_below).all():
-                weights_below = 1.0 - np.isfinite(weights_below)
+                weights_below = np.clip(1.0 - np.isfinite(weights_below), EPS, 1.0)
             mpe = self._parzen_estimator_cls(
                 observations, search_space, self._parzen_estimator_parameters, weights_below
             )
@@ -817,7 +817,7 @@ def _calculate_weights_below_for_multi_objective(
             [hv - WFG().compute(lvals[indices_mat[i]], reference_point) for i in range(n_below)]
         )
         contributions = np.clip(contributions, EPS, None)
-        weights_below = np.clip(contributions / np.max(contributions), EPS, 1)
+        weights_below = np.clip(contributions / np.max(contributions), EPS, 1.0)
 
     # For now, EPS weight is assigned to infeasible trials.
     weights_below_all = np.full(len(below_trials), EPS)

--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -816,6 +816,7 @@ def _calculate_weights_below_for_multi_objective(
         contributions = np.asarray(
             [hv - WFG().compute(lvals[indices_mat[i]], reference_point) for i in range(n_below)]
         )
+        contributions = np.clip(contributions, EPS, None)
         weights_below = np.clip(contributions / np.max(contributions), EPS, 1)
 
     # For now, EPS weight is assigned to infeasible trials.

--- a/tests/samplers_tests/tpe_tests/test_multi_objective_sampler.py
+++ b/tests/samplers_tests/tpe_tests/test_multi_objective_sampler.py
@@ -442,7 +442,8 @@ def test_calculate_weights_below_for_multi_objective() -> None:
         None,
     )
     assert len(weights_below) == 3
-    assert all([np.isnan(w) for w in weights_below])
+    assert not any([np.isnan(w) for w in weights_below])
+    assert sum(weights_below) > 0
 
     # Three samples with two infeasible trials.
     study = optuna.create_study(directions=["minimize", "minimize"])


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

Resolve https://github.com/optuna/optuna/issues/5374

## Description of the changes
<!-- Describe the changes in this PR. -->

I added code to guarantee `weights_below` to be finite in MOTPE. Weights fall-back to uniform if it contains inf, nan, or a value large enough to be inf when summed.