### PR TITLE
Add hypervolume computation for a zero size array

### DIFF
--- a/optuna/_hypervolume/wfg.py
+++ b/optuna/_hypervolume/wfg.py
@@ -147,6 +147,8 @@ def compute_hypervolume(
     if not np.all(np.isfinite(reference_point)):
         # reference_point does not have nan, thanks to the verification above.
         return float("inf")
+    if len(loss_vals) == 0.0:
+        return 0.0
 
     if not assume_pareto:
         unique_lexsorted_loss_vals = np.unique(loss_vals, axis=0)

--- a/optuna/_hypervolume/wfg.py
+++ b/optuna/_hypervolume/wfg.py
@@ -147,7 +147,7 @@ def compute_hypervolume(
     if not np.all(np.isfinite(reference_point)):
         # reference_point does not have nan, thanks to the verification above.
         return float("inf")
-    if len(loss_vals) == 0:
+    if loss_vals.size == 0:
         return 0.0
 
     if not assume_pareto:

--- a/optuna/_hypervolume/wfg.py
+++ b/optuna/_hypervolume/wfg.py
@@ -147,7 +147,7 @@ def compute_hypervolume(
     if not np.all(np.isfinite(reference_point)):
         # reference_point does not have nan, thanks to the verification above.
         return float("inf")
-    if len(loss_vals) == 0.0:
+    if len(loss_vals) == 0:
         return 0.0
 
     if not assume_pareto:

--- a/tests/hypervolume_tests/test_wfg.py
+++ b/tests/hypervolume_tests/test_wfg.py
@@ -101,3 +101,9 @@ def test_invalid_input() -> None:
     s = np.atleast_2d(2 * np.ones(3))
     with pytest.raises(ValueError):
         _ = optuna._hypervolume.compute_hypervolume(s, r)
+
+
+@pytest.mark.parametrize("n_objectives", [2, 3, 4, 5])
+def test_empty_hypervolume(n_objectives: int) -> None:
+    s = np.empty((0, n_objectives), dtype=float)
+    assert optuna._hypervolume.compute_hypervolume(s, np.ones(n_objectives, dtype=float)) == 0.0


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. To minimize the review effort, we highly appreciate PRs only with related changes. Please note that submitted PRs may be closed if they include unrelated changes or significantly modified unit tests. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

This PR fixes a bug when there exists only one Pareto solution at `n_trials=10`.
By adding a handling for a zero size array, this issue goes away. 

## Description of the changes
<!-- Describe the changes in this PR. -->

- Add a handling for a zero size array.