### PR TITLE
refactor:replace.format() with f-string in frozen trial

### DIFF
--- a/optuna/trial/_frozen.py
+++ b/optuna/trial/_frozen.py
@@ -195,14 +195,14 @@ class FrozenTrial(BaseTrial):
         return "{cls}({kwargs})".format(
             cls=self.__class__.__name__,
             kwargs=", ".join(
-                "{field}={value}".format(
-                    field=field if not field.startswith("_") else field[1:],
-                    value=repr(getattr(self, field)),
-                )
+                f"{field if not field.startswith("_")else field[1:]}={repr(getattr(self,field))}"
+            
+            
                 for field in self.__dict__
-            )
-            + ", value=None",
-        )
+            
+            )+",value=None",
+    )
+        
 
     def suggest_float(
         self,


### PR DESCRIPTION
Replaced ` .format()` calls with `f` string in the Frozen-trial class .This change simplifies the internal logic for generating string representations of the object while maintaining the existing output format.
