### PR TITLE
Deprecated `constraints_func` in `plot_pareto_front` function

### DIFF
--- a/optuna/visualization/_pareto_front.py
+++ b/optuna/visualization/_pareto_front.py
@@ -7,6 +7,7 @@ from typing import NamedTuple
 import warnings
 
 import optuna
+from optuna import _deprecated
 from optuna.samplers._base import _CONSTRAINTS_KEY
 from optuna.study import Study
 from optuna.study._multi_objective import _get_pareto_front_trials_by_trials
@@ -238,12 +239,20 @@ def _get_pareto_front_info(
     targets: Callable[[FrozenTrial], Sequence[float]] | None = None,
 ) -> _ParetoFrontInfo:
     if axis_order is not None:
-        warnings.warn(
-            "`axis_order` has been deprecated in v3.0.0. "
-            "This feature will be removed in v5.0.0. "
-            "See https://github.com/optuna/optuna/releases/tag/v3.0.0.",
-            FutureWarning,
+        msg = _deprecated._DEPRECATION_WARNING_TEMPLATE.format(
+            name="`axis_order`",
+            d_ver="3.0.0",
+            r_ver="5.0.0",
         )
+        warnings.warn(msg, FutureWarning)
+
+    if constraints_func is not None:
+        msg = _deprecated._DEPRECATION_WARNING_TEMPLATE.format(
+            name="`constraints_func`",
+            d_ver="4.0.0",
+            r_ver="6.0.0",
+        )
+        warnings.warn(msg, FutureWarning)
 
     if targets is not None and axis_order is not None:
         raise ValueError(
@@ -255,12 +264,6 @@ def _get_pareto_front_info(
     infeasible_trials = []
     has_constraints = False
     if constraints_func is not None:
-        warnings.warn(
-            "`constraints_func` has been deprecated in v4.0.0. "
-            "This feature will be removed in v6.0.0. "
-            "See https://github.com/optuna/optuna/releases/tag/v4.0.0.",
-            FutureWarning,
-        )
         for trial in study.get_trials(deepcopy=False, states=(TrialState.COMPLETE,)):
             if all(map(lambda x: x <= 0.0, constraints_func(trial))):
                 feasible_trials.append(trial)
@@ -286,12 +289,8 @@ def _get_pareto_front_info(
         non_best_trials = []
 
     if len(best_trials) == 0:
-        _logger.warning(
-            (
-                "Your study does not have any completed"
-                f"{' and feasible' if has_constraints else ''} trials."
-            )
-        )
+        what_trial = "completed" if has_constraints else "completed and feasible"
+        _logger.warning(f"Your study does not have any {what_trial} trials. ")
 
     _targets = targets
     if _targets is None:

--- a/optuna/visualization/_pareto_front.py
+++ b/optuna/visualization/_pareto_front.py
@@ -240,17 +240,13 @@ def _get_pareto_front_info(
 ) -> _ParetoFrontInfo:
     if axis_order is not None:
         msg = _deprecated._DEPRECATION_WARNING_TEMPLATE.format(
-            name="`axis_order`",
-            d_ver="3.0.0",
-            r_ver="5.0.0",
+            name="`axis_order`", d_ver="3.0.0", r_ver="5.0.0"
         )
         warnings.warn(msg, FutureWarning)
 
     if constraints_func is not None:
         msg = _deprecated._DEPRECATION_WARNING_TEMPLATE.format(
-            name="`constraints_func`",
-            d_ver="4.0.0",
-            r_ver="6.0.0",
+            name="`constraints_func`", d_ver="4.0.0", r_ver="6.0.0"
         )
         warnings.warn(msg, FutureWarning)
 

--- a/optuna/visualization/_pareto_front.py
+++ b/optuna/visualization/_pareto_front.py
@@ -263,24 +263,22 @@ def _get_pareto_front_info(
     feasible_trials = []
     infeasible_trials = []
     has_constraints = False
-    if constraints_func is not None:
-        for trial in study.get_trials(deepcopy=False, states=(TrialState.COMPLETE,)):
+    for trial in study.get_trials(deepcopy=False, states=(TrialState.COMPLETE,)):
+        if constraints_func is not None:
+            # NOTE(nabenabe0928): This part is deprecated.
+            has_constraints = True
             if all(map(lambda x: x <= 0.0, constraints_func(trial))):
                 feasible_trials.append(trial)
             else:
                 infeasible_trials.append(trial)
-        has_constraints = True
-    else:
-        for trial in study.get_trials(deepcopy=False, states=(TrialState.COMPLETE,)):
-            constraints = trial.system_attrs.get(_CONSTRAINTS_KEY)
+            continue
 
-            if constraints is not None:
-                has_constraints = True
-
-            if constraints is None or all([x <= 0.0 for x in constraints]):
-                feasible_trials.append(trial)
-            else:
-                infeasible_trials.append(trial)
+        constraints = trial.system_attrs.get(_CONSTRAINTS_KEY)
+        has_constraints |= constraints is not None
+        if constraints is None or all([x <= 0.0 for x in constraints]):
+            feasible_trials.append(trial)
+        else:
+            infeasible_trials.append(trial)
 
     best_trials = _get_pareto_front_trials_by_trials(feasible_trials, study.directions)
     if include_dominated_trials:

--- a/optuna/visualization/_pareto_front.py
+++ b/optuna/visualization/_pareto_front.py
@@ -271,7 +271,7 @@ def _get_pareto_front_info(
 
         constraints = trial.system_attrs.get(_CONSTRAINTS_KEY)
         has_constraints |= constraints is not None
-        if constraints is None or all([x <= 0.0 for x in constraints]):
+        if constraints is None or all(x <= 0.0 for x in constraints):
             feasible_trials.append(trial)
         else:
             infeasible_trials.append(trial)

--- a/optuna/visualization/matplotlib/_pareto_front.py
+++ b/optuna/visualization/matplotlib/_pareto_front.py
@@ -84,6 +84,11 @@ def plot_pareto_front(
             If given, trials are classified into three categories: feasible and best, feasible but
             non-best, and infeasible. Categories are shown in different colors. Here, whether a
             trial is best (on Pareto front) or not is determined ignoring all infeasible trials.
+
+            .. warning::
+                Deprecated in v4.0.0. This feature will be removed in the future. The removal of
+                this feature is currently scheduled for v6.0.0, but this schedule is subject to
+                change. See https://github.com/optuna/optuna/releases/tag/v4.0.0.
         targets:
             A function that returns a tuple of target values to display.
             The argument to this function is :class:`~optuna.trial.FrozenTrial`.

--- a/tests/visualization_tests/test_pareto_front.py
+++ b/tests/visualization_tests/test_pareto_front.py
@@ -58,6 +58,7 @@ def create_study_2d(
     study.optimize(lambda t: [t.suggest_int("x", 0, 2), t.suggest_int("y", 0, 2)], n_trials=4)
     return study
 
+
 def create_study_3d() -> Study:
     study = optuna.create_study(directions=["minimize", "minimize", "minimize"])
 
@@ -85,7 +86,9 @@ def test_get_pareto_front_info_unconstrained(
     metric_names: list[str] | None,
 ) -> None:
     if axis_order is not None and targets is not None:
-        pytest.skip("skip using both axis_order and targets because they cannot be used at the same time.")
+        pytest.skip(
+            "skip using both axis_order and targets because they cannot be used at the same time."
+        )
 
     study = create_study_2d()
     if metric_names is not None:
@@ -130,7 +133,9 @@ def test_get_pareto_front_info_constrained(
     use_study_with_constraints: bool,
 ) -> None:
     if axis_order is not None and targets is not None:
-        pytest.skip("skip using both axis_order and targets because they cannot be used at the same time.")
+        pytest.skip(
+            "skip using both axis_order and targets because they cannot be used at the same time."
+        )
 
     # (x, y) = (1, 0) is infeasible; others are feasible.
     def constraints_func(t: FrozenTrial) -> Sequence[float]:
@@ -183,7 +188,9 @@ def test_get_pareto_front_info_all_infeasible(
     use_study_with_constraints: bool,
 ) -> None:
     if axis_order is not None and targets is not None:
-        pytest.skip("skip using both axis_order and targets because they cannot be used at the same time.")
+        pytest.skip(
+            "skip using both axis_order and targets because they cannot be used at the same time."
+        )
 
     # all trials are infeasible.
     def constraints_func(t: FrozenTrial) -> Sequence[float]:
@@ -237,7 +244,9 @@ def test_get_pareto_front_info_3d(
     target_names: list[str] | None,
 ) -> None:
     if axis_order is not None and targets is not None:
-        pytest.skip("skip using both axis_order and targets because they cannot be used at the same time.")
+        pytest.skip(
+            "skip using both axis_order and targets because they cannot be used at the same time."
+        )
 
     study = create_study_3d()
     trials = study.get_trials(deepcopy=False)

--- a/tests/visualization_tests/test_pareto_front.py
+++ b/tests/visualization_tests/test_pareto_front.py
@@ -45,19 +45,8 @@ def test_get_pareto_front_info_infer_n_targets() -> None:
         _get_pareto_front_info(study, targets=lambda _: [0.0, 1.0])
 
 
-def create_study_2d() -> Study:
-    study = optuna.create_study(directions=["minimize", "minimize"])
-
-    study.enqueue_trial({"x": 1, "y": 2})
-    study.enqueue_trial({"x": 1, "y": 1})
-    study.enqueue_trial({"x": 0, "y": 2})
-    study.enqueue_trial({"x": 1, "y": 0})
-    study.optimize(lambda t: [t.suggest_int("x", 0, 2), t.suggest_int("y", 0, 2)], n_trials=4)
-    return study
-
-
-def create_study_2d_with_constraints(
-    constraints_func: Callable[[FrozenTrial], Sequence[float]]
+def create_study_2d(
+    constraints_func: Callable[[FrozenTrial], Sequence[float]] | None = None
 ) -> Study:
     sampler = optuna.samplers.TPESampler(seed=0, constraints_func=constraints_func)
     study = optuna.create_study(directions=["minimize", "minimize"], sampler=sampler)
@@ -68,7 +57,6 @@ def create_study_2d_with_constraints(
     study.enqueue_trial({"x": 1, "y": 0})
     study.optimize(lambda t: [t.suggest_int("x", 0, 2), t.suggest_int("y", 0, 2)], n_trials=4)
     return study
-
 
 def create_study_3d() -> Study:
     study = optuna.create_study(directions=["minimize", "minimize", "minimize"])
@@ -149,7 +137,7 @@ def test_get_pareto_front_info_constrained(
         return [1.0] if t.params["x"] == 1 and t.params["y"] == 0 else [-1.0]
 
     if use_study_with_constraints:
-        study = create_study_2d_with_constraints(constraints_func=constraints_func)
+        study = create_study_2d(constraints_func=constraints_func)
     else:
         study = create_study_2d()
 
@@ -202,7 +190,7 @@ def test_get_pareto_front_info_all_infeasible(
         return [1.0]
 
     if use_study_with_constraints:
-        study = create_study_2d_with_constraints(constraints_func=constraints_func)
+        study = create_study_2d(constraints_func=constraints_func)
     else:
         study = create_study_2d()
 

--- a/tests/visualization_tests/test_pareto_front.py
+++ b/tests/visualization_tests/test_pareto_front.py
@@ -97,7 +97,7 @@ def test_get_pareto_front_info_unconstrained(
     metric_names: list[str] | None,
 ) -> None:
     if axis_order is not None and targets is not None:
-        pytest.skip("skip using both axis_order and targets")
+        pytest.skip("skip using both axis_order and targets because they cannot be used at the same time.")
 
     study = create_study_2d()
     if metric_names is not None:
@@ -142,7 +142,7 @@ def test_get_pareto_front_info_constrained(
     use_study_with_constraints: bool,
 ) -> None:
     if axis_order is not None and targets is not None:
-        pytest.skip("skip using both axis_order and targets")
+        pytest.skip("skip using both axis_order and targets because they cannot be used at the same time.")
 
     # (x, y) = (1, 0) is infeasible; others are feasible.
     def constraints_func(t: FrozenTrial) -> Sequence[float]:
@@ -159,23 +159,14 @@ def test_get_pareto_front_info_constrained(
 
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", category=FutureWarning)
-        if use_study_with_constraints:
-            info = _get_pareto_front_info(
-                study=study,
-                include_dominated_trials=include_dominated_trials,
-                axis_order=axis_order,
-                targets=targets,
-                target_names=target_names,
-            )
-        else:
-            info = _get_pareto_front_info(
-                study=study,
-                include_dominated_trials=include_dominated_trials,
-                axis_order=axis_order,
-                targets=targets,
-                target_names=target_names,
-                constraints_func=constraints_func,
-            )
+        info = _get_pareto_front_info(
+            study=study,
+            include_dominated_trials=include_dominated_trials,
+            axis_order=axis_order,
+            targets=targets,
+            target_names=target_names,
+            constraints_func=None if use_study_with_constraints else constraints_func,
+        )
 
     assert info == _ParetoFrontInfo(
         n_targets=2,
@@ -204,7 +195,7 @@ def test_get_pareto_front_info_all_infeasible(
     use_study_with_constraints: bool,
 ) -> None:
     if axis_order is not None and targets is not None:
-        pytest.skip("skip using both axis_order and targets")
+        pytest.skip("skip using both axis_order and targets because they cannot be used at the same time.")
 
     # all trials are infeasible.
     def constraints_func(t: FrozenTrial) -> Sequence[float]:
@@ -221,23 +212,14 @@ def test_get_pareto_front_info_all_infeasible(
 
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", category=FutureWarning)
-        if use_study_with_constraints:
-            info = _get_pareto_front_info(
-                study=study,
-                include_dominated_trials=include_dominated_trials,
-                axis_order=axis_order,
-                targets=targets,
-                target_names=target_names,
-            )
-        else:
-            info = _get_pareto_front_info(
-                study=study,
-                include_dominated_trials=include_dominated_trials,
-                axis_order=axis_order,
-                targets=targets,
-                target_names=target_names,
-                constraints_func=constraints_func,
-            )
+        info = _get_pareto_front_info(
+            study=study,
+            include_dominated_trials=include_dominated_trials,
+            axis_order=axis_order,
+            targets=targets,
+            target_names=target_names,
+            constraints_func=None if use_study_with_constraints else constraints_func,
+        )
 
     assert info == _ParetoFrontInfo(
         n_targets=2,
@@ -267,7 +249,7 @@ def test_get_pareto_front_info_3d(
     target_names: list[str] | None,
 ) -> None:
     if axis_order is not None and targets is not None:
-        pytest.skip("skip using both axis_order and targets")
+        pytest.skip("skip using both axis_order and targets because they cannot be used at the same time.")
 
     study = create_study_3d()
     trials = study.get_trials(deepcopy=False)


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

The function `plot_pareto_front` had an optional argument `constraints_func`, which was a different interface from other plot functions such as `plot_optimization_history`. In this PR, `constraints_func` in `plot_pareto_front` function is now deprecated, and instead makes it possible to apply the constraints passed to a sampler in `plot_pareto_front`. This allows the interfaces of plot functions to be aligned.

## Description of the changes
<!-- Describe the changes in this PR. -->

- Deprecated `constraints_func` argument in the `plot_pareto_front` function
- Made it possible to apply the constraints passed to a sampler in the `plot_pareto_front` function
- Modified tests of `plot_pareto_front`