### PR TITLE
Use f-strings in `optuna/integration/__init__.py`

### DIFF
--- a/optuna/integration/__init__.py
+++ b/optuna/integration/__init__.py
@@ -120,7 +120,7 @@ else:
                 module = self._get_module(self._class_to_module[name])
                 value = getattr(module, name)
             else:
-                raise AttributeError(f"module {self.__name__!r} has no attribute {name!r}")
+                raise AttributeError(f"module {self.__name__} has no attribute {name}")
 
             setattr(self, name, value)
             return value

--- a/optuna/integration/__init__.py
+++ b/optuna/integration/__init__.py
@@ -120,7 +120,7 @@ else:
                 module = self._get_module(self._class_to_module[name])
                 value = getattr(module, name)
             else:
-                raise AttributeError("module {} has no attribute {}".format(self.__name__, name))
+                raise AttributeError(f"module {self.__name__!r} has no attribute {name!r}")
 
             setattr(self, name, value)
             return value


### PR DESCRIPTION
## Description

Addresses #6305

Converted `.format()` to f-string in `optuna/integration/__init__.py`.

## Checklist
- [x] One file only