### PR TITLE
Fix the default sampler of `load_study` function

### DIFF
--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -1367,7 +1367,10 @@ def load_study(
             "study found in the storage."
         )
 
-    return Study(study_name=study_name, storage=storage, sampler=sampler, pruner=pruner)
+    study = Study(study_name=study_name, storage=storage, sampler=sampler, pruner=pruner)
+    if sampler is None and len(study.directions) > 1:
+        study.sampler = samplers.NSGAIISampler()
+    return study
 
 
 @convert_positional_args(

--- a/tests/study_tests/test_study.py
+++ b/tests/study_tests/test_study.py
@@ -18,6 +18,7 @@ import warnings
 import _pytest.capture
 import pytest
 
+import optuna
 from optuna import copy_study
 from optuna import create_study
 from optuna import create_trial
@@ -403,6 +404,22 @@ def test_load_study_study_name_none(storage_mode: str) -> None:
         # Ambiguous study.
         with pytest.raises(ValueError):
             load_study(study_name=None, storage=storage)
+
+
+def test_load_study_default_sampler() -> None:
+    storage = optuna.storages.InMemoryStorage()
+
+    # Single-objective
+    study_name = str(uuid.uuid4())
+    create_study(storage=storage, study_name=study_name)
+    loaded_study = load_study(study_name=study_name, storage=storage)
+    assert isinstance(loaded_study.sampler, optuna.samplers.TPESampler)
+
+    # Multi-objective
+    study_name = str(uuid.uuid4())
+    create_study(storage=storage, study_name=study_name, directions=["minimize", "maximize"])
+    loaded_study = load_study(study_name=study_name, storage=storage)
+    assert isinstance(loaded_study.sampler, optuna.samplers.NSGAIISampler)
 
 
 @pytest.mark.parametrize("storage_mode", STORAGE_MODES)


### PR DESCRIPTION
## Motivation

`optuna.load_study()` function unintentionally uses TPESampler even if the study is multi-objective.

Refs: https://github.com/optuna/optuna/discussions/5920#discussioncomment-11787004

## Description of the changes

Set `NSGAIISampler` when `load_study()` function returns the multi-objective study.