### PR TITLE
Use `TYPE_CHECKING` in `visualization/_parallel_coordinate.py`

### DIFF
--- a/optuna/visualization/_parallel_coordinate.py
+++ b/optuna/visualization/_parallel_coordinate.py
@@ -6,14 +6,18 @@ import math
 from typing import Any
 from typing import cast
 from typing import NamedTuple
+from typing import TYPE_CHECKING
 
 import numpy as np
 
 from optuna.distributions import CategoricalDistribution
 from optuna.logging import get_logger
-from optuna.study import Study
-from optuna.trial import FrozenTrial
 from optuna.trial import TrialState
+
+
+if TYPE_CHECKING:
+    from optuna.study import Study
+    from optuna.trial import FrozenTrial
 from optuna.visualization._plotly_imports import _imports
 from optuna.visualization._utils import _check_plot_args
 from optuna.visualization._utils import _filter_nonfinite


### PR DESCRIPTION
## Motivation

Part of #6029 — move type-only imports behind `TYPE_CHECKING`.

## Description of the changes

Moved `Study` and `FrozenTrial` imports to `TYPE_CHECKING` block in `optuna/visualization/_parallel_coordinate.py`. These are only used in type annotations (with `from __future__ import annotations`). `TrialState` stays at top level (runtime usage).

`ruff check` passes.