### PR TITLE
Change string formatting in `optuna/pruners/_hyperband.py`

### DIFF
--- a/optuna/pruners/_hyperband.py
+++ b/optuna/pruners/_hyperband.py
@@ -159,7 +159,7 @@ class HyperbandPruner(BasePruner):
 
         if not isinstance(self._max_resource, int) and self._max_resource != "auto":
             raise ValueError(
-                "The 'max_resource' should be integer or 'auto'."
+                "The 'max_resource' should be integer or 'auto'. "
                 f"But max_resource = {self._max_resource}"
             )
 


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. To minimize the review effort, we highly appreciate PRs only with related changes. Please note that submitted PRs may be closed if they include unrelated changes or significantly modified unit tests. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
I wanted to change the string formatting according to issue #6305 , and make it more readable.

## Description of the changes
I replaced using `"{}".format(var)` with `f"{var}"` formatting in [optuna/pruners/_hyperband.py](https://github.com/optuna/optuna/blob/181f4c117c81eeb50a65846b25a7b867beee6d80/optuna/pruners/_hyperband.py#L162)