### PR TITLE
Fix a bug that a gRPC server doesn't work with JournalStorage

### DIFF
--- a/optuna/storages/_grpc/servicer.py
+++ b/optuna/storages/_grpc/servicer.py
@@ -248,7 +248,7 @@ class OptunaStorageProxyService(api_pb2_grpc.StorageServiceServicer):
     ) -> api_pb2.SetTrialStateValuesReply:
         trial_id = request.trial_id
         state = request.state
-        values = request.values
+        values = list(request.values)
         try:
             trial_updated = self._backend.set_trial_state_values(
                 trial_id, _from_proto_trial_state(state), values

--- a/tests/storages_tests/test_storages.py
+++ b/tests/storages_tests/test_storages.py
@@ -772,7 +772,7 @@ def test_get_all_trials(storage_mode: str) -> None:
 def test_get_all_trials_params_order(storage_mode: str, param_names: list[str]) -> None:
     # We don't actually require that all storages to preserve the order of parameters,
     # but all current implementations except for GrpcStorageProxy do, so we test this property.
-    if storage_mode == "grpc_rdb" or storage_mode == "grpc_journal_file":
+    if storage_mode in ("grpc_rdb", "grpc_journal_file"):
         pytest.skip("GrpcStorageProxy does not preserve the order of parameters.")
 
     with StorageSupplier(storage_mode) as storage:

--- a/tests/storages_tests/test_storages.py
+++ b/tests/storages_tests/test_storages.py
@@ -772,7 +772,7 @@ def test_get_all_trials(storage_mode: str) -> None:
 def test_get_all_trials_params_order(storage_mode: str, param_names: list[str]) -> None:
     # We don't actually require that all storages to preserve the order of parameters,
     # but all current implementations except for GrpcStorageProxy do, so we test this property.
-    if storage_mode == "grpc":
+    if storage_mode == "grpc_rdb" or storage_mode == "grpc_journal_file":
         pytest.skip("GrpcStorageProxy does not preserve the order of parameters.")
 
     with StorageSupplier(storage_mode) as storage:

--- a/tests/study_tests/test_study.py
+++ b/tests/study_tests/test_study.py
@@ -1036,7 +1036,7 @@ def test_optimize_infinite_budget_progbar() -> None:
 
 @pytest.mark.parametrize("storage_mode", STORAGE_MODES)
 def test_get_trials(storage_mode: str) -> None:
-    if storage_mode == "grpc":
+    if storage_mode == "grpc_rdb" or storage_mode == "grpc_journal_file":
         pytest.skip("gRPC storage doesn't use `copy.deepcopy`.")
 
     with StorageSupplier(storage_mode) as storage:

--- a/tests/study_tests/test_study.py
+++ b/tests/study_tests/test_study.py
@@ -1651,7 +1651,7 @@ def test_tell_from_another_process() -> None:
 
 @pytest.mark.parametrize("storage_mode", STORAGE_MODES)
 def test_pop_waiting_trial_thread_safe(storage_mode: str) -> None:
-    if "sqlite" == storage_mode or "cached_sqlite" == storage_mode or "grpc" == storage_mode:
+    if storage_mode in ("sqlite", "cached_sqlite", "grpc_rdb"):
         pytest.skip("study._pop_waiting_trial is not thread-safe on SQLite3")
 
     num_enqueued = 10

--- a/tests/study_tests/test_study.py
+++ b/tests/study_tests/test_study.py
@@ -1036,7 +1036,7 @@ def test_optimize_infinite_budget_progbar() -> None:
 
 @pytest.mark.parametrize("storage_mode", STORAGE_MODES)
 def test_get_trials(storage_mode: str) -> None:
-    if storage_mode == "grpc_rdb" or storage_mode == "grpc_journal_file":
+    if storage_mode in ("grpc_rdb", "grpc_journal_file"):
         pytest.skip("gRPC storage doesn't use `copy.deepcopy`.")
 
     with StorageSupplier(storage_mode) as storage:


### PR DESCRIPTION


<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

Currently, the gRPC server fails to function properly when using JournalStorage.

## Description of the changes
<!-- Describe the changes in this PR. -->
The `RepeatedScalarContainer` class is used to convey arrays for protobuf. 
However, an instance of `RepeatedScalarContainer` cannot be converted to JSON. 
To address this, I made the following change:
```
values = list(request.values)
```

Additionally, to prevent issues like this in the future, I added `grpc_journal_file` to the `STORAGE_MODES` for pytest:
```
STORAGE_MODES: list[Any] = [
    "inmemory",
    "sqlite",
    "cached_sqlite",
    "journal",
    "journal_redis",
    "grpc_rdb",
    "grpc_journal_file",
]
```
