### PR TITLE
Fix a bug in distributed optimization using NSGA-II/III

### DIFF
--- a/optuna/samplers/_ga/_base.py
+++ b/optuna/samplers/_ga/_base.py
@@ -171,7 +171,10 @@ class BaseGASampler(BaseSampler, abc.ABC):
 
         if cached_parent_population_ids is not None:
             trials = study._get_trials(deepcopy=False)
-            return [trials[trial_id] for trial_id in cached_parent_population_ids]
+            trials_by_id = {}
+            for t in trials:
+                trials_by_id[t._trial_id] = t
+            return [trials_by_id[trial_id] for trial_id in cached_parent_population_ids]
         else:
             parent_population = self.select_parent(study, generation)
             study._storage.set_study_system_attr(

--- a/optuna/samplers/_ga/_base.py
+++ b/optuna/samplers/_ga/_base.py
@@ -171,10 +171,8 @@ class BaseGASampler(BaseSampler, abc.ABC):
 
         if cached_parent_population_ids is not None:
             trials = study._get_trials(deepcopy=False)
-            trials_by_id = {}
-            for t in trials:
-                trials_by_id[t._trial_id] = t
-            return [trials_by_id[trial_id] for trial_id in cached_parent_population_ids]
+            parent_population_ids = set(cached_parent_population_ids)
+            return [trial for trial in trials if trial._trial_id in parent_population_ids]
         else:
             parent_population = self.select_parent(study, generation)
             study._storage.set_study_system_attr(

--- a/tests/samplers_tests/test_base_gasampler.py
+++ b/tests/samplers_tests/test_base_gasampler.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from typing import Any
-from unittest.mock import call
 from unittest.mock import MagicMock
 from unittest.mock import Mock
 from unittest.mock import patch

--- a/tests/samplers_tests/test_base_gasampler.py
+++ b/tests/samplers_tests/test_base_gasampler.py
@@ -219,11 +219,10 @@ def test_get_parent_population(args: dict[str, Any]) -> None:
         class StrictTrialMock(MagicMock):
             def __getattr__(self, name):
                 if name != "_trial_id":
-                    raise AttributeError(
-                        f"Access to attribute '{name}' is not allowed."
-                    )
+                    raise AttributeError(f"Access to attribute '{name}' is not allowed.")
                 return super().__getattr__(name)
-    
+
+
         mock_study._get_trials.return_value = [
             StrictTrialMock(_trial_id=i)
             for i in args["study_system_attrs"][

--- a/tests/samplers_tests/test_base_gasampler.py
+++ b/tests/samplers_tests/test_base_gasampler.py
@@ -219,7 +219,7 @@ def test_get_parent_population(args: dict[str, Any]) -> None:
         mock_study._get_trials.return_value = [
             optuna.trial.FrozenTrial(
                 number=i,
-                trial_id=i+10,
+                trial_id=i + 10,
                 state=optuna.trial.TrialState.WAITING,
                 value=None,
                 datetime_start=None,

--- a/tests/samplers_tests/test_base_gasampler.py
+++ b/tests/samplers_tests/test_base_gasampler.py
@@ -217,7 +217,7 @@ def test_get_parent_population(args: dict[str, Any]) -> None:
     if args["cache"]:
 
         class StrictTrialMock(MagicMock):
-            def __getattr__(self, name: str):
+            def __getattr__(self, name: str) -> Any:
                 if name != "_trial_id":
                     raise AttributeError(f"Access to attribute '{name}' is not allowed.")
                 return super().__getattr__(name)

--- a/tests/samplers_tests/test_base_gasampler.py
+++ b/tests/samplers_tests/test_base_gasampler.py
@@ -219,7 +219,7 @@ def test_get_parent_population(args: dict[str, Any]) -> None:
         mock_study._get_trials.return_value = [
             optuna.trial.FrozenTrial(
                 number=i,
-                trial_id=i,
+                trial_id=i+10,
                 state=optuna.trial.TrialState.WAITING,
                 value=None,
                 datetime_start=None,
@@ -230,7 +230,10 @@ def test_get_parent_population(args: dict[str, Any]) -> None:
                 system_attrs={},
                 intermediate_values={},
                 values=None,
-            ) for i in args["study_system_attrs"][BaseGASamplerTestSampler._get_parent_cache_key_prefix() + "1"]
+            )
+            for i in args["study_system_attrs"][
+                BaseGASamplerTestSampler._get_parent_cache_key_prefix() + "1"
+            ]
         ]
 
     with patch.object(

--- a/tests/samplers_tests/test_base_gasampler.py
+++ b/tests/samplers_tests/test_base_gasampler.py
@@ -218,7 +218,7 @@ def test_get_parent_population(args: dict[str, Any]) -> None:
         mock_study._get_trials.return_value = [
             optuna.trial.FrozenTrial(
                 number=i,
-                trial_id=i + 10,
+                trial_id=i,
                 state=optuna.trial.TrialState.WAITING,
                 value=None,
                 datetime_start=None,

--- a/tests/samplers_tests/test_base_gasampler.py
+++ b/tests/samplers_tests/test_base_gasampler.py
@@ -247,7 +247,10 @@ def test_get_parent_population(args: dict[str, Any]) -> None:
 
     mock_study._storage.get_study_system_attrs.assert_called_once_with(mock_study._study_id)
 
-    if not args["cache"]:
+    if args["cache"]:
+        assert return_value == mock_study._get_trials.return_value
+        mock_study._get_trials.assert_called_once_with(deepcopy=False)
+    else:
         mock_select_parent.assert_called_once_with(mock_study, args["generation"])
         mock_study._storage.set_study_system_attr.assert_called_once_with(
             mock_study._study_id,

--- a/tests/samplers_tests/test_base_gasampler.py
+++ b/tests/samplers_tests/test_base_gasampler.py
@@ -222,7 +222,6 @@ def test_get_parent_population(args: dict[str, Any]) -> None:
                     raise AttributeError(f"Access to attribute '{name}' is not allowed.")
                 return super().__getattr__(name)
 
-
         mock_study._get_trials.return_value = [
             StrictTrialMock(_trial_id=i)
             for i in args["study_system_attrs"][

--- a/tests/samplers_tests/test_base_gasampler.py
+++ b/tests/samplers_tests/test_base_gasampler.py
@@ -217,7 +217,7 @@ def test_get_parent_population(args: dict[str, Any]) -> None:
     if args["cache"]:
 
         class StrictTrialMock(MagicMock):
-            def __getattr__(self, name):
+            def __getattr__(self, name: str):
                 if name != "_trial_id":
                     raise AttributeError(f"Access to attribute '{name}' is not allowed.")
                 return super().__getattr__(name)

--- a/tests/samplers_tests/test_base_gasampler.py
+++ b/tests/samplers_tests/test_base_gasampler.py
@@ -181,9 +181,9 @@ def test_get_population(args: dict[str, Any]) -> None:
     [
         {
             "study_system_attrs": {
-                BaseGASamplerTestSampler._get_parent_cache_key_prefix() + "1": [0, 1, 2]
+                BaseGASamplerTestSampler._get_parent_cache_key_prefix() + "1": [3, 4, 5]
             },
-            "parent_population": [0, 1, 2],
+            "parent_population": [3, 4, 5],
             "generation": 1,
             "cache": True,
         },
@@ -215,21 +215,17 @@ def test_get_parent_population(args: dict[str, Any]) -> None:
     mock_study = MagicMock()
     mock_study._storage.get_study_system_attrs.return_value = args["study_system_attrs"]
     if args["cache"]:
+
+        class StrictTrialMock(MagicMock):
+            def __getattr__(self, name):
+                if name != "_trial_id":
+                    raise AttributeError(
+                        f"Access to attribute '{name}' is not allowed."
+                    )
+                return super().__getattr__(name)
+    
         mock_study._get_trials.return_value = [
-            optuna.trial.FrozenTrial(
-                number=i,
-                trial_id=i,
-                state=optuna.trial.TrialState.WAITING,
-                value=None,
-                datetime_start=None,
-                datetime_complete=None,
-                params={},
-                distributions={},
-                user_attrs={},
-                system_attrs={},
-                intermediate_values={},
-                values=None,
-            )
+            StrictTrialMock(_trial_id=i)
             for i in args["study_system_attrs"][
                 BaseGASamplerTestSampler._get_parent_cache_key_prefix() + "1"
             ]


### PR DESCRIPTION
The cached parent stores as trial id but retrieves by index, created a quick work around

<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
I am using optuna with the NSGAIISampler and this is causing a crash

## Description of the changes
Dirty hack so that it can continue
