### PR TITLE
Use `TYPE_CHECKING` in `optuna/visualization/matplotlib/_contour.py`

### DIFF
--- a/optuna/visualization/matplotlib/_contour.py
+++ b/optuna/visualization/matplotlib/_contour.py
@@ -1,20 +1,25 @@
 from __future__ import annotations
 
-from collections.abc import Callable
-from collections.abc import Sequence
+from typing import TYPE_CHECKING
 
 import numpy as np
 
 from optuna._experimental import experimental_func
 from optuna._imports import try_import
-from optuna.study import Study
-from optuna.trial import FrozenTrial
 from optuna.visualization._contour import _AxisInfo
 from optuna.visualization._contour import _ContourInfo
 from optuna.visualization._contour import _get_contour_info
 from optuna.visualization._contour import _PlotValues
 from optuna.visualization._contour import _SubContourInfo
 from optuna.visualization.matplotlib._matplotlib_imports import _imports
+
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from collections.abc import Sequence
+
+    from optuna.study import Study
+    from optuna.trial import FrozenTrial
 
 
 with try_import() as _optuna_imports:


### PR DESCRIPTION
Move type-only imports (`Study`, `FrozenTrial`, `Callable`, `Sequence`) under `TYPE_CHECKING`.

Part of #6029

- Keep `numpy`, `_experimental`, `try_import`, visualization helpers as runtime imports
- `ruff check` passes