### PR TITLE
Use `TYPE_CHECKING` in `nsgaii/_crossovers/_uniform.py`

### DIFF
--- a/optuna/samplers/nsgaii/_crossovers/_uniform.py
+++ b/optuna/samplers/nsgaii/_crossovers/_uniform.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import numpy as np
-
 from optuna.samplers.nsgaii._crossovers._base import BaseCrossover
 
 
 if TYPE_CHECKING:
+    import numpy as np
+
     from optuna.study import Study
 
 


### PR DESCRIPTION
Part of #6029.

Moved numpy into TYPE_CHECKING. Only used in type annotations, not at runtime.

ruff check --select TCH passes clean.