### PR TITLE
Cosmetic fix to the terminator documents.

### DIFF
--- a/optuna/terminator/improvement/evaluator.py
+++ b/optuna/terminator/improvement/evaluator.py
@@ -215,10 +215,10 @@ class RegretBoundEvaluator(BaseImprovementEvaluator):
 class BestValueStagnationEvaluator(BaseImprovementEvaluator):
     """Evaluates the stagnation period of the best value in an optimization process.
 
-    This class is initialized with a maximum stagnation period (`max_stagnation_trials`)
+    This class is initialized with a maximum stagnation period (``max_stagnation_trials``)
     and is designed to evaluate the remaining trials before reaching this maximum period
     of allowed stagnation. If this remaining trials reach zero, the trial terminates.
-    Therefore, the default error evaluator is instantiated by StaticErrorEvaluator(const=0).
+    Therefore, the default error evaluator is instantiated by ``StaticErrorEvaluator(const=0)``.
 
     Args:
         max_stagnation_trials:

--- a/optuna/terminator/median_erroreval.py
+++ b/optuna/terminator/median_erroreval.py
@@ -31,7 +31,7 @@ class MedianErrorEvaluator(BaseErrorEvaluator):
             The ``warm_up_trials`` can exclude them from the calculation.
         n_initial_trials:
             A parameter specifies the number of initial trials considered in the calculation of
-            median after `warm_up_trials`. Default to 20.
+            median after ``warm_up_trials``. Default to 20.
         threshold_ratio:
             A parameter specifies the ratio between the threshold and initial median.
             Default to 0.01.


### PR DESCRIPTION
## Motivation
This PR includes minor documentation updates to improve consistency in formatting within docstrings in the `optuna/terminator` module. Specifically, single backticks have been replaced with double backticks for inline code references.

## Description of the changes

* Inline code-blocks are supposed to be wrapped with double backtics. 
  * https://github.com/optuna/optuna/wiki/Coding-Style-Conventions#docstrings
  * https://sublime-and-sphinx-guide.readthedocs.io/en/latest/inline.html#code-text.