### PR TITLE
Cache split infromation for TPE sampler.

### DIFF
--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -341,6 +341,7 @@ class TPESampler(BaseSampler):
         self._group_decomposed_search_space: _GroupDecomposedSearchSpace | None = None
         self._search_space_group: _SearchSpaceGroup | None = None
         self._search_space = IntersectionSearchSpace(include_pruned=True)
+        self._split_cache: dict[int, dict[str, set[int]]] = {}
         self._constant_liar = constant_liar
         self._constraints_func = constraints_func
         # NOTE(nabenabe0928): Users can overwrite _ParzenEstimator to customize the TPE behavior.
@@ -469,15 +470,22 @@ class TPESampler(BaseSampler):
                     values[param_name].append(distribution.to_internal_repr(param))
         return {k: np.asarray(v) for k, v in values.items()}
 
-    def _sample(
-        self, study: Study, trial: FrozenTrial, search_space: dict[str, BaseDistribution]
-    ) -> dict[str, Any]:
+    def _split_trials_with_cache(
+        self, study: Study, trial: FrozenTrial
+    ) -> tuple[list[FrozenTrial], list[FrozenTrial]]:
         if self._constant_liar:
             states = [TrialState.COMPLETE, TrialState.PRUNED, TrialState.RUNNING]
         else:
             states = [TrialState.COMPLETE, TrialState.PRUNED]
         use_cache = not self._constant_liar
         trials = study._get_trials(deepcopy=False, states=states, use_cache=use_cache)
+        if trial.number in self._split_cache:
+            # NOTE(nabenabe0928): Split must be shared across all dimensions.
+            # https://github.com/optuna/optuna/pull/1166
+            split_cache = self._split_cache[trial.number]
+            below_trials = [t for t in trials if t.number in split_cache["below"]]
+            above_trials = [t for t in trials if t.number in split_cache["above"]]
+            return below_trials, above_trials
 
         # We divide data into below and above.
         n = sum(trial.state != TrialState.RUNNING for trial in trials)  # Ignore running trials.
@@ -487,6 +495,20 @@ class TPESampler(BaseSampler):
             self._gamma(n),
             self._constraints_func is not None,
         )
+        self._split_cache[trial.number] = {
+            "below": set([t.number for t in below_trials]),
+            "above": set([t.number for t in above_trials]),
+        }
+        if len(self._split_cache) > 64:
+            # Delete the oldest cache.
+            self._split_cache.pop(min(trial_number for trial_number in self._split_cache))
+
+        return below_trials, above_trials
+
+    def _sample(
+        self, study: Study, trial: FrozenTrial, search_space: dict[str, BaseDistribution]
+    ) -> dict[str, Any]:
+        below_trials, above_trials = self._split_trials_with_cache(study, trial)
 
         mpe_below = self._build_parzen_estimator(
             study, search_space, below_trials, handle_below=True

--- a/optuna/storages/_grpc/server.py
+++ b/optuna/storages/_grpc/server.py
@@ -69,6 +69,13 @@ def run_grpc_proxy_server(
         thread_pool:
             Thread pool to use for the server. If :obj:`None`, a default thread pool
             with 10 workers will be used.
+
+    .. warning::
+
+        Currently, gRPC storage proxy does not support the
+        :class:`~optuna.storages.JournalStorage`. This issue is tracked in
+        https://github.com/optuna/optuna/issues/6084. Please use
+        :class:`~optuna.storages.RDBStorage` instead.
     """
     server = make_server(storage, host, port, thread_pool)
     server.start()

--- a/tests/storages_tests/test_with_server.py
+++ b/tests/storages_tests/test_with_server.py
@@ -15,6 +15,14 @@ from optuna.storages.journal import JournalRedisBackend
 from optuna.study import StudyDirection
 from optuna.trial import TrialState
 
+from .test_storages import _test_set_and_get_study_system_attrs_for_floats
+from .test_storages import _test_set_and_get_study_user_attrs_for_floats
+from .test_storages import _test_set_and_get_trial_param_for_floats
+from .test_storages import _test_set_and_get_trial_system_attr_for_floats
+from .test_storages import _test_set_and_get_trial_user_attr_for_floats
+from .test_storages import _test_set_trial_intermediate_value_for_floats
+from .test_storages import _test_set_trial_state_values_for_floats
+
 
 _STUDY_NAME = "_test_multiprocess"
 
@@ -211,3 +219,31 @@ def test_get_best_trial(direction: StudyDirection, values: Sequence[float]) -> N
     )
     expected_value = max(values) if direction == StudyDirection.MAXIMIZE else min(values)
     assert study.best_value == expected_value
+
+
+def test_set_and_get_study_user_attrs_for_floats() -> None:
+    _test_set_and_get_study_user_attrs_for_floats(get_storage())
+
+
+def test_set_and_get_study_system_attrs_for_floats() -> None:
+    _test_set_and_get_study_system_attrs_for_floats(get_storage())
+
+
+def test_set_trial_state_values_for_floats() -> None:
+    _test_set_trial_state_values_for_floats(get_storage())
+
+
+def test_set_and_get_trial_param_for_floats() -> None:
+    _test_set_and_get_trial_param_for_floats(get_storage())
+
+
+def test_set_trial_intermediate_value_for_floats() -> None:
+    _test_set_trial_intermediate_value_for_floats(get_storage())
+
+
+def test_set_and_get_trial_user_attr_for_floats() -> None:
+    _test_set_and_get_trial_user_attr_for_floats(get_storage())
+
+
+def test_set_and_get_trial_system_attr_for_floats() -> None:
+    _test_set_and_get_trial_system_attr_for_floats(get_storage())

--- a/tests/study_tests/test_study.py
+++ b/tests/study_tests/test_study.py
@@ -2,11 +2,11 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from concurrent.futures import as_completed
+from concurrent.futures import ProcessPoolExecutor
 from concurrent.futures import ThreadPoolExecutor
 import copy
 import multiprocessing
 import pickle
-import platform
 import threading
 import time
 from typing import Any
@@ -46,6 +46,9 @@ from optuna.trial import TrialState
 
 
 CallbackFuncType = TypingCallable[[Study, FrozenTrial], None]
+
+NUM_MINIMAL_TRIALS = 2
+MINIMUM_TIMEOUT_SEC = 0.01
 
 
 def func(trial: Trial) -> float:
@@ -109,6 +112,22 @@ def check_study(study: Study) -> None:
         check_frozen_trial(study.best_trial)
 
 
+def check_progressbar(err: str, is_shown: bool = True, without_n_trials: bool = False) -> None:
+    # Testing for a character that forms progress bar borders.
+    # e.g.
+    # 1. without n_trials=False:
+    # Best trial: 0. Best value: 1: 100%|██████████| 2/2 [00:00<00:00, 2456.40it/s, 0.00/10.0 seconds]  # NOQA: E501
+    # 2. without n_trials=True:
+    # Best trial: 0. Best value: 1:  100%|██████████| 00:01/00:01
+    if is_shown:
+        assert "%|" in err
+        if not without_n_trials:
+            assert "it/s" in err
+    else:
+        assert "%|" not in err
+        assert "it/s" not in err
+
+
 def stop_objective(threshold_number: int) -> Callable[[Trial], float]:
     def objective(trial: Trial) -> float:
         if trial.number >= threshold_number:
@@ -121,31 +140,31 @@ def stop_objective(threshold_number: int) -> Callable[[Trial], float]:
 
 def test_optimize_trivial_in_memory_new() -> None:
     study = create_study()
-    study.optimize(func, n_trials=10)
+    study.optimize(func, n_trials=NUM_MINIMAL_TRIALS)
     check_study(study)
 
 
 def test_optimize_trivial_in_memory_resume() -> None:
     study = create_study()
-    study.optimize(func, n_trials=10)
-    study.optimize(func, n_trials=10)
+    study.optimize(func, n_trials=NUM_MINIMAL_TRIALS)
+    study.optimize(func, n_trials=NUM_MINIMAL_TRIALS)
     check_study(study)
 
 
 def test_optimize_trivial_rdb_resume_study() -> None:
     study = create_study(storage="sqlite:///:memory:")
-    study.optimize(func, n_trials=10)
+    study.optimize(func, n_trials=NUM_MINIMAL_TRIALS)
     check_study(study)
 
 
 def test_optimize_with_direction() -> None:
     study = create_study(direction="minimize")
-    study.optimize(func, n_trials=10)
+    study.optimize(func, n_trials=NUM_MINIMAL_TRIALS)
     assert study.direction == StudyDirection.MINIMIZE
     check_study(study)
 
     study = create_study(direction="maximize")
-    study.optimize(func, n_trials=10)
+    study.optimize(func, n_trials=NUM_MINIMAL_TRIALS)
     assert study.direction == StudyDirection.MAXIMIZE
     check_study(study)
 
@@ -159,7 +178,7 @@ def test_optimize_with_direction() -> None:
         create_study(directions="minimize")
 
 
-@pytest.mark.parametrize("n_trials", (0, 1, 20))
+@pytest.mark.parametrize("n_trials", (0, 1, NUM_MINIMAL_TRIALS))
 @pytest.mark.parametrize("n_jobs", (1, 2, -1))
 @pytest.mark.parametrize("storage_mode", STORAGE_MODES)
 def test_optimize_parallel(n_trials: int, n_jobs: int, storage_mode: str) -> None:
@@ -177,18 +196,18 @@ def test_optimize_with_thread_pool_executor() -> None:
         return t.suggest_float("x", -10, 10)
 
     study = create_study()
-    with ThreadPoolExecutor(max_workers=5) as pool:
-        for _ in range(10):
-            pool.submit(study.optimize, objective, n_trials=10)
-    assert len(study.trials) == 100
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        for _ in range(2):
+            pool.submit(study.optimize, objective, n_trials=NUM_MINIMAL_TRIALS)
+    assert len(study.trials) == 2 * NUM_MINIMAL_TRIALS
 
 
-@pytest.mark.parametrize("n_trials", (0, 1, 20, None))
+@pytest.mark.parametrize("n_trials", (0, 1, NUM_MINIMAL_TRIALS, None))
 @pytest.mark.parametrize("n_jobs", (1, 2, -1))
 @pytest.mark.parametrize("storage_mode", STORAGE_MODES)
 def test_optimize_parallel_timeout(n_trials: int, n_jobs: int, storage_mode: str) -> None:
-    sleep_sec = 0.1
-    timeout_sec = 1.0
+    sleep_sec = MINIMUM_TIMEOUT_SEC / 2
+    timeout_sec = MINIMUM_TIMEOUT_SEC
     f = Func(sleep_sec=sleep_sec)
 
     with StorageSupplier(storage_mode) as storage:
@@ -215,26 +234,26 @@ def test_optimize_with_catch(storage_mode: str) -> None:
 
         # Test default exceptions.
         with pytest.raises(ValueError):
-            study.optimize(fail_objective, n_trials=20)
+            study.optimize(fail_objective, n_trials=NUM_MINIMAL_TRIALS)
         assert len(study.trials) == 1
         assert all(trial.state == TrialState.FAIL for trial in study.trials)
 
         # Test acceptable exception.
-        study.optimize(fail_objective, n_trials=20, catch=(ValueError,))
-        assert len(study.trials) == 21
+        study.optimize(fail_objective, n_trials=NUM_MINIMAL_TRIALS, catch=(ValueError,))
+        assert len(study.trials) == 1 + NUM_MINIMAL_TRIALS
         assert all(trial.state == TrialState.FAIL for trial in study.trials)
 
         # Test trial with unacceptable exception.
         with pytest.raises(ValueError):
-            study.optimize(fail_objective, n_trials=20, catch=(ArithmeticError,))
-        assert len(study.trials) == 22
+            study.optimize(fail_objective, n_trials=NUM_MINIMAL_TRIALS, catch=(ArithmeticError,))
+        assert len(study.trials) == 1 + NUM_MINIMAL_TRIALS + 1
         assert all(trial.state == TrialState.FAIL for trial in study.trials)
 
 
 @pytest.mark.parametrize("catch", [ValueError, (ValueError,), [ValueError], {ValueError}])
 def test_optimize_with_catch_valid_type(catch: Any) -> None:
     study = create_study()
-    study.optimize(fail_objective, n_trials=20, catch=catch)
+    study.optimize(fail_objective, n_trials=NUM_MINIMAL_TRIALS, catch=catch)
 
 
 @pytest.mark.parametrize("catch", [None, 1])
@@ -242,7 +261,7 @@ def test_optimize_with_catch_invalid_type(catch: Any) -> None:
     study = create_study()
 
     with pytest.raises(TypeError):
-        study.optimize(fail_objective, n_trials=20, catch=catch)
+        study.optimize(fail_objective, n_trials=NUM_MINIMAL_TRIALS, catch=catch)
 
 
 @pytest.mark.parametrize("n_jobs", (2, -1))
@@ -254,7 +273,7 @@ def test_optimize_with_reseeding(n_jobs: int, storage_mode: str) -> None:
         study = create_study(storage=storage)
         sampler = study.sampler
         with patch.object(sampler, "reseed_rng", wraps=sampler.reseed_rng) as mock_object:
-            study.optimize(f, n_trials=1, n_jobs=2)
+            study.optimize(f, n_trials=1, n_jobs=n_jobs)
             assert mock_object.call_count == 1
 
 
@@ -265,12 +284,12 @@ def test_call_another_study_optimize_in_optimize() -> None:
     def objective(t: Trial) -> float:
         inner_study = create_study()
         inner_study.enqueue_trial({"x": t.suggest_int("initial_point", -10, 10)})
-        inner_study.optimize(inner_objective, n_trials=10)
+        inner_study.optimize(inner_objective, n_trials=NUM_MINIMAL_TRIALS)
         return inner_study.best_value
 
     study = create_study()
-    study.optimize(objective, n_trials=10)
-    assert len(study.trials) == 10
+    study.optimize(objective, n_trials=NUM_MINIMAL_TRIALS)
+    assert len(study.trials) == NUM_MINIMAL_TRIALS
 
 
 @pytest.mark.parametrize("storage_mode", STORAGE_MODES)
@@ -301,13 +320,13 @@ def test_trial_set_and_get_user_attrs(storage_mode: str) -> None:
 def test_get_all_study_summaries(storage_mode: str, include_best_trial: bool) -> None:
     with StorageSupplier(storage_mode) as storage:
         study = create_study(storage=storage)
-        study.optimize(func, n_trials=5)
+        study.optimize(func, n_trials=NUM_MINIMAL_TRIALS)
 
         summaries = get_all_study_summaries(study._storage, include_best_trial)
         summary = [s for s in summaries if s._study_id == study._study_id][0]
 
         assert summary.study_name == study.study_name
-        assert summary.n_trials == 5
+        assert summary.n_trials == NUM_MINIMAL_TRIALS
         if include_best_trial:
             assert summary.best_trial is not None
         else:
@@ -342,18 +361,18 @@ def test_get_all_study_names(storage_mode: str) -> None:
 
 def test_study_pickle() -> None:
     study_1 = create_study()
-    study_1.optimize(func, n_trials=10)
+    study_1.optimize(func, n_trials=NUM_MINIMAL_TRIALS)
     check_study(study_1)
-    assert len(study_1.trials) == 10
+    assert len(study_1.trials) == NUM_MINIMAL_TRIALS
     dumped_bytes = pickle.dumps(study_1)
 
     study_2 = pickle.loads(dumped_bytes)
     check_study(study_2)
-    assert len(study_2.trials) == 10
+    assert len(study_2.trials) == NUM_MINIMAL_TRIALS
 
-    study_2.optimize(func, n_trials=10)
+    study_2.optimize(func, n_trials=NUM_MINIMAL_TRIALS)
     check_study(study_2)
-    assert len(study_2.trials) == 20
+    assert len(study_2.trials) == NUM_MINIMAL_TRIALS + NUM_MINIMAL_TRIALS
 
 
 @pytest.mark.parametrize("storage_mode", STORAGE_MODES)
@@ -510,39 +529,39 @@ def test_nested_optimization() -> None:
         return 1.0
 
     study = create_study()
-    study.optimize(objective, n_trials=10, catch=())
+    study.optimize(objective, n_trials=NUM_MINIMAL_TRIALS, catch=())
 
 
 def test_stop_in_objective() -> None:
     # Test stopping the optimization: it should stop once the trial number reaches 4.
     study = create_study()
-    study.optimize(stop_objective(4), n_trials=10)
-    assert len(study.trials) == 5
+    study.optimize(stop_objective(2), n_trials=10)
+    assert len(study.trials) == 3
 
     # Test calling `optimize` again: it should stop once the trial number reaches 11.
-    study.optimize(stop_objective(11), n_trials=10)
-    assert len(study.trials) == 12
+    study.optimize(stop_objective(5), n_trials=10)
+    assert len(study.trials) == 6
 
 
 def test_stop_in_callback() -> None:
     def callback(study: Study, trial: FrozenTrial) -> None:
-        if trial.number >= 4:
+        if trial.number >= NUM_MINIMAL_TRIALS - 1:
             study.stop()
 
     # Test stopping the optimization inside a callback.
     study = create_study()
     study.optimize(lambda _: 1.0, n_trials=10, callbacks=[callback])
-    assert len(study.trials) == 5
+    assert len(study.trials) == NUM_MINIMAL_TRIALS
 
 
 def test_stop_n_jobs() -> None:
     def callback(study: Study, trial: FrozenTrial) -> None:
-        if trial.number >= 4:
+        if trial.number >= NUM_MINIMAL_TRIALS - 1:
             study.stop()
 
     study = create_study()
     study.optimize(lambda _: 1.0, n_trials=None, callbacks=[callback], n_jobs=2)
-    assert 5 <= len(study.trials) <= 6
+    assert NUM_MINIMAL_TRIALS <= len(study.trials) <= NUM_MINIMAL_TRIALS + 1
 
 
 def test_stop_outside_optimize() -> None:
@@ -589,16 +608,16 @@ def test_add_trials(storage_mode: str) -> None:
         study.add_trials([])
         assert len(study.trials) == 0
 
-        trials = [create_trial(value=i) for i in range(3)]
+        trials = [create_trial(value=i) for i in range(NUM_MINIMAL_TRIALS)]
         study.add_trials(trials)
-        assert len(study.trials) == 3
+        assert len(study.trials) == NUM_MINIMAL_TRIALS
         for i, trial in enumerate(study.trials):
             assert trial.number == i
             assert trial.value == i
 
         other_study = create_study(storage=storage)
         other_study.add_trials(study.trials)
-        assert len(other_study.trials) == 3
+        assert len(other_study.trials) == NUM_MINIMAL_TRIALS
         for i, trial in enumerate(other_study.trials):
             assert trial.number == i
             assert trial.value == i
@@ -661,7 +680,7 @@ def test_enqueue_trial_properly_sets_user_attr(storage_mode: str) -> None:
             y = trial.suggest_int("y", -10, 10)
             return x**2 + y**2
 
-        study.optimize(objective, n_trials=2)
+        study.optimize(objective, n_trials=NUM_MINIMAL_TRIALS)
         t0 = study.trials[0]
         assert t0.user_attrs == {"is_optimal": False}
 
@@ -812,15 +831,15 @@ def test_enqueue_trial_skip_existing_handles_common_types(storage_mode: str, par
 @patch("optuna.study._optimize.gc.collect")
 def test_optimize_with_gc(collect_mock: Mock) -> None:
     study = create_study()
-    study.optimize(func, n_trials=10, gc_after_trial=True)
+    study.optimize(func, n_trials=NUM_MINIMAL_TRIALS, gc_after_trial=True)
     check_study(study)
-    assert collect_mock.call_count == 10
+    assert collect_mock.call_count == NUM_MINIMAL_TRIALS
 
 
 @patch("optuna.study._optimize.gc.collect")
 def test_optimize_without_gc(collect_mock: Mock) -> None:
     study = create_study()
-    study.optimize(func, n_trials=10, gc_after_trial=False)
+    study.optimize(func, n_trials=NUM_MINIMAL_TRIALS, gc_after_trial=False)
     check_study(study)
     assert collect_mock.call_count == 0
 
@@ -828,43 +847,39 @@ def test_optimize_without_gc(collect_mock: Mock) -> None:
 @pytest.mark.parametrize("n_jobs", [1, 2])
 def test_optimize_with_progbar(n_jobs: int, capsys: _pytest.capture.CaptureFixture) -> None:
     study = create_study()
-    study.optimize(lambda _: 1.0, n_trials=10, n_jobs=n_jobs, show_progress_bar=True)
+    study.optimize(
+        lambda _: 1.0, n_trials=NUM_MINIMAL_TRIALS, n_jobs=n_jobs, show_progress_bar=True
+    )
     _, err = capsys.readouterr()
 
     # Search for progress bar elements in stderr.
     assert "Best trial: 0" in err
     assert "Best value: 1" in err
-    assert "10/10" in err
-    if platform.system() != "Windows":
-        # Skip this assertion because the progress bar sometimes stops at 99% on Windows.
-        assert "100%" in err
+    assert f"{NUM_MINIMAL_TRIALS}/{NUM_MINIMAL_TRIALS}" in err
+    check_progressbar(err)
 
 
 @pytest.mark.parametrize("n_jobs", [1, 2])
 def test_optimize_without_progbar(n_jobs: int, capsys: _pytest.capture.CaptureFixture) -> None:
     study = create_study()
-    study.optimize(lambda _: 1.0, n_trials=10, n_jobs=n_jobs)
+    study.optimize(lambda _: 1.0, n_trials=NUM_MINIMAL_TRIALS, n_jobs=n_jobs)
     _, err = capsys.readouterr()
 
     assert "Best trial: 0" not in err
     assert "Best value: 1" not in err
     assert "10/10" not in err
-    if platform.system() != "Windows":
-        # Skip this assertion because the progress bar sometimes stops at 99% on Windows.
-        assert "100%" not in err
+    check_progressbar(err, is_shown=False)
 
 
 def test_optimize_with_progbar_timeout(capsys: _pytest.capture.CaptureFixture) -> None:
     study = create_study()
-    study.optimize(lambda _: 1.0, timeout=2.0, show_progress_bar=True)
+    study.optimize(lambda _: 1.0, timeout=MINIMUM_TIMEOUT_SEC, show_progress_bar=True)
     _, err = capsys.readouterr()
 
     assert "Best trial: 0" in err
     assert "Best value: 1" in err
-    assert "00:02/00:02" in err
-    if platform.system() != "Windows":
-        # Skip this assertion because the progress bar sometimes stops at 99% on Windows.
-        assert "100%" in err
+    assert "00:00/00:00" in err
+    check_progressbar(err, without_n_trials=True)
 
 
 def test_optimize_with_progbar_parallel_timeout(capsys: _pytest.capture.CaptureFixture) -> None:
@@ -872,11 +887,13 @@ def test_optimize_with_progbar_parallel_timeout(capsys: _pytest.capture.CaptureF
     with pytest.warns(
         UserWarning, match="The timeout-based progress bar is not supported with n_jobs != 1."
     ):
-        study.optimize(lambda _: 1.0, timeout=2.0, show_progress_bar=True, n_jobs=2)
+        study.optimize(
+            lambda _: 1.0, timeout=MINIMUM_TIMEOUT_SEC, show_progress_bar=True, n_jobs=2
+        )
     _, err = capsys.readouterr()
 
-    # Testing for a character that forms progress bar borders.
-    assert "|" not in err
+    # progress bar should not shown when n_jobs != 1.
+    check_progressbar(err, is_shown=False)
 
 
 @pytest.mark.parametrize(
@@ -903,15 +920,13 @@ def test_optimize_without_progbar_timeout(
     n_jobs: int, capsys: _pytest.capture.CaptureFixture
 ) -> None:
     study = create_study()
-    study.optimize(lambda _: 1.0, timeout=2.0, n_jobs=n_jobs)
+    study.optimize(lambda _: 1.0, timeout=MINIMUM_TIMEOUT_SEC, n_jobs=n_jobs)
     _, err = capsys.readouterr()
 
     assert "Best trial: 0" not in err
     assert "Best value: 1.0" not in err
-    assert "00:02/00:02" not in err
-    if platform.system() != "Windows":
-        # Skip this assertion because the progress bar sometimes stops at 99% on Windows.
-        assert "100%" not in err
+    assert "00:00/00:00" not in err
+    check_progressbar(err, is_shown=False)
 
 
 @pytest.mark.parametrize("n_jobs", [1, 2])
@@ -919,16 +934,19 @@ def test_optimize_progbar_n_trials_prioritized(
     n_jobs: int, capsys: _pytest.capture.CaptureFixture
 ) -> None:
     study = create_study()
-    study.optimize(lambda _: 1.0, n_trials=10, n_jobs=n_jobs, timeout=10.0, show_progress_bar=True)
+    study.optimize(
+        lambda _: 1.0,
+        n_trials=NUM_MINIMAL_TRIALS,
+        n_jobs=n_jobs,
+        timeout=10.0,
+        show_progress_bar=True,
+    )
     _, err = capsys.readouterr()
 
     assert "Best trial: 0" in err
     assert "Best value: 1" in err
-    assert "10/10" in err
-    if platform.system() != "Windows":
-        # Skip this assertion because the progress bar sometimes stops at 99% on Windows.
-        assert "100%" in err
-    assert "it" in err
+    assert f"{NUM_MINIMAL_TRIALS}/{NUM_MINIMAL_TRIALS}" in err
+    check_progressbar(err)
 
 
 @pytest.mark.parametrize("n_jobs", [1, 2])
@@ -936,11 +954,10 @@ def test_optimize_without_progbar_n_trials_prioritized(
     n_jobs: int, capsys: _pytest.capture.CaptureFixture
 ) -> None:
     study = create_study()
-    study.optimize(lambda _: 1.0, n_trials=10, n_jobs=n_jobs, timeout=10.0)
+    study.optimize(lambda _: 1.0, n_trials=NUM_MINIMAL_TRIALS, n_jobs=n_jobs, timeout=10.0)
     _, err = capsys.readouterr()
 
-    # Testing for a character that forms progress bar borders.
-    assert "|" not in err
+    check_progressbar(err, is_shown=False)
 
 
 @pytest.mark.parametrize("n_jobs", [1, 2])
@@ -953,10 +970,8 @@ def test_optimize_progbar_no_constraints(
         study.optimize(stop_objective(5), n_jobs=n_jobs, show_progress_bar=True)
     _, err = capsys.readouterr()
 
-    # We can't simply test if stderr is empty, since we're not sure
-    # what else could write to it. Instead, we are testing for a character
-    # that forms progress bar borders.
-    assert "|" not in err
+    # optimization is controlled by `stop_objective`, so the progress bar should be shown.
+    check_progressbar(err, is_shown=False)
 
 
 @pytest.mark.parametrize("n_jobs", [1, 2])
@@ -967,8 +982,7 @@ def test_optimize_without_progbar_no_constraints(
     study.optimize(stop_objective(5), n_jobs=n_jobs)
     _, err = capsys.readouterr()
 
-    # Testing for a character that forms progress bar borders.
-    assert "|" not in err
+    check_progressbar(err, is_shown=False)
 
 
 @pytest.mark.parametrize("n_jobs", [1, 4])
@@ -1186,9 +1200,9 @@ def test_optimize_with_multi_objectives(n_objectives: int) -> None:
     def objective(trial: Trial) -> list[float]:
         return [trial.suggest_float("v{}".format(i), 0, 5) for i in range(n_objectives)]
 
-    study.optimize(objective, n_trials=10)
+    study.optimize(objective, n_trials=NUM_MINIMAL_TRIALS)
 
-    assert len(study.trials) == 10
+    assert len(study.trials) == NUM_MINIMAL_TRIALS
 
     for trial in study.trials:
         assert trial.values
@@ -1270,7 +1284,7 @@ def test_wrong_n_objectives() -> None:
     def objective(trial: Trial) -> list[float]:
         return [trial.suggest_float("v{}".format(i), 0, 5) for i in range(n_objectives + 1)]
 
-    study.optimize(objective, n_trials=10)
+    study.optimize(objective, n_trials=NUM_MINIMAL_TRIALS)
 
     for trial in study.trials:
         assert trial.state is TrialState.FAIL
@@ -1629,31 +1643,29 @@ def _process_tell(study: Study, trial: Trial | int, values: float) -> None:
 
 
 def test_tell_from_another_process() -> None:
-    pool = multiprocessing.Pool()
-
     with StorageSupplier("sqlite") as storage:
         # Create a study and ask for a new trial.
         study = create_study(storage=storage)
         trial0 = study.ask()
 
-        # Test normal behaviour.
-        pool.starmap(_process_tell, [(study, trial0, 1.2)])
+        with ProcessPoolExecutor() as pool:
+            # Test normal behaviour.
+            pool.submit(_process_tell, study=study, trial=trial0, values=1.2).result()
+            assert len(study.trials) == 1
+            assert study.best_trial.state == TrialState.COMPLETE
+            assert study.best_value == 1.2
 
-        assert len(study.trials) == 1
-        assert study.best_trial.state == TrialState.COMPLETE
-        assert study.best_value == 1.2
+            # Test study.tell using trial number.
+            trial = study.ask()
+            pool.submit(_process_tell, study=study, trial=trial.number, values=1.5).result()
+            assert len(study.trials) == 2
+            assert study.best_trial.state == TrialState.COMPLETE
+            assert study.best_value == 1.2
 
-        # Test study.tell using trial number.
-        trial = study.ask()
-        pool.starmap(_process_tell, [(study, trial.number, 1.5)])
-
-        assert len(study.trials) == 2
-        assert study.best_trial.state == TrialState.COMPLETE
-        assert study.best_value == 1.2
-
-        # Should fail because the trial0 is already finished.
-        with pytest.raises(ValueError):
-            pool.starmap(_process_tell, [(study, trial0, 1.2)])
+            # Should fail because the trial0 is already finished.
+            with pytest.raises(ValueError):
+                fut = pool.submit(_process_tell, study=study, trial=trial0, values=1.2)
+                fut.result()
 
 
 @pytest.mark.parametrize("storage_mode", STORAGE_MODES)

--- a/tests/visualization_tests/test_timeline.py
+++ b/tests/visualization_tests/test_timeline.py
@@ -159,8 +159,7 @@ def test_get_timeline_info_negative_elapsed_time(capsys: _pytest.capture.Capture
         ([TrialState.RUNNING, TrialState.FAIL, TrialState.PRUNED, TrialState.COMPLETE], None),
         ([TrialState.COMPLETE, TrialState.PRUNED, TrialState.FAIL, TrialState.RUNNING], 2),
         ([TrialState.RUNNING, TrialState.FAIL, TrialState.PRUNED, TrialState.COMPLETE], 1),
-        ([TrialState.COMPLETE, TrialState.PRUNED, TrialState.FAIL], 5),  # More than available
-        ([TrialState.COMPLETE, TrialState.FAIL], 0),  # Zero trials
+        ([TrialState.COMPLETE, TrialState.PRUNED, TrialState.FAIL], 5),  # More than available.
     ],
 )
 def test_get_timeline_plot(
@@ -169,7 +168,7 @@ def test_get_timeline_plot(
     n_recent_trials: int | None,
 ) -> None:
     study = _create_study(trial_states)
-    figure = plot_timeline(study)
+    figure = plot_timeline(study, n_recent_trials=n_recent_trials)
 
     if isinstance(figure, go.Figure):
         figure.write_image(BytesIO())
@@ -189,7 +188,7 @@ def test_plot_timeline_n_recent_trials_invalid(
 ) -> None:
     states = [TrialState.COMPLETE, TrialState.PRUNED, TrialState.FAIL, TrialState.RUNNING]
     study = _create_study(states)
-    with pytest.raises(ValueError, match="n_recent_trials must be a positive integer or None"):
+    with pytest.raises(ValueError):
         plot_timeline(study, n_recent_trials=n_recent_trials)
 
 


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
This is a revival of https://github.com/optuna/optuna/pull/5464.
In the current implementation,  `_split_cache` is unnecessarily repeated even when the results would be identical.
This PR aims to eliminate such redundant computations and improve efficiency.

## Description of the changes
<!-- Describe the changes in this PR. -->
The content is same as https://github.com/optuna/optuna/pull/5464 for now.
The cache uses `trial.number` as the key, and the value is the result of the split operation.
