### PR TITLE
Add tests for passing `Iterable` objects to optimize `callbacks`

### DIFF
--- a/tests/study_tests/test_study.py
+++ b/tests/study_tests/test_study.py
@@ -1004,6 +1004,28 @@ def test_callbacks(n_jobs: int) -> None:
     assert states == []
 
 
+def test_callbacks_with_iterables() -> None:
+
+    def callback(study: Study, trial: FrozenTrial) -> None:
+        if trial.number >= 4:
+            study.stop()
+
+    def objective(trial: Trial) -> float:
+        x = trial.suggest_int("x", -10, 10)
+        y = trial.suggest_int("y", -10, 10)
+        return x**2 + y**2
+    
+    # Test with lists
+    study = create_study()
+    study.optimize(objective, n_trials=10, callbacks=[callback])
+    assert len(study.trials) == 5
+
+    # Test with tuples
+    study = create_study()
+    study.optimize(objective, n_trials=10, callbacks=(callback,))
+    assert len(study.trials) == 5
+
+
 def test_optimize_infinite_budget_progbar() -> None:
     def terminate_study(study: Study, trial: FrozenTrial) -> None:
         study.stop()

--- a/tests/study_tests/test_study.py
+++ b/tests/study_tests/test_study.py
@@ -1014,7 +1014,7 @@ def test_callbacks_with_iterables() -> None:
         x = trial.suggest_int("x", -10, 10)
         y = trial.suggest_int("y", -10, 10)
         return x**2 + y**2
-    
+
     # Test with lists
     study = create_study()
     study.optimize(objective, n_trials=10, callbacks=[callback])


### PR DESCRIPTION
Add the test `test_callbacks_with_iterables`. This tests the use of `callbacks` in `optimize` with tuples.

<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
This is a follow up to PR #5542 and issue #5509 . As requested, I have added test cases for the type changes.

## Description of the changes
<!-- Describe the changes in this PR. -->
A test case has been added to ensure that the `callbacks` parameter in `optimize` accepts both lists and tuples. 
