### PR TITLE
Add `set_trial_user_attrs` method for bulk upsert

### DIFF
--- a/optuna/storages/_base.py
+++ b/optuna/storages/_base.py
@@ -420,6 +420,27 @@ class BaseStorage(abc.ABC):
         raise NotImplementedError
 
     @abc.abstractmethod
+    def set_trial_user_attrs(self, trial_id: int, attrs: dict[str, Any]) -> None:
+        """Set user-defined attributes to a trial.
+
+        This method overwrites any existing attribute.
+
+        Args:
+            trial_id:
+                ID of the trial.
+            attrs:
+                Dictionary of attributes. Keys are attribute keys and values are attribute values.
+                Each attribute value should be JSON serializable.
+
+        Raises:
+            :exc:`KeyError`:
+                If no trial with the matching ``trial_id`` exists.
+            :exc:`RuntimeError`:
+                If the trial is already finished.
+        """
+        raise NotImplementedError
+
+    @abc.abstractmethod
     def set_trial_system_attr(self, trial_id: int, key: str, value: JSONSerializable) -> None:
         """Set an optuna-internal attribute to a trial.
 

--- a/optuna/storages/_cached_storage.py
+++ b/optuna/storages/_cached_storage.py
@@ -190,6 +190,9 @@ class _CachedStorage(BaseStorage, BaseHeartbeat):
     def set_trial_user_attr(self, trial_id: int, key: str, value: Any) -> None:
         self._backend.set_trial_user_attr(trial_id, key=key, value=value)
 
+    def set_trial_user_attrs(self, trial_id: int, attrs: dict[str, Any]) -> None:
+        self._backend.set_trial_user_attrs(trial_id, attrs)
+
     def set_trial_system_attr(self, trial_id: int, key: str, value: JSONSerializable) -> None:
         self._backend.set_trial_system_attr(trial_id, key=key, value=value)
 

--- a/optuna/storages/_in_memory.py
+++ b/optuna/storages/_in_memory.py
@@ -326,6 +326,17 @@ class InMemoryStorage(BaseStorage):
             trial.user_attrs[key] = value
             self._set_trial(trial_id, trial)
 
+    def set_trial_user_attrs(self, trial_id: int, attrs: dict[str, Any]) -> None:
+        with self._lock:
+            self._check_trial_id(trial_id)
+            trial = self._get_trial(trial_id)
+            self.check_trial_is_updatable(trial_id, trial.state)
+
+            trial = copy.copy(trial)
+            trial.user_attrs = copy.copy(trial.user_attrs)
+            trial.user_attrs.update(attrs)
+            self._set_trial(trial_id, trial)
+
     def set_trial_system_attr(self, trial_id: int, key: str, value: JSONSerializable) -> None:
         with self._lock:
             trial = self._get_trial(trial_id)

--- a/optuna/storages/_rdb/storage.py
+++ b/optuna/storages/_rdb/storage.py
@@ -43,7 +43,7 @@ if TYPE_CHECKING:
     import alembic.migration as alembic_migration
     import alembic.script as alembic_script
     import sqlalchemy
-    from sqlalchemy.dialects.mysql import insert as mysql_insert
+    import sqlalchemy.dialects.mysql as sqlalchemy_dialects_mysql
     import sqlalchemy.exc as sqlalchemy_exc
     import sqlalchemy.orm as sqlalchemy_orm
     import sqlalchemy.sql.functions as sqlalchemy_sql_functions
@@ -56,10 +56,10 @@ else:
     alembic_script = _LazyImport("alembic.script")
 
     sqlalchemy = _LazyImport("sqlalchemy")
+    sqlalchemy_dialects_mysql = _LazyImport("sqlalchemy.dialects.mysql")
     sqlalchemy_exc = _LazyImport("sqlalchemy.exc")
     sqlalchemy_orm = _LazyImport("sqlalchemy.orm")
     sqlalchemy_sql_functions = _LazyImport("sqlalchemy.sql.functions")
-    mysql_insert = _LazyImport("sqlalchemy.dialects.mysql.insert")
 
     models = _LazyImport("optuna.storages._rdb.models")
 
@@ -755,7 +755,7 @@ class RDBStorage(BaseStorage, BaseHeartbeat):
         self.check_trial_is_updatable(trial_id, trial.state)
 
         if self.engine.name == "mysql":
-            insert_stmt = mysql_insert(models.TrialUserAttributeModel).values(
+            insert_stmt = sqlalchemy_dialects_mysql.insert(models.TrialUserAttributeModel).values(
                 [
                     {"trial_id": trial_id, "key": key, "value_json": json.dumps(value)}
                     for key, value in attrs.items()

--- a/optuna/storages/journal/_storage.py
+++ b/optuna/storages/journal/_storage.py
@@ -351,6 +351,10 @@ class JournalStorage(BaseStorage):
             self._write_log(JournalOperation.SET_TRIAL_USER_ATTR, log)
             self._sync_with_backend()
 
+    def set_trial_user_attrs(self, trial_id: int, attrs: Dict[str, Any]) -> None:
+        for key, value in attrs.items():
+            self.set_trial_user_attr(trial_id, key, value)
+
     def set_trial_system_attr(self, trial_id: int, key: str, value: JSONSerializable) -> None:
         log: Dict[str, Any] = {
             "trial_id": trial_id,

--- a/optuna/trial/_base.py
+++ b/optuna/trial/_base.py
@@ -98,6 +98,10 @@ class BaseTrial(abc.ABC):
         raise NotImplementedError
 
     @abc.abstractmethod
+    def set_user_attrs(self, attrs: dict[str, Any]) -> None:
+        raise NotImplementedError
+
+    @abc.abstractmethod
     @deprecated_func("3.1.0", "5.0.0")
     def set_system_attr(self, key: str, value: Any) -> None:
         raise NotImplementedError

--- a/optuna/trial/_fixed.py
+++ b/optuna/trial/_fixed.py
@@ -131,6 +131,9 @@ class FixedTrial(BaseTrial):
     def set_user_attr(self, key: str, value: Any) -> None:
         self._user_attrs[key] = value
 
+    def set_user_attrs(self, attrs: dict[str, Any]) -> None:
+        self._user_attrs.update(attrs)
+
     @deprecated_func("3.1.0", "5.0.0")
     def set_system_attr(self, key: str, value: Any) -> None:
         self._system_attrs[key] = value

--- a/optuna/trial/_frozen.py
+++ b/optuna/trial/_frozen.py
@@ -297,6 +297,9 @@ class FrozenTrial(BaseTrial):
     def set_user_attr(self, key: str, value: Any) -> None:
         self._user_attrs[key] = value
 
+    def set_user_attrs(self, attrs: dict[str, Any]) -> None:
+        self._user_attrs.update(attrs)
+
     @deprecated_func("3.1.0", "5.0.0")
     def set_system_attr(self, key: str, value: Any) -> None:
         self._system_attrs[key] = value

--- a/optuna/trial/_trial.py
+++ b/optuna/trial/_trial.py
@@ -535,7 +535,7 @@ class Trial(BaseTrial):
         return self.study.pruner.prune(self.study, trial)
 
     def set_user_attr(self, key: str, value: Any) -> None:
-        """Set user attributes to the trial.
+        """Set a user attribute to the trial.
 
         The user attributes in the trial can be access via :func:`optuna.trial.Trial.user_attrs`.
 
@@ -590,6 +590,23 @@ class Trial(BaseTrial):
 
         self.storage.set_trial_user_attr(self._trial_id, key, value)
         self._cached_frozen_trial.user_attrs[key] = value
+
+    def set_user_attrs(self, attrs: dict[str, Any]) -> None:
+        """Set user attributes to the trial.
+
+        The user attributes in the trial can be access via :func:`optuna.trial.Trial.user_attrs`.
+
+        .. seealso::
+
+            See the recipe on :ref:`attributes`.
+
+        Args:
+            attrs:
+                A dictionary containing the attributes. The keys are attribute names (str) and
+                values are attribute values. The values should be JSON serializable.
+        """
+        self.storage.set_trial_user_attrs(self._trial_id, attrs)
+        self._cached_frozen_trial.user_attrs.update(attrs)
 
     @deprecated_func("3.1.0", "5.0.0")
     def set_system_attr(self, key: str, value: Any) -> None:

--- a/tests/storages_tests/test_storages.py
+++ b/tests/storages_tests/test_storages.py
@@ -685,14 +685,15 @@ def test_set_trial_user_attrs(storage_mode: str) -> None:
 
         # Test overwriting value.
         storage.set_trial_user_attrs(trial_id_1, {"dataset": "ImageNet"})
-        assert storage.get_trial(trial_id_1).user_attrs == EXAMPLE_ATTRS | {"dataset": "ImageNet"}
+        assert storage.get_trial(trial_id_1).user_attrs == dict(EXAMPLE_ATTRS, dataset="ImageNet")
 
         # Test upserting value.
         storage.set_trial_user_attrs(trial_id_1, {"dataset": "MNIST", "new_attr": 0.1})
-        assert storage.get_trial(trial_id_1).user_attrs == EXAMPLE_ATTRS | {
-            "dataset": "MNIST",
-            "new_attr": 0.1,
-        }
+        assert storage.get_trial(trial_id_1).user_attrs == dict(
+            EXAMPLE_ATTRS,
+            dataset="MNIST",
+            new_attr=0.1,
+        )
 
         # Cannot set attributes of non-existent trials.
         non_existent_trial_id = trial_id_1 + 1

--- a/tests/storages_tests/test_with_server.py
+++ b/tests/storages_tests/test_with_server.py
@@ -27,6 +27,8 @@ def objective(trial: optuna.Trial) -> float:
     trial.report(x, 0)
     trial.report(y, 1)
     trial.set_user_attr("x", x)
+    trial.set_user_attr("overwritten_x", x)
+    trial.set_user_attrs({"y": y, "overwritten_x": 2 * x})
     return f(x, y)
 
 
@@ -81,6 +83,20 @@ def _check_trials(trials: Sequence[optuna.trial.FrozenTrial]) -> None:
         np.isclose(
             [trial.user_attrs["x"] for trial in trials],
             [trial.params["x"] for trial in trials],
+            atol=1e-4,
+        ).tolist()
+    )
+    assert all(
+        np.isclose(
+            [trial.user_attrs["y"] for trial in trials],
+            [trial.params["y"] for trial in trials],
+            atol=1e-4,
+        ).tolist()
+    )
+    assert all(
+        np.isclose(
+            [trial.user_attrs["overwritten_x"] for trial in trials],
+            [2 * trial.params["x"] for trial in trials],
             atol=1e-4,
         ).tolist()
     )

--- a/tests/trial_tests/test_trials.py
+++ b/tests/trial_tests/test_trials.py
@@ -191,10 +191,19 @@ def test_not_contained_param(
 
 
 @parametrize_trial_type
-def test_set_user_attrs(trial_type: type) -> None:
+def test_set_user_attr(trial_type: type) -> None:
     trial = _create_trial(trial_type)
     trial.set_user_attr("data", "MNIST")
     assert trial.user_attrs["data"] == "MNIST"
+
+
+@parametrize_trial_type
+def test_set_user_attrs(trial_type: type) -> None:
+    trial = _create_trial(trial_type)
+    trial.set_user_attrs({"data": "MNIST", "score": 0.99})
+    assert len(trial.user_attrs) == 2
+    assert trial.user_attrs["data"] == "MNIST"
+    assert trial.user_attrs["score"] == 0.99
 
 
 @parametrize_trial_type


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

The `set_trial_user_attr` method in `RDBStorage` has two issues:

1. When adding or updating an attribute, the method first checks whether the attribute already exists in the trial. If it does, it updates the value; if not, it adds a new one. This process results in two SQL calls for every single attribute addition or update.
2. The method only accepts a single key-value pair at a time. When adding or updating multiple attributes simultaneously, `set_trial_user_attr` must be called multiple times, leading to unnecessary SQL calls.

This PR addresses these issues by implementing the `set_trial_user_attrs` method. 

## Description of the changes
<!-- Describe the changes in this PR. -->

This PR introduces the `set_trial_user_attrs` method to `BaseStorage` and the `set_user_attrs` method to `BaseTrial`, with their implementations in the respective concrete classes.

However, for `RDBStorage`, this PR only supports MySQL dialect. For other dialects (such as SQLite or PostgreSQL), `set_trial_user_attrs` just internally calls `set_trial_user_attr` repeatedly. These should be addressed in a future follow-up PR.

## Verification of SQL Changes

### Before

```python
import optuna
import logging


optuna.logging.set_verbosity(logging.WARN)

study = optuna.create_study(storage="mysql+pymysql://optuna:password@127.0.0.1:3306/optuna")
storage = study._storage


def objective(trial: optuna.Trial) -> float:
    trial.set_user_attr("user_attr_1", "user_value_1")

    logging.basicConfig()
    logging.getLogger("sqlalchemy.engine").setLevel(logging.INFO)
    trial.set_user_attr("user_attr_1", "new_user_value_1")
    trial.set_user_attr("user_attr_2", "user_value_2")
    trial.set_user_attr("user_attr_3", "user_value_3")
    logging.getLogger("sqlalchemy.engine").setLevel(logging.WARN)

    return trial.suggest_float("x", -10, 10) ** 2


study.optimize(objective, n_trials=1)
```

```
INFO:sqlalchemy.engine.Engine:BEGIN (implicit)
INFO:sqlalchemy.engine.Engine:SELECT trials.trial_id AS trials_trial_id, trials.number AS trials_number, trials.study_id AS trials_study_id, trials.state AS trials_state, trials.datetime_start AS trials_datetime_start, trials.datetime_complete AS trials_datetime_complete 
FROM trials 
WHERE trials.trial_id = %(trial_id_1)s
INFO:sqlalchemy.engine.Engine:[cached since 0.02255s ago] {'trial_id_1': 5145}
INFO:sqlalchemy.engine.Engine:SELECT trial_user_attributes.trial_user_attribute_id AS trial_user_attributes_trial_user_attribute_id, trial_user_attributes.trial_id AS trial_user_attributes_trial_id, trial_user_attributes.`key` AS trial_user_attributes_key, trial_user_attributes.value_json AS trial_user_attributes_value_json 
FROM trial_user_attributes 
WHERE trial_user_attributes.trial_id = %(trial_id_1)s AND trial_user_attributes.`key` = %(key_1)s
INFO:sqlalchemy.engine.Engine:[cached since 0.00741s ago] {'trial_id_1': 5145, 'key_1': 'user_attr_1'}
INFO:sqlalchemy.engine.Engine:UPDATE trial_user_attributes SET value_json=%(value_json)s WHERE trial_user_attributes.trial_user_attribute_id = %(trial_user_attributes_trial_user_attribute_id)s
INFO:sqlalchemy.engine.Engine:[generated in 0.00012s] {'value_json': '"new_user_value_1"', 'trial_user_attributes_trial_user_attribute_id': 323449}
INFO:sqlalchemy.engine.Engine:COMMIT
INFO:sqlalchemy.engine.Engine:BEGIN (implicit)
INFO:sqlalchemy.engine.Engine:SELECT trials.trial_id AS trials_trial_id, trials.number AS trials_number, trials.study_id AS trials_study_id, trials.state AS trials_state, trials.datetime_start AS trials_datetime_start, trials.datetime_complete AS trials_datetime_complete 
FROM trials 
WHERE trials.trial_id = %(trial_id_1)s
INFO:sqlalchemy.engine.Engine:[cached since 0.02998s ago] {'trial_id_1': 5145}
INFO:sqlalchemy.engine.Engine:SELECT trial_user_attributes.trial_user_attribute_id AS trial_user_attributes_trial_user_attribute_id, trial_user_attributes.trial_id AS trial_user_attributes_trial_id, trial_user_attributes.`key` AS trial_user_attributes_key, trial_user_attributes.value_json AS trial_user_attributes_value_json 
FROM trial_user_attributes 
WHERE trial_user_attributes.trial_id = %(trial_id_1)s AND trial_user_attributes.`key` = %(key_1)s
INFO:sqlalchemy.engine.Engine:[cached since 0.01484s ago] {'trial_id_1': 5145, 'key_1': 'user_attr_2'}
INFO:sqlalchemy.engine.Engine:INSERT INTO trial_user_attributes (trial_id, `key`, value_json) VALUES (%(trial_id)s, %(key)s, %(value_json)s)
INFO:sqlalchemy.engine.Engine:[cached since 0.01436s ago] {'trial_id': 5145, 'key': 'user_attr_2', 'value_json': '"user_value_2"'}
INFO:sqlalchemy.engine.Engine:COMMIT
INFO:sqlalchemy.engine.Engine:BEGIN (implicit)
INFO:sqlalchemy.engine.Engine:SELECT trials.trial_id AS trials_trial_id, trials.number AS trials_number, trials.study_id AS trials_study_id, trials.state AS trials_state, trials.datetime_start AS trials_datetime_start, trials.datetime_complete AS trials_datetime_complete 
FROM trials 
WHERE trials.trial_id = %(trial_id_1)s
INFO:sqlalchemy.engine.Engine:[cached since 0.03676s ago] {'trial_id_1': 5145}
INFO:sqlalchemy.engine.Engine:SELECT trial_user_attributes.trial_user_attribute_id AS trial_user_attributes_trial_user_attribute_id, trial_user_attributes.trial_id AS trial_user_attributes_trial_id, trial_user_attributes.`key` AS trial_user_attributes_key, trial_user_attributes.value_json AS trial_user_attributes_value_json 
FROM trial_user_attributes 
WHERE trial_user_attributes.trial_id = %(trial_id_1)s AND trial_user_attributes.`key` = %(key_1)s
INFO:sqlalchemy.engine.Engine:[cached since 0.02183s ago] {'trial_id_1': 5145, 'key_1': 'user_attr_3'}
INFO:sqlalchemy.engine.Engine:INSERT INTO trial_user_attributes (trial_id, `key`, value_json) VALUES (%(trial_id)s, %(key)s, %(value_json)s)
INFO:sqlalchemy.engine.Engine:[cached since 0.02152s ago] {'trial_id': 5145, 'key': 'user_attr_3', 'value_json': '"user_value_3"'}
INFO:sqlalchemy.engine.Engine:COMMIT
```

### After

```python
...
def objective(trial: optuna.Trial) -> float:
    trial.set_user_attr("user_attr_1", "user_value_1")

    logging.basicConfig()
    logging.getLogger("sqlalchemy.engine").setLevel(logging.INFO)
    storage.set_trial_user_attrs(trial._trial_id, {
        "user_attr_1": "new_user_value_1",
        "user_attr_2": "user_value_2",
        "user_attr_3": "user_value_3",
    })
    logging.getLogger("sqlalchemy.engine").setLevel(logging.WARN)

    return trial.suggest_float("x", -10, 10) ** 2
...
```

```
INFO:sqlalchemy.engine.Engine:BEGIN (implicit)
INFO:sqlalchemy.engine.Engine:SELECT trials.trial_id AS trials_trial_id, trials.number AS trials_number, trials.study_id AS trials_study_id, trials.state AS trials_state, trials.datetime_start AS trials_datetime_start, trials.datetime_complete AS trials_datetime_complete 
FROM trials 
WHERE trials.trial_id = %(trial_id_1)s
INFO:sqlalchemy.engine.Engine:[cached since 0.01996s ago] {'trial_id_1': 5144}
INFO:sqlalchemy.engine.Engine:INSERT INTO trial_user_attributes (trial_id, `key`, value_json) VALUES (%(trial_id_m0)s, %(key_m0)s, %(value_json_m0)s), (%(trial_id_m1)s, %(key_m1)s, %(value_json_m1)s), (%(trial_id_m2)s, %(key_m2)s, %(value_json_m2)s) AS new ON DUPLICATE KEY UPDATE value_json = new.value_json
INFO:sqlalchemy.engine.Engine:[no key 0.00013s] {'trial_id_m0': 5144, 'key_m0': 'user_attr_1', 'value_json_m0': '"new_user_value_1"', 'trial_id_m1': 5144, 'key_m1': 'user_attr_2', 'value_json_m1': '"user_value_2"', 'trial_id_m2': 5144, 'key_m2': 'user_attr_3', 'value_json_m2': '"user_value_3"'}
INFO:sqlalchemy.engine.Engine:COMMIT
```

## Performance Check

As shown below, both the number of SQL calls and execution time are expected to improve.

### Implementation with multiple calls to `set_trial_user_attr`

```python
import optuna
import time


def objective(trial: optuna.Trial) -> float:
    for i in range(16):
        trial.set_user_attr(f"attr{i}", f"dummy user attribute value {i}")

    s = 0.0
    for i in range(8):
        s += trial.suggest_float(f"x{i}", -10, 10) ** 2
    return s


start = time.time()

study = optuna.create_study(
    storage="mysql+pymysql://optuna:password@127.0.0.1:3306/optuna",
    sampler=optuna.samplers.RandomSampler()
)
study.optimize(objective, 1000, n_jobs=12)

print(f"Elapsed time: {time.time() - start:.1f} [s]")
```

Execution time: 146.9 [s]

Analysis with `mysqldumpslow`:

```
Count: 33750  Time=0.00s (64s)  Lock=0.00s (0s)  Rows=0.0 (0), optuna[optuna]@[192.168.65.1]
  COMMIT

Count: 36743  Time=0.00s (5s)  Lock=0.00s (0s)  Rows=1.0 (36743), optuna[optuna]@[192.168.65.1]
  SELECT trials.trial_id AS trials_trial_id, trials.number AS trials_number, trials.study_id AS trials_study_id, trials.state AS trials_state, trials.datetime_start AS trials_datetime_start, trials.datetime_complete AS trials_datetime_complete 
  FROM trials 
  WHERE trials.trial_id = N

Count: 1000  Time=0.00s (3s)  Lock=0.00s (0s)  Rows=1.0 (1000), optuna[optuna]@[192.168.65.1]
  SELECT trials.trial_id AS trials_trial_id 
  FROM trials INNER JOIN trial_values ON trials.trial_id = trial_values.trial_id 
  WHERE trials.study_id = N AND trials.state = 'S' AND trial_values.objective = N ORDER BY CASE trial_values.value_type WHEN 'S' THEN -N WHEN 'S' THEN N WHEN 'S' THEN N END ASC, trial_values.value ASC 
  LIMIT N

Count: 16000  Time=0.00s (3s)  Lock=0.00s (0s)  Rows=0.0 (0), optuna[optuna]@[192.168.65.1]
  INSERT INTO trial_user_attributes (trial_id, `key`, value_json) VALUES (N, 'S', 'S')

Count: 16000  Time=0.00s (2s)  Lock=0.00s (0s)  Rows=0.0 (0), optuna[optuna]@[192.168.65.1]
  SELECT trial_user_attributes.trial_user_attribute_id AS trial_user_attributes_trial_user_attribute_id, trial_user_attributes.trial_id AS trial_user_attributes_trial_id, trial_user_attributes.`key` AS trial_user_attributes_key, trial_user_attributes.value_json AS trial_user_attributes_value_json 
  FROM trial_user_attributes 
  WHERE trial_user_attributes.trial_id = N AND trial_user_attributes.`key` = 'S'

Count: 33753  Time=0.00s (2s)  Lock=0.00s (0s)  Rows=0.0 (0), optuna[optuna]@[192.168.65.1]
  ROLLBACK

Count: 8000  Time=0.00s (2s)  Lock=0.00s (0s)  Rows=1.0 (7988), optuna[optuna]@[192.168.65.1]
  SELECT trial_params.param_id AS trial_params_param_id, trial_params.trial_id AS trial_params_trial_id, trial_params.param_name AS trial_params_param_name, trial_params.param_value AS trial_params_param_value, trial_params.distribution_json AS trial_params_distribution_json 
  FROM trial_params INNER JOIN trials ON trials.trial_id = trial_params.trial_id 
  WHERE trials.study_id = N AND trial_params.param_name = 'S' 
  LIMIT N

Count: 33723  Time=0.00s (1s)  Lock=0.00s (0s)  Rows=0.0 (0), optuna[optuna]@[192.168.65.1]
  #

Count: 8000  Time=0.00s (1s)  Lock=0.00s (0s)  Rows=0.0 (0), optuna[optuna]@[192.168.65.1]
  SELECT trial_params.param_id AS trial_params_param_id, trial_params.trial_id AS trial_params_trial_id, trial_params.param_name AS trial_params_param_name, trial_params.param_value AS trial_params_param_value, trial_params.distribution_json AS trial_params_distribution_json 
  FROM trial_params 
  WHERE trial_params.trial_id = N AND trial_params.param_name = 'S'
```

-----

```python
import optuna
import time


def objective(trial: optuna.Trial) -> float:
    for i in range(16):
        trial.set_user_attr(f"attr{i}", f"dummy user attribute value {i}")

    s = 0.0
    for i in range(8):
        s += trial.suggest_float(f"x{i}", -10, 10) ** 2
    return s


start = time.time()

study = optuna.create_study(
    storage="mysql+pymysql://optuna:password@127.0.0.1:3306/optuna",
    sampler=optuna.samplers.RandomSampler()
)
study.optimize(objective, 10000, n_jobs=12)

print(f"Elapsed time: {time.time() - start:.1f} [s]")
```

Execution time: 2109.1 [s]

Analysis with `mysqldumpslow`:

```
Count: 333086  Time=0.00s (668s)  Lock=0.00s (0s)  Rows=0.0 (0), optuna[optuna]@[192.168.65.1]
  COMMIT

Count: 10000  Time=0.04s (420s)  Lock=0.00s (0s)  Rows=1.0 (10000), optuna[optuna]@[192.168.65.1]
  SELECT trials.trial_id AS trials_trial_id 
  FROM trials INNER JOIN trial_values ON trials.trial_id = trial_values.trial_id 
  WHERE trials.study_id = N AND trials.state = 'S' AND trial_values.objective = N ORDER BY CASE trial_values.value_type WHEN 'S' THEN -N WHEN 'S' THEN N WHEN 'S' THEN N END ASC, trial_values.value ASC 
  LIMIT N

Count: 363080  Time=0.00s (62s)  Lock=0.00s (0s)  Rows=1.0 (363080), optuna[optuna]@[192.168.65.1]
  SELECT trials.trial_id AS trials_trial_id, trials.number AS trials_number, trials.study_id AS trials_study_id, trials.state AS trials_state, trials.datetime_start AS trials_datetime_start, trials.datetime_complete AS trials_datetime_complete 
  FROM trials 
  WHERE trials.trial_id = N

Count: 160000  Time=0.00s (34s)  Lock=0.00s (0s)  Rows=0.0 (0), optuna[optuna]@[192.168.65.1]
  INSERT INTO trial_user_attributes (trial_id, `key`, value_json) VALUES (N, 'S', 'S')

Count: 160000  Time=0.00s (28s)  Lock=0.00s (0s)  Rows=0.0 (0), optuna[optuna]@[192.168.65.1]
  SELECT trial_user_attributes.trial_user_attribute_id AS trial_user_attributes_trial_user_attribute_id, trial_user_attributes.trial_id AS trial_user_attributes_trial_id, trial_user_attributes.`key` AS trial_user_attributes_key, trial_user_attributes.value_json AS trial_user_attributes_value_json 
  FROM trial_user_attributes 
  WHERE trial_user_attributes.trial_id = N AND trial_user_attributes.`key` = 'S'

Count: 10000  Time=0.00s (24s)  Lock=0.00s (0s)  Rows=4998.7 (49987459), optuna[optuna]@[192.168.65.1]
  SELECT trials.trial_id AS trials_trial_id 
  FROM trials 
  WHERE trials.study_id = N

Count: 333090  Time=0.00s (23s)  Lock=0.00s (0s)  Rows=0.0 (0), optuna[optuna]@[192.168.65.1]
  ROLLBACK

Count: 80000  Time=0.00s (22s)  Lock=0.00s (0s)  Rows=1.0 (79988), optuna[optuna]@[192.168.65.1]
  SELECT trial_params.param_id AS trial_params_param_id, trial_params.trial_id AS trial_params_trial_id, trial_params.param_name AS trial_params_param_name, trial_params.param_value AS trial_params_param_value, trial_params.distribution_json AS trial_params_distribution_json 
  FROM trial_params INNER JOIN trials ON trials.trial_id = trial_params.trial_id 
  WHERE trials.study_id = N AND trial_params.param_name = 'S' 
  LIMIT N

Count: 10000  Time=0.00s (19s)  Lock=0.00s (0s)  Rows=1.0 (10000), optuna[optuna]@[192.168.65.1]
  SELECT count(trials.trial_id) AS count_1 
  FROM trials 
  WHERE trials.study_id = N AND trials.trial_id < N

Count: 333051  Time=0.00s (14s)  Lock=0.00s (0s)  Rows=0.0 (0), optuna[optuna]@[192.168.65.1]
  #

Count: 80000  Time=0.00s (13s)  Lock=0.00s (0s)  Rows=0.0 (0), optuna[optuna]@[192.168.65.1]
  SELECT trial_params.param_id AS trial_params_param_id, trial_params.trial_id AS trial_params_trial_id, trial_params.param_name AS trial_params_param_name, trial_params.param_value AS trial_params_param_value, trial_params.distribution_json AS trial_params_distribution_json 
  FROM trial_params 
  WHERE trial_params.trial_id = N AND trial_params.param_name = 'S'
```


### Implementation with `set_trial_user_attrs`

```python
import optuna
import time


def objective(trial: optuna.Trial) -> float:
    user_attrs = {f"attr{i}": f"dummy user attribute value {i}" for i in range(16)}
    trial.set_user_attrs(user_attrs)

    s = 0.0
    for i in range(8):
        s += trial.suggest_float(f"x{i}", -10, 10) ** 2
    return s


start = time.time()

study = optuna.create_study(
    storage="mysql+pymysql://optuna:password@127.0.0.1:3306/optuna",
    sampler=optuna.samplers.RandomSampler()
)
study.optimize(objective, 1000, n_jobs=12)

print(f"Elapsed time: {time.time() - start:.1f} [s]")
```

Execution time: 99.3 [s]

Analysis with `mysqldumpslow`:

```
Count: 18549  Time=0.00s (25s)  Lock=0.00s (0s)  Rows=0.0 (0), optuna[optuna]@[192.168.65.1]
  COMMIT

Count: 21499  Time=0.00s (3s)  Lock=0.00s (0s)  Rows=1.0 (21499), optuna[optuna]@[192.168.65.1]
  SELECT trials.trial_id AS trials_trial_id, trials.number AS trials_number, trials.study_id AS trials_study_id, trials.state AS trials_state, trials.datetime_start AS trials_datetime_start, trials.datetime_complete AS trials_datetime_complete 
  FROM trials 
  WHERE trials.trial_id = N

Count: 1000  Time=0.00s (2s)  Lock=0.00s (0s)  Rows=1.0 (1000), optuna[optuna]@[192.168.65.1]
  SELECT trials.trial_id AS trials_trial_id 
  FROM trials INNER JOIN trial_values ON trials.trial_id = trial_values.trial_id 
  WHERE trials.study_id = N AND trials.state = 'S' AND trial_values.objective = N ORDER BY CASE trial_values.value_type WHEN 'S' THEN -N WHEN 'S' THEN N WHEN 'S' THEN N END ASC, trial_values.value ASC 
  LIMIT N

Count: 8000  Time=0.00s (2s)  Lock=0.00s (0s)  Rows=1.0 (7988), optuna[optuna]@[192.168.65.1]
  SELECT trial_params.param_id AS trial_params_param_id, trial_params.trial_id AS trial_params_trial_id, trial_params.param_name AS trial_params_param_name, trial_params.param_value AS trial_params_param_value, trial_params.distribution_json AS trial_params_distribution_json 
  FROM trial_params INNER JOIN trials ON trials.trial_id = trial_params.trial_id 
  WHERE trials.study_id = N AND trial_params.param_name = 'S' 
  LIMIT N

Count: 8000  Time=0.00s (1s)  Lock=0.00s (0s)  Rows=0.0 (0), optuna[optuna]@[192.168.65.1]
  SELECT trial_params.param_id AS trial_params_param_id, trial_params.trial_id AS trial_params_trial_id, trial_params.param_name AS trial_params_param_name, trial_params.param_value AS trial_params_param_value, trial_params.distribution_json AS trial_params_distribution_json 
  FROM trial_params 
  WHERE trial_params.trial_id = N AND trial_params.param_name = 'S'
```

-----

```python
import optuna
import time


def objective(trial: optuna.Trial) -> float:
    user_attrs = {f"attr{i}": f"dummy user attribute value {i}" for i in range(16)}
    trial.set_user_attrs(user_attrs)

    s = 0.0
    for i in range(8):
        s += trial.suggest_float(f"x{i}", -10, 10) ** 2
    return s


start = time.time()

study = optuna.create_study(
    storage="mysql+pymysql://optuna:password@127.0.0.1:3306/optuna",
    sampler=optuna.samplers.RandomSampler()
)
study.optimize(objective, 10000, n_jobs=12)

print(f"Elapsed time: {time.time() - start:.1f} [s]")
```

Execution time: 1524.6 [s]

Analysis with `mysqldumpslow`:

```
Count: 184267  Time=0.00s (257s)  Lock=0.00s (0s)  Rows=0.0 (0), optuna[optuna]@[192.168.65.1]
  COMMIT

Count: 10000  Time=0.01s (109s)  Lock=0.00s (0s)  Rows=1.0 (10000), optuna[optuna]@[192.168.65.1]
  SELECT trials.trial_id AS trials_trial_id 
  FROM trials INNER JOIN trial_values ON trials.trial_id = trial_values.trial_id 
  WHERE trials.study_id = N AND trials.state = 'S' AND trial_values.objective = N ORDER BY CASE trial_values.value_type WHEN 'S' THEN -N WHEN 'S' THEN N WHEN 'S' THEN N END ASC, trial_values.value ASC 
  LIMIT N

Count: 214260  Time=0.00s (33s)  Lock=0.00s (0s)  Rows=1.0 (214260), optuna[optuna]@[192.168.65.1]
  SELECT trials.trial_id AS trials_trial_id, trials.number AS trials_number, trials.study_id AS trials_study_id, trials.state AS trials_state, trials.datetime_start AS trials_datetime_start, trials.datetime_complete AS trials_datetime_complete 
  FROM trials 
  WHERE trials.trial_id = N

Count: 10000  Time=0.00s (28s)  Lock=0.00s (0s)  Rows=1.0 (10000), optuna[optuna]@[192.168.65.1]
  SELECT count(trials.trial_id) AS count_1 
  FROM trials 
  WHERE trials.study_id = N AND trials.trial_id < N

Count: 10000  Time=0.00s (22s)  Lock=0.00s (0s)  Rows=4998.7 (49987095), optuna[optuna]@[192.168.65.1]
  SELECT trials.trial_id AS trials_trial_id 
  FROM trials 
  WHERE trials.study_id = N

Count: 80000  Time=0.00s (20s)  Lock=0.00s (0s)  Rows=1.0 (79942), optuna[optuna]@[192.168.65.1]
  SELECT trial_params.param_id AS trial_params_param_id, trial_params.trial_id AS trial_params_trial_id, trial_params.param_name AS trial_params_param_name, trial_params.param_value AS trial_params_param_value, trial_params.distribution_json AS trial_params_distribution_json 
  FROM trial_params INNER JOIN trials ON trials.trial_id = trial_params.trial_id 
  WHERE trials.study_id = N AND trial_params.param_name = 'S' 
  LIMIT N

Count: 80000  Time=0.00s (12s)  Lock=0.00s (0s)  Rows=0.0 (0), optuna[optuna]@[192.168.65.1]
  SELECT trial_params.param_id AS trial_params_param_id, trial_params.trial_id AS trial_params_trial_id, trial_params.param_name AS trial_params_param_name, trial_params.param_value AS trial_params_param_value, trial_params.distribution_json AS trial_params_distribution_json 
  FROM trial_params 
  WHERE trial_params.trial_id = N AND trial_params.param_name = 'S'
```

## Reference

- https://docs.sqlalchemy.org/en/20/orm/queryguide/dml.html#orm-upsert-statements