### PR TITLE
Add rdb create new trial test

### DIFF
--- a/optuna/storages/_rdb/storage.py
+++ b/optuna/storages/_rdb/storage.py
@@ -491,6 +491,8 @@ class RDBStorage(BaseStorage, BaseHeartbeat):
                     models.StudyModel.find_or_raise_by_id(study_id, session, for_update=True)
                     trial = self._get_prepared_new_trial(study_id, template_trial, session)
                     return _create_frozen_trial(trial, template_trial)
+            
+            # sqlalchemy_exc.OperationalError is converted to optuna.exceptions.StorageInternalError.
             except optuna.exceptions.StorageInternalError as e:
                 # Note: According to SQLAlchemy specifications,
                 # `sqlalchemy_exc.OperationalError` can be raised in situations where

--- a/optuna/storages/_rdb/storage.py
+++ b/optuna/storages/_rdb/storage.py
@@ -480,6 +480,7 @@ class RDBStorage(BaseStorage, BaseHeartbeat):
                 # Optuna's philosophy is that it is better for the DB administrator to detect
                 # such saturation and augment the server than for Optuna itself to detect
                 # DB congestion and slow it down.
+                print("slept")
                 time.sleep(random.random() * 2.0)
             try:
                 with _create_scoped_session(self.scoped_session) as session:
@@ -491,7 +492,7 @@ class RDBStorage(BaseStorage, BaseHeartbeat):
                     models.StudyModel.find_or_raise_by_id(study_id, session, for_update=True)
                     trial = self._get_prepared_new_trial(study_id, template_trial, session)
                     return _create_frozen_trial(trial, template_trial)
-            except sqlalchemy_exc.OperationalError as e:
+            except optuna.exceptions.StorageInternalError as e:
                 # Note: According to SQLAlchemy specifications,
                 # `sqlalchemy_exc.OperationalError` can be raised in situations where
                 # retries are not effective (e.g., input string is too long).

--- a/optuna/storages/_rdb/storage.py
+++ b/optuna/storages/_rdb/storage.py
@@ -480,7 +480,6 @@ class RDBStorage(BaseStorage, BaseHeartbeat):
                 # Optuna's philosophy is that it is better for the DB administrator to detect
                 # such saturation and augment the server than for Optuna itself to detect
                 # DB congestion and slow it down.
-                print("slept")
                 time.sleep(random.random() * 2.0)
             try:
                 with _create_scoped_session(self.scoped_session) as session:

--- a/optuna/storages/_rdb/storage.py
+++ b/optuna/storages/_rdb/storage.py
@@ -491,8 +491,9 @@ class RDBStorage(BaseStorage, BaseHeartbeat):
                     models.StudyModel.find_or_raise_by_id(study_id, session, for_update=True)
                     trial = self._get_prepared_new_trial(study_id, template_trial, session)
                     return _create_frozen_trial(trial, template_trial)
-            
-            # sqlalchemy_exc.OperationalError is converted to optuna.exceptions.StorageInternalError.
+
+            # sqlalchemy_exc.OperationalError is converted to
+            # optuna.exceptions.StorageInternalError.
             except optuna.exceptions.StorageInternalError as e:
                 # Note: According to SQLAlchemy specifications,
                 # `sqlalchemy_exc.OperationalError` can be raised in situations where

--- a/tests/storages_tests/rdb_tests/test_storage.py
+++ b/tests/storages_tests/rdb_tests/test_storage.py
@@ -360,3 +360,4 @@ def test_create_new_trial_with_retries() -> None:
     # The added trials in the session were rollbacked.
     trials = storage.get_all_trials(study_id)
     assert len(trials) == 1
+    assert trials[0].number == 0


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
The PR #5497 missed the unit tests. This PR aims to add the test.

## Description of the changes
<!-- Describe the changes in this PR. -->
- Add the unit test to validate PR #5497.

## The output of the added test before #5497 
We can see that the 3 trials (created in the retries without any rollback) are created. This is unintended behavior and has fixed in #5497.
```
(venv) mamu@hideakis-mbp optuna % pytest tests/storages_tests/test_with_server.py -k test_create_new_trial_with_retries -vv
======================================================================================= test session starts ========================================================================================
platform darwin -- Python 3.9.6, pytest-7.4.2, pluggy-1.3.0 -- /Users/mamu/Work-and-Study/optuna/venv/bin/python3
cachedir: .pytest_cache
rootdir: /Users/mamu/Work-and-Study/optuna
configfile: pyproject.toml
plugins: jaxtyping-0.2.23, typeguard-2.13.3
collected 20 items / 19 deselected / 1 selected                                                                                                                                                    

tests/storages_tests/test_with_server.py::test_create_new_trial_with_retries FAILED                                                                                                          [100%]

============================================================================================= FAILURES =============================================================================================
________________________________________________________________________________ test_create_new_trial_with_retries ________________________________________________________________________________

    def test_create_new_trial_with_retries() -> None:
        storage = get_storage()
        study_id = storage.create_new_study(directions=[StudyDirection.MINIMIZE])
    
        n_retries = 0
        def mock_func(
            study_id: int,
            template_trial: FrozenTrial,
            session: "sqlalchemy_orm.Session",
        ) -> FrozenTrial:
            nonlocal n_retries
            n_retries += 1
            trial = models.TrialModel(
                study_id=study_id,
                number=None,
                state=TrialState.RUNNING,
                datetime_start=datetime.now(),
            )
            session.add(trial)
            session.flush()
            trial.number = trial.count_past_trials(session)
            session.add(trial)
    
            if n_retries == 3:
                return trial
            raise sqlalchemy_exc.OperationalError("xxx", "yyy", "zzz")
    
        with patch(
            "optuna.storages._rdb.storage.RDBStorage._get_prepared_new_trial",
            new=Mock(side_effect=mock_func)
        ):
            _ = storage.create_new_trial(study_id)
    
        trials = storage.get_all_trials(study_id)
>       assert len(trials) == 1
E       assert 3 == 1
E        +  where 3 = len([FrozenTrial(number=0, state=TrialState.RUNNING, values=None, datetime_start=datetime.datetime(2024, 6, 26, 13, 54, 56), datetime_complete=None, params={}, user_attrs={}, system_attrs={}, intermediate_values={}, distributions={}, trial_id=77, value=None), FrozenTrial(number=1, state=TrialState.RUNNING, values=None, datetime_start=datetime.datetime(2024, 6, 26, 13, 54, 56), datetime_complete=None, params={}, user_attrs={}, system_attrs={}, intermediate_values={}, distributions={}, trial_id=78, value=None), FrozenTrial(number=2, state=TrialState.RUNNING, values=None, datetime_start=datetime.datetime(2024, 6, 26, 13, 54, 56), datetime_complete=None, params={}, user_attrs={}, system_attrs={}, intermediate_values={}, distributions={}, trial_id=79, value=None)])

tests/storages_tests/test_with_server.py:251: AssertionError
--------------------------------------------------------------------------------------- Captured stderr call ---------------------------------------------------------------------------------------
[I 2024-06-26 13:54:55,884] A new study created in RDB with name: no-name-66300393-b10b-4ca4-ace4-0473442afd04
===================================================================================== short test summary info ======================================================================================
FAILED tests/storages_tests/test_with_server.py::test_create_new_trial_with_retries - assert 3 == 1
================================================================================= 1 failed, 19 deselected in 0.50s =================================================================================
```
