### PR TITLE
Add arguments of versions to `convert_positional_args`

### DIFF
--- a/optuna/_convert_positional_args.py
+++ b/optuna/_convert_positional_args.py
@@ -25,7 +25,7 @@ _DEPRECATION_WARNING_TEMPLATE = (
     "Positional arguments {deprecated_positional_arg_names} in {func_name}() "
     "have been deprecated since v{d_ver}. "
     "They will be replaced with the corresponding keyword arguments in v{r_ver}, "
-    "so please use keyword specification instead. "
+    "so please use the keyword specification instead. "
     "See https://github.com/optuna/optuna/releases/tag/v{d_ver} for details."
 )
 

--- a/optuna/_convert_positional_args.py
+++ b/optuna/_convert_positional_args.py
@@ -6,7 +6,6 @@ from functools import wraps
 from inspect import Parameter
 from inspect import signature
 from typing import Any
-from typing import Optional
 from typing import TYPE_CHECKING
 from typing import TypeVar
 import warnings
@@ -50,8 +49,8 @@ def convert_positional_args(
     *,
     previous_positional_arg_names: Sequence[str],
     warning_stacklevel: int = 2,
-    deprecated_version: Optional[str] = None,
-    removed_version: Optional[str] = None,
+    deprecated_version: str | None = None,
+    removed_version: str | None = None,
 ) -> "Callable[[Callable[_P, _T]], Callable[_P, _T]]":
     """Convert positional arguments to keyword arguments.
 

--- a/optuna/_convert_positional_args.py
+++ b/optuna/_convert_positional_args.py
@@ -93,7 +93,7 @@ def convert_positional_args(
             positional_arg_names = _get_positional_arg_names(func)
             inferred_kwargs = _infer_kwargs(previous_positional_arg_names, *args)
 
-            if args and (deprecated_version or removed_version):
+            if inferred_kwargs and (deprecated_version or removed_version):
                 warning_messages.append(
                     _DEPRECATION_WARNING_TEMPLATE.format(
                         positional_arg=previous_positional_arg_names,

--- a/optuna/_convert_positional_args.py
+++ b/optuna/_convert_positional_args.py
@@ -6,6 +6,7 @@ from functools import wraps
 from inspect import Parameter
 from inspect import signature
 from typing import Any
+from typing import Optional
 from typing import TYPE_CHECKING
 from typing import TypeVar
 import warnings
@@ -22,9 +23,10 @@ if TYPE_CHECKING:
 
 
 _DEPRECATION_WARNING_TEMPLATE = (
-    "Positional arguments {positional_arg} in {func_name}() have been deprecated since v{d_ver}. "
-    "They will be removed in v{r_ver}. "
-    "Please use keyword arguments instead. "
+    "Positional arguments {deprecated_positional_arg_names} in {func_name}() "
+    "have been deprecated since v{d_ver}. "
+    "They will be replaced with the corresponding keyword arguments in v{r_ver}, "
+    "so please use keyword specification instead. "
     "See https://github.com/optuna/optuna/releases/tag/v{d_ver} for details."
 )
 
@@ -48,8 +50,8 @@ def convert_positional_args(
     *,
     previous_positional_arg_names: Sequence[str],
     warning_stacklevel: int = 2,
-    deprecated_version: str | None = None,
-    removed_version: str | None = None,
+    deprecated_version: Optional[str] = None,
+    removed_version: Optional[str] = None,
 ) -> "Callable[[Callable[_P, _T]], Callable[_P, _T]]":
     """Convert positional arguments to keyword arguments.
 
@@ -64,9 +66,7 @@ def convert_positional_args(
             The version in which the use of positional arguments will be removed.
     """
 
-    if deprecated_version is None and removed_version is None:
-        pass
-    else:
+    if deprecated_version is not None or removed_version is not None:
         if deprecated_version is None:
             raise ValueError(
                 "deprecated_version must not be None when removed_version is specified."
@@ -103,7 +103,7 @@ def convert_positional_args(
                 if deprecated_version or removed_version:
                     warning_messages.append(
                         _DEPRECATION_WARNING_TEMPLATE.format(
-                            positional_arg=previous_positional_arg_names,
+                            deprecated_positional_arg_names=previous_positional_arg_names,
                             func_name=func.__name__,
                             d_ver=deprecated_version,
                             r_ver=removed_version,

--- a/optuna/_convert_positional_args.py
+++ b/optuna/_convert_positional_args.py
@@ -5,10 +5,15 @@ from collections.abc import Sequence
 from functools import wraps
 from inspect import Parameter
 from inspect import signature
+import textwrap
 from typing import Any
 from typing import TYPE_CHECKING
 from typing import TypeVar
 import warnings
+
+from optuna._deprecated import _get_docstring_indent
+from optuna._deprecated import _validate_two_version
+from optuna._experimental import _validate_version
 
 
 if TYPE_CHECKING:
@@ -16,6 +21,22 @@ if TYPE_CHECKING:
 
     _P = ParamSpec("_P")
     _T = TypeVar("_T")
+
+_DEPRECATION_NOTE_TEMPLATE = """
+
+.. warning::
+    Using positional arguments is deprecated since v{d_ver}. Support for positional arguments
+    will be removed in the future. The removal is currently scheduled for v{r_ver}, but this
+    schedule is subject to change. Please use keyword arguments instead.
+    See https://github.com/optuna/optuna/releases/tag/v{d_ver}.
+"""
+
+_DEPRECATION_WARNING_TEMPLATE = (
+    "Positional arguments in {name} have been deprecated since v{d_ver}. "
+    "They will be removed in v{r_ver}. "
+    "Please use keyword arguments instead. "
+    "See https://github.com/optuna/optuna/releases/tag/v{d_ver} for details."
+)
 
 
 def _get_positional_arg_names(func: "Callable[_P, _T]") -> list[str]:
@@ -37,15 +58,38 @@ def convert_positional_args(
     *,
     previous_positional_arg_names: Sequence[str],
     warning_stacklevel: int = 2,
+    deprecated_version: str | None = None,
+    removed_version: str | None = None,
 ) -> "Callable[[Callable[_P, _T]], Callable[_P, _T]]":
     """Convert positional arguments to keyword arguments.
 
     Args:
-        previous_positional_arg_names: List of names previously given as positional arguments.
-        warning_stacklevel: Level of the stack trace where decorated function locates.
+        previous_positional_arg_names:
+            List of names previously given as positional arguments.
+        warning_stacklevel:
+            Level of the stack trace where decorated function locates.
+        deprecated_version:
+            Version number in which the use of positional arguments is deprecated.
+        removed_version:
+            Version number in which the use of positional arguments was completely removed.
     """
 
+    if deprecated_version is not None or removed_version is not None:
+        _validate_version(deprecated_version)
+        _validate_version(removed_version)
+        _validate_two_version(deprecated_version, removed_version)
+
     def converter_decorator(func: "Callable[_P, _T]") -> "Callable[_P, _T]":
+        if deprecated_version or removed_version:
+            if func.__doc__ is None:
+                func.__doc__ = ""
+
+            note = _DEPRECATION_NOTE_TEMPLATE.format(
+                d_ver=deprecated_version, r_ver=removed_version
+            )
+            indent = _get_docstring_indent(func.__doc__)
+            func.__doc__ = func.__doc__.strip() + textwrap.indent(note, indent) + indent
+
         assert set(previous_positional_arg_names).issubset(set(signature(func).parameters)), (
             f"{set(previous_positional_arg_names)} is not a subset of"
             f" {set(signature(func).parameters)}"
@@ -53,6 +97,16 @@ def convert_positional_args(
 
         @wraps(func)
         def converter_wrapper(*args: Any, **kwargs: Any) -> "_T":
+            if deprecated_version or removed_version:
+                warnings.warn(
+                    _DEPRECATION_WARNING_TEMPLATE.format(
+                        name=func.__name__,
+                        d_ver=deprecated_version,
+                        r_ver=removed_version,
+                    ),
+                    FutureWarning,
+                    stacklevel=warning_stacklevel,
+                )
             positional_arg_names = _get_positional_arg_names(func)
             inferred_kwargs = _infer_kwargs(previous_positional_arg_names, *args)
             if len(inferred_kwargs) > len(positional_arg_names):

--- a/optuna/_convert_positional_args.py
+++ b/optuna/_convert_positional_args.py
@@ -93,22 +93,22 @@ def convert_positional_args(
             positional_arg_names = _get_positional_arg_names(func)
             inferred_kwargs = _infer_kwargs(previous_positional_arg_names, *args)
 
-            if inferred_kwargs and (deprecated_version or removed_version):
-                warning_messages.append(
-                    _DEPRECATION_WARNING_TEMPLATE.format(
-                        positional_arg=previous_positional_arg_names,
-                        func_name=func.__name__,
-                        d_ver=deprecated_version,
-                        r_ver=removed_version,
-                    )
-                )
-
             if len(inferred_kwargs) > len(positional_arg_names):
                 expected_kwds = set(inferred_kwargs) - set(positional_arg_names)
                 warning_messages.append(
                     f"{func.__name__}() got {expected_kwds} as positional arguments "
                     "but they were expected to be given as keyword arguments."
                 )
+
+                if deprecated_version or removed_version:
+                    warning_messages.append(
+                        _DEPRECATION_WARNING_TEMPLATE.format(
+                            positional_arg=previous_positional_arg_names,
+                            func_name=func.__name__,
+                            d_ver=deprecated_version,
+                            r_ver=removed_version,
+                        )
+                    )
 
             if warning_messages:
                 warnings.warn(

--- a/optuna/_convert_positional_args.py
+++ b/optuna/_convert_positional_args.py
@@ -11,7 +11,6 @@ from typing import TYPE_CHECKING
 from typing import TypeVar
 import warnings
 
-from optuna._deprecated import _get_docstring_indent
 from optuna._deprecated import _validate_two_version
 from optuna._experimental import _validate_version
 
@@ -37,6 +36,10 @@ _DEPRECATION_WARNING_TEMPLATE = (
     "Please use keyword arguments instead. "
     "See https://github.com/optuna/optuna/releases/tag/v{d_ver} for details."
 )
+
+
+def _get_docstring_indent(docstring: str) -> str:
+    return docstring.split("\n")[-1] if "\n" in docstring else ""
 
 
 def _get_positional_arg_names(func: "Callable[_P, _T]") -> list[str]:
@@ -74,7 +77,18 @@ def convert_positional_args(
             Version number in which the use of positional arguments was completely removed.
     """
 
-    if deprecated_version is not None or removed_version is not None:
+    if deprecated_version is None and removed_version is None:
+        pass
+    else:
+        if deprecated_version is None:
+            raise ValueError(
+                "deprecated_version must not be None when removed_version is specified"
+            )
+        if removed_version is None:
+            raise ValueError(
+                "removed_version must not be None when deprecated_version is specified"
+            )
+
         _validate_version(deprecated_version)
         _validate_version(removed_version)
         _validate_two_version(deprecated_version, removed_version)


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
This PR is from https://github.com/optuna/optuna/issues/5485
## Description of the changes
<!-- Describe the changes in this PR. -->

I added arguments and warning for `deprecated_version` and `removed_version`, referring to `deprecated_func`
The format of warning is:
```
"Positional arguments in {name} have been deprecated since v{d_ver}. "
"They will be removed in v{r_ver}. "
"Please use keyword arguments instead. "
"See https://github.com/optuna/optuna/releases/tag/v{d_ver} for details."
```

