### PR TITLE
Deprecate `use_separable_cma` in `CmaEsSampler`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
   "sqlalchemy>=1.4.2",
   "tqdm",
   "PyYAML",  # Only used in `optuna/cli.py`.
+  "cmaes>=0.10.0",  # optuna/samplers/_cmaes.py.
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
- Simplify the `CmaEsSampler` implementation by reducing the number of arguments.
- ref: [Introduce ExtendedCmaEsSampler #252](https://github.com/optuna/optunahub-registry/pull/252/files)

## Description of the changes
- Deprecates the `_use_separable_cma` argument.
- Introduces `ExtendedCmaEsSampler` in OptunaHub, which inherits from `CmaEsSampler` and retains support for `_use_separable_cma`.
