### PR TITLE
Enhance plot_parallel_coordinate()

### DIFF
--- a/optuna/visualization/_utils.py
+++ b/optuna/visualization/_utils.py
@@ -70,14 +70,26 @@ def _check_plot_args(
 
 
 def _is_log_scale(trials: list[FrozenTrial], param: str) -> bool:
-    return any(param in t.params and isinstance(t.distributions[param], (FloatDistribution, IntDistribution)) and t.distributions[param].log for t in trials)
+    for trial in trials:
+        if param in trial.params:
+            dist = trial.distributions[param]
+            if isinstance(dist, (FloatDistribution, IntDistribution)) and dist.log:
+                return True
+    return False
 
 def _is_categorical(trials: list[FrozenTrial], param: str) -> bool:
-    return any(param in t.params and isinstance(t.distributions[param], CategoricalDistribution) for t in trials)
+    return any(
+        param in t.params and isinstance(t.distributions[param], CategoricalDistribution)
+        for t in trials
+    )
 
 def _is_numerical(trials: list[FrozenTrial], param: str) -> bool:
-    return all(param in t.params and isinstance(t.params[param], (int, float)) and not isinstance(t.params[param], bool) for t in trials)
-
+    for trial in trials:
+        if param in trial.params:
+            value = trial.params[param]
+            if not isinstance(value, (int, float)) or isinstance(value, bool):
+                return False
+    return True
 
 def _get_param_values(trials: list[FrozenTrial], p_name: str) -> list[Any]:
     values = [t.params[p_name] for t in trials if p_name in t.params]

--- a/optuna/visualization/_utils.py
+++ b/optuna/visualization/_utils.py
@@ -70,32 +70,13 @@ def _check_plot_args(
 
 
 def _is_log_scale(trials: list[FrozenTrial], param: str) -> bool:
-    for trial in trials:
-        if param in trial.params:
-            dist = trial.distributions[param]
-
-            if isinstance(dist, (FloatDistribution, IntDistribution)):
-                if dist.log:
-                    return True
-
-    return False
-
+    return any(param in t.params and isinstance(t.distributions[param], (FloatDistribution, IntDistribution)) and t.distributions[param].log for t in trials)
 
 def _is_categorical(trials: list[FrozenTrial], param: str) -> bool:
-    return any(
-        isinstance(t.distributions[param], CategoricalDistribution)
-        for t in trials
-        if param in t.params
-    )
-
+    return any(param in t.params and isinstance(t.distributions[param], CategoricalDistribution) for t in trials)
 
 def _is_numerical(trials: list[FrozenTrial], param: str) -> bool:
-    return all(
-        (isinstance(t.params[param], int) or isinstance(t.params[param], float))
-        and not isinstance(t.params[param], bool)
-        for t in trials
-        if param in t.params
-    )
+    return all(param in t.params and isinstance(t.params[param], (int, float)) and not isinstance(t.params[param], bool) for t in trials)
 
 
 def _get_param_values(trials: list[FrozenTrial], p_name: str) -> list[Any]:

--- a/optuna/visualization/_utils.py
+++ b/optuna/visualization/_utils.py
@@ -77,11 +77,13 @@ def _is_log_scale(trials: list[FrozenTrial], param: str) -> bool:
                 return True
     return False
 
+
 def _is_categorical(trials: list[FrozenTrial], param: str) -> bool:
     return any(
         param in t.params and isinstance(t.distributions[param], CategoricalDistribution)
         for t in trials
     )
+
 
 def _is_numerical(trials: list[FrozenTrial], param: str) -> bool:
     for trial in trials:
@@ -90,6 +92,7 @@ def _is_numerical(trials: list[FrozenTrial], param: str) -> bool:
             if not isinstance(value, (int, float)) or isinstance(value, bool):
                 return False
     return True
+
 
 def _get_param_values(trials: list[FrozenTrial], p_name: str) -> list[Any]:
     values = [t.params[p_name] for t in trials if p_name in t.params]


### PR DESCRIPTION
Fix : https://github.com/optuna/optuna/issues/5409
Enhance plot_parallel_coordinate() by eliminating redundant for-loops

# Motivation
In parallel coordinate plot, _is_log_scale(), _is_categorical(), and _is_numerical() functions are invoked.

# Description of the changes
* _is_log_scale():

Combines the checks for FloatDistribution and IntDistribution and the log attribute in a single if statement.
If a log-scaled distribution is found, it immediately returns True, avoiding further iterations.
* _is_categorical():

Uses a generator expression with any() to check if any trial contains a categorical distribution for the parameter.
This short-circuits as soon as a categorical distribution is found, making it faster.
* _is_numerical():

Iterates over the trials, checking if the parameter value is either an int or float and not a bool.
If a non-numerical value is found, it immediately returns False, avoiding further checks.
If all values are numerical, it returns True.

This change makes the code more efficient by avoiding unnecessary iterations over the trials.