### PR TITLE
add understandable error message for direction in multi-objective opt…

### DIFF
--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -1239,6 +1239,10 @@ def create_study(
     elif direction is not None and directions is not None:
         raise ValueError("Specify only one of `direction` and `directions`.")
     elif direction is not None:
+        if isinstance(direction, Sequence) and not isinstance(direction, str):
+            raise ValueError(
+                "For multi-objective optimization, using `directions` instead of `direction`."
+            )
         directions = [direction]
     elif directions is not None:
         directions = list(directions)


### PR DESCRIPTION
This PR is a new one to work around this #6021 Check issue.

issue: #5806

## Motivation

Users sometimes makes the mistake of passing the list of directions to the direction argument. The error message for this mistake is hard to understand what is the problem.

- Correct
```python
optuna.create_study(directions=["minimize", "minimize"])
```
- Wrong

Using direction instead of directions

```python
optuna.create_study(direction=["minimize", "minimize"])
```
```
ValueError: Please set either 'minimize' or 'maximize' to direction. You can also set the corresponding `StudyDirection` member.
```


## Description of the changes
The error message displayed when a list object, is assigned to the direction parameter of create_study has been changed as follows.

- previous
```
ValueError: Please set either 'minimize' or 'maximize' to direction. You can also set the corresponding `StudyDirection` member.
```

- new
```
ValueError: For multi-objective optimization, using `directions` instead of `direction`.
```
