### PR TITLE
Skip trial validation on copy_study

### DIFF
--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -1571,7 +1571,14 @@ def copy_study(
         to_study.set_user_attr(key, value)
 
     # Trials are deep copied on `add_trials`.
-    to_study.add_trials(from_study.get_trials(deepcopy=False))
+    for trial in from_study.get_trials(deepcopy=False):
+        if trial.values is not None and len(to_study.directions) != len(trial.values):
+            raise ValueError(
+                f"The added trial has {len(trial.values)} values, which is different from the "
+                f"number of objectives {len(to_study.directions)} in the study (determined by "
+                "Study.directions)."
+            )
+        to_study._storage.create_new_trial(to_study._study_id, template_trial=trial)
 
 
 def get_all_study_summaries(


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. To minimize the review effort, we highly appreciate PRs only with related changes. Please note that submitted PRs may be closed if they include unrelated changes or significantly modified unit tests. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation for submitting this PR. This is useful for reviewers to understand the context of the PR. -->
Fix #6163.

As mentioned in #6163, `copy_study` does not allow `enqueued_trial`s whose parameters are out of the distribution range. This is because `copy_study` internally calls `trial._validate` on every trial.

In `copy_study`, we can assume that the trials in the study are valid (unless the user has modified the database or storage directly). Therefore, I believe that simply skipping the validation is the best solution.

## Description of the changes
<!-- Describe the changes in this PR. -->
- Modified `copy_study` to skip trial validation.
