### PR TITLE
Make `assume_unique_lexsorted` in `is_pareto_front` required

### DIFF
--- a/optuna/_hypervolume/wfg.py
+++ b/optuna/_hypervolume/wfg.py
@@ -28,7 +28,8 @@ class WFG(BaseHypervolume):
 
         if not assume_pareto:
             unique_lexsorted_sols = np.unique(solution_set, axis=0)
-            sorted_pareto_sols = unique_lexsorted_sols[_is_pareto_front(unique_lexsorted_sols)]
+            on_front = _is_pareto_front(unique_lexsorted_sols, assume_unique_lexsorted=True)
+            sorted_pareto_sols = unique_lexsorted_sols[on_front]
         else:
             sorted_pareto_sols = solution_set[solution_set[:, 0].argsort()]
 

--- a/optuna/study/_multi_objective.py
+++ b/optuna/study/_multi_objective.py
@@ -158,7 +158,7 @@ def _is_pareto_front_for_unique_sorted(unique_lexsorted_loss_values: np.ndarray)
         return _is_pareto_front_nd(unique_lexsorted_loss_values)
 
 
-def _is_pareto_front(loss_values: np.ndarray, assume_unique_lexsorted: bool = True) -> np.ndarray:
+def _is_pareto_front(loss_values: np.ndarray, assume_unique_lexsorted: bool) -> np.ndarray:
     if assume_unique_lexsorted:
         return _is_pareto_front_for_unique_sorted(loss_values)
 
@@ -188,7 +188,7 @@ def _calculate_nondomination_rank(
     rank = 0
     indices = np.arange(n_unique)
     while n_unique - indices.size < n_below:
-        on_front = _is_pareto_front(unique_lexsorted_loss_values)
+        on_front = _is_pareto_front(unique_lexsorted_loss_values, assume_unique_lexsorted=True)
         ranks[indices[on_front]] = rank
         # Remove the recent Pareto solutions.
         indices = indices[~on_front]


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

As it is unsafe to assume unique lexsorted by default in `is_pareto_front`, I removed the default value for this.

## Description of the changes
<!-- Describe the changes in this PR. -->

- Remove the default value for `is_pareto_front` 
