### PR TITLE
Dispose SQLAlchemy's engine in `storage_tests/test_cached_storage.py`

### DIFF
--- a/tests/storages_tests/test_cached_storage.py
+++ b/tests/storages_tests/test_cached_storage.py
@@ -172,7 +172,6 @@ def test_unfinished_trial_ids() -> None:
             create_rdb_storage(storage_url) as base_storage1,
             create_rdb_storage(storage_url) as base_storage2,
         ):
-
             storage1 = _CachedStorage(base_storage1)
             study1 = optuna.create_study(
                 study_name=study_name,


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. To minimize the review effort, we highly appreciate PRs only with related changes. Please note that submitted PRs may be closed if they include unrelated changes or significantly modified unit tests. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->


This PR is the follow-up on:
- https://github.com/optuna/optuna/pull/6303,

and runs in parallel with::

- https://github.com/optuna/optuna/pull/6330, and
- https://github.com/optuna/optuna/pull/6338.

The original PR did not cover all test cases. This PR addresses the remaining ones in `storage_tests/test_cached_storage.py`.


> [!IMPORTANT]
> With these PRs and this PR, all the tests creating `RDBStorage` in `test_storages` has been addressed.

The remaining tests creating `RDBStorage` is only `study_tests/test_study_summary.py`, which creates the `RDBStorage` instance for only two times and considered to be less likely to encounter the SQLAlchemy's issue.


## Description of the changes
<!-- Describe the changes in this PR. -->


- Use `RDBStorage` within a context manager so that `storage.engine.dispose()` is executed every time.

> [!NOTE]
> To ensure that `dispose()` is always called even when an assert fails, it should be invoked inside `__exit__` rather than at the end of the test function.



> [!IMPORTANT]
> Most of the diff comes from increased indentation after introducing the context manager.


