### PR TITLE
Move type-only imports to `TYPE_CHECKING` in `_constrained_optimization.py`

### DIFF
--- a/optuna/study/_constrained_optimization.py
+++ b/optuna/study/_constrained_optimization.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+from typing import TYPE_CHECKING
 
-from optuna.trial import FrozenTrial
+
+if TYPE_CHECKING:
+    from optuna.trial import FrozenTrial
 
 
 _CONSTRAINTS_KEY = "constraints"


### PR DESCRIPTION
## Motivation

This PR is part of the type-checking cleanup effort. In `optuna/study/_constrained_optimization.py`, the `FrozenTrial` import is used only for type annotations and is not needed at runtime. Moving it under a `TYPE_CHECKING` block reduces unnecessary runtime imports and aligns the file with Optuna's type-hinting conventions.

## Description of the changes

- Moved the type-only import `FrozenTrial` into a `TYPE_CHECKING` block.
- No functional behavior was changed.

Related to #6029
