### PR TITLE
Use `TYPE_CHECKING` in `visualization/_contour.py`

### DIFF
--- a/optuna/visualization/_contour.py
+++ b/optuna/visualization/_contour.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-from collections.abc import Callable
 import math
 from typing import Any
 from typing import NamedTuple
+from typing import TYPE_CHECKING
 
 import numpy as np
 
@@ -15,6 +15,11 @@ from optuna.study import StudyDirection
 from optuna.trial import FrozenTrial
 from optuna.trial import TrialState
 from optuna.visualization._plotly_imports import _imports
+
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
 from optuna.visualization._utils import _check_plot_args
 from optuna.visualization._utils import _filter_nonfinite
 from optuna.visualization._utils import _is_log_scale


### PR DESCRIPTION
Part of #6029.

Moved Callable into TYPE_CHECKING. Only used in type annotations, not at runtime.

ruff check --select TCH passes clean.