### PR TITLE
Implement NSGA-III using `BaseGASampler`

### DIFF
--- a/optuna/samplers/_nsgaiii/_sampler.py
+++ b/optuna/samplers/_nsgaiii/_sampler.py
@@ -1,18 +1,15 @@
 from __future__ import annotations
 
-from collections import defaultdict
 from collections.abc import Callable
 from collections.abc import Sequence
-import hashlib
 from typing import Any
 from typing import TYPE_CHECKING
 
 import numpy as np
 
-import optuna
 from optuna._experimental import experimental_class
 from optuna.distributions import BaseDistribution
-from optuna.samplers._base import BaseSampler
+from optuna.samplers._ga import BaseGASampler
 from optuna.samplers._lazy_random_state import LazyRandomState
 from optuna.samplers._nsgaiii._elite_population_selection_strategy import (
     NSGAIIIElitePopulationSelectionStrategy,
@@ -31,13 +28,8 @@ if TYPE_CHECKING:
     from optuna.study import Study
 
 
-# Define key names of `Trial.system_attrs`.
-_GENERATION_KEY = "nsga3:generation"
-_POPULATION_CACHE_KEY_PREFIX = "nsga3:population"
-
-
 @experimental_class("3.2.0")
-class NSGAIIISampler(BaseSampler):
+class NSGAIIISampler(BaseGASampler):
     """Multi-objective sampler using the NSGA-III algorithm.
 
     NSGA-III stands for "Nondominated Sorting Genetic Algorithm III",
@@ -120,6 +112,7 @@ class NSGAIIISampler(BaseSampler):
                 f" The specified `population_size` is {population_size}."
             )
 
+        super().__init__(population_size=population_size)
         self._population_size = population_size
         self._random_sampler = RandomSampler(seed=seed)
         self._rng = LazyRandomState(seed)
@@ -169,20 +162,23 @@ class NSGAIIISampler(BaseSampler):
             search_space[name] = distribution
         return search_space
 
+    def select_parent(self, study: Study, generation: int) -> list[FrozenTrial]:
+        return self._elite_population_selection_strategy(
+            study,
+            self.get_population(study, generation - 1)
+            + self.get_parent_population(study, generation - 1),
+        )
+
     def sample_relative(
         self,
         study: Study,
         trial: FrozenTrial,
         search_space: dict[str, BaseDistribution],
     ) -> dict[str, Any]:
-        parent_generation, parent_population = self._collect_parent_population(study)
-
-        generation = parent_generation + 1
-        study._storage.set_trial_system_attr(trial._trial_id, _GENERATION_KEY, generation)
-
-        if parent_generation < 0:
+        generation = self.get_trial_generation(study, trial)
+        parent_population = self.get_parent_population(study, generation)
+        if len(parent_population) == 0:
             return {}
-
         return self._child_generation_strategy(study, search_space, parent_population)
 
     def sample_independent(
@@ -200,81 +196,6 @@ class NSGAIIISampler(BaseSampler):
         return self._random_sampler.sample_independent(
             study, trial, param_name, param_distribution
         )
-
-    def _collect_parent_population(self, study: Study) -> tuple[int, list[FrozenTrial]]:
-        trials = study.get_trials(deepcopy=False)
-
-        generation_to_runnings = defaultdict(list)
-        generation_to_population = defaultdict(list)
-        for trial in trials:
-            if _GENERATION_KEY not in trial.system_attrs:
-                continue
-
-            generation = trial.system_attrs[_GENERATION_KEY]
-            if trial.state != optuna.trial.TrialState.COMPLETE:
-                if trial.state == optuna.trial.TrialState.RUNNING:
-                    generation_to_runnings[generation].append(trial)
-                continue
-
-            # Do not use trials whose states are not COMPLETE, or `constraint` will be unavailable.
-            generation_to_population[generation].append(trial)
-
-        hasher = hashlib.sha256()
-        parent_population: list[FrozenTrial] = []
-        parent_generation = -1
-        while True:
-            generation = parent_generation + 1
-            population = generation_to_population[generation]
-
-            # Under multi-worker settings, the population size might become larger than
-            # `self._population_size`.
-            if len(population) < self._population_size:
-                break
-
-            # [NOTE]
-            # It's generally safe to assume that once the above condition is satisfied,
-            # there are no additional individuals added to the generation (i.e., the members of
-            # the generation have been fixed).
-            # If the number of parallel workers is huge, this assumption can be broken, but
-            # this is a very rare case and doesn't significantly impact optimization performance.
-            # So we can ignore the case.
-
-            # The cache key is calculated based on the key of the previous generation and
-            # the remaining running trials in the current population.
-            # If there are no running trials, the new cache key becomes exactly the same as
-            # the previous one, and the cached content will be overwritten. This allows us to
-            # skip redundant cache key calculations when this method is called for the subsequent
-            # trials.
-            for trial in generation_to_runnings[generation]:
-                hasher.update(bytes(str(trial.number), "utf-8"))
-
-            cache_key = "{}:{}".format(_POPULATION_CACHE_KEY_PREFIX, hasher.hexdigest())
-            study_system_attrs = study._storage.get_study_system_attrs(study._study_id)
-            cached_generation, cached_population_numbers = study_system_attrs.get(
-                cache_key, (-1, [])
-            )
-            if cached_generation >= generation:
-                generation = cached_generation
-                population = [trials[n] for n in cached_population_numbers]
-            else:
-                population.extend(parent_population)
-                population = self._elite_population_selection_strategy(study, population)
-
-                # To reduce the number of system attribute entries,
-                # we cache the population information only if there are no running trials
-                # (i.e., the information of the population has been fixed).
-                # Usually, if there are no too delayed running trials, the single entry
-                # will be used.
-                if len(generation_to_runnings[generation]) == 0:
-                    population_numbers = [t.number for t in population]
-                    study._storage.set_study_system_attr(
-                        study._study_id, cache_key, (generation, population_numbers)
-                    )
-
-            parent_generation = generation
-            parent_population = population
-
-        return parent_generation, parent_population
 
     def before_trial(self, study: Study, trial: FrozenTrial) -> None:
         self._random_sampler.before_trial(study, trial)

--- a/optuna/samplers/_nsgaiii/_sampler.py
+++ b/optuna/samplers/_nsgaiii/_sampler.py
@@ -113,7 +113,6 @@ class NSGAIIISampler(BaseGASampler):
             )
 
         super().__init__(population_size=population_size)
-        self._population_size = population_size
         self._random_sampler = RandomSampler(seed=seed)
         self._rng = LazyRandomState(seed)
         self._constraints_func = constraints_func


### PR DESCRIPTION
## Motivation & Description of the changes
This PR implements NSGAIII using BaseGASampler as in https://github.com/optuna/optuna/pull/5864.
This change reduces code duplication. It also eliminates some unintuitive internal differences between NSGA-II and NSGA-III.
For example, in Optuna v4.4, _GENERATION_KEY is not defined in NSGA-III, as shown below, but it is now defined.
```python
>>> import optuna
>>> optuna.samplers.NSGAIISampler._GENERATION_KEY
'NSGAIISampler:generation'
>>> optuna.samplers.NSGAIIISampler._GENERATION_KEY
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: type object 'NSGAIIISampler' has no attribute '_GENERATION_KEY'
>>>
```