### PR TITLE
Reduce `SELECT` statements by removing unnecessary distribution compatibility check in `set_trial_param()`

### DIFF
--- a/optuna/storages/_rdb/storage.py
+++ b/optuna/storages/_rdb/storage.py
@@ -588,27 +588,14 @@ class RDBStorage(BaseStorage, BaseHeartbeat):
         trial = models.TrialModel.find_or_raise_by_id(trial_id, session)
         self.check_trial_is_updatable(trial_id, trial.state)
 
-        trial_param = models.TrialParamModel.find_by_trial_and_param_name(
-            trial, param_name, session
+        trial_param = models.TrialParamModel(
+            trial_id=trial_id,
+            param_name=param_name,
+            param_value=param_value_internal,
+            distribution_json=distributions.distribution_to_json(distribution),
         )
 
-        if trial_param is not None:
-            # Raise error in case distribution is incompatible.
-            distributions.check_distribution_compatibility(
-                distributions.json_to_distribution(trial_param.distribution_json), distribution
-            )
-
-            trial_param.param_value = param_value_internal
-            trial_param.distribution_json = distributions.distribution_to_json(distribution)
-        else:
-            trial_param = models.TrialParamModel(
-                trial_id=trial_id,
-                param_name=param_name,
-                param_value=param_value_internal,
-                distribution_json=distributions.distribution_to_json(distribution),
-            )
-
-            trial_param.check_and_add(session)
+        trial_param.check_and_add(session)
 
     def _check_and_set_param_distribution(
         self,

--- a/tests/storages_tests/test_storages.py
+++ b/tests/storages_tests/test_storages.py
@@ -486,11 +486,6 @@ def test_set_trial_param(storage_mode: str) -> None:
         # Check set_param breaks neither get_trial nor get_trial_params.
         assert storage.get_trial(trial_id_1).params == {"x": 0.5, "y": "Meguro"}
         assert storage.get_trial_params(trial_id_1) == {"x": 0.5, "y": "Meguro"}
-        # Duplicated registration should overwrite.
-        storage.set_trial_param(trial_id_1, "x", 0.6, distribution_x)
-        assert storage.get_trial_param(trial_id_1, "x") == 0.6
-        assert storage.get_trial(trial_id_1).params == {"x": 0.6, "y": "Meguro"}
-        assert storage.get_trial_params(trial_id_1) == {"x": 0.6, "y": "Meguro"}
 
         # Set params to another trial.
         storage.set_trial_param(trial_id_2, "x", 0.3, distribution_x)


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

The `set_trial_param()` process includes a flow that checks if the same `param_name` has already been set, issuing `UPDATE` if it exists or `INSERT` if it does not. However, the need to issue `UPDATE` instead of `INSERT` is limited to few cases: when storage is used directly or when parameters are suggested from multiple processes. By removing this check, we can reduce the number of `SELECT` statements.

## Description of the changes
<!-- Describe the changes in this PR. -->

- Modified the storage logic so that it always issues `INSERT`, regardless of the case.
- Removed test cases where this check was necessary.

## Verification of reduced `SELECT` statements

```python
import optuna
import logging

optuna.logging.set_verbosity(optuna.logging.WARNING)

study = optuna.create_study(storage="mysql+pymysql://optuna:password@127.0.0.1:3306/optuna")


def objective(trial: optuna.Trial) -> float:
    s = 0.0
    for i in range(8):
        s += trial.suggest_float(f"x{i}", 0.0, 1.0)
    return s


logging.basicConfig()
logging.getLogger("sqlalchemy.engine").setLevel(logging.INFO)
study.optimize(objective, n_trials=1)
```

```
❯ python mysql_optimize.py 2>! tmp.txt
❯ grep -o SELECT tmp.txt | wc -l
```

I confirmed by running the above code that 8 `SELECT` statements were reduced.  Note that this is  because `suggest_float()` is called 8 times.

