### PR TITLE
Update PostgreSQL version in CI to latest

### DIFF
--- a/.github/workflows/tests-storage.yml
+++ b/.github/workflows/tests-storage.yml
@@ -50,7 +50,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
       postgres:
-        image: postgres:10.1-alpine
+        image: postgres:latest
         ports:
           - 5432:5432
         env:


### PR DESCRIPTION
## Motivation
The current CI uses PostgreSQL 10.1, but it has already reached the end of life.
https://www.postgresql.org/support/versioning/

## Description of the changes
This PR updates the PostgreSQL version in CI to the latest.