### PR TITLE
Rename `test_cache_is_invalidated` and remove `assert study._thread_local.cached_all_trials is None`

### DIFF
--- a/tests/samplers_tests/test_samplers.py
+++ b/tests/samplers_tests/test_samplers.py
@@ -1043,22 +1043,17 @@ def test_reproducible_in_other_process(sampler_name: str, unset_seed_in_test: No
 
 @pytest.mark.parametrize("n_jobs", [1, 2])
 @parametrize_relative_sampler
-def test_cache_is_invalidated(
+def test_trial_relative_params(
     n_jobs: int, relative_sampler_class: Callable[[], BaseSampler]
 ) -> None:
+    # TODO(nabenabe): Consider moving this test to study.
     sampler = relative_sampler_class()
-    original_before_trial = sampler.before_trial
-
-    def mock_before_trial(study: Study, trial: FrozenTrial) -> None:
-        assert study._thread_local.cached_all_trials is None
-        original_before_trial(study, trial)
 
     with patch.object(sampler, "before_trial", side_effect=mock_before_trial):
         study = optuna.study.create_study(sampler=sampler)
 
         def objective(trial: Trial) -> float:
             assert trial._relative_params is None
-
             trial.suggest_float("x", -10, 10)
             trial.suggest_float("y", -10, 10)
             assert trial._relative_params is not None

--- a/tests/samplers_tests/test_samplers.py
+++ b/tests/samplers_tests/test_samplers.py
@@ -1048,15 +1048,14 @@ def test_trial_relative_params(
 ) -> None:
     # TODO(nabenabe): Consider moving this test to study.
     sampler = relative_sampler_class()
+    study = optuna.study.create_study(sampler=sampler)
 
-    with patch.object(sampler, "before_trial", side_effect=mock_before_trial):
-        study = optuna.study.create_study(sampler=sampler)
+    def objective(trial: Trial) -> float:
+        assert trial._relative_params is None
 
-        def objective(trial: Trial) -> float:
-            assert trial._relative_params is None
-            trial.suggest_float("x", -10, 10)
-            trial.suggest_float("y", -10, 10)
-            assert trial._relative_params is not None
-            return -1
+        trial.suggest_float("x", -10, 10)
+        trial.suggest_float("y", -10, 10)
+        assert trial._relative_params is not None
+        return -1
 
-        study.optimize(objective, n_trials=10, n_jobs=n_jobs)
+    study.optimize(objective, n_trials=10, n_jobs=n_jobs)

--- a/tests/samplers_tests/test_samplers.py
+++ b/tests/samplers_tests/test_samplers.py
@@ -7,7 +7,6 @@ from multiprocessing.managers import DictProxy
 import os
 import pickle
 from typing import Any
-from unittest.mock import Mock
 from unittest.mock import patch
 import warnings
 
@@ -1054,15 +1053,15 @@ def test_cache_is_invalidated(
         assert study._thread_local.cached_all_trials is None
         original_before_trial(study, trial)
 
-    sampler.before_trial = Mock(side_effect=mock_before_trial)
-    study = optuna.study.create_study(sampler=sampler)
+    with patch.object(sampler, "before_trial", side_effect=mock_before_trial):
+        study = optuna.study.create_study(sampler=sampler)
 
-    def objective(trial: Trial) -> float:
-        assert trial._relative_params is None
+        def objective(trial: Trial) -> float:
+            assert trial._relative_params is None
 
-        trial.suggest_float("x", -10, 10)
-        trial.suggest_float("y", -10, 10)
-        assert trial._relative_params is not None
-        return -1
+            trial.suggest_float("x", -10, 10)
+            trial.suggest_float("y", -10, 10)
+            assert trial._relative_params is not None
+            return -1
 
-    study.optimize(objective, n_trials=10, n_jobs=n_jobs)
+        study.optimize(objective, n_trials=10, n_jobs=n_jobs)


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

The original version test checks the cache clear after before_trial, so if we call `_get_all_trials` with `use_cache=True` at `before_trial`, this unit test fails.
To avoid this problem, we actually need to check the cache clear before `before_trial`.
To this end, I introduced a mock function to do so.

## Description of the changes
<!-- Describe the changes in this PR. -->

- Add a mock function so that we can check the cache clear before each trial

> [!NOTE]
> I thought through if I should add any tests for this regard to `study_tests`, but as this check should happen before `before_trial`, which is a method of each sampler, I simply modified the existing test in `test_samplers.py` instead of `study_tests`.