### PR TITLE
Fix RST note directive typo in `QMCSampler` docstring

### DIFF
--- a/optuna/samplers/_qmc.py
+++ b/optuna/samplers/_qmc.py
@@ -50,7 +50,7 @@ class QMCSampler(BaseSampler):
     see the Scipy API references on `scipy.stats.qmc
     <https://scipy.github.io/devdocs/reference/stats.qmc.html>`__.
 
-    .. note:
+    .. note::
         If your search space contains categorical parameters, it samples the categorical
         parameters by its `independent_sampler` without using QMC algorithm.
 


### PR DESCRIPTION
## Motivation

`QMCSampler` has a malformed RST directive on line 53 of `optuna/samplers/_qmc.py`:

```python
.. note:      # ← single colon — renders as plain indented text, not a note box
```

All other notes in this file (lines 57, 77, 91, 122) and throughout the codebase use the correct double-colon syntax (`.. note::`). The broken directive renders as a plain indented paragraph in the generated Sphinx documentation instead of a styled admonition box.

## Description of the changes

Change `.. note:` → `.. note::` on line 53 of `optuna/samplers/_qmc.py`.

**Before:** plain indented paragraph  
**After:** proper Sphinx `note` admonition box matching the rest of the docstring

## Tests

This is a one-character documentation fix — no behavior change, no test changes needed.