### PR TITLE
Simplify annotation in `trial`

### DIFF
--- a/optuna/trial/_base.py
+++ b/optuna/trial/_base.py
@@ -1,10 +1,10 @@
+from __future__ import annotations
+
 import abc
+from collections.abc import Sequence
 import datetime
 from typing import Any
-from typing import Dict
-from typing import Optional
 from typing import overload
-from typing import Sequence
 
 from optuna._deprecated import deprecated_func
 from optuna.distributions import BaseDistribution
@@ -22,13 +22,7 @@ class BaseTrial(abc.ABC):
 
     @abc.abstractmethod
     def suggest_float(
-        self,
-        name: str,
-        low: float,
-        high: float,
-        *,
-        step: Optional[float] = None,
-        log: bool = False,
+        self, name: str, low: float, high: float, *, step: float | None = None, log: bool = False,
     ) -> float:
         raise NotImplementedError
 
@@ -104,27 +98,27 @@ class BaseTrial(abc.ABC):
 
     @property
     @abc.abstractmethod
-    def params(self) -> Dict[str, Any]:
+    def params(self) -> dict[str, Any]:
         raise NotImplementedError
 
     @property
     @abc.abstractmethod
-    def distributions(self) -> Dict[str, BaseDistribution]:
+    def distributions(self) -> dict[str, BaseDistribution]:
         raise NotImplementedError
 
     @property
     @abc.abstractmethod
-    def user_attrs(self) -> Dict[str, Any]:
+    def user_attrs(self) -> dict[str, Any]:
         raise NotImplementedError
 
     @property
     @abc.abstractmethod
-    def system_attrs(self) -> Dict[str, Any]:
+    def system_attrs(self) -> dict[str, Any]:
         raise NotImplementedError
 
     @property
     @abc.abstractmethod
-    def datetime_start(self) -> Optional[datetime.datetime]:
+    def datetime_start(self) -> datetime.datetime | None:
         raise NotImplementedError
 
     @property

--- a/optuna/trial/_base.py
+++ b/optuna/trial/_base.py
@@ -22,7 +22,13 @@ class BaseTrial(abc.ABC):
 
     @abc.abstractmethod
     def suggest_float(
-        self, name: str, low: float, high: float, *, step: float | None = None, log: bool = False,
+        self,
+        name: str,
+        low: float,
+        high: float,
+        *,
+        step: float | None = None,
+        log: bool = False,
     ) -> float:
         raise NotImplementedError
 

--- a/optuna/trial/_fixed.py
+++ b/optuna/trial/_fixed.py
@@ -1,9 +1,9 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
 import datetime
 from typing import Any
-from typing import Dict
-from typing import Optional
 from typing import overload
-from typing import Sequence
 import warnings
 
 from optuna import distributions
@@ -59,12 +59,12 @@ class FixedTrial(BaseTrial):
 
     """
 
-    def __init__(self, params: Dict[str, Any], number: int = 0) -> None:
+    def __init__(self, params: dict[str, Any], number: int = 0) -> None:
         self._params = params
-        self._suggested_params: Dict[str, Any] = {}
-        self._distributions: Dict[str, BaseDistribution] = {}
-        self._user_attrs: Dict[str, Any] = {}
-        self._system_attrs: Dict[str, Any] = {}
+        self._suggested_params: dict[str, Any] = {}
+        self._distributions: dict[str, BaseDistribution] = {}
+        self._user_attrs: dict[str, Any] = {}
+        self._system_attrs: dict[str, Any] = {}
         self._datetime_start = datetime.datetime.now()
         self._number = number
 
@@ -74,7 +74,7 @@ class FixedTrial(BaseTrial):
         low: float,
         high: float,
         *,
-        step: Optional[float] = None,
+        step: float | None = None,
         log: bool = False,
     ) -> float:
         return self._suggest(name, FloatDistribution(low, high, log=log, step=step))
@@ -159,23 +159,23 @@ class FixedTrial(BaseTrial):
         return value
 
     @property
-    def params(self) -> Dict[str, Any]:
+    def params(self) -> dict[str, Any]:
         return self._suggested_params
 
     @property
-    def distributions(self) -> Dict[str, BaseDistribution]:
+    def distributions(self) -> dict[str, BaseDistribution]:
         return self._distributions
 
     @property
-    def user_attrs(self) -> Dict[str, Any]:
+    def user_attrs(self) -> dict[str, Any]:
         return self._user_attrs
 
     @property
-    def system_attrs(self) -> Dict[str, Any]:
+    def system_attrs(self) -> dict[str, Any]:
         return self._system_attrs
 
     @property
-    def datetime_start(self) -> Optional[datetime.datetime]:
+    def datetime_start(self) -> datetime.datetime | None:
         return self._datetime_start
 
     @property

--- a/optuna/trial/_frozen.py
+++ b/optuna/trial/_frozen.py
@@ -6,6 +6,7 @@ import datetime
 import math
 from typing import Any
 from typing import cast
+from typing import Dict
 from typing import overload
 import warnings
 
@@ -445,7 +446,7 @@ class FrozenTrial(BaseTrial):
 
     @system_attrs.setter
     def system_attrs(self, value: Mapping[str, JSONSerializable]) -> None:
-        self._system_attrs = cast(dict, value)
+        self._system_attrs = cast(Dict[str, Any], value)
 
     @property
     def last_step(self) -> int | None:

--- a/optuna/trial/_frozen.py
+++ b/optuna/trial/_frozen.py
@@ -6,7 +6,6 @@ import datetime
 import math
 from typing import Any
 from typing import cast
-from typing import Dict
 from typing import overload
 import warnings
 
@@ -446,7 +445,7 @@ class FrozenTrial(BaseTrial):
 
     @system_attrs.setter
     def system_attrs(self, value: Mapping[str, JSONSerializable]) -> None:
-        self._system_attrs = cast(Dict[str, Any], value)
+        self._system_attrs = cast(dict, value)
 
     @property
     def last_step(self) -> int | None:

--- a/optuna/trial/_frozen.py
+++ b/optuna/trial/_frozen.py
@@ -7,6 +7,7 @@ import math
 from typing import Any
 from typing import cast
 from typing import overload
+from typing import Dict
 import warnings
 
 from optuna import distributions
@@ -445,7 +446,7 @@ class FrozenTrial(BaseTrial):
 
     @system_attrs.setter
     def system_attrs(self, value: Mapping[str, JSONSerializable]) -> None:
-        self._system_attrs = cast(dict[str, Any], value)
+        self._system_attrs = cast(Dict[str, Any], value)
 
     @property
     def last_step(self) -> int | None:

--- a/optuna/trial/_frozen.py
+++ b/optuna/trial/_frozen.py
@@ -6,8 +6,8 @@ import datetime
 import math
 from typing import Any
 from typing import cast
-from typing import overload
 from typing import Dict
+from typing import overload
 import warnings
 
 from optuna import distributions

--- a/optuna/trial/_frozen.py
+++ b/optuna/trial/_frozen.py
@@ -1,13 +1,12 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from collections.abc import Sequence
 import datetime
 import math
 from typing import Any
 from typing import cast
-from typing import Dict
-from typing import List
-from typing import Mapping
-from typing import Optional
 from typing import overload
-from typing import Sequence
 import warnings
 
 from optuna import distributions
@@ -142,21 +141,21 @@ class FrozenTrial(BaseTrial):
         self,
         number: int,
         state: TrialState,
-        value: Optional[float],
-        datetime_start: Optional[datetime.datetime],
-        datetime_complete: Optional[datetime.datetime],
-        params: Dict[str, Any],
-        distributions: Dict[str, BaseDistribution],
-        user_attrs: Dict[str, Any],
-        system_attrs: Dict[str, Any],
-        intermediate_values: Dict[int, float],
+        value: float | None,
+        datetime_start: datetime.datetime | None,
+        datetime_complete: datetime.datetime | None,
+        params: dict[str, Any],
+        distributions: dict[str, BaseDistribution],
+        user_attrs: dict[str, Any],
+        system_attrs: dict[str, Any],
+        intermediate_values: dict[int, float],
         trial_id: int,
         *,
-        values: Optional[Sequence[float]] = None,
+        values: Sequence[float] | None = None,
     ) -> None:
         self._number = number
         self.state = state
-        self._values: Optional[List[float]] = None
+        self._values: list[float] | None = None
         if value is not None and values is not None:
             raise ValueError("Specify only one of `value` and `values`.")
         elif value is not None:
@@ -211,7 +210,7 @@ class FrozenTrial(BaseTrial):
         low: float,
         high: float,
         *,
-        step: Optional[float] = None,
+        step: float | None = None,
         log: bool = False,
     ) -> float:
         return self._suggest(name, FloatDistribution(low, high, log=log, step=step))
@@ -372,7 +371,7 @@ class FrozenTrial(BaseTrial):
         self._number = value
 
     @property
-    def value(self) -> Optional[float]:
+    def value(self) -> float | None:
         if self._values is not None:
             if len(self._values) > 1:
                 raise RuntimeError(
@@ -382,7 +381,7 @@ class FrozenTrial(BaseTrial):
         return None
 
     @value.setter
-    def value(self, v: Optional[float]) -> None:
+    def value(self, v: float | None) -> None:
         if self._values is not None:
             if len(self._values) > 1:
                 raise RuntimeError(
@@ -397,10 +396,10 @@ class FrozenTrial(BaseTrial):
     # These `_get_values`, `_set_values`, and `values = property(_get_values, _set_values)` are
     # defined to pass the mypy.
     # See https://github.com/python/mypy/issues/3004#issuecomment-726022329.
-    def _get_values(self) -> Optional[List[float]]:
+    def _get_values(self) -> list[float] | None:
         return self._values
 
-    def _set_values(self, v: Optional[Sequence[float]]) -> None:
+    def _set_values(self, v: Sequence[float] | None) -> None:
         if v is not None:
             self._values = list(v)
         else:
@@ -409,47 +408,47 @@ class FrozenTrial(BaseTrial):
     values = property(_get_values, _set_values)
 
     @property
-    def datetime_start(self) -> Optional[datetime.datetime]:
+    def datetime_start(self) -> datetime.datetime | None:
         return self._datetime_start
 
     @datetime_start.setter
-    def datetime_start(self, value: Optional[datetime.datetime]) -> None:
+    def datetime_start(self, value: datetime.datetime | None) -> None:
         self._datetime_start = value
 
     @property
-    def params(self) -> Dict[str, Any]:
+    def params(self) -> dict[str, Any]:
         return self._params
 
     @params.setter
-    def params(self, params: Dict[str, Any]) -> None:
+    def params(self, params: dict[str, Any]) -> None:
         self._params = params
 
     @property
-    def distributions(self) -> Dict[str, BaseDistribution]:
+    def distributions(self) -> dict[str, BaseDistribution]:
         return self._distributions
 
     @distributions.setter
-    def distributions(self, value: Dict[str, BaseDistribution]) -> None:
+    def distributions(self, value: dict[str, BaseDistribution]) -> None:
         self._distributions = value
 
     @property
-    def user_attrs(self) -> Dict[str, Any]:
+    def user_attrs(self) -> dict[str, Any]:
         return self._user_attrs
 
     @user_attrs.setter
-    def user_attrs(self, value: Dict[str, Any]) -> None:
+    def user_attrs(self, value: dict[str, Any]) -> None:
         self._user_attrs = value
 
     @property
-    def system_attrs(self) -> Dict[str, Any]:
+    def system_attrs(self) -> dict[str, Any]:
         return self._system_attrs
 
     @system_attrs.setter
     def system_attrs(self, value: Mapping[str, JSONSerializable]) -> None:
-        self._system_attrs = cast(Dict[str, Any], value)
+        self._system_attrs = cast(dict[str, Any], value)
 
     @property
-    def last_step(self) -> Optional[int]:
+    def last_step(self) -> int | None:
         """Return the maximum step of :attr:`intermediate_values` in the trial.
 
         Returns:
@@ -462,7 +461,7 @@ class FrozenTrial(BaseTrial):
             return max(self.intermediate_values.keys())
 
     @property
-    def duration(self) -> Optional[datetime.timedelta]:
+    def duration(self) -> datetime.timedelta | None:
         """Return the elapsed time taken to complete the trial.
 
         Returns:
@@ -478,13 +477,13 @@ class FrozenTrial(BaseTrial):
 def create_trial(
     *,
     state: TrialState = TrialState.COMPLETE,
-    value: Optional[float] = None,
-    values: Optional[Sequence[float]] = None,
-    params: Optional[Dict[str, Any]] = None,
-    distributions: Optional[Dict[str, BaseDistribution]] = None,
-    user_attrs: Optional[Dict[str, Any]] = None,
-    system_attrs: Optional[Dict[str, Any]] = None,
-    intermediate_values: Optional[Dict[int, float]] = None,
+    value: float | None = None,
+    values: Sequence[float] | None = None,
+    params: dict[str, Any] | None = None,
+    distributions: dict[str, BaseDistribution] | None = None,
+    user_attrs: dict[str, Any] | None = None,
+    system_attrs: dict[str, Any] | None = None,
+    intermediate_values: dict[int, float] | None = None,
 ) -> FrozenTrial:
     """Create a new :class:`~optuna.trial.FrozenTrial`.
 
@@ -569,7 +568,7 @@ def create_trial(
         datetime_start = datetime.datetime.now()
 
     if state.is_finished():
-        datetime_complete: Optional[datetime.datetime] = datetime_start
+        datetime_complete: datetime.datetime | None = datetime_start
     else:
         datetime_complete = None
 

--- a/optuna/trial/_trial.py
+++ b/optuna/trial/_trial.py
@@ -1,13 +1,11 @@
 from __future__ import annotations
 
 from collections import UserDict
+from collections.abc import Sequence
 import copy
 import datetime
 from typing import Any
-from typing import Dict
-from typing import Optional
 from typing import overload
-from typing import Sequence
 import warnings
 
 import optuna
@@ -63,11 +61,11 @@ class Trial(BaseTrial):
         self.relative_search_space = self.study.sampler.infer_relative_search_space(
             study, self._cached_frozen_trial
         )
-        self._relative_params: Optional[Dict[str, Any]] = None
+        self._relative_params: dict[str, Any] | None = None
         self._fixed_params = self._cached_frozen_trial.system_attrs.get("fixed_params", {})
 
     @property
-    def relative_params(self) -> Dict[str, Any]:
+    def relative_params(self) -> dict[str, Any]:
         if self._relative_params is None:
             study = pruners._filter_study(self.study, self._cached_frozen_trial)
             self._relative_params = self.study.sampler.sample_relative(
@@ -81,7 +79,7 @@ class Trial(BaseTrial):
         low: float,
         high: float,
         *,
-        step: Optional[float] = None,
+        step: float | None = None,
         log: bool = False,
     ) -> float:
         """Suggest a value for the floating point parameter.
@@ -697,7 +695,7 @@ class Trial(BaseTrial):
         return latest_trial
 
     @property
-    def params(self) -> Dict[str, Any]:
+    def params(self) -> dict[str, Any]:
         """Return parameters to be optimized.
 
         Returns:
@@ -707,7 +705,7 @@ class Trial(BaseTrial):
         return copy.deepcopy(self._cached_frozen_trial.params)
 
     @property
-    def distributions(self) -> Dict[str, BaseDistribution]:
+    def distributions(self) -> dict[str, BaseDistribution]:
         """Return distributions of parameters to be optimized.
 
         Returns:
@@ -717,7 +715,7 @@ class Trial(BaseTrial):
         return copy.deepcopy(self._cached_frozen_trial.distributions)
 
     @property
-    def user_attrs(self) -> Dict[str, Any]:
+    def user_attrs(self) -> dict[str, Any]:
         """Return user attributes.
 
         Returns:
@@ -728,7 +726,7 @@ class Trial(BaseTrial):
 
     @property
     @deprecated_func("3.1.0", "5.0.0")
-    def system_attrs(self) -> Dict[str, Any]:
+    def system_attrs(self) -> dict[str, Any]:
         """Return system attributes.
 
         Returns:
@@ -738,7 +736,7 @@ class Trial(BaseTrial):
         return copy.deepcopy(self.storage.get_trial_system_attrs(self._trial_id))
 
     @property
-    def datetime_start(self) -> Optional[datetime.datetime]:
+    def datetime_start(self) -> datetime.datetime | None:
         """Return start datetime.
 
         Returns:


### PR DESCRIPTION
## Motivation
Related to https://github.com/optuna/optuna/issues/4508

## Description of the changes
I removed the calls to the typing module except for `Any`, `cast` and `overload`.
