### PR TITLE
Move `fit_kernel_params` to `GPRegressor`

### DIFF
--- a/optuna/_gp/gp.py
+++ b/optuna/_gp/gp.py
@@ -287,6 +287,7 @@ def fit_kernel_params(
     gtol: float = 1e-2,
 ) -> GPRegressor:
     default_kernel_params = torch.ones(X.shape[1] + 2, dtype=torch.float64)
+    # TODO: Move this function into a method of `GPRegressor`
 
     def _default_gpr() -> GPRegressor:
         return GPRegressor(

--- a/optuna/_gp/gp.py
+++ b/optuna/_gp/gp.py
@@ -117,7 +117,7 @@ class GPRegressor:
     def _cache_matrix(self) -> None:
         assert (
             self._cov_Y_Y_inv is None and self._cov_Y_Y_inv_Y is None
-        ), "Cannot cache_matrix more than once."
+        ), "Cannot call cache_matrix more than once."
         with torch.no_grad():
             cov_Y_Y = self.kernel(self._X_train, self._X_train).detach().numpy()
 

--- a/optuna/_gp/gp.py
+++ b/optuna/_gp/gp.py
@@ -127,6 +127,12 @@ class GPRegressor:
         # NOTE(nabenabe): Here we use NumPy to guarantee the reproducibility from the past.
         self._cov_Y_Y_inv = torch.from_numpy(cov_Y_Y_inv)
         self._cov_Y_Y_inv_Y = torch.from_numpy(cov_Y_Y_inv_Y)
+        self.inverse_squared_lengthscales = self.inverse_squared_lengthscales.detach()
+        self.inverse_squared_lengthscales.grad = None
+        self.kernel_scale = self.kernel_scale.detach()
+        self.kernel_scale.grad = None
+        self.noise_var = self.noise_var.detach()
+        self.noise_var.grad = None
 
     def kernel(self, X1: torch.Tensor, X2: torch.Tensor) -> torch.Tensor:
         """

--- a/optuna/_gp/gp.py
+++ b/optuna/_gp/gp.py
@@ -215,7 +215,7 @@ class GPRegressor:
         minimum_noise: float,
         deterministic_objective: bool,
         gtol: float,
-    ) -> GPRegressor:
+    ) -> Self:
         n_params = self._X_train.shape[1]
 
         # We apply log transform to enforce the positivity of the kernel parameters.

--- a/optuna/_gp/gp.py
+++ b/optuna/_gp/gp.py
@@ -215,7 +215,7 @@ class GPRegressor:
         minimum_noise: float,
         deterministic_objective: bool,
         gtol: float,
-    ) -> Self:
+    ) -> GPRegressor:
         n_params = self._X_train.shape[1]
 
         # We apply log transform to enforce the positivity of the kernel parameters.

--- a/tests/gp_tests/test_gp.py
+++ b/tests/gp_tests/test_gp.py
@@ -4,7 +4,6 @@ import numpy as np
 import pytest
 import torch
 
-from optuna._gp.gp import _fit_kernel_params
 from optuna._gp.gp import GPRegressor
 from optuna._gp.gp import warn_and_convert_inf
 import optuna._gp.prior as prior
@@ -85,29 +84,23 @@ def test_fit_kernel_params(
     with torch.set_grad_enabled(torch_set_grad_enabled):
         log_prior = prior.default_log_prior
         minimum_noise = prior.DEFAULT_MINIMUM_NOISE_VAR
-        initial_gpr = GPRegressor(
+        gtol: float = 1e-2
+        gpr = GPRegressor(
             X_train=torch.from_numpy(X),
             y_train=torch.from_numpy(Y),
             is_categorical=torch.from_numpy(is_categorical),
             inverse_squared_lengthscales=torch.ones(X.shape[1], dtype=torch.float64),
             kernel_scale=torch.tensor(1.0, dtype=torch.float64),
             noise_var=torch.tensor(1.0, dtype=torch.float64),
-        )
-        gtol: float = 1e-2
-
-        gpr = _fit_kernel_params(
-            X=X,
-            Y=Y,
-            is_categorical=is_categorical,
+        )._fit_kernel_params(
             log_prior=log_prior,
             minimum_noise=minimum_noise,
-            gpr_cache=initial_gpr,
             deterministic_objective=deterministic_objective,
             gtol=gtol,
         )
 
         assert (
-            (gpr.inverse_squared_lengthscales != initial_gpr.inverse_squared_lengthscales).sum()
-            + (gpr.kernel_scale != initial_gpr.kernel_scale).sum()
-            + (gpr.noise_var != initial_gpr.noise_var).sum()
+            (gpr.inverse_squared_lengthscales != 1.0).sum()
+            + (gpr.kernel_scale != 1.0).sum()
+            + (gpr.noise_var != 1.0).sum()
         )


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. To minimize the review effort, we highly appreciate PRs only with related changes. Please note that submitted PRs may be closed if they include unrelated changes or significantly modified unit tests. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

This PR is necessary to cache the pair-wise distances of `X_train`, which speeds up `GPSampler`, done in:
- https://github.com/optuna/optuna/pull/6244


## Description of the changes
<!-- Describe the changes in this PR. -->

- Move `fit_kernel_params` to `GPRegressor`
