### PR TITLE
Remove warning messages for Matplotlib-based `plot_contour` and `plot_rank`

### DIFF
--- a/optuna/visualization/matplotlib/_contour.py
+++ b/optuna/visualization/matplotlib/_contour.py
@@ -7,7 +7,6 @@ import numpy as np
 
 from optuna._experimental import experimental_func
 from optuna._imports import try_import
-from optuna.logging import get_logger
 from optuna.study import Study
 from optuna.trial import FrozenTrial
 from optuna.visualization._contour import _AxisInfo
@@ -27,8 +26,6 @@ if _imports.is_successful():
     from optuna.visualization.matplotlib._matplotlib_imports import ContourSet
     from optuna.visualization.matplotlib._matplotlib_imports import plt
 
-_logger = get_logger(__name__)
-
 
 CONTOUR_POINT_NUM = 100
 
@@ -47,11 +44,6 @@ def plot_contour(
 
     .. seealso::
         Please refer to :func:`optuna.visualization.plot_contour` for an example.
-
-    Warnings:
-        Output figures of this Matplotlib-based
-        :func:`~optuna.visualization.matplotlib.plot_contour` function would be different from
-        those of the Plotly-based :func:`~optuna.visualization.plot_contour`.
 
     Args:
         study:
@@ -76,10 +68,6 @@ def plot_contour(
     """
 
     _imports.check()
-    _logger.warning(
-        "Output figures of this Matplotlib-based `plot_contour` function would be different from "
-        "those of the Plotly-based `plot_contour`."
-    )
     info = _get_contour_info(study, params, target, target_name)
     return _get_contour_plot(info)
 

--- a/optuna/visualization/matplotlib/_rank.py
+++ b/optuna/visualization/matplotlib/_rank.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from collections.abc import Callable
 
 from optuna._experimental import experimental_func
-from optuna.logging import get_logger
 from optuna.study import Study
 from optuna.trial import FrozenTrial
 from optuna.visualization._rank import _get_rank_info
@@ -17,9 +16,6 @@ if _imports.is_successful():
     from optuna.visualization.matplotlib._matplotlib_imports import Axes
     from optuna.visualization.matplotlib._matplotlib_imports import PathCollection
     from optuna.visualization.matplotlib._matplotlib_imports import plt
-
-
-_logger = get_logger(__name__)
 
 
 @experimental_func("3.2.0")
@@ -36,11 +32,6 @@ def plot_rank(
 
     .. seealso::
         Please refer to :func:`optuna.visualization.plot_rank` for an example.
-
-    Warnings:
-        Output figures of this Matplotlib-based
-        :func:`~optuna.visualization.matplotlib.plot_rank` function would be different from
-        those of the Plotly-based :func:`~optuna.visualization.plot_rank`.
 
     Args:
         study:
@@ -61,10 +52,6 @@ def plot_rank(
     """
 
     _imports.check()
-    _logger.warning(
-        "Output figures of this Matplotlib-based `plot_rank` function would be different from "
-        "those of the Plotly-based `plot_rank`."
-    )
     info = _get_rank_info(study, params, target, target_name)
     return _get_rank_plot(info)
 


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

The difference between plotly-based `plot_contour` and Matplotlib-based one is resolved by #2810. So the warning message is no longer needed.
(If you want to see the difference between them, check out the [Optuna Visual Regression Tests](https://optuna.github.io/optuna-visualization-regression-tests/).)

## Description of the changes
<!-- Describe the changes in this PR. -->
Removing warning messages for Matplotlib-based `plot_contour` and `plot_rank`.
