### PR TITLE
Add acqf import inside a `TYPE_CHECKING` block

### DIFF
--- a/optuna/_gp/optim_sample.py
+++ b/optuna/_gp/optim_sample.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import numpy as np
 
-from optuna._gp import acqf as acqf_module
+
+if TYPE_CHECKING:
+    from optuna._gp import acqf as acqf_module
 
 
 def optimize_acqf_sample(


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. To minimize the review effort, we highly appreciate PRs only with related changes. Please note that submitted PRs may be closed if they include unrelated changes or significantly modified unit tests. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
The import of optuna._gp.acqf was used only for type hints.
Moving it under TYPE_CHECKING avoids runtime imports and potential circular dependencies.
## Description of the changes
- Move type-only import to TYPE_CHECKING block in optim_sample.py
## Tests
- ruff check optuna/_gp/optim_sample.py --select TCH

Part of #6029 
