### PR TITLE
Use TYPE_CHECKING in nsgaii/_constraints_evaluation.py

### DIFF
--- a/optuna/samplers/nsgaii/_constraints_evaluation.py
+++ b/optuna/samplers/nsgaii/_constraints_evaluation.py
@@ -1,15 +1,20 @@
 from __future__ import annotations
 
-from collections.abc import Sequence
+from typing import TYPE_CHECKING
 
 import numpy as np
 
 from optuna._warnings import optuna_warn
 from optuna.samplers._base import _CONSTRAINTS_KEY
-from optuna.study import StudyDirection
 from optuna.study._multi_objective import _dominates
-from optuna.trial import FrozenTrial
 from optuna.trial import TrialState
+
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from optuna.study import StudyDirection
+    from optuna.trial import FrozenTrial
 
 
 def _constrained_dominates(


### PR DESCRIPTION
Part of #6029.

Moved Sequence, StudyDirection, and FrozenTrial into the TYPE_CHECKING block. All three are only used in type annotations. TrialState stays at module level since it's used as a value on lines 61 and 64.

ruff check --select TCH passes clean.