### PR TITLE
Move `JSONSerializable` import to `TYPE_CHECKING` in `study/study.py`

### DIFF
--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -25,7 +25,6 @@ from optuna._convert_positional_args import convert_positional_args
 from optuna._deprecated import deprecated_func
 from optuna._experimental import experimental_func
 from optuna._imports import _LazyImport
-from optuna._typing import JSONSerializable
 from optuna._warnings import optuna_warn
 from optuna.distributions import _convert_old_distribution_to_new_distribution
 from optuna.distributions import BaseDistribution
@@ -45,6 +44,7 @@ from optuna.trial import TrialState
 _dataframe = _LazyImport("optuna.study._dataframe")
 
 if TYPE_CHECKING:
+    from optuna._typing import JSONSerializable
     from optuna.study._dataframe import pd
     from optuna.trial import FrozenTrial
     from optuna.trial import Trial


### PR DESCRIPTION
## Summary

Moves the `JSONSerializable` import in `optuna/study/study.py` under a `TYPE_CHECKING` guard, as it is only used in a type annotation (the `params` parameter of `_should_skip_enqueue`).

This is part of the effort tracked in issue #6029.

## Changes

- `optuna/study/study.py`: Move `from optuna.distributions import JSONSerializable` to the `if TYPE_CHECKING:` block

## Motivation

`JSONSerializable` is only referenced in the type annotation of `_should_skip_enqueue(self, params: Mapping[str, JSONSerializable])`. Moving it under `TYPE_CHECKING` eliminates the runtime import overhead and follows the pattern established for other type-annotation-only imports in the codebase.

## Testing

No behavioral changes. The annotation is only evaluated by type checkers (e.g., mypy), not at runtime.