### PR TITLE
Remove all `generated` directories in `docs/source` recursively

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -26,8 +26,7 @@ doctest:
 # Copy from https://sphinx-gallery.github.io/stable/advanced.html#cleaning-the-gallery-files
 clean:
 	rm -rf $(BUILDDIR)/*
-	rm -rf source/reference/generated/
-	rm -rf source/reference/visualization/generated/
+	find source -type d -name generated -prune -exec rm -rf {} \;
 	rm -f source/sg_execution_times.rst
 	rm -rf source/tutorial/10_key_features
 	rm -rf source/tutorial/20_recipes
@@ -37,5 +36,3 @@ clean:
 	rm -f ../tutorial/20_recipes/journal.log
 	rm -rf ../tutorial/20_recipes/tmp
 	rm -f ../tutorial/20_recipes/best_atoms.png
-	rm -rf ./source/reference/visualization/generated
-	rm -rf ./source/reference/visualization/matplotlib/generated


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->


I realised that `make clean` does not remove `docs/source/reference/samplers/generated`. This causing a unexpected sphinx error like https://github.com/optuna/optuna/issues/5463#issuecomment-2449614995.

Sometimes optuna adds such a `generated` directory by hand in `Makefile`, which sounds a bit tedious.


## Description of the changes
<!-- Describe the changes in this PR. -->


Remove all `generated` directories in `docs/source` with a single command and remove existing `rm -rf`.