### PR TITLE
Enforce serial execution of fragile tests

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -72,7 +72,7 @@ jobs:
         COVERAGE_PROCESS_START: .coveragerc  # https://coverage.readthedocs.io/en/6.4.1/subprocess.html
         COVERAGE_COVERAGE: yes  # https://github.com/nedbat/coveragepy/blob/65bf33fc03209ffb01bbbc0d900017614645ee7a/coverage/control.py#L255-L261
       run: |
-        coverage run --source=optuna -m pytest tests -m "not skip_coverage and not slow" -n 8
+        coverage run --source=optuna -m pytest tests -m "not skip_coverage and not slow" -n auto --dist=loadgroup
         coverage combine
         coverage xml
 

--- a/.github/workflows/mac-tests.yml
+++ b/.github/workflows/mac-tests.yml
@@ -64,8 +64,8 @@ jobs:
     - name: Scheduled tests
       if:  ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
       run: |
-        pytest tests -n 8
+        pytest tests -n auto --dist=loadgroup
     - name: Tests
       if:  ${{ github.event_name != 'schedule' && github.event_name != 'workflow_dispatch' }}
       run: |
-        pytest tests -m "not slow" -n 8
+        pytest tests -m "not slow" -n auto --dist=loadgroup

--- a/.github/workflows/tests-with-minimum-versions.yml
+++ b/.github/workflows/tests-with-minimum-versions.yml
@@ -95,9 +95,9 @@ jobs:
     - name: Scheduled tests
       if:  ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
       run: |
-        pytest tests -n 8
+        pytest tests -n auto --dist=loadgroup
 
     - name: Tests
       if:  ${{ github.event_name != 'schedule' && github.event_name != 'workflow_dispatch' }}
       run: |
-        pytest tests -m "not slow" -n 8
+        pytest tests -m "not slow" -n auto --dist=loadgroup

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -102,6 +102,6 @@ jobs:
           target="not slow"
         fi
 
-        pytest tests -m "$target" -n 8
+        pytest tests -m "$target" -n auto --dist=loadgroup
       env:
         SQLALCHEMY_WARN_20: 1

--- a/.github/workflows/windows-tests.yml
+++ b/.github/workflows/windows-tests.yml
@@ -69,7 +69,7 @@ jobs:
     - name: Scheduled tests
       if:  ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
       run: |
-        pytest -n 8
+        pytest -n auto --dist=loadgroup
       env:
         SQLALCHEMY_WARN_20: 1
         MPLBACKEND: "QtAgg" # Use QtAgg as matplotlib backend.
@@ -77,6 +77,6 @@ jobs:
     - name: Tests
       if:  ${{ github.event_name != 'schedule' && github.event_name != 'workflow_dispatch' }}
       run: |
-        pytest -m "not slow" -n 8
+        pytest -m "not slow" -n auto --dist=loadgroup
       env:
         MPLBACKEND: "QtAgg" # Use QtAgg as matplotlib backend.

--- a/tests/samplers_tests/test_brute_force.py
+++ b/tests/samplers_tests/test_brute_force.py
@@ -304,6 +304,8 @@ def test_parallel_optimize() -> None:
     assert {x1, x2} == {"a", "b"}
 
 
+# TODO(c-bata): Make this test robust against parallel execution.
+@pytest.mark.xdist_group(name="serial")
 def test_parallel_optimize_with_sleep() -> None:
     def objective(trial: Trial) -> float:
         x = trial.suggest_int("x", 0, 1)


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
Refs #6209 

## Description of the changes
<!-- Describe the changes in this PR. -->
This is a temporary fix of `test_parallel_optimize_with_sleep`. To enforce serial execution, this PR specifies `pytest.xdist_group` decorator.

> --dist loadgroup: Tests are grouped by the xdist_group mark. Groups are distributed to available workers as whole units. This guarantees that all tests with same xdist_group name run in the same worker. If a test has multiple groups, they will be joined together into a new group, the order of the marks doesn’t matter. This works along with marks from fixtures and from the pytestmark global variable.
> https://pytest-xdist.readthedocs.io/en/stable/distribution.html