### PR TITLE
Use `TYPE_CHECKING` in `optuna/visualization/matplotlib/_edf.py`

### DIFF
--- a/optuna/visualization/matplotlib/_edf.py
+++ b/optuna/visualization/matplotlib/_edf.py
@@ -1,14 +1,19 @@
 from __future__ import annotations
 
-from collections.abc import Callable
-from collections.abc import Sequence
+from typing import TYPE_CHECKING
 
 from optuna._experimental import experimental_func
 from optuna.logging import get_logger
-from optuna.study import Study
-from optuna.trial import FrozenTrial
 from optuna.visualization._edf import _get_edf_info
 from optuna.visualization.matplotlib._matplotlib_imports import _imports
+
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from collections.abc import Sequence
+
+    from optuna.study import Study
+    from optuna.trial import FrozenTrial
 
 
 if _imports.is_successful():


### PR DESCRIPTION
Move type-only imports (`Study`, `FrozenTrial`, `Callable`, `Sequence`) under `TYPE_CHECKING`.

Part of #6029

- Keep `get_logger`, `_get_edf_info`, `_imports` as runtime imports
- `ruff check` passes