### PR TITLE
Validate artifact_id in FileSystemArtifactStore to prevent path traversal

### DIFF
--- a/tests/artifacts_tests/test_filesystem.py
+++ b/tests/artifacts_tests/test_filesystem.py
@@ -39,3 +39,17 @@ def test_file_not_found(tmp_path: str) -> None:
 
     with pytest.raises(ArtifactNotFound):
         backend.remove("not-found-id")
+
+
+def test_path_traversal(tmp_path: Path) -> None:
+    backend = FileSystemArtifactStore(tmp_path)
+    invalid_ids = ["../test.txt", "/etc/passwd", ".."]
+    for invalid_id in invalid_ids:
+        with pytest.raises(ValueError, match="Invalid artifact_id"):
+            backend.open_reader(invalid_id)
+
+        with pytest.raises(ValueError, match="Invalid artifact_id"):
+            backend.write(invalid_id, io.BytesIO(b""))
+
+        with pytest.raises(ValueError, match="Invalid artifact_id"):
+            backend.remove(invalid_id)


### PR DESCRIPTION
## Motivation
Validation was missing for `artifact_id` in `FileSystemArtifactStore`, which meant joined paths could potentially point outside the intended base directory. While our higher-level APIs use UUIDs, adding a check here ensures the storage remains robust regardless of how it's called. I think it's better to enforce this at the storage level rather than relying on upstream callers.

## Description of the changes
A new `_get_filepath` helper handles the path construction and boundary checks. If someone tries to pass an absolute path or something with `..` as an ID, the code now throws a `ValueError`. All file operations in the class now use this helper, and I also added a test case in `tests/artifacts_tests/test_filesystem.py` to verify it works as expected.