### PR TITLE
Update `consider_prior` Behavior and Remove Support for `False`  

### DIFF
--- a/optuna/importance/_ped_anova/evaluator.py
+++ b/optuna/importance/_ped_anova/evaluator.py
@@ -131,9 +131,7 @@ class PedAnovaImportanceEvaluator(BaseImportanceEvaluator):
         # Advanced Setups.
         # Discretize a domain [low, high] as `np.linspace(low, high, n_steps)`.
         self._n_steps: int = 50
-        # Prior is used for regularization.
-        self._consider_prior = True
-        # Control the regularization effect.
+        # Control the regularization effect of prior.
         self._prior_weight = 1.0
         # How many `trials` must be included in `top_trials`.
         self._min_n_top_trials = 2
@@ -171,17 +169,15 @@ class PedAnovaImportanceEvaluator(BaseImportanceEvaluator):
         all_trials: list[FrozenTrial],
     ) -> float:
         # When pdf_all == pdf_top, i.e. all_trials == top_trials, this method will give 0.0.
-        consider_prior, prior_weight = self._consider_prior, self._prior_weight
-        pe_top = _build_parzen_estimator(
-            param_name, dist, top_trials, self._n_steps, consider_prior, prior_weight
-        )
+        prior_weight = self._prior_weight
+        pe_top = _build_parzen_estimator(param_name, dist, top_trials, self._n_steps, prior_weight)
         # NOTE: pe_top.n_steps could be different from self._n_steps.
         grids = np.arange(pe_top.n_steps)
         pdf_top = pe_top.pdf(grids) + 1e-12
 
         if self._evaluate_on_local:  # The importance of param during the study.
             pe_local = _build_parzen_estimator(
-                param_name, dist, all_trials, self._n_steps, consider_prior, prior_weight
+                param_name, dist, all_trials, self._n_steps, prior_weight
             )
             pdf_local = pe_local.pdf(grids) + 1e-12
         else:  # The importance of param in the search space.

--- a/optuna/importance/_ped_anova/evaluator.py
+++ b/optuna/importance/_ped_anova/evaluator.py
@@ -131,7 +131,7 @@ class PedAnovaImportanceEvaluator(BaseImportanceEvaluator):
         # Advanced Setups.
         # Discretize a domain [low, high] as `np.linspace(low, high, n_steps)`.
         self._n_steps: int = 50
-        # Control the regularization effect of prior.
+        # Control the regularization effect by prior.
         self._prior_weight = 1.0
         # How many `trials` must be included in `top_trials`.
         self._min_n_top_trials = 2

--- a/optuna/importance/_ped_anova/scott_parzen_estimator.py
+++ b/optuna/importance/_ped_anova/scott_parzen_estimator.py
@@ -158,5 +158,9 @@ def _build_parzen_estimator(
 
     # counts.astype(float) is necessary for weight calculation in ParzenEstimator.
     return _ScottParzenEstimator(
-        param_name, rounded_dist, counts.astype(np.float64), True, prior_weight
+        param_name=param_name,
+        dist=rounded_dist,
+        counts=counts.astype(np.float64),
+        consider_prior=True,
+        prior_weight=prior_weight,
     )

--- a/optuna/importance/_ped_anova/scott_parzen_estimator.py
+++ b/optuna/importance/_ped_anova/scott_parzen_estimator.py
@@ -21,7 +21,6 @@ class _ScottParzenEstimator(_ParzenEstimator):
         param_name: str,
         dist: IntDistribution | CategoricalDistribution,
         counts: np.ndarray,
-        consider_prior: bool,
         prior_weight: float,
     ):
         assert isinstance(dist, (CategoricalDistribution, IntDistribution))
@@ -36,7 +35,6 @@ class _ScottParzenEstimator(_ParzenEstimator):
             observations={param_name: np.arange(self._n_steps)[counts > 0.0]},
             search_space={param_name: dist},
             parameters=_ParzenEstimatorParameters(
-                consider_prior=consider_prior,
                 prior_weight=prior_weight,
                 consider_magic_clip=False,
                 consider_endpoints=False,
@@ -143,7 +141,6 @@ def _build_parzen_estimator(
     dist: BaseDistribution,
     trials: list[FrozenTrial],
     n_steps: int,
-    consider_prior: bool,
     prior_weight: float,
 ) -> _ScottParzenEstimator:
     rounded_dist: IntDistribution | CategoricalDistribution
@@ -161,6 +158,5 @@ def _build_parzen_estimator(
         param_name=param_name,
         dist=rounded_dist,
         counts=counts.astype(np.float64),
-        consider_prior=True,
         prior_weight=prior_weight,
     )

--- a/optuna/importance/_ped_anova/scott_parzen_estimator.py
+++ b/optuna/importance/_ped_anova/scott_parzen_estimator.py
@@ -36,7 +36,7 @@ class _ScottParzenEstimator(_ParzenEstimator):
             observations={param_name: np.arange(self._n_steps)[counts > 0.0]},
             search_space={param_name: dist},
             parameters=_ParzenEstimatorParameters(
-                consider_prior=True,
+                consider_prior=consider_prior,
                 prior_weight=prior_weight,
                 consider_magic_clip=False,
                 consider_endpoints=False,

--- a/optuna/importance/_ped_anova/scott_parzen_estimator.py
+++ b/optuna/importance/_ped_anova/scott_parzen_estimator.py
@@ -36,7 +36,7 @@ class _ScottParzenEstimator(_ParzenEstimator):
             observations={param_name: np.arange(self._n_steps)[counts > 0.0]},
             search_space={param_name: dist},
             parameters=_ParzenEstimatorParameters(
-                consider_prior=consider_prior,
+                consider_prior=True,
                 prior_weight=prior_weight,
                 consider_magic_clip=False,
                 consider_endpoints=False,
@@ -75,9 +75,8 @@ class _ScottParzenEstimator(_ParzenEstimator):
         # To avoid numerical errors. 0.5/1.64 means 1.64sigma (=90%) will fit in the target grid.
         sigma_min = 0.5 / 1.64
         sigmas = np.full_like(mus, max(sigma_est, sigma_min), dtype=np.float64)
-        if parameters.consider_prior:
-            mus = np.append(mus, [0.5 * (low + high)])
-            sigmas = np.append(sigmas, [1.0 * (high - low + 1)])
+        mus = np.append(mus, [0.5 * (low + high)])
+        sigmas = np.append(sigmas, [1.0 * (high - low + 1)])
 
         return _BatchedDiscreteTruncNormDistributions(
             mu=mus, sigma=sigmas, low=0, high=self.n_steps - 1, step=1
@@ -159,5 +158,5 @@ def _build_parzen_estimator(
 
     # counts.astype(float) is necessary for weight calculation in ParzenEstimator.
     return _ScottParzenEstimator(
-        param_name, rounded_dist, counts.astype(np.float64), consider_prior, prior_weight
+        param_name, rounded_dist, counts.astype(np.float64), True, prior_weight
     )

--- a/optuna/importance/_ped_anova/scott_parzen_estimator.py
+++ b/optuna/importance/_ped_anova/scott_parzen_estimator.py
@@ -154,9 +154,4 @@ def _build_parzen_estimator(
         assert False, f"Got an unknown dist with the type {type(dist)}."
 
     # counts.astype(float) is necessary for weight calculation in ParzenEstimator.
-    return _ScottParzenEstimator(
-        param_name=param_name,
-        dist=rounded_dist,
-        counts=counts.astype(np.float64),
-        prior_weight=prior_weight,
-    )
+    return _ScottParzenEstimator(param_name, rounded_dist, counts.astype(np.float64), prior_weight)

--- a/optuna/samplers/_tpe/parzen_estimator.py
+++ b/optuna/samplers/_tpe/parzen_estimator.py
@@ -21,7 +21,7 @@ EPS = 1e-12
 
 
 class _ParzenEstimatorParameters(NamedTuple):
-    prior_weight: float | None
+    prior_weight: float
     consider_magic_clip: bool
     consider_endpoints: bool
     weights: Callable[[int], np.ndarray]

--- a/optuna/samplers/_tpe/parzen_estimator.py
+++ b/optuna/samplers/_tpe/parzen_estimator.py
@@ -39,7 +39,7 @@ class _ParzenEstimator:
         parameters: _ParzenEstimatorParameters,
         predetermined_weights: np.ndarray | None = None,
     ) -> None:
-        if parameters.prior_weight <= 0:
+        if parameters.prior_weight < 0:
             raise ValueError(
                 "A positive value must be specified for prior_weight,"
                 f" but got {parameters.prior_weight}."
@@ -206,7 +206,8 @@ class _ParzenEstimator:
         else:
             weights[np.arange(len(observed_indices)), observed_indices] += 1
 
-        weights /= weights.sum(axis=1, keepdims=True)
+        row_sums = weights.sum(axis=1, keepdims=True)
+        weights /= np.where(row_sums == 0, 1, row_sums)
         return _BatchedCategoricalDistributions(weights)
 
     def _calculate_numerical_distributions(

--- a/optuna/samplers/_tpe/parzen_estimator.py
+++ b/optuna/samplers/_tpe/parzen_estimator.py
@@ -41,7 +41,7 @@ class _ParzenEstimator:
     ) -> None:
         if parameters.prior_weight < 0:
             raise ValueError(
-                "A positive value must be specified for prior_weight,"
+                "None negative value must be specified for prior_weight,"
                 f" but got {parameters.prior_weight}."
             )
 

--- a/optuna/samplers/_tpe/parzen_estimator.py
+++ b/optuna/samplers/_tpe/parzen_estimator.py
@@ -39,7 +39,7 @@ class _ParzenEstimator:
         parameters: _ParzenEstimatorParameters,
         predetermined_weights: np.ndarray | None = None,
     ) -> None:
-        if parameters.prior_weight is None or parameters.prior_weight <= 0:
+        if parameters.prior_weight <= 0:
             raise ValueError(
                 "A positive value must be specified for prior_weight,"
                 f" but got {parameters.prior_weight}."
@@ -189,7 +189,6 @@ class _ParzenEstimator:
             )
 
         n_kernels = len(observations) + 1  # NOTE(sawa3030): +1 for prior.
-        assert parameters.prior_weight is not None
         weights = np.full(
             shape=(n_kernels, n_choices),
             fill_value=parameters.prior_weight / n_kernels,

--- a/optuna/samplers/_tpe/parzen_estimator.py
+++ b/optuna/samplers/_tpe/parzen_estimator.py
@@ -41,7 +41,7 @@ class _ParzenEstimator:
     ) -> None:
         if parameters.prior_weight < 0:
             raise ValueError(
-                "None negative value must be specified for prior_weight,"
+                "A non-negative value must be specified for prior_weight,"
                 f" but got {parameters.prior_weight}."
             )
 

--- a/optuna/samplers/_tpe/parzen_estimator.py
+++ b/optuna/samplers/_tpe/parzen_estimator.py
@@ -21,7 +21,6 @@ EPS = 1e-12
 
 
 class _ParzenEstimatorParameters(NamedTuple):
-    consider_prior: bool
     prior_weight: float | None
     consider_magic_clip: bool
     consider_endpoints: bool
@@ -40,11 +39,6 @@ class _ParzenEstimator:
         parameters: _ParzenEstimatorParameters,
         predetermined_weights: np.ndarray | None = None,
     ) -> None:
-        if not parameters.consider_prior:
-            raise ValueError(
-                "The implementation for `consider_prior=False` has been removed at v4.3.0."
-            )
-
         if parameters.prior_weight is None or parameters.prior_weight <= 0:
             raise ValueError(
                 "A positive value must be specified for prior_weight,"

--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -128,6 +128,7 @@ class TPESampler(BaseSampler):
                 Deprecated in v4.3.0. ``consider_prior`` argument will be removed in the future.
                 The removal of this feature is currently scheduled for v6.0.0,
                 but this schedule is subject to change.
+                From v4.3.0 onward, ``consider_prior`` is always ``True``.
                 See https://github.com/optuna/optuna/releases/tag/v4.3.0.
         prior_weight:
             The weight of the prior. This argument is used in
@@ -296,7 +297,7 @@ class TPESampler(BaseSampler):
         if consider_prior is False:
             msg = _deprecated._DEPRECATION_WARNING_TEMPLATE.format(
                 name="`consider_prior`", d_ver="4.3.0", r_ver="6.0.0"
-            )
+            ) + ("From v4.3.0 onward, `consider_prior` is always `True`.")
             warnings.warn(msg, FutureWarning)
 
         self._parzen_estimator_parameters = _ParzenEstimatorParameters(

--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -304,13 +304,12 @@ class TPESampler(BaseSampler):
             )
 
         self._parzen_estimator_parameters = _ParzenEstimatorParameters(
-            consider_prior=True,
-            prior_weight=prior_weight,
-            consider_magic_clip=consider_magic_clip,
-            consider_endpoints=consider_endpoints,
-            weights=weights,
-            multivariate=multivariate,
-            categorical_distance_func=categorical_distance_func or {},
+            prior_weight,
+            consider_magic_clip,
+            consider_endpoints,
+            weights,
+            multivariate,
+            categorical_distance_func or {},
         )
         self._n_startup_trials = n_startup_trials
         self._n_ei_candidates = n_ei_candidates

--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -304,13 +304,13 @@ class TPESampler(BaseSampler):
             )
 
         self._parzen_estimator_parameters = _ParzenEstimatorParameters(
-            True,
-            prior_weight,
-            consider_magic_clip,
-            consider_endpoints,
-            weights,
-            multivariate,
-            categorical_distance_func or {},
+            consider_prior=True,
+            prior_weight=prior_weight,
+            consider_magic_clip=consider_magic_clip,
+            consider_endpoints=consider_endpoints,
+            weights=weights,
+            multivariate=multivariate,
+            categorical_distance_func=categorical_distance_func or {},
         )
         self._n_startup_trials = n_startup_trials
         self._n_ei_candidates = n_ei_candidates

--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -128,7 +128,7 @@ class TPESampler(BaseSampler):
                 Deprecated in v4.3.0. ``consider_prior`` argument will be removed in the future.
                 The removal of this feature is currently scheduled for v6.0.0,
                 but this schedule is subject to change.
-                From v4.3.0 onward, ``consider_prior`` is always ``True``.
+                From v4.3.0 onward, ``consider_prior`` automatically falls back to ``True``.
                 See https://github.com/optuna/optuna/releases/tag/v4.3.0.
         prior_weight:
             The weight of the prior. This argument is used in

--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -297,8 +297,11 @@ class TPESampler(BaseSampler):
         if not consider_prior:
             msg = _deprecated._DEPRECATION_WARNING_TEMPLATE.format(
                 name="`consider_prior`", d_ver="4.3.0", r_ver="6.0.0"
-            ) + ("From v4.3.0 onward, `consider_prior` is always `True`.")
-            warnings.warn(msg, FutureWarning)
+            )
+            warnings.warn(
+                f"{msg} From v4.3.0 onward, `consider_prior` automatically falls back to `True`.",
+                FutureWarning,
+            )
 
         self._parzen_estimator_parameters = _ParzenEstimatorParameters(
             True,

--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -10,6 +10,7 @@ import warnings
 
 import numpy as np
 
+from optuna import _deprecated
 from optuna._experimental import warn_experimental_argument
 from optuna._hypervolume import compute_hypervolume
 from optuna._hypervolume.hssp import _solve_hssp
@@ -122,6 +123,12 @@ class TPESampler(BaseSampler):
             :obj:`True`. The prior is only effective if the sampling distribution is
             either :class:`~optuna.distributions.FloatDistribution`,
             or :class:`~optuna.distributions.IntDistribution`.
+
+            .. warning::
+                Deprecated in v4.3.0. ``consider_prior`` argument will be removed in the future.
+                The removal of this feature is currently scheduled for v6.0.0,
+                but this schedule is subject to change.
+                See https://github.com/optuna/optuna/releases/tag/v4.3.0.
         prior_weight:
             The weight of the prior. This argument is used in
             :class:`~optuna.distributions.FloatDistribution`,
@@ -286,6 +293,12 @@ class TPESampler(BaseSampler):
             dict[str, Callable[[CategoricalChoiceType, CategoricalChoiceType], float]] | None
         ) = None,
     ) -> None:
+        if consider_prior is False:
+            msg = _deprecated._DEPRECATION_WARNING_TEMPLATE.format(
+                name="`consider_prior`", d_ver="4.3.0", r_ver="6.0.0"
+            )
+            warnings.warn(msg, FutureWarning)
+
         self._parzen_estimator_parameters = _ParzenEstimatorParameters(
             consider_prior,
             prior_weight,

--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -301,7 +301,7 @@ class TPESampler(BaseSampler):
             warnings.warn(msg, FutureWarning)
 
         self._parzen_estimator_parameters = _ParzenEstimatorParameters(
-            consider_prior,
+            True,
             prior_weight,
             consider_magic_clip,
             consider_endpoints,

--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -304,12 +304,12 @@ class TPESampler(BaseSampler):
             )
 
         self._parzen_estimator_parameters = _ParzenEstimatorParameters(
-            prior_weight,
-            consider_magic_clip,
-            consider_endpoints,
-            weights,
-            multivariate,
-            categorical_distance_func or {},
+            prior_weight=prior_weight,
+            consider_magic_clip=consider_magic_clip,
+            consider_endpoints=consider_endpoints,
+            weights=weights,
+            multivariate=multivariate,
+            categorical_distance_func=categorical_distance_func or {},
         )
         self._n_startup_trials = n_startup_trials
         self._n_ei_candidates = n_ei_candidates

--- a/tests/importance_tests/pedanova_tests/test_scott_parzen_estimator.py
+++ b/tests/importance_tests/pedanova_tests/test_scott_parzen_estimator.py
@@ -35,8 +35,8 @@ def test_init_scott_parzen_estimator(dist_type: str) -> None:
             else CategoricalDistribution(choices=["a" * i for i in range(counts.size)])
         ),
         counts=counts,
-        consider_prior=False,
-        prior_weight=0.0,
+        consider_prior=True,
+        prior_weight=1.0,
     )
     assert len(pe._mixture_distribution.distributions) == 1
     assert pe.n_steps == counts.size
@@ -51,16 +51,31 @@ def test_init_scott_parzen_estimator(dist_type: str) -> None:
     "counts,mu,sigma,weights",
     [
         # NOTE: sigma could change depending on sigma_min picked by heuristic.
-        (np.array([0, 0, 0, 1]), np.array([3]), np.array([0.304878]), np.array([1.0])),
-        (np.array([0, 0, 100, 0]), np.array([2]), np.array([0.304878]), np.array([1.0])),
-        (np.array([1, 2, 3, 4]), np.arange(4), np.array([0.7043276] * 4), (np.arange(4) + 1) / 10),
+        (np.array([0, 0, 0, 1]), np.array([3, 1.5]), np.array([0.304878, 4]), np.array([0.5] * 2)),
+        (
+            np.array([0, 0, 100, 0]),
+            np.array([2, 1.5]),
+            np.array([0.304878, 4]),
+            np.array([0.990099, 0.009901]),
+        ),
+        (
+            np.array([1, 2, 3, 4]),
+            np.array([0, 1, 2, 3, 1.5]),
+            np.array([0.7043276] * 4 + [4]),
+            [0.0909091, 0.1818182, 0.2727273, 0.3636364, 0.0909091],
+        ),
         (
             np.array([90, 0, 0, 90]),
-            np.array([0, 3]),
-            np.array([0.5638226] * 2),
-            np.array([0.5] * 2),
+            np.array([0, 3.0, 1.5]),
+            np.array([0.5638226] * 2 + [4]),
+            np.array([0.4972376, 0.4972376, 0.0055249]),
         ),
-        (np.array([1, 0, 0, 1]), np.array([0, 3]), np.array([1.9556729] * 2), np.array([0.5] * 2)),
+        (
+            np.array([1, 0, 0, 1]),
+            np.array([0, 3, 1.5]),
+            np.array([1.9556729] * 2 + [4]),
+            np.array([1.0 / 3] * 3),
+        ),
     ],
 )
 def test_build_int_scott_parzen_estimator(
@@ -71,8 +86,8 @@ def test_build_int_scott_parzen_estimator(
         param_name="a",
         dist=IntDistribution(low=0, high=_counts.size - 1),
         counts=_counts,
-        consider_prior=False,
-        prior_weight=0.0,
+        consider_prior=True,
+        prior_weight=1.0,
     )
     dist = _BatchedDiscreteTruncNormDistributions(
         mu=mu, sigma=sigma, low=0, high=_counts.size - 1, step=1

--- a/tests/importance_tests/pedanova_tests/test_scott_parzen_estimator.py
+++ b/tests/importance_tests/pedanova_tests/test_scott_parzen_estimator.py
@@ -35,7 +35,6 @@ def test_init_scott_parzen_estimator(dist_type: str) -> None:
             else CategoricalDistribution(choices=["a" * i for i in range(counts.size)])
         ),
         counts=counts,
-        consider_prior=True,
         prior_weight=1.0,
     )
     assert len(pe._mixture_distribution.distributions) == 1
@@ -86,7 +85,6 @@ def test_build_int_scott_parzen_estimator(
         param_name="a",
         dist=IntDistribution(low=0, high=_counts.size - 1),
         counts=_counts,
-        consider_prior=True,
         prior_weight=1.0,
     )
     dist = _BatchedDiscreteTruncNormDistributions(
@@ -154,7 +152,6 @@ def test_build_cat_scott_parzen_estimator(
         param_name="a",
         dist=CategoricalDistribution(choices=["a" * i for i in range(counts.size)]),
         counts=_counts,
-        consider_prior=True,
         prior_weight=1.0,
     )
     dist = _BatchedCategoricalDistributions(weights=categorical_weights)
@@ -216,7 +213,6 @@ def test_build_parzen_estimator(
         dist=dist,
         trials=trials,
         n_steps=50,
-        consider_prior=True,
         prior_weight=1.0,
     )
     if isinstance(dist, (IntDistribution, FloatDistribution)):
@@ -248,6 +244,5 @@ def test_assert_in_build_parzen_estimator() -> None:
             dist=UnknownDistribution(),
             trials=[],
             n_steps=50,
-            consider_prior=True,
             prior_weight=1.0,
         )

--- a/tests/importance_tests/pedanova_tests/test_scott_parzen_estimator.py
+++ b/tests/importance_tests/pedanova_tests/test_scott_parzen_estimator.py
@@ -211,5 +211,5 @@ def test_assert_in_build_parzen_estimator() -> None:
             dist=UnknownDistribution(),
             trials=[],
             n_steps=50,
-            prior_weight=0.0,
+            prior_weight=1.0,
         )

--- a/tests/importance_tests/pedanova_tests/test_scott_parzen_estimator.py
+++ b/tests/importance_tests/pedanova_tests/test_scott_parzen_estimator.py
@@ -56,19 +56,19 @@ def test_init_scott_parzen_estimator(dist_type: str) -> None:
             np.array([0, 0, 100, 0]),
             np.array([2, 1.5]),
             np.array([0.304878, 4]),
-            np.array([0.990099, 0.009901]),
+            np.array([100.0 / 101, 1.0 / 101]),
         ),
         (
             np.array([1, 2, 3, 4]),
             np.array([0, 1, 2, 3, 1.5]),
             np.array([0.7043276] * 4 + [4]),
-            [0.0909091, 0.1818182, 0.2727273, 0.3636364, 0.0909091],
+            np.array([1.0 / 11, 2.0 / 11, 3.0 / 11, 4.0 / 11, 1.0 / 11]),
         ),
         (
             np.array([90, 0, 0, 90]),
             np.array([0, 3.0, 1.5]),
             np.array([0.5638226] * 2 + [4]),
-            np.array([0.4972376, 0.4972376, 0.0055249]),
+            np.array([90.0 / 181, 90.0 / 181, 1.0 / 181]),
         ),
         (
             np.array([1, 0, 0, 1]),
@@ -97,7 +97,7 @@ def test_build_int_scott_parzen_estimator(
 
 
 @pytest.mark.parametrize(
-    "counts,dist_weights,weights",
+    "counts,categorical_weights,weights",
     [
         (
             np.array([0, 0, 0, 1]),
@@ -147,7 +147,7 @@ def test_build_int_scott_parzen_estimator(
     ],
 )
 def test_build_cat_scott_parzen_estimator(
-    counts: np.ndarray, dist_weights: np.ndarray, weights: np.ndarray
+    counts: np.ndarray, categorical_weights: np.ndarray, weights: np.ndarray
 ) -> None:
     _counts = counts.astype(float)
     pe = _ScottParzenEstimator(
@@ -157,7 +157,7 @@ def test_build_cat_scott_parzen_estimator(
         consider_prior=True,
         prior_weight=1.0,
     )
-    dist = _BatchedCategoricalDistributions(weights=dist_weights)
+    dist = _BatchedCategoricalDistributions(weights=categorical_weights)
     expected_dist = _MixtureOfProductDistribution(weights=weights, distributions=[dist])
     assert_distribution_almost_equal(pe._mixture_distribution, expected_dist)
 

--- a/tests/importance_tests/pedanova_tests/test_scott_parzen_estimator.py
+++ b/tests/importance_tests/pedanova_tests/test_scott_parzen_estimator.py
@@ -35,7 +35,7 @@ def test_init_scott_parzen_estimator(dist_type: str) -> None:
             else CategoricalDistribution(choices=["a" * i for i in range(counts.size)])
         ),
         counts=counts,
-        prior_weight=1.0,
+        prior_weight=0.0,
     )
     assert len(pe._mixture_distribution.distributions) == 1
     assert pe.n_steps == counts.size
@@ -50,30 +50,35 @@ def test_init_scott_parzen_estimator(dist_type: str) -> None:
     "counts,mu,sigma,weights",
     [
         # NOTE: sigma could change depending on sigma_min picked by heuristic.
-        (np.array([0, 0, 0, 1]), np.array([3, 1.5]), np.array([0.304878, 4]), np.array([0.5] * 2)),
+        (
+            np.array([0, 0, 0, 1]),
+            np.array([3, 1.5]),
+            np.array([0.304878, 4]),
+            np.array([1.0, 0.0]),
+        ),
         (
             np.array([0, 0, 100, 0]),
             np.array([2, 1.5]),
             np.array([0.304878, 4]),
-            np.array([100.0 / 101, 1.0 / 101]),
+            np.array([1.0, 0.0]),
         ),
         (
             np.array([1, 2, 3, 4]),
-            np.array([0, 1, 2, 3, 1.5]),
+            np.array([0.0, 1.0, 2.0, 3.0, 1.5]),
             np.array([0.7043276] * 4 + [4]),
-            np.array([1.0 / 11, 2.0 / 11, 3.0 / 11, 4.0 / 11, 1.0 / 11]),
+            np.array([0.1, 0.2, 0.3, 0.4, 0.0]),
         ),
         (
             np.array([90, 0, 0, 90]),
-            np.array([0, 3.0, 1.5]),
+            np.array([0, 3, 1.5]),
             np.array([0.5638226] * 2 + [4]),
-            np.array([90.0 / 181, 90.0 / 181, 1.0 / 181]),
+            np.array([0.5] * 2 + [0.0]),
         ),
         (
             np.array([1, 0, 0, 1]),
             np.array([0, 3, 1.5]),
             np.array([1.9556729] * 2 + [4]),
-            np.array([1.0 / 3] * 3),
+            np.array([0.5] * 2 + [0.0]),
         ),
     ],
 )
@@ -85,7 +90,7 @@ def test_build_int_scott_parzen_estimator(
         param_name="a",
         dist=IntDistribution(low=0, high=_counts.size - 1),
         counts=_counts,
-        prior_weight=1.0,
+        prior_weight=0.0,
     )
     dist = _BatchedDiscreteTruncNormDistributions(
         mu=mu, sigma=sigma, low=0, high=_counts.size - 1, step=1
@@ -95,66 +100,28 @@ def test_build_int_scott_parzen_estimator(
 
 
 @pytest.mark.parametrize(
-    "counts,categorical_weights,weights",
+    "counts,weights",
     [
-        (
-            np.array([0, 0, 0, 1]),
-            np.array([[1.0 / 6, 1.0 / 6, 1.0 / 6, 0.5], [0.25, 0.25, 0.25, 0.25]]),
-            np.array([0.5] * 2),
-        ),
-        (
-            np.array([0, 0, 100, 0]),
-            np.array([[1.0 / 6, 1.0 / 6, 0.5, 1.0 / 6], [0.25, 0.25, 0.25, 0.25]]),
-            np.array([0.990099, 0.009901]),
-        ),
-        (
-            np.array([1, 2, 3, 4]),
-            np.array(
-                [
-                    [2.0 / 3, 1.0 / 9, 1.0 / 9, 1.0 / 9],
-                    [1.0 / 9, 2.0 / 3, 1.0 / 9, 1.0 / 9],
-                    [1.0 / 9, 1.0 / 9, 2.0 / 3, 1.0 / 9],
-                    [1.0 / 9, 1.0 / 9, 1.0 / 9, 2.0 / 3],
-                    [0.25, 0.25, 0.25, 0.25],
-                ]
-            ),
-            np.array([1.0 / 11, 2.0 / 11, 3.0 / 11, 4.0 / 11, 1.0 / 11]),
-        ),
-        (
-            np.array([90, 0, 0, 90]),
-            np.array(
-                [
-                    [4.0 / 7, 1.0 / 7, 1.0 / 7, 1.0 / 7],
-                    [1.0 / 7, 1.0 / 7, 1.0 / 7, 4.0 / 7],
-                    [0.25, 0.25, 0.25, 0.25],
-                ]
-            ),
-            np.array([90.0 / 181, 90.0 / 181, 1.0 / 181]),
-        ),
-        (
-            np.array([1, 0, 0, 1]),
-            np.array(
-                [
-                    [4.0 / 7, 1.0 / 7, 1.0 / 7, 1.0 / 7],
-                    [1.0 / 7, 1.0 / 7, 1.0 / 7, 4.0 / 7],
-                    [0.25, 0.25, 0.25, 0.25],
-                ]
-            ),
-            np.array([1.0 / 3] * 3),
-        ),
+        (np.array([0, 0, 0, 1]), np.array([1.0, 0.0])),
+        (np.array([0, 0, 100, 0]), np.array([1.0, 0.0])),
+        (np.array([1, 2, 3, 4]), np.array([0.1, 0.2, 0.3, 0.4, 0.0])),
+        (np.array([90, 0, 0, 90]), np.array([0.5] * 2 + [0.0])),
+        (np.array([1, 0, 0, 1]), np.array([0.5] * 2 + [0.0])),
     ],
 )
-def test_build_cat_scott_parzen_estimator(
-    counts: np.ndarray, categorical_weights: np.ndarray, weights: np.ndarray
-) -> None:
+def test_build_cat_scott_parzen_estimator(counts: np.ndarray, weights: np.ndarray) -> None:
     _counts = counts.astype(float)
     pe = _ScottParzenEstimator(
         param_name="a",
         dist=CategoricalDistribution(choices=["a" * i for i in range(counts.size)]),
         counts=_counts,
-        prior_weight=1.0,
+        prior_weight=0.0,
     )
-    dist = _BatchedCategoricalDistributions(weights=categorical_weights)
+    dist = _BatchedCategoricalDistributions(
+        weights=np.concatenate(
+            [np.identity(counts.size)[counts > 0.0], np.zeros((1, counts.size))], axis=0
+        )
+    )
     expected_dist = _MixtureOfProductDistribution(weights=weights, distributions=[dist])
     assert_distribution_almost_equal(pe._mixture_distribution, expected_dist)
 
@@ -213,7 +180,7 @@ def test_build_parzen_estimator(
         dist=dist,
         trials=trials,
         n_steps=50,
-        prior_weight=1.0,
+        prior_weight=0.0,
     )
     if isinstance(dist, (IntDistribution, FloatDistribution)):
         assert isinstance(
@@ -244,5 +211,5 @@ def test_assert_in_build_parzen_estimator() -> None:
             dist=UnknownDistribution(),
             trials=[],
             n_steps=50,
-            prior_weight=1.0,
+            prior_weight=0.0,
         )

--- a/tests/samplers_tests/tpe_tests/test_multi_objective_sampler.py
+++ b/tests/samplers_tests/tpe_tests/test_multi_objective_sampler.py
@@ -73,9 +73,6 @@ def test_multi_objective_sample_independent_prior() -> None:
     sampler = TPESampler(seed=0)
     suggestion = suggest(sampler, study, trial, dist, past_trials)
 
-    sampler = TPESampler(consider_prior=False, seed=0)
-    assert suggest(sampler, study, trial, dist, past_trials) != suggestion
-
     sampler = TPESampler(prior_weight=0.5, seed=0)
     assert suggest(sampler, study, trial, dist, past_trials) != suggestion
 

--- a/tests/samplers_tests/tpe_tests/test_parzen_estimator.py
+++ b/tests/samplers_tests/tpe_tests/test_parzen_estimator.py
@@ -61,47 +61,41 @@ def test_init_parzen_estimator(multivariate: bool) -> None:
 
     mpe = _ParzenEstimator(MULTIVARIATE_SAMPLES, SEARCH_SPACE, parameters)
 
-    consider_prior = True
-    weights = np.array([1] + consider_prior * [1], dtype=float)
+    weights = np.array([1, 1], dtype=float)
     weights /= weights.sum()
 
     expected_univariate = _MixtureOfProductDistribution(
         weights=weights,
         distributions=[
             _BatchedTruncNormDistributions(
-                mu=np.array([1.0] + consider_prior * [50.5]),
-                sigma=np.array([49.5 if consider_prior else 99.0] + consider_prior * [99.0]),
+                mu=np.array([1.0, 50.5]),
+                sigma=np.array([49.5, 99.0]),
                 low=1.0,
                 high=100.0,
             ),
             _BatchedTruncNormDistributions(
-                mu=np.array([np.log(1.0)] + consider_prior * [np.log(100) / 2.0]),
-                sigma=np.array([np.log(100) / 2] + consider_prior * [np.log(100)]),
+                mu=np.array([np.log(1.0), np.log(100) / 2.0]),
+                sigma=np.array([np.log(100) / 2, np.log(100)]),
                 low=np.log(1.0),
                 high=np.log(100.0),
             ),
             _BatchedDiscreteTruncNormDistributions(
-                mu=np.array([1.0] + consider_prior * [50.5]),
-                sigma=np.array([49.5] + consider_prior * [102.0]),
+                mu=np.array([1.0, 50.5]),
+                sigma=np.array([49.5, 102.0]),
                 low=1.0,
                 high=100.0,
                 step=3.0,
             ),
             _BatchedDiscreteTruncNormDistributions(
-                mu=np.array([1.0] + consider_prior * [50.5]),
-                sigma=np.array([49.5] + consider_prior * [100.0]),
+                mu=np.array([1.0, 50.5]),
+                sigma=np.array([49.5, 100.0]),
                 low=1,
                 high=100,
                 step=1,
             ),
             _BatchedTruncNormDistributions(
-                mu=np.array(
-                    [np.log(1.0)] + consider_prior * [(np.log(100.5) + np.log(0.5)) / 2.0]
-                ),
-                sigma=np.array(
-                    [(np.log(100.5) + np.log(0.5)) / 2]
-                    + consider_prior * [np.log(100.5) - np.log(0.5)]
-                ),
+                mu=np.array([np.log(1.0), (np.log(100.5) + np.log(0.5)) / 2.0]),
+                sigma=np.array([(np.log(100.5) + np.log(0.5)) / 2, np.log(100.5) - np.log(0.5)]),
                 low=np.log(0.5),
                 high=np.log(100.5),
             ),
@@ -123,38 +117,35 @@ def test_init_parzen_estimator(multivariate: bool) -> None:
         weights=weights,
         distributions=[
             _BatchedTruncNormDistributions(
-                mu=np.array([1.0] + consider_prior * [50.5]),
-                sigma=np.array([SIGMA0 * 99.0] + consider_prior * [99.0]),
+                mu=np.array([1.0, 50.5]),
+                sigma=np.array([SIGMA0 * 99.0, 99.0]),
                 low=1.0,
                 high=100.0,
             ),
             _BatchedTruncNormDistributions(
-                mu=np.array([np.log(1.0)] + consider_prior * [np.log(100) / 2.0]),
-                sigma=np.array([SIGMA0 * np.log(100)] + consider_prior * [np.log(100)]),
+                mu=np.array([np.log(1.0), np.log(100) / 2.0]),
+                sigma=np.array([SIGMA0 * np.log(100), np.log(100)]),
                 low=np.log(1.0),
                 high=np.log(100.0),
             ),
             _BatchedDiscreteTruncNormDistributions(
-                mu=np.array([1.0] + consider_prior * [50.5]),
-                sigma=np.array([SIGMA0 * 102.0] + consider_prior * [102.0]),
+                mu=np.array([1.0, 50.5]),
+                sigma=np.array([SIGMA0 * 102.0, 102.0]),
                 low=1.0,
                 high=100.0,
                 step=3.0,
             ),
             _BatchedDiscreteTruncNormDistributions(
-                mu=np.array([1.0] + consider_prior * [50.5]),
-                sigma=np.array([SIGMA0 * 100.0] + consider_prior * [100.0]),
+                mu=np.array([1.0, 50.5]),
+                sigma=np.array([SIGMA0 * 100.0, 100.0]),
                 low=1,
                 high=100,
                 step=1,
             ),
             _BatchedTruncNormDistributions(
-                mu=np.array(
-                    [np.log(1.0)] + consider_prior * [(np.log(100.5) + np.log(0.5)) / 2.0]
-                ),
+                mu=np.array([np.log(1.0), (np.log(100.5) + np.log(0.5)) / 2.0]),
                 sigma=np.array(
-                    [SIGMA0 * (np.log(100.5) - np.log(0.5))]
-                    + consider_prior * [np.log(100.5) - np.log(0.5)]
+                    [SIGMA0 * (np.log(100.5) - np.log(0.5)), np.log(100.5) - np.log(0.5)]
                 ),
                 low=np.log(0.5),
                 high=np.log(100.5),
@@ -209,8 +200,9 @@ def test_calculate_shape_check(
     mpe = _ParzenEstimator(
         {"a": mus}, {"a": distributions.FloatDistribution(-1.0, 1.0)}, parameters
     )
-    consider_prior = True
-    assert len(mpe._mixture_distribution.weights) == max(len(mus) + int(consider_prior), 1)
+    assert len(mpe._mixture_distribution.weights) == max(
+        len(mus) + 1, 1
+    )  # NOTE(sawa3030): +1 for prior.
 
 
 @pytest.mark.parametrize("mus", (np.asarray([]), np.asarray([0.4]), np.asarray([-0.4, 0.4])))
@@ -236,8 +228,9 @@ def test_calculate_shape_check_categorical(
     mpe = _ParzenEstimator(
         {"c": mus}, {"c": distributions.CategoricalDistribution([0.0, 1.0, 2.0])}, parameters
     )
-    consider_prior = True
-    assert len(mpe._mixture_distribution.weights) == max(len(mus) + int(consider_prior), 1)
+    assert len(mpe._mixture_distribution.weights) == max(
+        len(mus) + 1, 1
+    )  # NOTE(sawa3030): +1 for prior
 
 
 @pytest.mark.parametrize("prior_weight", [None, -1.0, 0.0])

--- a/tests/samplers_tests/tpe_tests/test_parzen_estimator.py
+++ b/tests/samplers_tests/tpe_tests/test_parzen_estimator.py
@@ -200,9 +200,7 @@ def test_calculate_shape_check(
     mpe = _ParzenEstimator(
         {"a": mus}, {"a": distributions.FloatDistribution(-1.0, 1.0)}, parameters
     )
-    assert len(mpe._mixture_distribution.weights) == max(
-        len(mus) + 1, 1
-    )  # NOTE(sawa3030): +1 for prior.
+    assert len(mpe._mixture_distribution.weights) == len(mus) + 1  # NOTE(sawa3030): +1 for prior.
 
 
 @pytest.mark.parametrize("mus", (np.asarray([]), np.asarray([0.4]), np.asarray([-0.4, 0.4])))
@@ -228,9 +226,7 @@ def test_calculate_shape_check_categorical(
     mpe = _ParzenEstimator(
         {"c": mus}, {"c": distributions.CategoricalDistribution([0.0, 1.0, 2.0])}, parameters
     )
-    assert len(mpe._mixture_distribution.weights) == max(
-        len(mus) + 1, 1
-    )  # NOTE(sawa3030): +1 for prior
+    assert len(mpe._mixture_distribution.weights) == len(mus) + 1  # NOTE(sawa3030): +1 for prior
 
 
 @pytest.mark.parametrize("prior_weight", [None, -1.0, 0.0])

--- a/tests/samplers_tests/tpe_tests/test_parzen_estimator.py
+++ b/tests/samplers_tests/tpe_tests/test_parzen_estimator.py
@@ -50,7 +50,6 @@ MULTIVARIATE_SAMPLES = {
 @pytest.mark.parametrize("multivariate", [True, False])
 def test_init_parzen_estimator(multivariate: bool) -> None:
     parameters = _ParzenEstimatorParameters(
-        consider_prior=True,
         prior_weight=1.0,
         consider_magic_clip=False,
         consider_endpoints=False,
@@ -190,7 +189,6 @@ def test_calculate_shape_check(
 ) -> None:
     parameters = _ParzenEstimatorParameters(
         prior_weight=prior_weight,
-        consider_prior=True,
         consider_magic_clip=magic_clip,
         consider_endpoints=endpoints,
         weights=default_weights,
@@ -216,7 +214,6 @@ def test_calculate_shape_check_categorical(
 ) -> None:
     parameters = _ParzenEstimatorParameters(
         prior_weight=prior_weight,
-        consider_prior=True,
         consider_magic_clip=True,
         consider_endpoints=False,
         weights=default_weights,
@@ -234,7 +231,6 @@ def test_calculate_shape_check_categorical(
 def test_invalid_prior_weight(prior_weight: float, mus: np.ndarray) -> None:
     parameters = _ParzenEstimatorParameters(
         prior_weight=prior_weight,
-        consider_prior=True,
         consider_magic_clip=False,
         consider_endpoints=False,
         weights=default_weights,
@@ -299,7 +295,6 @@ def test_calculate(
 ) -> None:
     parameters = _ParzenEstimatorParameters(
         prior_weight=1.0,
-        consider_prior=True,
         consider_magic_clip=flags["magic_clip"],
         consider_endpoints=flags["endpoints"],
         weights=default_weights,
@@ -336,7 +331,6 @@ def test_calculate(
 def test_invalid_weights(weights: Callable[[int], np.ndarray]) -> None:
     parameters = _ParzenEstimatorParameters(
         prior_weight=1.0,
-        consider_prior=True,
         consider_magic_clip=False,
         consider_endpoints=False,
         weights=weights,

--- a/tests/samplers_tests/tpe_tests/test_parzen_estimator.py
+++ b/tests/samplers_tests/tpe_tests/test_parzen_estimator.py
@@ -226,11 +226,10 @@ def test_calculate_shape_check_categorical(
     assert len(mpe._mixture_distribution.weights) == len(mus) + 1  # NOTE(sawa3030): +1 for prior
 
 
-@pytest.mark.parametrize("prior_weight", [-1.0, 0.0])
 @pytest.mark.parametrize("mus", (np.asarray([]), np.asarray([0.4]), np.asarray([-0.4, 0.4])))
-def test_invalid_prior_weight(prior_weight: float, mus: np.ndarray) -> None:
+def test_invalid_prior_weight(mus: np.ndarray) -> None:
     parameters = _ParzenEstimatorParameters(
-        prior_weight=prior_weight,
+        prior_weight=-1.0,
         consider_magic_clip=False,
         consider_endpoints=False,
         weights=default_weights,

--- a/tests/samplers_tests/tpe_tests/test_parzen_estimator.py
+++ b/tests/samplers_tests/tpe_tests/test_parzen_estimator.py
@@ -226,7 +226,7 @@ def test_calculate_shape_check_categorical(
     assert len(mpe._mixture_distribution.weights) == len(mus) + 1  # NOTE(sawa3030): +1 for prior
 
 
-@pytest.mark.parametrize("prior_weight", [None, -1.0, 0.0])
+@pytest.mark.parametrize("prior_weight", [-1.0, 0.0])
 @pytest.mark.parametrize("mus", (np.asarray([]), np.asarray([0.4]), np.asarray([-0.4, 0.4])))
 def test_invalid_prior_weight(prior_weight: float, mus: np.ndarray) -> None:
     parameters = _ParzenEstimatorParameters(

--- a/tests/samplers_tests/tpe_tests/test_sampler.py
+++ b/tests/samplers_tests/tpe_tests/test_sampler.py
@@ -146,12 +146,6 @@ def test_sample_relative_prior() -> None:
 
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", optuna.exceptions.ExperimentalWarning)
-        sampler = TPESampler(consider_prior=False, n_startup_trials=5, seed=0, multivariate=True)
-    with patch.object(study._storage, "get_all_trials", return_value=past_trials):
-        assert sampler.sample_relative(study, trial, {"param-a": dist}) != suggestion
-
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", optuna.exceptions.ExperimentalWarning)
         sampler = TPESampler(prior_weight=0.2, n_startup_trials=5, seed=0, multivariate=True)
     with patch.object(study._storage, "get_all_trials", return_value=past_trials):
         assert sampler.sample_relative(study, trial, {"param-a": dist}) != suggestion
@@ -449,10 +443,6 @@ def test_sample_independent_prior() -> None:
     sampler = TPESampler(n_startup_trials=5, seed=0)
     with patch.object(study._storage, "get_all_trials", return_value=past_trials):
         suggestion = sampler.sample_independent(study, trial, "param-a", dist)
-
-    sampler = TPESampler(consider_prior=False, n_startup_trials=5, seed=0)
-    with patch.object(study._storage, "get_all_trials", return_value=past_trials):
-        assert sampler.sample_independent(study, trial, "param-a", dist) != suggestion
 
     sampler = TPESampler(prior_weight=0.1, n_startup_trials=5, seed=0)
     with patch.object(study._storage, "get_all_trials", return_value=past_trials):


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
- Update the behavior of `consider_prior` to always be `True`.  
- Ref: [#6005](https://github.com/optuna/optuna/pull/6005).  
- note: Make `consider_prior` positional args in the following PR.

## Description of Changes
- Update the warning message to explicitly state that `consider_prior` is now always `True`.  
- Update the code to always consider prior.
- Set `consider_prior = True` when constructing `_ParzenEstimatorParameters`.  
- Delete tests that previously verified behavior when `consider_prior = False`.  
