### PR TITLE
Simplify type annotations for `optuna/visualization/matplotlib/_param_importances.py`

### DIFF
--- a/optuna/visualization/matplotlib/_param_importances.py
+++ b/optuna/visualization/matplotlib/_param_importances.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Callable
+from collections.abc import Callable
 
 import numpy as np
 


### PR DESCRIPTION
## Motivation
Apply changes to `optuna/visualization/matplotlib/_param_importances.py` by replacing `Callable` from `typing` module with `collections.abc` module. 

## Description of the changes
This PR aims to enhance type annotation handling in `Optuna` to the module `optuna/visualization/matplotlib/_param_importances.py` and contributes to solving https://github.com/optuna/optuna/issues/4508.
