### PR TITLE
Drop the support for Python 3.7 and update package metadata for Python 3.13 support

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -29,11 +29,8 @@ jobs:
 
     strategy:
       matrix:
-        python_version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python_version: ['3.8', '3.9', '3.10', '3.11']
         build_type: ['', 'dev']  # "dev" installs all the dependencies including pytest.
-        exclude:
-        - python_version: '3.7'
-          build_type: 'dev'
 
     # This action cannot be executed in the forked repository.
     if: github.repository == 'optuna/optuna'

--- a/.github/workflows/tests-storage.yml
+++ b/.github/workflows/tests-storage.yml
@@ -23,16 +23,18 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
         test-trigger-type:
           - ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && 'Scheduled' || '' }}
         exclude:
           - test-trigger-type: ""
-            python-version: "3.8"
-          - test-trigger-type: ""
             python-version: "3.9"
           - test-trigger-type: ""
             python-version: "3.10"
+          - test-trigger-type: ""
+            python-version: "3.11"
+          - test-trigger-type: ""
+            python-version: "3.12"
 
     services:
       mysql:

--- a/.github/workflows/tests-with-minimum-versions.yml
+++ b/.github/workflows/tests-with-minimum-versions.yml
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9']
+        python-version: ['3.8', '3.9']
 
     services:
       redis:
@@ -72,10 +72,7 @@ jobs:
         pip uninstall -y alembic cmaes packaging sqlalchemy plotly scikit-learn pillow
         pip install alembic==1.5.0 cmaes==0.10.0 packaging==20.0 sqlalchemy==1.3.0 tqdm==4.27.0 colorlog==0.3 PyYAML==5.1 'pillow<10.4.0'
         pip uninstall -y matplotlib pandas scipy
-        # Python v3.6 was dropped at NumPy v1.20.3.
-        if [ "${{ matrix.python-version }}" = "3.7" ]; then
-          pip install matplotlib==3.5.3 pandas==1.3.5 scipy==1.7.3 numpy==1.20.3 "fakeredis<2.26.0"
-        elif [ "${{ matrix.python-version }}" = "3.8" ]; then
+        if [ "${{ matrix.python-version }}" = "3.8" ]; then
           pip install matplotlib==3.7.5 pandas==2.0.3 scipy==1.10.1 numpy==1.20.3
         elif [ "${{ matrix.python-version }}" = "3.9" ]; then
           pip install matplotlib==3.8.4 pandas==2.2.2 scipy==1.13.0 numpy==1.26.4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,12 +20,10 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
         test-trigger-type:
           - ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && 'Scheduled' || '' }}
         exclude:
-          - test-trigger-type: ""
-            python-version: "3.8"
           - test-trigger-type: ""
             python-version: "3.9"
           - test-trigger-type: ""
@@ -76,8 +74,6 @@ jobs:
 
         pip install --progress-bar off .[test] --extra-index-url https://download.pytorch.org/whl/cpu
         pip install --progress-bar off .[optional] --extra-index-url https://download.pytorch.org/whl/cpu
-        # TODO(c-bata): Remove the version constraint after dropping Python 3.7
-        pip install --progress-bar off "fakeredis<2.26.0"
 
         # TODO(gen740): Remove this after pytorch supports Python 3.13
         if [ "${{ matrix.python-version }}" = "3.13" ] ; then

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Optuna: A hyperparameter optimization framework
 
-[![Python](https://img.shields.io/badge/python-3.7%20%7C%203.8%20%7C%203.9%20%7C%203.10%20%7C%203.11%20%7C%203.12-blue)](https://www.python.org)
+[![Python](https://img.shields.io/badge/python-3.8%20%7C%203.9%20%7C%203.10%20%7C%203.11%20%7C%203.12%20%7C%203.13-blue)](https://www.python.org)
 [![pypi](https://img.shields.io/pypi/v/optuna.svg)](https://pypi.python.org/pypi/optuna)
 [![conda](https://img.shields.io/conda/vn/conda-forge/optuna.svg)](https://anaconda.org/conda-forge/optuna)
 [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/optuna/optuna)
@@ -115,7 +115,7 @@ $ conda install -c conda-forge optuna
 ```
 
 > [!IMPORTANT]
-> Optuna supports Python 3.7 or newer.
+> Optuna supports Python 3.8 or newer.
 >
 > Also, we provide Optuna docker images on [DockerHub](https://hub.docker.com/r/optuna/optuna).
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -1,7 +1,7 @@
 Installation
 ============
 
-Optuna supports Python 3.7 or newer.
+Optuna supports Python 3.8 or newer.
 
 We recommend to install Optuna via pip:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,12 +15,12 @@ classifiers = [
   "Intended Audience :: Developers",
   "License :: OSI Approved :: MIT License",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.7",
   "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: 3 :: Only",
   "Topic :: Scientific/Engineering",
   "Topic :: Scientific/Engineering :: Mathematics",
@@ -29,7 +29,7 @@ classifiers = [
   "Topic :: Software Development :: Libraries",
   "Topic :: Software Development :: Libraries :: Python Modules",
 ]
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 dependencies = [
   "alembic>=1.5.0",
   "colorlog",


### PR DESCRIPTION
## Motivation
Closes https://github.com/optuna/optuna/issues/4586

## Description of the changes
This PR updates followings to drop the support for Python 3.7.

* CI settings
* README and documentation
* Package metadata

For any remaining TODO comments in the implementation and tests, I will open a follow-up PR after this one is merged: https://github.com/optuna/optuna/compare/master...c-bata:optuna:resolve-todo-comments-for-python3.7?expand=1