### PR TITLE
Simplify type annotations for `tests/pruners_tests/test_median.py`

### DIFF
--- a/tests/pruners_tests/test_median.py
+++ b/tests/pruners_tests/test_median.py
@@ -1,5 +1,4 @@
-from typing import List
-from typing import Tuple
+from __future__ import annotations
 
 import pytest
 
@@ -17,7 +16,7 @@ def test_median_pruner_with_one_trial() -> None:
 
 
 @pytest.mark.parametrize("direction_value", [("minimize", 2), ("maximize", 0.5)])
-def test_median_pruner_intermediate_values(direction_value: Tuple[str, float]) -> None:
+def test_median_pruner_intermediate_values(direction_value: tuple[str, float]) -> None:
     direction, intermediate_value = direction_value
     pruner = optuna.pruners.MedianPruner(0, 0)
     study = optuna.study.create_study(direction=direction, pruner=pruner)
@@ -110,7 +109,7 @@ def test_median_pruner_n_warmup_steps() -> None:
     ],
 )
 def test_median_pruner_interval_steps(
-    n_warmup_steps: int, interval_steps: int, report_steps: int, expected_prune_steps: List[int]
+    n_warmup_steps: int, interval_steps: int, report_steps: int, expected_prune_steps: list[int]
 ) -> None:
     pruner = optuna.pruners.MedianPruner(0, n_warmup_steps, interval_steps)
     study = optuna.study.create_study(pruner=pruner)


### PR DESCRIPTION
## Motivation
This PR aims to enhance type annotation handling in `Optuna` to the module `tests/pruners_tests/test_median.py` and contributes to solving https://github.com/optuna/optuna/issues/4508.

## Description of the changes
Apply changes to `tests/pruners_tests/test_median.py` by replacing `List` and `Tuple` from `typing` module.
