### PR TITLE
Pinned every action for pypi-publish to a commit SHA

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -20,11 +20,11 @@ jobs:
     if: github.repository == 'optuna/optuna'
 
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python 3.12
-      uses: actions/setup-python@v5
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+    - name: Set up Python 3.13
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
       with:
-        python-version: 3.12
+        python-version: 3.13
 
     - name: Install twine
       run: |
@@ -53,22 +53,9 @@ jobs:
     - name: Publish distribution to TestPyPI
       # The following upload action cannot be executed in the forked repository.
       if: (github.event_name == 'schedule') || (github.event_name == 'release')
-      uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        repository-url: https://test.pypi.org/legacy/
-        # Temporary workaround to bypass Twine's bug with attestation support
-        # See https://github.com/pypa/gh-action-pypi-publish/issues/283
-        # TODO(c-bata): Once a new version of twine is released, delete this line.
-        # https://github.com/pypa/twine/pull/1172 
-        attestations: false
+      uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0
 
     - name: Publish distribution to PyPI
       # The following upload action cannot be executed in the forked repository.
       if: github.event_name == 'release'
-      uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        # Temporary workaround to bypass Twine's bug with attestation support
-        # See https://github.com/pypa/gh-action-pypi-publish/issues/283
-        # TODO(c-bata): Once a new version of twine is released, delete this line.
-        # https://github.com/pypa/twine/pull/1172 
-        attestations: false
+      uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. To minimize the review effort, we highly appreciate PRs only with related changes. Please note that submitted PRs may be closed if they include unrelated changes or significantly modified unit tests. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
Refs https://github.com/optuna/optuna-integration/pull/285/

## Description of the changes
<!-- Describe the changes in this PR. -->

Based on the incident report from tanstack dev team, we decided to pin every actions in the org to a commit SHA.
As a first step, this PR updates `pypi-publish.yml`, which is our highest priority for preventing similar attacks. Please see https://tanstack.com/blog/incident-followup for details.