### PR TITLE
style: simplify tuple return in _get_y_range

### DIFF
--- a/optuna/visualization/_terminator_improvement.py
+++ b/optuna/visualization/_terminator_improvement.py
@@ -185,7 +185,7 @@ def _get_y_range(info: _ImprovementInfo, min_n_trials: int) -> tuple[float, floa
         max_value = max(max_value, max(info.errors))
 
     padding = (max_value - min_value) * PADDING_RATIO_Y
-    return (min_value - padding, max_value + padding)
+    return min_value - padding, max_value + padding
 
 
 def _get_improvement_plot(info: _ImprovementInfo, min_n_trials: int) -> "go.Figure":


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
To improve code consistency with Optuna's style and PEP8 guidelines, particularly regarding how tuples are returned.

## Description of the changes
Replaced return (a, b) with return a, b in _get_y_range to align with common Optuna codebase practices. No logic was changed—only syntax style.