### PR TITLE
Simplify type annotations for `tests/importance_tests/test_init.py`

### DIFF
--- a/tests/importance_tests/test_init.py
+++ b/tests/importance_tests/test_init.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from typing import Any
-from typing import Type
 
 import numpy as np
 import pytest
@@ -22,7 +21,7 @@ from optuna.testing.storages import StorageSupplier
 from optuna.trial import Trial
 
 
-evaluators: list[Type[BaseImportanceEvaluator]] = [
+evaluators: list[type[BaseImportanceEvaluator]] = [
     MeanDecreaseImpurityImportanceEvaluator,
     FanovaImportanceEvaluator,
 ]


### PR DESCRIPTION
## Motivation
This PR aims to enhance type annotation handling in `Optuna` to the module `tests/importance_tests/test_init.py` and contributes to solving https://github.com/optuna/optuna/issues/4508.

## Description of the changes
Apply changes to `tests/importance_tests/test_init.py` by replacing `Type` from `typing` module.
