### PR TITLE
Fix a bug in constrained `GPSampler`

### DIFF
--- a/optuna/samplers/_gp/sampler.py
+++ b/optuna/samplers/_gp/sampler.py
@@ -334,15 +334,16 @@ class GPSampler(BaseSampler):
                 constraint_vals, internal_search_space, normalized_params
             )
             i_opt = np.argmax(y_with_neginf)
+            best_feasible_y = y_with_neginf[i_opt]
             acqf = acqf_module.ConstrainedLogEI(
                 gpr=gprs_list[0],
                 search_space=internal_search_space,
-                threshold=y_with_neginf[i_opt],
+                threshold=best_feasible_y,
                 constraints_gpr_list=constr_gpr_list,
                 constraints_threshold_list=constr_threshold_list,
             )
             best_params = (
-                None if np.isneginf(y_with_neginf[i_opt]) else normalized_params[i_opt, np.newaxis]
+                None if np.isneginf(best_feasible_y) else normalized_params[i_opt, np.newaxis]
             )
 
         normalized_param = self._optimize_acqf(acqf, best_params)

--- a/optuna/samplers/_gp/sampler.py
+++ b/optuna/samplers/_gp/sampler.py
@@ -342,6 +342,7 @@ class GPSampler(BaseSampler):
                 constraints_gpr_list=constr_gpr_list,
                 constraints_threshold_list=constr_threshold_list,
             )
+            assert normalized_params.shape[:-1] == y_with_neginf.shape
             best_params = (
                 None if np.isneginf(best_feasible_y) else normalized_params[i_opt, np.newaxis]
             )


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

The original implementation takes `best_params` as the `x` fetched by  `argmax(Y[is_feasible])`.
However, what we really want is `x` with the best feasible `y`.

See the example below,

```python
X = [[1.0], [4.0], [2.0]]
Y = [2.0, 3.0, 5.0]
C = [1.0, -1.0, -1.0]
```

In this case, `feasible = [False, True, True]`, meaning that `Y_feasible = [3.0, 5.0]` and `X_feasible = [[4.0], [2.0]]`.
So `X[argmax(Y_feasible)]` becomes `[4.0]` instead of `[2.0]`, which is the actual best feasible params.
I fixed this bug in this PR.

> [!NOTE]
> Here, we aim to maximize `Y`.

## Description of the changes
<!-- Describe the changes in this PR. -->

- See the motivation
