### PR TITLE
Fix the version conflicts in the workflow for the minimum version constraints

### DIFF
--- a/.github/workflows/tests-with-minimum-versions.yml
+++ b/.github/workflows/tests-with-minimum-versions.yml
@@ -70,14 +70,14 @@ jobs:
       run: |
         # Install dependencies with minimum versions.
         pip uninstall -y alembic cmaes packaging sqlalchemy plotly scikit-learn
-        pip install alembic==1.5.0 cmaes==0.10.0 packaging==20.0 sqlalchemy==1.3.0 numpy==1.20.3 tqdm==4.27.0 colorlog==0.3 PyYAML==5.1
+        pip install alembic==1.5.0 cmaes==0.10.0 packaging==20.0 sqlalchemy==1.3.0 tqdm==4.27.0 colorlog==0.3 PyYAML==5.1
         pip uninstall -y matplotlib pandas scipy
         if [ "${{ matrix.python-version }}" = "3.7" ]; then
-          pip install matplotlib==3.5.3 pandas==1.3.5 scipy==1.7.3
+          pip install matplotlib==3.5.3 pandas==1.3.5 scipy==1.7.3 numpy==1.20.3
         elif [ "${{ matrix.python-version }}" = "3.8" ]; then
-          pip install matplotlib==3.7.5 pandas==2.0.3 scipy==1.10.1
+          pip install matplotlib==3.7.5 pandas==2.0.3 scipy==1.10.1 numpy==1.20.3
         elif [ "${{ matrix.python-version }}" = "3.9" ]; then
-          pip install matplotlib==3.8.3 pandas==2.2.1 scipy==1.12.0
+          pip install matplotlib==3.8.3 pandas==2.2.1 scipy==1.12.0 numpy==1.26.4
         fi
         pip install plotly==5.0.0 scikit-learn==0.24.2  # optional extras
 

--- a/.github/workflows/tests-with-minimum-versions.yml
+++ b/.github/workflows/tests-with-minimum-versions.yml
@@ -69,8 +69,8 @@ jobs:
     - name: Install dependencies with minimum versions
       run: |
         # Install dependencies with minimum versions.
-        pip uninstall -y alembic cmaes packaging sqlalchemy plotly scikit-learn
-        pip install alembic==1.5.0 cmaes==0.10.0 packaging==20.0 sqlalchemy==1.3.0 tqdm==4.27.0 colorlog==0.3 PyYAML==5.1
+        pip uninstall -y alembic cmaes packaging sqlalchemy plotly scikit-learn pillow
+        pip install alembic==1.5.0 cmaes==0.10.0 packaging==20.0 sqlalchemy==1.3.0 tqdm==4.27.0 colorlog==0.3 PyYAML==5.1 pillow<10.4.0
         pip uninstall -y matplotlib pandas scipy
         # Python v3.6 was dropped at NumPy v1.20.3.
         if [ "${{ matrix.python-version }}" = "3.7" ]; then

--- a/.github/workflows/tests-with-minimum-versions.yml
+++ b/.github/workflows/tests-with-minimum-versions.yml
@@ -77,7 +77,7 @@ jobs:
         elif [ "${{ matrix.python-version }}" = "3.8" ]; then
           pip install matplotlib==3.7.5 pandas==2.0.3 scipy==1.10.1 numpy==1.20.3
         elif [ "${{ matrix.python-version }}" = "3.9" ]; then
-          pip install matplotlib==3.8.3 pandas==2.2.1 scipy==1.12.0 numpy==1.26.4
+          pip install matplotlib==3.8.4 pandas==2.2.2 scipy==1.13.0 numpy==1.26.4
         fi
         pip install plotly==5.0.0 scikit-learn==0.24.2  # optional extras
 

--- a/.github/workflows/tests-with-minimum-versions.yml
+++ b/.github/workflows/tests-with-minimum-versions.yml
@@ -70,7 +70,7 @@ jobs:
       run: |
         # Install dependencies with minimum versions.
         pip uninstall -y alembic cmaes packaging sqlalchemy plotly scikit-learn pillow
-        pip install alembic==1.5.0 cmaes==0.10.0 packaging==20.0 sqlalchemy==1.3.0 tqdm==4.27.0 colorlog==0.3 PyYAML==5.1 pillow<10.4.0
+        pip install alembic==1.5.0 cmaes==0.10.0 packaging==20.0 sqlalchemy==1.3.0 tqdm==4.27.0 colorlog==0.3 PyYAML==5.1 'pillow<10.4.0'
         pip uninstall -y matplotlib pandas scipy
         # Python v3.6 was dropped at NumPy v1.20.3.
         if [ "${{ matrix.python-version }}" = "3.7" ]; then

--- a/.github/workflows/tests-with-minimum-versions.yml
+++ b/.github/workflows/tests-with-minimum-versions.yml
@@ -71,8 +71,15 @@ jobs:
         # Install dependencies with minimum versions.
         pip uninstall -y alembic cmaes packaging sqlalchemy plotly scikit-learn
         pip install alembic==1.5.0 cmaes==0.10.0 packaging==20.0 sqlalchemy==1.3.0 numpy==1.20.3 tqdm==4.27.0 colorlog==0.3 PyYAML==5.1
+        pip uninstall -y matplotlib pandas scipy
+        if [ "${{ matrix.python-version }}" = "3.7" ]; then
+          pip install matplotlib==3.5.3 pandas==1.3.5 scipy==1.7.3
+        elif [ "${{ matrix.python-version }}" = "3.8" ]; then
+          pip install matplotlib==3.7.5 pandas==2.0.3 scipy==1.10.1
+        elif [ "${{ matrix.python-version }}" = "3.9" ]; then
+          pip install matplotlib==3.8.3 pandas==2.2.1 scipy==1.12.0
+        fi
         pip install plotly==5.0.0 scikit-learn==0.24.2  # optional extras
-        pip install --upgrade "numpy<=1.26.4"  # TODO(nabe): Remove this part, because this is a hotfix.
 
     - name: Output installed packages
       run: |

--- a/.github/workflows/tests-with-minimum-versions.yml
+++ b/.github/workflows/tests-with-minimum-versions.yml
@@ -72,6 +72,7 @@ jobs:
         pip uninstall -y alembic cmaes packaging sqlalchemy plotly scikit-learn
         pip install alembic==1.5.0 cmaes==0.10.0 packaging==20.0 sqlalchemy==1.3.0 tqdm==4.27.0 colorlog==0.3 PyYAML==5.1
         pip uninstall -y matplotlib pandas scipy
+        # Python v3.6 was dropped at NumPy v1.20.3.
         if [ "${{ matrix.python-version }}" = "3.7" ]; then
           pip install matplotlib==3.5.3 pandas==1.3.5 scipy==1.7.3 numpy==1.20.3
         elif [ "${{ matrix.python-version }}" = "3.8" ]; then


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

Fixes #5499 

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

This PR fixes the issue #5499 where the version of numpy in the `tests-with-minimum-versions.yml` workflow was not as intended.

## Description of the changes
<!-- Describe the changes in this PR. -->

The packages that conflicted with numpy were `matplotlib`, `pandas`, and `scipy`. By explicitly specifying the same versions of these packages as used in the following workflows, the specified version of numpy is now being correctly used:

- https://github.com/optuna/optuna/actions/runs/8656988956/job/23738403280
- https://github.com/optuna/optuna/actions/runs/8656988956/job/23738403643
- https://github.com/optuna/optuna/actions/runs/8656988956/job/23738403940

Note that python v3.9 has not been using  numpy `1.20.3` in this workflow for some time and instead has been using numpy `1.26.4`. Considering the purpose of this workflow, it might be reasonable to remove the tests for python v3.9, but as I think it is beyond the scope of this PR, it will be left as is for now.