### PR TITLE
Speed up `mypy` by stopping the checks in `torch`

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -44,6 +44,6 @@ jobs:
     - name: isort
       run: isort . --check --diff
     - name: mypy
-      run: mypy --follow-imports=normal .
+      run: awk '/\[mypy-torch\.\*\]/{exit} {print}' setup.cfg | mypy --config-file=/dev/stdin .
     - name: blackdoc
       run: blackdoc . --check --diff

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -44,6 +44,6 @@ jobs:
     - name: isort
       run: isort . --check --diff
     - name: mypy
-      run: mypy .
+      run: mypy --follow-imports=normal .
     - name: blackdoc
       run: blackdoc . --check --diff

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -44,6 +44,6 @@ jobs:
     - name: isort
       run: isort . --check --diff
     - name: mypy
-      run: awk '/\[mypy-torch\.\*\]/{exit} {print}' setup.cfg | mypy --config-file=/dev/stdin .
+      run: sed '/# IGNORE MYPY TORCH START/,/# IGNORE MYPY TORCH END/d' setup.cfg | mypy --config-file=/dev/stdin .
     - name: blackdoc
       run: blackdoc . --check --diff

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,8 @@ no_implicit_reexport = True
 ignore_missing_imports = True
 exclude = .venv|venv|build|docs|tutorial|optuna/storages/_rdb/alembic
 
+# IGNORE MYPY TORCH START (This line is used in checks.yml)
 [mypy-torch.*]
 # Any `torch`-related modules will be replaced with `typing.Any` at type checking.
 follow_imports = skip
+# IGNORE MYPY TORCH END (This line is used in checks.yml)

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,4 +26,5 @@ ignore_missing_imports = True
 exclude = .venv|venv|build|docs|tutorial|optuna/storages/_rdb/alembic
 
 [mypy-torch.*]
+# Any `torch`-related modules will be replaced with `typing.Any` at type checking.
 follow_imports = skip

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,3 +24,6 @@ no_implicit_reexport = True
 
 ignore_missing_imports = True
 exclude = .venv|venv|build|docs|tutorial|optuna/storages/_rdb/alembic
+
+[mypy-torch.*]
+follow_imports = skip


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

I want to speed up `$ mypy --no-incremental . ` by stopping the checks inside `torch`.
I want `checks.yml` in GitHub Workflow not to ignore `torch`, because it can utilize mypy_cache and therefore ignoring brings no benefit.

## Description of the changes
<!-- Describe the changes in this PR. -->

Update `setup.cfg`. This change will make `mypy` stop checking `torch`, resulting in about half the time required (in my local environment).