### PR TITLE
Move type-only TracebackType import in optuna.testing.tempfile_pool behind TYPE_CHECKING

### DIFF
--- a/optuna/testing/tempfile_pool.py
+++ b/optuna/testing/tempfile_pool.py
@@ -8,11 +8,15 @@ import copy
 import os
 import tempfile
 import threading
-from types import TracebackType
 from typing import Any
 from typing import cast
 from typing import ClassVar
 from typing import IO
+from typing import TYPE_CHECKING
+
+
+if TYPE_CHECKING:
+    from types import TracebackType
 
 
 class NamedTemporaryFilePool:


### PR DESCRIPTION
## Summary
- move type-only TracebackType import into a TYPE_CHECKING block in optuna/testing/tempfile_pool.py
- keep runtime behavior unchanged

## Testing
- uv run ruff check optuna/testing/tempfile_pool.py --select TCH
- uv run ruff check optuna/testing/tempfile_pool.py
- uv run ruff format --check optuna/testing/tempfile_pool.py
- uv run mypy optuna/testing/tempfile_pool.py
- uv run pytest tests/storages_tests/journal_tests/test_journal.py -q

Closes #6029
