### PR TITLE
Simplify type annotations for `tests/test_deprecated.py`

### DIFF
--- a/tests/test_deprecated.py
+++ b/tests/test_deprecated.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 from typing import Any
-from typing import Optional
 
 import pytest
 
@@ -120,7 +121,7 @@ def test_deprecation_decorator_name() -> None:
 
 
 @pytest.mark.parametrize("text", [None, "", "test", "test" * 100])
-def test_deprecation_text_specified(text: Optional[str]) -> None:
+def test_deprecation_text_specified(text: str | None) -> None:
     def _func() -> int:
         return 10
 
@@ -148,7 +149,7 @@ def test_deprecation_text_specified(text: Optional[str]) -> None:
 
 
 @pytest.mark.parametrize("text", [None, "", "test", "test" * 100])
-def test_deprecation_class_text_specified(text: Optional[str]) -> None:
+def test_deprecation_class_text_specified(text: str | None) -> None:
     class _Class:
         def __init__(self, a: Any, b: Any, c: Any) -> None:
             pass


### PR DESCRIPTION
## Motivation
This PR aims to enhance type annotation handling in `Optuna` to the module `tests/test_deprecated.py` and contributes to solving https://github.com/optuna/optuna/issues/4508.

## Description of the changes
Apply changes to `tests/test_deprecated.py` by replacing `Optional` from `typing` module.
