### PR TITLE
refactor: move type-only imports into TYPE_CHECKING in pruners/_percentile.py

### DIFF
--- a/optuna/pruners/_percentile.py
+++ b/optuna/pruners/_percentile.py
@@ -1,15 +1,19 @@
 from __future__ import annotations
 
-from collections.abc import KeysView
 import functools
 import math
+from typing import TYPE_CHECKING
 
 import numpy as np
 
-import optuna
 from optuna.pruners import BasePruner
 from optuna.study._study_direction import StudyDirection
 from optuna.trial._state import TrialState
+
+if TYPE_CHECKING:
+    from collections.abc import KeysView
+
+    import optuna
 
 
 def _get_best_intermediate_result_over_steps(


### PR DESCRIPTION
Closes #6029

Move `import optuna` and `from collections.abc import KeysView` into a `TYPE_CHECKING` block in `optuna/pruners/_percentile.py`, since both are only used in type annotations and the file already has `from __future__ import annotations`.

Verified with `ruff check optuna/pruners/_percentile.py --select TCH` — all checks pass.