### PR TITLE
Fix write ordering in RDBStorage.set_trial_state_values

### DIFF
--- a/optuna/storages/_rdb/storage.py
+++ b/optuna/storages/_rdb/storage.py
@@ -658,12 +658,12 @@ class RDBStorage(BaseStorage, BaseHeartbeat):
                 trial = models.TrialModel.find_or_raise_by_id(trial_id, session, for_update=True)
                 self.check_trial_is_updatable(trial_id, trial.state)
 
+                if state == TrialState.RUNNING and trial.state != TrialState.WAITING:
+                    return False
+
                 if values is not None:
                     for objective, v in enumerate(values):
                         self._set_trial_value_without_commit(session, trial, objective, v)
-
-                if state == TrialState.RUNNING and trial.state != TrialState.WAITING:
-                    return False
 
                 trial.state = state
 

--- a/tests/storages_tests/rdb_tests/test_storage.py
+++ b/tests/storages_tests/rdb_tests/test_storage.py
@@ -376,3 +376,18 @@ def test_create_new_trial_with_retries() -> None:
         trials = storage.get_all_trials(study_id)
         assert len(trials) == 1
         assert trials[0].number == 0
+
+
+def test_set_trial_state_values_does_not_write_values_on_invalid_state_transition() -> None:
+    storage = RDBStorage("sqlite:///:memory:")
+    study_id = storage.create_new_study(directions=[StudyDirection.MINIMIZE])
+    trial_id = storage.create_new_trial(study_id)
+
+    # The new trial starts in RUNNING state (via create_new_trial).
+    # Attempting RUNNING -> RUNNING should fail because current state is not WAITING.
+    result = storage.set_trial_state_values(trial_id, state=TrialState.RUNNING, values=[1.0])
+    assert result is False
+
+    # Verify that trial values were NOT persisted despite the early return.
+    trial = storage.get_trial(trial_id)
+    assert trial.values is None


### PR DESCRIPTION
## Motivation

`RDBStorage.set_trial_state_values()` writes trial values to the database before checking whether the state transition is valid. When the method returns `False` (e.g., attempting to set `RUNNING` on a non-`WAITING` trial), the scoped session commits on normal exit, persisting the written values without the intended state change.

`InMemoryStorage` and `JournalStorage` both perform the state check before writing values, so this is an inconsistency specific to `RDBStorage`.

## Description of the changes

Move the state-transition check before the values-writing loop to match the behavior of other storage backends. Add a regression test.