### PR TITLE
Migrate `.coveragerc` to `pyproject.toml`

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -69,7 +69,7 @@ jobs:
       env:
         OMP_NUM_THREADS: 1
         PYTHONPATH: .  # To invoke sitecutomize.py
-        COVERAGE_PROCESS_START: .coveragerc  # https://coverage.readthedocs.io/en/6.4.1/subprocess.html
+        COVERAGE_PROCESS_START: pyproject.toml  # https://coverage.readthedocs.io/en/6.4.1/subprocess.html
         COVERAGE_COVERAGE: yes  # https://github.com/nedbat/coveragepy/blob/65bf33fc03209ffb01bbbc0d900017614645ee7a/coverage/control.py#L255-L261
       run: |
         coverage run --source=optuna -m pytest tests -m "not skip_coverage and not slow" -n 8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,6 +6,7 @@ default_language_version:
   python: python3
 
 repos:
+  # Args are based on setup.cfg.
   - repo: https://github.com/psf/black
     rev: 25.1.0
     hooks:
@@ -15,7 +16,11 @@ repos:
     hooks:
       - id: flake8
         exclude: tutorial|docs/visualization_examples|docs/visualization_matplotlib_examples|optuna/storages/_grpc/auto_generated
-
+        args: [
+            "--max-line-length=99",
+            "--ignore=E203,E704,W503",
+            "--statistics",
+        ]
   - repo: https://github.com/pycqa/isort
     rev: 6.0.1
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,6 @@ default_language_version:
   python: python3
 
 repos:
-  # Args are based on setup.cfg.
   - repo: https://github.com/psf/black
     rev: 25.1.0
     hooks:
@@ -16,11 +15,7 @@ repos:
     hooks:
       - id: flake8
         exclude: tutorial|docs/visualization_examples|docs/visualization_matplotlib_examples|optuna/storages/_grpc/auto_generated
-        args: [
-            "--max-line-length=99",
-            "--ignore=E203,E704,W503",
-            "--statistics",
-        ]
+
   - repo: https://github.com/pycqa/isort
     rev: 6.0.1
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -170,8 +170,8 @@ force_sort_within_sections = 'True'
 order_by_type = 'False'
 
 [tool.flake8]
-ignore = ["E203", "E704", "W503"]
 max-line-length = 99
+ignore = ["E203", "E704", "W503"]
 statistics = true
 exclude = [
     "tutorial",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -169,17 +169,6 @@ force_single_line = 'True'
 force_sort_within_sections = 'True'
 order_by_type = 'False'
 
-[tool.flake8]
-max-line-length = 99
-ignore = ["E203", "E704", "W503"]
-statistics = true
-exclude = [
-    "tutorial",
-    "docs/visualization_examples",
-    "docs/visualization_matplotlib_examples",
-    "optuna/storages/_grpc/auto_generated"
-]
-
 [tool.pytest.ini_options]
 addopts = "--color=yes"
 filterwarnings = 'ignore::optuna.exceptions.ExperimentalWarning'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -169,6 +169,17 @@ force_single_line = 'True'
 force_sort_within_sections = 'True'
 order_by_type = 'False'
 
+[tool.flake8]
+ignore = ["E203", "E704", "W503"]
+max-line-length = 99
+statistics = true
+exclude = [
+    "tutorial",
+    "docs/visualization_examples",
+    "docs/visualization_matplotlib_examples",
+    "optuna/storages/_grpc/auto_generated"
+]
+
 [tool.pytest.ini_options]
 addopts = "--color=yes"
 filterwarnings = 'ignore::optuna.exceptions.ExperimentalWarning'
@@ -176,6 +187,10 @@ markers = [
   "skip_coverage: marks tests are skipped when calculating the coverage",
   "slow: marks tests as slow (deselect with '-m \"not slow\"')"
 ]
+
+[tool.coverage.run]
+concurrency = ["multiprocessing", "thread"]
+source = ["optuna/"]
 
 [tool.mypy]
 # Options configure mypy's strict mode.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,9 @@
+# This section is for flake8.
+[flake8]
+ignore =
+    E203,
+    E704,
+    W503
+max-line-length = 99
+statistics = True
+exclude = .venv,venv,build,tutorial,.asv,docs/visualization_examples,docs/visualization_matplotlib_examples,optuna/storages/_grpc/auto_generated

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,9 +1,0 @@
-# This section is for flake8.
-[flake8]
-ignore =
-    E203,
-    E704,
-    W503
-max-line-length = 99
-statistics = True
-exclude = .venv,venv,build,tutorial,.asv,docs/visualization_examples,docs/visualization_matplotlib_examples,optuna/storages/_grpc/auto_generated


### PR DESCRIPTION
Fixes #6173 

As per #6221, I've only migrated .coveragerc file to pyproject.toml  and not modified any other config files. Could you please review the changes?


## Motivation
Have less config files to manage.

## Description of the changes
Migrate `.coveragerc` to `pyproject.toml`
