### PR TITLE
 Ensure gRPC server readiness before proceeding to prevent test failures

### DIFF
--- a/optuna/testing/storages.py
+++ b/optuna/testing/storages.py
@@ -105,12 +105,10 @@ class StorageSupplier:
             while True:
                 try:
                     proxy.get_all_studies()
-                    break
+                    return proxy
                 except grpc.RpcError:
                     time.sleep(1)
                     continue
-
-            return proxy
         else:
             assert False
 

--- a/optuna/testing/storages.py
+++ b/optuna/testing/storages.py
@@ -98,7 +98,17 @@ class StorageSupplier:
             self.thread = threading.Thread(target=self.server.start)
             self.thread.start()
 
-            return GrpcStorageProxy(host="localhost", port=port)
+            proxy = GrpcStorageProxy(host="localhost", port=port)
+
+            # Wait until the server is ready.
+            while True:
+                try:
+                    proxy.get_all_studies()
+                    break
+                except grpc.RpcError:
+                    continue
+
+            return proxy
         else:
             assert False
 

--- a/optuna/testing/storages.py
+++ b/optuna/testing/storages.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import socket
 import threading
+import time
 from types import TracebackType
 from typing import Any
 from typing import IO
@@ -106,6 +107,7 @@ class StorageSupplier:
                     proxy.get_all_studies()
                     break
                 except grpc.RpcError:
+                    time.sleep(1)
                     continue
 
             return proxy


### PR DESCRIPTION
## Motivation
ref: [Fix `StorageSupplier("grpc")` to make unit tests robust. #5925](https://github.com/optuna/optuna/issues/5925)
The issue occurs when the proxy begins communicating with the server before the server has fully started. By ensuring the server is ready before proceeding, this change aims to make the unit tests more robust.

## Description of the changes
- Implement loop to confirm that the gRPC server is ready before continuing execution.
