### PR TITLE
Update Type-Checking for `optuna/_deprecated.py`

### DIFF
--- a/optuna/_deprecated.py
+++ b/optuna/_deprecated.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Callable
 import functools
 import textwrap
 from typing import Any
@@ -15,6 +14,8 @@ from optuna._experimental import _validate_version
 
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from typing_extensions import ParamSpec
 
     FT = TypeVar("FT")


### PR DESCRIPTION
## Motivation
Refs #6029

As described in the issue, I have updated type checking for the file and flake8 does not show any warnings.

Could you please review?

cc: @nabenabe0928

## Description of the changes

Updated type checking for `optuna/_deprecated.py`
