### PR TITLE
Use TYPE_CHECKING in optuna/pruners/_percentile.py

### DIFF
--- a/optuna/pruners/_percentile.py
+++ b/optuna/pruners/_percentile.py
@@ -3,13 +3,13 @@ from __future__ import annotations
 from collections.abc import KeysView
 import functools
 import math
-
+from typing import TYPE_CHECKING
 import numpy as np
-
-import optuna
 from optuna.pruners import BasePruner
 from optuna.study._study_direction import StudyDirection
 from optuna.trial._state import TrialState
+if TYPE_CHECKING:
+    import optuna
 
 
 def _get_best_intermediate_result_over_steps(


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. To minimize the review effort, we highly appreciate PRs only with related changes. Please note that submitted PRs may be closed if they include unrelated changes or significantly modified unit tests. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

## Description of the changes
<!-- Describe the changes in this PR. -->
This PR updates optuna/pruners/_percentile.py to use the typing.TYPE_CHECKING guard for imports that are only needed for static type checking. This change improves import efficiency and avoids potential circular dependencies at runtime.

Changes made:
Wrapped type-only imports under if TYPE_CHECKING:.
Cleaned up redundant runtime imports.
