### PR TITLE
Update docstrings of `_get_best_trial` to follow coding conventions.

### DIFF
--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -289,13 +289,14 @@ class Study:
         """Return the best trial in the study.
 
         Args:
-            deepcopy: Flag to control whether to apply copy.deepcopy() to the trial.
-                     If False, returns the trial without deep copying for better performance.
-                     Note that if you set this to False, you shouldn't mutate any fields
-                     of the returned trial.
+            deepcopy:
+                Flag to control whether to apply ``copy.deepcopy()`` to the trial.
+                If :obj:`False`, returns the trial without deep copying for better performance.
+                Note that if you set this to :obj:`False`, you shouldn't mutate any fields
+                of the returned trial.
 
         Returns:
-            A FrozenTrial object of the best trial.
+            A :class:`~optuna.trial.FrozenTrial` object of the best trial.
         """
         if self._is_multi_objective():
             raise RuntimeError(


### PR DESCRIPTION
## Motivation

This is a follow-up PR for #6119.
I think this is optional since the `_get_best_trial` docstring is not rendered in a reference.

## Description of the changes

- Updated the docstring to follow the existing code base, such as https://github.com/optuna/optuna/blob/8f053dc8995bb6d69c8e40a2d2db2e4f2b0973b5/optuna/study/study.py#L255-L264