### PR TITLE
fix: handle JSONDecodeError in TPESampler._get_params to avoid race condition

### DIFF
--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -506,7 +506,12 @@ class TPESampler(BaseSampler):
 
         if len(params_strs) == 0:
             return trial.params
-        params = json.loads("".join(params_strs))
+        try:
+            params = json.loads("".join(params_strs))
+        except json.JSONDecodeError:
+            # A race condition can occur when multiple workers write chunks
+            # concurrently. If the JSON is incomplete, fall back to trial.params.
+            return trial.params
         params.update(trial.params)
         return params
 


### PR DESCRIPTION
Fixes #6626

When `TPESampler(multivariate=True, constant_liar=True)` is used with 
multiple parallel workers sharing `RDBStorage`, a race condition can occur:

- Worker A writes relative params JSON in chunks (multiple separate 
  `set_trial_system_attr` calls, not atomic)
- Worker B reads mid-write and gets a truncated JSON prefix
- `json.loads` crashes with `JSONDecodeError` at the 2045-char boundary

Fix: wrap `json.loads` in `try/except json.JSONDecodeError` and fall back 
to `trial.params` if the JSON is incomplete. This matches the approach 
suggested by @not522 in the issue.