### PR TITLE
Simplify type annotations for `optuna/visualization/matplotlib/_rank.py`

### DIFF
--- a/optuna/visualization/matplotlib/_rank.py
+++ b/optuna/visualization/matplotlib/_rank.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Callable
+from collections.abc import Callable
 
 from optuna._experimental import experimental_func
 from optuna.logging import get_logger


### PR DESCRIPTION
## Motivation
This PR aims to enhance type annotation handling in `Optuna` to the module `optuna/visualization/matplotlib/_rank.py` and contributes to solving https://github.com/optuna/optuna/issues/4508.

## Description of the changes
Apply changes to `optuna/visualization/matplotlib/_rank.py` by replacing `Callable` from `typing` module with `collections.abc` module. 
