### PR TITLE
Deprecate `optuna.terminator` module

### DIFF
--- a/docs/source/reference/terminator.rst
+++ b/docs/source/reference/terminator.rst
@@ -5,6 +5,12 @@ optuna.terminator
 
 The :mod:`~optuna.terminator` module implements a mechanism for automatically terminating the optimization process, accompanied by a callback class for the termination and evaluators for the estimated room for improvement in the optimization and statistical error of the objective function. The terminator stops the optimization process when the estimated potential improvement is smaller than the statistical error.
 
+.. warning::
+
+   Deprecated in v4.9.0. The :mod:`~optuna.terminator` module will be removed
+   in v6.0.0. Its functionality is planned to be published in
+   https://github.com/optuna/optunahub-registry.
+
 .. autosummary::
    :toctree: generated/
    :nosignatures:

--- a/docs/source/reference/terminator.rst
+++ b/docs/source/reference/terminator.rst
@@ -9,7 +9,7 @@ The :mod:`~optuna.terminator` module implements a mechanism for automatically te
 
    Deprecated in v4.9.0. The :mod:`~optuna.terminator` module will be removed
    in v6.0.0. Its functionality is planned to be published in
-   https://github.com/optuna/optunahub-registry.
+   https://hub.optuna.org.
 
 .. autosummary::
    :toctree: generated/

--- a/optuna/terminator/callback.py
+++ b/optuna/terminator/callback.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from optuna._deprecated import deprecated_class
 from optuna._experimental import experimental_class
 from optuna.logging import get_logger
 from optuna.terminator.terminator import Terminator
@@ -16,6 +17,7 @@ if TYPE_CHECKING:
 _logger = get_logger(__name__)
 
 
+@deprecated_class("4.9.0", "6.0.0", name="`optuna.terminator.TerminatorCallback`")
 @experimental_class("3.2.0")
 class TerminatorCallback:
     """A callback that terminates the optimization using Terminator.

--- a/optuna/terminator/callback.py
+++ b/optuna/terminator/callback.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from optuna._deprecated import deprecated_class
-from optuna._experimental import experimental_class
+from optuna._deprecated import _DEPRECATION_WARNING_TEMPLATE
+from optuna._warnings import optuna_warn
 from optuna.logging import get_logger
 from optuna.terminator.terminator import Terminator
 
@@ -16,9 +16,13 @@ if TYPE_CHECKING:
 
 _logger = get_logger(__name__)
 
+_DEPRECATION_WARNING_MESSAGE = _DEPRECATION_WARNING_TEMPLATE.format(
+    name="`optuna.terminator` module",
+    d_ver="4.9.0",
+    r_ver="6.0.0",
+)
 
-@deprecated_class("4.9.0", "6.0.0", name="`optuna.terminator.TerminatorCallback`")
-@experimental_class("3.2.0")
+
 class TerminatorCallback:
     """A callback that terminates the optimization using Terminator.
 
@@ -70,6 +74,7 @@ class TerminatorCallback:
     """
 
     def __init__(self, terminator: BaseTerminator | None = None) -> None:
+        optuna_warn(_DEPRECATION_WARNING_MESSAGE, FutureWarning)
         self._terminator = terminator or Terminator()
 
     def __call__(self, study: Study, trial: FrozenTrial) -> None:

--- a/optuna/terminator/erroreval.py
+++ b/optuna/terminator/erroreval.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
+from optuna._deprecated import deprecated_func
 from optuna._experimental import experimental_class
 from optuna.study import StudyDirection
 from optuna.trial._state import TrialState
@@ -89,6 +90,11 @@ class CrossValidationErrorEvaluator(BaseErrorEvaluator):
         return float(std)
 
 
+@deprecated_func(
+    "4.9.0",
+    "6.0.0",
+    name="`optuna.terminator.report_cross_validation_scores`",
+)
 @experimental_class("3.2.0")
 def report_cross_validation_scores(trial: Trial, scores: list[float]) -> None:
     """A function to report cross-validation scores of a trial.

--- a/optuna/terminator/erroreval.py
+++ b/optuna/terminator/erroreval.py
@@ -6,8 +6,9 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
-from optuna._deprecated import deprecated_func
+from optuna._deprecated import _DEPRECATION_WARNING_TEMPLATE
 from optuna._experimental import experimental_class
+from optuna._warnings import optuna_warn
 from optuna.study import StudyDirection
 from optuna.trial._state import TrialState
 
@@ -18,6 +19,11 @@ if TYPE_CHECKING:
 
 
 _CROSS_VALIDATION_SCORES_KEY = "terminator:cv_scores"
+_DEPRECATION_WARNING_MESSAGE = _DEPRECATION_WARNING_TEMPLATE.format(
+    name="`optuna.terminator` module",
+    d_ver="4.9.0",
+    r_ver="6.0.0",
+)
 
 
 class BaseErrorEvaluator(metaclass=abc.ABCMeta):
@@ -90,12 +96,6 @@ class CrossValidationErrorEvaluator(BaseErrorEvaluator):
         return float(std)
 
 
-@deprecated_func(
-    "4.9.0",
-    "6.0.0",
-    name="`optuna.terminator.report_cross_validation_scores`",
-)
-@experimental_class("3.2.0")
 def report_cross_validation_scores(trial: Trial, scores: list[float]) -> None:
     """A function to report cross-validation scores of a trial.
 
@@ -110,6 +110,8 @@ def report_cross_validation_scores(trial: Trial, scores: list[float]) -> None:
             The cross-validation scores of the trial.
 
     """
+    optuna_warn(_DEPRECATION_WARNING_MESSAGE, FutureWarning)
+
     if len(scores) <= 1:
         raise ValueError("The length of `scores` is expected to be greater than one.")
     trial.storage.set_trial_system_attr(trial._trial_id, _CROSS_VALIDATION_SCORES_KEY, scores)

--- a/optuna/terminator/terminator.py
+++ b/optuna/terminator/terminator.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import abc
 
+from optuna._deprecated import deprecated_class
 from optuna._experimental import experimental_class
 from optuna.study.study import Study
 from optuna.terminator.erroreval import BaseErrorEvaluator
@@ -22,6 +23,7 @@ class BaseTerminator(metaclass=abc.ABCMeta):
         pass
 
 
+@deprecated_class("4.9.0", "6.0.0", name="`optuna.terminator.Terminator`")
 @experimental_class("3.2.0")
 class Terminator(BaseTerminator):
     """Automatic stopping mechanism for Optuna studies.

--- a/optuna/terminator/terminator.py
+++ b/optuna/terminator/terminator.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import abc
 
-from optuna._deprecated import deprecated_class
-from optuna._experimental import experimental_class
+from optuna._deprecated import _DEPRECATION_WARNING_TEMPLATE
+from optuna._warnings import optuna_warn
 from optuna.study.study import Study
 from optuna.terminator.erroreval import BaseErrorEvaluator
 from optuna.terminator.erroreval import CrossValidationErrorEvaluator
@@ -15,6 +15,13 @@ from optuna.terminator.improvement.evaluator import RegretBoundEvaluator
 from optuna.trial import TrialState
 
 
+_DEPRECATION_WARNING_MESSAGE = _DEPRECATION_WARNING_TEMPLATE.format(
+    name="`optuna.terminator` module",
+    d_ver="4.9.0",
+    r_ver="6.0.0",
+)
+
+
 class BaseTerminator(metaclass=abc.ABCMeta):
     """Base class for terminators."""
 
@@ -23,8 +30,6 @@ class BaseTerminator(metaclass=abc.ABCMeta):
         pass
 
 
-@deprecated_class("4.9.0", "6.0.0", name="`optuna.terminator.Terminator`")
-@experimental_class("3.2.0")
 class Terminator(BaseTerminator):
     """Automatic stopping mechanism for Optuna studies.
 
@@ -106,6 +111,8 @@ class Terminator(BaseTerminator):
         error_evaluator: BaseErrorEvaluator | None = None,
         min_n_trials: int = DEFAULT_MIN_N_TRIALS,
     ) -> None:
+        optuna_warn(_DEPRECATION_WARNING_MESSAGE, FutureWarning)
+
         if min_n_trials <= 0:
             raise ValueError("`min_n_trials` is expected to be a positive integer.")
 


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. To minimize the review effort, we highly appreciate PRs only with related changes. Please note that submitted PRs may be closed if they include unrelated changes or significantly modified unit tests. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation

We plan to remove `optuna.terminator` in v6.0.0.

To start guiding users away from this module, this PR adds deprecation warnings to the main entry points of the terminator API. This module is planned to be migrated to OptunaHub in the near future. However, that migration is not ready yet, so this PR only introduces the deprecation warnings for now.

  ## Description of the changes

- Add deprecation warnings for `optuna.terminator.Terminator`,  `optuna.terminator.TerminatorCallback`, and  `optuna.terminator.report_cross_validation_scores`.
- Limit the warnings to the main public entry points to avoid excessive warnings from internally instantiated evaluator classes
- As a follow-up, once the OptunaHub migration is ready, we can update the deprecation messages to explicitly guide users to the new alternative.