### PR TITLE
Move `Study` import to `TYPE_CHECKING` in `_timeline.py`

### DIFF
--- a/optuna/visualization/_timeline.py
+++ b/optuna/visualization/_timeline.py
@@ -2,13 +2,17 @@ from __future__ import annotations
 
 import datetime
 from typing import NamedTuple
+from typing import TYPE_CHECKING
 
 from optuna.logging import get_logger
 from optuna.samplers._base import _CONSTRAINTS_KEY
-from optuna.study import Study
 from optuna.trial import TrialState
 from optuna.visualization._plotly_imports import _imports
 from optuna.visualization._utils import _make_hovertext
+
+
+if TYPE_CHECKING:
+    from optuna.study import Study
 
 
 if _imports.is_successful():


### PR DESCRIPTION
## Motivation
This PR is part of the type-checking cleanup effort tracked in #6029.

In `optuna/visualization/_timeline.py`, `Study` is used only for type annotations. Importing it at runtime is unnecessary and may contribute to circular import risks. This PR moves that type-only import under `TYPE_CHECKING` following the repository guidance.

## Description of the changes
- Added `from typing import TYPE_CHECKING` to `optuna/visualization/_timeline.py`.
- Moved `from optuna.study import Study` into an `if TYPE_CHECKING:` block.

### Validation
- Ran `python -m ruff check optuna/visualization/_timeline.py --fix`
- Ran `python -m ruff check optuna/visualization/_timeline.py --select TCH`
- Ran `python -m ruff check optuna/visualization/_timeline.py`
- Result: all checks passed.