### PR TITLE
Simplify type annotations for `tests/visualization_tests/test_pareto_front.py`

### DIFF
--- a/tests/visualization_tests/test_pareto_front.py
+++ b/tests/visualization_tests/test_pareto_front.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
+from collections.abc import Callable
+from collections.abc import Sequence
 from io import BytesIO
 from typing import Any
-from typing import Callable
-from typing import Sequence
 import warnings
 
 import pytest


### PR DESCRIPTION
### Motivation

This PR aims to enhance type annotation handling in Optuna to the module tests/visualization_tests/test_pareto_front.py and contributes to solving https://github.com/optuna/optuna/issues/4508.

### Description of the changes
---
Apply changes to tests/visualization_tests/test_pareto_front.py by replacing `Optional` and `Sequence` from `typing` module with `collections.abc` module