### PR TITLE
Replace `.format()` with f-string in `_setup_studies`

### DIFF
--- a/tests/storages_tests/test_storages.py
+++ b/tests/storages_tests/test_storages.py
@@ -1149,7 +1149,7 @@ def _setup_studies(
     study_id_to_frozen_study: dict[int, FrozenStudy] = {}
     study_id_to_trials: dict[int, dict[int, FrozenTrial]] = {}
     for i in range(n_study):
-        study_name = "test-study-name-{}".format(i)
+        study_name = f"test-study-name-{i}"
         if direction is None:
             direction = generator.choice([StudyDirection.MINIMIZE, StudyDirection.MAXIMIZE])
         study_id = storage.create_new_study(directions=(direction,), study_name=study_name)


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. To minimize the review effort, we highly appreciate PRs only with related changes. Please note that submitted PRs may be closed if they include unrelated changes or significantly modified unit tests. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
Contributes to the ongoing effort in https://github.com/optuna/optuna/issues/6305 to replace old-style `.format()` calls with modern f-strings.

## Description of the changes
**Changes**  
- Updated `tests/storages_tests/test_storages.py`  
- Replaced the single `.format()` usage in `_setup_studies` with an f-string:

```diff
- study_name = "test-study-name-{}".format(i)
+ study_name = f"test-study-name-{i}"
