### PR TITLE
Move type-only imports to TYPE_CHECKING in `_param_importances.py`

### DIFF
--- a/optuna/visualization/_param_importances.py
+++ b/optuna/visualization/_param_importances.py
@@ -1,18 +1,23 @@
 from __future__ import annotations
 
-from collections.abc import Callable
 from typing import NamedTuple
+from typing import TYPE_CHECKING
 
 import optuna
-from optuna.distributions import BaseDistribution
-from optuna.importance._base import BaseImportanceEvaluator
 from optuna.logging import get_logger
-from optuna.study import Study
-from optuna.trial import FrozenTrial
 from optuna.trial import TrialState
 from optuna.visualization._plotly_imports import _imports
 from optuna.visualization._utils import _check_plot_args
 from optuna.visualization._utils import _filter_nonfinite
+
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from optuna.distributions import BaseDistribution
+    from optuna.importance._base import BaseImportanceEvaluator
+    from optuna.study import Study
+    from optuna.trial import FrozenTrial
 
 
 if _imports.is_successful():


### PR DESCRIPTION
**Summary**
Move type-only imports in `optuna/visualization/_param_importances.py` into a `TYPE_CHECKING` block.

**Motivation**
- Limits runtime imports by isolating type-only dependencies under `TYPE_CHECKING`.
- Clarifies the boundary between imports required at runtime and those used solely for type checking.
- The implementation follows the guideline proposed in issue #6029.

**Changes**
- Moved type-only imports (`Callable`, `BaseDistribution`, `BaseImportanceEvaluator`, `Study`, `FrozenTrial`) into `if TYPE_CHECKING:`.

**Verification**
- Existing visualization tests passed.
- Pre-commit checks (ruff, formatting, mypy) passed.