### PR TITLE
Install older `kaleido` to fix CI errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ document = [
   "ase",
   "cmaes>=0.10.0",  # optuna/samplers/_cmaes.py.
   "fvcore",
-  "kaleido",
+  "kaleido<0.4",  # TODO(nzw0301): Remove the version constraint by installing browser separately.
   "lightgbm",
   "matplotlib!=3.6.0",
   "pandas",
@@ -94,7 +94,7 @@ optional = [
 test = [
   "coverage",
   "fakeredis[lua]",
-  "kaleido",
+  "kaleido<0.4",  # TODO(nzw0301): Remove the version constraint by installing browser separately.
   "moto",
   "pytest",
   "scipy>=1.9.2",


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

Hot-fix of CI errors (ex. https://github.com/optuna/optuna/actions/runs/11868449930/job/33077638402) due to `Kaleido>=0.4` requiring browser separately installed.

Ref: https://github.com/plotly/Kaleido/issues/223

## Description of the changes
<!-- Describe the changes in this PR. -->

Installing the browser separately was not enough https://github.com/optuna/optuna/pull/5770, so add the version constraint of `Kaleido<0.4`. 
