### PR TITLE
Fix combination between `PartialFixedSampler` and `TPESampler` with group decomposed search space

### DIFF
--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -418,12 +418,17 @@ class TPESampler(BaseSampler):
             assert self._search_space_group is not None
             params = {}
             for sub_space in self._search_space_group.search_spaces:
-                search_space = {}
+                _search_space = {}
                 # Sort keys because Python's string hashing is nondeterministic.
                 for name, distribution in sorted(sub_space.items()):
-                    if not distribution.single():
-                        search_space[name] = distribution
-                params.update(self._sample_relative(study, trial, search_space))
+                    if distribution.single():
+                        continue
+                    if name not in search_space:
+                        # When used together with PartialFixedSampler, the search space may be
+                        # smaller than what is inferred from the study.
+                        continue
+                    _search_space[name] = distribution
+                params.update(self._sample_relative(study, trial, _search_space))
         else:
             params = self._sample_relative(study, trial, search_space)
 

--- a/tests/samplers_tests/test_partial_fixed.py
+++ b/tests/samplers_tests/test_partial_fixed.py
@@ -1,38 +1,55 @@
+from collections.abc import Callable
 from unittest.mock import patch
 import warnings
 
 import pytest
 
 import optuna
+from optuna.samplers import BaseSampler
 from optuna.samplers import PartialFixedSampler
 from optuna.samplers import RandomSampler
 from optuna.trial import Trial
 
 
-def test_fixed_sampling() -> None:
+parametrize_sampler = pytest.mark.parametrize(
+    "sampler_class",
+    [
+        optuna.samplers.RandomSampler,
+        lambda: optuna.samplers.TPESampler(n_startup_trials=0),
+        lambda: optuna.samplers.TPESampler(n_startup_trials=0, multivariate=True),
+        lambda: optuna.samplers.TPESampler(n_startup_trials=0, multivariate=True, group=True),
+        lambda: optuna.samplers.CmaEsSampler(n_startup_trials=0),
+        lambda: optuna.samplers.CmaEsSampler(n_startup_trials=0, use_separable_cma=True),
+        optuna.samplers.NSGAIISampler,
+        optuna.samplers.NSGAIIISampler,
+        optuna.samplers.QMCSampler,
+        lambda: optuna.samplers.GPSampler(n_startup_trials=0),
+        lambda: optuna.samplers.GPSampler(n_startup_trials=0, deterministic_objective=True),
+    ],
+)
+
+
+@parametrize_sampler
+def test_fixed_sampling(sampler_class: Callable[[], BaseSampler]) -> None:
     def objective(trial: Trial) -> float:
         x = trial.suggest_float("x", -10, 10)
         y = trial.suggest_float("y", -10, 10)
-        return x**2 + y**2
+        z = trial.suggest_float("z", -10, 10)
+        return x**2 + y**2 + z**2
 
-    study0 = optuna.create_study()
-    study0.sampler = RandomSampler(seed=42)
-    study0.optimize(objective, n_trials=1)
-    x_sampled0 = study0.trials[0].params["x"]
+    base_sampler = sampler_class()
 
-    # Fix parameter ``y`` as 0.
-    study1 = optuna.create_study()
+    study = optuna.create_study(sampler=base_sampler)
+    study.optimize(objective, n_trials=1)
+
+    # Fix parameter ``z`` as 0.
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", optuna.exceptions.ExperimentalWarning)
-        study1.sampler = PartialFixedSampler(
-            fixed_params={"y": 0}, base_sampler=RandomSampler(seed=42)
-        )
-    study1.optimize(objective, n_trials=1)
+        sampler = PartialFixedSampler(fixed_params={"z": 0}, base_sampler=base_sampler)
+    study.sampler = sampler
+    study.optimize(objective, n_trials=1)
 
-    x_sampled1 = study1.trials[0].params["x"]
-    y_sampled1 = study1.trials[0].params["y"]
-    assert x_sampled1 == x_sampled0
-    assert y_sampled1 == 0
+    assert study.trials[1].params["z"] == 0
 
 
 def test_float_to_int() -> None:


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. To minimize the review effort, we highly appreciate PRs only with related changes. Please note that submitted PRs may be closed if they include unrelated changes or significantly modified unit tests. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
Fix #6427.
Since `TPESampler` contains a `GroupDecomposedSearchSpace`, it attempts to suggest parameters even for those that were excluded by the `PartialFixedSampler`.


## Description of the changes
<!-- Describe the changes in this PR. -->
- Fix the implementation of `TPESampler` to respect the `search_space` argument.
- Add tests.