### PR TITLE
Add warnings when `JournalStorage` lock acquisition is delayed

### DIFF
--- a/optuna/storages/journal/_file.py
+++ b/optuna/storages/journal/_file.py
@@ -159,6 +159,13 @@ class JournalFileSymlinkLock(BaseJournalFileLock):
                 return True
             except OSError as err:
                 if err.errno == errno.EEXIST:
+                    if time.monotonic() - last_warning_time > warning_interval:
+                        optuna_warn(
+                            f"It is taking longer than {warning_interval} seconds to acquire "
+                            f"the lock file: {self._lock_file} Retrying..."
+                        )
+                        last_warning_time = time.monotonic()
+
                     if self.grace_period is not None:
                         try:
                             current_mtime = os.stat(self._lock_file).st_mtime
@@ -179,13 +186,6 @@ class JournalFileSymlinkLock(BaseJournalFileLock):
                                 sleep_secs = 0.001
                             except RuntimeError:
                                 continue
-
-                    if time.monotonic() - last_warning_time > warning_interval:
-                        optuna_warn(
-                            f"It is taking longer than {warning_interval} seconds to acquire "
-                            f"the lock file: {self._lock_file} Retrying..."
-                        )
-                        last_warning_time = time.monotonic()
 
                     time.sleep(sleep_secs)
                     sleep_secs = min(sleep_secs * 2, 1)
@@ -252,6 +252,13 @@ class JournalFileOpenLock(BaseJournalFileLock):
                 return True
             except OSError as err:
                 if err.errno == errno.EEXIST:
+                    if time.monotonic() - last_warning_time > warning_interval:
+                        optuna_warn(
+                            f"It is taking longer than {warning_interval} seconds to acquire "
+                            f"the lock file: {self._lock_file} Retrying..."
+                        )
+                        last_warning_time = time.monotonic()
+
                     if self.grace_period is not None:
                         try:
                             current_mtime = os.stat(self._lock_file).st_mtime
@@ -272,13 +279,6 @@ class JournalFileOpenLock(BaseJournalFileLock):
                                 sleep_secs = 0.001
                             except RuntimeError:
                                 continue
-
-                    if time.monotonic() - last_warning_time > warning_interval:
-                        optuna_warn(
-                            f"It is taking longer than {warning_interval} seconds to acquire "
-                            f"the lock file: {self._lock_file} Retrying..."
-                        )
-                        last_warning_time = time.monotonic()
 
                     time.sleep(sleep_secs)
                     sleep_secs = min(sleep_secs * 2, 1)


### PR DESCRIPTION
## Motivation
- This PR is a follow-up to #5971.
- Currently, when JournalStorage keeps retrying to acquire a file lock, there is no feedback to the user. This can make it hard to tell whether the process is still running or stuck.
- This PR adds warnings when lock acquisition takes a long time, so users can see that the process is alive and waiting for the lock.

## Description of the changes
- Add a warning in the acquire method of `JournalFileSymlinkLock` and `JournalFileOpenLock` that is emitted when acquiring the file lock takes longer than a certain threshold.

## Note
- `warning_interval` is tentatively set to 10 seconds, and this value is open for discussion.