### PR TITLE
Add warning when param is suggested already in the same trial

### DIFF
--- a/optuna/trial/_trial.py
+++ b/optuna/trial/_trial.py
@@ -692,7 +692,7 @@ class Trial(BaseTrial):
             )
         elif old_distribution == distribution and not self._is_fixed_param(name, distribution):
             warnings.warn(
-                f'In the current trial, the parameter "{name}" has already been '
+                f'In the current trial, the parameter "{name}" has already been suggested. '
                 f"Use already suggested value instead of sampling again.",
                 RuntimeWarning,
             )

--- a/optuna/trial/_trial.py
+++ b/optuna/trial/_trial.py
@@ -619,6 +619,11 @@ class Trial(BaseTrial):
             # No need to sample if already suggested.
             distributions.check_distribution_compatibility(trial.distributions[name], distribution)
             param_value = trial.params[name]
+            warnings.warn(
+                f'In the current trial, the parameter "{name}" has already been '
+                f"Use already suggested value, `{param_value}` instead of sampling again.",
+                RuntimeWarning,
+            )
         else:
             if self._is_fixed_param(name, distribution):
                 param_value = self._fixed_params[name]
@@ -676,11 +681,11 @@ class Trial(BaseTrial):
         old_distribution = self._cached_frozen_trial.distributions.get(name, distribution)
         if old_distribution != distribution:
             warnings.warn(
-                'Inconsistent parameter values for distribution with name "{}"! '
+                'Inconsistent parameter values for distribution with name "{}" in the same trial! '
                 "This might be a configuration mistake. "
                 "Optuna allows to call the same distribution with the same "
                 "name more than once in a trial. "
-                "When the parameter values are inconsistent optuna only "
+                "When the parameter values are inconsistent among calls in the trial, optuna only "
                 "uses the values of the first call and ignores all following. "
                 "Using these values: {}".format(name, old_distribution._asdict()),
                 RuntimeWarning,


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

For discussion in #5890.

## Description of the changes
<!-- Describe the changes in this PR. -->

By this PR, a user will see a warning message when suggesting w/ the same param name multiple times in a trial:

```python
import optuna

def o(t):
    t.suggest_int("x", 0, 5)
    x = t.suggest_int("x", 0, 5)
    return x
s = optuna.create_study()
s.optimize(o, n_trials=2)
```

```
[I 2025-01-19 00:27:47,481] A new study created in memory with name: no-name-1bc02112-67a6-4b9c-8ad8-61113012fe88
/Users/nzw0301/Documents/oss/optuna/optuna/trial/_trial.py:694: RuntimeWarning: In the current trial, the parameter "x" has already been Use already suggested value instead of sampling again.
  warnings.warn(
[I 2025-01-19 00:27:47,493] Trial 0 finished with value: 2.0 and parameters: {'x': 2}. Best is trial 0 with value: 2.0.
[I 2025-01-19 00:27:47,494] Trial 1 finished with value: 5.0 and parameters: {'x': 5}. Best is trial 0 with value: 2.0.
```

Existing warning message case:
```python
import optuna

def o(t):
    t.suggest_int("x", 0, 5)
    x = t.suggest_int("x", -100, 5)
    return x
s = optuna.create_study()
s.optimize(o, n_trials=1)
```

```
[I 2025-01-19 00:28:46,493] A new study created in memory with name: no-name-6c34b3eb-5811-4e82-8308-f2d3f603af77
/Users/nzw0301/Documents/oss/optuna/optuna/trial/_trial.py:683: RuntimeWarning: Inconsistent parameter values for distribution with name "x" in the same trial! This might be a configuration mistake. Optuna allows to call the same distribution with the same name more than once in a trial. When the parameter values are inconsistent among calls in the trial, optuna only uses the values of the first call and ignores all following. Using these values: {'log': False, 'step': 1, 'low': 0, 'high': 5}
  warnings.warn(
[I 2025-01-19 00:28:46,503] Trial 0 finished with value: 3.0 and parameters: {'x': 3}. Best is trial 0 with value: 3.0.
```
