### PR TITLE
Avoid the port number conflict in the copy study tests

### DIFF
--- a/optuna/testing/storages.py
+++ b/optuna/testing/storages.py
@@ -124,4 +124,6 @@ def _find_free_port() -> int:
             return port
         except OSError:
             continue
+        except RuntimeError:
+            continue
     assert False, "must not reach here"

--- a/optuna/testing/storages.py
+++ b/optuna/testing/storages.py
@@ -5,7 +5,6 @@ from types import TracebackType
 from typing import Any
 from typing import IO
 from typing import TYPE_CHECKING
-import uuid
 
 import fakeredis
 
@@ -90,7 +89,7 @@ class StorageSupplier:
         elif self.storage_specifier == "grpc":
             self.tempfile = NamedTemporaryFilePool().tempfile()
             url = "sqlite:///{}".format(self.tempfile.name)
-            port = 13000 + uuid.uuid4().int % 1000
+            port = self.extra_args.get("port", 13000)
 
             self.server = optuna.storages._grpc.server.make_server(
                 optuna.storages.RDBStorage(url), "localhost", port

--- a/optuna/testing/storages.py
+++ b/optuna/testing/storages.py
@@ -120,10 +120,8 @@ def _find_free_port() -> int:
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     for port in range(13000, 13100):
         try:
-            sock.bind(("", port))
+            sock.bind(("localhost", port))
             return port
         except OSError:
-            continue
-        except RuntimeError:
             continue
     assert False, "must not reach here"

--- a/tests/study_tests/test_study.py
+++ b/tests/study_tests/test_study.py
@@ -424,18 +424,9 @@ def test_delete_study(storage_mode: str) -> None:
 @pytest.mark.parametrize("from_storage_mode", STORAGE_MODES)
 @pytest.mark.parametrize("to_storage_mode", STORAGE_MODES)
 def test_copy_study(from_storage_mode: str, to_storage_mode: str) -> None:
-    from_storage_extra_kwargs = {}
-    to_storage_extra_kwargs = {}
-
-    # If the both storages are gRPC storage proxy, we need to change the port number to avoid
-    # conflict.
-    if from_storage_mode == "grpc" and to_storage_mode == "grpc":
-        from_storage_extra_kwargs = {"port": 13000}
-        to_storage_extra_kwargs = {"port": 13001}
-
-    with StorageSupplier(
-        from_storage_mode, **from_storage_extra_kwargs
-    ) as from_storage, StorageSupplier(to_storage_mode, **to_storage_extra_kwargs) as to_storage:
+    with StorageSupplier(from_storage_mode) as from_storage, StorageSupplier(
+        to_storage_mode
+    ) as to_storage:
         from_study = create_study(storage=from_storage, directions=["maximize", "minimize"])
         from_study._storage.set_study_system_attr(from_study._study_id, "foo", "bar")
         from_study.set_user_attr("baz", "qux")
@@ -463,18 +454,9 @@ def test_copy_study(from_storage_mode: str, to_storage_mode: str) -> None:
 @pytest.mark.parametrize("from_storage_mode", STORAGE_MODES)
 @pytest.mark.parametrize("to_storage_mode", STORAGE_MODES)
 def test_copy_study_to_study_name(from_storage_mode: str, to_storage_mode: str) -> None:
-    from_storage_extra_kwargs = {}
-    to_storage_extra_kwargs = {}
-
-    # If the both storages are gRPC storage proxy, we need to change the port number to avoid
-    # conflict.
-    if from_storage_mode == "grpc" and to_storage_mode == "grpc":
-        from_storage_extra_kwargs = {"port": 13000}
-        to_storage_extra_kwargs = {"port": 13001}
-
-    with StorageSupplier(
-        from_storage_mode, **from_storage_extra_kwargs
-    ) as from_storage, StorageSupplier(to_storage_mode, **to_storage_extra_kwargs) as to_storage:
+    with StorageSupplier(from_storage_mode) as from_storage, StorageSupplier(
+        to_storage_mode
+    ) as to_storage:
         from_study = create_study(study_name="foo", storage=from_storage)
         _ = create_study(study_name="foo", storage=to_storage)
 

--- a/tests/study_tests/test_study.py
+++ b/tests/study_tests/test_study.py
@@ -424,9 +424,18 @@ def test_delete_study(storage_mode: str) -> None:
 @pytest.mark.parametrize("from_storage_mode", STORAGE_MODES)
 @pytest.mark.parametrize("to_storage_mode", STORAGE_MODES)
 def test_copy_study(from_storage_mode: str, to_storage_mode: str) -> None:
-    with StorageSupplier(from_storage_mode) as from_storage, StorageSupplier(
-        to_storage_mode
-    ) as to_storage:
+    from_storage_extra_kwargs = {}
+    to_storage_extra_kwargs = {}
+
+    # If the both storages are gRPC storage proxy, we need to change the port number to avoid
+    # conflict.
+    if from_storage_mode == "grpc" and to_storage_mode == "grpc":
+        from_storage_extra_kwargs = {"port": 13000}
+        to_storage_extra_kwargs = {"port": 13001}
+
+    with StorageSupplier(
+        from_storage_mode, **from_storage_extra_kwargs
+    ) as from_storage, StorageSupplier(to_storage_mode, **to_storage_extra_kwargs) as to_storage:
         from_study = create_study(storage=from_storage, directions=["maximize", "minimize"])
         from_study._storage.set_study_system_attr(from_study._study_id, "foo", "bar")
         from_study.set_user_attr("baz", "qux")
@@ -454,9 +463,18 @@ def test_copy_study(from_storage_mode: str, to_storage_mode: str) -> None:
 @pytest.mark.parametrize("from_storage_mode", STORAGE_MODES)
 @pytest.mark.parametrize("to_storage_mode", STORAGE_MODES)
 def test_copy_study_to_study_name(from_storage_mode: str, to_storage_mode: str) -> None:
-    with StorageSupplier(from_storage_mode) as from_storage, StorageSupplier(
-        to_storage_mode
-    ) as to_storage:
+    from_storage_extra_kwargs = {}
+    to_storage_extra_kwargs = {}
+
+    # If the both storages are gRPC storage proxy, we need to change the port number to avoid
+    # conflict.
+    if from_storage_mode == "grpc" and to_storage_mode == "grpc":
+        from_storage_extra_kwargs = {"port": 13000}
+        to_storage_extra_kwargs = {"port": 13001}
+
+    with StorageSupplier(
+        from_storage_mode, **from_storage_extra_kwargs
+    ) as from_storage, StorageSupplier(to_storage_mode, **to_storage_extra_kwargs) as to_storage:
         from_study = create_study(study_name="foo", storage=from_storage)
         _ = create_study(study_name="foo", storage=to_storage)
 


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
To fix the CI failure https://github.com/optuna/optuna/actions/runs/12539415670/job/34965531874.

This test fails by chance due to the port number conflict in `optuna.testing.storages.StorageSupplier` with `storage_classifier="grpc"`. I changed the code to allow us fixing the value of port number and fix them in the test of `copy_study`.

## Description of the changes
<!-- Describe the changes in this PR. -->
- Avoid the port number conflict in the copy study tests
