### PR TITLE
Move type-only imports to `TYPE_CHECKING` in `samplers/_nsgaiii/_elite_population_selection_strategy.py`

### DIFF
--- a/optuna/samplers/_nsgaiii/_elite_population_selection_strategy.py
+++ b/optuna/samplers/_nsgaiii/_elite_population_selection_strategy.py
@@ -13,6 +13,7 @@ from optuna.samplers.nsgaii._elite_population_selection_strategy import _rank_po
 if TYPE_CHECKING:
     from collections.abc import Callable
     from collections.abc import Sequence
+
     from optuna.samplers._lazy_random_state import LazyRandomState
     from optuna.study import Study
     from optuna.trial import FrozenTrial


### PR DESCRIPTION
This PR moves type-only imports in `optuna/samplers/_nsgaiii/_elite_population_selection_strategy.py` into a `TYPE_CHECKING` block, as requested in #6029.

### Changes

Moved into `TYPE_CHECKING`:
- `collections.abc.Callable` (only used in `constraints_func` type hint)
- `collections.abc.Sequence` (only used in `constraints_func` return type hint)
- `optuna.samplers._lazy_random_state.LazyRandomState` (only used as type annotation for `rng` parameter)
- `optuna.trial.FrozenTrial` (only used in population list type annotations)

`numpy` is kept as a regular import since it is used extensively at runtime for array operations.

With `from __future__ import annotations` already present, all annotations are evaluated lazily and these imports are not needed at runtime.

This was identified by running:
```shell
ruff check . --select TCH --output-format=concise
```

Fixes part of #6029