### PR TITLE
Fix type checking in optuna.study._frozen.py

### DIFF
--- a/optuna/study/_frozen.py
+++ b/optuna/study/_frozen.py
@@ -1,10 +1,15 @@
 from __future__ import annotations
 
-from collections.abc import Sequence
 from typing import Any
+from typing import TYPE_CHECKING
 
 from optuna import logging
-from optuna.study._study_direction import StudyDirection
+
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from optuna.study._study_direction import StudyDirection
 
 
 _logger = logging.get_logger(__name__)


### PR DESCRIPTION
## Motivation
Fixing the type checking of the optuna/study/_frozen.py as requested in  #6029 

## Description of the changes
Moved the needed imports to a TYPE_CHECKING block.

I ran the the flake8 command to check if the file doesn't have the type checking problem warning.
