### PR TITLE
fix: fetch all trials in `BruteForceSampler` for `HyperbandPruner`

### DIFF
--- a/optuna/samplers/_brute_force.py
+++ b/optuna/samplers/_brute_force.py
@@ -199,7 +199,11 @@ class BruteForceSampler(BaseSampler):
     ) -> Any:
         exclude_running = not self._avoid_premature_stop
 
-        trials = study.get_trials(
+        # We directly query the storage to get trials here instead of `study.get_trials`,
+        # since some pruners such as `HyperbandPruner` use the study transformed
+        # to filter trials. See https://github.com/optuna/optuna/issues/2327 for details.
+        trials = study._storage.get_all_trials(
+            study._study_id,
             deepcopy=False,
             states=(
                 TrialState.COMPLETE,
@@ -231,7 +235,11 @@ class BruteForceSampler(BaseSampler):
     ) -> None:
         exclude_running = not self._avoid_premature_stop
 
-        trials = study.get_trials(
+        # We directly query the storage to get trials here instead of `study.get_trials`,
+        # since some pruners such as `HyperbandPruner` use the study transformed
+        # to filter trials. See https://github.com/optuna/optuna/issues/2327 for details.
+        trials = study._storage.get_all_trials(
+            study._study_id,
             deepcopy=False,
             states=(
                 TrialState.COMPLETE,

--- a/tests/pruners_tests/test_hyperband.py
+++ b/tests/pruners_tests/test_hyperband.py
@@ -240,3 +240,22 @@ def test_hyperband_pruner_and_grid_sampler() -> None:
 
     trials = study.trials
     assert len(trials) == 9
+
+
+def test_hyperband_pruner_and_bruto_force_sampler() -> None:
+    def objective(trial):
+        x = trial.suggest_int("x", 0, 2)
+        y = trial.suggest_int("y", 0, 2)
+        for i in range(10):
+            trial.report(step=i, value=i*(x+y)/10)
+            if trial.should_prune():
+                raise optuna.TrialPruned
+        return x + y
+
+    sampler = optuna.samplers.BruteForceSampler()
+    pruner = optuna.pruners.HyperbandPruner()
+    study = optuna.create_study(sampler=sampler, pruner=pruner)
+    study.optimize(objective)
+
+    trials = study.trials
+    assert len(trials) == 9

--- a/tests/pruners_tests/test_hyperband.py
+++ b/tests/pruners_tests/test_hyperband.py
@@ -243,11 +243,11 @@ def test_hyperband_pruner_and_grid_sampler() -> None:
 
 
 def test_hyperband_pruner_and_bruto_force_sampler() -> None:
-    def objective(trial):
+    def objective(trial: optuna.trial.Trial) -> int:
         x = trial.suggest_int("x", 0, 2)
         y = trial.suggest_int("y", 0, 2)
         for i in range(10):
-            trial.report(step=i, value=i*(x+y)/10)
+            trial.report(step=i, value=i * (x + y) / 10)
             if trial.should_prune():
                 raise optuna.TrialPruned
         return x + y

--- a/tests/pruners_tests/test_hyperband.py
+++ b/tests/pruners_tests/test_hyperband.py
@@ -242,7 +242,7 @@ def test_hyperband_pruner_and_grid_sampler() -> None:
     assert len(trials) == 9
 
 
-def test_hyperband_pruner_and_bruto_force_sampler() -> None:
+def test_hyperband_pruner_and_brute_force_sampler() -> None:
     def objective(trial: optuna.trial.Trial) -> int:
         x = trial.suggest_int("x", 0, 2)
         y = trial.suggest_int("y", 0, 2)


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
HyperbandPruner has internally multiple sub studies due to its algorithm nation. Therefore `study.get_trials` is not guaranteed to fetch all trials of the root study.

## Description of the changes
* 🔗. https://github.com/optuna/optuna/pull/2353 

---

### Before

Since trials is not comprehensive, duplicated combinations of parameters are selected as trials.

```sh
> uv run -m pytest tests/pruners_tests/test_hyperband.py -k test_hyperband_pruner_and_bruto_force_sampler -s
================================================================ test session starts =================================================================
platform darwin -- Python 3.12.0, pytest-8.3.5, pluggy-1.6.0
rootdir: /Users/himkt/work/github.com/himkt/optuna
configfile: pyproject.toml
collected 19 items / 18 deselected / 1 selected                                                                                                      

tests/pruners_tests/test_hyperband.py [I 2025-05-31 11:40:51,560] A new study created in memory with name: no-name-5edbcb58-cee2-4580-9051-ba1e58d49e85
[I 2025-05-31 11:40:51,568] Trial 0 finished with value: 1.0 and parameters: {'x': 1, 'y': 0}. Best is trial 0 with value: 1.0.
[I 2025-05-31 11:40:51,569] Trial 1 finished with value: 3.0 and parameters: {'x': 1, 'y': 2}. Best is trial 0 with value: 1.0.
[I 2025-05-31 11:40:51,569] Trial 2 finished with value: 3.0 and parameters: {'x': 2, 'y': 1}. Best is trial 0 with value: 1.0.
[I 2025-05-31 11:40:51,570] Trial 3 finished with value: 3.0 and parameters: {'x': 1, 'y': 2}. Best is trial 0 with value: 1.0.
[I 2025-05-31 11:40:51,570] Trial 4 pruned. 
[I 2025-05-31 11:40:51,571] Trial 5 finished with value: 1.0 and parameters: {'x': 0, 'y': 1}. Best is trial 0 with value: 1.0.
[I 2025-05-31 11:40:51,571] Trial 6 finished with value: 1.0 and parameters: {'x': 0, 'y': 1}. Best is trial 0 with value: 1.0.
[I 2025-05-31 11:40:51,572] Trial 7 pruned. 
[I 2025-05-31 11:40:51,572] Trial 8 pruned. 
[I 2025-05-31 11:40:51,572] Trial 9 finished with value: 0.0 and parameters: {'x': 0, 'y': 0}. Best is trial 9 with value: 0.0.
[I 2025-05-31 11:40:51,573] Trial 10 pruned. 
[I 2025-05-31 11:40:51,574] Trial 11 finished with value: 1.0 and parameters: {'x': 1, 'y': 0}. Best is trial 9 with value: 0.0.
[I 2025-05-31 11:40:51,575] Trial 12 pruned. 
[I 2025-05-31 11:40:51,575] Trial 13 finished with value: 2.0 and parameters: {'x': 0, 'y': 2}. Best is trial 9 with value: 0.0.
[I 2025-05-31 11:40:51,576] Trial 14 pruned. 
[I 2025-05-31 11:40:51,576] Trial 15 finished with value: 0.0 and parameters: {'x': 0, 'y': 0}. Best is trial 9 with value: 0.0.
F

====================================================================== FAILURES ======================================================================
___________________________________________________ test_hyperband_pruner_and_bruto_force_sampler ____________________________________________________

    def test_hyperband_pruner_and_bruto_force_sampler() -> None:
        def objective(trial):
            x = trial.suggest_int("x", 0, 2)
            y = trial.suggest_int("y", 0, 2)
            for i in range(10):
                trial.report(step=i, value=i*(x+y)/10)
                if trial.should_prune():
                    raise optuna.TrialPruned
            return x + y
    
        sampler = optuna.samplers.BruteForceSampler()
        pruner = optuna.pruners.HyperbandPruner()
        study = optuna.create_study(sampler=sampler, pruner=pruner)
        study.optimize(objective)
    
        trials = study.trials
>       assert len(trials) == 9
E       AssertionError: assert 16 == 9
E        +  where 16 = len([FrozenTrial(number=0, state=1, values=[1.0], datetime_start=datetime.datetime(2025, 5, 31, 11, 40, 51, 560270), datet...gh=2, log=False, low=0, step=1), 'y': IntDistribution(high=2, log=False, low=0, step=1)}, trial_id=5, value=None), ...])

tests/pruners_tests/test_hyperband.py:261: AssertionError
============================================================== short test summary info ===============================================================
FAILED tests/pruners_tests/test_hyperband.py::test_hyperband_pruner_and_bruto_force_sampler - AssertionError: assert 16 == 9
========================================================== 1 failed, 18 deselected in 0.10s ==========================================================
```

### After

Now, the number of trials is the same as the total number of combinations.

```sh
> uv run -m pytest tests/pruners_tests/test_hyperband.py -k test_hyperband_pruner_and_bruto_force_sampler -s
=============================================================================== test session starts ===============================================================================
platform darwin -- Python 3.12.0, pytest-8.3.5, pluggy-1.6.0
rootdir: /Users/himkt/work/github.com/himkt/optuna
configfile: pyproject.toml
collected 19 items / 18 deselected / 1 selected

tests/pruners_tests/test_hyperband.py [I 2025-05-31 11:42:01,042] A new study created in memory with name: no-name-d3cc5197-7e5d-451c-bd67-51db6824ccfb
[I 2025-05-31 11:42:01,058] Trial 0 finished with value: 1.0 and parameters: {'x': 0, 'y': 1}. Best is trial 0 with value: 1.0.
[I 2025-05-31 11:42:01,058] Trial 1 finished with value: 2.0 and parameters: {'x': 0, 'y': 2}. Best is trial 0 with value: 1.0.
[I 2025-05-31 11:42:01,059] Trial 2 pruned.
[I 2025-05-31 11:42:01,059] Trial 3 finished with value: 3.0 and parameters: {'x': 2, 'y': 1}. Best is trial 0 with value: 1.0.
[I 2025-05-31 11:42:01,060] Trial 4 finished with value: 1.0 and parameters: {'x': 1, 'y': 0}. Best is trial 0 with value: 1.0.
[I 2025-05-31 11:42:01,060] Trial 5 pruned.
[I 2025-05-31 11:42:01,060] Trial 6 pruned.
[I 2025-05-31 11:42:01,061] Trial 7 finished with value: 0.0 and parameters: {'x': 0, 'y': 0}. Best is trial 7 with value: 0.0.
[I 2025-05-31 11:42:01,061] Trial 8 pruned.
.

======================================================================== 1 passed, 18 deselected in 0.04s =========================================================================
```