### PR TITLE
feat: support user_attrs in plot_parallel_coordinate

### DIFF
--- a/optuna/visualization/_parallel_coordinate.py
+++ b/optuna/visualization/_parallel_coordinate.py
@@ -130,11 +130,17 @@ def _get_parallel_coordinate_info(
     )
 
     all_params = {p_name for t in trials for p_name in t.params.keys()}
+    all_user_attr_keys = {k for t in trials for k in t.user_attrs.keys()}
     if params is not None:
         for input_p_name in params:
-            if input_p_name not in all_params:
-                raise ValueError(f"Parameter {input_p_name} does not exist in your study.")
+            if input_p_name not in all_params and input_p_name not in all_user_attr_keys:
+                raise ValueError(
+                    f"Parameter {input_p_name!r} does not exist in your study. "
+                    f"It is neither a parameter nor a user attribute."
+                )
         all_params = set(params)
+    else:
+        all_params = all_params | all_user_attr_keys
     sorted_params = sorted(all_params)
 
     if target is None:
@@ -188,6 +194,9 @@ def _get_parallel_coordinate_info(
             if p_name in t.params:
                 values.append(t.params[p_name])
                 is_categorical |= isinstance(t.distributions[p_name], CategoricalDistribution)
+            elif p_name in t.user_attrs:
+                values.append(t.user_attrs[p_name])
+                is_categorical |= isinstance(t.user_attrs[p_name], (str, bool))
         if _is_log_scale(trials, p_name):
             values = [math.log10(v) for v in values]
             min_value = min(values)

--- a/optuna/visualization/_utils.py
+++ b/optuna/visualization/_utils.py
@@ -123,7 +123,7 @@ def _get_skipped_trial_numbers(
     skipped_trial_numbers = set()
     for trial in trials:
         for used_param in used_param_names:
-            if used_param not in trial.params.keys():
+            if used_param not in trial.params.keys() and used_param not in trial.user_attrs.keys():
                 skipped_trial_numbers.add(trial.number)
                 break
     return skipped_trial_numbers

--- a/tests/visualization_tests/test_parallel_coordinate.py
+++ b/tests/visualization_tests/test_parallel_coordinate.py
@@ -379,7 +379,7 @@ def test_get_parallel_coordinate_info() -> None:
     )
 
     # Test with wrong params that do not exist in trials.
-    with pytest.raises(ValueError, match="Parameter optuna does not exist in your study."):
+    with pytest.raises(ValueError, match="Parameter 'optuna' does not exist in your study."):
         _get_parallel_coordinate_info(study, params=["optuna", "optuna"])
 
     # Ignore failed trials.
@@ -780,3 +780,47 @@ def test_nonfinite_multiobjective(objective: int, value: float) -> None:
         study, target=lambda t: t.values[objective], target_name="Target Name"
     )
     assert all(np.isfinite(info.dim_objective.values))
+
+
+def test_get_parallel_coordinate_info_user_attrs_numerical() -> None:
+    study = create_study()
+    study.add_trial(
+        create_trial(
+            value=0.3,
+            params={"x": 0.5},
+            distributions={"x": FloatDistribution(0, 1)},
+            user_attrs={"n_estimators": 100},
+        )
+    )
+    info = _get_parallel_coordinate_info(study, params=["x", "n_estimators"])
+    param_names = [d.label for d in info.dims_params]
+    assert "n_estimators" in param_names
+
+
+def test_get_parallel_coordinate_info_user_attrs_categorical() -> None:
+    study = create_study()
+    study.add_trial(
+        create_trial(
+            value=0.3,
+            params={"x": 0.5},
+            distributions={"x": FloatDistribution(0, 1)},
+            user_attrs={"model": "lgbm"},
+        )
+    )
+    info = _get_parallel_coordinate_info(study, params=["x", "model"])
+    model_dim = next(d for d in info.dims_params if d.label == "model")
+    assert model_dim.is_cat is True
+
+
+def test_get_parallel_coordinate_info_user_attrs_missing() -> None:
+    study = create_study()
+    study.add_trial(
+        create_trial(
+            value=0.3,
+            params={"x": 0.5},
+            distributions={"x": FloatDistribution(0, 1)},
+            user_attrs={"n_estimators": 100},
+        )
+    )
+    with pytest.raises(ValueError, match="does not exist in your study"):
+        _get_parallel_coordinate_info(study, params=["nonexistent_param"])


### PR DESCRIPTION
## Motivation

Closes #6329

Users who record custom attributes via `trial.set_user_attr()` 
(e.g. `n_estimators` from LightGBM early stopping) had no way 
to visualize them using `plot_parallel_coordinate`.

## Changes

- `_parallel_coordinate.py`: collect `user_attrs` keys alongside 
  `params`, extract values from `user_attrs` when not found in `params`,
  infer type automatically (str/bool → categorical, else numerical)
- `_utils.py`: updated `_get_skipped_trial_numbers` to check 
  `user_attrs` when a key is missing from `params`
- `test_parallel_coordinate.py`: added 3 tests covering numerical 
  user_attrs, categorical user_attrs, and missing param error

## Example
```python
study.add_trial(create_trial(
    value=0.3,
    params={"x": 0.5},
    distributions={"x": FloatDistribution(0, 1)},
    user_attrs={"n_estimators": 100},
))

plot_parallel_coordinate(study, params=["x", "n_estimators"])  # ✅ works now!
```