### PR TITLE
Deprecate `consider_prior` in `TPESampler`

### DIFF
--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -10,6 +10,7 @@ import warnings
 
 import numpy as np
 
+from optuna import _deprecated
 from optuna._experimental import warn_experimental_argument
 from optuna._hypervolume import compute_hypervolume
 from optuna._hypervolume.hssp import _solve_hssp
@@ -122,6 +123,12 @@ class TPESampler(BaseSampler):
             :obj:`True`. The prior is only effective if the sampling distribution is
             either :class:`~optuna.distributions.FloatDistribution`,
             or :class:`~optuna.distributions.IntDistribution`.
+
+            .. warning::
+                Deprecated in v4.3.0. ``consider_prior`` argument will be removed in the future.
+                The removal of this feature is currently scheduled for v6.0.0,
+                but this schedule is subject to change.
+                See https://github.com/optuna/optuna/releases/tag/v4.3.0.
         prior_weight:
             The weight of the prior. This argument is used in
             :class:`~optuna.distributions.FloatDistribution`,
@@ -286,6 +293,12 @@ class TPESampler(BaseSampler):
             dict[str, Callable[[CategoricalChoiceType, CategoricalChoiceType], float]] | None
         ) = None,
     ) -> None:
+        if consider_prior is False:
+            msg = _deprecated._DEPRECATION_WARNING_TEMPLATE.format(
+                name="`consider_prior`", d_ver="4.3.0", r_ver="6.0.0"
+            )
+            warnings.warn(msg, FutureWarning)
+
         self._parzen_estimator_parameters = _ParzenEstimatorParameters(
             consider_prior,
             prior_weight,


### PR DESCRIPTION
## Motivation
In `TPESampler`, when `consider_prior` is set to `False`, samples that were not selected during the initial exploration are unlikely to be chosen in subsequent samplings. This behavior is undesirable, so `consider_prior` should be deprecated and always set to `True`.  

## Description of the changes
- Deprecation warning is added to the code and the docstring of `TPESampler`.
    - `consider_prior` constructs `_ParzenEstimatorParameters` in the init function of `TPESampler`, so ideally, deprecation warning is generated in the `_ParzenEstimatorParameters`. However, [`NamedTuple` doesn’t support overriding __new__](https://github.com/python/typing/issues/526), and the adding a deprecation warning there would require extensive refactoring. Therefore, the warning is instead placed in `TPESampler`.  
    - In addition to that, field names in NamedTuple cannot start with an underscore, and changing the field name to `_consider_prior` is not allowed in `_ParzenEstimatorParameters`.
- `consider_prior` will be fixed to `True` in future PRs.  