### PR TITLE
refactor: move Study import into TYPE_CHECKING in terminator/terminator.py

### DIFF
--- a/optuna/terminator/terminator.py
+++ b/optuna/terminator/terminator.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import abc
+from typing import TYPE_CHECKING
 
 from optuna._experimental import experimental_class
-from optuna.study.study import Study
 from optuna.terminator.erroreval import BaseErrorEvaluator
 from optuna.terminator.erroreval import CrossValidationErrorEvaluator
 from optuna.terminator.erroreval import StaticErrorEvaluator
@@ -12,6 +12,9 @@ from optuna.terminator.improvement.evaluator import BestValueStagnationEvaluator
 from optuna.terminator.improvement.evaluator import DEFAULT_MIN_N_TRIALS
 from optuna.terminator.improvement.evaluator import RegretBoundEvaluator
 from optuna.trial import TrialState
+
+if TYPE_CHECKING:
+    from optuna.study.study import Study
 
 
 class BaseTerminator(metaclass=abc.ABCMeta):


### PR DESCRIPTION
Closes part of #6029.

`Study` is only used in type annotations (method signatures), so it can be moved into the `TYPE_CHECKING` block to avoid runtime import overhead.

Changes:
- Added `TYPE_CHECKING` import
- Moved `from optuna.study.study import Study` into the `if TYPE_CHECKING:` block