### PR TITLE
Remove unnecessary NumPy usage

### DIFF
--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -49,7 +49,7 @@ def default_gamma(x: int) -> int:
 
 
 def hyperopt_default_gamma(x: int) -> int:
-    return min(int(np.ceil(0.25 * x**0.5)), 25)
+    return min(math.ceil(0.25 * x**0.5), 25)
 
 
 def default_weights(x: int) -> np.ndarray:

--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -45,11 +45,11 @@ _logger = get_logger(__name__)
 
 
 def default_gamma(x: int) -> int:
-    return min(int(np.ceil(0.1 * x)), 25)
+    return min(math.ceil(0.1 * x), 25)
 
 
 def hyperopt_default_gamma(x: int) -> int:
-    return min(int(np.ceil(0.25 * np.sqrt(x))), 25)
+    return min(int(np.ceil(0.25 * x**0.5)), 25)
 
 
 def default_weights(x: int) -> np.ndarray:
@@ -703,7 +703,7 @@ def _split_complete_trials_multi_objective(
 
     assert 0 < n_below < len(trials)
     lvals = np.array([trial.values for trial in trials])
-    lvals *= np.array([-1.0 if d == StudyDirection.MAXIMIZE else 1.0 for d in study.directions])
+    lvals *= [-1.0 if d == StudyDirection.MAXIMIZE else 1.0 for d in study.directions]
     nondomination_ranks = _fast_non_domination_rank(lvals, n_below=n_below)
     ranks, rank_counts = np.unique(nondomination_ranks, return_counts=True)
     last_rank_before_tiebreak = int(np.max(ranks[np.cumsum(rank_counts) <= n_below], initial=-1))
@@ -784,12 +784,12 @@ def _calculate_weights_below_for_multi_objective(
         return weights_below
 
     lvals = np.asarray([t.values for t in below_trials])[is_feasible]
-    lvals *= np.array([-1.0 if d == StudyDirection.MAXIMIZE else 1.0 for d in study.directions])
+    lvals *= [-1.0 if d == StudyDirection.MAXIMIZE else 1.0 for d in study.directions]
     ref_point = _get_reference_point(lvals)
     on_front = _is_pareto_front(lvals, assume_unique_lexsorted=False)
     pareto_sols = lvals[on_front]
     hv = compute_hypervolume(pareto_sols, ref_point, assume_pareto=True)
-    if np.isinf(hv):
+    if math.isinf(hv):
         # TODO(nabenabe): Assign EPS to non-Pareto solutions, and
         # solutions with finite contrib if hv is inf. Ref: PR#5813.
         return weights_below


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

`math` is usually quicker than `numpy` for a scalar, so I replaced `numpy` with `math`.

## Description of the changes
<!-- Describe the changes in this PR. -->

- Use `math` instead of `numpy` for a scalar call

> [!NOTE]
> `math.ceil` returns an integer value instead of a floating number. [ref](https://docs.python.org/3/library/math.html#math.ceil)

## Benchmarking

```python
In [1]: import math
   ...: import numpy as np
   ...: 
   ...: 
   ...: %timeit math.isinf(100)
   ...: %timeit np.isinf(100)    
16 ns ± 0.776 ns per loop (mean ± std. dev. of 7 runs, 100,000,000 loops each)
390 ns ± 9.09 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)

In [2]: %timeit 1000**0.5
   ...: %timeit math.sqrt(1000)
   ...: %timeit np.sqrt(1000)
3.37 ns ± 0.0315 ns per loop (mean ± std. dev. of 7 runs, 100,000,000 loops each)
21.1 ns ± 0.662 ns per loop (mean ± std. dev. of 7 runs, 100,000,000 loops each)
573 ns ± 1.84 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)

In [3]: %timeit math.ceil(0.1 * 777)
   ...: %timeit np.ceil(0.1 * 777)
14.6 ns ± 0.269 ns per loop (mean ± std. dev. of 7 runs, 100,000,000 loops each)
394 ns ± 2.01 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
```