### PR TITLE
Fix string format for `optuna/study/study.py`

### DIFF
--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -1089,7 +1089,7 @@ class Study:
             except exceptions.UpdateFinishedTrialError:
                 continue
 
-            _logger.debug("Trial {} popped from the trial queue.".format(trial.number))
+            _logger.debug(f"Trial {trial.number} popped from the trial queue.")
             return trial._trial_id
 
         return None
@@ -1140,9 +1140,7 @@ class Study:
             else:
                 trial_values = {name: value for name, value in zip(metric_names, values)}
             _logger.info(
-                "Trial {} finished with values: {} and parameters: {}.".format(
-                    number, trial_values, params
-                )
+                f"Trial {number} finished with values: {trial_values} and parameters: {params}."
             )
         elif len(values) == 1:
             trial_value: float | dict[str, float]
@@ -1302,8 +1300,8 @@ def create_study(
             assert study_name is not None
 
             _logger.info(
-                "Using an existing study with name '{}' instead of "
-                "creating a new one.".format(study_name)
+                f"Using an existing study with name '{study_name}' instead of "
+                "creating a new one."
             )
             study_id = storage.get_study_id_from_name(study_name)
         else:


### PR DESCRIPTION
## Motivation
As mentioned in issue #6305, Optuna no longer supports Python 3.8. This allows us to replace `.format()` with f-strings, which provide a cleaner and more readable syntax.

## Description of the changes
In the file `optuna/study/study.py`, I replaced string formatting using `.format()` with f-strings as suggested in the issue.

## Additional Notes

This change is part of the ongoing effort to modernize the codebase and improve readability.

Thank you!