### PR TITLE
Stabilize artifact APIs

### DIFF
--- a/optuna/artifacts/_boto3.py
+++ b/optuna/artifacts/_boto3.py
@@ -4,7 +4,6 @@ import io
 import shutil
 from typing import TYPE_CHECKING
 
-from optuna._experimental import experimental_class
 from optuna._imports import try_import
 from optuna.artifacts.exceptions import ArtifactNotFound
 
@@ -19,7 +18,6 @@ with try_import():
     from botocore.exceptions import ClientError
 
 
-@experimental_class("3.3.0")
 class Boto3ArtifactStore:
     """An artifact backend for Boto3.
 

--- a/optuna/artifacts/_download.py
+++ b/optuna/artifacts/_download.py
@@ -3,11 +3,9 @@ from __future__ import annotations
 import os
 import shutil
 
-from optuna._experimental import experimental_func
 from optuna.artifacts._protocol import ArtifactStore
 
 
-@experimental_func("4.0.0")
 def download_artifact(*, artifact_store: ArtifactStore, file_path: str, artifact_id: str) -> None:
     """Download an artifact from the artifact store.
 

--- a/optuna/artifacts/_filesystem.py
+++ b/optuna/artifacts/_filesystem.py
@@ -5,7 +5,6 @@ from pathlib import Path
 import shutil
 from typing import TYPE_CHECKING
 
-from optuna._experimental import experimental_class
 from optuna.artifacts.exceptions import ArtifactNotFound
 
 
@@ -13,7 +12,6 @@ if TYPE_CHECKING:
     from typing import BinaryIO
 
 
-@experimental_class("3.3.0")
 class FileSystemArtifactStore:
     """An artifact store for file systems.
 

--- a/optuna/artifacts/_list_artifact_meta.py
+++ b/optuna/artifacts/_list_artifact_meta.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import json
 
-from optuna._experimental import experimental_func
 from optuna.artifacts._upload import ArtifactMeta
 from optuna.artifacts._upload import ARTIFACTS_ATTR_PREFIX
 from optuna.storages import BaseStorage
@@ -11,7 +10,6 @@ from optuna.trial import FrozenTrial
 from optuna.trial import Trial
 
 
-@experimental_func("4.0.0")
 def get_all_artifact_meta(
     study_or_trial: Trial | FrozenTrial | Study, *, storage: BaseStorage | None = None
 ) -> list[ArtifactMeta]:

--- a/optuna/artifacts/_upload.py
+++ b/optuna/artifacts/_upload.py
@@ -8,7 +8,6 @@ import os
 import uuid
 
 from optuna._convert_positional_args import convert_positional_args
-from optuna._experimental import experimental_func
 from optuna.artifacts._protocol import ArtifactStore
 from optuna.storages import BaseStorage
 from optuna.study import Study
@@ -48,7 +47,6 @@ class ArtifactMeta:
     encoding: str | None
 
 
-@experimental_func("3.3.0")
 @convert_positional_args(
     previous_positional_arg_names=["study_or_trial", "file_path", "artifact_store"]
 )


### PR DESCRIPTION
## Motivation
This PR stabilizes the artifact APIs for `FileSystemArtifactStore` and `Boto3ArtifactStore`.
I think we've had enough discussion and implementation of the artifact API and it's ready to be stabilized.

## Description of the changes
- Remove `experimental_class` from `FileSystemArtifactStore` and `Boto3ArtifactStore`
- Remove `experimental_func` from `upload_artifact`, `download_artifact`, and `get_all_artifact_meta`