### PR TITLE
Refactor `tell_with_warning` to avoid unnecessary `get_trial` call

### DIFF
--- a/optuna/study/_optimize.py
+++ b/optuna/study/_optimize.py
@@ -210,7 +210,7 @@ def _run_trial(
 
     # `_tell_with_warning` may raise during trial post-processing.
     try:
-        updated_state, values, params, warning_message = _tell_with_warning(
+        updated_state, values, warning_message = _tell_with_warning(
             study=study,
             trial=trial,
             value_or_values=value_or_values,
@@ -221,20 +221,19 @@ def _run_trial(
         frozen_trial = study._storage.get_trial(trial._trial_id)
         updated_state = frozen_trial.state
         values = frozen_trial.values
-        params = frozen_trial.params
         warning_message = None
         raise
     finally:
         if updated_state == TrialState.COMPLETE:
             assert values is not None
-            study._log_completed_trial(values, trial.number, params)
+            study._log_completed_trial(values, trial.number, trial.params)
         elif updated_state == TrialState.PRUNED:
             _logger.info("Trial {} pruned. {}".format(trial.number, str(func_err)))
         elif updated_state == TrialState.FAIL:
             if func_err is not None:
                 _log_failed_trial(
                     trial.number,
-                    params,
+                    trial.params,
                     repr(func_err),
                     exc_info=func_err_fail_exc_info,
                     value_or_values=value_or_values,
@@ -242,7 +241,7 @@ def _run_trial(
             elif warning_message is not None:
                 _log_failed_trial(
                     trial.number,
-                    params,
+                    trial.params,
                     warning_message,
                     value_or_values=value_or_values,
                 )

--- a/optuna/study/_tell.py
+++ b/optuna/study/_tell.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 import math
-from typing import Any
 from typing import TYPE_CHECKING
 import warnings
 
@@ -87,7 +86,7 @@ def _tell_with_warning(
     state: TrialState | None = None,
     skip_if_finished: bool = False,
     suppress_warning: bool = False,
-) -> tuple[TrialState, list[float] | None, dict[str, Any], str | None]:
+) -> tuple[TrialState, list[float] | None, str | None]:
     """Internal method of :func:`~optuna.study.Study.tell`.
 
     Refer to the document for :func:`~optuna.study.Study.tell` for the reference.
@@ -111,7 +110,7 @@ def _tell_with_warning(
             f"{value_or_values} and state {state} since trial was already finished. "
             f"Finished trial has values {frozen_trial.values} and state {frozen_trial.state}."
         )
-        return frozen_trial.state, frozen_trial.values, frozen_trial.params, None
+        return frozen_trial.state, frozen_trial.values, None
     elif frozen_trial.state != TrialState.RUNNING:
         raise ValueError(f"Cannot tell a {frozen_trial.state.name} trial.")
 
@@ -175,4 +174,4 @@ def _tell_with_warning(
     finally:
         study._storage.set_trial_state_values(frozen_trial._trial_id, state, values)
 
-    return state, values, frozen_trial.params, values_conversion_failure_message
+    return state, values, values_conversion_failure_message

--- a/optuna/study/_tell.py
+++ b/optuna/study/_tell.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 import math
+from typing import Any
 from typing import TYPE_CHECKING
 import warnings
 
@@ -86,7 +87,7 @@ def _tell_with_warning(
     state: TrialState | None = None,
     skip_if_finished: bool = False,
     suppress_warning: bool = False,
-) -> tuple[FrozenTrial, str | None]:
+) -> tuple[TrialState, list[float] | None, dict[str, Any], str | None]:
     """Internal method of :func:`~optuna.study.Study.tell`.
 
     Refer to the document for :func:`~optuna.study.Study.tell` for the reference.
@@ -110,7 +111,7 @@ def _tell_with_warning(
             f"{value_or_values} and state {state} since trial was already finished. "
             f"Finished trial has values {frozen_trial.values} and state {frozen_trial.state}."
         )
-        return frozen_trial, None
+        return frozen_trial.state, frozen_trial.values, frozen_trial.params, None
     elif frozen_trial.state != TrialState.RUNNING:
         raise ValueError(f"Cannot tell a {frozen_trial.state.name} trial.")
 
@@ -174,6 +175,4 @@ def _tell_with_warning(
     finally:
         study._storage.set_trial_state_values(frozen_trial._trial_id, state, values)
 
-    frozen_trial = study._storage.get_trial(frozen_trial._trial_id)
-
-    return frozen_trial, values_conversion_failure_message
+    return state, values, frozen_trial.params, values_conversion_failure_message

--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -36,6 +36,7 @@ from optuna.study._multi_objective import _get_pareto_front_trials
 from optuna.study._optimize import _optimize
 from optuna.study._study_direction import StudyDirection
 from optuna.study._study_summary import StudySummary  # NOQA
+from optuna.study._tell import _get_frozen_trial
 from optuna.study._tell import _tell_with_warning
 from optuna.trial import create_trial
 from optuna.trial import TrialState
@@ -675,9 +676,7 @@ class Study:
             state=state,
             skip_if_finished=skip_if_finished,
         )
-        return copy.deepcopy(
-            self._storage.get_trial(trial if isinstance(trial, int) else trial._trial_id)
-        )
+        return copy.deepcopy(_get_frozen_trial(self, trial))
 
     def set_user_attr(self, key: str, value: Any) -> None:
         """Set a user attribute to the study.

--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -36,7 +36,6 @@ from optuna.study._multi_objective import _get_pareto_front_trials
 from optuna.study._optimize import _optimize
 from optuna.study._study_direction import StudyDirection
 from optuna.study._study_summary import StudySummary  # NOQA
-from optuna.study._tell import _get_frozen_trial
 from optuna.study._tell import _tell_with_warning
 from optuna.trial import create_trial
 from optuna.trial import TrialState
@@ -676,7 +675,9 @@ class Study:
             state=state,
             skip_if_finished=skip_if_finished,
         )
-        return copy.deepcopy(_get_frozen_trial(self, trial))
+        return copy.deepcopy(
+            self._storage.get_trial(trial if isinstance(trial, int) else trial._trial_id)
+        )
 
     def set_user_attr(self, key: str, value: Any) -> None:
         """Set a user attribute to the study.

--- a/tests/study_tests/test_optimize.py
+++ b/tests/study_tests/test_optimize.py
@@ -39,19 +39,22 @@ def test_run_trial(storage_mode: str, caplog: LogCaptureFixture) -> None:
         study = create_study(storage=storage)
 
         caplog.clear()
-        frozen_trial = _optimize._run_trial(study, lambda _: 1.0, catch=())
+        frozen_trial_id = _optimize._run_trial(study, lambda _: 1.0, catch=())
+        frozen_trial = study._storage.get_trial(frozen_trial_id)
         assert frozen_trial.state == TrialState.COMPLETE
         assert frozen_trial.value == 1.0
         assert "Trial 0 finished with value: 1.0 and parameters" in caplog.text
 
         caplog.clear()
-        frozen_trial = _optimize._run_trial(study, lambda _: float("inf"), catch=())
+        frozen_trial_id = _optimize._run_trial(study, lambda _: float("inf"), catch=())
+        frozen_trial = study._storage.get_trial(frozen_trial_id)
         assert frozen_trial.state == TrialState.COMPLETE
         assert frozen_trial.value == float("inf")
         assert "Trial 1 finished with value: inf and parameters" in caplog.text
 
         caplog.clear()
-        frozen_trial = _optimize._run_trial(study, lambda _: -float("inf"), catch=())
+        frozen_trial_id = _optimize._run_trial(study, lambda _: -float("inf"), catch=())
+        frozen_trial = study._storage.get_trial(frozen_trial_id)
         assert frozen_trial.state == TrialState.COMPLETE
         assert frozen_trial.value == -float("inf")
         assert "Trial 2 finished with value: -inf and parameters" in caplog.text
@@ -62,19 +65,23 @@ def test_run_trial_automatically_fail(storage_mode: str, caplog: LogCaptureFixtu
     with StorageSupplier(storage_mode) as storage:
         study = create_study(storage=storage)
 
-        frozen_trial = _optimize._run_trial(study, lambda _: float("nan"), catch=())
+        frozen_trial_id = _optimize._run_trial(study, lambda _: float("nan"), catch=())
+        frozen_trial = study._storage.get_trial(frozen_trial_id)
         assert frozen_trial.state == TrialState.FAIL
         assert frozen_trial.value is None
 
-        frozen_trial = _optimize._run_trial(study, lambda _: None, catch=())  # type: ignore[arg-type,return-value] # noqa: E501
+        frozen_trial_id = _optimize._run_trial(study, lambda _: None, catch=())  # type: ignore[arg-type,return-value] # noqa: E501
+        frozen_trial = study._storage.get_trial(frozen_trial_id)
         assert frozen_trial.state == TrialState.FAIL
         assert frozen_trial.value is None
 
-        frozen_trial = _optimize._run_trial(study, lambda _: object(), catch=())  # type: ignore[arg-type,return-value] # noqa: E501
+        frozen_trial_id = _optimize._run_trial(study, lambda _: object(), catch=())  # type: ignore[arg-type,return-value] # noqa: E501
+        frozen_trial = study._storage.get_trial(frozen_trial_id)
         assert frozen_trial.state == TrialState.FAIL
         assert frozen_trial.value is None
 
-        frozen_trial = _optimize._run_trial(study, lambda _: [0, 1], catch=())
+        frozen_trial_id = _optimize._run_trial(study, lambda _: [0, 1], catch=())
+        frozen_trial = study._storage.get_trial(frozen_trial_id)
         assert frozen_trial.state == TrialState.FAIL
         assert frozen_trial.value is None
 
@@ -93,19 +100,24 @@ def test_run_trial_pruned(storage_mode: str, caplog: LogCaptureFixture) -> None:
         study = create_study(storage=storage)
 
         caplog.clear()
-        frozen_trial = _optimize._run_trial(study, gen_func(), catch=())
+        frozen_trial_id = _optimize._run_trial(study, gen_func(), catch=())
+        frozen_trial = study._storage.get_trial(frozen_trial_id)
         assert frozen_trial.state == TrialState.PRUNED
         assert frozen_trial.value is None
         assert "Trial 0 pruned." in caplog.text
 
         caplog.clear()
-        frozen_trial = _optimize._run_trial(study, gen_func(intermediate=1), catch=())
+        frozen_trial_id = _optimize._run_trial(study, gen_func(intermediate=1), catch=())
+        frozen_trial = study._storage.get_trial(frozen_trial_id)
         assert frozen_trial.state == TrialState.PRUNED
         assert frozen_trial.value == 1
         assert "Trial 1 pruned." in caplog.text
 
         caplog.clear()
-        frozen_trial = _optimize._run_trial(study, gen_func(intermediate=float("nan")), catch=())
+        frozen_trial_id = _optimize._run_trial(
+            study, gen_func(intermediate=float("nan")), catch=()
+        )
+        frozen_trial = study._storage.get_trial(frozen_trial_id)
         assert frozen_trial.state == TrialState.PRUNED
         assert frozen_trial.value is None
         assert "Trial 2 pruned." in caplog.text
@@ -115,7 +127,8 @@ def test_run_trial_pruned(storage_mode: str, caplog: LogCaptureFixture) -> None:
 def test_run_trial_catch_exception(storage_mode: str) -> None:
     with StorageSupplier(storage_mode) as storage:
         study = create_study(storage=storage)
-        frozen_trial = _optimize._run_trial(study, fail_objective, catch=(ValueError,))
+        frozen_trial_id = _optimize._run_trial(study, fail_objective, catch=(ValueError,))
+        frozen_trial = study._storage.get_trial(frozen_trial_id)
         assert frozen_trial.state == TrialState.FAIL
 
 

--- a/tests/study_tests/test_study.py
+++ b/tests/study_tests/test_study.py
@@ -1136,17 +1136,17 @@ def test_log_completed_trial_skip_storage_access() -> None:
     storage = study._storage
 
     with patch.object(storage, "get_best_trial", wraps=storage.get_best_trial) as mock_object:
-        study._log_completed_trial(frozen_trial)
+        study._log_completed_trial(frozen_trial.values, frozen_trial.number, frozen_trial.params)
         assert mock_object.call_count == 1
 
     logging.set_verbosity(logging.WARNING)
     with patch.object(storage, "get_best_trial", wraps=storage.get_best_trial) as mock_object:
-        study._log_completed_trial(frozen_trial)
+        study._log_completed_trial(frozen_trial.values, frozen_trial.number, frozen_trial.params)
         assert mock_object.call_count == 0
 
     logging.set_verbosity(logging.DEBUG)
     with patch.object(storage, "get_best_trial", wraps=storage.get_best_trial) as mock_object:
-        study._log_completed_trial(frozen_trial)
+        study._log_completed_trial(frozen_trial.values, frozen_trial.number, frozen_trial.params)
         assert mock_object.call_count == 1
 
 


### PR DESCRIPTION
## Motivation  
Remove unnecessary calls to `storage.get_trial` to improve efficiency.

## Description of the changes  
- Removed the final `storage.get_trial` call in `tell_with_warning`.  
- Instead of returning the `FrozenTrial`, `tell_with_warning` now returns `state`, `values`, `params`, and `values_conversion_failure_message`, which are required for subsequent log output.