### PR TITLE
Flip the sign of constraints in `GPSampler`

### DIFF
--- a/optuna/_gp/acqf.py
+++ b/optuna/_gp/acqf.py
@@ -148,12 +148,13 @@ class LogPI(BaseAcquisitionFunc):
         super().__init__(gpr.length_scales, search_space)
 
     def eval_acqf(self, x: torch.Tensor) -> torch.Tensor:
-        # Return the integral of N(mean, var) from -inf to f0
-        # This is identical to the integral of N(0, 1) from -inf to (f0-mean)/sigma
-        # Return E_{y ~ N(mean, var)}[bool(y <= f0)]
+        # Return the integral of N(mean, var) from f0 to inf.
+        # This is identical to the integral of N(0, 1) from (f0-mean)/sigma to inf.
+        # Return E_{y ~ N(mean, var)}[bool(y >= f0)]
         mean, var = self._gpr.posterior(x)
         sigma = torch.sqrt(var + self._stabilizing_noise)
-        return torch.special.log_ndtr((self._threshold - mean) / sigma)
+        # NOTE(nabenabe): integral from a to b of f(x) is integral from -b to -a of f(-x).
+        return torch.special.log_ndtr((mean - self._threshold) / sigma)
 
 
 class UCB(BaseAcquisitionFunc):

--- a/optuna/samplers/_gp/sampler.py
+++ b/optuna/samplers/_gp/sampler.py
@@ -236,7 +236,8 @@ class GPSampler(BaseSampler):
         internal_search_space: gp_search_space.SearchSpace,
         normalized_params: np.ndarray,
     ) -> tuple[list[gp.GPRegressor], list[float]]:
-        standardized_constraint_vals, means, stds = _standardize_values(constraint_vals)
+        # NOTE(nabenabe): Flip the sign of constraints since they are always to be minimized.
+        standardized_constraint_vals, means, stds = _standardize_values(-constraint_vals)
         if self._gprs_cache_list is not None and len(
             self._gprs_cache_list[0].inverse_squared_lengthscales
         ) != len(internal_search_space.scale_types):


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

Since GPSampler conventionally trains regressors on `y` to be maximized, we adapt constraints to this convention.

## Description of the changes
<!-- Describe the changes in this PR. -->

- Flip the sign of constraints
- Flip the sign in log probability of improvement

## Math Background

Suppose $p(x | \mu, \sigma^2)$ is the probability density function of the Gauss distribution $\mathcal{N}(\mu, \sigma^2)$.

The previous version (x is better when it is **lower**):
$\int\_{-\infty}^{f_0} p(x | \mu, \sigma^2) dx = \int\_{-\infty}^{\frac{f_0 - \mu}{\sigma}} p( t \coloneqq \frac{x - \mu}{\sigma} | 0, 1) dt$

This version (x is better when it is **higher**):
$\int\_{f_0}^{\infty} p(x | \mu, \sigma^2) dx = \int\_{\frac{f_0 - \mu}{\sigma}}^{\infty} p( t \coloneqq \frac{x - \mu}{\sigma} | 0, 1) dt = \int\_{-\frac{f_0 - \mu}{\sigma}}^{-\infty} -p( u \coloneqq -t | 0, 1) du = \int\_{-\infty}^{-\frac{f_0 - \mu}{\sigma}} p( u | 0, 1) du$
