### PR TITLE
Simplify type annotations for `tests/pruners_tests/test_successive_halving.py`

### DIFF
--- a/tests/pruners_tests/test_successive_halving.py
+++ b/tests/pruners_tests/test_successive_halving.py
@@ -1,4 +1,4 @@
-from typing import Tuple
+from __future__ import annotations
 
 import pytest
 
@@ -6,7 +6,7 @@ import optuna
 
 
 @pytest.mark.parametrize("direction_value", [("minimize", 2), ("maximize", 0.5)])
-def test_successive_halving_pruner_intermediate_values(direction_value: Tuple[str, float]) -> None:
+def test_successive_halving_pruner_intermediate_values(direction_value: tuple[str, float]) -> None:
     direction, intermediate_value = direction_value
     pruner = optuna.pruners.SuccessiveHalvingPruner(
         min_resource=1, reduction_factor=2, min_early_stopping_rate=0


### PR DESCRIPTION
## Motivation
This PR aims to enhance type annotation handling in `Optuna` to the module `tests/pruners_tests/test_successive_halving.py` and contributes to solving https://github.com/optuna/optuna/issues/4508.

## Description of the changes
Apply changes to `tests/pruners_tests/test_successive_halving.py` by replacing `Tuple` from `typing` module.

