### PR TITLE
Simplify type annotations for `tests/pruners_tests/test_percentile.py`

### DIFF
--- a/tests/pruners_tests/test_percentile.py
+++ b/tests/pruners_tests/test_percentile.py
@@ -1,6 +1,6 @@
+from __future__ import annotations
+
 import math
-from typing import List
-from typing import Tuple
 import warnings
 
 import pytest
@@ -65,7 +65,7 @@ def test_percentile_pruner_with_one_trial() -> None:
     "direction_value", [("minimize", [1, 2, 3, 4, 5], 2.1), ("maximize", [1, 2, 3, 4, 5], 3.9)]
 )
 def test_25_percentile_pruner_intermediate_values(
-    direction_value: Tuple[str, List[float], float]
+    direction_value: tuple[str, list[float], float]
 ) -> None:
     direction, intermediate_values, latest_value = direction_value
     pruner = optuna.pruners.PercentilePruner(25.0, 0, 0)
@@ -112,7 +112,7 @@ def test_25_percentile_pruner_intermediate_values_nan() -> None:
     "direction_expected", [(StudyDirection.MINIMIZE, 0.1), (StudyDirection.MAXIMIZE, 0.2)]
 )
 def test_get_best_intermediate_result_over_steps(
-    direction_expected: Tuple[StudyDirection, float]
+    direction_expected: tuple[StudyDirection, float]
 ) -> None:
     direction, expected = direction_expected
 
@@ -161,7 +161,7 @@ def test_get_best_intermediate_result_over_steps(
 
 
 def test_get_percentile_intermediate_result_over_trials() -> None:
-    def setup_study(trial_num: int, _intermediate_values: List[List[float]]) -> Study:
+    def setup_study(trial_num: int, _intermediate_values: list[list[float]]) -> Study:
         _study = optuna.study.create_study(direction="minimize")
         trial_ids = [_study._storage.create_new_trial(_study._study_id) for _ in range(trial_num)]
 


### PR DESCRIPTION
## Motivation
This PR aims to enhance type annotation handling in `Optuna` to the module `tests/pruners_tests/test_percentile.py` and contributes to solving https://github.com/optuna/optuna/issues/4508.

## Description of the changes
Apply changes to `tests/pruners_tests/test_percentile.py` by replacing `List` and `Tuple` from `typing` module.

