### PR TITLE
Simplify type annotations for `optuna/samplers/nsgaii/_crossovers/_spx.py`

### DIFF
--- a/optuna/samplers/nsgaii/_crossovers/_spx.py
+++ b/optuna/samplers/nsgaii/_crossovers/_spx.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from typing import Optional
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -34,7 +33,7 @@ class SPXCrossover(BaseCrossover):
 
     n_parents = 3
 
-    def __init__(self, epsilon: Optional[float] = None) -> None:
+    def __init__(self, epsilon: float | None = None) -> None:
         self._epsilon = epsilon
 
     def crossover(


### PR DESCRIPTION
## Motivation
This PR aims to enhance type annotation handling in `Optuna` to the module `optuna/samplers/nsgaii/_crossovers/_spx.py` and contributes to solving https://github.com/optuna/optuna/issues/4508.

## Description of the changes
Apply changes to `optuna/samplers/nsgaii/_crossovers/_spx.py` by replacing `Optional` from `typing` module.

