### PR TITLE
Restore TestPyPI repository URL for scheduled publishes

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -55,6 +55,9 @@ jobs:
       if: (github.event_name == 'schedule') || (github.event_name == 'release')
       uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0
 
+      with:
+        repository-url: https://test.pypi.org/legacy/
+
     - name: Publish distribution to PyPI
       # The following upload action cannot be executed in the forked repository.
       if: github.event_name == 'release'


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. To minimize the review effort, we highly appreciate PRs only with related changes. Please note that submitted PRs may be closed if they include unrelated changes or significantly modified unit tests. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
PR #6675 unintentionally removed the repository-url setting from the scheduled publish step in pypi-publish.yml. As a result, a dev version was published to PyPI by the scheduled workflow instead of being sent to TestPyPI.

https://pypi.org/manage/project/optuna/releases/

## Description of the changes
<!-- Describe the changes in this PR. -->
- Restore repository-url: https://test.pypi.org/legacy/ in the scheduled publish step.
