### PR TITLE
Fix type annotations for `tests/study_tests/test_study.py`

### DIFF
--- a/tests/study_tests/test_study.py
+++ b/tests/study_tests/test_study.py
@@ -10,7 +10,6 @@ import pickle
 import threading
 import time
 from typing import Any
-from typing import Callable as TypingCallable
 from unittest.mock import MagicMock
 from unittest.mock import Mock
 from unittest.mock import patch
@@ -45,7 +44,7 @@ from optuna.trial import FrozenTrial
 from optuna.trial import TrialState
 
 
-CallbackFuncType = TypingCallable[[Study, FrozenTrial], None]
+CallbackFuncType = Callable[[Study, FrozenTrial], None]
 
 NUM_MINIMAL_TRIALS = 2
 MINIMUM_TIMEOUT_SEC = 0.01


### PR DESCRIPTION
## Motivation
This PR aims to enhance type annotation handling in Optuna to the module `tests/study_tests/test_study.py` and contributes to solving https://github.com/optuna/optuna/issues/4508.

## Description of the changes
Apply changes to `tests/study_tests/test_study.py` following [PEP 585](https://peps.python.org/pep-0585/) to reduce `Callable` in the type definition.
