### PR TITLE
refactor: move type-only imports into TYPE_CHECKING in samplers/_base.py

### DIFF
--- a/optuna/samplers/_base.py
+++ b/optuna/samplers/_base.py
@@ -1,21 +1,22 @@
 from __future__ import annotations
 
 import abc
-from collections.abc import Callable
-from collections.abc import Sequence
 from typing import Any
 from typing import TYPE_CHECKING
 
 import numpy as np
 
 from optuna._warnings import optuna_warn
-from optuna.distributions import BaseDistribution
-from optuna.trial import FrozenTrial
 from optuna.trial import TrialState
 
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+    from collections.abc import Sequence
+
+    from optuna.distributions import BaseDistribution
     from optuna.study import Study
+    from optuna.trial import FrozenTrial
 
 
 _INDEPENDENT_SAMPLING_WARNING_TEMPLATE = (


### PR DESCRIPTION
Closes #6029

Move `Callable` and `Sequence` (from `collections.abc`), `BaseDistribution`, and `FrozenTrial` into the existing `TYPE_CHECKING` block in `optuna/samplers/_base.py`, since all are only used in type annotations and the file already has `from __future__ import annotations`.

Verified with `ruff check optuna/samplers/_base.py --select TCH` — all checks pass.