### PR TITLE
Emit ExperimentalWarning if heartbeat is enabled

### DIFF
--- a/optuna/storages/_rdb/storage.py
+++ b/optuna/storages/_rdb/storage.py
@@ -23,6 +23,7 @@ import uuid
 import optuna
 from optuna import distributions
 from optuna import version
+from optuna._experimental import warn_experimental_argument
 from optuna._imports import _LazyImport
 from optuna._typing import JSONSerializable
 from optuna.storages._base import BaseStorage
@@ -206,8 +207,11 @@ class RDBStorage(BaseStorage, BaseHeartbeat):
         self.engine_kwargs = engine_kwargs or {}
         self.url = self._fill_storage_url_template(url)
         self.skip_compatibility_check = skip_compatibility_check
-        if heartbeat_interval is not None and heartbeat_interval <= 0:
-            raise ValueError("The value of `heartbeat_interval` should be a positive integer.")
+        if heartbeat_interval is not None:
+            if heartbeat_interval <= 0:
+                raise ValueError("The value of `heartbeat_interval` should be a positive integer.")
+            else:
+                warn_experimental_argument("heartbeat_interval")
         if grace_period is not None and grace_period <= 0:
             raise ValueError("The value of `grace_period` should be a positive integer.")
         self.heartbeat_interval = heartbeat_interval

--- a/optuna/study/_optimize.py
+++ b/optuna/study/_optimize.py
@@ -21,6 +21,7 @@ from optuna import exceptions
 from optuna import logging
 from optuna import progress_bar as pbar_module
 from optuna import trial as trial_module
+from optuna.exceptions import ExperimentalWarning
 from optuna.storages._heartbeat import get_heartbeat_thread
 from optuna.storages._heartbeat import is_heartbeat_enabled
 from optuna.study._tell import _tell_with_warning
@@ -183,7 +184,10 @@ def _run_trial(
     catch: tuple[type[Exception], ...],
 ) -> trial_module.FrozenTrial:
     if is_heartbeat_enabled(study._storage):
-        optuna.storages.fail_stale_trials(study)
+        with warnings.catch_warnings():
+            # Ignore ExperimentalWarning when using fail_stale_trials internally.
+            warnings.simplefilter("ignore", ExperimentalWarning)
+            optuna.storages.fail_stale_trials(study)
 
     trial = study.ask()
 

--- a/tests/storages_tests/test_heartbeat.py
+++ b/tests/storages_tests/test_heartbeat.py
@@ -12,6 +12,7 @@ import pytest
 
 import optuna
 from optuna import Study
+from optuna.exceptions import ExperimentalWarning
 from optuna.storages import RDBStorage
 from optuna.storages._callbacks import RetryFailedTrialCallback
 from optuna.storages._heartbeat import BaseHeartbeat
@@ -82,6 +83,13 @@ def test_invalid_heartbeat_interval_and_grace_period(storage_mode: str) -> None:
 
     with pytest.raises(ValueError):
         with StorageSupplier(storage_mode, grace_period=-1):
+            pass
+
+
+@pytest.mark.parametrize("storage_mode", STORAGE_MODES_HEARTBEAT)
+def test_heartbeat_experimental_warnings(storage_mode: str) -> None:
+    with pytest.warns(ExperimentalWarning, match="heartbeat_interval"):
+        with StorageSupplier(storage_mode, heartbeat_interval=2):
             pass
 
 

--- a/tests/storages_tests/test_heartbeat.py
+++ b/tests/storages_tests/test_heartbeat.py
@@ -88,9 +88,16 @@ def test_invalid_heartbeat_interval_and_grace_period(storage_mode: str) -> None:
 
 @pytest.mark.parametrize("storage_mode", STORAGE_MODES_HEARTBEAT)
 def test_heartbeat_experimental_warnings(storage_mode: str) -> None:
-    with pytest.warns(ExperimentalWarning, match="heartbeat_interval"):
-        with StorageSupplier(storage_mode, heartbeat_interval=2):
-            pass
+    with pytest.warns(ExperimentalWarning, match="heartbeat_interval") as record:
+        with StorageSupplier(storage_mode, heartbeat_interval=2) as storage:
+            study = optuna.create_study(storage=storage)
+            study.optimize(lambda _: 1.0, n_trials=1)
+
+    # Check other ExperimentalWarning related to heartbeat are not raised.
+    assert (
+        len([warning for warning in record if isinstance(warning.message, ExperimentalWarning)])
+        == 1
+    )
 
 
 @pytest.mark.parametrize("storage_mode", STORAGE_MODES_HEARTBEAT)


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

When we use the heartbeat mechanism of RDBStorage, only `fail_stale_trials` emits ExperimentalWarning currently.
Because the heartbeat mechanism itself is an experimental feature at this moment, it is more helpful to emit an ExperimentalWarning more holistically. 


## Description of the changes
<!-- Describe the changes in this PR. -->

This PR emits ExperimentalWarning at initializing RDBStorage with `heartbeat_interval`. 

This PR does not address the existing ExperimentalWarning from `fail_stale_trials`. Thus, we will see two distinct ExperimentalWarning if we use `fail_stale_trials`.