### PR TITLE
Fix the return type of `BruteForceSampler`

### DIFF
--- a/optuna/samplers/_brute_force.py
+++ b/optuna/samplers/_brute_force.py
@@ -105,7 +105,7 @@ class _TreeNode:
                 if child.is_running:
                     weights[i] = 0.0
         weights /= weights.sum()
-        return rng.choice(list(self.children.keys()), p=weights)
+        return rng.choice(list(self.children.keys()), p=weights).item()
 
 
 @experimental_class("3.1.0")
@@ -227,7 +227,7 @@ class BruteForceSampler(BaseSampler):
         # where we get trials[i].params = {} for some i.
         self._populate_tree(tree, (t for t in trials if t.number != trial.number), trial.params)
         if tree.count_unexpanded(exclude_running) == 0:
-            return param_distribution.to_external_repr(self._rng.rng.choice(candidates))
+            return param_distribution.to_external_repr(self._rng.rng.choice(candidates).item())
         else:
             return param_distribution.to_external_repr(
                 tree.sample_child(self._rng.rng, exclude_running)


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. To minimize the review effort, we highly appreciate PRs only with related changes. Please note that submitted PRs may be closed if they include unrelated changes or significantly modified unit tests. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

Currently, BruteForceSampler returns numpy.float, so I fixed it.

## Description of the changes
<!-- Describe the changes in this PR. -->

- Return float instead of numpy.float