### PR TITLE
Use TYPE_CHECKING in samplers/_base.py

### DIFF
--- a/optuna/samplers/_base.py
+++ b/optuna/samplers/_base.py
@@ -1,21 +1,22 @@
 from __future__ import annotations
 
 import abc
-from collections.abc import Callable
-from collections.abc import Sequence
 from typing import Any
 from typing import TYPE_CHECKING
 
 import numpy as np
 
 from optuna._warnings import optuna_warn
-from optuna.distributions import BaseDistribution
-from optuna.trial import FrozenTrial
 from optuna.trial import TrialState
 
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+    from collections.abc import Sequence
+
+    from optuna.distributions import BaseDistribution
     from optuna.study import Study
+    from optuna.trial import FrozenTrial
 
 
 _INDEPENDENT_SAMPLING_WARNING_TEMPLATE = (


### PR DESCRIPTION
## Motivation

Part of #6029.

## Description

Move type-only imports into `TYPE_CHECKING` block in `optuna/samplers/_base.py`:

- `collections.abc.Callable` → `TYPE_CHECKING`
- `collections.abc.Sequence` → `TYPE_CHECKING`
- `optuna.distributions.BaseDistribution` → `TYPE_CHECKING`
- `optuna.trial.FrozenTrial` → `TYPE_CHECKING`

`TrialState` remains at module level since it is used as runtime values (`TrialState.COMPLETE`, `TrialState.PRUNED`).

`ruff check --select TCH` passes clean after the change.