### PR TITLE
Fix typing import issues in scott_parzen_estimator

### DIFF
--- a/optuna/importance/_ped_anova/scott_parzen_estimator.py
+++ b/optuna/importance/_ped_anova/scott_parzen_estimator.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import numpy as np
 
 from optuna.distributions import BaseDistribution
@@ -10,7 +12,10 @@ from optuna.samplers._tpe.parzen_estimator import _ParzenEstimator
 from optuna.samplers._tpe.parzen_estimator import _ParzenEstimatorParameters
 from optuna.samplers._tpe.probability_distributions import _BatchedDiscreteTruncNormDistributions
 from optuna.samplers._tpe.probability_distributions import _BatchedDistributions
-from optuna.trial import FrozenTrial
+
+
+if TYPE_CHECKING:
+    from optuna.trial import FrozenTrial
 
 
 class _ScottParzenEstimator(_ParzenEstimator):


### PR DESCRIPTION
## Motivation
This PR is part of the type-checking cleanup effort in #6029.

In `optuna/importance/_ped_anova/scott_parzen_estimator.py`, `FrozenTrial` is used only for type annotations. Importing it at runtime is unnecessary and can contribute to circular import issues. To follow the project guidance, this PR moves the type-only import under `TYPE_CHECKING`.

## Description of the changes
- Added `from typing import TYPE_CHECKING` to `optuna/importance/_ped_anova/scott_parzen_estimator.py`.
- Moved `from optuna.trial import FrozenTrial` into an `if TYPE_CHECKING:` block.
- Kept runtime behavior unchanged; only type-checking import behavior is adjusted.

### Validation
- Ran `ruff check optuna/importance/_ped_anova/scott_parzen_estimator.py --select TCH`
- Result: `All checks passed!`