### PR TITLE
refactor: move Callable import into TYPE_CHECKING in visualization/_contour.py

### DIFF
--- a/optuna/visualization/_contour.py
+++ b/optuna/visualization/_contour.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
-from collections.abc import Callable
 import math
+from typing import TYPE_CHECKING
 from typing import Any
 from typing import NamedTuple
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 import numpy as np
 


### PR DESCRIPTION
Closes part of #6029.

`Callable` is only used in type annotations, so it can be moved into the `TYPE_CHECKING` block to avoid runtime import overhead.