### PR TITLE
Fix for mypy.

### DIFF
--- a/optuna/_convert_positional_args.py
+++ b/optuna/_convert_positional_args.py
@@ -80,7 +80,7 @@ def convert_positional_args(
 
             kwargs.update(inferred_kwargs)
 
-            return func(**kwargs)
+            return func(**kwargs)  # type: ignore
 
         return converter_wrapper
 

--- a/optuna/_convert_positional_args.py
+++ b/optuna/_convert_positional_args.py
@@ -80,7 +80,7 @@ def convert_positional_args(
 
             kwargs.update(inferred_kwargs)
 
-            return func(**kwargs)  # type: ignore
+            return func(**kwargs)  # type: ignore[call-arg]
 
         return converter_wrapper
 

--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -1091,8 +1091,7 @@ class Study:
                     if isinstance(param_value, Real)
                     else param_value == existing_param
                 )
-                assert isinstance(is_repeated, bool)
-                repeated_params.append(is_repeated)
+                repeated_params.append(bool(is_repeated))
 
             if all(repeated_params):
                 return True

--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -1091,6 +1091,7 @@ class Study:
                     if isinstance(param_value, Real)
                     else param_value == existing_param
                 )
+                assert isinstance(is_repeated, bool)
                 repeated_params.append(is_repeated)
 
             if all(repeated_params):


### PR DESCRIPTION
## Motivation & Description of the changes

Checks CI fails because of an upgrade to the latest version of mypy (v 1.12.0).
This PR modifies some code slightly to resolve the corresponding errors.

- For `study.py`, an error is caused by the return type of [`numpy.isnan`](https://numpy.org/doc/2.0/reference/generated/numpy.isnan.html), which is `ndarray or bool` rather than `bool`.  In our case, adding an explicit conversion to `bool` resolves this error.
- For `_convert_positional_args.py`, I add `# type: ignore` since I can't find the cause of this strange mypy error.