### PR TITLE
Add an FAQ entry about specifying optimization parameters

### DIFF
--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -775,3 +775,10 @@ However, if it is necessary to remove artifacts from a Python script, users can 
         for artifact_meta in get_all_artifact_meta(study):
             # Remove the artifacts uploaded to ``base_path``.
             artifact_store.remove(artifact_meta.artifact_id)
+
+Can I specify parameter starting points before optimization?
+------------------------------------------------------------
+
+Yes, it's possible.
+
+For a more comprehensive guide, refer to the `Specify Hyperparameters Manually <https://optuna.readthedocs.io/en/stable/tutorial/20_recipes/008_specify_params.html>`_.


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation

Addresses https://github.com/optuna/optuna/issues/1080#issuecomment-2967031231 given that the issue has several reactions and users seemingly end up here instead of in the tutorial https://optuna.readthedocs.io/en/stable/tutorial/20_recipes/008_specify_params.html . 

## Description of the changes

Adds an entry to the FAQ answering _if_ it's possible to specify parameter starting points before the optimization.
_How_ this is done is addressed in the tutorial, so the entry is merely a pointer to the tutorial. Improving the searchability of the tutorial may be a less straight forward but alternative solution.