### PR TITLE
Changed the old `.format` code to the new f string format in the `test_journal.py`

### DIFF
--- a/tests/storages_tests/journal_tests/test_journal.py
+++ b/tests/storages_tests/journal_tests/test_journal.py
@@ -70,7 +70,7 @@ class JournalLogStorageSupplier:
             journal_redis_storage._redis = FakeStrictRedis()
             return journal_redis_storage
         else:
-            raise RuntimeError(f"Unknown Log Storage Type: {self.storage_type}")
+            raise RuntimeError(f"Unknown log storage type: {self.storage_type}")
 
     def __exit__(
         self, exc_type: type[BaseException], exc_val: BaseException, exc_tb: TracebackType


### PR DESCRIPTION
**Motivation**

Now that Optuna has dropped the support for Python 3.8 we can use modern f string syntax in the codebase which replaces the old .format method.

**Description Of The Changes**

Replaced the occurence of the old '.format()' formatting technique with the new f string technique in the test_journal.py file. The file is present at the location tests/storage_tests/journal_tests/test_journal.py.

No other functional changes were made in this.