### PR TITLE
Simplify a SQL query for getting the best_trial's trial_id

### DIFF
--- a/optuna/storages/_rdb/models.py
+++ b/optuna/storages/_rdb/models.py
@@ -188,11 +188,10 @@ class TrialModel(BaseModel):
     )
 
     @classmethod
-    def find_max_value_trial(
-        cls, study_id: int, objective: int, session: orm.Session
-    ) -> "TrialModel":
+    def find_max_value_trial_id(cls, study_id: int, objective: int, session: orm.Session) -> int:
         trial = (
             session.query(cls)
+            .with_entities(cls.trial_id)
             .filter(cls.study_id == study_id)
             .filter(cls.state == TrialState.COMPLETE)
             .join(TrialValueModel)
@@ -211,14 +210,13 @@ class TrialModel(BaseModel):
         )
         if trial is None:
             raise ValueError(NOT_FOUND_MSG)
-        return trial
+        return trial[0]
 
     @classmethod
-    def find_min_value_trial(
-        cls, study_id: int, objective: int, session: orm.Session
-    ) -> "TrialModel":
+    def find_min_value_trial_id(cls, study_id: int, objective: int, session: orm.Session) -> int:
         trial = (
             session.query(cls)
+            .with_entities(cls.trial_id)
             .filter(cls.study_id == study_id)
             .filter(cls.state == TrialState.COMPLETE)
             .join(TrialValueModel)
@@ -237,7 +235,7 @@ class TrialModel(BaseModel):
         )
         if trial is None:
             raise ValueError(NOT_FOUND_MSG)
-        return trial
+        return trial[0]
 
     @classmethod
     def find_or_raise_by_id(

--- a/optuna/storages/_rdb/storage.py
+++ b/optuna/storages/_rdb/storage.py
@@ -918,10 +918,9 @@ class RDBStorage(BaseStorage, BaseHeartbeat):
             direction = _directions[0]
 
             if direction == StudyDirection.MAXIMIZE:
-                trial = models.TrialModel.find_max_value_trial(study_id, 0, session)
+                trial_id = models.TrialModel.find_max_value_trial_id(study_id, 0, session)
             else:
-                trial = models.TrialModel.find_min_value_trial(study_id, 0, session)
-            trial_id = trial.trial_id
+                trial_id = models.TrialModel.find_min_value_trial_id(study_id, 0, session)
 
         return self.get_trial(trial_id)
 


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

I ran a simple example to identify slow queries. As shown in the output of mysqldumpslow, the query for getting the best trial is relatively slow.
https://gist.github.com/c-bata/db3deb181ff20329e523610678c1eb29

From my quick analysis, the query's speed can be improved by the following two changes.

1. Create an index: `ALTER TABLE trials ADD INDEX ix_study_id_state(study_id, state);` (this shortened the query time from 7.01s to 3.54s in my environment, where n_trials is about 58000)
2. Apply the patch in this PR (this further reduced the time from 3.54s to 2.12s).

While adding an index is difficult in Optuna v4 release because we don't want to require users to perform database migrations, the latter change is acceptable since it just simplifies the code.

## Description of the changes

This patch modifies the query as follows:

* Before: `SELECT * FROM trials ...`
* After: `SELECT trials.trial_id FROM trials ...`

### Script to check the SQL

```python
import optuna
import logging


def objective(trial: optuna.Trial) -> float:
    return trial.suggest_float("x", -10, 10) ** 2


optuna.logging.set_verbosity(optuna.logging.WARN)
study = optuna.create_study(storage="sqlite:///example.db")
study.optimize(objective, 100)

logging.basicConfig()
logging.getLogger("sqlalchemy.engine").setLevel(logging.INFO)

study._storage.get_best_trial(study._study_id)
```

### Before

```
INFO:sqlalchemy.engine.Engine:BEGIN (implicit)
INFO:sqlalchemy.engine.Engine:SELECT trials.trial_id AS trials_trial_id, trials.number AS trials_number, trials.study_id AS trials_study_id, trials.state AS trials_state, trials.datetime_start AS trials_datetime_start, trials.datetime_complete AS trials_datetime_complete 
FROM trials JOIN trial_values ON trials.trial_id = trial_values.trial_id 
WHERE trials.study_id = ? AND trials.state = ? AND trial_values.objective = ? ORDER BY CASE trial_values.value_type WHEN ? THEN ? WHEN ? THEN ? WHEN ? THEN ? END ASC, trial_values.value ASC
 LIMIT ? OFFSET ?
INFO:sqlalchemy.engine.Engine:[generated in 0.00012s] (4, 'COMPLETE', 0, 'INF_NEG', -1, 'FINITE', 0, 'INF_POS', 1, 1, 0)
INFO:sqlalchemy.engine.Engine:COMMIT
```

### After

```
INFO:sqlalchemy.engine.Engine:BEGIN (implicit)
INFO:sqlalchemy.engine.Engine:SELECT trials.trial_id AS trials_trial_id 
FROM trials JOIN trial_values ON trials.trial_id = trial_values.trial_id 
WHERE trials.study_id = ? AND trials.state = ? AND trial_values.objective = ? ORDER BY CASE trial_values.value_type WHEN ? THEN ? WHEN ? THEN ? WHEN ? THEN ? END ASC, trial_values.value ASC
 LIMIT ? OFFSET ?
INFO:sqlalchemy.engine.Engine:[generated in 0.00014s] (3, 'COMPLETE', 0, 'INF_NEG', -1, 'FINITE', 0, 'INF_POS', 1, 1, 0)
INFO:sqlalchemy.engine.Engine:COMMIT
```
