### PR TITLE
Fix broken link in the artifacts tutorial

### DIFF
--- a/tutorial/20_recipes/012_artifact_tutorial.py
+++ b/tutorial/20_recipes/012_artifact_tutorial.py
@@ -42,7 +42,7 @@ are not suitable for storing large data. With Optuna's artifact module, users ca
 chemical structures, image and audio data, etc.) for each trial.
 
 Also, while this tutorial does not touch upon it, it's possible to manage artifacts associated not only with trials but also with
-studies. Please refer to the `official documentation <https://optuna.readthedocs.io/en/stable/reference/generated/optuna.artifacts.upload_artifact.html>`__
+studies. Please refer to the `official documentation <https://optuna.readthedocs.io/en/stable/reference/artifacts.html#optuna.artifacts.upload_artifact>`__
 if you are interested in.
 
 Situations where artifacts are useful


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

The link to the "official documentation" in [the Concepts section of the artifact tutorial](https://optuna.readthedocs.io/en/stable/tutorial/20_recipes/012_artifact_tutorial.html#concepts) is broken.

<img width="495" alt="Screenshot 2024-09-20 at 18 04 28" src="https://github.com/user-attachments/assets/5ac52764-99bd-4e1c-ae5c-7f2437cf3c39">


## Description of the changes
<!-- Describe the changes in this PR. -->

- Fixed [the broken link](https://optuna.readthedocs.io/en/stable/reference/generated/optuna.artifacts.upload_artifact.html) by updating it to [the correct one](https://optuna.readthedocs.io/en/stable/reference/artifacts.html#optuna.artifacts.upload_artifact).
