### PR TITLE
Use TYPE_CHECKING in pruners/_percentile.py

### DIFF
--- a/optuna/pruners/_percentile.py
+++ b/optuna/pruners/_percentile.py
@@ -1,15 +1,20 @@
 from __future__ import annotations
 
-from collections.abc import KeysView
 import functools
 import math
+from typing import TYPE_CHECKING
 
 import numpy as np
 
-import optuna
 from optuna.pruners import BasePruner
 from optuna.study._study_direction import StudyDirection
 from optuna.trial._state import TrialState
+
+
+if TYPE_CHECKING:
+    from collections.abc import KeysView
+
+    import optuna
 
 
 def _get_best_intermediate_result_over_steps(


### PR DESCRIPTION
Part of #6029.

Moved KeysView and optuna into the TYPE_CHECKING block. Both are only used in type annotations and docstring examples, not at runtime. StudyDirection and TrialState stay at module level since they're used as values.

ruff check --select TCH passes clean.