### PR TITLE
Fix `TPESampler._ParzenEstimator._calculate_categorical_distributions` when `consider_prior is False`

### DIFF
--- a/optuna/samplers/_tpe/parzen_estimator.py
+++ b/optuna/samplers/_tpe/parzen_estimator.py
@@ -191,13 +191,22 @@ class _ParzenEstimator:
             )
 
         n_kernels = len(observations) + parameters.consider_prior
-        assert parameters.prior_weight is not None
-        weights = np.full(
-            shape=(n_kernels, n_choices),
-            fill_value=parameters.prior_weight / n_kernels,
-        )
+        if parameters.consider_prior is False:
+            weights = np.full(
+                shape=(n_kernels, n_choices),
+                fill_value=0.0,
+            )
+        else:
+            assert parameters.prior_weight is not None
+            weights = np.full(
+                shape=(n_kernels, n_choices),
+                fill_value=parameters.prior_weight / n_kernels,
+            )
         observed_indices = observations.astype(int)
-        if param_name in parameters.categorical_distance_func:
+        if (
+            param_name in parameters.categorical_distance_func
+            and parameters.prior_weight is not None
+        ):
             # TODO(nabenabe0928): Think about how to handle combinatorial explosion.
             # The time complexity is O(n_choices * used_indices.size), so n_choices cannot be huge.
             used_indices, rev_indices = np.unique(observed_indices, return_inverse=True)

--- a/optuna/samplers/_tpe/parzen_estimator.py
+++ b/optuna/samplers/_tpe/parzen_estimator.py
@@ -191,16 +191,16 @@ class _ParzenEstimator:
             )
 
         n_kernels = len(observations) + parameters.consider_prior
-        if parameters.consider_prior is False:
-            weights = np.full(
-                shape=(n_kernels, n_choices),
-                fill_value=0.0,
-            )
-        else:
+        if parameters.consider_prior:
             assert parameters.prior_weight is not None
             weights = np.full(
                 shape=(n_kernels, n_choices),
                 fill_value=parameters.prior_weight / n_kernels,
+            )
+        else:
+            weights = np.full(
+                shape=(n_kernels, n_choices),
+                fill_value=0.0,
             )
         observed_indices = observations.astype(int)
         if (

--- a/optuna/samplers/_tpe/parzen_estimator.py
+++ b/optuna/samplers/_tpe/parzen_estimator.py
@@ -193,26 +193,25 @@ class _ParzenEstimator:
         n_kernels = len(observations) + parameters.consider_prior
         if parameters.consider_prior:
             assert parameters.prior_weight is not None
-            weights = np.full(
-                shape=(n_kernels, n_choices),
-                fill_value=parameters.prior_weight / n_kernels,
-            )
+            fill_value = parameters.prior_weight / n_kernels
         else:
-            weights = np.full(
-                shape=(n_kernels, n_choices),
-                fill_value=0.0,
-            )
+            fill_value = 0.0
+        weights = np.full(
+            shape=(n_kernels, n_choices),
+            fill_value=fill_value,
+        )
         observed_indices = observations.astype(int)
-        if (
-            param_name in parameters.categorical_distance_func
-            and parameters.prior_weight is not None
-        ):
+        if param_name in parameters.categorical_distance_func:
             # TODO(nabenabe0928): Think about how to handle combinatorial explosion.
             # The time complexity is O(n_choices * used_indices.size), so n_choices cannot be huge.
             used_indices, rev_indices = np.unique(observed_indices, return_inverse=True)
             dist_func = parameters.categorical_distance_func[param_name]
             dists = np.array([[dist_func(choices[i], c) for c in choices] for i in used_indices])
-            coef = np.log(n_kernels / parameters.prior_weight) * np.log(n_choices) / np.log(6)
+            if parameters.consider_prior:
+                assert parameters.prior_weight is not None
+                coef = np.log(n_kernels / parameters.prior_weight) * np.log(n_choices) / np.log(6)
+            else:
+                coef = 1.0
             cat_weights = np.exp(-((dists / np.max(dists, axis=1)[:, np.newaxis]) ** 2) * coef)
             weights[: len(observed_indices)] = cat_weights[rev_indices]
         else:

--- a/tests/samplers_tests/tpe_tests/test_parzen_estimator.py
+++ b/tests/samplers_tests/tpe_tests/test_parzen_estimator.py
@@ -111,7 +111,7 @@ def test_init_parzen_estimator(consider_prior: bool, multivariate: bool) -> None
             _BatchedCategoricalDistributions(
                 np.array([[0.2, 0.6, 0.2], [1.0 / 3.0, 1.0 / 3.0, 1.0 / 3.0]])
                 if consider_prior
-                else np.array([[0.25, 0.5, 0.25]])
+                else np.array([[0.0, 1.0, 0.0]])
             ),
             _BatchedCategoricalDistributions(
                 np.array(
@@ -121,7 +121,7 @@ def test_init_parzen_estimator(consider_prior: bool, multivariate: bool) -> None
                     ]
                 )
                 if consider_prior
-                else np.array([[0.2, 0.4, 0.2, 0.2]])
+                else np.array([[0.0, 1.0, 0.0, 0.0]])
             ),
         ],
     )
@@ -169,7 +169,7 @@ def test_init_parzen_estimator(consider_prior: bool, multivariate: bool) -> None
             _BatchedCategoricalDistributions(
                 np.array([[0.2, 0.6, 0.2], [1.0 / 3.0, 1.0 / 3.0, 1.0 / 3.0]])
                 if consider_prior
-                else np.array([[0.25, 0.5, 0.25]])
+                else np.array([[0.0, 1.0, 0.0]])
             ),
             _BatchedCategoricalDistributions(
                 np.array(
@@ -178,7 +178,7 @@ def test_init_parzen_estimator(consider_prior: bool, multivariate: bool) -> None
                         [1.0 / 4.0, 1.0 / 4.0, 1.0 / 4.0, 1.0 / 4.0],
                     ]
                     if consider_prior
-                    else np.array([[0.2, 0.4, 0.2, 0.2]])
+                    else np.array([[0.0, 1.0, 0.0, 0.0]])
                 )
             ),
         ],


### PR DESCRIPTION
## Motivation
- Fix `TPESampler._ParzenEstimator._calculate_categorical_distribution` to ensure the correct behavior when `consider_prior is False`

## Description of the changes
- Set the initial weights to 0 when the `consider_prior is False`
- Update the corresponding tests to reflect this change.
