### PR TITLE
Fix the expired links caused by the directory name change in optuna-examples

### DIFF
--- a/optuna/pruners/_successive_halving.py
+++ b/optuna/pruners/_successive_halving.py
@@ -20,7 +20,7 @@ class SuccessiveHalvingPruner(BasePruner):
     Note that, this class does not take care of the parameter for the maximum
     resource, referred to as :math:`R` in the paper. The maximum resource allocated to a trial is
     typically limited inside the objective function (e.g., ``step`` number in `simple_pruning.py
-    <https://github.com/optuna/optuna-examples/blob/main/simple_pruning.py>`__,
+    <https://github.com/optuna/optuna-examples/blob/main/basic/pruning.py>`__,
     ``EPOCH`` number in `chainer_integration.py
     <https://github.com/optuna/optuna-examples/tree/main/chainer/chainer_integration.py#L73>`__).
 


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

This PR aims to resolve the following issue:
- https://github.com/optuna/optuna/issues/5622

## Description of the changes
<!-- Describe the changes in this PR. -->

- Resolve #5622
- Fix the expired link to `basic/pruning.py` in `optuna-examples`

This PR depends on:
- https://github.com/optuna/optuna-examples/pull/277

As the PR above adds `basic/pruning.py`, this PR must be merged after [this PR](https://github.com/optuna/optuna-examples/pull/277).