### PR TITLE
Use `TYPE_CHECKING` in `nsgaii/_sampler.py`

### DIFF
--- a/optuna/samplers/nsgaii/_sampler.py
+++ b/optuna/samplers/nsgaii/_sampler.py
@@ -1,12 +1,9 @@
 from __future__ import annotations
 
-from collections.abc import Callable
-from collections.abc import Sequence
 from typing import Any
 from typing import TYPE_CHECKING
 
 from optuna._experimental import warn_experimental_argument
-from optuna.distributions import BaseDistribution
 from optuna.samplers._ga import BaseGASampler
 from optuna.samplers._lazy_random_state import LazyRandomState
 from optuna.samplers._random import RandomSampler
@@ -23,6 +20,10 @@ from optuna.trial import TrialState
 
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+    from collections.abc import Sequence
+
+    from optuna.distributions import BaseDistribution
     from optuna.study import Study
 
 


### PR DESCRIPTION
Part of #6029.

Moved Callable, Sequence, and BaseDistribution into TYPE_CHECKING. All three are only used in type annotations.

ruff check --select TCH passes clean.