### PR TITLE
Reduce `SELECT` statements by using outer join

### DIFF
--- a/optuna/storages/_rdb/models.py
+++ b/optuna/storages/_rdb/models.py
@@ -239,17 +239,28 @@ class TrialModel(BaseModel):
 
     @classmethod
     def find_or_raise_by_id(
-        cls, trial_id: int, session: orm.Session, for_update: bool = False
+        cls,
+        trial_id: int,
+        session: orm.Session,
+        for_update: bool = False,
+        include_trial_values: bool = False,
+        include_trial_params: bool = False,
+        include_trial_user_attributes: bool = False,
+        include_trial_system_attributes: bool = False,
+        include_trial_intermediate_values: bool = False,
     ) -> "TrialModel":
-        query = (
-            session.query(cls)
-            .options(orm.joinedload(cls.values))
-            .options(orm.joinedload(cls.params))
-            .options(orm.joinedload(cls.user_attributes))
-            .options(orm.joinedload(cls.system_attributes))
-            .options(orm.joinedload(cls.intermediate_values))
-            .filter(cls.trial_id == trial_id)
-        )
+        query = session.query(cls)
+        if include_trial_values:
+            query = query.options(orm.joinedload(cls.values))
+        if include_trial_params:
+            query = query.options(orm.joinedload(cls.params))
+        if include_trial_user_attributes:
+            query = query.options(orm.joinedload(cls.user_attributes))
+        if include_trial_system_attributes:
+            query = query.options(orm.joinedload(cls.system_attributes))
+        if include_trial_intermediate_values:
+            query = query.options(orm.joinedload(cls.intermediate_values))
+        query = query.filter(cls.trial_id == trial_id)
 
         # "FOR UPDATE" clause is used for row-level locking.
         # Please note that SQLite3 doesn't support this clause.

--- a/optuna/storages/_rdb/models.py
+++ b/optuna/storages/_rdb/models.py
@@ -241,7 +241,15 @@ class TrialModel(BaseModel):
     def find_or_raise_by_id(
         cls, trial_id: int, session: orm.Session, for_update: bool = False
     ) -> "TrialModel":
-        query = session.query(cls).filter(cls.trial_id == trial_id)
+        query = (
+            session.query(cls)
+            .options(orm.joinedload(cls.values))
+            .options(orm.joinedload(cls.params))
+            .options(orm.joinedload(cls.user_attributes))
+            .options(orm.joinedload(cls.system_attributes))
+            .options(orm.joinedload(cls.intermediate_values))
+            .filter(cls.trial_id == trial_id)
+        )
 
         # "FOR UPDATE" clause is used for row-level locking.
         # Please note that SQLite3 doesn't support this clause.

--- a/optuna/storages/_rdb/storage.py
+++ b/optuna/storages/_rdb/storage.py
@@ -780,7 +780,15 @@ class RDBStorage(BaseStorage, BaseHeartbeat):
 
     def get_trial(self, trial_id: int) -> FrozenTrial:
         with _create_scoped_session(self.scoped_session) as session:
-            trial_model = models.TrialModel.find_or_raise_by_id(trial_id, session)
+            trial_model = models.TrialModel.find_or_raise_by_id(
+                trial_id,
+                session,
+                include_trial_values=True,
+                include_trial_params=True,
+                include_trial_user_attributes=True,
+                include_trial_system_attributes=True,
+                include_trial_intermediate_values=True,
+            )
             frozen_trial = self._build_frozen_trial_from_trial_model(trial_model)
 
         return frozen_trial

--- a/optuna/storages/_rdb/storage.py
+++ b/optuna/storages/_rdb/storage.py
@@ -607,8 +607,7 @@ class RDBStorage(BaseStorage, BaseHeartbeat):
                 param_value=param_value_internal,
                 distribution_json=distributions.distribution_to_json(distribution),
             )
-
-            trial_param.check_and_add(session)
+            session.add(trial_param)
 
     def _check_and_set_param_distribution(
         self,

--- a/optuna/storages/_rdb/storage.py
+++ b/optuna/storages/_rdb/storage.py
@@ -607,7 +607,8 @@ class RDBStorage(BaseStorage, BaseHeartbeat):
                 param_value=param_value_internal,
                 distribution_json=distributions.distribution_to_json(distribution),
             )
-            session.add(trial_param)
+
+            trial_param.check_and_add(session)
 
     def _check_and_set_param_distribution(
         self,


### PR DESCRIPTION
## Motivation 

This PR is motivated by the desire to improve performance by reducing the number of unnecessary `SELECT` statements being executed in the basic optimization flow.

## Description of the changes

- In `RDBStorage.get_trial`, individual queries were being executed due to lazy loading when creating `frozen_trial` right after retrieving `trial`. I modified this to use an outer join, which eliminates the need for these separate queries.

## Verification of reduced `SELECT` statements

```python
import optuna
import logging

optuna.logging.set_verbosity(optuna.logging.WARNING)

study = optuna.create_study(storage="mysql+pymysql://optuna:password@127.0.0.1:3306/optuna")


def objective(trial: optuna.Trial) -> float:
    s = 0.0
    for i in range(8):
        s += trial.suggest_float(f"x{i}", 0.0, 1.0)
    return s


logging.basicConfig()
logging.getLogger("sqlalchemy.engine").setLevel(logging.INFO)
study.optimize(objective, n_trials=1)
```

```bash
❯ python mysql_optimize.py 2>! tmp.txt
❯ grep -o SELECT tmp.txt | wc -l
```

### Number of `SELECT` statements

Before the change: 66
After the change: 51
