### PR TITLE
Add workflow_dispatch trigger to all the CI

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -7,6 +7,7 @@ on:
   pull_request: {}
   schedule:
     - cron: '0 23 * * SUN-THU'
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/master' && github.run_number || github.ref }}

--- a/.github/workflows/matplotlib-tests.yml
+++ b/.github/workflows/matplotlib-tests.yml
@@ -6,6 +6,7 @@ on:
       - .github/workflows/matplotlib-tests.yml
       - optuna/visualization/**.py
       - tests/visualization_tests/**
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/master' && github.run_number || github.ref }}

--- a/.github/workflows/speed-benchmarks.yml
+++ b/.github/workflows/speed-benchmarks.yml
@@ -3,6 +3,7 @@ name: Speed benchmarks
 on:
   schedule:
     - cron: '0 23 * * SUN-THU'
+  workflow_dispatch:
 
 jobs:
   speed-benchmarks:

--- a/.github/workflows/sphinx-build.yml
+++ b/.github/workflows/sphinx-build.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
   pull_request: {}
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/master' && github.run_number || github.ref }}

--- a/.github/workflows/tests-storage.yml
+++ b/.github/workflows/tests-storage.yml
@@ -1,13 +1,13 @@
 name: Tests (Storage with server)
 
 on:
-  workflow_dispatch:
   push:
     branches:
       - master
   pull_request: {}
   schedule:
     - cron: '0 23 * * SUN-THU'
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/master' && github.run_number || github.ref }}


### PR DESCRIPTION
## Motivation
Add workflow_dispatch trigger to the rest of the CIs for convenience.


## Description of the changes
This PR introduces workflow_dispatch trigger to the all CIs, except `Coverage`, `Build Docker Image`, `Publish distributions to PyPI or TestPyPI`, `Reviewdog`, and `Stale`

