### PR TITLE
Refactor cli.py to use f-string

### DIFF
--- a/optuna/cli.py
+++ b/optuna/cli.py
@@ -922,7 +922,7 @@ def _get_parser(description: str = "") -> tuple[ArgumentParser, dict[str, Argume
 
     main_parser = ArgumentParser(description=description, parents=[parent_parser])
     main_parser.add_argument(
-        "--version", action="version", version="{0} {1}".format("optuna", optuna.__version__)
+        "--version", action="version", version=f"optuna {optuna.__version__}"
     )
     command_name_to_subparser = _add_commands(main_parser, parent_parser)
     return main_parser, command_name_to_subparser


### PR DESCRIPTION
## Summary
- Replace `.format()` with f-string in `cli.py` for version string formatting
- Part of the f-string migration effort

## Changes Made
- **File:** `optuna/cli.py`
- **Line 925:** Changed `"{0} {1}".format("optuna", optuna.__version__)` to `f"optuna {optuna.__version__}"`
- Follows modern Python conventions now that Python 3.8 support is dropped

## Rationale
This change simplifies string formatting and improves code readability by using Python's f-string syntax instead of the older `.format()` method. This is part of the codebase-wide refactoring initiative to modernize string formatting.

Fixes #6305