### PR TITLE
Reorganize names related to `search_space` in `terminator/improvement/evaluator.py`

### DIFF
--- a/optuna/terminator/improvement/evaluator.py
+++ b/optuna/terminator/improvement/evaluator.py
@@ -166,10 +166,8 @@ class RegretBoundEvaluator(BaseImprovementEvaluator):
         # _gp module assumes that optimization direction is maximization
         sign = -1 if study_direction == StudyDirection.MINIMIZE else 1
         values = np.array([t.value for t in complete_trials]) * sign
-        search_space, normalized_params = (
-            gp_search_space.get_search_space_and_normalized_params(
-                complete_trials, optuna_search_space
-            )
+        search_space, normalized_params = gp_search_space.get_search_space_and_normalized_params(
+            complete_trials, optuna_search_space
         )
         normalized_top_n_params, top_n_values = self._get_top_n(normalized_params, values)
         top_n_values_mean = top_n_values.mean()
@@ -179,9 +177,7 @@ class RegretBoundEvaluator(BaseImprovementEvaluator):
         kernel_params = gp.fit_kernel_params(
             X=normalized_top_n_params,
             Y=standarized_top_n_values,
-            is_categorical=(
-                search_space.scale_types == gp_search_space.ScaleType.CATEGORICAL
-            ),
+            is_categorical=(search_space.scale_types == gp_search_space.ScaleType.CATEGORICAL),
             log_prior=self._log_prior,
             minimum_noise=self._minimum_noise,
             # TODO(contramundum53): Add option to specify this.

--- a/optuna/terminator/improvement/evaluator.py
+++ b/optuna/terminator/improvement/evaluator.py
@@ -108,7 +108,7 @@ class RegretBoundEvaluator(BaseImprovementEvaluator):
     def _compute_standardized_regret_bound(
         self,
         kernel_params: gp.KernelParamsTensor,
-        considered_search_space: gp_search_space.SearchSpace,
+        search_space: gp_search_space.SearchSpace,
         normalized_top_n_params: np.ndarray,
         standarized_top_n_values: np.ndarray,
     ) -> float:
@@ -127,7 +127,7 @@ class RegretBoundEvaluator(BaseImprovementEvaluator):
         ucb_acqf_params = acqf.create_acqf_params(
             acqf_type=acqf.AcquisitionFunctionType.UCB,
             kernel_params=kernel_params,
-            search_space=considered_search_space,
+            search_space=search_space,
             X=normalized_top_n_params,
             Y=standarized_top_n_values,
             beta=beta,
@@ -144,7 +144,7 @@ class RegretBoundEvaluator(BaseImprovementEvaluator):
         lcb_acqf_params = acqf.create_acqf_params(
             acqf_type=acqf.AcquisitionFunctionType.LCB,
             kernel_params=kernel_params,
-            search_space=considered_search_space,
+            search_space=search_space,
             X=normalized_top_n_params,
             Y=standarized_top_n_values,
             beta=beta,
@@ -166,7 +166,7 @@ class RegretBoundEvaluator(BaseImprovementEvaluator):
         # _gp module assumes that optimization direction is maximization
         sign = -1 if study_direction == StudyDirection.MINIMIZE else 1
         values = np.array([t.value for t in complete_trials]) * sign
-        considered_search_space, normalized_params = (
+        search_space, normalized_params = (
             gp_search_space.get_search_space_and_normalized_params(
                 complete_trials, optuna_search_space
             )
@@ -180,7 +180,7 @@ class RegretBoundEvaluator(BaseImprovementEvaluator):
             X=normalized_top_n_params,
             Y=standarized_top_n_values,
             is_categorical=(
-                considered_search_space.scale_types == gp_search_space.ScaleType.CATEGORICAL
+                search_space.scale_types == gp_search_space.ScaleType.CATEGORICAL
             ),
             log_prior=self._log_prior,
             minimum_noise=self._minimum_noise,
@@ -192,7 +192,7 @@ class RegretBoundEvaluator(BaseImprovementEvaluator):
 
         standardized_regret_bound = self._compute_standardized_regret_bound(
             kernel_params,
-            considered_search_space,
+            search_space,
             normalized_top_n_params,
             standarized_top_n_values,
         )

--- a/optuna/terminator/improvement/evaluator.py
+++ b/optuna/terminator/improvement/evaluator.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
     from optuna._gp import gp
     from optuna._gp import optim_sample
     from optuna._gp import prior
-    from optuna._gp import search_space
+    from optuna._gp import search_space as gp_search_space
 else:
     from optuna._imports import _LazyImport
 
@@ -27,7 +27,7 @@ else:
     optim_sample = _LazyImport("optuna._gp.optim_sample")
     acqf = _LazyImport("optuna._gp.acqf")
     prior = _LazyImport("optuna._gp.prior")
-    search_space = _LazyImport("optuna._gp.search_space")
+    gp_search_space = _LazyImport("optuna._gp.search_space")
 
 DEFAULT_TOP_TRIALS_RATIO = 0.5
 DEFAULT_MIN_N_TRIALS = 20
@@ -108,7 +108,7 @@ class RegretBoundEvaluator(BaseImprovementEvaluator):
     def _compute_standardized_regret_bound(
         self,
         kernel_params: gp.KernelParamsTensor,
-        considered_search_space: search_space.SearchSpace,
+        considered_search_space: gp_search_space.SearchSpace,
         normalized_top_n_params: np.ndarray,
         standarized_top_n_values: np.ndarray,
     ) -> float:
@@ -167,7 +167,7 @@ class RegretBoundEvaluator(BaseImprovementEvaluator):
         sign = -1 if study_direction == StudyDirection.MINIMIZE else 1
         values = np.array([t.value for t in complete_trials]) * sign
         considered_search_space, normalized_params = (
-            search_space.get_search_space_and_normalized_params(
+            gp_search_space.get_search_space_and_normalized_params(
                 complete_trials, optuna_search_space
             )
         )
@@ -180,7 +180,7 @@ class RegretBoundEvaluator(BaseImprovementEvaluator):
             X=normalized_top_n_params,
             Y=standarized_top_n_values,
             is_categorical=(
-                considered_search_space.scale_types == search_space.ScaleType.CATEGORICAL
+                considered_search_space.scale_types == gp_search_space.ScaleType.CATEGORICAL
             ),
             log_prior=self._log_prior,
             minimum_noise=self._minimum_noise,


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

I want to avoid name collisions which exist in `Terminator` module.

## Description of the changes
<!-- Describe the changes in this PR. -->

- Renamed colliding name of variables, `gp_search_space`,  to ~`considered_search_space`~`search_space`. The name `gp_search_space` is used in following: https://github.com/optuna/optuna/blob/39f83f7eda0979af27d5e9dd6acc7a08fa1c63ec/optuna/samplers/_gp/sampler.py#L30
- Replaced `from optuna._gp import search_space` with `from optuna._gp import search_space as gp_search_space`.
  - Fixed affected codes.