### PR TITLE
Add `EMMREvaluator` and `MedianErrorEvaluator`

### DIFF
--- a/docs/source/reference/terminator.rst
+++ b/docs/source/reference/terminator.rst
@@ -14,9 +14,11 @@ The :mod:`~optuna.terminator` module implements a mechanism for automatically te
    optuna.terminator.BaseImprovementEvaluator
    optuna.terminator.RegretBoundEvaluator
    optuna.terminator.BestValueStagnationEvaluator
+   optuna.terminator.EMMREvaluator
    optuna.terminator.BaseErrorEvaluator
    optuna.terminator.CrossValidationErrorEvaluator
    optuna.terminator.StaticErrorEvaluator
+   optuna.terminator.MedianErrorEvaluator
    optuna.terminator.TerminatorCallback
    optuna.terminator.report_cross_validation_scores
 

--- a/optuna/terminator/__init__.py
+++ b/optuna/terminator/__init__.py
@@ -3,9 +3,11 @@ from optuna.terminator.erroreval import BaseErrorEvaluator
 from optuna.terminator.erroreval import CrossValidationErrorEvaluator
 from optuna.terminator.erroreval import report_cross_validation_scores
 from optuna.terminator.erroreval import StaticErrorEvaluator
+from optuna.terminator.improvement.emmr import EMMREvaluator
 from optuna.terminator.improvement.evaluator import BaseImprovementEvaluator
 from optuna.terminator.improvement.evaluator import BestValueStagnationEvaluator
 from optuna.terminator.improvement.evaluator import RegretBoundEvaluator
+from optuna.terminator.median_erroreval import MedianErrorEvaluator
 from optuna.terminator.terminator import BaseTerminator
 from optuna.terminator.terminator import Terminator
 
@@ -16,9 +18,11 @@ __all__ = [
     "CrossValidationErrorEvaluator",
     "report_cross_validation_scores",
     "StaticErrorEvaluator",
+    "MedianErrorEvaluator",
     "BaseImprovementEvaluator",
     "BestValueStagnationEvaluator",
     "RegretBoundEvaluator",
+    "EMMREvaluator",
     "BaseTerminator",
     "Terminator",
 ]

--- a/optuna/terminator/improvement/emmr.py
+++ b/optuna/terminator/improvement/emmr.py
@@ -272,7 +272,7 @@ class EMMREvaluator(BaseImprovementEvaluator):
             alg1_delta_r_tilde_t_term1
             + alg1_delta_r_tilde_t_term2
             + alg1_delta_r_tilde_t_term3
-            + alg1_delta_r_tilde_t_term4
+            + alg1_delta_r_tilde_t_term4,
         )
 
 

--- a/optuna/terminator/improvement/emmr.py
+++ b/optuna/terminator/improvement/emmr.py
@@ -12,8 +12,8 @@ from optuna._experimental import experimental_class
 from optuna.samplers._lazy_random_state import LazyRandomState
 from optuna.search_space import intersection_search_space
 from optuna.study import StudyDirection
+from optuna.terminator.improvement.evaluator import _compute_standardized_regret_bound
 from optuna.terminator.improvement.evaluator import BaseImprovementEvaluator
-from optuna.terminator.improvement.evaluator import RegretBoundEvaluator
 from optuna.trial import FrozenTrial
 from optuna.trial import TrialState
 
@@ -225,7 +225,7 @@ class EMMREvaluator(BaseImprovementEvaluator):
         )
 
         y_t = standarized_score_vals[-1]
-        kappa_t1 = RegretBoundEvaluator.compute_standardized_regret_bound(
+        kappa_t1 = _compute_standardized_regret_bound(
             kernel_params_t1,
             search_space,
             normalized_params[:-1, :],

--- a/optuna/terminator/improvement/emmr.py
+++ b/optuna/terminator/improvement/emmr.py
@@ -92,8 +92,9 @@ class EMMREvaluator(BaseImprovementEvaluator):
 
                 if terminator.should_terminate(study):
                     print("Terminated by Optuna Terminator!")
-                    exit()
-            print("Not terminated.")
+                    break
+            else:
+                print("Not terminated.")
 
     """
 

--- a/optuna/terminator/improvement/emmr.py
+++ b/optuna/terminator/improvement/emmr.py
@@ -88,7 +88,6 @@ class EMMREvaluator(BaseImprovementEvaluator):
 
                 ys = [trial.suggest_float(f"x{i}", -10.0, 10.0) for i in range(5)]
                 value = sum(ys[i] ** 2 for i in range(5))
-                logging.info(f"Trial #{trial.number} finished with value {value}.")
 
                 study.tell(trial, value)
 

--- a/optuna/terminator/improvement/emmr.py
+++ b/optuna/terminator/improvement/emmr.py
@@ -68,6 +68,8 @@ class EMMREvaluator(BaseImprovementEvaluator):
 
         .. testcode::
 
+            import logging
+
             import optuna
             from optuna.terminator import EMMREvaluator, MedianErrorEvaluator, Terminator
 
@@ -86,15 +88,15 @@ class EMMREvaluator(BaseImprovementEvaluator):
 
                 ys = [trial.suggest_float(f"x{i}", -10.0, 10.0) for i in range(5)]
                 value = sum(ys[i] ** 2 for i in range(5))
-                print(f"Trial #{trial.number} finished with value {value}.")
+                logging.info(f"Trial #{trial.number} finished with value {value}.")
 
                 study.tell(trial, value)
 
                 if terminator.should_terminate(study):
-                    print("Terminated by Optuna Terminator!")
+                    logging.info("Terminated by Optuna Terminator!")
                     break
             else:
-                print("Not terminated.")
+                logging.info("Not terminated.")
 
     """
 

--- a/optuna/terminator/improvement/emmr.py
+++ b/optuna/terminator/improvement/emmr.py
@@ -60,6 +60,38 @@ class EMMREvaluator(BaseImprovementEvaluator):
             A float number related to the criterion for termination. Default to 0.1.
         min_n_trials:
             A minimum number of complete trials to compute the criterion. Default to 3.
+
+    Example:
+
+        .. testcode::
+
+            import optuna
+            from optuna.terminator import EMMREvaluator, MedianErrorEvaluator, Terminator
+
+            sampler = optuna.samplers.TPESampler(seed=0)
+            study = optuna.create_study(sampler=sampler, direction="minimize")
+            emmr_improvement_valuator = EMMREvaluator()
+            median_error_evaluator = MedianErrorEvaluator(emmr_improvement_valuator)
+            terminator = Terminator(
+                improvement_evaluator=emmr_improvement_valuator,
+                error_evaluator=median_error_evaluator,
+            )
+
+
+            for i in range(1000):
+                trial = study.ask()
+
+                ys = [trial.suggest_float(f"x{i}", -10.0, 10.0) for i in range(5)]
+                value = sum(ys[i] ** 2 for i in range(5))
+                print(f"Trial #{trial.number} finished with value {value}.")
+
+                study.tell(trial, value)
+
+                if terminator.should_terminate(study):
+                    print("Terminated by Optuna Terminator!")
+                    exit()
+            print("Not terminated.")
+
     """
 
     def __init__(

--- a/optuna/terminator/improvement/emmr.py
+++ b/optuna/terminator/improvement/emmr.py
@@ -137,7 +137,7 @@ class EMMREvaluator(BaseImprovementEvaluator):
         len_params = len(search_space.scale_types)
         assert normalized_params.shape == (len_trials, len_params)
 
-        # _gp module assumes that optimization direction is maximization
+        # _gp module assumes that optimization direction is maximization.
         sign = -1 if study_direction == StudyDirection.MINIMIZE else 1
         score_vals = np.array([cast(float, t.value) for t in complete_trials]) * sign
 

--- a/optuna/terminator/improvement/emmr.py
+++ b/optuna/terminator/improvement/emmr.py
@@ -1,0 +1,367 @@
+from __future__ import annotations
+
+import math
+import sys
+from typing import cast
+from typing import TYPE_CHECKING
+import warnings
+
+import numpy as np
+
+from optuna._experimental import experimental_class
+from optuna.samplers._lazy_random_state import LazyRandomState
+from optuna.search_space import intersection_search_space
+from optuna.study import StudyDirection
+from optuna.terminator.improvement.evaluator import BaseImprovementEvaluator
+from optuna.terminator.improvement.evaluator import RegretBoundEvaluator
+from optuna.trial import FrozenTrial
+from optuna.trial import TrialState
+
+
+if TYPE_CHECKING:
+    import scipy.stats as scipy_stats
+    import torch
+
+    from optuna._gp import acqf
+    from optuna._gp import gp
+    from optuna._gp import prior
+    from optuna._gp import search_space as gp_search_space
+else:
+    from optuna._imports import _LazyImport
+
+    torch = _LazyImport("torch")
+    gp = _LazyImport("optuna._gp.gp")
+    acqf = _LazyImport("optuna._gp.acqf")
+    prior = _LazyImport("optuna._gp.prior")
+    gp_search_space = _LazyImport("optuna._gp.search_space")
+    scipy_stats = _LazyImport("scipy.stats")
+
+
+@experimental_class("4.0.0")
+class EMMREvaluator(BaseImprovementEvaluator):
+    """Evaluates a kind of regrets, called the Expected Minimum Model Regret(EMMR).
+
+    EMMR is an upper bound of "expected minimum simple regret" in the optimization process.
+
+    Expected minimum simple regret is a quantity that converges to zero only if the
+    optimization process has found the global optima.
+
+    For further information about expected minimum simple regret and the algorithm,
+    please refer to the following paper:
+
+    - `A stopping criterion for Bayesian optimization by the gap of expected minimum simple
+      regrets <https://proceedings.mlr.press/v206/ishibashi23a.html>`__
+
+    Args:
+        deterministic_objective:
+            A boolean value which indicates whether the objective function is deterministic.
+            Default is :obj:`False`.
+        delta:
+            A float number related to the criterion for termination. Default to 0.1.
+        min_n_trials:
+            A minimum number of complete trials to compute the criterion. Default to 3.
+    """
+
+    def __init__(
+        self,
+        deterministic_objective: bool = False,
+        delta: float = 0.1,
+        min_n_trials: int = 3,
+        seed: int | None = None,
+    ) -> None:
+        if min_n_trials <= 2 or not np.isfinite(min_n_trials):
+            raise ValueError("`min_n_trials` is expected to be a finite integer more than two.")
+
+        self._deterministic = deterministic_objective
+        self._delta = delta
+        self.min_n_trials = min_n_trials
+        self._rng = LazyRandomState(seed)
+
+    def evaluate(self, trials: list[FrozenTrial], study_direction: StudyDirection) -> float:
+
+        optuna_search_space = intersection_search_space(trials)
+        complete_trials = [t for t in trials if t.state == TrialState.COMPLETE]
+
+        if len(complete_trials) < self.min_n_trials:
+            return sys.float_info.max  # Do not terminate.
+
+        search_space, normalized_params = gp_search_space.get_search_space_and_normalized_params(
+            complete_trials, optuna_search_space
+        )
+        if len(search_space.scale_types) == 0:
+            warnings.warn(
+                f"{self.__class__.__name__} cannot consider any search space."
+                "Termination will never occur in this study."
+            )
+            return sys.float_info.max  # Do not terminate.
+
+        len_trials = len(complete_trials)
+        len_params = len(search_space.scale_types)
+        assert normalized_params.shape == (len_trials, len_params)
+
+        # _gp module assumes that optimization direction is maximization
+        sign = -1 if study_direction == StudyDirection.MINIMIZE else 1
+        score_vals = np.array([cast(float, t.value) for t in complete_trials]) * sign
+
+        if np.any(~np.isfinite(score_vals)):
+            warnings.warn(
+                f"{self.__class__.__name__} cannot handle infinite values."
+                "Those values are clamped to worst/best finite value."
+            )
+
+            finite_score_vals = score_vals[np.isfinite(score_vals)]
+            best_finite_score = np.max(finite_score_vals, initial=0.0)
+            worst_finite_score = np.min(finite_score_vals, initial=0.0)
+
+            score_vals = np.clip(score_vals, worst_finite_score, best_finite_score)
+
+        standarized_score_vals = (score_vals - score_vals.mean()) / max(
+            sys.float_info.min, score_vals.std()
+        )
+
+        assert len(standarized_score_vals) == len(normalized_params)
+
+        kernel_params_t2 = gp.fit_kernel_params(  # Fit kernel with up to (t-2)-th observation
+            X=normalized_params[..., :-2, :],
+            Y=standarized_score_vals[:-2],
+            is_categorical=(search_space.scale_types == gp_search_space.ScaleType.CATEGORICAL),
+            log_prior=prior.default_log_prior,
+            minimum_noise=prior.DEFAULT_MINIMUM_NOISE_VAR,
+            initial_kernel_params=None,
+            deterministic_objective=self._deterministic,
+        )
+
+        kernel_params_t1 = gp.fit_kernel_params(  # Fit kernel with up to (t-1)-th observation
+            X=normalized_params[..., :-1, :],
+            Y=standarized_score_vals[:-1],
+            is_categorical=(search_space.scale_types == gp_search_space.ScaleType.CATEGORICAL),
+            log_prior=prior.default_log_prior,
+            minimum_noise=prior.DEFAULT_MINIMUM_NOISE_VAR,
+            initial_kernel_params=kernel_params_t2,
+            deterministic_objective=self._deterministic,
+        )
+
+        kernel_params_t = gp.fit_kernel_params(  # Fit kernel with up to t-th observation
+            X=normalized_params,
+            Y=standarized_score_vals,
+            is_categorical=(search_space.scale_types == gp_search_space.ScaleType.CATEGORICAL),
+            log_prior=prior.default_log_prior,
+            minimum_noise=prior.DEFAULT_MINIMUM_NOISE_VAR,
+            initial_kernel_params=kernel_params_t1,
+            deterministic_objective=self._deterministic,
+        )
+
+        theta_t_star_index = int(np.argmax(standarized_score_vals))
+        theta_t1_star_index = int(np.argmax(standarized_score_vals[:-1]))
+        theta_t_star = normalized_params[theta_t_star_index, :]
+        theta_t1_star = normalized_params[theta_t1_star_index, :]
+        covariance_theta_t_star_theta_t1_star = _compute_gp_posterior_cov_two_thetas(
+            search_space,
+            normalized_params,
+            standarized_score_vals,
+            kernel_params_t,
+            theta_t_star_index,
+            theta_t1_star_index,
+        )
+
+        mu_t1_theta_t, sigma_t1_theta_t = _compute_gp_posterior(
+            search_space,
+            normalized_params[:-1, :],
+            standarized_score_vals[:-1],
+            normalized_params[-1, :],
+            kernel_params_t1,
+        )
+        mu_t1_theta_t_star, sigma_t1_theta_t_star = _compute_gp_posterior(
+            search_space,
+            normalized_params[:-1, :],
+            standarized_score_vals[:-1],
+            theta_t_star,
+            kernel_params_t1,
+        )
+        mu_t2_theta_t1_star, _ = _compute_gp_posterior(
+            search_space,
+            normalized_params[:-1, :],
+            standarized_score_vals[:-1],
+            theta_t_star,
+            kernel_params_t1,
+            # Use kernel_params_t1 instead of t2.
+            # Use t1 under the assumption that t1 and t2 are approximately the same.
+            # This is because kernel should same when comparing difference of mus.
+        )
+        mu_t_theta_t_star, sigma_t_theta_t_star = _compute_gp_posterior(
+            search_space,
+            normalized_params,
+            standarized_score_vals,
+            theta_t_star,
+            kernel_params_t,
+        )
+        mu_t1_theta_t1_star, _ = _compute_gp_posterior(
+            search_space,
+            normalized_params[:-1, :],
+            standarized_score_vals[:-1],
+            theta_t1_star,
+            kernel_params_t1,
+        )
+        sigma_t1_theta_t_squared = sigma_t1_theta_t**2
+
+        sigma_t1_theta_t_star_squared = sigma_t1_theta_t_star**2
+        sigma_t_theta_t_star_squared = sigma_t_theta_t_star**2
+
+        y_t = standarized_score_vals[-1]
+        kappa_t1 = RegretBoundEvaluator._compute_standardized_regret_bound(
+            kernel_params_t1,
+            search_space,
+            normalized_params[:-1, :],
+            standarized_score_vals[:-1],
+            self._delta,
+            rng=self._rng.rng,
+        )
+
+        theorem1_delta_mu_t_star = mu_t2_theta_t1_star - mu_t1_theta_t_star
+
+        alg1_delta_r_tilde_t_term1 = theorem1_delta_mu_t_star
+
+        theorem1_v = math.sqrt(
+            max(
+                sys.float_info.min,
+                sigma_t_theta_t_star_squared
+                - 2.0 * covariance_theta_t_star_theta_t1_star
+                + sigma_t1_theta_t_star_squared,
+            )
+        )
+        theorem1_g = (mu_t_theta_t_star - mu_t1_theta_t1_star) / theorem1_v
+
+        alg1_delta_r_tilde_t_term2 = theorem1_v * scipy_stats.norm.pdf(theorem1_g)
+        alg1_delta_r_tilde_t_term3 = theorem1_v * theorem1_g * scipy_stats.norm.cdf(theorem1_g)
+
+        _lambda = prior.DEFAULT_MINIMUM_NOISE_VAR
+        eq4_rhs_term1 = 0.5 * math.log(1.0 + _lambda * sigma_t1_theta_t_squared)
+        eq4_rhs_term2 = 0.5 * sigma_t1_theta_t_squared / (sigma_t1_theta_t_squared + _lambda**-1)
+        eq4_rhs_term3 = (
+            0.5
+            * sigma_t1_theta_t_squared
+            * (y_t - mu_t1_theta_t) ** 2
+            / (sigma_t1_theta_t_squared + _lambda**-1) ** 2
+        )
+
+        alg1_delta_r_tilde_t_term4 = kappa_t1 * math.sqrt(
+            0.5 * (eq4_rhs_term1 + eq4_rhs_term2 + eq4_rhs_term3)
+        )
+
+        return (
+            alg1_delta_r_tilde_t_term1
+            + alg1_delta_r_tilde_t_term2
+            + alg1_delta_r_tilde_t_term3
+            + alg1_delta_r_tilde_t_term4
+        )
+
+
+def _compute_gp_posterior(
+    search_space: gp_search_space.SearchSpace,
+    X: np.ndarray,
+    Y: np.ndarray,
+    x_params: np.ndarray,
+    kernel_params: gp.KernelParamsTensor,
+) -> tuple[float, float]:  # mean, var
+
+    acqf_params = acqf.create_acqf_params(
+        acqf_type=acqf.AcquisitionFunctionType.LOG_EI,
+        kernel_params=kernel_params,
+        search_space=search_space,
+        X=X,  # normalized_params[..., :-1, :],
+        Y=Y,  # standarized_score_vals[:-1],
+    )
+    mean, var = gp.posterior(
+        acqf_params.kernel_params,
+        torch.from_numpy(acqf_params.X),
+        torch.from_numpy(
+            acqf_params.search_space.scale_types == gp_search_space.ScaleType.CATEGORICAL
+        ),
+        torch.from_numpy(acqf_params.cov_Y_Y_inv),
+        torch.from_numpy(acqf_params.cov_Y_Y_inv_Y),
+        torch.from_numpy(x_params),  # best_params or normalized_params[..., -1, :]),
+    )
+    mean = mean.detach().numpy().flatten()
+    var = var.detach().numpy().flatten()
+    assert len(mean) == 1 and len(var) == 1
+    return float(mean[0]), float(var[0])
+
+
+def _posterior_of_batched_theta(
+    kernel_params: gp.KernelParamsTensor,
+    X: torch.Tensor,  # [len(trials), len(params)]
+    is_categorical: torch.Tensor,  # bool[len(params)]
+    cov_Y_Y_inv: torch.Tensor,  # [len(trials), len(trials)]
+    cov_Y_Y_inv_Y: torch.Tensor,  # [len(trials)]
+    theta: torch.Tensor,  # [batch, len(params)]
+) -> tuple[torch.Tensor, torch.Tensor]:  # (mean: [(batch,)], var: [(batch,batch)])
+
+    assert len(X.shape) == 2
+    len_trials, len_params = X.shape
+    assert len(theta.shape) == 2
+    len_batch = theta.shape[0]
+    assert theta.shape == (len_batch, len_params)
+    assert is_categorical.shape == (len_params,)
+    assert cov_Y_Y_inv.shape == (len_trials, len_trials)
+    assert cov_Y_Y_inv_Y.shape == (len_trials,)
+
+    cov_ftheta_fX = gp.kernel(is_categorical, kernel_params, theta[..., None, :], X)[..., 0, :]
+    assert cov_ftheta_fX.shape == (len_batch, len_trials)
+    cov_ftheta_ftheta = gp.kernel(is_categorical, kernel_params, theta[..., None, :], theta)[
+        ..., 0, :
+    ]
+    assert cov_ftheta_ftheta.shape == (len_batch, len_batch)
+
+    assert torch.allclose(cov_ftheta_ftheta.diag(), gp.kernel_at_zero_distance(kernel_params))
+    assert torch.allclose(cov_ftheta_ftheta, cov_ftheta_ftheta.T)
+
+    mean = cov_ftheta_fX @ cov_Y_Y_inv_Y
+    assert mean.shape == (len_batch,)
+    var = cov_ftheta_ftheta - cov_ftheta_fX @ cov_Y_Y_inv @ cov_ftheta_fX.T
+    assert var.shape == (len_batch, len_batch)
+
+    # We need to clamp the variance to avoid negative values due to numerical errors.
+    return mean, torch.clamp(var, min=0.0)
+
+
+def _compute_gp_posterior_cov_two_thetas(
+    search_space: gp_search_space.SearchSpace,
+    normalized_params: np.ndarray,
+    standarized_score_vals: np.ndarray,
+    kernel_params: gp.KernelParamsTensor,
+    theta1_index: int,
+    theta2_index: int,
+) -> float:  # cov
+
+    if theta1_index == theta2_index:
+        return _compute_gp_posterior(
+            search_space,
+            normalized_params,
+            standarized_score_vals,
+            normalized_params[theta1_index],
+            kernel_params,
+        )[1]
+
+    assert normalized_params.shape[0] == standarized_score_vals.shape[0]
+
+    acqf_params = acqf.create_acqf_params(
+        acqf_type=acqf.AcquisitionFunctionType.LOG_EI,
+        kernel_params=kernel_params,
+        search_space=search_space,
+        X=normalized_params,
+        Y=standarized_score_vals,
+    )
+
+    _, var = _posterior_of_batched_theta(
+        acqf_params.kernel_params,
+        torch.from_numpy(acqf_params.X),
+        torch.from_numpy(
+            acqf_params.search_space.scale_types == gp_search_space.ScaleType.CATEGORICAL
+        ),
+        torch.from_numpy(acqf_params.cov_Y_Y_inv),
+        torch.from_numpy(acqf_params.cov_Y_Y_inv_Y),
+        torch.from_numpy(normalized_params[[theta1_index, theta2_index]]),
+    )
+    assert var.shape == (2, 2)
+    var = var.detach().numpy()[0, 1]
+    return float(var)

--- a/optuna/terminator/improvement/emmr.py
+++ b/optuna/terminator/improvement/emmr.py
@@ -68,10 +68,10 @@ class EMMREvaluator(BaseImprovementEvaluator):
 
         .. testcode::
 
-            import logging
-
             import optuna
-            from optuna.terminator import EMMREvaluator, MedianErrorEvaluator, Terminator
+            from optuna.terminator import EMMREvaluator
+            from optuna.terminator import MedianErrorEvaluator
+            from optuna.terminator import Terminator
 
             sampler = optuna.samplers.TPESampler(seed=0)
             study = optuna.create_study(sampler=sampler, direction="minimize")
@@ -93,10 +93,8 @@ class EMMREvaluator(BaseImprovementEvaluator):
                 study.tell(trial, value)
 
                 if terminator.should_terminate(study):
-                    logging.info("Terminated by Optuna Terminator!")
+                    # Terminated by Optuna Terminator!
                     break
-            else:
-                logging.info("Not terminated.")
 
     """
 

--- a/optuna/terminator/improvement/evaluator.py
+++ b/optuna/terminator/improvement/evaluator.py
@@ -116,13 +116,11 @@ class RegretBoundEvaluator(BaseImprovementEvaluator):
         optimize_n_samples: int = 2048,
         rng: np.random.RandomState | None = None,
     ) -> float:
-        """
-        In the original paper, f(x) was intended to be minimized, but here we would like to
-        maximize f(x). Hence, the following changes happen:
-            1. min(ucb) over top trials becomes max(lcb) over top trials, and
-            2. min(lcb) over the search space becomes max(ucb) over the search space, and
-            3. Regret bound becomes max(ucb) over the search space minus max(lcb) over top trials.
-        """
+        # In the original paper, f(x) was intended to be minimized, but here we would like to
+        # maximize f(x). Hence, the following changes happen:
+        # 1. min(ucb) over top trials becomes max(lcb) over top trials, and
+        # 2. min(lcb) over the search space becomes max(ucb) over the search space, and
+        # 3. Regret bound becomes max(ucb) over the search space minus max(lcb) over top trials.
 
         n_trials, n_params = normalized_top_n_params.shape
 

--- a/optuna/terminator/improvement/evaluator.py
+++ b/optuna/terminator/improvement/evaluator.py
@@ -94,7 +94,7 @@ class RegretBoundEvaluator(BaseImprovementEvaluator):
         return normalized_params[top_n_mask], values[top_n_mask]
 
     @staticmethod
-    def _get_beta(n_params: int, n_trials: int, delta: float = 0.1) -> float:
+    def get_beta(n_params: int, n_trials: int, delta: float = 0.1) -> float:
         # TODO(nabenabe0928): Check the original implementation to verify.
         # Especially, |D| seems to be the domain size, but not the dimension based on Theorem 1.
         beta = 2 * np.log(n_params * n_trials**2 * np.pi**2 / 6 / delta)
@@ -107,7 +107,7 @@ class RegretBoundEvaluator(BaseImprovementEvaluator):
         return beta
 
     @staticmethod
-    def _compute_standardized_regret_bound(
+    def compute_standardized_regret_bound(
         kernel_params: gp.KernelParamsTensor,
         search_space: gp_search_space.SearchSpace,
         normalized_top_n_params: np.ndarray,
@@ -127,7 +127,7 @@ class RegretBoundEvaluator(BaseImprovementEvaluator):
         n_trials, n_params = normalized_top_n_params.shape
 
         # calculate max_ucb
-        beta = RegretBoundEvaluator._get_beta(n_params, n_trials, delta)
+        beta = RegretBoundEvaluator.get_beta(n_params, n_trials, delta)
         ucb_acqf_params = acqf.create_acqf_params(
             acqf_type=acqf.AcquisitionFunctionType.UCB,
             kernel_params=kernel_params,
@@ -190,7 +190,7 @@ class RegretBoundEvaluator(BaseImprovementEvaluator):
             initial_kernel_params=None,
         )
 
-        standardized_regret_bound = RegretBoundEvaluator._compute_standardized_regret_bound(
+        standardized_regret_bound = RegretBoundEvaluator.compute_standardized_regret_bound(
             kernel_params,
             search_space,
             normalized_top_n_params,

--- a/optuna/terminator/median_erroreval.py
+++ b/optuna/terminator/median_erroreval.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import sys
+
+import numpy as np
+
+from optuna._experimental import experimental_class
+from optuna.study import StudyDirection
+from optuna.terminator.erroreval import BaseErrorEvaluator
+from optuna.terminator.improvement.evaluator import BaseImprovementEvaluator
+from optuna.trial import FrozenTrial
+from optuna.trial._state import TrialState
+
+
+@experimental_class("4.0.0")
+class MedianErrorEvaluator(BaseErrorEvaluator):
+    """An error evaluator that returns the ratio to initial median.
+
+
+    Args:
+        paired_improvement_evaluator:
+            The ``improvement_evaluator`` instance which is set with this ``error_evaluator``.
+        warm_up_trials:
+            A parameter specifies the number of initial trials to be discarded before
+            the calculation of median. Default to 10.
+        n_initial_trials:
+            A parameter specifies the number of initial trials considered in the calculation of
+            median. Default to 20.
+        threshold_ratio:
+            A parameter specifies the ratio between the threshold and initial median.
+            Default to 0.01.
+    """
+
+    def __init__(
+        self,
+        paired_improvement_evaluator: BaseImprovementEvaluator,
+        warm_up_trials: int = 10,
+        n_initial_trials: int = 20,
+        threshold_ratio: float = 0.01,
+    ) -> None:
+        if warm_up_trials < 0:
+            raise ValueError("`warm_up_trials` is expected to be a non-negative integer.")
+        if n_initial_trials <= 0:
+            raise ValueError("`n_initial_trials` is expected to be a positive integer.")
+        if threshold_ratio <= 0.0 or not np.isfinite(threshold_ratio):
+            raise ValueError("`threshold_ratio_to_initial_median` is expected to be a positive.")
+
+        self._paired_improvement_evaluator = paired_improvement_evaluator
+        self._warm_up_trials = warm_up_trials
+        self._n_initial_trials = n_initial_trials
+        self._threshold_ratio = threshold_ratio
+        self._threshold: float | None = None
+
+    def evaluate(
+        self,
+        trials: list[FrozenTrial],
+        study_direction: StudyDirection,
+    ) -> float:
+
+        if self._threshold is not None:
+            return self._threshold
+
+        trials = [trial for trial in trials if trial.state == TrialState.COMPLETE]
+        if len(trials) < (self._warm_up_trials + self._n_initial_trials):
+            return -sys.float_info.max  # Do not terminate.
+        trials.sort(key=lambda trial: trial.number)
+        criteria = []
+        for i in range(self._warm_up_trials, self._warm_up_trials + self._n_initial_trials):
+            criteria.append(
+                self._paired_improvement_evaluator.evaluate(
+                    trials[self._warm_up_trials : self._warm_up_trials + i + 1], study_direction
+                )
+            )
+        criteria.sort()
+        self._threshold = criteria[len(criteria) // 2]
+        self._threshold *= self._threshold_ratio
+        assert self._threshold is not None
+        return self._threshold

--- a/optuna/terminator/median_erroreval.py
+++ b/optuna/terminator/median_erroreval.py
@@ -27,6 +27,8 @@ class MedianErrorEvaluator(BaseErrorEvaluator):
         warm_up_trials:
             A parameter specifies the number of initial trials to be discarded before
             the calculation of median. Default to 10.
+            In optuna, the first 10 trials are often random sampling.
+            The ``warm_up_trials`` can exclude them from the calculation.
         n_initial_trials:
             A parameter specifies the number of initial trials considered in the calculation of
             median after `warm_up_trials`. Default to 20.
@@ -66,7 +68,9 @@ class MedianErrorEvaluator(BaseErrorEvaluator):
 
         trials = [trial for trial in trials if trial.state == TrialState.COMPLETE]
         if len(trials) < (self._warm_up_trials + self._n_initial_trials):
-            return -sys.float_info.max  # Do not terminate.
+            return (
+                -sys.float_info.min
+            )  # Do not terminate. It assumes that improvement must non-negative.
         trials.sort(key=lambda trial: trial.number)
         criteria = []
         for i in range(1, self._n_initial_trials + 1):

--- a/tests/terminator_tests/improvement_tests/test_emmr_evaluator.py
+++ b/tests/terminator_tests/improvement_tests/test_emmr_evaluator.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 import sys
 
 import numpy as np
@@ -8,6 +9,7 @@ import pytest
 from optuna.distributions import FloatDistribution
 from optuna.study import StudyDirection
 from optuna.terminator import EMMREvaluator
+from optuna.terminator.improvement.emmr import MARGIN_FOR_NUMARICAL_STABILITY
 from optuna.trial import create_trial
 from optuna.trial import FrozenTrial
 
@@ -37,7 +39,7 @@ def test_emmr_evaluate_with_insufficient_trials() -> None:
     trials: list[FrozenTrial] = []
     for _ in range(2):
         criterion = evaluator.evaluate(trials=trials, study_direction=StudyDirection.MAXIMIZE)
-        assert criterion == sys.float_info.max
+        assert math.isclose(criterion, sys.float_info.max * MARGIN_FOR_NUMARICAL_STABILITY)
         trials.append(create_trial(value=0, distributions={}, params={}))
 
 
@@ -46,4 +48,4 @@ def test_emmr_evaluate_with_empty_intersection_search_space() -> None:
     trials = [create_trial(value=0, distributions={}, params={}) for _ in range(3)]
     with pytest.warns(UserWarning):
         criterion = evaluator.evaluate(trials=trials, study_direction=StudyDirection.MAXIMIZE)
-    assert criterion == sys.float_info.max
+    assert math.isclose(criterion, sys.float_info.max * MARGIN_FOR_NUMARICAL_STABILITY)

--- a/tests/terminator_tests/improvement_tests/test_emmr_evaluator.py
+++ b/tests/terminator_tests/improvement_tests/test_emmr_evaluator.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import sys
+
+import numpy as np
+import pytest
+
+from optuna.distributions import FloatDistribution
+from optuna.study import StudyDirection
+from optuna.terminator import EMMREvaluator
+from optuna.trial import create_trial
+from optuna.trial import FrozenTrial
+
+
+def test_emmr_evaluate() -> None:
+    evaluator = EMMREvaluator(min_n_trials=3)
+    trials = [
+        create_trial(
+            value=i,
+            distributions={"a": FloatDistribution(-1.0, 10.0)},
+            params={"a": float(i)},
+        )
+        for i in range(3)
+    ]
+    criterion = evaluator.evaluate(trials=trials, study_direction=StudyDirection.MAXIMIZE)
+    assert np.isfinite(criterion)
+    assert criterion < sys.float_info.max
+
+
+def test_emmr_evaluate_with_invalid_argument() -> None:
+    with pytest.raises(ValueError):
+        EMMREvaluator(min_n_trials=2)
+
+
+def test_emmr_evaluate_with_insufficient_trials() -> None:
+    evaluator = EMMREvaluator()
+    trials: list[FrozenTrial] = []
+    for _ in range(3):
+        criterion = evaluator.evaluate(trials=trials, study_direction=StudyDirection.MAXIMIZE)
+        assert criterion == sys.float_info.max
+        trials.append(create_trial(value=0, distributions={}, params={}))
+
+
+def test_emmr_evaluate_with_empty_intersection_search_space() -> None:
+    evaluator = EMMREvaluator()
+    trials = [create_trial(value=0, distributions={}, params={}) for _ in range(4)]
+    with pytest.warns(UserWarning):
+        criterion = evaluator.evaluate(trials=trials, study_direction=StudyDirection.MAXIMIZE)
+    assert criterion == sys.float_info.max

--- a/tests/terminator_tests/improvement_tests/test_emmr_evaluator.py
+++ b/tests/terminator_tests/improvement_tests/test_emmr_evaluator.py
@@ -29,13 +29,13 @@ def test_emmr_evaluate() -> None:
 
 def test_emmr_evaluate_with_invalid_argument() -> None:
     with pytest.raises(ValueError):
-        EMMREvaluator(min_n_trials=2)
+        EMMREvaluator(min_n_trials=1)
 
 
 def test_emmr_evaluate_with_insufficient_trials() -> None:
     evaluator = EMMREvaluator()
     trials: list[FrozenTrial] = []
-    for _ in range(3):
+    for _ in range(2):
         criterion = evaluator.evaluate(trials=trials, study_direction=StudyDirection.MAXIMIZE)
         assert criterion == sys.float_info.max
         trials.append(create_trial(value=0, distributions={}, params={}))
@@ -43,7 +43,7 @@ def test_emmr_evaluate_with_insufficient_trials() -> None:
 
 def test_emmr_evaluate_with_empty_intersection_search_space() -> None:
     evaluator = EMMREvaluator()
-    trials = [create_trial(value=0, distributions={}, params={}) for _ in range(4)]
+    trials = [create_trial(value=0, distributions={}, params={}) for _ in range(3)]
     with pytest.warns(UserWarning):
         criterion = evaluator.evaluate(trials=trials, study_direction=StudyDirection.MAXIMIZE)
     assert criterion == sys.float_info.max

--- a/tests/terminator_tests/test_median_erroreval.py
+++ b/tests/terminator_tests/test_median_erroreval.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import sys
-
 import numpy as np
 import pytest
 
@@ -44,7 +42,7 @@ def test_ratio_to_initial_median_evaluator(
         )
     )
     criterion = evaluator.evaluate(trials, direction)
-    assert criterion == -sys.float_info.max
+    assert criterion <= 0.0
     trials.append(
         create_trial(
             value=22.0,
@@ -53,7 +51,7 @@ def test_ratio_to_initial_median_evaluator(
         )
     )
     criterion = evaluator.evaluate(trials, direction)
-    assert criterion == -sys.float_info.max
+    assert criterion <= 0.0
     trials.append(
         create_trial(
             value=333.0,
@@ -62,7 +60,7 @@ def test_ratio_to_initial_median_evaluator(
         )
     )
     criterion = evaluator.evaluate(trials, direction)
-    assert criterion == -sys.float_info.max
+    assert criterion <= 0.0
     trials.append(
         create_trial(
             value=4444.0,
@@ -72,4 +70,4 @@ def test_ratio_to_initial_median_evaluator(
     )
     criterion = evaluator.evaluate(trials, direction)
     assert np.isfinite(criterion)
-    assert -sys.float_info.max < criterion
+    assert 0.0 <= criterion

--- a/tests/terminator_tests/test_median_erroreval.py
+++ b/tests/terminator_tests/test_median_erroreval.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import sys
+
+import numpy as np
+import pytest
+
+from optuna.distributions import FloatDistribution
+from optuna.study.study import create_study
+from optuna.terminator import EMMREvaluator
+from optuna.terminator import MedianErrorEvaluator
+from optuna.trial import create_trial
+
+
+def test_validation_ratio_to_initial_median_evaluator() -> None:
+    with pytest.raises(ValueError):
+        MedianErrorEvaluator(paired_improvement_evaluator=EMMREvaluator(), warm_up_trials=-1)
+
+    with pytest.raises(ValueError):
+        MedianErrorEvaluator(paired_improvement_evaluator=EMMREvaluator(), n_initial_trials=0)
+
+    with pytest.raises(ValueError):
+        MedianErrorEvaluator(paired_improvement_evaluator=EMMREvaluator(), threshold_ratio=0.0)
+
+
+@pytest.mark.parametrize("direction", ["minimize", "maximize"])
+def test_ratio_to_initial_median_evaluator(
+    direction: str,
+) -> None:
+    study = create_study(direction=direction)
+    evaluator = MedianErrorEvaluator(
+        paired_improvement_evaluator=EMMREvaluator(min_n_trials=3),
+        warm_up_trials=1,
+        n_initial_trials=3,
+        threshold_ratio=2.0,
+    )
+
+    study.add_trial(
+        create_trial(
+            value=1.0,
+            distributions={"a": FloatDistribution(-1.0, 10000.0)},
+            params={"a": 1.0},
+        )
+    )
+    criterion = evaluator.evaluate(study.trials, study.direction)
+    assert criterion == -sys.float_info.max
+    study.add_trial(
+        create_trial(
+            value=22.0,
+            distributions={"a": FloatDistribution(-1.0, 10000.0)},
+            params={"a": 22.0},
+        )
+    )
+    criterion = evaluator.evaluate(study.trials, study.direction)
+    assert criterion == -sys.float_info.max
+    study.add_trial(
+        create_trial(
+            value=333.0,
+            distributions={"a": FloatDistribution(-1.0, 10000.0)},
+            params={"a": 333.0},
+        )
+    )
+    criterion = evaluator.evaluate(study.trials, study.direction)
+    assert criterion == -sys.float_info.max
+    study.add_trial(
+        create_trial(
+            value=4444.0,
+            distributions={"a": FloatDistribution(-1.0, 10000.0)},
+            params={"a": 4444.0},
+        )
+    )
+    criterion = evaluator.evaluate(study.trials, study.direction)
+    assert np.isfinite(criterion)
+    assert -sys.float_info.max < criterion


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

I want to add new terminator based on "Expected Minimum Model Regret(EMMR)", which is an upper bound of "Expected Minimum Simple Regret" introduced in [the paper](https://proceedings.mlr.press/v206/ishibashi23a/ishibashi23a.pdf).

## Description of the changes
<!-- Describe the changes in this PR. -->

- Added two classes, `EMMREvaluator` and `MedianErrorEvaluator` in `optuna/terminator` module.
- Added unittests.
- Done minimal refactoring to `RegretBoundEvaluator` to call its methods from `EMMREvaluator`. Such calling would be justified from a theoretical perspective.