### PR TITLE
Refactor warning handling of `_tell_with_warning`

### DIFF
--- a/optuna/study/_tell.py
+++ b/optuna/study/_tell.py
@@ -18,10 +18,6 @@ if TYPE_CHECKING:
     from optuna import Trial
 
 
-# This is used for propagating warning message to Study.optimize.
-STUDY_TELL_WARNING_KEY = "STUDY_TELL_WARNING"
-
-
 _logger = logging.get_logger(__name__)
 
 
@@ -91,7 +87,7 @@ def _tell_with_warning(
     state: TrialState | None = None,
     skip_if_finished: bool = False,
     suppress_warning: bool = False,
-) -> FrozenTrial:
+) -> tuple[FrozenTrial, str | None]:
     """Internal method of :func:`~optuna.study.Study.tell`.
 
     Refer to the document for :func:`~optuna.study.Study.tell` for the reference.
@@ -115,7 +111,7 @@ def _tell_with_warning(
             f"{value_or_values} and state {state} since trial was already finished. "
             f"Finished trial has values {frozen_trial.values} and state {frozen_trial.state}."
         )
-        return copy.deepcopy(frozen_trial)
+        return copy.deepcopy(frozen_trial), None
     elif frozen_trial.state != TrialState.RUNNING:
         raise ValueError(f"Cannot tell a {frozen_trial.state.name} trial.")
 
@@ -182,6 +178,4 @@ def _tell_with_warning(
 
     frozen_trial = copy.deepcopy(study._storage.get_trial(frozen_trial._trial_id))
 
-    if warning_message is not None:
-        frozen_trial._system_attrs[STUDY_TELL_WARNING_KEY] = warning_message
-    return frozen_trial
+    return frozen_trial, warning_message

--- a/optuna/study/_tell.py
+++ b/optuna/study/_tell.py
@@ -126,7 +126,7 @@ def _tell_with_warning(
 
     _check_state_and_values(state, values)
 
-    warning_message = None
+    values_conversion_failure_message = None
 
     if state == TrialState.COMPLETE:
         assert values is not None
@@ -158,8 +158,7 @@ def _tell_with_warning(
             values = None
             if not suppress_warning:
                 warnings.warn(values_conversion_failure_message)
-            else:
-                warning_message = values_conversion_failure_message
+                values_conversion_failure_message = None
 
     assert state is not None
 
@@ -178,4 +177,4 @@ def _tell_with_warning(
 
     frozen_trial = copy.deepcopy(study._storage.get_trial(frozen_trial._trial_id))
 
-    return frozen_trial, warning_message
+    return frozen_trial, values_conversion_failure_message

--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -654,13 +654,14 @@ class Study:
             A returned trial is deep copied thus user can modify it as needed.
         """
 
-        return _tell_with_warning(
+        frozen_trial, _ = _tell_with_warning(
             study=self,
             trial=trial,
             value_or_values=values,
             state=state,
             skip_if_finished=skip_if_finished,
         )
+        return frozen_trial
 
     def set_user_attr(self, key: str, value: Any) -> None:
         """Set a user attribute to the study.

--- a/tests/study_tests/test_optimize.py
+++ b/tests/study_tests/test_optimize.py
@@ -62,28 +62,21 @@ def test_run_trial_automatically_fail(storage_mode: str, caplog: LogCaptureFixtu
     with StorageSupplier(storage_mode) as storage:
         study = create_study(storage=storage)
 
-        caplog.clear()
         frozen_trial = _optimize._run_trial(study, lambda _: float("nan"), catch=())
         assert frozen_trial.state == TrialState.FAIL
         assert frozen_trial.value is None
-        assert "Trial 0 failed with value nan." in caplog.text
 
-        caplog.clear()
         frozen_trial = _optimize._run_trial(study, lambda _: None, catch=())  # type: ignore[arg-type,return-value] # noqa: E501
         assert frozen_trial.state == TrialState.FAIL
         assert frozen_trial.value is None
-        assert "Trial 1 failed with value None." in caplog.text
 
-        caplog.clear()
         frozen_trial = _optimize._run_trial(study, lambda _: object(), catch=())  # type: ignore[arg-type,return-value] # noqa: E501
         assert frozen_trial.state == TrialState.FAIL
         assert frozen_trial.value is None
-        assert "Trial 2 failed with value <object object" in caplog.text
 
         frozen_trial = _optimize._run_trial(study, lambda _: [0, 1], catch=())
         assert frozen_trial.state == TrialState.FAIL
         assert frozen_trial.value is None
-        assert "Trial 3 failed with value [0, 1]." in caplog.text
 
 
 @pytest.mark.parametrize("storage_mode", STORAGE_MODES)


### PR DESCRIPTION
## Motivation
The `warning_message` does not need to be stored in `frozen_trial.system_attrs`. This PR refactors the implementation to return the warning message directly from `_tell_with_warning`.

**Note:** After this change, the warning message will no longer be accessible via `frozen_trial.system_attrs[STUDY_TELL_WARNING_KEY]`. However, warning messages can still be captured via `logging.getLogger`. In addition, I checked public GitHub repositories, and it looks like `STUDY_TELL_WARNING_KEY` is not used directly by users, so the impact should be minimal.

## Description of the changes
- Refactored the warning handling logic to return the warning message from `_tell_with_warning` instead of storing it in `system_attrs`.
- Updated affected call sites to handle the returned warning message explicitly.
- Added tests to ensure the warning message is correctly returned and can be logged or captured as expected.
