### PR TITLE
[hotfix] Add version constraint on blackdoc

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -30,6 +30,7 @@ jobs:
         python -m pip install -U pip
         pip install --progress-bar off -U .[checking]
         # TODO(c-bata): Remove the version constraint on blackdoc
+        # See https://github.com/optuna/optuna/issues/6146 for details.
         pip install --progress-bar off "blackdoc<0.3.10"
 
     - name: Output installed packages

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -29,6 +29,8 @@ jobs:
       run: |
         python -m pip install -U pip
         pip install --progress-bar off -U .[checking]
+        # TODO(c-bata): Remove the version constraint on blackdoc
+        pip install --progress-bar off "blackdoc<0.3.10"
 
     - name: Output installed packages
       run: |

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -23,6 +23,9 @@ jobs:
       run: |
         python -m pip install -U pip
         pip install --progress-bar off -U .[checking]
+        # TODO(c-bata): Remove the version constraint on blackdoc
+        # See https://github.com/optuna/optuna/issues/6146 for details.
+        pip install --progress-bar off "blackdoc<0.3.10"
 
     - name: Output installed packages
       run: |


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
Fixes https://github.com/optuna/optuna/actions/runs/15572122231/job/43850030515

## Description of the changes
<!-- Describe the changes in this PR. -->
blackdoc 0.3.10 was released yesterday, causing the `checks` workflow to fail.
https://pypi.org/project/blackdoc/#history

This PR adds a version constraint on blackdoc to resolve the above issue.