### PR TITLE
fix type annotations for 'optuna/samplers/_grid.py'

### DIFF
--- a/optuna/samplers/_grid.py
+++ b/optuna/samplers/_grid.py
@@ -6,7 +6,6 @@ import itertools
 from numbers import Real
 from typing import Any
 from typing import TYPE_CHECKING
-from typing import Union
 
 import numpy as np
 
@@ -23,7 +22,7 @@ if TYPE_CHECKING:
     from optuna.study import Study
 
 
-GridValueType = Union[str, float, int, bool, None]
+GridValueType = str | float | int | bool | None
 
 
 _logger = get_logger(__name__)


### PR DESCRIPTION
## Motivation
This PR aims to enhance type annotation handling in Optuna to the module `optuna/samplers/_grid.py` and contributes to solving https://github.com/optuna/optuna/issues/4508.

## Description of the changes
Apply changes to `optuna/samplers/_grid.py` by replacing `Union` with `|`.
