### PR TITLE
Replace `torch.newaxis` with `None` for old PyTorch

### DIFF
--- a/optuna/_gp/acqf.py
+++ b/optuna/_gp/acqf.py
@@ -51,7 +51,7 @@ def logehvi(
     _EPS = torch.tensor(1e-12, dtype=torch.float64)  # NOTE(nabenabe): grad becomes nan when EPS=0.
     diff = torch.maximum(
         _EPS,
-        torch.minimum(Y_post[..., torch.newaxis, :], non_dominated_box_upper_bounds)
+        torch.minimum(Y_post[..., None, :], non_dominated_box_upper_bounds)
         - non_dominated_box_lower_bounds,
     )
     # NOTE(nabenabe): logsumexp with dim=-1 is for the HVI calculation and that with dim=-2 is for
@@ -262,12 +262,12 @@ class LogEHVI(BaseAcquisitionFunc):
             # Sobol is better than the standard Monte-Carlo w.r.t. the approximation stability.
             # cf. Appendix D of https://arxiv.org/pdf/2006.05078
             Y_post.append(
-                mean[..., torch.newaxis] + stdev[..., torch.newaxis] * self._fixed_samples[..., i]
+                mean[..., None] + stdev[..., None] * self._fixed_samples[..., i]
             )
 
         # NOTE(nabenabe): Use the following once multi-task GP is supported.
         # L = torch.linalg.cholesky(cov)
-        # Y_post = means[..., torch.newaxis, :] + torch.einsum("...MM,SM->...SM", L, fixed_samples)
+        # Y_post = means[..., None, :] + torch.einsum("...MM,SM->...SM", L, fixed_samples)
         return logehvi(
             Y_post=torch.stack(Y_post, dim=-1),
             non_dominated_box_lower_bounds=self._non_dominated_box_lower_bounds,

--- a/optuna/_gp/acqf.py
+++ b/optuna/_gp/acqf.py
@@ -261,9 +261,7 @@ class LogEHVI(BaseAcquisitionFunc):
             # deterministic, making it possible to optimize the acqf by l-BFGS.
             # Sobol is better than the standard Monte-Carlo w.r.t. the approximation stability.
             # cf. Appendix D of https://arxiv.org/pdf/2006.05078
-            Y_post.append(
-                mean[..., None] + stdev[..., None] * self._fixed_samples[..., i]
-            )
+            Y_post.append(mean[..., None] + stdev[..., None] * self._fixed_samples[..., i])
 
         # NOTE(nabenabe): Use the following once multi-task GP is supported.
         # L = torch.linalg.cholesky(cov)


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. To minimize the review effort, we highly appreciate PRs only with related changes. Please note that submitted PRs may be closed if they include unrelated changes or significantly modified unit tests. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

Since `torch.newaxis` is supported only after `torch>=2.4.0`, I will replace `torch.newaxis` with `None`.

## Description of the changes
<!-- Describe the changes in this PR. -->

- Replace `torch.newaxis` with `None