### PR TITLE
Make `QMCSampler` stateless

### DIFF
--- a/optuna/samplers/_qmc.py
+++ b/optuna/samplers/_qmc.py
@@ -295,7 +295,7 @@ class QMCSampler(BaseSampler):
         search_space_str = {
             param_name: str(search_space[param_name]) for param_name in sorted(search_space)
         }
-        qmc_vars = {"qmc_type": self._qmc_type, "search_space": search_space_str}
+        qmc_vars: dict[str, Any] = {"qmc_type": self._qmc_type, "search_space": search_space_str}
         # Sobol/Halton sequences without scrambling do not use seed.
         if self._scramble:
             qmc_vars.update(scramble=True, seed=self._seed)

--- a/optuna/samplers/_qmc.py
+++ b/optuna/samplers/_qmc.py
@@ -213,6 +213,10 @@ class QMCSampler(BaseSampler):
         )
 
     def _log_independent_sampling(self, trial: FrozenTrial, param_name: str) -> None:
+        # NOTE(nabenabe): We can extend `QMCSampler` to dynamic search space and categorical dist
+        # as well. For dynamic search space, we need to use the same mechanism as `group` by TPE.
+        # For categorical, we simply need to sample from [-1/2, C+1/2] and then round the number
+        # to get a categorical index.
         _logger.warning(
             _INDEPENDENT_SAMPLING_WARNING_TEMPLATE.format(
                 param_name=param_name,
@@ -292,8 +296,9 @@ class QMCSampler(BaseSampler):
         return sample
 
     def _find_sample_id(self, study: Study, search_space: dict[str, BaseDistribution]) -> int:
+        # Sort by keys to make the order static.
         search_space_str = {
-            param_name: str(search_space[param_name]) for param_name in sorted(search_space)
+            param_name: str(dist) for param_name, dist in sorted(search_space.items())
         }
         qmc_vars: dict[str, Any] = {"qmc_type": self._qmc_type, "search_space": search_space_str}
         # Sobol/Halton sequences without scrambling do not use seed.

--- a/optuna/samplers/_qmc.py
+++ b/optuna/samplers/_qmc.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
+import json
 import threading
-from typing import Any
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -11,18 +11,19 @@ from optuna import logging
 from optuna._experimental import experimental_class
 from optuna._imports import _LazyImport
 from optuna._transform import _SearchSpaceTransform
-from optuna.distributions import BaseDistribution
 from optuna.distributions import CategoricalDistribution
 from optuna.samplers import BaseSampler
 from optuna.samplers._base import _INDEPENDENT_SAMPLING_WARNING_TEMPLATE
-from optuna.trial import FrozenTrial
 from optuna.trial import TrialState
 
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
+    from typing import Any
 
+    from optuna.distributions import BaseDistribution
     from optuna.study import Study
+    from optuna.trial import FrozenTrial
 
 
 _logger = logging.get_logger(__name__)
@@ -162,7 +163,6 @@ class QMCSampler(BaseSampler):
         self._scramble = scramble
         self._seed = np.random.PCG64().random_raw() if seed is None else seed
         self._independent_sampler = independent_sampler or optuna.samplers.RandomSampler(seed=seed)
-        self._initial_search_space: dict[str, BaseDistribution] | None = None
         self._warn_independent_sampling = warn_independent_sampling
 
         if qmc_type in ("halton", "sobol"):
@@ -185,9 +185,6 @@ class QMCSampler(BaseSampler):
     def infer_relative_search_space(
         self, study: Study, trial: FrozenTrial
     ) -> dict[str, BaseDistribution]:
-        if self._initial_search_space is not None:
-            return self._initial_search_space
-
         past_trials = study._get_trials(deepcopy=False, states=_SUGGESTED_STATES, use_cache=True)
         # The initial trial is sampled by the independent sampler.
         if len(past_trials) == 0:
@@ -195,8 +192,7 @@ class QMCSampler(BaseSampler):
         # If an initial trial was already made,
         # construct search_space of this sampler from the initial trial.
         first_trial = min(past_trials, key=lambda t: t.number)
-        self._initial_search_space = self._infer_initial_search_space(first_trial)
-        return self._initial_search_space
+        return self._infer_initial_search_space(first_trial)
 
     def _infer_initial_search_space(self, trial: FrozenTrial) -> dict[str, BaseDistribution]:
         search_space: dict[str, BaseDistribution] = {}
@@ -237,7 +233,7 @@ class QMCSampler(BaseSampler):
         param_name: str,
         param_distribution: BaseDistribution,
     ) -> Any:
-        if self._initial_search_space is not None:
+        if len(study._get_trials(deepcopy=False, states=_SUGGESTED_STATES, use_cache=True)):
             if self._warn_independent_sampling:
                 self._log_independent_sampling(trial, param_name)
 
@@ -262,7 +258,7 @@ class QMCSampler(BaseSampler):
     def after_trial(
         self,
         study: Study,
-        trial: "optuna.trial.FrozenTrial",
+        trial: FrozenTrial,
         state: TrialState,
         values: Sequence[float] | None,
     ) -> None:
@@ -272,7 +268,7 @@ class QMCSampler(BaseSampler):
         # Lazy import because the `scipy.stats.qmc` is slow to import.
         qmc_module = _LazyImport("scipy.stats.qmc")
 
-        sample_id = self._find_sample_id(study)
+        sample_id = self._find_sample_id(study, search_space)
         d = len(search_space)
 
         if self._qmc_type == "halton":
@@ -295,25 +291,21 @@ class QMCSampler(BaseSampler):
 
         return sample
 
-    def _find_sample_id(self, study: Study) -> int:
-        qmc_id = ""
-        qmc_id += self._qmc_type
+    def _find_sample_id(self, study: Study, search_space: dict[str, BaseDistribution]) -> int:
+        search_space_str = {
+            param_name: str(search_space[param_name]) for param_name in sorted(search_space)
+        }
+        qmc_vars = {"qmc_type": self._qmc_type, "search_space": search_space_str}
         # Sobol/Halton sequences without scrambling do not use seed.
         if self._scramble:
-            qmc_id += f" (scramble=True, seed={self._seed})"
+            qmc_vars.update(scramble=True, seed=self._seed)
         else:
-            qmc_id += " (scramble=False)"
-        key_qmc_id = qmc_id + "'s last sample id"
+            qmc_vars.update(scramble=False)
 
+        key_qmc_id = json.dumps(qmc_vars, separators=(",", ":"))
         # TODO(kstoneriv3): Here, we ideally assume that the following block is
         # an atomic transaction. Without such an assumption, the current implementation
         # only ensures that each `sample_id` is sampled at least once.
-        system_attrs = study._storage.get_study_system_attrs(study._study_id)
-        if key_qmc_id in system_attrs.keys():
-            sample_id = system_attrs[key_qmc_id]
-            sample_id += 1
-        else:
-            sample_id = 0
+        sample_id = study._storage.get_study_system_attrs(study._study_id).get(key_qmc_id, -1) + 1
         study._storage.set_study_system_attr(study._study_id, key_qmc_id, sample_id)
-
         return sample_id

--- a/optuna/samplers/_qmc.py
+++ b/optuna/samplers/_qmc.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 import threading
 from typing import Any
@@ -307,7 +308,7 @@ class QMCSampler(BaseSampler):
         else:
             qmc_vars.update(scramble=False)
 
-        key_qmc_id = json.dumps(qmc_vars, separators=(",", ":"))
+        key_qmc_id = "qmc:" + hashlib.sha256(json.dumps(qmc_vars).encode()).hexdigest()
         # TODO(kstoneriv3): Here, we ideally assume that the following block is
         # an atomic transaction. Without such an assumption, the current implementation
         # only ensures that each `sample_id` is sampled at least once.

--- a/optuna/samplers/_qmc.py
+++ b/optuna/samplers/_qmc.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import threading
+from typing import Any
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -11,6 +12,7 @@ from optuna import logging
 from optuna._experimental import experimental_class
 from optuna._imports import _LazyImport
 from optuna._transform import _SearchSpaceTransform
+from optuna.distributions import BaseDistribution
 from optuna.distributions import CategoricalDistribution
 from optuna.samplers import BaseSampler
 from optuna.samplers._base import _INDEPENDENT_SAMPLING_WARNING_TEMPLATE
@@ -19,9 +21,7 @@ from optuna.trial import TrialState
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
-    from typing import Any
 
-    from optuna.distributions import BaseDistribution
     from optuna.study import Study
     from optuna.trial import FrozenTrial
 

--- a/tests/samplers_tests/test_qmc.py
+++ b/tests/samplers_tests/test_qmc.py
@@ -70,7 +70,7 @@ def test_infer_relative_search_space() -> None:
 
     sampler = _init_QMCSampler_without_exp_warning()
     study = optuna.create_study(sampler=sampler)
-    trial = Mock()
+    trial = study.ask()
     # In case no past trials.
     assert sampler.infer_relative_search_space(study, trial) == {}
     # In case there is a past trial.
@@ -80,8 +80,8 @@ def test_infer_relative_search_space() -> None:
     assert set(relative_search_space.keys()) == {"x1", "x2", "x3", "x4", "x5"}
     # In case past trials exist and the new trial has some fixed params.
     study.enqueue_trial(params={"x1": 5, "x2": 3})
-    trial = study.ask()
-    assert all(k in sampler.infer_relative_search_space(study, trial) for k in ["x3", "x4", "x5"])
+    trial2 = study.ask()  # Pop the enqueued trial (with fixed params)
+    assert all(k in sampler.infer_relative_search_space(study, trial2) for k in ["x3", "x4", "x5"])
 
 
 def test_infer_initial_search_space() -> None:

--- a/tests/samplers_tests/test_qmc.py
+++ b/tests/samplers_tests/test_qmc.py
@@ -78,13 +78,6 @@ def test_infer_relative_search_space() -> None:
     relative_search_space = sampler.infer_relative_search_space(study, trial)
     assert len(relative_search_space.keys()) == 5
     assert set(relative_search_space.keys()) == {"x1", "x2", "x3", "x4", "x5"}
-    # In case past trials exist and the new trial has some fixed params.
-    partial_sampler = optuna.samplers.PartialFixedSampler(
-        fixed_params={"x1": 5, "x2": 3}, base_sampler=sampler
-    )
-    study.ask()  # Spawn a new trial.
-    trial2 = study.trials[-1]  # Pop the new trial as frozen (with fixed params)
-    assert set(partial_sampler.infer_relative_search_space(study, trial2)) == {"x3", "x4", "x5"}
 
 
 def test_infer_initial_search_space() -> None:
@@ -339,3 +332,23 @@ def test_find_sample_id() -> None:
     # Change qmc_type.
     with patch.object(sampler, "_qmc_type", "sobol") as _:
         assert sampler._find_sample_id(study, {}) == 0
+
+
+def test_find_sample_id_dynamic() -> None:
+    def _objective(trial: optuna.Trial) -> float:
+        x = trial.suggest_float("x", -5, 5)
+        y = trial.suggest_float("y", -5, 5)
+        return (x - 2) ** 2 + (y - 2) ** 2
+
+    study = optuna.create_study()
+    base_sampler = optuna.samplers.QMCSampler()
+    study.sampler = base_sampler
+    study.optimize(_objective, n_trials=8)
+    # The first trial is used to identify the search space, so it's not counted for QMC.
+    assert base_sampler._find_sample_id(study, search_space=study.trials[-1].distributions) == 7
+    study.sampler = optuna.samplers.PartialFixedSampler(
+        fixed_params={"x": study.best_params["x"]}, base_sampler=base_sampler
+    )
+    study.optimize(_objective, n_trials=8)
+    partial_search_space = {"y": study.trials[-1].distributions["y"]}
+    assert base_sampler._find_sample_id(study, search_space=partial_search_space) == 8

--- a/tests/samplers_tests/test_qmc.py
+++ b/tests/samplers_tests/test_qmc.py
@@ -74,8 +74,6 @@ def test_infer_relative_search_space() -> None:
     relative_search_space = sampler.infer_relative_search_space(study, trial)
     assert len(relative_search_space.keys()) == 5
     assert set(relative_search_space.keys()) == {"x1", "x2", "x3", "x4", "x5"}
-    # In case self._initial_trial already exists.
-    new_search_space: dict[str, BaseDistribution] = {"x": Mock()}
 
 
 def test_infer_initial_search_space() -> None:

--- a/tests/samplers_tests/test_qmc.py
+++ b/tests/samplers_tests/test_qmc.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import Any
+from typing import TYPE_CHECKING
 from unittest.mock import Mock
 from unittest.mock import patch
 import warnings
@@ -9,9 +10,12 @@ import numpy as np
 import pytest
 
 import optuna
-from optuna.distributions import BaseDistribution
 from optuna.trial import Trial
 from optuna.trial import TrialState
+
+
+if TYPE_CHECKING:
+    from optuna.distributions import BaseDistribution
 
 
 _SEARCH_SPACE = {

--- a/tests/samplers_tests/test_qmc.py
+++ b/tests/samplers_tests/test_qmc.py
@@ -74,6 +74,10 @@ def test_infer_relative_search_space() -> None:
     relative_search_space = sampler.infer_relative_search_space(study, trial)
     assert len(relative_search_space.keys()) == 5
     assert set(relative_search_space.keys()) == {"x1", "x2", "x3", "x4", "x5"}
+    # In case past trials exist and the new trial has some fixed params.
+    study.enqueue_trial(params={"x1": 5, "x2": 3})
+    trial = study.ask()
+    assert all(k in sampler.infer_relative_search_space(study, trial) for k in ["x3", "x4", "x5"])
 
 
 def test_infer_initial_search_space() -> None:

--- a/tests/samplers_tests/test_qmc.py
+++ b/tests/samplers_tests/test_qmc.py
@@ -70,7 +70,7 @@ def test_infer_relative_search_space() -> None:
 
     sampler = _init_QMCSampler_without_exp_warning()
     study = optuna.create_study(sampler=sampler)
-    trial = study.ask()
+    trial = Mock()
     # In case no past trials.
     assert sampler.infer_relative_search_space(study, trial) == {}
     # In case there is a past trial.
@@ -80,7 +80,7 @@ def test_infer_relative_search_space() -> None:
     assert set(relative_search_space.keys()) == {"x1", "x2", "x3", "x4", "x5"}
     # In case past trials exist and the new trial has some fixed params.
     study.enqueue_trial(params={"x1": 5, "x2": 3})
-    trial2 = study.ask()  # Pop the enqueued trial (with fixed params)
+    trial2 = study.trials[-1]  # Pop the enqueued trial as frozen (with fixed params)
     assert all(k in sampler.infer_relative_search_space(study, trial2) for k in ["x3", "x4", "x5"])
 
 

--- a/tests/samplers_tests/test_qmc.py
+++ b/tests/samplers_tests/test_qmc.py
@@ -79,9 +79,12 @@ def test_infer_relative_search_space() -> None:
     assert len(relative_search_space.keys()) == 5
     assert set(relative_search_space.keys()) == {"x1", "x2", "x3", "x4", "x5"}
     # In case past trials exist and the new trial has some fixed params.
-    study.enqueue_trial(params={"x1": 5, "x2": 3})
-    trial2 = study.trials[-1]  # Pop the enqueued trial as frozen (with fixed params)
-    assert all(k in sampler.infer_relative_search_space(study, trial2) for k in ["x3", "x4", "x5"])
+    partial_sampler = optuna.samplers.PartialFixedSampler(
+        fixed_params={"x1": 5, "x2": 3}, base_sampler=sampler
+    )
+    study.ask()  # Spawn a new trial.
+    trial2 = study.trials[-1]  # Pop the new trial as frozen (with fixed params)
+    assert set(partial_sampler.infer_relative_search_space(study, trial2)) == {"x3", "x4", "x5"}
 
 
 def test_infer_initial_search_space() -> None:

--- a/tests/samplers_tests/test_qmc.py
+++ b/tests/samplers_tests/test_qmc.py
@@ -76,8 +76,6 @@ def test_infer_relative_search_space() -> None:
     assert set(relative_search_space.keys()) == {"x1", "x2", "x3", "x4", "x5"}
     # In case self._initial_trial already exists.
     new_search_space: dict[str, BaseDistribution] = {"x": Mock()}
-    sampler._initial_search_space = new_search_space
-    assert sampler.infer_relative_search_space(study, trial) == new_search_space
 
 
 def test_infer_initial_search_space() -> None:
@@ -319,16 +317,16 @@ def test_find_sample_id() -> None:
     sampler = _init_QMCSampler_without_exp_warning(qmc_type="halton", seed=0)
     study = optuna.create_study()
     for i in range(5):
-        assert sampler._find_sample_id(study) == i
+        assert sampler._find_sample_id(study, {}) == i
 
     # Change seed but without scramble. The hash should remain the same.
     with patch.object(sampler, "_seed", 1) as _:
-        assert sampler._find_sample_id(study) == 5
+        assert sampler._find_sample_id(study, {}) == 5
 
         # Seed is considered only when scrambling is enabled.
         with patch.object(sampler, "_scramble", True) as _:
-            assert sampler._find_sample_id(study) == 0
+            assert sampler._find_sample_id(study, {}) == 0
 
     # Change qmc_type.
     with patch.object(sampler, "_qmc_type", "sobol") as _:
-        assert sampler._find_sample_id(study) == 0
+        assert sampler._find_sample_id(study, {}) == 0

--- a/tests/samplers_tests/test_qmc.py
+++ b/tests/samplers_tests/test_qmc.py
@@ -334,7 +334,7 @@ def test_find_sample_id() -> None:
         assert sampler._find_sample_id(study, {}) == 0
 
 
-def test_find_sample_id_dynamic() -> None:
+def test_find_sample_id_partial_fix() -> None:
     def _objective(trial: optuna.Trial) -> float:
         x = trial.suggest_float("x", -5, 5)
         y = trial.suggest_float("y", -5, 5)


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. To minimize the review effort, we highly appreciate PRs only with related changes. Please note that submitted PRs may be closed if they include unrelated changes or significantly modified unit tests. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

There are several issues in `QMCSampler`:
1. `QMCSampler` is not stateless

For example, the following code automatically falls back to `RandomSampler`.

```python
import optuna


def objective(trial: optuna.Trial) -> float:
    return trial.suggest_float("x", 0, 1)**2


def objective2(trial: optuna.Trial) -> float:
    return trial.suggest_float("y", 0, 1)**2


sampler = optuna.samplers.QMCSampler()
study = optuna.create_study(sampler=sampler)
study.optimize(objective, n_trials=4)
study2 = optuna.create_study(sampler=sampler)
study2.optimize(objective2, n_trials=4)

```

2. `QMCSampler` does not work as intended when combined with `PartialFixedSampler`

First of all, `QMCSampler`'s `initial_search_space` is broken by `PartialFixedSampler`.
Second, even if it's not broken by the sampler, `QMCSampler` is not aware of what sequence was sampled, breaking the balance of the sequence for `y` in the case below.

```python
import optuna


def objective(trial: optuna.Trial) -> float:
    x = 10 * trial.suggest_float("x", 0, 1) - 5
    y = 10 * trial.suggest_float("y", 0, 1) - 5
    return (x - 2)**2 + (y - 2)**2


study = optuna.create_study()
study.enqueue_trial(params={"x": 0.5})
base_sampler = optuna.samplers.QMCSampler()
study.sampler = optuna.samplers.PartialFixedSampler(fixed_params={"y": 0.5}, base_sampler=base_sampler)
study.optimize(objective, n_trials=8)
fixed_params = study.best_params.copy()
fixed_params.pop("y")
study.sampler = optuna.samplers.PartialFixedSampler(fixed_params=fixed_params, base_sampler=base_sampler)
study.optimize(objective, n_trials=8)
print(study.system_attrs)
```

## Description of the changes
<!-- Describe the changes in this PR. -->

- Make `QMCSampler` stateless
- Resume the QMC sequence based on the combination of the provided study and the target relative search space
    - So if the target relative search space has not been seen before, the QMC sequence will start from scratch, preserving the consistency.