### PR TITLE
Use TYPE_CHECKING in importance/_mean_decrease_impurity.py

### DIFF
--- a/optuna/importance/_mean_decrease_impurity.py
+++ b/optuna/importance/_mean_decrease_impurity.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Callable
+from typing import TYPE_CHECKING
 
 import numpy as np
 
@@ -13,8 +13,13 @@ from optuna.importance._base import _get_trans_params
 from optuna.importance._base import _param_importances_to_dict
 from optuna.importance._base import _sort_dict_by_importance
 from optuna.importance._base import BaseImportanceEvaluator
-from optuna.study import Study
-from optuna.trial import FrozenTrial
+
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from optuna.study import Study
+    from optuna.trial import FrozenTrial
 
 
 with try_import() as _imports:


### PR DESCRIPTION
## Motivation

Part of #6029 — move type-only imports into `TYPE_CHECKING` blocks to prevent potential circular import issues and reduce runtime import overhead.

## Description

Move `Callable`, `Study`, and `FrozenTrial` imports into a `TYPE_CHECKING` block in `optuna/importance/_mean_decrease_impurity.py`. These imports are only used in type annotations, which are already strings at runtime due to `from __future__ import annotations`.

## Changes

- `collections.abc.Callable` → moved into `TYPE_CHECKING`
- `optuna.study.Study` → moved into `TYPE_CHECKING`
- `optuna.trial.FrozenTrial` → moved into `TYPE_CHECKING`

`ruff check --select TCH` passes clean on this file after the change.