### PR TITLE
Use a fixed seed value when `seed=None` in `GridSampler`

### DIFF
--- a/optuna/samplers/_grid.py
+++ b/optuna/samplers/_grid.py
@@ -125,9 +125,10 @@ class GridSampler(BaseSampler):
         self._all_grids = list(itertools.product(*self._search_space.values()))
         self._param_names = sorted(search_space.keys())
         self._n_min_trials = len(self._all_grids)
-        self._rng = LazyRandomState(seed or 0)
-        if seed is not None:
-            self._rng.rng.shuffle(self._all_grids)  # type: ignore[arg-type]
+        if seed is None:
+            seed = 0
+        self._rng = LazyRandomState(seed)
+        self._rng.rng.shuffle(self._all_grids)  # type: ignore[arg-type]
 
     def reseed_rng(self) -> None:
         self._rng.rng.seed()

--- a/optuna/samplers/_grid.py
+++ b/optuna/samplers/_grid.py
@@ -198,9 +198,6 @@ class GridSampler(BaseSampler):
             message = "The parameter name, {}, is not found in the given grid.".format(param_name)
             raise ValueError(message)
 
-        # TODO(c-bata): Reduce the number of duplicated evaluations on multiple workers.
-        # Current selection logic may evaluate the same parameters multiple times.
-        # See https://gist.github.com/c-bata/f759f64becb24eea2040f4b2e3afce8f for details.
         grid_id = trial.system_attrs["grid_id"]
         param_value = self._all_grids[grid_id][self._param_names.index(param_name)]
         contains = param_distribution._contains(param_distribution.to_internal_repr(param_value))

--- a/optuna/samplers/_grid.py
+++ b/optuna/samplers/_grid.py
@@ -104,11 +104,10 @@ class GridSampler(BaseSampler):
         seed:
             A seed to fix the order of trials as the grid is randomly shuffled. This shuffle is
             beneficial when the number of grids is larger than ``n_trials`` in
-            :meth:`~optuna.Study.optimize` not to suggest similar grids. Please note that it is
-            recommended using the same ``seed`` or :obj:`None` in distributed optimization
-            settings because internally each grid is assigned to an integer after shuffling grids.
-            Otherwise, this sampler may increase the number of duplicate suggestions during
-            distributed optimization.
+            :meth:`~optuna.Study.optimize` to suppress suggesting similar grids. If ``seed`` is
+            :obj:`None`, the shuffle does not happen. Please note that fixing ``seed`` for each
+            process is strongly recommended in distributed optimization to avoid duplicated
+            suggestions.
     """
 
     def __init__(

--- a/optuna/samplers/_grid.py
+++ b/optuna/samplers/_grid.py
@@ -122,7 +122,9 @@ class GridSampler(BaseSampler):
         self._all_grids = list(itertools.product(*self._search_space.values()))
         self._param_names = sorted(search_space.keys())
         self._n_min_trials = len(self._all_grids)
-        self._rng = LazyRandomState(seed)
+        self._rng = LazyRandomState(seed or 0)
+        if seed is not None:
+            self._rng.rng.shuffle(self._all_grids) # type: ignore[arg-type]
 
     def reseed_rng(self) -> None:
         self._rng.rng.seed()

--- a/optuna/samplers/_grid.py
+++ b/optuna/samplers/_grid.py
@@ -123,7 +123,6 @@ class GridSampler(BaseSampler):
         self._param_names = sorted(search_space.keys())
         self._n_min_trials = len(self._all_grids)
         self._rng = LazyRandomState(seed)
-        self._rng.rng.shuffle(self._all_grids)  # type: ignore[arg-type]
 
     def reseed_rng(self) -> None:
         self._rng.rng.seed()

--- a/optuna/samplers/_grid.py
+++ b/optuna/samplers/_grid.py
@@ -124,7 +124,7 @@ class GridSampler(BaseSampler):
         self._n_min_trials = len(self._all_grids)
         self._rng = LazyRandomState(seed or 0)
         if seed is not None:
-            self._rng.rng.shuffle(self._all_grids) # type: ignore[arg-type]
+            self._rng.rng.shuffle(self._all_grids)  # type: ignore[arg-type]
 
     def reseed_rng(self) -> None:
         self._rng.rng.seed()

--- a/optuna/samplers/_grid.py
+++ b/optuna/samplers/_grid.py
@@ -102,10 +102,13 @@ class GridSampler(BaseSampler):
             A dictionary whose key and value are a parameter name and the corresponding candidates
             of values, respectively.
         seed:
-            A seed to fix the order of trials as the grid is randomly shuffled. Please note that
-            it is not recommended using this option in distributed optimization settings since
-            this option cannot ensure the order of trials and may increase the number of duplicate
-            suggestions during distributed optimization.
+            A seed to fix the order of trials as the grid is randomly shuffled. This shuffle is
+            beneficial when the number of grids is larger than ``n_trials`` in
+            :meth:`~optuna.Study.optimize` not to suggest similar grids. Please note that it is
+            recommended using the same ``seed`` or :obj:`None` in distributed optimization
+            settings because internally each grid is assigned to an integer after shuffling grids.
+            Otherwise, this sampler may increase the number of duplicate suggestions during
+            distributed optimization.
     """
 
     def __init__(

--- a/optuna/samplers/_grid.py
+++ b/optuna/samplers/_grid.py
@@ -123,9 +123,7 @@ class GridSampler(BaseSampler):
         self._all_grids = list(itertools.product(*self._search_space.values()))
         self._param_names = sorted(search_space.keys())
         self._n_min_trials = len(self._all_grids)
-        if seed is None:
-            seed = 0
-        self._rng = LazyRandomState(seed)
+        self._rng = LazyRandomState(seed or 0)
         self._rng.rng.shuffle(self._all_grids)  # type: ignore[arg-type]
 
     def reseed_rng(self) -> None:

--- a/optuna/samplers/_grid.py
+++ b/optuna/samplers/_grid.py
@@ -104,10 +104,9 @@ class GridSampler(BaseSampler):
         seed:
             A seed to fix the order of trials as the grid is randomly shuffled. This shuffle is
             beneficial when the number of grids is larger than ``n_trials`` in
-            :meth:`~optuna.Study.optimize` to suppress suggesting similar grids. If ``seed`` is
-            :obj:`None`, the shuffle does not happen. Please note that fixing ``seed`` for each
-            process is strongly recommended in distributed optimization to avoid duplicated
-            suggestions.
+            :meth:`~optuna.Study.optimize` to suppress suggesting similar grids. Please note
+            that fixing ``seed`` for each process is strongly recommended in distributed
+            optimization to avoid duplicated suggestions.
     """
 
     def __init__(


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

Resolve https://github.com/optuna/optuna/issues/5489. I'm happy to hear the opinion on this change because I'm not sure why this shuffle was introduced. 

## Description of the changes
<!-- Describe the changes in this PR. -->

~Remove the shuffle.~

For distributed optimisation, optuna docs suggest not setting `seed` for samplers or set different values. In this PR, call `shuffle` when `seed=0`.