### PR TITLE
Add a warning about the combination of gRPC Proxy and Journal Storage

### DIFF
--- a/optuna/storages/_grpc/client.py
+++ b/optuna/storages/_grpc/client.py
@@ -70,6 +70,13 @@ class GrpcStorageProxy(BaseStorage):
 
         Currently, gRPC storage proxy in combination with an SQLite3 database may cause unexpected
         behaviors when calling :func:`optuna.delete_study` due to non-invalidated cache.
+
+    .. warning::
+
+        Currently, gRPC storage proxy does not support the
+        :class:`~optuna.storages.JournalStorage`. This issue is tracked in
+        https://github.com/optuna/optuna/issues/6084. Please use
+        :class:`~optuna.storages.RDBStorage` instead.
     """
 
     def __init__(self, *, host: str = "localhost", port: int = 13000) -> None:


### PR DESCRIPTION
## Motivation

This PR adds a warning to the `GrpcStorageProxy` class documentation to clarify a known limitation regarding unsupported storage types. The corresponding issue is #6084.


## Description of the changes

- Add a warning section about combining the gRPC proxy and journal storage.

## Design choice

1. I'm unsure if we can add a link to the tracking issue (i.e., https://github.com/optuna/optuna/issues/6084).
2. IMHO, we can move this warning as well as the warning about SQLite3 to the reference of [`run_grpc_proxy_server`](https://optuna.readthedocs.io/en/stable/reference/generated/optuna.storages.run_grpc_proxy_server.html#optuna.storages.run_grpc_proxy_server) since users specify the storage there. Regarding consistency, I placed this warning in the `GrpcStorageProxy` reference.
