### PR TITLE
Rename filenames for `JournalFileStorage` in  documents and a tutorial

### DIFF
--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -555,7 +555,7 @@ If you want to use a file-based Optuna storage for these scenarios, please consi
    import optuna
    from optuna.storages import JournalStorage, JournalFileStorage
 
-   storage = JournalStorage(JournalFileStorage("optuna-file-storage.journal"))
+   storage = JournalStorage(JournalFileStorage("JournalFileStorageLog.jsonl"))
    study = optuna.create_study(storage=storage)
    ...
 

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -555,7 +555,7 @@ If you want to use a file-based Optuna storage for these scenarios, please consi
    import optuna
    from optuna.storages import JournalStorage, JournalFileStorage
 
-   storage = JournalStorage(JournalFileStorage("optuna-journal.log"))
+   storage = JournalStorage(JournalFileStorage("optuna-file-storage.journal"))
    study = optuna.create_study(storage=storage)
    ...
 

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -555,7 +555,7 @@ If you want to use a file-based Optuna storage for these scenarios, please consi
    import optuna
    from optuna.storages import JournalStorage, JournalFileStorage
 
-   storage = JournalStorage(JournalFileStorage("JournalFileStorageLog.jsonl"))
+   storage = JournalStorage(JournalFileStorage("journal_file_storage_jsonl.log"))
    study = optuna.create_study(storage=storage)
    ...
 

--- a/optuna/storages/_journal/storage.py
+++ b/optuna/storages/_journal/storage.py
@@ -78,7 +78,7 @@ class JournalStorage(BaseStorage):
 
 
             storage = optuna.storages.JournalStorage(
-                optuna.storages.JournalFileStorage("./journal.log"),
+                optuna.storages.JournalFileStorage("./optuna-file-storage.journal"),
             )
 
             study = optuna.create_study(storage=storage)
@@ -90,7 +90,7 @@ class JournalStorage(BaseStorage):
 
     .. code::
 
-        file_path = "./journal.log"
+        file_path = "./optuna-file-storage.journal"
         lock_obj = optuna.storages.JournalFileOpenLock(file_path)
 
         storage = optuna.storages.JournalStorage(

--- a/optuna/storages/_journal/storage.py
+++ b/optuna/storages/_journal/storage.py
@@ -78,7 +78,7 @@ class JournalStorage(BaseStorage):
 
 
             storage = optuna.storages.JournalStorage(
-                optuna.storages.JournalFileStorage("./optuna-file-storage.journal"),
+                optuna.storages.JournalFileStorage("./JournalFileStorageLog.jsonl"),
             )
 
             study = optuna.create_study(storage=storage)
@@ -90,7 +90,7 @@ class JournalStorage(BaseStorage):
 
     .. code::
 
-        file_path = "./optuna-file-storage.journal"
+        file_path = "./JournalFileStorageLog.jsonl"
         lock_obj = optuna.storages.JournalFileOpenLock(file_path)
 
         storage = optuna.storages.JournalStorage(

--- a/optuna/storages/_journal/storage.py
+++ b/optuna/storages/_journal/storage.py
@@ -78,7 +78,7 @@ class JournalStorage(BaseStorage):
 
 
             storage = optuna.storages.JournalStorage(
-                optuna.storages.JournalFileStorage("./JournalFileStorageLog.jsonl"),
+                optuna.storages.JournalFileStorage("./journal_file_storage_jsonl.log"),
             )
 
             study = optuna.create_study(storage=storage)
@@ -90,7 +90,7 @@ class JournalStorage(BaseStorage):
 
     .. code::
 
-        file_path = "./JournalFileStorageLog.jsonl"
+        file_path = "./journal_file_storage_jsonl.log"
         lock_obj = optuna.storages.JournalFileOpenLock(file_path)
 
         storage = optuna.storages.JournalStorage(

--- a/tutorial/20_recipes/011_journal_storage.py
+++ b/tutorial/20_recipes/011_journal_storage.py
@@ -19,7 +19,7 @@ import optuna
 # Add stream handler of stdout to show the messages
 optuna.logging.get_logger("optuna").addHandler(logging.StreamHandler(sys.stdout))
 study_name = "example-study"  # Unique identifier of the study.
-file_path = "./JournalFileStorageLog.jsonl"
+file_path = "./journal_file_storage_jsonl.log"
 storage = optuna.storages.JournalStorage(
     optuna.storages.JournalFileStorage(file_path),  # NFS path for distributed optimization
 )

--- a/tutorial/20_recipes/011_journal_storage.py
+++ b/tutorial/20_recipes/011_journal_storage.py
@@ -19,7 +19,7 @@ import optuna
 # Add stream handler of stdout to show the messages
 optuna.logging.get_logger("optuna").addHandler(logging.StreamHandler(sys.stdout))
 study_name = "example-study"  # Unique identifier of the study.
-file_path = "./optuna-file-storage.journal"
+file_path = "./JournalFileStorageLog.jsonl"
 storage = optuna.storages.JournalStorage(
     optuna.storages.JournalFileStorage(file_path),  # NFS path for distributed optimization
 )

--- a/tutorial/20_recipes/011_journal_storage.py
+++ b/tutorial/20_recipes/011_journal_storage.py
@@ -19,8 +19,9 @@ import optuna
 # Add stream handler of stdout to show the messages
 optuna.logging.get_logger("optuna").addHandler(logging.StreamHandler(sys.stdout))
 study_name = "example-study"  # Unique identifier of the study.
+file_path = "./optuna-file-storage.journal"
 storage = optuna.storages.JournalStorage(
-    optuna.storages.JournalFileStorage("./journal.log"),  # NFS path for distributed optimization
+    optuna.storages.JournalFileStorage(file_path),  # NFS path for distributed optimization
 )
 
 study = optuna.create_study(study_name=study_name, storage=storage)


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

`journal.log` is currently used as the filename in example codes of documents and a tutorial of `JournalFileStorage`, but I think the name is ambiguous and confusing.

## Description of the changes
<!-- Describe the changes in this PR. -->

I renamed `journal.log` to ~`JournalFileStorageLog.jsonl`~ `journal_file_storage_jsonl.log`, in example codes of documents and a tutorial.
