### PR TITLE
Use `TYPE_CHECKING` in `visualization/_slice.py`

### DIFF
--- a/optuna/visualization/_slice.py
+++ b/optuna/visualization/_slice.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Callable
 from typing import Any
 from typing import cast
 from typing import NamedTuple
@@ -11,12 +10,14 @@ from optuna.distributions import CategoricalDistribution
 from optuna.logging import get_logger
 from optuna.samplers._base import _CONSTRAINTS_KEY
 from optuna.trial import TrialState
+from optuna.visualization._plotly_imports import _imports
 
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from optuna.study import Study
     from optuna.trial import FrozenTrial
-from optuna.visualization._plotly_imports import _imports
 from optuna.visualization._utils import _check_plot_args
 from optuna.visualization._utils import _filter_nonfinite
 from optuna.visualization._utils import _is_log_scale
@@ -64,7 +65,7 @@ def _get_slice_subplot_info(
     if target is None:
 
         def _target(t: FrozenTrial) -> float:
-            return cast(float, t.value)
+            return cast("float", t.value)
 
         target = _target
 


### PR DESCRIPTION
Part of #6029.

Moved Callable into TYPE_CHECKING. Also added quotes to the float type in a cast() call and fixed import ordering.

ruff check --select TCH passes clean.