### PR TITLE
Fix type annotations for `optuna/trial/_frozen.py`

### DIFF
--- a/optuna/trial/_frozen.py
+++ b/optuna/trial/_frozen.py
@@ -6,7 +6,6 @@ import datetime
 import math
 from typing import Any
 from typing import cast
-from typing import Dict
 from typing import overload
 
 from optuna import distributions
@@ -450,7 +449,7 @@ class FrozenTrial(BaseTrial):
 
     @system_attrs.setter
     def system_attrs(self, value: Mapping[str, JSONSerializable]) -> None:
-        self._system_attrs = cast(Dict[str, Any], value)
+        self._system_attrs = cast(dict[str, Any], value)
 
     @property
     def last_step(self) -> int | None:


### PR DESCRIPTION
## Motivation
This PR aims to enhance type annotation handling in Optuna to the module `optuna/trial/_frozen.py` and contributes to solving https://github.com/optuna/optuna/issues/4508.

## Description of the changes
Apply changes to `optuna/samplers/_frozen.py` following [PEP 585](https://peps.python.org/pep-0585/) to replace `typing.Dict` with `dict` in `cast`.
