### PR TITLE
fix: collect all infeasible values in error message instead of early return

### DIFF
--- a/optuna/study/_tell.py
+++ b/optuna/study/_tell.py
@@ -58,23 +58,22 @@ def _check_state_and_values(
 
 
 def _check_values_are_feasible(study: Study, values: Sequence[float]) -> str | None:
+    errors = []
     for v in values:
-        # TODO(Imamura): Construct error message taking into account all values and do not early
-        # return `value` is assumed to be ignored on failure so we can set it to any value.
         try:
             float(v)
         except (ValueError, TypeError):
-            return f"The value {repr(v)} could not be cast to float"
-
+            errors.append(f"The value {repr(v)} could not be cast to float")
+            continue
         if math.isnan(v):
-            return f"The value {v} is not acceptable"
-
+            errors.append(f"The value {v} is not acceptable")
+    if errors:
+        return "; ".join(errors)
     if len(study.directions) != len(values):
         return (
             f"The number of the values {len(values)} did not match the number of the objectives "
             f"{len(study.directions)}"
         )
-
     return None
 
 

--- a/tests/study_tests/test_study.py
+++ b/tests/study_tests/test_study.py
@@ -1489,15 +1489,6 @@ def test_tell_automatically_fail() -> None:
         assert study.trials[-1].state == TrialState.FAIL
         assert study.trials[-1].values is None
 
-    # Check that all invalid values are reported together (not just the first one).
-    study_mo = create_study(directions=["minimize", "minimize"])
-    with pytest.warns(UserWarning, match="could not be cast to float") as warning_info:
-        study_mo.tell(study_mo.ask(), ["a", float("nan")])  # type: ignore
-        assert len(study_mo.trials) == 1
-        assert study_mo.trials[-1].state == TrialState.FAIL
-        assert study_mo.trials[-1].values is None
-    assert "nan" in str(warning_info[0].message)
-
 
 def test_tell_multi_objective() -> None:
     study = create_study(directions=["minimize", "maximize"])

--- a/tests/study_tests/test_study.py
+++ b/tests/study_tests/test_study.py
@@ -1489,6 +1489,15 @@ def test_tell_automatically_fail() -> None:
         assert study.trials[-1].state == TrialState.FAIL
         assert study.trials[-1].values is None
 
+    # Check that all invalid values are reported together (not just the first one).
+    study_mo = create_study(directions=["minimize", "minimize"])
+    with pytest.warns(UserWarning, match="could not be cast to float") as warning_info:
+        study_mo.tell(study_mo.ask(), ["a", float("nan")])  # type: ignore
+        assert len(study_mo.trials) == 1
+        assert study_mo.trials[-1].state == TrialState.FAIL
+        assert study_mo.trials[-1].values is None
+    assert "nan" in str(warning_info[0].message)
+
 
 def test_tell_multi_objective() -> None:
     study = create_study(directions=["minimize", "maximize"])


### PR DESCRIPTION
Resolves a TODO left by @Imamura in `_check_values_are_feasible`.

Previously the function returned on the first invalid value, so users 
only saw one error at a time when multiple values were infeasible.

This change collects all errors and returns them together in a single 
message, making it easier to debug multi-objective studies with multiple 
bad values.