### PR TITLE
Simplify type annotations for `optuna/samplers/_gp/sampler.py`

### DIFF
--- a/optuna/samplers/_gp/sampler.py
+++ b/optuna/samplers/_gp/sampler.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
+from collections.abc import Callable
+from collections.abc import Sequence
 from typing import Any
-from typing import Callable
 from typing import cast
-from typing import Sequence
 from typing import TYPE_CHECKING
 import warnings
 


### PR DESCRIPTION
## Motivation
This PR aims to enhance type annotation handling in `Optuna` to the module `optuna/samplers/_gp/sampler.py` and contributes to solving https://github.com/optuna/optuna/issues/4508.

## Description of the changes
Apply changes to `optuna/samplers/_gp/sampler.py` by replacing `Callable` and `Sequence` from `typing` module with `collections.abc` module. 

