### PR TITLE
Refactor: Move FrozenTrial import to TYPE_CHECKING block

### DIFF
--- a/optuna/visualization/_utils.py
+++ b/optuna/visualization/_utils.py
@@ -5,6 +5,7 @@ from collections.abc import Sequence
 import json
 from typing import Any
 from typing import cast
+from typing import TYPE_CHECKING
 
 import numpy as np
 
@@ -15,8 +16,10 @@ from optuna.distributions import FloatDistribution
 from optuna.distributions import IntDistribution
 from optuna.study import Study
 from optuna.study._study_direction import StudyDirection
-from optuna.trial import FrozenTrial
 from optuna.visualization import _plotly_imports
+
+if TYPE_CHECKING:
+    from optuna.trial import FrozenTrial
 
 
 __all__ = ["is_available"]


### PR DESCRIPTION
Moved the `FrozenTrial` import in `optuna/visualization/_utils.py` behind a `TYPE_CHECKING` block to avoid unnecessary runtime overhead, as it is only used for type annotations.\n\nFixes #6029.