### PR TITLE
Simplify type annotations for `optuna/visualization/_slice.py`

### DIFF
--- a/optuna/visualization/_slice.py
+++ b/optuna/visualization/_slice.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from typing import Any
-from typing import Callable
 from typing import cast
 from typing import NamedTuple
 


### PR DESCRIPTION
## Motivation
This PR aims to enhance type annotation handling in `Optuna` to the module `optuna/visualization/_slice.py` and contributes to solving https://github.com/optuna/optuna/issues/4508.

## Description of the changes
Apply changes to `optuna/visualization/_slice.py` by replacing `Container` and `Callable` module with `collections.abc` module.
