### PR TITLE
fix(storage): Fix threading lock logic

### DIFF
--- a/optuna/storages/journal/_storage.py
+++ b/optuna/storages/journal/_storage.py
@@ -266,13 +266,13 @@ class JournalStorage(BaseStorage):
             self._sync_with_backend()
             trial_id = self._replay_result._last_created_trial_id_by_this_process
 
-        # Dump snapshot here.
-        if (
-            isinstance(self._backend, BaseJournalSnapshot)
-            and trial_id != 0
-            and trial_id % SNAPSHOT_INTERVAL == 0
-        ):
-            self._backend.save_snapshot(pickle.dumps(self._replay_result))
+            # Dump snapshot here.
+            if (
+                isinstance(self._backend, BaseJournalSnapshot)
+                and trial_id != 0
+                and trial_id % SNAPSHOT_INTERVAL == 0
+            ):
+                self._backend.save_snapshot(pickle.dumps(self._replay_result))
         return trial_id
 
     def set_trial_param(


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
As shown in #5862, journal storage sometimes fails on free-threaded Python. This is because the journal store accesses the shared data without getting the lock.

## Description of the changes
<!-- Describe the changes in this PR. -->
Increase the lock range in the journal storage.
