### PR TITLE
Simplify type annotations for `optuna/samplers/testing/threading.py`

### DIFF
--- a/optuna/testing/threading.py
+++ b/optuna/testing/threading.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 import threading
 from typing import Any
-from typing import Callable
 
 
 class _TestableThread(threading.Thread):


### PR DESCRIPTION
## Motivation
This PR aims to enhance type annotation handling in `Optuna` to the module `optuna/samplers/testing/threading.py` and contributes to solving https://github.com/optuna/optuna/issues/4508.

## Description of the changes
Apply changes to `optuna/samplers/testing/threading.py` by replacing `Callable` from `typing` module with `collections.abc` module.
