### PR TITLE
Fix BruteForceSampler failed trial handling

### DIFF
--- a/optuna/samplers/_brute_force.py
+++ b/optuna/samplers/_brute_force.py
@@ -184,11 +184,21 @@ class BruteForceSampler(BaseSampler):
             When this option is not enabled (default), the sampler applies a looser criterion for
             determining when to stop the search, which may result in incomplete coverage of the
             search space. For more information, see https://github.com/optuna/optuna/issues/5780.
+        consider_failed_trials:
+            If :obj:`True`, failed trials are treated as already sampled points and are not
+            retried. When this option is not enabled (default), failed trials are ignored during
+            sampling.
     """
 
-    def __init__(self, seed: int | None = None, avoid_premature_stop: bool = False) -> None:
+    def __init__(
+        self,
+        seed: int | None = None,
+        avoid_premature_stop: bool = False,
+        consider_failed_trials: bool = False,
+    ) -> None:
         self._rng = LazyRandomState(seed)
         self._avoid_premature_stop = avoid_premature_stop
+        self._consider_failed_trials = consider_failed_trials
 
     def infer_relative_search_space(
         self, study: Study, trial: FrozenTrial
@@ -201,9 +211,16 @@ class BruteForceSampler(BaseSampler):
         return {}
 
     @staticmethod
-    def _populate_tree(tree: _TreeNode, trials: list[FrozenTrial], params: dict[str, Any]) -> None:
+    def _populate_tree(
+        tree: _TreeNode,
+        trials: list[FrozenTrial],
+        params: dict[str, Any],
+        consider_failed_trials: bool,
+    ) -> None:
         # Populate tree under given params from the given trials.
         for trial in trials:
+            if trial.state == TrialState.FAIL and not consider_failed_trials:
+                continue
             if not all(p in trial.params and trial.params[p] == v for p, v in params.items()):
                 continue
             leaf = tree.add_path(
@@ -240,7 +257,7 @@ class BruteForceSampler(BaseSampler):
         # Populating must happen after the initialization above to prevent `tree` from
         # being initialized as an empty graph, which is created with n_jobs > 1
         # where we get trials[i].params = {} for some i.
-        self._populate_tree(tree, trials, trial.params)
+        self._populate_tree(tree, trials, trial.params, self._consider_failed_trials)
         if not tree.is_any_expandable(exclude_running):
             return param_distribution.to_external_repr(self._rng.rng.choice(candidates).item())
         else:
@@ -258,7 +275,7 @@ class BruteForceSampler(BaseSampler):
             state=state, values=values, params=trial.params, distributions=trial.distributions
         )
         tree = _TreeNode()
-        self._populate_tree(tree, trials, {})
+        self._populate_tree(tree, trials, {}, self._consider_failed_trials)
         if not tree.is_any_expandable(exclude_running):
             study.stop()
 

--- a/tests/samplers_tests/test_brute_force.py
+++ b/tests/samplers_tests/test_brute_force.py
@@ -285,7 +285,7 @@ def test_study_optimize_with_failed_trials() -> None:
         trial.suggest_int("x", 0, 99)
         return np.nan
 
-    study = optuna.create_study(sampler=samplers.BruteForceSampler())
+    study = optuna.create_study(sampler=samplers.BruteForceSampler(consider_failed_trials=True))
     study.optimize(objective, n_trials=100)
 
     expected_suggested_values = [{"x": i} for i in range(100)]
@@ -293,6 +293,24 @@ def test_study_optimize_with_failed_trials() -> None:
     assert len(all_suggested_values) == len(expected_suggested_values)
     for a in expected_suggested_values:
         assert a in all_suggested_values
+
+
+@pytest.mark.parametrize("consider_failed_trials, expected", [(False, 0), (True, 1)])
+def test_study_optimize_failed_trial_handling(consider_failed_trials: bool, expected: int) -> None:
+    study = optuna.create_study(
+        sampler=samplers.BruteForceSampler(seed=42, consider_failed_trials=consider_failed_trials)
+    )
+    study.add_trial(
+        optuna.create_trial(
+            state=optuna.trial.TrialState.FAIL,
+            params={"x": 0},
+            distributions={"x": optuna.distributions.IntDistribution(0, 1)},
+        )
+    )
+
+    trial = study.ask()
+
+    assert trial.suggest_int("x", 0, 1) == expected
 
 
 def test_parallel_optimize() -> None:


### PR DESCRIPTION
## Motivation
Fixes #6654.

`BruteForceSampler` currently treats failed trials as exhausted points. This makes transient failures permanently remove their parameter combination from future sampling, even though failed trials are generally ignored by Optuna samplers.

## Description of the changes
- Added a `consider_failed_trials` option to `BruteForceSampler`, defaulting to `False` so failed trials are ignored during tree construction.
- Kept the previous behavior available with `consider_failed_trials=True`.
- Added tests for both failed-trial handling modes.
