### PR TITLE
Add `Returns` to the docstring of `load_study`

### DIFF
--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -1346,6 +1346,9 @@ def load_study(
             If :obj:`None` is specified, :class:`~optuna.pruners.MedianPruner` is used
             as the default. See also :class:`~optuna.pruners`.
 
+    Returns:
+        A :class:`~optuna.study.Study` object.
+
     See also:
         :func:`optuna.load_study` is an alias of :func:`optuna.study.load_study`.
 


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

The return is missing in the docstring of the `load_study` function.
The current appearance of the doc can be observed [here](https://optuna.readthedocs.io/en/v3.6.1/reference/generated/optuna.load_study.html).

![image](https://github.com/optuna/optuna/assets/47781922/72473d39-8eb2-46ce-afa6-9515fccb6aaf)


## Description of the changes
<!-- Describe the changes in this PR. -->

- Add return docstring to `load_study` function.
- https://github.com/optuna/optuna/pull/5554