### PR TITLE
Move `FrozenTrial` import under `TYPE_CHECKING` for `_study_summary.py` file

### DIFF
--- a/optuna/study/_study_summary.py
+++ b/optuna/study/_study_summary.py
@@ -3,12 +3,15 @@ from __future__ import annotations
 from collections.abc import Sequence
 import datetime
 from typing import Any
+from typing import TYPE_CHECKING
 
 from optuna import logging
-from optuna import trial
 from optuna._warnings import optuna_warn
 from optuna.study._study_direction import StudyDirection
 
+
+if TYPE_CHECKING:
+    from optuna.trial import FrozenTrial
 
 _logger = logging.get_logger(__name__)
 
@@ -54,7 +57,7 @@ class StudySummary:
         self,
         study_name: str,
         direction: StudyDirection | None,
-        best_trial: trial.FrozenTrial | None,
+        best_trial: FrozenTrial | None,
         user_attrs: dict[str, Any],
         system_attrs: dict[str, Any],
         n_trials: int,


### PR DESCRIPTION
### Description

This PR addresses part of issue #6029: "Use TYPE_CHECKING if necessary" by moving the import of `FrozenTrial` in `study_summary.py` under a `TYPE_CHECKING` block.

`FrozenTrial` is only used for type annotations in this module and is not required at runtime. Moving this import under `TYPE_CHECKING` reduces unnecessary runtime imports and aligns with Optuna's ongoing cleanup of typing-only imports.


### Changes

- This PR moves the `FrozenTrial` import so that it is only loaded during type checking, since it is not needed at runtime.
- There are no runtime behavior changes.
