### PR TITLE
Unite the argument order of artifact APIs

### DIFF
--- a/optuna/artifacts/_backoff.py
+++ b/optuna/artifacts/_backoff.py
@@ -22,22 +22,24 @@ class Backoff:
     Example:
        .. code-block:: python
 
-            import optuna
-            from optuna.artifacts import upload_artifact
-            from optuna.artifacts import Boto3ArtifactStore
-            from optuna.artifacts import Backoff
+           import optuna
+           from optuna.artifacts import upload_artifact
+           from optuna.artifacts import Boto3ArtifactStore
+           from optuna.artifacts import Backoff
 
 
-            artifact_store = Backoff(Boto3ArtifactStore("my-bucket"))
+           artifact_store = Backoff(Boto3ArtifactStore("my-bucket"))
 
 
-            def objective(trial: optuna.Trial) -> float:
-                ... = trial.suggest_float("x", -10, 10)
-                file_path = generate_example(...)
-                upload_artifact(
-                    artifact_store=artifact_store, file_path=file_path, study_or_trial=trial,
-                )
-                return ...
+           def objective(trial: optuna.Trial) -> float:
+               ... = trial.suggest_float("x", -10, 10)
+               file_path = generate_example(...)
+               upload_artifact(
+                   artifact_store=artifact_store,
+                   file_path=file_path,
+                   study_or_trial=trial,
+               )
+               return ...
     """
 
     def __init__(

--- a/optuna/artifacts/_backoff.py
+++ b/optuna/artifacts/_backoff.py
@@ -22,20 +22,22 @@ class Backoff:
     Example:
        .. code-block:: python
 
-           import optuna
-           from optuna.artifacts import upload_artifact
-           from optuna.artifacts import Boto3ArtifactStore
-           from optuna.artifacts import Backoff
+            import optuna
+            from optuna.artifacts import upload_artifact
+            from optuna.artifacts import Boto3ArtifactStore
+            from optuna.artifacts import Backoff
 
 
-           artifact_store = Backoff(Boto3ArtifactStore("my-bucket"))
+            artifact_store = Backoff(Boto3ArtifactStore("my-bucket"))
 
 
-           def objective(trial: optuna.Trial) -> float:
-               ... = trial.suggest_float("x", -10, 10)
-               file_path = generate_example(...)
-               upload_artifact(trial, file_path, artifact_store)
-               return ...
+            def objective(trial: optuna.Trial) -> float:
+                ... = trial.suggest_float("x", -10, 10)
+                file_path = generate_example(...)
+                upload_artifact(
+                    artifact_store=artifact_store, file_path=file_path, study_or_trial=trial,
+                )
+                return ...
     """
 
     def __init__(

--- a/optuna/artifacts/_boto3.py
+++ b/optuna/artifacts/_boto3.py
@@ -50,7 +50,9 @@ class Boto3ArtifactStore:
             def objective(trial: optuna.Trial) -> float:
                 ... = trial.suggest_float("x", -10, 10)
                 file_path = generate_example(...)
-                upload_artifact(trial, file_path, artifact_store)
+                upload_artifact(
+                    artifact_store=artifact_store, file_path=file_path, study_or_trial=trial,
+                )
                 return ...
     """
 

--- a/optuna/artifacts/_boto3.py
+++ b/optuna/artifacts/_boto3.py
@@ -51,7 +51,9 @@ class Boto3ArtifactStore:
                 ... = trial.suggest_float("x", -10, 10)
                 file_path = generate_example(...)
                 upload_artifact(
-                    artifact_store=artifact_store, file_path=file_path, study_or_trial=trial,
+                    artifact_store=artifact_store,
+                    file_path=file_path,
+                    study_or_trial=trial,
                 )
                 return ...
     """

--- a/optuna/artifacts/_download.py
+++ b/optuna/artifacts/_download.py
@@ -8,14 +8,14 @@ from optuna.artifacts._protocol import ArtifactStore
 
 
 @experimental_func("4.0.0")
-def download_artifact(artifact_store: ArtifactStore, artifact_id: str, file_path: str) -> None:
+def download_artifact(file_path: str, artifact_store: ArtifactStore, artifact_id: str) -> None:
     """Download an artifact from the artifact store.
 
     Args:
-        artifact_store:
-            An artifact store.
         artifact_id:
             The identifier of the artifact to download.
+        artifact_store:
+            An artifact store.
         file_path:
             A path to save the downloaded artifact.
     """

--- a/optuna/artifacts/_download.py
+++ b/optuna/artifacts/_download.py
@@ -3,22 +3,21 @@ from __future__ import annotations
 import os
 import shutil
 
-from optuna._convert_positional_args import convert_positional_args
 from optuna._experimental import experimental_func
 from optuna.artifacts._protocol import ArtifactStore
 
 
 @experimental_func("4.0.0")
-def download_artifact(*, file_path: str, artifact_store: ArtifactStore, artifact_id: str) -> None:
+def download_artifact(*, artifact_store: ArtifactStore, file_path: str, artifact_id: str) -> None:
     """Download an artifact from the artifact store.
 
     Args:
-        artifact_id:
-            The identifier of the artifact to download.
         artifact_store:
             An artifact store.
         file_path:
             A path to save the downloaded artifact.
+        artifact_id:
+            The identifier of the artifact to download.
     """
     if os.path.exists(file_path):
         raise FileExistsError(f"File already exists: {file_path}")

--- a/optuna/artifacts/_download.py
+++ b/optuna/artifacts/_download.py
@@ -3,12 +3,13 @@ from __future__ import annotations
 import os
 import shutil
 
+from optuna._convert_positional_args import convert_positional_args
 from optuna._experimental import experimental_func
 from optuna.artifacts._protocol import ArtifactStore
 
 
 @experimental_func("4.0.0")
-def download_artifact(file_path: str, artifact_store: ArtifactStore, artifact_id: str) -> None:
+def download_artifact(*, file_path: str, artifact_store: ArtifactStore, artifact_id: str) -> None:
     """Download an artifact from the artifact store.
 
     Args:

--- a/optuna/artifacts/_filesystem.py
+++ b/optuna/artifacts/_filesystem.py
@@ -39,7 +39,9 @@ class FileSystemArtifactStore:
             def objective(trial: optuna.Trial) -> float:
                 ... = trial.suggest_float("x", -10, 10)
                 file_path = generate_example(...)
-                upload_artifact(trial, file_path, artifact_store)
+                upload_artifact(
+                    artifact_store=artifact_store, file_path=file_path, study_or_trial=trial,
+                )
                 return ...
     """
 

--- a/optuna/artifacts/_filesystem.py
+++ b/optuna/artifacts/_filesystem.py
@@ -40,7 +40,9 @@ class FileSystemArtifactStore:
                 ... = trial.suggest_float("x", -10, 10)
                 file_path = generate_example(...)
                 upload_artifact(
-                    artifact_store=artifact_store, file_path=file_path, study_or_trial=trial,
+                    artifact_store=artifact_store,
+                    file_path=file_path,
+                    study_or_trial=trial,
                 )
                 return ...
     """

--- a/optuna/artifacts/_gcs.py
+++ b/optuna/artifacts/_gcs.py
@@ -41,7 +41,9 @@ class GCSArtifactStore:
                 ... = trial.suggest_float("x", -10, 10)
                 file_path = generate_example(...)
                 upload_artifact(
-                    artifact_store=artifact_store, file_path=file_path, study_or_trial=trial,
+                    artifact_store=artifact_store,
+                    file_path=file_path,
+                    study_or_trial=trial,
                 )
                 return ...
 

--- a/optuna/artifacts/_gcs.py
+++ b/optuna/artifacts/_gcs.py
@@ -40,7 +40,9 @@ class GCSArtifactStore:
             def objective(trial: optuna.Trial) -> float:
                 ... = trial.suggest_float("x", -10, 10)
                 file_path = generate_example(...)
-                upload_artifact(trial, file_path, artifact_backend)
+                upload_artifact(
+                    artifact_store=artifact_store, file_path=file_path, study_or_trial=trial,
+                )
                 return ...
 
         Before running this code, you will have to install `gcloud` and run

--- a/optuna/artifacts/_upload.py
+++ b/optuna/artifacts/_upload.py
@@ -28,11 +28,14 @@ class ArtifactMeta:
 
 
 @experimental_func("3.3.0")
+@convert_positional_args(
+    previous_positional_arg_names=["study_or_trial", "file_path", "artifact_store"]
+)
 def upload_artifact(
-    study_or_trial: Trial | FrozenTrial | Study,
-    file_path: str,
-    artifact_store: ArtifactStore,
     *,
+    artifact_store: ArtifactStore,
+    file_path: str,
+    study_or_trial: Trial | FrozenTrial | Study,
     storage: BaseStorage | None = None,
     mimetype: str | None = None,
     encoding: str | None = None,
@@ -40,13 +43,13 @@ def upload_artifact(
     """Upload an artifact to the artifact store.
 
     Args:
+        artifact_store:
+            An artifact store.
+        file_path:
+            A path to the file to be uploaded.
         study_or_trial:
             A :class:`~optuna.trial.Trial` object, a :class:`~optuna.trial.FrozenTrial`, or
             a :class:`~optuna.study.Study` object.
-        file_path:
-            A path to the file to be uploaded.
-        artifact_store:
-            An artifact store.
         storage:
             A storage object. This argument is required only if ``study_or_trial`` is
             :class:`~optuna.trial.FrozenTrial`.

--- a/optuna/artifacts/_upload.py
+++ b/optuna/artifacts/_upload.py
@@ -7,6 +7,7 @@ import mimetypes
 import os
 import uuid
 
+from optuna._convert_positional_args import convert_positional_args
 from optuna._experimental import experimental_func
 from optuna.artifacts._protocol import ArtifactStore
 from optuna.storages import BaseStorage

--- a/tests/artifacts_tests/test_download_artifact.py
+++ b/tests/artifacts_tests/test_download_artifact.py
@@ -28,13 +28,19 @@ def test_download_artifact(tmp_path: pathlib.PurePath, artifact_store: ArtifactS
         dummy_file = str(tmp_path / f"dummy_{trial.number}.txt")
         with open(dummy_file, "w") as f:
             f.write(f"{x} {y}")
-        artifact_ids.append(upload_artifact(trial, dummy_file, artifact_store))
+        artifact_ids.append(
+            upload_artifact(
+                study_or_trial=trial, file_path=dummy_file, artifact_store=artifact_store
+            )
+        )
         return x**2 + y**2
 
     study.optimize(objective, n_trials=5)
 
     for i, artifact_id in enumerate(artifact_ids):
         dummy_downloaded_file = str(tmp_path / f"dummy_downloaded_{i}.txt")
-        download_artifact(dummy_downloaded_file, artifact_store, artifact_id)
+        download_artifact(
+            file_path=dummy_downloaded_file, artifact_store=artifact_store, artifact_id=artifact_id
+        )
         with open(dummy_downloaded_file, "r") as f:
             assert f.read() == f"{study.trials[i].params['x']} {study.trials[i].params['y']}"

--- a/tests/artifacts_tests/test_download_artifact.py
+++ b/tests/artifacts_tests/test_download_artifact.py
@@ -35,6 +35,6 @@ def test_download_artifact(tmp_path: pathlib.PurePath, artifact_store: ArtifactS
 
     for i, artifact_id in enumerate(artifact_ids):
         dummy_downloaded_file = str(tmp_path / f"dummy_downloaded_{i}.txt")
-        download_artifact(artifact_store, artifact_id, dummy_downloaded_file)
+        download_artifact(dummy_downloaded_file, artifact_store, artifact_id)
         with open(dummy_downloaded_file, "r") as f:
             assert f.read() == f"{study.trials[i].params['x']} {study.trials[i].params['y']}"

--- a/tests/artifacts_tests/test_list_artifact_meta.py
+++ b/tests/artifacts_tests/test_list_artifact_meta.py
@@ -39,9 +39,9 @@ def _check_uploaded_artifact_meta(
     encoding: str | None,
 ) -> None:
     artifact_id = upload_artifact(
-        study_or_trial,
-        file_path,
-        artifact_store,
+        study_or_trial=study_or_trial,
+        file_path=file_path,
+        artifact_store=artifact_store,
         storage=storage,
         mimetype=mimetype,
         encoding=encoding,

--- a/tests/artifacts_tests/test_upload_artifact.py
+++ b/tests/artifacts_tests/test_upload_artifact.py
@@ -123,10 +123,12 @@ def test_upload_artifact_with_positional_args(
     with pytest.warns(FutureWarning):
         artifact_id = upload_artifact(trial, file_path, artifact_store)  # type: ignore
         _validate(artifact_id=artifact_id)
+    with pytest.warns(FutureWarning):
         artifact_id = upload_artifact(
             trial, file_path, artifact_store=artifact_store  # type: ignore
         )
         _validate(artifact_id=artifact_id)
+    with pytest.warns(FutureWarning):
         artifact_id = upload_artifact(
             trial, file_path=file_path, artifact_store=artifact_store  # type: ignore
         )

--- a/tests/artifacts_tests/test_upload_artifact.py
+++ b/tests/artifacts_tests/test_upload_artifact.py
@@ -122,14 +122,14 @@ def test_upload_artifact_with_positional_args(
 
     with pytest.warns(FutureWarning):
         artifact_id = upload_artifact(trial, file_path, artifact_store)  # type: ignore
-        _validate(artifact_id=artifact_id)
+    _validate(artifact_id=artifact_id)
     with pytest.warns(FutureWarning):
         artifact_id = upload_artifact(
             trial, file_path, artifact_store=artifact_store  # type: ignore
         )
-        _validate(artifact_id=artifact_id)
+    _validate(artifact_id=artifact_id)
     with pytest.warns(FutureWarning):
         artifact_id = upload_artifact(
             trial, file_path=file_path, artifact_store=artifact_store  # type: ignore
         )
-        _validate(artifact_id=artifact_id)
+    _validate(artifact_id=artifact_id)

--- a/tests/artifacts_tests/test_upload_artifact.py
+++ b/tests/artifacts_tests/test_upload_artifact.py
@@ -120,11 +120,14 @@ def test_upload_artifact_with_positional_args(
     with open(file_path, "w") as f:
         f.write("foo")
 
-    artifact_id = upload_artifact(trial, file_path, artifact_store)  # type: ignore
-    _validate(artifact_id=artifact_id)
-    artifact_id = upload_artifact(trial, file_path, artifact_store=artifact_store)  # type: ignore
-    _validate(artifact_id=artifact_id)
-    artifact_id = upload_artifact(
-        trial, file_path=file_path, artifact_store=artifact_store  # type: ignore
-    )
-    _validate(artifact_id=artifact_id)
+    with pytest.warns(FutureWarning):
+        artifact_id = upload_artifact(trial, file_path, artifact_store)  # type: ignore
+        _validate(artifact_id=artifact_id)
+        artifact_id = upload_artifact(
+            trial, file_path, artifact_store=artifact_store  # type: ignore
+        )
+        _validate(artifact_id=artifact_id)
+        artifact_id = upload_artifact(
+            trial, file_path=file_path, artifact_store=artifact_store  # type: ignore
+        )
+        _validate(artifact_id=artifact_id)

--- a/tests/artifacts_tests/test_upload_artifact.py
+++ b/tests/artifacts_tests/test_upload_artifact.py
@@ -1,15 +1,14 @@
 from __future__ import annotations
 
-import json
 import pathlib
 
 import pytest
 
 import optuna
 from optuna.artifacts import FileSystemArtifactStore
+from optuna.artifacts import get_all_artifact_meta
 from optuna.artifacts import upload_artifact
 from optuna.artifacts._protocol import ArtifactStore
-from optuna.artifacts._upload import ArtifactMeta
 
 
 @pytest.fixture(params=["FileSystem"])
@@ -21,7 +20,6 @@ def artifact_store(tmp_path: pathlib.PurePath, request: pytest.FixtureRequest) -
 
 def test_upload_trial_artifact(tmp_path: pathlib.PurePath, artifact_store: ArtifactStore) -> None:
     file_path = str(tmp_path / "dummy.txt")
-
     with open(file_path, "w") as f:
         f.write("foo")
 
@@ -29,11 +27,8 @@ def test_upload_trial_artifact(tmp_path: pathlib.PurePath, artifact_store: Artif
     study = optuna.create_study(storage=storage)
 
     trial = study.ask()
-
     upload_artifact(study_or_trial=trial, file_path=file_path, artifact_store=artifact_store)
-
     frozen_trial = study._storage.get_trial(trial._trial_id)
-
     with pytest.raises(ValueError):
         upload_artifact(
             study_or_trial=frozen_trial, file_path=file_path, artifact_store=artifact_store
@@ -45,14 +40,7 @@ def test_upload_trial_artifact(tmp_path: pathlib.PurePath, artifact_store: Artif
         artifact_store=artifact_store,
         storage=trial.study._storage,
     )
-
-    system_attrs = storage.get_trial_system_attrs(frozen_trial._trial_id)
-    artifact_items = [
-        ArtifactMeta(**json.loads(val))
-        for key, val in system_attrs.items()
-        if key.startswith("artifacts:")
-    ]
-
+    artifact_items = get_all_artifact_meta(frozen_trial, storage=storage)
     assert len(artifact_items) == 2
     assert artifact_items[0].artifact_id != artifact_items[1].artifact_id
     assert artifact_items[0].filename == "dummy.txt"
@@ -62,7 +50,6 @@ def test_upload_trial_artifact(tmp_path: pathlib.PurePath, artifact_store: Artif
 
 def test_upload_study_artifact(tmp_path: pathlib.PurePath, artifact_store: ArtifactStore) -> None:
     file_path = str(tmp_path / "dummy.txt")
-
     with open(file_path, "w") as f:
         f.write("foo")
 
@@ -71,14 +58,7 @@ def test_upload_study_artifact(tmp_path: pathlib.PurePath, artifact_store: Artif
     artifact_id = upload_artifact(
         study_or_trial=study, file_path=file_path, artifact_store=artifact_store
     )
-
-    system_attrs = storage.get_study_system_attrs(study._study_id)
-    artifact_items = [
-        ArtifactMeta(**json.loads(val))
-        for key, val in system_attrs.items()
-        if key.startswith("artifacts:")
-    ]
-
+    artifact_items = get_all_artifact_meta(study)
     assert len(artifact_items) == 1
     assert artifact_items[0].artifact_id == artifact_id
     assert artifact_items[0].filename == "dummy.txt"
@@ -90,14 +70,11 @@ def test_upload_artifact_with_mimetype(
     tmp_path: pathlib.PurePath, artifact_store: ArtifactStore
 ) -> None:
     file_path = str(tmp_path / "dummy.obj")
-
     with open(file_path, "w") as f:
         f.write("foo")
 
     study = optuna.create_study()
-
     trial = study.ask()
-
     upload_artifact(
         study_or_trial=trial,
         file_path=file_path,
@@ -105,30 +82,49 @@ def test_upload_artifact_with_mimetype(
         mimetype="model/obj",
         encoding="utf-8",
     )
-
     frozen_trial = study._storage.get_trial(trial._trial_id)
-
     with pytest.raises(ValueError):
         upload_artifact(
             study_or_trial=frozen_trial, file_path=file_path, artifact_store=artifact_store
         )
-
     upload_artifact(
         study_or_trial=frozen_trial,
         file_path=file_path,
         artifact_store=artifact_store,
         storage=trial.study._storage,
     )
-
-    system_attrs = trial.study._storage.get_trial(frozen_trial._trial_id).system_attrs
-    artifact_items = [
-        ArtifactMeta(**json.loads(val))
-        for key, val in system_attrs.items()
-        if key.startswith("artifacts:")
-    ]
-
+    artifact_items = get_all_artifact_meta(frozen_trial, storage=study._storage)
     assert len(artifact_items) == 2
     assert artifact_items[0].artifact_id != artifact_items[1].artifact_id
     assert artifact_items[0].filename == "dummy.obj"
     assert artifact_items[0].mimetype == "model/obj"
     assert artifact_items[0].encoding == "utf-8"
+
+
+def test_upload_artifact_with_positional_args(
+    tmp_path: pathlib.PurePath, artifact_store: ArtifactStore
+) -> None:
+
+    storage = optuna.storages.InMemoryStorage()
+    study = optuna.create_study(storage=storage)
+    trial = study.ask()
+
+    def _validate(artifact_id: str) -> None:
+        artifact_items = get_all_artifact_meta(trial, storage=storage)
+        assert artifact_items[-1].artifact_id == artifact_id
+        assert artifact_items[-1].filename == "dummy.txt"
+        assert artifact_items[-1].mimetype == "text/plain"
+        assert artifact_items[-1].encoding is None
+
+    file_path = str(tmp_path / "dummy.txt")
+    with open(file_path, "w") as f:
+        f.write("foo")
+
+    artifact_id = upload_artifact(trial, file_path, artifact_store)  # type: ignore
+    _validate(artifact_id=artifact_id)
+    artifact_id = upload_artifact(trial, file_path, artifact_store=artifact_store)  # type: ignore
+    _validate(artifact_id=artifact_id)
+    artifact_id = upload_artifact(
+        trial, file_path=file_path, artifact_store=artifact_store  # type: ignore
+    )
+    _validate(artifact_id=artifact_id)

--- a/tests/artifacts_tests/test_upload_artifact.py
+++ b/tests/artifacts_tests/test_upload_artifact.py
@@ -30,14 +30,21 @@ def test_upload_trial_artifact(tmp_path: pathlib.PurePath, artifact_store: Artif
 
     trial = study.ask()
 
-    upload_artifact(trial, file_path, artifact_store)
+    upload_artifact(study_or_trial=trial, file_path=file_path, artifact_store=artifact_store)
 
     frozen_trial = study._storage.get_trial(trial._trial_id)
 
     with pytest.raises(ValueError):
-        upload_artifact(frozen_trial, file_path, artifact_store)
+        upload_artifact(
+            study_or_trial=frozen_trial, file_path=file_path, artifact_store=artifact_store
+        )
 
-    upload_artifact(frozen_trial, file_path, artifact_store, storage=trial.study._storage)
+    upload_artifact(
+        study_or_trial=frozen_trial,
+        file_path=file_path,
+        artifact_store=artifact_store,
+        storage=trial.study._storage,
+    )
 
     system_attrs = storage.get_trial_system_attrs(frozen_trial._trial_id)
     artifact_items = [
@@ -61,7 +68,9 @@ def test_upload_study_artifact(tmp_path: pathlib.PurePath, artifact_store: Artif
 
     storage = optuna.storages.InMemoryStorage()
     study = optuna.create_study(storage=storage)
-    artifact_id = upload_artifact(study, file_path, artifact_store)
+    artifact_id = upload_artifact(
+        study_or_trial=study, file_path=file_path, artifact_store=artifact_store
+    )
 
     system_attrs = storage.get_study_system_attrs(study._study_id)
     artifact_items = [
@@ -89,14 +98,27 @@ def test_upload_artifact_with_mimetype(
 
     trial = study.ask()
 
-    upload_artifact(trial, file_path, artifact_store, mimetype="model/obj", encoding="utf-8")
+    upload_artifact(
+        study_or_trial=trial,
+        file_path=file_path,
+        artifact_store=artifact_store,
+        mimetype="model/obj",
+        encoding="utf-8",
+    )
 
     frozen_trial = study._storage.get_trial(trial._trial_id)
 
     with pytest.raises(ValueError):
-        upload_artifact(frozen_trial, file_path, artifact_store)
+        upload_artifact(
+            study_or_trial=frozen_trial, file_path=file_path, artifact_store=artifact_store
+        )
 
-    upload_artifact(frozen_trial, file_path, artifact_store, storage=trial.study._storage)
+    upload_artifact(
+        study_or_trial=frozen_trial,
+        file_path=file_path,
+        artifact_store=artifact_store,
+        storage=trial.study._storage,
+    )
 
     system_attrs = trial.study._storage.get_trial(frozen_trial._trial_id).system_attrs
     artifact_items = [

--- a/tutorial/20_recipes/012_artifact_tutorial.py
+++ b/tutorial/20_recipes/012_artifact_tutorial.py
@@ -137,7 +137,7 @@ The simple pseudocode for the above case  would look something like this:
     # Downloading artifacts associated with the best trial.
     best_artifact_id = study.best_trial.user_attrs.get("artifact_id")
     download_file_path = ...  # Set the path to save the downloaded artifact.
-    download_artifact(artifact_store, best_artifact_id, download_file_path)
+    download_artifact(download_file_path, artifact_store, best_artifact_id)
     with open(download_file_path, "rb") as f:
         content = f.read().decode("utf-8")
     print(content)
@@ -221,7 +221,7 @@ read and write data transparently. Translating the above process into simple pse
     # Downloading artifacts associated with the best trial.
     best_artifact_id = study.best_trial.user_attrs.get("artifact_id")
     download_file_path = ...  # Set the path to save the downloaded artifact.
-    download_artifact(artifact_store, best_artifact_id, download_file_path)
+    download_artifact(download_file_path, artifact_store, best_artifact_id)
     with open(download_file_path, "rb") as f:
         content = f.read().decode("utf-8")
     print(content)
@@ -399,7 +399,7 @@ def main():
 
     with tempfile.TemporaryDirectory() as tmpdir_name:
         download_file_path = os.path.join(tmpdir_name, f"{best_artifact_id}.json")
-        download_artifact(artifact_store, best_artifact_id, download_file_path)
+        download_artifact(download_file_path, artifact_store, best_artifact_id)
 
         best_atoms = file_to_atoms(download_file_path)
         print(best_atoms)

--- a/tutorial/20_recipes/012_artifact_tutorial.py
+++ b/tutorial/20_recipes/012_artifact_tutorial.py
@@ -137,7 +137,9 @@ The simple pseudocode for the above case  would look something like this:
     # Downloading artifacts associated with the best trial.
     best_artifact_id = study.best_trial.user_attrs.get("artifact_id")
     download_file_path = ...  # Set the path to save the downloaded artifact.
-    download_artifact(download_file_path, artifact_store, best_artifact_id)
+    download_artifact(
+        artifact_store=artifact_store, file_path=download_file_path, artifact_id=best_artifact_id
+    )
     with open(download_file_path, "rb") as f:
         content = f.read().decode("utf-8")
     print(content)
@@ -221,7 +223,9 @@ read and write data transparently. Translating the above process into simple pse
     # Downloading artifacts associated with the best trial.
     best_artifact_id = study.best_trial.user_attrs.get("artifact_id")
     download_file_path = ...  # Set the path to save the downloaded artifact.
-    download_artifact(download_file_path, artifact_store, best_artifact_id)
+    download_artifact(
+        artifact_store=artifact_store, file_path=download_file_path, artifact_id=best_artifact_id
+    )
     with open(download_file_path, "rb") as f:
         content = f.read().decode("utf-8")
     print(content)
@@ -403,7 +407,11 @@ def main():
 
     with tempfile.TemporaryDirectory() as tmpdir_name:
         download_file_path = os.path.join(tmpdir_name, f"{best_artifact_id}.json")
-        download_artifact(download_file_path, artifact_store, best_artifact_id)
+        download_artifact(
+            artifact_store=artifact_store,
+            file_path=download_file_path,
+            artifact_id=best_artifact_id,
+        )
 
         best_atoms = file_to_atoms(download_file_path)
         print(best_atoms)

--- a/tutorial/20_recipes/012_artifact_tutorial.py
+++ b/tutorial/20_recipes/012_artifact_tutorial.py
@@ -122,7 +122,9 @@ The simple pseudocode for the above case  would look something like this:
         # Creating and writing an artifact.
         file_path = generate_example(...)  # This function returns some kind of file.
         artifact_id = upload_artifact(
-            artifact_store=artifact_store, file_path=file_path, study_or_trial=trial,
+            artifact_store=artifact_store,
+            file_path=file_path,
+            study_or_trial=trial,
         )  # The return value is the artifact ID.
         trial.set_user_attr(
             "artifact_id", artifact_id
@@ -205,7 +207,9 @@ read and write data transparently. Translating the above process into simple pse
         # Creating and writing an artifact.
         file_path = generate_example(...)  # This function returns some kind of file.
         artifact_id = upload_artifact(
-            artifact_store=artifact_store, file_path=file_path, study_or_trial=trial,
+            artifact_store=artifact_store,
+            file_path=file_path,
+            study_or_trial=trial,
         )  # The return value is the artifact ID.
         trial.set_user_attr(
             "artifact_id", artifact_id

--- a/tutorial/20_recipes/012_artifact_tutorial.py
+++ b/tutorial/20_recipes/012_artifact_tutorial.py
@@ -122,7 +122,7 @@ The simple pseudocode for the above case  would look something like this:
         # Creating and writing an artifact.
         file_path = generate_example(...)  # This function returns some kind of file.
         artifact_id = upload_artifact(
-            trial, file_path, artifact_store
+            artifact_store=artifact_store, file_path=file_path, study_or_trial=trial,
         )  # The return value is the artifact ID.
         trial.set_user_attr(
             "artifact_id", artifact_id
@@ -203,7 +203,7 @@ read and write data transparently. Translating the above process into simple pse
         # Creating and writing an artifact.
         file_path = generate_example(...)  # This function returns some kind of file.
         artifact_id = upload_artifact(
-            trial, file_path, artifact_store
+            artifact_store=artifact_store, file_path=file_path, study_or_trial=trial,
         )  # The return value is the artifact ID.
         trial.set_user_attr(
             "artifact_id", artifact_id
@@ -356,7 +356,11 @@ class Objective:
         E_slab_mol = get_opt_energy(slab, fmax=1e-2)
 
         write(f"./tmp/{trial.number}.json", slab, format="json")
-        artifact_id = upload_artifact(trial, f"./tmp/{trial.number}.json", self._artifact_store)
+        artifact_id = upload_artifact(
+            artifact_store=self._artifact_store,
+            file_path=f"./tmp/{trial.number}.json",
+            study_or_trial=trial,
+        )
         trial.set_user_attr("structure", artifact_id)
 
         return E_slab_mol - E_slab - E_mol


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

This PR is to match the argument order of artifact store APIs.

Related PR:
- https://github.com/optuna/optuna/pull/5529

## Description of the changes
<!-- Describe the changes in this PR. -->

After this PR, the APIs will look:

```python
def upload_artifact(*, artifact_store, file_path, study_or_trial,  ...) -> str:
    ...

def download_artifact(*, artifact_store, file_path, artifact_id) -> None:
    ...
```

Since `upload_artifact` is an existing API, I added `convert_potional_args` as a kind deprecation reminder for users. 