### PR TITLE
Move `optuna` import to `TYPE_CHECKING` in `pruners/_patient.py`

### DIFF
--- a/optuna/pruners/_patient.py
+++ b/optuna/pruners/_patient.py
@@ -8,6 +8,7 @@ from optuna._experimental import experimental_class
 from optuna.pruners import BasePruner
 from optuna.study._study_direction import StudyDirection
 
+
 if TYPE_CHECKING:
     import optuna
 


### PR DESCRIPTION
Part of #6029

Moves `import optuna` (used only in type annotations) under `if TYPE_CHECKING:` in `optuna/pruners/_patient.py`.

Also removes redundant string quotes from the `prune()` method signature since `from __future__ import annotations` is already present.