### PR TITLE
Using f-string instead of `.format()`

### DIFF
--- a/optuna/pruners/_threshold.py
+++ b/optuna/pruners/_threshold.py
@@ -99,11 +99,11 @@ class ThresholdPruner(BasePruner):
             raise ValueError("lower should be smaller than upper.")
         if n_warmup_steps < 0:
             raise ValueError(
-                "Number of warmup steps cannot be negative but got {}.".format(n_warmup_steps)
+                f"Number of warmup steps cannot be negative but got {n_warmup_steps}."
             )
         if interval_steps < 1:
             raise ValueError(
-                "Pruning interval steps must be at least 1 but got {}.".format(interval_steps)
+                f"Pruning interval steps must be at least 1 but got {interval_steps}."
             )
 
         self._lower = lower


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. To minimize the review effort, we highly appreciate PRs only with related changes. Please note that submitted PRs may be closed if they include unrelated changes or significantly modified unit tests. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
Instead of .format(), used f-string to improve code readability.

## Description of the changes
Made changes in optuna/pruners/_threshold.py. Replaced strings with .format() with f-strings in lines 102 and 106.
