### PR TITLE
Fix TC006 cast annotation in tests.test_distributions

### DIFF
--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -272,7 +272,7 @@ def test_categorical_internal_representation() -> None:
     # We need to create new objects to compare NaNs.
     # See https://github.com/optuna/optuna/pull/3567#pullrequestreview-974939837.
     c_ = distributions.json_to_distribution(EXAMPLE_JSONS["c1"])
-    for choice in cast(distributions.CategoricalDistribution, c_).choices:
+    for choice in cast("distributions.CategoricalDistribution", c_).choices:
         if isinstance(choice, float) and np.isnan(choice):
             assert np.isnan(c.to_external_repr(c.to_internal_repr(choice)))
         else:


### PR DESCRIPTION
## Motivation

Part of https://github.com/optuna/optuna/issues/6029.

`ruff check --select TCH` reports `TC006` in `tests/test_distributions.py`.

## What I changed

- Replaced `cast(distributions.CategoricalDistribution, ...)` with `cast("distributions.CategoricalDistribution", ...)` in `tests/test_distributions.py`.

This is a type-annotation-only change and does not modify runtime behavior.

## Validation

```bash
ruff check tests/test_distributions.py --select TCH
ruff check tests/test_distributions.py
ruff format --check tests/test_distributions.py
mypy tests/test_distributions.py
pytest tests/test_distributions.py -q
```

All commands passed locally.
