### PR TITLE
Simplify type annotations for `optuna/storages/journal/_file.py`

### DIFF
--- a/optuna/storages/journal/_file.py
+++ b/optuna/storages/journal/_file.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
 import abc
+from collections.abc import Iterator
 from contextlib import contextmanager
 import errno
 import json
 import os
 import time
 from typing import Any
-from typing import Iterator
 import uuid
 
 from optuna._deprecated import deprecated_class


### PR DESCRIPTION
## Motivation
This PR aims to enhance type annotation handling in `Optuna` to the module `optuna/storages/journal/_file.py` and contributes to solving https://github.com/optuna/optuna/issues/4508.

## Description of the changes
Apply changes to `optuna/storages/journal/_file.py` by replacing `Iterator` module with `collections.abc` module.
