### PR TITLE
Implement `waiting_trials_cache` in study

### DIFF
--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -1058,16 +1058,17 @@ class Study:
 
     def _pop_waiting_trial_id(self) -> int | None:
         if self._waiting_trials_cache is not None:
-            trials_to_be_removed = set()
+            # trials_to_be_removed = set()
             for trial in self._waiting_trials_cache:
-                trials_to_be_removed.add(trial)
+                # trials_to_be_removed.add(trial)
+                self._waiting_trials_cache -= {trial}
                 if not self._storage.set_trial_state_values(
                     trial._trial_id, state=TrialState.RUNNING
                 ):
                     continue
 
                 _logger.debug("Trial {} popped from the trial queue.".format(trial.number))
-                self._waiting_trials_cache -= trials_to_be_removed
+                # self._waiting_trials_cache -= trials_to_be_removed
                 return trial._trial_id
 
         waiting_trials = self._storage.get_all_trials(


### PR DESCRIPTION
## Motivation
- Fixes [#5948](https://github.com/optuna/optuna/issues/5948)
- (This PR is based on [#5987](https://github.com/optuna/optuna/pull/5987))

## Description of the changes
- Implement `waiting_trials_cache` in study
- If there are remaining trials in `waiting_trials_cache`, they are used directly, avoiding the need to check all trials via `self._storage.get_all_trials()`.
- As shown below, this optimization reduces the execution time of `get_all_trials()`, leading to a faster `_pop_waiting_trial_id()`.

## Performance Improvement
- This change improves performance by reducing the overhead of fetching all trials. Below are benchmark results comparing the current master branch.

**Before (master)**
- `ntimes`: 100
- `total time`: 0.0009652 sec
- `per call`: 9.652e-06 sec
- `cumulative time`: 0.01285 sec
- `per call (cumulative)`: 0.0001285 sec
![image](https://github.com/user-attachments/assets/dbe00652-537b-46ac-8792-cb736269936b)

**After (PR)**
- `ntimes`: 100
- `totime`: 0.0007828 sec
- `percall`: 7.828e-06 sec
- `cumtime`: 0.01078 sec
- `percall`: 0.0001078 sec
![image](https://github.com/user-attachments/assets/0006291d-cef5-4668-98d4-7bce53ae0c41)

Here is the code used to generate the results above
```
import optuna
import cProfile

study = optuna.create_study()

def objective(trial):
    x = trial.suggest_uniform("x", -10, 10)
    y = trial.suggest_uniform("y", -10, 10)
    return x**2 + y**2

study.optimize(objective, n_trials=100)

for i in range(-5, 5):
    study.enqueue_trial({"x": i, "y": i})

def profile_objective():
    study.optimize(objective, n_trials=100)

cProfile.run('profile_objective()', 'journal_storage_master_100.prof')
```


