### PR TITLE
Fix TC006 cast annotation in optuna.study.study

### DIFF
--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -317,9 +317,9 @@ class Study:
             if len(feasible_trials) == 0:
                 raise ValueError("No feasible trials are completed yet.")
             if self.direction == StudyDirection.MAXIMIZE:
-                best_trial = max(feasible_trials, key=lambda t: cast(float, t.value))
+                best_trial = max(feasible_trials, key=lambda t: cast("float", t.value))
             else:
-                best_trial = min(feasible_trials, key=lambda t: cast(float, t.value))
+                best_trial = min(feasible_trials, key=lambda t: cast("float", t.value))
 
         return copy.deepcopy(best_trial) if deepcopy else best_trial
 
@@ -1647,9 +1647,9 @@ def get_all_study_summaries(
             directions = None
             if include_best_trial and len(completed_trials) != 0:
                 if direction == StudyDirection.MAXIMIZE:
-                    best_trial = max(completed_trials, key=lambda t: cast(float, t.value))
+                    best_trial = max(completed_trials, key=lambda t: cast("float", t.value))
                 else:
-                    best_trial = min(completed_trials, key=lambda t: cast(float, t.value))
+                    best_trial = min(completed_trials, key=lambda t: cast("float", t.value))
             else:
                 best_trial = None
         else:


### PR DESCRIPTION
## Summary
- fix TC006 by quoting typing.cast type expressions in optuna/study/study.py
- keep runtime behavior unchanged

## Testing
- uv run ruff check optuna/study/study.py --select TC006
- uv run ruff check optuna/study/study.py
- uv run ruff format --check optuna/study/study.py
- uv run mypy optuna/study/study.py
- uv run pytest tests/study_tests/test_study.py -k "best_trial or best_trials or get_best_trial" -q

Closes #6029
