### PR TITLE
Speed up log pdf in `_BatchedTruncNormDistributions` by vectorization

### DIFF
--- a/optuna/samplers/_tpe/probability_distributions.py
+++ b/optuna/samplers/_tpe/probability_distributions.py
@@ -133,13 +133,18 @@ class _MixtureOfProductDistribution(NamedTuple):
                 )[mu_sigma_inv]
             else:
                 assert False
-        mus_cont = np.asarray([d.mu for d in cont_dists]).T
-        sigmas_cont = np.asarray([d.sigma for d in cont_dists]).T
-        weighted_log_pdf += _truncnorm.logpdf(
-            x[:, np.newaxis, cont_inds],
-            (np.asarray([d.low for d in cont_dists]) - mus_cont) / sigmas_cont,
-            (np.asarray([d.high for d in cont_dists]) - mus_cont) / sigmas_cont,
-        ).sum(axis=-1)
+
+        if len(cont_inds):
+            mus_cont = np.asarray([d.mu for d in cont_dists]).T
+            sigmas_cont = np.asarray([d.sigma for d in cont_dists]).T
+            weighted_log_pdf += _truncnorm.logpdf(
+                x[:, np.newaxis, cont_inds],
+                a=(np.asarray([d.low for d in cont_dists]) - mus_cont) / sigmas_cont,
+                b=(np.asarray([d.high for d in cont_dists]) - mus_cont) / sigmas_cont,
+                loc=mus_cont,
+                scale=sigmas_cont,
+            ).sum(axis=-1)
+
         weighted_log_pdf += np.log(self.weights[np.newaxis])
         max_ = weighted_log_pdf.max(axis=1)
         # We need to avoid (-inf) - (-inf) when the probability is zero.


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

The vectorization for continuous distributions can speed up for `multivariate=True`.

## Description of the changes
<!-- Describe the changes in this PR. -->

- Use vectorization instead of dimension-wise log pdf calls 
