### PR TITLE
Use `TYPE_CHECKING` in `optuna/_gp/acqf.py` to avoid circular imports

### DIFF
--- a/optuna/_gp/acqf.py
+++ b/optuna/_gp/acqf.py
@@ -7,14 +7,15 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
-from optuna._gp.gp import GPRegressor
-from optuna._gp.search_space import SearchSpace
 from optuna._hypervolume import get_non_dominated_box_bounds
 from optuna.study._multi_objective import _is_pareto_front
 
 
 if TYPE_CHECKING:
     import torch
+
+    from optuna._gp.gp import GPRegressor
+    from optuna._gp.search_space import SearchSpace
 else:
     from optuna._imports import _LazyImport
 


### PR DESCRIPTION
## Motivation
Currently, two modules (GPRegressor and SearchSpace) are imported unconditionally in optuna/_gp/acqf.py, which can trigger circular‐import errors at runtime. By moving these imports into a if TYPE_CHECKING: block, we ensure that they’re only used for static type hints and never executed during normal imports.

## Description of the changes
This fixes issue  #6029 by wrapping the two imports in optuna/_gp/acqf.py with if TYPE_CHECKING: so they’re only for type hints.
Also ran python3 -m flake8 optuna/_gp/acqf.py —> no more TC001 warnings in that file.

Fixes  #6029