### PR TITLE
Refactor `_tell_with_warning`

### DIFF
--- a/optuna/study/_optimize.py
+++ b/optuna/study/_optimize.py
@@ -7,6 +7,7 @@ from concurrent.futures import FIRST_COMPLETED
 from concurrent.futures import Future
 from concurrent.futures import ThreadPoolExecutor
 from concurrent.futures import wait
+import copy
 import datetime
 import gc
 import itertools
@@ -23,7 +24,6 @@ from optuna import trial as trial_module
 from optuna.storages._heartbeat import get_heartbeat_thread
 from optuna.storages._heartbeat import is_heartbeat_enabled
 from optuna.study._tell import _tell_with_warning
-from optuna.study._tell import STUDY_TELL_WARNING_KEY
 from optuna.trial import FrozenTrial
 from optuna.trial import TrialState
 
@@ -168,6 +168,7 @@ def _optimize_sequential(
 
         if callbacks is not None:
             for callback in callbacks:
+                frozen_trial = copy.deepcopy(frozen_trial)
                 callback(study, frozen_trial)
 
         if progress_bar is not None:
@@ -206,7 +207,7 @@ def _run_trial(
 
     # `_tell_with_warning` may raise during trial post-processing.
     try:
-        frozen_trial = _tell_with_warning(
+        frozen_trial, warning_message = _tell_with_warning(
             study=study,
             trial=trial,
             value_or_values=value_or_values,
@@ -215,6 +216,7 @@ def _run_trial(
         )
     except Exception:
         frozen_trial = study._storage.get_trial(trial._trial_id)
+        warning_message = None
         raise
     finally:
         if frozen_trial.state == TrialState.COMPLETE:
@@ -229,10 +231,10 @@ def _run_trial(
                     exc_info=func_err_fail_exc_info,
                     value_or_values=value_or_values,
                 )
-            elif STUDY_TELL_WARNING_KEY in frozen_trial.system_attrs:
+            elif warning_message is not None:
                 _log_failed_trial(
                     frozen_trial,
-                    frozen_trial.system_attrs[STUDY_TELL_WARNING_KEY],
+                    warning_message,
                     value_or_values=value_or_values,
                 )
             else:

--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -654,13 +654,14 @@ class Study:
             A returned trial is deep copied thus user can modify it as needed.
         """
 
-        return _tell_with_warning(
+        frozen_trial, _ = _tell_with_warning(
             study=self,
             trial=trial,
             value_or_values=values,
             state=state,
             skip_if_finished=skip_if_finished,
         )
+        return copy.deepcopy(frozen_trial)
 
     def set_user_attr(self, key: str, value: Any) -> None:
         """Set a user attribute to the study.

--- a/tests/study_tests/test_optimize.py
+++ b/tests/study_tests/test_optimize.py
@@ -13,7 +13,6 @@ from optuna import Trial
 from optuna import TrialPruned
 from optuna.study import _optimize
 from optuna.study._tell import _tell_with_warning
-from optuna.study._tell import STUDY_TELL_WARNING_KEY
 from optuna.testing.objectives import fail_objective
 from optuna.testing.storages import STORAGE_MODES
 from optuna.testing.storages import StorageSupplier
@@ -118,7 +117,6 @@ def test_run_trial_catch_exception(storage_mode: str) -> None:
         study = create_study(storage=storage)
         frozen_trial = _optimize._run_trial(study, fail_objective, catch=(ValueError,))
         assert frozen_trial.state == TrialState.FAIL
-        assert STUDY_TELL_WARNING_KEY not in frozen_trial.system_attrs
 
 
 @pytest.mark.parametrize("storage_mode", STORAGE_MODES)

--- a/tests/study_tests/test_optimize.py
+++ b/tests/study_tests/test_optimize.py
@@ -62,21 +62,29 @@ def test_run_trial_automatically_fail(storage_mode: str, caplog: LogCaptureFixtu
     with StorageSupplier(storage_mode) as storage:
         study = create_study(storage=storage)
 
+        caplog.clear()
         frozen_trial = _optimize._run_trial(study, lambda _: float("nan"), catch=())
         assert frozen_trial.state == TrialState.FAIL
         assert frozen_trial.value is None
+        assert "Trial 0 failed with value nan." in caplog.text
 
+        caplog.clear()
         frozen_trial = _optimize._run_trial(study, lambda _: None, catch=())  # type: ignore[arg-type,return-value] # noqa: E501
         assert frozen_trial.state == TrialState.FAIL
         assert frozen_trial.value is None
+        assert "Trial 1 failed with value None." in caplog.text
 
+        caplog.clear()
         frozen_trial = _optimize._run_trial(study, lambda _: object(), catch=())  # type: ignore[arg-type,return-value] # noqa: E501
         assert frozen_trial.state == TrialState.FAIL
         assert frozen_trial.value is None
+        assert "Trial 2 failed with value <object object" in caplog.text
 
+        caplog.clear()
         frozen_trial = _optimize._run_trial(study, lambda _: [0, 1], catch=())
         assert frozen_trial.state == TrialState.FAIL
         assert frozen_trial.value is None
+        assert "Trial 3 failed with value [0, 1]." in caplog.text
 
 
 @pytest.mark.parametrize("storage_mode", STORAGE_MODES)


### PR DESCRIPTION
## Motivation
Improve the performance of `_tell_with_warning` by reducing unnecessary deep copies and simplifying how warning messages are handled.

## Description of the Changes
- Replaced `deepcopy` with a shallow copy in `_tell_with_warning` to reduce overhead when returning a `FrozenTrial`.
- A `deepcopy` is performed only in contexts where the `FrozenTrial` might be modified, such as when it is passed into callbacks or used in `study.tell()`.
- Refactored warning handling by returning the `warning_message` directly from `_tell_with_warning`, rather than storing it in `system_attrs`.
- Added tests to ensure that warning messages are correctly returned and handled in affected scenarios.
