### PR TITLE
Refactor: Replace .format() with f-strings in _frozen.py

### DIFF
--- a/optuna/trial/_frozen.py
+++ b/optuna/trial/_frozen.py
@@ -193,17 +193,11 @@ class FrozenTrial(BaseTrial):
         return hash(tuple(getattr(self, field) for field in self.__dict__))
 
     def __repr__(self) -> str:
-        return "{cls}({kwargs})".format(
-            cls=self.__class__.__name__,
-            kwargs=", ".join(
-                "{field}={value}".format(
-                    field=field if not field.startswith("_") else field[1:],
-                    value=repr(getattr(self, field)),
-                )
-                for field in self.__dict__
-            )
-            + ", value=None",
-        )
+        kwargs = ", ".join(
+            f"{field if not field.startswith('_') else field[1:]}={getattr(self, field)!r}"
+            for field in self.__dict__
+        ) + ", value=None"
+        return f"{self.__class__.__name__}({kwargs})"
 
     def suggest_float(
         self,


### PR DESCRIPTION
## Motivation

Following the recommendation in #6305, I'm replacing the old-style `.format()` string formatting with the cleaner f-string syntax. 

## Description of the changes

- Replaced `.format()` calls with f-strings in the `__repr__` method
- Used `!r` specifier for `repr()` calls to follow f-string conventions
- Maintained the exact same functionality and output format