### PR TITLE
Add `_prev_waiting_trial_number` in `InMemoryStorage` to improve the efficiency of `_pop_waiting_trial_id`

### DIFF
--- a/optuna/storages/_in_memory.py
+++ b/optuna/storages/_in_memory.py
@@ -380,15 +380,12 @@ class InMemoryStorage(BaseStorage):
 
             if states == (TrialState.WAITING,):
                 trials: list[FrozenTrial] = []
-                for i in range(
-                    self._prev_waiting_trial_number[study_id], len(self._studies[study_id].trials)
-                ):
-                    trial = self.get_trial(
-                        self.get_trial_id_from_study_id_trial_number(study_id, i)
-                    )
+                for trial in self._studies[study_id].trials[
+                    self._prev_waiting_trial_number[study_id] :
+                ]:
                     if trial.state == TrialState.WAITING:
                         if not trials:
-                            self._prev_waiting_trial_number[study_id] = i
+                            self._prev_waiting_trial_number[study_id] = trial.number
                         trials.append(trial)
                 if not trials:
                     self._prev_waiting_trial_number[study_id] = len(self._studies[study_id].trials)

--- a/optuna/storages/_in_memory.py
+++ b/optuna/storages/_in_memory.py
@@ -378,6 +378,8 @@ class InMemoryStorage(BaseStorage):
         with self._lock:
             self._check_study_id(study_id)
 
+            # Optimized retrieval of trials in the WAITING state to improve performance
+            # for the call, `get_all_trials(states=(TrialState.WAITING,))`.
             if states == (TrialState.WAITING,):
                 trials: list[FrozenTrial] = []
                 for trial in self._studies[study_id].trials[

--- a/optuna/storages/_in_memory.py
+++ b/optuna/storages/_in_memory.py
@@ -376,7 +376,7 @@ class InMemoryStorage(BaseStorage):
         with self._lock:
             self._check_study_id(study_id)
 
-            if states is (TrialState.WAITING,):
+            if states == (TrialState.WAITING,):
                 trials: list[FrozenTrial] = []
                 for i in range(self._prev_waiting_trial_id, self._max_trial_id + 1):
                     try:


### PR DESCRIPTION
## Motivation
- Fix [_pop_waiting_trials for InMemoryStorage is slow #5948](https://github.com/optuna/optuna/issues/5948)

## Description of the changes
- Introduced `_prev_waiting_trial_id` in InMemoryStorage to improve efficiency of `get_all_trials(states = (TrialState.WAITING))`.