### PR TITLE
Fix TC006 cast annotation in optuna.trial._frozen

### DIFF
--- a/optuna/trial/_frozen.py
+++ b/optuna/trial/_frozen.py
@@ -451,7 +451,7 @@ class FrozenTrial(BaseTrial):
 
     @system_attrs.setter
     def system_attrs(self, value: Mapping[str, JSONSerializable]) -> None:
-        self._system_attrs = cast(dict[str, Any], value)
+        self._system_attrs = cast("dict[str, Any]", value)
 
     @property
     def last_step(self) -> int | None:


### PR DESCRIPTION
## Motivation

Part of https://github.com/optuna/optuna/issues/6029.

`ruff check --select TCH` reports `TC006` in `optuna/trial/_frozen.py`.

## What I changed

- Replaced `cast(dict[str, Any], ...)` with `cast("dict[str, Any]", ...)` in `optuna/trial/_frozen.py`.

This is a type-annotation-only change and does not modify runtime behavior.

## Validation

```bash
ruff check optuna/trial/_frozen.py --select TCH
ruff check optuna/trial/_frozen.py
ruff format --check optuna/trial/_frozen.py
mypy optuna/trial/_frozen.py
pytest tests/trial_tests/test_frozen.py -q
```

All commands passed locally.
