### PR TITLE
Add `n_recent_trials` to `plot_timeline`

### DIFF
--- a/optuna/visualization/_timeline.py
+++ b/optuna/visualization/_timeline.py
@@ -30,19 +30,22 @@ class _TimelineInfo(NamedTuple):
     bars: list[_TimelineBarInfo]
 
 
-def plot_timeline(study: Study) -> "go.Figure":
+def plot_timeline(study: Study, n_recent_trials: int | None = None) -> "go.Figure":
     """Plot the timeline of a study.
 
     Args:
         study:
             A :class:`~optuna.study.Study` object whose trials are plotted with
             their lifetime.
+        n_recent_trials:
+            The number of recent trials to plot. If :obj:`None`, all trials are plotted.
+            If specified, only the most recent n_recent_trials will be displayed.
 
     Returns:
         A :class:`plotly.graph_objects.Figure` object.
     """
     _imports.check()
-    info = _get_timeline_info(study)
+    info = _get_timeline_info(study, n_recent_trials=n_recent_trials)
     return _get_timeline_plot(info)
 
 
@@ -80,12 +83,17 @@ def _is_running_trials_in_study(study: Study, max_run_duration: datetime.timedel
     )
 
 
-def _get_timeline_info(study: Study) -> _TimelineInfo:
+def _get_timeline_info(study: Study, n_recent_trials: int | None = None) -> _TimelineInfo:
     bars = []
 
     max_datetime = _get_max_datetime_complete(study)
     timedelta_for_small_bar = datetime.timedelta(seconds=1)
-    for trial in study.get_trials(deepcopy=False):
+
+    trials = study.get_trials(deepcopy=False)
+    if n_recent_trials is not None and n_recent_trials > 0:
+        trials = trials[-n_recent_trials:]
+
+    for trial in trials:
         datetime_start = trial.datetime_start or max_datetime
         datetime_complete = (
             max_datetime + timedelta_for_small_bar

--- a/optuna/visualization/_timeline.py
+++ b/optuna/visualization/_timeline.py
@@ -40,13 +40,18 @@ def plot_timeline(study: Study, n_recent_trials: int | None = None) -> "go.Figur
         n_recent_trials:
             The number of recent trials to plot. If :obj:`None`, all trials are plotted.
             If specified, only the most recent ``n_recent_trials`` will be displayed.
-            If ``n_recent_trials`` is 0 or negative,
-            it is treated as :obj:`None` and all trials are plotted.
-
+            Must be a positive integer.
 
     Returns:
         A :class:`plotly.graph_objects.Figure` object.
+
+    Raises:
+        ValueError: if ``n_recent_trials`` is 0 or negative.
     """
+
+    if n_recent_trials is not None and n_recent_trials <= 0:
+        raise ValueError("n_recent_trials must be a positive integer or None.")
+
     _imports.check()
     info = _get_timeline_info(study, n_recent_trials=n_recent_trials)
     return _get_timeline_plot(info)
@@ -93,7 +98,7 @@ def _get_timeline_info(study: Study, n_recent_trials: int | None = None) -> _Tim
     timedelta_for_small_bar = datetime.timedelta(seconds=1)
 
     trials = study.get_trials(deepcopy=False)
-    if n_recent_trials is not None and n_recent_trials > 0:
+    if n_recent_trials is not None:
         trials = trials[-n_recent_trials:]
 
     for trial in trials:

--- a/optuna/visualization/_timeline.py
+++ b/optuna/visualization/_timeline.py
@@ -39,7 +39,10 @@ def plot_timeline(study: Study, n_recent_trials: int | None = None) -> "go.Figur
             their lifetime.
         n_recent_trials:
             The number of recent trials to plot. If :obj:`None`, all trials are plotted.
-            If specified, only the most recent n_recent_trials will be displayed.
+            If specified, only the most recent ``n_recent_trials`` will be displayed.
+            If ``n_recent_trials`` is 0 or negative,
+            it is treated as :obj:`None` and all trials are plotted.
+
 
     Returns:
         A :class:`plotly.graph_objects.Figure` object.

--- a/optuna/visualization/matplotlib/_timeline.py
+++ b/optuna/visualization/matplotlib/_timeline.py
@@ -33,13 +33,18 @@ def plot_timeline(study: Study, n_recent_trials: int | None = None) -> "Axes":
         n_recent_trials:
             The number of recent trials to plot. If :obj:`None`, all trials are plotted.
             If specified, only the most recent ``n_recent_trials`` will be displayed.
-            If ``n_recent_trials`` is 0 or negative,
-            it is treated as :obj:`None` and all trials are plotted.
-
+            Must be a positive integer.
 
     Returns:
-        A :class:`matplotlib.axes.Axes` object.
+        A :class:`plotly.graph_objects.Figure` object.
+
+    Raises:
+        ValueError: if ``n_recent_trials`` is 0 or negative.
     """
+
+    if n_recent_trials is not None and n_recent_trials <= 0:
+        raise ValueError("n_recent_trials must be a positive integer or None.")
+
     _imports.check()
     info = _get_timeline_info(study, n_recent_trials)
     return _get_timeline_plot(info)

--- a/optuna/visualization/matplotlib/_timeline.py
+++ b/optuna/visualization/matplotlib/_timeline.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from optuna._experimental import experimental_func
 from optuna.study import Study
 from optuna.trial import TrialState

--- a/optuna/visualization/matplotlib/_timeline.py
+++ b/optuna/visualization/matplotlib/_timeline.py
@@ -29,6 +29,11 @@ def plot_timeline(study: Study, n_recent_trials: int | None = None) -> "Axes":
             A :class:`~optuna.study.Study` object whose trials are plotted with
             their lifetime.
         n_recent_trials:
+            The number of recent trials to plot. If :obj:`None`, all trials are plotted.
+            If specified, only the most recent ``n_recent_trials`` will be displayed.
+            If ``n_recent_trials`` is 0 or negative,
+            it is treated as :obj:`None` and all trials are plotted.
+
 
     Returns:
         A :class:`matplotlib.axes.Axes` object.

--- a/optuna/visualization/matplotlib/_timeline.py
+++ b/optuna/visualization/matplotlib/_timeline.py
@@ -18,7 +18,7 @@ _INFEASIBLE_KEY = "INFEASIBLE"
 
 
 @experimental_func("3.2.0")
-def plot_timeline(study: Study) -> "Axes":
+def plot_timeline(study: Study, n_recent_trials: int | None = None) -> "Axes":
     """Plot the timeline of a study.
 
     .. seealso::
@@ -28,12 +28,13 @@ def plot_timeline(study: Study) -> "Axes":
         study:
             A :class:`~optuna.study.Study` object whose trials are plotted with
             their lifetime.
+        n_recent_trials:
 
     Returns:
         A :class:`matplotlib.axes.Axes` object.
     """
     _imports.check()
-    info = _get_timeline_info(study)
+    info = _get_timeline_info(study, n_recent_trials)
     return _get_timeline_plot(info)
 
 

--- a/tests/visualization_tests/test_timeline.py
+++ b/tests/visualization_tests/test_timeline.py
@@ -104,6 +104,32 @@ def test_get_timeline_info(trial_sys_attrs: dict[str, Any] | None, infeasible: b
         assert bar.infeasible == infeasible
 
 
+@pytest.mark.parametrize(
+    "n_recent_trials, expected_count",
+    [
+        (None, 4),
+        (2, 2),
+        (0, 0),
+        (-1, 4),
+        (100, 4),
+    ],
+)
+def test_get_timeline_info_n_recent_trials(
+    n_recent_trials: int | None, expected_count: int
+) -> None:
+    states = [TrialState.COMPLETE, TrialState.PRUNED, TrialState.FAIL, TrialState.RUNNING]
+    study = _create_study(states)
+    info = _get_timeline_info(study, n_recent_trials=n_recent_trials)
+
+    assert len(info.bars) == expected_count
+
+    if n_recent_trials is not None and n_recent_trials > 0 and expected_count > 0:
+        all_trials = study.get_trials(deepcopy=False)
+        expected_trials = all_trials[-expected_count:]
+        for bar, trial in zip(info.bars, expected_trials):
+            assert bar.number == trial.number
+
+
 def test_get_timeline_info_negative_elapsed_time(capsys: _pytest.capture.CaptureFixture) -> None:
     # We need to reconstruct our default handler to properly capture stderr.
     optuna.logging._reset_library_root_logger()
@@ -128,11 +154,15 @@ def test_get_timeline_info_negative_elapsed_time(capsys: _pytest.capture.Capture
 
 @parametrize_plot_timeline
 @pytest.mark.parametrize(
-    "trial_states",
+    "trial_states, n_recent_trials",
     [
-        [],
-        [TrialState.COMPLETE, TrialState.PRUNED, TrialState.FAIL, TrialState.RUNNING],
-        [TrialState.RUNNING, TrialState.FAIL, TrialState.PRUNED, TrialState.COMPLETE],
+        ([], None),
+        ([TrialState.COMPLETE, TrialState.PRUNED, TrialState.FAIL, TrialState.RUNNING], None),
+        ([TrialState.RUNNING, TrialState.FAIL, TrialState.PRUNED, TrialState.COMPLETE], None),
+        ([TrialState.COMPLETE, TrialState.PRUNED, TrialState.FAIL, TrialState.RUNNING], 2),
+        ([TrialState.RUNNING, TrialState.FAIL, TrialState.PRUNED, TrialState.COMPLETE], 1),
+        ([TrialState.COMPLETE, TrialState.PRUNED, TrialState.FAIL], 5),  # More than available
+        ([TrialState.COMPLETE, TrialState.FAIL], 0),  # Zero trials
     ],
 )
 def test_get_timeline_plot(

--- a/tests/visualization_tests/test_timeline.py
+++ b/tests/visualization_tests/test_timeline.py
@@ -166,7 +166,9 @@ def test_get_timeline_info_negative_elapsed_time(capsys: _pytest.capture.Capture
     ],
 )
 def test_get_timeline_plot(
-    plot_timeline: Callable[..., Any], trial_states: list[TrialState]
+    plot_timeline: Callable[..., Any],
+    trial_states: list[TrialState],
+    n_recent_trials: int | None,
 ) -> None:
     study = _create_study(trial_states)
     figure = plot_timeline(study)

--- a/tests/visualization_tests/test_timeline.py
+++ b/tests/visualization_tests/test_timeline.py
@@ -109,7 +109,7 @@ def test_get_timeline_info(trial_sys_attrs: dict[str, Any] | None, infeasible: b
     [
         (None, 4),
         (2, 2),
-        (0, 0),
+        (0, 4),
         (-1, 4),
         (100, 4),
     ],

--- a/tests/visualization_tests/test_timeline.py
+++ b/tests/visualization_tests/test_timeline.py
@@ -109,8 +109,6 @@ def test_get_timeline_info(trial_sys_attrs: dict[str, Any] | None, infeasible: b
     [
         (None, 4),
         (2, 2),
-        (0, 4),
-        (-1, 4),
         (100, 4),
     ],
 )
@@ -178,6 +176,21 @@ def test_get_timeline_plot(
     else:
         plt.savefig(BytesIO())
         plt.close()
+
+
+@parametrize_plot_timeline
+@pytest.mark.parametrize(
+    "n_recent_trials",
+    [0, -1, -10],
+)
+def test_plot_timeline_n_recent_trials_invalid(
+    plot_timeline: Callable[..., Any],
+    n_recent_trials: int | None,
+) -> None:
+    states = [TrialState.COMPLETE, TrialState.PRUNED, TrialState.FAIL, TrialState.RUNNING]
+    study = _create_study(states)
+    with pytest.raises(ValueError, match="n_recent_trials must be a positive integer or None"):
+        plot_timeline(study, n_recent_trials=n_recent_trials)
 
 
 @parametrize_plot_timeline


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

## Description of the changes
Added `n_recent_trials` parameter to `plot_timeline()` to limit the number of trials displayed.
### Changes
- Added `n_recent_trials: int | None = None` parameter
- When specified, only the most recent N trials are plotted
- Raises `ValueError` if `n_recent_trials <= 0`
- Updated docstring and added comprehensive tests

### Usage
```python
# Plot all trials (default)
plot_timeline(study)

# Plot only the 10 most recent trials
plot_timeline(study, n_recent_trials=10)
```
