### PR TITLE
Fix TC006 cast annotation in optuna.terminator.improvement.emmr

### DIFF
--- a/optuna/terminator/improvement/emmr.py
+++ b/optuna/terminator/improvement/emmr.py
@@ -141,7 +141,7 @@ class EMMREvaluator(BaseImprovementEvaluator):
 
         # _gp module assumes that optimization direction is maximization
         sign = -1 if study_direction == StudyDirection.MINIMIZE else 1
-        score_vals = np.array([cast(float, t.value) for t in complete_trials]) * sign
+        score_vals = np.array([cast("float", t.value) for t in complete_trials]) * sign
         score_vals = gp.warn_and_convert_inf(score_vals)
         standarized_score_vals = (score_vals - score_vals.mean()) / max(
             sys.float_info.min, score_vals.std()


### PR DESCRIPTION
## Summary
- fix TC006 by quoting the typing.cast type expression in optuna/terminator/improvement/emmr.py
- keep behavior unchanged (type-checking-only update)

## Testing
- uv run ruff check optuna/terminator/improvement/emmr.py --select TC006
- uv run ruff check optuna/terminator/improvement/emmr.py
- uv run ruff format --check optuna/terminator/improvement/emmr.py
- uv run mypy optuna/terminator/improvement/emmr.py
- uv run pytest tests/terminator_tests/improvement_tests/test_emmr_evaluator.py -q

Closes #6029
