### PR TITLE
Made error message for `create_study`'s direction easier to understand `optuna.study`

### DIFF
--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -1256,8 +1256,8 @@ def create_study(
         for d in directions
     ):
         raise ValueError(
-            "Please set either 'minimize' or 'maximize' to direction. You can also set the "
-            "corresponding `StudyDirection` member."
+            f"`directions` must be a list of `minimize` or `maximize`, but got {directions}. "
+            "For single-objective optimization, please use `direction` instead of `directions`."
         )
 
     direction_objects = [

--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -1239,6 +1239,10 @@ def create_study(
     elif direction is not None and directions is not None:
         raise ValueError("Specify only one of `direction` and `directions`.")
     elif direction is not None:
+        if isinstance(direction, Sequence) and not isinstance(direction, str):
+            raise ValueError(
+                "For multi-objective optimization, using `directions` instead of `direction`."
+            )
         directions = [direction]
     elif directions is not None:
         directions = list(directions)

--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -1241,7 +1241,7 @@ def create_study(
     elif direction is not None:
         if isinstance(direction, Sequence) and not isinstance(direction, str):
             raise ValueError(
-                "For multi-objective optimization, using `directions` instead of `direction`."
+                "Use `directions` instead of `direction` for multi-objective optimization."
             )
         directions = [direction]
     elif directions is not None:

--- a/tests/study_tests/test_study.py
+++ b/tests/study_tests/test_study.py
@@ -154,6 +154,9 @@ def test_optimize_with_direction() -> None:
     with pytest.raises(ValueError):
         create_study(direction=["maximize", "minimize"])  # type: ignore [arg-type]
 
+    with pytest.raises(ValueError):
+        create_study(directions="minimize")
+
 
 @pytest.mark.parametrize("n_trials", (0, 1, 20))
 @pytest.mark.parametrize("n_jobs", (1, 2, -1))

--- a/tests/study_tests/test_study.py
+++ b/tests/study_tests/test_study.py
@@ -152,8 +152,6 @@ def test_optimize_with_direction() -> None:
         create_study(direction="test")
 
     with pytest.raises(ValueError):
-        # Type hintingly wrong input.
-        # Make mypy detection be ignored.
         create_study(direction=["maximize", "minimize"])  # type: ignore [arg-type]
 
 

--- a/tests/study_tests/test_study.py
+++ b/tests/study_tests/test_study.py
@@ -148,8 +148,19 @@ def test_optimize_with_direction() -> None:
     assert study.direction == StudyDirection.MAXIMIZE
     check_study(study)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError) as e:
         create_study(direction="test")
+    assert str(e.value) == (
+        "Please set either 'minimize' or 'maximize' to direction. You can also set the "
+        + "corresponding `StudyDirection` member."
+    )
+
+    with pytest.raises(ValueError) as e:
+        create_study(direction=["maximize", "minimize"])
+    assert (
+        str(e.value)
+        == "For multi-objective optimization, using `directions` instead of `direction`."
+    )
 
 
 @pytest.mark.parametrize("n_trials", (0, 1, 20))
@@ -1152,15 +1163,18 @@ def test_create_study_with_multi_objectives() -> None:
     assert study.directions == [StudyDirection.MAXIMIZE, StudyDirection.MINIMIZE]
     assert study._is_multi_objective()
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError) as e:
         # Empty `direction` isn't allowed.
         _ = create_study(directions=[])
+    assert str(e.value) == "The number of objectives must be greater than 0."
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError) as e:
         _ = create_study(direction="minimize", directions=["maximize"])
+    assert str(e.value) == "Specify only one of `direction` and `directions`."
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError) as e:
         _ = create_study(direction="minimize", directions=[])
+    assert str(e.value) == "Specify only one of `direction` and `directions`."
 
 
 def test_create_study_with_direction_object() -> None:

--- a/tests/study_tests/test_study.py
+++ b/tests/study_tests/test_study.py
@@ -148,19 +148,13 @@ def test_optimize_with_direction() -> None:
     assert study.direction == StudyDirection.MAXIMIZE
     check_study(study)
 
-    with pytest.raises(ValueError) as e:
+    with pytest.raises(ValueError):
         create_study(direction="test")
-    assert str(e.value) == (
-        "Please set either 'minimize' or 'maximize' to direction. You can also set the "
-        + "corresponding `StudyDirection` member."
-    )
 
-    with pytest.raises(ValueError) as e:
-        create_study(direction=["maximize", "minimize"])
-    assert (
-        str(e.value)
-        == "For multi-objective optimization, using `directions` instead of `direction`."
-    )
+    with pytest.raises(ValueError):
+        # Type hintingly wrong input.
+        # Make mypy detection be ignored.
+        create_study(direction=["maximize", "minimize"])  # type: ignore [arg-type]
 
 
 @pytest.mark.parametrize("n_trials", (0, 1, 20))
@@ -1163,18 +1157,15 @@ def test_create_study_with_multi_objectives() -> None:
     assert study.directions == [StudyDirection.MAXIMIZE, StudyDirection.MINIMIZE]
     assert study._is_multi_objective()
 
-    with pytest.raises(ValueError) as e:
+    with pytest.raises(ValueError):
         # Empty `direction` isn't allowed.
         _ = create_study(directions=[])
-    assert str(e.value) == "The number of objectives must be greater than 0."
 
-    with pytest.raises(ValueError) as e:
+    with pytest.raises(ValueError):
         _ = create_study(direction="minimize", directions=["maximize"])
-    assert str(e.value) == "Specify only one of `direction` and `directions`."
 
-    with pytest.raises(ValueError) as e:
+    with pytest.raises(ValueError):
         _ = create_study(direction="minimize", directions=[])
-    assert str(e.value) == "Specify only one of `direction` and `directions`."
 
 
 def test_create_study_with_direction_object() -> None:


### PR DESCRIPTION
issue: #5806

## Motivation

Users sometimes makes the mistake of passing the list of directions to the direction argument. The error message for this mistake is hard to understand what is the problem.

- Correct
```python
optuna.create_study(directions=["minimize", "minimize"])
```
- Wrong

Using direction instead of directions

```python
optuna.create_study(direction=["minimize", "minimize"])
```
```
ValueError: Please set either 'minimize' or 'maximize' to direction. You can also set the corresponding `StudyDirection` member.
```


## Description of the changes
The error message displayed when a list object, is assigned to the direction parameter of create_study has been changed as follows.

- previous
```
ValueError: Please set either 'minimize' or 'maximize' to direction. You can also set the corresponding `StudyDirection` member.
```

- new
```
ValueError: For multi-objective optimization, using `directions` instead of `direction`.
```
