### PR TITLE
Use the Newton method instead of bisect in `ndtri_exp`

### DIFF
--- a/optuna/samplers/_tpe/_truncnorm.py
+++ b/optuna/samplers/_tpe/_truncnorm.py
@@ -180,7 +180,10 @@ def _ndtri_exp_single(y: float) -> float:
         --> x = sqrt(-2 * (y + 1/2 * log(2pi))
 
     For the moderate y, we use Eq. (13), i.e., standard logistic CDF, in the following paper:
-        - Approximating the Cumulative Distribution Function of the Normal Distribution.
+
+    - `Approximating the Cumulative Distribution Function of the Normal Distribution
+      <https://jsr.isrt.ac.bd/wp-content/uploads/41n1_5.pdf>`__
+
     The standard logistic CDF approximates ndtr(x) with:
         exp(y) = ndtr(x) \\simeq 1 / (1 + exp(-pi * x / sqrt(3)))
         --> exp(-y) \\simeq 1 + exp(-pi * x / sqrt(3))

--- a/optuna/samplers/_tpe/_truncnorm.py
+++ b/optuna/samplers/_tpe/_truncnorm.py
@@ -45,6 +45,7 @@ from optuna.samplers._tpe._erf import erf
 
 _norm_pdf_C = math.sqrt(2 * math.pi)
 _norm_pdf_logC = math.log(_norm_pdf_C)
+_ndtri_exp_approx_C = math.sqrt(3) / math.pi
 
 
 def _log_sum(log_p: np.ndarray, log_q: np.ndarray) -> np.ndarray:
@@ -148,24 +149,68 @@ def _log_gauss_mass(a: np.ndarray, b: np.ndarray) -> np.ndarray:
     return np.real(out)  # discard ~0j
 
 
-def _bisect(f: Callable[[float], float], a: float, b: float, c: float) -> float:
-    if f(a) > c:
-        a, b = b, a
-    # In the algorithm, it is assumed that all of (a + b), (a * 2), and (b * 2) are finite.
-    for _ in range(100):
-        m = (a + b) / 2
-        if a == m or b == m:
-            return m
-        if f(m) < c:
-            a = m
-        else:
-            b = m
-    return (a + b) / 2
-
-
 def _ndtri_exp_single(y: float) -> float:
-    # TODO(amylase): Justify this constant
-    return _bisect(_log_ndtr_single, -100, +100, y)
+    """
+    Use the Newton method to efficiently find the root.
+
+    `ndtri_exp(y)` returns `x` such that `y = log_ndtr(x)`, meaning that the Newton method is
+    supposed to find the root of `f(x) := log_ndtr(x) - y = 0`.
+
+    Since `df/dx = d log_ndtr(x)/dx = (ndtr(x))'/ndtr(x) = norm_pdf(x)/ndtr(x)`, the Newton update
+    is x[n + 1] := x[n] - (log_ndtr(x) - y) * ndtr(x) / norm_pdf(x).
+
+    As an initial guess, we use the Gaussian tail asymptotic approximation:
+        1 - ndtr(x) \\simeq norm_pdf(x) / x
+        --> log(norm_pdf(x) / x) = -1/2 * x**2 - 1/2 * log(2pi) - log(x)
+
+    First recall that y is a non-positive value and y = log_ndtr(inf) = 0 and
+    y = log_ndtr(-inf) = -inf.
+
+    If abs(y) is very small, x is very large, meaning that x**2 >> log(x) and
+    ndtr(x) = exp(y) \\simeq 1 + y --> -y \\simeq 1 - ndtr(x). From this, we can calculate:
+        log(1 - ndtr(x)) \\simeq log(-y) \\simeq -1/2 * x**2 - 1/2 * log(2pi) - log(x).
+    Because x**2 >> log(x), we can ignore the second and third terms, leading to:
+        log(-y) \\simeq -1/2 * x**2 --> x \\simeq sqrt(-2 log(-y)).
+    where we take the positive `x` as abs(y) becomes very small only if x >> 0.
+    The second order approximation version is sqrt(-2 log(-y) - log(-2 log(-y))).
+
+    If abs(y) is very large, we use log_ndtr(x) \\simeq -1/2 * x**2 - 1/2 * log(2pi) - log(x).
+    To solve this equation analytically, we ignore the log term, yielding:
+        log_ndtr(x) = y \\simeq -1/2 * x**2 - 1/2 * log(2pi)
+        --> y + 1/2 * log(2pi) = -1/2 * x**2 --> x**2 = -2 * (y + 1/2 * log(2pi))
+        --> x = sqrt(-2 * (y + 1/2 * log(2pi))
+
+    For the moderate y, we use Eq. (13), i.e., standard logistic CDF, in the following paper:
+        - Approximating the Cumulative Distribution Function of the Normal Distribution.
+    The standard logistic CDF approximates ndtr(x) with:
+        exp(y) = ndtr(x) \\simeq 1 / (1 + exp(-pi * x / sqrt(3)))
+        --> exp(-y) \\simeq 1 + exp(-pi * x / sqrt(3))
+        --> log(exp(-y) - 1) \\simeq -pi * x / sqrt(3)
+        --> x \\simeq -sqrt(3) / pi * log(exp(-y) - 1).
+    """
+    if y > -sys.float_info.min:
+        return math.inf if y <= 0 else math.nan
+
+    if y > -1e-2:  # Case 1. abs(y) << 1.
+        u = -2.0 * math.log(-y)
+        x = math.sqrt(u - math.log(u))
+    elif y < -5:  # Case 2. abs(y) >> 1.
+        x = -math.sqrt(-2.0 * (y + _norm_pdf_logC))
+    else:  # Case 3. Moderate y.
+        x = -_ndtri_exp_approx_C * math.log(math.exp(-y) - 1)
+
+    log_ndtr_x = math.nan
+    for _ in range(100):
+        log_ndtr_x = _log_ndtr_single(x)
+        log_norm_pdf_x = -0.5 * x**2 - _norm_pdf_logC
+        # NOTE(nabenabe): Use exp(log_ndtr_x - log_norm_pdf_x) instead of ndtr_x / norm_pdf_x for
+        # numerical stability.
+        dx = (log_ndtr_x - y) * math.exp(log_ndtr_x - log_norm_pdf_x)
+        x -= dx
+        if abs(dx) < 1e-8 * abs(x):  # Equivalent to np.isclose with atol=0.0 and rtol=1e-8.
+            break
+
+    return x
 
 
 def _ndtri_exp(y: np.ndarray) -> np.ndarray:

--- a/optuna/samplers/_tpe/_truncnorm.py
+++ b/optuna/samplers/_tpe/_truncnorm.py
@@ -201,7 +201,6 @@ def _ndtri_exp_single(y: float) -> float:
     else:  # Case 3. Moderate y.
         x = -_ndtri_exp_approx_C * math.log(math.exp(-y) - 1)
 
-    log_ndtr_x = math.nan
     for _ in range(100):
         log_ndtr_x = _log_ndtr_single(x)
         log_norm_pdf_x = -0.5 * x**2 - _norm_pdf_logC

--- a/optuna/samplers/_tpe/_truncnorm.py
+++ b/optuna/samplers/_tpe/_truncnorm.py
@@ -33,7 +33,6 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
 import functools
 import math
 import sys

--- a/tests/samplers_tests/tpe_tests/test_truncnorm.py
+++ b/tests/samplers_tests/tpe_tests/test_truncnorm.py
@@ -1,3 +1,4 @@
+import math
 import sys
 
 import numpy as np
@@ -9,6 +10,7 @@ import optuna.samplers._tpe._truncnorm as truncnorm_ours
 
 
 with try_import() as _imports:
+    from scipy.special import ndtri_exp as ndtri_exp_scipy
     from scipy.stats._continuous_distns import _log_gauss_mass as _log_gauss_mass_scipy
 
 
@@ -55,3 +57,13 @@ def test_log_gass_mass(a: float, b: float) -> None:
     assert truncnorm_ours._log_gauss_mass(a_arr, b_arr) == pytest.approx(
         _log_gauss_mass_scipy(a_arr, b_arr), nan_ok=True
     ), f"_log_gauss_mass(a={a}, b={b})"
+
+
+@pytest.mark.skipif(
+    not _imports.is_successful(), reason="Failed to import SciPy's internal function."
+)
+def test_ndtri_exp_single() -> None:
+    for y in [-sys.float_info.min] + [-10 ** i for i in range(-300, 10)]:
+        x = truncnorm_ours._ndtri_exp_single(y)
+        ans = ndtri_exp_scipy(y).item()
+        assert math.isclose(x, ans), f"Failed with y={y}."

--- a/tests/samplers_tests/tpe_tests/test_truncnorm.py
+++ b/tests/samplers_tests/tpe_tests/test_truncnorm.py
@@ -63,7 +63,7 @@ def test_log_gass_mass(a: float, b: float) -> None:
     not _imports.is_successful(), reason="Failed to import SciPy's internal function."
 )
 def test_ndtri_exp_single() -> None:
-    for y in [-sys.float_info.min] + [-10 ** i for i in range(-300, 10)]:
+    for y in [-sys.float_info.min] + [-(10**i) for i in range(-300, 10)]:
         x = truncnorm_ours._ndtri_exp_single(y)
         ans = ndtri_exp_scipy(y).item()
         assert math.isclose(x, ans), f"Failed with y={y}."


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

Since `ndtri_exp` is one of the bottleneck in `TPESampler`, I speeded up the `ndtri_exp` implementation.
`ndtri_exp(y)` essentially finds the root of `f(x) = log_ndtr(x) - y = 0`.
Currently, our implementation uses the binary search, but the binary search is much slower than the Newton method, so I will replace the binary search with the Newton method.

## Description of the changes
<!-- Describe the changes in this PR. -->

- Replace the binary search with the Newton method
- Introduce the good initial guess for the Newton method
- Describe the algorithms in the documentation string

The landscape of the initial guess is available below:

![overview](https://github.com/user-attachments/assets/b27366e2-a406-422b-918a-94440a25f221)

![zoom](https://github.com/user-attachments/assets/5ce89118-720f-42be-a104-eb1d7ec97474)


### Benchmarking Results

> [!IMPORTANT]
> 27% speedup :tada: 

> [!NOTE]
> When using our initial guess, the iteration (the number of `log_ndtr_single` calls) reduces by 28% in comparison to `x=0` with the Newton method :smile: 
> When compared to the binary search, the reduction is 92% :sunglasses: 


| This PR | Master |
|:--:|:--:|
| 6.04 $\pm$ 0.117 | 8.27 $\pm$ 0.057 |

<details>
<summary>Code</summary>

```python
import time
import optuna


optuna.logging.set_verbosity(optuna.logging.CRITICAL)

for seed in range(10):
    print(f"Start with {seed=}")
    sampler = optuna.samplers.TPESampler(seed=42)
    study = optuna.create_study(sampler=sampler)
    start = time.time()
    study.optimize(lambda t: sum(t.suggest_float(f"x{i}", -5, 5)**2 for i in range(10)), n_trials=500)
    print(time.time() - start)
```

</details>

<details>
<summary>Results by Master</summary>

```
Start with seed=0
7.831433057785034
Start with seed=1
8.079424858093262
Start with seed=2
8.192095518112183
Start with seed=3
8.294391393661499
Start with seed=4
8.307274580001831
Start with seed=5
8.376489162445068
Start with seed=6
8.367579698562622
Start with seed=7
8.417609453201294
Start with seed=8
8.40910816192627
Start with seed=9
8.42704153060913
```
</details>

<details>
<summary>Results by this PR</summary>

```
Start with seed=0
5.634321689605713
Start with seed=1
5.7635557651519775
Start with seed=2
5.904412508010864
Start with seed=3
6.616066932678223
Start with seed=4
6.8322083950042725
Start with seed=5
6.148069143295288
Start with seed=6
6.042054891586304
Start with seed=7
5.861287593841553
Start with seed=8
5.825707912445068
Start with seed=9
5.786619663238525
```

</details>