### PR TITLE
Fix `_log_complete_trial` for constrained optimization

### DIFF
--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -1116,12 +1116,6 @@ class Study:
                 )
             )
         elif len(trial.values) == 1:
-            try:
-                best_trial = self.best_trial
-            except ValueError:
-                # If no feasible trials are completed yet, study.best_trial raises ValueError.
-                best_trial = None
-
             trial_value: float | dict[str, float]
             if metric_names is None:
                 trial_value = trial.values[0]
@@ -1132,8 +1126,12 @@ class Study:
                 f"Trial {trial.number} finished with value: {trial_value} and parameters: "
                 f"{trial.params}."
             )
-            if best_trial is not None:
+            try:
+                best_trial = self.best_trial
                 message += f" Best is trial {best_trial.number} with value: {best_trial.value}."
+            except ValueError:
+                # If no feasible trials are completed yet, study.best_trial raises ValueError.
+                pass
             _logger.info(message)
         else:
             assert False, "Should not reach."

--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -1111,27 +1111,30 @@ class Study:
             else:
                 trial_values = {name: value for name, value in zip(metric_names, trial.values)}
             _logger.info(
-                "Trial {} finished with values: {} and parameters: {}. ".format(
+                "Trial {} finished with values: {} and parameters: {}.".format(
                     trial.number, trial_values, trial.params
                 )
             )
         elif len(trial.values) == 1:
-            best_trial = self.best_trial
+            try:
+                best_trial = self.best_trial
+            except ValueError:
+                # If no feasible trials are completed yet, study.best_trial raises ValueError.
+                best_trial = None
+
             trial_value: float | dict[str, float]
             if metric_names is None:
                 trial_value = trial.values[0]
             else:
                 trial_value = {metric_names[0]: trial.values[0]}
-            _logger.info(
-                "Trial {} finished with value: {} and parameters: {}. "
-                "Best is trial {} with value: {}.".format(
-                    trial.number,
-                    trial_value,
-                    trial.params,
-                    best_trial.number,
-                    best_trial.value,
-                )
+
+            message = (
+                f"Trial {trial.number} finished with value: {trial_value} and parameters: "
+                f"{trial.params}."
             )
+            if best_trial is not None:
+                message += f" Best is trial {best_trial.number} with value: {best_trial.value}."
+            _logger.info(message)
         else:
             assert False, "Should not reach."
 


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
`_log_complete_trial` assumes that `study.best_trial` does not raise `ValueError` because the latest trial is `COMPLETE` (Note: if no trial is `COMPLETE`, `best_trial` raises `ValueError`). But, after #5426 was merged, it raises `ValueError` if no trial is **feasible**.

## Description of the changes
<!-- Describe the changes in this PR. -->
This PR added try-except for the constrained optimization and fixed the logging message.