### PR TITLE
refactor: move type-only imports into TYPE_CHECKING in visualization/_utils.py

### DIFF
--- a/optuna/visualization/_utils.py
+++ b/optuna/visualization/_utils.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
-from collections.abc import Callable
-from collections.abc import Sequence
 import json
+from typing import TYPE_CHECKING
 from typing import Any
 from typing import cast
 
@@ -15,8 +14,12 @@ from optuna.distributions import FloatDistribution
 from optuna.distributions import IntDistribution
 from optuna.study import Study
 from optuna.study._study_direction import StudyDirection
-from optuna.trial import FrozenTrial
 from optuna.visualization import _plotly_imports
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from collections.abc import Sequence
+    from optuna.trial import FrozenTrial
 
 
 __all__ = ["is_available"]
@@ -141,7 +144,7 @@ def _filter_nonfinite(
     if target is None:
 
         def _target(t: FrozenTrial) -> float:
-            return cast(float, t.value)
+            return cast("float", t.value)
 
         target = _target
 


### PR DESCRIPTION
Closes part of #6029.

`Callable`, `Sequence`, and `FrozenTrial` are only used in type annotations, so they can be moved into the `TYPE_CHECKING` block. Also quotes the `cast()` type expression per TC006.