### PR TITLE
Move type-only imports to `TYPE_CHECKING` in `nsgaii/_crossover.py`

### DIFF
--- a/optuna/samplers/nsgaii/_crossover.py
+++ b/optuna/samplers/nsgaii/_crossover.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Callable
-from collections.abc import Sequence
 from typing import Any
 from typing import TYPE_CHECKING
 
@@ -11,13 +9,16 @@ from optuna._transform import _SearchSpaceTransform
 from optuna.distributions import BaseDistribution
 from optuna.distributions import FloatDistribution
 from optuna.distributions import IntDistribution
-from optuna.samplers.nsgaii._crossovers._base import BaseCrossover
-from optuna.study import StudyDirection
-from optuna.trial import FrozenTrial
 
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+    from collections.abc import Sequence
+
+    from optuna.samplers.nsgaii._crossovers._base import BaseCrossover
     from optuna.study import Study
+    from optuna.study import StudyDirection
+    from optuna.trial import FrozenTrial
 
 
 _NUMERICAL_DISTRIBUTIONS = (


### PR DESCRIPTION
## Motivation

Move type-only imports into the `TYPE_CHECKING` block to resolve ruff TCH001/TCH003 violations.

Part of #6029.

## Description

- Move `Callable`, `Sequence` (TCH003) and `BaseCrossover`, `StudyDirection`, `FrozenTrial` (TCH001) into `TYPE_CHECKING` block
- `from __future__ import annotations` is already present, so all annotation-only imports are safe to defer

## Testing

- `ruff check optuna/samplers/nsgaii/_crossover.py --select TCH` → All checks passed
- `pytest tests/samplers_tests/test_nsgaii.py` → 151 passed