### PR TITLE
Use f-strings in `_intermediate_values.py`

### DIFF
--- a/optuna/visualization/matplotlib/_intermediate_values.py
+++ b/optuna/visualization/matplotlib/_intermediate_values.py
@@ -56,7 +56,7 @@ def _get_intermediate_plot(info: _IntermediatePlotInfo) -> "Axes":
             color=cmap(i) if tinfo.feasible else "#CCCCCC",
             marker=".",
             alpha=0.7,
-            label="Trial{}".format(tinfo.trial_number),
+            label=f"Trial{tinfo.trial_number}",
         )
 
     if len(trial_infos) >= 2:


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. To minimize the review effort, we highly appreciate PRs only with related changes. Please note that submitted PRs may be closed if they include unrelated changes or significantly modified unit tests. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

### Motivation
This PR partially satisfies:
- https://github.com/optuna/optuna/issues/6305

### Description of the Changes
Updates `visualization/matplotlib/_intermediate_values.py` to use f-strings, meeting recent Python standards.

This PR refactors `_intermediate_values.py` to replace `.format()` calls with
f-strings for improved readability and consistency.

Example:
```python
label="Trial{}".format(tinfo.trial_number)

label=f"Trial{tinfo.trial_number}"
