### PR TITLE
refactor: move type-only imports into TYPE_CHECKING in pruners/_wilcoxon.py

### DIFF
--- a/optuna/pruners/_wilcoxon.py
+++ b/optuna/pruners/_wilcoxon.py
@@ -4,18 +4,18 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
-import optuna
 from optuna._experimental import experimental_class
 from optuna._warnings import optuna_warn
 from optuna.pruners import BasePruner
 from optuna.study._study_direction import StudyDirection
-from optuna.trial import FrozenTrial
 
 
 if TYPE_CHECKING:
     from typing import Literal
 
+    import optuna
     import scipy.stats as ss
+    from optuna.trial import FrozenTrial
 else:
     from optuna._imports import _LazyImport
 


### PR DESCRIPTION
Closes #6029

Move `import optuna` and `from optuna.trial import FrozenTrial` into the existing `TYPE_CHECKING` block in `optuna/pruners/_wilcoxon.py`, since both are only used in type annotations and the file already has `from __future__ import annotations`.

Verified with `ruff check optuna/pruners/_wilcoxon.py --select TCH` — all checks pass.