### PR TITLE
Update CmaEsSampler docstring regarding categorical support

### DIFF
--- a/optuna/samplers/_cmaes.py
+++ b/optuna/samplers/_cmaes.py
@@ -73,13 +73,10 @@ class CmaEsSampler(BaseSampler):
             study.optimize(objective, n_trials=20)
 
     Please note that this sampler does not support CategoricalDistribution.
-    However, :class:`~optuna.distributions.FloatDistribution` with ``step``,
-    (:func:`~optuna.trial.Trial.suggest_float`) and
-    :class:`~optuna.distributions.IntDistribution` (:func:`~optuna.trial.Trial.suggest_int`)
-    are supported.
+    If your search space includes categorical parameters, it is recommended to use
+    `CatCmawmSampler <https://hub.optuna.org/samplers/catcmawm/>`__ available on
+    `OptunaHub <https://hub.optuna.org/>`__.
 
-    If your search space contains categorical parameters, I recommend you
-    to use :class:`~optuna.samplers.TPESampler` instead.
     Furthermore, there is room for performance improvements in parallel
     optimization settings. This sampler cannot use some trials for updating
     the parameters of multivariate normal distribution.


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. To minimize the review effort, we highly appreciate PRs only with related changes. Please note that submitted PRs may be closed if they include unrelated changes or significantly modified unit tests. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
~~The previous docstring stated that `CmaEsSampler` does not support `CategoricalDistribution` and suggested using `TPESampler` instead. However, this is not accurate since the `with_margin `option was introduced to handle discrete parameters.~~

As pointed out by @not522, `CategoricalDistribution` is not supported even with the `with_margin` option enabled. To provide a more relevant alternative for users seeking CMA-ES-based mixed-variable optimization, I have updated the docstring to recommend CatCMA with Margin (CatCmawmSampler), which is available on OptunaHub.


## Description of the changes
<!-- Describe the changes in this PR. -->
* Remove the outdated note about `CategoricalDistribution` support.