### PR TITLE
Use `TYPE_CHECKING` in `study/_study_summary.py`

### DIFF
--- a/optuna/study/_study_summary.py
+++ b/optuna/study/_study_summary.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Sequence
-import datetime
 from typing import Any
 from typing import TYPE_CHECKING
 
@@ -11,6 +9,9 @@ from optuna.study._study_direction import StudyDirection
 
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+    import datetime
+
     from optuna.trial import FrozenTrial
 
 _logger = logging.get_logger(__name__)


### PR DESCRIPTION
Partial fix for #6029

Move `Sequence` and `datetime` imports into `TYPE_CHECKING` block in `optuna/study/_study_summary.py`. These are only used in type annotations and `from __future__ import annotations` is already present.

```
ruff check optuna/study/_study_summary.py --select TC002,TC003
# All checks passed!
```