### PR TITLE
Use `TYPE_CHECKING` in `storages/_cached_storage.py`

### DIFF
--- a/optuna/storages/_cached_storage.py
+++ b/optuna/storages/_cached_storage.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
-from collections.abc import Callable
-from collections.abc import Container
-from collections.abc import Sequence
 import copy
 import threading
 from typing import Any
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from collections.abc import Container
+    from collections.abc import Sequence
 
 import optuna
 from optuna import distributions


### PR DESCRIPTION
Partial fix for #6029

Move `Callable`, `Container`, and `Sequence` imports from `collections.abc` into `TYPE_CHECKING` block in `optuna/storages/_cached_storage.py`. These are only used in type annotations and `from __future__ import annotations` is already present.

```
ruff check optuna/storages/_cached_storage.py --select TC002,TC003
# All checks passed!
```