### PR TITLE
Dispose SQLAlchemy's engine in `storage_tests/test_with_server.py`

### DIFF
--- a/tests/storages_tests/test_with_server.py
+++ b/tests/storages_tests/test_with_server.py
@@ -58,10 +58,11 @@ def get_storage() -> Generator[BaseStorage, None, None]:
     else:
         assert False, f"The mode {storage_mode} is not supported."
 
-    yield storage
-
-    if isinstance(storage, optuna.storages.RDBStorage):
-        storage.engine.dispose()
+    try:
+        yield storage
+    finally:
+        if isinstance(storage, optuna.storages.RDBStorage):
+            storage.engine.dispose()
 
 
 def run_optimize(study_name: str, n_trials: int) -> None:


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. To minimize the review effort, we highly appreciate PRs only with related changes. Please note that submitted PRs may be closed if they include unrelated changes or significantly modified unit tests. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

This PR is the follow-up on:
- https://github.com/optuna/optuna/pull/6303,


and runs in parallel with::

- https://github.com/optuna/optuna/pull/6337, and
- https://github.com/optuna/optuna/pull/6338.

The original PR did not cover all test cases. This PR addresses the remaining ones in `storage_tests/test_with_server.py`.

> [!IMPORTANT]
> With these PRs and this PR, all the tests creating `RDBStorage` in `test_storages` has been addressed.


The remaining tests creating `RDBStorage` is only `study_tests/test_study_summary.py`, which creates the `RDBStorage` instance for only two times and considered to be less likely to encounter the SQLAlchemy's issue.



## Description of the changes
<!-- Describe the changes in this PR. -->

- Make the `get_storage` funciton contextmanager and use it for all tests in `storage_tests/test_with_server.py`.

> [!NOTE]
> To ensure that `dispose()` is always called even when an assert fails, it should be invoked inside `__exit__` rather than at the end of the test function.


> [!IMPORTANT]
> Most of the diff comes from increased indentation after introducing the context manager.


