### PR TITLE
Print fully qualified name of experimental function by default

### DIFF
--- a/optuna/_experimental.py
+++ b/optuna/_experimental.py
@@ -57,7 +57,8 @@ def experimental_func(
 
     Args:
         version: The first version that supports the target feature.
-        name: The name of the feature. Defaults to the function name. Optional.
+        name: The name of the feature. Defaults to fully qualified name of
+        the function, i.e. `f"{func.__module__}.{func.__qualname__}"`. Optional.
     """
 
     _validate_version(version)
@@ -70,13 +71,13 @@ def experimental_func(
         indent = _get_docstring_indent(func.__doc__)
         func.__doc__ = func.__doc__.strip() + textwrap.indent(note, indent) + indent
 
+        _name = name or f"{func.__module__}.{func.__qualname__}"
+
         @functools.wraps(func)
         def wrapper(*args: Any, **kwargs: Any) -> FT:
             warnings.warn(
                 "{} is experimental (supported from v{}). "
-                "The interface can change in the future.".format(
-                    name if name is not None else func.__name__, version
-                ),
+                "The interface can change in the future.".format(_name, version),
                 ExperimentalWarning,
                 stacklevel=2,
             )

--- a/tests/test_experimental.py
+++ b/tests/test_experimental.py
@@ -32,6 +32,10 @@ class _Sample:
         """
         pass
 
+    @staticmethod
+    def _static_method() -> None:
+        pass
+
 
 @pytest.mark.parametrize("version", ["1.1", 100, None])
 def test_experimental_raises_error_for_invalid_version(version: Any) -> None:
@@ -51,9 +55,33 @@ def test_experimental_func_decorator() -> None:
     assert decorated_func.__name__ == _sample_func.__name__
     assert decorated_func.__doc__ == _experimental._EXPERIMENTAL_NOTE_TEMPLATE.format(ver=version)
 
-    with pytest.warns(ExperimentalWarning):
+    with pytest.warns(ExperimentalWarning) as warnings:
         decorated_func()
 
+    (warning,) = warnings
+
+    assert _sample_func.__module__ in str(warning.message), warning.message
+    assert _sample_func.__qualname__ in str(warning.message), warning.message
+    assert version in str(warning.message), warning.message
+
+
+def test_experimental_func_decorator_with_static_method() -> None:
+    version = "1.1.0"
+    decorator_experimental = _experimental.experimental_func(version)
+    assert callable(decorator_experimental)
+
+    decorated_func = decorator_experimental(_Sample._static_method)
+    assert decorated_func.__name__ == _Sample._static_method.__name__
+    assert decorated_func.__doc__ == _experimental._EXPERIMENTAL_NOTE_TEMPLATE.format(ver=version)
+
+    with pytest.warns(ExperimentalWarning) as warnings:
+        decorated_func()
+
+    (warning,) = warnings
+
+    assert _Sample._static_method.__module__ in str(warning.message), warning.message
+    assert _Sample._static_method.__qualname__ in str(warning.message), warning.message
+    assert version in str(warning.message), warning.message
 
 def test_experimental_instance_method_decorator() -> None:
     version = "1.1.0"


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
Currently, warning messages from experimental functions decorated by `optuna._experimental.experimental_func` seems only include their function name and not include which module they are defined in.

## Description of the changes
 This PR change the decorator so that the warning messages include module name and include `__qualname__` instead of `__name__`.
