### PR TITLE
refactor: move optuna import into TYPE_CHECKING in pruners/_threshold.py

### DIFF
--- a/optuna/pruners/_threshold.py
+++ b/optuna/pruners/_threshold.py
@@ -2,10 +2,13 @@ from __future__ import annotations
 
 import math
 from typing import Any
+from typing import TYPE_CHECKING
 
-import optuna
 from optuna.pruners import BasePruner
 from optuna.pruners._percentile import _is_first_in_interval_step
+
+if TYPE_CHECKING:
+    import optuna
 
 
 def _check_value(value: Any) -> float:


### PR DESCRIPTION
Closes #6029

Move `import optuna` into a `TYPE_CHECKING` block in `optuna/pruners/_threshold.py`, since it is only used in type annotations and the file already has `from __future__ import annotations`.

Verified with `ruff check optuna/pruners/_threshold.py --select TCH` — all checks pass.