### PR TITLE
refactor: move type-only imports into TYPE_CHECKING in visualization/_slice.py

### DIFF
--- a/optuna/visualization/_slice.py
+++ b/optuna/visualization/_slice.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Callable
+from typing import TYPE_CHECKING
 from typing import Any
 from typing import cast
 from typing import NamedTuple
@@ -9,9 +9,12 @@ from optuna.distributions import CategoricalChoiceType
 from optuna.distributions import CategoricalDistribution
 from optuna.logging import get_logger
 from optuna.samplers._base import _CONSTRAINTS_KEY
-from optuna.study import Study
 from optuna.trial import FrozenTrial
 from optuna.trial import TrialState
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from optuna.study import Study
 from optuna.visualization._plotly_imports import _imports
 from optuna.visualization._utils import _check_plot_args
 from optuna.visualization._utils import _filter_nonfinite
@@ -60,7 +63,7 @@ def _get_slice_subplot_info(
     if target is None:
 
         def _target(t: FrozenTrial) -> float:
-            return cast(float, t.value)
+            return cast("float", t.value)
 
         target = _target
 


### PR DESCRIPTION
Closes part of #6029.

`Callable` and `Study` are only used in type annotations, so they can be moved into the `TYPE_CHECKING` block. Also quotes the `cast()` type expression per TC006.