### PR TITLE
Adding check in `cli.py` to handle an empty database

### DIFF
--- a/optuna/cli.py
+++ b/optuna/cli.py
@@ -199,6 +199,7 @@ def _dump_value(records: list[dict[str, Any]], header: list[str]) -> str:
 
 
 def _dump_table(records: list[dict[str, Any]], header: list[str]) -> str:
+
     rows = []
     for record in records:
         row = []
@@ -215,7 +216,10 @@ def _dump_table(records: list[dict[str, Any]], header: list[str]) -> str:
         for t in value_types:
             if t == ValueType.STRING:
                 value_type = ValueType.STRING
-        max_width = max(len(header[column]), max(row[column].width() for row in rows))
+        if not rows:
+            max_width = len(header[column])
+        else:
+            max_width = max(len(header[column]), max(row[column].width() for row in rows))
         separator += "-" * (max_width + 2) + "+"
         if value_type == ValueType.NUMERIC:
             header_string += f" {header[column]:>{max_width}} |"
@@ -228,7 +232,8 @@ def _dump_table(records: list[dict[str, Any]], header: list[str]) -> str:
     ret += separator + "\n"
     ret += header_string + "\n"
     ret += separator + "\n"
-    ret += "\n".join(rows_string) + "\n"
+    if rows:
+        ret += "\n".join(rows_string) + "\n"
     ret += separator + "\n"
 
     return ret

--- a/optuna/cli.py
+++ b/optuna/cli.py
@@ -231,8 +231,8 @@ def _dump_table(records: list[dict[str, Any]], header: list[str]) -> str:
     ret += separator + "\n"
     ret += header_string + "\n"
     ret += separator + "\n"
-    if len(rows) == 0:
-        ret += "\n".join(rows_string) + "\n"
+    for row_string in rows_string:
+        ret += row_string + "\n"
     ret += separator + "\n"
 
     return ret

--- a/optuna/cli.py
+++ b/optuna/cli.py
@@ -215,7 +215,7 @@ def _dump_table(records: list[dict[str, Any]], header: list[str]) -> str:
         for t in value_types:
             if t == ValueType.STRING:
                 value_type = ValueType.STRING
-        if not rows:
+        if len(rows) == 0:
             max_width = len(header[column])
         else:
             max_width = max(len(header[column]), max(row[column].width() for row in rows))

--- a/optuna/cli.py
+++ b/optuna/cli.py
@@ -231,7 +231,7 @@ def _dump_table(records: list[dict[str, Any]], header: list[str]) -> str:
     ret += separator + "\n"
     ret += header_string + "\n"
     ret += separator + "\n"
-    if rows:
+    if len(rows) == 0:
         ret += "\n".join(rows_string) + "\n"
     ret += separator + "\n"
 

--- a/optuna/cli.py
+++ b/optuna/cli.py
@@ -199,7 +199,6 @@ def _dump_value(records: list[dict[str, Any]], header: list[str]) -> str:
 
 
 def _dump_table(records: list[dict[str, Any]], header: list[str]) -> str:
-
     rows = []
     for record in records:
         row = []


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
This PR aims to close #5816 

## Description of the changes
<!-- Describe the changes in this PR. -->
- Added a check in `cli.py` in `_dump_table` to handle cases where no rows exist (empty database).
- If `rows` is empty, the column width is determined based only on the header length, so that `max()` isn't called on an empty sequence.
- Also created a conditional block to append row strings (`ret += "\n".join(rows_string) + "\n"`) only if rows exist, to avoid unnecessary empty lines in the output.