### PR TITLE
Bugfix and refactor `_create_new_trial`

### DIFF
--- a/optuna/storages/_rdb/storage.py
+++ b/optuna/storages/_rdb/storage.py
@@ -500,10 +500,6 @@ class RDBStorage(BaseStorage, BaseHeartbeat):
                 # Should unavoidable exceptions be raised, the last exception is propagated
                 # after five retries.
                 error_obj = e
-                pass
-            except Exception as e:
-                error_obj = e
-                raise
         assert error_obj is not None
         raise error_obj
 

--- a/optuna/storages/_rdb/storage.py
+++ b/optuna/storages/_rdb/storage.py
@@ -491,7 +491,7 @@ class RDBStorage(BaseStorage, BaseHeartbeat):
                     models.StudyModel.find_or_raise_by_id(study_id, session, for_update=True)
                     trial = self._get_prepared_new_trial(study_id, template_trial, session)
                     return _create_frozen_trial(trial, template_trial)
-            except sqlalchemy_exc.OperationalError:
+            except sqlalchemy_exc.OperationalError as e:
                 # Note: According to SQLAlchemy specifications,
                 # `sqlalchemy_exc.OperationalError` can be raised in situations where
                 # retries are not effective (e.g., input string is too long).

--- a/optuna/storages/_rdb/storage.py
+++ b/optuna/storages/_rdb/storage.py
@@ -446,7 +446,7 @@ class RDBStorage(BaseStorage, BaseHeartbeat):
 
         # Retry a couple of times. Deadlocks may occur in distributed environments.
         n_retries = 0
-        error_obj = None
+        error_obj: Exception | None = None
         MAX_RETRIES = 5
         while n_retries < MAX_RETRIES:
             with _create_scoped_session(self.scoped_session) as session:


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

I want to refactor `_create_new_trial`
I want `_create_new_trial` to generate no empty trial_id when transaction processing fails.

(note: I want to clarify by separating single issue in PR https://github.com/optuna/optuna/pull/5466 , which involves multiple issues and becomes complicated.)

## Description of the changes
<!-- Describe the changes in this PR. -->

In the current implementation, `with _create_scoped_session` is outside and `while` loop is inside, so if the transaction fails in `_get_prepared_new_trial`, Optuna retries without rollback of the preceding `find_or_raise_by_id`. As a result, empty `trial_id` can be generated. (I confirmed the behaviour by a simple experiment that inserts a line raising an exception at `random` in `_get_prepared_new_trial`.)
In the proposed implementation, `with _create_scoped_session` is inside the for loop, so a rollback occurs against every fail of transaction.

## Note
In the current inplementation, only `sqlalchemy_exc.OperationalError:` will be caught, and other exceptions are re-raised as is. I believe the proposed implementation does not change the behaviour.