### PR TITLE
fix(types): use TYPE_CHECKING for BaseDistribution import in _transform.py

### DIFF
--- a/optuna/_transform.py
+++ b/optuna/_transform.py
@@ -2,13 +2,17 @@ from __future__ import annotations
 
 import math
 from typing import Any
+from typing import TYPE_CHECKING
 
 import numpy as np
 
-from optuna.distributions import BaseDistribution
 from optuna.distributions import CategoricalDistribution
 from optuna.distributions import FloatDistribution
 from optuna.distributions import IntDistribution
+
+
+if TYPE_CHECKING:
+    from optuna.distributions import BaseDistribution
 
 
 class _SearchSpaceTransform:


### PR DESCRIPTION
Part of #6029.

Moves `BaseDistribution` under `TYPE_CHECKING` guard in `optuna/_transform.py` since it is only referenced in type annotations. With `from __future__ import annotations`, this import is not needed at runtime.

Reduces import time and avoids optional-dependency errors for users who do not have these optional dependencies installed.