### PR TITLE
Replace `sleep` function with spin waiting to stabilize the frequent Mac test failure

### DIFF
--- a/tests/visualization_tests/test_timeline.py
+++ b/tests/visualization_tests/test_timeline.py
@@ -154,7 +154,11 @@ def test_get_timeline_plot_with_killed_running_trials(
     plot_timeline: Callable[..., Any], waiting_time: float
 ) -> None:
     def _objective_with_sleep(trial: optuna.Trial) -> float:
-        time.sleep(0.1)
+        sleep_start_datetime = datetime.datetime.now()
+        # Spin waiting is used here because high accuracy is necessary even in weak VM.
+        while datetime.datetime.now() - sleep_start_datetime < datetime.timedelta(seconds=0.1):
+            pass
+        assert datetime.datetime.now() - sleep_start_datetime < datetime.timedelta(seconds=0.19)
         trial.suggest_float("x", -1.0, 1.0)
         return 1.0
 

--- a/tests/visualization_tests/test_timeline.py
+++ b/tests/visualization_tests/test_timeline.py
@@ -158,6 +158,9 @@ def test_get_timeline_plot_with_killed_running_trials(
         # Spin waiting is used here because high accuracy is necessary even in weak VM.
         # Please check the motivation of the bugfix in https://github.com/optuna/optuna/pull/5549/
         while datetime.datetime.now() - sleep_start_datetime < datetime.timedelta(seconds=0.1):
+            # `sleep(0.1)` is only guaranteed to rest for more than 0.1 second; the actual time
+            # depends on the OS. spin waiting is used here to rest for 0.1 second as precisely as
+            # possible without voluntarily releasing the context.
             pass
         assert datetime.datetime.now() - sleep_start_datetime < datetime.timedelta(seconds=0.19)
         trial.suggest_float("x", -1.0, 1.0)

--- a/tests/visualization_tests/test_timeline.py
+++ b/tests/visualization_tests/test_timeline.py
@@ -156,6 +156,7 @@ def test_get_timeline_plot_with_killed_running_trials(
     def _objective_with_sleep(trial: optuna.Trial) -> float:
         sleep_start_datetime = datetime.datetime.now()
         # Spin waiting is used here because high accuracy is necessary even in weak VM.
+        # Please check the motivation of the bugfix in https://github.com/optuna/optuna/pull/5549/
         while datetime.datetime.now() - sleep_start_datetime < datetime.timedelta(seconds=0.1):
             pass
         assert datetime.datetime.now() - sleep_start_datetime < datetime.timedelta(seconds=0.19)


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

Mac test for timeline plot has been failing sometimes, for example:
- https://github.com/optuna/optuna/actions/runs/8931602414

The test fails if the first trial is presumed to be `RUNNING`.
This happens when a `trial` sleeps for more than 0.2 seconds although it should sleep exactly for 0.1 seconds.
Then, since the right edge of the plot is `datetime.now()`, the width of the plot will be a little more than 1500 milliseconds, which is why the test fails.

If my guess above is correct, replacing the `sleep` function with spin waiting may resolve the problem.
Additionally, I have added an assert statement in this PR, helping to isolate the problem.

## Description of the changes
<!-- Describe the changes in this PR. -->

- Replace `sleep` function with spin waiting in the timeline plot unittest
- Added an assert statement there
