### PR TITLE
Simplify type annotations for `tests/pruners_tests/test_hyperband.py`

### DIFF
--- a/tests/pruners_tests/test_hyperband.py
+++ b/tests/pruners_tests/test_hyperband.py
@@ -1,4 +1,6 @@
-from typing import Callable
+from __future__ import annotations
+
+from collections.abc import Callable
 from unittest import mock
 
 import numpy as np


### PR DESCRIPTION
## Motivation
This PR aims to enhance type annotation handling in `Optuna` to the module `tests/pruners_tests/test_hyperband.py` and contributes to solving https://github.com/optuna/optuna/issues/4508.

## Description of the changes
Apply changes to `tests/pruners_tests/test_hyperband.py` by replacing `Callable` from `typing` module with `collections.abc` module.
