### PR TITLE
fix(types): use TYPE_CHECKING for imports in samplers/_brute_force.py

### DIFF
--- a/optuna/samplers/_brute_force.py
+++ b/optuna/samplers/_brute_force.py
@@ -8,14 +8,12 @@ from typing import TYPE_CHECKING
 import numpy as np
 
 from optuna._experimental import experimental_class
-from optuna.distributions import BaseDistribution
 from optuna.distributions import CategoricalDistribution
 from optuna.distributions import FloatDistribution
 from optuna.distributions import IntDistribution
 from optuna.samplers import BaseSampler
 from optuna.samplers._lazy_random_state import LazyRandomState
 from optuna.trial import create_trial
-from optuna.trial import FrozenTrial
 from optuna.trial import TrialState
 
 
@@ -23,7 +21,9 @@ if TYPE_CHECKING:
     from collections.abc import Iterable
     from collections.abc import Sequence
 
+    from optuna.distributions import BaseDistribution
     from optuna.study import Study
+    from optuna.trial import FrozenTrial
 
 
 @dataclass


### PR DESCRIPTION
Part of #6029.

Moves `BaseDistribution` and `FrozenTrial` under `TYPE_CHECKING` guard in `optuna/samplers/_brute_force.py` since they are only referenced in type annotations. With `from __future__ import annotations`, these imports are not needed at runtime.

Reduces import time and avoids optional-dependency errors for users who do not have these optional dependencies installed.