### PR TITLE
Avoid the input validation fail in Wilcoxon signed ranked test for Scipy 1.15

### DIFF
--- a/optuna/pruners/_wilcoxon.py
+++ b/optuna/pruners/_wilcoxon.py
@@ -128,14 +128,15 @@ class WilcoxonPruner(BasePruner):
             Pruning starts only after you have ``n_startup_steps`` steps of
             available observations for comparison between the current trial
             and the best trial.
-            Defaults to 0 (pruning kicks in from the very first step).
+            Defaults to 2. Note that the trial is not pruned at the first and second steps even if
+            the `n_startup_steps` is set to 0 or 1 due to the lack of enough data for comparison.
     """  # NOQA: E501
 
     def __init__(
         self,
         *,
         p_threshold: float = 0.1,
-        n_startup_steps: int = 0,
+        n_startup_steps: int = 2,
     ) -> None:
         if n_startup_steps < 0:
             raise ValueError(f"n_startup_steps must be nonnegative but got {n_startup_steps}.")

--- a/optuna/pruners/_wilcoxon.py
+++ b/optuna/pruners/_wilcoxon.py
@@ -193,7 +193,7 @@ class WilcoxonPruner(BasePruner):
 
         diff_values = step_values[idx1] - best_step_values[idx2]
 
-        if len(diff_values) < self._n_startup_steps:
+        if len(diff_values) < max(2, self._n_startup_steps):
             return False
 
         if study.direction == StudyDirection.MAXIMIZE:

--- a/optuna/pruners/_wilcoxon.py
+++ b/optuna/pruners/_wilcoxon.py
@@ -138,7 +138,7 @@ class WilcoxonPruner(BasePruner):
         p_threshold: float = 0.1,
         n_startup_steps: int = 2,
     ) -> None:
-        if n_startup_steps < 0:
+        if n_startup_steps < 0:  # TODO: Consider changing the RHS to 2.
             raise ValueError(f"n_startup_steps must be nonnegative but got {n_startup_steps}.")
         if not 0.0 <= p_threshold <= 1.0:
             raise ValueError(f"p_threshold must be between 0 and 1 but got {p_threshold}.")


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
To fix the CI fails due to the latest release of Scipy.
- https://github.com/optuna/optuna/actions/runs/12623702887/job/35172998066
- https://github.com/optuna/optuna/actions/runs/12623689955/job/35172969351
- https://github.com/optuna/optuna/actions/runs/12623677141/job/35172940871

The input validation of `scipy.stats.wilcoxon` has became strict. We need to avoid to give the `diff_values` whose size are smaller than 2.

## Description of the changes
<!-- Describe the changes in this PR. -->
- Avoid to give the `diff_values` whose size are smaller than 2 to `scipy.stats.wilcoxon`.
