### PR TITLE
Replace `.format()`  with f-strings in `002_configurations.py`

### DIFF
--- a/tutorial/10_key_features/002_configurations.py
+++ b/tutorial/10_key_features/002_configurations.py
@@ -80,7 +80,7 @@ def objective(trial):
 #
 #         layers = []
 #         for i in range(n_layers):
-#             n_units = trial.suggest_int("n_units_l{}".format(i), 4, 128, log=True)
+#             n_units = trial.suggest_int(f"n_units_l{i}", 4, 128, log=True)
 #             layers.append(nn.Linear(in_size, n_units))
 #             layers.append(nn.ReLU())
 #             in_size = n_units


### PR DESCRIPTION
Motivation
This PR addresses the issue of replacing the legacy .format() string formatting with modern f-strings (#6305).
Since Optuna no longer supports Python 3.8, the project can adopt f-strings consistently for cleaner and more readable code.

As suggested in the issue, this PR updates the formatting in a single file.

Description of the changes

Replaced the usage of .format() with an f-string in the example code.

Specifically:

"n_units_l{}".format(i)

was replaced with:

f"n_units_l{i}"

No other logic or behavior was modified. The change is purely stylistic and improves code readability.