### PR TITLE
Simplify type annotations for multiple test files in `tests/visualization_tests/`

### DIFF
--- a/tests/visualization_tests/test_contour.py
+++ b/tests/visualization_tests/test_contour.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from io import BytesIO
 import math
 from typing import Any
-from typing import Callable
 
 import numpy as np
 import pytest

--- a/tests/visualization_tests/test_edf.py
+++ b/tests/visualization_tests/test_edf.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from io import BytesIO
 from typing import Any
-from typing import Callable
 
 import numpy as np
 import pytest

--- a/tests/visualization_tests/test_parallel_coordinate.py
+++ b/tests/visualization_tests/test_parallel_coordinate.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from io import BytesIO
 import math
 from typing import Any
-from typing import Callable
 
 import numpy as np
 import pytest

--- a/tests/visualization_tests/test_param_importances.py
+++ b/tests/visualization_tests/test_param_importances.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from io import BytesIO
 from typing import Any
-from typing import Callable
 
 import pytest
 

--- a/tests/visualization_tests/test_rank.py
+++ b/tests/visualization_tests/test_rank.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from io import BytesIO
 import math
 from typing import Any
-from typing import Callable
 
 import numpy as np
 import pytest

--- a/tests/visualization_tests/test_slice.py
+++ b/tests/visualization_tests/test_slice.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from io import BytesIO
 from typing import Any
-from typing import Callable
 
 import pytest
 

--- a/tests/visualization_tests/test_terminator_improvement.py
+++ b/tests/visualization_tests/test_terminator_improvement.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from io import BytesIO
 from typing import Any
-from typing import Callable
 
 import pytest
 

--- a/tests/visualization_tests/test_timeline.py
+++ b/tests/visualization_tests/test_timeline.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 import datetime
 from io import BytesIO
 import time
 from typing import Any
-from typing import Callable
 
 import _pytest.capture
 import pytest

--- a/tests/visualization_tests/test_visualizations.py
+++ b/tests/visualization_tests/test_visualizations.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Callable
+from collections.abc import Callable
 
 from matplotlib.axes._axes import Axes
 import matplotlib.pyplot as plt


### PR DESCRIPTION
## Motivation
This PR aims to enhance type annotation handling in `Optuna` to the module `tests/visualization_tests/test_intermediate_plot.py` and contributes to solving https://github.com/optuna/optuna/issues/4508.

## Description of the changes
Apply changes to multiple test files in `tests/visualization_tests/` by replacing `Callable`  from `collections.abc` module.

