### PR TITLE
Fix TC006 cast annotation in optuna.study._multi_objective

### DIFF
--- a/optuna/study/_multi_objective.py
+++ b/optuna/study/_multi_objective.py
@@ -141,7 +141,7 @@ def _is_pareto_front_nd(unique_lexsorted_loss_values: np.ndarray) -> np.ndarray:
             loss_values[remaining_indices] < loss_values[new_nondominated_index], axis=1
         )
         remaining_indices = cast(
-            np.ndarray[tuple[int], np.dtype[np.signedinteger]],
+            "np.ndarray[tuple[int], np.dtype[np.signedinteger]]",
             remaining_indices[nondominated_and_not_top],
         )
 


### PR DESCRIPTION
## Motivation

Part of https://github.com/optuna/optuna/issues/6029.

`ruff check --select TCH` reports `TC006` in `optuna/study/_multi_objective.py`.

## What I changed

- Replaced `cast(np.ndarray[...], ...)` with `cast("np.ndarray[...]", ...)` in `optuna/study/_multi_objective.py`.

This is a type-annotation-only change and does not modify runtime behavior.

## Validation

```bash
ruff check optuna/study/_multi_objective.py --select TC006
ruff check optuna/study/_multi_objective.py
ruff format --check optuna/study/_multi_objective.py
mypy optuna/study/_multi_objective.py
pytest tests/test_multi_objective.py -q
```

All commands passed locally.
