### PR TITLE
Rename `solution_set` to `loss_vals` in hypervolume computation

### DIFF
--- a/optuna/_hypervolume/wfg.py
+++ b/optuna/_hypervolume/wfg.py
@@ -67,8 +67,7 @@ def compute_hypervolume(
             In other words, if ``True``, none of loss vectors are dominated by another.
 
     Returns:
-        hypervolume:
-            The hypervolume of the given arguments.
+        The hypervolume of the given arguments.
 
     """
 

--- a/optuna/visualization/_hypervolume_history.py
+++ b/optuna/visualization/_hypervolume_history.py
@@ -146,7 +146,7 @@ def _get_hypervolume_history_info(
             filter(lambda t: not _dominates(trial, t, study.directions), best_trials)
         ) + [trial]
 
-        solution_set = np.asarray(
+        loss_vals = np.asarray(
             list(
                 filter(
                     lambda v: (v <= minimization_reference_point).all(),
@@ -154,8 +154,8 @@ def _get_hypervolume_history_info(
                 )
             )
         )
-        if solution_set.size > 0:
-            hypervolume = compute_hypervolume(solution_set, minimization_reference_point)
+        if loss_vals.size > 0:
+            hypervolume = compute_hypervolume(loss_vals, minimization_reference_point)
         values.append(hypervolume)
 
     if len(best_trials) == 0:


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

As `loss_vals` is used frequently in the Optuna codebase and `loss_vals` makes it clear for us to recognize the better directions for each objective, I renamed `solution_set` in hypervolume computation to `loss_vals`.

## Description of the changes
<!-- Describe the changes in this PR. -->

- Replace `solution_set` to `loss_vals`
- Add some docs