### PR TITLE
Use TYPE_CHECKING for type-only imports to avoid circular imports

### DIFF
--- a/optuna/importance/_ped_anova/scott_parzen_estimator.py
+++ b/optuna/importance/_ped_anova/scott_parzen_estimator.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import numpy as np
 
 from optuna.distributions import BaseDistribution
@@ -10,7 +12,9 @@ from optuna.samplers._tpe.parzen_estimator import _ParzenEstimator
 from optuna.samplers._tpe.parzen_estimator import _ParzenEstimatorParameters
 from optuna.samplers._tpe.probability_distributions import _BatchedDiscreteTruncNormDistributions
 from optuna.samplers._tpe.probability_distributions import _BatchedDistributions
-from optuna.trial import FrozenTrial
+
+if TYPE_CHECKING:
+    from optuna.trial import FrozenTrial
 
 
 class _ScottParzenEstimator(_ParzenEstimator):


### PR DESCRIPTION
## Problem

Some modules import other modules only for type annotations, which can cause circular import errors. This is a common issue in Python when type hints are used extensively.

## Solution

Wrapped type-only imports with `TYPE_CHECKING` from the `typing` module:

```python
from typing import TYPE_CHECKING

if TYPE_CHECKING:
    from module import TypeHintClass
```

This prevents runtime circular imports while maintaining type checking capabilities during static analysis.

## Validation

```bash
# Find files needing changes
ruff check . --select TCH

# No circular import errors at runtime
python -c "import optuna"
```

Fixes #6029