### PR TITLE
Simplify type annotations for `tests/artifacts_tests/test_gcs.py`

### DIFF
--- a/tests/artifacts_tests/test_gcs.py
+++ b/tests/artifacts_tests/test_gcs.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 import contextlib
 import io
 import os
-from typing import Dict
-from typing import Optional
 from typing import TYPE_CHECKING
 from unittest.mock import patch
 
@@ -19,11 +17,11 @@ if TYPE_CHECKING:
     from collections.abc import Iterator
 
 
-_MOCK_BUCKET_CONTENT: Dict[str, bytes] = dict()
+_MOCK_BUCKET_CONTENT: dict[str, bytes] = dict()
 
 
 class MockBucket:
-    def get_blob(self, blob_name: str) -> Optional["MockBlob"]:
+    def get_blob(self, blob_name: str) -> "MockBlob" | None:
         if blob_name in _MOCK_BUCKET_CONTENT:
             return MockBlob(blob_name)
         else:


### PR DESCRIPTION
## Motivation
This PR aims to enhance type annotation handling in `Optuna` to the module `tests/artifacts_tests/test_gcs.py` and contributes to solving https://github.com/optuna/optuna/issues/4508.

## Description of the changes
Apply changes to `tests/artifacts_tests/test_gcs.py` by replacing `Optional` and `Dict` from `typing` module.
