### PR TITLE
RFC: move mypy related entries in setup.cfg to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -166,3 +166,19 @@ markers = [
   "skip_coverage: marks tests are skipped when calculating the coverage",
   "slow: marks tests as slow (deselect with '-m \"not slow\"')",
 ]
+
+[tool.mypy]
+# Options configure mypy's strict mode.
+warn_unused_configs = true
+disallow_untyped_calls = true
+disallow_untyped_defs = true
+disallow_incomplete_defs = true
+check_untyped_defs = true
+no_implicit_optional = true
+warn_redundant_casts = true
+strict_equality = true
+extra_checks = true
+no_implicit_reexport = true
+
+ignore_missing_imports = true
+exclude = .venv|venv|build|docs|tutorial|optuna/storages/_rdb/alembic

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -181,4 +181,4 @@ extra_checks = true
 no_implicit_reexport = true
 
 ignore_missing_imports = true
-exclude = .venv|venv|build|docs|tutorial|optuna/storages/_rdb/alembic
+exclude = [".venv", "venv", "build", "docs", "tutorial", "optuna/storages/_rdb/alembic"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,20 +7,3 @@ ignore =
 max-line-length = 99
 statistics = True
 exclude = .venv,venv,build,tutorial,.asv,docs/visualization_examples,docs/visualization_matplotlib_examples
-
-# This section is for mypy.
-[mypy]
-# Options configure mypy's strict mode.
-warn_unused_configs = True
-disallow_untyped_calls = True
-disallow_untyped_defs = True
-disallow_incomplete_defs = True
-check_untyped_defs = True
-no_implicit_optional = True
-warn_redundant_casts = True
-strict_equality = True
-extra_checks = True
-no_implicit_reexport = True
-
-ignore_missing_imports = True
-exclude = .venv|venv|build|docs|tutorial|optuna/storages/_rdb/alembic


### PR DESCRIPTION
This PR is just to propose to move mypy related configurations to `pyproject.toml`.

## Motivation
Now `pyproject.toml` is prioritized over `setup.cfg` and we can easily use an array in `pyproject.toml`, which is bit human friendly I think.
https://mypy.readthedocs.io/en/stable/config_file.html#the-mypy-configuration-file

```
[mypy]
exclude = (?x)(
    ^one\.py$    # files named "one.py"
    | two\.pyi$  # or files ending with "two.pyi"
    | ^three\.   # or files starting with "three."
  )
```

```
[tool.mypy]
exclude = [
    "^one\\.py$",  # TOML's double-quoted strings require escaping backslashes
    'two\.pyi$',  # but TOML's single-quoted strings do not
    '^three\.',
]
```

Also, I just saw the discussion to replace flake8 with pyproject-flake8 (🔗. https://github.com/optuna/optuna/pull/5408#discussion_r1575653203). I'm wondering if it is the time to unify configurations to `pyproject.toml`.

## Description of the changes
<!-- Describe the changes in this PR. -->
