### PR TITLE
Fix type checking and GP integration for MDI importance

### DIFF
--- a/optuna/_gp/acqf.py
+++ b/optuna/_gp/acqf.py
@@ -311,5 +311,5 @@ class ConstrainedLogEHVI(BaseAcquisitionFunc):
     def eval_acqf(self, x: torch.Tensor) -> torch.Tensor:
         constraints_acqf_values = sum(acqf.eval_acqf(x) for acqf in self._constraints_acqf_list)
         if self._acqf is None:
-            return cast(torch.Tensor, constraints_acqf_values)
+            return cast("torch.Tensor", constraints_acqf_values)
         return constraints_acqf_values + self._acqf.eval_acqf(x)

--- a/optuna/_gp/optim_sample.py
+++ b/optuna/_gp/optim_sample.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 import numpy as np
+from typing import TYPE_CHECKING
 
-from optuna._gp import acqf as acqf_module
+if TYPE_CHECKING:
+    from optuna._gp.acqf import BaseAcquisitionFunc
 
 
 def optimize_acqf_sample(
-    acqf: acqf_module.BaseAcquisitionFunc,
+    acqf: "BaseAcquisitionFunc",
     *,
     n_samples: int = 2048,
     rng: np.random.RandomState | None = None,

--- a/optuna/importance/_mean_decrease_impurity.py
+++ b/optuna/importance/_mean_decrease_impurity.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
+from typing import TYPE_CHECKING
 
-from collections.abc import Callable
 
 import numpy as np
 
@@ -13,8 +13,11 @@ from optuna.importance._base import _get_trans_params
 from optuna.importance._base import _param_importances_to_dict
 from optuna.importance._base import _sort_dict_by_importance
 from optuna.importance._base import BaseImportanceEvaluator
-from optuna.study import Study
-from optuna.trial import FrozenTrial
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from optuna.study import Study
+    from optuna.trial import FrozenTrial
 
 
 with try_import() as _imports:

--- a/optuna/importance/_ped_anova/evaluator.py
+++ b/optuna/importance/_ped_anova/evaluator.py
@@ -1,21 +1,26 @@
 from __future__ import annotations
 
-from collections.abc import Callable
+from typing import TYPE_CHECKING
 
 import numpy as np
 
 from optuna._experimental import experimental_class
 from optuna._warnings import optuna_warn
-from optuna.distributions import BaseDistribution
-from optuna.importance._base import _get_distributions
-from optuna.importance._base import _get_filtered_trials
-from optuna.importance._base import _sort_dict_by_importance
-from optuna.importance._base import BaseImportanceEvaluator
+from optuna.importance._base import (
+    _get_distributions,
+    _get_filtered_trials,
+    _sort_dict_by_importance,
+    BaseImportanceEvaluator,
+)
 from optuna.importance._ped_anova.scott_parzen_estimator import _build_parzen_estimator
 from optuna.logging import get_logger
-from optuna.study import Study
 from optuna.study import StudyDirection
-from optuna.trial import FrozenTrial
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from optuna.distributions import BaseDistribution
+    from optuna.trial import FrozenTrial
+    from optuna.study import Study
 
 
 _logger = get_logger(__name__)

--- a/optuna/importance/_ped_anova/scott_parzen_estimator.py
+++ b/optuna/importance/_ped_anova/scott_parzen_estimator.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import numpy as np
+from typing import TYPE_CHECKING
 
 from optuna.distributions import BaseDistribution
 from optuna.distributions import CategoricalDistribution
@@ -10,7 +11,9 @@ from optuna.samplers._tpe.parzen_estimator import _ParzenEstimator
 from optuna.samplers._tpe.parzen_estimator import _ParzenEstimatorParameters
 from optuna.samplers._tpe.probability_distributions import _BatchedDiscreteTruncNormDistributions
 from optuna.samplers._tpe.probability_distributions import _BatchedDistributions
-from optuna.trial import FrozenTrial
+
+if TYPE_CHECKING:
+    from optuna.trial import FrozenTrial
 
 
 class _ScottParzenEstimator(_ParzenEstimator):


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. To minimize the review effort, we highly appreciate PRs only with related changes. Please note that submitted PRs may be closed if they include unrelated changes or significantly modified unit tests. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation

This PR is a partial contribution toward #6029. The goal of that issue is to move type-only imports behind `typing.TYPE_CHECKING` so we avoid circular imports and unnecessary runtime dependencies, while keeping static type checking working correctly.

## Description of the changes

This PR focuses on the following modules:

- `optuna/_gp/acqf.py`
- `optuna/_gp/optim_sample.py`
- `optuna/importance/_mean_decrease_impurity.py`
- `optuna/importance/_ped_anova/evaluator.py`
- `optuna/importance/_ped_anova/scott_parzen_estimator.py`

For these files I:

- Moved imports that are only used for type annotations into `if TYPE_CHECKING:` blocks.
- Updated type annotations to use forward references / fully qualified names where needed so they still work with the moved imports.
- Kept runtime behavior unchanged (imports that are actually needed at runtime stay at the top level).

These changes are intended to reduce the risk of circular imports and bring these modules in line with the pattern suggested in #6029.

## Testing

Locally I ran:

```bash
pytest -q tests/gp_tests/test_gp.py::test_fit_kernel_params -k "not slow" --maxfail=1