### PR TITLE
Update Trial doc comment

### DIFF
--- a/optuna/trial/_trial.py
+++ b/optuna/trial/_trial.py
@@ -32,9 +32,14 @@ class Trial(BaseTrial):
     """A trial is a process to evaluate an objective function.
 
     This mutable Trial object provides interfaces to:
-        - suggest parameters
-        - manage trial state
-        - set/get user-defined attributes
+        - suggest_float(name: str, low: float, high: float, *, step: float | None = None)
+        - suggest_int(name: str, low: int, high: int, *, step: int = 1) -> int
+        - suggest_categorical(name: str, choices: Sequence[Choice]) -> Choice
+            - where Choice = None | bool | int | float | str
+        - report objective values
+        - should_prune to suggest pruning this trial or not
+        - set_user_attr to set user-defined trial attributes
+        - user_attrs is a dict of user-defined attributes
 
     Automatic Optimization
     ----------------------

--- a/optuna/trial/_trial.py
+++ b/optuna/trial/_trial.py
@@ -33,8 +33,8 @@ class Trial(BaseTrial):
 
     This mutable Trial object provides interfaces to:
         - suggest_float(name: str, low: float, high: float, *, step: float | None = None)
-        - suggest_int(name: str, low: int, high: int, *, step: int = 1) -> int
-        - suggest_categorical(name: str, choices: Sequence[Choice]) -> Choice
+        - suggest_int(name: str, low: int, high: int, *, step: int = 1)
+        - suggest_categorical(name: str, choices: Sequence[Choice])
             - where Choice = None | bool | int | float | str
         - report objective values
         - should_prune to suggest pruning this trial or not

--- a/optuna/trial/_trial.py
+++ b/optuna/trial/_trial.py
@@ -34,10 +34,13 @@ class Trial(BaseTrial):
     This object is passed to an objective function and provides interfaces to get parameter
     suggestion, manage the trial's state, and set/get user-defined attributes of the trial.
 
-    Note that the direct use of this constructor is not recommended.
-    This object is seamlessly instantiated and passed to the objective function behind
-    the :func:`optuna.study.Study.optimize()` method; hence library users do not care about
-    instantiation of this object.
+    NOTE: the direct use of this constructor is not recommended.
+    
+    When using the :func:`optuna.study.Study.optimize()` method,
+    this object is automatically instantiated and passed to the objective function.
+
+    Library users may care about this constructor if they build custom training loops,
+    which do not rely on :func:`optuna.study.Study.optimize()`.
 
     Args:
         study:

--- a/optuna/trial/_trial.py
+++ b/optuna/trial/_trial.py
@@ -29,18 +29,35 @@ _suggest_deprecated_msg = "Use suggest_float{args} instead."
 
 
 class Trial(BaseTrial):
-    """A trial is a process of evaluating an objective function.
+    """A trial is a process to evaluate an objective function.
 
-    This object is passed to an objective function and provides interfaces to get parameter
-    suggestion, manage the trial's state, and set/get user-defined attributes of the trial.
+    This mutable Trial object provides interfaces to:
+        - suggest parameters
+        - manage trial state
+        - set/get user-defined attributes
 
-    NOTE: the direct use of this constructor is not recommended.
-    
-    When using the :func:`optuna.study.Study.optimize()` method,
-    this object is automatically instantiated and passed to the objective function.
+    Automatic Optimization
+    ----------------------
+        - The :func:`Study.optimize()` method:
+            - creates trials
+            - passes them to objective functions
+            - records objective results
 
-    Library users may care about this constructor if they build custom training loops,
-    which do not rely on :func:`optuna.study.Study.optimize()`.
+    Custom Optimization
+    -------------------
+
+        - Create Trials:
+            - :func:`Study.ask()` creates trials in custom optimization loops.
+
+        - List Trials:
+            - :func:`Study.get_trials()` lists FrozenTrial per trial.
+            - :func:`Study.trials_dataframe()` of FrozenTrials
+
+        - Read Trials:
+            - :func:`Storage.get_trial()` reads a FrozenTrial from a trial_id
+
+        - Update Trials:
+            - :func:`Study.tell()` sets trial state and reports objective values.
 
     Args:
         study:


### PR DESCRIPTION
## Motivation
The doc comment indicates users do not care about Trial.__init__, but I am a user and I care about it because I do not use `optimize`. 

Therefore, this doc comment implies users feel a certain way, which isn't necessarily true, and may lead maintainers to feel justified in lack of support for custom training loops.

## Description of the changes
Update the Trial doc comment to reflect usage in custom training loops