### PR TITLE
Use Python 3.12 for docs build CI

### DIFF
--- a/.github/workflows/sphinx-build.yml
+++ b/.github/workflows/sphinx-build.yml
@@ -19,10 +19,9 @@ jobs:
 
     - uses: actions/checkout@v4
 
-    # TODO(c-bata): Use the newer Python version
     - uses: actions/setup-python@v5
       with:
-        python-version: 3.8
+        python-version: 3.12
 
     # note (crcrpar): We've not updated tutorial frequently enough so far thus
     # it'd be okay to discard cache by any small changes including typo fix under tutorial directory.
@@ -34,7 +33,7 @@ jobs:
         path: |
           tutorial/MNIST
           docs/source/tutorial
-        key: py3.8-${{ env.cache-name }}-${{ hashFiles('tutorial/**/*') }}
+        key: py3.12-${{ env.cache-name }}-${{ hashFiles('tutorial/**/*') }}
 
     - name: Install Dependencies
       run: |
@@ -76,10 +75,9 @@ jobs:
 
     - uses: actions/checkout@v4
 
-    # TODO(c-bata): Use the newer Python version
     - uses: actions/setup-python@v5
       with:
-        python-version: 3.8
+        python-version: 3.12
 
     - name: Sphinx Gallery Cache
       uses: actions/cache@v3
@@ -89,7 +87,7 @@ jobs:
         path: |
           tutorial/MNIST
           docs/source/tutorial
-        key: py3.8-${{ env.cache-name }}-${{ hashFiles('tutorial/**/*') }}
+        key: py3.12-${{ env.cache-name }}-${{ hashFiles('tutorial/**/*') }}
 
     - name: Install Dependencies
       run: |

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,7 +8,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.11"
+    python: "3.12"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,9 +118,9 @@ Whether you edit any tutorial or not doesn't matter.
 
 To avoid having to run the tutorials, you may download executed tutorial artifacts named "tutorial" from our CI (see the capture below) and put them in `docs/build` before
 extracting the files in the zip to `docs/source/tutorial` directory.
-Note that the CI runs with Python 3.8 and the generated artifacts contain pickle files.
+Note that the CI runs with Python 3.12 and the generated artifacts contain pickle files.
 The pickle files are serialized with [the protocol version 5](https://docs.python.org/3/library/pickle.html#data-stream-format) so you will see the error with Python 3.7 or older.
-Please use Python 3.8 or later if you build the documentation with artifacts.
+Please use Python 3.12 or later if you build the documentation with artifacts.
 
 ![image](https://user-images.githubusercontent.com/16191443/107472296-0b211400-6bb2-11eb-9203-e2c42ce499ad.png)
 
@@ -205,4 +205,3 @@ Once you get a good understanding of how Minituna is designed, it will not be to
 We encourage you to practice reading the Minituna code with the following article.
 
 [An Introduction to the Implementation of Optuna, a Hyperparameter Optimization Framework](https://medium.com/optuna/an-introduction-to-the-implementation-of-optuna-a-hyperparameter-optimization-framework-33995d9ec354)
-

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,8 +119,7 @@ Whether you edit any tutorial or not doesn't matter.
 To avoid having to run the tutorials, you may download executed tutorial artifacts named "tutorial" from our CI (see the capture below) and put them in `docs/build` before
 extracting the files in the zip to `docs/source/tutorial` directory.
 Note that the CI runs with Python 3.12 and the generated artifacts contain pickle files.
-The pickle files are serialized with [the protocol version 5](https://docs.python.org/3/library/pickle.html#data-stream-format) so you will see the error with Python 3.7 or older.
-Please use Python 3.12 or later if you build the documentation with artifacts.
+Please use the same Python version as in the CI if you build the documentation with artifacts to avoid unexpected errors due to the python version difference.
 
 ![image](https://user-images.githubusercontent.com/16191443/107472296-0b211400-6bb2-11eb-9203-e2c42ce499ad.png)
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -186,7 +186,7 @@ autosummary_generate = True
 autodoc_typehints = "description"
 autodoc_default_options = {
     "members": True,
-    "inherited-members": True,
+    "inherited-members": "int",
     "exclude-members": "with_traceback",
 }
 

--- a/docs/source/reference/distributions.rst
+++ b/docs/source/reference/distributions.rst
@@ -11,14 +11,14 @@ Optuna users should not use distribution classes directly, but instead use utili
    :toctree: generated/
    :nosignatures:
 
-   optuna.distributions.FloatDistribution
-   optuna.distributions.IntDistribution
-   optuna.distributions.UniformDistribution
-   optuna.distributions.LogUniformDistribution
-   optuna.distributions.DiscreteUniformDistribution
-   optuna.distributions.IntUniformDistribution
-   optuna.distributions.IntLogUniformDistribution
-   optuna.distributions.CategoricalDistribution
-   optuna.distributions.distribution_to_json
-   optuna.distributions.json_to_distribution
-   optuna.distributions.check_distribution_compatibility
+   FloatDistribution
+   IntDistribution
+   UniformDistribution
+   LogUniformDistribution
+   DiscreteUniformDistribution
+   IntUniformDistribution
+   IntLogUniformDistribution
+   CategoricalDistribution
+   distribution_to_json
+   json_to_distribution
+   check_distribution_compatibility

--- a/docs/source/reference/exceptions.rst
+++ b/docs/source/reference/exceptions.rst
@@ -9,8 +9,8 @@ The :mod:`~optuna.exceptions` module defines Optuna-specific exceptions deriving
    :toctree: generated/
    :nosignatures:
 
-   optuna.exceptions.OptunaError
-   optuna.exceptions.TrialPruned
-   optuna.exceptions.CLIUsageError
-   optuna.exceptions.StorageInternalError
-   optuna.exceptions.DuplicatedStudyError
+   OptunaError
+   TrialPruned
+   CLIUsageError
+   StorageInternalError
+   DuplicatedStudyError

--- a/docs/source/reference/importance.rst
+++ b/docs/source/reference/importance.rst
@@ -12,13 +12,13 @@ The :mod:`~optuna.importance` module provides functionality for evaluating hyper
    that is a Cython accelerated fANOVA implementation. By using it, you can get hyperparameter
    importances within a few seconds.
    If ``n_trials`` is more than 10000, the Cython implementation takes more than a minute, so you can use :class:`~optuna.importance.PedAnovaImportanceEvaluator` instead, enabling the evaluation to finish in a second.
-    
+
 
 .. autosummary::
    :toctree: generated/
    :nosignatures:
 
-   optuna.importance.get_param_importances
-   optuna.importance.FanovaImportanceEvaluator
-   optuna.importance.MeanDecreaseImpurityImportanceEvaluator
-   optuna.importance.PedAnovaImportanceEvaluator
+   get_param_importances
+   FanovaImportanceEvaluator
+   MeanDecreaseImpurityImportanceEvaluator
+   PedAnovaImportanceEvaluator

--- a/docs/source/reference/logging.rst
+++ b/docs/source/reference/logging.rst
@@ -10,9 +10,9 @@ The :mod:`~optuna.logging` module implements logging using the Python ``logging`
    :toctree: generated/
    :nosignatures:
 
-   optuna.logging.get_verbosity
-   optuna.logging.set_verbosity
-   optuna.logging.disable_default_handler
-   optuna.logging.enable_default_handler
-   optuna.logging.disable_propagation
-   optuna.logging.enable_propagation
+   get_verbosity
+   set_verbosity
+   disable_default_handler
+   enable_default_handler
+   disable_propagation
+   enable_propagation

--- a/docs/source/reference/optuna.rst
+++ b/docs/source/reference/optuna.rst
@@ -9,10 +9,10 @@ The :mod:`optuna` module is primarily used as an alias for basic Optuna function
    :toctree: generated/
    :nosignatures:
 
-   optuna.create_study
-   optuna.load_study
-   optuna.delete_study
-   optuna.copy_study
-   optuna.get_all_study_names
-   optuna.get_all_study_summaries
-   optuna.TrialPruned
+   create_study
+   load_study
+   delete_study
+   copy_study
+   get_all_study_names
+   get_all_study_summaries
+   TrialPruned

--- a/docs/source/reference/pruners.rst
+++ b/docs/source/reference/pruners.rst
@@ -15,15 +15,15 @@ The :mod:`~optuna.pruners` module defines a :class:`~optuna.pruners.BasePruner` 
     :ref:`user_defined_pruner` tutorial could be helpful if you want to implement your own pruner classes.
 
 .. autosummary::
-   :toctree: generated/
-   :nosignatures:
+    :toctree: generated/
+    :nosignatures:
 
-   optuna.pruners.BasePruner
-   optuna.pruners.MedianPruner
-   optuna.pruners.NopPruner
-   optuna.pruners.PatientPruner
-   optuna.pruners.PercentilePruner
-   optuna.pruners.SuccessiveHalvingPruner
-   optuna.pruners.HyperbandPruner
-   optuna.pruners.ThresholdPruner
-   optuna.pruners.WilcoxonPruner
+    BasePruner
+    MedianPruner
+    NopPruner
+    PatientPruner
+    PercentilePruner
+    SuccessiveHalvingPruner
+    HyperbandPruner
+    ThresholdPruner
+    WilcoxonPruner

--- a/docs/source/reference/samplers/index.rst
+++ b/docs/source/reference/samplers/index.rst
@@ -82,17 +82,17 @@ The :mod:`~optuna.samplers` module defines a base class for parameter sampling a
     :toctree: generated/
     :nosignatures:
 
-    optuna.samplers.BaseSampler
-    optuna.samplers.GridSampler
-    optuna.samplers.RandomSampler
-    optuna.samplers.TPESampler
-    optuna.samplers.CmaEsSampler
-    optuna.samplers.GPSampler
-    optuna.samplers.PartialFixedSampler
-    optuna.samplers.NSGAIISampler
-    optuna.samplers.NSGAIIISampler
-    optuna.samplers.QMCSampler
-    optuna.samplers.BruteForceSampler
+    BaseSampler
+    GridSampler
+    RandomSampler
+    TPESampler
+    CmaEsSampler
+    GPSampler
+    PartialFixedSampler
+    NSGAIISampler
+    NSGAIIISampler
+    QMCSampler
+    BruteForceSampler
 
 .. note::
     The following :mod:`optuna.samplers.nsgaii` module defines crossover operations used by :class:`~optuna.samplers.NSGAIISampler`.

--- a/docs/source/reference/samplers/nsgaii.rst
+++ b/docs/source/reference/samplers/nsgaii.rst
@@ -9,10 +9,10 @@ The :mod:`~optuna.samplers.nsgaii` module defines crossover operations used by :
     :toctree: generated/
     :nosignatures:
 
-    optuna.samplers.nsgaii.BaseCrossover
-    optuna.samplers.nsgaii.UniformCrossover
-    optuna.samplers.nsgaii.BLXAlphaCrossover
-    optuna.samplers.nsgaii.SPXCrossover
-    optuna.samplers.nsgaii.SBXCrossover
-    optuna.samplers.nsgaii.VSBXCrossover
-    optuna.samplers.nsgaii.UNDXCrossover
+    BaseCrossover
+    UniformCrossover
+    BLXAlphaCrossover
+    SPXCrossover
+    SBXCrossover
+    VSBXCrossover
+    UNDXCrossover

--- a/docs/source/reference/search_space.rst
+++ b/docs/source/reference/search_space.rst
@@ -10,5 +10,5 @@ The :mod:`~optuna.search_space` module provides functionality for controlling se
    :toctree: generated/
    :nosignatures:
 
-   optuna.search_space.IntersectionSearchSpace
-   optuna.search_space.intersection_search_space
+   IntersectionSearchSpace
+   intersection_search_space

--- a/docs/source/reference/storages.rst
+++ b/docs/source/reference/storages.rst
@@ -9,11 +9,11 @@ The :mod:`~optuna.storages` module defines a :class:`~optuna.storages.BaseStorag
    :toctree: generated/
    :nosignatures:
 
-   optuna.storages.RDBStorage
-   optuna.storages.RetryFailedTrialCallback
-   optuna.storages.fail_stale_trials
-   optuna.storages.JournalStorage
-   optuna.storages.InMemoryStorage
+   RDBStorage
+   RetryFailedTrialCallback
+   fail_stale_trials
+   JournalStorage
+   InMemoryStorage
 
 optuna.storages.journal
 -----------------------
@@ -27,8 +27,8 @@ optuna.storages.journal
    :toctree: generated/
    :nosignatures:
 
-   optuna.storages.journal.JournalFileBackend
-   optuna.storages.journal.JournalRedisBackend
+   journal.JournalFileBackend
+   journal.JournalRedisBackend
 
 Users can flexibly choose a lock object for :class:`~optuna.storages.journal.JournalFileBackend` and here is the list of supported lock objects:
 
@@ -36,8 +36,8 @@ Users can flexibly choose a lock object for :class:`~optuna.storages.journal.Jou
    :toctree: generated/
    :nosignatures:
 
-   optuna.storages.journal.JournalFileSymlinkLock
-   optuna.storages.journal.JournalFileOpenLock
+   journal.JournalFileSymlinkLock
+   journal.JournalFileOpenLock
 
 Deprecated Modules
 ------------------
@@ -50,6 +50,6 @@ Deprecated Modules
    :toctree: generated/
    :nosignatures:
 
-   optuna.storages.BaseJournalLogStorage
-   optuna.storages.JournalFileStorage
-   optuna.storages.JournalRedisStorage
+   BaseJournalLogStorage
+   JournalFileStorage
+   JournalRedisStorage

--- a/docs/source/reference/study.rst
+++ b/docs/source/reference/study.rst
@@ -9,13 +9,13 @@ The :mod:`~optuna.study` module implements the :class:`~optuna.study.Study` obje
    :toctree: generated/
    :nosignatures:
 
-   optuna.study.Study
-   optuna.study.create_study
-   optuna.study.load_study
-   optuna.study.delete_study
-   optuna.study.copy_study
-   optuna.study.get_all_study_names
-   optuna.study.get_all_study_summaries
-   optuna.study.MaxTrialsCallback
-   optuna.study.StudyDirection
-   optuna.study.StudySummary
+   Study
+   create_study
+   load_study
+   delete_study
+   copy_study
+   get_all_study_names
+   get_all_study_summaries
+   MaxTrialsCallback
+   StudyDirection
+   StudySummary

--- a/docs/source/reference/terminator.rst
+++ b/docs/source/reference/terminator.rst
@@ -9,17 +9,17 @@ The :mod:`~optuna.terminator` module implements a mechanism for automatically te
    :toctree: generated/
    :nosignatures:
 
-   optuna.terminator.BaseTerminator
-   optuna.terminator.Terminator
-   optuna.terminator.BaseImprovementEvaluator
-   optuna.terminator.RegretBoundEvaluator
-   optuna.terminator.BestValueStagnationEvaluator
-   optuna.terminator.EMMREvaluator
-   optuna.terminator.BaseErrorEvaluator
-   optuna.terminator.CrossValidationErrorEvaluator
-   optuna.terminator.StaticErrorEvaluator
-   optuna.terminator.MedianErrorEvaluator
-   optuna.terminator.TerminatorCallback
-   optuna.terminator.report_cross_validation_scores
+   BaseTerminator
+   Terminator
+   BaseImprovementEvaluator
+   RegretBoundEvaluator
+   BestValueStagnationEvaluator
+   EMMREvaluator
+   BaseErrorEvaluator
+   CrossValidationErrorEvaluator
+   StaticErrorEvaluator
+   MedianErrorEvaluator
+   TerminatorCallback
+   report_cross_validation_scores
 
 For an example of using this module, please refer to `this example <https://github.com/optuna/optuna-examples/tree/main/terminator>`__.

--- a/docs/source/reference/trial.rst
+++ b/docs/source/reference/trial.rst
@@ -11,8 +11,8 @@ A :class:`~optuna.trial.Trial` instance represents a process of evaluating an ob
    :toctree: generated/
    :nosignatures:
 
-   optuna.trial.Trial
-   optuna.trial.FixedTrial
-   optuna.trial.FrozenTrial
-   optuna.trial.TrialState
-   optuna.trial.create_trial
+   Trial
+   FixedTrial
+   FrozenTrial
+   TrialState
+   create_trial


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->


Resolve https://github.com/optuna/optuna/issues/5732.

## Description of the changes
<!-- Describe the changes in this PR. -->

- Update python version 3.12 in `.github/workflows/sphinx-build.yml`
- Remove `'WARNING: Summarised items should not include the current module'`, which are the majority of changes in this PR. This change is suggested by the warning message like `WARNING: Summarised items should not include the current module. Replace 'optuna.delete_study' with 'delete_study'. [autosummary.import_cycle]` in https://github.com/optuna/optuna/actions/runs/11640162393/job/32417223006.
    - This change removes a parent module prefix of each class/method in a table on a page. for example

before: 
![Screenshot 2024-11-03 at 0 53 33](https://github.com/user-attachments/assets/a335fa55-e416-429e-88ae-db76140b7354)

after:
![Screenshot 2024-11-03 at 1 04 09](https://github.com/user-attachments/assets/957ca2df-0c56-41be-b738-cb5a6a2ffe4b)


- Remove "WARNING: Inline interpreted text or phrase reference start-string without end-string. [docutils]" for `TrialState` and `StudyDirection`. As I commented in https://github.com/optuna/optuna/pull/5742#discussion_r1826508957, I'm not sure how this change affects the docs.

