### PR TITLE
Simplify type annotations for `optuna/_callbacks.py`

### DIFF
--- a/optuna/_callbacks.py
+++ b/optuna/_callbacks.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 from typing import Container
-from typing import Optional
 
 import optuna
 from optuna.trial import FrozenTrial
@@ -45,7 +46,7 @@ class MaxTrialsCallback:
     """
 
     def __init__(
-        self, n_trials: int, states: Optional[Container[TrialState]] = (TrialState.COMPLETE,)
+        self, n_trials: int, states: Container[TrialState] | None = (TrialState.COMPLETE,)
     ) -> None:
         self._n_trials = n_trials
         self._states = states


### PR DESCRIPTION
## Motivation
This PR aims to enhance type annotation handling in `Optuna` to the module `optuna/_callbacks.py` and contributes to solving https://github.com/optuna/optuna/issues/4508.

## Description of the changes
Apply changes to `optuna/_callbacks.py` by replacing `Optional` from `typing` module.

