### PR TITLE
Move `type-hint` imports into `type-checking` block in `optuna\terminator\improvement\evaluator.py`

### DIFF
--- a/optuna/terminator/improvement/evaluator.py
+++ b/optuna/terminator/improvement/evaluator.py
@@ -10,7 +10,6 @@ from optuna.distributions import BaseDistribution
 from optuna.samplers._lazy_random_state import LazyRandomState
 from optuna.search_space import intersection_search_space
 from optuna.study import StudyDirection
-from optuna.trial import FrozenTrial
 from optuna.trial import TrialState
 
 
@@ -20,6 +19,8 @@ if TYPE_CHECKING:
     from optuna._gp import optim_sample
     from optuna._gp import prior
     from optuna._gp import search_space as gp_search_space
+    from optuna.trial import FrozenTrial
+
 else:
     from optuna._imports import _LazyImport
 


### PR DESCRIPTION
### Summary
This PR moves type-only imports (`FrozenTrial` ) into a `TYPE_CHECKING` block following Optuna’s type-hinting style, in the file `optuna\terminator\improvement\evaluator.py`

### What was changed?
- Moved type-only imports into a `TYPE_CHECKING:` block  
- Updated annotations accordingly  
- No functional behavior changed

related to #6029
