### PR TITLE
Simplify tuple return in `optuna/visualization/_terminator_improvement.py`

### DIFF
--- a/optuna/visualization/_terminator_improvement.py
+++ b/optuna/visualization/_terminator_improvement.py
@@ -185,7 +185,7 @@ def _get_y_range(info: _ImprovementInfo, min_n_trials: int) -> tuple[float, floa
         max_value = max(max_value, max(info.errors))
 
     padding = (max_value - min_value) * PADDING_RATIO_Y
-    return (min_value - padding, max_value + padding)
+    return min_value - padding, max_value + padding
 
 
 def _get_improvement_plot(info: _ImprovementInfo, min_n_trials: int) -> "go.Figure":


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation

This PR addresses [#6136](https://github.com/optuna/optuna/issues/6136).  
The goal is to improve code consistency with Optuna's style and PEP8 guidelines regarding tuple return formatting.

## Description of the changes
Simplify tuple return in optuna/visualization/_terminator_improvement.py

- In `_get_y_range`, replaced:
  
  ```python
       return (a, b)
  ```
  with 
  ```python
       return a, b
  ```

## Note
1 ) The CI check failure appears to be unrelated to the changes introduced in this PR.  
2 ) This PR only modifies the return syntax in `_get_y_range`, and no logic or affected files match the error logs from the   failed check.


