### PR TITLE
Simplify type annotations for `optuna/visualization/_rank.py`

### DIFF
--- a/optuna/visualization/_rank.py
+++ b/optuna/visualization/_rank.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 import math
 import typing
 from typing import Any
-from typing import Callable
 from typing import NamedTuple
 
 import numpy as np


### PR DESCRIPTION
## Motivation
This PR aims to enhance type annotation handling in `Optuna` to the module `optuna/visualization/_rank.py` and contributes to solving https://github.com/optuna/optuna/issues/4508.

## Description of the changes
Apply changes to `optuna/visualization/_rank.py` by replacing `Container` and `Callable` module with `collections.abc` module. 