### PR TITLE
Use `TYPE_CHECKING` in `nsgaii/_crossovers/_base.py`

### DIFF
--- a/optuna/samplers/nsgaii/_crossovers/_base.py
+++ b/optuna/samplers/nsgaii/_crossovers/_base.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 import abc
 from typing import TYPE_CHECKING
 
-import numpy as np
-
 
 if TYPE_CHECKING:
+    import numpy as np
+
     from optuna.study import Study
 
 


### PR DESCRIPTION
Part of #6029.

Moved numpy into TYPE_CHECKING. Only used in type annotations (np.ndarray, np.random.RandomState), not at runtime.

ruff check --select TCH passes clean.