### PR TITLE
feat(gp): add support for explicit heteroscedastic noise in GPSampler

### DIFF
--- a/tests/gp_tests/test_gp.py
+++ b/tests/gp_tests/test_gp.py
@@ -4,9 +4,9 @@ import numpy as np
 import pytest
 import torch
 
+from optuna._gp.gp import fit_kernel_params
 from optuna._gp.gp import GPRegressor
 from optuna._gp.gp import warn_and_convert_inf
-from optuna._gp.gp import fit_kernel_params
 import optuna._gp.prior as prior
 
 
@@ -164,9 +164,7 @@ def test_gp_heteroscedastic_noise() -> None:
         minimum_noise=1e-5,
         deterministic_objective=False,
     )
-    mean_standard, _ = gpr_standard.posterior(
-        torch.tensor([[1.0]], dtype=torch.float64)
-    )
+    mean_standard, _ = gpr_standard.posterior(torch.tensor([[1.0]], dtype=torch.float64))
 
     custom_noise_vars = np.array([0.0, 100.0, 0.0])
     gpr_custom = fit_kernel_params(


### PR DESCRIPTION
## Motivation
Resolves #6446

Currently, `GPSampler` assumes homoscedastic noise. When optimizing noisy objective functions, users often have access to per-trial noise estimates (e.g., bootstrapped error estimates, variance across cross-validation folds). If a trial returns a great objective value but has massive variance, the GP might mistakenly exploit that highly uncertain "fluke." 

This PR allows the sampler to accept user-provided heteroscedastic noise variances, enabling the surrogate model to intelligently discount noisy regions of the search space and vastly improve sample efficiency.

## Description of the changes
- Defines `"gp_noise_variance"` as a recognized key to be extracted from `trial.user_attrs`.
- Updates `optuna/samplers/_gp/sampler.py` to extract this user-provided variance, scale it mathematically using the internal objective standard deviations (`stds ** 2`), and pass it to the GP math engine.
- Updates `optuna/_gp/gp.py` (`GPRegressor` and `fit_kernel_params`) to accept the new `custom_noise_vars` array.
- Injects the custom variance array directly into the diagonal of the covariance matrix during both the `marginal_log_likelihood` parameter optimization and the posterior `_cache_matrix` computation.
- Adds a deterministic unit test in `tests/gp_tests/test_gp.py` verifying that the GP posterior mean successfully ignores an injected high-variance outlier.