### PR TITLE
Add pytest-xdist to speedup the ci test

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -72,7 +72,7 @@ jobs:
         COVERAGE_PROCESS_START: .coveragerc  # https://coverage.readthedocs.io/en/6.4.1/subprocess.html
         COVERAGE_COVERAGE: yes  # https://github.com/nedbat/coveragepy/blob/65bf33fc03209ffb01bbbc0d900017614645ee7a/coverage/control.py#L255-L261
       run: |
-        coverage run --source=optuna -m pytest tests -m "not skip_coverage and not slow"
+        coverage run --source=optuna -m pytest tests -m "not skip_coverage and not slow" -n 8
         coverage combine
         coverage xml
 

--- a/.github/workflows/mac-tests.yml
+++ b/.github/workflows/mac-tests.yml
@@ -64,8 +64,8 @@ jobs:
     - name: Scheduled tests
       if:  ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
       run: |
-        pytest tests
+        pytest tests -n 8
     - name: Tests
       if:  ${{ github.event_name != 'schedule' && github.event_name != 'workflow_dispatch' }}
       run: |
-        pytest tests -m "not slow"
+        pytest tests -m "not slow" -n 8

--- a/.github/workflows/matplotlib-tests.yml
+++ b/.github/workflows/matplotlib-tests.yml
@@ -59,5 +59,5 @@ jobs:
       if:  ${{ github.event_name != 'schedule' && github.event_name != 'workflow_dispatch' }}
       run: |
         pip uninstall -y plotly
-        pytest tests/visualization_tests/matplotlib_tests
+        pytest tests/visualization_tests/matplotlib_tests -n 8
 

--- a/.github/workflows/tests-storage.yml
+++ b/.github/workflows/tests-storage.yml
@@ -120,7 +120,7 @@ jobs:
 
     - name: Tests MySQL
       run: |
-        pytest tests/storages_tests/test_with_server.py
+        pytest tests/storages_tests/test_with_server.py -n 8
       env:
         SQLALCHEMY_WARN_20: 1
         OMP_NUM_THREADS: 1
@@ -128,14 +128,14 @@ jobs:
 
     - name: Tests PostgreSQL
       run: |
-        pytest tests/storages_tests/test_with_server.py
+        pytest tests/storages_tests/test_with_server.py -n 8
       env:
         OMP_NUM_THREADS: 1
         TEST_DB_URL: postgresql+psycopg2://user:test@127.0.0.1/optunatest
 
     - name: Tests Journal Redis
       run: |
-        pytest tests/storages_tests/test_with_server.py
+        pytest tests/storages_tests/test_with_server.py -n 8
       env:
         OMP_NUM_THREADS: 1
         TEST_DB_URL: redis://localhost:6379

--- a/.github/workflows/tests-with-minimum-versions.yml
+++ b/.github/workflows/tests-with-minimum-versions.yml
@@ -90,9 +90,9 @@ jobs:
     - name: Scheduled tests
       if:  ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
       run: |
-        pytest tests
+        pytest tests -n 8
 
     - name: Tests
       if:  ${{ github.event_name != 'schedule' && github.event_name != 'workflow_dispatch' }}
       run: |
-        pytest tests -m "not slow"
+        pytest tests -m "not slow" -n 8

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -97,6 +97,6 @@ jobs:
           target="not slow"
         fi
 
-        pytest tests -m "$target"
+        pytest tests -m "$target" -n 8
       env:
         SQLALCHEMY_WARN_20: 1

--- a/.github/workflows/windows-tests.yml
+++ b/.github/workflows/windows-tests.yml
@@ -69,7 +69,7 @@ jobs:
     - name: Scheduled tests
       if:  ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
       run: |
-        pytest
+        pytest -n 8
       env:
         SQLALCHEMY_WARN_20: 1
         MPLBACKEND: "QtAgg" # Use QtAgg as matplotlib backend.
@@ -77,6 +77,6 @@ jobs:
     - name: Tests
       if:  ${{ github.event_name != 'schedule' && github.event_name != 'workflow_dispatch' }}
       run: |
-        pytest -m "not slow"
+        pytest -m "not slow" -n 8
       env:
         MPLBACKEND: "QtAgg" # Use QtAgg as matplotlib backend.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,7 @@ test = [
   "kaleido<0.4",  # TODO(nzw0301): Remove the version constraint by installing browser separately.
   "moto",
   "pytest",
+  "pytest-xdist",
   "scipy>=1.9.2",
   "torch; python_version<='3.12'",  # TODO(gen740): Remove this line when 'torch', a dependency of 'optuna/_gp', supports Python 3.13
   "grpcio",  # optuna/storages/_grpc.
@@ -171,6 +172,7 @@ filterwarnings = 'ignore::optuna.exceptions.ExperimentalWarning'
 markers = [
   "skip_coverage: marks tests are skipped when calculating the coverage",
   "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+  "serial: marks tests as fragile when executed in parallel.",
 ]
 
 [tool.mypy]

--- a/tests/study_tests/test_study.py
+++ b/tests/study_tests/test_study.py
@@ -1660,6 +1660,8 @@ def test_tell_from_another_process() -> None:
 def test_pop_waiting_trial_thread_safe(storage_mode: str) -> None:
     if storage_mode in ("sqlite", "cached_sqlite", "grpc_rdb"):
         pytest.skip("study._pop_waiting_trial is not thread-safe on SQLite3")
+    if storage_mode == "grpc_journal_file":
+        pytest.skip("gRPC journal file storage does not support multi-threading")
 
     num_enqueued = 10
     with StorageSupplier(storage_mode) as storage:


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
Current ci test takes around 15 minutes. To improve the speed of ci tests, I added the `pytest-xdist` to parallelize.

## Description of the changes
<!-- Describe the changes in this PR. -->
- Add `pytest-xdist` to `pyproject.toml`
- Add `-n 8` to every pytest execution.
- Add lock file for getting free port to avoid race-condition of GRPC server.

## Additional context
To determine best worker number for the ci test, I ran a lot of test on [my repository](https://github.com/gen740/optuna/actions/runs/15773540575), and I found it seems the 8 workers are enough.

Following figures are the mean and stddev of 4 ci-tests varying the worker number from 1 to 10. The measurement was done by my repository. The elapsed time is just pytest execution. So this graph **DOES NOT** contain the pip install or other setup time.
![Figure_1](https://github.com/user-attachments/assets/08bc89d7-dc7c-4c93-b2a5-413ef03b5111)

