### PR TITLE
fix: move type-only imports to TYPE_CHECKING in StudySummary

### DIFF
--- a/optuna/study/_study_summary.py
+++ b/optuna/study/_study_summary.py
@@ -1,16 +1,17 @@
 from __future__ import annotations
 
-from collections.abc import Sequence
-import datetime
 from typing import Any
 from typing import TYPE_CHECKING
 
 from optuna import logging
 from optuna._warnings import optuna_warn
-from optuna.study._study_direction import StudyDirection
 
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+    from datetime import datetime
+
+    from optuna.study._study_direction import StudyDirection
     from optuna.trial import FrozenTrial
 
 _logger = logging.get_logger(__name__)
@@ -61,7 +62,7 @@ class StudySummary:
         user_attrs: dict[str, Any],
         system_attrs: dict[str, Any],
         n_trials: int,
-        datetime_start: datetime.datetime | None,
+        datetime_start: datetime | None,
         study_id: int,
         *,
         directions: Sequence[StudyDirection] | None = None,


### PR DESCRIPTION
## Summary

Move type-only imports to TYPE_CHECKING block in `optuna/study/_study_summary.py`:
- `collections.abc.Sequence`
- `datetime` 
- `optuna.study._study_direction.StudyDirection`

## Motivation

Addresses ruff violations (TC001, TC003) from issue #6029. With `from __future__ import annotations`, all type annotations are treated as strings at module load time, so these imports are not needed at runtime.

## Type of Change

- [x] Code quality improvement
- [ ] Bug fix
- [ ] New feature

## Test Plan

- Verified file compiles with `python -m py_compile`
- Verified no TC violations with `ruff check --select TCH`

## Notes

This is part of issue #6029, following the one file per contributor guideline.