### PR TITLE
Simplify type annotations for `tests/visualization_tests/test_intermediate_plot.py`

### DIFF
--- a/tests/visualization_tests/test_intermediate_plot.py
+++ b/tests/visualization_tests/test_intermediate_plot.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from collections.abc import Sequence
 from io import BytesIO
 from typing import Any
-from typing import Callable
-from typing import Sequence
 
 import pytest
 


### PR DESCRIPTION
## Motivation
This PR aims to enhance type annotation handling in `Optuna` to the module `tests/visualization_tests/test_intermediate_plot.py` and contributes to solving https://github.com/optuna/optuna/issues/4508.

## Description of the changes
Apply changes to `tests/visualization_tests/test_intermediate_plot.py` by replacing `Callable` and `Sequence` from `collections.abc` module.
