### PR TITLE
Refactor return statement style in `optuna/storages/_rdb/models.py` for consistency among the codebase

### DIFF
--- a/optuna/storages/_rdb/models.py
+++ b/optuna/storages/_rdb/models.py
@@ -421,11 +421,11 @@ class TrialValueModel(BaseModel):
     @classmethod
     def value_to_stored_repr(cls, value: float) -> tuple[float | None, TrialValueType]:
         if value == float("inf"):
-            return (None, cls.TrialValueType.INF_POS)
+            return None, cls.TrialValueType.INF_POS
         elif value == float("-inf"):
-            return (None, cls.TrialValueType.INF_NEG)
+            return None, cls.TrialValueType.INF_NEG
         else:
-            return (value, cls.TrialValueType.FINITE)
+            return value, cls.TrialValueType.FINITE
 
     @classmethod
     def stored_repr_to_value(cls, value: float | None, float_type: TrialValueType) -> float:
@@ -486,13 +486,13 @@ class TrialIntermediateValueModel(BaseModel):
         cls, value: float
     ) -> tuple[float | None, TrialIntermediateValueType]:
         if math.isnan(value):
-            return (None, cls.TrialIntermediateValueType.NAN)
+            return None, cls.TrialIntermediateValueType.NAN
         elif value == float("inf"):
-            return (None, cls.TrialIntermediateValueType.INF_POS)
+            return None, cls.TrialIntermediateValueType.INF_POS
         elif value == float("-inf"):
-            return (None, cls.TrialIntermediateValueType.INF_NEG)
+            return None, cls.TrialIntermediateValueType.INF_NEG
         else:
-            return (value, cls.TrialIntermediateValueType.FINITE)
+            return value, cls.TrialIntermediateValueType.FINITE
 
     @classmethod
     def stored_repr_to_intermediate_value(


### PR DESCRIPTION
### Motivation
This PR updates the return statement formatting in `optuna/storages/_rdb/models.py` to align with Optuna's code style, which prefers `return a, b` over `return (a, b)` for returning tuples.

### Changes
- Replaced parentheses-wrapped return tuples with comma-separated return values.
