### PR TITLE
Rename `RetryFailedTrialCallback` to `RetryHeartbeatStaleTrialCallback`

### DIFF
--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -631,21 +631,23 @@ from :obj:`~optuna.trial.TrialState.RUNNING`.
             if (datetime.now() - t.datetime_start).total_seconds() > grace_period:
                 study.tell(t, state=optuna.trial.TrialState.FAIL)
 
-You can also execute a callback function to process the failed trial.
-Optuna provides a callback to retry failed trials as :class:`~optuna.storages.RetryFailedTrialCallback`.
-Note that a callback is invoked at a beginning of each trial, which means :class:`~optuna.storages.RetryFailedTrialCallback`
-will retry failed trials when a new trial starts to evaluate.
+You can also execute a callback function to process heartbeat-stale trials.
+Optuna provides a callback to retry heartbeat-stale trials as
+:class:`~optuna.storages.RetryHeartbeatStaleTrialCallback`. Note that a callback is invoked at
+the beginning of each trial, which means
+:class:`~optuna.storages.RetryHeartbeatStaleTrialCallback` will retry heartbeat-stale trials when
+a new trial starts to evaluate.
 
 .. code-block:: python
 
     import optuna
-    from optuna.storages import RetryFailedTrialCallback
+    from optuna.storages import RetryHeartbeatStaleTrialCallback
 
     storage = optuna.storages.RDBStorage(
         url="sqlite:///:memory:",
         heartbeat_interval=60,
         grace_period=120,
-        failed_trial_callback=RetryFailedTrialCallback(max_retry=3),
+        heartbeat_stale_trial_callback=RetryHeartbeatStaleTrialCallback(max_retry=3),
     )
 
     study = optuna.create_study(storage=storage)

--- a/docs/source/reference/storages.rst
+++ b/docs/source/reference/storages.rst
@@ -10,7 +10,7 @@ The :mod:`~optuna.storages` module defines a :class:`~optuna.storages.BaseStorag
    :nosignatures:
 
    RDBStorage
-   RetryFailedTrialCallback
+   RetryHeartbeatStaleTrialCallback
    fail_stale_trials
    JournalStorage
    InMemoryStorage

--- a/optuna/samplers/_grid.py
+++ b/optuna/samplers/_grid.py
@@ -133,7 +133,8 @@ class GridSampler(BaseSampler):
         # object is hard to get at the beginning of trial, while we need the access to the object
         # to validate the sampled value.
 
-        # When the trial is created by RetryFailedTrialCallback or enqueue_trial, we should not
+        # When the trial is created by RetryHeartbeatStaleTrialCallback or enqueue_trial, we
+        # should not
         # assign a new grid_id.
         if "grid_id" in trial.system_attrs or "fixed_params" in trial.system_attrs:
             return

--- a/optuna/samplers/_grid.py
+++ b/optuna/samplers/_grid.py
@@ -134,8 +134,7 @@ class GridSampler(BaseSampler):
         # to validate the sampled value.
 
         # When the trial is created by RetryHeartbeatStaleTrialCallback or enqueue_trial, we
-        # should not
-        # assign a new grid_id.
+        # should not assign a new grid_id.
         if "grid_id" in trial.system_attrs or "fixed_params" in trial.system_attrs:
             return
 

--- a/optuna/storages/__init__.py
+++ b/optuna/storages/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from optuna.storages._base import BaseStorage
 from optuna.storages._cached_storage import _CachedStorage
 from optuna.storages._callbacks import RetryFailedTrialCallback
+from optuna.storages._callbacks import RetryHeartbeatStaleTrialCallback
 from optuna.storages._grpc import GrpcStorageProxy
 from optuna.storages._grpc import run_grpc_proxy_server
 from optuna.storages._heartbeat import fail_stale_trials
@@ -28,6 +29,7 @@ __all__ = [
     "JournalRedisStorage",
     "JournalFileSymlinkLock",
     "JournalFileOpenLock",
+    "RetryHeartbeatStaleTrialCallback",
     "RetryFailedTrialCallback",
     "_CachedStorage",
     "fail_stale_trials",

--- a/optuna/storages/_cached_storage.py
+++ b/optuna/storages/_cached_storage.py
@@ -289,5 +289,7 @@ class _CachedStorage(BaseStorage, BaseHeartbeat):
     def get_heartbeat_interval(self) -> int | None:
         return self._backend.get_heartbeat_interval()
 
-    def get_failed_trial_callback(self) -> Callable[["optuna.Study", FrozenTrial], None] | None:
-        return self._backend.get_failed_trial_callback()
+    def get_heartbeat_stale_trial_callback(
+        self,
+    ) -> Callable[["optuna.Study", FrozenTrial], None] | None:
+        return self._backend.get_heartbeat_stale_trial_callback()

--- a/optuna/storages/_callbacks.py
+++ b/optuna/storages/_callbacks.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 class RetryHeartbeatStaleTrialCallback:
     """Retry a heartbeat-stale trial up to a maximum number of times.
 
-    When a running trial becomes stale due to the RDB heartbeat mechanism, this callback can be
+    When a running trial becomes stale due to the heartbeat mechanism, this callback can be
     used with a class in :mod:`optuna.storages` to recreate the trial in ``TrialState.WAITING``
     to queue up the trial to be run again.
 

--- a/optuna/storages/_callbacks.py
+++ b/optuna/storages/_callbacks.py
@@ -4,6 +4,7 @@ from typing import Any
 from typing import TYPE_CHECKING
 
 import optuna
+from optuna._deprecated import deprecated_class
 from optuna._experimental import experimental_class
 from optuna._experimental import experimental_func
 
@@ -13,34 +14,35 @@ if TYPE_CHECKING:
 
 
 @experimental_class("2.8.0")
-class RetryFailedTrialCallback:
-    """Retry a failed trial up to a maximum number of times.
+class RetryHeartbeatStaleTrialCallback:
+    """Retry a heartbeat-stale trial up to a maximum number of times.
 
-    When a trial fails, this callback can be used with a class in :mod:`optuna.storages` to
-    recreate the trial in ``TrialState.WAITING`` to queue up the trial to be run again.
+    When a running trial becomes stale due to the RDB heartbeat mechanism, this callback can be
+    used with a class in :mod:`optuna.storages` to recreate the trial in ``TrialState.WAITING``
+    to queue up the trial to be run again.
 
-    The failed trial can be identified by the
-    :func:`~optuna.storages.RetryFailedTrialCallback.retried_trial_number` function.
-    Even if repetitive failure occurs (a retried trial fails again),
-    this method returns the number of the original trial.
-    To get a full list including the numbers of the retried trials as well as their original trial,
-    call the :func:`~optuna.storages.RetryFailedTrialCallback.retry_history` function.
+    The original stale trial can be identified by the
+    :func:`~optuna.storages.RetryHeartbeatStaleTrialCallback.retried_trial_number` function.
+    Even if repetitive failure occurs (a retried trial becomes stale again), this method returns
+    the number of the original trial. To get a full list including the numbers of the retried
+    trials as well as their original trial, call the
+    :func:`~optuna.storages.RetryHeartbeatStaleTrialCallback.retry_history` function.
 
-    This callback is helpful in environments where trials may fail due to external conditions,
-    such as being preempted by other processes.
+    This callback is helpful in environments where running trials may become stale due to external
+    conditions, such as worker preemption or unexpected process termination.
 
     Usage:
 
         .. testcode::
 
             import optuna
-            from optuna.storages import RetryFailedTrialCallback
+            from optuna.storages import RetryHeartbeatStaleTrialCallback
 
             storage = optuna.storages.RDBStorage(
                 url="sqlite:///:memory:",
                 heartbeat_interval=60,
                 grace_period=120,
-                failed_trial_callback=RetryFailedTrialCallback(max_retry=3),
+                heartbeat_stale_trial_callback=RetryHeartbeatStaleTrialCallback(max_retry=3),
             )
 
             study = optuna.create_study(
@@ -118,8 +120,22 @@ class RetryFailedTrialCallback:
         Returns:
             A list of trial numbers in ascending order of the series of retried trials.
             The first item of the list indicates the original trial which is identical
-            to the :func:`~optuna.storages.RetryFailedTrialCallback.retried_trial_number`,
+            to the :func:`~optuna.storages.RetryHeartbeatStaleTrialCallback.retried_trial_number`,
             and the last item is the one right before the specified trial in the retry series.
             If the specified trial is not a retry of any trial, returns an empty list.
         """
         return trial.system_attrs.get("retry_history", [])
+
+
+@deprecated_class(
+    "4.9.0",
+    "6.0.0",
+    text="Use `RetryHeartbeatStaleTrialCallback` instead.",
+)
+class RetryFailedTrialCallback(RetryHeartbeatStaleTrialCallback):
+    """Deprecated alias of :class:`~optuna.storages.RetryHeartbeatStaleTrialCallback`.
+
+    Deprecated in v4.9.0. This class will be removed in v6.0.0.
+    """
+
+    pass

--- a/optuna/storages/_heartbeat.py
+++ b/optuna/storages/_heartbeat.py
@@ -8,6 +8,7 @@ from threading import Thread
 from types import TracebackType
 
 import optuna
+from optuna._deprecated import deprecated_func
 from optuna._experimental import experimental_func
 from optuna.storages import BaseStorage
 from optuna.trial import FrozenTrial
@@ -61,13 +62,24 @@ class BaseHeartbeat(metaclass=abc.ABCMeta):
         raise NotImplementedError()
 
     @abc.abstractmethod
-    def get_failed_trial_callback(self) -> Callable[["optuna.Study", FrozenTrial], None] | None:
-        """Get the failed trial callback function.
+    def get_heartbeat_stale_trial_callback(
+        self,
+    ) -> Callable[["optuna.Study", FrozenTrial], None] | None:
+        """Get the heartbeat-stale trial callback function.
 
         Returns:
-            The failed trial callback function if it is set, otherwise :obj:`None`.
+            The heartbeat-stale trial callback function if it is set, otherwise :obj:`None`.
         """
         raise NotImplementedError()
+
+    @deprecated_func(
+        "4.9.0",
+        "6.0.0",
+        text="Use `get_heartbeat_stale_trial_callback` instead.",
+    )
+    def get_failed_trial_callback(self) -> Callable[["optuna.Study", FrozenTrial], None] | None:
+        """Get the failed trial callback function."""
+        return self.get_heartbeat_stale_trial_callback()
 
 
 class BaseHeartbeatThread(metaclass=abc.ABCMeta):
@@ -173,11 +185,11 @@ def fail_stale_trials(study: "optuna.Study") -> None:
             # optuna.exceptions.UpdateFinishedTrialError.
             pass
 
-    failed_trial_callback = storage.get_failed_trial_callback()
-    if failed_trial_callback is not None:
+    heartbeat_stale_trial_callback = storage.get_heartbeat_stale_trial_callback()
+    if heartbeat_stale_trial_callback is not None:
         for trial_id in failed_trial_ids:
             failed_trial = copy.deepcopy(storage.get_trial(trial_id))
-            failed_trial_callback(study, failed_trial)
+            heartbeat_stale_trial_callback(study, failed_trial)
 
 
 def is_heartbeat_enabled(storage: BaseStorage) -> bool:

--- a/optuna/storages/_rdb/storage.py
+++ b/optuna/storages/_rdb/storage.py
@@ -229,13 +229,9 @@ class RDBStorage(BaseStorage, BaseHeartbeat):
                 warn_experimental_argument("heartbeat_interval")
         if grace_period is not None and grace_period <= 0:
             raise ValueError("The value of `grace_period` should be a positive integer.")
-        if (
-            heartbeat_stale_trial_callback is not None
-            and failed_trial_callback is not None
-        ):
+        if heartbeat_stale_trial_callback is not None and failed_trial_callback is not None:
             raise ValueError(
-                "Specify only one of `heartbeat_stale_trial_callback` and "
-                "`failed_trial_callback`."
+                "Specify only one of `heartbeat_stale_trial_callback` and `failed_trial_callback`."
             )
         if failed_trial_callback is not None:
             msg = _deprecated._DEPRECATION_WARNING_TEMPLATE.format(

--- a/optuna/storages/_rdb/storage.py
+++ b/optuna/storages/_rdb/storage.py
@@ -21,11 +21,13 @@ from typing import TYPE_CHECKING
 import uuid
 
 import optuna
+from optuna import _deprecated
 from optuna import distributions
 from optuna import version
 from optuna._experimental import warn_experimental_argument
 from optuna._imports import _LazyImport
 from optuna._typing import JSONSerializable
+from optuna._warnings import optuna_warn
 from optuna.storages._base import BaseStorage
 from optuna.storages._base import DEFAULT_STUDY_NAME_PREFIX
 from optuna.storages._heartbeat import BaseHeartbeat
@@ -156,14 +158,17 @@ class RDBStorage(BaseStorage, BaseHeartbeat):
             Grace period before a running trial is failed from the last heartbeat.
             ``grace_period`` must be :obj:`None` or a positive integer.
             If it is :obj:`None`, the grace period will be `2 * heartbeat_interval`.
-        failed_trial_callback:
-            A callback function that is invoked after failing each stale trial.
+        heartbeat_stale_trial_callback:
+            A callback function that is invoked after failing each heartbeat-stale trial.
             The function must accept two parameters with the following types in this order:
             :class:`~optuna.study.Study` and :class:`~optuna.trial.FrozenTrial`.
 
             .. note::
                 The procedure to fail existing stale trials is called just before asking the
                 study for a new trial.
+        failed_trial_callback:
+            Deprecated in v4.9.0. This argument will be removed in v6.0.0.
+            Use ``heartbeat_stale_trial_callback`` instead.
 
         skip_table_creation:
             Flag to skip table creation if set to :obj:`True`.
@@ -188,14 +193,15 @@ class RDBStorage(BaseStorage, BaseHeartbeat):
     .. note::
         Mainly in a cluster environment, running trials are often killed unexpectedly.
         If you want to detect a failure of trials, please use the heartbeat
-        mechanism. Set ``heartbeat_interval``, ``grace_period``, and ``failed_trial_callback``
-        appropriately according to your use case. For more details, please refer to the
-        :ref:`tutorial <heartbeat_monitoring>` and `Example page
+        mechanism. Set ``heartbeat_interval``, ``grace_period``, and
+        ``heartbeat_stale_trial_callback`` appropriately according to your use case.
+        For more details, please refer to the :ref:`tutorial <heartbeat_monitoring>` and
+        `Example page
         <https://github.com/optuna/optuna-examples/blob/main/pytorch/pytorch_checkpoint.py>`__.
 
     .. seealso::
-        You can use :class:`~optuna.storages.RetryFailedTrialCallback` to automatically retry
-        failed trials detected by heartbeat.
+        You can use :class:`~optuna.storages.RetryHeartbeatStaleTrialCallback` to automatically
+        retry heartbeat-stale trials.
 
     """
 
@@ -207,6 +213,9 @@ class RDBStorage(BaseStorage, BaseHeartbeat):
         *,
         heartbeat_interval: int | None = None,
         grace_period: int | None = None,
+        heartbeat_stale_trial_callback: (
+            Callable[["optuna.study.Study", FrozenTrial], None] | None
+        ) = None,
         failed_trial_callback: Callable[["optuna.study.Study", FrozenTrial], None] | None = None,
         skip_table_creation: bool = False,
     ) -> None:
@@ -220,9 +229,28 @@ class RDBStorage(BaseStorage, BaseHeartbeat):
                 warn_experimental_argument("heartbeat_interval")
         if grace_period is not None and grace_period <= 0:
             raise ValueError("The value of `grace_period` should be a positive integer.")
+        if (
+            heartbeat_stale_trial_callback is not None
+            and failed_trial_callback is not None
+        ):
+            raise ValueError(
+                "Specify only one of `heartbeat_stale_trial_callback` and "
+                "`failed_trial_callback`."
+            )
+        if failed_trial_callback is not None:
+            msg = _deprecated._DEPRECATION_WARNING_TEMPLATE.format(
+                name="`failed_trial_callback`", d_ver="4.9.0", r_ver="6.0.0"
+            )
+            optuna_warn(
+                f"{msg} Use `heartbeat_stale_trial_callback` instead.",
+                FutureWarning,
+            )
         self.heartbeat_interval = heartbeat_interval
         self.grace_period = grace_period
-        self.failed_trial_callback = failed_trial_callback
+        self.heartbeat_stale_trial_callback = (
+            heartbeat_stale_trial_callback or failed_trial_callback
+        )
+        self.failed_trial_callback = self.heartbeat_stale_trial_callback
 
         self._set_default_engine_kwargs_for_mysql(url, self.engine_kwargs)
 
@@ -1070,10 +1098,10 @@ class RDBStorage(BaseStorage, BaseHeartbeat):
     def get_heartbeat_interval(self) -> int | None:
         return self.heartbeat_interval
 
-    def get_failed_trial_callback(
+    def get_heartbeat_stale_trial_callback(
         self,
     ) -> Callable[["optuna.study.Study", FrozenTrial], None] | None:
-        return self.failed_trial_callback
+        return self.heartbeat_stale_trial_callback
 
 
 class _VersionManager:

--- a/tests/samplers_tests/test_grid.py
+++ b/tests/samplers_tests/test_grid.py
@@ -11,7 +11,7 @@ import pytest
 import optuna
 from optuna import samplers
 from optuna.samplers._grid import GridValueType
-from optuna.storages import RetryFailedTrialCallback
+from optuna.storages import RetryHeartbeatStaleTrialCallback
 from optuna.testing.objectives import fail_objective
 from optuna.testing.objectives import pruned_objective
 from optuna.testing.storages import StorageSupplier
@@ -199,7 +199,7 @@ def test_retried_trial() -> None:
     trial = study.ask()
     trial.suggest_int("a", 0, 100)
 
-    callback = RetryFailedTrialCallback()
+    callback = RetryHeartbeatStaleTrialCallback()
     callback(study, study.trials[0])
 
     study.optimize(lambda trial: trial.suggest_int("a", 0, 100))

--- a/tests/storages_tests/test_callbacks.py
+++ b/tests/storages_tests/test_callbacks.py
@@ -1,5 +1,5 @@
 import optuna
-from optuna.storages import RetryFailedTrialCallback
+from optuna.storages import RetryHeartbeatStaleTrialCallback
 from optuna.testing.storages import StorageSupplier
 from optuna.trial import TrialState
 
@@ -10,14 +10,14 @@ def test_retry_history_with_success() -> None:
         study = optuna.create_study(storage=storage)
         trial = study.ask()
         study.tell(trial, 1.0)  # Complete the trial to get FrozenTrial.
-        assert RetryFailedTrialCallback.retry_history(study.trials[0]) == []
+        assert RetryHeartbeatStaleTrialCallback.retry_history(study.trials[0]) == []
 
 
 def test_retry_history_with_failures() -> None:
     max_retry = 3
-    callback = RetryFailedTrialCallback(max_retry=max_retry)
+    callback = RetryHeartbeatStaleTrialCallback(max_retry=max_retry)
     with StorageSupplier(
-        "sqlite", heartbeat_interval=1, grace_period=2, failed_trial_callback=callback
+        "sqlite", heartbeat_interval=1, grace_period=2, heartbeat_stale_trial_callback=callback
     ) as storage:
         study = optuna.create_study(storage=storage)
         for n_retries in range(1, max_retry + 1):
@@ -33,16 +33,16 @@ def test_retry_history_with_failures() -> None:
             # The last trial before the retried trial must be failed.
             assert trials[trial.number].state == TrialState.FAIL
             # Retry should show the full history of the previous trials.
-            assert RetryFailedTrialCallback.retry_history(trials[trial.number + 1]) == list(
-                range(n_retries)
-            )
+            assert RetryHeartbeatStaleTrialCallback.retry_history(
+                trials[trial.number + 1]
+            ) == list(range(n_retries))
 
 
 def test_retry_history_with_more_than_max_retry() -> None:
     max_retry = 3
-    callback = RetryFailedTrialCallback(max_retry=max_retry)
+    callback = RetryHeartbeatStaleTrialCallback(max_retry=max_retry)
     with StorageSupplier(
-        "sqlite", heartbeat_interval=1, grace_period=2, failed_trial_callback=callback
+        "sqlite", heartbeat_interval=1, grace_period=2, heartbeat_stale_trial_callback=callback
     ) as storage:
         study = optuna.create_study(storage=storage)
         for n_retries in range(max_retry + 2):

--- a/tests/storages_tests/test_heartbeat.py
+++ b/tests/storages_tests/test_heartbeat.py
@@ -254,7 +254,6 @@ def test_fail_stale_trials(grace_period: int | None) -> None:
         storage.heartbeat_interval = heartbeat_interval
         storage.grace_period = grace_period
         storage.heartbeat_stale_trial_callback = heartbeat_stale_trial_callback
-        storage.failed_trial_callback = heartbeat_stale_trial_callback
         study = optuna.create_study(storage=storage)
         study._storage.set_study_system_attr(study._study_id, "test", "A")
 

--- a/tests/storages_tests/test_heartbeat.py
+++ b/tests/storages_tests/test_heartbeat.py
@@ -14,7 +14,8 @@ import optuna
 from optuna import Study
 from optuna.exceptions import ExperimentalWarning
 from optuna.storages import RDBStorage
-from optuna.storages._callbacks import RetryFailedTrialCallback
+from optuna.storages import RetryFailedTrialCallback
+from optuna.storages._callbacks import RetryHeartbeatStaleTrialCallback
 from optuna.storages._heartbeat import BaseHeartbeat
 from optuna.storages._heartbeat import is_heartbeat_enabled
 from optuna.testing.storages import STORAGE_MODES_HEARTBEAT
@@ -101,21 +102,21 @@ def test_heartbeat_experimental_warnings(storage_mode: str) -> None:
 
 
 @pytest.mark.parametrize("storage_mode", STORAGE_MODES_HEARTBEAT)
-def test_failed_trial_callback(storage_mode: str) -> None:
+def test_heartbeat_stale_trial_callback(storage_mode: str) -> None:
     heartbeat_interval = 1
     grace_period = 2
 
-    def _failed_trial_callback(study: Study, trial: FrozenTrial) -> None:
+    def _heartbeat_stale_trial_callback(study: Study, trial: FrozenTrial) -> None:
         assert study._storage.get_study_system_attrs(study._study_id)["test"] == "A"
         assert trial.system_attrs["test"] == "B"
 
-    failed_trial_callback = Mock(wraps=_failed_trial_callback)
+    heartbeat_stale_trial_callback = Mock(wraps=_heartbeat_stale_trial_callback)
 
     with StorageSupplier(
         storage_mode,
         heartbeat_interval=heartbeat_interval,
         grace_period=grace_period,
-        failed_trial_callback=failed_trial_callback,
+        heartbeat_stale_trial_callback=heartbeat_stale_trial_callback,
     ) as storage:
         assert is_heartbeat_enabled(storage)
         assert isinstance(storage, BaseHeartbeat)
@@ -132,13 +133,13 @@ def test_failed_trial_callback(storage_mode: str) -> None:
         # Exceptions raised in spawned threads are caught by `_TestableThread`.
         with patch("optuna.storages._heartbeat.Thread", _TestableThread):
             study.optimize(lambda _: 1.0, n_trials=1)
-            failed_trial_callback.assert_called_once()
+            heartbeat_stale_trial_callback.assert_called_once()
 
 
 @pytest.mark.parametrize(
     "storage_mode,max_retry", itertools.product(STORAGE_MODES_HEARTBEAT, [None, 0, 1])
 )
-def test_retry_failed_trial_callback(storage_mode: str, max_retry: int | None) -> None:
+def test_retry_heartbeat_stale_trial_callback(storage_mode: str, max_retry: int | None) -> None:
     heartbeat_interval = 1
     grace_period = 2
 
@@ -146,7 +147,7 @@ def test_retry_failed_trial_callback(storage_mode: str, max_retry: int | None) -
         storage_mode,
         heartbeat_interval=heartbeat_interval,
         grace_period=grace_period,
-        failed_trial_callback=RetryFailedTrialCallback(max_retry=max_retry),
+        heartbeat_stale_trial_callback=RetryHeartbeatStaleTrialCallback(max_retry=max_retry),
     ) as storage:
         assert is_heartbeat_enabled(storage)
         assert isinstance(storage, BaseHeartbeat)
@@ -168,7 +169,7 @@ def test_retry_failed_trial_callback(storage_mode: str, max_retry: int | None) -
         # Test max_retry=None to see if trial is retried.
         # Test max_retry=0 to see if no trials are retried.
         # Test max_retry=1 to see if trial is retried.
-        assert RetryFailedTrialCallback.retried_trial_number(study.trials[1]) == (
+        assert RetryHeartbeatStaleTrialCallback.retried_trial_number(study.trials[1]) == (
             None if max_retry == 0 else 0
         )
         # Test inheritance of trial fields.
@@ -183,7 +184,7 @@ def test_retry_failed_trial_callback(storage_mode: str, max_retry: int | None) -
 @pytest.mark.parametrize(
     "storage_mode,max_retry", itertools.product(STORAGE_MODES_HEARTBEAT, [None, 0, 1])
 )
-def test_retry_failed_trial_callback_intermediate(
+def test_retry_heartbeat_stale_trial_callback_intermediate(
     storage_mode: str, max_retry: int | None
 ) -> None:
     heartbeat_interval = 1
@@ -193,7 +194,7 @@ def test_retry_failed_trial_callback_intermediate(
         storage_mode,
         heartbeat_interval=heartbeat_interval,
         grace_period=grace_period,
-        failed_trial_callback=RetryFailedTrialCallback(
+        heartbeat_stale_trial_callback=RetryHeartbeatStaleTrialCallback(
             max_retry=max_retry, inherit_intermediate_values=True
         ),
     ) as storage:
@@ -218,7 +219,7 @@ def test_retry_failed_trial_callback_intermediate(
         # Test max_retry=None to see if trial is retried.
         # Test max_retry=0 to see if no trials are retried.
         # Test max_retry=1 to see if trial is retried.
-        assert RetryFailedTrialCallback.retried_trial_number(study.trials[1]) == (
+        assert RetryHeartbeatStaleTrialCallback.retried_trial_number(study.trials[1]) == (
             None if max_retry == 0 else 0
         )
         # Test inheritance of trial fields.
@@ -235,7 +236,7 @@ def test_fail_stale_trials(grace_period: int | None) -> None:
     heartbeat_interval = 1
     _grace_period = (heartbeat_interval * 2) if grace_period is None else grace_period
 
-    def failed_trial_callback(study: "optuna.Study", trial: FrozenTrial) -> None:
+    def heartbeat_stale_trial_callback(study: "optuna.Study", trial: FrozenTrial) -> None:
         assert study._storage.get_study_system_attrs(study._study_id)["test"] == "A"
         assert trial.system_attrs["test"] == "B"
 
@@ -253,7 +254,8 @@ def test_fail_stale_trials(grace_period: int | None) -> None:
         assert isinstance(storage, RDBStorage)
         storage.heartbeat_interval = heartbeat_interval
         storage.grace_period = grace_period
-        storage.failed_trial_callback = failed_trial_callback
+        storage.heartbeat_stale_trial_callback = heartbeat_stale_trial_callback
+        storage.failed_trial_callback = heartbeat_stale_trial_callback
         study = optuna.create_study(storage=storage)
         study._storage.set_study_system_attr(study._study_id, "test", "A")
 
@@ -336,7 +338,7 @@ def test_get_stale_trial_ids() -> None:
 
 
 @pytest.mark.parametrize("storage_mode", STORAGE_MODES_HEARTBEAT)
-def test_retry_failed_trial_callback_repetitive_failure(storage_mode: str) -> None:
+def test_retry_heartbeat_stale_trial_callback_repetitive_failure(storage_mode: str) -> None:
     heartbeat_interval = 1
     grace_period = 2
     max_retry = 3
@@ -346,7 +348,7 @@ def test_retry_failed_trial_callback_repetitive_failure(storage_mode: str) -> No
         storage_mode,
         heartbeat_interval=heartbeat_interval,
         grace_period=grace_period,
-        failed_trial_callback=RetryFailedTrialCallback(max_retry=max_retry),
+        heartbeat_stale_trial_callback=RetryHeartbeatStaleTrialCallback(max_retry=max_retry),
     ) as storage:
         assert is_heartbeat_enabled(storage)
         assert isinstance(storage, BaseHeartbeat)

--- a/tests/storages_tests/test_heartbeat.py
+++ b/tests/storages_tests/test_heartbeat.py
@@ -14,7 +14,6 @@ import optuna
 from optuna import Study
 from optuna.exceptions import ExperimentalWarning
 from optuna.storages import RDBStorage
-from optuna.storages import RetryFailedTrialCallback
 from optuna.storages._callbacks import RetryHeartbeatStaleTrialCallback
 from optuna.storages._heartbeat import BaseHeartbeat
 from optuna.storages._heartbeat import is_heartbeat_enabled


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. To minimize the review effort, we highly appreciate PRs only with related changes. Please note that submitted PRs may be closed if they include unrelated changes or significantly modified unit tests. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation

Fixes #6085

Issue #6085 pointed out that `RetryFailedTrialCallback` and the corresponding `RDBStorage.failed_trial_callback` argument are misleading.

These APIs do not handle arbitrary failed trials. They are specifically used for trials that become stale under the RDB heartbeat mechanism. The current names can therefore give users the wrong expectation, so this PR renames them to make their scope clearer.

## Description of the changes

- Rename `RetryFailedTrialCallback` to `RetryHeartbeatStaleTrialCallback`
    - We also considered shorter names such as `RetryStaleTrialCallback`, but decided against them because a shorter name would not be helpful if it still left room for the same misreading.
- Rename `RDBStorage.failed_trial_callback` to `heartbeat_stale_trial_callback`
- Keep the old class name and argument for backward compatibility, with deprecation warnings
- Update the related documentation and examples to clarify that this feature is for heartbeat-stale trials

```python
$ python3
>>> import optuna
... from optuna.storages import RetryFailedTrialCallback
...
... storage = optuna.storages.RDBStorage(
...     url="sqlite:///:memory:",
...     heartbeat_interval=60,
...     grace_period=120,
...     failed_trial_callback=RetryFailedTrialCallback(max_retry=3),
... )
...
... study = optuna.create_study(storage=storage)
...
<python-input-0>:8: FutureWarning: RetryFailedTrialCallback has been deprecated in v4.9.0. This feature will be removed in v6.0.0. See https://github.com/optuna/optuna/releases/tag/v4.9.0. Use `RetryHeartbeatStaleTrialCallback` instead.
/Users/c-bata/go/src/github.com/optuna/optuna/optuna/_deprecated.py:180: ExperimentalWarning: RetryHeartbeatStaleTrialCallback is experimental (supported from v2.8.0). The interface can change in the future.
  _original_init(self, *args, **kwargs)
<python-input-0>:4: ExperimentalWarning: Argument ``heartbeat_interval`` is an experimental feature. The interface can change in the future.
<python-input-0>:4: FutureWarning: `failed_trial_callback` has been deprecated in v4.9.0. This feature will be removed in v6.0.0. See https://github.com/optuna/optuna/releases/tag/v4.9.0. Use `heartbeat_stale_trial_callback` instead.
[I 2026-05-14 11:16:15,759] A new study created in RDB with name: no-name-9bc99b68-03de-4541-afb3-fd8c23375b3d
```