### PR TITLE
Refactor return style #6136

### DIFF
--- a/optuna/storages/_rdb/alembic/versions/v3.0.0.c.py
+++ b/optuna/storages/_rdb/alembic/versions/v3.0.0.c.py
@@ -56,13 +56,13 @@ class IntermediateValueModel(BaseModel):
         value: float,
     ) -> tuple[float | None, TrialIntermediateValueType]:
         if np.isnan(value):
-            return (None, cls.TrialIntermediateValueType.NAN)
+            return None, cls.TrialIntermediateValueType.NAN
         elif value == float("inf"):
-            return (None, cls.TrialIntermediateValueType.INF_POS)
+            return None, cls.TrialIntermediateValueType.INF_POS
         elif value == float("-inf"):
-            return (None, cls.TrialIntermediateValueType.INF_NEG)
+            return None, cls.TrialIntermediateValueType.INF_NEG
         else:
-            return (value, cls.TrialIntermediateValueType.FINITE)
+            return value, cls.TrialIntermediateValueType.FINITE
 
 
 def upgrade():


### PR DESCRIPTION
### Description:

This PR updates the return statement style in `optuna/storages/_rdb/alembic/versions/v3.0.0.c.py` to follow Optuna’s convention of using tuple unpacking without parentheses, i.e., `return a, b` instead of `return (a, b)`.

### Motivation:

According to the project’s code style and consistency guidelines (referenced in issue #6136), Optuna prefers return a, b over return (a, b) when returning multiple values. This change aligns the file with that convention and improves consistency across the codebase.

### Note:

The changes made in the file did not change any logic of the code.