### PR TITLE
test(test_brute_force): Fix fragile test_parallel_optimize_with_sleep

### DIFF
--- a/tests/samplers_tests/test_brute_force.py
+++ b/tests/samplers_tests/test_brute_force.py
@@ -326,7 +326,8 @@ def test_not_avoid_premature_stop() -> None:
         #   trials[1]: x = 1         # Running
         #   trials[2]: x = 0, y = 0  # Running
         #
-        # Assume that all possible combinations of x and y have been exhausted.
+        # Since the sampler assumes that running trials already suggest all parameters, the sampler
+        # considers all possible combinations of x and y have been exhausted.
         study.tell(trials[1], 0.0)
         study.tell(trials[2], 0.0)
         assert mock_stop.call_count == 2
@@ -356,8 +357,9 @@ def test_avoid_premature_stop() -> None:
         #   trials[1]: x = 1         # Running
         #   trials[2]: x = 0, y = 0  # Running
         #
-        # If `avoid_premature_stop` is set to `True`, the sampler should not stop,
-        # because BruteForceSampler assumes that `y` for trials[1] has not been suggested yet
+        # If `avoid_premature_stop` is `True`, the sampler assumes that running trials may still
+        # suggest new parameters, considering the possibility for trials[1] to suggest `y`.
+        # So the sampler should not stop.
         study.tell(trials[2], 0.0)
         mock_stop.assert_not_called()
 
@@ -387,6 +389,6 @@ def test_avoid_premature_stop() -> None:
         #   trials[2]: x = 0, y = 0  # Completed
         #   trials[3]: x = 1, y = 1  # Running
         #
-        # Assume that all possible combinations of x and y have been exhausted.
+        # All possible combinations of x and y have been exhausted.
         study.tell(trials[3], 0.0)
         mock_stop.assert_called_once()


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. To minimize the review effort, we highly appreciate PRs only with related changes. Please note that submitted PRs may be closed if they include unrelated changes or significantly modified unit tests. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

Fix #6206.
Related to #6217, #6209.

`test_parallel_optimize_with_sleep` is supposed to test `avoid_premature_stop`. Instead of using sleep to test this behavior, which is potentially fragile, I used the ask-and-tell API instead.

## Description of the changes
<!-- Describe the changes in this PR. -->
- Add `test_avoid_premature_stop/test_not_avoid_premature_stop` instead of `test_parallel_optimize_with_sleep`.