### PR TITLE
Improve time complexity of IntersectionSearchSpace #5949

### DIFF
--- a/optuna/search_space/intersection.py
+++ b/optuna/search_space/intersection.py
@@ -26,12 +26,15 @@ def _calculate(
     if include_pruned:
         states_of_interest.append(optuna.trial.TrialState.PRUNED)
 
-    trials_of_interest = [trial for trial in trials if trial.state in states_of_interest]
+    next_cached_trial_number = -1
 
-    next_cached_trial_number = (
-        trials_of_interest[-1].number + 1 if len(trials_of_interest) > 0 else -1
-    )
-    for trial in reversed(trials_of_interest):
+    for trial in reversed(trials):
+        if trial.state not in states_of_interest:
+            continue
+
+        if next_cached_trial_number == -1:
+            next_cached_trial_number = trial.number + 1
+
         if cached_trial_number > trial.number:
             break
 


### PR DESCRIPTION
## Motivation
Fix #5949 

## Description of the changes
Removed this line 
https://github.com/optuna/optuna/blob/5a7760c8ee640fb95d3f7626056c0d71a282b202/optuna/search_space/intersection.py#L29

Added filtering logic inside the for-loop so that the loop breaks to avoid putting filter checks on the trials with `trial.number` less than `cached_trial_number`
