### PR TITLE
Replace `.format` with f-string in `_param_importances.py`

### DIFF
--- a/optuna/visualization/_param_importances.py
+++ b/optuna/visualization/_param_importances.py
@@ -205,7 +205,8 @@ def _get_distribution(param_name: str, study: Study) -> BaseDistribution:
 
 
 def _make_hovertext(param_name: str, importance: float, study: Study) -> str:
-    return f"{param_name} ({_get_distribution(param_name, study).__class__.__name__}): {importance}<extra></extra>"
+    class_name = _get_distribution(param_name, study).__class__.__name__
+    return f"{param_name} ({class_name}): {importance}<extra></extra>"
 
 
 def _get_hover_template(importances_info: _ImportancesInfo, study: Study) -> list[str]:


### PR DESCRIPTION
## Motivation
Improved code readability and modernized string formatting using f-strings instead of .format method.

## Description of changes
Replaced .format with f-string in _param_importances.py.

