### PR TITLE
Simplify type annotations for `tests/sampler_tests/tpe_tests/test_sampler.py`

### DIFF
--- a/tests/samplers_tests/tpe_tests/test_sampler.py
+++ b/tests/samplers_tests/tpe_tests/test_sampler.py
@@ -1,10 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 import random
-from typing import Callable
-from typing import Dict
-from typing import Optional
-from typing import Union
 from unittest.mock import Mock
 from unittest.mock import patch
 import warnings
@@ -974,9 +971,9 @@ def frozen_trial_factory(
     state_fn: Callable[
         [int], optuna.trial.TrialState
     ] = lambda _: optuna.trial.TrialState.COMPLETE,
-    value_fn: Optional[Callable[[int], Union[int, float]]] = None,
+    value_fn: Callable[[int], int | float] | None = None,
     target_fn: Callable[[float], float] = lambda val: (val - 20.0) ** 2,
-    interm_val_fn: Callable[[int], Dict[int, float]] = lambda _: {},
+    interm_val_fn: Callable[[int], dict[int, float]] = lambda _: {},
 ) -> optuna.trial.FrozenTrial:
     if value_fn is None:
         random.seed(idx)


### PR DESCRIPTION
## Motivation
This PR aims to enhance type annotation handling in Optuna to the module `tests/sampler_tests/tpe_tests/test_sampler.py` and contributes to solving https://github.com/optuna/optuna/issues/4508.

## Description of the changes
Apply changes to `tests/sampler_tests/tpe_tests/test_sampler.py` by replacing `Callable` from `typing` module with `collections.abc` module. Also replaced `Dict`, `Union` and `Optional` from `Typing` module
