### PR TITLE
Refactor PED-ANOVA

### DIFF
--- a/optuna/importance/_ped_anova/evaluator.py
+++ b/optuna/importance/_ped_anova/evaluator.py
@@ -183,6 +183,8 @@ class PedAnovaImportanceEvaluator(BaseImportanceEvaluator):
         quantile: float,
         target: Callable[[FrozenTrial], float] | None,
     ) -> list[FrozenTrial]:
+        if quantile == 1.0:
+            return trials
         is_lower_better = study.directions[0] == StudyDirection.MINIMIZE
         if target is not None:
             optuna_warn(

--- a/optuna/importance/_ped_anova/evaluator.py
+++ b/optuna/importance/_ped_anova/evaluator.py
@@ -214,13 +214,13 @@ class PedAnovaImportanceEvaluator(BaseImportanceEvaluator):
         )
         # NOTE: pe_top.n_steps could be different from self._n_steps.
         grids = np.arange(grid_size)
-        pdf_top = pe_top.log_pdf({param_name: grids}) + 1e-12
+        pdf_top = pe_top.pdf({param_name: grids}) + 1e-12
 
         if self._evaluate_on_local:  # The importance of param during the study.
             pe_local, _ = build_parzen_estimator_on_grid(
                 param_name, dist, region_trials, self._n_steps, prior_weight
             )
-            pdf_local = pe_local.log_pdf({param_name: grids}) + 1e-12
+            pdf_local = pe_local.pdf({param_name: grids}) + 1e-12
         else:  # The importance of param in the search space.
             pdf_local = np.full(grid_size, 1.0 / grid_size)
 

--- a/optuna/importance/_ped_anova/evaluator.py
+++ b/optuna/importance/_ped_anova/evaluator.py
@@ -252,11 +252,7 @@ class PedAnovaImportanceEvaluator(BaseImportanceEvaluator):
             return {k: 0.0 for k in dists}
 
         target_trials = self._get_top_quantile_trials(study, trials, self._target_quantile, target)
-        region_trials = (
-            trials
-            if self._region_quantile == 1.0
-            else self._get_top_quantile_trials(study, trials, self._region_quantile, target)
-        )
+        region_trials = self._get_top_quantile_trials(study, trials, self._region_quantile, target)
         if len(target_trials) == len(region_trials):
             optuna_warn(
                 "Target and region quantiles select the same set of trials. "

--- a/optuna/importance/_ped_anova/evaluator.py
+++ b/optuna/importance/_ped_anova/evaluator.py
@@ -212,7 +212,6 @@ class PedAnovaImportanceEvaluator(BaseImportanceEvaluator):
         pe_top, grid_size = build_parzen_estimator_on_grid(
             param_name, dist, target_trials, self._n_steps, prior_weight
         )
-        # NOTE: pe_top.n_steps could be different from self._n_steps.
         grids = np.arange(grid_size)
         pdf_top = pe_top.pdf({param_name: grids}) + 1e-12
 

--- a/optuna/importance/_ped_anova/evaluator.py
+++ b/optuna/importance/_ped_anova/evaluator.py
@@ -11,7 +11,7 @@ from optuna.importance._base import _get_distributions
 from optuna.importance._base import _get_filtered_trials
 from optuna.importance._base import _sort_dict_by_importance
 from optuna.importance._base import BaseImportanceEvaluator
-from optuna.importance._ped_anova.scott_parzen_estimator import _build_parzen_estimator
+from optuna.importance._ped_anova.scott_parzen_estimator import build_parzen_estimator_on_grid
 from optuna.study import StudyDirection
 
 

--- a/optuna/importance/_ped_anova/evaluator.py
+++ b/optuna/importance/_ped_anova/evaluator.py
@@ -209,20 +209,20 @@ class PedAnovaImportanceEvaluator(BaseImportanceEvaluator):
     ) -> float:
         # When pdf_all == pdf_top, i.e. all_trials == top_trials, this method will give 0.0.
         prior_weight = self._prior_weight
-        pe_top = _build_parzen_estimator(
+        pe_top, grid_size = build_parzen_estimator_on_grid(
             param_name, dist, target_trials, self._n_steps, prior_weight
         )
         # NOTE: pe_top.n_steps could be different from self._n_steps.
-        grids = np.arange(pe_top.n_steps)
-        pdf_top = pe_top.pdf(grids) + 1e-12
+        grids = np.arange(grid_size)
+        pdf_top = pe_top.log_pdf({param_name: grids}) + 1e-12
 
         if self._evaluate_on_local:  # The importance of param during the study.
-            pe_local = _build_parzen_estimator(
+            pe_local, _ = build_parzen_estimator_on_grid(
                 param_name, dist, region_trials, self._n_steps, prior_weight
             )
-            pdf_local = pe_local.pdf(grids) + 1e-12
+            pdf_local = pe_local.log_pdf({param_name: grids}) + 1e-12
         else:  # The importance of param in the search space.
-            pdf_local = np.full(pe_top.n_steps, 1.0 / pe_top.n_steps)
+            pdf_local = np.full(grid_size, 1.0 / grid_size)
 
         return float(pdf_local @ ((pdf_top / pdf_local - 1) ** 2))
 

--- a/optuna/importance/_ped_anova/scott_parzen_estimator.py
+++ b/optuna/importance/_ped_anova/scott_parzen_estimator.py
@@ -45,36 +45,32 @@ class ScottParzenEstimator(_ParzenEstimator):
         step = search_space.step
         assert step is not None and np.isclose(step, 1.0), "MyPy redefinition."
 
-        n_trials = np.sum(self._counts)
-        counts_non_zero = self._counts[self._counts > 0]
-        weights = counts_non_zero / n_trials
-        mus = np.arange(self.n_steps)[self._counts > 0]
-        mean_est = mus @ weights
-        sigma_est = np.sqrt((mus - mean_est) ** 2 @ counts_non_zero / max(1, n_trials - 1))
+        low, high = search_space.low, search_space.high
+        weights_sum = np.sum(self._weights)
+        n_observations = len(observations)
+        if search_space.log:
+            observations = np.log(observations)
+            low, high = math.log(low), math.log(high)
 
-        count_cum = np.cumsum(counts_non_zero)
-        idx_q25 = np.searchsorted(count_cum, n_trials // 4, side="left")
-        idx_q75 = np.searchsorted(count_cum, n_trials * 3 // 4, side="right")
-        interquantile_range = mus[min(mus.size - 1, idx_q75)] - mus[idx_q25]
-        sigma_est = 1.059 * min(interquantile_range / 1.34, sigma_est) * n_trials ** (-0.2)
+        mean_est = (observations @ self._weights) / weights_sum
+        sigma_est = np.sqrt(((observations - mean_est) ** 2 @ self._weights) / max(1, weights_sum - 1))
+        if observations.size == 0:
+            inter_quantile_range = 0.0
+        else:
+            sorted_obs = np.sort(observations)
+            q1_idx = int(0.25 * (n_observations - 1))
+            q3_idx = int(0.75 * (n_observations - 1))
+            inter_quantile_range = sorted_obs[q3_idx] - sorted_obs[q1_idx]
+        sigma_est = 1.059 * min(inter_quantile_range / 1.34, sigma_est) * weights_sum ** -0.2
         # To avoid numerical errors. 0.5/1.64 means 1.64sigma (=90%) will fit in the target grid.
         sigma_min = 0.5 / 1.64
-        sigmas = np.full_like(mus, max(sigma_est, sigma_min), dtype=np.float64)
-        mus = np.append(mus, [0.5 * (search_space.low + search_space.high)])
-        sigmas = np.append(sigmas, [1.0 * (search_space.high - search_space.low + 1)])
+        mus_with_prior = np.r_[observations, 0.5 * (search_space.low + search_space.high)]
+        sigmas = np.full_like(observations, max(sigma_est, sigma_min), dtype=np.float64)
+        sigmas_with_prior = np.r_[sigmas, sigma_min]
 
         return _BatchedDiscreteTruncNormDistributions(
-            mu=mus, sigma=sigmas, low=0, high=self.n_steps - 1, step=1
+            mu=mus_with_prior, sigma=sigmas_with_prior, low=low, high=high, step=1
         )
-
-    @property
-    def n_steps(self) -> int:
-        return self._n_steps
-
-    def pdf(self, samples: np.ndarray) -> np.ndarray:
-        return np.exp(self.log_pdf({self._param_name: samples}))
-
-
 
 
 def _count_numerical_param_in_grid(

--- a/optuna/importance/_ped_anova/scott_parzen_estimator.py
+++ b/optuna/importance/_ped_anova/scott_parzen_estimator.py
@@ -88,7 +88,9 @@ def _count_numerical_param_in_grid(
     low, high = (math.log(dist.low), math.log(dist.high)) if dist.log else (dist.low, dist.high)
     param_values = (np.log if dist.log else np.asarray)([t.params[param_name] for t in trials])
     step_size = (high - low) / (n_steps - 1)
-    indices = np.minimum(((param_values - low) / step_size).astype(int), n_steps - 1)
+    # For backward compatibility, midpoint ties go to the lower grid.
+    indices = np.ceil((param_values - low) / step_size - 0.5).astype(int)
+    indices = np.clip(indices, 0, n_steps - 1)
     return np.bincount(indices, minlength=n_steps)
 
 

--- a/optuna/importance/_ped_anova/scott_parzen_estimator.py
+++ b/optuna/importance/_ped_anova/scott_parzen_estimator.py
@@ -93,7 +93,7 @@ def _count_categorical_param_in_grid(
     return np.bincount(indices, minlength=len(dist.choices))
 
 
-def _build_parzen_estimator(
+def build_parzen_estimator_on_grid(
     param_name: str,
     dist: BaseDistribution,
     trials: list[FrozenTrial],
@@ -124,7 +124,7 @@ def _build_parzen_estimator(
     )
     return ScottParzenEstimator(
         {param_name: observations},
-        {param_name: dist},
+        {param_name: rounded_dist},
         parameters,
         weights,
     )

--- a/optuna/importance/_ped_anova/scott_parzen_estimator.py
+++ b/optuna/importance/_ped_anova/scott_parzen_estimator.py
@@ -111,7 +111,7 @@ def build_parzen_estimator_on_grid(
         assert False, f"Got an unknown dist with the type {type(dist)}."
 
     observations = np.flatnonzero(counts)
-    weights = counts[observations].astype(np.float64)
+    weights = counts[observations]
     parameters = _ParzenEstimatorParameters(
         prior_weight=prior_weight,
         consider_magic_clip=False,

--- a/optuna/importance/_ped_anova/scott_parzen_estimator.py
+++ b/optuna/importance/_ped_anova/scott_parzen_estimator.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
+import math
 from typing import TYPE_CHECKING
 
 import numpy as np
-import math
 
 from optuna.distributions import CategoricalDistribution
 from optuna.distributions import FloatDistribution
@@ -53,7 +53,9 @@ class ScottParzenEstimator(_ParzenEstimator):
             low, high = math.log(low), math.log(high)
 
         mean_est = (observations @ self._weights) / weights_sum
-        sigma_est = np.sqrt(((observations - mean_est) ** 2 @ self._weights) / max(1, weights_sum - 1))
+        sigma_est = np.sqrt(
+            ((observations - mean_est) ** 2 @ self._weights) / max(1, weights_sum - 1)
+        )
         if observations.size == 0:
             inter_quantile_range = 0.0
         else:
@@ -61,7 +63,7 @@ class ScottParzenEstimator(_ParzenEstimator):
             q1_idx = int(0.25 * (n_observations - 1))
             q3_idx = int(0.75 * (n_observations - 1))
             inter_quantile_range = sorted_obs[q3_idx] - sorted_obs[q1_idx]
-        sigma_est = 1.059 * min(inter_quantile_range / 1.34, sigma_est) * weights_sum ** -0.2
+        sigma_est = 1.059 * min(inter_quantile_range / 1.34, sigma_est) * weights_sum**-0.2
         # To avoid numerical errors. 0.5/1.64 means 1.64sigma (=90%) will fit in the target grid.
         sigma_min = 0.5 / 1.64
         mus_with_prior = np.r_[observations, 0.5 * (search_space.low + search_space.high)]

--- a/optuna/importance/_ped_anova/scott_parzen_estimator.py
+++ b/optuna/importance/_ped_anova/scott_parzen_estimator.py
@@ -110,8 +110,6 @@ def build_parzen_estimator_on_grid(
     else:
         assert False, f"Got an unknown dist with the type {type(dist)}."
 
-    # # counts.astype(float) is necessary for weight calculation in ParzenEstimator.
-    # return _ScottParzenEstimator(param_name, rounded_dist, counts.astype(np.float64), prior_weight)
     observations = np.flatnonzero(counts)
     weights = counts[observations].astype(np.float64)
     parameters = _ParzenEstimatorParameters(

--- a/optuna/importance/_ped_anova/scott_parzen_estimator.py
+++ b/optuna/importance/_ped_anova/scott_parzen_estimator.py
@@ -22,35 +22,6 @@ if TYPE_CHECKING:
 class ScottParzenEstimator(_ParzenEstimator):
     """1D ParzenEstimator using the bandwidth selection by Scott's rule."""
 
-    def __init__(
-        self,
-        param_name: str,
-        dist: IntDistribution | CategoricalDistribution,
-        counts: np.ndarray,
-        prior_weight: float,
-    ) -> None:
-        assert isinstance(dist, (CategoricalDistribution, IntDistribution))
-        assert not isinstance(dist, IntDistribution) or dist.low == 0
-        n_choices = dist.high + 1 if isinstance(dist, IntDistribution) else len(dist.choices)
-        assert len(counts) == n_choices, counts
-
-        self._n_steps = len(counts)
-        self._param_name = param_name
-        self._counts = counts.copy()
-        super().__init__(
-            observations={param_name: np.arange(self._n_steps)[counts > 0.0]},
-            search_space={param_name: dist},
-            parameters=_ParzenEstimatorParameters(
-                prior_weight=prior_weight,
-                consider_magic_clip=False,
-                consider_endpoints=False,
-                weights=lambda x: np.empty(0),
-                multivariate=True,
-                categorical_distance_func={},
-            ),
-            predetermined_weights=counts[counts > 0.0],
-        )
-
     def _calculate_numerical_distributions(
         self,
         observations: np.ndarray,

--- a/optuna/importance/_ped_anova/scott_parzen_estimator.py
+++ b/optuna/importance/_ped_anova/scott_parzen_estimator.py
@@ -108,7 +108,7 @@ def build_parzen_estimator_on_grid(
     trials: list[FrozenTrial],
     n_steps: int,
     prior_weight: float,
-) -> ScottParzenEstimator:
+) -> tuple[ScottParzenEstimator, int]:
     rounded_dist: IntDistribution | CategoricalDistribution
     if isinstance(dist, (IntDistribution, FloatDistribution)):
         counts = _count_numerical_param_in_grid(param_name, dist, trials, n_steps)
@@ -129,9 +129,10 @@ def build_parzen_estimator_on_grid(
         multivariate=True,
         categorical_distance_func={},
     )
-    return ScottParzenEstimator(
+    pe = ScottParzenEstimator(
         {param_name: observations},
         {param_name: rounded_dist},
         parameters,
         weights,
     )
+    return pe, counts.size

--- a/optuna/importance/_ped_anova/scott_parzen_estimator.py
+++ b/optuna/importance/_ped_anova/scott_parzen_estimator.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import numpy as np
+import math
 
 from optuna.distributions import CategoricalDistribution
 from optuna.distributions import FloatDistribution
@@ -92,27 +93,6 @@ class _ScottParzenEstimator(_ParzenEstimator):
         return np.exp(self.log_pdf({self._param_name: samples}))
 
 
-def _get_grids_and_grid_indices_of_trials(
-    param_name: str,
-    dist: IntDistribution | FloatDistribution,
-    trials: list[FrozenTrial],
-    n_steps: int,
-) -> tuple[int, np.ndarray]:
-    assert isinstance(dist, (FloatDistribution, IntDistribution)), "Unexpected distribution."
-    if isinstance(dist, IntDistribution) and dist.log:
-        log2_domain_size = int(np.ceil(np.log(dist.high - dist.low + 1) / np.log(2))) + 1
-        n_steps = min(log2_domain_size, n_steps)
-    elif dist.step is not None:
-        assert not dist.log, "log must be False when step is not None."
-        n_steps = min(round((dist.high - dist.low) / dist.step) + 1, n_steps)
-
-    scaler = np.log if dist.log else np.asarray
-    grids = np.linspace(scaler(dist.low), scaler(dist.high), n_steps)
-    params = scaler([t.params[param_name] for t in trials])
-    step_size = grids[1] - grids[0]
-    # grids[indices[n] - 1] < param - step_size / 2 <= grids[indices[n]]
-    indices = np.searchsorted(grids, params - step_size / 2)
-    return grids.size, indices
 
 
 def _count_numerical_param_in_grid(
@@ -121,12 +101,18 @@ def _count_numerical_param_in_grid(
     trials: list[FrozenTrial],
     n_steps: int,
 ) -> np.ndarray:
-    n_grids, grid_indices_of_trials = _get_grids_and_grid_indices_of_trials(
-        param_name, dist, trials, n_steps
-    )
-    unique_vals, counts_in_unique = np.unique(grid_indices_of_trials, return_counts=True)
-    counts = np.zeros(n_grids, dtype=np.int32)
-    counts[unique_vals] += counts_in_unique
+    assert isinstance(dist, (FloatDistribution, IntDistribution)), "Unexpected distribution."
+    if isinstance(dist, IntDistribution) and dist.log:
+        log2_domain_size = int(np.ceil(np.log(dist.high - dist.low + 1) / np.log(2))) + 1
+        n_steps = min(log2_domain_size, n_steps)
+    elif dist.step is not None:
+        assert not dist.log, "log must be False when step is not None."
+        n_steps = min(round((dist.high - dist.low) / dist.step) + 1, n_steps)
+    low, high = (math.log(dist.low), math.log(dist.high)) if dist.log else (dist.low, dist.high)
+    param_values = (np.log if dist.log else np.asarray)([t.params[param_name] for t in trials])
+    step_size = (high - low) / (n_steps - 1)
+    indices = np.minimum(((param_values - low) / step_size).astype(int), n_steps - 1)
+    counts = np.bincount(indices, minlength=n_steps)
     return counts
 
 

--- a/optuna/importance/_ped_anova/scott_parzen_estimator.py
+++ b/optuna/importance/_ped_anova/scott_parzen_estimator.py
@@ -46,8 +46,8 @@ class ScottParzenEstimator(_ParzenEstimator):
         assert step is not None and np.isclose(step, 1.0), "MyPy redefinition."
 
         low, high = search_space.low, search_space.high
-        weights_sum = np.sum(self._weights)
-        n_observations = len(observations)
+        weights_cum = np.cumsum(self._weights)
+        weights_sum = weights_cum[-1]
         if search_space.log:
             observations = np.log(observations)
             low, high = math.log(low), math.log(high)
@@ -56,19 +56,16 @@ class ScottParzenEstimator(_ParzenEstimator):
         sigma_est = np.sqrt(
             ((observations - mean_est) ** 2 @ self._weights) / max(1, weights_sum - 1)
         )
-        if observations.size == 0:
-            inter_quantile_range = 0.0
-        else:
-            sorted_obs = np.sort(observations)
-            q1_idx = int(0.25 * (n_observations - 1))
-            q3_idx = int(0.75 * (n_observations - 1))
-            inter_quantile_range = sorted_obs[q3_idx] - sorted_obs[q1_idx]
-        sigma_est = 1.059 * min(inter_quantile_range / 1.34, sigma_est) * weights_sum**-0.2
+
+        q1_idx = np.searchsorted(weights_cum, weights_sum // 4, side="left")
+        q3_idx = np.searchsorted(weights_cum, weights_sum * 3 // 4, side="right")
+        iqr = observations[min(observations.size - 1, q3_idx)] - observations[q1_idx]
+        sigma_est = 1.059 * min(iqr / 1.34, sigma_est) * weights_sum**-0.2
         # To avoid numerical errors. 0.5/1.64 means 1.64sigma (=90%) will fit in the target grid.
         sigma_min = 0.5 / 1.64
-        mus_with_prior = np.r_[observations, 0.5 * (search_space.low + search_space.high)]
+        mus_with_prior = np.r_[observations, (low + high) / 2.0]
         sigmas = np.full_like(observations, max(sigma_est, sigma_min), dtype=np.float64)
-        sigmas_with_prior = np.r_[sigmas, sigma_min]
+        sigmas_with_prior = np.r_[sigmas, high - low + 1]
 
         return _BatchedDiscreteTruncNormDistributions(
             mu=mus_with_prior, sigma=sigmas_with_prior, low=low, high=high, step=1

--- a/optuna/importance/_ped_anova/scott_parzen_estimator.py
+++ b/optuna/importance/_ped_anova/scott_parzen_estimator.py
@@ -99,7 +99,7 @@ def _build_parzen_estimator(
     trials: list[FrozenTrial],
     n_steps: int,
     prior_weight: float,
-) -> _ScottParzenEstimator:
+) -> ScottParzenEstimator:
     rounded_dist: IntDistribution | CategoricalDistribution
     if isinstance(dist, (IntDistribution, FloatDistribution)):
         counts = _count_numerical_param_in_grid(param_name, dist, trials, n_steps)
@@ -110,5 +110,21 @@ def _build_parzen_estimator(
     else:
         assert False, f"Got an unknown dist with the type {type(dist)}."
 
-    # counts.astype(float) is necessary for weight calculation in ParzenEstimator.
-    return _ScottParzenEstimator(param_name, rounded_dist, counts.astype(np.float64), prior_weight)
+    # # counts.astype(float) is necessary for weight calculation in ParzenEstimator.
+    # return _ScottParzenEstimator(param_name, rounded_dist, counts.astype(np.float64), prior_weight)
+    observations = np.flatnonzero(counts)
+    weights = counts[observations].astype(np.float64)
+    parameters = _ParzenEstimatorParameters(
+        prior_weight=prior_weight,
+        consider_magic_clip=False,
+        consider_endpoints=False,
+        weights=lambda x: np.empty(0),
+        multivariate=True,
+        categorical_distance_func={},
+    )
+    return ScottParzenEstimator(
+        {param_name: observations},
+        {param_name: dist},
+        parameters,
+        weights,
+    )

--- a/optuna/importance/_ped_anova/scott_parzen_estimator.py
+++ b/optuna/importance/_ped_anova/scott_parzen_estimator.py
@@ -112,8 +112,7 @@ def _count_numerical_param_in_grid(
     param_values = (np.log if dist.log else np.asarray)([t.params[param_name] for t in trials])
     step_size = (high - low) / (n_steps - 1)
     indices = np.minimum(((param_values - low) / step_size).astype(int), n_steps - 1)
-    counts = np.bincount(indices, minlength=n_steps)
-    return counts
+    return np.bincount(indices, minlength=n_steps)
 
 
 def _count_categorical_param_in_grid(

--- a/optuna/importance/_ped_anova/scott_parzen_estimator.py
+++ b/optuna/importance/_ped_anova/scott_parzen_estimator.py
@@ -118,11 +118,8 @@ def _count_numerical_param_in_grid(
 def _count_categorical_param_in_grid(
     param_name: str, dist: CategoricalDistribution, trials: list[FrozenTrial]
 ) -> np.ndarray:
-    cat_indices = [int(dist.to_internal_repr(t.params[param_name])) for t in trials]
-    unique_vals, counts_in_unique = np.unique(cat_indices, return_counts=True)
-    counts = np.zeros(len(dist.choices), dtype=np.int32)
-    counts[unique_vals] += counts_in_unique
-    return counts
+    indices = [int(dist.to_internal_repr(t.params[param_name])) for t in trials]
+    return np.bincount(indices, minlength=len(dist.choices))
 
 
 def _build_parzen_estimator(

--- a/optuna/importance/_ped_anova/scott_parzen_estimator.py
+++ b/optuna/importance/_ped_anova/scott_parzen_estimator.py
@@ -29,9 +29,9 @@ class ScottParzenEstimator(_ParzenEstimator):
         parameters: _ParzenEstimatorParameters,
         predetermined_weights: np.ndarray | None = None,
     ) -> None:
-        super().__init__(observations, search_space, parameters, predetermined_weights)
         assert predetermined_weights is not None
         self._weights = predetermined_weights
+        super().__init__(observations, search_space, parameters, predetermined_weights)
 
     def _calculate_numerical_distributions(
         self,

--- a/optuna/importance/_ped_anova/scott_parzen_estimator.py
+++ b/optuna/importance/_ped_anova/scott_parzen_estimator.py
@@ -71,6 +71,9 @@ class ScottParzenEstimator(_ParzenEstimator):
             mu=mus_with_prior, sigma=sigmas_with_prior, low=low, high=high, step=1
         )
 
+    def pdf(self, samples: dict[str, np.ndarray]) -> np.ndarray:
+        return np.exp(self.log_pdf(samples))
+
 
 def _count_numerical_param_in_grid(
     param_name: str,

--- a/optuna/importance/_ped_anova/scott_parzen_estimator.py
+++ b/optuna/importance/_ped_anova/scott_parzen_estimator.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
     from optuna.trial import FrozenTrial
 
 
-class _ScottParzenEstimator(_ParzenEstimator):
+class ScottParzenEstimator(_ParzenEstimator):
     """1D ParzenEstimator using the bandwidth selection by Scott's rule."""
 
     def __init__(
@@ -28,7 +28,7 @@ class _ScottParzenEstimator(_ParzenEstimator):
         dist: IntDistribution | CategoricalDistribution,
         counts: np.ndarray,
         prior_weight: float,
-    ):
+    ) -> None:
         assert isinstance(dist, (CategoricalDistribution, IntDistribution))
         assert not isinstance(dist, IntDistribution) or dist.low == 0
         n_choices = dist.high + 1 if isinstance(dist, IntDistribution) else len(dist.choices)

--- a/optuna/importance/_ped_anova/scott_parzen_estimator.py
+++ b/optuna/importance/_ped_anova/scott_parzen_estimator.py
@@ -22,6 +22,17 @@ if TYPE_CHECKING:
 class ScottParzenEstimator(_ParzenEstimator):
     """1D ParzenEstimator using the bandwidth selection by Scott's rule."""
 
+    def __init__(
+        self,
+        observations: dict[str, np.ndarray],
+        search_space: dict[str, BaseDistribution],
+        parameters: _ParzenEstimatorParameters,
+        predetermined_weights: np.ndarray | None = None,
+    ) -> None:
+        super().__init__(observations, search_space, parameters, predetermined_weights)
+        assert predetermined_weights is not None
+        self._weights = predetermined_weights
+
     def _calculate_numerical_distributions(
         self,
         observations: np.ndarray,

--- a/tests/importance_tests/pedanova_tests/test_scott_parzen_estimator.py
+++ b/tests/importance_tests/pedanova_tests/test_scott_parzen_estimator.py
@@ -93,10 +93,10 @@ def test_build_int_scott_parzen_estimator(
     counts: np.ndarray, mu: np.ndarray, sigma: np.ndarray, weights: np.ndarray
 ) -> None:
     pe = ScottParzenEstimator(
-        {"a": np.arange(counts.size)},
+        {"a": (obs := np.flatnonzero(counts))},
         {"a": IntDistribution(low=0, high=counts.size - 1)},
         pe_parameters,
-        counts.astype(float),
+        counts[obs].astype(float),
     )
     dist = _BatchedDiscreteTruncNormDistributions(
         mu=mu, sigma=sigma, low=0, high=counts.size - 1, step=1

--- a/tests/importance_tests/pedanova_tests/test_scott_parzen_estimator.py
+++ b/tests/importance_tests/pedanova_tests/test_scott_parzen_estimator.py
@@ -199,7 +199,7 @@ def test_assert_in_build_parzen_estimator() -> None:
             raise NotImplementedError
 
     with pytest.raises(AssertionError):
-        _build_parzen_estimator(
+        build_parzen_estimator_on_grid(
             param_name="a",
             dist=UnknownDistribution(),
             trials=[],

--- a/tests/importance_tests/pedanova_tests/test_scott_parzen_estimator.py
+++ b/tests/importance_tests/pedanova_tests/test_scott_parzen_estimator.py
@@ -117,10 +117,10 @@ def test_build_int_scott_parzen_estimator(
 )
 def test_build_cat_scott_parzen_estimator(counts: np.ndarray, weights: np.ndarray) -> None:
     pe = ScottParzenEstimator(
-        {"a": np.arange(counts.size)},
+        {"a": (obs := np.flatnonzero(counts))},
         {"a": CategoricalDistribution(choices=["a" * i for i in range(counts.size)])},
         pe_parameters,
-        counts.astype(float),
+        counts[obs].astype(float),
     )
     dist = _BatchedCategoricalDistributions(
         weights=np.concatenate(

--- a/tests/importance_tests/pedanova_tests/test_scott_parzen_estimator.py
+++ b/tests/importance_tests/pedanova_tests/test_scott_parzen_estimator.py
@@ -104,12 +104,11 @@ def test_build_int_scott_parzen_estimator(
     ],
 )
 def test_build_cat_scott_parzen_estimator(counts: np.ndarray, weights: np.ndarray) -> None:
-    _counts = counts.astype(float)
-    pe = _ScottParzenEstimator(
-        param_name="a",
-        dist=CategoricalDistribution(choices=["a" * i for i in range(counts.size)]),
-        counts=_counts,
-        prior_weight=0.0,
+    pe = ScottParzenEstimator(
+        {"a": np.arange(counts.size)},
+        {"a": CategoricalDistribution(choices=["a" * i for i in range(counts.size)])},
+        pe_parameters,
+        counts.astype(float),
     )
     dist = _BatchedCategoricalDistributions(
         weights=np.concatenate(

--- a/tests/importance_tests/pedanova_tests/test_scott_parzen_estimator.py
+++ b/tests/importance_tests/pedanova_tests/test_scott_parzen_estimator.py
@@ -80,15 +80,14 @@ def test_init_scott_parzen_estimator(dist_type: str) -> None:
 def test_build_int_scott_parzen_estimator(
     counts: np.ndarray, mu: np.ndarray, sigma: np.ndarray, weights: np.ndarray
 ) -> None:
-    _counts = counts.astype(float)
-    pe = _ScottParzenEstimator(
-        param_name="a",
-        dist=IntDistribution(low=0, high=_counts.size - 1),
-        counts=_counts,
-        prior_weight=0.0,
+    pe = ScottParzenEstimator(
+        {"a": np.arange(counts.size)},
+        {"a": IntDistribution(low=0, high=counts.size - 1)},
+        pe_parameters,
+        counts.astype(float),
     )
     dist = _BatchedDiscreteTruncNormDistributions(
-        mu=mu, sigma=sigma, low=0, high=_counts.size - 1, step=1
+        mu=mu, sigma=sigma, low=0, high=counts.size - 1, step=1
     )
     expected_dist = _MixtureOfProductDistribution(weights=weights, distributions=[dist])
     assert_distribution_almost_equal(pe._mixture_distribution, expected_dist)

--- a/tests/importance_tests/pedanova_tests/test_scott_parzen_estimator.py
+++ b/tests/importance_tests/pedanova_tests/test_scott_parzen_estimator.py
@@ -22,7 +22,7 @@ from tests.samplers_tests.tpe_tests.test_parzen_estimator import assert_distribu
 
 
 pe_parameters = _ParzenEstimatorParameters(
-    prior_weight=1.0,
+    prior_weight=0.0,
     consider_magic_clip=False,
     consider_endpoints=False,
     weights=lambda x: np.empty(0),

--- a/tests/importance_tests/pedanova_tests/test_scott_parzen_estimator.py
+++ b/tests/importance_tests/pedanova_tests/test_scott_parzen_estimator.py
@@ -168,7 +168,7 @@ def test_build_parzen_estimator(
     params: list[int] | list[float] | list[str],
 ) -> None:
     trials = [create_trial(value=0.0, params={"a": p}, distributions={"a": dist}) for p in params]
-    pe = _build_parzen_estimator(
+    pe, _ = build_parzen_estimator_on_grid(
         param_name="a",
         dist=dist,
         trials=trials,

--- a/tests/importance_tests/pedanova_tests/test_scott_parzen_estimator.py
+++ b/tests/importance_tests/pedanova_tests/test_scott_parzen_estimator.py
@@ -23,22 +23,17 @@ from tests.samplers_tests.tpe_tests.test_parzen_estimator import assert_distribu
 DIST_TYPES = ["int", "cat"]
 
 
-@pytest.mark.parametrize("dist_type", DIST_TYPES)
+@pytest.mark.parametrize("dist_type", ["int", "cat"])
 def test_init_scott_parzen_estimator(dist_type: str) -> None:
     counts = np.array([1, 1, 1, 1]).astype(float)
     is_cat = dist_type == "cat"
-    pe = _ScottParzenEstimator(
-        param_name="a",
-        dist=(
-            IntDistribution(low=0, high=counts.size - 1)
-            if not is_cat
-            else CategoricalDistribution(choices=["a" * i for i in range(counts.size)])
-        ),
-        counts=counts,
-        prior_weight=0.0,
+    pe = ScottParzenEstimator(
+        {"a": np.arange(counts.size)},
+        {"a": IntDistribution(low=0, high=counts.size - 1) if not is_cat else CategoricalDistribution(choices=["a" * i for i in range(counts.size)])},
+        pe_parameters,
+        counts,
     )
     assert len(pe._mixture_distribution.distributions) == 1
-    assert pe.n_steps == counts.size
     target_pe = pe._mixture_distribution.distributions[0]
     if is_cat:
         assert isinstance(target_pe, _BatchedCategoricalDistributions)

--- a/tests/importance_tests/pedanova_tests/test_scott_parzen_estimator.py
+++ b/tests/importance_tests/pedanova_tests/test_scott_parzen_estimator.py
@@ -10,17 +10,25 @@ from optuna.distributions import BaseDistribution
 from optuna.distributions import CategoricalDistribution
 from optuna.distributions import FloatDistribution
 from optuna.distributions import IntDistribution
-from optuna.importance._ped_anova.scott_parzen_estimator import _build_parzen_estimator
 from optuna.importance._ped_anova.scott_parzen_estimator import _count_categorical_param_in_grid
 from optuna.importance._ped_anova.scott_parzen_estimator import _count_numerical_param_in_grid
-from optuna.importance._ped_anova.scott_parzen_estimator import _ScottParzenEstimator
+from optuna.importance._ped_anova.scott_parzen_estimator import build_parzen_estimator_on_grid
+from optuna.importance._ped_anova.scott_parzen_estimator import ScottParzenEstimator
+from optuna.samplers._tpe.parzen_estimator import _ParzenEstimatorParameters
 from optuna.samplers._tpe.probability_distributions import _BatchedCategoricalDistributions
 from optuna.samplers._tpe.probability_distributions import _BatchedDiscreteTruncNormDistributions
 from optuna.samplers._tpe.probability_distributions import _MixtureOfProductDistribution
 from tests.samplers_tests.tpe_tests.test_parzen_estimator import assert_distribution_almost_equal
 
 
-DIST_TYPES = ["int", "cat"]
+pe_parameters = _ParzenEstimatorParameters(
+    prior_weight=1.0,
+    consider_magic_clip=False,
+    consider_endpoints=False,
+    weights=lambda x: np.empty(0),
+    multivariate=True,
+    categorical_distance_func={},
+)
 
 
 @pytest.mark.parametrize("dist_type", ["int", "cat"])
@@ -29,7 +37,11 @@ def test_init_scott_parzen_estimator(dist_type: str) -> None:
     is_cat = dist_type == "cat"
     pe = ScottParzenEstimator(
         {"a": np.arange(counts.size)},
-        {"a": IntDistribution(low=0, high=counts.size - 1) if not is_cat else CategoricalDistribution(choices=["a" * i for i in range(counts.size)])},
+        {
+            "a": IntDistribution(low=0, high=counts.size - 1)
+            if not is_cat
+            else CategoricalDistribution(choices=["a" * i for i in range(counts.size)])
+        },
         pe_parameters,
         counts,
     )


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. To minimize the review effort, we highly appreciate PRs only with related changes. Please note that submitted PRs may be closed if they include unrelated changes or significantly modified unit tests. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

This PR refactors PED-ANOVA to improve maintainability.

Currently, `ScottParzenEstimator` mixes two responsibilities: handling grid discretization, which is part of PED-ANOVA's logic, and applying Scott's bandwidth rule. In addition, the constructor logic is split between `_build_parzen_estimator` and the class constructor.

Furthermore, although `ScottParzenEstimator` sets the observations and weights in its constructor:

https://github.com/optuna/optuna/blob/9552b229779e700a39968c222ffa75b8526cf990/optuna/importance/_ped_anova/scott_parzen_estimator.py#L39-L51

the `_calculate_numerical_distributions` method does not use them.  Instead, it reconstructs them inside the method:

https://github.com/optuna/optuna/blob/9552b229779e700a39968c222ffa75b8526cf990/optuna/importance/_ped_anova/scott_parzen_estimator.py#L68

https://github.com/optuna/optuna/blob/9552b229779e700a39968c222ffa75b8526cf990/optuna/importance/_ped_anova/scott_parzen_estimator.py#L66

This makes the implementation less natural and harder to follow.



Also, there is no need to perform a binary search over the grid to get the indices of numerical parameters, since these indices can be computed directly by dividing the parameter values by the grid size:

https://github.com/optuna/optuna/blob/9552b229779e700a39968c222ffa75b8526cf990/optuna/importance/_ped_anova/scott_parzen_estimator.py#L110-L114


## Description of the changes
<!-- Describe the changes in this PR. -->

- Refactor `optuna/importance/_ped_anova/evaluator.py` and `optuna/importance/_ped_anova/scott_parzen_estimator.py` to address them

## Compatibility check

To confirm that this refactoring does not change the behavior, I check whether the outputs of PED-ANOVA are exactly the same on the master branch ([`c8781c85a5a314b61bdd7df32abf47af113ec91e`](https://github.com/optuna/optuna/tree/c8781c85a5a314b61bdd7df32abf47af113ec91e)) and in this PR ([`cd0649d4413bf9461e33be80d5f7f10c7daaed99`](https://github.com/kAIto47802/optuna/tree/cd0649d4413bf9461e33be80d5f7f10c7daaed99)).

The following objective includes both

- `suggest_int`; and
- `suggest_float`,

with the following settings:

- default `log` and `step` values (`log=False` for both `suggest_int` and `suggest_float`, `step=1` for `suggest_int`, and `step=None` for `suggest_float`);
- `log=True` and default `step`; and
- `step=2` and default `log`,

as well as

- `suggest_categorical`.

Thus, the objective has `2 * 3 + 1 = 7` parameters in total.

The results confirm that PED-ANOVA produces identical importance scores on both branches.



```py
from __future__ import annotations

import math
import json

import optuna
from optuna.importance import get_param_importances, PedAnovaImportanceEvaluator


def objective(trial: optuna.Trial) -> float:
    x1 = trial.suggest_int("x1", -5, 10)
    x2 = trial.suggest_int("x2", 1, 1000, log=True)
    x3 = trial.suggest_int("x3", -5, 10, step=2)
    x4 = trial.suggest_float("x4", -5, 10)
    x5 = trial.suggest_float("x5", 1, 1000, log=True)
    x6 = trial.suggest_float("x6", -5, 10, step=2)
    x7 = trial.suggest_categorical("x7", ["a", "b", "c"])
    return x1**2 + math.log(x2) + x3**2 + x4**2 + math.log(x5) + x6**2 + ord(x7)


sampler = optuna.samplers.RandomSampler(seed=42)
study = optuna.create_study(sampler=sampler)
study.optimize(objective, n_trials=100)

evaluator = PedAnovaImportanceEvaluator()
importance = get_param_importances(study, evaluator=evaluator)
print(json.dumps(importance))

evaluator = PedAnovaImportanceEvaluator(target_quantile=0.2, region_quantile=0.8)
importance = get_param_importances(study, evaluator=evaluator)
print(json.dumps(importance))

evaluator = PedAnovaImportanceEvaluator(evaluate_on_local=False)
importance = get_param_importances(study, evaluator=evaluator)
print(json.dumps(importance))
```

```bash
#!/bin/bash
set -xeuo pipefail

digits="${DIGITS:-10}"

normalize_json() {
  jq -cS --argjson scale "1e${digits}" \
    'walk(if type == "number" then (. * $scale | round / $scale) else . end)'
}

git switch master
base_rev="$(git rev-parse --short HEAD)"
python check.py | normalize_json >"${base_rev}.jsonl"

git switch refactor-ped-anova
target_rev="$(git rev-parse --short HEAD)"
python check.py | normalize_json >"${target_rev}.jsonl"

if cmp -s "${base_rev}.jsonl" "${target_rev}.jsonl"; then
  echo "Both branches produce the same output."
  exit 0
else
  echo "The outputs differ between the branches."
  diff -u "${base_rev}.jsonl" "${target_rev}.jsonl" | head -100
  exit 1
fi
```



