### PR TITLE
Use `TYPE_CHECKING` in `visualization/_rank.py`

### DIFF
--- a/optuna/visualization/_rank.py
+++ b/optuna/visualization/_rank.py
@@ -5,14 +5,18 @@ import math
 import typing
 from typing import Any
 from typing import NamedTuple
+from typing import TYPE_CHECKING
 
 import numpy as np
 
 from optuna.logging import get_logger
 from optuna.samplers._base import _CONSTRAINTS_KEY
-from optuna.study import Study
-from optuna.trial import FrozenTrial
 from optuna.trial import TrialState
+
+
+if TYPE_CHECKING:
+    from optuna.study import Study
+    from optuna.trial import FrozenTrial
 from optuna.visualization._plotly_imports import _imports
 from optuna.visualization._utils import _check_plot_args
 from optuna.visualization._utils import _is_log_scale


### PR DESCRIPTION
## Motivation

Part of #6029 — move type-only imports behind `TYPE_CHECKING` to avoid potential circular import issues.

## Description of the changes

Moved `Study` and `FrozenTrial` imports to `TYPE_CHECKING` block in `optuna/visualization/_rank.py`. These imports are only used in type annotations (with `from __future__ import annotations`), not at runtime. `TrialState` remains at top level since it's accessed at runtime (`TrialState.COMPLETE`).

Ran `ruff check` — all checks passed.