### PR TITLE
Use `TYPE_CHECKING` for typing-only imports in `test_timeline.py`

### DIFF
--- a/tests/visualization_tests/test_timeline.py
+++ b/tests/visualization_tests/test_timeline.py
@@ -1,16 +1,14 @@
 from __future__ import annotations
 
-from collections.abc import Callable
 import datetime
 from io import BytesIO
 from typing import Any
+from typing import TYPE_CHECKING
 
-import _pytest.capture
 import pytest
 
 import optuna
 from optuna.samplers._base import _CONSTRAINTS_KEY
-from optuna.study.study import Study
 from optuna.trial import TrialState
 from optuna.visualization import plot_timeline as plotly_plot_timeline
 from optuna.visualization._plotly_imports import _imports as plotly_imports
@@ -18,6 +16,13 @@ from optuna.visualization._timeline import _get_timeline_info
 from optuna.visualization.matplotlib import plot_timeline as plt_plot_timeline
 from optuna.visualization.matplotlib._matplotlib_imports import _imports as plt_imports
 
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    import _pytest.capture
+
+    from optuna.study.study import Study
 
 if plotly_imports.is_successful():
     from optuna.visualization._plotly_imports import go


### PR DESCRIPTION
## Summary
Move typing-only imports in `optuna/tests/visualization_tests/test_timeline.py` under `if TYPE_CHECKING` guard to prevent potential circular import issues

## Motivation

- Follows the guideline proposed in #6029

## Description of the changes

- Added `from typing import TYPE_CHECKING`

- Moved `from collections.abc import Callable`, `import _pytest.capture`, and `from optuna.study.study import Study` under `TYPE_CHECKING` block
