### PR TITLE
Use TYPE_CHECKING in pruners/_wilcoxon.py

### DIFF
--- a/optuna/pruners/_wilcoxon.py
+++ b/optuna/pruners/_wilcoxon.py
@@ -4,18 +4,19 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
-import optuna
 from optuna._experimental import experimental_class
 from optuna._warnings import optuna_warn
 from optuna.pruners import BasePruner
 from optuna.study._study_direction import StudyDirection
-from optuna.trial import FrozenTrial
 
 
 if TYPE_CHECKING:
     from typing import Literal
 
     import scipy.stats as ss
+
+    import optuna
+    from optuna.trial import FrozenTrial
 else:
     from optuna._imports import _LazyImport
 


### PR DESCRIPTION
## Motivation

Part of #6029.

## Description

Move `optuna` and `FrozenTrial` into the `TYPE_CHECKING` block in `optuna/pruners/_wilcoxon.py`. Both are only used in type annotations and docstring examples, not at runtime.

`StudyDirection` stays at module level since it's used as a value (`StudyDirection.MAXIMIZE`).

`ruff check --select TCH` passes clean after the change.