### PR TITLE
Introduce `UPSERT` in `set_trial_user_attr`

### DIFF
--- a/.github/workflows/tests-with-minimum-versions.yml
+++ b/.github/workflows/tests-with-minimum-versions.yml
@@ -70,7 +70,7 @@ jobs:
       run: |
         # Install dependencies with minimum versions.
         pip uninstall -y alembic cmaes packaging sqlalchemy plotly scikit-learn pillow
-        pip install alembic==1.5.0 cmaes==0.10.0 packaging==20.0 sqlalchemy==1.3.0 tqdm==4.27.0 colorlog==0.3 PyYAML==5.1 'pillow<10.4.0'
+        pip install alembic==1.5.0 cmaes==0.10.0 packaging==20.0 sqlalchemy==1.4.0 tqdm==4.27.0 colorlog==0.3 PyYAML==5.1 'pillow<10.4.0'
         pip uninstall -y matplotlib pandas scipy
         # Python v3.6 was dropped at NumPy v1.20.3.
         if [ "${{ matrix.python-version }}" = "3.7" ]; then

--- a/.github/workflows/tests-with-minimum-versions.yml
+++ b/.github/workflows/tests-with-minimum-versions.yml
@@ -70,7 +70,7 @@ jobs:
       run: |
         # Install dependencies with minimum versions.
         pip uninstall -y alembic cmaes packaging sqlalchemy plotly scikit-learn pillow
-        pip install alembic==1.5.0 cmaes==0.10.0 packaging==20.0 sqlalchemy==1.4.0 tqdm==4.27.0 colorlog==0.3 PyYAML==5.1 'pillow<10.4.0'
+        pip install alembic==1.5.0 cmaes==0.10.0 packaging==20.0 sqlalchemy==1.4.2 tqdm==4.27.0 colorlog==0.3 PyYAML==5.1 'pillow<10.4.0'
         pip uninstall -y matplotlib pandas scipy
         # Python v3.6 was dropped at NumPy v1.20.3.
         if [ "${{ matrix.python-version }}" = "3.7" ]; then

--- a/optuna/storages/_rdb/storage.py
+++ b/optuna/storages/_rdb/storage.py
@@ -9,6 +9,7 @@ import json
 import logging
 import os
 import random
+import sqlite3
 import time
 from typing import Any
 from typing import Callable
@@ -745,7 +746,7 @@ class RDBStorage(BaseStorage, BaseHeartbeat):
                 value_json=mysql_insert_stmt.inserted.value_json
             )
             session.execute(mysql_upsert_stmt)
-        elif self.engine.name == "sqlite":
+        elif self.engine.name == "sqlite" and sqlite3.sqlite_version_info >= (3, 24, 0):
             sqlite_insert_stmt = sqlalchemy_dialects_sqlite.insert(
                 models.TrialUserAttributeModel
             ).values(trial_id=trial_id, key=key, value_json=json.dumps(value))

--- a/optuna/storages/_rdb/storage.py
+++ b/optuna/storages/_rdb/storage.py
@@ -758,6 +758,7 @@ class RDBStorage(BaseStorage, BaseHeartbeat):
             )
             session.execute(upsert_stmt)
         else:
+            # TODO(porink0424): Add support for other databases, e.g., PostgreSQL.
             attribute = models.TrialUserAttributeModel.find_by_trial_and_key(trial, key, session)
             if attribute is None:
                 attribute = models.TrialUserAttributeModel(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
   "colorlog",
   "numpy",
   "packaging>=20.0",
-  "sqlalchemy>=1.4.0",
+  "sqlalchemy>=1.4.2",
   "tqdm",
   "PyYAML",  # Only used in `optuna/cli.py`.
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
   "colorlog",
   "numpy",
   "packaging>=20.0",
-  "sqlalchemy>=1.3.0",
+  "sqlalchemy>=1.4.0",
   "tqdm",
   "PyYAML",  # Only used in `optuna/cli.py`.
 ]


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

When adding or updating an attribute, the method first checks whether the attribute already exists in the trial. If it does, it updates the value; if not, it adds a new one. This process results in two SQL calls for every single attribute addition or update.
This PR addresses this issue by combining two queries into one by using `UPSERT`.

## Description of the changes
<!-- Describe the changes in this PR. -->

- Since the implementation of `UPSERT` differs across databases, I implemented conditonal handling within `_set_trial_user_attr_without_commit`. 
  - Note that PostgreSQL is not yet supported, and this should be implemented in a follow-up PR.
- SQLAlchemy versions below v1.4.0 [do not have `insert` function](https://github.com/sqlalchemy/sqlalchemy/blob/rel_1_3_24/lib/sqlalchemy/dialects/sqlite/__init__.py) in `sqlalchemy.dialects.sqlite`, which causes [an error](https://github.com/optuna/optuna/actions/runs/11290270102/job/31401781464?pr=5703). To fix this, I have updated SQLAlchemy to v1.4.2. 
  - Since SQLAlchemy v1.4.0 [supports Python 3.7 or upper](https://github.com/sqlalchemy/sqlalchemy/blob/rel_1_4_0/setup.cfg), which Optuna also needs to support, I believe this change will not cause any issues for Optuna.
  - Note that I am specifying v1.4.2 instead of v1.4.0 because some tests encounter [a bug in SQLAlchemy v1.4.0](https://github.com/sqlalchemy/sqlalchemy/issues/6097), which is resolved in v1.4.2.

## Verification of SQL Changes

### mysql

```python
import optuna
import logging

optuna.logging.set_verbosity(optuna.logging.WARNING)

study = optuna.create_study(storage="mysql+pymysql://optuna:password@127.0.0.1:3306/optuna")
storage = study._storage


def objective(trial: optuna.Trial) -> float:
    trial.set_user_attr("user_attr_1", "value_1")

    logging.basicConfig()
    logging.getLogger("sqlalchemy.engine").setLevel(logging.INFO)
    trial.set_user_attr("user_attr_1", "new_value_1")
    trial.set_user_attr("user_attr_2", "value_2")
    logging.getLogger("sqlalchemy.engine").setLevel(logging.WARNING)

    return trial.suggest_float("x", 0.0, 1.0) ** 2


study.optimize(objective, n_trials=1)
```

I confirmed that the `SELECT` statement issued with each call to `set_trial_user_attr` has been eliminated and integrated into the `INSERT INTO ... ON DUPLICATE KEY UPDATE ...` statement.
Only the differences are shown below:

#### Before

```
...
INFO:sqlalchemy.engine.Engine:SELECT trial_user_attributes.trial_user_attribute_id AS trial_user_attributes_trial_user_attribute_id, trial_user_attributes.trial_id AS trial_user_attributes_trial_id, trial_user_attributes.`key` AS trial_user_attributes_key, trial_user_attributes.value_json AS trial_user_attributes_value_json 
FROM trial_user_attributes 
WHERE trial_user_attributes.trial_id = %(trial_id_1)s AND trial_user_attributes.`key` = %(key_1)s
INFO:sqlalchemy.engine.Engine:[cached since 0.005871s ago] {'trial_id_1': 163, 'key_1': 'user_attr_1'}
INFO:sqlalchemy.engine.Engine:UPDATE trial_user_attributes SET value_json=%(value_json)s WHERE trial_user_attributes.trial_user_attribute_id = %(trial_user_attributes_trial_user_attribute_id)s
INFO:sqlalchemy.engine.Engine:[generated in 0.00011s] {'value_json': '"new_value_1"', 'trial_user_attributes_trial_user_attribute_id': 4}
...
INFO:sqlalchemy.engine.Engine:SELECT trial_user_attributes.trial_user_attribute_id AS trial_user_attributes_trial_user_attribute_id, trial_user_attributes.trial_id AS trial_user_attributes_trial_id, trial_user_attributes.`key` AS trial_user_attributes_key, trial_user_attributes.value_json AS trial_user_attributes_value_json 
FROM trial_user_attributes 
WHERE trial_user_attributes.trial_id = %(trial_id_1)s AND trial_user_attributes.`key` = %(key_1)s
INFO:sqlalchemy.engine.Engine:[cached since 0.01159s ago] {'trial_id_1': 163, 'key_1': 'user_attr_2'}
INFO:sqlalchemy.engine.Engine:INSERT INTO trial_user_attributes (trial_id, `key`, value_json) VALUES (%(trial_id)s, %(key)s, %(value_json)s)
INFO:sqlalchemy.engine.Engine:[cached since 0.01137s ago] {'trial_id': 163, 'key': 'user_attr_2', 'value_json': '"value_2"'}
...
```

#### After

```
...
INFO:sqlalchemy.engine.Engine:INSERT INTO trial_user_attributes (trial_id, `key`, value_json) VALUES (%(trial_id)s, %(key)s, %(value_json)s) AS new ON DUPLICATE KEY UPDATE value_json = new.value_json
INFO:sqlalchemy.engine.Engine:[no key 0.00009s] {'trial_id': 162, 'key': 'user_attr_1', 'value_json': '"new_value_1"'}
...
INFO:sqlalchemy.engine.Engine:INSERT INTO trial_user_attributes (trial_id, `key`, value_json) VALUES (%(trial_id)s, %(key)s, %(value_json)s) AS new ON DUPLICATE KEY UPDATE value_json = new.value_json
INFO:sqlalchemy.engine.Engine:[no key 0.00009s] {'trial_id': 162, 'key': 'user_attr_2', 'value_json': '"value_2"'}
...
```

### sqlite

```python
...
study = optuna.create_study(storage="sqlite:///example.db")
...
```

#### Before

```
...
INFO:sqlalchemy.engine.Engine:SELECT trial_user_attributes.trial_user_attribute_id AS trial_user_attributes_trial_user_attribute_id, trial_user_attributes.trial_id AS trial_user_attributes_trial_id, trial_user_attributes."key" AS trial_user_attributes_key, trial_user_attributes.value_json AS trial_user_attributes_value_json 
FROM trial_user_attributes 
WHERE trial_user_attributes.trial_id = ? AND trial_user_attributes."key" = ?
INFO:sqlalchemy.engine.Engine:[cached since 0.003007s ago] (1, 'user_attr_1')
INFO:sqlalchemy.engine.Engine:UPDATE trial_user_attributes SET value_json=? WHERE trial_user_attributes.trial_user_attribute_id = ?
INFO:sqlalchemy.engine.Engine:[generated in 0.00010s] ('"new_value_1"', 1)
...
INFO:sqlalchemy.engine.Engine:SELECT trial_user_attributes.trial_user_attribute_id AS trial_user_attributes_trial_user_attribute_id, trial_user_attributes.trial_id AS trial_user_attributes_trial_id, trial_user_attributes."key" AS trial_user_attributes_key, trial_user_attributes.value_json AS trial_user_attributes_value_json 
FROM trial_user_attributes 
WHERE trial_user_attributes.trial_id = ? AND trial_user_attributes."key" = ?
INFO:sqlalchemy.engine.Engine:[cached since 0.005931s ago] (1, 'user_attr_2')
INFO:sqlalchemy.engine.Engine:INSERT INTO trial_user_attributes (trial_id, "key", value_json) VALUES (?, ?, ?)
INFO:sqlalchemy.engine.Engine:[cached since 0.005662s ago] (1, 'user_attr_2', '"value_2"')
...
```

#### After

```
...
INFO:sqlalchemy.engine.Engine:INSERT INTO trial_user_attributes (trial_id, "key", value_json) VALUES (?, ?, ?) ON CONFLICT (trial_id, "key") DO UPDATE SET value_json = excluded.value_json
INFO:sqlalchemy.engine.Engine:[no key 0.00009s] (1, 'user_attr_1', '"new_value_1"')
...
INFO:sqlalchemy.engine.Engine:INSERT INTO trial_user_attributes (trial_id, "key", value_json) VALUES (?, ?, ?) ON CONFLICT (trial_id, "key") DO UPDATE SET value_json = excluded.value_json
INFO:sqlalchemy.engine.Engine:[no key 0.00009s] (1, 'user_attr_2', '"value_2"')
...
```
