### PR TITLE
Move type-only Callable import in optuna.testing.threading behind TYPE_CHECKING

### DIFF
--- a/optuna/testing/threading.py
+++ b/optuna/testing/threading.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
-from collections.abc import Callable
 import threading
 from typing import Any
+from typing import TYPE_CHECKING
+
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 
 class _TestableThread(threading.Thread):


### PR DESCRIPTION
## Summary
- move the type-only Callable import behind TYPE_CHECKING in optuna/testing/threading.py
- keep runtime behavior unchanged

## Testing
- uv run ruff check optuna/testing/threading.py --select TCH
- uv run ruff check optuna/testing/threading.py
- uv run ruff format --check optuna/testing/threading.py
- uv run mypy optuna/testing/threading.py
- uv run pytest tests/storages_tests/test_heartbeat.py -q

Closes #6029
