### PR TITLE
Simplify type annotations for `optuna/study/study.py`

### DIFF
--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -1,15 +1,15 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from collections.abc import Container
 from collections.abc import Iterable
 from collections.abc import Mapping
+from collections.abc import Sequence
 import copy
 from numbers import Real
 import threading
 from typing import Any
-from typing import Callable
 from typing import cast
-from typing import Sequence
 from typing import TYPE_CHECKING
 from typing import Union
 import warnings


### PR DESCRIPTION
## Motivation
This PR aims to enhance type annotation handling in `Optuna` to the module `optuna/study/study.py` and contributes to solving https://github.com/optuna/optuna/issues/4508.

## Description of the changes
Apply changes to `optuna/study/study.py` by replacing `Callable` and `Sequence` from `typing` module with `collections.abc` module.
