### PR TITLE
Simplify type annotations for `optuna/samplers/_random.py`

### DIFF
--- a/optuna/samplers/_random.py
+++ b/optuna/samplers/_random.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
 from typing import Any
-from typing import Dict
-from typing import Optional
 from typing import TYPE_CHECKING
 
 from optuna import distributions
@@ -43,7 +41,7 @@ class RandomSampler(BaseSampler):
         seed: Seed for random number generator.
     """
 
-    def __init__(self, seed: Optional[int] = None) -> None:
+    def __init__(self, seed: int | None = None) -> None:
         self._rng = LazyRandomState(seed)
 
     def reseed_rng(self) -> None:
@@ -51,12 +49,12 @@ class RandomSampler(BaseSampler):
 
     def infer_relative_search_space(
         self, study: Study, trial: FrozenTrial
-    ) -> Dict[str, BaseDistribution]:
+    ) -> dict[str, BaseDistribution]:
         return {}
 
     def sample_relative(
-        self, study: Study, trial: FrozenTrial, search_space: Dict[str, BaseDistribution]
-    ) -> Dict[str, Any]:
+        self, study: Study, trial: FrozenTrial, search_space: dict[str, BaseDistribution]
+    ) -> dict[str, Any]:
         return {}
 
     def sample_independent(


### PR DESCRIPTION
## Motivation
This PR aims to enhance type annotation handling in `Optuna` to the module `optuna/samplers/_random.py` and contributes to solving https://github.com/optuna/optuna/issues/4508.

## Description of the changes
Apply changes to `optuna/samplers/_random.py` by replacing `Dict` and `Optional` from `typing` module.
