### PR TITLE
Use `TYPE_CHECKING` in `visualization/matplotlib/_parallel_coordinate.py`

### DIFF
--- a/optuna/visualization/matplotlib/_parallel_coordinate.py
+++ b/optuna/visualization/matplotlib/_parallel_coordinate.py
@@ -9,6 +9,7 @@ from optuna.visualization._parallel_coordinate import _get_parallel_coordinate_i
 from optuna.visualization._parallel_coordinate import _ParallelCoordinateInfo
 from optuna.visualization.matplotlib._matplotlib_imports import _imports
 
+
 if TYPE_CHECKING:
     from collections.abc import Callable
 


### PR DESCRIPTION
Moves `Callable`, `Study`, and `FrozenTrial` into the `if TYPE_CHECKING` block in `visualization/matplotlib/_parallel_coordinate.py`. All three are only referenced in type annotations, and `from __future__ import annotations` defers their evaluation.

Part of #6029.