### PR TITLE
Use `TYPE_CHECKING` in `visualization/_hypervolume_history.py`

### DIFF
--- a/optuna/visualization/_hypervolume_history.py
+++ b/optuna/visualization/_hypervolume_history.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from typing import NamedTuple
+from typing import TYPE_CHECKING
 
 import numpy as np
 
@@ -9,9 +10,12 @@ from optuna._experimental import experimental_func
 from optuna._hypervolume import compute_hypervolume
 from optuna.logging import get_logger
 from optuna.samplers._base import _CONSTRAINTS_KEY
-from optuna.study import Study
 from optuna.study._study_direction import StudyDirection
 from optuna.trial import TrialState
+
+
+if TYPE_CHECKING:
+    from optuna.study import Study
 from optuna.visualization._plotly_imports import _imports
 
 


### PR DESCRIPTION
## Motivation

Part of #6029 — move type-only imports behind `TYPE_CHECKING`.

## Description of the changes

Moved `Study` import to `TYPE_CHECKING` block in `optuna/visualization/_hypervolume_history.py`. It's only used in type annotations (with `from __future__ import annotations`). `StudyDirection` and `TrialState` stay at top level (runtime usage).

`ruff check` passes.