### PR TITLE
Enhance the warning message for `TPESampler` with `multivariate=True`

### DIFF
--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -484,7 +484,8 @@ class TPESampler(BaseSampler):
                         independent_sampler_name=self._random_sampler.__class__.__name__,
                         sampler_name=self.__class__.__name__,
                         fallback_reason=(
-                            "dynamic search space is not supported for `multivariate=True`"
+                            "`multivariate=True,group=False` does not support dynamic search space"
+                            " (but `multivariate=True,group=True` works)"
                         ),
                     )
                 )


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. To minimize the review effort, we highly appreciate PRs only with related changes. Please note that submitted PRs may be closed if they include unrelated changes or significantly modified unit tests. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
Technically speaking, dynamic search space is supported for `multivariate=True` in combination with `group=True`.
This PR adds this information to the message.

## Description of the changes
<!-- Describe the changes in this PR. -->
- Make the warning message clearer.

Check the warning message by the following:

```python
import optuna


def objective(trial: optuna.Trial) -> float:
    c = trial.suggest_categorical("c", ["a", "b"])
    if c == "a":
        return trial.suggest_float("x", 0, 1)**2
    elif c == "b":
        return trial.suggest_float("y", 0, 1)**2


sampler = optuna.samplers.TPESampler(multivariate=True, n_startup_trials=2, group=False)
study = optuna.create_study(sampler=sampler)
study.optimize(objective, n_trials=20)

```