### PR TITLE
[hotfix] Add a version constraint on fakeredis

### DIFF
--- a/.github/workflows/tests-with-minimum-versions.yml
+++ b/.github/workflows/tests-with-minimum-versions.yml
@@ -74,7 +74,7 @@ jobs:
         pip uninstall -y matplotlib pandas scipy
         # Python v3.6 was dropped at NumPy v1.20.3.
         if [ "${{ matrix.python-version }}" = "3.7" ]; then
-          pip install matplotlib==3.5.3 pandas==1.3.5 scipy==1.7.3 numpy==1.20.3
+          pip install matplotlib==3.5.3 pandas==1.3.5 scipy==1.7.3 numpy==1.20.3 "fakeredis<2.26.0"
         elif [ "${{ matrix.python-version }}" = "3.8" ]; then
           pip install matplotlib==3.7.5 pandas==2.0.3 scipy==1.10.1 numpy==1.20.3
         elif [ "${{ matrix.python-version }}" = "3.9" ]; then

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -76,6 +76,8 @@ jobs:
 
         pip install --progress-bar off .[test] --extra-index-url https://download.pytorch.org/whl/cpu
         pip install --progress-bar off .[optional] --extra-index-url https://download.pytorch.org/whl/cpu
+        # TODO(c-bata): Remove the version constraint after dropping Python 3.7
+        pip install --progress-bar off "fakeredis<2.26.0"
 
     - name: Output installed packages
       run: |


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
To fix https://github.com/optuna/optuna/actions/runs/11508811418

Refs https://github.com/cunla/fakeredis-py/issues/341

## Description of the changes
<!-- Describe the changes in this PR. -->
Add a version constraint on fakeredis to avoid using the fakeredis 2.26.0 with Python 3.7.