### PR TITLE
Cache pair-wise distances to speed up `GPSampler`

### DIFF
--- a/optuna/_gp/gp.py
+++ b/optuna/_gp/gp.py
@@ -103,6 +103,10 @@ class GPRegressor:
         self._is_categorical = is_categorical
         self._X_train = X_train
         self._y_train = y_train
+        self._squared_X_diff = (X_train[..., None, :] - X_train[..., None, :, :]).square()
+        self._squared_X_diff[..., self._is_categorical] = (
+            self._squared_X_diff[..., self._is_categorical] > 0.0
+        ).type(torch.float64)
         self._cov_Y_Y_inv: torch.Tensor | None = None
         self._cov_Y_Y_inv_Y: torch.Tensor | None = None
         # TODO(nabenabe): Rename the attributes to private with `_`.
@@ -119,7 +123,7 @@ class GPRegressor:
             self._cov_Y_Y_inv is None and self._cov_Y_Y_inv_Y is None
         ), "Cannot call cache_matrix more than once."
         with torch.no_grad():
-            cov_Y_Y = self.kernel(self._X_train, self._X_train).detach().numpy()
+            cov_Y_Y = self.kernel().detach().numpy()
 
         cov_Y_Y[np.diag_indices(self._X_train.shape[0])] += self.noise_var.item()
         cov_Y_Y_inv = np.linalg.inv(cov_Y_Y)
@@ -134,7 +138,7 @@ class GPRegressor:
         self.noise_var = self.noise_var.detach()
         self.noise_var.grad = None
 
-    def kernel(self, X1: torch.Tensor, X2: torch.Tensor) -> torch.Tensor:
+    def kernel(self, X: torch.Tensor | None = None) -> torch.Tensor:
         """
         Return the kernel matrix with the shape of (..., n_A, n_B) given X1 and X2 each with the
         shapes of (..., n_A, len(params)) and (..., n_B, len(params)).
@@ -147,8 +151,14 @@ class GPRegressor:
         categorical, d2(x1, x2)[i] = int(x1[i] != x2[i]).
         Note that the distance for categorical parameters is the Hamming distance.
         """
-        d2 = (X1[..., :, None, :] - X2[..., None, :, :]) ** 2
-        d2[..., self._is_categorical] = (d2[..., self._is_categorical] > 0.0).type(torch.float64)
+        if X is None:
+            d2 = self._squared_X_diff
+        else:
+            d2 = (X[..., None, :] - self._X_train[..., None, :, :]) ** 2
+            if self._is_categorical.any():
+                d2[..., self._is_categorical] = (d2[..., self._is_categorical] > 0.0).type(
+                    torch.float64
+                )
         d2 = (d2 * self.inverse_squared_lengthscales).sum(dim=-1)
         return Matern52Kernel.apply(d2) * self.kernel_scale  # type: ignore
 
@@ -166,7 +176,7 @@ class GPRegressor:
         assert (
             self._cov_Y_Y_inv is not None and self._cov_Y_Y_inv_Y is not None
         ), "Call cache_matrix before calling posterior."
-        cov_fx_fX = self.kernel(x[..., None, :], self._X_train)[..., 0, :]
+        cov_fx_fX = self.kernel(x[..., None, :])[..., 0, :]
         cov_fx_fx = self.kernel_scale  # kernel(x, x) = kernel_scale
         mean = cov_fx_fX @ self._cov_Y_Y_inv_Y
         var = cov_fx_fx - (cov_fx_fX * (cov_fx_fX @ self._cov_Y_Y_inv)).sum(dim=-1)
@@ -200,7 +210,7 @@ class GPRegressor:
         """
         n_points = self._X_train.shape[0]
         const = -0.5 * n_points * math.log(2 * math.pi)
-        cov_Y_Y = self.kernel(self._X_train, self._X_train) + self.noise_var * torch.eye(
+        cov_Y_Y = self.kernel() + self.noise_var * torch.eye(
             n_points, dtype=torch.float64
         )
         L = torch.linalg.cholesky(cov_Y_Y)

--- a/optuna/_gp/gp.py
+++ b/optuna/_gp/gp.py
@@ -104,9 +104,10 @@ class GPRegressor:
         self._X_train = X_train
         self._y_train = y_train
         self._squared_X_diff = (X_train[..., None, :] - X_train[..., None, :, :]).square()
-        self._squared_X_diff[..., self._is_categorical] = (
-            self._squared_X_diff[..., self._is_categorical] > 0.0
-        ).type(torch.float64)
+        if self._is_categorical.any():
+            self._squared_X_diff[..., self._is_categorical] = (
+                self._squared_X_diff[..., self._is_categorical] > 0.0
+            ).type(torch.float64)
         self._cov_Y_Y_inv: torch.Tensor | None = None
         self._cov_Y_Y_inv_Y: torch.Tensor | None = None
         # TODO(nabenabe): Rename the attributes to private with `_`.

--- a/optuna/_gp/gp.py
+++ b/optuna/_gp/gp.py
@@ -159,7 +159,8 @@ class GPRegressor:
         else:
             if X2 is None:
                 X2 = self._X_train
-            d2 = (X1[..., None, :] - X2[..., None, :, :]) ** 2
+
+            d2 = (X1 - X2) ** 2 if X1.ndim == 1 else (X1[..., None, :] - X2[..., None, :, :]) ** 2
             if self._is_categorical.any():
                 d2[..., self._is_categorical] = (d2[..., self._is_categorical] > 0.0).type(
                     torch.float64

--- a/optuna/_gp/gp.py
+++ b/optuna/_gp/gp.py
@@ -181,7 +181,7 @@ class GPRegressor:
         assert (
             self._cov_Y_Y_inv is not None and self._cov_Y_Y_inv_Y is not None
         ), "Call cache_matrix before calling posterior."
-        cov_fx_fX = self.kernel(x[..., None, :])[..., 0, :]
+        cov_fx_fX = self.kernel(x)
         cov_fx_fx = self.kernel_scale  # kernel(x, x) = kernel_scale
         mean = cov_fx_fX @ self._cov_Y_Y_inv_Y
         var = cov_fx_fx - (cov_fx_fX * (cov_fx_fX @ self._cov_Y_Y_inv)).sum(dim=-1)


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. To minimize the review effort, we highly appreciate PRs only with related changes. Please note that submitted PRs may be closed if they include unrelated changes or significantly modified unit tests. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

This PR speeds up `GPSampler` by skipping the pair-wise distance calculations in the kernel parameter fitting.
Please note that this PR depends on:
- https://github.com/optuna/optuna/pull/6243

> [!IMPORTANT]
> 7% speedup by this PR (240 sec to 223 sec) in the benchmark below :tada: 

## Description of the changes
<!-- Describe the changes in this PR. -->

- Cache the pair-wise distances

```python
import optuna


def objective(trial: optuna.Trial) -> float:
    return sum(trial.suggest_float(f"x{i}", -5, 5)**2 for i in range(5))


sampler = optuna.samplers.GPSampler(seed=0)
study = optuna.create_study(sampler=sampler)
study.optimize(objective, n_trials=300)
print((study.trials[-1].datetime_complete - study.trials[0].datetime_start).total_seconds())
```
