### PR TITLE
Move typing-only imports under `TYPE_CHECKING` in `matplotlib/_slice.py`

### DIFF
--- a/optuna/visualization/matplotlib/_slice.py
+++ b/optuna/visualization/matplotlib/_slice.py
@@ -1,18 +1,23 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from collections.abc import Callable
 import math
 from typing import Any
+from typing import TYPE_CHECKING
 
 from optuna._experimental import experimental_func
-from optuna.study import Study
-from optuna.trial import FrozenTrial
 from optuna.visualization._slice import _get_slice_plot_info
 from optuna.visualization._slice import _PlotValues
 from optuna.visualization._slice import _SlicePlotInfo
 from optuna.visualization._slice import _SliceSubplotInfo
 from optuna.visualization.matplotlib._matplotlib_imports import _imports
+
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from optuna.study import Study
+    from optuna.trial import FrozenTrial
 
 
 if _imports.is_successful():


### PR DESCRIPTION
## Motivation
This PR moves type-only imports (`Callable`, `Study` and `FrozenTrial` ) into a `TYPE_CHECKING` block following Optuna’s type-hinting style, in the file `optuna/visualization/matplotlib/_slice.py
`
## Description of the changes
- Moved the type-only import `Callable`, `Study` and `FrozenTrial` into a `TYPE_CHECKING` block.
- No functional behavior was changed.
