### PR TITLE
Fix TC006 violation in tests/visualization_tests/test_utils.py

### DIFF
--- a/tests/visualization_tests/test_utils.py
+++ b/tests/visualization_tests/test_utils.py
@@ -64,7 +64,7 @@ def test_check_plot_args() -> None:
         _check_plot_args(study, None, "Objective Value")
 
     with pytest.warns(UserWarning):
-        _check_plot_args(study, lambda t: cast(float, t.value), "Objective Value")
+        _check_plot_args(study, lambda t: cast("float", t.value), "Objective Value")
 
 
 @pytest.mark.parametrize("value, expected", [(float("inf"), 1), (-float("inf"), 1), (0.0, 2)])


### PR DESCRIPTION
## Motivation

This PR fixes a TC006 violation reported by flake8-type-checking in the visualization test.

Using a string literal in typing.cast() follows the recommended typing practice
and avoids unnecessary runtime dependencies.

## Description of the changes

- Replace the concrete type annotation in typing.cast() with a string literal in a visualization test.
- No functional behavior is changed.
