### PR TITLE
Introduce `UpdateFinishedTrialError` to raise an error when attempting to modify a finished trial

### DIFF
--- a/docs/source/reference/exceptions.rst
+++ b/docs/source/reference/exceptions.rst
@@ -14,3 +14,4 @@ The :mod:`~optuna.exceptions` module defines Optuna-specific exceptions deriving
    CLIUsageError
    StorageInternalError
    DuplicatedStudyError
+   UpdateFinishedTrialError

--- a/optuna/exceptions.py
+++ b/optuna/exceptions.py
@@ -81,6 +81,15 @@ class DuplicatedStudyError(OptunaError):
     pass
 
 
+class UpdateFinishedTrialError(OptunaError, RuntimeError):
+    """Exception for updating a finished trial.
+
+    This error is raised when attempting to update a finished trial.
+    """
+
+    pass
+
+
 class ExperimentalWarning(Warning):
     """Experimental Warning class.
 

--- a/optuna/storages/_base.py
+++ b/optuna/storages/_base.py
@@ -8,6 +8,7 @@ from typing import cast
 
 from optuna._typing import JSONSerializable
 from optuna.distributions import BaseDistribution
+from optuna.exceptions import UpdateFinishedTrialError
 from optuna.study._frozen import FrozenStudy
 from optuna.study._study_direction import StudyDirection
 from optuna.trial import FrozenTrial
@@ -271,7 +272,7 @@ class BaseStorage(abc.ABC):
         Raises:
             :exc:`KeyError`:
                 If no trial with the matching ``trial_id`` exists.
-            :exc:`RuntimeError`:
+            :exc:`optuna.exceptions.UpdateFinishedTrialError`:
                 If the trial is already finished.
         """
         raise NotImplementedError
@@ -368,7 +369,7 @@ class BaseStorage(abc.ABC):
         Raises:
             :exc:`KeyError`:
                 If no trial with the matching ``trial_id`` exists.
-            :exc:`RuntimeError`:
+            :exc:`optuna.exceptions.UpdateFinishedTrialError`:
                 If the trial is already finished.
         """
         raise NotImplementedError
@@ -392,7 +393,7 @@ class BaseStorage(abc.ABC):
         Raises:
             :exc:`KeyError`:
                 If no trial with the matching ``trial_id`` exists.
-            :exc:`RuntimeError`:
+            :exc:`optuna.exceptions.UpdateFinishedTrialError`:
                 If the trial is already finished.
         """
         raise NotImplementedError
@@ -414,7 +415,7 @@ class BaseStorage(abc.ABC):
         Raises:
             :exc:`KeyError`:
                 If no trial with the matching ``trial_id`` exists.
-            :exc:`RuntimeError`:
+            :exc:`optuna.exceptions.UpdateFinishedTrialError`:
                 If the trial is already finished.
         """
         raise NotImplementedError
@@ -436,7 +437,7 @@ class BaseStorage(abc.ABC):
         Raises:
             :exc:`KeyError`:
                 If no trial with the matching ``trial_id`` exists.
-            :exc:`RuntimeError`:
+            :exc:`optuna.exceptions.UpdateFinishedTrialError`:
                 If the trial is already finished.
         """
         raise NotImplementedError
@@ -614,11 +615,11 @@ class BaseStorage(abc.ABC):
                 Trial state to check.
 
         Raises:
-            :exc:`RuntimeError`:
+            :exc:`optuna.exceptions.UpdateFinishedTrialError`:
                 If the trial is already finished.
         """
         if trial_state.is_finished():
             trial = self.get_trial(trial_id)
-            raise RuntimeError(
+            raise UpdateFinishedTrialError(
                 "Trial#{} has already finished and can not be updated.".format(trial.number)
             )

--- a/optuna/storages/_base.py
+++ b/optuna/storages/_base.py
@@ -272,7 +272,7 @@ class BaseStorage(abc.ABC):
         Raises:
             :exc:`KeyError`:
                 If no trial with the matching ``trial_id`` exists.
-            :exc:`optuna.exceptions.UpdateFinishedTrialError`:
+            :exc:`~optuna.exceptions.UpdateFinishedTrialError`:
                 If the trial is already finished.
         """
         raise NotImplementedError
@@ -369,7 +369,7 @@ class BaseStorage(abc.ABC):
         Raises:
             :exc:`KeyError`:
                 If no trial with the matching ``trial_id`` exists.
-            :exc:`optuna.exceptions.UpdateFinishedTrialError`:
+            :exc:`~optuna.exceptions.UpdateFinishedTrialError`:
                 If the trial is already finished.
         """
         raise NotImplementedError
@@ -393,7 +393,7 @@ class BaseStorage(abc.ABC):
         Raises:
             :exc:`KeyError`:
                 If no trial with the matching ``trial_id`` exists.
-            :exc:`optuna.exceptions.UpdateFinishedTrialError`:
+            :exc:`~optuna.exceptions.UpdateFinishedTrialError`:
                 If the trial is already finished.
         """
         raise NotImplementedError
@@ -415,7 +415,7 @@ class BaseStorage(abc.ABC):
         Raises:
             :exc:`KeyError`:
                 If no trial with the matching ``trial_id`` exists.
-            :exc:`optuna.exceptions.UpdateFinishedTrialError`:
+            :exc:`~optuna.exceptions.UpdateFinishedTrialError`:
                 If the trial is already finished.
         """
         raise NotImplementedError
@@ -437,7 +437,7 @@ class BaseStorage(abc.ABC):
         Raises:
             :exc:`KeyError`:
                 If no trial with the matching ``trial_id`` exists.
-            :exc:`optuna.exceptions.UpdateFinishedTrialError`:
+            :exc:`~optuna.exceptions.UpdateFinishedTrialError`:
                 If the trial is already finished.
         """
         raise NotImplementedError
@@ -615,7 +615,7 @@ class BaseStorage(abc.ABC):
                 Trial state to check.
 
         Raises:
-            :exc:`optuna.exceptions.UpdateFinishedTrialError`:
+            :exc:`~optuna.exceptions.UpdateFinishedTrialError`:
                 If the trial is already finished.
         """
         if trial_state.is_finished():

--- a/optuna/storages/_grpc/client.py
+++ b/optuna/storages/_grpc/client.py
@@ -14,6 +14,7 @@ from optuna._imports import _LazyImport
 from optuna.distributions import BaseDistribution
 from optuna.distributions import distribution_to_json
 from optuna.exceptions import DuplicatedStudyError
+from optuna.exceptions import UpdateFinishedTrialError
 from optuna.storages._base import BaseStorage
 from optuna.storages._base import DEFAULT_STUDY_NAME_PREFIX
 from optuna.study._frozen import FrozenStudy
@@ -252,7 +253,7 @@ class GrpcStorageProxy(BaseStorage):
             if e.code() == grpc.StatusCode.NOT_FOUND:
                 raise KeyError from e
             elif e.code() == grpc.StatusCode.FAILED_PRECONDITION:
-                raise RuntimeError from e
+                raise UpdateFinishedTrialError from e
             elif e.code() == grpc.StatusCode.INVALID_ARGUMENT:
                 raise ValueError from e
             else:
@@ -272,7 +273,7 @@ class GrpcStorageProxy(BaseStorage):
             if e.code() == grpc.StatusCode.NOT_FOUND:
                 raise KeyError from e
             elif e.code() == grpc.StatusCode.FAILED_PRECONDITION:
-                raise RuntimeError from e
+                raise UpdateFinishedTrialError from e
             else:
                 raise
 
@@ -290,7 +291,7 @@ class GrpcStorageProxy(BaseStorage):
             if e.code() == grpc.StatusCode.NOT_FOUND:
                 raise KeyError from e
             elif e.code() == grpc.StatusCode.FAILED_PRECONDITION:
-                raise RuntimeError from e
+                raise UpdateFinishedTrialError from e
             else:
                 raise
 
@@ -304,7 +305,7 @@ class GrpcStorageProxy(BaseStorage):
             if e.code() == grpc.StatusCode.NOT_FOUND:
                 raise KeyError from e
             elif e.code() == grpc.StatusCode.FAILED_PRECONDITION:
-                raise RuntimeError from e
+                raise UpdateFinishedTrialError from e
             else:
                 raise
 
@@ -318,7 +319,7 @@ class GrpcStorageProxy(BaseStorage):
             if e.code() == grpc.StatusCode.NOT_FOUND:
                 raise KeyError from e
             elif e.code() == grpc.StatusCode.FAILED_PRECONDITION:
-                raise RuntimeError from e
+                raise UpdateFinishedTrialError from e
             else:
                 raise
 

--- a/optuna/storages/_grpc/servicer.py
+++ b/optuna/storages/_grpc/servicer.py
@@ -10,6 +10,7 @@ from optuna._imports import _LazyImport
 from optuna.distributions import distribution_to_json
 from optuna.distributions import json_to_distribution
 from optuna.exceptions import DuplicatedStudyError
+from optuna.exceptions import UpdateFinishedTrialError
 from optuna.storages import BaseStorage
 from optuna.study._study_direction import StudyDirection
 from optuna.trial._frozen import FrozenTrial
@@ -219,7 +220,7 @@ class OptunaStorageProxyService(api_pb2_grpc.StorageServiceServicer):
             self._backend.set_trial_param(trial_id, param_name, param_value_internal, distribution)
         except KeyError as e:
             context.abort(code=grpc.StatusCode.NOT_FOUND, details=str(e))
-        except RuntimeError as e:
+        except UpdateFinishedTrialError as e:
             context.abort(code=grpc.StatusCode.FAILED_PRECONDITION, details=str(e))
         except ValueError as e:
             context.abort(code=grpc.StatusCode.INVALID_ARGUMENT, details=str(e))
@@ -255,7 +256,7 @@ class OptunaStorageProxyService(api_pb2_grpc.StorageServiceServicer):
             )
         except KeyError as e:
             context.abort(code=grpc.StatusCode.NOT_FOUND, details=str(e))
-        except RuntimeError as e:
+        except UpdateFinishedTrialError as e:
             context.abort(code=grpc.StatusCode.FAILED_PRECONDITION, details=str(e))
         return api_pb2.SetTrialStateValuesReply(trial_updated=trial_updated)
 
@@ -271,7 +272,7 @@ class OptunaStorageProxyService(api_pb2_grpc.StorageServiceServicer):
             self._backend.set_trial_intermediate_value(trial_id, step, intermediate_value)
         except KeyError as e:
             context.abort(code=grpc.StatusCode.NOT_FOUND, details=str(e))
-        except RuntimeError as e:
+        except UpdateFinishedTrialError as e:
             context.abort(code=grpc.StatusCode.FAILED_PRECONDITION, details=str(e))
         return api_pb2.SetTrialIntermediateValueReply()
 
@@ -287,7 +288,7 @@ class OptunaStorageProxyService(api_pb2_grpc.StorageServiceServicer):
             self._backend.set_trial_user_attr(trial_id, key, value)
         except KeyError as e:
             context.abort(code=grpc.StatusCode.NOT_FOUND, details=str(e))
-        except RuntimeError as e:
+        except UpdateFinishedTrialError as e:
             context.abort(code=grpc.StatusCode.FAILED_PRECONDITION, details=str(e))
         return api_pb2.SetTrialUserAttributeReply()
 
@@ -303,7 +304,7 @@ class OptunaStorageProxyService(api_pb2_grpc.StorageServiceServicer):
             self._backend.set_trial_system_attr(trial_id, key, value)
         except KeyError as e:
             context.abort(code=grpc.StatusCode.NOT_FOUND, details=str(e))
-        except RuntimeError as e:
+        except UpdateFinishedTrialError as e:
             context.abort(code=grpc.StatusCode.FAILED_PRECONDITION, details=str(e))
         return api_pb2.SetTrialSystemAttributeReply()
 

--- a/optuna/storages/_heartbeat.py
+++ b/optuna/storages/_heartbeat.py
@@ -168,8 +168,9 @@ def fail_stale_trials(study: "optuna.Study") -> None:
         try:
             if storage.set_trial_state_values(trial_id, state=TrialState.FAIL):
                 failed_trial_ids.append(trial_id)
-        except RuntimeError:
-            # If another process fails the trial, the storage raises RuntimeError.
+        except optuna.exceptions.UpdateFinishedTrialError:
+            # If another process fails the trial, the storage raises
+            # optuna.exceptions.UpdateFinishedTrialError.
             pass
 
     failed_trial_callback = storage.get_failed_trial_callback()

--- a/optuna/storages/journal/_storage.py
+++ b/optuna/storages/journal/_storage.py
@@ -17,6 +17,7 @@ from optuna.distributions import check_distribution_compatibility
 from optuna.distributions import distribution_to_json
 from optuna.distributions import json_to_distribution
 from optuna.exceptions import DuplicatedStudyError
+from optuna.exceptions import UpdateFinishedTrialError
 from optuna.storages import BaseStorage
 from optuna.storages._base import DEFAULT_STUDY_NAME_PREFIX
 from optuna.storages.journal._base import BaseJournalBackend
@@ -650,7 +651,7 @@ class JournalStorageReplayResult:
             return False
         elif self._trials[trial_id].state.is_finished():
             if self._is_issued_by_this_worker(log):
-                raise RuntimeError(
+                raise UpdateFinishedTrialError(
                     "Trial#{} has already finished and can not be updated.".format(
                         self._trials[trial_id].number
                     )

--- a/tests/storages_tests/test_storages.py
+++ b/tests/storages_tests/test_storages.py
@@ -14,6 +14,7 @@ import optuna
 from optuna._typing import JSONSerializable
 from optuna.distributions import CategoricalDistribution
 from optuna.distributions import FloatDistribution
+from optuna.exceptions import UpdateFinishedTrialError
 from optuna.storages import _CachedStorage
 from optuna.storages import BaseStorage
 from optuna.storages import GrpcStorageProxy
@@ -429,7 +430,7 @@ def test_set_trial_state_values_for_state(storage_mode: str) -> None:
             storage.set_trial_state_values(trial_id, state=state, values=(0.0,))
             for state2 in ALL_STATES:
                 # Cannot update states of finished trials.
-                with pytest.raises(RuntimeError):
+                with pytest.raises(UpdateFinishedTrialError):
                     storage.set_trial_state_values(trial_id, state=state2)
 
 
@@ -503,13 +504,13 @@ def test_set_trial_param(storage_mode: str) -> None:
 
         storage.set_trial_state_values(trial_id_2, state=TrialState.COMPLETE)
         # Cannot assign params to finished trial.
-        with pytest.raises(RuntimeError):
+        with pytest.raises(UpdateFinishedTrialError):
             storage.set_trial_param(trial_id_2, "y", 2, distribution_y_1)
         # Check the previous call does not change the params.
         with pytest.raises(KeyError):
             storage.get_trial_param(trial_id_2, "y")
         # State should be checked prior to distribution compatibility.
-        with pytest.raises(RuntimeError):
+        with pytest.raises(UpdateFinishedTrialError):
             storage.set_trial_param(trial_id_2, "y", 0.4, distribution_z)
 
         # Set params of trials in a different study.
@@ -562,7 +563,7 @@ def test_set_trial_state_values_for_values(storage_mode: str) -> None:
             )
 
         # Cannot change values of finished trials.
-        with pytest.raises(RuntimeError):
+        with pytest.raises(UpdateFinishedTrialError):
             storage.set_trial_state_values(trial_id_1, state=TrialState.COMPLETE, values=(1,))
 
 
@@ -607,7 +608,7 @@ def test_set_trial_intermediate_value(storage_mode: str) -> None:
 
         storage.set_trial_state_values(trial_id_1, state=TrialState.COMPLETE)
         # Cannot change values of finished trials.
-        with pytest.raises(RuntimeError):
+        with pytest.raises(UpdateFinishedTrialError):
             storage.set_trial_intermediate_value(trial_id_1, 0, 0.2)
 
 
@@ -660,7 +661,7 @@ def test_set_trial_user_attr(storage_mode: str) -> None:
 
         # Cannot set attributes of finished trials.
         storage.set_trial_state_values(trial_id_1, state=TrialState.COMPLETE)
-        with pytest.raises(RuntimeError):
+        with pytest.raises(UpdateFinishedTrialError):
             storage.set_trial_user_attr(trial_id_1, "key", "value")
 
 
@@ -711,7 +712,7 @@ def test_set_trial_system_attr(storage_mode: str) -> None:
 
         # Cannot set attributes of finished trials.
         storage.set_trial_state_values(trial_id_1, state=TrialState.COMPLETE)
-        with pytest.raises(RuntimeError):
+        with pytest.raises(UpdateFinishedTrialError):
             storage.set_trial_system_attr(trial_id_1, "key", "value")
 
 
@@ -1158,11 +1159,11 @@ def test_check_trial_is_updatable(storage_mode: str) -> None:
         storage.check_trial_is_updatable(trial_id, TrialState.RUNNING)
         storage.check_trial_is_updatable(trial_id, TrialState.WAITING)
 
-        with pytest.raises(RuntimeError):
+        with pytest.raises(UpdateFinishedTrialError):
             storage.check_trial_is_updatable(trial_id, TrialState.FAIL)
 
-        with pytest.raises(RuntimeError):
+        with pytest.raises(UpdateFinishedTrialError):
             storage.check_trial_is_updatable(trial_id, TrialState.PRUNED)
 
-        with pytest.raises(RuntimeError):
+        with pytest.raises(UpdateFinishedTrialError):
             storage.check_trial_is_updatable(trial_id, TrialState.COMPLETE)


### PR DESCRIPTION
## Motivation
In the current implementation, modifying finished trials in Optuna raises a RuntimeError. However, RuntimeError is a generic exception that does not accurately reflect the nature of the issue. This PR introduces a more specific exception `UpdateFinishedTrialError` to improve clarity and maintainability.

## Description of the changes
- Introduced `UpdateFinishedTrialError`, a new exception that inherits from both `RuntimeError` and `OptunaError`.
- Updated the following methods in `BaseStorage` to raise UpdateFinishedTrialError when attempting to modify a finished trial:
    - `set_trial_param`
    - `set_trial_state_values`
    - `set_trial_user_attr`
    - `set_trial_system_attr`
- The error is raised using `check_trial_is_updatable`, except in JournalStorage, where trial updatability is checked within `_trial_exists_and_updatable`.
- Update the tests
