### PR TITLE
Remove dependency specifier for installing SciPy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,7 +97,7 @@ test = [
   "kaleido",
   "moto",
   "pytest",
-  "scipy>=1.9.2; python_version>='3.8'",
+  "scipy>=1.9.2",
   "torch; python_version<='3.12'", # TODO(gen740): Remove this line when 'torch', a dependency of 'optuna/_gp', supports Python 3.13
 ]
 


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

Follow-up #5727

`requires-python` has been updated for `>=3.8`. So, the dependency specifier for installing SciPy is no longer required.

## Description of the changes
<!-- Describe the changes in this PR. -->

- Remove dependency specifier for installing SciPy