### PR TITLE
Use `TYPE_CHECKING` in `visualization/_intermediate_values.py`

### DIFF
--- a/optuna/visualization/_intermediate_values.py
+++ b/optuna/visualization/_intermediate_values.py
@@ -1,12 +1,16 @@
 from __future__ import annotations
 
 from typing import NamedTuple
+from typing import TYPE_CHECKING
 
 from optuna.logging import get_logger
 from optuna.samplers._base import _CONSTRAINTS_KEY
-from optuna.study import Study
-from optuna.trial import FrozenTrial
 from optuna.trial import TrialState
+
+
+if TYPE_CHECKING:
+    from optuna.study import Study
+    from optuna.trial import FrozenTrial
 from optuna.visualization._plotly_imports import _imports
 
 


### PR DESCRIPTION
## Motivation

Part of #6029 — move type-only imports behind `TYPE_CHECKING`.

## Description of the changes

Moved `Study` and `FrozenTrial` imports to `TYPE_CHECKING` block in `optuna/visualization/_intermediate_values.py`. These are only used in type annotations (with `from __future__ import annotations`). `TrialState` stays at top level (runtime usage).

`ruff check` passes.