### PR TITLE
Use `TYPE_CHECKING` in `optuna/visualization/matplotlib/_utils.py`

### DIFF
--- a/optuna/visualization/matplotlib/_utils.py
+++ b/optuna/visualization/matplotlib/_utils.py
@@ -1,11 +1,16 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from optuna._experimental import experimental_func
 from optuna.distributions import CategoricalDistribution
 from optuna.distributions import FloatDistribution
 from optuna.distributions import IntDistribution
-from optuna.trial import FrozenTrial
 from optuna.visualization.matplotlib import _matplotlib_imports
+
+
+if TYPE_CHECKING:
+    from optuna.trial import FrozenTrial
 
 
 __all__ = ["is_available"]


### PR DESCRIPTION
Move type-only import (`FrozenTrial`) under `TYPE_CHECKING` in `optuna/visualization/matplotlib/_utils.py`.

Part of #6029

**Changes:**
- Move `FrozenTrial` import under `if TYPE_CHECKING`
- Keep `CategoricalDistribution`, `FloatDistribution`, `IntDistribution` as runtime imports (used in `isinstance` checks)
- `ruff check` passes