### PR TITLE
Update MySQL version in CI from 5.7 to 8

### DIFF
--- a/.github/workflows/tests-storage.yml
+++ b/.github/workflows/tests-storage.yml
@@ -36,7 +36,7 @@ jobs:
 
     services:
       mysql:
-        image: mysql:5.7
+        image: mysql:8
         ports:
           - 3306:3306
         env:


### PR DESCRIPTION
## Motivation
MySQL 5.7 already reached the end of life, and users are encouraged to migrate to MySQL 8.
https://www.mysql.com/news-and-events/web-seminars/migrating-from-mysql-5-7-to-mysql-8/

MySQL 9 has already been released, but since it was released recently and MySQL 8 may still be more popular, MySQL 8 would be a better choice for the CI.

## Description of the changes
- Update MySQL version in CI from 5.7 to 8