### PR TITLE
Fix JSONDecodeError in TPESampler due to partial system_attrs reads

### DIFF
--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -506,7 +506,19 @@ class TPESampler(BaseSampler):
 
         if len(params_strs) == 0:
             return trial.params
-        params = json.loads("".join(params_strs))
+
+        try:
+            # NOTE:
+            # system_attrs are written in multiple chunks without atomicity.
+            # Concurrent workers may read partial data and fail JSON decoding.
+            params = json.loads("".join(params_strs))
+        except json.JSONDecodeError:
+            _logger.debug(
+                "Failed to decode relative params due to partial write. "
+                "Falling back to trial.params."
+            )
+            return trial.params
+
         params.update(trial.params)
         return params
 


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. To minimize the review effort, we highly appreciate PRs only with related changes. Please note that submitted PRs may be closed if they include unrelated changes or significantly modified unit tests. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
When using TPESampler with `multivariate=True` and `constant_liar=True`
under parallel optimization with shared RDBStorage, workers may crash
with `JSONDecodeError`.

This occurs because relative parameters are written to `system_attrs`
in multiple chunks without atomicity. Concurrent workers can read
incomplete chunks and attempt to parse invalid JSON.

This PR addresses this issue by safely handling partial reads.

## Description of the changes
This PR modifies the `_get_params` method in `TPESampler` to guard against
`JSONDecodeError` caused by partial reads of chunked `system_attrs`.

### Changes:
- Wraps `json.loads` in a try/except block
- Falls back to `trial.params` if decoding fails

### Behavior:
- Prevents worker crashes during parallel optimization
- Safely handles in-flight trials with incomplete writes
- Does not affect completed trials or valid data

### Scope:
This is a minimal reader-side fix and does not modify the storage layer
or chunk-writing logic.

## Related Issue
Fixes #6626

## Testing
- Verified the fix logically for partial JSON read scenarios
- Relies on CI for full test validation

## Notes
This fix handles partial reads caused by non-atomic chunk writes.
A writer-side atomic solution could be explored separately.