### PR TITLE
Made error message easier to understand for create_study's direction #5806

### DIFF
--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -1252,8 +1252,7 @@ def create_study(
         for d in directions
     ):
         raise ValueError(
-            "Please set either 'minimize' or 'maximize' to direction. You can also set the "
-            "corresponding `StudyDirection` member."
+            "Use 'directions' instead of 'direction' for multi-objective optimization."
         )
 
     direction_objects = [


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
Users sometimes pass a list of directions to the direction argument, expecting multi-objective optimization, when they should use directions instead. 
The previous error message: 
`ValueError: Please set either 'minimize' or 'maximize' to direction. You can also set the corresponding 'StudyDirection' member.`

This message doesn't clearly explain that multi-objective optimization requires using directions. The updated message provides clearer guidance. The issue was raised in the #5806

## Description of the changes
<!-- Describe the changes in this PR. -->
The error message is changed to `Use 'directions' instead of 'direction' for multi-objective optimization.`
