### PR TITLE
Fix logger.warn() deprecation warning in GP module

### DIFF
--- a/optuna/_gp/gp.py
+++ b/optuna/_gp/gp.py
@@ -257,7 +257,7 @@ def fit_kernel_params(
         except RuntimeError as e:
             error = e
 
-    logger.warn(
+    logger.warning(
         f"The optimization of kernel_params failed: \n{error}\n"
         "The default initial kernel params will be used instead."
     )


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
The code was using the deprecated `logger.warn()` method which triggers deprecation warnings. According to Python's logging documentation, `warn()` is deprecated in favor of `warning()`. This PR fixes the deprecation warning to ensure clean logs and follow Python best practices.

## Description of the changes
- Replace deprecated `logger.warn()` with `logger.warning()` in `optuna/_gp/gp.py`
- The change is a straightforward method name update with no functional changes to the logging behavior