### PR TITLE
Refactor `_is_categorical()` in `optuna/optuna/visualization`

### DIFF
--- a/optuna/visualization/_parallel_coordinate.py
+++ b/optuna/visualization/_parallel_coordinate.py
@@ -204,16 +204,13 @@ def _get_parallel_coordinate_info(
     dims = []
     for dim_index, p_name in enumerate(sorted_params, start=1):
         values = []
-        distribution: BaseDistribution | None = None
+        is_categorical = False
         for t in trials:
             if t.number in skipped_trial_numbers:
                 continue
-
             if p_name in t.params:
                 values.append(t.params[p_name])
-                distribution = t.distributions[p_name]
-        assert distribution is not None
-
+                is_categorical |= isinstance(t.distributions[p_name], CategoricalDistribution)
         if _is_log_scale(trials, p_name):
             values = [math.log10(v) for v in values]
             min_value = min(values)
@@ -234,7 +231,7 @@ def _get_parallel_coordinate_info(
                 tickvals=tickvals,
                 ticktext=["{:.3g}".format(math.pow(10, x)) for x in tickvals],
             )
-        elif isinstance(distribution, CategoricalDistribution):
+        elif is_categorical:
             vocab: defaultdict[int | str, int] = defaultdict(lambda: len(vocab))
 
             ticktext: list[str]

--- a/optuna/visualization/_parallel_coordinate.py
+++ b/optuna/visualization/_parallel_coordinate.py
@@ -9,7 +9,6 @@ from typing import NamedTuple
 
 import numpy as np
 
-from optuna.distributions import BaseDistribution
 from optuna.distributions import CategoricalDistribution
 from optuna.logging import get_logger
 from optuna.study import Study

--- a/optuna/visualization/_parallel_coordinate.py
+++ b/optuna/visualization/_parallel_coordinate.py
@@ -9,6 +9,8 @@ from typing import NamedTuple
 
 import numpy as np
 
+from optuna.distributions import BaseDistribution
+from optuna.distributions import CategoricalDistribution
 from optuna.logging import get_logger
 from optuna.study import Study
 from optuna.trial import FrozenTrial
@@ -17,7 +19,6 @@ from optuna.visualization._plotly_imports import _imports
 from optuna.visualization._utils import _check_plot_args
 from optuna.visualization._utils import _filter_nonfinite
 from optuna.visualization._utils import _get_skipped_trial_numbers
-from optuna.visualization._utils import _is_categorical
 from optuna.visualization._utils import _is_log_scale
 from optuna.visualization._utils import _is_numerical
 from optuna.visualization._utils import _is_reverse_scale
@@ -203,12 +204,15 @@ def _get_parallel_coordinate_info(
     dims = []
     for dim_index, p_name in enumerate(sorted_params, start=1):
         values = []
+        distribution: BaseDistribution | None = None
         for t in trials:
             if t.number in skipped_trial_numbers:
                 continue
 
             if p_name in t.params:
                 values.append(t.params[p_name])
+                distribution = t.distributions[p_name]
+        assert distribution is not None
 
         if _is_log_scale(trials, p_name):
             values = [math.log10(v) for v in values]
@@ -230,7 +234,7 @@ def _get_parallel_coordinate_info(
                 tickvals=tickvals,
                 ticktext=["{:.3g}".format(math.pow(10, x)) for x in tickvals],
             )
-        elif _is_categorical(trials, p_name):
+        elif isinstance(distribution, CategoricalDistribution):
             vocab: defaultdict[int | str, int] = defaultdict(lambda: len(vocab))
 
             ticktext: list[str]

--- a/optuna/visualization/_utils.py
+++ b/optuna/visualization/_utils.py
@@ -86,7 +86,9 @@ def _is_numerical(trials: list[FrozenTrial], param: str) -> bool:
         if isinstance(dist, (IntDistribution, FloatDistribution)):
             return True
         elif isinstance(dist, CategoricalDistribution):
-            return all(isinstance(v, (int, float)) and not isinstance(v, bool) for v in dist.choices)
+            return all(
+                isinstance(v, (int, float)) and not isinstance(v, bool) for v in dist.choices
+            )
         else:
             assert False, "Should not reach."
     return True

--- a/optuna/visualization/_utils.py
+++ b/optuna/visualization/_utils.py
@@ -81,13 +81,6 @@ def _is_log_scale(trials: list[FrozenTrial], param: str) -> bool:
     return False
 
 
-def _is_categorical(trials: list[FrozenTrial], param: str) -> bool:
-    for trial in trials:
-        if param in trial.params:
-            return isinstance(trial.distributions[param], CategoricalDistribution)
-    return False
-
-
 def _is_numerical(trials: list[FrozenTrial], param: str) -> bool:
     for trial in trials:
         if param in trial.params:

--- a/optuna/visualization/_utils.py
+++ b/optuna/visualization/_utils.py
@@ -71,29 +71,25 @@ def _check_plot_args(
 
 def _is_log_scale(trials: list[FrozenTrial], param: str) -> bool:
     for trial in trials:
-        if param in trial.params:
-            dist = trial.distributions[param]
-
-            if isinstance(dist, (FloatDistribution, IntDistribution)):
-                return dist.log
-            else:
-                return False
+        if param not in trial.params:
+            continue
+        dist = trial.distributions[param]
+        return isinstance(dist, (FloatDistribution, IntDistribution)) and dist.log
     return False
 
 
 def _is_numerical(trials: list[FrozenTrial], param: str) -> bool:
     for trial in trials:
-        if param in trial.params:
-            target_distribution = trial.distributions[param]
-            if isinstance(target_distribution, CategoricalDistribution):
-                choices = target_distribution.choices
-                return all(
-                    (isinstance(v, int) or isinstance(v, float)) and not isinstance(v, bool)
-                    for v in choices
-                )
-            else:
-                return True
-    return False
+        if param not in trial.params:
+            continue
+        dist = trial.distributions[param]
+        if isinstance(dist, (IntDistribution, FloatDistribution)):
+            return True
+        elif isinstance(dist, CategoricalDistribution):
+            return all(isinstance(v, (int, float)) and not isinstance(v, bool) for v in dist.choices)
+        else:
+            assert False, "Should not reach."
+    return True
 
 
 def _get_param_values(trials: list[FrozenTrial], p_name: str) -> list[Any]:

--- a/optuna/visualization/_utils.py
+++ b/optuna/visualization/_utils.py
@@ -86,6 +86,7 @@ def _is_numerical(trials: list[FrozenTrial], param: str) -> bool:
         if isinstance(dist, (IntDistribution, FloatDistribution)):
             return True
         elif isinstance(dist, CategoricalDistribution):
+            # NOTE: Although it is a bit odd to do so, we keep it as is only for visualization.
             return all(
                 isinstance(v, (int, float)) and not isinstance(v, bool) for v in dist.choices
             )

--- a/optuna/visualization/_utils.py
+++ b/optuna/visualization/_utils.py
@@ -91,8 +91,9 @@ def _is_categorical(trials: list[FrozenTrial], param: str) -> bool:
 def _is_numerical(trials: list[FrozenTrial], param: str) -> bool:
     for trial in trials:
         if param in trial.params:
-            if isinstance(trial.distributions[param], CategoricalDistribution):
-                choices = trial.distributions[param].choices
+            target_distribution = trial.distributions[param]
+            if isinstance(target_distribution, CategoricalDistribution):
+                choices = target_distribution.choices
                 return all(
                     (isinstance(v, int) or isinstance(v, float)) and not isinstance(v, bool)
                     for v in choices


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

This PR is related to:
- #5409 

## Description of the changes
<!-- Describe the changes in this PR. -->
For the function `_is_categorical()`, the problem of iterating over trials multiple times, which is indicated in #5409, is already resolved. This is because the function `_is_categorical()` was originally designed to return as soon as it encountered a categorical trial, and in Optuna, the categorical distribution should be consistent across all trials.

Also, the function `_get_parallel_coordinate_info()` originally contains a section that iterated over trials:
https://github.com/optuna/optuna/blob/fcffbeab86859c32c3c646947f4fd764860c922b/optuna/visualization/_parallel_coordinate.py#L205-L211
Therefore, by combining these parts, we can address the visually redundant iteration. Additionally, since the function `_is_categorical()` is used only in the function `_get_parallel_coordinate_info()`, there is no need to separate this into `_utils.py`.
