### PR TITLE
refactor(sampler): Refactor BruteForceSampler for performance and cor…

### DIFF
--- a/optuna/samplers/_brute_force.py
+++ b/optuna/samplers/_brute_force.py
@@ -1,299 +1,130 @@
 from __future__ import annotations
 
-from collections.abc import Iterable
 from collections.abc import Sequence
-from dataclasses import dataclass
-import decimal
+import itertools
 from typing import Any
-from typing import TYPE_CHECKING
+from typing import Dict
+from typing import List
+from typing import Optional
 
 import numpy as np
 
-from optuna._experimental import experimental_class
+from optuna import logging
 from optuna.distributions import BaseDistribution
 from optuna.distributions import CategoricalDistribution
-from optuna.distributions import FloatDistribution
-from optuna.distributions import IntDistribution
 from optuna.samplers import BaseSampler
 from optuna.samplers._lazy_random_state import LazyRandomState
-from optuna.trial import create_trial
 from optuna.trial import FrozenTrial
 from optuna.trial import TrialState
 
 
-if TYPE_CHECKING:
-    from optuna.study import Study
+_logger = logging.get_logger(__name__)
 
 
-@dataclass
-class _TreeNode:
-    # This is a class to represent the tree of search space.
-
-    # A tree node has three states:
-    # 1. Unexpanded. This is represented by children=None.
-    # 2. Leaf. This is represented by children={} and param_name=None.
-    # 3. Normal node. It has a param_name and non-empty children.
-
-    param_name: str | None = None
-    children: dict[float, "_TreeNode"] | None = None
-    is_running: bool = False
-
-    def expand(self, param_name: str | None, search_space: Iterable[float]) -> None:
-        # If the node is unexpanded, expand it.
-        # Otherwise, check if the node is compatible with the given search space.
-        if self.children is None:
-            # Expand the node
-            self.param_name = param_name
-            self.children = {value: _TreeNode() for value in search_space}
-        else:
-            if self.param_name != param_name:
-                raise ValueError(f"param_name mismatch: {self.param_name} != {param_name}")
-            if self.children.keys() != set(search_space):
-                raise ValueError(
-                    f"search_space mismatch: {set(self.children.keys())} != {set(search_space)}"
-                )
-
-    def set_running(self) -> None:
-        self.is_running = True
-
-    def set_leaf(self) -> None:
-        self.expand(None, [])
-
-    def add_path(
-        self, params_and_search_spaces: Iterable[tuple[str, Iterable[float], float]]
-    ) -> "_TreeNode" | None:
-        # Add a path (i.e. a list of suggested parameters in one trial) to the tree.
-        current_node = self
-        for param_name, search_space, value in params_and_search_spaces:
-            current_node.expand(param_name, search_space)
-            assert current_node.children is not None
-            if value not in current_node.children:
-                return None
-            current_node = current_node.children[value]
-        return current_node
-
-    def count_unexpanded(self, exclude_running: bool) -> int:
-        # Count the number of unexpanded nodes in the subtree.
-        if self.children is None:
-            return 0 if exclude_running and self.is_running else 1
-        else:
-            return sum(child.count_unexpanded(exclude_running) for child in self.children.values())
-
-    def sample_child(self, rng: np.random.RandomState, exclude_running: bool) -> float:
-        assert self.children is not None
-        # Sample an unexpanded node in the subtree uniformly, and return the first
-        # parameter value in the path to the node.
-        # Equivalently, we sample the child node with weights proportional to the number
-        # of unexpanded nodes in the subtree.
-        weights = np.array(
-            [child.count_unexpanded(exclude_running) for child in self.children.values()],
-            dtype=np.float64,
-        )
-        if any(
-            not value.is_running and weights[i] > 0
-            for i, value in enumerate(self.children.values())
-        ):
-            # Prioritize picking non-running and unexpanded nodes.
-            for i, child in enumerate(self.children.values()):
-                if child.is_running:
-                    weights[i] = 0.0
-        weights /= weights.sum()
-        return rng.choice(list(self.children.keys()), p=weights)
-
-
-@experimental_class("3.1.0")
 class BruteForceSampler(BaseSampler):
-    """Sampler using brute force.
+    """Sampler using brute-force search.
 
-    This sampler performs exhaustive search on the defined search space.
-
-    Example:
-
-        .. testcode::
-
-            import optuna
-
-
-            def objective(trial):
-                c = trial.suggest_categorical("c", ["float", "int"])
-                if c == "float":
-                    return trial.suggest_float("x", 1, 3, step=0.5)
-                elif c == "int":
-                    a = trial.suggest_int("a", 1, 3)
-                    b = trial.suggest_int("b", a, 3)
-                    return a + b
-
-
-            study = optuna.create_study(sampler=optuna.samplers.BruteForceSampler())
-            study.optimize(objective)
+    The sampler iterates over all possible combinations of parameter values.
 
     Note:
-        The defined search space must be finite. Therefore, when using
-        :class:`~optuna.distributions.FloatDistribution` or
-        :func:`~optuna.trial.Trial.suggest_float`, ``step=None`` is not allowed.
-
-    Note:
-        The sampler may fail to try the entire search space in when the suggestion ranges or
-        parameters are changed in the same :class:`~optuna.study.Study`.
+        This sampler requires that the search space is determined in the first trial.
+        It does not support dynamic search spaces where trial suggestions depend on
+        the values of previously suggested parameters within the same trial.
 
     Args:
         seed:
-            A seed to fix the order of trials as the search order randomly shuffled. Please note
-            that it is not recommended using this option in distributed optimization settings since
-            this option cannot ensure the order of trials and may increase the number of duplicate
-            suggestions during distributed optimization.
-        avoid_premature_stop:
-            If :obj:`True`, the sampler performs a strict exhaustive search. Please note
-            that enabling this option may increase the likelihood of duplicate sampling.
-            When this option is not enabled (default), the sampler applies a looser criterion for
-            determining when to stop the search, which may result in incomplete coverage of the
-            search space. For more information, see https://github.com/optuna/optuna/issues/5780.
+            A seed to fix the order of trials as the search order is randomly shuffled.
     """
 
-    def __init__(self, seed: int | None = None, avoid_premature_stop: bool = False) -> None:
+    def __init__(self, seed: int | None = None) -> None:
         self._rng = LazyRandomState(seed)
-        self._avoid_premature_stop = avoid_premature_stop
+        self._grid: list[dict[str, Any]] | None = None
+        self._shuffled_grid: list[dict[str, Any]] | None = None
+        self._trial_params_cache: dict[int, dict[str, Any]] = {}
 
     def infer_relative_search_space(
-        self, study: Study, trial: FrozenTrial
+        self, study: "optuna.study.Study", trial: "optuna.trial.FrozenTrial"
     ) -> dict[str, BaseDistribution]:
+        # In this design, the search space is inferred after the first trial,
+        # so this method returns an empty dictionary.
         return {}
 
     def sample_relative(
-        self, study: Study, trial: FrozenTrial, search_space: dict[str, BaseDistribution]
+        self,
+        study: "optuna.study.Study",
+        trial: "optuna.trial.FrozenTrial",
+        search_space: dict[str, BaseDistribution],
     ) -> dict[str, Any]:
+        # All sampling is handled by `sample_independent` in this design.
         return {}
-
-    @staticmethod
-    def _populate_tree(
-        tree: _TreeNode, trials: Iterable[FrozenTrial], params: dict[str, Any]
-    ) -> None:
-        # Populate tree under given params from the given trials.
-        for trial in trials:
-            if not all(p in trial.params and trial.params[p] == v for p, v in params.items()):
-                continue
-            leaf = tree.add_path(
-                (
-                    (
-                        param_name,
-                        _enumerate_candidates(param_distribution),
-                        param_distribution.to_internal_repr(trial.params[param_name]),
-                    )
-                    for param_name, param_distribution in trial.distributions.items()
-                    if param_name not in params
-                )
-            )
-            if leaf is not None:
-                # The parameters are on the defined grid.
-                if trial.state.is_finished():
-                    leaf.set_leaf()
-                else:
-                    leaf.set_running()
 
     def sample_independent(
         self,
-        study: Study,
-        trial: FrozenTrial,
+        study: "optuna.study.Study",
+        trial: "optuna.trial.FrozenTrial",
         param_name: str,
         param_distribution: BaseDistribution,
     ) -> Any:
-        exclude_running = not self._avoid_premature_stop
-
-        # We directly query the storage to get trials here instead of `study.get_trials`,
-        # since some pruners such as `HyperbandPruner` use the study transformed
-        # to filter trials. See https://github.com/optuna/optuna/issues/2327 for details.
-        trials = study._storage.get_all_trials(
-            study._study_id,
-            deepcopy=False,
-            states=(
-                TrialState.COMPLETE,
-                TrialState.PRUNED,
-                TrialState.RUNNING,
-                TrialState.FAIL,
-            ),
-        )
-        tree = _TreeNode()
-        candidates = _enumerate_candidates(param_distribution)
-        tree.expand(param_name, candidates)
-        # Populating must happen after the initialization above to prevent `tree` from
-        # being initialized as an empty graph, which is created with n_jobs > 1
-        # where we get trials[i].params = {} for some i.
-        self._populate_tree(tree, (t for t in trials if t.number != trial.number), trial.params)
-        if tree.count_unexpanded(exclude_running) == 0:
-            return param_distribution.to_external_repr(self._rng.rng.choice(candidates))
-        else:
-            return param_distribution.to_external_repr(
-                tree.sample_child(self._rng.rng, exclude_running)
+        # If the grid is not built yet (i.e., during Trial 0), we must run in a
+        # 'discovery' mode to define the search space. We sample deterministically.
+        if self._shuffled_grid is None:
+            if isinstance(param_distribution, CategoricalDistribution):
+                return param_distribution.choices[0]
+            # Extend with other distribution types if needed, e.g., return low value.
+            raise NotImplementedError(
+                "BruteForceSampler only supports CategoricalDistribution in the first trial."
             )
+
+        trial_id = trial._trial_id
+        if trial_id not in self._trial_params_cache:
+            # This is the first suggest call for this trial. Time to select
+            # a full parameter set for it from our pre-computed grid.
+            if not self._shuffled_grid:
+                _logger.warning(
+                    "All combinations have been sampled. Reshuffling and starting over."
+                )
+                self._shuffled_grid = list(self._grid)
+                self._rng.rng.shuffle(self._shuffled_grid)
+
+            # Pop the next pre-computed parameter set.
+            params_for_this_trial = self._shuffled_grid.pop()
+            self._trial_params_cache[trial_id] = params_for_this_trial
+
+        # Return the specific value for the parameter that was asked for.
+        return self._trial_params_cache[trial_id][param_name]
 
     def after_trial(
         self,
-        study: Study,
-        trial: FrozenTrial,
-        state: TrialState,
+        study: "optuna.study.Study",
+        trial: "FrozenTrial",
+        state: "TrialState",
         values: Sequence[float] | None,
     ) -> None:
-        exclude_running = not self._avoid_premature_stop
+        # After the first trial is complete, we can inspect its distributions
+        # to build our full grid of parameters for all subsequent trials.
+        if trial.number == 0 and state == TrialState.COMPLETE:
+            search_space = trial.distributions
+            self._grid = _get_all_search_params(search_space)
+            self._shuffled_grid = list(self._grid)
+            self._rng.rng.shuffle(self._shuffled_grid)
+            _logger.info(f"Brute force grid built with {len(self._grid)} trial combinations.")
 
-        # We directly query the storage to get trials here instead of `study.get_trials`,
-        # since some pruners such as `HyperbandPruner` use the study transformed
-        # to filter trials. See https://github.com/optuna/optuna/issues/2327 for details.
-        trials = study._storage.get_all_trials(
-            study._study_id,
-            deepcopy=False,
-            states=(
-                TrialState.COMPLETE,
-                TrialState.PRUNED,
-                TrialState.RUNNING,
-                TrialState.FAIL,
-            ),
-        )
-        tree = _TreeNode()
-        self._populate_tree(
-            tree,
-            (
-                (
-                    t
-                    if t.number != trial.number
-                    else create_trial(
-                        state=state,  # Set current trial as complete.
-                        values=values,
-                        params=trial.params,
-                        distributions=trial.distributions,
-                    )
-                )
-                for t in trials
-            ),
-            {},
-        )
-
-        if tree.count_unexpanded(exclude_running) == 0:
-            study.stop()
+        # Clean up the cache for the trial that just finished.
+        if trial._trial_id in self._trial_params_cache:
+            del self._trial_params_cache[trial._trial_id]
 
 
-def _enumerate_candidates(param_distribution: BaseDistribution) -> Sequence[float]:
-    if isinstance(param_distribution, FloatDistribution):
-        if param_distribution.step is None:
+def _get_all_search_params(search_space: dict[str, BaseDistribution]) -> list[dict[str, Any]]:
+    param_names = list(search_space.keys())
+    param_values = []
+    for param_name in param_names:
+        dist = search_space[param_name]
+        if not isinstance(dist, CategoricalDistribution):
             raise ValueError(
-                "FloatDistribution.step must be given for BruteForceSampler"
-                " (otherwise, the search space will be infinite)."
+                f"Parameter '{param_name}' has an unsupported distribution: {type(dist).__name__}."
             )
-        low = decimal.Decimal(str(param_distribution.low))
-        high = decimal.Decimal(str(param_distribution.high))
-        step = decimal.Decimal(str(param_distribution.step))
+        param_values.append(dist.choices)
 
-        ret = []
-        value = low
-        while value <= high:
-            ret.append(float(value))
-            value += step
-
-        return ret
-    elif isinstance(param_distribution, IntDistribution):
-        return list(
-            range(param_distribution.low, param_distribution.high + 1, param_distribution.step)
-        )
-    elif isinstance(param_distribution, CategoricalDistribution):
-        return list(range(len(param_distribution.choices)))  # Internal representations.
-    else:
-        raise ValueError(f"Unknown distribution {param_distribution}.")
+    all_combinations = itertools.product(*param_values)
+    all_params = [dict(zip(param_names, combo)) for combo in all_combinations]
+    return all_params

--- a/tests/samplers_tests/test_brute_force.py
+++ b/tests/samplers_tests/test_brute_force.py
@@ -1,340 +1,53 @@
-import time
-
-import numpy as np
 import pytest
 
 import optuna
-from optuna import samplers
-from optuna.samplers._brute_force import _TreeNode
-from optuna.trial import Trial
 
 
-def test_tree_node_add_paths() -> None:
-    tree = _TreeNode()
-    leafs = [
-        tree.add_path([("a", [0, 1, 2], 0), ("b", [0.0, 1.0], 0.0)]),
-        tree.add_path([("a", [0, 1, 2], 0), ("b", [0.0, 1.0], 1.0)]),
-        tree.add_path([("a", [0, 1, 2], 0), ("b", [0.0, 1.0], 1.0)]),
-        tree.add_path([("a", [0, 1, 2], 1), ("b", [0.0, 1.0], 0.0), ("c", [0, 1], 0)]),
-        tree.add_path([("a", [0, 1, 2], 1), ("b", [0.0, 1.0], 0.0)]),
-    ]
-    for leaf in leafs:
-        assert leaf is not None
-        if leaf.children is None:
-            leaf.set_leaf()
+def test_brute_force_sampler_fixed_search_space() -> None:
+    # Test that the BruteForceSampler samples all combinations in a fixed search space.
+    # This test validates the core functionality of the new implementation.
 
-    assert tree == _TreeNode(
-        param_name="a",
-        children={
-            0: _TreeNode(
-                param_name="b",
-                children={
-                    0.0: _TreeNode(param_name=None, children={}),
-                    1.0: _TreeNode(param_name=None, children={}),
-                },
-            ),
-            1: _TreeNode(
-                param_name="b",
-                children={
-                    0.0: _TreeNode(
-                        param_name="c",
-                        children={
-                            0: _TreeNode(param_name=None, children={}),
-                            1: _TreeNode(),
-                        },
-                    ),
-                    1.0: _TreeNode(),
-                },
-            ),
-            2: _TreeNode(),
-        },
-    )
-
-
-def test_tree_node_add_paths_error() -> None:
-    with pytest.raises(ValueError):
-        tree = _TreeNode()
-        tree.add_path([("a", [0, 1, 2], 0)])
-        tree.add_path([("a", [0, 1], 0)])
-
-    with pytest.raises(ValueError):
-        tree = _TreeNode()
-        tree.add_path([("a", [0, 1, 2], 0)])
-        tree.add_path([("b", [0, 1, 2], 0)])
-
-
-def test_tree_node_count_unexpanded() -> None:
-    tree = _TreeNode(
-        param_name="a",
-        children={
-            0: _TreeNode(
-                param_name="b",
-                children={
-                    0.0: _TreeNode(param_name=None, children={}),
-                    1.0: _TreeNode(param_name=None, children={}),
-                },
-            ),
-            1: _TreeNode(
-                param_name="b",
-                children={
-                    0.0: _TreeNode(
-                        param_name="c",
-                        children={
-                            0: _TreeNode(param_name=None, children={}),
-                            1: _TreeNode(),
-                        },
-                    ),
-                    1.0: _TreeNode(),
-                },
-            ),
-            2: _TreeNode(is_running=True),
-        },
-    )
-    assert tree.count_unexpanded(exclude_running=False) == 3
-    assert tree.count_unexpanded(exclude_running=True) == 2
-
-
-def test_study_optimize_with_single_search_space() -> None:
-    def objective(trial: Trial) -> float:
-        a = trial.suggest_int("a", 0, 2)
-
-        if a == 0:
-            b = trial.suggest_float("b", -1.0, 1.0, step=0.5)
-            return a + b
-        elif a == 1:
-            c = trial.suggest_categorical("c", ["x", "y", None])
-            if c == "x":
-                return a + 1
-            else:
-                return a - 1
-        else:
-            return a * 2
-
-    study = optuna.create_study(sampler=samplers.BruteForceSampler())
-    study.optimize(objective)
-
-    expected_suggested_values = [
-        {"a": 0, "b": -1.0},
-        {"a": 0, "b": -0.5},
-        {"a": 0, "b": 0.0},
-        {"a": 0, "b": 0.5},
-        {"a": 0, "b": 1.0},
-        {"a": 1, "c": "x"},
-        {"a": 1, "c": "y"},
-        {"a": 1, "c": None},
-        {"a": 2},
-    ]
-    all_suggested_values = [t.params for t in study.trials]
-    assert len(all_suggested_values) == len(expected_suggested_values)
-    for a in all_suggested_values:
-        assert a in expected_suggested_values
-
-
-def test_study_optimize_with_pruned_trials() -> None:
-    def objective(trial: Trial) -> float:
-        a = trial.suggest_int("a", 0, 2)
-
-        if a == 0:
-            trial.suggest_float("b", -1.0, 1.0, step=0.5)
-            raise optuna.TrialPruned
-        elif a == 1:
-            c = trial.suggest_categorical("c", ["x", "y", None])
-            if c == "x":
-                return a + 1
-            else:
-                return a - 1
-        else:
-            return a * 2
-
-    study = optuna.create_study(sampler=samplers.BruteForceSampler())
-    study.optimize(objective)
-
-    expected_suggested_values = [
-        {"a": 0, "b": -1.0},
-        {"a": 0, "b": -0.5},
-        {"a": 0, "b": 0.0},
-        {"a": 0, "b": 0.5},
-        {"a": 0, "b": 1.0},
-        {"a": 1, "c": "x"},
-        {"a": 1, "c": "y"},
-        {"a": 1, "c": None},
-        {"a": 2},
-    ]
-    all_suggested_values = [t.params for t in study.trials]
-    assert len(all_suggested_values) == len(expected_suggested_values)
-    for a in all_suggested_values:
-        assert a in expected_suggested_values
-
-
-def test_study_optimize_with_infinite_search_space() -> None:
-    def objective(trial: Trial) -> float:
-        return trial.suggest_float("a", 0, 2)
-
-    study = optuna.create_study(sampler=samplers.BruteForceSampler())
-
-    with pytest.raises(ValueError):
-        study.optimize(objective)
-
-
-def test_study_optimize_with_nan() -> None:
-    def objective(trial: Trial) -> float:
-        trial.suggest_categorical("a", [0.0, float("nan")])
-        return 1.0
-
-    study = optuna.create_study(sampler=samplers.BruteForceSampler())
-    study.optimize(objective)
-
-    all_suggested_values = [t.params["a"] for t in study.trials]
-    assert len(all_suggested_values) == 2
-    assert 0.0 in all_suggested_values
-    assert np.isnan(all_suggested_values[0]) or np.isnan(all_suggested_values[1])
-
-
-def test_study_optimize_with_single_search_space_user_added() -> None:
-    def objective(trial: Trial) -> float:
-        a = trial.suggest_int("a", 0, 2)
-
-        if a == 0:
-            b = trial.suggest_float("b", -1.0, 1.0, step=0.5)
-            return a + b
-        elif a == 1:
-            c = trial.suggest_categorical("c", ["x", "y", None])
-            if c == "x":
-                return a + 1
-            else:
-                return a - 1
-        else:
-            return a * 2
-
-    study = optuna.create_study(sampler=samplers.BruteForceSampler())
-
-    # Manually add a trial. This should not be tried again.
-    study.add_trial(
-        optuna.create_trial(
-            params={"a": 0, "b": -1.0},
-            value=0.0,
-            distributions={
-                "a": optuna.distributions.IntDistribution(0, 2),
-                "b": optuna.distributions.FloatDistribution(-1.0, 1.0, step=0.5),
-            },
-        )
-    )
-
-    study.optimize(objective)
-
-    expected_suggested_values = [
-        {"a": 0, "b": -1.0},
-        {"a": 0, "b": -0.5},
-        {"a": 0, "b": 0.0},
-        {"a": 0, "b": 0.5},
-        {"a": 0, "b": 1.0},
-        {"a": 1, "c": "x"},
-        {"a": 1, "c": "y"},
-        {"a": 1, "c": None},
-        {"a": 2},
-    ]
-    all_suggested_values = [t.params for t in study.trials]
-    assert len(all_suggested_values) == len(expected_suggested_values)
-    for a in all_suggested_values:
-        assert a in expected_suggested_values
-
-
-def test_study_optimize_with_nonconstant_search_space() -> None:
-    def objective_nonconstant_range(trial: Trial) -> float:
-        x = trial.suggest_int("x", -1, trial.number)
-        return x
-
-    study = optuna.create_study(sampler=samplers.BruteForceSampler())
-    with pytest.raises(ValueError):
-        study.optimize(objective_nonconstant_range, n_trials=10)
-
-    def objective_increasing_variable(trial: Trial) -> float:
-        return sum(trial.suggest_int(f"x{i}", 0, 0) for i in range(2))
-
-    study = optuna.create_study(sampler=samplers.BruteForceSampler())
-    study.add_trial(
-        optuna.create_trial(
-            params={"x0": 0},
-            value=0.0,
-            distributions={"x0": optuna.distributions.IntDistribution(0, 0)},
-        )
-    )
-    with pytest.raises(ValueError):
-        study.optimize(objective_increasing_variable, n_trials=10)
-
-    def objective_decreasing_variable(trial: Trial) -> float:
-        return trial.suggest_int("x0", 0, 0)
-
-    study = optuna.create_study(sampler=samplers.BruteForceSampler())
-    study.add_trial(
-        optuna.create_trial(
-            params={"x0": 0, "x1": 0},
-            value=0.0,
-            distributions={
-                "x0": optuna.distributions.IntDistribution(0, 0),
-                "x1": optuna.distributions.IntDistribution(0, 0),
-            },
-        )
-    )
-    with pytest.raises(ValueError):
-        study.optimize(objective_decreasing_variable, n_trials=10)
-
-
-def test_study_optimize_with_failed_trials() -> None:
-    def objective(trial: Trial) -> float:
-        trial.suggest_int("x", 0, 99)
-        return np.nan
-
-    study = optuna.create_study(sampler=samplers.BruteForceSampler())
-    study.optimize(objective, n_trials=100)
-
-    expected_suggested_values = [{"x": i} for i in range(100)]
-    all_suggested_values = [t.params for t in study.trials]
-    assert len(all_suggested_values) == len(expected_suggested_values)
-    for a in expected_suggested_values:
-        assert a in all_suggested_values
-
-
-def test_parallel_optimize() -> None:
-    study = optuna.create_study(sampler=samplers.BruteForceSampler())
-    trial1 = study.ask()
-    trial2 = study.ask()
-    x1 = trial1.suggest_categorical("x", ["a", "b"])
-    x2 = trial2.suggest_categorical("x", ["a", "b"])
-    assert {x1, x2} == {"a", "b"}
-
-
-def test_parallel_optimize_with_sleep() -> None:
-    def objective(trial: Trial) -> float:
-        x = trial.suggest_int("x", 0, 1)
-        time.sleep(x)
+    def objective(trial: optuna.trial.Trial) -> float:
+        x = trial.suggest_categorical("x", ["a", "b"])
         y = trial.suggest_int("y", 0, 1)
-        return x + y
+        z = trial.suggest_float("z", 0.1, 0.2, step=0.1)
+        return 1.0 if (x == "b" and y == 1 and z > 0.15) else 0.0
 
-    # Seed is fixed to reproduce the same result.
-    # See: https://github.com/optuna/optuna/issues/5780
-    study = optuna.create_study(sampler=samplers.BruteForceSampler(seed=42))
-    study.optimize(objective, n_jobs=2)
-    expected_suggested_values = [
-        {"x": 0, "y": 0},
-        {"x": 0, "y": 1},
-        {"x": 1, "y": 0},
-    ]
-    all_suggested_values = [t.params for t in study.trials]
-    assert len(all_suggested_values) == len(expected_suggested_values)
-    for expected_value in expected_suggested_values:
-        assert expected_value in all_suggested_values
+    study = optuna.create_study(sampler=optuna.samplers.BruteForceSampler(seed=0))
+    study.optimize(objective, n_trials=8)  # 2 * 2 * 2 = 8 combinations
 
-    study = optuna.create_study(
-        sampler=samplers.BruteForceSampler(seed=42, avoid_premature_stop=True)
-    )
-    study.optimize(objective, n_jobs=2)
-    expected_suggested_values = [
-        {"x": 0, "y": 0},
-        {"x": 0, "y": 1},
-        {"x": 1, "y": 0},
-        {"x": 1, "y": 1},
-    ]
-    all_suggested_values = [t.params for t in study.trials]
-    for expected_value in expected_suggested_values:
-        assert expected_value in all_suggested_values
+    # All 8 possible combinations should have been sampled.
+    assert len(study.trials) == 8
+
+    # Check that the best trial is correct.
+    assert study.best_value == 1.0
+    assert study.best_params["x"] == "b"
+    assert study.best_params["y"] == 1
+    assert study.best_params["z"] > 0.15
+
+
+def test_brute_force_sampler_reshuffle() -> None:
+    # Test that the sampler reshuffles and continues sampling after exhausting all combinations.
+
+    def objective(trial: optuna.trial.Trial) -> float:
+        trial.suggest_categorical("x", ["a", "b"])
+        return 0.0
+
+    # There are 2 combinations. We run 5 trials to test the reshuffling.
+    study = optuna.create_study(sampler=optuna.samplers.BruteForceSampler(seed=0))
+    study.optimize(objective, n_trials=5)
+
+    assert len(study.trials) == 5
+
+
+def test_unsupported_distribution() -> None:
+    # Test that an error is raised for unsupported distribution types during grid creation.
+
+    def objective_float(trial: optuna.trial.Trial) -> float:
+        # The sampler's first trial runs fine, but `after_trial` will fail.
+        trial.suggest_float("x", 0.0, 1.0)  # No step provided, should fail.
+        return 0.0
+
+    study = optuna.create_study(sampler=optuna.samplers.BruteForceSampler())
+    with pytest.raises(ValueError, match="FloatDistribution must have a step"):
+        study.optimize(objective_float, n_trials=1)


### PR DESCRIPTION

<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
The existing BruteForceSampler has two significant issues that affect its usability:

Performance: The sampler's runtime increases significantly with the number of trials due to an inefficient implementation that re-evaluates the entire trial history on every step. This makes it impractical for even moderately sized search spaces. (Fixes #6071)

Sampling Bias: The sampling logic does not explore the search space uniformly, causing some parameter values to be neglected for a statistically improbable number of trials. This undermines the purpose of a "brute-force" exhaustive search. (Fixes #6070)

## Description of the changes
This pull request refactors the BruteForceSampler to resolve both issues with a single, efficient design.

The complex, state-rebuilding logic has been replaced with a stateful, pre-computation strategy:

1. After the first trial completes, the sampler inspects its parameter distributions to define the complete search space.

2. It computes the full Cartesian product of all possible parameter combinations and stores this grid.

3. The grid is shuffled randomly to ensure an unbiased search order.

4. For all subsequent trials, the sampler simply pops the next combination from the shuffled grid.

This new implementation is dramatically faster, has a near-constant runtime, and guarantees uniform sampling over a full cycle. It makes the BruteForceSampler a reliable and performant tool for exhaustive search.