### PR TITLE
Remove duplicated definition of license in `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,6 @@ build-backend = "setuptools.build_meta"
 name = "optuna"
 description = "A hyperparameter optimization framework"
 readme = "README.md"
-license = {file = "LICENSE"}
 authors = [
   {name = "Takuya Akiba"}
 ]


### PR DESCRIPTION
## Motivation

In the metadata section of [pypi](https://pypi.org/project/optuna/), the license of optuna is not fully shown.
I think this is because `pyproject.toml` imports the contents of the `LICENSE` file.
Instead, we can use 'classifiers' starting with `License ::` according to [Python packaging user guide](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license).

<img width="290" alt="image" src="https://github.com/user-attachments/assets/591322d4-ee5a-4e0b-9875-5301382028e1">

The related PR of the OptunaHub library is https://github.com/optuna/optunahub/pull/58.


## Description of the changes

This PR stops importing the license file and keeps the [definition in the classifiers](https://github.com/optuna/optuna/blob/569191d1a16d4b5f1e54f59381e1293cbe80af0a/pyproject.toml#L17).
