### PR TITLE
Avoid using functions in `sphinx_gallery_conf` to remove document build error with python 3.12

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -20,8 +20,6 @@ import warnings
 
 import plotly.io as pio
 from sklearn.exceptions import ConvergenceWarning
-from sphinx_gallery.sorting import FileNameSortKey
-from plotly.io._sg_scraper import plotly_sg_scraper
 
 import optuna
 
@@ -214,10 +212,10 @@ sphinx_gallery_conf = {
     ],
     "compress_images": ("images", "thumbnails"),
     "thumbnail_size": (400, 280),
-    "within_subsection_order": FileNameSortKey,
+    "within_subsection_order": "FileNameSortKey",
     "filename_pattern": r"/*\.py",
     "first_notebook_cell": None,
-    "image_scrapers": ("matplotlib", plotly_sg_scraper),
+    "image_scrapers": ("matplotlib", "plotly.io._sg_scraper.plotly_sg_scraper"),
 }
 
 # matplotlib plot directive


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

Reduce one warning reported in https://github.com/optuna/optuna/issues/5732. Concretely, 

```shell
WARNING: cannot cache unpickable configuration value: 'sphinx_gallery_conf' (because it contains a function, class, or module object) [config.cache]
```

## Description of the changes
<!-- Describe the changes in this PR. -->


Instead of callable as a value of `sphinx_gallery_conf`, use the string alias of `FileNameSortKey` as implemented in https://github.com/sphinx-gallery/sphinx-gallery/pull/1289 and string expression for plotly by following https://sphinx-gallery.github.io/stable/configuration.html#importing-callables.