### PR TITLE
Escape `\D` for python 3.12 with sphinx build

### DIFF
--- a/tutorial/20_recipes/013_wilcoxon_pruner.py
+++ b/tutorial/20_recipes/013_wilcoxon_pruner.py
@@ -27,8 +27,8 @@ SA starts with an initial solution (it can be constructed by a simpler heuristic
 like greedy method), and it randomly checks the neighborhood (defined later)
 of the solution. If a neighbor is better, the solution is updated to the neighbor.
 If the neighbor is worse, SA still updates the solution to the neighbor with
-probability :math:`e^{-\Delta c / T}`, where
-:math:`\Delta c (> 0)` is the difference of
+probability :math:`e^{-\\Delta c / T}`, where
+:math:`\\Delta c (> 0)` is the difference of
 the cost (sum of the distance) between the new solution and the old one and
 :math:`T` is a parameter called "temperature". The temperature controls
 how much worsening of the solution is tolerated to escape from the local minimum


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

Reduce one error reported in https://github.com/optuna/optuna/issues/5732. Concretely, 

```
[I 2024-10-28 08:01:57,031] Trial 2 finished with value: -0.00017131257501556973 and parameters: {'phi': -0.6554252043123148, 'theta': -0.38835362995237843, 'psi': -0.01952095085234462, 'x_pos': 0.3491348930743934, 'y_pos': 0.25382330637298517, 'z_hig': 4.996780176004947}. Best is trial 1 with value: -0.8459529990880332.
generating gallery for tutorial/20_recipes... [100%] 013_wilcoxon_pruner.py
<unknown>:1: SyntaxWarning:

invalid escape sequence '\D'
```

## Description of the changes
<!-- Describe the changes in this PR. -->
