### PR TITLE
Clarify catch requirement for RetryFailedTrialCallback

### DIFF
--- a/optuna/storages/_callbacks.py
+++ b/optuna/storages/_callbacks.py
@@ -14,6 +14,9 @@ class RetryFailedTrialCallback:
 
     When a trial fails, this callback can be used with a class in :mod:`optuna.storages` to
     recreate the trial in ``TrialState.WAITING`` to queue up the trial to be run again.
+    Note that the optimization loop must continue running after a failure for retries to
+    occur; therefore, exceptions must be caught in
+    :func:`~optuna.study.Study.optimize` (e.g., via the ``catch`` argument).
 
     The failed trial can be identified by the
     :func:`~optuna.storages.RetryFailedTrialCallback.retried_trial_number` function.


### PR DESCRIPTION

## Motivation
Users reported confusion around `RetryFailedTrialCallback` where retries do not occur if
the optimization terminates on an uncaught exception (see #6085).

The current documentation does not explicitly mention that exceptions must be caught in
`Study.optimize` for the retry mechanism to take effect.

## Description of the changes
This PR clarifies the usage contract of `RetryFailedTrialCallback` by adding a note to the
documentation explaining that retries require the optimization loop to continue running.

It explicitly states that users must specify exceptions to catch in `Study.optimize` and
provides a minimal working example using the `catch` argument. No runtime behavior is changed.

