### PR TITLE
fix(terminator): use TYPE_CHECKING for type-only import

### DIFF
--- a/optuna/terminator/terminator.py
+++ b/optuna/terminator/terminator.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import abc
+from typing import TYPE_CHECKING
 
 from optuna._experimental import experimental_class
-from optuna.study.study import Study
 from optuna.terminator.erroreval import BaseErrorEvaluator
 from optuna.terminator.erroreval import CrossValidationErrorEvaluator
 from optuna.terminator.erroreval import StaticErrorEvaluator
@@ -12,6 +12,10 @@ from optuna.terminator.improvement.evaluator import BestValueStagnationEvaluator
 from optuna.terminator.improvement.evaluator import DEFAULT_MIN_N_TRIALS
 from optuna.terminator.improvement.evaluator import RegretBoundEvaluator
 from optuna.trial import TrialState
+
+
+if TYPE_CHECKING:
+    from optuna.study.study import Study
 
 
 class BaseTerminator(metaclass=abc.ABCMeta):


### PR DESCRIPTION
## Problem

`optuna/terminator/terminator.py` imports `Study` at module level, but it is only used in type annotations. Since the file already uses `from __future__ import annotations`, annotations are evaluated lazily and this import is unnecessary at runtime.

## Solution

Move the `Study` import into a `TYPE_CHECKING` block to avoid potential circular imports at runtime.

## Changes

- Added `from typing import TYPE_CHECKING`
- Moved `from optuna.study.study import Study` into `if TYPE_CHECKING:` block

## Verification

```
$ ruff check optuna/terminator/terminator.py --select TC001,TC002,TC003
All checks passed!
```

Part of #6029.