### PR TITLE
Modify class paths and remove unused deprecated class related to `JournalStorage`

### DIFF
--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -556,7 +556,7 @@ If you want to use a file-based Optuna storage for these scenarios, please consi
    from optuna.storages import JournalStorage
    from optuna.storages.journal import JournalFileBackend
 
-   storage = JournalStorage(JournalFileStorage("journal_file_storage_jsonl.log"))
+   storage = JournalStorage(JournalFileStorage("optuna_journal_storage.log"))
 
    study = optuna.create_study(storage=storage)
    ...

--- a/optuna/storages/journal/_base.py
+++ b/optuna/storages/journal/_base.py
@@ -73,7 +73,7 @@ class BaseJournalSnapshot(abc.ABC):
 
 
 @deprecated_class(
-    "4.0.0", "6.0.0", text="Use :class:`~optuna.storages.BaseJournalBackend` instead."
+    "4.0.0", "6.0.0", text="Use :class:`~optuna.storages.journal.BaseJournalBackend` instead."
 )
 class BaseJournalLogStorage(BaseJournalBackend):
     """Base class for Journal storages.
@@ -88,7 +88,7 @@ class BaseJournalLogStorage(BaseJournalBackend):
 
 
 @deprecated_class(
-    "4.0.0", "6.0.0", text="Use :class:`~optuna.storages.BaseJournalSnapshot` instead."
+    "4.0.0", "6.0.0", text="Use :class:`~optuna.storages.journal.BaseJournalSnapshot` instead."
 )
 class BaseJournalLogSnapshot(BaseJournalSnapshot):
     """Optional base class for Journal storages.

--- a/optuna/storages/journal/_base.py
+++ b/optuna/storages/journal/_base.py
@@ -13,8 +13,8 @@ class BaseJournalBackend(abc.ABC):
     Storage classes implementing this base class must guarantee process safety. This means,
     multiple processes might concurrently call ``read_logs`` and ``append_logs``. If the
     backend storage does not internally support mutual exclusion mechanisms, such as locks,
-    you might want to use :class:`~optuna.storages.JournalFileSymlinkLock` or
-    :class:`~optuna.storages.JournalFileOpenLock` for creating a critical section.
+    you might want to use :class:`~optuna.storages.journal.JournalFileSymlinkLock` or
+    :class:`~optuna.storages.journal.JournalFileOpenLock` for creating a critical section.
 
     """
 
@@ -81,8 +81,8 @@ class BaseJournalLogStorage(BaseJournalBackend):
     Storage classes implementing this base class must guarantee process safety. This means,
     multiple processes might concurrently call ``read_logs`` and ``append_logs``. If the
     backend storage does not internally support mutual exclusion mechanisms, such as locks,
-    you might want to use :class:`~optuna.storages.JournalFileSymlinkLock` or
-    :class:`~optuna.storages.JournalFileOpenLock` for creating a critical section.
+    you might want to use :class:`~optuna.storages.journal.JournalFileSymlinkLock` or
+    :class:`~optuna.storages.journal.JournalFileOpenLock` for creating a critical section.
 
     """
 

--- a/optuna/storages/journal/_base.py
+++ b/optuna/storages/journal/_base.py
@@ -85,16 +85,3 @@ class BaseJournalLogStorage(BaseJournalBackend):
     :class:`~optuna.storages.journal.JournalFileOpenLock` for creating a critical section.
 
     """
-
-
-@deprecated_class(
-    "4.0.0", "6.0.0", text="Use :class:`~optuna.storages.journal.BaseJournalSnapshot` instead."
-)
-class BaseJournalLogSnapshot(BaseJournalSnapshot):
-    """Optional base class for Journal storages.
-
-    Storage classes implementing this base class may work faster when
-    constructing the internal state from the large amount of logs.
-    """
-
-    # Note: As of v4.0.0, this base class is NOT exposed to users.

--- a/optuna/storages/journal/_file.py
+++ b/optuna/storages/journal/_file.py
@@ -47,8 +47,8 @@ class JournalFileBackend(BaseJournalBackend):
 
         lock_obj:
             Lock object for process exclusivity. An instance of
-            :class:`~optuna.storages.JournalFileSymlinkLock` and
-            :class:`~optuna.storages.JournalFileOpenLock` can be passed.
+            :class:`~optuna.storages.Journal.JournalFileSymlinkLock` and
+            :class:`~optuna.storages.Journal.JournalFileOpenLock` can be passed.
     """
 
     def __init__(self, file_path: str, lock_obj: BaseJournalFileLock | None = None) -> None:
@@ -233,7 +233,7 @@ def get_lock_file(lock_obj: BaseJournalFileLock) -> Iterator[None]:
 
 
 @deprecated_class(
-    "4.0.0", "6.0.0", text="Use :class:`~optuna.storages.JournalFileBackend` instead."
+    "4.0.0", "6.0.0", text="Use :class:`~optuna.storages.Journal.JournalFileBackend` instead."
 )
 class JournalFileStorage(JournalFileBackend):
     pass

--- a/optuna/storages/journal/_storage.py
+++ b/optuna/storages/journal/_storage.py
@@ -86,12 +86,12 @@ class JournalStorage(BaseStorage):
 
     In a Windows environment, an error message "A required privilege is not held by the
     client" may appear. In this case, you can solve the problem with creating storage
-    by specifying :class:`~optuna.storages.JournalFileOpenLock` as follows.
+    by specifying :class:`~optuna.storages.journal.JournalFileOpenLock` as follows.
 
     .. code::
 
         file_path = "./journal_file_storage_jsonl.log"
-        lock_obj = optuna.storages.JournalFileOpenLock(file_path)
+        lock_obj = optuna.storages.journal.JournalFileOpenLock(file_path)
 
         storage = optuna.storages.JournalStorage(
             optuna.storages.journal.JournalFileBackend(file_path, lock_obj=lock_obj),

--- a/optuna/storages/journal/_storage.py
+++ b/optuna/storages/journal/_storage.py
@@ -78,7 +78,7 @@ class JournalStorage(BaseStorage):
 
 
             storage = optuna.storages.JournalStorage(
-                optuna.storages.journal.JournalFileBackend("./journal_file_storage_jsonl.log")
+                optuna.storages.journal.JournalFileBackend("./optuna_journal_storage.log")
             )
 
             study = optuna.create_study(storage=storage)
@@ -90,7 +90,7 @@ class JournalStorage(BaseStorage):
 
     .. code::
 
-        file_path = "./journal_file_storage_jsonl.log"
+        file_path = "./optuna_journal_storage.log"
         lock_obj = optuna.storages.journal.JournalFileOpenLock(file_path)
 
         storage = optuna.storages.JournalStorage(

--- a/tutorial/20_recipes/011_journal_storage.py
+++ b/tutorial/20_recipes/011_journal_storage.py
@@ -19,7 +19,7 @@ import optuna
 # Add stream handler of stdout to show the messages
 optuna.logging.get_logger("optuna").addHandler(logging.StreamHandler(sys.stdout))
 study_name = "example-study"  # Unique identifier of the study.
-file_path = "./journal_file_storage_jsonl.log"
+file_path = "./optuna_journal_storage.log"
 storage = optuna.storages.JournalStorage(
     optuna.storages.journal.JournalFileBackend(file_path),  # NFS path for distributed optimization
 )

--- a/tutorial/20_recipes/011_journal_storage.py
+++ b/tutorial/20_recipes/011_journal_storage.py
@@ -43,5 +43,5 @@ study.optimize(objective, n_trials=3)
 # .. note::
 #     In a Windows environment, an error message "A required privilege is not held by the client"
 #     may appear. In this case, you can solve the problem with creating storage by specifying
-#     :class:`~optuna.storages.JournalFileOpenLock`. See the reference of
+#     :class:`~optuna.storages.Journal.JournalFileOpenLock`. See the reference of
 #     :class:`~optuna.storages.JournalStorage` for any details.


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

## Description of the changes
<!-- Describe the changes in this PR. -->

- replaced wrong path: `optuna.storages.JournalFileSymlinkLock`-> `optuna.storages.journal.JournalFileSymlinkLock`
- replaced wrong path: `optuna.storages.JournalFileOpenLock`-> `optuna.storages.journal.JournalFileOpenLock`
- replaced wrong path: `optuna.storages.JournalFileBackend`-> `optuna.storages.journal.JournalFileBackend`
- replaced wrong path: `optuna.storages.BaseJournalBackend`-> `optuna.storages.journal.BaseJournalBackend`
- removed unused deprecated class: `BaseJournalLogSnapshot`
- renamed file path in docs: `journal_file_storage_jsonl.log` -> `optuna_journal_storage.log`