### PR TITLE
Move `type-hint` imports into `type-checking` block in `median_erroreval.py`

### DIFF
--- a/optuna/terminator/median_erroreval.py
+++ b/optuna/terminator/median_erroreval.py
@@ -1,15 +1,19 @@
 from __future__ import annotations
 
 import sys
+from typing import TYPE_CHECKING
 
 import numpy as np
 
 from optuna._experimental import experimental_class
-from optuna.study import StudyDirection
 from optuna.terminator.erroreval import BaseErrorEvaluator
-from optuna.terminator.improvement.evaluator import BaseImprovementEvaluator
-from optuna.trial import FrozenTrial
 from optuna.trial._state import TrialState
+
+
+if TYPE_CHECKING:
+    from optuna.study import StudyDirection
+    from optuna.terminator.improvement.evaluator import BaseImprovementEvaluator
+    from optuna.trial import FrozenTrial
 
 
 @experimental_class("4.0.0")


### PR DESCRIPTION
### Summary
This PR moves type-only imports (`FrozenTrial`, `StudyDirection`, `BaseImprovementEvaluator` ) into a `TYPE_CHECKING` block following Optuna’s type-hinting style, in the file `optuna\terminator\median_erroreval.py`

### What was changed?
- Moved type-only imports into a `TYPE_CHECKING:` block  
- Updated annotations accordingly  
- No functional behavior changed

related to #6029
