### PR TITLE
Fix fragile `test_brute_force.py`

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -72,7 +72,7 @@ jobs:
         COVERAGE_PROCESS_START: .coveragerc  # https://coverage.readthedocs.io/en/6.4.1/subprocess.html
         COVERAGE_COVERAGE: yes  # https://github.com/nedbat/coveragepy/blob/65bf33fc03209ffb01bbbc0d900017614645ee7a/coverage/control.py#L255-L261
       run: |
-        coverage run --source=optuna -m pytest tests -m "not skip_coverage and not slow" -n 8
+        coverage run --source=optuna -m pytest tests -m "not skip_coverage and not slow" -n auto
         coverage combine
         coverage xml
 

--- a/.github/workflows/mac-tests.yml
+++ b/.github/workflows/mac-tests.yml
@@ -64,8 +64,8 @@ jobs:
     - name: Scheduled tests
       if:  ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
       run: |
-        pytest tests -n 8
+        pytest tests -n auto
     - name: Tests
       if:  ${{ github.event_name != 'schedule' && github.event_name != 'workflow_dispatch' }}
       run: |
-        pytest tests -m "not slow" -n 8
+        pytest tests -m "not slow" -n auto

--- a/.github/workflows/matplotlib-tests.yml
+++ b/.github/workflows/matplotlib-tests.yml
@@ -59,5 +59,5 @@ jobs:
       if:  ${{ github.event_name != 'schedule' && github.event_name != 'workflow_dispatch' }}
       run: |
         pip uninstall -y plotly
-        pytest tests/visualization_tests/matplotlib_tests -n 8
+        pytest tests/visualization_tests/matplotlib_tests -n auto
 

--- a/.github/workflows/tests-with-minimum-versions.yml
+++ b/.github/workflows/tests-with-minimum-versions.yml
@@ -95,9 +95,9 @@ jobs:
     - name: Scheduled tests
       if:  ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
       run: |
-        pytest tests -n 8
+        pytest tests -n auto
 
     - name: Tests
       if:  ${{ github.event_name != 'schedule' && github.event_name != 'workflow_dispatch' }}
       run: |
-        pytest tests -m "not slow" -n 8
+        pytest tests -m "not slow" -n auto

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -102,6 +102,6 @@ jobs:
           target="not slow"
         fi
 
-        pytest tests -m "$target" -n 8
+        pytest tests -m "$target" -n auto
       env:
         SQLALCHEMY_WARN_20: 1

--- a/.github/workflows/windows-tests.yml
+++ b/.github/workflows/windows-tests.yml
@@ -69,7 +69,7 @@ jobs:
     - name: Scheduled tests
       if:  ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
       run: |
-        pytest -n 8
+        pytest -n auto
       env:
         SQLALCHEMY_WARN_20: 1
         MPLBACKEND: "QtAgg" # Use QtAgg as matplotlib backend.
@@ -77,6 +77,6 @@ jobs:
     - name: Tests
       if:  ${{ github.event_name != 'schedule' && github.event_name != 'workflow_dispatch' }}
       run: |
-        pytest -m "not slow" -n 8
+        pytest -m "not slow" -n auto
       env:
         MPLBACKEND: "QtAgg" # Use QtAgg as matplotlib backend.

--- a/tests/samplers_tests/test_brute_force.py
+++ b/tests/samplers_tests/test_brute_force.py
@@ -317,6 +317,7 @@ def test_parallel_optimize_with_sleep() -> None:
             # Guarantee that the trial with x=0 is completed before the trial with x=1.
             while len(study.get_trials(states=[optuna.trial.TrialState.COMPLETE])) < 2:
                 time.sleep(0.5)
+                limit -= 1
                 assert limit > 0  # Timeout, this should not happen.
 
         y = trial.suggest_int("y", 0, 1)

--- a/tests/samplers_tests/test_brute_force.py
+++ b/tests/samplers_tests/test_brute_force.py
@@ -312,7 +312,7 @@ def test_parallel_optimize_with_sleep() -> None:
     def objective(trial: Trial) -> float:
         x = trial.suggest_int("x", 0, 1)
         if x == 1:
-            limit = 20  # avoid infinite loop after 10 seconds
+            limit = 200  # avoid infinite after 100 seconds
 
             # Guarantee that the trial with x=0 is completed before the trial with x=1.
             while len(study.get_trials(states=[optuna.trial.TrialState.COMPLETE])) < 2:

--- a/tests/samplers_tests/test_brute_force.py
+++ b/tests/samplers_tests/test_brute_force.py
@@ -312,11 +312,11 @@ def test_parallel_optimize_with_sleep() -> None:
     def objective(trial: Trial) -> float:
         x = trial.suggest_int("x", 0, 1)
         if x == 1:
-            limit = 200  # avoid infinite after 100 seconds
+            limit = 300  # avoid infinite after 300 seconds
 
             # Guarantee that the trial with x=0 is completed before the trial with x=1.
             while len(study.get_trials(states=[optuna.trial.TrialState.COMPLETE])) < 2:
-                time.sleep(0.5)
+                time.sleep(1)
                 limit -= 1
                 assert limit > 0  # Timeout, this should not happen.
 


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
Related to #6206.

## Description of the changes
<!-- Describe the changes in this PR. -->
Under the high-load environment (like ci with xdist), the `sleep(1)` is not enough to guarantee the suggestion order. So I fixed it to guarantee the suggestion order.
