### PR TITLE
refactor: move BaseDistribution into TYPE_CHECKING in search_space/intersection.py

### DIFF
--- a/optuna/search_space/intersection.py
+++ b/optuna/search_space/intersection.py
@@ -4,10 +4,10 @@ import copy
 from typing import TYPE_CHECKING
 
 import optuna
-from optuna.distributions import BaseDistribution
 
 
 if TYPE_CHECKING:
+    from optuna.distributions import BaseDistribution
     from optuna.study import Study
 
 


### PR DESCRIPTION
Refs #6029

Move `from optuna.distributions import BaseDistribution` into the existing `TYPE_CHECKING` block in `optuna/search_space/intersection.py`, since it is only used in type annotations and the file already has `from __future__ import annotations`.

Verified with `ruff check optuna/search_space/intersection.py --select TCH` — all checks pass.