### PR TITLE
Add atomic operations that write an attribute only if the key is absent

### DIFF
--- a/optuna/storages/_base.py
+++ b/optuna/storages/_base.py
@@ -89,10 +89,10 @@ class BaseStorage(abc.ABC):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def set_study_user_attr(self, study_id: int, key: str, value: Any) -> None:
+    def set_study_user_attr(
+        self, study_id: int, key: str, value: Any, set_only_if_key_is_absent: bool = False
+    ) -> None:
         """Register a user-defined attribute to a study.
-
-        This method overwrites any existing attribute.
 
         Args:
             study_id:
@@ -101,6 +101,9 @@ class BaseStorage(abc.ABC):
                 Attribute key.
             value:
                 Attribute value. It should be JSON serializable.
+            set_only_if_key_is_absent:
+                if :obj:`False`, this method overwrites any existing attribute.
+                if :obj:`True`, this method never overwrites it.
 
         Raises:
             :exc:`KeyError`:
@@ -109,10 +112,14 @@ class BaseStorage(abc.ABC):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def set_study_system_attr(self, study_id: int, key: str, value: JSONSerializable) -> None:
+    def set_study_system_attr(
+        self,
+        study_id: int,
+        key: str,
+        value: JSONSerializable,
+        set_only_if_key_is_absent: bool = False,
+    ) -> None:
         """Register an optuna-internal attribute to a study.
-
-        This method overwrites any existing attribute.
 
         Args:
             study_id:
@@ -121,6 +128,9 @@ class BaseStorage(abc.ABC):
                 Attribute key.
             value:
                 Attribute value. It should be JSON serializable.
+            set_only_if_key_is_absent:
+                if :obj:`False`, this method overwrites any existing attribute.
+                if :obj:`True`, this method never overwrites it.
 
         Raises:
             :exc:`KeyError`:
@@ -399,10 +409,10 @@ class BaseStorage(abc.ABC):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def set_trial_user_attr(self, trial_id: int, key: str, value: Any) -> None:
+    def set_trial_user_attr(
+        self, trial_id: int, key: str, value: Any, set_only_if_key_is_absent: bool = False
+    ) -> None:
         """Set a user-defined attribute to a trial.
-
-        This method overwrites any existing attribute.
 
         Args:
             trial_id:
@@ -411,6 +421,9 @@ class BaseStorage(abc.ABC):
                 Attribute key.
             value:
                 Attribute value. It should be JSON serializable.
+            set_only_if_key_is_absent:
+                if :obj:`False`, this method overwrites any existing attribute.
+                if :obj:`True`, this method never overwrites it.
 
         Raises:
             :exc:`KeyError`:
@@ -421,10 +434,14 @@ class BaseStorage(abc.ABC):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def set_trial_system_attr(self, trial_id: int, key: str, value: JSONSerializable) -> None:
+    def set_trial_system_attr(
+        self,
+        trial_id: int,
+        key: str,
+        value: JSONSerializable,
+        set_only_if_key_is_absent: bool = False,
+    ) -> None:
         """Set an optuna-internal attribute to a trial.
-
-        This method overwrites any existing attribute.
 
         Args:
             trial_id:
@@ -433,6 +450,9 @@ class BaseStorage(abc.ABC):
                 Attribute key.
             value:
                 Attribute value. It should be JSON serializable.
+            set_only_if_key_is_absent:
+                if :obj:`False`, this method overwrites any existing attribute.
+                if :obj:`True`, this method never overwrites it.
 
         Raises:
             :exc:`KeyError`:

--- a/optuna/storages/_cached_storage.py
+++ b/optuna/storages/_cached_storage.py
@@ -101,11 +101,19 @@ class _CachedStorage(BaseStorage, BaseHeartbeat):
 
         self._backend.delete_study(study_id)
 
-    def set_study_user_attr(self, study_id: int, key: str, value: Any) -> None:
-        self._backend.set_study_user_attr(study_id, key, value)
+    def set_study_user_attr(
+        self, study_id: int, key: str, value: Any, set_only_if_key_is_absent: bool = False
+    ) -> None:
+        self._backend.set_study_user_attr(study_id, key, value, set_only_if_key_is_absent)
 
-    def set_study_system_attr(self, study_id: int, key: str, value: JSONSerializable) -> None:
-        self._backend.set_study_system_attr(study_id, key, value)
+    def set_study_system_attr(
+        self,
+        study_id: int,
+        key: str,
+        value: JSONSerializable,
+        set_only_if_key_is_absent: bool = False,
+    ) -> None:
+        self._backend.set_study_system_attr(study_id, key, value, set_only_if_key_is_absent)
 
     def get_study_id_from_name(self, study_name: str) -> int:
         return self._backend.get_study_id_from_name(study_name)
@@ -191,11 +199,23 @@ class _CachedStorage(BaseStorage, BaseHeartbeat):
     ) -> None:
         self._backend.set_trial_intermediate_value(trial_id, step, intermediate_value)
 
-    def set_trial_user_attr(self, trial_id: int, key: str, value: Any) -> None:
-        self._backend.set_trial_user_attr(trial_id, key=key, value=value)
+    def set_trial_user_attr(
+        self, trial_id: int, key: str, value: Any, set_only_if_key_is_absent: bool = False
+    ) -> None:
+        self._backend.set_trial_user_attr(
+            trial_id, key=key, value=value, set_only_if_key_is_absent=set_only_if_key_is_absent
+        )
 
-    def set_trial_system_attr(self, trial_id: int, key: str, value: JSONSerializable) -> None:
-        self._backend.set_trial_system_attr(trial_id, key=key, value=value)
+    def set_trial_system_attr(
+        self,
+        trial_id: int,
+        key: str,
+        value: JSONSerializable,
+        set_only_if_key_is_absent: bool = False,
+    ) -> None:
+        self._backend.set_trial_system_attr(
+            trial_id, key=key, value=value, set_only_if_key_is_absent=set_only_if_key_is_absent
+        )
 
     def _get_cached_trial(self, trial_id: int) -> Optional[FrozenTrial]:
         if trial_id not in self._trial_id_to_study_id_and_number:

--- a/optuna/storages/_in_memory.py
+++ b/optuna/storages/_in_memory.py
@@ -81,16 +81,28 @@ class InMemoryStorage(BaseStorage):
             del self._study_name_to_id[study_name]
             del self._studies[study_id]
 
-    def set_study_user_attr(self, study_id: int, key: str, value: Any) -> None:
+    def set_study_user_attr(
+        self, study_id: int, key: str, value: Any, set_only_if_key_is_absent: bool = False
+    ) -> None:
         with self._lock:
             self._check_study_id(study_id)
 
+            if set_only_if_key_is_absent and key in self._studies[study_id].user_attrs:
+                return
             self._studies[study_id].user_attrs[key] = value
 
-    def set_study_system_attr(self, study_id: int, key: str, value: JSONSerializable) -> None:
+    def set_study_system_attr(
+        self,
+        study_id: int,
+        key: str,
+        value: JSONSerializable,
+        set_only_if_key_is_absent: bool = False,
+    ) -> None:
         with self._lock:
             self._check_study_id(study_id)
 
+            if set_only_if_key_is_absent and key in self._studies[study_id].system_attrs:
+                return
             self._studies[study_id].system_attrs[key] = value
 
     def get_study_id_from_name(self, study_name: str) -> int:
@@ -317,7 +329,9 @@ class InMemoryStorage(BaseStorage):
             trial.intermediate_values[step] = intermediate_value
             self._set_trial(trial_id, trial)
 
-    def set_trial_user_attr(self, trial_id: int, key: str, value: Any) -> None:
+    def set_trial_user_attr(
+        self, trial_id: int, key: str, value: Any, set_only_if_key_is_absent: bool = False
+    ) -> None:
         with self._lock:
             self._check_trial_id(trial_id)
             trial = self._get_trial(trial_id)
@@ -325,16 +339,26 @@ class InMemoryStorage(BaseStorage):
 
             trial = copy.copy(trial)
             trial.user_attrs = copy.copy(trial.user_attrs)
+            if set_only_if_key_is_absent and key in trial.user_attrs:
+                return
             trial.user_attrs[key] = value
             self._set_trial(trial_id, trial)
 
-    def set_trial_system_attr(self, trial_id: int, key: str, value: JSONSerializable) -> None:
+    def set_trial_system_attr(
+        self,
+        trial_id: int,
+        key: str,
+        value: JSONSerializable,
+        set_only_if_key_is_absent: bool = False,
+    ) -> None:
         with self._lock:
             trial = self._get_trial(trial_id)
             self.check_trial_is_updatable(trial_id, trial.state)
 
             trial = copy.copy(trial)
             trial.system_attrs = copy.copy(trial.system_attrs)
+            if set_only_if_key_is_absent and key in trial.system_attrs:
+                return
             trial.system_attrs[key] = value
             self._set_trial(trial_id, trial)
 

--- a/tests/storages_tests/test_storages.py
+++ b/tests/storages_tests/test_storages.py
@@ -214,6 +214,21 @@ def test_set_and_get_study_user_attrs(storage_mode: str) -> None:
 
 
 @pytest.mark.parametrize("storage_mode", STORAGE_MODES)
+def test_set_and_get_study_user_attrs_set_only_if_key_is_absent(storage_mode: str) -> None:
+    with StorageSupplier(storage_mode) as storage:
+        study_id = storage.create_new_study(directions=[StudyDirection.MINIMIZE])
+
+        # Test setting value.
+        key, old_value, new_value = "dataset", "MNIST", "ImageNet"
+        storage.set_study_user_attr(study_id, key, old_value, True)
+        assert storage.get_study_user_attrs(study_id) == {key: old_value}
+        storage.set_study_user_attr(study_id, key, new_value, True)
+        assert storage.get_study_user_attrs(study_id) == {key: old_value}
+        storage.set_study_user_attr(study_id, key, new_value)
+        assert storage.get_study_user_attrs(study_id) == {key: new_value}
+
+
+@pytest.mark.parametrize("storage_mode", STORAGE_MODES)
 def test_set_and_get_study_system_attrs(storage_mode: str) -> None:
     with StorageSupplier(storage_mode) as storage:
         study_id = storage.create_new_study(directions=[StudyDirection.MINIMIZE])
@@ -238,6 +253,21 @@ def test_set_and_get_study_system_attrs(storage_mode: str) -> None:
         # Non-existent study id.
         with pytest.raises(KeyError):
             storage.set_study_system_attr(non_existent_study_id, "key", "value")
+
+
+@pytest.mark.parametrize("storage_mode", STORAGE_MODES)
+def test_set_and_get_study_system_attrs_set_only_if_key_is_absent(storage_mode: str) -> None:
+    with StorageSupplier(storage_mode) as storage:
+        study_id = storage.create_new_study(directions=[StudyDirection.MINIMIZE])
+
+        # Test setting value.
+        key, old_value, new_value = "dataset", "MNIST", "ImageNet"
+        storage.set_study_system_attr(study_id, key, old_value, True)
+        assert storage.get_study_system_attrs(study_id) == {key: old_value}
+        storage.set_study_system_attr(study_id, key, new_value, True)
+        assert storage.get_study_system_attrs(study_id) == {key: old_value}
+        storage.set_study_system_attr(study_id, key, new_value)
+        assert storage.get_study_system_attrs(study_id) == {key: new_value}
 
 
 @pytest.mark.parametrize("storage_mode", STORAGE_MODES)
@@ -673,6 +703,23 @@ def test_set_trial_user_attr(storage_mode: str) -> None:
 
 
 @pytest.mark.parametrize("storage_mode", STORAGE_MODES)
+def test_set_trial_user_attr_set_only_if_key_is_absent(storage_mode: str) -> None:
+    with StorageSupplier(storage_mode) as storage:
+        trial_id_1 = storage.create_new_trial(
+            storage.create_new_study(directions=[StudyDirection.MINIMIZE])
+        )
+
+        # Test setting value.
+        key, old_value, new_value = "dataset", "MNIST", "ImageNet"
+        storage.set_trial_user_attr(trial_id_1, key, old_value, True)
+        assert storage.get_trial(trial_id_1).user_attrs == {key: old_value}
+        storage.set_trial_user_attr(trial_id_1, key, new_value, True)
+        assert storage.get_trial(trial_id_1).user_attrs == {key: old_value}
+        storage.set_trial_user_attr(trial_id_1, key, new_value)
+        assert storage.get_trial(trial_id_1).user_attrs == {key: new_value}
+
+
+@pytest.mark.parametrize("storage_mode", STORAGE_MODES)
 def test_get_trial_system_attrs(storage_mode: str) -> None:
     with StorageSupplier(storage_mode) as storage:
         _, study_to_trials = _setup_studies(storage, n_study=2, n_trial=5, seed=10)
@@ -721,6 +768,23 @@ def test_set_trial_system_attr(storage_mode: str) -> None:
         storage.set_trial_state_values(trial_id_1, state=TrialState.COMPLETE)
         with pytest.raises(RuntimeError):
             storage.set_trial_system_attr(trial_id_1, "key", "value")
+
+
+@pytest.mark.parametrize("storage_mode", STORAGE_MODES)
+def test_set_trial_system_attr_set_only_if_key_is_absent(storage_mode: str) -> None:
+    with StorageSupplier(storage_mode) as storage:
+        trial_id_1 = storage.create_new_trial(
+            storage.create_new_study(directions=[StudyDirection.MINIMIZE])
+        )
+
+        # Test setting value.
+        key, old_value, new_value = "dataset", "MNIST", "ImageNet"
+        storage.set_trial_system_attr(trial_id_1, key, old_value, True)
+        assert storage.get_trial(trial_id_1).system_attrs == {key: old_value}
+        storage.set_trial_system_attr(trial_id_1, key, new_value, True)
+        assert storage.get_trial(trial_id_1).system_attrs == {key: old_value}
+        storage.set_trial_system_attr(trial_id_1, key, new_value)
+        assert storage.get_trial(trial_id_1).system_attrs == {key: new_value}
 
 
 @pytest.mark.parametrize("storage_mode", STORAGE_MODES)


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

I want to solve PR https://github.com/optuna/optuna/pull/5490.
I does not want to cause any breaking change or affect any public interface.
I want to empower OptunaHub contributors from the features to be introduced in this PR.

## Description of the changes
<!-- Describe the changes in this PR. -->

This PR will add the atomic operations that write value only if key does not exist, to all tha `storage`s. Supporting destinations are all `(study|trial)_(system|user)_attrs`.
