### PR TITLE
Avoid duplications in `_log_gauss_mass` evaluations

### DIFF
--- a/optuna/samplers/_tpe/probability_distributions.py
+++ b/optuna/samplers/_tpe/probability_distributions.py
@@ -38,10 +38,7 @@ def _log_gauss_mass_unique(a: np.ndarray, b: np.ndarray) -> np.ndarray:
     """
     This function reduces the the log Gaussian probability mass computation by avoiding the
     duplcated evaluations using the np.unique_inverse(...) equivalent operation.
-
-    The lexsort below guarantees that a_order[i] <= a_order[j] and b_order[i] >= b_order[j] for
-    any i < j, enabling us to detect the first occurrence easily. inv is equivalent to the
-    inverse mapping obtained by np.unique_inverse(np.stack([a, b], axis=-1)).
+    inv is equivalent to the inverse mapping by np.unique_inverse(np.stack([a, b], axis=-1)).
     """
     order = np.lexsort([(b_ravel := b.ravel()), (a_ravel := a.ravel())])
     a_order = a_ravel[order]

--- a/optuna/samplers/_tpe/probability_distributions.py
+++ b/optuna/samplers/_tpe/probability_distributions.py
@@ -40,16 +40,16 @@ def _unique_inverse_2d(a: np.ndarray, b: np.ndarray) -> tuple[np.ndarray, np.nda
         np.unique(np.concatenate([a[:, None], b[:, None]], axis=-1), return_inverse=True).
     """
     assert a.shape == b.shape and len(a.shape) == 1
-    order_by_b = np.argsort(b)
+    order = np.argsort(b)
     # Stable sorting is required for the tie breaking.
-    lexsort_order = order_by_b[np.argsort(a[order_by_b], kind="stable")]
-    a_order = a[lexsort_order]
-    b_order = b[lexsort_order]
-    is_first_occurrence = np.empty_like(a_order, dtype=bool)
+    order = order[np.argsort(a[order], kind="stable")]
+    a_order = a[order]
+    b_order = b[order]
+    is_first_occurrence = np.empty_like(a, dtype=bool)
     is_first_occurrence[0] = True
     is_first_occurrence[1:] = (a_order[1:] != a_order[:-1]) | (b_order[1:] != b_order[:-1])
     inv = np.empty(a_order.size, dtype=int)
-    inv[lexsort_order] = np.cumsum(is_first_occurrence) - 1
+    inv[order] = np.cumsum(is_first_occurrence) - 1
     return a_order[is_first_occurrence], b_order[is_first_occurrence], inv
 
 

--- a/optuna/samplers/_tpe/probability_distributions.py
+++ b/optuna/samplers/_tpe/probability_distributions.py
@@ -34,21 +34,32 @@ _BatchedDistributions = Union[
 ]
 
 
+def _unique_inverse_2d(a: np.ndarray, b: np.ndarray) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """
+    This function is a quicker version of:
+        np.unique(np.concatenate([a[:, None], b[:, None]], axis=-1), return_inverse=True).
+    """
+    assert a.shape == b.shape and len(a.shape) == 1
+    order_by_b = np.argsort(b)
+    # Stable sorting is required for the tie breaking.
+    lexsort_order = order_by_b[np.argsort(a[order_by_b], kind="stable")]
+    a_order = a[lexsort_order]
+    b_order = b[lexsort_order]
+    is_first_occurrence = np.empty_like(a_order, dtype=bool)
+    is_first_occurrence[0] = True
+    is_first_occurrence[1:] = (a_order[1:] != a_order[:-1]) | (b_order[1:] != b_order[:-1])
+    inv = np.empty(a_order.size, dtype=int)
+    inv[lexsort_order] = np.cumsum(is_first_occurrence) - 1
+    return a_order[is_first_occurrence], b_order[is_first_occurrence], inv
+
+
 def _log_gauss_mass_unique(a: np.ndarray, b: np.ndarray) -> np.ndarray:
     """
     This function reduces the log Gaussian probability mass computation by avoiding the
     duplicated evaluations using the np.unique_inverse(...) equivalent operation.
-    inv is equivalent to the inverse mapping by np.unique_inverse(np.stack([a, b], axis=-1)).
     """
-    order = np.lexsort([(b_ravel := b.ravel()), (a_ravel := a.ravel())])
-    a_order = a_ravel[order]
-    b_order = b_ravel[order]
-    is_first_occurrence = np.ones_like(a_ravel, dtype=bool)
-    is_first_occurrence[1:] = (a_order[1:] != a_order[:-1]) | (b_order[1:] != b_order[:-1])
-    out = _truncnorm._log_gauss_mass(a_order[is_first_occurrence], b_order[is_first_occurrence])
-    inv = np.empty(a_order.size, dtype=int)
-    inv[order] = np.cumsum(is_first_occurrence) - 1
-    return out[inv].reshape(a.shape)
+    a_uniq, b_uniq, inv = _unique_inverse_2d(a.ravel(), b.ravel())
+    return _truncnorm._log_gauss_mass(a_uniq, b_uniq)[inv].reshape(a.shape)
 
 
 class _MixtureOfProductDistribution(NamedTuple):

--- a/optuna/samplers/_tpe/probability_distributions.py
+++ b/optuna/samplers/_tpe/probability_distributions.py
@@ -43,10 +43,10 @@ def _log_gauss_mass_unique(a: np.ndarray, b: np.ndarray) -> np.ndarray:
     any i < j, enabling us to detect the first occurrence easily. inv is equivalent to the
     inverse mapping obtained by np.unique_inverse(np.stack([a, b], axis=-1)).
     """
-    order = np.lexsort([b.ravel(), a.ravel()])
-    a_order = a.ravel()[order]
-    b_order = b.ravel()[order]
-    is_first_occurrence = np.ones_like(a.ravel(), dtype=bool)
+    order = np.lexsort([(b_ravel := b.ravel()), (a_ravel := a.ravel())])
+    a_order = a_ravel[order]
+    b_order = b_ravel[order]
+    is_first_occurrence = np.ones_like(a_ravel, dtype=bool)
     is_first_occurrence[1:] = (a_order[1:] != a_order[:-1]) | (b_order[1:] != b_order[:-1])
     out = _truncnorm._log_gauss_mass(a_order[is_first_occurrence], b_order[is_first_occurrence])
     inv = np.empty(a_order.size, dtype=int)

--- a/optuna/samplers/_tpe/probability_distributions.py
+++ b/optuna/samplers/_tpe/probability_distributions.py
@@ -140,7 +140,7 @@ class _MixtureOfProductDistribution(NamedTuple):
                 )[mu_sigma_inv]
             else:
                 assert False
-        weighted_log_pdf += np.log(self.weights[None, :])
+        weighted_log_pdf += np.log(self.weights[np.newaxis])
         max_ = weighted_log_pdf.max(axis=1)
         # We need to avoid (-inf) - (-inf) when the probability is zero.
         max_[np.isneginf(max_)] = 0

--- a/optuna/samplers/_tpe/probability_distributions.py
+++ b/optuna/samplers/_tpe/probability_distributions.py
@@ -36,8 +36,8 @@ _BatchedDistributions = Union[
 
 def _log_gauss_mass_unique(a: np.ndarray, b: np.ndarray) -> np.ndarray:
     """
-    This function reduces the the log Gaussian probability mass computation by avoiding the
-    duplcated evaluations using the np.unique_inverse(...) equivalent operation.
+    This function reduces the log Gaussian probability mass computation by avoiding the
+    duplicated evaluations using the np.unique_inverse(...) equivalent operation.
     inv is equivalent to the inverse mapping by np.unique_inverse(np.stack([a, b], axis=-1)).
     """
     order = np.lexsort([(b_ravel := b.ravel()), (a_ravel := a.ravel())])


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

This PR speeds up `_log_gauss_mass` evaluations for `TPESampler`.

## Description of the changes
<!-- Describe the changes in this PR. -->

- Apply the `np.unique_inverse` equivalent operation to avoid duplications
- Use the application-specific implementation of `np.unique_inverse` for speedup
- Replace `_truncnorm._log_gauss_mass` with the new implementation
