### PR TITLE
Speed up `BruteForceSampler`

### DIFF
--- a/optuna/samplers/_brute_force.py
+++ b/optuna/samplers/_brute_force.py
@@ -176,20 +176,20 @@ class BruteForceSampler(BaseSampler):
         tree: _TreeNode, trials: Iterable[FrozenTrial], params: dict[str, Any]
     ) -> None:
         # Populate tree under given params from the given trials.
+        cand_cache = {}
+
+        def _gen(trial: FrozenTrial):
+            for name, dist in trial.distributions.items():
+                if name in params:
+                    continue
+                if name not in cand_cache:
+                    cand_cache[name] = _enumerate_candidates(dist)
+                yield name, cand_cache[name], dist.to_internal_repr(trial.params[name])
+
         for trial in trials:
             if not all(p in trial.params and trial.params[p] == v for p, v in params.items()):
                 continue
-            leaf = tree.add_path(
-                (
-                    (
-                        param_name,
-                        _enumerate_candidates(param_distribution),
-                        param_distribution.to_internal_repr(trial.params[param_name]),
-                    )
-                    for param_name, param_distribution in trial.distributions.items()
-                    if param_name not in params
-                )
-            )
+            leaf = tree.add_path(_gen(trial))
             if leaf is not None:
                 # The parameters are on the defined grid.
                 if trial.state.is_finished():

--- a/optuna/samplers/_brute_force.py
+++ b/optuna/samplers/_brute_force.py
@@ -54,9 +54,7 @@ class _TreeNode:
     choices_fingerprint: tuple[int, float, float] | None = None
 
     def expand(self, param_name: str | None, choices: list[float]) -> dict[float, "_TreeNode"]:
-        choices_fingerprint = (
-            (len(choices), choices[0], choices[-1]) if choices else (0, 0, 0)
-        )
+        choices_fingerprint = (len(choices), choices[0], choices[-1]) if choices else (0, 0, 0)
         if self.children is None:
             self.param_name = param_name
             self.children = {value: _TreeNode() for value in choices}

--- a/optuna/samplers/_brute_force.py
+++ b/optuna/samplers/_brute_force.py
@@ -27,9 +27,10 @@ if TYPE_CHECKING:
 
 
 _TREE_SIZE_KEY = "brute_force:tree_size"
+_NaN = float("nan")
 
 
-@dataclass
+@dataclass(slots=True)
 class _TreeNode:
     # This is a class to represent the tree of search space.
 
@@ -213,7 +214,7 @@ class BruteForceSampler(BaseSampler):
 
         for trial in trials:
             # NOTE(nabenabe): `nan` cannot be assigned as a param value.
-            if not all(trial.params.get(p, float("nan")) == v for p, v in params.items()):
+            if not all(trial.params.get(p, _NaN) == v for p, v in params.items()):
                 continue
             leaf = tree.add_path(_gen(trial))
             if leaf is not None:
@@ -247,11 +248,7 @@ class BruteForceSampler(BaseSampler):
             )
 
     def after_trial(
-        self,
-        study: Study,
-        trial: FrozenTrial,
-        state: TrialState,
-        values: Sequence[float] | None,
+        self, study: Study, trial: FrozenTrial, state: TrialState, values: Sequence[float] | None
     ) -> None:
         tree_size = study._storage.get_study_system_attrs(study._study_id).get(_TREE_SIZE_KEY, 0)
         exclude_running = not self._avoid_premature_stop

--- a/optuna/samplers/_brute_force.py
+++ b/optuna/samplers/_brute_force.py
@@ -2,12 +2,16 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import decimal
+from functools import lru_cache
+import sys
 from typing import Any
+from typing import cast
 from typing import TYPE_CHECKING
 
 import numpy as np
 
 from optuna._experimental import experimental_class
+from optuna.distributions import CategoricalChoiceType
 from optuna.distributions import CategoricalDistribution
 from optuna.distributions import FloatDistribution
 from optuna.distributions import IntDistribution
@@ -18,6 +22,7 @@ from optuna.trial import TrialState
 
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
     from collections.abc import Sequence
 
     from optuna.distributions import BaseDistribution
@@ -25,40 +30,49 @@ if TYPE_CHECKING:
     from optuna.trial import FrozenTrial
 
 
+_NaN = float("nan")
 _TREE_SIZE_KEY = "brute_force:tree_size"
-_NaN = float("nan")  # NOTE: Define once to save runtime overhead.
 
 
-# TODO(nabenabe): Use `dict` instead of `dataclass` because dataclass instantiation is too slow.
-@dataclass  # TODO(nabenabe): Add `slots=True` once Python 3.9 is dropped.
+# TODO(nabenabe): Simply use `slots=True` once Python 3.9 is dropped.
+@dataclass(**({"slots": True} if sys.version_info >= (3, 10) else {}))
 class _TreeNode:
-    # This is a class to represent the tree of search space.
+    """
+    This is a class to represent the tree of search space.
 
-    # A tree node has three states:
-    # 1. Unexpanded. This is represented by children=None.
-    # 2. Leaf. This is represented by children={} and param_name=None.
-    # 3. Normal node. It has a param_name and non-empty children.
+    A tree node has three states:
+        1. Unexpanded. This is represented by children=None.
+        2. Leaf. This is represented by children={} and param_name=None.
+        3. Normal node. It has a param_name and non-empty children.
+
+    NOTE(nabenabe): I tried representations by list and dict, but they did not really speed up.
+    """
 
     param_name: str | None = None
     children: dict[float, "_TreeNode"] | None = None
     is_running: bool = False
+    choices_fingerprint: tuple[int, float, float] | None = None
 
-    def expand(
-        self, param_name: str | None, search_space: list[float]
-    ) -> dict[float, "_TreeNode"]:
-        # If the node is unexpanded, expand it.
-        # Otherwise, check if the node is compatible with the given search space.
+    def expand(self, param_name: str | None, choices: list[float]) -> dict[float, "_TreeNode"]:
+        choices_fingerprint = (
+            (len(choices), choices[0], choices[-1]) if choices else (0, 0, 0)
+        )
         if self.children is None:
-            # Expand the node
             self.param_name = param_name
-            self.children = {value: _TreeNode() for value in search_space}
+            self.children = {value: _TreeNode() for value in choices}
+            self.choices_fingerprint = choices_fingerprint
             return self.children
         else:
             if self.param_name != param_name:
                 raise ValueError(f"param_name mismatch: {self.param_name} != {param_name}")
-            if self.children.keys() != set(search_space):
+            if (
+                # NOTE(nabenabe): search space and children are sorted, and the step size is always
+                # fixed due to the Optuna constraint, so the first and last elements and length
+                # check are equivalent to ``children.keys() != set(search_space)``.
+                choices_fingerprint != self.choices_fingerprint
+            ):
                 raise ValueError(
-                    f"search_space mismatch: {set(self.children.keys())} != {set(search_space)}"
+                    f"search_space mismatch: {set(self.children.keys())} != {set(choices)}"
                 )
             return self.children
 
@@ -69,27 +83,25 @@ class _TreeNode:
         self.expand(None, [])
 
     def add_path(
-        self, params_and_search_spaces: list[tuple[str, list[float], float]]
+        self, params_and_choices: Iterable[tuple[str, list[float], float]]
     ) -> _TreeNode | None:
-        # Add a path (i.e. a list of suggested parameters in one trial) to the tree.
         current_node = self
-        for param_name, search_space, value in params_and_search_spaces:
-            next_node = current_node.expand(param_name, search_space).get(value)
+        for param_name, choices, value in params_and_choices:
+            next_node = current_node.expand(param_name, choices).get(value)
             if next_node is None:
                 return None
             current_node = next_node
         return current_node
 
     def is_any_expandable(self, exclude_running: bool) -> bool:
-        if self.children is None:
+        if (children := self.children) is None:
             return not exclude_running or not self.is_running
-        return any(child.is_any_expandable(exclude_running) for child in self.children.values())
+        return any(child.is_any_expandable(exclude_running) for child in children.values())
 
     def count_unexpanded(self, exclude_running: bool) -> int:
-        # Count the number of unexpanded nodes in the subtree.
-        if self.children is None:
+        if (children := self.children) is None:
             return 0 if exclude_running and self.is_running else 1
-        return sum(child.count_unexpanded(exclude_running) for child in self.children.values())
+        return sum(child.count_unexpanded(exclude_running) for child in children.values())
 
     def count_total_combinations(self) -> int:
         if not self.children:
@@ -97,11 +109,9 @@ class _TreeNode:
         return sum(child.count_total_combinations() for child in self.children.values())
 
     def sample_child(self, rng: np.random.RandomState, exclude_running: bool) -> float:
-        assert self.children is not None
-
+        assert (children := self.children) is not None
         unexpanded_counts = np.array(
-            [child.count_unexpanded(exclude_running) for child in self.children.values()],
-            dtype=np.float64,
+            [child.count_unexpanded(exclude_running) for child in children.values()], dtype=float
         )
 
         # Blend exact uniform sampling with flat uniform sampling
@@ -110,25 +120,33 @@ class _TreeNode:
         weights_orig = unexpanded_counts / unexpanded_counts.sum()
         weights_flat = np.where(unexpanded_counts > 0, 1.0, 0.0)
         weights_flat /= weights_flat.sum()
+
         weights = (1.0 - alpha) * weights_orig + alpha * weights_flat
         if any(
-            not value.is_running and weights[i] > 0
-            for i, value in enumerate(self.children.values())
+            not value.is_running and weights[i] > 0 for i, value in enumerate(children.values())
         ):
             # Prioritize picking non-running and unexpanded nodes.
-            for i, child in enumerate(self.children.values()):
+            for i, child in enumerate(children.values()):
                 if child.is_running:
                     weights[i] = 0.0
         weights /= weights.sum()
-        return rng.choice(list(self.children.keys()), p=weights)
+        return rng.choice(list(children.keys()), p=weights).item()
 
 
-def _get_non_waiting_trials(study: Study) -> list[FrozenTrial]:
+def _get_non_waiting_trials_and_current_trial_index(
+    study: Study, current_trial_number: int
+) -> tuple[list[FrozenTrial], int]:
     # We directly query the storage to get trials here instead of `study.get_trials`,
     # since some pruners such as `HyperbandPruner` use the study transformed
     # to filter trials. See https://github.com/optuna/optuna/issues/2327 for details.
     states = (TrialState.COMPLETE, TrialState.PRUNED, TrialState.RUNNING, TrialState.FAIL)
-    return study._storage.get_all_trials(study._study_id, deepcopy=False, states=states)
+    trials = study._storage.get_all_trials(study._study_id, deepcopy=False, states=states)
+    for i in range(1, len(trials) + 1):
+        # The current trial can be found at the later part for almost all cases.
+        t = trials[-i]
+        if t.number == current_trial_number:
+            return trials, len(trials) - i
+    assert False, "Should not reach"
 
 
 @experimental_class("3.1.0")
@@ -196,33 +214,36 @@ class BruteForceSampler(BaseSampler):
         return {}
 
     @staticmethod
-    def _populate_tree(
-        tree: _TreeNode, trials: list[FrozenTrial], params: dict[str, Any]
-    ) -> None:
-        # Populate tree under given params from the given trials.
-        cand_cache = {}
-        internal_repr_cache = {}
+    def _populate_tree(tree: _TreeNode, trials: list[FrozenTrial], params: dict[str, Any]) -> None:
+        internal_repr_cache: dict[str, dict[CategoricalChoiceType, float]] = {}
 
-        def _get_path(trial: FrozenTrial) -> list[tuple[str, list[float], float]]:
-            edges = []
+        def _get_trial_path(trial: FrozenTrial) -> list[tuple[str, list[float], float]]:
+            trial_path: list[tuple[str, list[float], float]] = []
             for name, dist in trial.distributions.items():
                 if name in params:
                     continue
-                if name not in cand_cache:
-                    cand_cache[name] = _enumerate_candidates(dist)
-                cache_key = (name, param_val := trial.params[name])
-                if cache_key not in internal_repr_cache:
-                    internal_repr_cache[cache_key] = dist.to_internal_repr(param_val)
-                edges.append((name, cand_cache[name], internal_repr_cache[cache_key]))
-            return edges
+                if name not in internal_repr_cache:
+                    internal_repr_cache[name] = {}
+                    if isinstance(dist, CategoricalDistribution):
+                        internal_repr_cache[name] = {c: i for i, c in enumerate(dist.choices)}
+                if cat_repr := internal_repr_cache[name]:
+                    cands = _enumerate_candidates(0, len(cat_repr) - 1, 1)
+                    value = cat_repr.get(param_val := trial.params[name])
+                    if value is None:  # most likely param_val is nan.
+                        value = dist.to_internal_repr(param_val)
+                else:
+                    dist = cast("IntDistribution | FloatDistribution", dist)
+                    cands = _enumerate_candidates(dist.low, dist.high, dist.step)
+                    value = trial.params[name]
+                trial_path.append((name, cands, value))
+            return trial_path
 
         for trial in trials:
             # NOTE(nabenabe): `nan` cannot be assigned as a param value.
             if params and not all(trial.params.get(p, _NaN) == v for p, v in params.items()):
                 continue
-            leaf = tree.add_path(_get_path(trial))
+            leaf = tree.add_path(_get_trial_path(trial))
             if leaf is not None:
-                # The parameters are on the defined grid.
                 if trial.state.is_finished():
                     leaf.set_leaf()
                 else:
@@ -236,16 +257,24 @@ class BruteForceSampler(BaseSampler):
         param_distribution: BaseDistribution,
     ) -> Any:
         exclude_running = not self._avoid_premature_stop
-        trials = _get_non_waiting_trials(study)
+        trials, current_idx = _get_non_waiting_trials_and_current_trial_index(study, trial.number)
+        trials.pop(current_idx)
         tree = _TreeNode()
-        candidates = _enumerate_candidates(param_distribution)
+        if isinstance(param_distribution, CategoricalDistribution):
+            candidates = _enumerate_candidates(0, len(param_distribution.choices) - 1, 1)
+        elif isinstance(param_distribution, (IntDistribution, FloatDistribution)):
+            candidates = _enumerate_candidates(
+                param_distribution.low, param_distribution.high, param_distribution.step
+            )
+        else:
+            assert False, "Should not reach."
         tree.expand(param_name, candidates)
         # Populating must happen after the initialization above to prevent `tree` from
         # being initialized as an empty graph, which is created with n_jobs > 1
         # where we get trials[i].params = {} for some i.
-        self._populate_tree(tree, [t for t in trials if t.number != trial.number], trial.params)
+        self._populate_tree(tree, trials, trial.params)
         if not tree.is_any_expandable(exclude_running):
-            return param_distribution.to_external_repr(self._rng.rng.choice(candidates))
+            return param_distribution.to_external_repr(self._rng.rng.choice(candidates).item())
         else:
             return param_distribution.to_external_repr(
                 tree.sample_child(self._rng.rng, exclude_running)
@@ -256,18 +285,16 @@ class BruteForceSampler(BaseSampler):
     ) -> None:
         tree_size = study._storage.get_study_system_attrs(study._study_id).get(_TREE_SIZE_KEY, 0)
         exclude_running = not self._avoid_premature_stop
-        trials = _get_non_waiting_trials(study)
+        trials, current_idx = _get_non_waiting_trials_and_current_trial_index(study, trial.number)
         if len(trials) < tree_size:
             # NOTE(nabenabe): No need to stop study. Early return to avoid tree build overhead.
             return
         # Set current trial as complete.
-        current_trial = create_trial(
+        trials[current_idx] = create_trial(
             state=state, values=values, params=trial.params, distributions=trial.distributions
         )
         tree = _TreeNode()
-        self._populate_tree(
-            tree, [t if t.number != trial.number else current_trial for t in trials], {}
-        )
+        self._populate_tree(tree, trials, {})
         if not tree.is_any_expandable(exclude_running):
             study.stop()
         if trial.number % self._tree_size_check_interval == 0:
@@ -275,29 +302,24 @@ class BruteForceSampler(BaseSampler):
             study._storage.set_study_system_attr(study._study_id, _TREE_SIZE_KEY, tree_size)
 
 
-def _enumerate_candidates(param_distribution: BaseDistribution) -> list[float]:
-    if isinstance(param_distribution, FloatDistribution):
-        if param_distribution.step is None:
-            raise ValueError(
-                "FloatDistribution.step must be given for BruteForceSampler"
-                " (otherwise, the search space will be infinite)."
-            )
-        low = decimal.Decimal(str(param_distribution.low))
-        high = decimal.Decimal(str(param_distribution.high))
-        step = decimal.Decimal(str(param_distribution.step))
-
-        ret = []
-        value = low
-        while value <= high:
-            ret.append(float(value))
-            value += step
-
-        return ret
-    elif isinstance(param_distribution, IntDistribution):
-        return list(
-            range(param_distribution.low, param_distribution.high + 1, param_distribution.step)
+@lru_cache
+def _enumerate_candidates(
+    low: int | float, high: int | float, step: int | float | None
+) -> list[float]:
+    if step is None:
+        raise ValueError(
+            "FloatDistribution.step must be given for BruteForceSampler"
+            " (otherwise, the search space will be infinite)."
         )
-    elif isinstance(param_distribution, CategoricalDistribution):
-        return list(range(len(param_distribution.choices)))  # Internal representations.
+    if isinstance(low, int) and isinstance(high, int) and isinstance(step, int):
+        return list(range(low, high + 1, step))
     else:
-        raise ValueError(f"Unknown distribution {param_distribution}.")
+        low_ = decimal.Decimal(str(low))
+        high_ = decimal.Decimal(str(high))
+        step_ = decimal.Decimal(str(step))
+        ret = []
+        value = low_
+        while value <= high_:
+            ret.append(float(value))
+            value += step_
+        return ret

--- a/optuna/samplers/_brute_force.py
+++ b/optuna/samplers/_brute_force.py
@@ -26,6 +26,9 @@ if TYPE_CHECKING:
     from optuna.trial import FrozenTrial
 
 
+_TREE_SIZE_KEY = "brute_force:tree_size"
+
+
 @dataclass
 class _TreeNode:
     # This is a class to represent the tree of search space.
@@ -76,17 +79,18 @@ class _TreeNode:
     def is_any_expandable(self, exclude_running: bool) -> bool:
         if self.children is None:
             return not exclude_running or not self.is_running
-        else:
-            return any(
-                child.is_any_expandable(exclude_running) for child in self.children.values()
-            )
+        return any(child.is_any_expandable(exclude_running) for child in self.children.values())
 
     def count_unexpanded(self, exclude_running: bool) -> int:
         # Count the number of unexpanded nodes in the subtree.
         if self.children is None:
             return 0 if exclude_running and self.is_running else 1
-        else:
-            return sum(child.count_unexpanded(exclude_running) for child in self.children.values())
+        return sum(child.count_unexpanded(exclude_running) for child in self.children.values())
+
+    def count_total_combinations(self) -> int:
+        if not self.children:
+            return 1
+        return sum(child.count_total_combinations() for child in self.children.values())
 
     def sample_child(self, rng: np.random.RandomState, exclude_running: bool) -> float:
         assert self.children is not None
@@ -114,6 +118,14 @@ class _TreeNode:
                     weights[i] = 0.0
         weights /= weights.sum()
         return rng.choice(list(self.children.keys()), p=weights)
+
+
+def _get_non_waiting_trials(study: Study) -> list[FrozenTrial]:
+    # We directly query the storage to get trials here instead of `study.get_trials`,
+    # since some pruners such as `HyperbandPruner` use the study transformed
+    # to filter trials. See https://github.com/optuna/optuna/issues/2327 for details.
+    states = (TrialState.COMPLETE, TrialState.PRUNED, TrialState.RUNNING, TrialState.FAIL)
+    return study._storage.get_all_trials(study._study_id, deepcopy=False, states=states)
 
 
 @experimental_class("3.1.0")
@@ -168,6 +180,7 @@ class BruteForceSampler(BaseSampler):
     def __init__(self, seed: int | None = None, avoid_premature_stop: bool = False) -> None:
         self._rng = LazyRandomState(seed)
         self._avoid_premature_stop = avoid_premature_stop
+        self._tree_size_check_interval = 500
 
     def infer_relative_search_space(
         self, study: Study, trial: FrozenTrial
@@ -218,20 +231,7 @@ class BruteForceSampler(BaseSampler):
         param_distribution: BaseDistribution,
     ) -> Any:
         exclude_running = not self._avoid_premature_stop
-
-        # We directly query the storage to get trials here instead of `study.get_trials`,
-        # since some pruners such as `HyperbandPruner` use the study transformed
-        # to filter trials. See https://github.com/optuna/optuna/issues/2327 for details.
-        trials = study._storage.get_all_trials(
-            study._study_id,
-            deepcopy=False,
-            states=(
-                TrialState.COMPLETE,
-                TrialState.PRUNED,
-                TrialState.RUNNING,
-                TrialState.FAIL,
-            ),
-        )
+        trials = _get_non_waiting_trials(study)
         tree = _TreeNode()
         candidates = _enumerate_candidates(param_distribution)
         tree.expand(param_name, candidates)
@@ -253,42 +253,27 @@ class BruteForceSampler(BaseSampler):
         state: TrialState,
         values: Sequence[float] | None,
     ) -> None:
+        tree_size = study._storage.get_study_system_attrs(study._study_id).get(_TREE_SIZE_KEY, 0)
         exclude_running = not self._avoid_premature_stop
-
-        # We directly query the storage to get trials here instead of `study.get_trials`,
-        # since some pruners such as `HyperbandPruner` use the study transformed
-        # to filter trials. See https://github.com/optuna/optuna/issues/2327 for details.
-        trials = study._storage.get_all_trials(
-            study._study_id,
-            deepcopy=False,
-            states=(
-                TrialState.COMPLETE,
-                TrialState.PRUNED,
-                TrialState.RUNNING,
-                TrialState.FAIL,
-            ),
+        trials = _get_non_waiting_trials(study)
+        if len(trials) < tree_size:
+            # NOTE(nabenabe): No need to stop study. Early return to avoid tree build overhead.
+            return
+        # Set current trial as complete.
+        current_trial = create_trial(
+            state=state, values=values, params=trial.params, distributions=trial.distributions
         )
         tree = _TreeNode()
         self._populate_tree(
-            tree,
-            (
-                (
-                    t
-                    if t.number != trial.number
-                    else create_trial(
-                        state=state,  # Set current trial as complete.
-                        values=values,
-                        params=trial.params,
-                        distributions=trial.distributions,
-                    )
-                )
-                for t in trials
-            ),
-            {},
+            tree, (t if t.number != trial.number else current_trial for t in trials), {}
         )
 
         if not tree.is_any_expandable(exclude_running):
             study.stop()
+
+        if trial.number % self._tree_size_check_interval == 0:
+            tree_size = max(tree_size, tree.count_total_combinations())
+            study._storage.set_study_system_attr(study._study_id, _TREE_SIZE_KEY, tree_size)
 
 
 def _enumerate_candidates(param_distribution: BaseDistribution) -> Sequence[float]:

--- a/optuna/samplers/_brute_force.py
+++ b/optuna/samplers/_brute_force.py
@@ -30,6 +30,7 @@ _TREE_SIZE_KEY = "brute_force:tree_size"
 _NaN = float("nan")  # NOTE: Define once to save runtime overhead.
 
 
+# TODO(nabenabe): Use `dict` instead of `dataclass` because dataclass instantiation is too slow.
 @dataclass  # TODO(nabenabe): Add `slots=True` once Python 3.9 is dropped.
 class _TreeNode:
     # This is a class to represent the tree of search space.
@@ -43,13 +44,16 @@ class _TreeNode:
     children: dict[float, "_TreeNode"] | None = None
     is_running: bool = False
 
-    def expand(self, param_name: str | None, search_space: Iterable[float]) -> None:
+    def expand(
+        self, param_name: str | None, search_space: Iterable[float]
+    ) -> dict[float, "_TreeNode"]:
         # If the node is unexpanded, expand it.
         # Otherwise, check if the node is compatible with the given search space.
         if self.children is None:
             # Expand the node
             self.param_name = param_name
             self.children = {value: _TreeNode() for value in search_space}
+            return self.children
         else:
             if self.param_name != param_name:
                 raise ValueError(f"param_name mismatch: {self.param_name} != {param_name}")
@@ -57,6 +61,7 @@ class _TreeNode:
                 raise ValueError(
                     f"search_space mismatch: {set(self.children.keys())} != {set(search_space)}"
                 )
+            return self.children
 
     def set_running(self) -> None:
         self.is_running = True
@@ -70,11 +75,10 @@ class _TreeNode:
         # Add a path (i.e. a list of suggested parameters in one trial) to the tree.
         current_node = self
         for param_name, search_space, value in params_and_search_spaces:
-            current_node.expand(param_name, search_space)
-            assert current_node.children is not None
-            if value not in current_node.children:
+            next_node = current_node.expand(param_name, search_space).get(value)
+            if next_node is None:
                 return None
-            current_node = current_node.children[value]
+            current_node = next_node
         return current_node
 
     def is_any_expandable(self, exclude_running: bool) -> bool:
@@ -213,7 +217,7 @@ class BruteForceSampler(BaseSampler):
 
         for trial in trials:
             # NOTE(nabenabe): `nan` cannot be assigned as a param value.
-            if not all(trial.params.get(p, _NaN) == v for p, v in params.items()):
+            if params and not all(trial.params.get(p, _NaN) == v for p, v in params.items()):
                 continue
             leaf = tree.add_path(_gen(trial))
             if leaf is not None:

--- a/optuna/samplers/_brute_force.py
+++ b/optuna/samplers/_brute_force.py
@@ -185,14 +185,18 @@ class BruteForceSampler(BaseSampler):
     ) -> None:
         # Populate tree under given params from the given trials.
         cand_cache = {}
+        internal_repr_cache = {}
 
-        def _gen(trial: FrozenTrial):
+        def _gen(trial: FrozenTrial) -> Iterable[tuple[str, Sequence[float], float]]:
             for name, dist in trial.distributions.items():
                 if name in params:
                     continue
                 if name not in cand_cache:
                     cand_cache[name] = _enumerate_candidates(dist)
-                yield name, cand_cache[name], dist.to_internal_repr(trial.params[name])
+                cache_key = (name, param_val := trial.params[name])
+                if cache_key not in internal_repr_cache:
+                    internal_repr_cache[cache_key] = dist.to_internal_repr(param_val)
+                yield name, cand_cache[name], internal_repr_cache[cache_key]
 
         for trial in trials:
             # NOTE(nabenabe): `nan` cannot be assigned as a param value.

--- a/optuna/samplers/_brute_force.py
+++ b/optuna/samplers/_brute_force.py
@@ -73,6 +73,14 @@ class _TreeNode:
             current_node = current_node.children[value]
         return current_node
 
+    def is_any_expandable(self, exclude_running: bool) -> bool:
+        if self.children is None:
+            return not exclude_running or not self.is_running
+        else:
+            return any(
+                child.is_any_expandable(exclude_running) for child in self.children.values()
+            )
+
     def count_unexpanded(self, exclude_running: bool) -> int:
         # Count the number of unexpanded nodes in the subtree.
         if self.children is None:
@@ -187,7 +195,8 @@ class BruteForceSampler(BaseSampler):
                 yield name, cand_cache[name], dist.to_internal_repr(trial.params[name])
 
         for trial in trials:
-            if not all(p in trial.params and trial.params[p] == v for p, v in params.items()):
+            # NOTE(nabenabe): `nan` cannot be assigned as a param value.
+            if not all(trial.params.get(p, float("nan")) == v for p, v in params.items()):
                 continue
             leaf = tree.add_path(_gen(trial))
             if leaf is not None:
@@ -226,7 +235,7 @@ class BruteForceSampler(BaseSampler):
         # being initialized as an empty graph, which is created with n_jobs > 1
         # where we get trials[i].params = {} for some i.
         self._populate_tree(tree, (t for t in trials if t.number != trial.number), trial.params)
-        if tree.count_unexpanded(exclude_running) == 0:
+        if not tree.is_any_expandable(exclude_running):
             return param_distribution.to_external_repr(self._rng.rng.choice(candidates))
         else:
             return param_distribution.to_external_repr(
@@ -274,7 +283,7 @@ class BruteForceSampler(BaseSampler):
             {},
         )
 
-        if tree.count_unexpanded(exclude_running) == 0:
+        if not tree.is_any_expandable(exclude_running):
             study.stop()
 
 

--- a/optuna/samplers/_brute_force.py
+++ b/optuna/samplers/_brute_force.py
@@ -18,7 +18,6 @@ from optuna.trial import TrialState
 
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable
     from collections.abc import Sequence
 
     from optuna.distributions import BaseDistribution
@@ -45,7 +44,7 @@ class _TreeNode:
     is_running: bool = False
 
     def expand(
-        self, param_name: str | None, search_space: Iterable[float]
+        self, param_name: str | None, search_space: list[float]
     ) -> dict[float, "_TreeNode"]:
         # If the node is unexpanded, expand it.
         # Otherwise, check if the node is compatible with the given search space.
@@ -70,7 +69,7 @@ class _TreeNode:
         self.expand(None, [])
 
     def add_path(
-        self, params_and_search_spaces: Iterable[tuple[str, Iterable[float], float]]
+        self, params_and_search_spaces: list[tuple[str, list[float], float]]
     ) -> _TreeNode | None:
         # Add a path (i.e. a list of suggested parameters in one trial) to the tree.
         current_node = self
@@ -198,13 +197,14 @@ class BruteForceSampler(BaseSampler):
 
     @staticmethod
     def _populate_tree(
-        tree: _TreeNode, trials: Iterable[FrozenTrial], params: dict[str, Any]
+        tree: _TreeNode, trials: list[FrozenTrial], params: dict[str, Any]
     ) -> None:
         # Populate tree under given params from the given trials.
         cand_cache = {}
         internal_repr_cache = {}
 
-        def _gen(trial: FrozenTrial) -> Iterable[tuple[str, Sequence[float], float]]:
+        def _get_path(trial: FrozenTrial) -> list[tuple[str, list[float], float]]:
+            edges = []
             for name, dist in trial.distributions.items():
                 if name in params:
                     continue
@@ -213,13 +213,14 @@ class BruteForceSampler(BaseSampler):
                 cache_key = (name, param_val := trial.params[name])
                 if cache_key not in internal_repr_cache:
                     internal_repr_cache[cache_key] = dist.to_internal_repr(param_val)
-                yield name, cand_cache[name], internal_repr_cache[cache_key]
+                edges.append((name, cand_cache[name], internal_repr_cache[cache_key]))
+            return edges
 
         for trial in trials:
             # NOTE(nabenabe): `nan` cannot be assigned as a param value.
             if params and not all(trial.params.get(p, _NaN) == v for p, v in params.items()):
                 continue
-            leaf = tree.add_path(_gen(trial))
+            leaf = tree.add_path(_get_path(trial))
             if leaf is not None:
                 # The parameters are on the defined grid.
                 if trial.state.is_finished():
@@ -242,7 +243,7 @@ class BruteForceSampler(BaseSampler):
         # Populating must happen after the initialization above to prevent `tree` from
         # being initialized as an empty graph, which is created with n_jobs > 1
         # where we get trials[i].params = {} for some i.
-        self._populate_tree(tree, (t for t in trials if t.number != trial.number), trial.params)
+        self._populate_tree(tree, [t for t in trials if t.number != trial.number], trial.params)
         if not tree.is_any_expandable(exclude_running):
             return param_distribution.to_external_repr(self._rng.rng.choice(candidates))
         else:
@@ -265,7 +266,7 @@ class BruteForceSampler(BaseSampler):
         )
         tree = _TreeNode()
         self._populate_tree(
-            tree, (t if t.number != trial.number else current_trial for t in trials), {}
+            tree, [t if t.number != trial.number else current_trial for t in trials], {}
         )
         if not tree.is_any_expandable(exclude_running):
             study.stop()
@@ -274,7 +275,7 @@ class BruteForceSampler(BaseSampler):
             study._storage.set_study_system_attr(study._study_id, _TREE_SIZE_KEY, tree_size)
 
 
-def _enumerate_candidates(param_distribution: BaseDistribution) -> Sequence[float]:
+def _enumerate_candidates(param_distribution: BaseDistribution) -> list[float]:
     if isinstance(param_distribution, FloatDistribution):
         if param_distribution.step is None:
             raise ValueError(

--- a/optuna/samplers/_brute_force.py
+++ b/optuna/samplers/_brute_force.py
@@ -27,10 +27,10 @@ if TYPE_CHECKING:
 
 
 _TREE_SIZE_KEY = "brute_force:tree_size"
-_NaN = float("nan")
+_NaN = float("nan")  # NOTE: Define once to save runtime overhead.
 
 
-@dataclass(slots=True)
+@dataclass  # TODO(nabenabe): Add `slots=True` once Python 3.9 is dropped.
 class _TreeNode:
     # This is a class to represent the tree of search space.
 
@@ -107,7 +107,6 @@ class _TreeNode:
         weights_orig = unexpanded_counts / unexpanded_counts.sum()
         weights_flat = np.where(unexpanded_counts > 0, 1.0, 0.0)
         weights_flat /= weights_flat.sum()
-
         weights = (1.0 - alpha) * weights_orig + alpha * weights_flat
         if any(
             not value.is_running and weights[i] > 0
@@ -264,12 +263,10 @@ class BruteForceSampler(BaseSampler):
         self._populate_tree(
             tree, (t if t.number != trial.number else current_trial for t in trials), {}
         )
-
         if not tree.is_any_expandable(exclude_running):
             study.stop()
-
         if trial.number % self._tree_size_check_interval == 0:
-            tree_size = max(tree_size, tree.count_total_combinations())
+            tree_size = int(max(tree_size, tree.count_total_combinations()))
             study._storage.set_study_system_attr(study._study_id, _TREE_SIZE_KEY, tree_size)
 
 

--- a/tests/samplers_tests/test_brute_force.py
+++ b/tests/samplers_tests/test_brute_force.py
@@ -23,15 +23,17 @@ def test_tree_node_add_paths() -> None:
         if leaf.children is None:
             leaf.set_leaf()
 
+    _zs = (0, 0, 0)
     assert tree == _TreeNode(
         param_name="a",
         children={
             0: _TreeNode(
                 param_name="b",
                 children={
-                    0.0: _TreeNode(param_name=None, children={}),
-                    1.0: _TreeNode(param_name=None, children={}),
+                    0.0: _TreeNode(param_name=None, children={}, choices_fingerprint=_zs),
+                    1.0: _TreeNode(param_name=None, children={}, choices_fingerprint=_zs),
                 },
+                choices_fingerprint=(2, 0.0, 1.0),
             ),
             1: _TreeNode(
                 param_name="b",
@@ -39,15 +41,18 @@ def test_tree_node_add_paths() -> None:
                     0.0: _TreeNode(
                         param_name="c",
                         children={
-                            0: _TreeNode(param_name=None, children={}),
+                            0: _TreeNode(param_name=None, children={}, choices_fingerprint=_zs),
                             1: _TreeNode(),
                         },
+                        choices_fingerprint=(2, 0, 1),
                     ),
                     1.0: _TreeNode(),
                 },
+                choices_fingerprint=(2, 0.0, 1.0),
             ),
             2: _TreeNode(),
         },
+        choices_fingerprint=(3, 0, 2),
     )
 
 


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. To minimize the review effort, we highly appreciate PRs only with related changes. Please note that submitted PRs may be closed if they include unrelated changes or significantly modified unit tests. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
This PR attempts to speed up `BruteForceSampler` as mentioned in:
- https://github.com/optuna/optuna/issues/6071

## Description of the changes
<!-- Describe the changes in this PR. -->

### PR: Speed up `BruteForceSampler`

This PR applies several optimizations to reduce the runtime overhead of `BruteForceSampler`, particularly for `_populate_tree` and the termination check in `after_trial`.

1. **Cache candidates and internal representations during tree population**
   - `_populate_tree` now maintains `cand_cache` and `internal_repr_cache` dicts so that `_enumerate_candidates(dist)` and `dist.to_internal_repr(...)` are called at most once per unique `(name, value)` pair across all trials, instead of once per trial.
   - The per-trial param filtering was simplified from `all(p in trial.params and trial.params[p] == v ...)` to `all(trial.params.get(p, _NaN) == v ...)`, using a module-level `_NaN` sentinel.

2. **Replace `count_unexpanded() == 0` with `is_any_expandable()`**
   - Added `_TreeNode.is_any_expandable()` which short-circuits via `any(...)` as soon as one expandable leaf is found, instead of counting every unexpanded node in the entire tree.

3. **Skip termination check using cached tree size**
   - Added `_TreeNode.count_total_combinations()` to compute the total number of leaf nodes.
   - In `after_trial`, the total combination count is periodically (every 500 trials) stored as a study system attribute (`brute_force:tree_size`). If `len(trials) < tree_size`, the termination check is skipped entirely — the study can't possibly be exhausted yet.

4. **Extract `_get_non_waiting_trials()` helper** — deduplicates the storage query that was previously inlined in both `sample_independent` and `after_trial`.

5. **Minor cleanups** — added a `TODO` comment for `slots=True` on `_TreeNode`, removed a stray blank line, and reformatted the `after_trial` signature to fit on fewer lines.


---

## Benchmarking Results

<img width="601" height="449" alt="runtime" src="https://github.com/user-attachments/assets/eb01b435-90e9-431e-a699-21e33e73e93e" />


<details>
<summary>Script</summary>

```python
from argparse import ArgumentParser

import optuna


parser = ArgumentParser()
parser.add_argument("--n_params", type=int, default=5)
parser.add_argument("--n_choices", type=int, default=5)
args = parser.parse_args()
n_params = args.n_params
n_choices = args.n_choices
search_space = {f"c{i}": [str(i) for i in range(n_choices)] for i in range(n_params)}


def objective(trial: optuna.Trial) -> float:
    for k, v in search_space.items():
        trial.suggest_categorical(k, v)
    return 0.0


def experiment(
    n_trials: int | None = None, skip_grid: bool = False
) -> tuple[list[float], list[float]]:
    study = optuna.create_study(sampler=optuna.samplers.BruteForceSampler(seed=0))
    study.optimize(objective, n_trials=n_trials)
    start = study.trials[0].datetime_start
    runtime_brute_force = [(t.datetime_complete - start).total_seconds() for t in study.trials]
    if skip_grid:
        return runtime_brute_force, []

    study = optuna.create_study(sampler=optuna.samplers.GridSampler(search_space=search_space, seed=0))
    study.optimize(objective, n_trials=n_trials)
    start = study.trials[0].datetime_start
    runtime_grid = [(t.datetime_complete - start).total_seconds() for t in study.trials]
    return runtime_brute_force, runtime_grid


def plot() -> None:
    import matplotlib.pyplot as plt

    plt.rcParams["font.family"] = "Times New Roman"
    plt.rcParams["font.size"] = 18
    plt.rcParams["mathtext.fontset"] = "stix"  # The setting of math font
    plt.rcParams["text.usetex"] = True
    runtime_brute_force, runtime_grid = experiment()
    dx = [i + 1 for i in range(len(runtime_grid))]
    _, ax = plt.subplots()
    ax.plot(dx, runtime_brute_force, color="blue", label="BruteForceSampler")
    ax.plot(dx, runtime_grid, color="red", label="GridSampler")
    ax.legend()
    ax.set_xlabel("Number of Trials")
    ax.set_ylabel("Runtime [s]")
    ax.grid(which="minor", color="gray", linestyle=":")
    ax.grid(which="major", color="black")
    ax.set_yscale("log")
    plt.savefig("runtime.png", bbox_inches="tight")


if __name__ == "__main__":
    plot()

```

</details>