### PR TITLE
Add unit tests for `retry_history` method in `RetryFailedTrialCallback`

### DIFF
--- a/tests/storages_tests/test_callbacks.py
+++ b/tests/storages_tests/test_callbacks.py
@@ -1,55 +1,53 @@
 import optuna
 from optuna.storages import RetryFailedTrialCallback
+from optuna.testing.storages import StorageSupplier
 from optuna.trial import TrialState
 
 
 def test_retry_history() -> None:
     # Test case 1: Trial that is not a retry should return empty list
-    storage = optuna.storages.RDBStorage("sqlite:///:memory:")
-    study = optuna.create_study(storage=storage)
-    trial = study.ask()
-    study.tell(trial, 1.0)  # Complete the trial to get FrozenTrial
-    assert RetryFailedTrialCallback.retry_history(study.trials[0]) == []
+    with StorageSupplier("sqlite") as storage:
+        study = optuna.create_study(storage=storage)
+        trial = study.ask()
+        study.tell(trial, 1.0)  # Complete the trial to get FrozenTrial
+        assert RetryFailedTrialCallback.retry_history(study.trials[0]) == []
 
     # Test case 2: First retry should contain only the original trial number
     callback = RetryFailedTrialCallback(max_retry=3)
-    storage = optuna.storages.RDBStorage(
-        "sqlite:///:memory:",
-        heartbeat_interval=1,
-        grace_period=2,
-        failed_trial_callback=callback,
-    )
-    study = optuna.create_study(storage=storage)
+    with StorageSupplier(
+        "sqlite", heartbeat_interval=1, grace_period=2, failed_trial_callback=callback
+    ) as storage:
+        study = optuna.create_study(storage=storage)
 
-    # Create a trial and manually set it as failed
-    trial = study.ask()
-    trial.suggest_float("x", -1, 1)
-    storage.set_trial_state_values(trial._trial_id, state=TrialState.FAIL)
-    callback(study, study.trials[0])  # Manually call callback
+        # Create a trial and manually set it as failed
+        trial = study.ask()
+        trial.suggest_float("x", -1, 1)
+        storage.set_trial_state_values(trial._trial_id, state=TrialState.FAIL)
+        callback(study, study.trials[0])  # Manually call callback
 
-    trials = study.trials
-    assert len(trials) == 2  # Original failed trial + retried trial
-    assert trials[0].state == TrialState.FAIL
-    assert RetryFailedTrialCallback.retry_history(trials[1]) == [0]
+        trials = study.trials
+        assert len(trials) == 2  # Original failed trial + retried trial
+        assert trials[0].state == TrialState.FAIL
+        assert RetryFailedTrialCallback.retry_history(trials[1]) == [0]
 
-    # Test case 3: Multiple retries should show the full history
-    trial = study.ask()
-    trial.suggest_float("x", -1, 1)
-    storage.set_trial_state_values(trial._trial_id, state=TrialState.FAIL)
-    callback(study, study.trials[1])  # Manually call callback
+        # Test case 3: Multiple retries should show the full history
+        trial = study.ask()
+        trial.suggest_float("x", -1, 1)
+        storage.set_trial_state_values(trial._trial_id, state=TrialState.FAIL)
+        callback(study, study.trials[1])  # Manually call callback
 
-    trials = study.trials
-    assert len(trials) == 3
-    assert trials[1].state == TrialState.FAIL
-    assert RetryFailedTrialCallback.retry_history(trials[2]) == [0, 1]
+        trials = study.trials
+        assert len(trials) == 3
+        assert trials[1].state == TrialState.FAIL
+        assert RetryFailedTrialCallback.retry_history(trials[2]) == [0, 1]
 
-    # Test case 4: Verify retry history for a new trial series
-    trial = study.ask()
-    trial.suggest_float("x", -1, 1)
-    storage.set_trial_state_values(trial._trial_id, state=TrialState.FAIL)
-    callback(study, study.trials[2])  # Manually call callback
+        # Test case 4: Verify retry history for a new trial series
+        trial = study.ask()
+        trial.suggest_float("x", -1, 1)
+        storage.set_trial_state_values(trial._trial_id, state=TrialState.FAIL)
+        callback(study, study.trials[2])  # Manually call callback
 
-    trials = study.trials
-    assert len(trials) == 4
-    assert trials[2].state == TrialState.FAIL
-    assert RetryFailedTrialCallback.retry_history(trials[3]) == [0, 1, 2]
+        trials = study.trials
+        assert len(trials) == 4
+        assert trials[2].state == TrialState.FAIL
+        assert RetryFailedTrialCallback.retry_history(trials[3]) == [0, 1, 2]

--- a/tests/storages_tests/test_callbacks.py
+++ b/tests/storages_tests/test_callbacks.py
@@ -4,14 +4,16 @@ from optuna.testing.storages import StorageSupplier
 from optuna.trial import TrialState
 
 
-def test_retry_history() -> None:
-    # Test case 1: Trial that is not a retry should return empty list
+def test_retry_history_with_success() -> None:
+    # Trial that is not a retry should return empty list.
     with StorageSupplier("sqlite") as storage:
         study = optuna.create_study(storage=storage)
         trial = study.ask()
-        study.tell(trial, 1.0)  # Complete the trial to get FrozenTrial
+        study.tell(trial, 1.0)  # Complete the trial to get FrozenTrial.
         assert RetryFailedTrialCallback.retry_history(study.trials[0]) == []
 
+
+def test_retry_history_with_failures() -> None:
     # Test case 2: First retry should contain only the original trial number
     callback = RetryFailedTrialCallback(max_retry=3)
     with StorageSupplier(

--- a/tests/storages_tests/test_callbacks.py
+++ b/tests/storages_tests/test_callbacks.py
@@ -1,0 +1,55 @@
+import optuna
+from optuna.storages import RetryFailedTrialCallback
+from optuna.trial import TrialState
+
+
+def test_retry_history() -> None:
+    # Test case 1: Trial that is not a retry should return empty list
+    storage = optuna.storages.RDBStorage("sqlite:///:memory:")
+    study = optuna.create_study(storage=storage)
+    trial = study.ask()
+    study.tell(trial, 1.0)  # Complete the trial to get FrozenTrial
+    assert RetryFailedTrialCallback.retry_history(study.trials[0]) == []
+
+    # Test case 2: First retry should contain only the original trial number
+    callback = RetryFailedTrialCallback(max_retry=3)
+    storage = optuna.storages.RDBStorage(
+        "sqlite:///:memory:",
+        heartbeat_interval=1,
+        grace_period=2,
+        failed_trial_callback=callback,
+    )
+    study = optuna.create_study(storage=storage)
+
+    # Create a trial and manually set it as failed
+    trial = study.ask()
+    trial.suggest_float("x", -1, 1)
+    storage.set_trial_state_values(trial._trial_id, state=TrialState.FAIL)
+    callback(study, study.trials[0])  # Manually call callback
+
+    trials = study.trials
+    assert len(trials) == 2  # Original failed trial + retried trial
+    assert trials[0].state == TrialState.FAIL
+    assert RetryFailedTrialCallback.retry_history(trials[1]) == [0]
+
+    # Test case 3: Multiple retries should show the full history
+    trial = study.ask()
+    trial.suggest_float("x", -1, 1)
+    storage.set_trial_state_values(trial._trial_id, state=TrialState.FAIL)
+    callback(study, study.trials[1])  # Manually call callback
+
+    trials = study.trials
+    assert len(trials) == 3
+    assert trials[1].state == TrialState.FAIL
+    assert RetryFailedTrialCallback.retry_history(trials[2]) == [0, 1]
+
+    # Test case 4: Verify retry history for a new trial series
+    trial = study.ask()
+    trial.suggest_float("x", -1, 1)
+    storage.set_trial_state_values(trial._trial_id, state=TrialState.FAIL)
+    callback(study, study.trials[2])  # Manually call callback
+
+    trials = study.trials
+    assert len(trials) == 4
+    assert trials[2].state == TrialState.FAIL
+    assert RetryFailedTrialCallback.retry_history(trials[3]) == [0, 1, 2]

--- a/tests/storages_tests/test_callbacks.py
+++ b/tests/storages_tests/test_callbacks.py
@@ -14,42 +14,26 @@ def test_retry_history_with_success() -> None:
 
 
 def test_retry_history_with_failures() -> None:
-    # Test case 2: First retry should contain only the original trial number
-    callback = RetryFailedTrialCallback(max_retry=3)
+    max_retry = 3
+    callback = RetryFailedTrialCallback(max_retry=max_retry)
     with StorageSupplier(
         "sqlite", heartbeat_interval=1, grace_period=2, failed_trial_callback=callback
     ) as storage:
         study = optuna.create_study(storage=storage)
+        for n_retries in range(1, max_retry + 1):
+            # Create a trial and manually set it as failed.
+            trial = study.ask({"x": optuna.distributions.FloatDistribution(-1, 1)})
+            storage.set_trial_state_values(trial._trial_id, state=TrialState.FAIL)
+            callback(study, study.trials[trial.number])  # Manually call callback.
 
-        # Create a trial and manually set it as failed
-        trial = study.ask()
-        trial.suggest_float("x", -1, 1)
-        storage.set_trial_state_values(trial._trial_id, state=TrialState.FAIL)
-        callback(study, study.trials[0])  # Manually call callback
+            # Get all trials after another trial for retry is enqueued.
+            trials = study.trials
+            # Original failed trial + retried trials.
+            assert len(trials) == n_retries + 1
+            # The last trial before the retried trial must be failed.
+            assert trials[trial.number].state == TrialState.FAIL
+            # Retry should show the full history of the previous trials.
+            assert RetryFailedTrialCallback.retry_history(trials[trial.number + 1]) == list(
+                range(n_retries)
+            )
 
-        trials = study.trials
-        assert len(trials) == 2  # Original failed trial + retried trial
-        assert trials[0].state == TrialState.FAIL
-        assert RetryFailedTrialCallback.retry_history(trials[1]) == [0]
-
-        # Test case 3: Multiple retries should show the full history
-        trial = study.ask()
-        trial.suggest_float("x", -1, 1)
-        storage.set_trial_state_values(trial._trial_id, state=TrialState.FAIL)
-        callback(study, study.trials[1])  # Manually call callback
-
-        trials = study.trials
-        assert len(trials) == 3
-        assert trials[1].state == TrialState.FAIL
-        assert RetryFailedTrialCallback.retry_history(trials[2]) == [0, 1]
-
-        # Test case 4: Verify retry history for a new trial series
-        trial = study.ask()
-        trial.suggest_float("x", -1, 1)
-        storage.set_trial_state_values(trial._trial_id, state=TrialState.FAIL)
-        callback(study, study.trials[2])  # Manually call callback
-
-        trials = study.trials
-        assert len(trials) == 4
-        assert trials[2].state == TrialState.FAIL
-        assert RetryFailedTrialCallback.retry_history(trials[3]) == [0, 1, 2]


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
The `retry_history` method in `RetryFailedTrialCallback` class was not covered by any tests, as noted in issue #5814. This method is important as it provides the complete history of retried trials, which is crucial for tracking and debugging trial failures and retries. Adding test coverage ensures the method works as expected and maintains its functionality through future changes.

## Description of the changes
Added a new test file `tests/storages_tests/test_callbacks.py` with comprehensive test coverage for the `retry_history` method. The test includes four key scenarios:

1. Verifying that a non-retry trial returns an empty history list
2. Testing that the first retry contains only the original trial number
3. Ensuring multiple retries show the complete history in ascending order
4. Verifying the full retry history after multiple retries
