### PR TITLE
Simplify type annotations for `optuna/study/_dataframe.py`

### DIFF
--- a/optuna/study/_dataframe.py
+++ b/optuna/study/_dataframe.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import collections
 from typing import Any
 from typing import DefaultDict
-from typing import Set
 
 import optuna
 from optuna._imports import try_import
@@ -36,7 +35,7 @@ def _create_records_and_aggregate_column(
     # column_agg is an aggregator of column names.
     # Keys of column agg are attributes of `FrozenTrial` such as 'trial_id' and 'params'.
     # Values are dataframe columns such as ('trial_id', '') and ('params', 'n_layers').
-    column_agg: DefaultDict[str, Set] = collections.defaultdict(set)
+    column_agg: DefaultDict[str, set] = collections.defaultdict(set)
     non_nested_attr = ""
 
     metric_names = study.metric_names


### PR DESCRIPTION
## Motivation
Apply changes to `optuna/study/_dataframe.py` by replacing `Container` and `Sequence` from `typing` module with `collections.abc` module. Also replaced `Optional`, `Dict`, `List` and `Tuple` from `typing` module.


## Description of the changes
Apply changes to `optuna/study/_dataframe.py` by replacing `Set` from `typing` module.
