### PR TITLE
Simplify type annotations for `optuna/_experimental.py`

### DIFF
--- a/optuna/_experimental.py
+++ b/optuna/_experimental.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 import functools
 import textwrap
 from typing import Any
-from typing import Callable
 from typing import TYPE_CHECKING
 from typing import TypeVar
 import warnings


### PR DESCRIPTION
## Motivation
This PR aims to enhance type annotation handling in `Optuna` to the module `optuna/_experimental.py` and contributes to solving https://github.com/optuna/optuna/issues/4508.

## Description of the changes
Apply changes to `optuna/_experimental.py` by replacing `Callable` from `typing` module with `collections.abc` module.
