### PR TITLE
Add `InMemoryStorage` to document

### DIFF
--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -72,7 +72,7 @@ Can I use Optuna without remote RDB servers?
 
 Yes, it's possible.
 
-In the simplest form, Optuna works with :class:`~optuna.storages.BaseStorage`:
+In the simplest form, Optuna works with :class:`~optuna.storages.InMemoryStorage`:
 
 .. code-block:: python
 
@@ -94,7 +94,7 @@ How can I save and resume studies?
 ----------------------------------------------------
 
 There are two ways of persisting studies, which depend if you are using
-:class:`~optuna.storages.BaseStorage` (default) or remote databases (RDB). In-memory studies can be
+:class:`~optuna.storages.InMemoryStorage` (default) or remote databases (RDB). In-memory studies can be
 saved and loaded like usual Python objects using ``pickle`` or ``joblib``. For
 example, using ``joblib``:
 

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -72,7 +72,7 @@ Can I use Optuna without remote RDB servers?
 
 Yes, it's possible.
 
-In the simplest form, Optuna works with in-memory storage:
+In the simplest form, Optuna works with :class:`~optuna.storages.BaseStorage`:
 
 .. code-block:: python
 
@@ -94,7 +94,7 @@ How can I save and resume studies?
 ----------------------------------------------------
 
 There are two ways of persisting studies, which depend if you are using
-in-memory storage (default) or remote databases (RDB). In-memory studies can be
+:class:`~optuna.storages.BaseStorage` (default) or remote databases (RDB). In-memory studies can be
 saved and loaded like usual Python objects using ``pickle`` or ``joblib``. For
 example, using ``joblib``:
 

--- a/docs/source/reference/storages.rst
+++ b/docs/source/reference/storages.rst
@@ -13,6 +13,7 @@ The :mod:`~optuna.storages` module defines a :class:`~optuna.storages.BaseStorag
    optuna.storages.RetryFailedTrialCallback
    optuna.storages.fail_stale_trials
    optuna.storages.JournalStorage
+   optuna.storages.InMemoryStorage
 
 optuna.storages.journal
 -----------------------

--- a/docs/source/reference/storages.rst
+++ b/docs/source/reference/storages.rst
@@ -3,7 +3,7 @@
 optuna.storages
 ===============
 
-The :mod:`~optuna.storages` module defines a :class:`~optuna.storages.BaseStorage` class which abstracts a backend database and provides library-internal interfaces to the read/write histories of the studies and trials. Library users who wish to use storage solutions other than the default in-memory storage should use one of the child classes of :class:`~optuna.storages.BaseStorage` documented below.
+The :mod:`~optuna.storages` module defines a :class:`~optuna.storages.BaseStorage` class which abstracts a backend database and provides library-internal interfaces to the read/write histories of the studies and trials. Library users who wish to use storage solutions other than the default :class:`~optuna.storages.InMemoryStorage` should use one of the child classes of :class:`~optuna.storages.BaseStorage` documented below.
 
 .. autosummary::
    :toctree: generated/

--- a/optuna/search_space/group_decomposed.py
+++ b/optuna/search_space/group_decomposed.py
@@ -51,8 +51,10 @@ class _GroupDecomposedSearchSpace:
         if self._study_id is None:
             self._study_id = study._study_id
         else:
-            # Note that the check below is meaningless when :class:`~optuna.storages.InMemoryStorage` is used
-            # because :func:`~optuna.storages.InMemoryStorage.create_new_study` always returns the same study ID.
+            # Note that the check below is meaningless when
+            # :class:`~optuna.storages.InMemoryStorage` is used because
+            # :func:`~optuna.storages.InMemoryStorage.create_new_study`
+            # always returns the same study ID.
             if self._study_id != study._study_id:
                 raise ValueError("`_GroupDecomposedSearchSpace` cannot handle multiple studies.")
 

--- a/optuna/search_space/group_decomposed.py
+++ b/optuna/search_space/group_decomposed.py
@@ -51,8 +51,8 @@ class _GroupDecomposedSearchSpace:
         if self._study_id is None:
             self._study_id = study._study_id
         else:
-            # Note that the check below is meaningless when `InMemoryStorage` is used
-            # because `InMemoryStorage.create_new_study` always returns the same study ID.
+            # Note that the check below is meaningless when :class:`~optuna.storages.InMemoryStorage` is used
+            # because :func:`~optuna.storages.InMemoryStorage.create_new_study` always returns the same study ID.
             if self._study_id != study._study_id:
                 raise ValueError("`_GroupDecomposedSearchSpace` cannot handle multiple studies.")
 

--- a/optuna/search_space/intersection.py
+++ b/optuna/search_space/intersection.py
@@ -96,8 +96,8 @@ class IntersectionSearchSpace:
         if self._study_id is None:
             self._study_id = study._study_id
         else:
-            # Note that the check below is meaningless when `InMemoryStorage` is used
-            # because `InMemoryStorage.create_new_study` always returns the same study ID.
+            # Note that the check below is meaningless when :class:`~optuna.storages.InMemoryStorage` is used
+            # because :func:`~optuna.storages.InMemoryStorage.create_new_study` always returns the same study ID.
             if self._study_id != study._study_id:
                 raise ValueError("`IntersectionSearchSpace` cannot handle multiple studies.")
 

--- a/optuna/search_space/intersection.py
+++ b/optuna/search_space/intersection.py
@@ -96,8 +96,10 @@ class IntersectionSearchSpace:
         if self._study_id is None:
             self._study_id = study._study_id
         else:
-            # Note that the check below is meaningless when :class:`~optuna.storages.InMemoryStorage` is used
-            # because :func:`~optuna.storages.InMemoryStorage.create_new_study` always returns the same study ID.
+            # Note that the check below is meaningless when
+            # :class:`~optuna.storages.InMemoryStorage` is used because
+            # :func:`~optuna.storages.InMemoryStorage.create_new_study`
+            # always returns the same study ID.
             if self._study_id != study._study_id:
                 raise ValueError("`IntersectionSearchSpace` cannot handle multiple studies.")
 

--- a/optuna/storages/_in_memory.py
+++ b/optuna/storages/_in_memory.py
@@ -39,6 +39,7 @@ class InMemoryStorage(BaseStorage):
                 x = trial.suggest_float("x", -100, 100)
                 return x**2
 
+
             storage = optuna.storages.InMemoryStorage()
 
             study = optuna.create_study(storage=storage)

--- a/optuna/storages/_in_memory.py
+++ b/optuna/storages/_in_memory.py
@@ -26,7 +26,23 @@ _logger = optuna.logging.get_logger(__name__)
 class InMemoryStorage(BaseStorage):
     """Storage class that stores data in memory of the Python process.
 
-    This class is not supposed to be directly accessed by library users.
+    Example:
+
+        Create an :class:`~optuna.storages.InMemoryStorage` instance.
+
+        .. testcode::
+
+            import optuna
+
+
+            def objective(trial):
+                x = trial.suggest_float("x", -100, 100)
+                return x**2
+
+            storage = optuna.storages.InMemoryStorage()
+
+            study = optuna.create_study(storage=storage)
+            study.optimize(objective, n_trials=10)
     """
 
     def __init__(self) -> None:

--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -1176,7 +1176,7 @@ def create_study(
 
     Args:
         storage:
-            Database URL. If this argument is set to None, in-memory storage is used, and the
+            Database URL. If this argument is set to None, :class:`~optuna.storages.BaseStorage` is used, and the
             :class:`~optuna.study.Study` will not be persistent.
 
             .. note::

--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -1176,8 +1176,9 @@ def create_study(
 
     Args:
         storage:
-            Database URL. If this argument is set to None, :class:`~optuna.storages.InMemoryStorage`
-            is used, and the :class:`~optuna.study.Study` will not be persistent.
+            Database URL. If this argument is set to None,
+            :class:`~optuna.storages.InMemoryStorage` is used, and the
+            :class:`~optuna.study.Study` will not be persistent.
 
             .. note::
                 When a database URL is passed, Optuna internally uses `SQLAlchemy`_ to handle

--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -1176,7 +1176,7 @@ def create_study(
 
     Args:
         storage:
-            Database URL. If this argument is set to None, :class:`~optuna.storages.BaseStorage`
+            Database URL. If this argument is set to None, :class:`~optuna.storages.InMemoryStorage`
             is used, and the :class:`~optuna.study.Study` will not be persistent.
 
             .. note::

--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -1176,8 +1176,8 @@ def create_study(
 
     Args:
         storage:
-            Database URL. If this argument is set to None, :class:`~optuna.storages.BaseStorage` is used, and the
-            :class:`~optuna.study.Study` will not be persistent.
+            Database URL. If this argument is set to None, :class:`~optuna.storages.BaseStorage`
+            is used, and the :class:`~optuna.study.Study` will not be persistent.
 
             .. note::
                 When a database URL is passed, Optuna internally uses `SQLAlchemy`_ to handle

--- a/tests/study_tests/test_study.py
+++ b/tests/study_tests/test_study.py
@@ -364,7 +364,7 @@ def test_create_study(storage_mode: str) -> None:
 def test_load_study(storage_mode: str) -> None:
     with StorageSupplier(storage_mode) as storage:
         if storage is None:
-            # `InMemoryStorage` can not be used with `load_study` function.
+            # :class:`~optuna.storages.InMemoryStorage` can not be used with `load_study` function.
             return
 
         study_name = str(uuid.uuid4())
@@ -385,7 +385,7 @@ def test_load_study(storage_mode: str) -> None:
 def test_load_study_study_name_none(storage_mode: str) -> None:
     with StorageSupplier(storage_mode) as storage:
         if storage is None:
-            # `InMemoryStorage` can not be used with `load_study` function.
+            # :class:`~optuna.storages.InMemoryStorage` can not be used with `load_study` function.
             return
 
         study_name = str(uuid.uuid4())


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

Currently, there are no reference of `InMemoryStorage` in [`optuna.storage` API reference](https://optuna.readthedocs.io/en/stable/reference/storages.html).

<img width="90%" alt="Screenshot 2024-09-17 at 17 43 08" src="https://github.com/user-attachments/assets/34ecf974-b779-4d46-8259-a75bcb074468">

<img width="50%" alt="Screenshot 2024-09-17 at 17 47 30" src="https://github.com/user-attachments/assets/81803a65-0d99-432b-acf3-e30983ae2e34">

## Description of the changes
<!-- Describe the changes in this PR. -->

- Add `optuna.storages.InMemoryStorage` to optuna.storages sections of [`storages.rst`](https://github.com/optuna/optuna/blob/5f9d9216b44cd692bb7bf2ede76f75b3cc063927/docs/source/reference/storages.rst?plain=1).
 
 https://github.com/optuna/optuna/blob/5f9d9216b44cd692bb7bf2ede76f75b3cc063927/docs/source/reference/storages.rst?plain=1#L3-L15

- Use `:class:~optuna.storages.BaseStorage` in docs for in-memory storage.
