### PR TITLE
Fix `TPESampler` with `multivariate` and `constant_liar`

### DIFF
--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -550,7 +550,9 @@ class TPESampler(BaseSampler):
     ) -> _ParzenEstimator:
         observations = self._get_internal_repr(trials, search_space)
         if handle_below and study._is_multi_objective():
-            param_mask_below = [search_space.keys() <= self._get_params(trial).keys() for trial in trials]
+            param_mask_below = [
+                search_space.keys() <= self._get_params(trial).keys() for trial in trials
+            ]
             weights_below = _calculate_weights_below_for_multi_objective(
                 study, trials, self._constraints_func
             )[param_mask_below]

--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -474,7 +474,8 @@ class TPESampler(BaseSampler):
 
     def _get_params(self, trial: FrozenTrial) -> dict[str, Any]:
         if trial.state.is_finished() or not self._multivariate:
-            # NOTE(not522): If not multivariate, `relative_params` does not exist and `system_attrs` access will be unnecessary, so we skip it.
+            # NOTE(not522): If not multivariate, `relative_params` does not exist and
+            # `system_attrs` access will be unnecessary, so we skip it.
             return trial.params
 
         params_strs = []

--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -516,6 +516,10 @@ class TPESampler(BaseSampler):
         use_cache = not self._constant_liar
         trials = study._get_trials(deepcopy=False, states=states, use_cache=use_cache)
 
+        if self._constant_liar:
+            # For constant_liar, filter out the current trial.
+            trials = [t for t in trials if trial.number != t.number]
+
         # We divide data into below and above.
         n = sum(trial.state != TrialState.RUNNING for trial in trials)  # Ignore running trials.
         below_trials, above_trials = _split_trials(

--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -485,11 +485,9 @@ class TPESampler(BaseSampler):
 
         if len(params_strs) == 0:
             return trial.params
-        else:
-            params_str = "".join(params_strs)
-            params = json.loads(params_str)
-            params.update(trial.params)
-            return params
+        params = json.loads("".join(params_strs))
+        params.update(trial.params)
+        return params
 
     def _get_internal_repr(
         self, trials: list[FrozenTrial], search_space: dict[str, BaseDistribution]

--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -474,6 +474,7 @@ class TPESampler(BaseSampler):
 
     def _get_params(self, trial: FrozenTrial) -> dict[str, Any]:
         if trial.state.is_finished() or not self._multivariate:
+            # NOTE(not522): If not multivariate, `relative_params` does not exist and `system_attrs` access will be unnecessary, so we skip it.
             return trial.params
 
         params_strs = []

--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -418,7 +418,7 @@ class TPESampler(BaseSampler):
             params = self._sample_relative(study, trial, search_space)
 
         if search_space != {} and self._constant_liar:
-            # Store the results of relative sampling to make them available to other processes.
+            # Share the params obtained by the relative sampling with the other processes.
             params_str = json.dumps(params)
             for i in range(0, len(params_str), _SYSTEM_ATTR_MAX_LENGTH):
                 study._storage.set_trial_system_attr(

--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -473,7 +473,7 @@ class TPESampler(BaseSampler):
         return self._sample(study, trial, {param_name: param_distribution})[param_name]
 
     def _get_params(self, trial: FrozenTrial) -> dict[str, Any]:
-        if trial.state.is_finished():
+        if trial.state.is_finished() or not self._multivariate:
             return trial.params
 
         params_strs = []

--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -417,7 +417,7 @@ class TPESampler(BaseSampler):
         else:
             params = self._sample_relative(study, trial, search_space)
 
-        if search_space != {} and self._constant_liar:
+        if params != {} and self._constant_liar:
             # Share the params obtained by the relative sampling with the other processes.
             params_str = json.dumps(params)
             for i in range(0, len(params_str), _SYSTEM_ATTR_MAX_LENGTH):

--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -476,15 +476,16 @@ class TPESampler(BaseSampler):
         if trial.state.is_finished():
             return trial.params
 
-        params_str = ""
+        params_strs = []
         i = 0
         while params_str_i := trial.system_attrs.get(f"{_RELATIVE_PARAMS_KEY}:{i}"):
-            params_str += params_str_i
+            params_strs.append(params_str_i)
             i += 1
 
-        if params_str == "":
+        if len(params_strs) == 0:
             return trial.params
         else:
+            params_str = "".join(params_strs)
             params = json.loads(params_str)
             params.update(trial.params)
             return params


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
Combining `TPESampler`'s `multivariate` and `constant_liar` can sometimes cause the `constant_liar` to function improperly during batch optimization.

Running the following script demonstrates that the result remains unchanged whether `constant_liar` is `True` or `False` in the current master branch.

```python
import matplotlib.pyplot as plt
import optuna

N_TRIAL = 50
N_BATCH = 10

for multivariate in (False, True):
    for constant_liar in (False, True):
        sampler = optuna.samplers.TPESampler(
            seed=42,
            multivariate=multivariate,
            constant_liar=constant_liar,
        )
        study = optuna.create_study(sampler=sampler)

        for i in range(0, N_TRIAL, N_BATCH):
            trials = []
            for j in range(N_BATCH):
                trials.append(study.ask())
            X = [trial.suggest_float("x", -10, 10) for trial in trials]
            Y = [trial.suggest_float("y", -10, 10) for trial in trials]
            for j in range(N_BATCH):
                study.tell(trials[j], X[j] ** 2 + Y[j] ** 2)

            # Skip first random sampling.
            if i > 0:
                plt.plot(X, Y, ".")
        plt.xlim(-10, 10)
        plt.ylim(-10, 10)
        plt.savefig(f"{multivariate}-{constant_liar}.png")
        plt.clf()
```

After applying this PR, we can see that sampling becomes more dispersed when `constant_liar` is set to `True`. (Same colors indicate samples in the same batch.)

- master
  - `multivariate=True`, `constant_liar=False`
![True-False](https://github.com/user-attachments/assets/f81bcc97-758b-42c4-9d7a-fe219bd54064)
  - `multivariate=True`, `constant_liar=True`
![True-True](https://github.com/user-attachments/assets/cb7dfdce-6bed-437f-b6cb-13a4c82240a5)

- PR
  - `multivariate=True`, `constant_liar=False`
![True-False](https://github.com/user-attachments/assets/a9c2a55b-6756-4334-990b-9d7efe8f3695)
  - `multivariate=True`, `constant_liar=True`
![True-True](https://github.com/user-attachments/assets/6a651898-94dd-402d-bdee-c4e17f01c3fa)


## Description of the changes
<!-- Describe the changes in this PR. -->

- Store the results of relative sampling in `system_attrs` to make them available to other processes.
- Use them before `RUNNING` trials do actual sampling.

## Benchmarks

### Speed

It takes slightly longer to save parameters in `system_attrs`, but the difference isn't significant.

<details>

```python
import time
import optuna
from tqdm import tqdm

N_TRIAL = 1000
N_BATCH = 10

for multivariate in (False, True):
    for constant_liar in (False, True):
        start = time.time()
        sampler = optuna.samplers.TPESampler(
            seed=42,
            multivariate=multivariate,
            constant_liar=constant_liar,
        )
        study = optuna.create_study(sampler=sampler, storage="sqlite:///tmp.db")

        for i in range(0, N_TRIAL, N_BATCH):
            trials = []
            for j in range(N_BATCH):
                trials.append(study.ask())
            X = [trial.suggest_float("x", -10, 10) for trial in trials]
            Y = [trial.suggest_float("y", -10, 10) for trial in trials]
            for j in range(N_BATCH):
                study.tell(trials[j], X[j] ** 2 + Y[j] ** 2)
        print(f"{multivariate=} {constant_liar=} {time.time()-start}")
```

- master

```
multivariate=False constant_liar=False 9.37236499786377
multivariate=False constant_liar=True 11.942036867141724
multivariate=True constant_liar=False 10.05676007270813
multivariate=True constant_liar=True 11.465260982513428
```

- PR

```
multivariate=False constant_liar=False 9.201738119125366
multivariate=False constant_liar=True 12.185273170471191
multivariate=True constant_liar=False 9.935747146606445
multivariate=True constant_liar=True 12.39444088935852
```

</details>

### Optimization performance

The difference in optimization performance becomes identical to simply having or not having `constant_liar`.

<details>

```python
from multiprocessing import Pool
import optuna
import optunahub
import matplotlib.pyplot as plt
from tqdm import tqdm
import numpy as np
from scipy.stats import mannwhitneyu

optuna.logging.set_verbosity(optuna.logging.WARNING)

N_STUDY = 100
N_TRIAL = 1000
N_BATCH = 50
function_id = 3

bbob = optunahub.load_module("benchmarks/bbob")


def run_study(args):
    n_dim, constant_liar, seed = args
    objective = bbob.Problem(function_id=function_id, dimension=n_dim, instance_id=1)
    assert objective.directions == [optuna.study.StudyDirection.MINIMIZE]

    study_name = f"{n_dim}_{constant_liar}_{seed:02d}"
    sampler = optuna.samplers.TPESampler(
        seed=seed,
        multivariate=True,
        constant_liar=constant_liar,
    )
    study = optuna.create_study(study_name=study_name, sampler=sampler)

    for i in range(0, N_TRIAL, N_BATCH):
        trials = [study.ask() for _ in range(N_BATCH)]
        for d in range(n_dim):
            for trial in trials:
                trial.suggest_float(f"x{d}", -5, 5)
        values = [objective(trial) for trial in trials]
        for trial, value in zip(trials, values):
            study.tell(trial, value)

    storage = optuna.storages.JournalStorage(
        optuna.storages.journal.JournalFileBackend(f"./benchmark_{function_id:02d}/{study_name}.log")
    )
    optuna.copy_study(
        from_study_name=study_name,
        from_storage=study._storage,
        to_storage=storage,
    )


def main():
    for n_dim in [2, 3, 5, 10, 20, 40]:
        args = []
        for constant_liar in (True, False):
            for seed in range(N_STUDY):
                args.append((n_dim, constant_liar, seed))
        with Pool(processes=10) as pool:
            with tqdm(total=len(args)) as t:
                for _ in pool.imap_unordered(run_study, args):
                    t.update(1)
        all_best_values = [[], []]
        for constant_liar in (True, False):
            for seed in range(N_STUDY):
                study_name = f"{n_dim}_{constant_liar}_{seed:02d}"
                storage = optuna.storages.JournalStorage(
                    optuna.storages.journal.JournalFileBackend(f"./benchmark_{function_id:02d}/{study_name}.log")
                )
                study = optuna.load_study(storage=storage, study_name=study_name)
                best_values = []
                best_value = float("inf")
                for trial in study.trials:
                    if best_value > trial.value:
                        best_value = trial.value
                    best_values.append(best_value)
                all_best_values[int(constant_liar)].append(best_values)
        all_best_values = np.asarray(all_best_values)
        p_values = []
        for i in range(N_TRIAL):
            p_value = mannwhitneyu(
                all_best_values[1, :, i],
                all_best_values[0, :, i],
                alternative='less',
            ).pvalue
            p_values.append(p_value)
        plt.plot(range(N_TRIAL), p_values, label=f"D={n_dim}")
    plt.ylim(0, 1)
    plt.legend(loc=1)
    plt.savefig(f"benchmark_{function_id:02}.png")


if __name__ == "__main__":
    main()
```

The following figures show the Mann-Whitney U tests. If the line is close to 0, `constant_liar` would result in better performance. Conversely, if it's close to 1, the effect would be the opposite. Overall, the effect isn't clear, but some settings clearly show an advantage with `constant_liar`.

- function_id=3 (Rastrigin Function)

![benchmark_03](https://github.com/user-attachments/assets/575815ba-f212-4ba4-bb4d-ecdc5c9bb3cb)

- function_id=19 (Composite Griewank-Rosenbrock Function F8F2)

![benchmark_19](https://github.com/user-attachments/assets/581b215f-734a-4439-bfd0-b695ac25d1f5)

- function_id=22 (Gallagher’s Gaussian 21-hi Peaks Function)

![benchmark_22](https://github.com/user-attachments/assets/689f5ec0-9200-475b-bcde-5314a523b804)

</details>