### PR TITLE
Simplify type annotations for `tests/storage_tests/rdb_tests/create_db.py`

### DIFF
--- a/tests/storages_tests/rdb_tests/create_db.py
+++ b/tests/storages_tests/rdb_tests/create_db.py
@@ -37,7 +37,6 @@ If you use `venv`, simply `deactivate` and re-activate your development environm
 """
 
 from argparse import ArgumentParser
-from typing import Tuple
 
 from packaging import version
 
@@ -54,7 +53,7 @@ def objective_test_upgrade(trial: optuna.trial.Trial) -> float:
     return x**2 + y**2 + z**2
 
 
-def mo_objective_test_upgrade(trial: optuna.trial.Trial) -> Tuple[float, float]:
+def mo_objective_test_upgrade(trial: optuna.trial.Trial) -> tuple[float, float]:
     x = trial.suggest_float("x", -5, 5)
     y = trial.suggest_int("y", 0, 10)
     z = trial.suggest_categorical("z", [-5, 0, 5])


### PR DESCRIPTION
## Motivation
This PR aims to enhance type annotation handling in `Optuna` to the module `tests/storage_tests/rdb_tests/create_db.py` and contributes to solving https://github.com/optuna/optuna/issues/4508.

## Description of the changes
Apply changes to `tests/storage_tests/rdb_tests/create_db.py` by replacing `Tuple` from `typing` module.
