### PR TITLE
Move type-only `datetime` import in `tests/trial_tests/test_trial.py`

### DIFF
--- a/tests/trial_tests/test_trial.py
+++ b/tests/trial_tests/test_trial.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-import datetime
 import math
 from typing import Any
+from typing import TYPE_CHECKING
 from unittest.mock import Mock
 from unittest.mock import patch
 import warnings
@@ -29,6 +29,10 @@ from optuna.trial import FrozenTrial
 from optuna.trial import Trial
 from optuna.trial import TrialState
 from optuna.trial._trial import _LazyTrialSystemAttrs
+
+
+if TYPE_CHECKING:
+    import datetime
 
 
 @pytest.mark.filterwarnings("ignore::FutureWarning")


### PR DESCRIPTION
## Summary
- move type-only standard library import (`datetime`) in `tests/trial_tests/test_trial.py` under `TYPE_CHECKING`
- keep runtime behavior unchanged while satisfying Ruff `TC003`

## Motivation
- address type-checking import hygiene tracked in #6029

## Testing
- `uv run ruff check tests/trial_tests/test_trial.py --select TCH`
- `uv run ruff check tests/trial_tests/test_trial.py`
- `uv run ruff format --check tests/trial_tests/test_trial.py`
- `uv run mypy tests/trial_tests/test_trial.py`
- `uv run pytest tests/trial_tests/test_trial.py -q`

Part of #6029
