### PR TITLE
Replace .format() with f-string in _imports.py

### DIFF
--- a/optuna/_imports.py
+++ b/optuna/_imports.py
@@ -59,15 +59,15 @@ class _DeferredImportExceptionContextManager:
         if isinstance(exc_value, (ImportError, SyntaxError)):
             if isinstance(exc_value, ImportError):
                 message = (
-                    "Tried to import '{}' but failed. Please make sure that the package is "
-                    "installed correctly to use this feature. Actual error: {}."
-                ).format(exc_value.name, exc_value)
+                    f"Tried to import '{exc_value.name}' but failed. Please make sure that the "
+                    f"package is installed correctly to use this feature. Actual error: {exc_value}."
+                )
             elif isinstance(exc_value, SyntaxError):
                 message = (
-                    "Tried to import a package but failed due to a syntax error in {}. Please "
-                    "make sure that the Python version is correct to use this feature. Actual "
-                    "error: {}."
-                ).format(exc_value.filename, exc_value)
+                    f"Tried to import a package but failed due to a syntax error in "
+                    f"{exc_value.filename}. Please make sure that the Python version is correct "
+                    f"to use this feature. Actual error: {exc_value}."
+                )
             else:
                 assert False
 


### PR DESCRIPTION
## Summary

Part of #6305 - Replace `.format()` with f-string in `optuna/_imports.py`.

## Changes

Converted error messages in `_DeferredImportExceptionContextManager.__exit__()` to use f-strings for both ImportError and SyntaxError cases.

## Test Plan

- Existing tests should pass
- No functional change, only formatting style