### PR TITLE
Simplify type annotations for `tests/pruners_tests/test_patient.py`

### DIFF
--- a/tests/pruners_tests/test_patient.py
+++ b/tests/pruners_tests/test_patient.py
@@ -1,4 +1,4 @@
-from typing import List
+from __future__ import annotations
 
 import pytest
 
@@ -76,8 +76,8 @@ def test_patient_pruner_intermediate_values(
     patience: int,
     min_delta: float,
     direction: str,
-    intermediates: List[int],
-    expected_prune_steps: List[int],
+    intermediates: list[int],
+    expected_prune_steps: list[int],
 ) -> None:
     pruner = optuna.pruners.PatientPruner(None, patience, min_delta)
     study = optuna.study.create_study(pruner=pruner, direction=direction)


### PR DESCRIPTION
## Motivation
Apply changes to `tests/pruners_tests/test_patient.py` by replacing `Callable` from `typing` module with `collections.abc` module. Also replaced `Optional`, `Dict`, `List` and `Tuple` from `typing` module.

## Description of the changes
Apply changes to `tests/pruners_tests/test_patient.py` by replacing `List` from `typing` module.

