### PR TITLE
Use `JournalStorage` in `test_cli.py`

### DIFF
--- a/optuna/testing/storages.py
+++ b/optuna/testing/storages.py
@@ -85,7 +85,8 @@ class StorageSupplier:
             )
             return optuna.storages.JournalStorage(journal_redis_storage)
         elif "journal" in self.storage_specifier:
-            self.tempfile = NamedTemporaryFilePool().tempfile()
+            self.tempfile = self.extra_args.get("file", NamedTemporaryFilePool().tempfile())
+            assert self.tempfile is not None
             file_storage = JournalFileBackend(self.tempfile.name)
             return optuna.storages.JournalStorage(file_storage)
         elif self.storage_specifier == "grpc":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1144,12 +1144,9 @@ def test_storage_upgrade_command() -> None:
 
 @pytest.mark.skip_coverage
 def test_storage_upgrade_command_with_invalid_url() -> None:
-    with StorageSupplier("journal") as storage:
-        assert isinstance(storage, JournalStorage)
-
-        command = ["optuna", "storage", "upgrade", "--storage", "invalid-storage-url"]
-        with pytest.raises(CalledProcessError):
-            subprocess.check_call(command)
+    command = ["optuna", "storage", "upgrade", "--storage", "invalid-storage-url"]
+    with pytest.raises(CalledProcessError):
+        subprocess.check_call(command)
 
 
 parametrize_for_ask = pytest.mark.parametrize(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -120,7 +120,7 @@ def _get_output(command: list[str], output_format: str) -> Any:
 
 @pytest.mark.skip_coverage
 def test_create_study_command() -> None:
-    with tempfile.NamedTemporaryFile() as fp, StorageSupplier("journal", file=fp) as storage:
+    with NamedTemporaryFilePool() as fp, StorageSupplier("journal", file=fp) as storage:
         assert isinstance(storage, JournalStorage)
         storage_url = fp.name
 
@@ -140,7 +140,7 @@ def test_create_study_command() -> None:
 
 @pytest.mark.skip_coverage
 def test_create_study_command_with_study_name() -> None:
-    with tempfile.NamedTemporaryFile() as fp, StorageSupplier("journal", file=fp) as storage:
+    with NamedTemporaryFilePool() as fp, StorageSupplier("journal", file=fp) as storage:
         assert isinstance(storage, JournalStorage)
         storage_url = fp.name
         study_name = "test_study"
@@ -167,7 +167,7 @@ def test_create_study_command_without_storage_url() -> None:
 
 @pytest.mark.skip_coverage
 def test_create_study_command_with_storage_env() -> None:
-    with tempfile.NamedTemporaryFile() as fp, StorageSupplier("journal", file=fp) as storage:
+    with NamedTemporaryFilePool() as fp, StorageSupplier("journal", file=fp) as storage:
         assert isinstance(storage, JournalStorage)
         storage_url = fp.name
 
@@ -188,7 +188,7 @@ def test_create_study_command_with_storage_env() -> None:
 
 @pytest.mark.skip_coverage
 def test_create_study_command_with_direction() -> None:
-    with tempfile.NamedTemporaryFile() as fp, StorageSupplier("journal", file=fp) as storage:
+    with NamedTemporaryFilePool() as fp, StorageSupplier("journal", file=fp) as storage:
         assert isinstance(storage, JournalStorage)
         storage_url = fp.name
 
@@ -211,7 +211,7 @@ def test_create_study_command_with_direction() -> None:
 
 @pytest.mark.skip_coverage
 def test_create_study_command_with_multiple_directions() -> None:
-    with tempfile.NamedTemporaryFile() as fp, StorageSupplier("journal", file=fp) as storage:
+    with NamedTemporaryFilePool() as fp, StorageSupplier("journal", file=fp) as storage:
         assert isinstance(storage, JournalStorage)
         storage_url = fp.name
         command = [
@@ -264,7 +264,7 @@ def test_create_study_command_with_multiple_directions() -> None:
 
 @pytest.mark.skip_coverage
 def test_delete_study_command() -> None:
-    with tempfile.NamedTemporaryFile() as fp, StorageSupplier("journal", file=fp) as storage:
+    with NamedTemporaryFilePool() as fp, StorageSupplier("journal", file=fp) as storage:
         assert isinstance(storage, JournalStorage)
         storage_url = fp.name
         study_name = "delete-study-test"
@@ -291,7 +291,7 @@ def test_delete_study_command_without_storage_url() -> None:
 
 @pytest.mark.skip_coverage
 def test_study_set_user_attr_command() -> None:
-    with tempfile.NamedTemporaryFile() as fp, StorageSupplier("journal", file=fp) as storage:
+    with NamedTemporaryFilePool() as fp, StorageSupplier("journal", file=fp) as storage:
         assert isinstance(storage, JournalStorage)
         storage_url = fp.name
 
@@ -324,7 +324,7 @@ def test_study_set_user_attr_command() -> None:
 @pytest.mark.skip_coverage
 @output_formats
 def test_study_names_command(output_format: str | None) -> None:
-    with tempfile.NamedTemporaryFile() as fp, StorageSupplier("journal", file=fp) as storage:
+    with NamedTemporaryFilePool() as fp, StorageSupplier("journal", file=fp) as storage:
         assert isinstance(storage, JournalStorage)
         storage_url = fp.name
 
@@ -387,7 +387,7 @@ def test_study_names_command_without_storage_url() -> None:
 @pytest.mark.skip_coverage
 @output_formats
 def test_studies_command(output_format: str | None) -> None:
-    with tempfile.NamedTemporaryFile() as fp, StorageSupplier("journal", file=fp) as storage:
+    with NamedTemporaryFilePool() as fp, StorageSupplier("journal", file=fp) as storage:
         assert isinstance(storage, JournalStorage)
         storage_url = fp.name
 
@@ -455,7 +455,7 @@ def test_studies_command(output_format: str | None) -> None:
 @pytest.mark.skip_coverage
 @output_formats
 def test_studies_command_flatten(output_format: str | None) -> None:
-    with tempfile.NamedTemporaryFile() as fp, StorageSupplier("journal", file=fp) as storage:
+    with NamedTemporaryFilePool() as fp, StorageSupplier("journal", file=fp) as storage:
         assert isinstance(storage, JournalStorage)
         storage_url = fp.name
 
@@ -547,7 +547,7 @@ def test_studies_command_flatten(output_format: str | None) -> None:
 @pytest.mark.parametrize("objective", (objective_func, objective_func_branched_search_space))
 @output_formats
 def test_trials_command(objective: Callable[[Trial], float], output_format: str | None) -> None:
-    with tempfile.NamedTemporaryFile() as fp, StorageSupplier("journal", file=fp) as storage:
+    with NamedTemporaryFilePool() as fp, StorageSupplier("journal", file=fp) as storage:
         assert isinstance(storage, JournalStorage)
         storage_url = fp.name
         study_name = "test_study"
@@ -628,7 +628,7 @@ def test_trials_command(objective: Callable[[Trial], float], output_format: str 
 def test_trials_command_flatten(
     objective: Callable[[Trial], float], output_format: str | None
 ) -> None:
-    with tempfile.NamedTemporaryFile() as fp, StorageSupplier("journal", file=fp) as storage:
+    with NamedTemporaryFilePool() as fp, StorageSupplier("journal", file=fp) as storage:
         assert isinstance(storage, JournalStorage)
         storage_url = fp.name
         study_name = "test_study"
@@ -705,7 +705,7 @@ def test_trials_command_flatten(
 def test_best_trial_command(
     objective: Callable[[Trial], float], output_format: str | None
 ) -> None:
-    with tempfile.NamedTemporaryFile() as fp, StorageSupplier("journal", file=fp) as storage:
+    with NamedTemporaryFilePool() as fp, StorageSupplier("journal", file=fp) as storage:
         assert isinstance(storage, JournalStorage)
         storage_url = fp.name
         study_name = "test_study"
@@ -787,7 +787,7 @@ def test_best_trial_command(
 def test_best_trial_command_flatten(
     objective: Callable[[Trial], float], output_format: str | None
 ) -> None:
-    with tempfile.NamedTemporaryFile() as fp, StorageSupplier("journal", file=fp) as storage:
+    with NamedTemporaryFilePool() as fp, StorageSupplier("journal", file=fp) as storage:
         assert isinstance(storage, JournalStorage)
         storage_url = fp.name
         study_name = "test_study"
@@ -861,7 +861,7 @@ def test_best_trial_command_flatten(
 @pytest.mark.skip_coverage
 @output_formats
 def test_best_trials_command(output_format: str | None) -> None:
-    with tempfile.NamedTemporaryFile() as fp, StorageSupplier("journal", file=fp) as storage:
+    with NamedTemporaryFilePool() as fp, StorageSupplier("journal", file=fp) as storage:
         assert isinstance(storage, JournalStorage)
         storage_url = fp.name
         study_name = "test_study"
@@ -947,7 +947,7 @@ def test_best_trials_command(output_format: str | None) -> None:
 @pytest.mark.skip_coverage
 @output_formats
 def test_best_trials_command_flatten(output_format: str | None) -> None:
-    with tempfile.NamedTemporaryFile() as fp, StorageSupplier("journal", file=fp) as storage:
+    with NamedTemporaryFilePool() as fp, StorageSupplier("journal", file=fp) as storage:
         assert isinstance(storage, JournalStorage)
         storage_url = fp.name
         study_name = "test_study"
@@ -1026,7 +1026,7 @@ def test_best_trials_command_flatten(output_format: str | None) -> None:
 
 @pytest.mark.skip_coverage
 def test_create_study_command_with_skip_if_exists() -> None:
-    with tempfile.NamedTemporaryFile() as fp, StorageSupplier("journal", file=fp) as storage:
+    with NamedTemporaryFilePool() as fp, StorageSupplier("journal", file=fp) as storage:
         assert isinstance(storage, JournalStorage)
         storage_url = fp.name
         study_name = "test_study"
@@ -1181,7 +1181,7 @@ def test_ask(
         '"y": {"name": "CategoricalDistribution", "attributes": {"choices": ["foo"]}}}'
     )
 
-    with tempfile.NamedTemporaryFile(suffix=".log") as fp:
+    with NamedTemporaryFilePool() as fp:
         args = ["optuna", "create-study", "--storage", fp.name, "--study-name", study_name]
         subprocess.run(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
@@ -1238,7 +1238,7 @@ def test_ask_flatten(
         '"y": {"name": "CategoricalDistribution", "attributes": {"choices": ["foo"]}}}'
     )
 
-    with tempfile.NamedTemporaryFile(suffix=".log") as fp:
+    with NamedTemporaryFilePool() as fp:
         args = ["optuna", "create-study", "--storage", fp.name, "--study-name", study_name]
         subprocess.run(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
@@ -1286,7 +1286,7 @@ def test_ask_flatten(
 def test_ask_empty_search_space(output_format: str) -> None:
     study_name = "test_study"
 
-    with tempfile.NamedTemporaryFile(suffix=".log") as fp:
+    with NamedTemporaryFilePool() as fp:
         args = ["optuna", "create-study", "--storage", fp.name, "--study-name", study_name]
         subprocess.run(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
@@ -1325,7 +1325,7 @@ def test_ask_empty_search_space(output_format: str) -> None:
 def test_ask_empty_search_space_flatten(output_format: str) -> None:
     study_name = "test_study"
 
-    with tempfile.NamedTemporaryFile(suffix=".log") as fp:
+    with NamedTemporaryFilePool() as fp:
         args = ["optuna", "create-study", "--storage", fp.name, "--study-name", study_name]
         subprocess.run(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
@@ -1366,7 +1366,7 @@ def test_ask_sampler_kwargs_without_sampler() -> None:
         '"y": {"name": "CategoricalDistribution", "attributes": {"choices": ["foo"]}}}'
     )
 
-    with tempfile.NamedTemporaryFile(suffix=".log") as fp:
+    with NamedTemporaryFilePool() as fp:
         args = ["optuna", "create-study", "--storage", fp.name, "--study-name", study_name]
         subprocess.run(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
@@ -1396,7 +1396,7 @@ def test_ask_without_create_study_beforehand() -> None:
         '"y": {"name": "CategoricalDistribution", "attributes": {"choices": ["foo"]}}}'
     )
 
-    with tempfile.NamedTemporaryFile(suffix=".log") as fp:
+    with NamedTemporaryFilePool() as fp:
         args = [
             "optuna",
             "ask",
@@ -1439,7 +1439,7 @@ def test_create_study_and_ask(
         '"y": {"name": "CategoricalDistribution", "attributes": {"choices": ["foo"]}}}'
     )
 
-    with tempfile.NamedTemporaryFile(suffix=".log") as fp:
+    with NamedTemporaryFilePool() as fp:
         create_study_args = [
             "optuna",
             "create-study",
@@ -1612,7 +1612,7 @@ def test_tell_with_nan() -> None:
     ],
 )
 def test_configure_logging_verbosity(verbosity: str, expected: bool) -> None:
-    with tempfile.NamedTemporaryFile() as fp, StorageSupplier("journal", file=fp) as storage:
+    with NamedTemporaryFilePool() as fp, StorageSupplier("journal", file=fp) as storage:
         assert isinstance(storage, JournalStorage)
         storage_url = fp.name
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1480,10 +1480,8 @@ def test_create_study_and_ask(
 def test_tell() -> None:
     study_name = "test_study"
 
-    with NamedTemporaryFilePool() as tf:
-        db_url = "sqlite:///{}".format(tf.name)
-
-        args = ["optuna", "create-study", "--storage", db_url, "--study-name", study_name]
+    with NamedTemporaryFilePool() as fp:
+        args = ["optuna", "create-study", "--storage", fp.name, "--study-name", study_name]
         subprocess.run(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
         output: Any = subprocess.check_output(
@@ -1491,7 +1489,7 @@ def test_tell() -> None:
                 "optuna",
                 "ask",
                 "--storage",
-                db_url,
+                fp.name,
                 "--study-name",
                 study_name,
                 "--format",
@@ -1507,7 +1505,7 @@ def test_tell() -> None:
                 "optuna",
                 "tell",
                 "--storage",
-                db_url,
+                fp.name,
                 "--trial-number",
                 str(trial_number),
                 "--values",
@@ -1515,7 +1513,10 @@ def test_tell() -> None:
             ]
         )
 
-        study = optuna.load_study(storage=db_url, study_name=study_name)
+        storage = optuna.storages.JournalStorage(
+            optuna.storages.journal.JournalFileBackend(fp.name)
+        )
+        study = optuna.load_study(storage=storage, study_name=study_name)
         assert len(study.trials) == 1
         assert study.trials[0].state == TrialState.COMPLETE
         assert study.trials[0].values == [1.2]
@@ -1526,7 +1527,7 @@ def test_tell() -> None:
                 "optuna",
                 "tell",
                 "--storage",
-                db_url,
+                fp.name,
                 "--trial-number",
                 str(trial_number),
                 "--values",
@@ -1541,7 +1542,7 @@ def test_tell() -> None:
                 "optuna",
                 "tell",
                 "--storage",
-                db_url,
+                fp.name,
                 "--trial-number",
                 str(trial_number),
                 "--values",
@@ -1550,7 +1551,10 @@ def test_tell() -> None:
             ]
         )
 
-        study = optuna.load_study(storage=db_url, study_name=study_name)
+        storage = optuna.storages.JournalStorage(
+            optuna.storages.journal.JournalFileBackend(fp.name)
+        )
+        study = optuna.load_study(storage=storage, study_name=study_name)
         assert len(study.trials) == 1
         assert study.trials[0].state == TrialState.COMPLETE
         assert study.trials[0].values == [1.2]
@@ -1560,10 +1564,8 @@ def test_tell() -> None:
 def test_tell_with_nan() -> None:
     study_name = "test_study"
 
-    with NamedTemporaryFilePool() as tf:
-        db_url = "sqlite:///{}".format(tf.name)
-
-        args = ["optuna", "create-study", "--storage", db_url, "--study-name", study_name]
+    with NamedTemporaryFilePool() as fp:
+        args = ["optuna", "create-study", "--storage", fp.name, "--study-name", study_name]
         subprocess.run(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
         output: Any = subprocess.check_output(
@@ -1571,7 +1573,7 @@ def test_tell_with_nan() -> None:
                 "optuna",
                 "ask",
                 "--storage",
-                db_url,
+                fp.name,
                 "--study-name",
                 study_name,
                 "--format",
@@ -1587,7 +1589,7 @@ def test_tell_with_nan() -> None:
                 "optuna",
                 "tell",
                 "--storage",
-                db_url,
+                fp.name,
                 "--trial-number",
                 str(trial_number),
                 "--values",
@@ -1595,7 +1597,10 @@ def test_tell_with_nan() -> None:
             ]
         )
 
-        study = optuna.load_study(storage=db_url, study_name=study_name)
+        storage = optuna.storages.JournalStorage(
+            optuna.storages.journal.JournalFileBackend(fp.name)
+        )
+        study = optuna.load_study(storage=storage, study_name=study_name)
         assert len(study.trials) == 1
         assert study.trials[0].state == TrialState.FAIL
         assert study.trials[0].values is None

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -134,8 +134,7 @@ def test_create_study_command() -> None:
         assert re.match(name_re, study_name) is not None
 
         # study_name should be stored in storage.
-        study_id = storage.get_study_id_from_name(study_name)
-        assert study_id == 1
+        storage.get_study_id_from_name(study_name)
 
 
 @pytest.mark.skip_coverage
@@ -182,8 +181,7 @@ def test_create_study_command_with_storage_env() -> None:
         assert re.match(name_re, study_name) is not None
 
         # study_name should be stored in storage.
-        study_id = storage.get_study_id_from_name(study_name)
-        assert study_id == 1
+        storage.get_study_id_from_name(study_name)
 
 
 @pytest.mark.skip_coverage


### PR DESCRIPTION
## Motivation
- Improve CI performance by replacing RDBStorage with JournalStorage in test_cli.py.

## Description of the changes
- Most instances of RDBStorage in test_cli.py have been replaced with JournalStorage to enhance efficiency.
- Exceptions:
    - Tests that do not explicitly define a storage type, such as test_create_study_command_without_storage_url().
    - Tests that require a specific storage type, such as test_storage_upgrade_command().
- [Remove the assertion of study_id ](https://github.com/optuna/optuna/pull/5990/files#diff-4e8715c7a425ee52e74b7df4d34efd32e8c92f3e60bd51bc2e1ad5943b82032eL138)because the initial study_id is not defined in the code, making the test fragile.