### PR TITLE
Move SciPy to the lazy import section in `_gp/scipy_blas_thread_patch.py`

### DIFF
--- a/optuna/_gp/scipy_blas_thread_patch.py
+++ b/optuna/_gp/scipy_blas_thread_patch.py
@@ -5,11 +5,16 @@ import os
 from typing import TYPE_CHECKING
 
 from packaging.version import Version
-import scipy
 
 
 if TYPE_CHECKING:
     from typing import Generator
+
+    import scipy
+else:
+    from optuna import _LazyImport
+
+    scipy = _LazyImport("scipy")
 
 
 @contextmanager


### PR DESCRIPTION
Import handling improvements:

## Motivation
This pull request refactors the import logic for `scipy` in `optuna/_gp/scipy_blas_thread_patch.py` to improve performance and avoid unnecessary imports. Instead of always importing `scipy`, it now uses a lazy import mechanism unless type checking is active.


## Description of the changes
* Replaced the unconditional import of `scipy` with a conditional lazy import using `_LazyImport`, which helps defer loading `scipy` until it is actually needed.
