### PR TITLE
Simplify type annotations for `optuna/visualization/matplotlib/_contour.py`

### DIFF
--- a/optuna/visualization/matplotlib/_contour.py
+++ b/optuna/visualization/matplotlib/_contour.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from typing import Callable
-from typing import Sequence
+from collections.abc import Callable
+from collections.abc import Sequence
 
 import numpy as np
 


### PR DESCRIPTION
## Motivation
This PR aims to enhance type annotation handling in `Optuna` to the module `optuna/visualization/matplotlib/_contour.py` and contributes to solving https://github.com/optuna/optuna/issues/4508.

## Description of the changes
Apply changes to `optuna/visualization/matplotlib/_contour.py` by replacing `Callable` and `Sequence` from `typing` module with `collections.abc` module.
