### PR TITLE
Fix mypy warnings in `matplotlib/_contour.py` with Python3.11

### DIFF
--- a/optuna/visualization/matplotlib/_contour.py
+++ b/optuna/visualization/matplotlib/_contour.py
@@ -282,10 +282,12 @@ def _calculate_griddata(
     )
 
 
-def _generate_contour_subplot(info: _SubContourInfo, ax: "Axes", cmap: "Colormap") -> "ContourSet":
+def _generate_contour_subplot(
+    info: _SubContourInfo, ax: "Axes", cmap: "Colormap"
+) -> "ContourSet" | None:
     if len(info.xaxis.indices) < 2 or len(info.yaxis.indices) < 2:
         ax.label_outer()
-        return ax
+        return None
 
     ax.set(xlabel=info.xaxis.name, ylabel=info.yaxis.name)
     ax.set_xlim(info.xaxis.range[0], info.xaxis.range[1])
@@ -293,7 +295,7 @@ def _generate_contour_subplot(info: _SubContourInfo, ax: "Axes", cmap: "Colormap
 
     if info.xaxis.name == info.yaxis.name:
         ax.label_outer()
-        return ax
+        return None
 
     (
         xi,
@@ -316,6 +318,7 @@ def _generate_contour_subplot(info: _SubContourInfo, ax: "Axes", cmap: "Colormap
             # Contour the gridded data.
             ax.contour(xi, yi, zi, 15, linewidths=0.5, colors="k")
             cs = ax.contourf(xi, yi, zi, 15, cmap=cmap.reversed())
+            assert isinstance(cs, ContourSet)
             # Plot data points.
             ax.scatter(
                 feasible_plot_values.x,


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

I want to improve type annotations. Currently, CI has confirmed that no issues found by mypy with Python 3.8. I checked with Python3.11, and some errors were found. I want to fix them without causing any issues with 3.8. I believe this activity improves quality of code. 

## Description of the changes
<!-- Describe the changes in this PR. -->

Fixed `matplotlib/_contour.py`. I confirmed that `_generate_contour_subplot` is used only in `matplotlib/_contour.py` by `$ git grep -l "_generate_contour_subplot"`, and the code-fix does not change any behaviour.
