### PR TITLE
Add `from __future__ import annotations` to 16 remaining modules

### DIFF
--- a/optuna/artifacts/__init__.py
+++ b/optuna/artifacts/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from optuna.artifacts._backoff import Backoff
 from optuna.artifacts._boto3 import Boto3ArtifactStore
 from optuna.artifacts._download import download_artifact

--- a/optuna/artifacts/exceptions.py
+++ b/optuna/artifacts/exceptions.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from optuna.exceptions import OptunaError
 
 

--- a/optuna/exceptions.py
+++ b/optuna/exceptions.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 class OptunaError(Exception):
     """Base class for Optuna specific errors."""
 

--- a/optuna/pruners/__init__.py
+++ b/optuna/pruners/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 from optuna.pruners._base import BasePruner
@@ -29,7 +31,7 @@ __all__ = [
 ]
 
 
-def _filter_study(study: "Study", trial: "FrozenTrial") -> "Study":
+def _filter_study(study: Study, trial: FrozenTrial) -> Study:
     if isinstance(study.pruner, HyperbandPruner):
         # Create `_BracketStudy` to use trials that have the same bracket id.
         pruner: HyperbandPruner = study.pruner

--- a/optuna/pruners/_median.py
+++ b/optuna/pruners/_median.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from optuna.pruners._percentile import PercentilePruner
 
 

--- a/optuna/search_space/__init__.py
+++ b/optuna/search_space/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from optuna.search_space.group_decomposed import _GroupDecomposedSearchSpace
 from optuna.search_space.group_decomposed import _SearchSpaceGroup
 from optuna.search_space.intersection import intersection_search_space

--- a/optuna/study/__init__.py
+++ b/optuna/study/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from optuna._callbacks import MaxTrialsCallback
 from optuna.study._study_direction import StudyDirection
 from optuna.study._study_summary import StudySummary

--- a/optuna/study/_study_direction.py
+++ b/optuna/study/_study_direction.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import enum
 
 

--- a/optuna/terminator/__init__.py
+++ b/optuna/terminator/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from optuna.terminator.callback import TerminatorCallback
 from optuna.terminator.erroreval import BaseErrorEvaluator
 from optuna.terminator.erroreval import CrossValidationErrorEvaluator

--- a/optuna/terminator/improvement/__init__.py
+++ b/optuna/terminator/improvement/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import annotations

--- a/optuna/testing/__init__.py
+++ b/optuna/testing/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import annotations

--- a/optuna/testing/objectives.py
+++ b/optuna/testing/objectives.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from optuna import TrialPruned
 from optuna.trial import Trial
 

--- a/optuna/testing/visualization.py
+++ b/optuna/testing/visualization.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from optuna import Study
 from optuna.distributions import FloatDistribution
 from optuna.study import create_study

--- a/optuna/trial/__init__.py
+++ b/optuna/trial/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from optuna.trial._base import BaseTrial
 from optuna.trial._fixed import FixedTrial
 from optuna.trial._frozen import create_trial

--- a/optuna/trial/_state.py
+++ b/optuna/trial/_state.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import enum
 
 

--- a/optuna/version.py
+++ b/optuna/version.py
@@ -1,1 +1,3 @@
+from __future__ import annotations
+
 __version__ = "4.9.0.dev"


### PR DESCRIPTION
## Problem

As tracked in #4508, some modules in the Optuna codebase are still missing `from __future__ import annotations` (PEP 563).

## Solution

Added `from __future__ import annotations` to 16 modules that were missing it:

- `optuna/pruners/__init__.py` and `_median.py`
- `optuna/terminator/__init__.py` and `improvement/__init__.py`
- `optuna/trial/__init__.py` and `_state.py`
- `optuna/study/__init__.py` and `_study_direction.py`
- `optuna/search_space/__init__.py`
- `optuna/testing/__init__.py`, `objectives.py`, and `visualization.py`
- `optuna/artifacts/__init__.py` and `exceptions.py`
- `optuna/exceptions.py`
- `optuna/version.py`

Also removed unnecessary string-quoted type annotations in `pruners/__init__.py` (`Study`, `FrozenTrial`) that are now resolved at parse time via PEP 563.

## Files Changed

16 files — purely additive `from __future__ import annotations` imports with one type annotation cleanup.

Closes part of #4508.