### PR TITLE
Update black target to Python 3.9.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,7 +133,7 @@ version = {attr = "optuna.version.__version__"}
 
 [tool.black]
 line-length = 99
-target-version = ['py38']
+target-version = ['py39']
 force-exclude = '''
 /(
   \.eggs

--- a/tests/samplers_tests/test_cmaes.py
+++ b/tests/samplers_tests/test_cmaes.py
@@ -285,11 +285,12 @@ def test_sample_relative_n_startup_trials() -> None:
 
     # The independent sampler is used for Trial#0 (FAILED), Trial#1 (COMPLETE)
     # and Trial#2 (COMPLETE). The CMA-ES is used for Trial#3 (COMPLETE).
-    with patch.object(
-        independent_sampler, "sample_independent", wraps=independent_sampler.sample_independent
-    ) as mock_independent, patch.object(
-        sampler, "sample_relative", wraps=sampler.sample_relative
-    ) as mock_relative:
+    with (
+        patch.object(
+            independent_sampler, "sample_independent", wraps=independent_sampler.sample_independent
+        ) as mock_independent,
+        patch.object(sampler, "sample_relative", wraps=sampler.sample_relative) as mock_relative,
+    ):
         study.optimize(objective, n_trials=4, catch=(Exception,))
         assert mock_independent.call_count == 6  # The objective function has two parameters.
         assert mock_relative.call_count == 4

--- a/tests/samplers_tests/tpe_tests/test_multi_objective_sampler.py
+++ b/tests/samplers_tests/tpe_tests/test_multi_objective_sampler.py
@@ -29,14 +29,18 @@ def suggest(
     past_trials: list[optuna.trial.FrozenTrial],
 ) -> float:
     attrs = MockSystemAttr()
-    with patch.object(study._storage, "get_all_trials", return_value=past_trials), patch.object(
-        study._storage, "set_trial_system_attr", side_effect=attrs.set_trial_system_attr
-    ), patch.object(study._storage, "get_trial", return_value=trial), patch(
-        "optuna.trial.Trial.system_attrs", new_callable=PropertyMock
-    ) as mock1, patch(
-        "optuna.trial.FrozenTrial.system_attrs",
-        new_callable=PropertyMock,
-    ) as mock2:
+    with (
+        patch.object(study._storage, "get_all_trials", return_value=past_trials),
+        patch.object(
+            study._storage, "set_trial_system_attr", side_effect=attrs.set_trial_system_attr
+        ),
+        patch.object(study._storage, "get_trial", return_value=trial),
+        patch("optuna.trial.Trial.system_attrs", new_callable=PropertyMock) as mock1,
+        patch(
+            "optuna.trial.FrozenTrial.system_attrs",
+            new_callable=PropertyMock,
+        ) as mock2,
+    ):
         mock1.return_value = attrs.value
         mock2.return_value = attrs.value
         suggestion = sampler.sample_independent(study, trial, "param-a", distribution)
@@ -89,22 +93,23 @@ def test_multi_objective_sample_independent_n_startup_trial() -> None:
         past_trials: list[optuna.trial.FrozenTrial],
     ) -> int:
         attrs = MockSystemAttr()
-        with patch.object(
-            study._storage, "get_all_trials", return_value=past_trials
-        ), patch.object(
-            study._storage, "set_trial_system_attr", side_effect=attrs.set_trial_system_attr
-        ), patch.object(
-            study._storage, "get_trial", return_value=trial
-        ), patch(
-            "optuna.trial.Trial.system_attrs", new_callable=PropertyMock
-        ) as mock1, patch(
-            "optuna.trial.FrozenTrial.system_attrs",
-            new_callable=PropertyMock,
-        ) as mock2, patch.object(
-            optuna.samplers.RandomSampler,
-            "sample_independent",
-            return_value=1.0,
-        ) as sample_method:
+        with (
+            patch.object(study._storage, "get_all_trials", return_value=past_trials),
+            patch.object(
+                study._storage, "set_trial_system_attr", side_effect=attrs.set_trial_system_attr
+            ),
+            patch.object(study._storage, "get_trial", return_value=trial),
+            patch("optuna.trial.Trial.system_attrs", new_callable=PropertyMock) as mock1,
+            patch(
+                "optuna.trial.FrozenTrial.system_attrs",
+                new_callable=PropertyMock,
+            ) as mock2,
+            patch.object(
+                optuna.samplers.RandomSampler,
+                "sample_independent",
+                return_value=1.0,
+            ) as sample_method,
+        ):
             mock1.return_value = attrs.value
             mock2.return_value = attrs.value
             sampler.sample_independent(study, trial, "param-a", dist)

--- a/tests/study_tests/test_study.py
+++ b/tests/study_tests/test_study.py
@@ -468,9 +468,10 @@ def test_delete_study(storage_mode: str) -> None:
 @pytest.mark.parametrize("from_storage_mode", STORAGE_MODES)
 @pytest.mark.parametrize("to_storage_mode", STORAGE_MODES)
 def test_copy_study(from_storage_mode: str, to_storage_mode: str) -> None:
-    with StorageSupplier(from_storage_mode) as from_storage, StorageSupplier(
-        to_storage_mode
-    ) as to_storage:
+    with (
+        StorageSupplier(from_storage_mode) as from_storage,
+        StorageSupplier(to_storage_mode) as to_storage,
+    ):
         from_study = create_study(storage=from_storage, directions=["maximize", "minimize"])
         from_study._storage.set_study_system_attr(from_study._study_id, "foo", "bar")
         from_study.set_user_attr("baz", "qux")
@@ -498,9 +499,10 @@ def test_copy_study(from_storage_mode: str, to_storage_mode: str) -> None:
 @pytest.mark.parametrize("from_storage_mode", STORAGE_MODES)
 @pytest.mark.parametrize("to_storage_mode", STORAGE_MODES)
 def test_copy_study_to_study_name(from_storage_mode: str, to_storage_mode: str) -> None:
-    with StorageSupplier(from_storage_mode) as from_storage, StorageSupplier(
-        to_storage_mode
-    ) as to_storage:
+    with (
+        StorageSupplier(from_storage_mode) as from_storage,
+        StorageSupplier(to_storage_mode) as to_storage,
+    ):
         from_study = create_study(study_name="foo", storage=from_storage)
         _ = create_study(study_name="foo", storage=to_storage)
 

--- a/tests/trial_tests/test_trial.py
+++ b/tests/trial_tests/test_trial.py
@@ -241,9 +241,12 @@ def test_suggest_discrete_uniform(storage_mode: str) -> None:
 @pytest.mark.filterwarnings("ignore::FutureWarning")
 @pytest.mark.parametrize("storage_mode", STORAGE_MODES)
 def test_suggest_low_equals_high(storage_mode: str) -> None:
-    with patch.object(
-        distributions, "_get_single_value", wraps=distributions._get_single_value
-    ) as mock_object, StorageSupplier(storage_mode) as storage:
+    with (
+        patch.object(
+            distributions, "_get_single_value", wraps=distributions._get_single_value
+        ) as mock_object,
+        StorageSupplier(storage_mode) as storage,
+    ):
         study = create_study(storage=storage, sampler=samplers.TPESampler(n_startup_trials=0))
 
         trial = study.ask()
@@ -314,9 +317,10 @@ def test_suggest_discrete_uniform_range(storage_mode: str, range_config: dict[st
     # Check upper endpoints.
     mock = Mock()
     mock.side_effect = lambda study, trial, param_name, distribution: distribution.high
-    with patch.object(sampler, "sample_independent", mock) as mock_object, StorageSupplier(
-        storage_mode
-    ) as storage:
+    with (
+        patch.object(sampler, "sample_independent", mock) as mock_object,
+        StorageSupplier(storage_mode) as storage,
+    ):
         study = create_study(storage=storage, sampler=sampler)
         trial = study.ask()
 
@@ -330,9 +334,10 @@ def test_suggest_discrete_uniform_range(storage_mode: str, range_config: dict[st
     # Check lower endpoints.
     mock = Mock()
     mock.side_effect = lambda study, trial, param_name, distribution: distribution.low
-    with patch.object(sampler, "sample_independent", mock) as mock_object, StorageSupplier(
-        storage_mode
-    ) as storage:
+    with (
+        patch.object(sampler, "sample_independent", mock) as mock_object,
+        StorageSupplier(storage_mode) as storage,
+    ):
         study = create_study(storage=storage, sampler=sampler)
         trial = study.ask()
 
@@ -384,9 +389,10 @@ def test_suggest_int_range(storage_mode: str, range_config: dict[str, int]) -> N
     # Check upper endpoints.
     mock = Mock()
     mock.side_effect = lambda study, trial, param_name, distribution: distribution.high
-    with patch.object(sampler, "sample_independent", mock) as mock_object, StorageSupplier(
-        storage_mode
-    ) as storage:
+    with (
+        patch.object(sampler, "sample_independent", mock) as mock_object,
+        StorageSupplier(storage_mode) as storage,
+    ):
         study = create_study(storage=storage, sampler=sampler)
         trial = study.ask()
 
@@ -400,9 +406,10 @@ def test_suggest_int_range(storage_mode: str, range_config: dict[str, int]) -> N
     # Check lower endpoints.
     mock = Mock()
     mock.side_effect = lambda study, trial, param_name, distribution: distribution.low
-    with patch.object(sampler, "sample_independent", mock) as mock_object, StorageSupplier(
-        storage_mode
-    ) as storage:
+    with (
+        patch.object(sampler, "sample_independent", mock) as mock_object,
+        StorageSupplier(storage_mode) as storage,
+    ):
         study = create_study(storage=storage, sampler=sampler)
         trial = study.ask()
 


### PR DESCRIPTION
## Motivation

This is a follow-up PR to #6302.
See also https://github.com/optuna/optuna-integration/pull/254.

## Description of the changes
* Update the black's target version from Python 3.8 to 3.9.
  *  The major code change is to enclose them in parentheses when using multiple context managers in a with statement.
