### PR TITLE
 Fix for Kaleido Chromium Dependency Issue in Visualization Tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,6 +65,9 @@ jobs:
         python -m pip install --upgrade pip
         pip install --progress-bar off -U setuptools
 
+    - name: Install Chromium
+      run: sudo apt-get update && sudo apt-get install -y chromium-browser
+      
     - name: Install
       run: |
         # Install minimal dependencies and confirm that `import optuna` is successful.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ document = [
   "ase",
   "cmaes>=0.10.0",  # optuna/samplers/_cmaes.py.
   "fvcore",
-  "kaleido<0.4",  # TODO(nzw0301): Remove the version constraint by installing browser separately.
+  "kaleido>=0.4",  
   "lightgbm",
   "matplotlib!=3.6.0",
   "pandas",
@@ -94,7 +94,7 @@ optional = [
 test = [
   "coverage",
   "fakeredis[lua]",
-  "kaleido<0.4",  # TODO(nzw0301): Remove the version constraint by installing browser separately.
+  "kaleido>=0.4", 
   "moto",
   "pytest",
   "scipy>=1.9.2",


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

This PR is currently a draft to address CI errors. I couldn’t run actions on local PRs, possibly due to security restrictions, so I’ll need CI feedback to confirm the fix.

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
The dependency `kaleido>=4.0`,  was failing CI tests(ref: #5771) due to a new requirement that chrome be installed separately(ref: https://github.com/plotly/Kaleido/issues/223). 

## Description of the changes
<!-- Describe the changes in this PR. -->

I added Chromium installation to the test workflow to fix the Kaleido dependency issue. This ensures visualization tests have the environment they need to run properly. I think adding it here makes more sense than the Sphinx workflow because it directly addresses where the issue happens. 

Closes #5776 