### PR TITLE
Simplify type annotations `optuna/_transform.py`

### DIFF
--- a/optuna/_transform.py
+++ b/optuna/_transform.py
@@ -1,9 +1,7 @@
+from __future__ import annotations
+
 import math
 from typing import Any
-from typing import Dict
-from typing import List
-from typing import Tuple
-from typing import Union
 
 import numpy as np
 
@@ -62,7 +60,7 @@ class _SearchSpaceTransform:
 
     def __init__(
         self,
-        search_space: Dict[str, BaseDistribution],
+        search_space: dict[str, BaseDistribution],
         transform_log: bool = True,
         transform_step: bool = True,
         transform_0_1: bool = False,
@@ -85,14 +83,14 @@ class _SearchSpaceTransform:
             return self._raw_bounds
 
     @property
-    def column_to_encoded_columns(self) -> List[np.ndarray]:
+    def column_to_encoded_columns(self) -> list[np.ndarray]:
         return self._column_to_encoded_columns
 
     @property
     def encoded_column_to_column(self) -> np.ndarray:
         return self._encoded_column_to_column
 
-    def transform(self, params: Dict[str, Any]) -> np.ndarray:
+    def transform(self, params: dict[str, Any]) -> np.ndarray:
         """Transform a parameter configuration from actual values to continuous space.
 
         Args:
@@ -130,7 +128,7 @@ class _SearchSpaceTransform:
 
         return trans_params
 
-    def untransform(self, trans_params: np.ndarray) -> Dict[str, Any]:
+    def untransform(self, trans_params: np.ndarray) -> dict[str, Any]:
         """Untransform a parameter configuration from continuous space to actual values.
 
         Args:
@@ -171,8 +169,8 @@ class _SearchSpaceTransform:
 
 
 def _transform_search_space(
-    search_space: Dict[str, BaseDistribution], transform_log: bool, transform_step: bool
-) -> Tuple[np.ndarray, List[np.ndarray], np.ndarray]:
+    search_space: dict[str, BaseDistribution], transform_log: bool, transform_step: bool
+) -> tuple[np.ndarray, list[np.ndarray], np.ndarray]:
     assert len(search_space) > 0, "Cannot transform if no distributions are given."
 
     n_bounds = sum(
@@ -181,7 +179,7 @@ def _transform_search_space(
     )
 
     bounds = np.empty((n_bounds, 2), dtype=np.float64)
-    column_to_encoded_columns: List[np.ndarray] = []
+    column_to_encoded_columns: list[np.ndarray] = []
     encoded_column_to_column = np.empty(n_bounds, dtype=np.int64)
 
     bound_idx = 0
@@ -242,7 +240,7 @@ def _transform_search_space(
 
 
 def _transform_numerical_param(
-    param: Union[int, float], distribution: BaseDistribution, transform_log: bool
+    param: int | float, distribution: BaseDistribution, transform_log: bool
 ) -> float:
     d = distribution
 
@@ -266,7 +264,7 @@ def _transform_numerical_param(
 
 def _untransform_numerical_param(
     trans_param: float, distribution: BaseDistribution, transform_log: bool
-) -> Union[int, float]:
+) -> int | float:
     d = distribution
 
     if isinstance(d, CategoricalDistribution):


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation

Work towards https://github.com/optuna/optuna/issues/4508

## Description of the changes

This update introduces the use of `__future__.annotations` to simplify type annotations across the codebase. Key improvements include replacing `Union` with modern syntax (`int | float`, etc.) and using `list[...]`, `dict[...]`, and `tuple[...]` instead of the legacy `List[...]`, `Dict[...]`, and `Tuple[...]`. These changes enhance code readability and maintainability while retaining full functionality. The refactored implementation preserves compatibility with Optuna's core functionality and modern Python standards, aligning with PEP 563, PEP 585, and PEP 604.


