### PR TITLE
Add `wait_server_ready` method in GrpcStorageProxy

### DIFF
--- a/optuna/storages/_grpc/client.py
+++ b/optuna/storages/_grpc/client.py
@@ -90,6 +90,7 @@ class GrpcStorageProxy(BaseStorage):
         self._cache = GrpcClientCache(self._stub)
 
     def __del__(self) -> None:
+        del self._cache
         self._channel.close()
 
     def __getstate__(self) -> dict[Any, Any]:

--- a/optuna/storages/_grpc/client.py
+++ b/optuna/storages/_grpc/client.py
@@ -78,11 +78,17 @@ class GrpcStorageProxy(BaseStorage):
         self._setup()
 
     def _setup(self) -> None:
+        """Set up the gRPC channel and stub."""
         self._channel = create_insecure_channel(self._host, self._port)
         self._stub = api_pb2_grpc.StorageServiceStub(self._channel)
         self._cache = GrpcClientCache(self._stub)
 
     def wait_server_ready(self, timeout: float | None = None) -> None:
+        """Wait until the gRPC server is ready.
+
+        Args:
+            timeout: The maximum time to wait in seconds. If :obj:`None`, wait indefinitely.
+        """
         try:
             with create_insecure_channel(self._host, self._port) as channel:
                 grpc.channel_ready_future(channel).result(timeout=timeout)
@@ -90,6 +96,7 @@ class GrpcStorageProxy(BaseStorage):
             raise ConnectionError("GRPC connection timeout") from e
 
     def close(self) -> None:
+        """Close the gRPC channel."""
         self._channel.close()
 
     def __getstate__(self) -> dict[Any, Any]:

--- a/optuna/storages/_grpc/client.py
+++ b/optuna/storages/_grpc/client.py
@@ -88,6 +88,10 @@ class GrpcStorageProxy(BaseStorage):
         self._host = host
         self._port = port
 
+    def __del__(self) -> None:
+        del self._stub
+        del self._cache
+
     def __getstate__(self) -> dict[Any, Any]:
         state = self.__dict__.copy()
         del state["_stub"]

--- a/optuna/storages/_grpc/client.py
+++ b/optuna/storages/_grpc/client.py
@@ -41,11 +41,6 @@ def create_insecure_channel(host: str, port: int) -> grpc.Channel:
         f"{host}:{port}", options=[("grpc.max_receive_message_length", -1)]
     )
 
-
-def create_stub(channel: grpc.Channel) -> api_pb2_grpc.StorageServiceStub:
-    return api_pb2_grpc.StorageServiceStub(channel)
-
-
 @experimental_class("4.2.0")
 class GrpcStorageProxy(BaseStorage):
     """gRPC client for :func:`~optuna.storages.run_grpc_proxy_server`.
@@ -111,7 +106,7 @@ class GrpcStorageProxy(BaseStorage):
             study_name=study_name or DEFAULT_STUDY_NAME_PREFIX + str(uuid.uuid4()),
         )
         with create_insecure_channel(self._host, self._port) as channel:
-            stub = create_stub(channel)
+            stub = api_pb2_grpc.StorageServiceStub(channel)
             try:
                 response = stub.CreateNewStudy(request)
             except grpc.RpcError as e:
@@ -123,7 +118,7 @@ class GrpcStorageProxy(BaseStorage):
     def delete_study(self, study_id: int) -> None:
         request = api_pb2.DeleteStudyRequest(study_id=study_id)
         with create_insecure_channel(self._host, self._port) as channel:
-            stub = create_stub(channel)
+            stub = api_pb2_grpc.StorageServiceStub(channel)
             try:
                 stub.DeleteStudy(request)
             except grpc.RpcError as e:
@@ -139,7 +134,7 @@ class GrpcStorageProxy(BaseStorage):
             study_id=study_id, key=key, value=json.dumps(value)
         )
         with create_insecure_channel(self._host, self._port) as channel:
-            stub = create_stub(channel)
+            stub = api_pb2_grpc.StorageServiceStub(channel)
             try:
                 stub.SetStudyUserAttribute(request)
             except grpc.RpcError as e:
@@ -152,7 +147,7 @@ class GrpcStorageProxy(BaseStorage):
             study_id=study_id, key=key, value=json.dumps(value)
         )
         with create_insecure_channel(self._host, self._port) as channel:
-            stub = create_stub(channel)
+            stub = api_pb2_grpc.StorageServiceStub(channel)
             try:
                 stub.SetStudySystemAttribute(request)
             except grpc.RpcError as e:
@@ -163,7 +158,7 @@ class GrpcStorageProxy(BaseStorage):
     def get_study_id_from_name(self, study_name: str) -> int:
         request = api_pb2.GetStudyIdFromNameRequest(study_name=study_name)
         with create_insecure_channel(self._host, self._port) as channel:
-            stub = create_stub(channel)
+            stub = api_pb2_grpc.StorageServiceStub(channel)
             try:
                 response = stub.GetStudyIdFromName(request)
             except grpc.RpcError as e:
@@ -175,7 +170,7 @@ class GrpcStorageProxy(BaseStorage):
     def get_study_name_from_id(self, study_id: int) -> str:
         request = api_pb2.GetStudyNameFromIdRequest(study_id=study_id)
         with create_insecure_channel(self._host, self._port) as channel:
-            stub = create_stub(channel)
+            stub = api_pb2_grpc.StorageServiceStub(channel)
             try:
                 response = stub.GetStudyNameFromId(request)
             except grpc.RpcError as e:
@@ -187,7 +182,7 @@ class GrpcStorageProxy(BaseStorage):
     def get_study_directions(self, study_id: int) -> list[StudyDirection]:
         request = api_pb2.GetStudyDirectionsRequest(study_id=study_id)
         with create_insecure_channel(self._host, self._port) as channel:
-            stub = create_stub(channel)
+            stub = api_pb2_grpc.StorageServiceStub(channel)
             try:
                 response = stub.GetStudyDirections(request)
             except grpc.RpcError as e:
@@ -202,7 +197,7 @@ class GrpcStorageProxy(BaseStorage):
     def get_study_user_attrs(self, study_id: int) -> dict[str, Any]:
         request = api_pb2.GetStudyUserAttributesRequest(study_id=study_id)
         with create_insecure_channel(self._host, self._port) as channel:
-            stub = create_stub(channel)
+            stub = api_pb2_grpc.StorageServiceStub(channel)
             try:
                 response = stub.GetStudyUserAttributes(request)
             except grpc.RpcError as e:
@@ -214,7 +209,7 @@ class GrpcStorageProxy(BaseStorage):
     def get_study_system_attrs(self, study_id: int) -> dict[str, Any]:
         request = api_pb2.GetStudySystemAttributesRequest(study_id=study_id)
         with create_insecure_channel(self._host, self._port) as channel:
-            stub = create_stub(channel)
+            stub = api_pb2_grpc.StorageServiceStub(channel)
             try:
                 response = stub.GetStudySystemAttributes(request)
             except grpc.RpcError as e:
@@ -226,7 +221,7 @@ class GrpcStorageProxy(BaseStorage):
     def get_all_studies(self) -> list[FrozenStudy]:
         request = api_pb2.GetAllStudiesRequest()
         with create_insecure_channel(self._host, self._port) as channel:
-            stub = create_stub(channel)
+            stub = api_pb2_grpc.StorageServiceStub(channel)
             response = stub.GetAllStudies(request)
         return [
             FrozenStudy(
@@ -257,7 +252,7 @@ class GrpcStorageProxy(BaseStorage):
                 template_trial_is_none=False,
             )
         with create_insecure_channel(self._host, self._port) as channel:
-            stub = create_stub(channel)
+            stub = api_pb2_grpc.StorageServiceStub(channel)
             try:
                 response = stub.CreateNewTrial(request)
             except grpc.RpcError as e:
@@ -280,7 +275,7 @@ class GrpcStorageProxy(BaseStorage):
             distribution=distribution_to_json(distribution),
         )
         with create_insecure_channel(self._host, self._port) as channel:
-            stub = create_stub(channel)
+            stub = api_pb2_grpc.StorageServiceStub(channel)
             try:
                 stub.SetTrialParameter(request)
             except grpc.RpcError as e:
@@ -302,7 +297,7 @@ class GrpcStorageProxy(BaseStorage):
             values=values,
         )
         with create_insecure_channel(self._host, self._port) as channel:
-            stub = create_stub(channel)
+            stub = api_pb2_grpc.StorageServiceStub(channel)
             try:
                 response = stub.SetTrialStateValues(request)
             except grpc.RpcError as e:
@@ -321,7 +316,7 @@ class GrpcStorageProxy(BaseStorage):
             trial_id=trial_id, step=step, intermediate_value=intermediate_value
         )
         with create_insecure_channel(self._host, self._port) as channel:
-            stub = create_stub(channel)
+            stub = api_pb2_grpc.StorageServiceStub(channel)
             try:
                 stub.SetTrialIntermediateValue(request)
             except grpc.RpcError as e:
@@ -337,7 +332,7 @@ class GrpcStorageProxy(BaseStorage):
             trial_id=trial_id, key=key, value=json.dumps(value)
         )
         with create_insecure_channel(self._host, self._port) as channel:
-            stub = create_stub(channel)
+            stub = api_pb2_grpc.StorageServiceStub(channel)
             try:
                 stub.SetTrialUserAttribute(request)
             except grpc.RpcError as e:
@@ -353,7 +348,7 @@ class GrpcStorageProxy(BaseStorage):
             trial_id=trial_id, key=key, value=json.dumps(value)
         )
         with create_insecure_channel(self._host, self._port) as channel:
-            stub = create_stub(channel)
+            stub = api_pb2_grpc.StorageServiceStub(channel)
             try:
                 stub.SetTrialSystemAttribute(request)
             except grpc.RpcError as e:
@@ -369,7 +364,7 @@ class GrpcStorageProxy(BaseStorage):
             study_id=study_id, trial_number=trial_number
         )
         with create_insecure_channel(self._host, self._port) as channel:
-            stub = create_stub(channel)
+            stub = api_pb2_grpc.StorageServiceStub(channel)
             try:
                 response = stub.GetTrialIdFromStudyIdTrialNumber(request)
             except grpc.RpcError as e:
@@ -381,7 +376,7 @@ class GrpcStorageProxy(BaseStorage):
     def get_trial(self, trial_id: int) -> FrozenTrial:
         request = api_pb2.GetTrialRequest(trial_id=trial_id)
         with create_insecure_channel(self._host, self._port) as channel:
-            stub = create_stub(channel)
+            stub = api_pb2_grpc.StorageServiceStub(channel)
             try:
                 response = stub.GetTrial(request)
             except grpc.RpcError as e:
@@ -436,7 +431,7 @@ class GrpcClientCache:
             trial_id_greater_than=study.last_finished_trial_id,
         )
         with create_insecure_channel(self.host, self.port) as channel:
-            stub = create_stub(channel)
+            stub = api_pb2_grpc.StorageServiceStub(channel)
             try:
                 res = stub.GetTrials(req)
             except grpc.RpcError as e:

--- a/optuna/storages/_grpc/client.py
+++ b/optuna/storages/_grpc/client.py
@@ -36,6 +36,15 @@ else:
     grpc_servicer = _LazyImport("optuna.storages._grpc.servicer")
 
 
+def create_insecure_channel(host: str, port: int) -> grpc.Channel:
+    return grpc.insecure_channel(
+        f"{host}:{port}", options=[("grpc.max_receive_message_length", -1)]
+    )
+
+
+def create_stub(channel: grpc.Channel) -> api_pb2_grpc.StorageServiceStub:
+    return api_pb2_grpc.StorageServiceStub(channel)
+
 @experimental_class("4.2.0")
 class GrpcStorageProxy(BaseStorage):
     """gRPC client for :func:`~optuna.storages.run_grpc_proxy_server`.
@@ -68,42 +77,30 @@ class GrpcStorageProxy(BaseStorage):
     """
 
     def __init__(self, *, host: str = "localhost", port: int = 13000, timeout: int = 900) -> None:
+        self._host = host
+        self._port = port
+        self._timeout = timeout
+        self.setup()
+
+    def setup(self) -> None:
         def wait_server(host: str, port: int, timeout: int) -> None:
             try:
-                with grpc.insecure_channel(
-                    f"{host}:{port}", options=[("grpc.max_receive_message_length", -1)]
-                ) as channel:
+                with self.create_insecure_channel(host, port) as channel:
                     grpc.channel_ready_future(channel).result(timeout=timeout)
             except grpc.FutureTimeoutError as e:
                 raise ConnectionError("GRPC connection timeout") from e
 
-        wait_server(host, port, timeout)
-        self._stub = api_pb2_grpc.StorageServiceStub(
-            grpc.insecure_channel(
-                f"{host}:{port}",
-                options=[("grpc.max_receive_message_length", -1)],
-            )
-        )  # type: ignore
-        self._cache = GrpcClientCache(self._stub)
-        self._host = host
-        self._port = port
-
-    def __del__(self) -> None:
-        del self._stub
-        del self._cache
+        wait_server(self._host, self._port, self._timeout)
+        self._cache = GrpcClientCache(self._host, self._port)
 
     def __getstate__(self) -> dict[Any, Any]:
         state = self.__dict__.copy()
-        del state["_stub"]
         del state["_cache"]
         return state
 
     def __setstate__(self, state: dict[Any, Any]) -> None:
         self.__dict__.update(state)
-        self._stub = api_pb2_grpc.StorageServiceStub(
-            grpc.insecure_channel(f"{self._host}:{self._port}")
-        )  # type: ignore
-        self._cache = GrpcClientCache(self._stub)
+        self.setup()
 
     def create_new_study(
         self, directions: Sequence[StudyDirection], study_name: str | None = None
@@ -115,22 +112,26 @@ class GrpcStorageProxy(BaseStorage):
             ],
             study_name=study_name or DEFAULT_STUDY_NAME_PREFIX + str(uuid.uuid4()),
         )
-        try:
-            response = self._stub.CreateNewStudy(request)
-        except grpc.RpcError as e:
-            if e.code() == grpc.StatusCode.ALREADY_EXISTS:
-                raise DuplicatedStudyError from e
-            raise
+        with create_insecure_channel(self._host, self._port) as channel:
+            stub = create_stub(channel)
+            try:
+                response = stub.CreateNewStudy(request)
+            except grpc.RpcError as e:
+                if e.code() == grpc.StatusCode.ALREADY_EXISTS:
+                    raise DuplicatedStudyError from e
+                raise
         return response.study_id
 
     def delete_study(self, study_id: int) -> None:
         request = api_pb2.DeleteStudyRequest(study_id=study_id)
-        try:
-            self._stub.DeleteStudy(request)
-        except grpc.RpcError as e:
-            if e.code() == grpc.StatusCode.NOT_FOUND:
-                raise KeyError from e
-            raise
+        with create_insecure_channel(self._host, self._port) as channel:
+            stub = create_stub(channel)
+            try:
+                stub.DeleteStudy(request)
+            except grpc.RpcError as e:
+                if e.code() == grpc.StatusCode.NOT_FOUND:
+                    raise KeyError from e
+                raise
         # TODO(c-bata): Fix a cache invalidation issue when using SQLite3
         # Please see https://github.com/optuna/optuna/pull/5872/files#r1893708995 for details.
         self._cache.delete_study_cache(study_id)
@@ -139,52 +140,62 @@ class GrpcStorageProxy(BaseStorage):
         request = api_pb2.SetStudyUserAttributeRequest(
             study_id=study_id, key=key, value=json.dumps(value)
         )
-        try:
-            self._stub.SetStudyUserAttribute(request)
-        except grpc.RpcError as e:
-            if e.code() == grpc.StatusCode.NOT_FOUND:
-                raise KeyError from e
-            raise
+        with create_insecure_channel(self._host, self._port) as channel:
+            stub = create_stub(channel)
+            try:
+                stub.SetStudyUserAttribute(request)
+            except grpc.RpcError as e:
+                if e.code() == grpc.StatusCode.NOT_FOUND:
+                    raise KeyError from e
+                raise
 
     def set_study_system_attr(self, study_id: int, key: str, value: Any) -> None:
         request = api_pb2.SetStudySystemAttributeRequest(
             study_id=study_id, key=key, value=json.dumps(value)
         )
-        try:
-            self._stub.SetStudySystemAttribute(request)
-        except grpc.RpcError as e:
-            if e.code() == grpc.StatusCode.NOT_FOUND:
-                raise KeyError from e
-            raise
+        with create_insecure_channel(self._host, self._port) as channel:
+            stub = create_stub(channel)
+            try:
+                stub.SetStudySystemAttribute(request)
+            except grpc.RpcError as e:
+                if e.code() == grpc.StatusCode.NOT_FOUND:
+                    raise KeyError from e
+                raise
 
     def get_study_id_from_name(self, study_name: str) -> int:
         request = api_pb2.GetStudyIdFromNameRequest(study_name=study_name)
-        try:
-            response = self._stub.GetStudyIdFromName(request)
-        except grpc.RpcError as e:
-            if e.code() == grpc.StatusCode.NOT_FOUND:
-                raise KeyError from e
-            raise
+        with create_insecure_channel(self._host, self._port) as channel:
+            stub = create_stub(channel)
+            try:
+                response = stub.GetStudyIdFromName(request)
+            except grpc.RpcError as e:
+                if e.code() == grpc.StatusCode.NOT_FOUND:
+                    raise KeyError from e
+                raise
         return response.study_id
 
     def get_study_name_from_id(self, study_id: int) -> str:
         request = api_pb2.GetStudyNameFromIdRequest(study_id=study_id)
-        try:
-            response = self._stub.GetStudyNameFromId(request)
-        except grpc.RpcError as e:
-            if e.code() == grpc.StatusCode.NOT_FOUND:
-                raise KeyError from e
-            raise
+        with create_insecure_channel(self._host, self._port) as channel:
+            stub = create_stub(channel)
+            try:
+                response = stub.GetStudyNameFromId(request)
+            except grpc.RpcError as e:
+                if e.code() == grpc.StatusCode.NOT_FOUND:
+                    raise KeyError from e
+                raise
         return response.study_name
 
     def get_study_directions(self, study_id: int) -> list[StudyDirection]:
         request = api_pb2.GetStudyDirectionsRequest(study_id=study_id)
-        try:
-            response = self._stub.GetStudyDirections(request)
-        except grpc.RpcError as e:
-            if e.code() == grpc.StatusCode.NOT_FOUND:
-                raise KeyError from e
-            raise
+        with create_insecure_channel(self._host, self._port) as channel:
+            stub = create_stub(channel)
+            try:
+                response = stub.GetStudyDirections(request)
+            except grpc.RpcError as e:
+                if e.code() == grpc.StatusCode.NOT_FOUND:
+                    raise KeyError from e
+                raise
         return [
             StudyDirection.MINIMIZE if d == api_pb2.MINIMIZE else StudyDirection.MAXIMIZE
             for d in response.directions
@@ -192,27 +203,33 @@ class GrpcStorageProxy(BaseStorage):
 
     def get_study_user_attrs(self, study_id: int) -> dict[str, Any]:
         request = api_pb2.GetStudyUserAttributesRequest(study_id=study_id)
-        try:
-            response = self._stub.GetStudyUserAttributes(request)
-        except grpc.RpcError as e:
-            if e.code() == grpc.StatusCode.NOT_FOUND:
-                raise KeyError from e
-            raise
+        with create_insecure_channel(self._host, self._port) as channel:
+            stub = create_stub(channel)
+            try:
+                response = stub.GetStudyUserAttributes(request)
+            except grpc.RpcError as e:
+                if e.code() == grpc.StatusCode.NOT_FOUND:
+                    raise KeyError from e
+                raise
         return {key: json.loads(value) for key, value in response.user_attributes.items()}
 
     def get_study_system_attrs(self, study_id: int) -> dict[str, Any]:
         request = api_pb2.GetStudySystemAttributesRequest(study_id=study_id)
-        try:
-            response = self._stub.GetStudySystemAttributes(request)
-        except grpc.RpcError as e:
-            if e.code() == grpc.StatusCode.NOT_FOUND:
-                raise KeyError from e
-            raise
+        with create_insecure_channel(self._host, self._port) as channel:
+            stub = create_stub(channel)
+            try:
+                response = stub.GetStudySystemAttributes(request)
+            except grpc.RpcError as e:
+                if e.code() == grpc.StatusCode.NOT_FOUND:
+                    raise KeyError from e
+                raise
         return {key: json.loads(value) for key, value in response.system_attributes.items()}
 
     def get_all_studies(self) -> list[FrozenStudy]:
         request = api_pb2.GetAllStudiesRequest()
-        response = self._stub.GetAllStudies(request)
+        with create_insecure_channel(self._host, self._port) as channel:
+            stub = create_stub(channel)
+            response = stub.GetAllStudies(request)
         return [
             FrozenStudy(
                 study_id=study.study_id,
@@ -241,12 +258,14 @@ class GrpcStorageProxy(BaseStorage):
                 template_trial=grpc_servicer._to_proto_trial(template_trial),
                 template_trial_is_none=False,
             )
-        try:
-            response = self._stub.CreateNewTrial(request)
-        except grpc.RpcError as e:
-            if e.code() == grpc.StatusCode.NOT_FOUND:
-                raise KeyError from e
-            raise
+        with create_insecure_channel(self._host, self._port) as channel:
+            stub = create_stub(channel)
+            try:
+                response = stub.CreateNewTrial(request)
+            except grpc.RpcError as e:
+                if e.code() == grpc.StatusCode.NOT_FOUND:
+                    raise KeyError from e
+                raise
         return response.trial_id
 
     def set_trial_param(
@@ -262,17 +281,19 @@ class GrpcStorageProxy(BaseStorage):
             param_value_internal=param_value_internal,
             distribution=distribution_to_json(distribution),
         )
-        try:
-            self._stub.SetTrialParameter(request)
-        except grpc.RpcError as e:
-            if e.code() == grpc.StatusCode.NOT_FOUND:
-                raise KeyError from e
-            elif e.code() == grpc.StatusCode.FAILED_PRECONDITION:
-                raise UpdateFinishedTrialError from e
-            elif e.code() == grpc.StatusCode.INVALID_ARGUMENT:
-                raise ValueError from e
-            else:
-                raise
+        with create_insecure_channel(self._host, self._port) as channel:
+            stub = create_stub(channel)
+            try:
+                stub.SetTrialParameter(request)
+            except grpc.RpcError as e:
+                if e.code() == grpc.StatusCode.NOT_FOUND:
+                    raise KeyError from e
+                elif e.code() == grpc.StatusCode.FAILED_PRECONDITION:
+                    raise UpdateFinishedTrialError from e
+                elif e.code() == grpc.StatusCode.INVALID_ARGUMENT:
+                    raise ValueError from e
+                else:
+                    raise
 
     def set_trial_state_values(
         self, trial_id: int, state: TrialState, values: Sequence[float] | None = None
@@ -282,16 +303,17 @@ class GrpcStorageProxy(BaseStorage):
             state=grpc_servicer._to_proto_trial_state(state),
             values=values,
         )
-        try:
-            response = self._stub.SetTrialStateValues(request)
-        except grpc.RpcError as e:
-            if e.code() == grpc.StatusCode.NOT_FOUND:
-                raise KeyError from e
-            elif e.code() == grpc.StatusCode.FAILED_PRECONDITION:
-                raise UpdateFinishedTrialError from e
-            else:
-                raise
-
+        with create_insecure_channel(self._host, self._port) as channel:
+            stub = create_stub(channel)
+            try:
+                response = stub.SetTrialStateValues(request)
+            except grpc.RpcError as e:
+                if e.code() == grpc.StatusCode.NOT_FOUND:
+                    raise KeyError from e
+                elif e.code() == grpc.StatusCode.FAILED_PRECONDITION:
+                    raise UpdateFinishedTrialError from e
+                else:
+                    raise
         return response.trial_updated
 
     def set_trial_intermediate_value(
@@ -300,64 +322,74 @@ class GrpcStorageProxy(BaseStorage):
         request = api_pb2.SetTrialIntermediateValueRequest(
             trial_id=trial_id, step=step, intermediate_value=intermediate_value
         )
-        try:
-            self._stub.SetTrialIntermediateValue(request)
-        except grpc.RpcError as e:
-            if e.code() == grpc.StatusCode.NOT_FOUND:
-                raise KeyError from e
-            elif e.code() == grpc.StatusCode.FAILED_PRECONDITION:
-                raise UpdateFinishedTrialError from e
-            else:
-                raise
+        with create_insecure_channel(self._host, self._port) as channel:
+            stub = create_stub(channel)
+            try:
+                stub.SetTrialIntermediateValue(request)
+            except grpc.RpcError as e:
+                if e.code() == grpc.StatusCode.NOT_FOUND:
+                    raise KeyError from e
+                elif e.code() == grpc.StatusCode.FAILED_PRECONDITION:
+                    raise UpdateFinishedTrialError from e
+                else:
+                    raise
 
     def set_trial_user_attr(self, trial_id: int, key: str, value: Any) -> None:
         request = api_pb2.SetTrialUserAttributeRequest(
             trial_id=trial_id, key=key, value=json.dumps(value)
         )
-        try:
-            self._stub.SetTrialUserAttribute(request)
-        except grpc.RpcError as e:
-            if e.code() == grpc.StatusCode.NOT_FOUND:
-                raise KeyError from e
-            elif e.code() == grpc.StatusCode.FAILED_PRECONDITION:
-                raise UpdateFinishedTrialError from e
-            else:
-                raise
+        with create_insecure_channel(self._host, self._port) as channel:
+            stub = create_stub(channel)
+            try:
+                stub.SetTrialUserAttribute(request)
+            except grpc.RpcError as e:
+                if e.code() == grpc.StatusCode.NOT_FOUND:
+                    raise KeyError from e
+                elif e.code() == grpc.StatusCode.FAILED_PRECONDITION:
+                    raise UpdateFinishedTrialError from e
+                else:
+                    raise
 
     def set_trial_system_attr(self, trial_id: int, key: str, value: Any) -> None:
         request = api_pb2.SetTrialSystemAttributeRequest(
             trial_id=trial_id, key=key, value=json.dumps(value)
         )
-        try:
-            self._stub.SetTrialSystemAttribute(request)
-        except grpc.RpcError as e:
-            if e.code() == grpc.StatusCode.NOT_FOUND:
-                raise KeyError from e
-            elif e.code() == grpc.StatusCode.FAILED_PRECONDITION:
-                raise UpdateFinishedTrialError from e
-            else:
-                raise
+        with create_insecure_channel(self._host, self._port) as channel:
+            stub = create_stub(channel)
+            try:
+                stub.SetTrialSystemAttribute(request)
+            except grpc.RpcError as e:
+                if e.code() == grpc.StatusCode.NOT_FOUND:
+                    raise KeyError from e
+                elif e.code() == grpc.StatusCode.FAILED_PRECONDITION:
+                    raise UpdateFinishedTrialError from e
+                else:
+                    raise
 
     def get_trial_id_from_study_id_trial_number(self, study_id: int, trial_number: int) -> int:
         request = api_pb2.GetTrialIdFromStudyIdTrialNumberRequest(
             study_id=study_id, trial_number=trial_number
         )
-        try:
-            response = self._stub.GetTrialIdFromStudyIdTrialNumber(request)
-        except grpc.RpcError as e:
-            if e.code() == grpc.StatusCode.NOT_FOUND:
-                raise KeyError from e
-            raise
+        with create_insecure_channel(self._host, self._port) as channel:
+            stub = create_stub(channel)
+            try:
+                response = stub.GetTrialIdFromStudyIdTrialNumber(request)
+            except grpc.RpcError as e:
+                if e.code() == grpc.StatusCode.NOT_FOUND:
+                    raise KeyError from e
+                raise
         return response.trial_id
 
     def get_trial(self, trial_id: int) -> FrozenTrial:
         request = api_pb2.GetTrialRequest(trial_id=trial_id)
-        try:
-            response = self._stub.GetTrial(request)
-        except grpc.RpcError as e:
-            if e.code() == grpc.StatusCode.NOT_FOUND:
-                raise KeyError from e
-            raise
+        with create_insecure_channel(self._host, self._port) as channel:
+            stub = create_stub(channel)
+            try:
+                response = stub.GetTrial(request)
+            except grpc.RpcError as e:
+                if e.code() == grpc.StatusCode.NOT_FOUND:
+                    raise KeyError from e
+                raise
         return grpc_servicer._from_proto_trial(response.trial)
 
     def get_all_trials(
@@ -371,9 +403,10 @@ class GrpcStorageProxy(BaseStorage):
 
 
 class GrpcClientCache:
-    def __init__(self, grpc_client: api_pb2_grpc.StorageServiceStub) -> None:
+    def __init__(self, host: str, port: int) -> None:
         self.studies: dict[int, GrpcClientCacheEntry] = {}
-        self.grpc_client = grpc_client
+        self.host = host
+        self.port = port
         self.lock = threading.Lock()
 
     def delete_study_cache(self, study_id: int) -> None:
@@ -404,13 +437,15 @@ class GrpcClientCache:
             included_trial_ids=study.unfinished_trial_ids,
             trial_id_greater_than=study.last_finished_trial_id,
         )
-        try:
-            res = self.grpc_client.GetTrials(req)
-        except grpc.RpcError as e:
-            if e.code() == grpc.StatusCode.NOT_FOUND:
-                self.studies.pop(study_id, None)
-                raise KeyError from e
-            raise
+        with create_insecure_channel(self.host, self.port) as channel:
+            stub = create_stub(channel)
+            try:
+                res = stub.GetTrials(req)
+            except grpc.RpcError as e:
+                if e.code() == grpc.StatusCode.NOT_FOUND:
+                    self.studies.pop(study_id, None)
+                    raise KeyError from e
+                raise
         if not res.trials:
             return
 

--- a/optuna/storages/_grpc/client.py
+++ b/optuna/storages/_grpc/client.py
@@ -89,8 +89,7 @@ class GrpcStorageProxy(BaseStorage):
         self._stub = api_pb2_grpc.StorageServiceStub(self._channel)
         self._cache = GrpcClientCache(self._stub)
 
-    def __del__(self) -> None:
-        del self._cache
+    def close(self) -> None:
         self._channel.close()
 
     def __getstate__(self) -> dict[Any, Any]:

--- a/optuna/storages/_grpc/client.py
+++ b/optuna/storages/_grpc/client.py
@@ -45,6 +45,7 @@ def create_insecure_channel(host: str, port: int) -> grpc.Channel:
 def create_stub(channel: grpc.Channel) -> api_pb2_grpc.StorageServiceStub:
     return api_pb2_grpc.StorageServiceStub(channel)
 
+
 @experimental_class("4.2.0")
 class GrpcStorageProxy(BaseStorage):
     """gRPC client for :func:`~optuna.storages.run_grpc_proxy_server`.

--- a/optuna/storages/_grpc/client.py
+++ b/optuna/storages/_grpc/client.py
@@ -84,14 +84,11 @@ class GrpcStorageProxy(BaseStorage):
         self.setup()
 
     def setup(self) -> None:
-        def wait_server(host: str, port: int, timeout: int) -> None:
-            try:
-                with create_insecure_channel(host, port) as channel:
-                    grpc.channel_ready_future(channel).result(timeout=timeout)
-            except grpc.FutureTimeoutError as e:
-                raise ConnectionError("GRPC connection timeout") from e
-
-        wait_server(self._host, self._port, self._timeout)
+        try:
+            with create_insecure_channel(self._host, self._port) as channel:
+                grpc.channel_ready_future(channel).result(timeout=self._timeout)
+        except grpc.FutureTimeoutError as e:
+            raise ConnectionError("GRPC connection timeout") from e
         self._cache = GrpcClientCache(self._host, self._port)
 
     def __getstate__(self) -> dict[Any, Any]:

--- a/optuna/storages/_grpc/client.py
+++ b/optuna/storages/_grpc/client.py
@@ -77,7 +77,7 @@ class GrpcStorageProxy(BaseStorage):
         self._port = port
         self.setup()
 
-    def setup(self) -> None:
+    def _setup(self) -> None:
         self._channel = create_insecure_channel(self._host, self._port)
         self._stub = api_pb2_grpc.StorageServiceStub(self._channel)
         self._cache = GrpcClientCache(self._stub)

--- a/optuna/storages/_grpc/client.py
+++ b/optuna/storages/_grpc/client.py
@@ -82,7 +82,7 @@ class GrpcStorageProxy(BaseStorage):
         self._stub = api_pb2_grpc.StorageServiceStub(self._channel)
         self._cache = GrpcClientCache(self._stub)
 
-    def wait_server_ready(self, timeout: float) -> None:
+    def wait_server_ready(self, timeout: float | None = None) -> None:
         try:
             with create_insecure_channel(self._host, self._port) as channel:
                 grpc.channel_ready_future(channel).result(timeout=timeout)

--- a/optuna/storages/_grpc/client.py
+++ b/optuna/storages/_grpc/client.py
@@ -75,7 +75,7 @@ class GrpcStorageProxy(BaseStorage):
     def __init__(self, *, host: str = "localhost", port: int = 13000) -> None:
         self._host = host
         self._port = port
-        self.setup()
+        self._setup()
 
     def _setup(self) -> None:
         self._channel = create_insecure_channel(self._host, self._port)
@@ -101,7 +101,7 @@ class GrpcStorageProxy(BaseStorage):
 
     def __setstate__(self, state: dict[Any, Any]) -> None:
         self.__dict__.update(state)
-        self.setup()
+        self._setup()
 
     def create_new_study(
         self, directions: Sequence[StudyDirection], study_name: str | None = None

--- a/optuna/storages/_grpc/client.py
+++ b/optuna/storages/_grpc/client.py
@@ -86,7 +86,7 @@ class GrpcStorageProxy(BaseStorage):
     def setup(self) -> None:
         def wait_server(host: str, port: int, timeout: int) -> None:
             try:
-                with self.create_insecure_channel(host, port) as channel:
+                with create_insecure_channel(host, port) as channel:
                     grpc.channel_ready_future(channel).result(timeout=timeout)
             except grpc.FutureTimeoutError as e:
                 raise ConnectionError("GRPC connection timeout") from e

--- a/optuna/storages/_grpc/client.py
+++ b/optuna/storages/_grpc/client.py
@@ -41,6 +41,7 @@ def create_insecure_channel(host: str, port: int) -> grpc.Channel:
         f"{host}:{port}", options=[("grpc.max_receive_message_length", -1)]
     )
 
+
 @experimental_class("4.2.0")
 class GrpcStorageProxy(BaseStorage):
     """gRPC client for :func:`~optuna.storages.run_grpc_proxy_server`.

--- a/optuna/testing/storages.py
+++ b/optuna/testing/storages.py
@@ -121,7 +121,7 @@ class StorageSupplier:
 
         if self.server:
             assert self.thread is not None
-            self.server.stop(None)
+            self.server.stop(5).wait()
             self.thread.join()
             self.server = None
             self.thread = None

--- a/optuna/testing/storages.py
+++ b/optuna/testing/storages.py
@@ -48,6 +48,7 @@ class StorageSupplier:
         self.tempfile: IO[Any] | None = None
         self.server: grpc.Server | None = None
         self.thread: threading.Thread | None = None
+        self.proxy: GrpcStorageProxy | None = None
 
     def __enter__(
         self,
@@ -99,7 +100,8 @@ class StorageSupplier:
             self.thread = threading.Thread(target=self.server.start)
             self.thread.start()
 
-            return GrpcStorageProxy(host="localhost", port=port, timeout=60)
+            self.proxy = GrpcStorageProxy(host="localhost", port=port, timeout=60)
+            return self.proxy
         else:
             assert False
 
@@ -108,6 +110,10 @@ class StorageSupplier:
     ) -> None:
         if self.tempfile:
             self.tempfile.close()
+
+        if self.proxy:
+            del self.proxy
+            self.proxy = None
 
         if self.server:
             assert self.thread is not None

--- a/optuna/testing/storages.py
+++ b/optuna/testing/storages.py
@@ -95,16 +95,7 @@ class StorageSupplier:
             self.thread = threading.Thread(target=self.server.start)
             self.thread.start()
 
-            self.storage = GrpcStorageProxy(host="localhost", port=port)
-
-            # Wait until the server is ready.
-            while True:
-                try:
-                    self.storage.get_all_studies()
-                    break
-                except grpc.RpcError:
-                    time.sleep(1)
-                    continue
+            self.storage = GrpcStorageProxy(host="localhost", port=port, timeout=60)
         else:
             assert False
         assert self.storage is not None

--- a/optuna/testing/storages.py
+++ b/optuna/testing/storages.py
@@ -95,12 +95,12 @@ class StorageSupplier:
             port = _find_free_port()
 
             self.server = optuna.storages._grpc.server.make_server(
-                optuna.storages.RDBStorage(url), "127.0.0.1", port
+                optuna.storages.RDBStorage(url), "localhost", port
             )
             self.thread = threading.Thread(target=self.server.start)
             self.thread.start()
 
-            proxy = GrpcStorageProxy(host="127.0.0.1", port=port)
+            proxy = GrpcStorageProxy(host="localhost", port=port)
 
             # Wait until the server is ready.
             while True:

--- a/optuna/testing/storages.py
+++ b/optuna/testing/storages.py
@@ -48,7 +48,6 @@ class StorageSupplier:
         self.tempfile: IO[Any] | None = None
         self.server: grpc.Server | None = None
         self.thread: threading.Thread | None = None
-        self.storage: optuna.storages.BaseStorage | None = None
 
     def __enter__(
         self,
@@ -109,10 +108,6 @@ class StorageSupplier:
     ) -> None:
         if self.tempfile:
             self.tempfile.close()
-
-        if self.storage:
-            del self.storage
-            self.storage = None
 
         if self.server:
             assert self.thread is not None

--- a/optuna/testing/storages.py
+++ b/optuna/testing/storages.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import socket
 import threading
-import time
 from types import TracebackType
 from typing import Any
 from typing import IO

--- a/optuna/testing/storages.py
+++ b/optuna/testing/storages.py
@@ -119,9 +119,9 @@ class StorageSupplier:
 
 
 def _find_free_port() -> int:
-    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     for port in range(13000, 13100):
         try:
+            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             sock.bind(("localhost", port))
             return port
         except OSError:

--- a/optuna/testing/storages.py
+++ b/optuna/testing/storages.py
@@ -95,12 +95,12 @@ class StorageSupplier:
             port = _find_free_port()
 
             self.server = optuna.storages._grpc.server.make_server(
-                optuna.storages.RDBStorage(url), "localhost", port
+                optuna.storages.RDBStorage(url), "127.0.0.1", port
             )
             self.thread = threading.Thread(target=self.server.start)
             self.thread.start()
 
-            proxy = GrpcStorageProxy(host="localhost", port=port)
+            proxy = GrpcStorageProxy(host="127.0.0.1", port=port)
 
             # Wait until the server is ready.
             while True:

--- a/optuna/testing/storages.py
+++ b/optuna/testing/storages.py
@@ -99,7 +99,7 @@ class StorageSupplier:
             self.thread = threading.Thread(target=self.server.start)
             self.thread.start()
 
-            return GrpcStorageProxy(host="localhost", port=port)
+            return GrpcStorageProxy(host="localhost", port=port, timeout=60)
         else:
             assert False
 

--- a/optuna/testing/storages.py
+++ b/optuna/testing/storages.py
@@ -53,13 +53,7 @@ class StorageSupplier:
 
     def __enter__(
         self,
-    ) -> (
-        optuna.storages.InMemoryStorage
-        | optuna.storages._CachedStorage
-        | optuna.storages.RDBStorage
-        | optuna.storages.JournalStorage
-        | optuna.storages.GrpcStorageProxy
-    ):
+    ) -> optuna.storages.BaseStorage:
         if self.storage_specifier == "inmemory":
             if len(self.extra_args) > 0:
                 raise ValueError("InMemoryStorage does not accept any arguments!")
@@ -113,6 +107,7 @@ class StorageSupplier:
                     continue
         else:
             assert False
+        assert self.storage is not None
         return self.storage
 
     def __exit__(
@@ -123,6 +118,7 @@ class StorageSupplier:
 
         if self.storage:
             del self.storage
+            self.storage = None
 
         if self.server:
             assert self.thread is not None

--- a/optuna/testing/storages.py
+++ b/optuna/testing/storages.py
@@ -120,7 +120,7 @@ class StorageSupplier:
             self.tempfile.close()
 
         if self.proxy:
-            del self.proxy
+            self.proxy.close()
             self.proxy = None
 
         if self.server:

--- a/optuna/testing/storages.py
+++ b/optuna/testing/storages.py
@@ -110,7 +110,8 @@ class StorageSupplier:
         self.server = optuna.storages._grpc.server.make_server(storage, "localhost", port)
         self.thread = threading.Thread(target=self.server.start)
         self.thread.start()
-        self.proxy = GrpcStorageProxy(host="localhost", port=port, timeout=60)
+        self.proxy = GrpcStorageProxy(host="localhost", port=port)
+        self.proxy.wait_server_ready(timeout=60)
         return self.proxy
 
     def __exit__(


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
The GrpcStorageProxy class introduced in v4.2.0 does not have any mechanism to wait for the server to start, so users need to write code to wait for the server to start. In this PR, we change the GrpcStorageProxy class to wait for the server to start when initializing. 

## Description of the changes
<!-- Describe the changes in this PR. -->
Use grpc.channel_ready_future function for wait to server.