### PR TITLE
Simplify type annotations for `optuna/visualization/_utils.py`

### DIFF
--- a/optuna/visualization/_utils.py
+++ b/optuna/visualization/_utils.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
+from collections.abc import Callable
+from collections.abc import Sequence
 import json
 from typing import Any
-from typing import Callable
 from typing import cast
-from typing import Sequence
 import warnings
 
 import numpy as np


### PR DESCRIPTION
## Motivation
This PR aims to enhance type annotation handling in `Optuna` to the module `optuna/visualization/_utils.py` and contributes to solving https://github.com/optuna/optuna/issues/4508.

## Description of the changes
Apply changes to `optuna/visualization/_utils.py` by replacing `Callable` and `Sequence` from `typing` module with `collections.abc` module.
