### PR TITLE
Move `type-hint` import inside `Type-Checking` block in `optuna\terminator\erroreval.py`

### DIFF
--- a/optuna/terminator/erroreval.py
+++ b/optuna/terminator/erroreval.py
@@ -2,14 +2,18 @@ from __future__ import annotations
 
 import abc
 from typing import cast
+from typing import TYPE_CHECKING
 
 import numpy as np
 
 from optuna._experimental import experimental_class
 from optuna.study import StudyDirection
-from optuna.trial import FrozenTrial
-from optuna.trial import Trial
 from optuna.trial._state import TrialState
+
+
+if TYPE_CHECKING:
+    from optuna.trial import FrozenTrial
+    from optuna.trial import Trial
 
 
 _CROSS_VALIDATION_SCORES_KEY = "terminator:cv_scores"


### PR DESCRIPTION
### Summary
This PR moves type-only imports (`FrozenTrial` and `Trial` ) into a `TYPE_CHECKING` block following Optuna’s type-hinting style, in the file `optuna\terminator\erroreval.py`

### What was changed?
- Moved type-only imports into a `TYPE_CHECKING:` block  
- Updated annotations accordingly  
- No functional behavior changed

related to #6029
