### PR TITLE
Remove unused intersphinx mappings

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -177,14 +177,9 @@ texinfo_documents = [
 
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
-    "distributed": ("https://distributed.dask.org/en/stable", None),
-    "lightgbm": ("https://lightgbm.readthedocs.io/en/stable", None),
     "matplotlib": ("https://matplotlib.org/stable", None),
     "numpy": ("https://numpy.org/doc/stable", None),
     "scipy": ("https://docs.scipy.org/doc/scipy", None),
-    "sklearn": ("https://scikit-learn.org/stable", None),
-    "torch": ("https://pytorch.org/docs/stable", None),
-    "pandas": ("https://pandas.pydata.org/docs", None),
     "plotly": ("https://plotly.com/python-api-reference", None),
     "optuna_integration": ("https://optuna-integration.readthedocs.io/en/latest/", None),
 }


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. To minimize the review effort, we highly appreciate PRs only with related changes. Please note that submitted PRs may be closed if they include unrelated changes or significantly modified unit tests. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation

The documentation build treats warnings as errors via the `-W` flag. Recently, the PyTorch intersphinx inventory fetch has been frequently failing (404 error), causing the documentation build to exit with status 1.

> loading intersphinx inventory 'torch' from https://pytorch.org/docs/stable/objects.inv ...
> loading intersphinx inventory 'pandas' from https://pandas.pydata.org/docs/objects.inv ...
> loading intersphinx inventory 'plotly' from https://plotly.com/python-api-reference/objects.inv ...
> loading intersphinx inventory 'optuna_integration' from https://optuna-integration.readthedocs.io/en/latest/objects.inv ...
> WARNING: failed to reach any of the inventories with the following issues:
> intersphinx inventory 'https://pytorch.org/docs/stable/objects.inv' not fetchable due to <class 'requests.exceptions.HTTPError'>: 404 Client Error: Not Found for url: https://docs.pytorch.org/docs/stable/objects.inv
> https://github.com/optuna/optuna/actions/runs/25177161686/job/73812390900?pr=6642

## Description of the changes

In my recognition, the intersphinx mappings for `dask.distributed`, `lightgbm`, `sklearn`, `torch`, and `pandas`, were originally added for `optuna.integration` modules. However, those modules and their associated documentation have been migrated to https://github.com/optuna/optuna-integration. 

This PR removes these unused intersphinx mappings to prevent CI failures.