### PR TITLE
Move imports to `TYPE_CHECKING` in `tests/test_multi_objective`

### DIFF
--- a/tests/test_multi_objective.py
+++ b/tests/test_multi_objective.py
@@ -1,14 +1,19 @@
 from __future__ import annotations
 
-from collections.abc import Sequence
+from typing import TYPE_CHECKING
 
 import pytest
 
 from optuna import create_study
 from optuna import trial
-from optuna.study import StudyDirection
 from optuna.study._multi_objective import _get_pareto_front_trials_by_trials
-from optuna.trial import FrozenTrial
+
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from optuna.study import StudyDirection
+    from optuna.trial import FrozenTrial
 
 
 def _trial_to_values(t: FrozenTrial) -> tuple[float, ...]:


### PR DESCRIPTION
## Motivation

This PR is part of the effort to fix `TYPE_CHECKING` usage across the codebase (issue #6029 ).

## Description of the changes

Fixed `TYPE_CHECKING` usage in the test file for `test_multi_objective`:

- Moved imports of  `FrozenTrial`, `StudyDirection` and `Sequence` under `TYPE_CHECKING` .


This file was flagged by `ruff check . --select TCH`.