### PR TITLE
Fix TC006 cast annotation in optuna._gp.acqf

### DIFF
--- a/optuna/_gp/acqf.py
+++ b/optuna/_gp/acqf.py
@@ -398,5 +398,5 @@ class ConstrainedLogEHVI(BaseAcquisitionFunc):
     def eval_acqf(self, x: torch.Tensor) -> torch.Tensor:
         constraints_acqf_values = sum(acqf.eval_acqf(x) for acqf in self._constraints_acqf_list)
         if self._acqf is None:
-            return cast(torch.Tensor, constraints_acqf_values)
+            return cast("torch.Tensor", constraints_acqf_values)
         return constraints_acqf_values + self._acqf.eval_acqf(x)


### PR DESCRIPTION
## Motivation

Part of https://github.com/optuna/optuna/issues/6029.

`ruff check --select TCH` reports `TC006` in `optuna/_gp/acqf.py`.

## What I changed

- Replaced `cast(torch.Tensor, ...)` with `cast("torch.Tensor", ...)` in `optuna/_gp/acqf.py`.

This is a type-annotation-only change and does not modify runtime behavior.

## Validation

```bash
ruff check optuna/_gp/acqf.py --select TCH
ruff check optuna/_gp/acqf.py
ruff format --check optuna/_gp/acqf.py
mypy optuna/_gp/acqf.py
pytest tests/gp_tests/test_acqf.py -q
```

All commands passed locally.
