### PR TITLE
Simplify tuple return in `test_trial.py`

### DIFF
--- a/tests/trial_tests/test_trial.py
+++ b/tests/trial_tests/test_trial.py
@@ -650,10 +650,7 @@ def test_suggest_with_multi_objectives() -> None:
         p5 = trial.suggest_categorical("p5", [7, 1, 100])
         p6 = trial.suggest_float("p6", -10, 10, step=1.0)
         p7 = trial.suggest_int("p7", 1, 7, log=True)
-        return (
-            p0 + p1 + p2,
-            p3 + p4 + p5 + p6 + p7,
-        )
+        return p0 + p1 + p2, p3 + p4 + p5 + p6 + p7
 
     study.optimize(objective, n_trials=10)
 


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation

This PR addresses https://github.com/optuna/optuna/issues/6136 it simplifies the tuple return in `tests/trial_tests/test_trial.py` to align with the existing Optuna code style, which prefers returning tuples without parentheses when possible, improving code consistency.
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

## Description of the changes
<!-- Describe the changes in this PR. -->
Removed parentheses in tuple return statements in `test_trial.py`.

Tested function that was changed:
![image](https://github.com/user-attachments/assets/0fb9cc5b-423e-4272-bf74-535bada85903)


## Notes
This PR only modifies the return syntax in `test_trial.py`.