### PR TITLE
Use CPU-only PyTorch wheels on GitHub Actions

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -51,7 +51,7 @@ jobs:
         python -c 'import optuna'
         optuna --version
 
-        pip install --progress-bar off .[test]
+        pip install --progress-bar off .[test] --extra-index-url https://download.pytorch.org/whl/cpu
         pip install --progress-bar off .[optional] --extra-index-url https://download.pytorch.org/whl/cpu
         # TODO(c-bata): Remove a version constraint after releasing https://github.com/cunla/fakeredis-py/pull/303
         pip install --progress-bar off 'fakeredis[lua]<2.21.2'

--- a/.github/workflows/mac-tests.yml
+++ b/.github/workflows/mac-tests.yml
@@ -49,8 +49,8 @@ jobs:
         pip install --progress-bar off .
         python -c 'import optuna'
         optuna --version
-        pip install --progress-bar off .[test]
-        pip install --progress-bar off .[optional]
+        pip install --progress-bar off .[test] --extra-index-url https://download.pytorch.org/whl/cpu
+        pip install --progress-bar off .[optional] --extra-index-url https://download.pytorch.org/whl/cpu
         # TODO(c-bata): Remove a version constraint after releasing https://github.com/cunla/fakeredis-py/pull/303
         pip install --progress-bar off 'fakeredis[lua]<2.21.2'
 

--- a/.github/workflows/matplotlib-tests.yml
+++ b/.github/workflows/matplotlib-tests.yml
@@ -44,8 +44,8 @@ jobs:
         pip install --progress-bar off .
         python -c 'import optuna'
         optuna --version
-        pip install --progress-bar off .[test]
-        pip install --progress-bar off .[optional]
+        pip install --progress-bar off .[test] --extra-index-url https://download.pytorch.org/whl/cpu
+        pip install --progress-bar off .[optional] --extra-index-url https://download.pytorch.org/whl/cpu
 
     - name: Output installed packages
       run: |

--- a/.github/workflows/tests-storage.yml
+++ b/.github/workflows/tests-storage.yml
@@ -101,7 +101,7 @@ jobs:
         python -c 'import optuna'
         optuna --version
 
-        pip install --progress-bar off .[test]
+        pip install --progress-bar off .[test] --extra-index-url https://download.pytorch.org/whl/cpu
         pip install --progress-bar off .[optional] --extra-index-url https://download.pytorch.org/whl/cpu
 
     - name: Install DB bindings

--- a/.github/workflows/tests-with-minimum-versions.yml
+++ b/.github/workflows/tests-with-minimum-versions.yml
@@ -63,7 +63,7 @@ jobs:
         python -c 'import optuna'
         optuna --version
 
-        pip install --progress-bar off .[test]
+        pip install --progress-bar off .[test] --extra-index-url https://download.pytorch.org/whl/cpu
         pip install --progress-bar off .[optional] --extra-index-url https://download.pytorch.org/whl/cpu
         # TODO(c-bata): Remove a version constraint after releasing https://github.com/cunla/fakeredis-py/pull/303
         pip install --progress-bar off 'fakeredis[lua]<2.21.2'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -74,7 +74,7 @@ jobs:
         python -c 'import optuna'
         optuna --version
 
-        pip install --progress-bar off .[test]
+        pip install --progress-bar off .[test] --extra-index-url https://download.pytorch.org/whl/cpu
         pip install --progress-bar off .[optional] --extra-index-url https://download.pytorch.org/whl/cpu
         # TODO(c-bata): Remove a version constraint after releasing https://github.com/cunla/fakeredis-py/pull/303
         pip install --progress-bar off 'fakeredis[lua]<2.21.2'

--- a/.github/workflows/windows-tests.yml
+++ b/.github/workflows/windows-tests.yml
@@ -49,8 +49,8 @@ jobs:
         pip install --progress-bar off .
         python -c 'import optuna'
         optuna --version
-        pip install --progress-bar off .[test]
-        pip install --progress-bar off .[optional]
+        pip install --progress-bar off .[test] --extra-index-url https://download.pytorch.org/whl/cpu
+        pip install --progress-bar off .[optional] --extra-index-url https://download.pytorch.org/whl/cpu
         # TODO(c-bata): Remove a version constraint after releasing https://github.com/cunla/fakeredis-py/pull/303
         pip install --progress-bar off 'fakeredis[lua]<2.21.2'
         pip install PyQt6 # Install PyQT for using QtAgg as matplotlib backend.


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

resolved #5410 

## Description of the changes
<!-- Describe the changes in this PR. -->

As issue #5410 says, although PyTorch wheels with CUDA-related files were not required on GitHub Actions, workflows used to include downloading them. This PR would resolve the problem by explicitly setting options for only installing cpu-version PyTorch.
