### PR TITLE
Include legend within image bounds for optimization history plot

### DIFF
--- a/docs/visualization_matplotlib_examples/optuna.visualization.matplotlib.optimization_history.py
+++ b/docs/visualization_matplotlib_examples/optuna.visualization.matplotlib.optimization_history.py
@@ -24,4 +24,3 @@ study = optuna.create_study(sampler=sampler)
 study.optimize(objective, n_trials=10)
 
 optuna.visualization.matplotlib.plot_optimization_history(study)
-plt.tight_layout()

--- a/docs/visualization_matplotlib_examples/optuna.visualization.matplotlib.optimization_history.py
+++ b/docs/visualization_matplotlib_examples/optuna.visualization.matplotlib.optimization_history.py
@@ -10,8 +10,6 @@ The following code snippet shows how to plot optimization history.
 """
 
 import optuna
-import matplotlib.pyplot as plt
-
 
 def objective(trial):
     x = trial.suggest_float("x", -100, 100)

--- a/optuna/visualization/matplotlib/_optimization_history.py
+++ b/optuna/visualization/matplotlib/_optimization_history.py
@@ -72,7 +72,7 @@ def _get_optimization_history_plot(
 ) -> "Axes":
     # Set up the graph style.
     plt.style.use("ggplot")  # Use ggplot style sheet for similar outputs to plotly.
-    _, ax = plt.subplots()
+    _, ax = plt.subplots(tight_layout=True)
     ax.set_title("Optimization History Plot")
     ax.set_xlabel("Trial")
     ax.set_ylabel(target_name)

--- a/optuna/visualization/matplotlib/_optimization_history.py
+++ b/optuna/visualization/matplotlib/_optimization_history.py
@@ -35,10 +35,6 @@ def plot_optimization_history(
     .. seealso::
         Please refer to :func:`optuna.visualization.plot_optimization_history` for an example.
 
-    .. note::
-        You need to adjust the size of the plot by yourself using ``plt.tight_layout()`` or
-        ``plt.savefig(IMAGE_NAME, bbox_inches='tight')``.
-
     Args:
         study:
             A :class:`~optuna.study.Study` object whose trials are plotted for their target values.


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. To minimize the review effort, we highly appreciate PRs only with related changes. Please note that submitted PRs may be closed if they include unrelated changes or significantly modified unit tests. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
Legend gets cut off when using `optuna.visualization.matplotlib.plot_optimization_history`.

## Description of the changes
<!-- Describe the changes in this PR. -->
The issue was that the legend fell outside the figure boundaries. I fixed this by adding `tight_layout=True`.
This doesn't appear to exist in other plot functions.
I also edited docs related to the change.
