### PR TITLE
test: move type-only imports in optuna.testing.trials behind TYPE_CHECKING

### DIFF
--- a/optuna/testing/trials.py
+++ b/optuna/testing/trials.py
@@ -1,13 +1,17 @@
 from __future__ import annotations
 
-from collections.abc import Sequence
 from typing import Any
+from typing import TYPE_CHECKING
 
-import optuna
-from optuna.distributions import BaseDistribution
 from optuna.samplers._base import _CONSTRAINTS_KEY
 from optuna.trial import FrozenTrial
 from optuna.trial import TrialState
+
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from optuna.distributions import BaseDistribution
 
 
 def _create_frozen_trial(
@@ -17,7 +21,7 @@ def _create_frozen_trial(
     params: dict[str, Any] | None = None,
     param_distributions: dict[str, BaseDistribution] | None = None,
     state: TrialState = TrialState.COMPLETE,
-) -> optuna.trial.FrozenTrial:
+) -> FrozenTrial:
     return FrozenTrial(
         number=number,
         value=1.0 if values is None else None,


### PR DESCRIPTION
## Summary
- move type-only imports in `optuna/testing/trials.py` under `TYPE_CHECKING`
- switch return annotation to `FrozenTrial` to avoid runtime imports used only for typing

## Motivation
- follow Ruff TCH guidance by avoiding runtime-only imports for typing

## Testing
- `uv run ruff check optuna/testing/trials.py --select TCH`
- `uv run ruff check optuna/testing/trials.py`
- `uv run ruff format --check optuna/testing/trials.py`
- `uv run mypy optuna/testing/trials.py`
- `uv run pytest tests/samplers_tests/test_nsgaii.py -q`

Part of #6029
