### PR TITLE
Fix: Resolve PG17 incompatibility for ENUMS in CASE statements 

### DIFF
--- a/.github/workflows/tests-storage.yml
+++ b/.github/workflows/tests-storage.yml
@@ -108,7 +108,7 @@ jobs:
 
     - name: Install DB bindings
       run: |
-        pip install --progress-bar off PyMySQL cryptography psycopg2-binary redis
+        pip install --progress-bar off PyMySQL cryptography psycopg2-binary psycopg redis
 
     - name: Output installed packages
       run: |

--- a/.github/workflows/tests-storage.yml
+++ b/.github/workflows/tests-storage.yml
@@ -126,12 +126,19 @@ jobs:
         OMP_NUM_THREADS: 1
         TEST_DB_URL: mysql+pymysql://user:test@127.0.0.1/optunatest
 
-    - name: Tests PostgreSQL
+    - name: Tests PostgreSQL with psycopg2
       run: |
         pytest tests/storages_tests/test_with_server.py
       env:
         OMP_NUM_THREADS: 1
         TEST_DB_URL: postgresql+psycopg2://user:test@127.0.0.1/optunatest
+
+    - name: Tests PostgreSQL with psycopg3
+      run: |
+        pytest tests/storages_tests/test_with_server.py
+      env:
+        OMP_NUM_THREADS: 1
+        TEST_DB_URL: postgresql+psycopg://user:test@127.0.0.1/optunatest
 
     - name: Tests Journal Redis
       run: |

--- a/optuna/storages/_rdb/models.py
+++ b/optuna/storages/_rdb/models.py
@@ -198,8 +198,18 @@ class TrialModel(BaseModel):
             .order_by(
                 desc(
                     case(
-                        {"INF_NEG": -1, "FINITE": 0, "INF_POS": 1},
-                        value=TrialValueModel.value_type,
+                        (
+                            TrialValueModel.value_type == TrialValueModel.TrialValueType.INF_NEG,
+                            -1,
+                        ),
+                        (
+                            TrialValueModel.value_type == TrialValueModel.TrialValueType.FINITE,
+                            0,
+                        ),
+                        (
+                            TrialValueModel.value_type == TrialValueModel.TrialValueType.INF_POS,
+                            1,
+                        ),
                     )
                 ),
                 desc(TrialValueModel.value),
@@ -223,11 +233,21 @@ class TrialModel(BaseModel):
             .order_by(
                 asc(
                     case(
-                        {"INF_NEG": -1, "FINITE": 0, "INF_POS": 1},
-                        value=TrialValueModel.value_type,
+                        (
+                            TrialValueModel.value_type == TrialValueModel.TrialValueType.INF_NEG,
+                            -1,
+                        ),
+                        (
+                            TrialValueModel.value_type == TrialValueModel.TrialValueType.FINITE,
+                            0,
+                        ),
+                        (
+                            TrialValueModel.value_type == TrialValueModel.TrialValueType.INF_POS,
+                            1,
+                        ),
                     )
                 ),
-                asc(TrialValueModel.value),
+                asc(TrialValueModel.value),  # Note: asc here
             )
             .limit(1)
             .one_or_none()


### PR DESCRIPTION
## Motivation
I have a postgresql 17.3 DB that I also wanted to use for the results of the trials ran through Optuna - potentially linking them with my own tables through a common id. Unfortunately this lead to an error: `operator does not exist: trialvaluetype = character varying` error when using PostgreSQL 17.3 as explained in #6096.

## Description of the changes
This changes the SQLAlchemy case() structure in TrialModel.find_max/min_value_trial_id to directly compare the ENUM column with Python ENUM members, avoiding problematic VARCHAR casts on string literals.
