### PR TITLE
Use `TYPE_CHECKING` in `storages/_in_memory.py`

### DIFF
--- a/optuna/storages/_in_memory.py
+++ b/optuna/storages/_in_memory.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
-from collections.abc import Container
-from collections.abc import Sequence
 import copy
 from datetime import datetime
 import threading
 from typing import Any
+from typing import TYPE_CHECKING
 import uuid
+
+if TYPE_CHECKING:
+    from collections.abc import Container
+    from collections.abc import Sequence
 
 import optuna
 from optuna import distributions  # NOQA


### PR DESCRIPTION
Partial fix for #6029

Move `Container` and `Sequence` imports from `collections.abc` into `TYPE_CHECKING` block in `optuna/storages/_in_memory.py`. These are only used in type annotations and `from __future__ import annotations` is already present.

```
ruff check optuna/storages/_in_memory.py --select TC002,TC003
# All checks passed!
```