### PR TITLE
docs: add Spark example using ask-and-tell interface

### DIFF
--- a/optuna/artifacts/_download.py
+++ b/optuna/artifacts/_download.py
@@ -2,8 +2,11 @@ from __future__ import annotations
 
 import os
 import shutil
+from typing import TYPE_CHECKING
 
-from optuna.artifacts._protocol import ArtifactStore
+
+if TYPE_CHECKING:
+    from optuna.artifacts._protocol import ArtifactStore
 
 
 def download_artifact(*, artifact_store: ArtifactStore, file_path: str, artifact_id: str) -> None:

--- a/tutorial/20_recipes/014_spark_ask_and_tell.py
+++ b/tutorial/20_recipes/014_spark_ask_and_tell.py
@@ -1,0 +1,43 @@
+"""
+Spark with Ask-and-Tell
+========================
+
+An example showing how to use Optuna's ask-and-tell interface with Apache Spark
+to distribute the evaluation of trials.
+
+This script uses PySpark's RDD to parallelize a simple quadratic function.
+"""
+
+import optuna
+
+try:
+    from pyspark.sql import SparkSession
+except ImportError:
+    SparkSession = None  # Allow docs to build without pyspark
+
+
+def evaluate(x):
+    # Simulates a trial evaluation on a Spark worker node
+    return (x - 2) ** 2
+
+
+if __name__ == "__main__":
+    if SparkSession is None:
+        print("This example requires pyspark. Please install it to run this script.")
+    else:
+        spark = SparkSession.builder.appName("OptunaSparkExample").getOrCreate()
+        study = optuna.create_study()
+
+        for i in range(20):
+            trial = study.ask()
+            x = trial.suggest_float("x", -10, 10)
+
+            # Simulate distributed evaluation with Spark
+            rdd = spark.sparkContext.parallelize([x])
+            result = rdd.map(evaluate).collect()[0]
+
+            study.tell(trial, result)
+            print(f"Trial {i + 1}: x = {x:.4f}, result = {result:.4f}")
+
+        print("Best trial:", study.best_trial)
+        spark.stop()

--- a/tutorial/20_recipes/README.rst
+++ b/tutorial/20_recipes/README.rst
@@ -4,3 +4,18 @@ Recipes
 -------
 
 Showcases the recipes that might help you using Optuna with comfort.
+
+Spark with Ask-and-Tell
+------------------------
+
+This example demonstrates how to use Optuna's ask-and-tell interface with Apache Spark
+to distribute the evaluation of trials. This is a minimal example to illustrate how distributed
+trial evaluation can be performed in Spark. In real-world scenarios, the evaluation function
+would typically involve more complex or expensive computations.
+
+For more details, see the
+`Optuna ask-and-tell documentation <https://optuna.readthedocs.io/en/stable/tutorial/20_recipes/009_ask_and_tell.html>`_.
+
+.. literalinclude:: 014_spark_ask_and_tell.py
+   :language: python
+   :linenos:


### PR DESCRIPTION
## Add Spark Example using Ask-and-Tell Interface

This PR adds a minimal working example that demonstrates how to use Optuna with Apache Spark via the ask-and-tell interface.

✅ Simulates distributed trial evaluation using Spark  
📘 Adds `014_spark_ask_and_tell.py` under `tutorial/20_recipes/`  
📝 Includes doc entry in `README.rst`  

Based on the suggestion in this issue: #6077  
Inspired by this blog: https://fritshermans.github.io/posts/optuna_spark.html

Let me know if any changes or simplifications are needed!
Closes #6077