### PR TITLE
Fix TC006 cast annotation in optuna.terminator.erroreval

### DIFF
--- a/optuna/terminator/erroreval.py
+++ b/optuna/terminator/erroreval.py
@@ -65,9 +65,9 @@ class CrossValidationErrorEvaluator(BaseErrorEvaluator):
         assert len(trials) > 0
 
         if study_direction == StudyDirection.MAXIMIZE:
-            best_trial = max(trials, key=lambda t: cast(float, t.value))
+            best_trial = max(trials, key=lambda t: cast("float", t.value))
         else:
-            best_trial = min(trials, key=lambda t: cast(float, t.value))
+            best_trial = min(trials, key=lambda t: cast("float", t.value))
 
         best_trial_attrs = best_trial.system_attrs
         if _CROSS_VALIDATION_SCORES_KEY in best_trial_attrs:


### PR DESCRIPTION
## Summary
- fix TC006 by quoting the typing.cast type expressions in optuna/terminator/erroreval.py
- keep runtime behavior unchanged

## Testing
- uv run ruff check optuna/terminator/erroreval.py --select TC006
- uv run ruff check optuna/terminator/erroreval.py
- uv run ruff format --check optuna/terminator/erroreval.py
- uv run mypy optuna/terminator/erroreval.py
- uv run pytest tests/terminator_tests/test_erroreval.py -q

Closes #6029
