### PR TITLE
Simplify type annotations for `tests/hypervolume_tests/test_hssp.py`

### DIFF
--- a/tests/hypervolume_tests/test_hssp.py
+++ b/tests/hypervolume_tests/test_hssp.py
@@ -1,6 +1,7 @@
+from __future__ import annotations
+
 import itertools
 import math
-from typing import Tuple
 
 import numpy as np
 import pytest
@@ -8,7 +9,7 @@ import pytest
 import optuna
 
 
-def _compute_hssp_truth_and_approx(test_case: np.ndarray, subset_size: int) -> Tuple[float, float]:
+def _compute_hssp_truth_and_approx(test_case: np.ndarray, subset_size: int) -> tuple[float, float]:
     r = 1.1 * np.max(test_case, axis=0)
     truth = 0.0
     for subset in itertools.permutations(test_case, subset_size):


### PR DESCRIPTION
## Motivation
This PR aims to enhance type annotation handling in `Optuna` to the module `tests/hypervolume_tests/test_hssp.py` and contributes to solving https://github.com/optuna/optuna/issues/4508.

## Description of the changes
Apply changes to `tests/hypervolume_tests/test_hssp.py` by replacing `Tuple` from `typing` module.