### PR TITLE
Enhance the error message for integration installation

### DIFF
--- a/optuna/_imports.py
+++ b/optuna/_imports.py
@@ -55,9 +55,9 @@ class _DeferredImportExceptionContextManager:
         """
         if isinstance(exc_value, (ImportError, SyntaxError)):
             if isinstance(exc_value, ImportError):
-                assert traceback is not None  # MyPy redefinition.
                 is_import_error_from_integration = (
-                    "optuna_integration/" in traceback.tb_frame.f_code.co_filename
+                    traceback is not None
+                    and "optuna_integration/" in traceback.tb_frame.f_code.co_filename
                 )
                 message = f"Tried to import '{exc_value.name}' but failed. "
                 if is_import_error_from_integration:

--- a/optuna/_imports.py
+++ b/optuna/_imports.py
@@ -7,6 +7,11 @@ from typing import Tuple
 from typing import Type
 
 
+_INTEGRATION_IMPORT_ERROR_TEMPLATE = (
+    "Could not find `optuna-integration` for `{0}`. Please run `pip optuna-integration[{0}]`."
+)
+
+
 class _DeferredImportExceptionContextManager:
     """Context manager to defer exceptions from imports.
 

--- a/optuna/_imports.py
+++ b/optuna/_imports.py
@@ -50,10 +50,23 @@ class _DeferredImportExceptionContextManager:
         """
         if isinstance(exc_value, (ImportError, SyntaxError)):
             if isinstance(exc_value, ImportError):
-                message = (
-                    "Tried to import '{}' but failed. Please make sure that the package is "
-                    "installed correctly to use this feature. Actual error: {}."
-                ).format(exc_value.name, exc_value)
+                assert traceback is not None  # MyPy redefinition.
+                is_import_error_from_integration = (
+                    "optuna_integration/" in traceback.tb_frame.f_code.co_filename
+                )
+                message = f"Tried to import '{exc_value.name}' but failed. "
+                if is_import_error_from_integration:
+                    integration_installation_url = (
+                        "https://optuna.readthedocs.io/en/stable/installation.html"
+                    )
+                    message += (
+                        f"Please check {integration_installation_url} to install the dependencies "
+                        "required for the integration module."
+                    )
+                else:
+                    message += f"Please manually install {exc_value.name}."
+
+                message += f" Actual error: {exc_value}."
             elif isinstance(exc_value, SyntaxError):
                 message = (
                     "Tried to import a package but failed due to a syntax error in {}. Please "

--- a/optuna/_imports.py
+++ b/optuna/_imports.py
@@ -8,7 +8,7 @@ from typing import Type
 
 
 _INTEGRATION_IMPORT_ERROR_TEMPLATE = (
-    "Could not find `optuna-integration` for `{0}`. Please run `pip optuna-integration[{0}]`."
+    "\nCould not find `optuna-integration` for `{0}`.\nPlease run `pip optuna-integration[{0}]`."
 )
 
 
@@ -55,23 +55,10 @@ class _DeferredImportExceptionContextManager:
         """
         if isinstance(exc_value, (ImportError, SyntaxError)):
             if isinstance(exc_value, ImportError):
-                is_import_error_from_integration = (
-                    traceback is not None
-                    and "optuna_integration/" in traceback.tb_frame.f_code.co_filename
-                )
-                message = f"Tried to import '{exc_value.name}' but failed. "
-                if is_import_error_from_integration:
-                    integration_installation_url = (
-                        "https://optuna.readthedocs.io/en/stable/installation.html"
-                    )
-                    message += (
-                        f"Please check {integration_installation_url} to install the dependencies "
-                        "required for the integration module."
-                    )
-                else:
-                    message += f"Please manually install {exc_value.name}."
-
-                message += f" Actual error: {exc_value}."
+                message = (
+                    "Tried to import '{}' but failed. Please make sure that the package is "
+                    "installed correctly to use this feature. Actual error: {}."
+                ).format(exc_value.name, exc_value)
             elif isinstance(exc_value, SyntaxError):
                 message = (
                     "Tried to import a package but failed due to a syntax error in {}. Please "

--- a/optuna/_imports.py
+++ b/optuna/_imports.py
@@ -8,7 +8,8 @@ from typing import Type
 
 
 _INTEGRATION_IMPORT_ERROR_TEMPLATE = (
-    "\nCould not find `optuna-integration` for `{0}`.\nPlease run `pip optuna-integration[{0}]`."
+    "\nCould not find `optuna-integration` for `{0}`.\n"
+    "Please run `pip install optuna-integration[{0}]`."
 )
 
 

--- a/optuna/integration/__init__.py
+++ b/optuna/integration/__init__.py
@@ -4,6 +4,8 @@ from types import ModuleType
 from typing import Any
 from typing import TYPE_CHECKING
 
+from optuna._imports import _INTEGRATION_IMPORT_ERROR_TEMPLATE
+
 
 _import_structure = {
     "allennlp": ["AllenNLPExecutor", "AllenNLPPruningCallback"],
@@ -130,11 +132,14 @@ else:
                 return importlib.import_module("." + module_name, self.__name__)
             except ModuleNotFoundError:
                 is_module_deprecated = module_name in ("allennlp", "chainer", "chainermn")
-                pip_cmd = "pip install optuna-integration"
-                pip_cmd += "" if is_module_deprecated else f"[{module_name}]"
-                raise ModuleNotFoundError(
-                    "Optuna integration modules for third-party libraries have been migrated to "
-                    f"`optuna-integration`. Please run `{pip_cmd}`."
-                )
+                if is_module_deprecated:
+                    msg = (
+                        "\nCould not find `optuna-integration`."
+                        "\nPlease run `pip install optuna-integration`."
+                    )
+                else:
+                    msg = _INTEGRATION_IMPORT_ERROR_TEMPLATE.format(module_name)
+
+                raise ModuleNotFoundError(msg)
 
     sys.modules[__name__] = _IntegrationModule(__name__)

--- a/optuna/integration/__init__.py
+++ b/optuna/integration/__init__.py
@@ -131,15 +131,6 @@ else:
             try:
                 return importlib.import_module("." + module_name, self.__name__)
             except ModuleNotFoundError:
-                is_module_deprecated = module_name in ("allennlp", "chainer", "chainermn")
-                if is_module_deprecated:
-                    msg = (
-                        "\nCould not find `optuna-integration`."
-                        "\nPlease run `pip install optuna-integration`."
-                    )
-                else:
-                    msg = _INTEGRATION_IMPORT_ERROR_TEMPLATE.format(module_name)
-
-                raise ModuleNotFoundError(msg)
+                raise ModuleNotFoundError(_INTEGRATION_IMPORT_ERROR_TEMPLATE.format(module_name))
 
     sys.modules[__name__] = _IntegrationModule(__name__)

--- a/optuna/integration/__init__.py
+++ b/optuna/integration/__init__.py
@@ -129,12 +129,12 @@ else:
             try:
                 return importlib.import_module("." + module_name, self.__name__)
             except ModuleNotFoundError:
+                is_module_deprecated = module_name in ("allennlp", "chainer", "chainermn")
+                pip_cmd = "pip install optuna-integration"
+                pip_cmd += "" if is_module_deprecated else f"[{module_name}]"
                 raise ModuleNotFoundError(
-                    "Optuna's integration modules for third-party libraries have started "
-                    "migrating from Optuna itself to a package called `optuna-integration`. "
-                    "The module you are trying to use has already been migrated to "
-                    "`optuna-integration`. Please install the package by running "
-                    "`pip install optuna-integration`."
+                    "Optuna integration modules for third-party libraries have been migrated to "
+                    f"`optuna-integration`. Please run `{pip_cmd}`."
                 )
 
     sys.modules[__name__] = _IntegrationModule(__name__)

--- a/optuna/integration/allennlp/__init__.py
+++ b/optuna/integration/allennlp/__init__.py
@@ -1,6 +1,12 @@
-from optuna_integration.allennlp._dump_best_config import dump_best_config
-from optuna_integration.allennlp._executor import AllenNLPExecutor
-from optuna_integration.allennlp._pruner import AllenNLPPruningCallback
+from optuna._imports import _INTEGRATION_IMPORT_ERROR_TEMPLATE
+
+
+try:
+    from optuna_integration.allennlp._dump_best_config import dump_best_config
+    from optuna_integration.allennlp._executor import AllenNLPExecutor
+    from optuna_integration.allennlp._pruner import AllenNLPPruningCallback
+except ModuleNotFoundError:
+    raise ModuleNotFoundError(_INTEGRATION_IMPORT_ERROR_TEMPLATE.format("allennlp"))
 
 
 __all__ = ["dump_best_config", "AllenNLPExecutor", "AllenNLPPruningCallback"]

--- a/optuna/integration/botorch.py
+++ b/optuna/integration/botorch.py
@@ -1,4 +1,10 @@
-from optuna_integration import BoTorchSampler
+from optuna._imports import _INTEGRATION_IMPORT_ERROR_TEMPLATE
+
+
+try:
+    from optuna_integration import BoTorchSampler
+except ModuleNotFoundError:
+    raise ModuleNotFoundError(_INTEGRATION_IMPORT_ERROR_TEMPLATE.format("botorch"))
 
 
 __all__ = ["BoTorchSampler"]

--- a/optuna/integration/catboost.py
+++ b/optuna/integration/catboost.py
@@ -1,4 +1,10 @@
-from optuna_integration.catboost import CatBoostPruningCallback
+from optuna._imports import _INTEGRATION_IMPORT_ERROR_TEMPLATE
+
+
+try:
+    from optuna_integration.catboost import CatBoostPruningCallback
+except ModuleNotFoundError:
+    raise ModuleNotFoundError(_INTEGRATION_IMPORT_ERROR_TEMPLATE.format("catboost"))
 
 
 __all__ = ["CatBoostPruningCallback"]

--- a/optuna/integration/chainer.py
+++ b/optuna/integration/chainer.py
@@ -1,4 +1,10 @@
-from optuna_integration.chainer import ChainerPruningExtension
+from optuna._imports import _INTEGRATION_IMPORT_ERROR_TEMPLATE
+
+
+try:
+    from optuna_integration.chainer import ChainerPruningExtension
+except ModuleNotFoundError:
+    raise ModuleNotFoundError(_INTEGRATION_IMPORT_ERROR_TEMPLATE.format("chainer"))
 
 
 __all__ = ["ChainerPruningExtension"]

--- a/optuna/integration/chainermn.py
+++ b/optuna/integration/chainermn.py
@@ -1,4 +1,10 @@
-from optuna_integration.chainermn import ChainerMNStudy
+from optuna._imports import _INTEGRATION_IMPORT_ERROR_TEMPLATE
+
+
+try:
+    from optuna_integration.chainermn import ChainerMNStudy
+except ModuleNotFoundError:
+    raise ModuleNotFoundError(_INTEGRATION_IMPORT_ERROR_TEMPLATE.format("chainermn"))
 
 
 __all__ = ["ChainerMNStudy"]

--- a/optuna/integration/cma.py
+++ b/optuna/integration/cma.py
@@ -1,4 +1,10 @@
-from optuna_integration.cma import PyCmaSampler
+from optuna._imports import _INTEGRATION_IMPORT_ERROR_TEMPLATE
+
+
+try:
+    from optuna_integration.cma import PyCmaSampler
+except ModuleNotFoundError:
+    raise ModuleNotFoundError(_INTEGRATION_IMPORT_ERROR_TEMPLATE.format("cma"))
 
 
 __all__ = ["PyCmaSampler"]

--- a/optuna/integration/dask.py
+++ b/optuna/integration/dask.py
@@ -1,4 +1,10 @@
-from optuna_integration.dask import DaskStorage
+from optuna._imports import _INTEGRATION_IMPORT_ERROR_TEMPLATE
+
+
+try:
+    from optuna_integration.dask import DaskStorage
+except ModuleNotFoundError:
+    raise ModuleNotFoundError(_INTEGRATION_IMPORT_ERROR_TEMPLATE.format("dask"))
 
 
 __all__ = ["DaskStorage"]

--- a/optuna/integration/fastaiv2.py
+++ b/optuna/integration/fastaiv2.py
@@ -1,5 +1,11 @@
-from optuna_integration.fastaiv2 import FastAIPruningCallback
-from optuna_integration.fastaiv2 import FastAIV2PruningCallback
+from optuna._imports import _INTEGRATION_IMPORT_ERROR_TEMPLATE
+
+
+try:
+    from optuna_integration.fastaiv2 import FastAIPruningCallback
+    from optuna_integration.fastaiv2 import FastAIV2PruningCallback
+except ModuleNotFoundError:
+    raise ModuleNotFoundError(_INTEGRATION_IMPORT_ERROR_TEMPLATE.format("fastaiv2"))
 
 
 __all__ = ["FastAIV2PruningCallback", "FastAIPruningCallback"]

--- a/optuna/integration/keras.py
+++ b/optuna/integration/keras.py
@@ -1,4 +1,10 @@
-from optuna_integration.keras import KerasPruningCallback
+from optuna._imports import _INTEGRATION_IMPORT_ERROR_TEMPLATE
+
+
+try:
+    from optuna_integration.keras import KerasPruningCallback
+except ModuleNotFoundError:
+    raise ModuleNotFoundError(_INTEGRATION_IMPORT_ERROR_TEMPLATE.format("keras"))
 
 
 __all__ = ["KerasPruningCallback"]

--- a/optuna/integration/lightgbm.py
+++ b/optuna/integration/lightgbm.py
@@ -37,7 +37,6 @@ class _LightGBMModule(ModuleType):
     __path__ = [os.path.dirname(__file__)]
 
     def __getattr__(self, name: str) -> Any:
-        print(lgb.__dict__)
         return lgb.__dict__[name]
 
 

--- a/optuna/integration/lightgbm.py
+++ b/optuna/integration/lightgbm.py
@@ -4,7 +4,12 @@ from types import ModuleType
 from typing import Any
 from typing import TYPE_CHECKING
 
-import optuna_integration.lightgbm as lgb
+from optuna._imports import _INTEGRATION_IMPORT_ERROR_TEMPLATE
+
+try:
+    import optuna_integration.lightgbm as lgb
+except ModuleNotFoundError:
+    raise ModuleNotFoundError(_INTEGRATION_IMPORT_ERROR_TEMPLATE.format("lightgbm"))
 
 
 if TYPE_CHECKING:

--- a/optuna/integration/lightgbm.py
+++ b/optuna/integration/lightgbm.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 
 from optuna._imports import _INTEGRATION_IMPORT_ERROR_TEMPLATE
 
+
 try:
     import optuna_integration.lightgbm as lgb
 except ModuleNotFoundError:
@@ -13,15 +14,18 @@ except ModuleNotFoundError:
 
 
 if TYPE_CHECKING:
+    # These modules are from optuna-integration.
     from optuna.integration.lightgbm_tuner import LightGBMPruningCallback
     from optuna.integration.lightgbm_tuner import LightGBMTuner
     from optuna.integration.lightgbm_tuner import LightGBMTunerCV
+    from optuna.integration.lightgbm_tuner import train
 
 
 __all__ = [
     "LightGBMPruningCallback",
     "LightGBMTuner",
     "LightGBMTunerCV",
+    "train",
 ]
 
 
@@ -33,6 +37,7 @@ class _LightGBMModule(ModuleType):
     __path__ = [os.path.dirname(__file__)]
 
     def __getattr__(self, name: str) -> Any:
+        print(lgb.__dict__)
         return lgb.__dict__[name]
 
 

--- a/optuna/integration/mlflow.py
+++ b/optuna/integration/mlflow.py
@@ -1,4 +1,10 @@
-from optuna_integration.mlflow import MLflowCallback
+from optuna._imports import _INTEGRATION_IMPORT_ERROR_TEMPLATE
+
+
+try:
+    from optuna_integration.mlflow import MLflowCallback
+except ModuleNotFoundError:
+    raise ModuleNotFoundError(_INTEGRATION_IMPORT_ERROR_TEMPLATE.format("mlflow"))
 
 
 __all__ = ["MLflowCallback"]

--- a/optuna/integration/mxnet.py
+++ b/optuna/integration/mxnet.py
@@ -1,4 +1,10 @@
-from optuna_integration.mxnet import MXNetPruningCallback
+from optuna._imports import _INTEGRATION_IMPORT_ERROR_TEMPLATE
+
+
+try:
+    from optuna_integration.mxnet import MXNetPruningCallback
+except ModuleNotFoundError:
+    raise ModuleNotFoundError(_INTEGRATION_IMPORT_ERROR_TEMPLATE.format("mxnet"))
 
 
 __all__ = ["MXNetPruningCallback"]

--- a/optuna/integration/pytorch_distributed.py
+++ b/optuna/integration/pytorch_distributed.py
@@ -1,4 +1,10 @@
-from optuna_integration.pytorch_distributed import TorchDistributedTrial
+from optuna._imports import _INTEGRATION_IMPORT_ERROR_TEMPLATE
+
+
+try:
+    from optuna_integration.pytorch_distributed import TorchDistributedTrial
+except ModuleNotFoundError:
+    raise ModuleNotFoundError(_INTEGRATION_IMPORT_ERROR_TEMPLATE.format("pytorch_distributed"))
 
 
 __all__ = ["TorchDistributedTrial"]

--- a/optuna/integration/pytorch_ignite.py
+++ b/optuna/integration/pytorch_ignite.py
@@ -1,4 +1,10 @@
-from optuna_integration.pytorch_ignite import PyTorchIgnitePruningHandler
+from optuna._imports import _INTEGRATION_IMPORT_ERROR_TEMPLATE
+
+
+try:
+    from optuna_integration.pytorch_ignite import PyTorchIgnitePruningHandler
+except ModuleNotFoundError:
+    raise ModuleNotFoundError(_INTEGRATION_IMPORT_ERROR_TEMPLATE.format("pytorch_ignite"))
 
 
 __all__ = ["PyTorchIgnitePruningHandler"]

--- a/optuna/integration/pytorch_lightning.py
+++ b/optuna/integration/pytorch_lightning.py
@@ -1,4 +1,10 @@
-from optuna_integration.pytorch_lightning import PyTorchLightningPruningCallback
+from optuna._imports import _INTEGRATION_IMPORT_ERROR_TEMPLATE
+
+
+try:
+    from optuna_integration.pytorch_lightning import PyTorchLightningPruningCallback
+except ModuleNotFoundError:
+    raise ModuleNotFoundError(_INTEGRATION_IMPORT_ERROR_TEMPLATE.format("pytorch_lightning"))
 
 
 __all__ = ["PyTorchLightningPruningCallback"]

--- a/optuna/integration/shap.py
+++ b/optuna/integration/shap.py
@@ -1,4 +1,10 @@
-from optuna_integration.shap import ShapleyImportanceEvaluator
+from optuna._imports import _INTEGRATION_IMPORT_ERROR_TEMPLATE
+
+
+try:
+    from optuna_integration.shap import ShapleyImportanceEvaluator
+except ModuleNotFoundError:
+    raise ModuleNotFoundError(_INTEGRATION_IMPORT_ERROR_TEMPLATE.format("shap"))
 
 
 __all__ = ["ShapleyImportanceEvaluator"]

--- a/optuna/integration/sklearn.py
+++ b/optuna/integration/sklearn.py
@@ -1,4 +1,10 @@
-from optuna_integration import OptunaSearchCV
+from optuna._imports import _INTEGRATION_IMPORT_ERROR_TEMPLATE
+
+
+try:
+    from optuna_integration.sklearn import OptunaSearchCV
+except ModuleNotFoundError:
+    raise ModuleNotFoundError(_INTEGRATION_IMPORT_ERROR_TEMPLATE.format("sklearn"))
 
 
 __all__ = ["OptunaSearchCV"]

--- a/optuna/integration/skorch.py
+++ b/optuna/integration/skorch.py
@@ -1,4 +1,10 @@
-from optuna_integration.skorch import SkorchPruningCallback
+from optuna._imports import _INTEGRATION_IMPORT_ERROR_TEMPLATE
+
+
+try:
+    from optuna_integration.skorch import SkorchPruningCallback
+except ModuleNotFoundError:
+    raise ModuleNotFoundError(_INTEGRATION_IMPORT_ERROR_TEMPLATE.format("skorch"))
 
 
 __all__ = ["SkorchPruningCallback"]

--- a/optuna/integration/tensorboard.py
+++ b/optuna/integration/tensorboard.py
@@ -1,4 +1,10 @@
-from optuna_integration.tensorboard import TensorBoardCallback
+from optuna._imports import _INTEGRATION_IMPORT_ERROR_TEMPLATE
+
+
+try:
+    from optuna_integration.tensorboard import TensorBoardCallback
+except ModuleNotFoundError:
+    raise ModuleNotFoundError(_INTEGRATION_IMPORT_ERROR_TEMPLATE.format("tensorboard"))
 
 
 __all__ = ["TensorBoardCallback"]

--- a/optuna/integration/tensorflow.py
+++ b/optuna/integration/tensorflow.py
@@ -1,4 +1,10 @@
-from optuna_integration.tensorflow import TensorFlowPruningHook
+from optuna._imports import _INTEGRATION_IMPORT_ERROR_TEMPLATE
+
+
+try:
+    from optuna_integration.tensorflow import TensorFlowPruningHook
+except ModuleNotFoundError:
+    raise ModuleNotFoundError(_INTEGRATION_IMPORT_ERROR_TEMPLATE.format("tensorflow"))
 
 
 __all__ = ["TensorFlowPruningHook"]

--- a/optuna/integration/tfkeras.py
+++ b/optuna/integration/tfkeras.py
@@ -1,4 +1,10 @@
-from optuna_integration.tfkeras import TFKerasPruningCallback
+from optuna._imports import _INTEGRATION_IMPORT_ERROR_TEMPLATE
+
+
+try:
+    from optuna_integration.tfkeras import TFKerasPruningCallback
+except ModuleNotFoundError:
+    raise ModuleNotFoundError(_INTEGRATION_IMPORT_ERROR_TEMPLATE.format("tfkeras"))
 
 
 __all__ = ["TFKerasPruningCallback"]

--- a/optuna/integration/wandb.py
+++ b/optuna/integration/wandb.py
@@ -1,4 +1,10 @@
-from optuna_integration.wandb import WeightsAndBiasesCallback
+from optuna._imports import _INTEGRATION_IMPORT_ERROR_TEMPLATE
+
+
+try:
+    from optuna_integration.wandb import WeightsAndBiasesCallback
+except ModuleNotFoundError:
+    raise ModuleNotFoundError(_INTEGRATION_IMPORT_ERROR_TEMPLATE.format("wandb"))
 
 
 __all__ = ["WeightsAndBiasesCallback"]

--- a/optuna/integration/xgboost.py
+++ b/optuna/integration/xgboost.py
@@ -1,4 +1,10 @@
-from optuna_integration.xgboost import XGBoostPruningCallback
+from optuna._imports import _INTEGRATION_IMPORT_ERROR_TEMPLATE
+
+
+try:
+    from optuna_integration.xgboost import XGBoostPruningCallback
+except ModuleNotFoundError:
+    raise ModuleNotFoundError(_INTEGRATION_IMPORT_ERROR_TEMPLATE.format("xgboost"))
 
 
 __all__ = ["XGBoostPruningCallback"]


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

This PR is a followup of this PR:
- https://github.com/optuna/optuna-integration/pull/130

## Description of the changes
<!-- Describe the changes in this PR. -->
Enhance the error message for `from optuna.integration import X` and `from optuna.integration.Y import X`.

> [!NOTE]
> We do not have to use `try_import` in each integration module file because `__init__.py` does the lazy import for each of them.
> However, `ImportError` in each integration module file is necessary as we would like to raise an error when `optuna.integration.X` path is specified explicitly.
