### PR TITLE
Replace .format() with f-string in _deprecated.py

### DIFF
--- a/optuna/_deprecated.py
+++ b/optuna/_deprecated.py
@@ -43,8 +43,7 @@ def _validate_two_version(old_version: str, new_version: str) -> None:
     if version.parse(old_version) > version.parse(new_version):
         raise ValueError(
             "Invalid version relationship. The deprecated version must be smaller than "
-            "the removed version, but (deprecated version, removed version) = ({}, {}) are "
-            "specified.".format(old_version, new_version)
+            f"the removed version, but {(old_version, new_version)=} are specified."
         )
 
 


### PR DESCRIPTION
## Summary

Part of #6305 - Replace `.format()` with f-string in `optuna/_deprecated.py`.

## Changes

Converted the error message in `_validate_two_version()` to use f-string with `{var_name=}` format for clearer output.

## Test Plan

- Existing tests should pass
- No functional change, only formatting style