### PR TITLE
Use `TYPE_CHECKING` in `study/_constrained_optimization.py`

### DIFF
--- a/optuna/study/_constrained_optimization.py
+++ b/optuna/study/_constrained_optimization.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
-from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from optuna.trial import FrozenTrial
 
 


### PR DESCRIPTION
## Motivation

Addresses #6029. The `Sequence` import from `collections.abc` is only used in type annotations, so it can be moved into the existing `TYPE_CHECKING` block.

## Description of the changes

- Moved `from collections.abc import Sequence` into the existing `if TYPE_CHECKING:` block in `optuna/study/_constrained_optimization.py`
- Safe because the file already uses `from __future__ import annotations`