### PR TITLE
Use `TYPE_CHECKING` in `visualization/matplotlib/_rank.py`

### DIFF
--- a/optuna/visualization/matplotlib/_rank.py
+++ b/optuna/visualization/matplotlib/_rank.py
@@ -11,6 +11,7 @@ from optuna.visualization._rank import _RankPlotInfo
 from optuna.visualization._rank import _RankSubplotInfo
 from optuna.visualization.matplotlib._matplotlib_imports import _imports
 
+
 if TYPE_CHECKING:
     from collections.abc import Callable
 


### PR DESCRIPTION
Moves `Callable`, `Study`, and `FrozenTrial` into the `if TYPE_CHECKING` block in `visualization/matplotlib/_rank.py`. All three are only referenced in type annotations, and `from __future__ import annotations` defers their evaluation.

Part of #6029.