### PR TITLE
Speed up WFG by skipping `is_pareto_front` and using simple Python loops

### DIFF
--- a/optuna/_hypervolume/wfg.py
+++ b/optuna/_hypervolume/wfg.py
@@ -39,14 +39,23 @@ def _compute_3d(sorted_pareto_sols: np.ndarray, reference_point: np.ndarray) -> 
 
 
 def _compute_hv(sorted_loss_vals: np.ndarray, reference_point: np.ndarray) -> float:
-    inclusive_hvs = np.prod(reference_point - sorted_loss_vals, axis=-1)
-    if inclusive_hvs.shape[0] == 1:
-        return float(inclusive_hvs[0])
-    elif inclusive_hvs.shape[0] == 2:
+    if sorted_loss_vals.shape[0] == 1:
+        # NOTE(nabenabe): NumPy overhead is slower than the simple for-loop here.
+        inclusive_hv = 1.0
+        for r, v in zip(reference_point, sorted_loss_vals[0]):
+            inclusive_hv *= r - v
+        return float(inclusive_hv)
+    elif sorted_loss_vals.shape[0] == 2:
+        # NOTE(nabenabe): NumPy overhead is slower than the simple for-loop here.
         # S(A v B) = S(A) + S(B) - S(A ^ B).
-        intersec = np.prod(reference_point - np.maximum(sorted_loss_vals[0], sorted_loss_vals[1]))
-        return np.sum(inclusive_hvs) - intersec
+        hv1, hv2, intersec = 1.0, 1.0, 1.0
+        for r, v1, v2 in zip(reference_point, sorted_loss_vals[0], sorted_loss_vals[1]):
+            hv1 *= r - v1
+            hv2 *= r - v2
+            intersec *= r - max(v1, v2)
+        return hv1 + hv2 - intersec
 
+    inclusive_hvs = np.prod(reference_point - sorted_loss_vals, axis=-1)
     # c.f. Eqs. (6) and (7) of ``A Fast Way of Calculating Exact Hypervolumes``.
     limited_sols_array = np.maximum(sorted_loss_vals[:, np.newaxis], sorted_loss_vals)
     return sum(
@@ -60,6 +69,9 @@ def _compute_exclusive_hv(
 ) -> float:
     if limited_sols.shape[0] == 0:
         return inclusive_hv
+    elif limited_sols.shape[0] <= 3:
+        # NOTE(nabenabe): Don't use _is_pareto_front for 3 or fewer points to avoid its overhead.
+        return inclusive_hv - _compute_hv(limited_sols, reference_point)
 
     # NOTE(nabenabe): As the following line is a hack for speedup, I will describe several
     # important points to note. Even if we do not run _is_pareto_front below or use

--- a/optuna/_hypervolume/wfg.py
+++ b/optuna/_hypervolume/wfg.py
@@ -58,18 +58,17 @@ def _compute_hv(sorted_loss_vals: np.ndarray, reference_point: np.ndarray) -> fl
     inclusive_hvs = np.prod(reference_point - sorted_loss_vals, axis=-1)
     # c.f. Eqs. (6) and (7) of ``A Fast Way of Calculating Exact Hypervolumes``.
     limited_sols_array = np.maximum(sorted_loss_vals[:, np.newaxis], sorted_loss_vals)
-    return sum(
-        _compute_exclusive_hv(limited_sols_array[i, i + 1 :], inclusive_hv, reference_point)
-        for i, inclusive_hv in enumerate(inclusive_hvs)
+    return inclusive_hvs[-1] + sum(
+        _compute_exclusive_hv(limited_sols_array[i, i + 1 :], inclusive_hvs[i], reference_point)
+        for i in range(inclusive_hvs.size - 1)
     )
 
 
 def _compute_exclusive_hv(
     limited_sols: np.ndarray, inclusive_hv: float, reference_point: np.ndarray
 ) -> float:
-    if limited_sols.shape[0] == 0:
-        return inclusive_hv
-    elif limited_sols.shape[0] <= 3:
+    assert limited_sols.shape[0] >= 1
+    if limited_sols.shape[0] <= 3:
         # NOTE(nabenabe): Don't use _is_pareto_front for 3 or fewer points to avoid its overhead.
         return inclusive_hv - _compute_hv(limited_sols, reference_point)
 

--- a/optuna/_hypervolume/wfg.py
+++ b/optuna/_hypervolume/wfg.py
@@ -55,7 +55,7 @@ def _compute_hv(sorted_loss_vals: np.ndarray, reference_point: np.ndarray) -> fl
             intersec *= r - max(v1, v2)
         return hv1 + hv2 - intersec
 
-    inclusive_hvs = np.prod(reference_point - sorted_loss_vals, axis=-1)
+    inclusive_hvs = (reference_point - sorted_loss_vals).prod(axis=-1)
     # c.f. Eqs. (6) and (7) of ``A Fast Way of Calculating Exact Hypervolumes``.
     limited_sols_array = np.maximum(sorted_loss_vals[:, np.newaxis], sorted_loss_vals)
     return inclusive_hvs[-1] + sum(

--- a/optuna/study/_multi_objective.py
+++ b/optuna/study/_multi_objective.py
@@ -135,7 +135,6 @@ def _is_pareto_front_nd(unique_lexsorted_loss_values: np.ndarray) -> np.ndarray:
         # NOTE: trials[j] cannot dominate trials[i] for i < j because of lexsort.
         # Therefore, remaining_indices[0] is always non-dominated.
         on_front[new_nondominated_index := remaining_indices[0]] = True
-        new_nondominated_loss = loss_values[new_nondominated_index]
         nondominated_and_not_top = np.any(
             loss_values[remaining_indices] < loss_values[new_nondominated_index], axis=1
         )

--- a/optuna/study/_multi_objective.py
+++ b/optuna/study/_multi_objective.py
@@ -134,7 +134,7 @@ def _is_pareto_front_nd(unique_lexsorted_loss_values: np.ndarray) -> np.ndarray:
     while len(remaining_indices):
         # NOTE: trials[j] cannot dominate trials[i] for i < j because of lexsort.
         # Therefore, remaining_indices[0] is always non-dominated.
-        on_front[new_nondominated_index := remaining_indices[0]] = True
+        on_front[(new_nondominated_index := remaining_indices[0])] = True
         nondominated_and_not_top = np.any(
             loss_values[remaining_indices] < loss_values[new_nondominated_index], axis=1
         )

--- a/optuna/study/_multi_objective.py
+++ b/optuna/study/_multi_objective.py
@@ -127,20 +127,21 @@ def _is_pareto_front_nd(unique_lexsorted_loss_values: np.ndarray) -> np.ndarray:
     n_trials = loss_values.shape[0]
     on_front = np.zeros(n_trials, dtype=bool)
     # TODO(nabenabe): Replace with the following once Python 3.8 is dropped.
-    # nondominated_indices: np.ndarray[tuple[int], np.dtype[np.signedinteger]] = ...
-    nondominated_indices: np.ndarray[tuple[int, ...], np.dtype[np.signedinteger]] = np.arange(
+    # remaining_indices: np.ndarray[tuple[int], np.dtype[np.signedinteger]] = ...
+    remaining_indices: np.ndarray[tuple[int, ...], np.dtype[np.signedinteger]] = np.arange(
         n_trials
     )
-    while len(loss_values):
-        # The following judges `np.any(loss_values[i] < loss_values[0])` for each `i`.
-        nondominated_and_not_top = np.any(loss_values < loss_values[0], axis=1)
+    while len(remaining_indices):
         # NOTE: trials[j] cannot dominate trials[i] for i < j because of lexsort.
-        # Therefore, nondominated_indices[0] is always non-dominated.
-        on_front[nondominated_indices[0]] = True
-        loss_values = loss_values[nondominated_and_not_top]
+        # Therefore, remaining_indices[0] is always non-dominated.
+        on_front[new_nondominated_index := remaining_indices[0]] = True
+        new_nondominated_loss = loss_values[new_nondominated_index]
+        nondominated_and_not_top = np.any(
+            loss_values[remaining_indices] < loss_values[new_nondominated_index], axis=1
+        )
         # TODO(nabenabe): Replace with the following once Python 3.8 is dropped.
         # ... = cast(np.ndarray[tuple[int], np.dtype[np.signedinteger]], ...)
-        nondominated_indices = nondominated_indices[nondominated_and_not_top]
+        remaining_indices = remaining_indices[nondominated_and_not_top]
 
     return on_front
 


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

Since WFG becomes very slow for many-objective problems, I speeded up the routine.

|**This PR**|Master|
|:--:|:--:|
|3.66 seconds|5.86 seconds|

<details>
<summary>Benchmarking Code</summary>

```python
import time

import optuna

import numpy as np


rng = np.random.RandomState(42)
runtime = 0.0
n_objectives = 5
for _ in range(10):
    X = np.unique(rng.normal(size=(1000, n_objectives)), axis=0)
    pareto_sols = X[optuna.study._multi_objective._is_pareto_front(X, False)]
    start = time.time()
    hv = optuna._hypervolume.compute_hypervolume(pareto_sols, np.full(n_objectives, 10.0), True)
    runtime += time.time() - start
    print(hv)

print(runtime)

```

</details>

## Description of the changes
<!-- Describe the changes in this PR. -->

- Use Python loops instead of NumPy for short iterations
- Avoid using `is_pareto_front` for small arrays
- Avoid filtering `loss_values` to reduce the copy

> [!NOTE]
> Since the summation and subtraction orders change by this PR, the result of WFG will not be identical to the master branch anymore.