### PR TITLE
Use TYPE_CHECKING in nsgaii/_child_generation_strategy.py

### DIFF
--- a/optuna/samplers/nsgaii/_child_generation_strategy.py
+++ b/optuna/samplers/nsgaii/_child_generation_strategy.py
@@ -1,21 +1,22 @@
 from __future__ import annotations
 
-from collections.abc import Callable
-from collections.abc import Sequence
 from typing import Any
 from typing import TYPE_CHECKING
 
-from optuna.distributions import BaseDistribution
-from optuna.samplers._lazy_random_state import LazyRandomState
 from optuna.samplers.nsgaii._constraints_evaluation import _constrained_dominates
 from optuna.samplers.nsgaii._crossover import perform_crossover
 from optuna.samplers.nsgaii._crossovers._base import BaseCrossover
 from optuna.study._multi_objective import _dominates
-from optuna.trial import FrozenTrial
 
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+    from collections.abc import Sequence
+
+    from optuna.distributions import BaseDistribution
+    from optuna.samplers._lazy_random_state import LazyRandomState
     from optuna.study import Study
+    from optuna.trial import FrozenTrial
 
 
 class NSGAIIChildGenerationStrategy:


### PR DESCRIPTION
Part of #6029.

Moved Callable, Sequence, BaseDistribution, LazyRandomState, and FrozenTrial into TYPE_CHECKING. None are used as runtime values.

ruff check --select TCH passes clean.