### PR TITLE
Add followup of journal storage module structure organization PR

### DIFF
--- a/optuna/storages/__init__.py
+++ b/optuna/storages/__init__.py
@@ -1,6 +1,7 @@
 from typing import Union
 
 from optuna._callbacks import RetryFailedTrialCallback
+from optuna._deprecated import deprecated_class
 from optuna.storages._base import BaseStorage
 from optuna.storages._cached_storage import _CachedStorage
 from optuna.storages._heartbeat import fail_stale_trials
@@ -8,10 +9,61 @@ from optuna.storages._in_memory import InMemoryStorage
 from optuna.storages._rdb.storage import RDBStorage
 from optuna.storages.journal._backend import JournalFileStorage
 from optuna.storages.journal._base import BaseJournalLogStorage
-from optuna.storages.journal._file_lock import JournalFileOpenLock
-from optuna.storages.journal._file_lock import JournalFileSymlinkLock
+from optuna.storages.journal._file_lock import JournalFileOpenLock as _JournalFileOpenLock
+from optuna.storages.journal._file_lock import JournalFileSymlinkLock as _JournalFileSymlinkLock
 from optuna.storages.journal._redis import JournalRedisStorage
 from optuna.storages.journal._storage import JournalStorage
+
+
+@deprecated_class(
+    "4.0.0", "6.0.0", text="Use :class:`~optuna.storages.journal.JournalFileOpenLock` instead."
+)
+class JournalFileOpenLock(_JournalFileOpenLock):
+    """Lock class for synchronizing processes for NFSv3 or later.
+
+    On acquiring the lock, open system call is called with the O_EXCL option to create an exclusive
+    file. The file is deleted when the lock is released. This class is only supported when using
+    NFSv3 or later on kernel 2.6 or later. In prior NFS environments, use
+    :class:`~optuna.storages.journal.JournalFileSymlinkLock`.
+
+    Args:
+        filepath:
+            The path of the file whose race condition must be protected.
+
+    .. note::
+
+        The path of :class:`~optuna.storages.JournalFileOpenLock` has been moved to
+        :class:`~optuna.storages.journal.JournalFileOpenLock`.
+
+    """
+
+    def __init__(self, filepath: str) -> None:
+        super().__init__(filepath=filepath)
+
+
+@deprecated_class(
+    "4.0.0", "6.0.0", text="Use :class:`~optuna.storages.journal.JournalFileSymlinkLock` instead."
+)
+class JournalFileSymlinkLock(_JournalFileSymlinkLock):
+    """Lock class for synchronizing processes for NFSv2 or later.
+
+    On acquiring the lock, link system call is called to create an exclusive file. The file is
+    deleted when the lock is released. In NFS environments prior to NFSv3, use this instead of
+    :class:`~optuna.storages.journal.JournalFileOpenLock`.
+
+    Args:
+        filepath:
+            The path of the file whose race condition must be protected.
+
+    .. note::
+
+        The path of :class:`~optuna.storages.JournalFileSymlinkLock` has been moved to
+        :class:`~optuna.storages.journal.JournalFileSymlinkLock`.
+
+    """
+
+    def __init__(self, filepath: str) -> None:
+        super().__init__(filepath=filepath)
 
 
 __all__ = [
@@ -20,8 +72,6 @@ __all__ = [
     "InMemoryStorage",
     "RDBStorage",
     "JournalStorage",
-    "JournalFileSymlinkLock",
-    "JournalFileOpenLock",
     "JournalFileStorage",
     "JournalRedisStorage",
     "RetryFailedTrialCallback",

--- a/optuna/storages/__init__.py
+++ b/optuna/storages/__init__.py
@@ -16,7 +16,10 @@ from optuna.storages.journal._storage import JournalStorage
 
 
 @deprecated_class(
-    "4.0.0", "6.0.0", text="Use :class:`~optuna.storages.journal.JournalFileOpenLock` instead."
+    deprecated_version="4.0.0",
+    removed_version="6.0.0",
+    name="The import path :class:`~optuna.storages.JournalFileOpenLock`",
+    text="Use :class:`~optuna.storages.journal.JournalFileOpenLock` instead.",
 )
 class JournalFileOpenLock(_JournalFileOpenLock):
     """Lock class for synchronizing processes for NFSv3 or later.
@@ -42,7 +45,10 @@ class JournalFileOpenLock(_JournalFileOpenLock):
 
 
 @deprecated_class(
-    "4.0.0", "6.0.0", text="Use :class:`~optuna.storages.journal.JournalFileSymlinkLock` instead."
+    deprecated_version="4.0.0",
+    removed_version="6.0.0",
+    name="The import path :class:`~optuna.storages.JournalFileSymlinkLock`",
+    text="Use :class:`~optuna.storages.journal.JournalFileSymlinkLock` instead.",
 )
 class JournalFileSymlinkLock(_JournalFileSymlinkLock):
     """Lock class for synchronizing processes for NFSv2 or later.

--- a/optuna/storages/journal/__init__.py
+++ b/optuna/storages/journal/__init__.py
@@ -6,6 +6,7 @@ from optuna.storages.journal._redis import JournalRedisBackend
 from optuna.storages.journal._storage import JournalStorage
 
 
+# NOTE(nabenabe0928): Do not add objects deprecated at v4.0.0 here, e.g., JournalFileStorage.
 __all__ = [
     "JournalFileBackend",
     "BaseJournalBackend",

--- a/optuna/storages/journal/__init__.py
+++ b/optuna/storages/journal/__init__.py
@@ -6,7 +6,9 @@ from optuna.storages.journal._redis import JournalRedisBackend
 from optuna.storages.journal._storage import JournalStorage
 
 
-# NOTE(nabenabe0928): Do not add objects deprecated at v4.0.0 here, e.g., JournalFileStorage.
+# NOTE(nabenabe0928): Do not add objects deprecated at v4.0.0 here, e.g., JournalFileStorage
+# because ``optuna/storages/journal`` was added at v4.0.0 and it will be confusing to keep them in
+# the non-deprecated directory.
 __all__ = [
     "JournalFileBackend",
     "BaseJournalBackend",

--- a/optuna/storages/journal/__init__.py
+++ b/optuna/storages/journal/__init__.py
@@ -1,22 +1,16 @@
 from optuna.storages.journal._backend import JournalFileBackend
-from optuna.storages.journal._backend import JournalFileStorage
 from optuna.storages.journal._base import BaseJournalBackend
-from optuna.storages.journal._base import BaseJournalLogStorage
 from optuna.storages.journal._file_lock import JournalFileOpenLock
 from optuna.storages.journal._file_lock import JournalFileSymlinkLock
 from optuna.storages.journal._redis import JournalRedisBackend
-from optuna.storages.journal._redis import JournalRedisStorage
 from optuna.storages.journal._storage import JournalStorage
 
 
 __all__ = [
     "JournalFileBackend",
-    "JournalFileStorage",
     "BaseJournalBackend",
-    "BaseJournalLogStorage",
     "JournalFileOpenLock",
     "JournalFileSymlinkLock",
     "JournalRedisBackend",
-    "JournalRedisStorage",
     "JournalStorage",
 ]

--- a/optuna/storages/journal/_file_lock.py
+++ b/optuna/storages/journal/_file_lock.py
@@ -19,7 +19,7 @@ class JournalFileSymlinkLock(BaseJournalFileLock):
 
     On acquiring the lock, link system call is called to create an exclusive file. The file is
     deleted when the lock is released. In NFS environments prior to NFSv3, use this instead of
-    :class:`~optuna.storages.JournalFileOpenLock`
+    :class:`~optuna.storages.journal.JournalFileOpenLock`.
 
     Args:
         filepath:
@@ -72,7 +72,7 @@ class JournalFileOpenLock(BaseJournalFileLock):
     On acquiring the lock, open system call is called with the O_EXCL option to create an exclusive
     file. The file is deleted when the lock is released. This class is only supported when using
     NFSv3 or later on kernel 2.6 or later. In prior NFS environments, use
-    :class:`~optuna.storages.JournalFileSymlinkLock`.
+    :class:`~optuna.storages.journal.JournalFileSymlinkLock`.
 
     Args:
         filepath:

--- a/tests/storages_tests/journal_tests/test_journal.py
+++ b/tests/storages_tests/journal_tests/test_journal.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from concurrent.futures import as_completed
 from concurrent.futures import ProcessPoolExecutor
 from concurrent.futures import ThreadPoolExecutor
+import pathlib
 import pickle
 from types import TracebackType
 from typing import Any
@@ -233,7 +234,7 @@ def test_future_warning_of_deprecated_file_lock_obj_paths(
     lock_obj: type[DeprecatedJournalFileOpenLock | DeprecatedJournalFileSymlinkLock],
 ) -> None:
     with pytest.warns(FutureWarning):
-        lock_obj(filepath=tmp_path)
+        lock_obj(filepath=str(tmp_path))
 
 
 def test_raise_error_for_deprecated_class_import_from_journal() -> None:

--- a/tests/storages_tests/journal_tests/test_journal.py
+++ b/tests/storages_tests/journal_tests/test_journal.py
@@ -229,11 +229,11 @@ def test_if_future_warning_occurs() -> None:
     "lock_obj", (DeprecatedJournalFileOpenLock, DeprecatedJournalFileSymlinkLock)
 )
 def test_future_warning_of_deprecated_file_lock_obj_paths(
+    tmp_path: pathlib.PurePath,
     lock_obj: type[DeprecatedJournalFileOpenLock | DeprecatedJournalFileSymlinkLock],
 ) -> None:
     with pytest.warns(FutureWarning):
-        dummy_file_path = "dummy"
-        lock_obj(filepath=dummy_file_path)
+        lock_obj(filepath=tmp_path)
 
 
 def test_raise_error_for_deprecated_class_import_from_journal() -> None:

--- a/tests/storages_tests/journal_tests/test_journal.py
+++ b/tests/storages_tests/journal_tests/test_journal.py
@@ -46,9 +46,9 @@ class JournalLogStorageSupplier:
             self.tempfile = NamedTemporaryFilePool().tempfile()
             lock: BaseJournalFileLock
             if self.storage_type == "file_with_open_lock":
-                lock = optuna.storages.JournalFileOpenLock(self.tempfile.name)
+                lock = optuna.storages.journal.JournalFileOpenLock(self.tempfile.name)
             elif self.storage_type == "file_with_link_lock":
-                lock = optuna.storages.JournalFileSymlinkLock(self.tempfile.name)
+                lock = optuna.storages.journal.JournalFileSymlinkLock(self.tempfile.name)
             else:
                 raise Exception("Must not reach here")
             return optuna.storages.journal.JournalFileBackend(self.tempfile.name, lock)

--- a/tests/storages_tests/journal_tests/test_journal.py
+++ b/tests/storages_tests/journal_tests/test_journal.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from concurrent.futures import as_completed
 from concurrent.futures import ProcessPoolExecutor
 from concurrent.futures import ThreadPoolExecutor
-import importlib
 import pickle
 from types import TracebackType
 from typing import Any
@@ -19,10 +18,10 @@ import pytest
 import optuna
 from optuna import create_study
 from optuna.storages import BaseJournalLogStorage
+from optuna.storages import journal
 from optuna.storages import JournalFileOpenLock as DeprecatedJournalFileOpenLock
 from optuna.storages import JournalFileSymlinkLock as DeprecatedJournalFileSymlinkLock
 from optuna.storages import JournalStorage
-from optuna.storages import journal
 from optuna.storages.journal._base import BaseJournalFileLock
 from optuna.storages.journal._base import BaseJournalSnapshot
 from optuna.storages.journal._storage import JournalStorageReplayResult

--- a/tests/storages_tests/journal_tests/test_journal.py
+++ b/tests/storages_tests/journal_tests/test_journal.py
@@ -19,8 +19,11 @@ import optuna
 from optuna import create_study
 from optuna.storages import BaseJournalLogStorage
 from optuna.storages import JournalStorage
+from optuna.storages import JournalFileOpenLock as DeprecatedJournalFileOpenLock
+from optuna.storages import JournalFileSymlinkLock as DeprecatedJournalFileSymlinkLock
 from optuna.storages.journal._base import BaseJournalFileLock
 from optuna.storages.journal._base import BaseJournalSnapshot
+from optuna.storages.journal._file_lock import BaseJournalFileLock
 from optuna.storages.journal._storage import JournalStorageReplayResult
 from optuna.testing.storages import StorageSupplier
 from optuna.testing.tempfile_pool import NamedTemporaryFilePool
@@ -220,3 +223,12 @@ def test_if_future_warning_occurs() -> None:
 
     with pytest.warns(FutureWarning):
         _ = _CustomJournalBackendInheritingDeprecatedClass()
+
+
+@pytest.mark.parametrize(
+    "lock_obj", (DeprecatedJournalFileOpenLock, DeprecatedJournalFileSymlinkLock)
+)
+def test_future_warning_of_deprecated_file_lock_obj_paths(lock_obj: BaseJournalFileLock) -> None:
+    with pytest.warns(FutureWarning):
+        dummy_file_path = "dummy"
+        lock_obj(filepath=dummy_file_path)

--- a/tests/storages_tests/journal_tests/test_journal.py
+++ b/tests/storages_tests/journal_tests/test_journal.py
@@ -236,7 +236,7 @@ def test_future_warning_of_deprecated_file_lock_obj_paths(
         lock_obj(filepath=dummy_file_path)
 
 
-def test_invalid_imports_from_journal() -> None:
+def test_raise_error_for_deprecated_class_import_from_journal() -> None:
     # TODO(nabenabe0928): Remove this test once deprecated objects, e.g., JournalFileStorage,
     # are removed.
     from optuna.storages import journal
@@ -249,7 +249,7 @@ def test_invalid_imports_from_journal() -> None:
         journal.BaseJournalLogStorage  # type: ignore[attr-defined]
 
 
-def test_invalid_journal_module_imports() -> None:
+def test_invalid_journal_related_non_storage_class_import() -> None:
     storages_module = importlib.import_module("optuna.storages")
     # TODO(nabenabe0928): Remove ``deprecated_objects`` once deprecated objects,
     # e.g., JournalFileStorage, are removed.

--- a/tests/storages_tests/journal_tests/test_journal.py
+++ b/tests/storages_tests/journal_tests/test_journal.py
@@ -252,4 +252,4 @@ def test_invalid_journal_related_non_storage_class_import() -> None:
         set(journal.__all__) & set(optuna.storages.__all__)
     )
     assert len(journal_related_modules_in_storages_init) == 1
-    assert journal_related_modules_in_storages_init[0] == "JournalStorage"
+    assert journal_related_modules_in_storages_init[0] == JournalStorage.__name__

--- a/tests/storages_tests/journal_tests/test_journal.py
+++ b/tests/storages_tests/journal_tests/test_journal.py
@@ -236,15 +236,17 @@ def test_future_warning_of_deprecated_file_lock_obj_paths(
         lock_obj(filepath=dummy_file_path)
 
 
-@pytest.mark.parametrize(
-    "obj_name", ("JournalFileStorage", "JournalRedisStorage", "BaseJournalLogStorage")
-)
-def test_invalid_imports_from_journal(obj_name: str) -> None:
+def test_invalid_imports_from_journal() -> None:
     # TODO(nabenabe0928): Remove this test once deprecated objects, e.g., JournalFileStorage,
     # are removed.
-    journal = importlib.import_module("optuna.storages.journal")
-    with pytest.raises(AttributeError):  # Meaning that the object cannot be imported from journal.
-        getattr(journal, obj_name)
+    from optuna.storages import journal
+
+    with pytest.raises(AttributeError):
+        journal.JournalFileStorage  # type: ignore[attr-defined]
+    with pytest.raises(AttributeError):
+        journal.JournalRedisStorage  # type: ignore[attr-defined]
+    with pytest.raises(AttributeError):
+        journal.BaseJournalLogStorage  # type: ignore[attr-defined]
 
 
 def test_invalid_journal_module_imports() -> None:

--- a/tests/storages_tests/journal_tests/test_journal.py
+++ b/tests/storages_tests/journal_tests/test_journal.py
@@ -18,12 +18,11 @@ import pytest
 import optuna
 from optuna import create_study
 from optuna.storages import BaseJournalLogStorage
-from optuna.storages import JournalStorage
 from optuna.storages import JournalFileOpenLock as DeprecatedJournalFileOpenLock
 from optuna.storages import JournalFileSymlinkLock as DeprecatedJournalFileSymlinkLock
+from optuna.storages import JournalStorage
 from optuna.storages.journal._base import BaseJournalFileLock
 from optuna.storages.journal._base import BaseJournalSnapshot
-from optuna.storages.journal._file_lock import BaseJournalFileLock
 from optuna.storages.journal._storage import JournalStorageReplayResult
 from optuna.testing.storages import StorageSupplier
 from optuna.testing.tempfile_pool import NamedTemporaryFilePool
@@ -228,7 +227,9 @@ def test_if_future_warning_occurs() -> None:
 @pytest.mark.parametrize(
     "lock_obj", (DeprecatedJournalFileOpenLock, DeprecatedJournalFileSymlinkLock)
 )
-def test_future_warning_of_deprecated_file_lock_obj_paths(lock_obj: BaseJournalFileLock) -> None:
+def test_future_warning_of_deprecated_file_lock_obj_paths(
+    lock_obj: type[DeprecatedJournalFileOpenLock | DeprecatedJournalFileSymlinkLock],
+) -> None:
     with pytest.warns(FutureWarning):
         dummy_file_path = "dummy"
         lock_obj(filepath=dummy_file_path)


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

This PR is a followup:

- https://github.com/optuna/optuna/pull/5544#issuecomment-2210427032

## Description of the changes
<!-- Describe the changes in this PR. -->

- Deprecate the import of `optuna.storages.JournalFile(Symlink|Open)Lock` object from `optuna.storages` and recommend it from `optuna.storages.journal`
- Remove deprecated modules in `.journal.__init__.py`
- Add unit tests to check whether future warning is triggered when importing deprecated modules 