### PR TITLE
Remove `prior_mu` from `compute_sigmas`

### DIFF
--- a/optuna/samplers/_tpe/parzen_estimator.py
+++ b/optuna/samplers/_tpe/parzen_estimator.py
@@ -193,13 +193,9 @@ class _ParzenEstimator:
                 )
                 sigmas = np.full(shape=(len(observations),), fill_value=sigma)
             else:
-                # TODO(contramundum53): Remove dependency on prior_mu
-                prior_mu = 0.5 * (low + high)
-                mus_with_prior = np.append(mus, prior_mu)
-
-                sorted_indices = np.argsort(mus_with_prior)
-                sorted_mus = mus_with_prior[sorted_indices]
-                sorted_mus_with_endpoints = np.empty(len(mus_with_prior) + 2, dtype=float)
+                sorted_indices = np.argsort(mus)
+                sorted_mus = mus[sorted_indices]
+                sorted_mus_with_endpoints = np.empty(len(mus) + 2, dtype=float)
                 sorted_mus_with_endpoints[0] = low
                 sorted_mus_with_endpoints[1:-1] = sorted_mus
                 sorted_mus_with_endpoints[-1] = high
@@ -215,12 +211,11 @@ class _ParzenEstimator:
                         sorted_mus_with_endpoints[-2] - sorted_mus_with_endpoints[-3]
                     )
 
-                sigmas = sorted_sigmas[np.argsort(sorted_indices)][: len(observations)]
+                sigmas = sorted_sigmas[np.argsort(sorted_indices)]
 
             # We adjust the range of the 'sigmas' according to the 'consider_magic_clip' flag.
             maxsigma = high - low
             if parameters.consider_magic_clip:
-                # TODO(contramundum53): Remove dependency of minsigma on consider_prior.
                 n_kernels = len(observations) + 1  # NOTE(sawa3030): +1 for prior.
                 minsigma = (high - low) / min(100.0, (1.0 + n_kernels))
             else:

--- a/tests/samplers_tests/tpe_tests/test_parzen_estimator.py
+++ b/tests/samplers_tests/tpe_tests/test_parzen_estimator.py
@@ -72,33 +72,33 @@ def test_init_parzen_estimator(multivariate: bool) -> None:
         distributions=[
             _BatchedTruncNormDistributions(
                 mu=np.array([1.0, 50.5]),
-                sigma=np.array([49.5, 99.0]),
+                sigma=np.array([99.0, 99.0]),
                 low=1.0,
                 high=100.0,
             ),
             _BatchedTruncLogNormDistributions(
                 mu=np.array([np.log(1.0), np.log(100) / 2.0]),
-                sigma=np.array([np.log(100) / 2, np.log(100)]),
+                sigma=np.array([np.log(100), np.log(100)]),
                 low=1.0,
                 high=100.0,
             ),
             _BatchedDiscreteTruncNormDistributions(
                 mu=np.array([1.0, 50.5]),
-                sigma=np.array([49.5, 102.0]),
+                sigma=np.array([100.5, 102.0]),
                 low=1.0,
                 high=100.0,
                 step=3.0,
             ),
             _BatchedDiscreteTruncNormDistributions(
                 mu=np.array([1.0, 50.5]),
-                sigma=np.array([49.5, 100.0]),
+                sigma=np.array([99.5, 100.0]),
                 low=1,
                 high=100,
                 step=1,
             ),
             _BatchedDiscreteTruncLogNormDistributions(
                 mu=np.array([np.log(1.0), (np.log(100.5) + np.log(0.5)) / 2.0]),
-                sigma=np.array([(np.log(100.5) + np.log(0.5)) / 2, np.log(100.5) - np.log(0.5)]),
+                sigma=np.array([np.log(100.5), np.log(100.5) - np.log(0.5)]),
                 low=1,
                 high=100,
                 step=1,
@@ -258,22 +258,22 @@ def test_invalid_prior_weight(mus: np.ndarray) -> None:
         [
             np.asarray([0.4]),
             {"magic_clip": False, "endpoints": True},
-            {"weights": [0.5, 0.5], "mus": [0.4, 0.0], "sigmas": [0.6, 2.0]},
+            {"weights": [0.5, 0.5], "mus": [0.4, 0.0], "sigmas": [1.4, 2.0]},
         ],
         [
             np.asarray([-0.4]),
             {"magic_clip": False, "endpoints": True},
-            {"weights": [0.5, 0.5], "mus": [-0.4, 0.0], "sigmas": [0.6, 2.0]},
+            {"weights": [0.5, 0.5], "mus": [-0.4, 0.0], "sigmas": [1.4, 2.0]},
         ],
         [
-            np.asarray([-0.4, 0.4]),
+            np.asarray([-0.3, 0.3]),
             {"magic_clip": False, "endpoints": True},
-            {"weights": [1.0 / 3] * 3, "mus": [-0.4, 0.4, 0.0], "sigmas": [0.6, 0.6, 2.0]},
+            {"weights": [1.0 / 3] * 3, "mus": [-0.3, 0.3, 0.0], "sigmas": [0.7, 0.7, 2.0]},
         ],
         [
-            np.asarray([-0.4, 0.4]),
+            np.asarray([-0.3, 0.3]),
             {"magic_clip": False, "endpoints": False},
-            {"weights": [1.0 / 3] * 3, "mus": [-0.4, 0.4, 0.0], "sigmas": [0.4, 0.4, 2.0]},
+            {"weights": [1.0 / 3] * 3, "mus": [-0.3, 0.3, 0.0], "sigmas": [0.6, 0.6, 2.0]},
         ],
         [
             np.asarray([-0.4, 0.4, 0.41, 0.42]),
@@ -281,7 +281,7 @@ def test_invalid_prior_weight(mus: np.ndarray) -> None:
             {
                 "weights": [0.2, 0.2, 0.2, 0.2, 0.2],
                 "mus": [-0.4, 0.4, 0.41, 0.42, 0.0],
-                "sigmas": [0.6, 0.4, 0.01, 0.58, 2.0],
+                "sigmas": [0.8, 0.8, 0.01, 0.58, 2.0],
             },
         ],
         [
@@ -290,7 +290,7 @@ def test_invalid_prior_weight(mus: np.ndarray) -> None:
             {
                 "weights": [0.2, 0.2, 0.2, 0.2, 0.2],
                 "mus": [-0.4, 0.4, 0.41, 0.42, 0.0],
-                "sigmas": [0.6, 0.4, 1.0 / 3, 0.58, 2.0],
+                "sigmas": [0.8, 0.8, 1.0 / 3, 0.58, 2.0],
             },
         ],
     ],

--- a/tests/samplers_tests/tpe_tests/test_sampler.py
+++ b/tests/samplers_tests/tpe_tests/test_sampler.py
@@ -440,11 +440,11 @@ def test_sample_independent_prior() -> None:
 
     # Prepare a trial and a sample for later checks.
     trial = frozen_trial_factory(8)
-    sampler = TPESampler(n_startup_trials=5, seed=0)
+    sampler = TPESampler(n_startup_trials=5, seed=0, n_ei_candidates=100)
     with patch.object(study._storage, "get_all_trials", return_value=past_trials):
         suggestion = sampler.sample_independent(study, trial, "param-a", dist)
 
-    sampler = TPESampler(prior_weight=0.1, n_startup_trials=5, seed=0)
+    sampler = TPESampler(prior_weight=0.1, n_startup_trials=5, seed=0, n_ei_candidates=100)
     with patch.object(study._storage, "get_all_trials", return_value=past_trials):
         assert sampler.sample_independent(study, trial, "param-a", dist) != suggestion
 
@@ -479,21 +479,24 @@ def test_sample_independent_misc_arguments() -> None:
 
     # Prepare a trial and a sample for later checks.
     trial = frozen_trial_factory(8)
-    sampler = TPESampler(n_startup_trials=5, seed=0)
+    sampler = TPESampler(n_startup_trials=5, seed=0, n_ei_candidates=100)
     with patch.object(study._storage, "get_all_trials", return_value=past_trials):
         suggestion = sampler.sample_independent(study, trial, "param-a", dist)
 
     # Test misc. parameters.
-    sampler = TPESampler(n_ei_candidates=13, n_startup_trials=5, seed=0)
+    sampler = TPESampler(n_startup_trials=5, seed=0, n_ei_candidates=13)
     with patch.object(study._storage, "get_all_trials", return_value=past_trials):
         assert sampler.sample_independent(study, trial, "param-a", dist) != suggestion
 
-    sampler = TPESampler(gamma=lambda _: 5, n_startup_trials=5, seed=0)
+    sampler = TPESampler(gamma=lambda _: 5, n_startup_trials=5, seed=0, n_ei_candidates=100)
     with patch.object(study._storage, "get_all_trials", return_value=past_trials):
         assert sampler.sample_independent(study, trial, "param-a", dist) != suggestion
 
     sampler = TPESampler(
-        weights=lambda i: np.asarray([10 - j for j in range(i)]), n_startup_trials=5, seed=0
+        weights=lambda i: np.asarray([10 - j for j in range(i)]),
+        n_startup_trials=5,
+        seed=0,
+        n_ei_candidates=100,
     )
     with patch("optuna.Study._get_trials", return_value=past_trials):
         assert sampler.sample_independent(study, trial, "param-a", dist) != suggestion


### PR DESCRIPTION
This PR is the same as #6261. The previous PR was closed due to performance concerns. But, after our subsequent discussion, we concluded that the performance changes were small enough to be acceptable.

The followings are copied from #6261.

## Motivation
The calculation of sigmas in `ParzenEstimator` is influenced by the prior's mu, but this is inappropriate for the window computation. This behavior stems from referencing the implementation of hyperopt (https://github.com/hyperopt/hyperopt/commit/5d8b88e65713314bdba788064c3be04cc4401189).

## Description of the changes
This PR removes `prior_mu` from `compute_sigmas`.

Benchmark results vary depending on the objective function, and when the optimal values are in the middle of the suggestion ranges, performance slightly deteriorated.

```python
import numpy as np
import matplotlib.pyplot as plt
import optuna

def objective(trial):
    params = np.empty(20)
    for i in range(20):
        params[i] = trial.suggest_float(f"x{i}", -10, 10)
    return np.sum(params ** 2)
    # return np.sum((params - 5) ** 2)

N_STUDIES = 100
N_TRIALS = 100

y = [[] for _ in  range(N_STUDIES)]
for seed in range(N_STUDIES):
    sampler = optuna.samplers.TPESampler(seed=seed)
    study = optuna.create_study(sampler=sampler)
    study.optimize(objective, n_trials=N_TRIALS)
    trials = study.trials
    y[seed].append(trials[0].value)
    for i in range(1, N_TRIALS):
        y[seed].append(min(y[seed][-1], trials[i].value))

y = np.asarray(y)
np.save("master.npy", y)
# np.save("pr.npy", y)
```
```python
y = np.load("master.npy")
mean = np.mean(y, axis=0)
std = np.std(y, axis=0)
plt.fill_between(range(N_TRIALS), mean + std, mean - std, alpha=0.1)
plt.plot(range(N_TRIALS), mean, label="master")

y = np.load("pr.npy")
mean = np.mean(y, axis=0)
std = np.std(y, axis=0)
plt.fill_between(range(N_TRIALS), mean + std, mean - std, alpha=0.1)
plt.plot(range(N_TRIALS), mean, label="fixed")

plt.xlabel("trial number")
plt.ylabel("loss")
plt.legend()
plt.savefig("sigma.png")
```

Σx^2 / Σ(x-5)^2

<img width="400" height="480" alt="sigma0" src="https://github.com/user-attachments/assets/66295e62-82c1-436b-bd99-ce08f4d7ed63" />

<img width="400" height="480" alt="sigma5" src="https://github.com/user-attachments/assets/a719f44d-a487-4a3a-b97b-fae8750d33aa" />

The internal state of the `ParzenEstimator` was verified using the following code:

```python
import numpy as np
import matplotlib.pyplot as plt
import optuna
import optunahub

def objective(trial):
    params = np.empty(20)
    for i in range(20):
        params[i] = trial.suggest_float(f"x{i}", -10, 10)
    return np.sum(params ** 2)

module = optunahub.load_module(
    package="visualization/tpe_acquisition_visualizer",
)
tpe_acquisition_visualizer = module.TPEAcquisitionVisualizer()
sampler = optuna.samplers.TPESampler(seed=0)
study = optuna.create_study(sampler=sampler)
study.optimize(objective, n_trials=11, callbacks=[tpe_acquisition_visualizer])
fig = tpe_acquisition_visualizer.plot(study, 10, "x0")
fig.savefig(f"x0_10.png")
plt.close(fig)
```

master / PR

<img width="400" height="600" alt="x0_10_master" src="https://github.com/user-attachments/assets/8a977de3-2448-4d5e-b59c-9851ed610585" />

<img width="400" height="600" alt="x0_10_pr" src="https://github.com/user-attachments/assets/dbc6e09b-3c9a-4f7a-9693-849fde89c679" />

