### PR TITLE
Refactor and speed up HV3D

### DIFF
--- a/optuna/_hypervolume/wfg.py
+++ b/optuna/_hypervolume/wfg.py
@@ -55,6 +55,7 @@ def _compute_3d(sorted_pareto_sols: np.ndarray, reference_point: np.ndarray) -> 
     x_vals = sorted_pareto_sols[:, 0]
     x_delta = np.concatenate([x_vals[1:], reference_point[:1]]) - x_vals
     y_delta = np.concatenate([y_vals[1:], reference_point[1:2]]) - y_vals
+    # NOTE(nabenabe): `np.vdot(A, B)` is a faster calculation of `np.sum(A * B)`.
     return np.vdot(x_delta[:, np.newaxis] * y_delta, z_delta)
 
 

--- a/optuna/_hypervolume/wfg.py
+++ b/optuna/_hypervolume/wfg.py
@@ -21,6 +21,11 @@ def _compress_coordinate(coords: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
 
     Example:
         _compress_coordinate([20.0, 40.0, 30.0, 10.0]) == ([1, 3, 2, 0], [10.0, 20.0, 30.0, 40.0])
+    
+    Note:
+        This function is equivalent to ``values, r = np.unique(coords, return_inverse=True)``
+        if ``coords`` does not have duplicated values. However, this function is quicker than
+        ``np.unique``.
     """
     assert len(coords.shape) == 1
     sorted_indices = np.argsort(coords)

--- a/optuna/_hypervolume/wfg.py
+++ b/optuna/_hypervolume/wfg.py
@@ -26,15 +26,15 @@ def _compute_3d(sorted_pareto_sols: np.ndarray, reference_point: np.ndarray) -> 
     assert sorted_pareto_sols.shape[1] == reference_point.shape[0] == 3
     n = sorted_pareto_sols.shape[0]
     y_order = np.argsort(sorted_pareto_sols[:, 1])
-    y_vals = sorted_pareto_sols[y_order, 1]
     z_delta = np.zeros((n, n), dtype=float)
     z_delta[y_order, np.arange(n)] = reference_point[2] - sorted_pareto_sols[y_order, 2]
     z_delta = np.maximum.accumulate(np.maximum.accumulate(z_delta, axis=0), axis=1)
     # The x axis is already sorted, so no need to compress this coordinate.
     x_vals = sorted_pareto_sols[:, 0]
+    y_vals = sorted_pareto_sols[y_order, 1]
     x_delta = np.concatenate([x_vals[1:], reference_point[:1]]) - x_vals
     y_delta = np.concatenate([y_vals[1:], reference_point[1:2]]) - y_vals
-    # NOTE(nabenabe): `np.vdot(A, B)` is a faster calculation of `np.sum(A * B)`.
+    # NOTE(nabenabe): Below is a faster calculation of `np.sum(A * B)`.
     return np.dot(np.dot(z_delta, y_delta), x_delta)
 
 

--- a/optuna/_hypervolume/wfg.py
+++ b/optuna/_hypervolume/wfg.py
@@ -34,7 +34,7 @@ def _compute_3d(sorted_pareto_sols: np.ndarray, reference_point: np.ndarray) -> 
     y_vals = sorted_pareto_sols[y_order, 1]
     x_delta = np.concatenate([x_vals[1:], reference_point[:1]]) - x_vals
     y_delta = np.concatenate([y_vals[1:], reference_point[1:2]]) - y_vals
-    # NOTE(nabenabe): Below is a faster calculation of `np.sum(A * B)`.
+    # NOTE(nabenabe): Below is the faster alternative of `np.sum(dx[:, None] * dy * dz)`.
     return np.dot(np.dot(z_delta, y_delta), x_delta)
 
 

--- a/optuna/_hypervolume/wfg.py
+++ b/optuna/_hypervolume/wfg.py
@@ -47,9 +47,10 @@ def _compute_3d(sorted_pareto_sols: np.ndarray, reference_point: np.ndarray) -> 
     """
     assert sorted_pareto_sols.shape[1] == reference_point.shape[0] == 3
     n = sorted_pareto_sols.shape[0]
-    y_indices, y_vals = _compress_coordinate(sorted_pareto_sols[:, 1])
+    y_order = np.argsort(sorted_pareto_sols[:, 1])
+    y_vals = sorted_pareto_sols[y_order, 1]
     z_delta = np.zeros((n, n), dtype=float)
-    z_delta[np.arange(n), y_indices] = reference_point[2] - sorted_pareto_sols[:, 2]
+    z_delta[y_order, np.arange(n)] = reference_point[2] - sorted_pareto_sols[y_order, 2]
     z_delta = np.maximum.accumulate(np.maximum.accumulate(z_delta, axis=0), axis=1)
     # The x axis is already sorted, so no need to compress this coordinate.
     x_vals = sorted_pareto_sols[:, 0]

--- a/optuna/_hypervolume/wfg.py
+++ b/optuna/_hypervolume/wfg.py
@@ -56,7 +56,7 @@ def _compute_3d(sorted_pareto_sols: np.ndarray, reference_point: np.ndarray) -> 
     x_delta = np.concatenate([x_vals[1:], reference_point[:1]]) - x_vals
     y_delta = np.concatenate([y_vals[1:], reference_point[1:2]]) - y_vals
     # NOTE(nabenabe): `np.vdot(A, B)` is a faster calculation of `np.sum(A * B)`.
-    return np.vdot(x_delta[:, np.newaxis] * y_delta, z_delta)
+    return np.dot(np.dot(z_delta, y_delta), x_delta)
 
 
 def _compute_hv(sorted_loss_vals: np.ndarray, reference_point: np.ndarray) -> float:

--- a/optuna/_hypervolume/wfg.py
+++ b/optuna/_hypervolume/wfg.py
@@ -13,28 +13,6 @@ def _compute_2d(sorted_pareto_sols: np.ndarray, reference_point: np.ndarray) -> 
     return edge_length_x @ edge_length_y
 
 
-def _compress_coordinate(coords: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
-    """
-    Return a permutation of 0, 1, ..., N-1 preserving the original order as well as the sorted
-    sequence. Note that since tie-breaking is not necessary for _compute_3d, this function does not
-    consider tie-breaking.
-
-    Example:
-        _compress_coordinate([20.0, 40.0, 30.0, 10.0]) == ([1, 3, 2, 0], [10.0, 20.0, 30.0, 40.0])
-
-    Note:
-        This function is equivalent to ``values, r = np.unique(coords, return_inverse=True)``
-        if ``coords`` does not have duplicated values. However, this function is quicker than
-        ``np.unique``.
-    """
-    assert len(coords.shape) == 1
-    sorted_indices = np.argsort(coords)
-    values = coords[sorted_indices]
-    r = np.zeros_like(sorted_indices, dtype=int)
-    r[sorted_indices] = np.arange(coords.shape[0], dtype=int)
-    return r, values
-
-
 def _compute_3d(sorted_pareto_sols: np.ndarray, reference_point: np.ndarray) -> float:
     """
     Compute hypervolume in 3D. Time complexity is O(N^2) where N is sorted_pareto_sols.shape[0].

--- a/optuna/_hypervolume/wfg.py
+++ b/optuna/_hypervolume/wfg.py
@@ -7,7 +7,7 @@ from optuna.study._multi_objective import _is_pareto_front
 
 def _compute_2d(sorted_pareto_sols: np.ndarray, reference_point: np.ndarray) -> float:
     assert sorted_pareto_sols.shape[1] == reference_point.shape[0] == 2
-    rect_diag_y = np.concat([reference_point[1:], sorted_pareto_sols[:-1, 1]])
+    rect_diag_y = np.concatenate([reference_point[1:], sorted_pareto_sols[:-1, 1]])
     edge_length_x = reference_point[0] - sorted_pareto_sols[:, 0]
     edge_length_y = rect_diag_y - sorted_pareto_sols[:, 1]
     return edge_length_x @ edge_length_y
@@ -21,7 +21,7 @@ def _compress_coordinate(coords: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
 
     Example:
         _compress_coordinate([20.0, 40.0, 30.0, 10.0]) == ([1, 3, 2, 0], [10.0, 20.0, 30.0, 40.0])
-    
+
     Note:
         This function is equivalent to ``values, r = np.unique(coords, return_inverse=True)``
         if ``coords`` does not have duplicated values. However, this function is quicker than
@@ -53,8 +53,8 @@ def _compute_3d(sorted_pareto_sols: np.ndarray, reference_point: np.ndarray) -> 
     z_delta = np.maximum.accumulate(np.maximum.accumulate(z_delta, axis=0), axis=1)
     # The x axis is already sorted, so no need to compress this coordinate.
     x_vals = sorted_pareto_sols[:, 0]
-    x_delta = np.concat([x_vals[1:], reference_point[:1]]) - x_vals
-    y_delta = np.concat([y_vals[1:], reference_point[1:2]]) - y_vals
+    x_delta = np.concatenate([x_vals[1:], reference_point[:1]]) - x_vals
+    y_delta = np.concatenate([y_vals[1:], reference_point[1:2]]) - y_vals
     return np.sum(z_delta * x_delta[:, np.newaxis] * y_delta[np.newaxis, :], axis=(0, 1))
 
 

--- a/optuna/_hypervolume/wfg.py
+++ b/optuna/_hypervolume/wfg.py
@@ -55,7 +55,7 @@ def _compute_3d(sorted_pareto_sols: np.ndarray, reference_point: np.ndarray) -> 
     x_vals = sorted_pareto_sols[:, 0]
     x_delta = np.concatenate([x_vals[1:], reference_point[:1]]) - x_vals
     y_delta = np.concatenate([y_vals[1:], reference_point[1:2]]) - y_vals
-    return np.sum(z_delta * x_delta[:, np.newaxis] * y_delta[np.newaxis, :], axis=(0, 1))
+    return np.vdot(x_delta[:, np.newaxis] * y_delta, z_delta)
 
 
 def _compute_hv(sorted_loss_vals: np.ndarray, reference_point: np.ndarray) -> float:


### PR DESCRIPTION
> [!NOTE]
> This branch completed the script below in 31.02 seconds while the latest HEAD completed it in 36.84 seconds, resulting in 15.8% speedup.

<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

This PR is a followup of:
- https://github.com/optuna/optuna/pull/6112

## Description of the changes
<!-- Describe the changes in this PR. -->

- Replace inline comments by `#` with `"""`
- Use more NumPy vectorization to speed up

In essence, here:

```python
z_delta[np.arange(n), y_indices] = reference_point[2] - sorted_pareto_sols[:, 2]
```

- Tweak a bit to reduce NumPy method calls to speed up

In essence, here:

```python
z_delta = np.maximum.accumulate(np.maximum.accumulate(z_delta, axis=0), axis=1)
```

and here:

```python
x_delta = np.concatenate([x_vals[1:], reference_point[:1]]) - x_vals
y_delta = np.concatenate([y_vals[1:], reference_point[1:2]]) - y_vals
```

- Use more efficient NumPy methods, i.e., `np.vdot(A, B)` instead of `np.sum(A * B)` and `np.concatenate` instead of `np.append`.

<details>
<summary>Benchmarking Code</summary>

```python
import optuna


def objective(trial: optuna.Trial) -> tuple[float, float, float]:
    x = trial.suggest_float("x", -5, 5)
    y = trial.suggest_float("y", -5, 5)
    return x**2 + y**2, (x - 2)**2 + (y - 2)**2, (x + 2)**2 + (y + 2)**2


sampler = optuna.samplers.TPESampler(seed=42)
study = optuna.create_study(sampler=sampler, directions=["minimize"]*3)
study.optimize(objective, n_trials=1000)
trials = study.trials
print((trials[-1].datetime_complete - trials[0].datetime_start).total_seconds())

```

</details>
