### PR TITLE
Use `TYPE_CHECKING` in `samplers/_tpe/parzen_estimator.py`

### DIFF
--- a/optuna/samplers/_tpe/parzen_estimator.py
+++ b/optuna/samplers/_tpe/parzen_estimator.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from collections.abc import Callable
 from typing import NamedTuple
+from typing import TYPE_CHECKING
 
 import numpy as np
 
@@ -19,6 +19,10 @@ from optuna.samplers._tpe.probability_distributions import _BatchedDistributions
 from optuna.samplers._tpe.probability_distributions import _BatchedTruncLogNormDistributions
 from optuna.samplers._tpe.probability_distributions import _BatchedTruncNormDistributions
 from optuna.samplers._tpe.probability_distributions import _MixtureOfProductDistribution
+
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 
 EPS = 1e-12


### PR DESCRIPTION
## Motivation

Addresses #6029. The `Callable` import from `collections.abc` is only used in type annotations, so it can be moved into a `TYPE_CHECKING` block to avoid unnecessary runtime imports.

## Description of the changes

- Moved `from collections.abc import Callable` into an `if TYPE_CHECKING:` block in `optuna/samplers/_tpe/parzen_estimator.py`
- Added `from typing import TYPE_CHECKING` import
- This is safe because the file already uses `from __future__ import annotations`, so all annotations are strings at runtime