### PR TITLE
Use f-strings in `_trial.py`

### DIFF
--- a/optuna/trial/_trial.py
+++ b/optuna/trial/_trial.py
@@ -656,9 +656,8 @@ class Trial(BaseTrial):
         contained = distribution._contains(param_value_in_internal_repr)
         if not contained:
             optuna_warn(
-                "Fixed parameter '{}' with value {} is out of range for distribution {}.".format(
-                    name, param_value, distribution
-                )
+                f"Fixed parameter {name!r} with value {param_value} is out of range "
+                f"for distribution {distribution}."
             )
         return True
 
@@ -670,8 +669,8 @@ class Trial(BaseTrial):
 
         if name not in self.relative_search_space:
             raise ValueError(
-                "The parameter '{}' was sampled by `sample_relative` method "
-                "but it is not contained in the relative search space.".format(name)
+                f"The parameter {name!r} was sampled by `sample_relative` method "
+                "but it is not contained in the relative search space."
             )
 
         relative_distribution = self.relative_search_space[name]
@@ -685,13 +684,13 @@ class Trial(BaseTrial):
         old_distribution = self._cached_frozen_trial.distributions.get(name, distribution)
         if old_distribution != distribution:
             optuna_warn(
-                'Inconsistent parameter values for distribution with name "{}"! '
+                f'Inconsistent parameter values for distribution with name "{name}"! '
                 "This might be a configuration mistake. "
                 "Optuna allows to call the same distribution with the same "
                 "name more than once in a trial. "
                 "When the parameter values are inconsistent optuna only "
                 "uses the values of the first call and ignores all following. "
-                "Using these values: {}".format(name, old_distribution._asdict()),
+                f"Using these values: {old_distribution._asdict()}",
                 RuntimeWarning,
             )
 

--- a/optuna/trial/_trial.py
+++ b/optuna/trial/_trial.py
@@ -656,7 +656,7 @@ class Trial(BaseTrial):
         contained = distribution._contains(param_value_in_internal_repr)
         if not contained:
             optuna_warn(
-                f"Fixed parameter {name!r} with value {param_value} is out of range "
+                f"Fixed parameter {name} with value {param_value} is out of range "
                 f"for distribution {distribution}."
             )
         return True
@@ -669,7 +669,7 @@ class Trial(BaseTrial):
 
         if name not in self.relative_search_space:
             raise ValueError(
-                f"The parameter {name!r} was sampled by `sample_relative` method "
+                f"The parameter {name} was sampled by `sample_relative` method "
                 "but it is not contained in the relative search space."
             )
 


### PR DESCRIPTION
## Description

Addresses #6305

Converted 3 direct `.format()` calls to f-strings in `optuna/trial/_trial.py`.

Note: Left `_suggest_deprecated_msg.format()` calls intact as they intentionally use a shared constant template.

## Checklist
- [x] One file only