### PR TITLE
Add a module to preprocess solutions for hypervolume improvement calculation

### DIFF
--- a/optuna/_hypervolume/__init__.py
+++ b/optuna/_hypervolume/__init__.py
@@ -1,5 +1,6 @@
+from optuna._hypervolume.box_decomposition import get_non_dominated_box_bounds
 from optuna._hypervolume.hssp import _solve_hssp
 from optuna._hypervolume.wfg import compute_hypervolume
 
 
-__all__ = ["_solve_hssp", "compute_hypervolume"]
+__all__ = ["_solve_hssp", "compute_hypervolume", "get_non_dominated_box_bounds"]

--- a/optuna/_hypervolume/box_decomposition.py
+++ b/optuna/_hypervolume/box_decomposition.py
@@ -116,12 +116,17 @@ def _get_non_dominated_box_bounds(
     # The calculation of u[k] and l[k] in the paper: https://arxiv.org/abs/2006.05078
     # NOTE(nabenabe): The paper handles maximization problems, but we consider minimization here.
     neg_upper_bound_set = -_get_upper_bound_set(sorted_pareto_sols, ref_point)[0]
-    sorted_neg_upper_bound_set = neg_upper_bound_set[np.argsort(neg_upper_bound_set[:, 0])]
+    sorted_neg_upper_bound_set = np.unique(neg_upper_bound_set, axis=0)  # lexsort by np.unique.
     # Use the sign-flipped upper_bound_set as the Pareto solutions. Then we can calculate the
     # lower bound set as well.
     point_at_infinity = np.full_like(ref_point, np.inf)
+    # NOTE(nabenabe): Since our goal is to partition the non-dominated space, we only need
+    # the Pareto solutions in the `neg_upper_bound_set`.
     neg_lower_bound_set, neg_def_points = _get_upper_bound_set(
-        sorted_neg_upper_bound_set, point_at_infinity
+        sorted_pareto_sols=sorted_neg_upper_bound_set[
+            _is_pareto_front(sorted_neg_upper_bound_set, assume_unique_lexsorted=True)
+        ],
+        ref_point=point_at_infinity,
     )
     box_upper_bounds, box_lower_bounds = -_get_box_bounds(
         neg_lower_bound_set, neg_def_points, point_at_infinity

--- a/optuna/_hypervolume/box_decomposition.py
+++ b/optuna/_hypervolume/box_decomposition.py
@@ -63,7 +63,8 @@ def _get_upper_bound_set(
         if not any(is_dominated):
             return ubs, dps
 
-        dominated_dps = dps[is_dominated]  # The set `A` in Line 5 of Alg. 2.
+        # The defining points `z(u)` for each `u in A` in Line 5 of Alg. 2.
+        dominated_dps = dps[is_dominated]
         n_bounds = dominated_dps.shape[0]
         # NOTE(nabenabe): `-inf` comes from Line 2 and `k!=j` in Line 3 of Alg. 2.
         # NOTE(nabenabe): If `update[i,j]=True`, update `ubs[i,j]` to `(z_j, u_{-j})`, i.e.,

--- a/optuna/_hypervolume/box_decomposition.py
+++ b/optuna/_hypervolume/box_decomposition.py
@@ -147,9 +147,14 @@ def _get_accepted_bound_indices(
         if not lb_non_dom or np.prod(bs[1] - bs[0]) <= threshold or max_idx_diff <= 1:
             continue
 
-        new_bs = np.stack([bound_indices, bound_indices])
-        new_bs[*np.diag_indices(2), max_idx] += [max_idx_diff // 2, -((max_idx_diff + 1) // 2)]
-        stack.extend([new_bs[1], new_bs[0]])
+        # Halve the hyperrectangle defined by the bound_indices in two parts.
+        bound_indices_above = bound_indices.copy()
+        bound_indices_below = bound_indices.copy()
+        # Increase the lower bound.
+        bound_indices_above[0, max_idx] += max_idx_diff // 2
+        # Decrease the upper bound.
+        bound_indices_below[1, max_idx] -= (max_idx_diff + 1) // 2
+        stack.extend([bound_indices_below, bound_indices_above])
 
     return np.concat(np.asarray(accepted_bound_indices)[..., np.newaxis, :], axis=1)
 

--- a/optuna/_hypervolume/box_decomposition.py
+++ b/optuna/_hypervolume/box_decomposition.py
@@ -21,6 +21,8 @@ We refer this paper as Lacour17 in this file.
 
 from __future__ import annotations
 
+import warnings
+
 import numpy as np
 
 from optuna.study._multi_objective import _is_pareto_front
@@ -115,6 +117,7 @@ def _get_non_dominated_hyper_rectangle_bounds(
     return lbs, ubs
 
 
+"""
 def _get_accepted_bound_indices(
     pareto_sols: np.ndarray, ref_point: np.ndarray, alpha: float
 ) -> np.ndarray:
@@ -170,6 +173,7 @@ def _approximate_non_dominated_hyper_rectangle_bounds(
     return aug_pareto_sols[accepted_bound_indices.flatten(), obj_indices].reshape(
         2, n_bounds, n_objectives
     )
+"""
 
 
 def get_non_dominated_hyper_rectangle_bounds(
@@ -185,10 +189,11 @@ def get_non_dominated_hyper_rectangle_bounds(
     n_objectives = loss_vals.shape[-1]
     # The condition here follows BoTorch.
     # https://github.com/pytorch/botorch/blob/v0.13.0/botorch/acquisition/multi_objective/utils.py#L55-L63
-    if n_objectives <= 4:
-        return _get_non_dominated_hyper_rectangle_bounds(sorted_pareto_sols, ref_point)
-    else:
-        alpha = alpha if alpha is not None else 10 ** (-2 if n_objectives >= 6 else -3)
-        return _approximate_non_dominated_hyper_rectangle_bounds(
-            sorted_pareto_sols, ref_point, alpha
-        )
+    if n_objectives > 4:
+        # alpha = alpha if alpha is not None else 10 ** (-2 if n_objectives >= 6 else -3)
+        # return _approximate_non_dominated_hyper_rectangle_bounds(
+        #     sorted_pareto_sols, ref_point, alpha
+        # )
+        warnings.warn("TODO")
+
+    return _get_non_dominated_hyper_rectangle_bounds(sorted_pareto_sols, ref_point)

--- a/optuna/_hypervolume/box_decomposition.py
+++ b/optuna/_hypervolume/box_decomposition.py
@@ -114,6 +114,8 @@ def _get_non_dominated_box_bounds(
     sorted_pareto_sols: np.ndarray, ref_point: np.ndarray
 ) -> tuple[np.ndarray, np.ndarray]:  # (n_bounds, n_objectives) and (n_bounds, n_objectives)
     # The calculation of u[k] and l[k] in the paper: https://arxiv.org/abs/2006.05078
+    # See below for the proof of this function's validity:
+    # cf. https://github.com/optuna/optuna/pull/6039#issuecomment-2831926573
     # NOTE(nabenabe): The paper handles maximization problems, but we consider minimization here.
     neg_upper_bound_set = -_get_upper_bound_set(sorted_pareto_sols, ref_point)[0]
     sorted_neg_upper_bound_set = np.unique(neg_upper_bound_set, axis=0)  # lexsort by np.unique.

--- a/optuna/_hypervolume/box_decomposition.py
+++ b/optuna/_hypervolume/box_decomposition.py
@@ -137,7 +137,7 @@ def get_non_dominated_box_bounds(
     # https://github.com/pytorch/botorch/blob/v0.13.0/botorch/acquisition/multi_objective/utils.py#L55-L63
     if n_objectives > 4:
         warnings.warn(
-            "GPSampler might be significantly slow for n_objectives > 4. "
+            "Box decomposition of solutions might be significantly slow for n_objectives > 4. "
             "Please consider using another sampler instead."
         )
 

--- a/optuna/_hypervolume/box_decomposition.py
+++ b/optuna/_hypervolume/box_decomposition.py
@@ -126,6 +126,8 @@ def _get_non_dominated_box_bounds(
 def get_non_dominated_box_bounds(
     loss_vals: np.ndarray, ref_point: np.ndarray
 ) -> tuple[np.ndarray, np.ndarray]:  # (n_bounds, n_objectives) and (n_bounds, n_objectives)
+    assert np.all(np.isfinite(loss_vals)), "loss_vals must be clipped before box decomposition."
+    # Remove duplications and lexsort the solutions by ``np.unique``.
     unique_lexsorted_loss_vals = np.unique(loss_vals, axis=0)
     sorted_pareto_sols = unique_lexsorted_loss_vals[
         _is_pareto_front(unique_lexsorted_loss_vals, assume_unique_lexsorted=True)

--- a/optuna/_hypervolume/box_decomposition.py
+++ b/optuna/_hypervolume/box_decomposition.py
@@ -143,7 +143,7 @@ def get_non_dominated_box_bounds(
     assert n_objectives > 1, "This function is used only for multi-objective problems."
     if n_objectives > 4:
         warnings.warn(
-            "Box decomposition (typically for `GPSampler`) might be significantly slow for "
+            "Box decomposition (typically used by `GPSampler`) might be significantly slow for "
             "n_objectives > 4. Please consider using another sampler instead."
         )
 

--- a/optuna/_hypervolume/box_decomposition.py
+++ b/optuna/_hypervolume/box_decomposition.py
@@ -5,10 +5,10 @@ but they are refactored significantly from the original version.
 For ``_get_upper_bound_set``, look at:
     * https://github.com/pytorch/botorch/blob/v0.13.0/botorch/utils/multi_objective/box_decompositions/utils.py#L101-L160
 
-For ``_get_hyper_rectangle_bounds``, look at:
+For ``_get_box_bounds``, look at:
     * https://github.com/pytorch/botorch/blob/v0.13.0/botorch/utils/multi_objective/box_decompositions/utils.py#L163-L193
 
-For ``_get_non_dominated_hyper_rectangle_bounds``, look at:
+For ``_get_non_dominated_box_bounds``, look at:
     * https://github.com/pytorch/botorch/blob/v0.13.0/botorch/utils/multi_objective/box_decompositions/non_dominated.py#L395-L430
 
 The preprocessing for four or fewer objectives, we use the algorithm proposed by:
@@ -89,7 +89,7 @@ def _get_upper_bound_set(
     return upper_bound_set, def_points
 
 
-def _get_hyper_rectangle_bounds(
+def _get_box_bounds(
     def_points: np.ndarray, upper_bound_set: np.ndarray, ref_point: np.ndarray
 ) -> np.ndarray:
     # Eq. (2) of Lacour17.
@@ -104,7 +104,7 @@ def _get_hyper_rectangle_bounds(
     return bounds[:, not_empty]
 
 
-def _get_non_dominated_hyper_rectangle_bounds(
+def _get_non_dominated_box_bounds(
     sorted_pareto_sols: np.ndarray, ref_point: np.ndarray
 ) -> tuple[np.ndarray, np.ndarray]:  # (n_bounds, n_objectives) and (n_bounds, n_objectives)
     # The calculation of u[k] and l[k] in the paper: https://arxiv.org/abs/2006.05078
@@ -114,12 +114,12 @@ def _get_non_dominated_hyper_rectangle_bounds(
     # Flip the sign and use upper_bound_set as the Pareto solutions. Then we can calculate the
     # lower bound set as well.
     point_at_infinity = np.full_like(ref_point, np.inf)
-    neg_bound_set, neg_def_points = _get_upper_bound_set(-upper_bound_set, point_at_infinity)
-    ubs, lbs = -_get_hyper_rectangle_bounds(neg_def_points, neg_bound_set, point_at_infinity)
+    neg_upper_bound_set, neg_def_points = _get_upper_bound_set(-upper_bound_set, point_at_infinity)
+    ubs, lbs = -_get_box_bounds(neg_def_points, neg_upper_bound_set, point_at_infinity)
     return lbs, ubs
 
 
-def get_non_dominated_hyper_rectangle_bounds(
+def get_non_dominated_box_bounds(
     loss_vals: np.ndarray, ref_point: np.ndarray, alpha: float | None = None
 ) -> tuple[np.ndarray, np.ndarray]:  # (n_bounds, n_objectives) and (n_bounds, n_objectives)
     unique_lexsorted_loss_vals = np.unique(loss_vals, axis=0)
@@ -135,4 +135,4 @@ def get_non_dominated_hyper_rectangle_bounds(
             "Please consider using another sampler instead."
         )
 
-    return _get_non_dominated_hyper_rectangle_bounds(sorted_pareto_sols, ref_point)
+    return _get_non_dominated_box_bounds(sorted_pareto_sols, ref_point)

--- a/optuna/_hypervolume/box_decomposition.py
+++ b/optuna/_hypervolume/box_decomposition.py
@@ -143,8 +143,8 @@ def get_non_dominated_box_bounds(
     assert n_objectives > 1, "This function is used only for multi-objective problems."
     if n_objectives > 4:
         warnings.warn(
-            "GPSampler might be significantly slow for n_objectives > 4. "
-            "Please consider using another sampler instead."
+            "Box decomposition (typically for `GPSampler`) might be significantly slow for "
+            "n_objectives > 4. Please consider using another sampler instead."
         )
 
     return _get_non_dominated_box_bounds(sorted_pareto_sols, ref_point)

--- a/optuna/_hypervolume/box_decomposition.py
+++ b/optuna/_hypervolume/box_decomposition.py
@@ -58,18 +58,18 @@ def _get_upper_bound_set(
     def update(sol: np.ndarray, ubs: np.ndarray, dps: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
         # The update rule is written in Section 2.2 of Lacour17.
         is_dominated = np.all(sol < ubs, axis=-1)
-        if not np.any(is_dominated):
+        if not any(is_dominated):
             return ubs, dps
 
-        dominated_dps = dps[is_dominated]  # The set A in Line 5 of Alg. 2.
+        dominated_dps = dps[is_dominated]  # The set `A` in Line 5 of Alg. 2.
         n_bounds = dominated_dps.shape[0]
-        # NOTE(nabenabe): -inf comes from Line 2 and k!=j in Line 3 of Alg. 2.
-        # NOTE(nabenabe): If True, include u in A at this index to the set in Line 3 of Alg. 2.
+        # NOTE(nabenabe): `-inf` comes from Line 2 and `k!=j` in Line 3 of Alg. 2.
+        # NOTE(nabenabe): If True, include `u` in `A` at this index to the set in Line 3 of Alg. 2.
         include = sol >= np.max(np.where(target_filter, dominated_dps, -np.inf), axis=-2)
-        # NOTE(nabenabe): The indices of u that got True in include. Each u can get True multiple
-        # times for different indices j. Vectorization can process everything simultaneously.
+        # NOTE(nabenabe): The indices of `u` with `True` in include. Each `u` can get `True`
+        # multiple times for different indices `j`.
         including_indices = np.tile(np.arange(n_bounds)[:, np.newaxis], n_objectives)[include]
-        # The index `j` for each u s.t. \hat{z}_j \geq \max_{k \neq j}{z_j^k(u)}.
+        # The index `j` for each `u` s.t. `\hat{z}_j \geq \max_{k \neq j}{z_j^k(u)}`.
         target_axis = np.tile(objective_indices, (n_bounds, 1))[include]
         target_indices = np.arange(target_axis.size)
         new_dps = dominated_dps[including_indices]  # The 2nd row of the last Eq in Page 5.

--- a/optuna/_hypervolume/box_decomposition.py
+++ b/optuna/_hypervolume/box_decomposition.py
@@ -3,13 +3,13 @@ The functions in this file are mostly based on BoTorch v0.13.0,
 but they are refactored significantly from the original version.
 
 For ``_get_upper_bound_set``, look at:
-- https://github.com/pytorch/botorch/blob/v0.13.0/botorch/utils/multi_objective/box_decompositions/utils.py#L101-L160
+    * https://github.com/pytorch/botorch/blob/v0.13.0/botorch/utils/multi_objective/box_decompositions/utils.py#L101-L160
 
 For ``_get_hyper_rectangle_bounds``, look at:
-- https://github.com/pytorch/botorch/blob/v0.13.0/botorch/utils/multi_objective/box_decompositions/utils.py#L163-L193
+    * https://github.com/pytorch/botorch/blob/v0.13.0/botorch/utils/multi_objective/box_decompositions/utils.py#L163-L193
 
 For ``_get_non_dominated_hyper_rectangle_bounds``, look at:
-- https://github.com/pytorch/botorch/blob/v0.13.0/botorch/utils/multi_objective/box_decompositions/non_dominated.py#L395-L430  # NOQA: E501
+    * https://github.com/pytorch/botorch/blob/v0.13.0/botorch/utils/multi_objective/box_decompositions/non_dominated.py#L395-L430
 
 The preprocessing for four or fewer objectives, we use the algorithm proposed by:
     Title: A Box Decomposition Algorithm to Compute the Hypervolume Indicator

--- a/optuna/_hypervolume/box_decomposition.py
+++ b/optuna/_hypervolume/box_decomposition.py
@@ -124,7 +124,7 @@ def _get_non_dominated_box_bounds(
         sorted_neg_upper_bound_set, point_at_infinity
     )
     box_upper_bounds, box_lower_bounds = -_get_box_bounds(
-        neg_def_points, neg_lower_bound_set, point_at_infinity
+        neg_lower_bound_set, neg_def_points, point_at_infinity
     )
     return box_lower_bounds, box_upper_bounds
 

--- a/optuna/_hypervolume/box_decomposition.py
+++ b/optuna/_hypervolume/box_decomposition.py
@@ -39,15 +39,17 @@ def _get_upper_bound_set(
         ref_point: The reference point.
 
     Returns:
-        upper_bound_set: The upper bound set, which is U(N) in the paper. The shape is
-        (n_bounds, n_objectives).
-        def_points: The defining points of each vector in U(N). The shape is
-        (n_bounds, n_objectives, n_objectives).
+        upper_bound_set: The upper bound set, which is ``U(N)`` in the paper. The shape is
+        ``(n_bounds, n_objectives)``.
+        def_points: The defining points of each vector in ``U(N)``. The shape is
+        ``(n_bounds, n_objectives, n_objectives)``.
 
     NOTE:
-        ``pareto_sols`` corresponds to N and ``upper_bound_set`` corresponds to U(N) in the paper.
-        ``def_points`` (the shape is (n_bounds, n_objectives, n_objectives)) is not well explained
-        in the paper, but basically, def_points[i, j] = z[j] of upper_bound_set[i].
+        ``pareto_sols`` corresponds to ``N`` and ``upper_bound_set`` corresponds to ``U(N)`` in the
+        paper.
+        ``def_points`` (the shape is ``(n_bounds, n_objectives, n_objectives)``) is not well
+        explained in the paper, but basically, ``def_points[i, j] = z[j]`` of
+        ``upper_bound_set[i]``.
     """
     (_, n_objectives) = sorted_pareto_sols.shape
     objective_indices = np.arange(n_objectives)
@@ -66,7 +68,7 @@ def _get_upper_bound_set(
         # NOTE(nabenabe): `-inf` comes from Line 2 and `k!=j` in Line 3 of Alg. 2.
         # NOTE(nabenabe): If True, include `u` in `A` at this index to the set in Line 3 of Alg. 2.
         include = sol >= np.max(np.where(target_filter, dominated_dps, -np.inf), axis=-2)
-        # NOTE(nabenabe): The indices of `u` with `True` in include. Each `u` can get `True`
+        # NOTE(nabenabe): The indices of `u` with `True` in include. Each `u` may yield `True`
         # multiple times for different indices `j`.
         including_indices = np.tile(np.arange(n_bounds)[:, np.newaxis], n_objectives)[include]
         # The index `j` for each `u` s.t. `\hat{z}_j \geq \max_{k \neq j}{z_j^k(u)}`.
@@ -81,7 +83,7 @@ def _get_upper_bound_set(
     upper_bound_set = np.asarray([ref_point])  # Line 1 of Alg. 2.
     def_points = np.full((1, n_objectives, n_objectives), -np.inf)  # z^k(z^r) = \hat{z}^k
     def_points[0, objective_indices, objective_indices] = ref_point  # \hat{z}^k is a dummy point.
-    for solution in sorted_pareto_sols:  # NOTE(nabenabe): Sorted is necessary.
+    for solution in sorted_pareto_sols:  # NOTE(nabenabe): Sorted must be fulfilled.
         upper_bound_set, def_points = update(solution, upper_bound_set, def_points)
 
     return upper_bound_set, def_points
@@ -106,7 +108,7 @@ def _get_non_dominated_hyper_rectangle_bounds(
     sorted_pareto_sols: np.ndarray, ref_point: np.ndarray
 ) -> tuple[np.ndarray, np.ndarray]:  # (n_bounds, n_objectives) and (n_bounds, n_objectives)
     # The calculation of u[k] and l[k] in the paper: https://arxiv.org/abs/2006.05078
-    # NOTE(nabenabe): The paper handles maximization problems, but we do minimization here.
+    # NOTE(nabenabe): The paper handles maximization problems, but we consider minimization here.
     _upper_bound_set = _get_upper_bound_set(sorted_pareto_sols, ref_point)[0]
     upper_bound_set = _upper_bound_set[np.argsort(_upper_bound_set[:, 0])[::-1]]
     # Flip the sign and use upper_bound_set as the Pareto solutions. Then we can calculate the

--- a/optuna/_hypervolume/box_decomposition.py
+++ b/optuna/_hypervolume/box_decomposition.py
@@ -54,7 +54,7 @@ def _get_upper_bound_set(
     (_, n_objectives) = sorted_pareto_sols.shape
     objective_indices = np.arange(n_objectives)
     skip_ineq_judge = np.eye(n_objectives, dtype=bool)
-    # NOTE(nabenabe): False at 0 comes from Line 2 of Alg. 2. (loss_vals is sorted w.r.t. 0-th obj)
+    # NOTE(nabenabe): True at 0 comes from Line 2 of Alg. 2. (loss_vals is sorted w.r.t. 0-th obj)
     skip_ineq_judge[:, 0] = True
 
     def update(sol: np.ndarray, ubs: np.ndarray, dps: np.ndarray) -> tuple[np.ndarray, np.ndarray]:

--- a/optuna/_hypervolume/box_decomposition.py
+++ b/optuna/_hypervolume/box_decomposition.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+import numpy as np
+
+from optuna.study._multi_objective import _is_pareto_front
+
+
+def _get_upper_bound_set(
+    sorted_pareto_sols: np.ndarray, ref_point: np.ndarray
+) -> tuple[np.ndarray, np.ndarray]:
+    """
+    This function follows Algorithm 2 of the paper ([Lacour17]) below:
+        Title: A Box Decomposition Algorithm to Compute the Hypervolume Indicator
+        Authors: Renaud Lacour, Kathrin Klamroth, and Carlos M. Fonseca
+        URL: https://arxiv.org/abs/1510.01963
+
+    Args:
+        sorted_pareto_sols: Pareto solutions sorted with respect to the first objective.
+        ref_point: The reference point.
+
+    Returns:
+        upper_bound_set: The upper bound set, which is U(N) in the paper. The shape is
+        (n_bounds, n_objectives).
+        def_points: The defining points of each vector in U(N). The shape is
+        (n_bounds, n_objectives, n_objectives).
+
+    NOTE:
+        ``pareto_sols`` corresponds to N and ``upper_bound_set`` corresponds to U(N) in the paper.
+        ``def_points`` (the shape is (n_bounds, n_objectives, n_objectives)) is not well explained
+        in the paper, but basically, def_points[i, j] = z[j] of upper_bound_set[i].
+    """
+    (_, n_objectives) = sorted_pareto_sols.shape
+    objective_indices = np.arange(n_objectives)
+    target_filter = ~np.eye(n_objectives, dtype=bool)
+    # NOTE(nabenabe): False at 0 comes from Line 2 of Alg. 2. (loss_vals is sorted w.r.t. 0-th obj)
+    target_filter[:, 0] = False
+
+    def update(sol: np.ndarray, ubs: np.ndarray, dps: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+        # The update rule is written in Section 2.2 of [Lacour17].
+        # Ref.: https://github.com/pytorch/botorch/blob/a0a2c0509dbbeec547a65f16cb0cb8d5b19fd7f1/botorch/utils/multi_objective/box_decompositions/utils.py#L102-L161  # NOQA: E501
+        is_dominated = np.all(sol < ubs, axis=-1)
+        if not np.any(is_dominated):
+            return ubs, dps
+
+        dominated_dps = dps[is_dominated]  # The set A in Line 5 of Alg. 2.
+        n_bounds = dominated_dps.shape[0]
+        # NOTE(nabenabe): -inf comes from Line 2 and k!=j in Line 3 of Alg. 2.
+        # NOTE(nabenabe): If True, include u in A at this index to the set in Line 3 of Alg. 2.
+        include = sol >= np.max(np.where(target_filter, dominated_dps, -np.inf), axis=-2)
+        # NOTE(nabenabe): The indices of u that got True in include. Each u can get True multiple
+        # times for different indices j. Vectorization can process everything simultaneously.
+        including_indices = np.tile(np.arange(n_bounds)[:, np.newaxis], n_objectives)[include]
+        # The index `j` for each u s.t. \hat{z}_j \geq \max_{k \neq j}{z_j^k(u)}.
+        target_axis = np.tile(objective_indices, (n_bounds, 1))[include]
+        target_indices = np.arange(target_axis.size)
+        new_dps = dominated_dps[including_indices]  # The 2nd row of the last Eq in Page 5.
+        new_dps[target_indices, target_axis] = sol  # The 1st row of the same Eq.
+        new_ubs = ubs[is_dominated][including_indices]  # Line 3 of Alg. 2.
+        new_ubs[target_indices, target_axis] = sol[target_axis]  # \bar{z}_j in Line 3.
+        return np.vstack([ubs[~is_dominated], new_ubs]), np.vstack([dps[~is_dominated], new_dps])
+
+    upper_bound_set = np.asarray([ref_point])  # Line 1 of Alg. 2.
+    def_points = np.full((1, n_objectives, n_objectives), -np.inf)  # z^k(z^r) = \hat{z}^k
+    def_points[0, objective_indices, objective_indices] = ref_point  # \hat{z}^k is a dummy point.
+    for solution in sorted_pareto_sols:  # NOTE(nabenabe): Sorted is necessary.
+        upper_bound_set, def_points = update(solution, upper_bound_set, def_points)
+
+    return upper_bound_set, def_points
+
+
+def _get_hyper_rectangle_bounds(
+    def_points: np.ndarray, upper_bound_set: np.ndarray, ref_point: np.ndarray
+) -> np.ndarray:
+    # Eq. (2) of [Lacour17].
+    # Ref.: https://github.com/pytorch/botorch/blob/a0a2c0509dbbeec547a65f16cb0cb8d5b19fd7f1/botorch/utils/multi_objective/box_decompositions/utils.py#L164-L194  # NOQA: E501
+    n_objectives = upper_bound_set.shape[-1]
+    bounds = np.empty((2, *upper_bound_set.shape))
+    bounds[0, :, 0] = def_points[:, 0, 0]
+    bounds[1, :, 0] = ref_point[0]
+    row, col = np.diag_indices(n_objectives - 1)
+    bounds[0, :, 1:] = np.maximum.accumulate(def_points, axis=-2)[:, row, col + 1]
+    bounds[1, :, 1:] = upper_bound_set[:, 1:]
+    not_empty = ~np.any(bounds[1] <= bounds[0], axis=-1)  # Remove [inf, inf] or [-inf, -inf].
+    return bounds[:, not_empty]
+
+
+def _get_non_dominated_hyper_rectangle_bounds(
+    sorted_pareto_sols: np.ndarray, ref_point: np.ndarray
+) -> tuple[np.ndarray, np.ndarray]:  # (n_bounds, n_objectives) and (n_bounds, n_objectives)
+    # The calculation of u[k] and l[k] in the paper below:
+    # [Daulton20]: https://arxiv.org/abs/2006.05078
+    # Ref.: https://github.com/pytorch/botorch/blob/a0a2c0509dbbeec547a65f16cb0cb8d5b19fd7f1/botorch/utils/multi_objective/box_decompositions/non_dominated.py#L395-L430  # NOQA: E501
+    # NOTE(nabenabe): The paper handles maximization problems, but we do minimization here.
+    _upper_bound_set = _get_upper_bound_set(sorted_pareto_sols, ref_point)[0]
+    upper_bound_set = _upper_bound_set[np.argsort(_upper_bound_set[:, 0])[::-1]]
+    # Flip the sign and use upper_bound_set as the Pareto solutions. Then we can calculate the
+    # lower bound set as well.
+    point_at_infinity = np.full_like(ref_point, np.inf)
+    neg_bound_set, neg_def_points = _get_upper_bound_set(-upper_bound_set, point_at_infinity)
+    ubs, lbs = -_get_hyper_rectangle_bounds(neg_def_points, neg_bound_set, point_at_infinity)
+    return lbs, ubs
+
+
+def _get_accepted_bound_indices(
+    pareto_sols: np.ndarray, ref_point: np.ndarray, alpha: float
+) -> np.ndarray:
+    aug_pareto_sols = np.vstack(
+        [np.min(pareto_sols, axis=0) - 1, pareto_sols, np.max(pareto_sols, axis=0) + 1]
+    )
+    aug_pareto_indices = np.argsort(aug_pareto_sols, axis=0)
+    threshold = alpha * np.prod(aug_pareto_sols[-1] - aug_pareto_sols[0])
+    (n_sols, n_objectives) = aug_pareto_sols.shape
+    obj_indices = np.arange(n_objectives)
+    init_bound_indices = np.tile(np.asarray([0, n_sols - 1])[:, np.newaxis], n_objectives)
+    if pareto_sols.shape[0] == 0:
+        return init_bound_indices[..., np.newaxis, :]
+
+    stack = [init_bound_indices]
+    accepted_bound_indices = []
+    while len(stack) > 0:
+        bound_indices = stack.pop()
+        target_sol_indices = aug_pareto_indices[bound_indices, obj_indices]
+        bs = aug_pareto_sols[target_sol_indices, obj_indices]  # Upper/Lower bounds.
+        non_doms = np.all(np.any(bs[:, np.newaxis] <= pareto_sols, axis=-1), axis=-1)
+        assert not isinstance(non_doms, np.bool) and non_doms.shape == (2,), "MyPy Redefinition."
+        lb_non_dom, ub_non_dom = non_doms
+        if ub_non_dom:  # Upper bound is non-dominated by all Pareto solutions.
+            accepted_bound_indices.append(target_sol_indices)
+            continue
+
+        max_idx = np.argmax(bound_indices[1] - bound_indices[0])
+        max_idx_diff = int(bound_indices[1, max_idx] - bound_indices[0, max_idx])
+        if not lb_non_dom or np.prod(bs[1] - bs[0]) <= threshold or max_idx_diff <= 1:
+            continue
+
+        new_bs = np.stack([bound_indices, bound_indices])
+        new_bs[*np.diag_indices(2), max_idx] += [max_idx_diff // 2, -((max_idx_diff + 1) // 2)]
+        stack.extend([new_bs[1], new_bs[0]])
+
+    return np.concat(np.asarray(accepted_bound_indices)[..., np.newaxis, :], axis=1)
+
+
+def _approximate_non_dominated_hyper_rectangle_bounds(
+    pareto_sols: np.ndarray, ref_point: np.ndarray, alpha: float
+) -> tuple[np.ndarray, np.ndarray]:  # (n_bounds, n_objectives) and (n_bounds, n_objectives)
+    # See ``Towards Efficient Multiobjective Optimization: Multiobjective statistical criterions``.
+    accepted_bound_indices = _get_accepted_bound_indices(pareto_sols, ref_point, alpha)
+    (_, n_bounds, n_objectives) = accepted_bound_indices.shape
+    aug_pareto_sols = np.vstack([np.full(n_objectives, -np.inf), pareto_sols, ref_point])
+    obj_indices = np.tile(np.arange(n_objectives), 2 * n_bounds)
+    return aug_pareto_sols[accepted_bound_indices.flatten(), obj_indices].reshape(
+        2, n_bounds, n_objectives
+    )
+
+
+def get_non_dominated_hyper_rectangle_bounds(
+    loss_vals: np.ndarray, ref_point: np.ndarray, alpha: float | None = None
+) -> tuple[np.ndarray, np.ndarray]:  # (n_bounds, n_objectives) and (n_bounds, n_objectives)
+    def _get_sorted_pareto_sols(loss_vals: np.ndarray) -> np.ndarray:
+        unique_lexsorted_loss_vals = np.unique(loss_vals, axis=0)
+        return unique_lexsorted_loss_vals[
+            _is_pareto_front(unique_lexsorted_loss_vals, assume_unique_lexsorted=True)
+        ]
+
+    sorted_pareto_sols = _get_sorted_pareto_sols(loss_vals)
+    n_objectives = loss_vals.shape[-1]
+    # The condition here follows BoTorch.
+    # https://github.com/pytorch/botorch/blob/0d5e13102ed0ddd89d767ddf89659fb2563d1d50/botorch/acquisition/multi_objective/utils.py#L55-L63
+    if n_objectives <= 4:
+        return _get_non_dominated_hyper_rectangle_bounds(sorted_pareto_sols, ref_point)
+    else:
+        alpha = alpha if alpha is not None else 10 ** (-2 if n_objectives >= 6 else -3)
+        return _approximate_non_dominated_hyper_rectangle_bounds(
+            sorted_pareto_sols, ref_point, alpha
+        )

--- a/optuna/_hypervolume/box_decomposition.py
+++ b/optuna/_hypervolume/box_decomposition.py
@@ -122,10 +122,10 @@ def _get_non_dominated_box_bounds(
     neg_lower_bound_set, neg_def_points = _get_upper_bound_set(
         sorted_neg_upper_bound_set, point_at_infinity
     )
-    upper_box_bounds, lower_box_bounds = -_get_box_bounds(
+    box_upper_bounds, box_lower_bounds = -_get_box_bounds(
         neg_def_points, neg_lower_bound_set, point_at_infinity
     )
-    return lower_box_bounds, upper_box_bounds
+    return box_lower_bounds, box_upper_bounds
 
 
 def get_non_dominated_box_bounds(

--- a/optuna/_hypervolume/box_decomposition.py
+++ b/optuna/_hypervolume/box_decomposition.py
@@ -95,7 +95,7 @@ def _get_upper_bound_set(
 
 
 def _get_box_bounds(
-    def_points: np.ndarray, upper_bound_set: np.ndarray, ref_point: np.ndarray
+    upper_bound_set: np.ndarray, def_points: np.ndarray, ref_point: np.ndarray
 ) -> np.ndarray:
     # Eq. (2) of Lacour17.
     n_objectives = upper_bound_set.shape[-1]

--- a/optuna/_hypervolume/box_decomposition.py
+++ b/optuna/_hypervolume/box_decomposition.py
@@ -74,13 +74,14 @@ def _get_upper_bound_set(
         ubs_indices_to_update = np.tile(np.arange(n_bounds)[:, np.newaxis], n_objectives)[update]
         # The dimension `j` for each `u` s.t. `\hat{z}_j \geq \max_{k \neq j}{z_j^k(u)}`.
         dimensions_to_update = np.tile(objective_indices, (n_bounds, 1))[update]
-        target_axis = np.tile(objective_indices, (n_bounds, 1))[update]
         assert ubs_indices_to_update.size == dimensions_to_update.size
-        target_indices = np.arange(dimensions_to_update.size)
-        new_dps = dominated_dps[ubs_indices_to_update]  # The 2nd row of the last Eq in Page 5.
-        new_dps[target_indices, dimensions_to_update] = sol  # The 1st row of the same Eq.
-        new_ubs = ubs[is_dominated][ubs_indices_to_update]  # Line 3 of Alg. 2.
-        new_ubs[target_indices, dimensions_to_update] = sol[dimensions_to_update]  # \bar{z}_j in Line 3.
+        indices_for_sweeping = np.arange(dimensions_to_update.size)
+        # The last Eq in Page 5.
+        new_dps = dominated_dps[ubs_indices_to_update]
+        new_dps[indices_for_sweeping, dimensions_to_update] = sol
+        # Line 3 of Alg. 2. `sol[dimensions_to_update]` is equivalent to `\bar{z}_j`.
+        new_ubs = ubs[is_dominated][ubs_indices_to_update]
+        new_ubs[indices_for_sweeping, dimensions_to_update] = sol[dimensions_to_update]
         return np.vstack([ubs[~is_dominated], new_ubs]), np.vstack([dps[~is_dominated], new_dps])
 
     upper_bound_set = np.asarray([ref_point])  # Line 1 of Alg. 2.

--- a/tests/hypervolume_tests/test_box_decomposition.py
+++ b/tests/hypervolume_tests/test_box_decomposition.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
-import pytest
-
 import numpy as np
-from optuna.study._multi_objective import _is_pareto_front
-from optuna._hypervolume.wfg import compute_hypervolume
-from optuna._hypervolume.box_decomposition import _get_non_dominated_hyper_rectangle_bounds
+import pytest
 import torch
+
+from optuna._hypervolume.box_decomposition import _get_non_dominated_hyper_rectangle_bounds
+from optuna._hypervolume.wfg import compute_hypervolume
+from optuna.study._multi_objective import _is_pareto_front
 
 
 def _generate_pareto_sols(n_objectives: int, n_trials: int, seed: int) -> np.ndarray:
@@ -33,6 +33,6 @@ def test_exact_box_decomposition(n_objectives: int) -> None:
         diff = torch.nn.functional.relu(
             torch.tensor(ubs) - torch.maximum(new_points[..., torch.newaxis, :], torch.tensor(lbs))
         )
-        ans[i] = torch.special.logsumexp(diff.log().sum(axis=-1), axis=-1).exp().detach().numpy()
+        ans[i] = torch.special.logsumexp(diff.log().sum(dim=-1), dim=-1).exp().detach().numpy()
 
     assert np.allclose(ans, correct)

--- a/tests/hypervolume_tests/test_box_decomposition.py
+++ b/tests/hypervolume_tests/test_box_decomposition.py
@@ -18,7 +18,7 @@ def _generate_pareto_sols(n_objectives: int, n_trials: int, seed: int) -> np.nda
 @pytest.mark.parametrize("n_objectives", range(2, 5))
 def test_exact_box_decomposition(n_objectives: int) -> None:
     pareto_sols = _generate_pareto_sols(n_objectives, n_trials=100, seed=42)
-    ref_point = np.ones(pareto_sols.shape[-1]) * 1.1
+    ref_point = np.ones(pareto_sols.shape[-1]) * 10.0
     n_sols = pareto_sols.shape[0]
     # LOO means leave one out.
     loo_mat = ~np.eye(n_sols, dtype=bool)

--- a/tests/hypervolume_tests/test_box_decomposition.py
+++ b/tests/hypervolume_tests/test_box_decomposition.py
@@ -103,8 +103,12 @@ def test_exact_box_decomposition(gen: InstanceGenerator, n_objectives: int) -> N
     ),
 )
 @pytest.mark.parametrize("n_objectives", [2, 3, 4])
-def test_box_decomposition_general_position(gen: InstanceGenerator, n_objectives: int) -> None:
+def test_box_decomposition_with_non_general_position(
+    gen: InstanceGenerator, n_objectives: int
+) -> None:
     # By using integer values, duplications can be guaranteed.
+    # We are testing Proposition 2.2 in the paper: https://arxiv.org/abs/1510.01963
+    # General position means that no two distinct points share the same value in any dimensions.
     pareto_sols = _extract_pareto_sols(
         np.round(gen(n_objectives=n_objectives, n_trials=100, seed=42) * 5)
     )

--- a/tests/hypervolume_tests/test_box_decomposition.py
+++ b/tests/hypervolume_tests/test_box_decomposition.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Protocol
+
 import numpy as np
 import pytest
 
@@ -8,16 +10,75 @@ from optuna._hypervolume.wfg import compute_hypervolume
 from optuna.study._multi_objective import _is_pareto_front
 
 
-def _generate_pareto_sols(n_objectives: int, n_trials: int, seed: int) -> np.ndarray:
-    rng = np.random.RandomState(seed)
-    sorted_loss_vals = np.unique(rng.random((n_trials, n_objectives)), axis=0)
+_EPS = 1e-12
+
+
+class InstanceGenerator(Protocol):
+    def __call__(self, n_trials: int, n_objectives: int, seed: int) -> np.ndarray:
+        raise NotImplementedError
+
+
+def _extract_pareto_sols(loss_values: np.ndarray) -> np.ndarray:
+    sorted_loss_vals = np.unique(loss_values, axis=0)
     on_front = _is_pareto_front(sorted_loss_vals, assume_unique_lexsorted=True)
     return sorted_loss_vals[on_front]
 
 
-@pytest.mark.parametrize("n_objectives", range(2, 5))
-def test_exact_box_decomposition(n_objectives: int) -> None:
-    pareto_sols = _generate_pareto_sols(n_objectives, n_trials=100, seed=42)
+def _generate_uniform_samples(n_trials: int, n_objectives: int, seed: int) -> np.ndarray:
+    rng = np.random.RandomState(seed)
+    return np.maximum(_EPS, rng.random((n_trials, n_objectives)))
+
+
+def _generate_instances_with_negative(n_objectives: int, n_trials: int, seed: int) -> np.ndarray:
+    rng = np.random.RandomState(seed)
+    return _extract_pareto_sols(rng.normal(size=(n_trials, n_objectives)))
+
+
+def _generate_concave_instances(n_trials: int, n_objectives: int, seed: int) -> np.ndarray:
+    """See Section 4.2 of https://arxiv.org/pdf/1510.01963"""
+    points = _generate_uniform_samples(n_trials, n_objectives, seed)
+    loss_values = points / np.maximum(_EPS, np.sum(points**2, axis=-1))[:, np.newaxis]
+    return _extract_pareto_sols(loss_values)
+
+
+def _generate_convex_instances(n_trials: int, n_objectives: int, seed: int) -> np.ndarray:
+    """See Section 4.2 of https://arxiv.org/pdf/1510.01963"""
+    points = _generate_uniform_samples(n_trials, n_objectives, seed)
+    loss_values = 1 - points / np.maximum(_EPS, np.sum(points**2, axis=-1))[:, np.newaxis]
+    return _extract_pareto_sols(loss_values)
+
+
+def _generate_linear_instances(n_trials: int, n_objectives: int, seed: int) -> np.ndarray:
+    """See Section 4.2 of https://arxiv.org/pdf/1510.01963"""
+    points = _generate_uniform_samples(n_trials, n_objectives, seed)
+    loss_values = points / np.maximum(_EPS, np.sum(points, axis=-1))[:, np.newaxis]
+    return _extract_pareto_sols(loss_values)
+
+
+def _calculate_hypervolume_improvement(
+    lbs: np.ndarray, ubs: np.ndarray, new_points: np.ndarray
+) -> np.ndarray:
+    diff = np.maximum(0.0, ubs - np.maximum(new_points[..., np.newaxis, :], lbs))
+    # The minimization version of Eq. (1) in https://arxiv.org/pdf/2006.05078.
+    return np.sum(np.prod(diff, axis=-1), axis=-1)
+
+
+parametrized_n_objectives = pytest.mark.parametrize("n_objectives", [2, 3, 4])
+
+
+@pytest.mark.parametrize(
+    "gen",
+    (
+        _generate_concave_instances,
+        _generate_convex_instances,
+        _generate_instances_with_negative,
+        _generate_linear_instances,
+    ),
+)
+@parametrized_n_objectives
+def test_exact_box_decomposition(gen: InstanceGenerator, n_objectives: int) -> None:
+    n_trials = 30 if n_objectives == 4 else 60
+    pareto_sols = gen(n_objectives=n_objectives, n_trials=n_trials, seed=42)
     ref_point = np.ones(pareto_sols.shape[-1]) * 10.0
     n_sols = pareto_sols.shape[0]
     # LOO means leave one out.
@@ -28,9 +89,39 @@ def test_exact_box_decomposition(n_objectives: int) -> None:
     ans = np.empty_like(correct)
     for i, loo in enumerate(loo_mat):
         lbs, ubs = get_non_dominated_box_bounds(pareto_sols[loo], ref_point)
-        new_points = pareto_sols[np.newaxis, i]
-        diff = np.maximum(0.0, ubs - np.maximum(new_points[..., np.newaxis, :], lbs))
-        # The minimization version of Eq. (1) in https://arxiv.org/pdf/2006.05078.
-        ans[i] = np.sum(np.prod(diff, axis=-1))
+        ans[i] = _calculate_hypervolume_improvement(lbs, ubs, pareto_sols[np.newaxis, i])[0]
 
     assert np.allclose(ans, correct)
+
+
+@parametrized_n_objectives
+def test_box_decomposition_with_1_solution(n_objectives: int) -> None:
+    pareto_sols = np.ones((1, n_objectives))
+    ref_point = np.ones(n_objectives) * 10.0
+    lbs, ubs = get_non_dominated_box_bounds(pareto_sols, ref_point)
+    hvi = _calculate_hypervolume_improvement(lbs, ubs, np.zeros((1, n_objectives)))[0]
+    assert np.isclose(hvi, 10**n_objectives - 9**n_objectives)
+
+
+@parametrized_n_objectives
+def test_box_decomposition_with_empty_set(n_objectives: int) -> None:
+    pareto_sols = np.ones((0, n_objectives))
+    ref_point = np.ones(n_objectives) * 10.0
+    lbs, ubs = get_non_dominated_box_bounds(pareto_sols, ref_point)
+    hvi = _calculate_hypervolume_improvement(lbs, ubs, np.zeros((1, n_objectives)))[0]
+    assert np.isclose(hvi, 10**n_objectives)
+
+
+def test_box_decomposition_general_position() -> None:
+    pass
+
+
+@pytest.mark.parametrize(
+    "values", [np.array([[np.inf, 0.0]]), np.array([[-np.inf, 0.0]]), np.array([[np.nan, 0.0]])]
+)
+def test_assertion_for_non_finite_values(values: np.ndarray) -> None:
+    # NOTE(nabenabe): Since GPSampler trains regression models, values must be clipped, which is
+    # done by `optuna._gp.gp.warn_and_convert_inf`. If `values` includes any non-finite values,
+    # hypervolume improvement becomes either `inf` or `nan` anyways.
+    with pytest.raises(AssertionError):
+        get_non_dominated_box_bounds(values, np.ones(values.shape[-1]) * 10.0)

--- a/tests/hypervolume_tests/test_box_decomposition.py
+++ b/tests/hypervolume_tests/test_box_decomposition.py
@@ -30,6 +30,7 @@ def test_exact_box_decomposition(n_objectives: int) -> None:
         lbs, ubs = _get_non_dominated_hyper_rectangle_bounds(pareto_sols[loo], ref_point)
         new_points = pareto_sols[np.newaxis, i]
         diff = np.maximum(0.0, ubs - np.maximum(new_points[..., np.newaxis, :], lbs))
+        # The minimization version of Eq. (1) in https://arxiv.org/pdf/2006.05078.
         ans[i] = np.sum(np.prod(diff, axis=-1), axis=-1)
 
     assert np.allclose(ans, correct)

--- a/tests/hypervolume_tests/test_box_decomposition.py
+++ b/tests/hypervolume_tests/test_box_decomposition.py
@@ -73,7 +73,7 @@ def _verify_exact_hypervolume_improvement(pareto_sols: np.ndarray) -> None:
         correct = hv - compute_hypervolume(pareto_sols[loo], ref_point)
         lbs, ubs = get_non_dominated_box_bounds(pareto_sols[loo], ref_point)
         out = _calculate_hypervolume_improvement(lbs, ubs, pareto_sols[np.newaxis, i])
-        assert out.shape == (1, )
+        assert out.shape == (1,)
         assert np.isclose(out[0], correct)
 
 

--- a/tests/hypervolume_tests/test_box_decomposition.py
+++ b/tests/hypervolume_tests/test_box_decomposition.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
-from optuna._hypervolume.box_decomposition import _get_non_dominated_hyper_rectangle_bounds
+from optuna._hypervolume.box_decomposition import get_non_dominated_box_bounds
 from optuna._hypervolume.wfg import compute_hypervolume
 from optuna.study._multi_objective import _is_pareto_front
 
@@ -27,10 +27,10 @@ def test_exact_box_decomposition(n_objectives: int) -> None:
     correct = hv - np.array([compute_hypervolume(pareto_sols[loo], ref_point) for loo in loo_mat])
     ans = np.empty_like(correct)
     for i, loo in enumerate(loo_mat):
-        lbs, ubs = _get_non_dominated_hyper_rectangle_bounds(pareto_sols[loo], ref_point)
+        lbs, ubs = get_non_dominated_box_bounds(pareto_sols[loo], ref_point)
         new_points = pareto_sols[np.newaxis, i]
         diff = np.maximum(0.0, ubs - np.maximum(new_points[..., np.newaxis, :], lbs))
         # The minimization version of Eq. (1) in https://arxiv.org/pdf/2006.05078.
-        ans[i] = np.sum(np.prod(diff, axis=-1), axis=-1)
+        ans[i] = np.sum(np.prod(diff, axis=-1))
 
     assert np.allclose(ans, correct)

--- a/tests/hypervolume_tests/test_box_decomposition.py
+++ b/tests/hypervolume_tests/test_box_decomposition.py
@@ -77,8 +77,7 @@ def _verify_exact_hypervolume_improvement(pareto_sols: np.ndarray) -> None:
         assert np.isclose(out[0], correct)
 
 
-parametrized_n_objectives = pytest.mark.parametrize("n_objectives", [2, 3, 4])
-parametrized_generators = pytest.mark.parametrize(
+@pytest.mark.parametrize(
     "gen",
     (
         _generate_concave_instances,
@@ -87,18 +86,23 @@ parametrized_generators = pytest.mark.parametrize(
         _generate_linear_instances,
     ),
 )
-
-
-@parametrized_generators
-@parametrized_n_objectives
+@pytest.mark.parametrize("n_objectives", [2, 3, 4])
 def test_exact_box_decomposition(gen: InstanceGenerator, n_objectives: int) -> None:
     n_trials = 30 if n_objectives == 4 else 60
     pareto_sols = gen(n_objectives=n_objectives, n_trials=n_trials, seed=42)
     _verify_exact_hypervolume_improvement(pareto_sols)
 
 
-@parametrized_generators
-@parametrized_n_objectives
+@pytest.mark.parametrize(
+    "gen",
+    (
+        _generate_concave_instances,
+        _generate_convex_instances,
+        _generate_instances_with_negative,
+        _generate_linear_instances,
+    ),
+)
+@pytest.mark.parametrize("n_objectives", [2, 3, 4])
 def test_box_decomposition_general_position(gen: InstanceGenerator, n_objectives: int) -> None:
     # By using integer values, duplications can be guaranteed.
     pareto_sols = _extract_pareto_sols(
@@ -107,7 +111,7 @@ def test_box_decomposition_general_position(gen: InstanceGenerator, n_objectives
     _verify_exact_hypervolume_improvement(pareto_sols)
 
 
-@parametrized_n_objectives
+@pytest.mark.parametrize("n_objectives", [2, 3, 4])
 def test_box_decomposition_with_1_solution(n_objectives: int) -> None:
     pareto_sols = np.ones((1, n_objectives))
     ref_point = np.ones(n_objectives) * 10.0
@@ -116,7 +120,7 @@ def test_box_decomposition_with_1_solution(n_objectives: int) -> None:
     assert np.isclose(hvi, 10**n_objectives - 9**n_objectives)
 
 
-@parametrized_n_objectives
+@pytest.mark.parametrize("n_objectives", [2, 3, 4])
 def test_box_decomposition_with_empty_set(n_objectives: int) -> None:
     pareto_sols = np.ones((0, n_objectives))
     ref_point = np.ones(n_objectives) * 10.0

--- a/tests/hypervolume_tests/test_box_decomposition.py
+++ b/tests/hypervolume_tests/test_box_decomposition.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import pytest
+
+import numpy as np
+from optuna.study._multi_objective import _is_pareto_front
+from optuna._hypervolume.wfg import compute_hypervolume
+from optuna._hypervolume.box_decomposition import _get_non_dominated_hyper_rectangle_bounds
+import torch
+
+
+def _generate_pareto_sols(n_objectives: int, n_trials: int, seed: int) -> np.ndarray:
+    rng = np.random.RandomState(seed)
+    sorted_loss_vals = np.unique(rng.random((n_trials, n_objectives)), axis=0)
+    on_front = _is_pareto_front(sorted_loss_vals, assume_unique_lexsorted=True)
+    return sorted_loss_vals[on_front]
+
+
+@pytest.mark.parametrize("n_objectives", range(2, 5))
+def test_exact_box_decomposition(n_objectives: int) -> None:
+    pareto_sols = _generate_pareto_sols(n_objectives, n_trials=100, seed=42)
+    ref_point = np.ones(pareto_sols.shape[-1]) * 1.1
+    n_sols = pareto_sols.shape[0]
+    llo_mat = ~np.eye(n_sols, dtype=bool)
+
+    hv = compute_hypervolume(pareto_sols, ref_point, assume_pareto=True)
+    correct = hv - np.array([compute_hypervolume(pareto_sols[llo], ref_point) for llo in llo_mat])
+    ans = np.empty_like(correct)
+    for i, llo in enumerate(llo_mat):
+        lbs, ubs = _get_non_dominated_hyper_rectangle_bounds(pareto_sols[llo], ref_point)
+        new_points = torch.tensor(pareto_sols[np.newaxis, i])
+        diff = torch.nn.functional.relu(
+            torch.tensor(ubs) - torch.maximum(new_points[..., torch.newaxis, :], torch.tensor(lbs))
+        )
+        ans[i] = torch.special.logsumexp(diff.log().sum(axis=-1), axis=-1).exp().detach().numpy()
+
+    assert np.allclose(ans, correct)


### PR DESCRIPTION
## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

This PR adds a module to preprocess for hypervolume improvement based on the papers `A Box Decomposition Algorithm to Compute the Hypervolume Indicator` and `Towards Efficient Multiobjective Optimization: Multiobjective statistical criterions`.

### `_get_upper_bound_set`

Basically, the main algorithm (`_get_upper_bound_set`) is based on the following pseudocode quoted from Algorithm 2 of [1]:

![image](https://github.com/user-attachments/assets/b9a83cc1-7843-4287-9aff-4455d0868143)

Figure 1 of [1] visualizes `upper_bound_set` as the black dots and the Pareto solutions (lower is better) as a cross.

![image](https://github.com/user-attachments/assets/53de9ab0-6589-42e5-82df-029a927ad573)

### `_get_hyper_rectangle_bounds`

This function calculates a set of diagonal points in the gray rectangles in the figure above, which is based the equation (2) in [1]:

![image](https://github.com/user-attachments/assets/b0cd9290-2b02-48d9-ba9b-1d597de3288d)

One of `B(u)` corresponds to a gray rectangle.

### `_get_non_dominated_hyper_rectangle_bounds`

This calculates a set of diagonal points in the white rectangles in Figure 1 of [2].
To do so, we perform `_get_upper_bound_set` twice: once for $l_k$ below and the other for $u_k$ below.

![image](https://github.com/user-attachments/assets/e44f0b6e-89c0-4d72-98c0-443674fdee84)

> [!NOTE]
> [2] considers the maximization problem unlike Optuna and [1].


[1] [A Box Decomposition Algorithm to Compute the Hypervolume Indicator](https://arxiv.org/abs/1510.01963)
[2] [Differentiable Expected Hypervolume Improvement for Parallel Multi-Objective Bayesian Optimization](https://arxiv.org/abs/2006.05078)