### PR TITLE
Replaces the type of callbacks in optimize from list to collections.abc.Iterable

### DIFF
--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -377,7 +377,7 @@ class Study:
         timeout: float | None = None,
         n_jobs: int = 1,
         catch: Iterable[type[Exception]] | type[Exception] = (),
-        callbacks: list[Callable[[Study, FrozenTrial], None]] | None = None,
+        callbacks: Iterable[Callable[[Study, FrozenTrial], None]] | None = None,
         gc_after_trial: bool = False,
         show_progress_bar: bool = False,
     ) -> None:

--- a/tests/study_tests/test_study.py
+++ b/tests/study_tests/test_study.py
@@ -1683,3 +1683,15 @@ def test_get_metric_names() -> None:
     assert study.metric_names == ["v0"]
     study.set_metric_names(["v1"])
     assert study.metric_names == ["v1"]
+    
+
+def test_optimize_with_tuple_callbacks():
+    study = optuna.create_study()
+    def objective(trial):
+        x = trial.suggest_float("x", -1, 1)
+        return x**2
+    def callback(study, trial):
+        pass
+    callbacks = (callback,)
+    study.optimize(objective, n_trials=3, callbacks=callbacks)
+    assert len(study.trials) == 3


### PR DESCRIPTION
Fix : #5509 
Replaces the type of callbacks in optimize from list to collections.abc.Iterable

<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
Improve flexibility by updating `optimize` method to accept a wider range of `iterable` types for the callbacks parameter, enhancing usability.

## Description of the changes
<!-- Describe the changes in this PR. -->
I Replaced the type of callbacks in optimize from list to collections.abc.Iterable.
added unit tests
need to update docs!!
