### PR TITLE
Deprecate a set of `TPESampler` arguments

### DIFF
--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -84,9 +84,7 @@ def _handle_deprecated_argument(
     is_deprecated: bool,
 ) -> _T:
     if is_deprecated:
-        msg = _deprecated._DEPRECATION_WARNING_TEMPLATE.format(
-            name=name, d_ver=d_ver, r_ver=r_ver
-        )
+        msg = _deprecated._DEPRECATION_WARNING_TEMPLATE.format(name=name, d_ver=d_ver, r_ver=r_ver)
         optuna_warn(
             f"{msg} From v{d_ver} onward, {name} automatically falls back to"
             f" {fallback_description}.",
@@ -400,27 +398,57 @@ class TPESampler(BaseSampler):
         ) = None,
     ) -> None:
         consider_prior = _handle_deprecated_argument(
-            "`consider_prior`", consider_prior, True, "4.3.0", "6.0.0", "`True`",
+            "`consider_prior`",
+            consider_prior,
+            True,
+            "4.3.0",
+            "6.0.0",
+            "`True`",
             is_deprecated=not consider_prior,
         )
         prior_weight = _handle_deprecated_argument(
-            "`prior_weight`", prior_weight, 1.0, "4.9.0", "6.0.0", "`1.0`",
+            "`prior_weight`",
+            prior_weight,
+            1.0,
+            "4.9.0",
+            "6.0.0",
+            "`1.0`",
             is_deprecated=prior_weight != 1.0,
         )
         consider_magic_clip = _handle_deprecated_argument(
-            "`consider_magic_clip`", consider_magic_clip, True, "4.9.0", "6.0.0", "`True`",
+            "`consider_magic_clip`",
+            consider_magic_clip,
+            True,
+            "4.9.0",
+            "6.0.0",
+            "`True`",
             is_deprecated=not consider_magic_clip,
         )
         consider_endpoints = _handle_deprecated_argument(
-            "`consider_endpoints`", consider_endpoints, False, "4.9.0", "6.0.0", "`False`",
+            "`consider_endpoints`",
+            consider_endpoints,
+            False,
+            "4.9.0",
+            "6.0.0",
+            "`False`",
             is_deprecated=consider_endpoints,
         )
         gamma = _handle_deprecated_argument(
-            "`gamma`", gamma, default_gamma, "4.9.0", "6.0.0", "the internal default",
+            "`gamma`",
+            gamma,
+            default_gamma,
+            "4.9.0",
+            "6.0.0",
+            "the internal default",
             is_deprecated=gamma is not default_gamma,
         )
         weights = _handle_deprecated_argument(
-            "`weights`", weights, default_weights, "4.9.0", "6.0.0", "the internal default",
+            "`weights`",
+            weights,
+            default_weights,
+            "4.9.0",
+            "6.0.0",
+            "the internal default",
             is_deprecated=weights is not default_weights,
         )
 
@@ -438,7 +466,11 @@ class TPESampler(BaseSampler):
         self._gamma = gamma
 
         warn_independent_sampling = _handle_deprecated_argument(
-            "`warn_independent_sampling`", warn_independent_sampling, False, "4.9.0", "6.0.0",
+            "`warn_independent_sampling`",
+            warn_independent_sampling,
+            False,
+            "4.9.0",
+            "6.0.0",
             "`False`",
             is_deprecated=warn_independent_sampling,
         )

--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -77,20 +77,13 @@ _T = TypeVar("_T")
 def _handle_deprecated_argument(
     name: str,
     value: _T,
-    fallback_value: _T,
     d_ver: str,
     r_ver: str,
-    fallback_description: str,
     is_deprecated: bool,
 ) -> _T:
     if is_deprecated:
         msg = _deprecated._DEPRECATION_WARNING_TEMPLATE.format(name=name, d_ver=d_ver, r_ver=r_ver)
-        optuna_warn(
-            f"{msg} From v{d_ver} onward, {name} automatically falls back to"
-            f" {fallback_description}.",
-            FutureWarning,
-        )
-        return fallback_value
+        optuna_warn(msg, FutureWarning)
     return value
 
 
@@ -178,7 +171,6 @@ class TPESampler(BaseSampler):
                 Deprecated in v4.9.0. ``prior_weight`` argument will be removed in the future.
                 The removal of this feature is currently scheduled for v6.0.0,
                 but this schedule is subject to change.
-                From v4.9.0 onward, ``prior_weight`` automatically falls back to ``1.0``.
                 See https://github.com/optuna/optuna/releases/tag/v4.9.0.
         consider_magic_clip:
             Enable a heuristic to limit the smallest variances of Gaussians used in
@@ -188,7 +180,6 @@ class TPESampler(BaseSampler):
                 Deprecated in v4.9.0. ``consider_magic_clip`` argument will be removed in the
                 future. The removal of this feature is currently scheduled for v6.0.0,
                 but this schedule is subject to change.
-                From v4.9.0 onward, ``consider_magic_clip`` automatically falls back to ``True``.
                 See https://github.com/optuna/optuna/releases/tag/v4.9.0.
         consider_endpoints:
             Take endpoints of domains into account when calculating variances of Gaussians
@@ -199,7 +190,6 @@ class TPESampler(BaseSampler):
                 Deprecated in v4.9.0. ``consider_endpoints`` argument will be removed in the
                 future. The removal of this feature is currently scheduled for v6.0.0,
                 but this schedule is subject to change.
-                From v4.9.0 onward, ``consider_endpoints`` automatically falls back to ``False``.
                 See https://github.com/optuna/optuna/releases/tag/v4.9.0.
         n_startup_trials:
             The random sampling is used instead of the TPE algorithm until the given number
@@ -215,7 +205,6 @@ class TPESampler(BaseSampler):
                 Deprecated in v4.9.0. ``gamma`` argument will be removed in the future.
                 The removal of this feature is currently scheduled for v6.0.0,
                 but this schedule is subject to change.
-                From v4.9.0 onward, ``gamma`` automatically falls back to the internal default.
                 See https://github.com/optuna/optuna/releases/tag/v4.9.0.
         weights:
             A function that takes the number of finished trials and returns a weight for them.
@@ -235,7 +224,6 @@ class TPESampler(BaseSampler):
                 Deprecated in v4.9.0. ``weights`` argument will be removed in the future.
                 The removal of this feature is currently scheduled for v6.0.0,
                 but this schedule is subject to change.
-                From v4.9.0 onward, ``weights`` automatically falls back to the internal default.
                 See https://github.com/optuna/optuna/releases/tag/v4.9.0.
         seed:
             Seed for random number generator.
@@ -295,8 +283,6 @@ class TPESampler(BaseSampler):
                 Deprecated in v4.9.0. ``warn_independent_sampling`` argument will be removed in
                 the future. The removal of this feature is currently scheduled for v6.0.0,
                 but this schedule is subject to change.
-                From v4.9.0 onward, ``warn_independent_sampling`` automatically falls back to
-                ``False``.
                 See https://github.com/optuna/optuna/releases/tag/v4.9.0.
         constant_liar:
             If :obj:`True`, penalize running trials to avoid suggesting parameter configurations
@@ -400,55 +386,43 @@ class TPESampler(BaseSampler):
         consider_prior = _handle_deprecated_argument(
             "`consider_prior`",
             consider_prior,
-            True,
             "4.3.0",
             "6.0.0",
-            "`True`",
             is_deprecated=not consider_prior,
         )
         prior_weight = _handle_deprecated_argument(
             "`prior_weight`",
             prior_weight,
-            1.0,
             "4.9.0",
             "6.0.0",
-            "`1.0`",
             is_deprecated=prior_weight != 1.0,
         )
         consider_magic_clip = _handle_deprecated_argument(
             "`consider_magic_clip`",
             consider_magic_clip,
-            True,
             "4.9.0",
             "6.0.0",
-            "`True`",
             is_deprecated=not consider_magic_clip,
         )
         consider_endpoints = _handle_deprecated_argument(
             "`consider_endpoints`",
             consider_endpoints,
-            False,
             "4.9.0",
             "6.0.0",
-            "`False`",
             is_deprecated=consider_endpoints,
         )
         gamma = _handle_deprecated_argument(
             "`gamma`",
             gamma,
-            default_gamma,
             "4.9.0",
             "6.0.0",
-            "the internal default",
             is_deprecated=gamma is not default_gamma,
         )
         weights = _handle_deprecated_argument(
             "`weights`",
             weights,
-            default_weights,
             "4.9.0",
             "6.0.0",
-            "the internal default",
             is_deprecated=weights is not default_weights,
         )
 
@@ -468,10 +442,8 @@ class TPESampler(BaseSampler):
         warn_independent_sampling = _handle_deprecated_argument(
             "`warn_independent_sampling`",
             warn_independent_sampling,
-            False,
             "4.9.0",
             "6.0.0",
-            "`False`",
             is_deprecated=warn_independent_sampling,
         )
 

--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -6,6 +6,7 @@ import math
 from typing import Any
 from typing import cast
 from typing import TYPE_CHECKING
+from typing import TypeVar
 
 import numpy as np
 
@@ -70,10 +71,17 @@ def default_weights(x: int) -> np.ndarray:
         return np.concatenate([ramp, flat], axis=0)
 
 
-def _warn_if_deprecated_argument(name: str, d_ver: str, r_ver: str, is_deprecated: bool) -> None:
-    if is_deprecated:
+_T = TypeVar("_T")
+
+
+def _warn_if_deprecated_argument(
+    name: str, value: _T | None, default: _T, d_ver: str, r_ver: str
+) -> _T:
+    if value is not None:
         msg = _deprecated._DEPRECATION_WARNING_TEMPLATE.format(name=name, d_ver=d_ver, r_ver=r_ver)
         optuna_warn(msg, FutureWarning)
+        return value
+    return default
 
 
 class TPESampler(BaseSampler):
@@ -323,11 +331,6 @@ class TPESampler(BaseSampler):
             specify prior knowledge on the structure of categorical parameters. When specified,
             categorical choices closer to current best choices are more likely to be sampled.
 
-            .. note::
-                Added in v3.4.0 as an experimental feature. The interface may change in newer
-                versions without prior notice.
-                See https://github.com/optuna/optuna/releases/tag/v3.4.0.
-
             .. warning::
                 Deprecated in v4.9.0. ``categorical_distance_func`` argument will be removed in
                 the future. The removal of this feature is currently scheduled for v5.0.0,
@@ -354,32 +357,46 @@ class TPESampler(BaseSampler):
     def __init__(
         self,
         *,
-        consider_prior: bool = True,
-        prior_weight: float = 1.0,
-        consider_magic_clip: bool = True,
-        consider_endpoints: bool = False,
+        consider_prior: bool | None = None,
+        prior_weight: float | None = None,
+        consider_magic_clip: bool | None = None,
+        consider_endpoints: bool | None = None,
         n_startup_trials: int = 10,
         n_ei_candidates: int = 24,
-        gamma: Callable[[int], int] = default_gamma,
-        weights: Callable[[int], np.ndarray] = default_weights,
+        gamma: Callable[[int], int] | None = None,
+        weights: Callable[[int], np.ndarray] | None = None,
         seed: int | None = None,
         multivariate: bool = False,
         group: bool = False,
-        warn_independent_sampling: bool = False,
+        warn_independent_sampling: bool | None = None,
         constant_liar: bool = False,
         constraints_func: Callable[[FrozenTrial], Sequence[float]] | None = None,
         categorical_distance_func: (
             dict[str, Callable[[CategoricalChoiceType, CategoricalChoiceType], float]] | None
         ) = None,
     ) -> None:
-        _warn_if_deprecated_argument("`consider_prior`", "4.3.0", "6.0.0", not consider_prior)
-        _warn_if_deprecated_argument("`prior_weight`", "4.9.0", "6.0.0", prior_weight != 1.0)
-        _warn_if_deprecated_argument(
-            "`consider_magic_clip`", "4.9.0", "6.0.0", not consider_magic_clip
+        consider_prior = _warn_if_deprecated_argument(
+            "`consider_prior`", consider_prior, True, "4.3.0", "6.0.0"
         )
-        _warn_if_deprecated_argument("`consider_endpoints`", "4.9.0", "6.0.0", consider_endpoints)
-        _warn_if_deprecated_argument("`gamma`", "4.9.0", "6.0.0", gamma is not default_gamma)
-        _warn_if_deprecated_argument("`weights`", "4.9.0", "6.0.0", weights is not default_weights)
+        prior_weight = _warn_if_deprecated_argument(
+            "`prior_weight`", prior_weight, 1.0, "4.9.0", "6.0.0"
+        )
+        consider_magic_clip = _warn_if_deprecated_argument(
+            "`consider_magic_clip`", consider_magic_clip, True, "4.9.0", "6.0.0"
+        )
+        consider_endpoints = _warn_if_deprecated_argument(
+            "`consider_endpoints`", consider_endpoints, False, "4.9.0", "6.0.0"
+        )
+        gamma = _warn_if_deprecated_argument("`gamma`", gamma, default_gamma, "4.9.0", "6.0.0")
+        weights = _warn_if_deprecated_argument(
+            "`weights`", weights, default_weights, "4.9.0", "6.0.0"
+        )
+        warn_independent_sampling = _warn_if_deprecated_argument(
+            "`warn_independent_sampling`", warn_independent_sampling, False, "4.9.0", "6.0.0"
+        )
+        categorical_distance_func = _warn_if_deprecated_argument(
+            "`categorical_distance_func`", categorical_distance_func, None, "4.9.0", "5.0.0"
+        )
 
         self._parzen_estimator_parameters = _ParzenEstimatorParameters(
             prior_weight=prior_weight,
@@ -393,10 +410,6 @@ class TPESampler(BaseSampler):
         self._n_startup_trials = n_startup_trials
         self._n_ei_candidates = n_ei_candidates
         self._gamma = gamma
-
-        _warn_if_deprecated_argument(
-            "`warn_independent_sampling`", "4.9.0", "6.0.0", warn_independent_sampling
-        )
 
         self._warn_independent_sampling = warn_independent_sampling
         self._rng = LazyRandomState(seed)
@@ -428,12 +441,6 @@ class TPESampler(BaseSampler):
 
         if constraints_func is not None:
             warn_experimental_argument("constraints_func")
-
-        if categorical_distance_func is not None:
-            warn_experimental_argument("categorical_distance_func")
-            _warn_if_deprecated_argument(
-                "`categorical_distance_func`", "4.9.0", "5.0.0", is_deprecated=True
-            )
 
     def reseed_rng(self) -> None:
         self._rng.rng.seed()

--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -6,6 +6,7 @@ import math
 from typing import Any
 from typing import cast
 from typing import TYPE_CHECKING
+from typing import TypeVar
 
 import numpy as np
 
@@ -68,6 +69,31 @@ def default_weights(x: int) -> np.ndarray:
         ramp = np.linspace(1.0 / x, 1.0, num=x - 25)
         flat = np.ones(25)
         return np.concatenate([ramp, flat], axis=0)
+
+
+_T = TypeVar("_T")
+
+
+def _handle_deprecated_argument(
+    name: str,
+    value: _T,
+    fallback_value: _T,
+    d_ver: str,
+    r_ver: str,
+    fallback_description: str,
+    is_deprecated: bool,
+) -> _T:
+    if is_deprecated:
+        msg = _deprecated._DEPRECATION_WARNING_TEMPLATE.format(
+            name=name, d_ver=d_ver, r_ver=r_ver
+        )
+        optuna_warn(
+            f"{msg} From v{d_ver} onward, {name} automatically falls back to"
+            f" {fallback_description}.",
+            FutureWarning,
+        )
+        return fallback_value
+    return value
 
 
 class TPESampler(BaseSampler):
@@ -149,13 +175,34 @@ class TPESampler(BaseSampler):
             :class:`~optuna.distributions.FloatDistribution`,
             :class:`~optuna.distributions.IntDistribution`, and
             :class:`~optuna.distributions.CategoricalDistribution`.
+
+            .. warning::
+                Deprecated in v4.9.0. ``prior_weight`` argument will be removed in the future.
+                The removal of this feature is currently scheduled for v6.0.0,
+                but this schedule is subject to change.
+                From v4.9.0 onward, ``prior_weight`` automatically falls back to ``1.0``.
+                See https://github.com/optuna/optuna/releases/tag/v4.9.0.
         consider_magic_clip:
             Enable a heuristic to limit the smallest variances of Gaussians used in
             the Parzen estimator.
+
+            .. warning::
+                Deprecated in v4.9.0. ``consider_magic_clip`` argument will be removed in the
+                future. The removal of this feature is currently scheduled for v6.0.0,
+                but this schedule is subject to change.
+                From v4.9.0 onward, ``consider_magic_clip`` automatically falls back to ``True``.
+                See https://github.com/optuna/optuna/releases/tag/v4.9.0.
         consider_endpoints:
             Take endpoints of domains into account when calculating variances of Gaussians
             in Parzen estimator. See the original paper for details on the heuristics
             to calculate the variances.
+
+            .. warning::
+                Deprecated in v4.9.0. ``consider_endpoints`` argument will be removed in the
+                future. The removal of this feature is currently scheduled for v6.0.0,
+                but this schedule is subject to change.
+                From v4.9.0 onward, ``consider_endpoints`` automatically falls back to ``False``.
+                See https://github.com/optuna/optuna/releases/tag/v4.9.0.
         n_startup_trials:
             The random sampling is used instead of the TPE algorithm until the given number
             of trials finish in the same study.
@@ -165,6 +212,13 @@ class TPESampler(BaseSampler):
             A function that takes the number of finished trials and returns the number
             of trials to form a density function for samples with low grains.
             See the original paper for more details.
+
+            .. warning::
+                Deprecated in v4.9.0. ``gamma`` argument will be removed in the future.
+                The removal of this feature is currently scheduled for v6.0.0,
+                but this schedule is subject to change.
+                From v4.9.0 onward, ``gamma`` automatically falls back to the internal default.
+                See https://github.com/optuna/optuna/releases/tag/v4.9.0.
         weights:
             A function that takes the number of finished trials and returns a weight for them.
             See `Making a Science of Model Search: Hyperparameter Optimization in Hundreds of
@@ -178,6 +232,13 @@ class TPESampler(BaseSampler):
                 ). The weights of good trials, i.e., trials to construct `l(x)`, are computed by a
                 rule based on the hypervolume contribution proposed in the `paper of MOTPE
                 <https://doi.org/10.1613/jair.1.13188>`__.
+
+            .. warning::
+                Deprecated in v4.9.0. ``weights`` argument will be removed in the future.
+                The removal of this feature is currently scheduled for v6.0.0,
+                but this schedule is subject to change.
+                From v4.9.0 onward, ``weights`` automatically falls back to the internal default.
+                See https://github.com/optuna/optuna/releases/tag/v4.9.0.
         seed:
             Seed for random number generator.
         multivariate:
@@ -231,6 +292,14 @@ class TPESampler(BaseSampler):
             If this is :obj:`True` and ``multivariate=True``, a warning message is emitted when
             the value of a parameter is sampled by using an independent sampler.
             If ``multivariate=False``, this flag has no effect.
+
+            .. warning::
+                Deprecated in v4.9.0. ``warn_independent_sampling`` argument will be removed in
+                the future. The removal of this feature is currently scheduled for v6.0.0,
+                but this schedule is subject to change.
+                From v4.9.0 onward, ``warn_independent_sampling`` automatically falls back to
+                ``False``.
+                See https://github.com/optuna/optuna/releases/tag/v4.9.0.
         constant_liar:
             If :obj:`True`, penalize running trials to avoid suggesting parameter configurations
             nearby.
@@ -285,6 +354,12 @@ class TPESampler(BaseSampler):
                 Added in v3.4.0 as an experimental feature. The interface may change in newer
                 versions without prior notice.
                 See https://github.com/optuna/optuna/releases/tag/v3.4.0.
+
+            .. warning::
+                Deprecated in v4.9.0. ``categorical_distance_func`` argument will be removed in
+                the future. The removal of this feature is currently scheduled for v5.0.0,
+                but this schedule is subject to change.
+                See https://github.com/optuna/optuna/releases/tag/v4.9.0.
     """
 
     @convert_positional_args(
@@ -317,21 +392,37 @@ class TPESampler(BaseSampler):
         seed: int | None = None,
         multivariate: bool = False,
         group: bool = False,
-        warn_independent_sampling: bool = True,
+        warn_independent_sampling: bool = False,
         constant_liar: bool = False,
         constraints_func: Callable[[FrozenTrial], Sequence[float]] | None = None,
         categorical_distance_func: (
             dict[str, Callable[[CategoricalChoiceType, CategoricalChoiceType], float]] | None
         ) = None,
     ) -> None:
-        if not consider_prior:
-            msg = _deprecated._DEPRECATION_WARNING_TEMPLATE.format(
-                name="`consider_prior`", d_ver="4.3.0", r_ver="6.0.0"
-            )
-            optuna_warn(
-                f"{msg} From v4.3.0 onward, `consider_prior` automatically falls back to `True`.",
-                FutureWarning,
-            )
+        consider_prior = _handle_deprecated_argument(
+            "`consider_prior`", consider_prior, True, "4.3.0", "6.0.0", "`True`",
+            is_deprecated=not consider_prior,
+        )
+        prior_weight = _handle_deprecated_argument(
+            "`prior_weight`", prior_weight, 1.0, "4.9.0", "6.0.0", "`1.0`",
+            is_deprecated=prior_weight != 1.0,
+        )
+        consider_magic_clip = _handle_deprecated_argument(
+            "`consider_magic_clip`", consider_magic_clip, True, "4.9.0", "6.0.0", "`True`",
+            is_deprecated=not consider_magic_clip,
+        )
+        consider_endpoints = _handle_deprecated_argument(
+            "`consider_endpoints`", consider_endpoints, False, "4.9.0", "6.0.0", "`False`",
+            is_deprecated=consider_endpoints,
+        )
+        gamma = _handle_deprecated_argument(
+            "`gamma`", gamma, default_gamma, "4.9.0", "6.0.0", "the internal default",
+            is_deprecated=gamma is not default_gamma,
+        )
+        weights = _handle_deprecated_argument(
+            "`weights`", weights, default_weights, "4.9.0", "6.0.0", "the internal default",
+            is_deprecated=weights is not default_weights,
+        )
 
         self._parzen_estimator_parameters = _ParzenEstimatorParameters(
             prior_weight=prior_weight,
@@ -341,9 +432,16 @@ class TPESampler(BaseSampler):
             multivariate=multivariate,
             categorical_distance_func=categorical_distance_func or {},
         )
+
         self._n_startup_trials = n_startup_trials
         self._n_ei_candidates = n_ei_candidates
         self._gamma = gamma
+
+        warn_independent_sampling = _handle_deprecated_argument(
+            "`warn_independent_sampling`", warn_independent_sampling, False, "4.9.0", "6.0.0",
+            "`False`",
+            is_deprecated=warn_independent_sampling,
+        )
 
         self._warn_independent_sampling = warn_independent_sampling
         self._rng = LazyRandomState(seed)
@@ -378,6 +476,10 @@ class TPESampler(BaseSampler):
 
         if categorical_distance_func is not None:
             warn_experimental_argument("categorical_distance_func")
+            msg = _deprecated._DEPRECATION_WARNING_TEMPLATE.format(
+                name="`categorical_distance_func`", d_ver="4.9.0", r_ver="5.0.0"
+            )
+            optuna_warn(msg, FutureWarning)
 
     def reseed_rng(self) -> None:
         self._rng.rng.seed()
@@ -625,6 +727,7 @@ class TPESampler(BaseSampler):
         return {k: v[best_idx].item() for k, v in samples.items()}
 
     @staticmethod
+    @_deprecated.deprecated_func("4.9.0", "6.0.0")
     def hyperopt_parameters() -> dict[str, Any]:
         """Return the the default parameters of hyperopt (v0.1.2).
 

--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -431,10 +431,9 @@ class TPESampler(BaseSampler):
 
         if categorical_distance_func is not None:
             warn_experimental_argument("categorical_distance_func")
-            msg = _deprecated._DEPRECATION_WARNING_TEMPLATE.format(
-                name="`categorical_distance_func`", d_ver="4.9.0", r_ver="5.0.0"
+            _warn_if_deprecated_argument(
+                "`categorical_distance_func`", "4.9.0", "5.0.0", is_deprecated=True
             )
-            optuna_warn(msg, FutureWarning)
 
     def reseed_rng(self) -> None:
         self._rng.rng.seed()

--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -6,7 +6,6 @@ import math
 from typing import Any
 from typing import cast
 from typing import TYPE_CHECKING
-from typing import TypeVar
 
 import numpy as np
 
@@ -71,20 +70,10 @@ def default_weights(x: int) -> np.ndarray:
         return np.concatenate([ramp, flat], axis=0)
 
 
-_T = TypeVar("_T")
-
-
-def _handle_deprecated_argument(
-    name: str,
-    value: _T,
-    d_ver: str,
-    r_ver: str,
-    is_deprecated: bool,
-) -> _T:
+def _warn_if_deprecated_argument(name: str, d_ver: str, r_ver: str, is_deprecated: bool) -> None:
     if is_deprecated:
         msg = _deprecated._DEPRECATION_WARNING_TEMPLATE.format(name=name, d_ver=d_ver, r_ver=r_ver)
         optuna_warn(msg, FutureWarning)
-    return value
 
 
 class TPESampler(BaseSampler):
@@ -383,48 +372,14 @@ class TPESampler(BaseSampler):
             dict[str, Callable[[CategoricalChoiceType, CategoricalChoiceType], float]] | None
         ) = None,
     ) -> None:
-        consider_prior = _handle_deprecated_argument(
-            "`consider_prior`",
-            consider_prior,
-            "4.3.0",
-            "6.0.0",
-            is_deprecated=not consider_prior,
+        _warn_if_deprecated_argument("`consider_prior`", "4.3.0", "6.0.0", not consider_prior)
+        _warn_if_deprecated_argument("`prior_weight`", "4.9.0", "6.0.0", prior_weight != 1.0)
+        _warn_if_deprecated_argument(
+            "`consider_magic_clip`", "4.9.0", "6.0.0", not consider_magic_clip
         )
-        prior_weight = _handle_deprecated_argument(
-            "`prior_weight`",
-            prior_weight,
-            "4.9.0",
-            "6.0.0",
-            is_deprecated=prior_weight != 1.0,
-        )
-        consider_magic_clip = _handle_deprecated_argument(
-            "`consider_magic_clip`",
-            consider_magic_clip,
-            "4.9.0",
-            "6.0.0",
-            is_deprecated=not consider_magic_clip,
-        )
-        consider_endpoints = _handle_deprecated_argument(
-            "`consider_endpoints`",
-            consider_endpoints,
-            "4.9.0",
-            "6.0.0",
-            is_deprecated=consider_endpoints,
-        )
-        gamma = _handle_deprecated_argument(
-            "`gamma`",
-            gamma,
-            "4.9.0",
-            "6.0.0",
-            is_deprecated=gamma is not default_gamma,
-        )
-        weights = _handle_deprecated_argument(
-            "`weights`",
-            weights,
-            "4.9.0",
-            "6.0.0",
-            is_deprecated=weights is not default_weights,
-        )
+        _warn_if_deprecated_argument("`consider_endpoints`", "4.9.0", "6.0.0", consider_endpoints)
+        _warn_if_deprecated_argument("`gamma`", "4.9.0", "6.0.0", gamma is not default_gamma)
+        _warn_if_deprecated_argument("`weights`", "4.9.0", "6.0.0", weights is not default_weights)
 
         self._parzen_estimator_parameters = _ParzenEstimatorParameters(
             prior_weight=prior_weight,
@@ -439,12 +394,8 @@ class TPESampler(BaseSampler):
         self._n_ei_candidates = n_ei_candidates
         self._gamma = gamma
 
-        warn_independent_sampling = _handle_deprecated_argument(
-            "`warn_independent_sampling`",
-            warn_independent_sampling,
-            "4.9.0",
-            "6.0.0",
-            is_deprecated=warn_independent_sampling,
+        _warn_if_deprecated_argument(
+            "`warn_independent_sampling`", "4.9.0", "6.0.0", warn_independent_sampling
         )
 
         self._warn_independent_sampling = warn_independent_sampling

--- a/tests/samplers_tests/tpe_tests/test_multi_objective_sampler.py
+++ b/tests/samplers_tests/tpe_tests/test_multi_objective_sampler.py
@@ -65,22 +65,6 @@ def test_multi_objective_sample_independent_seed_fix() -> None:
     assert suggest(sampler, study, trial, dist, past_trials) != suggestion
 
 
-def test_multi_objective_sample_independent_prior() -> None:
-    study = optuna.create_study(directions=["minimize", "maximize"])
-    dist = optuna.distributions.FloatDistribution(1.0, 100.0)
-
-    random.seed(128)
-    past_trials = [frozen_trial_factory(i, [random.random(), random.random()]) for i in range(16)]
-
-    # Prepare a trial and a sample for later checks.
-    trial = frozen_trial_factory(16, [0, 0])
-    sampler = TPESampler(seed=0)
-    suggestion = suggest(sampler, study, trial, dist, past_trials)
-
-    sampler = TPESampler(prior_weight=0.5, seed=0)
-    assert suggest(sampler, study, trial, dist, past_trials) != suggestion
-
-
 def test_multi_objective_sample_independent_n_startup_trial() -> None:
     study = optuna.create_study(directions=["minimize", "maximize"])
     dist = optuna.distributions.FloatDistribution(1.0, 100.0)
@@ -136,9 +120,6 @@ def test_multi_objective_sample_independent_misc_arguments() -> None:
 
     # Test misc. parameters.
     sampler = TPESampler(n_ei_candidates=13, seed=0)
-    assert suggest(sampler, study, trial, dist, past_trials) != suggestion
-
-    sampler = TPESampler(gamma=lambda _: 1, seed=0)
     assert suggest(sampler, study, trial, dist, past_trials) != suggestion
 
 

--- a/tests/samplers_tests/tpe_tests/test_multi_objective_sampler.py
+++ b/tests/samplers_tests/tpe_tests/test_multi_objective_sampler.py
@@ -4,6 +4,7 @@ from collections.abc import Callable
 import random
 from unittest.mock import patch
 from unittest.mock import PropertyMock
+import warnings
 
 import numpy as np
 import pytest
@@ -65,6 +66,24 @@ def test_multi_objective_sample_independent_seed_fix() -> None:
     assert suggest(sampler, study, trial, dist, past_trials) != suggestion
 
 
+def test_multi_objective_sample_independent_prior() -> None:
+    study = optuna.create_study(directions=["minimize", "maximize"])
+    dist = optuna.distributions.FloatDistribution(1.0, 100.0)
+
+    random.seed(128)
+    past_trials = [frozen_trial_factory(i, [random.random(), random.random()]) for i in range(16)]
+
+    # Prepare a trial and a sample for later checks.
+    trial = frozen_trial_factory(16, [0, 0])
+    sampler = TPESampler(seed=0)
+    suggestion = suggest(sampler, study, trial, dist, past_trials)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", FutureWarning)
+        sampler = TPESampler(prior_weight=0.5, seed=0)
+    assert suggest(sampler, study, trial, dist, past_trials) != suggestion
+
+
 def test_multi_objective_sample_independent_n_startup_trial() -> None:
     study = optuna.create_study(directions=["minimize", "maximize"])
     dist = optuna.distributions.FloatDistribution(1.0, 100.0)
@@ -120,6 +139,11 @@ def test_multi_objective_sample_independent_misc_arguments() -> None:
 
     # Test misc. parameters.
     sampler = TPESampler(n_ei_candidates=13, seed=0)
+    assert suggest(sampler, study, trial, dist, past_trials) != suggestion
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", FutureWarning)
+        sampler = TPESampler(gamma=lambda _: 1, seed=0)
     assert suggest(sampler, study, trial, dist, past_trials) != suggestion
 
 

--- a/tests/samplers_tests/tpe_tests/test_sampler.py
+++ b/tests/samplers_tests/tpe_tests/test_sampler.py
@@ -213,24 +213,6 @@ def test_sample_relative_empty_input(multivariate: bool) -> None:
     assert sampler.sample_relative(study, frozen_trial, {}) == {}
 
 
-def test_sample_relative_n_startup_trial() -> None:
-    study = optuna.create_study()
-    dist = optuna.distributions.FloatDistribution(1.0, 100.0)
-    past_trials = [frozen_trial_factory(i, dist=dist) for i in range(1, 8)]
-
-    trial = frozen_trial_factory(8)
-    # sample_relative returns {} for only 4 observations.
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", optuna.exceptions.ExperimentalWarning)
-        sampler = TPESampler(n_startup_trials=5, seed=0, multivariate=True)
-    with patch.object(study._storage, "get_all_trials", return_value=past_trials[:4]):
-        assert sampler.sample_relative(study, trial, {"param-a": dist}) == {}
-    # sample_relative returns some value for only 7 observations.
-    study._thread_local.cached_all_trials = None
-    with patch.object(study._storage, "get_all_trials", return_value=past_trials):
-        assert "param-a" in sampler.sample_relative(study, trial, {"param-a": dist}).keys()
-
-
 def test_sample_relative_prior() -> None:
     study = optuna.create_study()
     dist = optuna.distributions.FloatDistribution(1.0, 100.0)
@@ -250,6 +232,24 @@ def test_sample_relative_prior() -> None:
         sampler = TPESampler(prior_weight=0.2, n_startup_trials=5, seed=0, multivariate=True)
     with patch.object(study._storage, "get_all_trials", return_value=past_trials):
         assert sampler.sample_relative(study, trial, {"param-a": dist}) != suggestion
+
+
+def test_sample_relative_n_startup_trial() -> None:
+    study = optuna.create_study()
+    dist = optuna.distributions.FloatDistribution(1.0, 100.0)
+    past_trials = [frozen_trial_factory(i, dist=dist) for i in range(1, 8)]
+
+    trial = frozen_trial_factory(8)
+    # sample_relative returns {} for only 4 observations.
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", optuna.exceptions.ExperimentalWarning)
+        sampler = TPESampler(n_startup_trials=5, seed=0, multivariate=True)
+    with patch.object(study._storage, "get_all_trials", return_value=past_trials[:4]):
+        assert sampler.sample_relative(study, trial, {"param-a": dist}) == {}
+    # sample_relative returns some value for only 7 observations.
+    study._thread_local.cached_all_trials = None
+    with patch.object(study._storage, "get_all_trials", return_value=past_trials):
+        assert "param-a" in sampler.sample_relative(study, trial, {"param-a": dist}).keys()
 
 
 def test_sample_relative_misc_arguments() -> None:
@@ -518,6 +518,24 @@ def test_sample_relative_pruned_state() -> None:
     assert len(set(suggestions)) == 3
 
 
+def test_sample_independent_prior() -> None:
+    study = optuna.create_study()
+    dist = optuna.distributions.FloatDistribution(1.0, 100.0)
+    past_trials = [frozen_trial_factory(i, dist=dist) for i in range(1, 8)]
+
+    # Prepare a trial and a sample for later checks.
+    trial = frozen_trial_factory(8)
+    sampler = TPESampler(n_startup_trials=5, seed=0, n_ei_candidates=100)
+    with patch.object(study._storage, "get_all_trials", return_value=past_trials):
+        suggestion = sampler.sample_independent(study, trial, "param-a", dist)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", FutureWarning)
+        sampler = TPESampler(prior_weight=0.1, n_startup_trials=5, seed=0, n_ei_candidates=100)
+    with patch.object(study._storage, "get_all_trials", return_value=past_trials):
+        assert sampler.sample_independent(study, trial, "param-a", dist) != suggestion
+
+
 def test_sample_independent_n_startup_trial() -> None:
     study = optuna.create_study()
     dist = optuna.distributions.FloatDistribution(1.0, 100.0)
@@ -539,24 +557,6 @@ def test_sample_independent_n_startup_trial() -> None:
         ) as sample_method:
             sampler.sample_independent(study, trial, "param-a", dist)
     assert sample_method.call_count == 0
-
-
-def test_sample_independent_prior() -> None:
-    study = optuna.create_study()
-    dist = optuna.distributions.FloatDistribution(1.0, 100.0)
-    past_trials = [frozen_trial_factory(i, dist=dist) for i in range(1, 8)]
-
-    # Prepare a trial and a sample for later checks.
-    trial = frozen_trial_factory(8)
-    sampler = TPESampler(n_startup_trials=5, seed=0, n_ei_candidates=100)
-    with patch.object(study._storage, "get_all_trials", return_value=past_trials):
-        suggestion = sampler.sample_independent(study, trial, "param-a", dist)
-
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", FutureWarning)
-        sampler = TPESampler(prior_weight=0.1, n_startup_trials=5, seed=0, n_ei_candidates=100)
-    with patch.object(study._storage, "get_all_trials", return_value=past_trials):
-        assert sampler.sample_independent(study, trial, "param-a", dist) != suggestion
 
 
 def test_sample_independent_misc_arguments() -> None:

--- a/tests/samplers_tests/tpe_tests/test_sampler.py
+++ b/tests/samplers_tests/tpe_tests/test_sampler.py
@@ -93,76 +93,6 @@ def test_warn_independent_sampling_group(capsys: pytest.CaptureFixture) -> None:
     assert err == ""
 
 
-def test_prior_weight_deprecation_warning() -> None:
-    with pytest.warns(FutureWarning, match="prior_weight"):
-        TPESampler(prior_weight=2.0)
-
-
-def test_prior_weight_no_warning_for_default() -> None:
-    with warnings.catch_warnings():
-        warnings.simplefilter("error", FutureWarning)
-        TPESampler(prior_weight=1.0)
-
-
-def test_consider_magic_clip_deprecation_warning() -> None:
-    with pytest.warns(FutureWarning, match="consider_magic_clip"):
-        TPESampler(consider_magic_clip=False)
-
-
-def test_consider_magic_clip_no_warning_for_default() -> None:
-    with warnings.catch_warnings():
-        warnings.simplefilter("error", FutureWarning)
-        TPESampler(consider_magic_clip=True)
-
-
-def test_consider_endpoints_deprecation_warning() -> None:
-    with pytest.warns(FutureWarning, match="consider_endpoints"):
-        TPESampler(consider_endpoints=True)
-
-
-def test_consider_endpoints_no_warning_for_default() -> None:
-    with warnings.catch_warnings():
-        warnings.simplefilter("error", FutureWarning)
-        TPESampler(consider_endpoints=False)
-
-
-def test_gamma_deprecation_warning() -> None:
-    with pytest.warns(FutureWarning, match="gamma"):
-        TPESampler(gamma=lambda _: 5)
-
-
-def test_gamma_no_warning_for_default() -> None:
-    from optuna.samplers._tpe.sampler import default_gamma
-
-    with warnings.catch_warnings():
-        warnings.simplefilter("error", FutureWarning)
-        TPESampler(gamma=default_gamma)
-
-
-def test_weights_deprecation_warning() -> None:
-    with pytest.warns(FutureWarning, match="weights"):
-        TPESampler(weights=lambda n: np.ones(n))
-
-
-def test_weights_no_warning_for_default() -> None:
-    from optuna.samplers._tpe.sampler import default_weights
-
-    with warnings.catch_warnings():
-        warnings.simplefilter("error", FutureWarning)
-        TPESampler(weights=default_weights)
-
-
-def test_warn_independent_sampling_deprecation_warning() -> None:
-    with pytest.warns(FutureWarning, match="warn_independent_sampling"):
-        TPESampler(warn_independent_sampling=True)
-
-
-def test_warn_independent_sampling_no_warning_for_default() -> None:
-    with warnings.catch_warnings():
-        warnings.simplefilter("error", FutureWarning)
-        TPESampler(warn_independent_sampling=False)
-
-
 def test_infer_relative_search_space() -> None:
     sampler = TPESampler()
     search_space = {
@@ -1227,14 +1157,3 @@ def test_constant_liar_with_running_trial(multivariate: bool, multiobjective: bo
 def test_categorical_distance_func_experimental_warning() -> None:
     with pytest.warns(optuna.exceptions.ExperimentalWarning):
         _ = TPESampler(categorical_distance_func={"c": lambda x, y: 0.0})
-
-
-def test_categorical_distance_func_deprecation_warning() -> None:
-    with pytest.warns(FutureWarning, match="categorical_distance_func"):
-        _ = TPESampler(categorical_distance_func={"c": lambda x, y: 0.0})
-
-
-def test_categorical_distance_func_no_warning_for_default() -> None:
-    with warnings.catch_warnings():
-        warnings.simplefilter("error", FutureWarning)
-        TPESampler(categorical_distance_func=None)

--- a/tests/samplers_tests/tpe_tests/test_sampler.py
+++ b/tests/samplers_tests/tpe_tests/test_sampler.py
@@ -6,7 +6,6 @@ from unittest.mock import Mock
 from unittest.mock import patch
 import warnings
 
-import _pytest.capture
 import numpy as np
 import pytest
 
@@ -20,11 +19,18 @@ from optuna.trial import Trial
 
 @pytest.mark.parametrize("use_hyperband", [False, True])
 def test_hyperopt_parameters(use_hyperband: bool) -> None:
-    sampler = TPESampler(**TPESampler.hyperopt_parameters())
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", FutureWarning)
+        sampler = TPESampler(**TPESampler.hyperopt_parameters())
     study = optuna.create_study(
         sampler=sampler, pruner=optuna.pruners.HyperbandPruner() if use_hyperband else None
     )
     study.optimize(lambda t: t.suggest_float("x", 10, 20), n_trials=50)
+
+
+def test_hyperopt_parameters_deprecation_warning() -> None:
+    with pytest.warns(FutureWarning, match="hyperopt_parameters"):
+        TPESampler.hyperopt_parameters()
 
 
 def test_multivariate_experimental_warning() -> None:
@@ -37,48 +43,74 @@ def test_constraints_func_experimental_warning() -> None:
         optuna.samplers.TPESampler(constraints_func=lambda _: (0,))
 
 
-def test_warn_independent_sampling(capsys: _pytest.capture.CaptureFixture) -> None:
-    def objective(trial: Trial) -> float:
-        x = trial.suggest_categorical("x", ["a", "b"])
-        if x == "a":
-            return trial.suggest_float("y", 0, 1)
-        else:
-            return trial.suggest_float("z", 0, 1)
-
-    # We need to reconstruct our default handler to properly capture stderr.
-    optuna.logging._reset_library_root_logger()
-    optuna.logging.enable_default_handler()
-    optuna.logging.set_verbosity(optuna.logging.WARNING)
-
-    sampler = TPESampler(multivariate=True, warn_independent_sampling=True, n_startup_trials=0)
-    study = optuna.create_study(sampler=sampler)
-    study.optimize(objective, n_trials=10)
-
-    _, err = capsys.readouterr()
-    assert err
+def test_prior_weight_deprecation_warning() -> None:
+    with pytest.warns(FutureWarning, match="prior_weight"):
+        TPESampler(prior_weight=2.0)
 
 
-def test_warn_independent_sampling_group(capsys: _pytest.capture.CaptureFixture) -> None:
-    def objective(trial: Trial) -> float:
-        x = trial.suggest_categorical("x", ["a", "b"])
-        if x == "a":
-            return trial.suggest_float("y", 0, 1)
-        else:
-            return trial.suggest_float("z", 0, 1)
+def test_prior_weight_no_warning_for_default() -> None:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", FutureWarning)
+        TPESampler(prior_weight=1.0)
 
-    # We need to reconstruct our default handler to properly capture stderr.
-    optuna.logging._reset_library_root_logger()
-    optuna.logging.enable_default_handler()
-    optuna.logging.set_verbosity(optuna.logging.WARNING)
 
-    sampler = TPESampler(
-        multivariate=True, warn_independent_sampling=True, group=True, n_startup_trials=0
-    )
-    study = optuna.create_study(sampler=sampler)
-    study.optimize(objective, n_trials=10)
+def test_consider_magic_clip_deprecation_warning() -> None:
+    with pytest.warns(FutureWarning, match="consider_magic_clip"):
+        TPESampler(consider_magic_clip=False)
 
-    _, err = capsys.readouterr()
-    assert err == ""
+
+def test_consider_magic_clip_no_warning_for_default() -> None:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", FutureWarning)
+        TPESampler(consider_magic_clip=True)
+
+
+def test_consider_endpoints_deprecation_warning() -> None:
+    with pytest.warns(FutureWarning, match="consider_endpoints"):
+        TPESampler(consider_endpoints=True)
+
+
+def test_consider_endpoints_no_warning_for_default() -> None:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", FutureWarning)
+        TPESampler(consider_endpoints=False)
+
+
+def test_gamma_deprecation_warning() -> None:
+    with pytest.warns(FutureWarning, match="gamma"):
+        TPESampler(gamma=lambda _: 5)
+
+
+def test_gamma_no_warning_for_default() -> None:
+    from optuna.samplers._tpe.sampler import default_gamma
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", FutureWarning)
+        TPESampler(gamma=default_gamma)
+
+
+def test_weights_deprecation_warning() -> None:
+    with pytest.warns(FutureWarning, match="weights"):
+        TPESampler(weights=lambda n: np.ones(n))
+
+
+def test_weights_no_warning_for_default() -> None:
+    from optuna.samplers._tpe.sampler import default_weights
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", FutureWarning)
+        TPESampler(weights=default_weights)
+
+
+def test_warn_independent_sampling_deprecation_warning() -> None:
+    with pytest.warns(FutureWarning, match="warn_independent_sampling"):
+        TPESampler(warn_independent_sampling=True)
+
+
+def test_warn_independent_sampling_no_warning_for_default() -> None:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", FutureWarning)
+        TPESampler(warn_independent_sampling=False)
 
 
 def test_infer_relative_search_space() -> None:
@@ -131,26 +163,6 @@ def test_sample_relative_empty_input(multivariate: bool) -> None:
     assert sampler.sample_relative(study, frozen_trial, {}) == {}
 
 
-def test_sample_relative_prior() -> None:
-    study = optuna.create_study()
-    dist = optuna.distributions.FloatDistribution(1.0, 100.0)
-    past_trials = [frozen_trial_factory(i, dist=dist) for i in range(1, 8)]
-
-    # Prepare a trial and a sample for later checks.
-    trial = frozen_trial_factory(8)
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", optuna.exceptions.ExperimentalWarning)
-        sampler = TPESampler(n_startup_trials=5, seed=0, multivariate=True)
-    with patch.object(study._storage, "get_all_trials", return_value=past_trials):
-        suggestion = sampler.sample_relative(study, trial, {"param-a": dist})
-
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", optuna.exceptions.ExperimentalWarning)
-        sampler = TPESampler(prior_weight=0.2, n_startup_trials=5, seed=0, multivariate=True)
-    with patch.object(study._storage, "get_all_trials", return_value=past_trials):
-        assert sampler.sample_relative(study, trial, {"param-a": dist}) != suggestion
-
-
 def test_sample_relative_n_startup_trial() -> None:
     study = optuna.create_study()
     dist = optuna.distributions.FloatDistribution(1.0, 100.0)
@@ -186,23 +198,6 @@ def test_sample_relative_misc_arguments() -> None:
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", optuna.exceptions.ExperimentalWarning)
         sampler = TPESampler(n_ei_candidates=13, n_startup_trials=5, seed=0, multivariate=True)
-    with patch.object(study._storage, "get_all_trials", return_value=past_trials):
-        assert sampler.sample_relative(study, trial, {"param-a": dist}) != suggestion
-
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", optuna.exceptions.ExperimentalWarning)
-        sampler = TPESampler(gamma=lambda _: 5, n_startup_trials=5, seed=0, multivariate=True)
-    with patch.object(study._storage, "get_all_trials", return_value=past_trials):
-        assert sampler.sample_relative(study, trial, {"param-a": dist}) != suggestion
-
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", optuna.exceptions.ExperimentalWarning)
-        sampler = TPESampler(
-            weights=lambda n: np.asarray([i**2 + 1 for i in range(n)]),
-            n_startup_trials=5,
-            seed=0,
-            multivariate=True,
-        )
     with patch.object(study._storage, "get_all_trials", return_value=past_trials):
         assert sampler.sample_relative(study, trial, {"param-a": dist}) != suggestion
 
@@ -433,22 +428,6 @@ def test_sample_relative_pruned_state() -> None:
     assert len(set(suggestions)) == 3
 
 
-def test_sample_independent_prior() -> None:
-    study = optuna.create_study()
-    dist = optuna.distributions.FloatDistribution(1.0, 100.0)
-    past_trials = [frozen_trial_factory(i, dist=dist) for i in range(1, 8)]
-
-    # Prepare a trial and a sample for later checks.
-    trial = frozen_trial_factory(8)
-    sampler = TPESampler(n_startup_trials=5, seed=0, n_ei_candidates=100)
-    with patch.object(study._storage, "get_all_trials", return_value=past_trials):
-        suggestion = sampler.sample_independent(study, trial, "param-a", dist)
-
-    sampler = TPESampler(prior_weight=0.1, n_startup_trials=5, seed=0, n_ei_candidates=100)
-    with patch.object(study._storage, "get_all_trials", return_value=past_trials):
-        assert sampler.sample_independent(study, trial, "param-a", dist) != suggestion
-
-
 def test_sample_independent_n_startup_trial() -> None:
     study = optuna.create_study()
     dist = optuna.distributions.FloatDistribution(1.0, 100.0)
@@ -486,19 +465,6 @@ def test_sample_independent_misc_arguments() -> None:
     # Test misc. parameters.
     sampler = TPESampler(n_startup_trials=5, seed=0, n_ei_candidates=13)
     with patch.object(study._storage, "get_all_trials", return_value=past_trials):
-        assert sampler.sample_independent(study, trial, "param-a", dist) != suggestion
-
-    sampler = TPESampler(gamma=lambda _: 5, n_startup_trials=5, seed=0, n_ei_candidates=100)
-    with patch.object(study._storage, "get_all_trials", return_value=past_trials):
-        assert sampler.sample_independent(study, trial, "param-a", dist) != suggestion
-
-    sampler = TPESampler(
-        weights=lambda i: np.asarray([10 - j for j in range(i)]),
-        n_startup_trials=5,
-        seed=0,
-        n_ei_candidates=100,
-    )
-    with patch("optuna.Study._get_trials", return_value=past_trials):
         assert sampler.sample_independent(study, trial, "param-a", dist) != suggestion
 
 
@@ -1136,3 +1102,14 @@ def test_constant_liar_with_running_trial(multivariate: bool, multiobjective: bo
 def test_categorical_distance_func_experimental_warning() -> None:
     with pytest.warns(optuna.exceptions.ExperimentalWarning):
         _ = TPESampler(categorical_distance_func={"c": lambda x, y: 0.0})
+
+
+def test_categorical_distance_func_deprecation_warning() -> None:
+    with pytest.warns(FutureWarning, match="categorical_distance_func"):
+        _ = TPESampler(categorical_distance_func={"c": lambda x, y: 0.0})
+
+
+def test_categorical_distance_func_no_warning_for_default() -> None:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", FutureWarning)
+        TPESampler(categorical_distance_func=None)

--- a/tests/samplers_tests/tpe_tests/test_sampler.py
+++ b/tests/samplers_tests/tpe_tests/test_sampler.py
@@ -1152,8 +1152,3 @@ def test_constant_liar_with_running_trial(multivariate: bool, multiobjective: bo
     trial.suggest_float("y", 0, 10)
     trial.suggest_categorical("z", [0, 1, 2])
     study.tell(trial, [0, 0] if multiobjective else 0)
-
-
-def test_categorical_distance_func_experimental_warning() -> None:
-    with pytest.warns(optuna.exceptions.ExperimentalWarning):
-        _ = TPESampler(categorical_distance_func={"c": lambda x, y: 0.0})

--- a/tests/samplers_tests/tpe_tests/test_sampler.py
+++ b/tests/samplers_tests/tpe_tests/test_sampler.py
@@ -43,6 +43,56 @@ def test_constraints_func_experimental_warning() -> None:
         optuna.samplers.TPESampler(constraints_func=lambda _: (0,))
 
 
+def test_warn_independent_sampling(capsys: pytest.CaptureFixture) -> None:
+    def objective(trial: Trial) -> float:
+        x = trial.suggest_categorical("x", ["a", "b"])
+        if x == "a":
+            return trial.suggest_float("y", 0, 1)
+        else:
+            return trial.suggest_float("z", 0, 1)
+
+    # We need to reconstruct our default handler to properly capture stderr.
+    optuna.logging._reset_library_root_logger()
+    optuna.logging.enable_default_handler()
+    optuna.logging.set_verbosity(optuna.logging.WARNING)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", FutureWarning)
+        warnings.simplefilter("ignore", optuna.exceptions.ExperimentalWarning)
+        sampler = TPESampler(multivariate=True, warn_independent_sampling=True, n_startup_trials=0)
+    study = optuna.create_study(sampler=sampler)
+    study.optimize(objective, n_trials=10)
+
+    _, err = capsys.readouterr()
+    assert err
+
+
+def test_warn_independent_sampling_group(capsys: pytest.CaptureFixture) -> None:
+    def objective(trial: Trial) -> float:
+        x = trial.suggest_categorical("x", ["a", "b"])
+        if x == "a":
+            return trial.suggest_float("y", 0, 1)
+        else:
+            return trial.suggest_float("z", 0, 1)
+
+    # We need to reconstruct our default handler to properly capture stderr.
+    optuna.logging._reset_library_root_logger()
+    optuna.logging.enable_default_handler()
+    optuna.logging.set_verbosity(optuna.logging.WARNING)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", FutureWarning)
+        warnings.simplefilter("ignore", optuna.exceptions.ExperimentalWarning)
+        sampler = TPESampler(
+            multivariate=True, warn_independent_sampling=True, group=True, n_startup_trials=0
+        )
+    study = optuna.create_study(sampler=sampler)
+    study.optimize(objective, n_trials=10)
+
+    _, err = capsys.readouterr()
+    assert err == ""
+
+
 def test_prior_weight_deprecation_warning() -> None:
     with pytest.warns(FutureWarning, match="prior_weight"):
         TPESampler(prior_weight=2.0)
@@ -181,6 +231,27 @@ def test_sample_relative_n_startup_trial() -> None:
         assert "param-a" in sampler.sample_relative(study, trial, {"param-a": dist}).keys()
 
 
+def test_sample_relative_prior() -> None:
+    study = optuna.create_study()
+    dist = optuna.distributions.FloatDistribution(1.0, 100.0)
+    past_trials = [frozen_trial_factory(i, dist=dist) for i in range(1, 8)]
+
+    # Prepare a trial and a sample for later checks.
+    trial = frozen_trial_factory(8)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", optuna.exceptions.ExperimentalWarning)
+        sampler = TPESampler(n_startup_trials=5, seed=0, multivariate=True)
+    with patch.object(study._storage, "get_all_trials", return_value=past_trials):
+        suggestion = sampler.sample_relative(study, trial, {"param-a": dist})
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", optuna.exceptions.ExperimentalWarning)
+        warnings.simplefilter("ignore", FutureWarning)
+        sampler = TPESampler(prior_weight=0.2, n_startup_trials=5, seed=0, multivariate=True)
+    with patch.object(study._storage, "get_all_trials", return_value=past_trials):
+        assert sampler.sample_relative(study, trial, {"param-a": dist}) != suggestion
+
+
 def test_sample_relative_misc_arguments() -> None:
     study = optuna.create_study()
     dist = optuna.distributions.FloatDistribution(1.0, 100.0)
@@ -198,6 +269,25 @@ def test_sample_relative_misc_arguments() -> None:
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", optuna.exceptions.ExperimentalWarning)
         sampler = TPESampler(n_ei_candidates=13, n_startup_trials=5, seed=0, multivariate=True)
+    with patch.object(study._storage, "get_all_trials", return_value=past_trials):
+        assert sampler.sample_relative(study, trial, {"param-a": dist}) != suggestion
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", optuna.exceptions.ExperimentalWarning)
+        warnings.simplefilter("ignore", FutureWarning)
+        sampler = TPESampler(gamma=lambda _: 5, n_startup_trials=5, seed=0, multivariate=True)
+    with patch.object(study._storage, "get_all_trials", return_value=past_trials):
+        assert sampler.sample_relative(study, trial, {"param-a": dist}) != suggestion
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", optuna.exceptions.ExperimentalWarning)
+        warnings.simplefilter("ignore", FutureWarning)
+        sampler = TPESampler(
+            weights=lambda n: np.asarray([i**2 + 1 for i in range(n)]),
+            n_startup_trials=5,
+            seed=0,
+            multivariate=True,
+        )
     with patch.object(study._storage, "get_all_trials", return_value=past_trials):
         assert sampler.sample_relative(study, trial, {"param-a": dist}) != suggestion
 
@@ -451,6 +541,24 @@ def test_sample_independent_n_startup_trial() -> None:
     assert sample_method.call_count == 0
 
 
+def test_sample_independent_prior() -> None:
+    study = optuna.create_study()
+    dist = optuna.distributions.FloatDistribution(1.0, 100.0)
+    past_trials = [frozen_trial_factory(i, dist=dist) for i in range(1, 8)]
+
+    # Prepare a trial and a sample for later checks.
+    trial = frozen_trial_factory(8)
+    sampler = TPESampler(n_startup_trials=5, seed=0, n_ei_candidates=100)
+    with patch.object(study._storage, "get_all_trials", return_value=past_trials):
+        suggestion = sampler.sample_independent(study, trial, "param-a", dist)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", FutureWarning)
+        sampler = TPESampler(prior_weight=0.1, n_startup_trials=5, seed=0, n_ei_candidates=100)
+    with patch.object(study._storage, "get_all_trials", return_value=past_trials):
+        assert sampler.sample_independent(study, trial, "param-a", dist) != suggestion
+
+
 def test_sample_independent_misc_arguments() -> None:
     study = optuna.create_study()
     dist = optuna.distributions.FloatDistribution(1.0, 100.0)
@@ -464,6 +572,23 @@ def test_sample_independent_misc_arguments() -> None:
 
     # Test misc. parameters.
     sampler = TPESampler(n_startup_trials=5, seed=0, n_ei_candidates=13)
+    with patch.object(study._storage, "get_all_trials", return_value=past_trials):
+        assert sampler.sample_independent(study, trial, "param-a", dist) != suggestion
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", FutureWarning)
+        sampler = TPESampler(gamma=lambda _: 5, n_startup_trials=5, seed=0, n_ei_candidates=100)
+    with patch.object(study._storage, "get_all_trials", return_value=past_trials):
+        assert sampler.sample_independent(study, trial, "param-a", dist) != suggestion
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", FutureWarning)
+        sampler = TPESampler(
+            weights=lambda i: np.asarray([10 - j for j in range(i)]),
+            n_startup_trials=5,
+            seed=0,
+            n_ei_candidates=100,
+        )
     with patch.object(study._storage, "get_all_trials", return_value=past_trials):
         assert sampler.sample_independent(study, trial, "param-a", dist) != suggestion
 


### PR DESCRIPTION
## Motivation
Currently, `TPESampler` has 15 arguments, but we recognize that only a small subset of them is widely used in practice. To keep the sampler implementation concise, we would like to deprecate some features before future major releases. (We have done something similar with `CmaEsSampler` in the past #6025.)

## Description of the changes

- Deprecate `prior_weight`
- Deprecate `consider_magic_clip`
- Deprecate `consider_endpoints`
- Deprecate `gamma`
- Deprecate `weights`
- Deprecate `hyperopt_parameters`
- Deprecate `warn_independent_sampling` (Note: Change the default value to `False`)
- Deprecate `categorical_distance_func` (Note: Considering migrating this feature to OptunaHub)
