### PR TITLE
Fix `TPESampler` with `multivariate` and `constant_liar`

### DIFF
--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -455,7 +455,7 @@ class TPESampler(BaseSampler):
         if len(trials) < self._n_startup_trials:
             return {}
 
-        return self._sample(study, trial, search_space, use_trial_cache=True)
+        return self._sample(study, trial, search_space)
 
     def sample_independent(
         self,
@@ -488,10 +488,7 @@ class TPESampler(BaseSampler):
                     )
                 )
 
-        search_space = {param_name: param_distribution}
-        return self._sample(study, trial, search_space, use_trial_cache=not self._constant_liar)[
-            param_name
-        ]
+        return self._sample(study, trial, {param_name: param_distribution})[param_name]
 
     def _get_params(self, trial: FrozenTrial) -> dict[str, Any]:
         if trial.state.is_finished() or not self._multivariate:
@@ -524,17 +521,14 @@ class TPESampler(BaseSampler):
         return {k: np.asarray(v) for k, v in values.items()}
 
     def _sample(
-        self,
-        study: Study,
-        trial: FrozenTrial,
-        search_space: dict[str, BaseDistribution],
-        use_trial_cache: bool,
+        self, study: Study, trial: FrozenTrial, search_space: dict[str, BaseDistribution]
     ) -> dict[str, Any]:
         if self._constant_liar:
             states = [TrialState.COMPLETE, TrialState.PRUNED, TrialState.RUNNING]
         else:
             states = [TrialState.COMPLETE, TrialState.PRUNED]
-        trials = study._get_trials(deepcopy=False, states=states, use_cache=use_trial_cache)
+        use_cache = not self._constant_liar
+        trials = study._get_trials(deepcopy=False, states=states, use_cache=use_cache)
 
         if self._constant_liar:
             # For constant_liar, filter out the current trial.


### PR DESCRIPTION
## Motivation
Combining `TPESampler`'s `multivariate` and `constant_liar` can sometimes cause the `constant_liar` to function improperly during batch optimization.
#6189 fixed the bug that reappeared in #6265, so this PR addresses that issue.

```python
import matplotlib.pyplot as plt
import optuna

N_TRIAL = 50
N_BATCH = 10

multivariate = True
constant_liar = True
sampler = optuna.samplers.TPESampler(
    seed=42,
    multivariate=multivariate,
    constant_liar=constant_liar,
)
study = optuna.create_study(sampler=sampler)

for i in range(0, N_TRIAL, N_BATCH):
    trials = []
    for j in range(N_BATCH):
        trials.append(study.ask())
    X = [trial.suggest_float("x", -10, 10) for trial in trials]
    Y = [trial.suggest_float("y", -10, 10) for trial in trials]
    for j in range(N_BATCH):
        study.tell(trials[j], X[j] ** 2 + Y[j] ** 2)

    # Skip first random sampling.
    if i > 0:
        plt.plot(X, Y, ".")
plt.xlim(-10, 10)
plt.ylim(-10, 10)
plt.savefig(f"{multivariate}-{constant_liar}.png")
plt.clf()
```

- master

<img width="640" height="480" alt="True-True" src="https://github.com/user-attachments/assets/f2d035d3-c968-4179-be24-91525189fcd2" />

- PR

<img width="640" height="480" alt="True-True" src="https://github.com/user-attachments/assets/ee0055e4-fe1b-459d-8630-d3d5e00a2738" />

## Description of the changes
Revert #6265.

## Speed Benchmark

This PR increases storage access and degrades speed. Ideally, this access could be avoided, but making changes to the `Study` class would be required, which I haven't done in this PR.

```python
import optuna

def objective(trial: optuna.Trial) -> float:
    x = trial.suggest_float("x", -100, 100)
    y = trial.suggest_int("y", -100, 100)
    return x**2 + y**2

sampler = optuna.samplers.TPESampler(seed=42, multivariate=True, constant_liar=True)
study = optuna.create_study(sampler=sampler, storage="sqlite:///tmp.db")
study.optimize(objective, n_trials=1000)

```

| master | PR |
| - | - |
| 9.939s | 10.882s |
