### PR TITLE
Remove unused type ignore comment

### DIFF
--- a/optuna/visualization/_intermediate_values.py
+++ b/optuna/visualization/_intermediate_values.py
@@ -94,9 +94,7 @@ def _get_intermediate_plot(info: _IntermediatePlotInfo) -> "go.Figure":
             x=tuple((x for x, _ in tinfo.sorted_intermediate_values)),
             y=tuple((y for _, y in tinfo.sorted_intermediate_values)),
             mode="lines+markers",
-            marker=(
-                default_marker if tinfo.feasible else {**default_marker, "color": "#CCCCCC"}  # type: ignore[dict-item]
-            ),
+            marker=(default_marker if tinfo.feasible else {**default_marker, "color": "#CCCCCC"}),
             name=f"Trial{tinfo.trial_number}",
         )
         for tinfo in trial_infos


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. To minimize the review effort, we highly appreciate PRs only with related changes. Please note that submitted PRs may be closed if they include unrelated changes or significantly modified unit tests. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
Resolves https://github.com/optuna/optuna/actions/runs/23823854977/job/69442281967

## Description of the changes
<!-- Describe the changes in this PR. -->
According to the scheduled CI, there is an unused `type: ignore` comment, causing CI being failed.

> mypy . --warn-unused-ignores
> optuna/visualization/_intermediate_values.py:98: error: Unused "type: ignore" comment  [unused-ignore]
> Found 1 error in 1 file (checked 324 source files)