### PR TITLE
Use f-strings in `optuna/_experimental.py`

### DIFF
--- a/optuna/_experimental.py
+++ b/optuna/_experimental.py
@@ -75,8 +75,8 @@ def experimental_func(
         @functools.wraps(func)
         def wrapper(*args: Any, **kwargs: Any) -> FT:
             warnings.warn(
-                "{} is experimental (supported from v{}). "
-                "The interface can change in the future.".format(_name, version),
+                f"{_name} is experimental (supported from v{version}). "
+                "The interface can change in the future.",
                 ExperimentalWarning,
                 stacklevel=2,
             )


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. To minimize the review effort, we highly appreciate PRs only with related changes. Please note that submitted PRs may be closed if they include unrelated changes or significantly modified unit tests. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
This PR addresses #6305. Since Optuna no longer supports Python 3.8, we can use f-strings instead of `.format()`.

## Description of the changes
<!-- Describe the changes in this PR. -->
Replaced `.format()` usage with f-strings in `optuna/_experimental.py` (one file only).

## Testing
- `pre-commit run --all-files`
- `pytest tests/test_experimental.py -vv`

Refs #6305