### PR TITLE
fix: filter None values correctly in slice plots

### DIFF
--- a/optuna/visualization/_slice.py
+++ b/optuna/visualization/_slice.py
@@ -225,17 +225,22 @@ def _generate_slice_subplot(subplot_info: _SliceSubplotInfo) -> list[Scatter]:
     feasible = _PlotValues([], [], [])
     infeasible = _PlotValues([], [], [])
 
+    xs = (
+        [x if x is not None else "None" for x in subplot_info.x]
+        if not subplot_info.is_numerical
+        else subplot_info.x
+    )
+
     for x, y, num, c in zip(
-        subplot_info.x, subplot_info.y, subplot_info.trial_numbers, subplot_info.constraints
+        xs, subplot_info.y, subplot_info.trial_numbers, subplot_info.constraints
     ):
-        if x is not None or x != "None" or y is not None or y != "None":
-            if c:
-                feasible.x.append(x)
-                feasible.y.append(y)
-                feasible.trial_numbers.append(num)
-            else:
-                infeasible.x.append(x)
-                infeasible.y.append(y)
+        if c:
+            feasible.x.append(x)
+            feasible.y.append(y)
+            feasible.trial_numbers.append(num)
+        else:
+            infeasible.x.append(x)
+            infeasible.y.append(y)
     trace.append(
         go.Scatter(
             x=feasible.x,

--- a/optuna/visualization/matplotlib/_slice.py
+++ b/optuna/visualization/matplotlib/_slice.py
@@ -117,18 +117,24 @@ def _generate_slice_subplot(
 
     feasible = _PlotValues([], [], [])
     infeasible = _PlotValues([], [], [])
+
+    xs = (
+        [x if x is not None else "None" for x in subplot_info.x]
+        if not subplot_info.is_numerical
+        else subplot_info.x
+    )
+
     for x, y, num, c in zip(
-        subplot_info.x, subplot_info.y, subplot_info.trial_numbers, subplot_info.constraints
+        xs, subplot_info.y, subplot_info.trial_numbers, subplot_info.constraints
     ):
-        if x is not None or x != "None" or y is not None or y != "None":
-            if c:
-                feasible.x.append(x)
-                feasible.y.append(y)
-                feasible.trial_numbers.append(num)
-            else:
-                infeasible.x.append(x)
-                infeasible.y.append(y)
-                infeasible.trial_numbers.append(num)
+        if c:
+            feasible.x.append(x)
+            feasible.y.append(y)
+            feasible.trial_numbers.append(num)
+        else:
+            infeasible.x.append(x)
+            infeasible.y.append(y)
+            infeasible.trial_numbers.append(num)
     if subplot_info.is_log:
         ax.set_xscale("log")
         scale = "log"

--- a/tests/visualization_tests/test_slice.py
+++ b/tests/visualization_tests/test_slice.py
@@ -17,6 +17,7 @@ from optuna.testing.visualization import prepare_study_with_trials
 from optuna.trial import create_trial
 from optuna.visualization import plot_slice as plotly_plot_slice
 from optuna.visualization._plotly_imports import go
+from optuna.visualization._slice import _generate_slice_subplot
 from optuna.visualization._slice import _get_slice_plot_info
 from optuna.visualization._slice import _SlicePlotInfo
 from optuna.visualization._slice import _SliceSubplotInfo
@@ -448,3 +449,39 @@ def test_color_map(direction: str) -> None:
     marker = plotly_plot_slice(study).data[0]["marker"]
     assert COLOR_SCALE == [v[1] for v in marker["colorscale"]]
     assert "reversecale" not in marker
+
+
+def test_generate_slice_subplot_converts_none_to_string_for_categorical() -> None:
+    """None in categorical params should be converted to 'None' string, not filtered."""
+    subplot_info = _SliceSubplotInfo(
+        param_name="param_a",
+        x=[None, "a"],
+        y=[0.5, 0.6],
+        trial_numbers=[0, 1],
+        is_log=False,
+        is_numerical=False,
+        x_labels=(None, "a"),
+        constraints=[True, True],
+    )
+    traces = _generate_slice_subplot(subplot_info)
+    feasible_trace = traces[0]
+    assert list(feasible_trace.x) == ["None", "a"]
+    assert list(feasible_trace.y) == [0.5, 0.6]
+
+
+def test_generate_slice_subplot_numerical_none_kept_as_is() -> None:
+    """Numerical None values are not converted (no conversion for numerical params)."""
+    subplot_info = _SliceSubplotInfo(
+        param_name="param_a",
+        x=[None, 1.0],
+        y=[0.5, 0.6],
+        trial_numbers=[0, 1],
+        is_log=False,
+        is_numerical=True,
+        x_labels=None,
+        constraints=[True, True],
+    )
+    traces = _generate_slice_subplot(subplot_info)
+    feasible_trace = traces[0]
+    assert list(feasible_trace.x) == [None, 1.0]
+    assert list(feasible_trace.y) == [0.5, 0.6]


### PR DESCRIPTION
## Summary

Restore the `None` to `"None"` string conversion for categorical x-values in slice plots. `None` is a valid `CategoricalDistribution` choice and should be displayed rather than filtered out.

## Problem

The filter condition in both plotly and matplotlib backends used `or` instead of `and`:

```python
if x is not None or x != "None" or y is not None or y != "None":
```

This condition is always true for any value, so it never filters anything. But the deeper issue is that `None` is a valid choice in `CategoricalDistribution` and should not be filtered out at all.

## Fix

Instead of fixing the boolean logic to filter `None` values, replaced the filter with a `None` to `"None"` string conversion for non-numerical parameters before the loop. The `if` guard is removed entirely.

```python
xs = (
    [x if x is not None else "None" for x in subplot_info.x]
    if not subplot_info.is_numerical
    else subplot_info.x
)
```

This preserves `None` as a displayable categorical value rather than dropping those trials from the plot.

## Files changed

- `optuna/visualization/_slice.py`
- `optuna/visualization/matplotlib/_slice.py`
- `tests/visualization_tests/test_slice.py`

## Tests

Replaced old filter test with two new tests covering categorical `None` to `"None"` conversion and numerical pass-through.

```bash
python -m pytest tests/visualization_tests/test_slice.py -v -k "converts_none or numerical_none"
```
```