### PR TITLE
Use `TYPE_CHECKING` in `storages/_heartbeat.py`

### DIFF
--- a/optuna/storages/_heartbeat.py
+++ b/optuna/storages/_heartbeat.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
 import abc
-from collections.abc import Callable
 import copy
 from threading import Event
 from threading import Thread
-from types import TracebackType
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from types import TracebackType
 
 import optuna
 from optuna._experimental import experimental_func


### PR DESCRIPTION
Partial fix for #6029

Move `Callable` and `TracebackType` imports into `TYPE_CHECKING` block in `optuna/storages/_heartbeat.py`. These are only used in type annotations and `from __future__ import annotations` is already present.

```
ruff check optuna/storages/_heartbeat.py --select TC002,TC003
# All checks passed!
```