### PR TITLE
refactor: move BaseDistribution import to TYPE_CHECKING in search_space/group_decomposed.py

### DIFF
--- a/optuna/search_space/group_decomposed.py
+++ b/optuna/search_space/group_decomposed.py
@@ -3,11 +3,11 @@ from __future__ import annotations
 import copy
 from typing import TYPE_CHECKING
 
-from optuna.distributions import BaseDistribution
 from optuna.trial import TrialState
 
 
 if TYPE_CHECKING:
+    from optuna.distributions import BaseDistribution
     from optuna.study import Study
 
 


### PR DESCRIPTION
This PR moves the type-only import of `BaseDistribution` in `optuna/search_space/group_decomposed.py` into a `TYPE_CHECKING` block, as requested in #6029.

### Changes

- Move `from optuna.distributions import BaseDistribution` into the `TYPE_CHECKING` block
- `BaseDistribution` is only used in type annotations (method parameter and return type hints), not at runtime
- `TrialState` remains as a regular import since `TrialState.COMPLETE` and `TrialState.PRUNED` are accessed at runtime (lines 59, 61)

With `from __future__ import annotations` already present in this file, all annotations are evaluated lazily, so this import is not needed at runtime.

This was identified by running:
```shell
ruff check . --select TCH --output-format=concise
```

Fixes part of #6029