### PR TITLE
Lock the trial heartbeat model

### DIFF
--- a/optuna/storages/_rdb/models.py
+++ b/optuna/storages/_rdb/models.py
@@ -562,7 +562,7 @@ class TrialHeartbeatModel(BaseModel):
     def where_trial_id(
         cls, trial_id: int, session: orm.Session
     ) -> Optional["TrialHeartbeatModel"]:
-        return session.query(cls).filter(cls.trial_id == trial_id).one_or_none()
+        return session.query(cls).filter(cls.trial_id == trial_id).with_for_update().one_or_none()
 
 
 class VersionInfoModel(BaseModel):


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
When using RDB in Optuna, the thread that records Heartbeat for Trial runs in parallel with the threads running Study and Trial. When writing values to Study and Trial tables, we are calling `with_for_update` so that the FOR UPDATE clause is appended to the SELECT sentences, but not when writing values to Heartbeat tables. This may cause an unexpected lock when writing values to Heartbeat tables, resulting in a deadlock. This PR suggests calling `with_for_update` when writing to Heartbeat tables.

## Description of the changes
<!-- Describe the changes in this PR. -->
- Add `with_for_update` to the Heartbeat table.
