### PR TITLE
Use `study.ask()` in tests instead of `create_new_trial` (#5804)

### DIFF
--- a/tests/trial_tests/test_trial.py
+++ b/tests/trial_tests/test_trial.py
@@ -34,7 +34,7 @@ def test_check_distribution_suggest_float(storage_mode: str) -> None:
     sampler = samplers.RandomSampler()
     with StorageSupplier(storage_mode) as storage:
         study = create_study(storage=storage, sampler=sampler)
-        trial = Trial(study, study._storage.create_new_trial(study._study_id))
+        trial = study.ask()
 
         x1 = trial.suggest_float("x1", 10, 20)
         x2 = trial.suggest_uniform("x1", 10, 20)
@@ -56,7 +56,7 @@ def test_check_distribution_suggest_float(storage_mode: str) -> None:
         with pytest.raises(ValueError):
             trial.suggest_int("x1", 10, 20)
 
-        trial = Trial(study, study._storage.create_new_trial(study._study_id))
+        trial = study.ask()
         with pytest.raises(ValueError):
             trial.suggest_int("x1", 10, 20)
 
@@ -67,7 +67,7 @@ def test_check_distribution_suggest_uniform(storage_mode: str) -> None:
     sampler = samplers.RandomSampler()
     with StorageSupplier(storage_mode) as storage:
         study = create_study(storage=storage, sampler=sampler)
-        trial = Trial(study, study._storage.create_new_trial(study._study_id))
+        trial = study.ask()
 
         with pytest.warns() as record:
             trial.suggest_uniform("x", 10, 20)
@@ -80,7 +80,7 @@ def test_check_distribution_suggest_uniform(storage_mode: str) -> None:
         with pytest.raises(ValueError):
             trial.suggest_int("x", 10, 20)
 
-        trial = Trial(study, study._storage.create_new_trial(study._study_id))
+        trial = study.ask()
         with pytest.raises(ValueError):
             trial.suggest_int("x", 10, 20)
 
@@ -91,7 +91,7 @@ def test_check_distribution_suggest_loguniform(storage_mode: str) -> None:
     sampler = samplers.RandomSampler()
     with StorageSupplier(storage_mode) as storage:
         study = create_study(storage=storage, sampler=sampler)
-        trial = Trial(study, study._storage.create_new_trial(study._study_id))
+        trial = study.ask()
 
         with pytest.warns() as record:
             trial.suggest_loguniform("x", 10, 20)
@@ -104,7 +104,7 @@ def test_check_distribution_suggest_loguniform(storage_mode: str) -> None:
         with pytest.raises(ValueError):
             trial.suggest_int("x", 10, 20)
 
-        trial = Trial(study, study._storage.create_new_trial(study._study_id))
+        trial = study.ask()
         with pytest.raises(ValueError):
             trial.suggest_int("x", 10, 20)
 
@@ -115,7 +115,7 @@ def test_check_distribution_suggest_discrete_uniform(storage_mode: str) -> None:
     sampler = samplers.RandomSampler()
     with StorageSupplier(storage_mode) as storage:
         study = create_study(storage=storage, sampler=sampler)
-        trial = Trial(study, study._storage.create_new_trial(study._study_id))
+        trial = study.ask()
 
         with pytest.warns() as record:
             trial.suggest_discrete_uniform("x", 10, 20, 2)
@@ -128,7 +128,7 @@ def test_check_distribution_suggest_discrete_uniform(storage_mode: str) -> None:
         with pytest.raises(ValueError):
             trial.suggest_int("x", 10, 20, step=2)
 
-        trial = Trial(study, study._storage.create_new_trial(study._study_id))
+        trial = study.ask()
         with pytest.raises(ValueError):
             trial.suggest_int("x", 10, 20, step=2)
 
@@ -139,7 +139,7 @@ def test_check_distribution_suggest_int(storage_mode: str, enable_log: bool) -> 
     sampler = samplers.RandomSampler()
     with StorageSupplier(storage_mode) as storage:
         study = create_study(storage=storage, sampler=sampler)
-        trial = Trial(study, study._storage.create_new_trial(study._study_id))
+        trial = study.ask()
 
         with pytest.warns() as record:
             trial.suggest_int("x", 10, 20, log=enable_log)
@@ -152,7 +152,7 @@ def test_check_distribution_suggest_int(storage_mode: str, enable_log: bool) -> 
         with pytest.raises(ValueError):
             trial.suggest_float("x", 10, 20, log=enable_log)
 
-        trial = Trial(study, study._storage.create_new_trial(study._study_id))
+        trial = study.ask()
         with pytest.raises(ValueError):
             trial.suggest_float("x", 10, 20, log=enable_log)
 
@@ -162,7 +162,7 @@ def test_check_distribution_suggest_categorical(storage_mode: str) -> None:
     sampler = samplers.RandomSampler()
     with StorageSupplier(storage_mode) as storage:
         study = create_study(storage=storage, sampler=sampler)
-        trial = Trial(study, study._storage.create_new_trial(study._study_id))
+        trial = study.ask()
 
         trial.suggest_categorical("x", [10, 20, 30])
 
@@ -172,7 +172,7 @@ def test_check_distribution_suggest_categorical(storage_mode: str) -> None:
         with pytest.raises(ValueError):
             trial.suggest_int("x", 10, 20)
 
-        trial = Trial(study, study._storage.create_new_trial(study._study_id))
+        trial = study.ask()
         with pytest.raises(ValueError):
             trial.suggest_int("x", 10, 20)
 
@@ -184,7 +184,7 @@ def test_suggest_uniform(storage_mode: str) -> None:
 
     with StorageSupplier(storage_mode) as storage:
         study = create_study(storage=storage, sampler=sampler)
-        trial = Trial(study, study._storage.create_new_trial(study._study_id))
+        trial = study.ask()
 
         assert trial.suggest_uniform("x", 0.0, 3.0) == 1.0  # Test suggesting a param.
         assert trial.suggest_uniform("x", 0.0, 3.0) == 1.0  # Test suggesting the same param.
@@ -205,7 +205,7 @@ def test_suggest_loguniform(storage_mode: str) -> None:
 
     with StorageSupplier(storage_mode) as storage:
         study = create_study(storage=storage, sampler=sampler)
-        trial = Trial(study, study._storage.create_new_trial(study._study_id))
+        trial = study.ask()
 
         assert trial.suggest_loguniform("x", 0.1, 4.0) == 1.0  # Test suggesting a param.
         assert trial.suggest_loguniform("x", 0.1, 4.0) == 1.0  # Test suggesting the same param.
@@ -220,7 +220,7 @@ def test_suggest_discrete_uniform(storage_mode: str) -> None:
 
     with StorageSupplier(storage_mode) as storage:
         study = create_study(storage=storage, sampler=sampler)
-        trial = Trial(study, study._storage.create_new_trial(study._study_id))
+        trial = study.ask()
 
         assert (
             trial.suggest_discrete_uniform("x", 0.0, 3.0, 1.0) == 1.0
@@ -242,7 +242,7 @@ def test_suggest_low_equals_high(storage_mode: str) -> None:
     ) as mock_object, StorageSupplier(storage_mode) as storage:
         study = create_study(storage=storage, sampler=samplers.TPESampler(n_startup_trials=0))
 
-        trial = Trial(study, study._storage.create_new_trial(study._study_id))
+        trial = study.ask()
 
         assert trial.suggest_uniform("a", 1.0, 1.0) == 1.0  # Suggesting a param.
         assert mock_object.call_count == 1
@@ -314,7 +314,7 @@ def test_suggest_discrete_uniform_range(storage_mode: str, range_config: dict[st
         storage_mode
     ) as storage:
         study = create_study(storage=storage, sampler=sampler)
-        trial = Trial(study, study._storage.create_new_trial(study._study_id))
+        trial = study.ask()
 
         with pytest.warns(UserWarning):
             x = trial.suggest_discrete_uniform(
@@ -330,7 +330,7 @@ def test_suggest_discrete_uniform_range(storage_mode: str, range_config: dict[st
         storage_mode
     ) as storage:
         study = create_study(storage=storage, sampler=sampler)
-        trial = Trial(study, study._storage.create_new_trial(study._study_id))
+        trial = study.ask()
 
         with pytest.warns(UserWarning):
             x = trial.suggest_discrete_uniform(
@@ -357,7 +357,7 @@ def test_suggest_int(storage_mode: str) -> None:
 
     with StorageSupplier(storage_mode) as storage:
         study = create_study(storage=storage, sampler=sampler)
-        trial = Trial(study, study._storage.create_new_trial(study._study_id))
+        trial = study.ask()
 
         assert trial.suggest_int("x", 0, 3) == 1  # Test suggesting a param.
         assert trial.suggest_int("x", 0, 3) == 1  # Test suggesting the same param.
@@ -384,7 +384,7 @@ def test_suggest_int_range(storage_mode: str, range_config: dict[str, int]) -> N
         storage_mode
     ) as storage:
         study = create_study(storage=storage, sampler=sampler)
-        trial = Trial(study, study._storage.create_new_trial(study._study_id))
+        trial = study.ask()
 
         with pytest.warns(UserWarning):
             x = trial.suggest_int(
@@ -400,7 +400,7 @@ def test_suggest_int_range(storage_mode: str, range_config: dict[str, int]) -> N
         storage_mode
     ) as storage:
         study = create_study(storage=storage, sampler=sampler)
-        trial = Trial(study, study._storage.create_new_trial(study._study_id))
+        trial = study.ask()
 
         with pytest.warns(UserWarning):
             x = trial.suggest_int(
@@ -427,7 +427,7 @@ def test_suggest_int_log(storage_mode: str) -> None:
 
     with StorageSupplier(storage_mode) as storage:
         study = create_study(storage=storage, sampler=sampler)
-        trial = Trial(study, study._storage.create_new_trial(study._study_id))
+        trial = study.ask()
 
         assert trial.suggest_int("x", 1, 3, log=True) == 1  # Test suggesting a param.
         assert trial.suggest_int("x", 1, 3, log=True) == 1  # Test suggesting the same param.
@@ -440,7 +440,7 @@ def test_suggest_int_log_invalid_range(storage_mode: str) -> None:
     sampler = samplers.RandomSampler()
     with StorageSupplier(storage_mode) as storage:
         study = create_study(storage=storage, sampler=sampler)
-        trial = Trial(study, study._storage.create_new_trial(study._study_id))
+        trial = study.ask()
         with warnings.catch_warnings():
             # UserWarning will be raised since [0.5, 10] is not divisible by 1.
             warnings.simplefilter("ignore", category=UserWarning)
@@ -449,7 +449,7 @@ def test_suggest_int_log_invalid_range(storage_mode: str) -> None:
 
     with StorageSupplier(storage_mode) as storage:
         study = create_study(storage=storage, sampler=sampler)
-        trial = Trial(study, study._storage.create_new_trial(study._study_id))
+        trial = study.ask()
         with pytest.raises(ValueError):
             trial.suggest_int("w", 1, 3, step=2, log=True)
 
@@ -483,7 +483,7 @@ def test_distributions(storage_mode: str) -> None:
 def test_should_prune() -> None:
     pruner = DeterministicPruner(True)
     study = create_study(pruner=pruner)
-    trial = Trial(study, study._storage.create_new_trial(study._study_id))
+    trial = study.ask()
     trial.report(1, 1)
     assert trial.should_prune()
 
@@ -521,7 +521,7 @@ def test_relative_parameters(storage_mode: str) -> None:
         study = create_study(storage=storage, sampler=sampler)
 
         def create_trial() -> Trial:
-            return Trial(study, study._storage.create_new_trial(study._study_id))
+            return study.ask()
 
         # Suggested by `sample_relative`.
         trial0 = create_trial()
@@ -574,7 +574,7 @@ def test_datetime_start(storage_mode: str) -> None:
 
 def test_report_value() -> None:
     study = create_study()
-    trial = Trial(study, study._storage.create_new_trial(study._study_id))
+    trial = study.ask()
 
     # Report values that can be cast to `float` (OK).
     trial.report(1.23, 1)


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
The method `create_new_trial` has been replaced by `study.ask()` in the relevant tests to unify the backend logic and simplify the trial creation process. 

## Description of the changes
The lines of code from `Trial(study, study._storage.create_new_trial(study._study_id))` have been changed to `study.ask()` as mentioned in the issue #5804 
