### PR TITLE
Use `TYPE_CHECKING` in `visualization/_rank.py`

### DIFF
--- a/optuna/visualization/_rank.py
+++ b/optuna/visualization/_rank.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Callable
 import math
 import typing
 from typing import Any
@@ -12,12 +11,14 @@ import numpy as np
 from optuna.logging import get_logger
 from optuna.samplers._base import _CONSTRAINTS_KEY
 from optuna.trial import TrialState
+from optuna.visualization._plotly_imports import _imports
 
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from optuna.study import Study
     from optuna.trial import FrozenTrial
-from optuna.visualization._plotly_imports import _imports
 from optuna.visualization._utils import _check_plot_args
 from optuna.visualization._utils import _is_log_scale
 from optuna.visualization._utils import _is_numerical
@@ -141,7 +142,7 @@ def _get_rank_info(
     if target is None:
 
         def target(trial: FrozenTrial) -> float:
-            return typing.cast(float, trial.value)
+            return typing.cast("float", trial.value)
 
         has_custom_target = False
     target_values = np.array([target(trial) for trial in trials])


### PR DESCRIPTION
Part of #6029.

Moved Callable into TYPE_CHECKING. Also added quotes to the float type in a cast() call and fixed import ordering.

ruff check --select TCH passes clean.