### PR TITLE
Fix issue #6173 "migrating config files to pyproject.toml"

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,0 @@
-[run]
-concurrency = multiprocessing,thread
-source = optuna/

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -68,13 +68,14 @@ jobs:
     - name: Tests
       env:
         OMP_NUM_THREADS: 1
-        PYTHONPATH: .  # To invoke sitecutomize.py
-        COVERAGE_PROCESS_START: .coveragerc  # https://coverage.readthedocs.io/en/6.4.1/subprocess.html
-        COVERAGE_COVERAGE: yes  # https://github.com/nedbat/coveragepy/blob/65bf33fc03209ffb01bbbc0d900017614645ee7a/coverage/control.py#L255-L261
+        PYTHONPATH: .
+        COVERAGE_PROCESS_START: pyproject.toml
+        COVERAGE_COVERAGE: yes
       run: |
-        coverage run --source=optuna -m pytest tests -m "not skip_coverage and not slow" -n 8
-        coverage combine
-        coverage xml
+        coverage run --config=pyproject.toml --source=optuna -m pytest tests -m "not skip_coverage and not slow" -n 8
+        coverage combine --config=pyproject.toml
+        coverage xml --config=pyproject.toml
+
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,0 @@
-graft tests
-global-exclude *~ *.py[cod] *.so

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,6 @@ optional = [
   "plotly>=4.9.0",  # optuna/visualization.
   "redis",  # optuna/storages/journal/_redis.py.
   "scikit-learn>=0.24.2",  # optuna/importance.
-  "scipy",  # optuna/_gp.
   "torch; python_version<='3.12'",  # TODO(gen740): Remove this line when 'torch', a dependency of 'optuna/_gp', supports Python 3.13
   "grpcio",  # optuna/storages/_grpc.
   "protobuf>=5.28.1",  # optuna/storages/_grpc.
@@ -130,6 +129,14 @@ version = {attr = "optuna.version.__version__"}
   "py.typed",
 ]
 
+# Consolidated from MANIFEST.in
+[tool.setuptools]
+include-package-data = true
+
+[tool.setuptools.package-dir]
+"" = "."
+
+# Black configuration (already present)
 [tool.black]
 line-length = 99
 target-version = ['py38']
@@ -150,6 +157,23 @@ force-exclude = '''
 )/
 '''
 
+# Flake8 configuration (consolidated from setup.cfg)
+[tool.flake8]
+ignore = ["E203", "E704", "W503"]
+max-line-length = 99
+statistics = true
+exclude = [
+  ".venv",
+  "venv", 
+  "build",
+  "tutorial",
+  ".asv",
+  "docs/visualization_examples",
+  "docs/visualization_matplotlib_examples",
+  "optuna/storages/_grpc/auto_generated"
+]
+
+# isort configuration (already present)
 [tool.isort]
 profile = 'black'
 src_paths = ['optuna', 'tests', 'docs', 'benchmarks']
@@ -167,6 +191,7 @@ force_single_line = 'True'
 force_sort_within_sections = 'True'
 order_by_type = 'False'
 
+# pytest configuration (already present)
 [tool.pytest.ini_options]
 addopts = "--color=yes"
 filterwarnings = 'ignore::optuna.exceptions.ExperimentalWarning'
@@ -175,6 +200,7 @@ markers = [
   "slow: marks tests as slow (deselect with '-m \"not slow\"')"
 ]
 
+# mypy configuration (already present)
 [tool.mypy]
 # Options configure mypy's strict mode.
 warn_unused_configs = true
@@ -194,3 +220,8 @@ exclude = [".venv", "venv", "build", "docs", "tutorial", "optuna/storages/_rdb/a
 [[tool.mypy.overrides]]
 module = 'optuna.storages._grpc.auto_generated/*'
 follow_imports = "skip"
+
+# Coverage configuration (consolidated from .coveragerc)
+[tool.coverage.run]
+concurrency = ["multiprocessing", "thread"]
+source = ["optuna/"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,9 +1,0 @@
-# This section is for flake8.
-[flake8]
-ignore =
-    E203,
-    E704,
-    W503
-max-line-length = 99
-statistics = True
-exclude = .venv,venv,build,tutorial,.asv,docs/visualization_examples,docs/visualization_matplotlib_examples,optuna/storages/_grpc/auto_generated


### PR DESCRIPTION
## Motivation
Noticed this simple issue hanging for more than a month and went ahead and fixed it.

## Description of the changes
Migrated flake8 config from `setup.cfg` to `pyproject.toml`. Nothing fancy.
Also, removed `.coveragerc` and `MANIFEST.in` while fixing the `coverage.yml` to run properly with `pyproject.toml`.
