### PR TITLE
Fix sampling bias in `BruteForceSampler`

### DIFF
--- a/optuna/samplers/_brute_force.py
+++ b/optuna/samplers/_brute_force.py
@@ -82,15 +82,20 @@ class _TreeNode:
 
     def sample_child(self, rng: np.random.RandomState, exclude_running: bool) -> float:
         assert self.children is not None
-        # Sample uniformly from available choices to avoid biasing towards
-        # branches that have already been partially explored.
-        weights = np.array(
-            [
-                1.0 if child.count_unexpanded(exclude_running) > 0 else 0.0
-                for child in self.children.values()
-            ],
+
+        unexpanded_counts = np.array(
+            [child.count_unexpanded(exclude_running) for child in self.children.values()],
             dtype=np.float64,
         )
+
+        # Blend exact uniform sampling with flat uniform sampling
+        # to prevent starvation of unexplored branches
+        alpha = 0.5
+        weights_orig = unexpanded_counts / unexpanded_counts.sum()
+        weights_flat = np.where(unexpanded_counts > 0, 1.0, 0.0)
+        weights_flat /= weights_flat.sum()
+
+        weights = (1.0 - alpha) * weights_orig + alpha * weights_flat
         if any(
             not value.is_running and weights[i] > 0
             for i, value in enumerate(self.children.values())

--- a/optuna/samplers/_brute_force.py
+++ b/optuna/samplers/_brute_force.py
@@ -82,12 +82,13 @@ class _TreeNode:
 
     def sample_child(self, rng: np.random.RandomState, exclude_running: bool) -> float:
         assert self.children is not None
-        # Sample an unexpanded node in the subtree uniformly, and return the first
-        # parameter value in the path to the node.
-        # Equivalently, we sample the child node with weights proportional to the number
-        # of unexpanded nodes in the subtree.
+        # Sample uniformly from available choices to avoid biasing towards
+        # branches that have already been partially explored.
         weights = np.array(
-            [child.count_unexpanded(exclude_running) for child in self.children.values()],
+            [
+                1.0 if child.count_unexpanded(exclude_running) > 0 else 0.0
+                for child in self.children.values()
+            ],
             dtype=np.float64,
         )
         if any(


### PR DESCRIPTION
## Motivation
This PR fixes the sampling bias in `BruteForceSampler` reported in #6070.

Currently, `_TreeNode.sample_child()` weights choices using the recursive sum `child.count_unexpanded()`. This massively inflates weights for already-explored branches compared to unexplored ones, causing the sampler to get stuck on partially-explored paths instead of sampling uniformly.

*(Note: This resolves the issue targeted by the closed PR #6207, but preserves the memory-efficient lazy evaluation by avoiding Cartesian grid pre-computation).*

## Description of the changes
- Modified `sample_child` in `optuna/samplers/_brute_force.py` to flatten the available weights to `1.0` if a branch has any unexpanded nodes, and `0.0` otherwise.
- This ensures uniform sampling across available categories at the current tree level without altering the existing tree structure.

### Benchmarks
Using a streamlined version of the reproduction script provided in Issue #6070, we can observe the frequency of `c0`'s categories within the first 10 trials.

**Before this PR:**
`c0` gets completely stuck on a single category due to the recursive weight inflation.
```text
--- First 10 Trials Distribution ---
c0: unique_values=['1'], counts=[10]
c1: unique_values=['1' '4'], counts=[5 5]
c2: unique_values=['0' '1' '2' '3' '4'], counts=[5 1 2 1 1]
c3: unique_values=['0' '1' '2' '4'], counts=[2 1 4 3]
```

**After this PR:**
The sampler distributes the first 10 trials uniformly across all 5 available categories for `c0`, successfully mimicking true brute-force behavior.
```text
--- First 10 Trials Distribution ---
c0: unique_values=['0' '1' '2' '3' '4'], counts=[2 3 2 2 1]
c1: unique_values=['0' '1' '2' '3' '4'], counts=[4 1 1 2 2]
c2: unique_values=['0' '1' '2' '3' '4'], counts=[4 1 1 3 1]
c3: unique_values=['0' '1' '2' '4'], counts=[2 2 3 3]
```

Fixes #6070