### PR TITLE
Change `removed_version` of deprecated `JournalStorage` classes

### DIFF
--- a/optuna/storages/journal/_backend.py
+++ b/optuna/storages/journal/_backend.py
@@ -102,7 +102,7 @@ class JournalFileBackend(BaseJournalBackend):
 
 
 @deprecated_class(
-    "4.0.0", "7.0.0", text="Use :class:`~optuna.storages.JournalFileBackend` instead."
+    "4.0.0", "6.0.0", text="Use :class:`~optuna.storages.JournalFileBackend` instead."
 )
 class JournalFileStorage(JournalFileBackend):
     """File storage class for Journal log backend.

--- a/optuna/storages/journal/_base.py
+++ b/optuna/storages/journal/_base.py
@@ -18,7 +18,7 @@ class BaseJournalFileLock(abc.ABC):
 
 
 @deprecated_class(
-    "4.0.0", "7.0.0", text="Use :class:`~optuna.storages.BaseJournalFileLock` instead."
+    "4.0.0", "6.0.0", text="Use :class:`~optuna.storages.BaseJournalFileLock` instead."
 )
 class JournalFileBaseLock(BaseJournalFileLock):
     # Note: As of v4.0.0, this base class is NOT exposed to users.
@@ -91,7 +91,7 @@ class BaseJournalSnapshot(abc.ABC):
 
 
 @deprecated_class(
-    "4.0.0", "7.0.0", text="Use :class:`~optuna.storages.BaseJournalBackend` instead."
+    "4.0.0", "6.0.0", text="Use :class:`~optuna.storages.BaseJournalBackend` instead."
 )
 class BaseJournalLogStorage(BaseJournalBackend):
     """Base class for Journal storages.
@@ -106,7 +106,7 @@ class BaseJournalLogStorage(BaseJournalBackend):
 
 
 @deprecated_class(
-    "4.0.0", "7.0.0", text="Use :class:`~optuna.storages.BaseJournalSnapshot` instead."
+    "4.0.0", "6.0.0", text="Use :class:`~optuna.storages.BaseJournalSnapshot` instead."
 )
 class BaseJournalLogSnapshot(BaseJournalSnapshot):
     """Optional base class for Journal storages.

--- a/optuna/storages/journal/_redis.py
+++ b/optuna/storages/journal/_redis.py
@@ -102,7 +102,7 @@ class JournalRedisBackend(BaseJournalBackend, BaseJournalSnapshot):
 
 
 @deprecated_class(
-    "4.0.0", "7.0.0", text="Use :class:`~optuna.storages.journal.JournalRedisBackend` instead."
+    "4.0.0", "6.0.0", text="Use :class:`~optuna.storages.journal.JournalRedisBackend` instead."
 )
 class JournalRedisStorage(JournalRedisBackend):
     """Redis storage class for Journal log backend.


### PR DESCRIPTION
## Motivation
Usually, the `removed_version` is two majors after the `deprecated_version`, so I want to set the `removed_version`s of the deprecated `JournalStorage` classes to 6.0.0.

## Description of the changes
Change `removed_version` of deprecated `JournalStorage` classes to 6.0.0.