### PR TITLE
Simplify type annotations for `tests/study_tests/test_study.py`

### DIFF
--- a/tests/study_tests/test_study.py
+++ b/tests/study_tests/test_study.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from concurrent.futures import as_completed
 from concurrent.futures import ThreadPoolExecutor
 import copy
@@ -9,7 +10,6 @@ import platform
 import threading
 import time
 from typing import Any
-from typing import Callable
 from unittest.mock import Mock
 from unittest.mock import patch
 import uuid


### PR DESCRIPTION
## Motivation
This PR aims to enhance type annotation handling in `Optuna` to the module `tests/study_tests/test_study.py` and contributes to solving https://github.com/optuna/optuna/issues/4508.

## Description of the changes
Apply changes to `tests/study_tests/test_study.py` by replacing `Callable` from `typing` module with `collections.abc` module.
