### PR TITLE
feat: add heartbeat support to JournalStorage

### DIFF
--- a/optuna/storages/journal/_storage.py
+++ b/optuna/storages/journal/_storage.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from collections.abc import Container
 from collections.abc import Iterable
 from collections.abc import Sequence
@@ -12,6 +13,7 @@ from typing import Any
 import uuid
 
 import optuna
+from optuna._experimental import warn_experimental_argument
 from optuna._typing import JSONSerializable
 from optuna.distributions import BaseDistribution
 from optuna.distributions import check_distribution_compatibility
@@ -21,6 +23,7 @@ from optuna.exceptions import DuplicatedStudyError
 from optuna.exceptions import UpdateFinishedTrialError
 from optuna.storages import BaseStorage
 from optuna.storages._base import DEFAULT_STUDY_NAME_PREFIX
+from optuna.storages._heartbeat import BaseHeartbeat
 from optuna.storages.journal._base import BaseJournalBackend
 from optuna.storages.journal._base import BaseJournalSnapshot
 from optuna.study._frozen import FrozenStudy
@@ -48,9 +51,10 @@ class JournalOperation(enum.IntEnum):
     SET_TRIAL_INTERMEDIATE_VALUE = 7
     SET_TRIAL_USER_ATTR = 8
     SET_TRIAL_SYSTEM_ATTR = 9
+    RECORD_HEARTBEAT = 10
 
 
-class JournalStorage(BaseStorage):
+class JournalStorage(BaseStorage, BaseHeartbeat):
     """Storage class for Journal storage backend.
 
     Note that library users can instantiate this class, but the attributes
@@ -96,9 +100,63 @@ class JournalStorage(BaseStorage):
         storage = optuna.storages.JournalStorage(
             optuna.storages.journal.JournalFileBackend(file_path, lock_obj=lock_obj),
         )
+
+    Args:
+        log_storage:
+            The backend used to append and read journal logs.
+        heartbeat_interval:
+            Interval to record the heartbeat. It is recorded every ``interval`` seconds.
+            ``heartbeat_interval`` must be :obj:`None` or a positive integer.
+
+            .. note::
+                Heartbeat mechanism is experimental. API would change in the future.
+
+            .. note::
+                Since heartbeat timestamps are compared using worker-local clocks, the
+                ``grace_period`` should comfortably exceed clock drift between workers.
+
+        grace_period:
+            Grace period before a running trial is failed from the last heartbeat.
+            ``grace_period`` must be :obj:`None` or a positive integer.
+            If it is :obj:`None`, the grace period will be ``2 * heartbeat_interval``.
+        failed_trial_callback:
+            A callback function that is invoked after failing each stale trial.
+            The function must accept two parameters with the following types in this order:
+            :class:`~optuna.study.Study` and :class:`~optuna.trial.FrozenTrial`.
+
+            .. note::
+                The procedure to fail existing stale trials is called just before asking the
+                study for a new trial.
+
+    .. note::
+        If you want to detect failures of running trials, set ``heartbeat_interval``,
+        ``grace_period``, and optionally ``failed_trial_callback``. See the
+        :ref:`tutorial <heartbeat_monitoring>` and `Example page
+        <https://github.com/optuna/optuna-examples/tree/main/retry_failed_trial_callback>`_
+        for how the same mechanism works with :class:`~optuna.storages.RDBStorage`.
+        :class:`~optuna.storages.RetryFailedTrialCallback` can be passed as a
+        ``failed_trial_callback`` to retry failed trials detected by heartbeat.
     """
 
-    def __init__(self, log_storage: BaseJournalBackend) -> None:
+    def __init__(
+        self,
+        log_storage: BaseJournalBackend,
+        *,
+        heartbeat_interval: int | None = None,
+        grace_period: int | None = None,
+        failed_trial_callback: Callable[["optuna.study.Study", FrozenTrial], None] | None = None,
+    ) -> None:
+        if heartbeat_interval is not None:
+            if heartbeat_interval <= 0:
+                raise ValueError("The value of `heartbeat_interval` should be a positive integer.")
+            warn_experimental_argument("heartbeat_interval")
+        if grace_period is not None and grace_period <= 0:
+            raise ValueError("The value of `grace_period` should be a positive integer.")
+
+        self.heartbeat_interval = heartbeat_interval
+        self.grace_period = grace_period
+        self.failed_trial_callback = failed_trial_callback
+
         self._worker_id_prefix = str(uuid.uuid4()) + "-"
         self._backend = log_storage
         self._thread_lock = threading.Lock()
@@ -138,6 +196,10 @@ class JournalStorage(BaseStorage):
         r._worker_id_prefix = self._worker_id_prefix
         r._worker_id_to_owned_trial_id = {}
         r._last_created_trial_id_by_this_process = -1
+        # Backward compatibility: snapshots taken before heartbeat support for JournalStorage
+        # was introduced do not carry this field.
+        if not hasattr(r, "_trial_id_to_last_heartbeat"):
+            r._trial_id_to_last_heartbeat = {}
         self._replay_result = r
 
     def _write_log(self, op_code: int, extra_fields: dict[str, Any]) -> None:
@@ -398,6 +460,47 @@ class JournalStorage(BaseStorage):
                 return copy.deepcopy(frozen_trials)
             return frozen_trials
 
+    def record_heartbeat(self, trial_id: int) -> None:
+        log: dict[str, Any] = {
+            "trial_id": trial_id,
+            "heartbeat": datetime.datetime.now().isoformat(timespec="microseconds"),
+        }
+        with self._thread_lock:
+            self._write_log(JournalOperation.RECORD_HEARTBEAT, log)
+            self._sync_with_backend()
+
+    def _get_stale_trial_ids(self, study_id: int) -> list[int]:
+        assert self.heartbeat_interval is not None
+        if self.grace_period is None:
+            grace_period = 2 * self.heartbeat_interval
+        else:
+            grace_period = self.grace_period
+
+        stale_trial_ids: list[int] = []
+        with self._thread_lock:
+            self._sync_with_backend()
+            now = datetime.datetime.now()
+            running_trials = self._replay_result.get_all_trials(
+                study_id, states=(TrialState.RUNNING,)
+            )
+            for trial in running_trials:
+                last_heartbeat = self._replay_result._trial_id_to_last_heartbeat.get(
+                    trial._trial_id
+                )
+                if last_heartbeat is None:
+                    continue
+                if now - last_heartbeat > datetime.timedelta(seconds=grace_period):
+                    stale_trial_ids.append(trial._trial_id)
+        return stale_trial_ids
+
+    def get_heartbeat_interval(self) -> int | None:
+        return self.heartbeat_interval
+
+    def get_failed_trial_callback(
+        self,
+    ) -> Callable[["optuna.study.Study", FrozenTrial], None] | None:
+        return self.failed_trial_callback
+
 
 class JournalStorageReplayResult:
     def __init__(self, worker_id_prefix: str) -> None:
@@ -410,6 +513,7 @@ class JournalStorageReplayResult:
         self._trial_id_to_study_id: dict[int, int] = {}
         self._next_study_id: int = 0
         self._worker_id_to_owned_trial_id: dict[str, int] = {}
+        self._trial_id_to_last_heartbeat: dict[int, datetime.datetime] = {}
 
     def apply_logs(self, logs: Iterable[dict[str, Any]]) -> None:
         for log in logs:
@@ -435,6 +539,8 @@ class JournalStorageReplayResult:
                 self._apply_set_trial_user_attr(log)
             elif op == JournalOperation.SET_TRIAL_SYSTEM_ATTR:
                 self._apply_set_trial_system_attr(log)
+            elif op == JournalOperation.RECORD_HEARTBEAT:
+                self._apply_record_heartbeat(log)
             else:
                 assert False, "Should not reach."
 
@@ -663,6 +769,14 @@ class JournalStorageReplayResult:
                 **log["system_attr"],
             }
             self._trials[trial_id] = trial
+
+    def _apply_record_heartbeat(self, log: dict[str, Any]) -> None:
+        trial_id = log["trial_id"]
+        if trial_id not in self._trials:
+            return
+        self._trial_id_to_last_heartbeat[trial_id] = datetime.datetime.fromisoformat(
+            log["heartbeat"]
+        )
 
     def _trial_exists_and_updatable(self, trial_id: int, log: dict[str, Any]) -> bool:
         if trial_id not in self._trials:

--- a/optuna/testing/storages.py
+++ b/optuna/testing/storages.py
@@ -45,6 +45,7 @@ STORAGE_MODES: list[Any] = [
 STORAGE_MODES_HEARTBEAT = [
     "sqlite",
     "cached_sqlite",
+    "journal",
 ]
 
 SQLITE3_TIMEOUT = 300
@@ -137,7 +138,12 @@ class StorageSupplier(AbstractContextManager):
             self.tempfile = self.extra_args.get("file", NamedTemporaryFilePool().tempfile())
             assert self.tempfile is not None
             file_storage = JournalFileBackend(self.tempfile.name)
-            self.storage = optuna.storages.JournalStorage(file_storage)
+            journal_kwargs = {
+                k: v
+                for k, v in self.extra_args.items()
+                if k in ("heartbeat_interval", "grace_period", "failed_trial_callback")
+            }
+            self.storage = optuna.storages.JournalStorage(file_storage, **journal_kwargs)
         elif self.storage_specifier == "grpc_rdb":
             self.tempfile = NamedTemporaryFilePool().tempfile()
             url = f"sqlite:///{self.tempfile.name}"

--- a/tests/storages_tests/journal_tests/test_journal.py
+++ b/tests/storages_tests/journal_tests/test_journal.py
@@ -5,6 +5,7 @@ from concurrent.futures import ProcessPoolExecutor
 from concurrent.futures import ThreadPoolExecutor
 import pathlib
 import pickle
+import time
 from types import TracebackType
 from typing import Any
 from typing import IO
@@ -264,3 +265,69 @@ def test_invalid_grace_period(log_storage_type: str, grace_period: int) -> None:
     with pytest.raises(ValueError):
         with JournalLogStorageSupplier(log_storage_type, grace_period):
             pass
+
+
+def test_journal_record_heartbeat_returns_stale_trial_after_grace_period() -> None:
+    heartbeat_interval = 1
+    grace_period = 2
+
+    with NamedTemporaryFilePool() as file:
+        file_storage = optuna.storages.journal.JournalFileBackend(file.name)
+        with pytest.warns(optuna.exceptions.ExperimentalWarning):
+            storage = JournalStorage(
+                file_storage,
+                heartbeat_interval=heartbeat_interval,
+                grace_period=grace_period,
+            )
+        study = optuna.create_study(storage=storage)
+        with pytest.warns(UserWarning):
+            trial = study.ask()
+        storage.record_heartbeat(trial._trial_id)
+
+        # Within the grace period the trial is not stale.
+        assert storage._get_stale_trial_ids(study._study_id) == []
+
+        time.sleep(grace_period + 1)
+
+        stale_ids = storage._get_stale_trial_ids(study._study_id)
+        assert stale_ids == [trial._trial_id]
+
+
+def test_journal_record_heartbeat_ignores_trials_without_heartbeat() -> None:
+    heartbeat_interval = 1
+    grace_period = 2
+
+    with NamedTemporaryFilePool() as file:
+        file_storage = optuna.storages.journal.JournalFileBackend(file.name)
+        with pytest.warns(optuna.exceptions.ExperimentalWarning):
+            storage = JournalStorage(
+                file_storage,
+                heartbeat_interval=heartbeat_interval,
+                grace_period=grace_period,
+            )
+        study = optuna.create_study(storage=storage)
+        with pytest.warns(UserWarning):
+            study.ask()
+
+        # A running trial that has never recorded a heartbeat is not considered stale,
+        # mirroring the behavior of RDBStorage._get_stale_trial_ids.
+        assert storage._get_stale_trial_ids(study._study_id) == []
+
+
+def test_journal_heartbeat_snapshot_backward_compat() -> None:
+    # Snapshots taken with a version of Optuna before heartbeat support landed do not
+    # include _trial_id_to_last_heartbeat on JournalStorageReplayResult. The attribute
+    # must be re-initialized on restore to keep replay and _get_stale_trial_ids working.
+    with NamedTemporaryFilePool() as file:
+        file_storage = optuna.storages.journal.JournalFileBackend(file.name)
+        storage = JournalStorage(file_storage)
+        optuna.create_study(storage=storage)
+
+        # Build a replay result pickle that lacks the new heartbeat attribute.
+        legacy_replay = storage._replay_result
+        assert hasattr(legacy_replay, "_trial_id_to_last_heartbeat")
+        del legacy_replay._trial_id_to_last_heartbeat
+
+        storage.restore_replay_result(pickle.dumps(legacy_replay))
+        assert hasattr(storage._replay_result, "_trial_id_to_last_heartbeat")
+        assert storage._replay_result._trial_id_to_last_heartbeat == {}


### PR DESCRIPTION
## Motivation

Closes #6615.

Heartbeat detection of stale trials ships with `RDBStorage` today, but `JournalStorage` users running long distributed HPO jobs have no equivalent. This PR adds the same feature to `JournalStorage`, mirroring the `RDBStorage` public surface so switching backends is a one-line change.

## Description of the changes

### Public API (`JournalStorage.__init__`)

Three new keyword-only arguments, identical in name and semantics to `RDBStorage`:

- `heartbeat_interval: int | None`
- `grace_period: int | None`
- `failed_trial_callback: Callable[[Study, FrozenTrial], None] | None`

Same validation rules (positive integer) and the same `ExperimentalWarning` fires exactly once.

### Internals

- `JournalStorage` now inherits from `BaseHeartbeat` in addition to `BaseStorage`. The four abstract methods (`record_heartbeat`, `_get_stale_trial_ids`, `get_heartbeat_interval`, `get_failed_trial_callback`) are implemented on the class.
- A new `RECORD_HEARTBEAT = 10` enum value is added to `JournalOperation`. `record_heartbeat` appends a log entry through the existing `append_logs` path, so no `BaseJournalBackend` / `BaseJournalSnapshot` methods change.
- `JournalStorageReplayResult` gains a `_trial_id_to_last_heartbeat: dict[int, datetime]` field. The new `_apply_record_heartbeat` log handler writes to it. `_get_stale_trial_ids` iterates `RUNNING` trials in the given study and compares each last heartbeat to `datetime.now()` against `grace_period` (defaulting to `2 * heartbeat_interval`, same as `RDBStorage`).
- Module-level helpers (`fail_stale_trials`, `is_heartbeat_enabled`, `HeartbeatThread`) are unchanged; they already dispatch generically on `BaseHeartbeat`.

### Backward compatibility

- **Old snapshots**: `restore_replay_result` re-initializes `_trial_id_to_last_heartbeat = {}` when the attribute is missing on an unpickled `JournalStorageReplayResult`. Covered by `test_journal_heartbeat_snapshot_backward_compat`.
- **Old journal log files**: The `4.0.0.dev.log` fixture continues to pass `test_log_compatibility.py` unchanged. The new op code is additive, and `apply_logs` only dispatches ops that exist in the log.

### Tests

- `"journal"` is added to `STORAGE_MODES_HEARTBEAT`, so the existing parametrized suite in `tests/storages_tests/test_heartbeat.py` now runs the full heartbeat flow against `JournalStorage`. 13 additional test cases: `record_heartbeat`, `fail_stale_trials_with_optimize`, `invalid_heartbeat_interval_and_grace_period`, `heartbeat_experimental_warnings`, `failed_trial_callback`, `retry_failed_trial_callback` (3x over `max_retry`), `retry_failed_trial_callback_intermediate` (3x), `retry_failed_trial_callback_repetitive_failure`.
- Three new journal-specific tests in `tests/storages_tests/journal_tests/test_journal.py`:
  - `test_journal_record_heartbeat_returns_stale_trial_after_grace_period` (regression)
  - `test_journal_record_heartbeat_ignores_trials_without_heartbeat` (negative, mirrors RDB behavior)
  - `test_journal_heartbeat_snapshot_backward_compat` (unpickle old-shape replay result)

Local results:

```
tests/storages_tests/test_heartbeat.py .............................. 40 passed
tests/storages_tests/journal_tests/test_journal.py .................. 26 passed, 2 skipped
tests/storages_tests/journal_tests/test_log_compatibility.py ........ 8 passed
ruff check .                                                          All checks passed!
ruff format --check .                                                 3 files already formatted
```

`mypy` only surfaces two preexisting errors in unrelated files (`optuna/_gp/gp.py`, `optuna/samplers/_cmaes.py`), both present on `master` before this PR.

## Notes for reviewers

- **Clock skew**: `_get_stale_trial_ids` uses worker-local `datetime.now()`, consistent with how `datetime_start` and `datetime_complete` are already recorded throughout `JournalStorage`. NTP drift should stay well under any reasonable `grace_period`. Doc note added in the `heartbeat_interval` docstring.
- **Alternatives considered**: a side-channel (new `BaseJournalBackend` methods) was rejected because it breaks every existing backend. Storing heartbeat on a trial `system_attr` was rejected because it pollutes user-visible attributes. The chosen design persists heartbeats as ordinary journal operations, which is consistent with every other write in this backend.
- **Scope**: no changes to `BaseHeartbeat`, `HeartbeatThread`, `fail_stale_trials`, `RDBStorage`, `GrpcStorageProxy`, `_CachedStorage`, `FrozenTrial`, or any backend interface.

Happy to iterate on naming, docstring wording, or structure.