### PR TITLE
Move type-check imports to `TYPE_CHECKING` in `optuna/terminator/callback.py`

### DIFF
--- a/optuna/terminator/callback.py
+++ b/optuna/terminator/callback.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
 
 _logger = get_logger(__name__)
 
+
 @experimental_class("3.2.0")
 class TerminatorCallback:
     """A callback that terminates the optimization using Terminator.


### PR DESCRIPTION
### Summary
This PR moves type-only imports (`FrozenTrial`, `BaseTerminator`, and `Study` ) into a `TYPE_CHECKING` block following Optuna’s type-hinting style, in the file `optuna\terminator\callback.py`

### What was changed?
- Moved type-only imports into a `TYPE_CHECKING:` block  
- Updated annotations accordingly  
- No functional behavior changed

related to #6029
