### PR TITLE
refactor: move optuna import into TYPE_CHECKING in pruners/_patient.py

### DIFF
--- a/optuna/pruners/_patient.py
+++ b/optuna/pruners/_patient.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import numpy as np
 
-import optuna
 from optuna._experimental import experimental_class
 from optuna.pruners import BasePruner
 from optuna.study._study_direction import StudyDirection
+
+if TYPE_CHECKING:
+    import optuna
 
 
 @experimental_class("2.8.0")
@@ -87,7 +91,7 @@ class PatientPruner(BasePruner):
         self._patience = patience
         self._min_delta = min_delta
 
-    def prune(self, study: "optuna.study.Study", trial: "optuna.trial.FrozenTrial") -> bool:
+    def prune(self, study: optuna.study.Study, trial: optuna.trial.FrozenTrial) -> bool:
         step = trial.last_step
         if step is None:
             return False


### PR DESCRIPTION
## Summary

Closes #6029

The `import optuna` in `optuna/pruners/_patient.py` is only used for type annotations in the `prune` method signature (`optuna.study.Study` and `optuna.trial.FrozenTrial`). Moving it into a `TYPE_CHECKING` block avoids the runtime import overhead and prevents potential circular import issues.

Since the file already has `from __future__ import annotations`, the string quotes around the annotations are also removed.

**Changes:**
- Add `from typing import TYPE_CHECKING`
- Move `import optuna` inside `if TYPE_CHECKING:` block
- Remove unnecessary string quotes from `prune()` type annotations

Verified with `ruff check optuna/pruners/_patient.py --select TCH` — all checks pass.