### PR TITLE
Remove version & language selectors in the sidebar of docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -99,8 +99,8 @@ html_theme = "sphinx_rtd_theme"
 html_theme_options = {
     "logo_only": True,
     "navigation_with_keys": True,
-    "theme_language_selector": False,
-    "theme_version_selector": False,
+    "language_selector": False,
+    "version_selector": False,
 }
 
 html_favicon = "../image/favicon.ico"


### PR DESCRIPTION
## Motivation & Description of the changes

Since v4.1, there are unnecessary transparent version & language selectors. This PR disables them.

Current: https://optuna.readthedocs.io/en/latest/
<img width="303" height="229" alt="image" src="https://github.com/user-attachments/assets/874b8e15-c5cf-47ad-a0bd-bae337f2f3c0" />

Fixed: https://optuna--6482.org.readthedocs.build/en/6482/
<img width="323" height="347" alt="image" src="https://github.com/user-attachments/assets/bf8c14a1-cb7a-4894-877d-864762126d3b" />
