### PR TITLE
Fix ruff errors except for E731

### DIFF
--- a/optuna/distributions.py
+++ b/optuna/distributions.py
@@ -90,7 +90,7 @@ class BaseDistribution(abc.ABC):
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, BaseDistribution):
             return NotImplemented
-        if not type(self) is type(other):
+        if type(self) is not type(other):
             return False
         return self.__dict__ == other.__dict__
 

--- a/tests/samplers_tests/test_brute_force.py
+++ b/tests/samplers_tests/test_brute_force.py
@@ -279,7 +279,7 @@ def test_study_optimize_with_nonconstant_search_space() -> None:
 
 def test_study_optimize_with_failed_trials() -> None:
     def objective(trial: Trial) -> float:
-        x = trial.suggest_int("x", 0, 99)  # NOQA[F811]
+        trial.suggest_int("x", 0, 99)
         return np.nan
 
     study = optuna.create_study(sampler=samplers.BruteForceSampler())

--- a/tests/trial_tests/test_trial.py
+++ b/tests/trial_tests/test_trial.py
@@ -79,7 +79,7 @@ def test_check_distribution_suggest_uniform(storage_mode: str) -> None:
             trial.suggest_uniform("x", 10, 30)
 
         # we expect exactly one warning (not counting ones caused by deprecation)
-        assert len([r for r in record if r.category != FutureWarning]) == 1
+        assert len([r for r in record if r.category is not FutureWarning]) == 1
 
         with pytest.raises(ValueError):
             trial.suggest_int("x", 10, 20)
@@ -102,8 +102,8 @@ def test_check_distribution_suggest_loguniform(storage_mode: str) -> None:
             trial.suggest_loguniform("x", 10, 20)
             trial.suggest_loguniform("x", 10, 30)
 
-        # we expect exactly one warning (not counting ones caused by deprecation)
-        assert len([r for r in record if r.category != FutureWarning]) == 1
+        # We expect exactly one warning (not counting ones caused by deprecation).
+        assert len([r for r in record if r.category is not FutureWarning]) == 1
 
         with pytest.raises(ValueError):
             trial.suggest_int("x", 10, 20)
@@ -126,8 +126,8 @@ def test_check_distribution_suggest_discrete_uniform(storage_mode: str) -> None:
             trial.suggest_discrete_uniform("x", 10, 20, 2)
             trial.suggest_discrete_uniform("x", 10, 22, 2)
 
-        # we expect exactly one warning (not counting ones caused by deprecation)
-        assert len([r for r in record if r.category != FutureWarning]) == 1
+        # We expect exactly one warning (not counting ones caused by deprecation).
+        assert len([r for r in record if r.category is not FutureWarning]) == 1
 
         with pytest.raises(ValueError):
             trial.suggest_int("x", 10, 20, step=2)
@@ -151,7 +151,7 @@ def test_check_distribution_suggest_int(storage_mode: str, enable_log: bool) -> 
             trial.suggest_int("x", 10, 22, log=enable_log)
 
         # We expect exactly one warning (not counting ones caused by deprecation).
-        assert len([r for r in record if r.category != FutureWarning]) == 1
+        assert len([r for r in record if r.category is not FutureWarning]) == 1
 
         with pytest.raises(ValueError):
             trial.suggest_float("x", 10, 20, log=enable_log)

--- a/tutorial/20_recipes/002_multi_objective.py
+++ b/tutorial/20_recipes/002_multi_objective.py
@@ -131,7 +131,7 @@ optuna.visualization.plot_pareto_front(study, target_names=["FLOPS", "accuracy"]
 print(f"Number of trials on the Pareto front: {len(study.best_trials)}")
 
 trial_with_highest_accuracy = max(study.best_trials, key=lambda t: t.values[1])
-print(f"Trial with highest accuracy: ")
+print("Trial with highest accuracy: ")
 print(f"\tnumber: {trial_with_highest_accuracy.number}")
 print(f"\tparams: {trial_with_highest_accuracy.params}")
 print(f"\tvalues: {trial_with_highest_accuracy.values}")


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

When using `ruff`:  `ruff check tests optuna`, a few minor issues are detected.

## Description of the changes
<!-- Describe the changes in this PR. -->

Fixes ruff errors, mainly the following errors:

> E721 Use `is` and `is not` for type comparisons, or `isinstance()` for isinstance checks

In addition, applies minor code fixes detected by `ruff`