### PR TITLE
Replace .format() with f-string in test_hyperband.py

### DIFF
--- a/tests/pruners_tests/test_hyperband.py
+++ b/tests/pruners_tests/test_hyperband.py
@@ -131,7 +131,7 @@ def test_hyperband_filter_study(
                 reduction_factor=REDUCTION_FACTOR,
             )
             with mock.patch(
-                "optuna.samplers.{}.{}".format(sampler.__class__.__name__, method_name),
+                f"optuna.samplers.{sampler.__class__.__name__}.{method_name}",
                 wraps=getattr(sampler, method_name),
             ) as method_mock:
                 study = optuna.study.create_study(sampler=sampler, pruner=pruner)
@@ -166,7 +166,7 @@ def test_hyperband_no_filter_study(
         sampler = optuna.samplers.RandomSampler()
         pruner = pruner_init_func()
         with mock.patch(
-            "optuna.samplers.{}.{}".format(sampler.__class__.__name__, method_name),
+            f"optuna.samplers.{sampler.__class__.__name__}.{method_name}",
             wraps=getattr(sampler, method_name),
         ) as method_mock:
             study = optuna.study.create_study(sampler=sampler, pruner=pruner)


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. To minimize the review effort, we highly appreciate PRs only with related changes. Please note that submitted PRs may be closed if they include unrelated changes or significantly modified unit tests. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
This PR addresses Issue https://github.com/optuna/optuna/issues/6305 by refactoring string formatting in optuna/tests/pruners_tests/test_hyperband.py.

## Description of the changes
<!-- Describe the changes in this PR. -->
 Replaced all instances of the .format(...) method with modern f-strings. Specifically changed line 134 and line 169.