### PR TITLE
Use f-strings in `_intermediate_values.py`

### DIFF
--- a/optuna/visualization/_intermediate_values.py
+++ b/optuna/visualization/_intermediate_values.py
@@ -92,7 +92,7 @@ def _get_intermediate_plot(info: _IntermediatePlotInfo) -> "go.Figure":
             marker=(
                 default_marker if tinfo.feasible else {**default_marker, "color": "#CCCCCC"}  # type: ignore[dict-item]
             ),
-            name="Trial{}".format(tinfo.trial_number),
+            name=f"Trial{tinfo.trial_number}",
         )
         for tinfo in trial_infos
     ]


### PR DESCRIPTION
## Description

Addresses #6305

Converted `.format()` to f-string in `optuna/visualization/_intermediate_values.py`.

## Checklist
- [x] One file only