### PR TITLE
Add `SECURITY.md`

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,20 @@
+# Security Issue Reporting
+
+Optuna uses [GitHub’s Private Vulnerability Reporting feature](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability) to enable responsible and confidential reporting of security issues.
+
+If you discover a potential vulnerability, please report it to the development team through this feature:
+ [Report a Vulnerability](https://github.com/optuna/optuna/security/advisories/new)
+
+## How Reports Are Handled
+
+- Your submission will remain confidential within the Private Vulnerability Report until the development team decides to share it publicly.
+- The information you report will be used to help resolve security issues.
+- The development team includes members with write or higher permission to the repository, as well as security managers.
+- The development team will investigate and work toward a resolution.
+  Please refrain from posting the issue in public forums such as GitHub Issues, Pull Requests, or social media until the fix or disclosure is complete.
+- The timing of public disclosure will be determined through communication between the development team and the reporter.
+  If the reporter prefers not to disclose the issue, it will remain private.
+
+## Acknowledgment
+
+We appreciate your help in improving the security and reliability of Optuna.


### PR DESCRIPTION
## Motivation
This PR adds `SECURITY.md` to guide reporting security vulnerabilities. It provides instructions for confidential reporting via GitHub’s Private Vulnerability Reporting feature and outlines how the development team will handle reports.

The `SECURITY.md` will be rendered on the top page of the repository as follows:

<img width="949" height="746" alt="image" src="https://github.com/user-attachments/assets/8e95eff0-c547-4f9f-92e4-f9153b675aa9" />


## Description of the changes
- Add `SECURITY.md`