### PR TITLE
Vectorize `ndtri_exp`

### DIFF
--- a/optuna/samplers/_tpe/_truncnorm.py
+++ b/optuna/samplers/_tpe/_truncnorm.py
@@ -149,7 +149,7 @@ def _log_gauss_mass(a: np.ndarray, b: np.ndarray) -> np.ndarray:
     return np.real(out)  # discard ~0j
 
 
-def _ndtri_exp(y: np.ndarray, check_inf: bool = True) -> np.ndarray:
+def _ndtri_exp(y: np.ndarray) -> np.ndarray:
     """
     Use the Newton method to efficiently find the root.
 

--- a/optuna/samplers/_tpe/_truncnorm.py
+++ b/optuna/samplers/_tpe/_truncnorm.py
@@ -166,8 +166,8 @@ def _ndtri_exp(y: np.ndarray) -> np.ndarray:
     First recall that y is a non-positive value and y = log_ndtr(inf) = 0 and
     y = log_ndtr(-inf) = -inf.
 
-    If abs(y) is very small, x is very large, meaning that x**2 >> log(x). In this case, we first
-    derive x such that z = log_ndtr(-x) and then flip the sign. Please note that the following:
+    If abs(y) is very small, we first derive -x such that z = log_ndtr(-x) and then flip the sign.
+    Please note that the following holds:
         z = log_ndtr(-x) --> z = log(1 - ndtr(x)) = log(1 - exp(y)) = log(-expm1(y)).
     Recall that as long as ndtr(x) = exp(y) > 0.5 --> y > -log(2) = -0.693..., x becomes positive.
 
@@ -198,7 +198,7 @@ def _ndtri_exp(y: np.ndarray) -> np.ndarray:
     # Flip the sign of y close to zero for better numerical stability and flip back the sign later.
     flipped = y > -1e-2
     z = y.copy()
-    z[flipped] = np.log(-np.expm1(y[flipped]))  # y is always < -log(2) = -0.693...
+    z[flipped] = np.log(-np.expm1(y[flipped]))
     x = np.empty_like(y)
     if (small_inds := np.nonzero(z < -5))[0].size:
         x[small_inds] = -np.sqrt(-2.0 * (z[small_inds] + _norm_pdf_logC))
@@ -217,7 +217,7 @@ def _ndtri_exp(y: np.ndarray) -> np.ndarray:
             break
     x[flipped] *= -1
     # NOTE(nabe): x[y == 0.0] = np.inf, x[np.isneginf(y)] = -np.inf are necessary for the accurate
-    # computation, but we omit them as it is used only from the ppf function.
+    # computation, but we omit them as the ppf applies clipping, removing the need for them.
     return x
 
 

--- a/optuna/samplers/_tpe/_truncnorm.py
+++ b/optuna/samplers/_tpe/_truncnorm.py
@@ -203,9 +203,9 @@ def _ndtri_exp(y: np.ndarray) -> np.ndarray:
 
     for _ in range(100):
         log_ndtr_x = _log_ndtr(x)
-        # NOTE(nabenabe): Use exp(log_ndtr_x - norm_logpdf_x) instead of ndtr_x / norm_pdf_x for
+        log_norm_pdf_x = -0.5 * x**2 - _norm_pdf_logC
+        # NOTE(nabenabe): Use exp(log_ndtr_x - log_norm_pdf_x) instead of ndtr_x / norm_pdf_x for
         # numerical stability.
-        norm_logpdf_x = -(x**2) / 2.0 - _norm_pdf_logC
         dx = (log_ndtr_x - y) * np.exp(log_ndtr_x - norm_logpdf_x)
         x -= dx
         if np.all(np.abs(dx) < 1e-8 * -x):  # NOTE: x is always negative.

--- a/optuna/samplers/_tpe/_truncnorm.py
+++ b/optuna/samplers/_tpe/_truncnorm.py
@@ -195,15 +195,6 @@ def _ndtri_exp(y: np.ndarray, check_inf: bool = True) -> np.ndarray:
         --> log(exp(-y) - 1) \\simeq -pi * x / sqrt(3)
         --> x \\simeq -sqrt(3) / pi * log(exp(-y) - 1).
     """
-    if check_inf:
-        is_y_zero = y == 0.0
-        is_y_neginf = np.isneginf(y)
-        if np.any(is_y_zero) or np.any(is_y_neginf):
-            x = np.where(is_y_zero, np.inf, -np.inf)
-            is_x_finite = ~is_y_zero & ~is_y_neginf
-            x[is_x_finite] = _ndtri_exp(y[is_x_finite], check_inf=False)
-            return x
-
     # Flip the sign of y close to zero for better numerical stability and flip back the sign later.
     flipped = y > -1e-2
     z = y.copy()
@@ -225,6 +216,7 @@ def _ndtri_exp(y: np.ndarray, check_inf: bool = True) -> np.ndarray:
             # Equivalent to np.isclose with atol=0.0 and rtol=1e-8.
             break
     x[flipped] *= -1
+    x[y == 0.0] = np.inf
     return x
 
 

--- a/optuna/samplers/_tpe/_truncnorm.py
+++ b/optuna/samplers/_tpe/_truncnorm.py
@@ -216,7 +216,8 @@ def _ndtri_exp(y: np.ndarray) -> np.ndarray:
             # Equivalent to np.isclose with atol=0.0 and rtol=1e-8.
             break
     x[flipped] *= -1
-    x[y == 0.0] = np.inf
+    # NOTE(nabe): x[y == 0.0] = np.inf, x[np.isneginf(y)] = -np.inf are necessary for the accurate
+    # computation, but we omit them as it is used only from the ppf function.
     return x
 
 

--- a/optuna/samplers/_tpe/probability_distributions.py
+++ b/optuna/samplers/_tpe/probability_distributions.py
@@ -68,8 +68,11 @@ class _MixtureOfProductDistribution(NamedTuple):
 
     def sample(self, rng: np.random.RandomState, batch_size: int) -> np.ndarray:
         active_indices = rng.choice(len(self.weights), p=self.weights, size=batch_size)
-
-        ret = np.empty((batch_size, len(self.distributions)), dtype=np.float64)
+        ret = np.empty((batch_size, len(self.distributions)), dtype=float)
+        disc_inds, numerical_inds = [], []
+        numerical_dists: list[
+            _BatchedTruncNormDistributions | _BatchedDiscreteTruncNormDistributions
+        ] = []
         for i, d in enumerate(self.distributions):
             if isinstance(d, _BatchedCategoricalDistributions):
                 active_weights = d.weights[active_indices, :]
@@ -77,33 +80,35 @@ class _MixtureOfProductDistribution(NamedTuple):
                 cum_probs = np.cumsum(active_weights, axis=-1)
                 assert np.isclose(cum_probs[:, -1], 1).all()
                 cum_probs[:, -1] = 1  # Avoid numerical errors.
-                ret[:, i] = np.sum(cum_probs < rnd_quantile[:, None], axis=-1)
+                ret[:, i] = np.sum(cum_probs < rnd_quantile[:, np.newaxis], axis=-1)
             elif isinstance(d, _BatchedTruncNormDistributions):
-                active_mus = d.mu[active_indices]
-                active_sigmas = d.sigma[active_indices]
-                ret[:, i] = _truncnorm.rvs(
-                    a=(d.low - active_mus) / active_sigmas,
-                    b=(d.high - active_mus) / active_sigmas,
-                    loc=active_mus,
-                    scale=active_sigmas,
-                    random_state=rng,
-                )
+                numerical_dists.append(d)
+                numerical_inds.append(i)
             elif isinstance(d, _BatchedDiscreteTruncNormDistributions):
-                active_mus = d.mu[active_indices]
-                active_sigmas = d.sigma[active_indices]
-                samples = _truncnorm.rvs(
-                    a=(d.low - d.step / 2 - active_mus) / active_sigmas,
-                    b=(d.high + d.step / 2 - active_mus) / active_sigmas,
-                    loc=active_mus,
-                    scale=active_sigmas,
-                    random_state=rng,
-                )
-                ret[:, i] = np.clip(
-                    d.low + np.round((samples - d.low) / d.step) * d.step, d.low, d.high
-                )
+                disc_inds.append(i)
+                numerical_dists.append(d)
+                numerical_inds.append(i)
             else:
                 assert False
 
+        active_mus = np.asarray([d.mu[active_indices] for d in numerical_dists])
+        active_sigmas = np.asarray([d.sigma[active_indices] for d in numerical_dists])
+        lows = np.array([d.low for d in numerical_dists])
+        highs = np.array([d.high for d in numerical_dists])
+        steps = np.array([getattr(d, "step", 0.0) for d in numerical_dists])
+        ret[:, numerical_inds] = _truncnorm.rvs(
+            a=((lows - steps / 2)[:, np.newaxis] - active_mus) / active_sigmas,
+            b=((highs + steps / 2)[:, np.newaxis] - active_mus) / active_sigmas,
+            loc=active_mus,
+            scale=active_sigmas,
+            random_state=rng,
+        ).T
+        lows_disc, steps_disc = lows[disc_inds], steps[disc_inds]
+        ret[:, disc_inds] = np.clip(
+            lows_disc + np.round((ret[:, disc_inds] - lows_disc) / steps_disc) * steps_disc,
+            lows_disc,
+            highs[disc_inds],
+        )
         return ret
 
     def log_pdf(self, x: np.ndarray) -> np.ndarray:

--- a/optuna/samplers/_tpe/probability_distributions.py
+++ b/optuna/samplers/_tpe/probability_distributions.py
@@ -59,7 +59,7 @@ def _log_gauss_mass_unique(a: np.ndarray, b: np.ndarray) -> np.ndarray:
     duplicated evaluations using the np.unique_inverse(...) equivalent operation.
     """
     a_uniq, b_uniq, inv = _unique_inverse_2d(a.ravel(), b.ravel())
-    return _truncnorm.log_gauss_mass(a_uniq, b_uniq)[inv].reshape(a.shape)
+    return _truncnorm._log_gauss_mass(a_uniq, b_uniq)[inv].reshape(a.shape)
 
 
 class _MixtureOfProductDistribution(NamedTuple):
@@ -133,7 +133,7 @@ class _MixtureOfProductDistribution(NamedTuple):
                     ((xi_uniq + d.step / 2)[:, np.newaxis] - mu_uniq) / sigma_uniq,
                 )[np.ix_(xi_inv, mu_sigma_inv)]
                 # Very unlikely to observe duplications below, so we skip the unique operation.
-                weighted_log_pdf -= _truncnorm.log_gauss_mass(
+                weighted_log_pdf -= _truncnorm._log_gauss_mass(
                     (d.low - d.step / 2 - mu_uniq) / sigma_uniq,
                     (d.high + d.step / 2 - mu_uniq) / sigma_uniq,
                 )[mu_sigma_inv]

--- a/optuna/samplers/_tpe/probability_distributions.py
+++ b/optuna/samplers/_tpe/probability_distributions.py
@@ -104,11 +104,10 @@ class _MixtureOfProductDistribution(NamedTuple):
                 scale=active_sigmas,
                 random_state=rng,
             ).T
-            lows_disc, steps_disc = lows[disc_inds], steps[disc_inds]
+            steps_not_0 = np.nonzero(steps != 0.0)[0]
+            low_d, step_d, high_d = lows[steps_not_0], steps[steps_not_0], highs[steps_not_0]
             ret[:, disc_inds] = np.clip(
-                lows_disc + np.round((ret[:, disc_inds] - lows_disc) / steps_disc) * steps_disc,
-                lows_disc,
-                highs[disc_inds],
+                low_d + np.round((ret[:, disc_inds] - low_d) / step_d) * step_d, low_d, high_d
             )
         return ret
 

--- a/tests/samplers_tests/tpe_tests/test_truncnorm.py
+++ b/tests/samplers_tests/tpe_tests/test_truncnorm.py
@@ -24,7 +24,7 @@ def test_ppf(a: float, b: float) -> None:
     for x in np.concatenate(
         [np.linspace(0, 1, num=100), np.array([sys.float_info.min, 1 - sys.float_info.epsilon])]
     ):
-        assert truncnorm_ours._ppf(x, a, b) == pytest.approx(
+        assert truncnorm_ours.ppf(x, a, b) == pytest.approx(
             truncnorm_scipy.ppf(x, a, b), nan_ok=True
         ), f"ppf(x={x}, a={a}, b={b})"
 

--- a/tests/samplers_tests/tpe_tests/test_truncnorm.py
+++ b/tests/samplers_tests/tpe_tests/test_truncnorm.py
@@ -1,4 +1,5 @@
-import math
+from __future__ import annotations
+
 import sys
 
 import numpy as np

--- a/tests/samplers_tests/tpe_tests/test_truncnorm.py
+++ b/tests/samplers_tests/tpe_tests/test_truncnorm.py
@@ -62,7 +62,7 @@ def test_log_gass_mass(a: float, b: float) -> None:
 @pytest.mark.skipif(
     not _imports.is_successful(), reason="Failed to import SciPy's internal function."
 )
-def test_ndtri_exp_single() -> None:
+def test_ndtri_exp() -> None:
     y = np.asarray([-sys.float_info.min] + [-(10**i) for i in range(-300, 10)])
     x = truncnorm_ours._ndtri_exp(y)
     ans = ndtri_exp_scipy(y)

--- a/tests/samplers_tests/tpe_tests/test_truncnorm.py
+++ b/tests/samplers_tests/tpe_tests/test_truncnorm.py
@@ -63,7 +63,7 @@ def test_log_gass_mass(a: float, b: float) -> None:
     not _imports.is_successful(), reason="Failed to import SciPy's internal function."
 )
 def test_ndtri_exp_single() -> None:
-    for y in [-sys.float_info.min] + [-(10**i) for i in range(-300, 10)]:
-        x = truncnorm_ours._ndtri_exp_single(y)
-        ans = ndtri_exp_scipy(y).item()
-        assert math.isclose(x, ans), f"Failed with y={y}."
+    y = np.asarray([-sys.float_info.min] + [-(10**i) for i in range(-300, 10)])
+    x = truncnorm_ours._ndtri_exp(y)
+    ans = ndtri_exp_scipy(y)
+    assert np.allclose(x, ans), f"Failed with {y[~np.isclose(x, ans)]}."

--- a/tests/samplers_tests/tpe_tests/test_truncnorm.py
+++ b/tests/samplers_tests/tpe_tests/test_truncnorm.py
@@ -37,12 +37,12 @@ def test_ppf(a: float, b: float) -> None:
 @pytest.mark.parametrize("loc", [-10, 0, 10])
 @pytest.mark.parametrize("scale", [0.1, 1, 10])
 def test_logpdf(a: float, b: float, loc: float, scale: float) -> None:
-    x = np.concatenate(
+    for x in np.concatenate(
         [np.linspace(np.max([a, -100]), np.min([b, 100]), num=1000), np.array([-2000.0, +2000.0])]
-    )
-    assert truncnorm_ours.logpdf(x, a, b, loc, scale) == pytest.approx(
-        truncnorm_scipy.logpdf(x, a, b, loc, scale), nan_ok=True
-    ), f"logpdf(x={x}, a={a}, b={b})"
+    ):
+        assert truncnorm_ours.logpdf(x, a, b, loc, scale) == pytest.approx(
+            truncnorm_scipy.logpdf(x, a, b, loc, scale), nan_ok=True
+        ), f"logpdf(x={x}, a={a}, b={b})"
 
 
 @pytest.mark.skipif(

--- a/tests/samplers_tests/tpe_tests/test_truncnorm.py
+++ b/tests/samplers_tests/tpe_tests/test_truncnorm.py
@@ -55,7 +55,7 @@ def test_logpdf(a: float, b: float, loc: float, scale: float) -> None:
 )
 def test_log_gass_mass(a: float, b: float) -> None:
     a_arr, b_arr = np.array([a]), np.array([b])
-    assert truncnorm_ours.log_gauss_mass(a_arr, b_arr) == pytest.approx(
+    assert truncnorm_ours._log_gauss_mass(a_arr, b_arr) == pytest.approx(
         _log_gauss_mass_scipy(a_arr, b_arr), nan_ok=True
     ), f"_log_gauss_mass(a={a}, b={b})"
 

--- a/tests/samplers_tests/tpe_tests/test_truncnorm.py
+++ b/tests/samplers_tests/tpe_tests/test_truncnorm.py
@@ -24,7 +24,7 @@ def test_ppf(a: float, b: float) -> None:
     for x in np.concatenate(
         [np.linspace(0, 1, num=100), np.array([sys.float_info.min, 1 - sys.float_info.epsilon])]
     ):
-        assert truncnorm_ours.ppf(x, a, b) == pytest.approx(
+        assert truncnorm_ours._ppf(x, a, b) == pytest.approx(
             truncnorm_scipy.ppf(x, a, b), nan_ok=True
         ), f"ppf(x={x}, a={a}, b={b})"
 
@@ -37,12 +37,12 @@ def test_ppf(a: float, b: float) -> None:
 @pytest.mark.parametrize("loc", [-10, 0, 10])
 @pytest.mark.parametrize("scale", [0.1, 1, 10])
 def test_logpdf(a: float, b: float, loc: float, scale: float) -> None:
-    for x in np.concatenate(
+    x = np.concatenate(
         [np.linspace(np.max([a, -100]), np.min([b, 100]), num=1000), np.array([-2000.0, +2000.0])]
-    ):
-        assert truncnorm_ours.logpdf(x, a, b, loc, scale) == pytest.approx(
-            truncnorm_scipy.logpdf(x, a, b, loc, scale), nan_ok=True
-        ), f"logpdf(x={x}, a={a}, b={b})"
+    )
+    assert truncnorm_ours.logpdf(x, a, b, loc, scale) == pytest.approx(
+        truncnorm_scipy.logpdf(x, a, b, loc, scale), nan_ok=True
+    ), f"logpdf(x={x}, a={a}, b={b})"
 
 
 @pytest.mark.skipif(
@@ -55,7 +55,7 @@ def test_logpdf(a: float, b: float, loc: float, scale: float) -> None:
 )
 def test_log_gass_mass(a: float, b: float) -> None:
     a_arr, b_arr = np.array([a]), np.array([b])
-    assert truncnorm_ours._log_gauss_mass(a_arr, b_arr) == pytest.approx(
+    assert truncnorm_ours.log_gauss_mass(a_arr, b_arr) == pytest.approx(
         _log_gauss_mass_scipy(a_arr, b_arr), nan_ok=True
     ), f"_log_gauss_mass(a={a}, b={b})"
 


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

This PR vectorizes `ndtri_exp` for the future speedup.
In principle, we can further speed up `TPESampler` by vectorizing `_truncnorm.rvs`.
To do so, we need to vectorize `ndtri_exp`.
Another change includes the enhancement in the numerical stability for a large `y`.

## Description of the changes
<!-- Describe the changes in this PR. -->

- Replace `math` with `numpy` in `ndtri_exp`
- Calculate `-x` first if `x` is positive, and then flip the sign later 
