### PR TITLE
Include all test files in `sdist` by updating `MANIFEST.in`

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,2 @@
-include LICENSE
-include LICENSE_THIRD_PARTY
+graft tests
+global-exclude *~ *.py[cod] *.so


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

Previously, only files under `tests` directory that matched the pattern `test*.py` were included in the Optuna `sdist` package, resulting in an incomplete state. This PR resolves this issue by modifying `MANIFEST.in` to include all files under `tests` directory in the `sdist`.

## Description of the changes
<!-- Describe the changes in this PR. -->

- All files under `tests` are now included in the `sdist` package, excluding files like `*.pyc`.
- When the `license-files` parameter is not specified in `pyproject.toml`, files matching `LICENSE*` are automatically included in `sdist` [(reference)](https://setuptools.pypa.io/en/latest/userguide/miscellaneous.html#:~:text=All%20files%20specified%20by%20the%20license,COPYING*%2C%20NOTICE*%2C%20AUTHORS**%3B). As a result, the two files that were explicitly included in the original `MANIFEST.in` (i.e., `LICENSE` and `LICENSE_THIRD_PARTY`) no longer need to be specified, so this PR removes those explicit entries.

## Reference

- [Controlling files in the distribution](https://setuptools.pypa.io/en/latest/userguide/miscellaneous.html)
