### PR TITLE
Simplify type annotations for `optuna/_imports.py`

### DIFF
--- a/optuna/_imports.py
+++ b/optuna/_imports.py
@@ -4,7 +4,6 @@ import importlib
 import types
 from types import TracebackType
 from typing import Any
-from typing import Type
 
 
 _INTEGRATION_IMPORT_ERROR_TEMPLATE = (
@@ -35,7 +34,7 @@ class _DeferredImportExceptionContextManager:
 
     def __exit__(
         self,
-        exc_type: Type[Exception] | None,
+        exc_type: type[Exception] | None,
         exc_value: Exception | None,
         traceback: TracebackType | None,
     ) -> bool | None:


### PR DESCRIPTION
## Motivation
This PR aims to enhance type annotation handling in `Optuna` to the module `optuna/_imports.py` and contributes to solving https://github.com/optuna/optuna/issues/4508.

## Description of the changes
Apply changes to `optuna/_imports.py` by replacing `Type` from `typing` module.
