### PR TITLE
Fix windows-test failure due to `NamedTemporaryFilePool`

### DIFF
--- a/optuna/testing/tempfile_pool.py
+++ b/optuna/testing/tempfile_pool.py
@@ -57,7 +57,5 @@ class NamedTemporaryFilePool:
         for p in path:
             try:
                 os.unlink(p)
-            except FileNotFoundError:
-                pass
-            except PermissionError:
+            except (FileNotFoundError, PermissionError):
                 pass


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. To minimize the review effort, we highly appreciate PRs only with related changes. Please note that submitted PRs may be closed if they include unrelated changes or significantly modified unit tests. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation for submitting this PR. This is useful for reviewers to understand the context of the PR. -->
Sometimes, Windows-test failed due to a `Permission Error` (https://github.com/optuna/optuna/actions/runs/20156155033/job/57859104062?pr=6369).
This PR fixes this issue to make `NamedTemporaryFilePool` thread-safe.

## Description of the changes
<!-- Describe the changes in this PR. -->
- Make NamedTemporaryFilePool thread-safe.