### PR TITLE
Use `TYPE_CHECKING` for import in `pruners/_hyperband.py`

### DIFF
--- a/optuna/pruners/_hyperband.py
+++ b/optuna/pruners/_hyperband.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
 import binascii
-from collections.abc import Container
 import math
+from typing import TYPE_CHECKING
 
 import optuna
+
+
+if TYPE_CHECKING:
+    from collections.abc import Container
 from optuna import logging
 from optuna.pruners._base import BasePruner
 from optuna.pruners._successive_halving import SuccessiveHalvingPruner


### PR DESCRIPTION
## Summary

Part of #6029

Move `collections.abc.Container` import under `if TYPE_CHECKING:` guard in `optuna/pruners/_hyperband.py` to prevent unnecessary runtime import.

## Changes

- Add `from typing import TYPE_CHECKING`
- Move `from collections.abc import Container` under `if TYPE_CHECKING:` block
- `from __future__ import annotations` was already present