### PR TITLE
Replace .format() with f-strings in several modules

### DIFF
--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -386,11 +386,7 @@ Here's an example:
         if previous_best_value != study.best_value:
             study.set_user_attr("previous_best_value", study.best_value)
             print(
-                "Trial {} finished with best value: {} and parameters: {}. ".format(
-                frozen_trial.number,
-                frozen_trial.value,
-                frozen_trial.params,
-                )
+                f"Trial {frozen_trial.number} finished with best value: {frozen_trial.value} and parameters: {frozen_trial.params}. "
             )
 
 
@@ -503,13 +499,11 @@ The following example is a benchmark of Binh and Korn function, a multi-objectiv
     trials = sorted(study.best_trials, key=lambda t: t.values)
 
     for trial in trials:
-        print("  Trial#{}".format(trial.number))
+        print(f"  Trial#{trial.number}")
         print(
-            "    Values: Values={}, Constraint={}".format(
-                trial.values, trial.user_attrs["constraint"][0]
-            )
+            f"    Values: Values={trial.values}, Constraint={trial.user_attrs['constraint'][0]}"
         )
-        print("    Params: {}".format(trial.params))
+        print(f"    Params: {trial.params}")
 
 If you are interested in an example for `BoTorchSampler <https://optuna-integration.readthedocs.io/en/stable/reference/generated/optuna_integration.BoTorchSampler.html>`__, please refer to `this sample code <https://github.com/optuna/optuna-examples/blob/main/multi_objective/botorch_simple.py>`__.
 


### PR DESCRIPTION
## Motivation
Modern Python recommends using f-strings over the older `.format()` syntax because they are more readable, concise, and perform better. Optuna already uses f-strings in many places, so this PR helps maintain consistency across the codebase.

This change is part of issue #6305.

## Description of the changes
- Replaced occurrences of `.format()` with f-strings in several modules.
- No functional behavior was changed.
- Only minor style improvements for readability and consistency.
