### PR TITLE
fix: move FrozenTrial import into TYPE_CHECKING block in storages/_callbacks.py

### DIFF
--- a/optuna/storages/_callbacks.py
+++ b/optuna/storages/_callbacks.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
 from typing import Any
+from typing import TYPE_CHECKING
 
 import optuna
 from optuna._experimental import experimental_class
 from optuna._experimental import experimental_func
+
 
 if TYPE_CHECKING:
     from optuna.trial import FrozenTrial


### PR DESCRIPTION
Closes #6029 (partially - one file per PR as requested)

## Summary

Moves the `FrozenTrial` import in `optuna/storages/_callbacks.py` into a `TYPE_CHECKING` block, as it is only referenced in type annotations.

`from __future__ import annotations` is already present, so all annotations are evaluated lazily at runtime and the import is not needed outside of type checking.

## Verification

```
ruff check optuna/storages/_callbacks.py --select TCH
All checks passed!
```