### PR TITLE
Move type-only imports to `TYPE_CHECKING` in `samplers/_nsgaiii/_sampler.py`

### DIFF
--- a/optuna/samplers/_nsgaiii/_sampler.py
+++ b/optuna/samplers/_nsgaiii/_sampler.py
@@ -18,12 +18,14 @@ from optuna.search_space import IntersectionSearchSpace
 from optuna.trial import FrozenTrial
 from optuna.trial import TrialState
 
+
 if TYPE_CHECKING:
     from collections.abc import Callable
     from collections.abc import Sequence
-    import numpy as np
-    from optuna.distributions import BaseDistribution
 
+    import numpy as np
+
+    from optuna.distributions import BaseDistribution
     from optuna.study import Study
 
 


### PR DESCRIPTION
Move type-only imports in optuna/samplers/_nsgaiii/_sampler.py into the TYPE_CHECKING block, as requested in #6029.

Moved into TYPE_CHECKING: Callable, Sequence (stdlib), numpy (third-party), and BaseDistribution (application). These are only used in type annotations.

Kept as regular imports: LazyRandomState (instantiated at runtime), TrialState (enum values used at runtime), FrozenTrial (objects received at runtime).

Identified by: ruff check . --select TCH

Fixes part of #6029