### PR TITLE
Update Type-Checking for `optuna/_convert_positional_args.py`

### DIFF
--- a/optuna/_convert_positional_args.py
+++ b/optuna/_convert_positional_args.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Callable
-from collections.abc import Sequence
 from functools import wraps
 from inspect import Parameter
 from inspect import signature
@@ -15,6 +13,9 @@ from optuna._experimental import _validate_version
 
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+    from collections.abc import Sequence
+
     from typing_extensions import ParamSpec
 
     _P = ParamSpec("_P")


### PR DESCRIPTION
## Motivation
Refs #6029

As described in the issue, I have updated type checking for the file and flake8 does not show any warnings.

Could you please review?

cc: @nabenabe0928

## Description of the changes
Updated type checking for optuna/_convert_positional_args.py