### PR TITLE
refactor: move optuna import into TYPE_CHECKING in pruners/_successive_halving.py

### DIFF
--- a/optuna/pruners/_successive_halving.py
+++ b/optuna/pruners/_successive_halving.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
 import math
+from typing import TYPE_CHECKING
 
-import optuna
 from optuna.pruners._base import BasePruner
 from optuna.study._study_direction import StudyDirection
 from optuna.trial._state import TrialState
+
+if TYPE_CHECKING:
+    import optuna
 
 
 class SuccessiveHalvingPruner(BasePruner):


### PR DESCRIPTION
Closes #6029

Move `import optuna` into a `TYPE_CHECKING` block in `optuna/pruners/_successive_halving.py`, since it is only used in type annotations and the file already has `from __future__ import annotations`.

Verified with `ruff check optuna/pruners/_successive_halving.py --select TCH` — all checks pass.