### PR TITLE
Change string formatting for `_successive_halving.py`

### DIFF
--- a/optuna/pruners/_successive_halving.py
+++ b/optuna/pruners/_successive_halving.py
@@ -145,7 +145,8 @@ class SuccessiveHalvingPruner(BasePruner):
 
         if bootstrap_count < 0:
             raise ValueError(
-                f"The value of `bootstrap_count` is {bootstrap_count}, but must be `bootstrap_count >= 0`"
+                "The value of `bootstrap_count` is "
+                f"{bootstrap_count}, but must be `bootstrap_count >= 0`"
             )
 
         if bootstrap_count > 0 and min_resource == "auto":


### PR DESCRIPTION
## Motivation
I wanted to change the string formatting according to issue https://github.com/optuna/optuna/issues/6305  for compatibility.

## Description of the changes
I replaced the use of "{}".format(var) with f-strings as f"{var}" formatting in [optuna/pruners/_successive_halving.py](https://github.com/optuna/optuna/blob/master/optuna/pruners/_successive_halving.py)
