### PR TITLE
Use `TYPE_CHECKING` in `visualization/_slice.py`

### DIFF
--- a/optuna/visualization/_slice.py
+++ b/optuna/visualization/_slice.py
@@ -4,14 +4,18 @@ from collections.abc import Callable
 from typing import Any
 from typing import cast
 from typing import NamedTuple
+from typing import TYPE_CHECKING
 
 from optuna.distributions import CategoricalChoiceType
 from optuna.distributions import CategoricalDistribution
 from optuna.logging import get_logger
 from optuna.samplers._base import _CONSTRAINTS_KEY
-from optuna.study import Study
-from optuna.trial import FrozenTrial
 from optuna.trial import TrialState
+
+
+if TYPE_CHECKING:
+    from optuna.study import Study
+    from optuna.trial import FrozenTrial
 from optuna.visualization._plotly_imports import _imports
 from optuna.visualization._utils import _check_plot_args
 from optuna.visualization._utils import _filter_nonfinite


### PR DESCRIPTION
## Motivation

Part of #6029 — move type-only imports behind `TYPE_CHECKING`.

## Description of the changes

Moved `Study` and `FrozenTrial` imports to `TYPE_CHECKING` block in `optuna/visualization/_slice.py`. These are only used in type annotations (with `from __future__ import annotations`). `TrialState` stays at top level (runtime usage).

`ruff check` passes.