### PR TITLE
Add a comment for an unexpected bug in `CategoricalDistribution`

### DIFF
--- a/optuna/distributions.py
+++ b/optuna/distributions.py
@@ -530,6 +530,10 @@ class CategoricalDistribution(BaseDistribution):
 
     def to_internal_repr(self, param_value_in_external_repr: CategoricalChoiceType) -> float:
         try:
+            # NOTE(nabenabe): With this implementation, we cannot distinguish some values
+            # such as True and 1, or 1.0 and 1. For example, if choices=[True, 1] and external_repr
+            # is 1, this method wrongly returns 0 instead of 1. However, we decided to accept this
+            # bug for such exceptional choices for less complexity and faster processing.
             return self.choices.index(param_value_in_external_repr)
         except ValueError:  # ValueError: param_value_in_external_repr is not in choices.
             # ValueError also happens if external_repr is nan or includes precision error in float.


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

Here is the unexpected error that has existed since the Optuna v0.0.1.

```python
import optuna

d = optuna.distributions.CategoricalDistribution([1, 1.0, True])

print(d.to_internal_repr(1))  # Return: 0, Expected: 0.
print(d.to_internal_repr(1.0))  # Return: 0, Expected: 1.
print(d.to_internal_repr(True))  # Return: 0, Expected: 2.
```

As this bug has existed such a long time and has not really been a problem, we decided to accept this bug for less complexity and better processing speed.

However, since this statement may be raised by some other developers or users again, I added a comment about this decision. 

## Description of the changes
<!-- Describe the changes in this PR. -->

- Add a comment line about our decision