### PR TITLE
fix: include fixed params in PartialFixedSampler surrogate fitting 

### DIFF
--- a/optuna/samplers/_partial_fixed.py
+++ b/optuna/samplers/_partial_fixed.py
@@ -6,6 +6,8 @@ from typing import TYPE_CHECKING
 from optuna._experimental import experimental_class
 from optuna._warnings import optuna_warn
 from optuna.samplers import BaseSampler
+from optuna.search_space import intersection_search_space
+from optuna.trial import TrialState
 
 
 if TYPE_CHECKING:
@@ -14,7 +16,6 @@ if TYPE_CHECKING:
     from optuna.distributions import BaseDistribution
     from optuna.study import Study
     from optuna.trial import FrozenTrial
-    from optuna.trial import TrialState
 
 
 @experimental_class("2.4.0")
@@ -66,13 +67,20 @@ class PartialFixedSampler(BaseSampler):
     def infer_relative_search_space(
         self, study: Study, trial: FrozenTrial
     ) -> dict[str, BaseDistribution]:
+        # Obtain the base sampler's relative search space (covers unfixed params)
         search_space = self._base_sampler.infer_relative_search_space(study, trial)
 
-        # Remove fixed params from relative search space to return fixed values.
-        for param_name in self._fixed_params.keys():
-            if param_name in search_space:
-                del search_space[param_name]
-
+        # Also include distributions for fixed params so that the base sampler's
+        # surrogate model (e.g. GP, multivariate TPE) can use the fixed dimensions
+        # when fitting and when evaluating the acquisition function.  We derive the
+        # fixed-param distributions from the intersection search space of completed
+        # trials (same source the base samplers use internally).
+        all_distributions = intersection_search_space(
+            study.get_trials(deepcopy=False, states=(TrialState.COMPLETE,))
+        )
+        for param_name in self._fixed_params:
+            if param_name in all_distributions and param_name not in search_space:
+                search_space[param_name] = all_distributions[param_name]
         return search_space
 
     def sample_relative(
@@ -81,8 +89,23 @@ class PartialFixedSampler(BaseSampler):
         trial: FrozenTrial,
         search_space: dict[str, BaseDistribution],
     ) -> dict[str, Any]:
-        # Fixed params are never sampled here.
-        return self._base_sampler.sample_relative(study, trial, search_space)
+        if not search_space:
+            return {}
+        # Delegate to the base sampler with the full search space (including fixed
+        # param dimensions).  This allows surrogates like GPSampler or multivariate
+        # TPESampler to condition their acquisition function on the fixed values,
+        # producing better suggestions for the unfixed parameters.
+        params = self._base_sampler.sample_relative(study, trial, search_space)
+
+        # After the base sampler has done its work (surrogate fitting + acq
+        # optimisation), overwrite any fixed-param dimensions with the fixed values
+        # so that PartialFixedSampler's contract is preserved: fixed parameters are
+        # always returned at their fixed value, and the Trial machinery will
+        # subsequently skip re-sampling them via sample_independent.
+        for param_name, fixed_value in self._fixed_params.items():
+            if param_name in search_space:
+                params[param_name] = fixed_value
+        return params
 
     def sample_independent(
         self,

--- a/optuna/samplers/_partial_fixed.py
+++ b/optuna/samplers/_partial_fixed.py
@@ -7,7 +7,6 @@ from optuna._experimental import experimental_class
 from optuna._warnings import optuna_warn
 from optuna.samplers import BaseSampler
 from optuna.search_space import intersection_search_space
-from optuna.trial import TrialState
 
 
 if TYPE_CHECKING:
@@ -16,6 +15,7 @@ if TYPE_CHECKING:
     from optuna.distributions import BaseDistribution
     from optuna.study import Study
     from optuna.trial import FrozenTrial
+    from optuna.trial import TrialState
 
 
 @experimental_class("2.4.0")
@@ -76,7 +76,7 @@ class PartialFixedSampler(BaseSampler):
         # fixed-param distributions from the intersection search space of completed
         # trials (same source the base samplers use internally).
         all_distributions = intersection_search_space(
-            study.get_trials(deepcopy=False, states=(TrialState.COMPLETE,))
+            [t for t in study.get_trials(deepcopy=False) if t.state.is_finished()]
         )
         for param_name in self._fixed_params:
             if param_name in all_distributions and param_name not in search_space:

--- a/tests/samplers_tests/test_partial_fixed.py
+++ b/tests/samplers_tests/test_partial_fixed.py
@@ -6,8 +6,10 @@ import pytest
 
 import optuna
 from optuna.samplers import BaseSampler
+from optuna.samplers import GPSampler
 from optuna.samplers import PartialFixedSampler
 from optuna.samplers import RandomSampler
+from optuna.samplers import TPESampler
 from optuna.trial import Trial
 
 
@@ -149,3 +151,86 @@ def test_fixed_none_value_sampling() -> None:
 
     for trial in study.trials:
         assert trial.params["x"] is None
+
+
+def _make_study_with_warmup(n_warmup: int = 5) -> optuna.study.Study:
+    def objective(trial: optuna.Trial) -> float:
+        x = trial.suggest_float("x", -5, 5)
+        y = trial.suggest_float("y", -5, 5)
+        return x**2 + y**2
+
+    study = optuna.create_study()
+    study.optimize(objective, n_trials=n_warmup)
+    return study
+
+
+def test_fixed_params_in_search_space_gp_sampler() -> None:
+    """Fixed params must appear in infer_relative_search_space so GPSampler's
+    surrogate can condition on them"""
+    study = _make_study_with_warmup()
+    base_sampler = GPSampler(seed=0)
+
+    partial_sampler = PartialFixedSampler(
+        fixed_params={"x": study.best_params["x"]},
+        base_sampler=base_sampler,
+    )
+    study.sampler = partial_sampler
+
+    dummy_trial = study.ask()
+    frozen = study._storage.get_trial(dummy_trial._trial_id)
+    search_space = partial_sampler.infer_relative_search_space(study, frozen)
+    study.tell(dummy_trial, 0.0)
+
+    assert "x" in search_space, (
+        "Fixed param 'x' must be included in infer_relative_search_space "
+        "so that GPSampler can condition its surrogate on it."
+    )
+    assert "y" in search_space
+
+
+def test_fixed_params_in_search_space_tpe_multivariate() -> None:
+    """Same check for TPESampler(multivariate=True)"""
+    study = _make_study_with_warmup(n_warmup=15)
+    base_sampler = TPESampler(multivariate=True, seed=0)
+
+    partial_sampler = PartialFixedSampler(
+        fixed_params={"x": study.best_params["x"]},
+        base_sampler=base_sampler,
+    )
+    study.sampler = partial_sampler
+
+    dummy_trial = study.ask()
+    frozen = study._storage.get_trial(dummy_trial._trial_id)
+    search_space = partial_sampler.infer_relative_search_space(study, frozen)
+    study.tell(dummy_trial, 0.0)
+
+    assert "x" in search_space, (
+        "Fixed param 'x' must be included in infer_relative_search_space "
+        "so that multivariate TPESampler can condition on it."
+    )
+    assert "y" in search_space
+
+
+def test_sample_relative_always_returns_fixed_value_gp() -> None:
+    """sample_relative must honour the fixed value for fixed params, even when
+    the underlying GP sampler would suggest a different value"""
+    study = _make_study_with_warmup()
+
+    fixed_x = 1.23
+    partial_sampler = PartialFixedSampler(
+        fixed_params={"x": fixed_x},
+        base_sampler=GPSampler(seed=42),
+    )
+    study.sampler = partial_sampler
+
+    def objective(trial: optuna.Trial) -> float:
+        x = trial.suggest_float("x", -5, 5)
+        y = trial.suggest_float("y", -5, 5)
+        return x**2 + y**2
+
+    study.optimize(objective, n_trials=5)
+
+    for trial in study.trials[-5:]:
+        assert trial.params["x"] == pytest.approx(fixed_x), (
+            f"Trial {trial.number}: expected x={fixed_x}, got x={trial.params['x']}"
+        )


### PR DESCRIPTION
This PR solves issue #6620 

<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. To minimize the review effort, we highly appreciate PRs only with related changes. Please note that submitted PRs may be closed if they include unrelated changes or significantly modified unit tests. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
When PartialFixedSampler wraps GPSampler or TPESampler(multivariate=True), the fixed parameters are stored in trial.system_attrs["fixed_params"] but are silently excluded from the search space that gets passed to sample_relative(). This means the surrogate model (GP kernel / multivariate KDE) is trained and the acquisition function is optimized in a reduced space that doesn't include the fixed dimensions — even though those fixed dimensions affect the output. This produces suboptimal suggestions for the unfixed parameters.

## Description of the changes

- infer_relative_search_space — now calls intersection_search_space over completed trials to recover distributions for the fixed params, then merges those into the search space returned to the base sampler. This means the GP/TPE surrogate sees all dimensions (fixed + free) when it fits its model.
- sample_relative — delegates to the base sampler with the full (enlarged) search space so the acquisition function is optimised in the right space, then overwrites the fixed-param keys with their fixed values before returning. The base sampler's suggestion for those dimensions is discarded; their fixed values are enforced. This preserves PartialFixedSampler's core contract while fixing the surrogate-fitting blind spot.
- Additional unit tests added to tests/samplers_tests/test_partial_fixed.py