### PR TITLE
Use __future__.annotations in matplotlib/_intermediate_values

### DIFF
--- a/optuna/visualization/matplotlib/_intermediate_values.py
+++ b/optuna/visualization/matplotlib/_intermediate_values.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from optuna._experimental import experimental_func
 from optuna.logging import get_logger
 from optuna.study import Study
@@ -14,7 +16,7 @@ _logger = get_logger(__name__)
 
 
 @experimental_func("2.2.0")
-def plot_intermediate_values(study: Study) -> "Axes":
+def plot_intermediate_values(study: Study) -> Axes:
     """Plot intermediate values of all trials in a study with Matplotlib.
 
     .. seealso::
@@ -38,7 +40,7 @@ def plot_intermediate_values(study: Study) -> "Axes":
     return _get_intermediate_plot(_get_intermediate_plot_info(study))
 
 
-def _get_intermediate_plot(info: _IntermediatePlotInfo) -> "Axes":
+def _get_intermediate_plot(info: _IntermediatePlotInfo) -> Axes:
     # Set up the graph style.
     plt.style.use("ggplot")  # Use ggplot style sheet for similar outputs to plotly.
     _, ax = plt.subplots(tight_layout=True)


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. To minimize the review effort, we highly appreciate PRs only with related changes. Please note that submitted PRs may be closed if they include unrelated changes or significantly modified unit tests. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
Issue #4508 tracks the ongoing effort to use postponed evaluation of type annotations across the Optuna codebase.

The matplotlib intermediate values visualization currently uses quoted type annotations for Axes due to conditional imports. Using from __future__ import annotations allows these annotations to be evaluated lazily, improving readability and consistency with other visualization modules.

## Description of the changes

- Added from __future__ import annotations to the matplotlib intermediate values visualization module.
- Removed quoted return type annotations for Axes and replaced them with standard annotations.
- No functional or behavioral changes were introduced.

Fixes #4508
