### PR TITLE
Simplify type annotations for `tests/trial_tests/test_trials.py`

### DIFF
--- a/tests/trial_tests/test_trials.py
+++ b/tests/trial_tests/test_trials.py
@@ -1,8 +1,8 @@
+from __future__ import annotations
+
 import datetime
 import time
 from typing import Any
-from typing import Dict
-from typing import Optional
 
 import pytest
 
@@ -23,8 +23,8 @@ parametrize_trial_type = pytest.mark.parametrize("trial_type", [FixedTrial, Froz
 
 def _create_trial(
     trial_type: type,
-    params: Optional[Dict[str, Any]] = None,
-    distributions: Optional[Dict[str, BaseDistribution]] = None,
+    params: dict[str, Any] | None = None,
+    distributions: dict[str, BaseDistribution] | None = None,
 ) -> BaseTrial:
     if params is None:
         params = {"x": 10}


### PR DESCRIPTION
## Motivation

This PR aims to enhance type annotation handling in `Optuna` to the module `tests/trial_tests/test_trials.py` and contributes to solving https://github.com/optuna/optuna/issues/4508.

## Description of the changes
Apply changes to `tests/trial_tests/test_trials.py` by replacing `Callable` from `typing` module with `collections.abc` module. Also replaced `Optional` and `Dict` from `typing` module.
