### PR TITLE
Rename filename for `JournalFileBackend` in examples

### DIFF
--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -556,7 +556,7 @@ If you want to use a file-based Optuna storage for these scenarios, please consi
    from optuna.storages import JournalStorage
    from optuna.storages.journal import JournalFileBackend
 
-   storage = JournalStorage(JournalFileStorage("journal_file_storage_jsonl.log"))
+   storage = JournalStorage(JournalFileStorage("optuna_journal_storage.log"))
 
    study = optuna.create_study(storage=storage)
    ...

--- a/optuna/storages/journal/_storage.py
+++ b/optuna/storages/journal/_storage.py
@@ -78,7 +78,7 @@ class JournalStorage(BaseStorage):
 
 
             storage = optuna.storages.JournalStorage(
-                optuna.storages.journal.JournalFileBackend("./journal_file_storage_jsonl.log")
+                optuna.storages.journal.JournalFileBackend("./optuna_journal_storage.log")
             )
 
             study = optuna.create_study(storage=storage)
@@ -90,7 +90,7 @@ class JournalStorage(BaseStorage):
 
     .. code::
 
-        file_path = "./journal_file_storage_jsonl.log"
+        file_path = "./optuna_journal_storage.log"
         lock_obj = optuna.storages.JournalFileOpenLock(file_path)
 
         storage = optuna.storages.JournalStorage(

--- a/tutorial/20_recipes/011_journal_storage.py
+++ b/tutorial/20_recipes/011_journal_storage.py
@@ -19,7 +19,7 @@ import optuna
 # Add stream handler of stdout to show the messages
 optuna.logging.get_logger("optuna").addHandler(logging.StreamHandler(sys.stdout))
 study_name = "example-study"  # Unique identifier of the study.
-file_path = "./journal_file_storage_jsonl.log"
+file_path = "./optuna_journal_storage.log"
 storage = optuna.storages.JournalStorage(
     optuna.storages.journal.JournalFileBackend(file_path),  # NFS path for distributed optimization
 )


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

Related to PR https://github.com/optuna/optuna/pull/5555.

## Description of the changes
<!-- Describe the changes in this PR. -->

Renamed `journal_file_storage_jsonl.log` -> `optuna_journal_storage.log`, which is filename argument of `JournalFileBackend` used in example codes.