### PR TITLE
refactor: move type-only imports into TYPE_CHECKING in samplers/_grid.py

### DIFF
--- a/optuna/samplers/_grid.py
+++ b/optuna/samplers/_grid.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Mapping
-from collections.abc import Sequence
 import itertools
 from numbers import Real
 from typing import Any
@@ -11,16 +9,19 @@ from typing import Union
 import numpy as np
 
 from optuna._warnings import optuna_warn
-from optuna.distributions import BaseDistribution
 from optuna.logging import get_logger
 from optuna.samplers import BaseSampler
 from optuna.samplers._lazy_random_state import LazyRandomState
-from optuna.trial import FrozenTrial
 from optuna.trial import TrialState
 
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+    from collections.abc import Sequence
+
+    from optuna.distributions import BaseDistribution
     from optuna.study import Study
+    from optuna.trial import FrozenTrial
 
 
 GridValueType = Union[str, float, int, bool, None]


### PR DESCRIPTION
Closes #6029

Move `Mapping` and `Sequence` (from `collections.abc`), `BaseDistribution`, and `FrozenTrial` into the existing `TYPE_CHECKING` block in `optuna/samplers/_grid.py`, since all are only used in type annotations and the file already has `from __future__ import annotations`.

Verified with `ruff check optuna/samplers/_grid.py --select TCH` — all checks pass.