### PR TITLE
Use TYPE_CHECKING in optuna/_gp/optim_mixed.py to avoid circular imports

### DIFF
--- a/optuna/_gp/optim_mixed.py
+++ b/optuna/_gp/optim_mixed.py
@@ -4,8 +4,7 @@ import math
 from typing import TYPE_CHECKING
 
 import numpy as np
-if TYPE_CHECKING:
-    from optuna._gp.acqf import BaseAcquisitionFunc
+
 from optuna._gp.search_space import normalize_one_param
 from optuna._gp.search_space import sample_normalized_params
 from optuna._gp.search_space import ScaleType
@@ -14,6 +13,8 @@ from optuna.logging import get_logger
 
 if TYPE_CHECKING:
     import scipy.optimize as so
+
+    from optuna._gp.acqf import BaseAcquisitionFunc
 else:
     from optuna import _LazyImport
 

--- a/optuna/_gp/optim_mixed.py
+++ b/optuna/_gp/optim_mixed.py
@@ -4,8 +4,8 @@ import math
 from typing import TYPE_CHECKING
 
 import numpy as np
-
-from optuna._gp.acqf import BaseAcquisitionFunc
+if TYPE_CHECKING:
+    from optuna._gp.acqf import BaseAcquisitionFunc
 from optuna._gp.search_space import normalize_one_param
 from optuna._gp.search_space import sample_normalized_params
 from optuna._gp.search_space import ScaleType


### PR DESCRIPTION

## Motivation
 Currently, a module (optuna._gp.acqf.BaseAcquisitionFunc) is imported unconditionally in optuna/_gp/opim_mixed.py, which can trigger circular‐import errors at runtime. By moving these imports into a if TYPE_CHECKING: block, we ensure they’re only used for static type hints and never executed during normal imports. This improves import safety and prevents spurious CI failures or runtime import errors when using the GP acquisition‐function code.

## Description of the changes
 python3 -m flake8 optuna/_gp/opim_mixed.py
emits no TC001 warnings



Fixed #6029