### PR TITLE
Use `TYPE_CHECKING` for import in `pruners/_base.py`

### DIFF
--- a/optuna/pruners/_base.py
+++ b/optuna/pruners/_base.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import abc
 from typing import TYPE_CHECKING
 
+
 if TYPE_CHECKING:
     import optuna
 


### PR DESCRIPTION
## Summary

Part of #6029

Move `import optuna` under `if TYPE_CHECKING:` guard in `optuna/pruners/_base.py` to prevent potential circular import issues.

## Changes

- Add `from __future__ import annotations` for PEP 563 postponed evaluation
- Add `from typing import TYPE_CHECKING`
- Move `import optuna` under `if TYPE_CHECKING:` block