### PR TITLE
Fix missing blank line after `TYPE_CHECKING` in `visualization/_intermediate_values.py`

### DIFF
--- a/optuna/visualization/_intermediate_values.py
+++ b/optuna/visualization/_intermediate_values.py
@@ -11,6 +11,7 @@ from optuna.trial import TrialState
 if TYPE_CHECKING:
     from optuna.study import Study
     from optuna.trial import FrozenTrial
+
 from optuna.visualization._plotly_imports import _imports
 
 


### PR DESCRIPTION
Adds a missing blank line after the `if TYPE_CHECKING:` block in `visualization/_intermediate_values.py`, separating it from the module-level import below.

Part of #6029.