### PR TITLE
Replace .format() with f-string in progress_bar.py

### DIFF
--- a/optuna/progress_bar.py
+++ b/optuna/progress_bar.py
@@ -100,7 +100,7 @@ class _ProgressBar:
                 self._progress_bar.update(1)
                 if self._timeout is not None:
                     self._progress_bar.set_postfix_str(
-                        "{:.02f}/{} seconds".format(elapsed_seconds, self._timeout)
+                        f"{elapsed_seconds:.02f}/{self._timeout} seconds"
                     )
 
             elif self._timeout is not None:


### PR DESCRIPTION
## Description
This PR modernizes string formatting in `progress_bar.py` by replacing the `.format()` method with f-strings, as suggested in #6305.

## Changes
- Updated `progress_bar.py` line 105-106 to use f-string syntax
- Changed `"{:.02f}/{} seconds".format(elapsed_seconds, self._timeout)` to `f"{elapsed_seconds:.02f}/{self._timeout} seconds"`
- No functional changes, only code modernization

## Related Issue
Closes #6305

## Checklist
- [x] Code follows project style guidelines
- [x] Changes are limited to one file as per contribution guidelines
- [x] Maintains exact same functionality