### PR TITLE
Revise docs to specify ArtifactStore's methods as non-public

### DIFF
--- a/docs/source/reference/artifacts.rst
+++ b/docs/source/reference/artifacts.rst
@@ -4,6 +4,7 @@ optuna.artifacts
 ================
 
 The :mod:`~optuna.artifacts` module provides the way to manage artifacts (output files) in Optuna.
+Please note that methods defined in each ArtifactStore are not intended to be directly accessed by library users.
 
 .. autoclass:: optuna.artifacts.FileSystemArtifactStore
    :no-members:

--- a/optuna/artifacts/_protocol.py
+++ b/optuna/artifacts/_protocol.py
@@ -16,6 +16,8 @@ if TYPE_CHECKING:
 class ArtifactStore(Protocol):
     """A protocol defining the interface for an artifact backend.
 
+    Methods defined in this protocol are not supposed to be directly intended by library users.
+
     An artifact backend is responsible for managing the storage and retrieval
     of artifact data. The backend should provide methods for opening, writing
     and removing artifacts.

--- a/optuna/artifacts/_protocol.py
+++ b/optuna/artifacts/_protocol.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 class ArtifactStore(Protocol):
     """A protocol defining the interface for an artifact backend.
 
-    Methods defined in this protocol are not supposed to be directly intended by library users.
+    The methods defined in this protocol are not supposed to be directly called by library users.
 
     An artifact backend is responsible for managing the storage and retrieval
     of artifact data. The backend should provide methods for opening, writing


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
Like `optuna.samplers.BaseStorage`, the methods defined in `ArtifactStore` protocol are not intended to call directly by library users. Source code that calls ArtifactStore's method directly may be broken in the future release.

## Description of the changes
<!-- Describe the changes in this PR. -->
I updated the documentation and the docstring to let users know methods in ArtifactStore are private.