### PR TITLE
Limit the blackdoc version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ benchmark = [
 ]
 checking = [
   "black<25.9.0",  # TODO(nabe): Remove the version constraint after the fix in black.
-  "blackdoc",
+  "blackdoc<0.4.2",  # TODO(not522): Remove the version constraint after the fix in blackdoc.
   "flake8",
   "isort",
   "mypy",


### PR DESCRIPTION
## Motivation
blackdoc versions from v0.4.2 onward are broken, so setting a version upper limit.

## Description of the changes
Limit the blackdoc version to less than 0.4.2.