### PR TITLE
Quote cast type expression in `tests/test_distributions.py`

### DIFF
--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -272,7 +272,7 @@ def test_categorical_internal_representation() -> None:
     # We need to create new objects to compare NaNs.
     # See https://github.com/optuna/optuna/pull/3567#pullrequestreview-974939837.
     c_ = distributions.json_to_distribution(EXAMPLE_JSONS["c1"])
-    for choice in cast(distributions.CategoricalDistribution, c_).choices:
+    for choice in cast("distributions.CategoricalDistribution", c_).choices:
         if isinstance(choice, float) and np.isnan(choice):
             assert np.isnan(c.to_external_repr(c.to_internal_repr(choice)))
         else:


### PR DESCRIPTION
## Summary
- quote the type expression in `typing.cast` in `tests/test_distributions.py` to satisfy Ruff `TC006`
- keep runtime behavior unchanged

## Motivation
- address type-checking import hygiene tracked in #6029

## Testing
- `uv run ruff check tests/test_distributions.py --select TCH`
- `uv run ruff check tests/test_distributions.py`
- `uv run ruff format --check tests/test_distributions.py`
- `uv run mypy tests/test_distributions.py`
- `uv run pytest tests/test_distributions.py -q`

Part of #6029
