### PR TITLE
Remove `restart_strategy` and `inc_popsize` to simplify `CmaEsSampler`

### DIFF
--- a/optuna/samplers/_cmaes.py
+++ b/optuna/samplers/_cmaes.py
@@ -168,6 +168,7 @@ class CmaEsSampler(BaseSampler):
                 The removal of this feature is currently scheduled for v6.0.0,
                 but this schedule is subject to change.
                 See https://github.com/optuna/optuna/releases/tag/v4.3.0.
+                `restart_strategy` will be supported in OptunaHub.
 
         popsize:
             A population size of CMA-ES. When ``restart_strategy = 'ipop'``
@@ -266,7 +267,7 @@ class CmaEsSampler(BaseSampler):
             )
             warnings.warn(
                 f"{msg} From v4.3.0 onward, `restart_strategy` automatically falls back to "
-                "`None`.",
+                "`None`. `restart_strategy` will be supported in OptunaHub.",
                 FutureWarning,
             )
 

--- a/optuna/samplers/_cmaes.py
+++ b/optuna/samplers/_cmaes.py
@@ -153,11 +153,6 @@ class CmaEsSampler(BaseSampler):
             Note that the parameters of the first trial in a study are always sampled
             via an independent sampler, so no warning messages are emitted in this case.
 
-            .. note::
-                Added in v2.1.0 as an experimental feature. The interface may change in newer
-                versions without prior notice. See
-                https://github.com/optuna/optuna/releases/tag/v2.1.0.
-
         popsize:
             A population size of CMA-ES. When ``restart_strategy = 'ipop'``
             or ``restart_strategy = 'bipop'`` is specified,

--- a/optuna/samplers/_cmaes.py
+++ b/optuna/samplers/_cmaes.py
@@ -180,11 +180,11 @@ class CmaEsSampler(BaseSampler):
             or ``restart_strategy = 'bipop'`` is specified.
 
             .. warning::
-                Deprecated in v4.4.0. ``restart_strategy`` argument will be removed in the future.
+                Deprecated in v4.4.0. ``inc_posize`` argument will be removed in the future.
                 The removal of this feature is currently scheduled for v6.0.0,
                 but this schedule is subject to change.
-                From v4.4.0 onward, ``restart_strategy`` automatically falls back to ``None``, and
-                ``restart_strategy`` will be supported in OptunaHub.
+                From v4.4.0 onward, ``inc_posize`` automatically falls back to -1, and
+                ``inc_posize`` will be supported in OptunaHub.
                 See https://github.com/optuna/optuna/releases/tag/v4.4.0.
 
         consider_pruned_trials:

--- a/optuna/samplers/_cmaes.py
+++ b/optuna/samplers/_cmaes.py
@@ -405,7 +405,7 @@ class CmaEsSampler(BaseSampler):
 
         if len(solution_trials) >= optimizer.population_size:
             solutions: list[tuple[np.ndarray, float]] = []
-            for t in solution_trials[: self._popsize]:
+            for t in solution_trials[: optimizer.population_size]:
                 assert t.value is not None, "completed trials must have a value"
                 if isinstance(optimizer, cmaes.CMAwM):
                     x = np.array(t.system_attrs["x_for_tell"])

--- a/optuna/samplers/_cmaes.py
+++ b/optuna/samplers/_cmaes.py
@@ -167,8 +167,9 @@ class CmaEsSampler(BaseSampler):
                 Deprecated in v4.4.0. ``restart_strategy`` argument will be removed in the future.
                 The removal of this feature is currently scheduled for v6.0.0,
                 but this schedule is subject to change.
+                From v4.4.0 onward, ``restart_strategy`` automatically falls back to ``None``, and
+                ``restart_strategy`` will be supported in OptunaHub.
                 See https://github.com/optuna/optuna/releases/tag/v4.4.0.
-                `restart_strategy` will be supported in OptunaHub.
 
         popsize:
             A population size of CMA-ES.
@@ -179,7 +180,12 @@ class CmaEsSampler(BaseSampler):
             or ``restart_strategy = 'bipop'`` is specified.
 
             .. warning::
-                Deprecated along with ``restart_strategy``.
+                Deprecated in v4.4.0. ``restart_strategy`` argument will be removed in the future.
+                The removal of this feature is currently scheduled for v6.0.0,
+                but this schedule is subject to change.
+                From v4.4.0 onward, ``restart_strategy`` automatically falls back to ``None``, and
+                ``restart_strategy`` will be supported in OptunaHub.
+                See https://github.com/optuna/optuna/releases/tag/v4.4.0.
 
         consider_pruned_trials:
             If this is :obj:`True`, the PRUNED trials are considered for sampling.
@@ -262,7 +268,7 @@ class CmaEsSampler(BaseSampler):
         lr_adapt: bool = False,
         source_trials: list[FrozenTrial] | None = None,
     ) -> None:
-        if restart_strategy is not None:
+        if restart_strategy is not None or inc_popsize != 2:
             msg = _deprecated._DEPRECATION_WARNING_TEMPLATE.format(
                 name="`restart_strategy`", d_ver="4.4.0", r_ver="6.0.0"
             )

--- a/optuna/samplers/_cmaes.py
+++ b/optuna/samplers/_cmaes.py
@@ -384,9 +384,6 @@ class CmaEsSampler(BaseSampler):
             search_space, transform_step=not self._with_margin, transform_0_1=True
         )
 
-        if self._popsize is None:
-            self._popsize = 4 + math.floor(3 * math.log(len(trans.bounds)))
-
         optimizer = self._restore_optimizer(completed_trials)
         if optimizer is None:
             optimizer = self._init_optimizer(trans, study.direction)

--- a/optuna/samplers/_cmaes.py
+++ b/optuna/samplers/_cmaes.py
@@ -180,11 +180,11 @@ class CmaEsSampler(BaseSampler):
             or ``restart_strategy = 'bipop'`` is specified.
 
             .. warning::
-                Deprecated in v4.4.0. ``restart_strategy`` argument will be removed in the future.
+                Deprecated in v4.4.0. ``inc_popsize`` argument will be removed in the future.
                 The removal of this feature is currently scheduled for v6.0.0,
                 but this schedule is subject to change.
-                From v4.4.0 onward, ``restart_strategy`` automatically falls back to ``None``, and
-                ``restart_strategy`` will be supported in OptunaHub.
+                From v4.4.0 onward, ``inc_popsize`` automatically falls back to -1, and
+                ``inc_popsize`` will be supported in OptunaHub.
                 See https://github.com/optuna/optuna/releases/tag/v4.4.0.
 
         consider_pruned_trials:
@@ -262,13 +262,13 @@ class CmaEsSampler(BaseSampler):
         consider_pruned_trials: bool = False,
         restart_strategy: str | None = None,
         popsize: int | None = None,
-        inc_popsize: int = 2,
+        inc_popsize: int = -1,
         use_separable_cma: bool = False,
         with_margin: bool = False,
         lr_adapt: bool = False,
         source_trials: list[FrozenTrial] | None = None,
     ) -> None:
-        if restart_strategy is not None or inc_popsize != 2:
+        if restart_strategy is not None or inc_popsize != -1:
             msg = _deprecated._DEPRECATION_WARNING_TEMPLATE.format(
                 name="`restart_strategy`", d_ver="4.4.0", r_ver="6.0.0"
             )
@@ -384,12 +384,9 @@ class CmaEsSampler(BaseSampler):
             search_space, transform_step=not self._with_margin, transform_0_1=True
         )
 
-        if self._popsize is None:
-            self._popsize = 4 + math.floor(3 * math.log(len(trans.bounds)))
-
         optimizer = self._restore_optimizer(completed_trials)
         if optimizer is None:
-            optimizer = self._init_optimizer(trans, study.direction, population_size=self._popsize)
+            optimizer = self._init_optimizer(trans, study.direction)
 
         if optimizer.dim != len(trans.bounds):
             if self._warn_independent_sampling:
@@ -406,7 +403,7 @@ class CmaEsSampler(BaseSampler):
         # See https://github.com/optuna/optuna/pull/920#discussion_r385114002 for details.
         solution_trials = self._get_solution_trials(completed_trials, optimizer.generation)
 
-        if len(solution_trials) >= self._popsize:
+        if len(solution_trials) >= optimizer.population_size:
             solutions: list[tuple[np.ndarray, float]] = []
             for t in solution_trials[: self._popsize]:
                 assert t.value is not None, "completed trials must have a value"
@@ -496,7 +493,6 @@ class CmaEsSampler(BaseSampler):
         self,
         trans: _SearchSpaceTransform,
         direction: StudyDirection,
-        population_size: int | None = None,
     ) -> "CmaClass":
         lower_bounds = trans.bounds[:, 0]
         upper_bounds = trans.bounds[:, 1]
@@ -544,7 +540,7 @@ class CmaEsSampler(BaseSampler):
                 bounds=trans.bounds,
                 seed=self._cma_rng.rng.randint(1, 2**31 - 2),
                 n_max_resampling=10 * n_dimension,
-                population_size=population_size,
+                population_size=self._popsize,
             )
 
         if self._with_margin:
@@ -567,7 +563,7 @@ class CmaEsSampler(BaseSampler):
                 cov=cov,
                 seed=self._cma_rng.rng.randint(1, 2**31 - 2),
                 n_max_resampling=10 * n_dimension,
-                population_size=population_size,
+                population_size=self._popsize,
             )
 
         return cmaes.CMA(
@@ -577,7 +573,7 @@ class CmaEsSampler(BaseSampler):
             bounds=trans.bounds,
             seed=self._cma_rng.rng.randint(1, 2**31 - 2),
             n_max_resampling=10 * n_dimension,
-            population_size=population_size,
+            population_size=self._popsize,
             lr_adapt=self._lr_adapt,
         )
 

--- a/optuna/samplers/_cmaes.py
+++ b/optuna/samplers/_cmaes.py
@@ -389,7 +389,7 @@ class CmaEsSampler(BaseSampler):
 
         optimizer = self._restore_optimizer(completed_trials)
         if optimizer is None:
-            optimizer = self._init_optimizer(trans, study.direction, population_size=self._popsize)
+            optimizer = self._init_optimizer(trans, study.direction)
 
         if optimizer.dim != len(trans.bounds):
             if self._warn_independent_sampling:
@@ -406,7 +406,7 @@ class CmaEsSampler(BaseSampler):
         # See https://github.com/optuna/optuna/pull/920#discussion_r385114002 for details.
         solution_trials = self._get_solution_trials(completed_trials, optimizer.generation)
 
-        if len(solution_trials) >= self._popsize:
+        if len(solution_trials) >= optimizer.population_size:
             solutions: list[tuple[np.ndarray, float]] = []
             for t in solution_trials[: self._popsize]:
                 assert t.value is not None, "completed trials must have a value"
@@ -496,7 +496,6 @@ class CmaEsSampler(BaseSampler):
         self,
         trans: _SearchSpaceTransform,
         direction: StudyDirection,
-        population_size: int | None = None,
     ) -> "CmaClass":
         lower_bounds = trans.bounds[:, 0]
         upper_bounds = trans.bounds[:, 1]
@@ -544,7 +543,7 @@ class CmaEsSampler(BaseSampler):
                 bounds=trans.bounds,
                 seed=self._cma_rng.rng.randint(1, 2**31 - 2),
                 n_max_resampling=10 * n_dimension,
-                population_size=population_size,
+                population_size=self._popsize,
             )
 
         if self._with_margin:
@@ -567,7 +566,7 @@ class CmaEsSampler(BaseSampler):
                 cov=cov,
                 seed=self._cma_rng.rng.randint(1, 2**31 - 2),
                 n_max_resampling=10 * n_dimension,
-                population_size=population_size,
+                population_size=self._popsize,
             )
 
         return cmaes.CMA(
@@ -577,7 +576,7 @@ class CmaEsSampler(BaseSampler):
             bounds=trans.bounds,
             seed=self._cma_rng.rng.randint(1, 2**31 - 2),
             n_max_resampling=10 * n_dimension,
-            population_size=population_size,
+            population_size=self._popsize,
             lr_adapt=self._lr_adapt,
         )
 

--- a/optuna/samplers/_cmaes.py
+++ b/optuna/samplers/_cmaes.py
@@ -180,11 +180,11 @@ class CmaEsSampler(BaseSampler):
             or ``restart_strategy = 'bipop'`` is specified.
 
             .. warning::
-                Deprecated in v4.4.0. ``inc_posize`` argument will be removed in the future.
+                Deprecated in v4.4.0. ``inc_popsize`` argument will be removed in the future.
                 The removal of this feature is currently scheduled for v6.0.0,
                 but this schedule is subject to change.
-                From v4.4.0 onward, ``inc_posize`` automatically falls back to -1, and
-                ``inc_posize`` will be supported in OptunaHub.
+                From v4.4.0 onward, ``inc_popsize`` is no longer utilized within Optuna, and
+                ``inc_popsize`` will be supported in OptunaHub.
                 See https://github.com/optuna/optuna/releases/tag/v4.4.0.
 
         consider_pruned_trials:
@@ -262,13 +262,13 @@ class CmaEsSampler(BaseSampler):
         consider_pruned_trials: bool = False,
         restart_strategy: str | None = None,
         popsize: int | None = None,
-        inc_popsize: int = 2,
+        inc_popsize: int = -1,
         use_separable_cma: bool = False,
         with_margin: bool = False,
         lr_adapt: bool = False,
         source_trials: list[FrozenTrial] | None = None,
     ) -> None:
-        if restart_strategy is not None or inc_popsize != 2:
+        if restart_strategy is not None or inc_popsize != -1:
             msg = _deprecated._DEPRECATION_WARNING_TEMPLATE.format(
                 name="`restart_strategy`", d_ver="4.4.0", r_ver="6.0.0"
             )
@@ -384,12 +384,9 @@ class CmaEsSampler(BaseSampler):
             search_space, transform_step=not self._with_margin, transform_0_1=True
         )
 
-        if self._popsize is None:
-            self._popsize = 4 + math.floor(3 * math.log(len(trans.bounds)))
-
         optimizer = self._restore_optimizer(completed_trials)
         if optimizer is None:
-            optimizer = self._init_optimizer(trans, study.direction, population_size=self._popsize)
+            optimizer = self._init_optimizer(trans, study.direction)
 
         if optimizer.dim != len(trans.bounds):
             if self._warn_independent_sampling:
@@ -406,7 +403,7 @@ class CmaEsSampler(BaseSampler):
         # See https://github.com/optuna/optuna/pull/920#discussion_r385114002 for details.
         solution_trials = self._get_solution_trials(completed_trials, optimizer.generation)
 
-        if len(solution_trials) >= self._popsize:
+        if len(solution_trials) >= optimizer.population_size:
             solutions: list[tuple[np.ndarray, float]] = []
             for t in solution_trials[: self._popsize]:
                 assert t.value is not None, "completed trials must have a value"
@@ -496,7 +493,6 @@ class CmaEsSampler(BaseSampler):
         self,
         trans: _SearchSpaceTransform,
         direction: StudyDirection,
-        population_size: int | None = None,
     ) -> "CmaClass":
         lower_bounds = trans.bounds[:, 0]
         upper_bounds = trans.bounds[:, 1]
@@ -544,7 +540,7 @@ class CmaEsSampler(BaseSampler):
                 bounds=trans.bounds,
                 seed=self._cma_rng.rng.randint(1, 2**31 - 2),
                 n_max_resampling=10 * n_dimension,
-                population_size=population_size,
+                population_size=self._popsize,
             )
 
         if self._with_margin:
@@ -567,7 +563,7 @@ class CmaEsSampler(BaseSampler):
                 cov=cov,
                 seed=self._cma_rng.rng.randint(1, 2**31 - 2),
                 n_max_resampling=10 * n_dimension,
-                population_size=population_size,
+                population_size=self._popsize,
             )
 
         return cmaes.CMA(
@@ -577,7 +573,7 @@ class CmaEsSampler(BaseSampler):
             bounds=trans.bounds,
             seed=self._cma_rng.rng.randint(1, 2**31 - 2),
             n_max_resampling=10 * n_dimension,
-            population_size=population_size,
+            population_size=self._popsize,
             lr_adapt=self._lr_adapt,
         )
 

--- a/optuna/samplers/_cmaes.py
+++ b/optuna/samplers/_cmaes.py
@@ -400,9 +400,9 @@ class CmaEsSampler(BaseSampler):
         # See https://github.com/optuna/optuna/pull/920#discussion_r385114002 for details.
         solution_trials = self._get_solution_trials(completed_trials, optimizer.generation)
 
-        if len(solution_trials) >= optimizer.population_size:
+        if len(solution_trials) >= self._popsize:
             solutions: list[tuple[np.ndarray, float]] = []
-            for t in solution_trials[: optimizer.population_size]:
+            for t in solution_trials[: self._popsize]:
                 assert t.value is not None, "completed trials must have a value"
                 if isinstance(optimizer, cmaes.CMAwM):
                     x = np.array(t.system_attrs["x_for_tell"])

--- a/optuna/samplers/_cmaes.py
+++ b/optuna/samplers/_cmaes.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Callable
 from collections.abc import Sequence
 import copy
 import math
@@ -44,14 +43,8 @@ _SYSTEM_ATTR_MAX_LENGTH = 2045
 
 
 class _CmaEsAttrKeys(NamedTuple):
-    optimizer: Callable[[int], str]
-    generation: Callable[[int], str]
-    popsize: Callable[[], str]
-    n_restarts: Callable[[], str]
-    n_restarts_with_large: str
-    poptype: str
-    small_n_eval: str
-    large_n_eval: str
+    optimizer: str
+    generation: str
 
 
 class CmaEsSampler(BaseSampler):
@@ -160,14 +153,6 @@ class CmaEsSampler(BaseSampler):
             Note that the parameters of the first trial in a study are always sampled
             via an independent sampler, so no warning messages are emitted in this case.
 
-        restart_strategy:
-            Strategy for restarting CMA-ES optimization when converges to a local minimum.
-            If :obj:`None` is given, CMA-ES will not restart (default).
-            If 'ipop' is given, CMA-ES will restart with increasing population size.
-            if 'bipop' is given, CMA-ES will restart with the population size
-            increased or decreased.
-            Please see also ``inc_popsize`` parameter.
-
             .. note::
                 Added in v2.1.0 as an experimental feature. The interface may change in newer
                 versions without prior notice. See
@@ -177,11 +162,6 @@ class CmaEsSampler(BaseSampler):
             A population size of CMA-ES. When ``restart_strategy = 'ipop'``
             or ``restart_strategy = 'bipop'`` is specified,
             this is used as the initial population size.
-
-        inc_popsize:
-            Multiplier for increasing population size before each restart.
-            This argument will be used when ``restart_strategy = 'ipop'``
-            or ``restart_strategy = 'bipop'`` is specified.
 
         consider_pruned_trials:
             If this is :obj:`True`, the PRUNED trials are considered for sampling.
@@ -256,9 +236,7 @@ class CmaEsSampler(BaseSampler):
         seed: int | None = None,
         *,
         consider_pruned_trials: bool = False,
-        restart_strategy: str | None = None,
         popsize: int | None = None,
-        inc_popsize: int = 2,
         use_separable_cma: bool = False,
         with_margin: bool = False,
         lr_adapt: bool = False,
@@ -272,16 +250,11 @@ class CmaEsSampler(BaseSampler):
         self._cma_rng = LazyRandomState(seed)
         self._search_space = IntersectionSearchSpace()
         self._consider_pruned_trials = consider_pruned_trials
-        self._restart_strategy = restart_strategy
         self._initial_popsize = popsize
-        self._inc_popsize = inc_popsize
         self._use_separable_cma = use_separable_cma
         self._with_margin = with_margin
         self._lr_adapt = lr_adapt
         self._source_trials = source_trials
-
-        if self._restart_strategy:
-            warn_experimental_argument("restart_strategy")
 
         if self._consider_pruned_trials:
             warn_experimental_argument("consider_pruned_trials")
@@ -314,16 +287,6 @@ class CmaEsSampler(BaseSampler):
             raise ValueError(
                 "It is prohibited to pass `use_separable_cma` or `with_margin` argument when "
                 "using `lr_adapt`."
-            )
-
-        if restart_strategy not in (
-            "ipop",
-            "bipop",
-            None,
-        ):
-            raise ValueError(
-                "restart_strategy={} is unsupported. "
-                "Please specify: 'ipop', 'bipop', or None.".format(restart_strategy)
             )
 
         # TODO(knshnb): Support sep-CMA-ES with margin.
@@ -388,31 +351,7 @@ class CmaEsSampler(BaseSampler):
         if self._initial_popsize is None:
             self._initial_popsize = 4 + math.floor(3 * math.log(len(trans.bounds)))
 
-        popsize: int = self._initial_popsize
-        n_restarts: int = 0
-        n_restarts_with_large: int = 0
-        poptype: str = "small"
-        small_n_eval: int = 0
-        large_n_eval: int = 0
-        if len(completed_trials) != 0:
-            latest_trial = completed_trials[-1]
-
-            popsize_attr_key = self._attr_keys.popsize()
-            if popsize_attr_key in latest_trial.system_attrs:
-                popsize = latest_trial.system_attrs[popsize_attr_key]
-            else:
-                popsize = self._initial_popsize
-
-            n_restarts_attr_key = self._attr_keys.n_restarts()
-            n_restarts = latest_trial.system_attrs.get(n_restarts_attr_key, 0)
-            n_restarts_with_large = latest_trial.system_attrs.get(
-                self._attr_keys.n_restarts_with_large, 0
-            )
-            poptype = latest_trial.system_attrs.get(self._attr_keys.poptype, "small")
-            small_n_eval = latest_trial.system_attrs.get(self._attr_keys.small_n_eval, 0)
-            large_n_eval = latest_trial.system_attrs.get(self._attr_keys.large_n_eval, 0)
-
-        optimizer = self._restore_optimizer(completed_trials, n_restarts)
+        optimizer = self._restore_optimizer(completed_trials)
         if optimizer is None:
             optimizer = self._init_optimizer(
                 trans, study.direction, population_size=self._initial_popsize
@@ -431,13 +370,11 @@ class CmaEsSampler(BaseSampler):
 
         # TODO(c-bata): Reduce the number of wasted trials during parallel optimization.
         # See https://github.com/optuna/optuna/pull/920#discussion_r385114002 for details.
-        solution_trials = self._get_solution_trials(
-            completed_trials, optimizer.generation, n_restarts
-        )
+        solution_trials = self._get_solution_trials(completed_trials, optimizer.generation)
 
-        if len(solution_trials) >= popsize:
+        if len(solution_trials) >= optimizer.population_size:
             solutions: list[tuple[np.ndarray, float]] = []
-            for t in solution_trials[:popsize]:
+            for t in solution_trials[: optimizer.population_size]:
                 assert t.value is not None, "completed trials must have a value"
                 if isinstance(optimizer, cmaes.CMAwM):
                     x = np.array(t.system_attrs["x_for_tell"])
@@ -448,41 +385,9 @@ class CmaEsSampler(BaseSampler):
 
             optimizer.tell(solutions)
 
-            if self._restart_strategy == "ipop" and optimizer.should_stop():
-                n_restarts += 1
-                popsize = popsize * self._inc_popsize
-                optimizer = self._init_optimizer(
-                    trans, study.direction, population_size=popsize, randomize_start_point=True
-                )
-
-            if self._restart_strategy == "bipop" and optimizer.should_stop():
-                n_restarts += 1
-
-                n_eval = popsize * optimizer.generation
-                if poptype == "small":
-                    small_n_eval += n_eval
-                else:  # poptype == "large"
-                    large_n_eval += n_eval
-
-                if small_n_eval < large_n_eval:
-                    poptype = "small"
-                    popsize_multiplier = self._inc_popsize**n_restarts_with_large
-                    popsize = math.floor(
-                        self._initial_popsize
-                        * popsize_multiplier ** (self._cma_rng.rng.uniform() ** 2)
-                    )
-                else:
-                    poptype = "large"
-                    n_restarts_with_large += 1
-                    popsize = self._initial_popsize * (self._inc_popsize**n_restarts_with_large)
-
-                optimizer = self._init_optimizer(
-                    trans, study.direction, population_size=popsize, randomize_start_point=True
-                )
-
             # Store optimizer.
             optimizer_str = pickle.dumps(optimizer).hex()
-            optimizer_attrs = self._split_optimizer_str(optimizer_str, n_restarts)
+            optimizer_attrs = self._split_optimizer_str(optimizer_str)
             for key in optimizer_attrs:
                 study._storage.set_trial_system_attr(trial._trial_id, key, optimizer_attrs[key])
 
@@ -497,23 +402,9 @@ class CmaEsSampler(BaseSampler):
         else:
             params = optimizer.ask()
 
-        generation_attr_key = self._attr_keys.generation(n_restarts)
+        generation_attr_key = self._attr_keys.generation
         study._storage.set_trial_system_attr(
             trial._trial_id, generation_attr_key, optimizer.generation
-        )
-        popsize_attr_key = self._attr_keys.popsize()
-        study._storage.set_trial_system_attr(trial._trial_id, popsize_attr_key, popsize)
-        n_restarts_attr_key = self._attr_keys.n_restarts()
-        study._storage.set_trial_system_attr(trial._trial_id, n_restarts_attr_key, n_restarts)
-        study._storage.set_trial_system_attr(
-            trial._trial_id, self._attr_keys.n_restarts_with_large, n_restarts_with_large
-        )
-        study._storage.set_trial_system_attr(trial._trial_id, self._attr_keys.poptype, poptype)
-        study._storage.set_trial_system_attr(
-            trial._trial_id, self._attr_keys.small_n_eval, small_n_eval
-        )
-        study._storage.set_trial_system_attr(
-            trial._trial_id, self._attr_keys.large_n_eval, large_n_eval
         )
 
         external_values = trans.untransform(params)
@@ -529,78 +420,41 @@ class CmaEsSampler(BaseSampler):
         else:
             attr_prefix = "cma:"
 
-        def optimizer_key_template(restart: int) -> str:
-            if self._restart_strategy is None:
-                return attr_prefix + "optimizer"
-            else:
-                return attr_prefix + "{}:restart_{}:optimizer".format(
-                    self._restart_strategy, restart
-                )
-
-        def generation_attr_key_template(restart: int) -> str:
-            if self._restart_strategy is None:
-                return attr_prefix + "generation"
-            else:
-                return attr_prefix + "{}:restart_{}:generation".format(
-                    self._restart_strategy, restart
-                )
-
-        def popsize_attr_key_template() -> str:
-            if self._restart_strategy is None:
-                return attr_prefix + "popsize"
-            else:
-                return attr_prefix + "{}:popsize".format(self._restart_strategy)
-
-        def n_restarts_attr_key_template() -> str:
-            if self._restart_strategy is None:
-                return attr_prefix + "n_restarts"
-            else:
-                return attr_prefix + "{}:n_restarts".format(self._restart_strategy)
-
         return _CmaEsAttrKeys(
-            optimizer_key_template,
-            generation_attr_key_template,
-            popsize_attr_key_template,
-            n_restarts_attr_key_template,
-            attr_prefix + "n_restarts_with_large",
-            attr_prefix + "poptype",
-            attr_prefix + "small_n_eval",
-            attr_prefix + "large_n_eval",
+            attr_prefix + "optimizer",
+            attr_prefix + "generation",
         )
 
-    def _concat_optimizer_attrs(self, optimizer_attrs: dict[str, str], n_restarts: int = 0) -> str:
+    def _concat_optimizer_attrs(self, optimizer_attrs: dict[str, str]) -> str:
         return "".join(
-            optimizer_attrs["{}:{}".format(self._attr_keys.optimizer(n_restarts), i)]
+            optimizer_attrs["{}:{}".format(self._attr_keys.optimizer, i)]
             for i in range(len(optimizer_attrs))
         )
 
-    def _split_optimizer_str(self, optimizer_str: str, n_restarts: int = 0) -> dict[str, str]:
+    def _split_optimizer_str(self, optimizer_str: str) -> dict[str, str]:
         optimizer_len = len(optimizer_str)
         attrs = {}
         for i in range(math.ceil(optimizer_len / _SYSTEM_ATTR_MAX_LENGTH)):
             start = i * _SYSTEM_ATTR_MAX_LENGTH
             end = min((i + 1) * _SYSTEM_ATTR_MAX_LENGTH, optimizer_len)
-            attrs["{}:{}".format(self._attr_keys.optimizer(n_restarts), i)] = optimizer_str[
-                start:end
-            ]
+            attrs["{}:{}".format(self._attr_keys.optimizer, i)] = optimizer_str[start:end]
         return attrs
 
     def _restore_optimizer(
         self,
         completed_trials: "list[optuna.trial.FrozenTrial]",
-        n_restarts: int = 0,
     ) -> "CmaClass" | None:
         # Restore a previous CMA object.
         for trial in reversed(completed_trials):
             optimizer_attrs = {
                 key: value
                 for key, value in trial.system_attrs.items()
-                if key.startswith(self._attr_keys.optimizer(n_restarts))
+                if key.startswith(self._attr_keys.optimizer)
             }
             if len(optimizer_attrs) == 0:
                 continue
 
-            optimizer_str = self._concat_optimizer_attrs(optimizer_attrs, n_restarts)
+            optimizer_str = self._concat_optimizer_attrs(optimizer_attrs)
             return pickle.loads(bytes.fromhex(optimizer_str))
         return None
 
@@ -609,18 +463,13 @@ class CmaEsSampler(BaseSampler):
         trans: _SearchSpaceTransform,
         direction: StudyDirection,
         population_size: int | None = None,
-        randomize_start_point: bool = False,
     ) -> "CmaClass":
         lower_bounds = trans.bounds[:, 0]
         upper_bounds = trans.bounds[:, 1]
         n_dimension = len(trans.bounds)
 
         if self._source_trials is None:
-            if randomize_start_point:
-                mean = lower_bounds + (upper_bounds - lower_bounds) * self._cma_rng.rng.rand(
-                    n_dimension
-                )
-            elif self._x0 is None:
+            if self._x0 is None:
                 mean = lower_bounds + (upper_bounds - lower_bounds) / 2
             else:
                 # `self._x0` is external representations.
@@ -749,9 +598,9 @@ class CmaEsSampler(BaseSampler):
         return complete_trials
 
     def _get_solution_trials(
-        self, trials: list[FrozenTrial], generation: int, n_restarts: int
+        self, trials: list[FrozenTrial], generation: int
     ) -> list[FrozenTrial]:
-        generation_attr_key = self._attr_keys.generation(n_restarts)
+        generation_attr_key = self._attr_keys.generation
         return [t for t in trials if generation == t.system_attrs.get(generation_attr_key, -1)]
 
     def before_trial(self, study: optuna.Study, trial: FrozenTrial) -> None:

--- a/tests/samplers_tests/test_cmaes.py
+++ b/tests/samplers_tests/test_cmaes.py
@@ -410,8 +410,8 @@ def test_get_solution_trials() -> None:
 @pytest.mark.parametrize(
     "sampler_opts",
     [
-        ({"use_separable_cma": True}),
-        ({"with_margin": True}),
+        {"use_separable_cma": True},
+        {"with_margin": True},
     ],
 )
 def test_get_solution_trials_with_other_options(sampler_opts: dict[str, Any]) -> None:

--- a/tests/samplers_tests/test_cmaes.py
+++ b/tests/samplers_tests/test_cmaes.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import math
 from typing import Any
 from unittest.mock import MagicMock
 from unittest.mock import Mock
@@ -71,8 +70,7 @@ def test_init_cmaes_opts(use_separable_cma: bool, cma_class_str: str, popsize: i
         assert np.allclose(actual_kwargs["bounds"], np.array([(0, 1), (0, 1)]))
         assert actual_kwargs["seed"] == np.random.RandomState(1).randint(1, np.iinfo(np.int32).max)
         assert actual_kwargs["n_max_resampling"] == 10 * 2
-        expected_popsize = 4 + math.floor(3 * math.log(2)) if popsize is None else popsize
-        assert actual_kwargs["population_size"] == expected_popsize
+        assert actual_kwargs["population_size"] == popsize
 
 
 @pytest.mark.filterwarnings("ignore::optuna.exceptions.ExperimentalWarning")
@@ -106,8 +104,7 @@ def test_init_cmaes_opts_with_margin(popsize: int | None) -> None:
         assert np.allclose(actual_kwargs["steps"], np.array([0.0, 0.5]))
         assert actual_kwargs["seed"] == np.random.RandomState(1).randint(1, np.iinfo(np.int32).max)
         assert actual_kwargs["n_max_resampling"] == 10 * 2
-        expected_popsize = 4 + math.floor(3 * math.log(2)) if popsize is None else popsize
-        assert actual_kwargs["population_size"] == expected_popsize
+        assert actual_kwargs["population_size"] == popsize
 
 
 @pytest.mark.filterwarnings("ignore::optuna.exceptions.ExperimentalWarning")

--- a/tests/samplers_tests/test_cmaes.py
+++ b/tests/samplers_tests/test_cmaes.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 from typing import Any
 from unittest.mock import MagicMock
 from unittest.mock import Mock
@@ -70,7 +71,8 @@ def test_init_cmaes_opts(use_separable_cma: bool, cma_class_str: str, popsize: i
         assert np.allclose(actual_kwargs["bounds"], np.array([(0, 1), (0, 1)]))
         assert actual_kwargs["seed"] == np.random.RandomState(1).randint(1, np.iinfo(np.int32).max)
         assert actual_kwargs["n_max_resampling"] == 10 * 2
-        assert actual_kwargs["population_size"] == popsize
+        expected_popsize = 4 + math.floor(3 * math.log(2)) if popsize is None else popsize
+        assert actual_kwargs["population_size"] == expected_popsize
 
 
 @pytest.mark.filterwarnings("ignore::optuna.exceptions.ExperimentalWarning")
@@ -104,7 +106,8 @@ def test_init_cmaes_opts_with_margin(popsize: int | None) -> None:
         assert np.allclose(actual_kwargs["steps"], np.array([0.0, 0.5]))
         assert actual_kwargs["seed"] == np.random.RandomState(1).randint(1, np.iinfo(np.int32).max)
         assert actual_kwargs["n_max_resampling"] == 10 * 2
-        assert actual_kwargs["population_size"] == popsize
+        expected_popsize = 4 + math.floor(3 * math.log(2)) if popsize is None else popsize
+        assert actual_kwargs["population_size"] == expected_popsize
 
 
 @pytest.mark.filterwarnings("ignore::optuna.exceptions.ExperimentalWarning")

--- a/tests/samplers_tests/test_cmaes.py
+++ b/tests/samplers_tests/test_cmaes.py
@@ -210,11 +210,6 @@ def test_should_raise_exception() -> None:
         )
 
     with pytest.raises(ValueError):
-        optuna.samplers.CmaEsSampler(
-            restart_strategy="invalid-restart-strategy",
-        )
-
-    with pytest.raises(ValueError):
         optuna.samplers.CmaEsSampler(use_separable_cma=True, with_margin=True)
 
 
@@ -364,65 +359,8 @@ def test_sampler_attr_key(options: dict[str, bool], key: str) -> None:
     sampler = optuna.samplers.CmaEsSampler(
         with_margin=options["with_margin"], use_separable_cma=options["use_separable_cma"]
     )
-    assert sampler._attr_keys.optimizer(0).startswith(key)
-    assert sampler._attr_keys.popsize().startswith(key)
-    assert sampler._attr_keys.n_restarts().startswith(key)
-    assert sampler._attr_keys.n_restarts_with_large.startswith(key)
-    assert sampler._attr_keys.poptype.startswith(key)
-    assert sampler._attr_keys.small_n_eval.startswith(key)
-    assert sampler._attr_keys.large_n_eval.startswith(key)
-    assert sampler._attr_keys.generation(0).startswith(key)
-
-    for restart_strategy in ["ipop", "bipop"]:
-        sampler._restart_strategy = restart_strategy
-        for i in range(3):
-            assert sampler._attr_keys.generation(i).startswith(
-                (key + "{}:restart_{}:".format(restart_strategy, i) + "generation")
-            )
-
-
-@pytest.mark.parametrize("popsize", [None, 16])
-def test_population_size_is_multiplied_when_enable_ipop(popsize: int | None) -> None:
-    inc_popsize = 2
-    sampler = optuna.samplers.CmaEsSampler(
-        x0={"x": 0, "y": 0},
-        sigma0=0.1,
-        seed=1,
-        n_startup_trials=1,
-        restart_strategy="ipop",
-        popsize=popsize,
-        inc_popsize=inc_popsize,
-    )
-    study = optuna.create_study(sampler=sampler)
-
-    def objective(trial: optuna.Trial) -> float:
-        _ = trial.suggest_float("x", -1, 1)
-        _ = trial.suggest_float("y", -1, 1)
-        return 1.0
-
-    with patch("optuna.samplers._cmaes.cmaes.CMA") as cma_class_mock, patch(
-        "optuna.samplers._cmaes.pickle"
-    ) as pickle_mock:
-        pickle_mock.dump.return_value = b"serialized object"
-
-        should_stop_mock = MagicMock()
-        should_stop_mock.return_value = True
-
-        cma_obj = CMA(
-            mean=np.array([-1, -1], dtype=float),
-            sigma=1.3,
-            bounds=np.array([[-1, 1], [-1, 1]], dtype=float),
-            population_size=popsize,  # Already tested by test_init_cmaes_opts().
-        )
-        cma_obj.should_stop = should_stop_mock
-        cma_class_mock.return_value = cma_obj
-
-        initial_popsize = cma_obj.population_size
-        study.optimize(objective, n_trials=2 + initial_popsize)
-        assert cma_obj.should_stop.call_count == 1
-
-        _, actual_kwargs = cma_class_mock.call_args
-        assert actual_kwargs["population_size"] == inc_popsize * initial_popsize
+    assert sampler._attr_keys.optimizer.startswith(key)
+    assert sampler._attr_keys.generation.startswith(key)
 
 
 @pytest.mark.parametrize("sampler_opts", [{}, {"use_separable_cma": True}, {"with_margin": True}])
@@ -451,163 +389,44 @@ def test_restore_optimizer_from_substrings(sampler_opts: dict[str, Any]) -> None
         assert isinstance(optimizer, CMA)
 
 
-@pytest.mark.parametrize(
-    "sampler_opts",
-    [
-        {"restart_strategy": "ipop"},
-        {"restart_strategy": "bipop"},
-        {"restart_strategy": "ipop", "use_separable_cma": True},
-        {"restart_strategy": "bipop", "use_separable_cma": True},
-        {"restart_strategy": "ipop", "with_margin": True},
-        {"restart_strategy": "bipop", "with_margin": True},
-    ],
-)
-def test_restore_optimizer_after_restart(sampler_opts: dict[str, Any]) -> None:
-    def objective(trial: optuna.Trial) -> float:
-        x1 = trial.suggest_float("x1", -10, 10, step=1)
-        x2 = trial.suggest_float("x2", -10, 10)
-        return x1**2 + x2**2
-
-    if sampler_opts.get("with_margin"):
-        cma_class = CMAwM
-    elif sampler_opts.get("use_separable_cma"):
-        cma_class = SepCMA
-    else:
-        cma_class = CMA
-    with patch.object(cma_class, "should_stop") as mock_method:
-        mock_method.return_value = True
-        sampler = optuna.samplers.CmaEsSampler(popsize=5, **sampler_opts)
-        study = optuna.create_study(sampler=sampler)
-        study.optimize(objective, n_trials=5 + 2)
-
-    optimizer = sampler._restore_optimizer(study.trials, 1)
-    assert optimizer is not None
-    assert optimizer.generation == 0
-
-
-@pytest.mark.parametrize(
-    "sampler_opts, restart_strategy",
-    [
-        ({"use_separable_cma": True}, "ipop"),
-        ({"use_separable_cma": True}, "bipop"),
-        ({"with_margin": True}, "ipop"),
-        ({"with_margin": True}, "bipop"),
-    ],
-)
-def test_restore_optimizer_with_other_option(
-    sampler_opts: dict[str, Any], restart_strategy: str
-) -> None:
-    def objective(trial: optuna.Trial) -> float:
-        x1 = trial.suggest_float("x1", -10, 10, step=1)
-        x2 = trial.suggest_float("x2", -10, 10)
-        return x1**2 + x2**2
-
-    with patch.object(CMA, "should_stop") as mock_method:
-        mock_method.return_value = True
-        sampler = optuna.samplers.CmaEsSampler(popsize=5, restart_strategy=restart_strategy)
-        study = optuna.create_study(sampler=sampler)
-        study.optimize(objective, n_trials=5 + 2)
-
-    # Restore optimizer via SepCMA or CMAwM samplers.
-    sampler = optuna.samplers.CmaEsSampler(**sampler_opts)
-    optimizer = sampler._restore_optimizer(study.trials)
-    assert optimizer is None
-
-
-@pytest.mark.parametrize(
-    "sampler_opts",
-    [
-        {"restart_strategy": "ipop"},
-        {"restart_strategy": "bipop"},
-        {"restart_strategy": "ipop", "use_separable_cma": True},
-        {"restart_strategy": "bipop", "use_separable_cma": True},
-        {"restart_strategy": "ipop", "with_margin": True},
-        {"restart_strategy": "bipop", "with_margin": True},
-    ],
-)
-def test_get_solution_trials(sampler_opts: dict[str, Any]) -> None:
+def test_get_solution_trials() -> None:
     def objective(trial: optuna.Trial) -> float:
         x1 = trial.suggest_float("x1", -10, 10, step=1)
         x2 = trial.suggest_float("x2", -10, 10)
         return x1**2 + x2**2
 
     popsize = 5
-    sampler = optuna.samplers.CmaEsSampler(popsize=popsize, **sampler_opts)
+    sampler = optuna.samplers.CmaEsSampler(popsize=popsize)
     study = optuna.create_study(sampler=sampler)
     study.optimize(objective, n_trials=popsize + 2)
 
     # The number of solutions for generation 0 equals population size.
-    assert len(sampler._get_solution_trials(study.trials, 0, 0)) == popsize
+    assert len(sampler._get_solution_trials(study.trials, 0)) == popsize
 
     # The number of solutions for generation 1 is 1.
-    assert len(sampler._get_solution_trials(study.trials, 1, 0)) == 1
+    assert len(sampler._get_solution_trials(study.trials, 1)) == 1
 
 
 @pytest.mark.parametrize(
-    "sampler_opts, restart_strategy",
+    "sampler_opts",
     [
-        ({"use_separable_cma": True}, "ipop"),
-        ({"use_separable_cma": True}, "bipop"),
-        ({"with_margin": True}, "ipop"),
-        ({"with_margin": True}, "bipop"),
+        ({"use_separable_cma": True}),
+        ({"with_margin": True}),
     ],
 )
-def test_get_solution_trials_with_other_options(
-    sampler_opts: dict[str, Any], restart_strategy: str
-) -> None:
+def test_get_solution_trials_with_other_options(sampler_opts: dict[str, Any]) -> None:
     def objective(trial: optuna.Trial) -> float:
         x1 = trial.suggest_float("x1", -10, 10, step=1)
         x2 = trial.suggest_float("x2", -10, 10)
         return x1**2 + x2**2
 
-    sampler = optuna.samplers.CmaEsSampler(popsize=5, restart_strategy=restart_strategy)
+    sampler = optuna.samplers.CmaEsSampler(popsize=5)
     study = optuna.create_study(sampler=sampler)
     study.optimize(objective, n_trials=5 + 2)
 
     # The number of solutions is 0 after changed samplers
     sampler = optuna.samplers.CmaEsSampler(**sampler_opts)
-    assert len(sampler._get_solution_trials(study.trials, 0, 0)) == 0
-
-
-@pytest.mark.parametrize(
-    "sampler_opts",
-    [
-        {"restart_strategy": "ipop"},
-        {"restart_strategy": "bipop"},
-        {"restart_strategy": "ipop", "use_separable_cma": True},
-        {"restart_strategy": "bipop", "use_separable_cma": True},
-        {"restart_strategy": "ipop", "with_margin": True},
-        {"restart_strategy": "bipop", "with_margin": True},
-    ],
-)
-def test_get_solution_trials_after_restart(sampler_opts: dict[str, Any]) -> None:
-    def objective(trial: optuna.Trial) -> float:
-        x1 = trial.suggest_float("x1", -10, 10, step=1)
-        x2 = trial.suggest_float("x2", -10, 10)
-        return x1**2 + x2**2
-
-    if sampler_opts.get("with_margin"):
-        cma_class = CMAwM
-    elif sampler_opts.get("use_separable_cma"):
-        cma_class = SepCMA
-    else:
-        cma_class = CMA
-
-    popsize = 5
-    with patch.object(cma_class, "should_stop") as mock_method:
-        mock_method.return_value = True
-        sampler = optuna.samplers.CmaEsSampler(popsize=popsize, **sampler_opts)
-        study = optuna.create_study(sampler=sampler)
-        study.optimize(objective, n_trials=popsize + 2)
-
-    # The number of solutions for generation=0 and n_restarts=0 equals population size.
-    assert len(sampler._get_solution_trials(study.trials, 0, 0)) == popsize
-
-    # The number of solutions for generation=1 and n_restarts=0 is 0.
-    assert len(sampler._get_solution_trials(study.trials, 1, 0)) == 0
-
-    # The number of solutions for generation=0 and n_restarts=1 is 1 since it was restarted.
-    assert len(sampler._get_solution_trials(study.trials, 0, 1)) == 1
+    assert len(sampler._get_solution_trials(study.trials, 0)) == 0
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Motivation
Simplify the implementation of `CmaEsSampler` by removing support for restart strategies. The current implementation with `restart_strategy` will be put into OptunaHub

## Summary of Changes
- Removed support for `restart_strategy` and `inc_popsize` options in `CmaEsSampler`
- Cleaned up related logic:
  - Removed associated attributes from `_CmaEsAttrKeys`, including `popsize`, `n_restarts`, `n_restarts_with_large`, `poptype`, `small_n_eval`, and `large_n_eval`
  - Eliminated usage of `set_trial_system_attr` since state tracking is no longer needed
- Updated unit tests accordingly
