### PR TITLE
Simplify type annotations for `optuna/visualization/matplotlib/_slice.py`

### DIFF
--- a/optuna/visualization/matplotlib/_slice.py
+++ b/optuna/visualization/matplotlib/_slice.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 from collections import defaultdict
+from collections.abc import Callable
 import math
 from typing import Any
-from typing import Callable
 
 from optuna._experimental import experimental_func
 from optuna.study import Study


### PR DESCRIPTION
## Motivation
This PR aims to enhance type annotation handling in `Optuna` to the module `optuna/visualization/matplotlib/_slice.py` and contributes to solving https://github.com/optuna/optuna/issues/4508.

## Description of the changes
Apply changes to `optuna/visualization/matplotlib/_slice.py` by replacing `Callable` from `typing` module with `collections.abc` module.
