### PR TITLE
Fix the error caused in `plot_contour()` with an impossible pair of variables

### DIFF
--- a/optuna/visualization/_contour.py
+++ b/optuna/visualization/_contour.py
@@ -208,6 +208,9 @@ def _get_contour_subplot(
     x_indices = info.xaxis.indices
     y_indices = info.yaxis.indices
 
+    if len(x_indices) < 2 or len(y_indices) < 2 or len(info.z_values) == 0:
+        return go.Contour(), go.Scatter(), go.Scatter()
+
     feasible = _PlotValues([], [])
     infeasible = _PlotValues([], [])
 
@@ -226,9 +229,6 @@ def _get_contour_subplot(
     zs = np.array(list(info.z_values.values()))
 
     z_values[xys[:, 1], xys[:, 0]] = zs
-
-    if len(x_indices) < 2 or len(y_indices) < 2:
-        return go.Contour(), go.Scatter(), go.Scatter()
 
     contour = go.Contour(
         x=x_indices,

--- a/optuna/visualization/_contour.py
+++ b/optuna/visualization/_contour.py
@@ -4,6 +4,7 @@ import math
 from typing import Any
 from typing import Callable
 from typing import NamedTuple
+import warnings
 
 import numpy as np
 
@@ -208,7 +209,13 @@ def _get_contour_subplot(
     x_indices = info.xaxis.indices
     y_indices = info.yaxis.indices
 
-    if len(x_indices) < 2 or len(y_indices) < 2 or len(info.z_values) == 0:
+    if len(x_indices) < 2 or len(y_indices) < 2:
+        return go.Contour(), go.Scatter(), go.Scatter()
+    if len(info.z_values) == 0:
+        warnings.warn(
+            f"Contour plot will not be displayed because `{info.xaxis.name}` and "
+            f"`{info.yaxis.name}` cannot co-exist in `trial.params`."
+        )
         return go.Contour(), go.Scatter(), go.Scatter()
 
     feasible = _PlotValues([], [])

--- a/tests/visualization_tests/test_visualizations.py
+++ b/tests/visualization_tests/test_visualizations.py
@@ -88,10 +88,6 @@ def test_visualizations_with_single_objectives(
     study.optimize(objective_func, n_trials=20)
 
     # TODO(c-bata): Fix a bug to remove `pytest.xfail`.
-    if plot_func is plot_contour and objective_func is objective_single_dynamic_with_categorical:
-        pytest.xfail("There is a bug that IndexError is raised in plot_contour")
-
-    # TODO(c-bata): Fix a bug to remove `pytest.xfail`.
     if plot_func is matplotlib_plot_rank and objective_func is objective_single_none_categorical:
         pytest.xfail("There is a bug that TypeError is raised in matplotlib.plot_rank")
 


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

This PR aims to: 
- Resolve #5599 

Please check the issue above for more details.

## Description of the changes
<!-- Describe the changes in this PR. -->

- Return an empty plot if a pair of variables cannot exist
- Remove `xfail` from the unit tests because this PR solves the bug
- Add a warning for an impossible variable pair