### PR TITLE
Implement Type-Checking for `optuna/distributions.py`

### DIFF
--- a/optuna/distributions.py
+++ b/optuna/distributions.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import abc
-from collections.abc import Sequence
 import copy
 import decimal
 import json
@@ -13,6 +14,9 @@ from typing import Union
 import warnings
 
 from optuna._deprecated import deprecated_class
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 
 CategoricalChoiceType = Union[None, bool, int, float, str]
@@ -304,7 +308,7 @@ class DiscreteUniformDistribution(FloatDistribution):
         :class:`~optuna.distributions.FloatDistribution`.
         This property is a proxy for its ``step`` attribute.
         """
-        return cast(float, self.step)
+        return cast("float", self.step)
 
     @q.setter
     def q(self, v: float) -> None:


### PR DESCRIPTION
## Motivation
This PR addresses issue #6029 by updating type checking in `optuna/distributions.py`.  
After the changes, `flake8` reports no warnings.

## Description of the changes
Updated type checking for `optuna/distributions.py`.
