### PR TITLE
Update LightGBM links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,7 +111,7 @@ HTML files are generated under `build/html` directory. Open `index.html` with th
 if it is rendered as expected.
 
 Optuna's tutorial is built with [Sphinx-Gallery](https://sphinx-gallery.github.io/stable/index.html) and
-some other requirements like [LightGBM](https://github.com/microsoft/LightGBM) and [PyTorch](https://pytorch.org) meaning that
+some other requirements like [LightGBM](https://github.com/lightgbm-org/LightGBM) and [PyTorch](https://pytorch.org) meaning that
 all .py files in `tutorial` directory are run during the documentation build if there's no build cache.
 Whether you edit any tutorial or not doesn't matter.
 


### PR DESCRIPTION
## Motivation

LightGBM has moved out of `Microsoft/` to its own organization: https://github.com/lightgbm-org/LightGBM/issues/7187

This updates links in this project to reflect that.

Thanks for helping people use LightGBM!

## Description of the changes

* updates `microsoft/LightGBM` links to `lightgbm-org/LightGBM`
