### PR TITLE
Use TYPE_CHECKING in importance/_ped_anova/evaluator.py

### DIFF
--- a/optuna/importance/_ped_anova/evaluator.py
+++ b/optuna/importance/_ped_anova/evaluator.py
@@ -1,21 +1,26 @@
 from __future__ import annotations
 
-from collections.abc import Callable
+from typing import TYPE_CHECKING
 
 import numpy as np
 
 from optuna._deprecated import _DEPRECATION_WARNING_TEMPLATE
 from optuna._experimental import experimental_class
 from optuna._warnings import optuna_warn
-from optuna.distributions import BaseDistribution
 from optuna.importance._base import _get_distributions
 from optuna.importance._base import _get_filtered_trials
 from optuna.importance._base import _sort_dict_by_importance
 from optuna.importance._base import BaseImportanceEvaluator
 from optuna.importance._ped_anova.scott_parzen_estimator import _build_parzen_estimator
-from optuna.study import Study
 from optuna.study import StudyDirection
-from optuna.trial import FrozenTrial
+
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from optuna.distributions import BaseDistribution
+    from optuna.study import Study
+    from optuna.trial import FrozenTrial
 
 
 class _QuantileFilter:


### PR DESCRIPTION
## Motivation

Part of #6029.

## Description

Move type-only imports into a `TYPE_CHECKING` block in `optuna/importance/_ped_anova/evaluator.py`:

- `collections.abc.Callable` → `TYPE_CHECKING`
- `optuna.distributions.BaseDistribution` → `TYPE_CHECKING`
- `optuna.study.Study` → `TYPE_CHECKING`
- `optuna.trial.FrozenTrial` → `TYPE_CHECKING`

`StudyDirection` remains at module level since it is used as a runtime value (`StudyDirection.MINIMIZE`).

`ruff check --select TCH` passes clean after the change.