### PR TITLE
Use `TYPE_CHECKING` in `storages/_base.py`

### DIFF
--- a/optuna/storages/_base.py
+++ b/optuna/storages/_base.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
 import abc
-from collections.abc import Container
-from collections.abc import Sequence
 from typing import Any
 from typing import cast
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Container
+    from collections.abc import Sequence
 
 from optuna._typing import JSONSerializable
 from optuna.distributions import BaseDistribution


### PR DESCRIPTION
Partial fix for #6029

Move `Container` and `Sequence` imports from `collections.abc` into `TYPE_CHECKING` block in `optuna/storages/_base.py`. These are only used in type annotations and `from __future__ import annotations` is already present.

```
ruff check optuna/storages/_base.py --select TC002,TC003
# All checks passed!
```