### PR TITLE
Use `TYPE_CHECKING` in `pruners/_threshold.py`

### DIFF
--- a/optuna/pruners/_threshold.py
+++ b/optuna/pruners/_threshold.py
@@ -2,10 +2,15 @@ from __future__ import annotations
 
 import math
 from typing import Any
+from typing import TYPE_CHECKING
 
-import optuna
 from optuna.pruners import BasePruner
 from optuna.pruners._percentile import _is_first_in_interval_step
+
+
+if TYPE_CHECKING:
+    from optuna.study import Study
+    from optuna.trial import FrozenTrial
 
 
 def _check_value(value: Any) -> float:
@@ -111,7 +116,7 @@ class ThresholdPruner(BasePruner):
         self._n_warmup_steps = n_warmup_steps
         self._interval_steps = interval_steps
 
-    def prune(self, study: "optuna.study.Study", trial: "optuna.trial.FrozenTrial") -> bool:
+    def prune(self, study: Study, trial: FrozenTrial) -> bool:
         step = trial.last_step
         if step is None:
             return False


### PR DESCRIPTION
## Motivation

Refs #6029

## Description of the changes

Move `import optuna` into a `TYPE_CHECKING` block in `optuna/pruners/_threshold.py`, since it is only used in type annotations and the file already has `from __future__ import annotations`. Replaced string-quoted annotations with direct references.

Verified with `ruff check optuna/pruners/_threshold.py --select TCH`.