### PR TITLE
Move application import to `TYPE_CHECKING` in `pruners/_patient.py`

### DIFF
--- a/optuna/pruners/_patient.py
+++ b/optuna/pruners/_patient.py
@@ -1,11 +1,16 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import numpy as np
 
-import optuna
 from optuna._experimental import experimental_class
 from optuna.pruners import BasePruner
 from optuna.study._study_direction import StudyDirection
+
+
+if TYPE_CHECKING:
+    import optuna
 
 
 @experimental_class("2.8.0")


### PR DESCRIPTION
## Motivation

Part of #6029. Moves the `import optuna` statement into a `TYPE_CHECKING` block in `optuna/pruners/_patient.py`, since it is only used for type annotations.

## Description of the changes

- Moved `import optuna` into `if TYPE_CHECKING:` block
- Added `from typing import TYPE_CHECKING`
- Ran `ruff check --select TCH` to verify the fix
- All 13 tests in `tests/pruners_tests/test_patient.py` pass