### PR TITLE
Move typing-only imports under TYPE_CHECKING in `FanovaImportanceEvaluator`

### DIFF
--- a/optuna/importance/_fanova/_evaluator.py
+++ b/optuna/importance/_fanova/_evaluator.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Callable
+from typing import TYPE_CHECKING
 
 import numpy as np
 
@@ -13,8 +13,13 @@ from optuna.importance._base import _param_importances_to_dict
 from optuna.importance._base import _sort_dict_by_importance
 from optuna.importance._base import BaseImportanceEvaluator
 from optuna.importance._fanova._fanova import _Fanova
-from optuna.study import Study
-from optuna.trial import FrozenTrial
+
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from optuna.study import Study
+    from optuna.trial import FrozenTrial
 
 
 class FanovaImportanceEvaluator(BaseImportanceEvaluator):


### PR DESCRIPTION
## Motivation
This PR continues the type checking improvements tracked in #6029 for `optuna/importance/_fanova/_evaluator.py`.

## Changes
- Moved `Callable` import under `TYPE_CHECKING` in `optuna/importance/_fanova/_evaluator.py`.
- Ensures runtime dependencies remain minimal while keeping type hints correct.

## Notes
- Verified with `mypye`, `flake8` and `pytest` locally -- no issues. All tests pass.