### PR TITLE
Replace `np.linalg.inv` with `np.linalg.cholesky` to speed up `GPSampler` for `numpy>=2.0.0`

### DIFF
--- a/optuna/_gp/gp.py
+++ b/optuna/_gp/gp.py
@@ -196,13 +196,13 @@ class GPRegressor:
         cov_fx_fx = self.kernel_scale  # kernel(x, x) = kernel_scale
         mean = cov_fx_fX @ self._cov_Y_Y_inv_Y
         # K @ inv(C) = V --> K = V @ C --> K = V @ L @ L.T
-        cov_fx_fx_cov_Y_Y_inv = torch.linalg.solve_triangular(
+        cov_fx_fX_cov_Y_Y_inv = torch.linalg.solve_triangular(
             self._cov_Y_Y_chol,
             torch.linalg.solve_triangular(self._cov_Y_Y_chol.T, cov_fx_fX, upper=True, left=False),
             upper=False,
             left=False,
         )
-        var_ = (cov_fx_fx - torch.linalg.vecdot(cov_fx_fX, cov_fx_fx_cov_Y_Y_inv)).clamp_min_(0.0)
+        var_ = (cov_fx_fx - torch.linalg.vecdot(cov_fx_fX, cov_fx_fX_cov_Y_Y_inv)).clamp_min_(0.0)
         return (mean.squeeze(0), var_.squeeze(0)) if is_single_point else (mean, var_)
 
     def marginal_log_likelihood(self) -> torch.Tensor:  # Scalar

--- a/optuna/_gp/gp.py
+++ b/optuna/_gp/gp.py
@@ -129,6 +129,8 @@ class GPRegressor:
         cov_Y_Y[np.diag_indices(self._X_train.shape[0])] += self.noise_var.item()
         cov_Y_Y_chol = np.linalg.cholesky(cov_Y_Y)
         # cov_Y_Y_inv @ y = v --> y = cov_Y_Y @ v --> y = cov_Y_Y_chol @ cov_Y_Y_chol.T @ v
+        # NOTE(nabenabe): Don't use np.linalg.inv because it is too slow und unstable.
+        # cf. https://github.com/optuna/optuna/issues/6230
         cov_Y_Y_inv_Y = scipy.linalg.solve_triangular(
             cov_Y_Y_chol.T,
             scipy.linalg.solve_triangular(cov_Y_Y_chol, self._y_train.numpy(), lower=True),

--- a/optuna/_gp/gp.py
+++ b/optuna/_gp/gp.py
@@ -33,12 +33,12 @@ from optuna.logging import get_logger
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-    import scipy.optimize as so
+    import scipy
     import torch
 else:
     from optuna._imports import _LazyImport
 
-    so = _LazyImport("scipy.optimize")
+    scipy = _LazyImport("scipy")
     torch = _LazyImport("torch")
 
 logger = get_logger(__name__)
@@ -108,7 +108,7 @@ class GPRegressor:
             self._squared_X_diff[..., self._is_categorical] = (
                 self._squared_X_diff[..., self._is_categorical] > 0.0
             ).type(torch.float64)
-        self._cov_Y_Y_inv: torch.Tensor | None = None
+        self._cov_Y_Y_chol: torch.Tensor | None = None
         self._cov_Y_Y_inv_Y: torch.Tensor | None = None
         # TODO(nabenabe): Rename the attributes to private with `_`.
         self.inverse_squared_lengthscales = inverse_squared_lengthscales
@@ -121,16 +121,21 @@ class GPRegressor:
 
     def _cache_matrix(self) -> None:
         assert (
-            self._cov_Y_Y_inv is None and self._cov_Y_Y_inv_Y is None
+            self._cov_Y_Y_chol is None and self._cov_Y_Y_inv_Y is None
         ), "Cannot call cache_matrix more than once."
         with torch.no_grad():
             cov_Y_Y = self.kernel().detach().numpy()
 
         cov_Y_Y[np.diag_indices(self._X_train.shape[0])] += self.noise_var.item()
-        cov_Y_Y_inv = np.linalg.inv(cov_Y_Y)
-        cov_Y_Y_inv_Y = cov_Y_Y_inv @ self._y_train.numpy()
+        cov_Y_Y_chol = np.linalg.cholesky(cov_Y_Y)
+        # cov_Y_Y_inv @ y = v --> y = cov_Y_Y @ v --> y = cov_Y_Y_chol @ cov_Y_Y_chol.T @ v
+        cov_Y_Y_inv_Y = scipy.linalg.solve_triangular(
+            cov_Y_Y_chol.T,
+            scipy.linalg.solve_triangular(cov_Y_Y_chol, self._y_train.numpy(), lower=True),
+            lower=False,
+        )
         # NOTE(nabenabe): Here we use NumPy to guarantee the reproducibility from the past.
-        self._cov_Y_Y_inv = torch.from_numpy(cov_Y_Y_inv)
+        self._cov_Y_Y_chol = torch.from_numpy(cov_Y_Y_chol)
         self._cov_Y_Y_inv_Y = torch.from_numpy(cov_Y_Y_inv_Y)
         self.inverse_squared_lengthscales = self.inverse_squared_lengthscales.detach()
         self.inverse_squared_lengthscales.grad = None
@@ -181,13 +186,21 @@ class GPRegressor:
         Please note that we clamp the variance to avoid negative values due to numerical errors.
         """
         assert (
-            self._cov_Y_Y_inv is not None and self._cov_Y_Y_inv_Y is not None
+            self._cov_Y_Y_chol is not None and self._cov_Y_Y_inv_Y is not None
         ), "Call cache_matrix before calling posterior."
-        cov_fx_fX = self.kernel(x)
+        is_single_point = x.ndim == 1
+        cov_fx_fX = self.kernel(x) if not is_single_point else self.kernel(x.unsqueeze(0))
         cov_fx_fx = self.kernel_scale  # kernel(x, x) = kernel_scale
         mean = cov_fx_fX @ self._cov_Y_Y_inv_Y
-        var = cov_fx_fx - (cov_fx_fX * (cov_fx_fX @ self._cov_Y_Y_inv)).sum(dim=-1)
-        return mean, torch.clamp(var, min=0.0)
+        # K @ inv(C) = V --> K = V @ C --> K = V @ L @ L.T
+        cov_fx_fx_cov_Y_Y_inv = torch.linalg.solve_triangular(
+            self._cov_Y_Y_chol,
+            torch.linalg.solve_triangular(self._cov_Y_Y_chol.T, cov_fx_fX, upper=True, left=False),
+            upper=False,
+            left=False,
+        )
+        var_ = (cov_fx_fx - torch.linalg.vecdot(cov_fx_fX, cov_fx_fx_cov_Y_Y_inv)).clamp_min_(0.0)
+        return (mean.squeeze(0), var_.squeeze(0)) if is_single_point else (mean, var_)
 
     def marginal_log_likelihood(self) -> torch.Tensor:  # Scalar
         """
@@ -268,7 +281,7 @@ class GPRegressor:
 
         with single_blas_thread_if_scipy_v1_15_or_newer():
             # jac=True means loss_func returns the gradient for gradient descent.
-            res = so.minimize(
+            res = scipy.optimize.minimize(
                 # Too small `gtol` causes instability in loss_func optimization.
                 loss_func,
                 initial_raw_params,

--- a/optuna/_gp/gp.py
+++ b/optuna/_gp/gp.py
@@ -191,7 +191,8 @@ class GPRegressor:
             self._cov_Y_Y_chol is not None and self._cov_Y_Y_inv_Y is not None
         ), "Call cache_matrix before calling posterior."
         is_single_point = x.ndim == 1
-        cov_fx_fX = self.kernel(x) if not is_single_point else self.kernel(x.unsqueeze(0))
+        x_ = x if not is_single_point else x.unsqueeze(0)
+        cov_fx_fX = self.kernel(x_)
         cov_fx_fx = self.kernel_scale  # kernel(x, x) = kernel_scale
         mean = cov_fx_fX @ self._cov_Y_Y_inv_Y
         # K @ inv(C) = V --> K = V @ C --> K = V @ L @ L.T

--- a/optuna/terminator/improvement/emmr.py
+++ b/optuna/terminator/improvement/emmr.py
@@ -318,7 +318,7 @@ def _posterior_of_batched_theta(
         upper=False,
         left=False,
     )
-    var = cov_ftheta_ftheta - torch.linalg.vecdot(cov_ftheta_fX, V)
+    var = cov_ftheta_ftheta - V @ cov_ftheta_fX.T
     assert var.shape == (len_batch, len_batch)
 
     # We need to clamp the variance to avoid negative values due to numerical errors.


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. To minimize the review effort, we highly appreciate PRs only with related changes. Please note that submitted PRs may be closed if they include unrelated changes or significantly modified unit tests. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

This PR resolves the following issue:
- https://github.com/optuna/optuna/issues/6230

See also the issue in NumPy:
- https://github.com/numpy/numpy/issues/29884

Basically, `np.linalg.inv` suddenly slows down after `cov_Y_Y.shape` exceeds `(100, 100)`.
We avoid this issue by using `np.linalg.cholesky`.

Here are some backgrounds.
Let's denote $C \in \mathbb{R}^{N \times N}$ as the kernel matrix with the addition of a noise at the diagonal elements and $k = [k(x^\star, x_1), \dots, k(x^\star, x_N)]\in \mathbb{N}$ as the kernel vector at a new point $x^\star$.
The Gaussian process infers the posterior variance using $k^\top C^{-1} k$, necessitating the matrix inversion in our current implementation.
However, as $C$ is a positive definite matrix owing to the kernel matrix nature, we can indeed rewrite $v = C^{-1} k$ as $k = C v = L L^\top v$ where $L \in \mathbb{R}^{N \times N}$ is the lower triangular matrix yielded by the Cholesky decomposition of $C$.
We first obtain $u = L^\top v$ by solving  $L u = k$ and then obtain $v$ by solving $L^\top v = u$.
Please note that each linear system can be solved with the time complexity of $O(N^2)$ because $L$ is a triangular matrix.

By doing so, we can avoid the matrix inversion, leading to a significant speedup.
The by-product of this modification is the numerical stability.
The speedup effect can be found below:

<img width="859" height="554" alt="bench" src="https://github.com/user-attachments/assets/fca67078-6e9c-4e16-842c-a87b2a7a2f6c" />

## Description of the changes
<!-- Describe the changes in this PR. -->
- Replace `np.linalg.inv` with `np.linalg.cholesky`