### PR TITLE
Move application import to `TYPE_CHECKING` in `pruners/_successive_halving.py`

### DIFF
--- a/optuna/pruners/_successive_halving.py
+++ b/optuna/pruners/_successive_halving.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
 import math
+from typing import TYPE_CHECKING
 
-import optuna
 from optuna.pruners._base import BasePruner
 from optuna.study._study_direction import StudyDirection
 from optuna.trial._state import TrialState
+
+
+if TYPE_CHECKING:
+    import optuna
 
 
 class SuccessiveHalvingPruner(BasePruner):


### PR DESCRIPTION
## Motivation

Part of #6029. Moves the `import optuna` statement into a `TYPE_CHECKING` block in `optuna/pruners/_successive_halving.py`, since it is only used for type annotations.

## Description of the changes

- Moved `import optuna` into `if TYPE_CHECKING:` block
- Added `from typing import TYPE_CHECKING`
- Ran `ruff check --select TCH` to verify the fix
- All 16 tests in `tests/pruners_tests/test_successive_halving.py` pass