### PR TITLE
Refactor returns in `v3.0.0.d.py`

### DIFF
--- a/optuna/storages/_rdb/alembic/versions/v3.0.0.d.py
+++ b/optuna/storages/_rdb/alembic/versions/v3.0.0.d.py
@@ -55,11 +55,11 @@ class TrialValueModel(BaseModel):
         value: float,
     ) -> tuple[float | None, TrialValueType]:
         if value == float("inf"):
-            return (None, cls.TrialValueType.INF_POS)
+            return None, cls.TrialValueType.INF_POS
         elif value == float("-inf"):
-            return (None, cls.TrialValueType.INF_NEG)
+            return None, cls.TrialValueType.INF_NEG
         else:
-            return (value, cls.TrialValueType.FINITE)
+            return value, cls.TrialValueType.FINITE
 
     @classmethod
     def stored_repr_to_value(cls, value: float | None, float_type: TrialValueType) -> float:


### PR DESCRIPTION
## Motivation
Per #6136, we need to replace all tuple returns of the form `return (a, b)` with `return a, b`.

## Description of the changes
This PR refactors the `return` statements in `optuna/storages/_rdb/alembic/versions/v3.0.0.d.py` to use implicitly packed tuples rather than explicitly packed tuples.