### PR TITLE
Introduce server-side TTL cache in `GrpcStorageProxy`

### DIFF
--- a/optuna/storages/_grpc/servicer.py
+++ b/optuna/storages/_grpc/servicer.py
@@ -42,7 +42,7 @@ class CachedTrials:
 
 
 class OptunaStorageProxyService(api_pb2_grpc.StorageServiceServicer):
-    def __init__(self, storage: BaseStorage, ttl_seconds: float = 0.0) -> None:
+    def __init__(self, storage: BaseStorage, ttl_seconds: float = 10.0) -> None:
         self._backend = storage
         self._lock = threading.Lock()
         self._ttl_seconds = ttl_seconds

--- a/optuna/storages/_grpc/servicer.py
+++ b/optuna/storages/_grpc/servicer.py
@@ -341,6 +341,7 @@ class OptunaStorageProxyService(api_pb2_grpc.StorageServiceServicer):
         included_trial_ids = set(request.included_trial_ids)
         trial_id_greater_than = request.trial_id_greater_than
         if time.time() - self._cached_trials[study_id].last_sync_time >= self._ttl_seconds:
+            _logger.info("Syncing trials for study_id=%d", study_id)
             try:
                 self._cached_trials[study_id].trials = self._backend.get_all_trials(
                     study_id, deepcopy=False

--- a/optuna/storages/_grpc/servicer.py
+++ b/optuna/storages/_grpc/servicer.py
@@ -353,7 +353,7 @@ class OptunaStorageProxyService(api_pb2_grpc.StorageServiceServicer):
             with self._lock:
                 now = time.time()
                 if now >= self._cached_trials[study_id].last_sync_time + self._ttl_cache_seconds:
-                    _logger.info("Syncing trials for study_id=%d", study_id)
+                    _logger.debug("Syncing trials for study_id=%d", study_id)
                     self._cached_trials[study_id].trials = self._get_all_trials(study_id, context)
                     self._cached_trials[study_id].last_sync_time = now
             trials = self._cached_trials[study_id].trials

--- a/optuna/testing/storages.py
+++ b/optuna/testing/storages.py
@@ -40,6 +40,11 @@ STORAGE_MODES_HEARTBEAT = [
     "cached_sqlite",
 ]
 
+STORAGE_MODES_GRPC = [
+    "grpc_rdb",
+    "grpc_journal_file",
+]
+
 SQLITE3_TIMEOUT = 300
 
 
@@ -107,7 +112,9 @@ class StorageSupplier:
 
     def _create_proxy(self, storage: BaseStorage) -> GrpcStorageProxy:
         port = _find_free_port()
-        self.server = optuna.storages._grpc.server.make_server(storage, "localhost", port)
+        self.server = optuna.storages._grpc.server.make_server(
+            storage, "localhost", port, **self.extra_args
+        )
         self.thread = threading.Thread(target=self.server.start)
         self.thread.start()
         self.proxy = GrpcStorageProxy(host="localhost", port=port)

--- a/optuna/testing/storages.py
+++ b/optuna/testing/storages.py
@@ -114,7 +114,7 @@ class StorageSupplier:
         extra_args = self.extra_args.copy()
         extra_args.pop("base_storage", None)
         self.server = optuna.storages._grpc.server.make_server(
-            storage, "localhost", port, **self.extra_args
+            storage, "localhost", port, **extra_args
         )
         self.thread = threading.Thread(target=self.server.start)
         self.thread.start()

--- a/optuna/testing/storages.py
+++ b/optuna/testing/storages.py
@@ -40,10 +40,6 @@ STORAGE_MODES_HEARTBEAT = [
     "cached_sqlite",
 ]
 
-STORAGE_MODES_GRPC = [
-    "grpc_rdb",
-    "grpc_journal_file",
-]
 
 SQLITE3_TIMEOUT = 300
 

--- a/optuna/testing/storages.py
+++ b/optuna/testing/storages.py
@@ -111,6 +111,8 @@ class StorageSupplier:
 
     def _create_proxy(self, storage: BaseStorage) -> GrpcStorageProxy:
         port = _find_free_port()
+        extra_args = self.extra_args.copy()
+        extra_args.pop("base_storage", None)
         self.server = optuna.storages._grpc.server.make_server(
             storage, "localhost", port, **self.extra_args
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,6 +103,7 @@ test = [
   "torch; python_version<='3.12'",  # TODO(gen740): Remove this line when 'torch', a dependency of 'optuna/_gp', supports Python 3.13
   "grpcio",  # optuna/storages/_grpc.
   "protobuf>=5.28.1",  # optuna/storages/_grpc.
+  "freezegun",
 ]
 
 [project.urls]

--- a/tests/storages_tests/test_grpc.py
+++ b/tests/storages_tests/test_grpc.py
@@ -7,10 +7,15 @@ from freezegun import freeze_time
 import pytest
 
 from optuna.study._study_direction import StudyDirection
-from optuna.testing.storages import STORAGE_MODES_GRPC
 from optuna.testing.storages import StorageSupplier
 
 from .test_storages import generate_trial
+
+
+STORAGE_MODES_GRPC = [
+    "grpc_rdb",
+    "grpc_journal_file",
+]
 
 
 @pytest.mark.parametrize("storage_mode", STORAGE_MODES_GRPC)

--- a/tests/storages_tests/test_grpc.py
+++ b/tests/storages_tests/test_grpc.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from datetime import timedelta
+import random
+
+from freezegun import freeze_time
+import pytest
+
+from optuna.study._study_direction import StudyDirection
+from optuna.testing.storages import STORAGE_MODES_GRPC
+from optuna.testing.storages import StorageSupplier
+
+from .test_storages import generate_trial
+
+
+@pytest.mark.parametrize("storage_mode", STORAGE_MODES_GRPC)
+def test_get_all_trials_ttl_cache_is_none(storage_mode: str) -> None:
+    n_trials_init = 1
+    n_trials_add = 2
+    with StorageSupplier(storage_mode) as storage:
+        study_id = storage.create_new_study(directions=[StudyDirection.MAXIMIZE])
+        generator = random.Random(51)
+
+        for _ in range(n_trials_init):
+            t = generate_trial(generator)
+            storage.create_new_trial(study_id, template_trial=t)
+
+        # Synchronize the storage cache.
+        trials = storage.get_all_trials(study_id)
+        assert len(trials) == n_trials_init
+
+        for _ in range(n_trials_add):
+            t = generate_trial(generator)
+            storage.create_new_trial(study_id, template_trial=t)
+
+        # Synchronize the storage cache always if ttl_cache_seconds is None.
+        trials = storage.get_all_trials(study_id)
+        assert len(trials) == n_trials_init + n_trials_add
+
+
+@pytest.mark.parametrize("storage_mode", STORAGE_MODES_GRPC)
+def test_get_all_trials_ttl_cache(storage_mode: str) -> None:
+    n_trials_init = 1
+    n_trials_add = 2
+    ttl_cache_seconds = 10
+    with StorageSupplier(storage_mode, ttl_cache_seconds=ttl_cache_seconds) as storage:
+        with freeze_time() as frozen_datetime:
+            study_id = storage.create_new_study(directions=[StudyDirection.MAXIMIZE])
+            generator = random.Random(51)
+
+            for _ in range(n_trials_init):
+                t = generate_trial(generator)
+                storage.create_new_trial(study_id, template_trial=t)
+
+            # Synchronize the storage cache.
+            trials = storage.get_all_trials(study_id)
+            assert len(trials) == n_trials_init
+
+            for _ in range(n_trials_add):
+                t = generate_trial(generator)
+                storage.create_new_trial(study_id, template_trial=t)
+
+            # not synchronized yet.
+            trials = storage.get_all_trials(study_id)
+            assert len(trials) == n_trials_init
+
+            frozen_datetime.tick(delta=timedelta(seconds=ttl_cache_seconds))
+            # Synchronize the storage cache after the ttl_cache_seconds.
+            trials = storage.get_all_trials(study_id)
+            assert len(trials) == n_trials_init + n_trials_add

--- a/tests/storages_tests/test_storages.py
+++ b/tests/storages_tests/test_storages.py
@@ -784,14 +784,16 @@ def test_get_all_trials_grpc_proxy_server_ttl_cache(
             generator = random.Random(51)
 
             for _ in range(n_trials_init):
-                _generate_trial(generator)
+                t = _generate_trial(generator)
+                storage.create_new_trial(study_id, template_trial=t)
 
             # Synchronize the storage cache.
             trials = storage.get_all_trials(study_id)
             assert len(trials) == n_trials_init
 
             for _ in range(n_trials_add):
-                _generate_trial(generator)
+                t = _generate_trial(generator)
+                storage.create_new_trial(study_id, template_trial=t)
 
             # Synchronize the storage cache if ttl_cache_seconds is None.
             trials = storage.get_all_trials(study_id)


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
To make `GrpcStorageProxy` faster by introducing server-side TTL cache.
In the gRPC storage proxy, if a client reads get_all_trials continuously for a short period of time (e.g. 1 sec), the state of the RDB is expected to not change.
TTL cache for trials can be introduced on the server side to speed up the process. 

## Description of the changes
This PR makes `GrpcStorageProxy` faster by cache `OptunaStorageProxyService.GetTrials` calls. Here is the performance comparison results and the benchmark script I used.

### Results
|  | `master` branch | This PR (ttl_cache_seconds = 10) |
| --- | ------------- | ------------- |
| total | 859.9sec | 233.1sec |
| `client.py:368(get_all_trials)` | 705.3sec | 16.83sec |
| stats | ![image](https://github.com/user-attachments/assets/b4b541b1-29dd-4842-84b3-292a10570319) | ![image](https://github.com/user-attachments/assets/fb8b4f29-ed99-4541-b9d4-5da4cb0ac355) |

<details>
<summary>client.py</summary>

```python
from __future__ import annotations

import argparse
import cProfile
import time
import optuna
from typing import Literal
from optuna.storages import GrpcStorageProxy, BaseStorage
from time import sleep
from uuid import uuid4


study_name = "ttl" + str(uuid4())[:8]
n_trials = 1000

STORAGE_KIND = Literal["grpc", "rdb", "middleware"]
STORAGE_URL = "YOUR_STORAGE_URL"


def get_storage(storage_kind: STORAGE_KIND) -> BaseStorage:
    if storage_kind == "grpc":
        return GrpcStorageProxy(host="localhost", port=13000)
    elif storage_kind == "rdb":
        return optuna.storages.get_storage(STORAGE_URL)


def objective(trial: optuna.Trial) -> float:
    s = 0.0
    for i in range(10):
        trial.set_user_attr(f"attr{i}", "attr value")
    s += trial.suggest_float("x", -10, 10) ** 2
    return s


def study_optimize(storage_kind: STORAGE_KIND, n_trials: int) -> int:
    start = time.time()
    storage = get_storage(storage_kind)
    while True:
        try:
            study = optuna.load_study(storage=storage, study_name=study_name, sampler=optuna.samplers.RandomSampler())
            break
        except:
            sleep(10)
    study.optimize(objective, callbacks=[optuna.study.MaxTrialsCallback(n_trials)])
    elapsed = time.time() - start
    return elapsed


def bench_study_optimize(storage_kind: STORAGE_KIND) -> list[int]:
    elapsed = []
    _study = optuna.create_study(
        storage=get_storage("rdb"),
        study_name=study_name,
        load_if_exists=True,
        sampler=optuna.samplers.RandomSampler(),
    )
    study_optimize(storage_kind, n_trials)
    return elapsed


def main(storage: STORAGE_KIND, benchmark_file: str):
    try:
        optuna.delete_study(storage=get_storage("rdb"), study_name=study_name)
    except:
        pass
    cProfile.runctx(
        f"bench_study_optimize('{storage}')",
        globals(),
        locals(),
        filename=benchmark_file,
    )


if __name__ == "__main__":
    parser = argparse.ArgumentParser()
    parser.add_argument("--storage", type=str, required=True)
    parser.add_argument("--benchmark_file", type=str, required=True)
    args = parser.parse_args()
    main(args.storage, args.benchmark_file)
```

</details>

<details>
<summary>server.py</summary>

```
from __future__ import annotations

import argparse
from optuna.storages import run_grpc_proxy_server
import optuna
import signal


STORAGE_URL = "YOUR_STORAGE_URL"

def handler(signum, frame):
    print("Received signal", signum)
    exit(0)

if __name__ == "__main__":
    parser = argparse.ArgumentParser()
    parser.add_argument("--ttl-cache-seconds", type=float, default=None)
    args = parser.parse_args()
    signal.signal(signal.SIGINT, handler)
    signal.signal(signal.SIGTERM, handler)

    run_grpc_proxy_server(
        optuna.storages.RDBStorage(STORAGE_URL),
        host="localhost",
        port=13000,
        ttl_cache_seconds=args.ttl_cache_seconds,
    )
```

</details>