### PR TITLE
Fix type checking in `optuna.artifacts._download.py`

### DIFF
--- a/optuna/artifacts/_download.py
+++ b/optuna/artifacts/_download.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import os
 import shutil
 
-from optuna.artifacts._protocol import ArtifactStore
+
+if TYPE_CHECKING:
+    from optuna.artifacts._protocol import ArtifactStore
 
 
 def download_artifact(*, artifact_store: ArtifactStore, file_path: str, artifact_id: str) -> None:

--- a/optuna/artifacts/_download.py
+++ b/optuna/artifacts/_download.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 import os
 import shutil
+from typing import TYPE_CHECKING
 
 
 if TYPE_CHECKING:


### PR DESCRIPTION
## Motivation
This PR addresses #6029.

## Description of the changes
Fixes the circular import in `optuna.artifacts._download.py`.
