### PR TITLE
Update string formatting in `optuna/samplers/_grid.py`

### DIFF
--- a/optuna/samplers/_grid.py
+++ b/optuna/samplers/_grid.py
@@ -189,7 +189,7 @@ class GridSampler(BaseSampler):
             raise ValueError(message)
 
         if param_name not in self._search_space:
-            message = f"The parameter name, {param_name=}, is not found in the given grid."
+            message = f"The parameter name, {param_name}, is not found in the given grid."
             raise ValueError(message)
 
         grid_id = trial.system_attrs["grid_id"]
@@ -225,8 +225,8 @@ class GridSampler(BaseSampler):
             return
 
         message = (
-            f"{param_name=} contains a value with the type of {type(param_value)=}, "
-            "which is not supported by `GridSampler`. Please make sure a value is `str`,"
+            f"{param_name} contains a value with the type of {type(param_value)}, "
+            "which is not supported by `GridSampler`. Please make sure a value is `str`, "
             "`int`, `float`, `bool` or `None` for persistent storage."
         )
         optuna_warn(message)


### PR DESCRIPTION
## Motivation
- Updating the string formatting according to Python 3.8 compatibility in file `optuna/samplers/_grid.py`
- Addressing (https://github.com/optuna/optuna/issues/6305 for compatibility.)

## Description of the changes
- In the file `optuna/samplers/_grid.py`, I replaced string formatting using .format() with f-strings as suggested in the issue.
