### PR TITLE
Use f-string in `tutorial/10_key_features/005_visualization.py`

### DIFF
--- a/tutorial/10_key_features/005_visualization.py
+++ b/tutorial/10_key_features/005_visualization.py
@@ -85,7 +85,7 @@ def define_model(trial):
 
     in_features = 28 * 28
     for i in range(n_layers):
-        out_features = trial.suggest_int("n_units_l{}".format(i), 64, 512)
+        out_features = trial.suggest_int(f"n_units_l{i}", 64, 512)
         layers.append(nn.Linear(in_features, out_features))
         layers.append(nn.ReLU())
 


### PR DESCRIPTION
## Motivation
This PR addresses the good first issue to modernize string formatting across the Optuna codebase, specifically replacing older syntax with cleaner f-strings as requested in #6305.

## Description of the changes
* Updated `tutorial/10_key_features/005_visualization.py` to use an f-string instead of `.format()`.

Fixes #6305