### PR TITLE
Use `TYPE_CHECKING` in `visualization/_parallel_coordinate.py`

### DIFF
--- a/optuna/visualization/_parallel_coordinate.py
+++ b/optuna/visualization/_parallel_coordinate.py
@@ -1,9 +1,7 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from collections.abc import Callable
 import math
-from typing import Any
 from typing import cast
 from typing import NamedTuple
 from typing import TYPE_CHECKING
@@ -16,8 +14,12 @@ from optuna.trial import TrialState
 
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+    from typing import Any
+
     from optuna.study import Study
     from optuna.trial import FrozenTrial
+
 from optuna.visualization._plotly_imports import _imports
 from optuna.visualization._utils import _check_plot_args
 from optuna.visualization._utils import _filter_nonfinite


### PR DESCRIPTION
Moves `Callable` and `Any` into the `if TYPE_CHECKING` block in `visualization/_parallel_coordinate.py`. Both are only referenced in type annotations, and `from __future__ import annotations` defers their evaluation so they don't need to be available at runtime.

`cast` stays at module level because it's called at runtime (line 147).

Also fixes a missing blank line after the `TYPE_CHECKING` block.

Part of #6029.