### PR TITLE
Prevent Lock Blocking by Adding Timeout to `JournalStorage`

### DIFF
--- a/optuna/storages/journal/_file.py
+++ b/optuna/storages/journal/_file.py
@@ -150,7 +150,7 @@ class JournalFileSymlinkLock(BaseJournalFileLock):
             :obj:`True` if it succeeded in creating a symbolic link of ``self._lock_target_file``.
         """
         sleep_secs = 0.001
-        last_update_time = time.monotonic()
+        last_update_monotonic_time = time.monotonic()
         mtime = None
         while True:
             try:
@@ -165,9 +165,9 @@ class JournalFileSymlinkLock(BaseJournalFileLock):
                             continue
                         if current_mtime != mtime:
                             mtime = current_mtime
-                            last_update_time = time.monotonic()
+                            last_update_monotonic_time = time.monotonic()
 
-                        if time.monotonic() - last_update_time > self.grace_period:
+                        if time.monotonic() - last_update_monotonic_time > self.grace_period:
                             warnings.warn(
                                 "The existing lock file has not been released "
                                 "for an extended period. Forcibly releasing the lock file."
@@ -232,7 +232,7 @@ class JournalFileOpenLock(BaseJournalFileLock):
 
         """
         sleep_secs = 0.001
-        last_update_time = time.monotonic()
+        last_update_monotonic_time = time.monotonic()
         mtime = None
         while True:
             try:
@@ -248,9 +248,9 @@ class JournalFileOpenLock(BaseJournalFileLock):
                             continue
                         if current_mtime != mtime:
                             mtime = current_mtime
-                            last_update_time = time.monotonic()
+                            last_update_monotonic_time = time.monotonic()
 
-                        if time.monotonic() - last_update_time > self.grace_period:
+                        if time.monotonic() - last_update_monotonic_time > self.grace_period:
                             warnings.warn(
                                 "The existing lock file has not been released "
                                 "for an extended period. Forcibly releasing the lock file."

--- a/optuna/storages/journal/_file.py
+++ b/optuna/storages/journal/_file.py
@@ -159,17 +159,22 @@ class JournalFileSymlinkLock(BaseJournalFileLock):
                 if err.errno == errno.EEXIST:
                     try:
                         current_mtime = os.stat(self._lock_file).st_mtime
-                        if current_mtime != mtime:
-                            mtime = current_mtime
-                            last_update_time = time.monotonic()
-                        if time.monotonic() - last_update_time > self.grace_period:
-                            warnings.warn(
-                                "The existing lock file has not been released "
-                                "for an extended period. Forcibly releasing the lock file."
-                            )
-                            self.release()
                     except OSError:
                         continue
+                    if current_mtime != mtime:
+                        mtime = current_mtime
+                        last_update_time = time.monotonic()
+
+                    if time.monotonic() - last_update_time > self.grace_period:
+                        warnings.warn(
+                            "The existing lock file has not been released "
+                            "for an extended period. Forcibly releasing the lock file."
+                        )
+                        try:
+                            self.release()
+                        except OSError:
+                            continue
+
                     time.sleep(sleep_secs)
                     sleep_secs = min(sleep_secs * 2, 1)
                     continue
@@ -234,17 +239,21 @@ class JournalFileOpenLock(BaseJournalFileLock):
                 if err.errno == errno.EEXIST:
                     try:
                         current_mtime = os.stat(self._lock_file).st_mtime
-                        if current_mtime != mtime:
-                            mtime = current_mtime
-                            last_update_time = time.monotonic()
-                        if time.monotonic() - last_update_time > self.grace_period:
-                            warnings.warn(
-                                "The existing lock file has not been released "
-                                "for an extended period. Forcibly releasing the lock file."
-                            )
-                            self.release()
                     except OSError:
                         continue
+                    if current_mtime != mtime:
+                        mtime = current_mtime
+                        last_update_time = time.monotonic()
+
+                    if time.monotonic() - last_update_time > self.grace_period:
+                        warnings.warn(
+                            "The existing lock file has not been released "
+                            "for an extended period. Forcibly releasing the lock file."
+                        )
+                        try:
+                            self.release()
+                        except OSError:
+                            continue
                     time.sleep(sleep_secs)
                     sleep_secs = min(sleep_secs * 2, 1)
                     continue

--- a/optuna/storages/journal/_file.py
+++ b/optuna/storages/journal/_file.py
@@ -162,14 +162,14 @@ class JournalFileSymlinkLock(BaseJournalFileLock):
                         if current_mtime != mtime:
                             mtime = current_mtime
                             last_update_time = time.monotonic()
-                    except Exception:
-                        pass
-                    if time.monotonic() - last_update_time > self.grace_period:
-                        warnings.warn(
-                            "The existing lock file has not been released for an extended period. "
-                            "Forcibly releasing the lock file."
-                        )
-                        self.release()
+                        if time.monotonic() - last_update_time > self.grace_period:
+                            warnings.warn(
+                                "The existing lock file has not been released "
+                                "for an extended period. Forcibly releasing the lock file."
+                            )
+                            self.release()
+                    except OSError:
+                        continue
                     time.sleep(sleep_secs)
                     sleep_secs = min(sleep_secs * 2, 1)
                     continue
@@ -237,14 +237,14 @@ class JournalFileOpenLock(BaseJournalFileLock):
                         if current_mtime != mtime:
                             mtime = current_mtime
                             last_update_time = time.monotonic()
-                    except Exception:
-                        pass
-                    if time.monotonic() - last_update_time > self.grace_period:
-                        warnings.warn(
-                            "The existing lock file has not been released for an extended period. "
-                            "Forcibly releasing the lock file."
-                        )
-                        self.release()
+                        if time.monotonic() - last_update_time > self.grace_period:
+                            warnings.warn(
+                                "The existing lock file has not been released "
+                                "for an extended period. Forcibly releasing the lock file."
+                            )
+                            self.release()
+                    except OSError:
+                        continue
                     time.sleep(sleep_secs)
                     sleep_secs = min(sleep_secs * 2, 1)
                     continue

--- a/optuna/storages/journal/_file.py
+++ b/optuna/storages/journal/_file.py
@@ -175,7 +175,7 @@ class JournalFileSymlinkLock(BaseJournalFileLock):
                             try:
                                 self.release()
                                 sleep_secs = 0.001
-                            except OSError:
+                            except RuntimeError:
                                 continue
 
                     time.sleep(sleep_secs)
@@ -258,7 +258,7 @@ class JournalFileOpenLock(BaseJournalFileLock):
                             try:
                                 self.release()
                                 sleep_secs = 0.001
-                            except OSError:
+                            except RuntimeError:
                                 continue
 
                     time.sleep(sleep_secs)

--- a/optuna/storages/journal/_file.py
+++ b/optuna/storages/journal/_file.py
@@ -10,6 +10,7 @@ import os
 import time
 from typing import Any
 import uuid
+import warnings
 
 from optuna._deprecated import deprecated_class
 from optuna.storages.journal._base import BaseJournalBackend
@@ -138,6 +139,8 @@ class JournalFileSymlinkLock(BaseJournalFileLock):
         self._lock_file = filepath + LOCK_FILE_SUFFIX
         if grace_period is not None and grace_period <= 0:
             raise ValueError("The value of `grace_period` should be a positive integer.")
+        if grace_period < 3:
+            warnings.warn("The value of `grace_period` might be too small. ")
         self.grace_period = grace_period
 
     def acquire(self) -> bool:
@@ -202,6 +205,8 @@ class JournalFileOpenLock(BaseJournalFileLock):
         self._lock_file = filepath + LOCK_FILE_SUFFIX
         if grace_period is not None and grace_period <= 0:
             raise ValueError("The value of `grace_period` should be a positive integer.")
+        if grace_period < 3:
+            warnings.warn("The value of `grace_period` might be too small. ")
         self.grace_period = grace_period
 
     def acquire(self) -> bool:

--- a/optuna/storages/journal/_file.py
+++ b/optuna/storages/journal/_file.py
@@ -150,6 +150,7 @@ class JournalFileSymlinkLock(BaseJournalFileLock):
             :obj:`True` if it succeeded in creating a symbolic link of ``self._lock_target_file``.
         """
         sleep_secs = 0.001
+        start_time = time.monotonic()
         while True:
             try:
                 os.symlink(self._lock_target_file, self._lock_file)
@@ -158,8 +159,10 @@ class JournalFileSymlinkLock(BaseJournalFileLock):
                 if err.errno == errno.EEXIST:
                     try:
                         mtime = datetime.datetime.fromtimestamp(os.stat(self._lock_file).st_mtime)
-                        if datetime.datetime.now() - mtime > datetime.timedelta(
-                            seconds=self.grace_period
+                        if (
+                            datetime.datetime.now() - mtime
+                            > datetime.timedelta(seconds=self.grace_period)
+                            and time.monotonic() - start_time > self.grace_period
                         ):
                             self.release()
                     except Exception:
@@ -217,6 +220,7 @@ class JournalFileOpenLock(BaseJournalFileLock):
 
         """
         sleep_secs = 0.001
+        start_time = time.monotonic()
         while True:
             try:
                 open_flags = os.O_CREAT | os.O_EXCL | os.O_WRONLY
@@ -226,8 +230,10 @@ class JournalFileOpenLock(BaseJournalFileLock):
                 if err.errno == errno.EEXIST:
                     try:
                         mtime = datetime.datetime.fromtimestamp(os.stat(self._lock_file).st_mtime)
-                        if datetime.datetime.now() - mtime > datetime.timedelta(
-                            seconds=self.grace_period
+                        if (
+                            datetime.datetime.now() - mtime
+                            > datetime.timedelta(seconds=self.grace_period)
+                            and time.monotonic() - start_time > self.grace_period
                         ):
                             self.release()
                     except Exception:

--- a/tests/storages_tests/journal_tests/test_journal.py
+++ b/tests/storages_tests/journal_tests/test_journal.py
@@ -30,8 +30,10 @@ from optuna.testing.tempfile_pool import NamedTemporaryFilePool
 
 LOG_STORAGE_WITH_PARAMETER = [
     ("file_with_open_lock", 3),
+    ("file_with_open_lock", 30),
     ("file_with_open_lock", None),
     ("file_with_link_lock", 3),
+    ("file_with_link_lock", 30),
     ("file_with_link_lock", None),
     ("redis_default", None),
     ("redis_with_use_cluster", None),
@@ -51,19 +53,13 @@ class JournalLogStorageSupplier:
             self.tempfile = NamedTemporaryFilePool().tempfile()
             lock: BaseJournalFileLock
             if self.storage_type == "file_with_open_lock":
-                if self.grace_period is None:
-                    lock = optuna.storages.journal.JournalFileOpenLock(self.tempfile.name)
-                else:
-                    lock = optuna.storages.journal.JournalFileOpenLock(
-                        self.tempfile.name, self.grace_period
-                    )
+                lock = optuna.storages.journal.JournalFileOpenLock(
+                    self.tempfile.name, self.grace_period
+                )
             elif self.storage_type == "file_with_link_lock":
-                if self.grace_period is None:
-                    lock = optuna.storages.journal.JournalFileOpenLock(self.tempfile.name)
-                else:
-                    lock = optuna.storages.journal.JournalFileOpenLock(
-                        self.tempfile.name, self.grace_period
-                    )
+                lock = optuna.storages.journal.JournalFileOpenLock(
+                    self.tempfile.name, self.grace_period
+                )
             else:
                 raise Exception("Must not reach here")
             return optuna.storages.journal.JournalFileBackend(self.tempfile.name, lock)

--- a/tests/storages_tests/journal_tests/test_journal.py
+++ b/tests/storages_tests/journal_tests/test_journal.py
@@ -258,15 +258,8 @@ def test_raise_error_for_deprecated_class_import_from_journal() -> None:
         journal.BaseJournalLogStorage  # type: ignore[attr-defined]
 
 
-@pytest.mark.parametrize(
-    "log_storage_type,grace_period",
-    [
-        ("file_with_open_lock", 0),
-        ("file_with_open_lock", -1),
-        ("file_with_link_lock", 0),
-        ("file_with_link_lock", -1),
-    ],
-)
+@pytest.mark.parametrize("log_storage_type", ("file_with_open_lock", "file_with_link_lock"))
+@pytest.mark.parametrize("grace_period", (0, -1))
 def test_invalid_grace_period(log_storage_type: str, grace_period: int) -> None:
     with pytest.raises(ValueError):
         with JournalLogStorageSupplier(log_storage_type, grace_period):

--- a/tests/storages_tests/journal_tests/test_journal.py
+++ b/tests/storages_tests/journal_tests/test_journal.py
@@ -258,3 +258,18 @@ def test_raise_error_for_deprecated_class_import_from_journal() -> None:
         journal.JournalRedisStorage  # type: ignore[attr-defined]
     with pytest.raises(AttributeError):
         journal.BaseJournalLogStorage  # type: ignore[attr-defined]
+
+
+@pytest.mark.parametrize(
+    "log_storage_type,grace_period",
+    [
+        ("file_with_open_lock", 0),
+        ("file_with_open_lock", -1),
+        ("file_with_link_lock", 0),
+        ("file_with_link_lock", -1),
+    ],
+)
+def test_invalid_grace_period(log_storage_type: str, grace_period: int) -> None:
+    with pytest.raises(ValueError):
+        with JournalLogStorageSupplier(log_storage_type, grace_period):
+            pass

--- a/tests/storages_tests/journal_tests/test_journal.py
+++ b/tests/storages_tests/journal_tests/test_journal.py
@@ -29,10 +29,8 @@ from optuna.testing.tempfile_pool import NamedTemporaryFilePool
 
 
 LOG_STORAGE_WITH_PARAMETER = [
-    ("file_with_open_lock", 3),
     ("file_with_open_lock", 30),
     ("file_with_open_lock", None),
-    ("file_with_link_lock", 3),
     ("file_with_link_lock", 30),
     ("file_with_link_lock", None),
     ("redis_default", None),


### PR DESCRIPTION
## Motivation
- Currently, if a process is terminated without releasing the lock, the next process fails to resume. This change introduces a mechanism to release the existing lock if acquiring it takes too long.
- ref: [JournalStorage with JournalFileSymlinkLock may fail to resume #5921](https://github.com/optuna/optuna/issues/5921)

## Description of the changes
- Introduced a grace period for acquiring locks in `JournalFileSymlinkLock` and `JournalFileOpenLock`.
- If the lock cannot be acquired within the grace period, it is considered stale and released to prevent blocking new processes.