### PR TITLE
Temporarily disable `-W` option on Sphinx build

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    = -W --keep-going
+SPHINXOPTS    = --keep-going
 SPHINXBUILD   = sphinx-build
 SPHINXPROJ    = Optuna
 SOURCEDIR     = source


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. To minimize the review effort, we highly appreciate PRs only with related changes. Please note that submitted PRs may be closed if they include unrelated changes or significantly modified unit tests. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

Currently, CI has been failed due to the following error:

> WARNING: failed to reach any of the inventories with the following issues:
> intersphinx inventory 'https://docs.python.org/3/objects.inv' not fetchable due to <class 'requests.exceptions.HTTPError'>: 503 Server Error: Service Unavailable for url: https://docs.python.org/3/objects.inv
> https://github.com/optuna/optuna/actions/runs/19561736060/job/56015268613?pr=6317


## Description of the changes
<!-- Describe the changes in this PR. -->
Disable `-W` option, so that sphinx does not treat warnings as errors.