### PR TITLE
Remove the use of `evaluator.evaluate` function in the example of `PedAnovaImportanceEvaluator`

### DIFF
--- a/optuna/importance/_ped_anova/evaluator.py
+++ b/optuna/importance/_ped_anova/evaluator.py
@@ -114,7 +114,7 @@ class PedAnovaImportanceEvaluator(BaseImportanceEvaluator):
             study = optuna.create_study()
             study.optimize(objective, n_trials=100)
             evaluator = PedAnovaImportanceEvaluator()
-            evaluator.evaluate(study)
+            importance = optuna.importance.get_param_importances(study, evaluator=evaluator)
 
     """
 


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

In `PedAnovaImportanceEvaluator`,  `evaluator.evaluate` function is not meant to be called by library users. However, it was used in the examples within the documentation, which could cause confusion. This PR resolves the issue by replacing it with an implementation that uses `optuna.importance.get_param_importances`.


## Description of the changes
<!-- Describe the changes in this PR. -->

Replaced the implementation with one that uses `optuna.importance.get_param_importances`.
