### PR TITLE
Correct return type annotations for `Axes` in visualization functions

### DIFF
--- a/optuna/visualization/matplotlib/_contour.py
+++ b/optuna/visualization/matplotlib/_contour.py
@@ -37,7 +37,7 @@ def plot_contour(
     *,
     target: Callable[[FrozenTrial], float] | None = None,
     target_name: str = "Objective Value",
-) -> "Axes":
+) -> "Axes | np.ndarray":
     """Plot the parameter relationship as contour plot in a study with Matplotlib.
 
     Note that, if a parameter contains missing values, a trial with missing values is not plotted.
@@ -60,7 +60,8 @@ def plot_contour(
             Target's name to display on the color bar.
 
     Returns:
-        A :class:`matplotlib.axes.Axes` object.
+        A :class:`matplotlib.axes.Axes` object or a :class:`numpy.ndarray` of
+        :class:`matplotlib.axes.Axes` objects.
 
     .. note::
         The colormap is reversed when the ``target`` argument isn't :obj:`None` or ``direction``
@@ -72,7 +73,7 @@ def plot_contour(
     return _get_contour_plot(info)
 
 
-def _get_contour_plot(info: _ContourInfo) -> "Axes":
+def _get_contour_plot(info: _ContourInfo) -> "Axes | np.ndarray":
     sorted_params = info.sorted_params
     sub_plot_infos = info.sub_plot_infos
     reverse_scale = info.reverse_scale

--- a/optuna/visualization/matplotlib/_rank.py
+++ b/optuna/visualization/matplotlib/_rank.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from collections.abc import Callable
 
+import numpy as np
+
 from optuna._experimental import experimental_func
 from optuna.study import Study
 from optuna.trial import FrozenTrial
@@ -25,7 +27,7 @@ def plot_rank(
     *,
     target: Callable[[FrozenTrial], float] | None = None,
     target_name: str = "Objective Value",
-) -> "Axes":
+) -> "Axes | np.ndarray":
     """Plot parameter relations as scatter plots with colors indicating ranks of target value.
 
     Note that trials missing the specified parameters will not be plotted.
@@ -48,7 +50,8 @@ def plot_rank(
             Target's name to display on the color bar.
 
     Returns:
-        A :class:`matplotlib.axes.Axes` object.
+        A :class:`matplotlib.axes.Axes` object or a :class:`numpy.ndarray` of
+        :class:`matplotlib.axes.Axes` objects.
     """
 
     _imports.check()
@@ -58,7 +61,7 @@ def plot_rank(
 
 def _get_rank_plot(
     info: _RankPlotInfo,
-) -> "Axes":
+) -> "Axes | np.ndarray":
     params = info.params
     sub_plot_infos = info.sub_plot_infos
 

--- a/optuna/visualization/matplotlib/_slice.py
+++ b/optuna/visualization/matplotlib/_slice.py
@@ -5,6 +5,8 @@ import math
 from typing import Any
 from typing import TYPE_CHECKING
 
+import numpy as np
+
 from optuna._experimental import experimental_func
 from optuna.visualization._slice import _get_slice_plot_info
 from optuna.visualization._slice import _PlotValues
@@ -35,7 +37,7 @@ def plot_slice(
     *,
     target: Callable[[FrozenTrial], float] | None = None,
     target_name: str = "Objective Value",
-) -> "Axes":
+) -> "Axes | np.ndarray":
     """Plot the parameter relationship as slice plot in a study with Matplotlib.
 
     .. seealso::
@@ -57,14 +59,15 @@ def plot_slice(
 
 
     Returns:
-        A :class:`matplotlib.axes.Axes` object.
+        A :class:`matplotlib.axes.Axes` object or a :class:`numpy.ndarray` of
+        :class:`matplotlib.axes.Axes` objects.
     """
 
     _imports.check()
     return _get_slice_plot(_get_slice_plot_info(study, params, target, target_name))
 
 
-def _get_slice_plot(info: _SlicePlotInfo) -> "Axes":
+def _get_slice_plot(info: _SlicePlotInfo) -> "Axes | np.ndarray":
     if len(info.subplots) == 0:
         _, ax = plt.subplots()
         return ax


### PR DESCRIPTION
## Motivation

Several matplotlib visualization functions (`plot_contour`, `plot_rank`, `plot_slice`) annotate their return type as `Axes`, but actually return `np.ndarray` when `plt.subplots()` is called with multiple rows or columns. This causes false positives with type checkers like mypy.

See discussion: https://github.com/optuna/optuna/pull/6028#discussion_r2023882810

Fixes #6048

## Description of the changes

Updated return type annotations from `Axes` to `Axes | np.ndarray` in three files:

- `_contour.py`: `plot_contour()` and `_get_contour_plot()` return `np.ndarray` when `n_params > 2`
- `_rank.py`: `plot_rank()` and `_get_rank_plot()` return `np.ndarray` when `n_params >= 3`
- `_slice.py`: `plot_slice()` and `_get_slice_plot()` return `np.ndarray` when `len(info.subplots) > 1`

Also updated the docstring `Returns` section in each public function to document both possible return types.