### PR TITLE
Adding a `log_scale` option for `plot_contour`.

### DIFF
--- a/optuna/visualization/_contour.py
+++ b/optuna/visualization/_contour.py
@@ -56,6 +56,7 @@ class _ContourInfo(NamedTuple):
     sub_plot_infos: list[list[_SubContourInfo]]
     reverse_scale: bool
     target_name: str
+    log_scale: bool
 
 
 class _PlotValues(NamedTuple):
@@ -257,6 +258,7 @@ def _get_contour_info(
     params: list[str] | None = None,
     target: Callable[[FrozenTrial], float] | None = None,
     target_name: str = "Objective Value",
+    log_scale: bool = False,
 ) -> _ContourInfo:
     _check_plot_args(study, target, target_name)
 
@@ -300,6 +302,7 @@ def _get_contour_info(
         sub_plot_infos=sub_plot_infos,
         reverse_scale=reverse_scale,
         target_name=target_name,
+        log_scale=log_scale,
     )
 
 

--- a/optuna/visualization/_utils.py
+++ b/optuna/visualization/_utils.py
@@ -47,9 +47,7 @@ if is_available():
 
 
 def _check_plot_args(
-    study: Study | Sequence[Study],
-    target: Callable[[FrozenTrial], float] | None,
-    target_name: str,
+    study: Study | Sequence[Study], target: Callable[[FrozenTrial], float] | None, target_name: str
 ) -> None:
     studies: Sequence[Study]
     if isinstance(study, Study):

--- a/optuna/visualization/matplotlib/_contour.py
+++ b/optuna/visualization/matplotlib/_contour.py
@@ -80,9 +80,6 @@ def plot_contour(
     """
 
     _imports.check()
-    # not implementing log_scale in _check_plot_args because it s called by other plotting utils
-    if not isinstance(log_scale, bool):
-        raise ValueError("log_scale must be a boolean")
     _logger.warning(
         "Output figures of this Matplotlib-based `plot_contour` function would be different from "
         "those of the Plotly-based `plot_contour`."

--- a/optuna/visualization/matplotlib/_contour.py
+++ b/optuna/visualization/matplotlib/_contour.py
@@ -80,7 +80,7 @@ def plot_contour(
     """
 
     _imports.check()
-    # not implementing log_scale in _imports.check() because it s called by other plotting utils
+    # not implementing log_scale in _check_plot_args because it s called by other plotting utils
     if not isinstance(log_scale, bool):
         raise ValueError("log_scale must be a boolean")
     _logger.warning(

--- a/optuna/visualization/matplotlib/_matplotlib_imports.py
+++ b/optuna/visualization/matplotlib/_matplotlib_imports.py
@@ -14,6 +14,7 @@ with try_import() as _imports:
     from matplotlib.colors import Colormap
     from matplotlib.contour import ContourSet
     from matplotlib.figure import Figure
+    from matplotlib.ticker import LogLocator
 
     # TODO(ytknzw): Set precise version.
     if version.parse(matplotlib_version) < version.parse("3.0.0"):
@@ -36,4 +37,5 @@ __all__ = [
     "Colormap",
     "ContourSet",
     "Figure",
+    "LogLocator",
 ]


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
As discussed in [4850](https://github.com/optuna/optuna/issues/4850#issuecomment-2444757889), using a log scale for contour plots is not straight forward. So I added a `log_scale` option for both plotly and matplotlib backends. 

For plotly, I've followed the recommendations found [on their forum](https://community.plotly.com/t/how-to-set-log-scale-for-z-axis-on-a-heatmap/292/8) which plot the log-transformed value then makes use of a custom [ColorBar](https://plotly.github.io/plotly.py-docs/generated/plotly.graph_objects.contour.html#plotly.graph_objects.contour.ColorBar) (defined in a dictionary form) to display the original values.

For matplotlib it was quite easy since they propose a [LogLocator](https://matplotlib.org/stable/api/ticker_api.html#matplotlib.ticker.LogLocator).



