### PR TITLE
Use f-strings in `_deprecated.py`

### DIFF
--- a/optuna/_deprecated.py
+++ b/optuna/_deprecated.py
@@ -43,8 +43,8 @@ def _validate_two_version(old_version: str, new_version: str) -> None:
     if version.parse(old_version) > version.parse(new_version):
         raise ValueError(
             "Invalid version relationship. The deprecated version must be smaller than "
-            "the removed version, but (deprecated version, removed version) = ({}, {}) are "
-            "specified.".format(old_version, new_version)
+            "the removed version, but (deprecated version, removed version) = "
+            f"({old_version}, {new_version}) are specified."
         )
 
 


### PR DESCRIPTION
## Description

Addresses #6305

Converted direct `.format()` call to f-string in `optuna/_deprecated.py`.

Note: Left template-based formatting (`_DEPRECATION_WARNING_TEMPLATE.format()` etc.) intact.

## Checklist
- [x] One file only