### PR TITLE
Remove `CmaEsAttrKeys` and `_attr_keys` for Simplification

### DIFF
--- a/optuna/samplers/_cmaes.py
+++ b/optuna/samplers/_cmaes.py
@@ -434,7 +434,7 @@ class CmaEsSampler(BaseSampler):
         else:
             params = optimizer.ask()
 
-        generation_attr_key = self._attr_prefix + "generation"
+        generation_attr_key = self._attr_key_generation
         study._storage.set_trial_system_attr(
             trial._trial_id, generation_attr_key, optimizer.generation
         )
@@ -443,9 +443,17 @@ class CmaEsSampler(BaseSampler):
 
         return external_values
 
+    @property
+    def _attr_key_generation(self) -> str:
+        return self._attr_prefix + "generation"
+
+    @property
+    def _attr_key_optimizer(self) -> str:
+        return self._attr_prefix + "optimizer"
+
     def _concat_optimizer_attrs(self, optimizer_attrs: dict[str, str]) -> str:
         return "".join(
-            optimizer_attrs["{}:{}".format(self._attr_prefix + "optimizer", i)]
+            optimizer_attrs["{}:{}".format(self._attr_key_optimizer, i)]
             for i in range(len(optimizer_attrs))
         )
 
@@ -455,7 +463,7 @@ class CmaEsSampler(BaseSampler):
         for i in range(math.ceil(optimizer_len / _SYSTEM_ATTR_MAX_LENGTH)):
             start = i * _SYSTEM_ATTR_MAX_LENGTH
             end = min((i + 1) * _SYSTEM_ATTR_MAX_LENGTH, optimizer_len)
-            attrs["{}:{}".format(self._attr_prefix + "optimizer", i)] = optimizer_str[start:end]
+            attrs["{}:{}".format(self._attr_key_optimizer, i)] = optimizer_str[start:end]
         return attrs
 
     def _restore_optimizer(
@@ -467,7 +475,7 @@ class CmaEsSampler(BaseSampler):
             optimizer_attrs = {
                 key: value
                 for key, value in trial.system_attrs.items()
-                if key.startswith(self._attr_prefix + "optimizer")
+                if key.startswith(self._attr_key_optimizer)
             }
             if len(optimizer_attrs) == 0:
                 continue
@@ -617,7 +625,7 @@ class CmaEsSampler(BaseSampler):
     def _get_solution_trials(
         self, trials: list[FrozenTrial], generation: int
     ) -> list[FrozenTrial]:
-        generation_attr_key = self._attr_prefix + "generation"
+        generation_attr_key = self._attr_key_generation
         return [t for t in trials if generation == t.system_attrs.get(generation_attr_key, -1)]
 
     def before_trial(self, study: optuna.Study, trial: FrozenTrial) -> None:

--- a/tests/samplers_tests/test_cmaes.py
+++ b/tests/samplers_tests/test_cmaes.py
@@ -343,23 +343,6 @@ def _create_trials() -> list[FrozenTrial]:
     return trials
 
 
-@pytest.mark.parametrize(
-    "options, key",
-    [
-        ({"with_margin": False, "use_separable_cma": False}, "cma:"),
-        ({"with_margin": True, "use_separable_cma": False}, "cmawm:"),
-        ({"with_margin": False, "use_separable_cma": True}, "sepcma:"),
-    ],
-)
-def test_sampler_attr_key(options: dict[str, bool], key: str) -> None:
-    # Test sampler attr_key property.
-    sampler = optuna.samplers.CmaEsSampler(
-        with_margin=options["with_margin"], use_separable_cma=options["use_separable_cma"]
-    )
-    assert sampler._attr_keys.optimizer.startswith(key)
-    assert sampler._attr_keys.generation.startswith(key)
-
-
 @pytest.mark.parametrize("sampler_opts", [{}, {"use_separable_cma": True}, {"with_margin": True}])
 def test_restore_optimizer_from_substrings(sampler_opts: dict[str, Any]) -> None:
     popsize = 8


### PR DESCRIPTION
## Motivation  
- The callable functions in `CmaEsAttrKeys` were removed in [#6025](https://github.com/optuna/optuna/pull/6025).
- This cleanup further simplifies the CMA-ES implementation.  
- ref: [#6025 (comment)](https://github.com/optuna/optuna/pull/6025#discussion_r2070100306)

## Description of the Changes  
- Removed the `CmaEsAttrKeys` class.  
- Removed the `_attr_keys` method and replaced its usage with inline logic where necessary.
