### PR TITLE
Fix a minor bug in GPSampler for objective that returns `inf`

### DIFF
--- a/optuna/_gp/gp.py
+++ b/optuna/_gp/gp.py
@@ -38,14 +38,15 @@ logger = get_logger(__name__)
 
 
 def warn_and_convert_inf(values: np.ndarray) -> np.ndarray:
-    if np.all(np.isfinite(values)):
+    is_values_finite = np.isfinite(values)
+    if np.all(is_values_finite):
         return values
 
-    warnings.warn("Clip non-finite values to the min/max finite values for the GP fittings.")
-    finite_vals_with_nan = np.where(np.isfinite(values), values, np.nan)
-    is_any_finite = np.any(np.isfinite(finite_vals_with_nan), axis=0)
-    max_finite_vals = np.where(is_any_finite, np.nanmax(finite_vals_with_nan, axis=0), 0.0)
+    warnings.warn("Clip non-finite values to the min/max finite values for GP fittings.")
+    finite_vals_with_nan = np.where(is_values_finite, values, np.nan)
+    is_any_finite = np.any(is_values_finite, axis=0)
     min_finite_vals = np.where(is_any_finite, np.nanmin(finite_vals_with_nan, axis=0), 0.0)
+    max_finite_vals = np.where(is_any_finite, np.nanmax(finite_vals_with_nan, axis=0), 0.0)
     return np.clip(values, min_finite_vals, max_finite_vals)
 
 

--- a/optuna/_gp/gp.py
+++ b/optuna/_gp/gp.py
@@ -37,20 +37,16 @@ logger = get_logger(__name__)
 # d2: squared distance between two points
 
 
-def warn_and_convert_inf(
-    values: np.ndarray,
-) -> np.ndarray:
-    if np.any(~np.isfinite(values)):
-        warnings.warn(
-            "GP cannot handle non finite values, so we clip them to the best/worst finite value."
-        )
+def warn_and_convert_inf(values: np.ndarray) -> np.ndarray:
+    if np.all(np.isfinite(values)):
+        return values
 
-        finite_vals_with_nan = np.where(np.isfinite(values), values, np.nan)
-        is_any_finite = np.any(np.isfinite(finite_vals_with_nan), axis=0)
-        max_finite_vals = np.where(is_any_finite, np.nanmax(finite_vals_with_nan, axis=0), 0.0)
-        min_finite_vals = np.where(is_any_finite, np.nanmin(finite_vals_with_nan, axis=0), 0.0)
-        return np.clip(values, min_finite_vals, max_finite_vals)
-    return values
+    warnings.warn("Clip non-finite values to the min/max finite values for the GP fittings.")
+    finite_vals_with_nan = np.where(np.isfinite(values), values, np.nan)
+    is_any_finite = np.any(np.isfinite(finite_vals_with_nan), axis=0)
+    max_finite_vals = np.where(is_any_finite, np.nanmax(finite_vals_with_nan, axis=0), 0.0)
+    min_finite_vals = np.where(is_any_finite, np.nanmin(finite_vals_with_nan, axis=0), 0.0)
+    return np.clip(values, min_finite_vals, max_finite_vals)
 
 
 class Matern52Kernel(torch.autograd.Function):

--- a/optuna/samplers/_gp/sampler.py
+++ b/optuna/samplers/_gp/sampler.py
@@ -319,11 +319,11 @@ def _warn_and_convert_inf(
             "GPSampler cannot handle +/-inf, so we clip them to the best/worst finite value."
         )
 
-        finite_vals = values[np.isfinite(values)]
-        best_finite_val = np.max(finite_vals, axis=0, initial=0.0)
-        worst_finite_val = np.min(finite_vals, axis=0, initial=0.0)
-
-        return np.clip(values, worst_finite_val, best_finite_val)
+        finite_vals_with_nan = np.where(np.isfinite(values), values, np.nan)
+        is_any_finite = np.any(np.isfinite(finite_vals_with_nan), axis=0)
+        best_finite_vals = np.where(is_any_finite, np.nanmax(finite_vals_with_nan, axis=0), 0.0)
+        worst_finite_vals = np.where(is_any_finite, np.nanmin(finite_vals_with_nan, axis=0), 0.0)
+        return np.clip(values, worst_finite_vals, best_finite_vals)
     return values
 
 

--- a/optuna/samplers/_gp/sampler.py
+++ b/optuna/samplers/_gp/sampler.py
@@ -5,7 +5,6 @@ from collections.abc import Sequence
 from typing import Any
 from typing import cast
 from typing import TYPE_CHECKING
-import warnings
 
 import numpy as np
 
@@ -151,7 +150,7 @@ class GPSampler(BaseSampler):
         internal_search_space: gp_search_space.SearchSpace,
         normalized_params: np.ndarray,
     ) -> list[acqf.AcquisitionFunctionParams]:
-        constraint_vals = _warn_and_convert_inf(constraint_vals)
+        constraint_vals = gp.warn_and_convert_inf(constraint_vals)
         means = np.mean(constraint_vals, axis=0)
         stds = np.std(constraint_vals, axis=0)
         standardized_constraint_vals = (constraint_vals - means) / np.maximum(EPS, stds)
@@ -219,7 +218,7 @@ class GPSampler(BaseSampler):
         _sign = -1.0 if study.direction == StudyDirection.MINIMIZE else 1.0
         score_vals = np.array([_sign * cast(float, trial.value) for trial in trials])
 
-        score_vals = _warn_and_convert_inf(score_vals)
+        score_vals = gp.warn_and_convert_inf(score_vals)
         standardized_score_vals = (score_vals - np.mean(score_vals)) / max(EPS, np.std(score_vals))
 
         if self._kernel_params_cache is not None and len(
@@ -309,22 +308,6 @@ class GPSampler(BaseSampler):
         if self._constraints_func is not None:
             _process_constraints_after_trial(self._constraints_func, study, trial, state)
         self._independent_sampler.after_trial(study, trial, state, values)
-
-
-def _warn_and_convert_inf(
-    values: np.ndarray,
-) -> np.ndarray:
-    if np.any(~np.isfinite(values)):
-        warnings.warn(
-            "GPSampler cannot handle +/-inf, so we clip them to the best/worst finite value."
-        )
-
-        finite_vals_with_nan = np.where(np.isfinite(values), values, np.nan)
-        is_any_finite = np.any(np.isfinite(finite_vals_with_nan), axis=0)
-        best_finite_vals = np.where(is_any_finite, np.nanmax(finite_vals_with_nan, axis=0), 0.0)
-        worst_finite_vals = np.where(is_any_finite, np.nanmin(finite_vals_with_nan, axis=0), 0.0)
-        return np.clip(values, worst_finite_vals, best_finite_vals)
-    return values
 
 
 def _get_constraint_vals_and_feasibility(

--- a/optuna/terminator/improvement/emmr.py
+++ b/optuna/terminator/improvement/emmr.py
@@ -152,11 +152,11 @@ class EMMREvaluator(BaseImprovementEvaluator):
                 "Those values are clamped to worst/best finite value."
             )
 
-            finite_vals_with_nan = np.where(np.isfinite(score_vals), values, np.nan)
+            finite_vals_with_nan = np.where(np.isfinite(score_vals), score_vals, np.nan)
             is_any_finite = np.any(np.isfinite(finite_vals_with_nan), axis=0)
             best_finite_vals = np.where(is_any_finite, np.nanmax(finite_vals_with_nan, axis=0), 0)
             worst_finite_vals = np.where(is_any_finite, np.nanmin(finite_vals_with_nan, axis=0), 0)
-            score_vals = np.clip(values, worst_finite_vals, best_finite_vals)
+            score_vals = np.clip(score_vals, worst_finite_vals, best_finite_vals)
 
         standarized_score_vals = (score_vals - score_vals.mean()) / max(
             sys.float_info.min, score_vals.std()

--- a/optuna/terminator/improvement/emmr.py
+++ b/optuna/terminator/improvement/emmr.py
@@ -145,19 +145,7 @@ class EMMREvaluator(BaseImprovementEvaluator):
         # _gp module assumes that optimization direction is maximization
         sign = -1 if study_direction == StudyDirection.MINIMIZE else 1
         score_vals = np.array([cast(float, t.value) for t in complete_trials]) * sign
-
-        if np.any(~np.isfinite(score_vals)):
-            warnings.warn(
-                f"{self.__class__.__name__} cannot handle infinite values."
-                "Those values are clamped to worst/best finite value."
-            )
-
-            finite_vals_with_nan = np.where(np.isfinite(score_vals), score_vals, np.nan)
-            is_any_finite = np.any(np.isfinite(finite_vals_with_nan), axis=0)
-            best_finite_vals = np.where(is_any_finite, np.nanmax(finite_vals_with_nan, axis=0), 0)
-            worst_finite_vals = np.where(is_any_finite, np.nanmin(finite_vals_with_nan, axis=0), 0)
-            score_vals = np.clip(score_vals, worst_finite_vals, best_finite_vals)
-
+        score_vals = gp.warn_and_convert_inf(score_vals)
         standarized_score_vals = (score_vals - score_vals.mean()) / max(
             sys.float_info.min, score_vals.std()
         )

--- a/optuna/terminator/improvement/emmr.py
+++ b/optuna/terminator/improvement/emmr.py
@@ -152,11 +152,11 @@ class EMMREvaluator(BaseImprovementEvaluator):
                 "Those values are clamped to worst/best finite value."
             )
 
-            finite_score_vals = score_vals[np.isfinite(score_vals)]
-            best_finite_score = np.max(finite_score_vals, initial=0.0)
-            worst_finite_score = np.min(finite_score_vals, initial=0.0)
-
-            score_vals = np.clip(score_vals, worst_finite_score, best_finite_score)
+            finite_vals_with_nan = np.where(np.isfinite(score_vals), values, np.nan)
+            is_any_finite = np.any(np.isfinite(finite_vals_with_nan), axis=0)
+            best_finite_vals = np.where(is_any_finite, np.nanmax(finite_vals_with_nan, axis=0), 0)
+            worst_finite_vals = np.where(is_any_finite, np.nanmin(finite_vals_with_nan, axis=0), 0)
+            score_vals = np.clip(values, worst_finite_vals, best_finite_vals)
 
         standarized_score_vals = (score_vals - score_vals.mean()) / max(
             sys.float_info.min, score_vals.std()

--- a/tests/gp_tests/test_gp.py
+++ b/tests/gp_tests/test_gp.py
@@ -13,8 +13,11 @@ import optuna._gp.prior as prior
 @pytest.mark.parametrize(
     "values,ans",
     [
-        (np.array([-1, 0, 1]), np.array([-1, 0, 1])),
-        (np.array([-1, -np.inf, 0, np.inf, 1]), np.array([-1, -1, 0, 1, 1])),
+        (np.array([-1, 0, 1])[:, np.newaxis], np.array([-1, 0, 1])[:, np.newaxis]),
+        (
+            np.array([-1, -np.inf, 0, np.inf, 1])[:, np.newaxis],
+            np.array([-1, -1, 0, 1, 1])[:, np.newaxis]
+        ),
         (np.array([[-1, 2], [0, -2], [1, 0]]), np.array([[-1, 2], [0, -2], [1, 0]])),
         (
             np.array([[-1, 2], [-np.inf, np.inf], [0, -np.inf], [np.inf, -2], [1, 0]]),
@@ -31,15 +34,25 @@ import optuna._gp.prior as prior
             ),
             np.array([[-100, 0, 10], [-100, 0, 100], [-10, 0, 100], [-10, 0, 10]]),
         ),
+        (np.array([-np.inf, np.inf])[:, np.newaxis], np.array([0, 0])[:, np.newaxis]),
+        (np.array([])[:, np.newaxis], np.array([])[:, np.newaxis]),
+    ],
+)
+def test_warn_and_convert_inf_for_2d_array(values: np.ndarray, ans: np.ndarray) -> None:
+    assert np.allclose(warn_and_convert_inf(values), ans)
+
+
+@pytest.mark.parametrize(
+    "values,ans",
+    [
+        (np.array([-1, 0, 1]), np.array([-1, 0, 1])),
+        (np.array([-1, -np.inf, 0, np.inf, 1]), np.array([-1, -1, 0, 1, 1])),
         (np.array([-np.inf, np.inf]), np.array([0, 0])),
         (np.array([]), np.array([])),
     ],
 )
-def test_warn_and_convert_inf(values: np.ndarray, ans: np.ndarray) -> None:
+def test_warn_and_convert_inf_for_1d_array(values: np.ndarray, ans: np.ndarray) -> None:
     assert np.allclose(warn_and_convert_inf(values), ans)
-    if len(values.shape) == 1:
-        # Test also with the shape of (n, 1) to ensure the batched version.
-        assert np.allclose(warn_and_convert_inf(values[:, np.newaxis]), ans[:, np.newaxis])
 
 
 @pytest.mark.parametrize(

--- a/tests/gp_tests/test_gp.py
+++ b/tests/gp_tests/test_gp.py
@@ -6,7 +6,40 @@ import torch
 
 from optuna._gp.gp import _fit_kernel_params
 from optuna._gp.gp import KernelParamsTensor
+from optuna._gp.gp import warn_and_convert_inf
 import optuna._gp.prior as prior
+
+
+@pytest.mark.parametrize(
+    "values,ans",
+    [
+        (np.array([-1, 0, 1]), np.array([-1, 0, 1])),
+        (np.array([-1, -np.inf, 0, np.inf, 1]), np.array([-1, -1, 0, 1, 1])),
+        (np.array([[-1, 2], [0, -2], [1, 0]]), np.array([[-1, 2], [0, -2], [1, 0]])),
+        (
+            np.array([[-1, 2], [-np.inf, np.inf], [0, -np.inf], [np.inf, -2], [1, 0]]),
+            np.array([[-1, 2], [-1, 2], [0, -2], [1, -2], [1, 0]]),
+        ),
+        (
+            np.array(
+                [
+                    [-100, np.inf, 10],
+                    [-np.inf, np.inf, 100],
+                    [-10, -np.inf, np.inf],
+                    [np.inf, np.inf, -np.inf],
+                ]
+            ),
+            np.array([[-100, 0, 10], [-100, 0, 100], [-10, 0, 100], [-10, 0, 10]]),
+        ),
+        (np.array([-np.inf, np.inf]), np.array([0, 0])),
+        (np.array([]), np.array([])),
+    ],
+)
+def test_warn_and_convert_inf(values: np.ndarray, ans: np.ndarray) -> None:
+    assert np.allclose(warn_and_convert_inf(values), ans)
+    if len(values.shape) == 1:
+        # Test also with the shape of (n, 1) to ensure the batched version.
+        assert np.allclose(warn_and_convert_inf(values[:, np.newaxis]), ans[:, np.newaxis])
 
 
 @pytest.mark.parametrize(

--- a/tests/gp_tests/test_gp.py
+++ b/tests/gp_tests/test_gp.py
@@ -16,7 +16,7 @@ import optuna._gp.prior as prior
         (np.array([-1, 0, 1])[:, np.newaxis], np.array([-1, 0, 1])[:, np.newaxis]),
         (
             np.array([-1, -np.inf, 0, np.inf, 1])[:, np.newaxis],
-            np.array([-1, -1, 0, 1, 1])[:, np.newaxis]
+            np.array([-1, -1, 0, 1, 1])[:, np.newaxis],
         ),
         (np.array([[-1, 2], [0, -2], [1, 0]]), np.array([[-1, 2], [0, -2], [1, 0]])),
         (


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

This PR fixes a minor bug in `GPSampler`.
The bug of my interest was embedded here:
- https://github.com/optuna/optuna/commit/84502dcdf5747cc128a4caa1573c4bac9efb48be#diff-fe893dd86f2d66f2d847ab31510f07079718c70f104067a431616cd4117214b8

![image](https://github.com/user-attachments/assets/275e035f-5fac-4dd8-a90d-6c336484b7a5)

In principle, this change does not affect most users because this statement is triggered only if a user-defined objective function returns non-finite values.

The bug was originally introduced because of the following misunderstanding:
- whether to give the `initial` argument in `np.max` and `np.min` does not affect the result as long as the array of interest is not empty.

However, this is not actually true.
For example, `np.max([1], initial=10)` gives us `10` instead of `1`, which we would like to yield in fact.

To this end, I address this issue by modifying the corresponding part.
Note that `emmr` also needs to be fixed due to the same issue.

## Description of the changes
<!-- Describe the changes in this PR. -->

- Address the issue stated above