### PR TITLE
Enhance SBXCrossover

### DIFF
--- a/optuna/samplers/nsgaii/_crossovers/_sbx.py
+++ b/optuna/samplers/nsgaii/_crossovers/_sbx.py
@@ -111,7 +111,7 @@ class SBXCrossover(BaseCrossover):
         c1 = 0.5 * ((xs_min + xs_max) - betaq1 * xs_diff)  # Equation (4).
         c2 = 0.5 * ((xs_min + xs_max) + betaq2 * xs_diff)  # Equation (5).
 
-        # SBX applies crossover with use_chile_gene_probability and uniform_crossover_probability.,
+        # SBX applies crossover with use_child_gene_prob and uniform_crossover_prob.
         # the gene of the parent individual is the gene of the child individual.
         # The original SBX creates two child individuals,
         # but optuna's implementation creates only one child individual.

--- a/optuna/samplers/nsgaii/_crossovers/_sbx.py
+++ b/optuna/samplers/nsgaii/_crossovers/_sbx.py
@@ -29,6 +29,20 @@ class SBXCrossover(BaseCrossover):
             Distribution index. A small value of ``eta`` allows distant solutions
             to be selected as children solutions. If not specified, takes default
             value of ``2`` for single objective functions and ``20`` for multi objective.
+        establishment:
+            ``establishment`` is the probability of uniform crossover
+            between two individuals selected as candidate child individuals.
+            Optuna returns only one child individual at a time, while SBX crossover generates two.
+            This argument is whether or not two individual are
+            crossover to make one child individual.
+            If not specified, takes default value of ``0.5``.
+            The range of values is ``[0.0, 1.0]``.
+        probability:
+            ``probability`` is the probability of using the value of the generated
+            child variable rather than the value of the parent.
+            where ``1-probability`` is the probability of using the parent's values as it is.
+            If not specified, takes default value of ``0.5``.
+            The range of values is ``[0.0, 1.0]``.
     """
 
     n_parents = 2
@@ -96,16 +110,28 @@ class SBXCrossover(BaseCrossover):
         child_params_list = []
 
         for c1_i, c2_i, x1_i, x2_i in zip(c1, c2, parents_params[0], parents_params[1]):
-            if rng.rand() < self._establishment:
-                if index_prob < self._probability:
-                    child_params_list.append(c1_i)
+            if rng.rand() < self._probability:
+                if rng.rand() < self._establishment:
+                    if index_prob >= 0.5:
+                        child_params_list.append(c1_i)
+                    else:
+                        child_params_list.append(c2_i)
                 else:
-                    child_params_list.append(c2_i)
+                    if index_prob >= 0.5:
+                        child_params_list.append(c2_i)
+                    else:
+                        child_params_list.append(c1_i)
             else:
-                if index_prob < self._probability:
-                    child_params_list.append(x1_i)
+                if rng.rand() < self._establishment:
+                    if index_prob >= 0.5:
+                        child_params_list.append(x1_i)
+                    else:
+                        child_params_list.append(x2_i)
                 else:
-                    child_params_list.append(x2_i)
+                    if index_prob >= 0.5:
+                        child_params_list.append(x2_i)
+                    else:
+                        child_params_list.append(x1_i)
         child_params = np.array(child_params_list)
 
         return child_params

--- a/optuna/samplers/nsgaii/_crossovers/_sbx.py
+++ b/optuna/samplers/nsgaii/_crossovers/_sbx.py
@@ -40,6 +40,9 @@ class SBXCrossover(BaseCrossover):
             between two individuals selected as candidate child individuals.
             This argument is whether or not two individuals are
             crossover to make one child individual.
+            If the ``uniform_crossover_prob`` exceeds 0.5,
+            the result is equivalent to ``1-uniform_crossover_prob``,
+            because it returns one of the two individuals of the crossover result.
             If not specified, takes default value of ``0.5``.
             The range of values is ``[0.0, 1.0]``.
         use_child_gene_prob:

--- a/optuna/samplers/nsgaii/_crossovers/_sbx.py
+++ b/optuna/samplers/nsgaii/_crossovers/_sbx.py
@@ -33,7 +33,7 @@ class SBXCrossover(BaseCrossover):
             ``establishment`` is the probability of uniform crossover
             between two individuals selected as candidate child individuals.
             Optuna returns only one child individual at a time, while SBX crossover generates two.
-            This argument is whether or not two individual are
+            This argument is whether or not two individuals are
             crossover to make one child individual.
             If not specified, takes default value of ``0.5``.
             The range of values is ``[0.0, 1.0]``.
@@ -42,7 +42,7 @@ class SBXCrossover(BaseCrossover):
             child variable rather than the value of the parent.
             where ``1-probability`` is the probability of using the parent's values as it is.
             If not specified, takes default value of ``0.5``.
-            The range of values is ``[0.0, 1.0]``.
+            The range of values is ``(0.0, 1.0]``.
     """
 
     n_parents = 2
@@ -54,8 +54,8 @@ class SBXCrossover(BaseCrossover):
 
         if establishment < 0.0 or establishment > 1.0:
             raise ValueError("The value of `establishment` must be in the range [0.0, 1.0].")
-        if probability < 0.0 or probability > 1.0:
-            raise ValueError("The value of `probability` must be in the range [0.0, 1.0].")
+        if probability <= 0.0 or probability > 1.0:
+            raise ValueError("The value of `probability` must be in the range (0.0, 1.0].")
         self._establishment = establishment
         self._probability = probability
 

--- a/optuna/samplers/nsgaii/_crossovers/_sbx.py
+++ b/optuna/samplers/nsgaii/_crossovers/_sbx.py
@@ -37,6 +37,11 @@ class SBXCrossover(BaseCrossover):
         self, eta: float | None = None, establishment: float = 0.5, probability: float = 0.5
     ) -> None:
         self._eta = eta
+
+        if establishment < 0.0 or establishment > 1.0:
+            raise ValueError("The value of `establishment` must be in the range [0.0, 1.0].")
+        if probability < 0.0 or probability > 1.0:
+            raise ValueError("The value of `probability` must be in the range [0.0, 1.0].")
         self._establishment = establishment
         self._probability = probability
 
@@ -90,15 +95,17 @@ class SBXCrossover(BaseCrossover):
         index_prob = rng.rand()
         child_params_list = []
 
-        def select_parameter(a: np.ndarray, b: np.ndarray, index_prob: float) -> np.ndarray:
-            return a if index_prob < 0.5 else b
-
         for c1_i, c2_i, x1_i, x2_i in zip(c1, c2, parents_params[0], parents_params[1]):
             if rng.rand() < self._establishment:
-                options = (c1_i, c2_i) if rng.rand() < self._probability else (c2_i, c1_i)
+                if index_prob < self._probability:
+                    child_params_list.append(c1_i)
+                else:
+                    child_params_list.append(c2_i)
             else:
-                options = (x1_i, x2_i) if rng.rand() < self._probability else (x2_i, x1_i)
-            child_params_list.append(select_parameter(*options, index_prob))
+                if index_prob < self._probability:
+                    child_params_list.append(x1_i)
+                else:
+                    child_params_list.append(x2_i)
         child_params = np.array(child_params_list)
 
         return child_params

--- a/tests/samplers_tests/test_nsgaii.py
+++ b/tests/samplers_tests/test_nsgaii.py
@@ -900,8 +900,8 @@ def test_crossover_duplicated_param_values(crossover: BaseCrossover) -> None:
         (SPXCrossover(), 0.5, np.array([2.75735931, 3.75735931])),  # rs = [0.5, 0.25].
         (SPXCrossover(), 1.0, np.array([-1.0, 0.0])),  # rs = [1, 1], xks[0].
         (SBXCrossover(), 0.0, np.array([2.0, 3.0])),  # c1 = (p1 + p2) / 2.
-        (SBXCrossover(), 0.5, np.array([3.0, 4.0])),  # p2.
-        (SBXCrossover(), 1.0, np.array([3.0, 4.0])),  # p2.
+        (SBXCrossover(), 0.5, np.array([1.0, 2.0])),  # p2.
+        (SBXCrossover(), 1.0, np.array([1.0, 2.0])),  # p2.
         (VSBXCrossover(), 0.0, np.array([2.0, 3.0])),  # c1 = (p1 + p2) / 2.
         (VSBXCrossover(), 0.5, np.array([3.0, 4.0])),  # p2.
         (VSBXCrossover(), 1.0, np.array([3.0, 4.0])),  # p2.

--- a/tests/samplers_tests/test_nsgaii.py
+++ b/tests/samplers_tests/test_nsgaii.py
@@ -900,8 +900,8 @@ def test_crossover_duplicated_param_values(crossover: BaseCrossover) -> None:
         (SPXCrossover(), 0.5, np.array([2.75735931, 3.75735931])),  # rs = [0.5, 0.25].
         (SPXCrossover(), 1.0, np.array([-1.0, 0.0])),  # rs = [1, 1], xks[0].
         (SBXCrossover(), 0.0, np.array([2.0, 3.0])),  # c1 = (p1 + p2) / 2.
-        (SBXCrossover(), 0.5, np.array([1.0, 2.0])),  # p2.
-        (SBXCrossover(), 1.0, np.array([1.0, 2.0])),  # p2.
+        (SBXCrossover(), 0.5, np.array([3.0, 4.0])),  # p2.
+        (SBXCrossover(), 1.0, np.array([3.0, 4.0])),  # p2.
         (VSBXCrossover(), 0.0, np.array([2.0, 3.0])),  # c1 = (p1 + p2) / 2.
         (VSBXCrossover(), 0.5, np.array([3.0, 4.0])),  # p2.
         (VSBXCrossover(), 1.0, np.array([3.0, 4.0])),  # p2.


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

I would like to reduce the difference in the distribution of children between the reference paper and optuna's SBX as shown in [this discussion](https://github.com/optuna/optuna/discussions/6000)

## Description of the changes
<!-- Describe the changes in this PR. -->

The fixed values of “establishment” and “probability” are used as arguments to reproduce the same distribution as in the paper.

I have two questions.

1. Would this change be better for Optunahub?
2. Although `establishment` and `probability` are names that originally appeared in comments in the code, I think that expressions such as `variable_crossover_prob`, for example, would be easier to understand.
