### PR TITLE
Support 1D Search Spaces in `CmaEsSampler`

### DIFF
--- a/.github/workflows/tests-with-minimum-versions.yml
+++ b/.github/workflows/tests-with-minimum-versions.yml
@@ -75,7 +75,7 @@ jobs:
       run: |
         # Install dependencies with minimum versions.
         pip uninstall -y alembic cmaes packaging sqlalchemy plotly scikit-learn pillow
-        pip install alembic==1.5.0 cmaes==0.10.0 packaging==20.0 sqlalchemy==1.4.2 tqdm==4.27.0 colorlog==0.3 PyYAML==5.1 'pillow<10.4.0'
+        pip install alembic==1.5.0 cmaes==0.12.0 packaging==20.0 sqlalchemy==1.4.2 tqdm==4.27.0 colorlog==0.3 PyYAML==5.1 'pillow<10.4.0'
         pip uninstall -y matplotlib pandas scipy
         if [ "${{ matrix.python-version }}" = "3.8" ]; then
           pip install matplotlib==3.7.5 pandas==2.0.3 scipy==1.10.1 numpy==1.20.3

--- a/optuna/samplers/_cmaes.py
+++ b/optuna/samplers/_cmaes.py
@@ -377,7 +377,7 @@ class CmaEsSampler(BaseSampler):
 
         optimizer = self._restore_optimizer(completed_trials)
         if optimizer is None:
-            optimizer = self._init_optimizer(trans, study.direction, len(search_space) == 1)
+            optimizer = self._init_optimizer(trans, study.direction)
 
         if optimizer.dim != len(trans.bounds):
             if self._warn_independent_sampling:
@@ -478,7 +478,6 @@ class CmaEsSampler(BaseSampler):
         self,
         trans: _SearchSpaceTransform,
         direction: StudyDirection,
-        is_single_dimension: bool,
     ) -> "CmaClass":
         lower_bounds = trans.bounds[:, 0]
         upper_bounds = trans.bounds[:, 1]
@@ -520,7 +519,7 @@ class CmaEsSampler(BaseSampler):
         sigma0 = max(sigma0, _EPS)
 
         if self._use_separable_cma:
-            if is_single_dimension:
+            if len(trans.bounds) == 1:
                 warnings.warn(
                     "Separable CMA-ES does not operate meaningfully on single-dimensional "
                     "search spaces. The setting `use_separable_cma=True` will be ignored.",

--- a/optuna/samplers/_cmaes.py
+++ b/optuna/samplers/_cmaes.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 import copy
-from importlib.metadata import version
 import math
 import pickle
 from typing import Any
@@ -12,7 +11,6 @@ from typing import Union
 import warnings
 
 import numpy as np
-from packaging.version import parse
 
 import optuna
 from optuna import _deprecated
@@ -371,13 +369,6 @@ class CmaEsSampler(BaseSampler):
         completed_trials = self._get_trials(study)
         if len(completed_trials) < self._n_startup_trials:
             return {}
-
-        if len(search_space) == 1:
-            cmaes_version = version("cmaes")
-            assert parse(cmaes_version) >= parse("0.12.0"), (
-                f"`cmaes` version 0.12.0 or later is required to support single-dimensional "
-                f"search spaces. Current version: {cmaes_version}."
-            )
 
         # When `with_margin=True`, bounds in discrete dimensions are handled inside `CMAwM`.
         trans = _SearchSpaceTransform(

--- a/optuna/samplers/_cmaes.py
+++ b/optuna/samplers/_cmaes.py
@@ -519,15 +519,22 @@ class CmaEsSampler(BaseSampler):
         # Avoid ZeroDivisionError in cmaes.
         sigma0 = max(sigma0, _EPS)
 
-        if self._use_separable_cma and not is_single_dimension:
-            return cmaes.SepCMA(
-                mean=mean,
-                sigma=sigma0,
-                bounds=trans.bounds,
-                seed=self._cma_rng.rng.randint(1, 2**31 - 2),
-                n_max_resampling=10 * n_dimension,
-                population_size=self._popsize,
-            )
+        if self._use_separable_cma:
+            if is_single_dimension:
+                warnings.warn(
+                    "Separable CMA-ES does not operate meaningfully on single-dimensional "
+                    "search spaces. The setting `use_separable_cma=True` will be ignored.",
+                    UserWarning,
+                )
+            else:
+                return cmaes.SepCMA(
+                    mean=mean,
+                    sigma=sigma0,
+                    bounds=trans.bounds,
+                    seed=self._cma_rng.rng.randint(1, 2**31 - 2),
+                    n_max_resampling=10 * n_dimension,
+                    population_size=self._popsize,
+                )
 
         if self._with_margin:
             steps = np.empty(len(trans._search_space), dtype=float)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ checking = [
 ]
 document = [
   "ase",
-  "cmaes>=0.10.0",  # optuna/samplers/_cmaes.py.
+  "cmaes>=0.12.0",  # optuna/samplers/_cmaes.py.
   "fvcore",
   "kaleido<0.4",  # TODO(nzw0301): Remove the version constraint by installing browser separately.
   "lightgbm",
@@ -82,7 +82,7 @@ document = [
 ]
 optional = [
   "boto3",  # optuna/artifacts/_boto3.py.
-  "cmaes>=0.10.0",  # optuna/samplers/_cmaes.py.
+  "cmaes>=0.12.0",  # optuna/samplers/_cmaes.py.
   "google-cloud-storage",  # optuna/artifacts/_gcs.py.
   "matplotlib!=3.6.0",  # optuna/visualization/matplotlib.
   "pandas",  # optuna/study/_dataframe.py.

--- a/tests/samplers_tests/test_cmaes.py
+++ b/tests/samplers_tests/test_cmaes.py
@@ -579,4 +579,4 @@ def test_1d_search_space_with_margin(with_margin: bool) -> None:
 
     sampler = optuna.samplers.CmaEsSampler(with_margin=with_margin)
     study = optuna.create_study(sampler=sampler)
-    study.optimize(objective, n_trials=3)
+    study.optimize(objective, n_trials=2)

--- a/tests/samplers_tests/test_cmaes.py
+++ b/tests/samplers_tests/test_cmaes.py
@@ -252,19 +252,6 @@ def test_infer_relative_search_space_1d() -> None:
     assert sampler.infer_relative_search_space(study, study.best_trial) == {}
 
 
-def test_sample_relative_1d() -> None:
-    independent_sampler = optuna.samplers.RandomSampler()
-    sampler = optuna.samplers.CmaEsSampler(independent_sampler=independent_sampler)
-    study = optuna.create_study(sampler=sampler)
-
-    # If search space is one dimensional, the independent sampler is always used.
-    with patch.object(
-        independent_sampler, "sample_independent", wraps=independent_sampler.sample_independent
-    ) as mock_object:
-        study.optimize(lambda t: t.suggest_int("x", -1, 1), n_trials=2)
-        assert mock_object.call_count == 2
-
-
 def test_sample_relative_n_startup_trials() -> None:
     independent_sampler = optuna.samplers.RandomSampler()
     sampler = optuna.samplers.CmaEsSampler(
@@ -512,9 +499,6 @@ def test_internal_optimizer_with_margin() -> None:
 def test_warn_independent_sampling(
     capsys: _pytest.capture.CaptureFixture, warn_independent_sampling: bool
 ) -> None:
-    def objective_single(trial: optuna.trial.Trial) -> float:
-        return trial.suggest_float("x", 0, 1)
-
     def objective_shrink(trial: optuna.trial.Trial) -> float:
         if trial.number != 5:
             x = trial.suggest_float("x", 0, 1)
@@ -537,7 +521,7 @@ def test_warn_independent_sampling(
             z = trial.suggest_float("z", 0, 1)
             return x + y + z
 
-    for objective in [objective_single, objective_shrink, objective_expand]:
+    for objective in [objective_shrink, objective_expand]:
         # We need to reconstruct our default handler to properly capture stderr.
         optuna.logging._reset_library_root_logger()
         optuna.logging.enable_default_handler()


### PR DESCRIPTION
## Motivation
Thanks to [CMA-ES PR #190](https://github.com/CyberAgentAILab/cmaes/pull/190), the CMA-ES library now supports 1-dimensional search spaces. This PR updates CmaEsSampler to allow the use of 1D search spaces accordingly.

## Description of the changes
- Removed the logic that falls back to the independent sampler for 1D search spaces.
- Since SepCMA currently does not support 1D search spaces (see [source](https://github.com/CyberAgentAILab/cmaes/blob/main/cmaes/_sepcma.py#L82)), SepCMA will be bypassed when `use_separable_cma=True` and the search space is 1D.
- Updated the `cmaes` version in `pyproject.toml`.

