### PR TITLE
Fix mypy error for np.select

### DIFF
--- a/optuna/samplers/_tpe/_truncnorm.py
+++ b/optuna/samplers/_tpe/_truncnorm.py
@@ -259,7 +259,11 @@ def ppf(q: np.ndarray, a: np.ndarray | float, b: np.ndarray | float) -> np.ndarr
     if (q_right := q[case_right]).size:
         out[case_right] = ppf_right(q_right, a[case_right], b[case_right], log_mass[case_right])
 
-    return np.select([a == b, q == 1, q == 0], [math.nan, b, a], default=out)
+    out[q == 0] = a[q == 0]
+    out[q == 1] = b[q == 1]
+    out[a == b] = math.nan
+
+    return out
 
 
 def rvs(


### PR DESCRIPTION
## Motivation
Recent releases of `numpy-typing-compat` have begun installing numpy 2.4.0rc1, which causes mypy error. This PR rewrites `np.select` with explicit implementation.

## Description of the changes
Rewriting `np.select` to fix mypy error.