### PR TITLE
Use f-strings in `cli.py`

### DIFF
--- a/optuna/cli.py
+++ b/optuna/cli.py
@@ -921,9 +921,7 @@ def _get_parser(description: str = "") -> tuple[ArgumentParser, dict[str, Argume
     parent_parser = _add_common_arguments(parent_parser)
 
     main_parser = ArgumentParser(description=description, parents=[parent_parser])
-    main_parser.add_argument(
-        "--version", action="version", version=f"optuna {optuna.__version__}"
-    )
+    main_parser.add_argument("--version", action="version", version=f"optuna {optuna.__version__}")
     command_name_to_subparser = _add_commands(main_parser, parent_parser)
     return main_parser, command_name_to_subparser
 


### PR DESCRIPTION
## Description

Addresses #6305

Converted `.format()` to f-string in `optuna/cli.py`.

## Checklist
- [x] One file only