### PR TITLE
Expand the type of `callbacks` in optimize to `Iterable`

### DIFF
--- a/optuna/study/_optimize.py
+++ b/optuna/study/_optimize.py
@@ -125,7 +125,7 @@ def _optimize_sequential(
     n_trials: int | None,
     timeout: float | None,
     catch: tuple[type[Exception], ...],
-    callbacks: list[Callable[["optuna.Study", FrozenTrial], None]] | None,
+    callbacks: Iterable[Callable[["optuna.Study", FrozenTrial], None]] | None,
     gc_after_trial: bool,
     reseed_sampler_rng: bool,
     time_start: datetime.datetime | None,

--- a/optuna/study/_optimize.py
+++ b/optuna/study/_optimize.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Iterable
 from collections.abc import Sequence
 from concurrent.futures import FIRST_COMPLETED
 from concurrent.futures import Future
@@ -37,7 +38,7 @@ def _optimize(
     timeout: float | None = None,
     n_jobs: int = 1,
     catch: tuple[type[Exception], ...] = (),
-    callbacks: list[Callable[["optuna.Study", FrozenTrial], None]] | None = None,
+    callbacks: Iterable[Callable[["optuna.Study", FrozenTrial], None]] | None = None,
     gc_after_trial: bool = False,
     show_progress_bar: bool = False,
 ) -> None:

--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -377,7 +377,7 @@ class Study:
         timeout: float | None = None,
         n_jobs: int = 1,
         catch: Iterable[type[Exception]] | type[Exception] = (),
-        callbacks: list[Callable[[Study, FrozenTrial], None]] | None = None,
+        callbacks: Iterable[Callable[[Study, FrozenTrial], None]] | None = None,
         gc_after_trial: bool = False,
         show_progress_bar: bool = False,
     ) -> None:


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
This is an update for issue #5509. 

## Description of the changes
<!-- Describe the changes in this PR. -->
The type of `callbacks` in `optimize` has been changed from `list` to `Iterable`. 

All CI checks pass successfully. 

