### PR TITLE
Use `TYPE_CHECKING` in `visualization/matplotlib/_optimization_history.py`

### DIFF
--- a/optuna/visualization/matplotlib/_optimization_history.py
+++ b/optuna/visualization/matplotlib/_optimization_history.py
@@ -11,6 +11,7 @@ from optuna.visualization._optimization_history import _OptimizationHistoryInfo
 from optuna.visualization._optimization_history import _ValueState
 from optuna.visualization.matplotlib._matplotlib_imports import _imports
 
+
 if TYPE_CHECKING:
     from collections.abc import Callable
     from collections.abc import Sequence


### PR DESCRIPTION
Moves `Callable`, `Sequence`, `Study`, and `FrozenTrial` into the `if TYPE_CHECKING` block in `visualization/matplotlib/_optimization_history.py`. All four are only referenced in type annotations, and `from __future__ import annotations` defers their evaluation so they don't need to be available at runtime.

Part of #6029.