### PR TITLE
Fix invalid `StorageTestCase` scenarios involving trial state and values

### DIFF
--- a/optuna/testing/pytest_storages.py
+++ b/optuna/testing/pytest_storages.py
@@ -744,8 +744,7 @@ class StorageTestCase:
         for state in states:
             t = _generate_trial(generator)
             t.state = state
-            if t.state == TrialState.COMPLETE:
-                t.values = [0.0]
+            t.values = [0.0] if t.state == TrialState.COMPLETE else None
             storage.create_new_trial(study_id, template_trial=t)
 
         trials = storage.get_all_trials(study_id, states=None)
@@ -817,8 +816,7 @@ class StorageTestCase:
         for s in states:
             t = _generate_trial(generator)
             t.state = s
-            if t.state == TrialState.COMPLETE:
-                t.values = [0.0]
+            t.values = [0.0] if t.state == TrialState.COMPLETE else None
             storage.create_new_trial(study_id, template_trial=t)
 
         assert storage.get_n_trials(study_id, TrialState.COMPLETE) == 2


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. To minimize the review effort, we highly appreciate PRs only with related changes. Please note that submitted PRs may be closed if they include unrelated changes or significantly modified unit tests. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
Follow-up #6369

## Description of the changes

`StorageTestCase` includes several scenarios that do not align with Optuna’s expected trial lifecycle. These patterns are not valid in normal usage and can cause inconsistencies with the current validation logic.

This PR removes or updates the following cases:
* Marking a trial as COMPLETE without providing values.
* Providing values when marking a trial as FAIL, which violates the constraints enforced by [`FrozenTrial._validate()`](https://github.com/optuna/optuna/blob/a8f7033ea22d6443ebb1825f6fb4807861f28aac/optuna/trial/_frozen.py#L322-L323).
* Providing values for a WAITING trial, which is obviously unexpected scenario.