### PR TITLE
Remove `optuna.samplers.MOTPESampler`

### DIFF
--- a/optuna/samplers/__init__.py
+++ b/optuna/samplers/__init__.py
@@ -26,13 +26,3 @@ __all__ = [
     "GPSampler",
     "nsgaii",
 ]
-
-
-class MOTPESampler:
-    def __init__(self, *args, **kwargs):  # type: ignore[no-untyped-def]
-        # TODO(nabenabe0928): Come up with any ways to remove this file.
-        # NOTE(nabenabe0928): Discuss when to remove this class.
-        raise ImportError(
-            "`MOTPESampler` was removed at v4.0.0. "
-            "Please use `TPESampler` instead or downgrade your Optuna version."
-        )


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
Follow-up https://github.com/optuna/optuna/pull/5390

While the implementation of `MOTPESampler` was removed in #5390, the `optuna.samplers.MOTPESampler` class itself still exists. In my opinion, the existence of `MOTPESampler` is a bit confusing as it may make it difficult to detect errors with mypy or flake8. It would be better to remove it at v4 major release, rather than leaving it in its current state.

## Description of the changes
<!-- Describe the changes in this PR. -->
Remove `MOTPESampler` from `optuna.samplers` module.