### PR TITLE
Move typing-only imports under `TYPE_CHECKING` in `optuna.importance.__init__`

### DIFF
--- a/optuna/importance/__init__.py
+++ b/optuna/importance/__init__.py
@@ -1,15 +1,19 @@
 from __future__ import annotations
 
-from collections.abc import Callable
+from typing import TYPE_CHECKING
 
 from optuna._experimental import warn_experimental_argument
 from optuna.importance._base import BaseImportanceEvaluator
 from optuna.importance._fanova import FanovaImportanceEvaluator
 from optuna.importance._mean_decrease_impurity import MeanDecreaseImpurityImportanceEvaluator
 from optuna.importance._ped_anova import PedAnovaImportanceEvaluator
-from optuna.study import Study
-from optuna.trial import FrozenTrial
 
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from optuna.study import Study
+    from optuna.trial import FrozenTrial
 
 __all__ = [
     "BaseImportanceEvaluator",


### PR DESCRIPTION
**Description**
This PR improves type checking in the `optuna.importance` module by moving imports that are only used for typing under a `TYPE_CHECKING` guard.

**Motivation**

* Reduces unnecessary runtime imports.
* Ensures cleaner separation between runtime and type-only dependencies.
* Aligns with Optuna’s type-checking conventions (see #6029).

**Changes**

* Updated `optuna/importance/__init__.py` so that `Callable`, `Study`, and `FrozenTrial` are imported only when `TYPE_CHECKING` is enabled.

**Notes**

* No runtime behaviour changes observed.
* Verified with `mypy`, 'flake8' and `pytest` -- all checks pass locally for the change. 