### PR TITLE
Move type-only imports in `optuna.samplers._partial_fixed` to TYPE_CHECKING

### DIFF
--- a/optuna/samplers/_partial_fixed.py
+++ b/optuna/samplers/_partial_fixed.py
@@ -1,19 +1,20 @@
 from __future__ import annotations
 
-from collections.abc import Sequence
 from typing import Any
 from typing import TYPE_CHECKING
 
 from optuna._experimental import experimental_class
 from optuna._warnings import optuna_warn
-from optuna.distributions import BaseDistribution
 from optuna.samplers import BaseSampler
-from optuna.trial import FrozenTrial
-from optuna.trial import TrialState
 
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from optuna.distributions import BaseDistribution
     from optuna.study import Study
+    from optuna.trial import FrozenTrial
+    from optuna.trial import TrialState
 
 
 @experimental_class("2.4.0")


### PR DESCRIPTION
## Motivation

Part of https://github.com/optuna/optuna/issues/6029.

`ruff check --select TCH` reports type-checking import violations in `optuna/samplers/_partial_fixed.py`.

## What I changed

- Moved type-only imports to the `if TYPE_CHECKING:` block in `optuna/samplers/_partial_fixed.py`:
  - `Sequence`
  - `BaseDistribution`
  - `FrozenTrial`
  - `TrialState`
- Kept runtime behavior unchanged (no functional logic changes).

## Validation

```bash
ruff check optuna/samplers/_partial_fixed.py --select TCH
ruff check optuna/samplers/_partial_fixed.py
ruff format --check optuna/samplers/_partial_fixed.py
pytest tests/samplers_tests/test_partial_fixed.py -q
mypy optuna/samplers/_partial_fixed.py
```

All commands passed locally.
