### PR TITLE
Fix the explanation of returned values of `get_trial_params`

### DIFF
--- a/optuna/storages/_base.py
+++ b/optuna/storages/_base.py
@@ -558,7 +558,7 @@ class BaseStorage(abc.ABC):
                 ID of the trial.
 
         Returns:
-            Dictionary of a parameters. Keys are parameter names and values are internal
+            Dictionary of a parameters. Keys are parameter names and values are external
             representations of the parameter values.
 
         Raises:


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
The explanation of the returned value of `get_trial_params` in the `BaseStorage` is `Keys are parameter names and values are **internal** representations of the parameter values.`. However, actually, it returns the **externel** representations of the parameter values. I will fix the word of "internal" to "external".

## Description of the changes
<!-- Describe the changes in this PR. -->
- Fix the explanation of returned values of `get_trial_params`