### PR TITLE
Use cached study direction and trial for `_CachedStorage`'s `get_best_trial`

### DIFF
--- a/optuna/storages/_cached_storage.py
+++ b/optuna/storages/_cached_storage.py
@@ -177,7 +177,14 @@ class _CachedStorage(BaseStorage, BaseHeartbeat):
         return self._backend.get_trial_id_from_study_id_trial_number(study_id, trial_number)
 
     def get_best_trial(self, study_id: int) -> FrozenTrial:
-        return self._backend.get_best_trial(study_id)
+        _directions = self.get_study_directions(study_id)
+        if len(_directions) > 1:
+            raise RuntimeError(
+                "Best trial can be obtained only for single-objective optimization."
+            )
+        direction = _directions[0]
+        trial_id = self._backend._get_best_trial_id(study_id, direction)
+        return self.get_trial(trial_id)
 
     def set_trial_state_values(
         self, trial_id: int, state: TrialState, values: Sequence[float] | None = None


### PR DESCRIPTION
## Motivation
Currently,  `_CachedStorage`'s `get_best_trial` just calls the method of the backend storage (`RDBStorage`). However, performance can be improved by using cached study directions and trials.

## Description of the changes
- Introduce `_get_best_trial_id` in `RDBStorage`
- Use cached study direction and trial for `_CachedStorage`'s `get_best_trial`

## Benchmark

```python
import optuna

def objective(trial: optuna.Trial) -> float:
    x = trial.suggest_float("x", -100, 100)
    y = trial.suggest_int("y", -100, 100)
    return x**2 + y**2

sampler = optuna.samplers.TPESampler(seed=42, multivariate=True, constant_liar=True)
study = optuna.create_study(sampler=sampler, storage="sqlite:///tmp.db")
study.optimize(objective, n_trials=1000)

```

| master | PR |
| - | - |
| 10.02s | 9.00s |