### PR TITLE
Speed up WFG by using a fact that hypervolume calculation does not need (second or later) duplicated Pareto solutions

### DIFF
--- a/optuna/_hypervolume/wfg.py
+++ b/optuna/_hypervolume/wfg.py
@@ -38,7 +38,7 @@ def _compute_exclusive_hv(
 
     # NOTE(nabenabe): For hypervolume calculation, duplicated Pareto solutions can be ignored. As
     # limited_sols[:, 0] is sorted, all the Pareto solutions necessary for hypervolume calculation
-    # will be filtered out with assume_unique_lexsorted=True.
+    # will be eliminated with assume_unique_lexsorted=True.
     on_front = _is_pareto_front(limited_sols, assume_unique_lexsorted=True)
     return inclusive_hv - _compute_hv(limited_sols[on_front], reference_point)
 

--- a/optuna/_hypervolume/wfg.py
+++ b/optuna/_hypervolume/wfg.py
@@ -36,7 +36,10 @@ def _compute_exclusive_hv(
     if limited_sols.shape[0] == 0:
         return inclusive_hv
 
-    on_front = _is_pareto_front(limited_sols, assume_unique_lexsorted=False)
+    # NOTE(nabenabe): For hypervolume calculation, duplicated Pareto solutions can be ignored. As
+    # limited_sols[:, 0] is sorted, all the Pareto solutions necessary for hypervolume calculation
+    # will be filtered out with assume_unique_lexsorted=True.
+    on_front = _is_pareto_front(limited_sols, assume_unique_lexsorted=True)
     return inclusive_hv - _compute_hv(limited_sols[on_front], reference_point)
 
 
@@ -65,6 +68,9 @@ def compute_hypervolume(
         assume_pareto:
             Whether to assume the Pareto optimality to ``loss_vals``.
             In other words, if ``True``, none of loss vectors are dominated by another.
+            ``assume_pareto`` is used only for speedup and it does not change the result even if
+            this argument is wrongly given. If there are many non-Pareto solutions in
+            ``loss_vals``, ``assume_pareto=True`` will speed up the calculation.
 
     Returns:
         The hypervolume of the given arguments.

--- a/optuna/study/_multi_objective.py
+++ b/optuna/study/_multi_objective.py
@@ -162,7 +162,7 @@ def _is_pareto_front_for_unique_sorted(unique_lexsorted_loss_values: np.ndarray)
 def _is_pareto_front(loss_values: np.ndarray, assume_unique_lexsorted: bool) -> np.ndarray:
     # NOTE(nabenabe): If assume_unique_lexsorted=True, but loss_values is not a unique array,
     # Duplicated Pareto solutions will be filtered out except for the earliest occurrences.
-    # If assume_unique_lexsorted=True and loss_vals[:, 0] is not sorted, then the result will be
+    # If assume_unique_lexsorted=True and loss_values[:, 0] is not sorted, then the result will be
     # incorrect.
     if assume_unique_lexsorted:
         return _is_pareto_front_for_unique_sorted(loss_values)

--- a/optuna/study/_multi_objective.py
+++ b/optuna/study/_multi_objective.py
@@ -122,7 +122,8 @@ def _fast_non_domination_rank(
 def _is_pareto_front_nd(unique_lexsorted_loss_values: np.ndarray) -> np.ndarray:
     # NOTE(nabenabe0928): I tried the Kung's algorithm below, but it was not really quick.
     # https://github.com/optuna/optuna/pull/5302#issuecomment-1988665532
-    loss_values = unique_lexsorted_loss_values.copy()
+    # As unique_lexsorted_loss_values[:, 0] is sorted, we do not need it to judge dominance.
+    loss_values = unique_lexsorted_loss_values[:, 1:]
     n_trials = loss_values.shape[0]
     on_front = np.zeros(n_trials, dtype=bool)
     nondominated_indices = np.arange(n_trials)
@@ -159,6 +160,10 @@ def _is_pareto_front_for_unique_sorted(unique_lexsorted_loss_values: np.ndarray)
 
 
 def _is_pareto_front(loss_values: np.ndarray, assume_unique_lexsorted: bool) -> np.ndarray:
+    # NOTE(nabenabe): If assume_unique_lexsorted=True, but loss_values is not a unique array,
+    # Duplicated Pareto solutions will be filtered out except for the earliest occurrences.
+    # If assume_unique_lexsorted=True and loss_vals[:, 0] is not sorted, then the result will be
+    # incorrect.
     if assume_unique_lexsorted:
         return _is_pareto_front_for_unique_sorted(loss_values)
 


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

The biggest motivation is to speed up MOTPE.
By this change, the routine of WFG will be quicker in 3D Hypervolume calculation using balanced-binary tree introduced in
- https://github.com/optuna/optuna/issues/5203

## Description of the changes
<!-- Describe the changes in this PR. -->
- Stop `np.unique` operation for `limited_sols`
- Add the explanations why we can make the change above. 

Basically, `limited_sols` is sorted by the first objective, so `is_pareto_front` works as intended except for duplicated solutions after the first found ones will be eliminated from Pareto solutions.
The duplicated elimination does not affect the result of hypervolume because duplicated solutions do not contribute to the hypervolume at all. 