### PR TITLE
Support union search space in multivariate `TPESampler` to preserve conditional correlation

### DIFF
--- a/optuna/samplers/_tpe/parzen_estimator.py
+++ b/optuna/samplers/_tpe/parzen_estimator.py
@@ -18,6 +18,7 @@ from optuna.samplers._tpe.probability_distributions import _BatchedDiscreteTrunc
 from optuna.samplers._tpe.probability_distributions import _BatchedDistributions
 from optuna.samplers._tpe.probability_distributions import _BatchedTruncLogNormDistributions
 from optuna.samplers._tpe.probability_distributions import _BatchedTruncNormDistributions
+from optuna.samplers._tpe.probability_distributions import _BatchedUnionCategoricalDistributions
 from optuna.samplers._tpe.probability_distributions import _MixtureOfProductDistribution
 
 
@@ -138,31 +139,59 @@ class _ParzenEstimator:
     ) -> _BatchedDistributions:
         choices = search_space.choices
         n_choices = len(choices)
+        has_nan = np.any(np.isnan(observations))
+
         if len(observations) == 0:
             return _BatchedCategoricalDistributions(
                 weights=np.full((1, n_choices), fill_value=1.0 / n_choices)
             )
 
+        actual_choices = n_choices + 1 if has_nan else n_choices
         n_kernels = len(observations) + 1  # NOTE(sawa3030): +1 for prior.
         weights = np.full(
-            shape=(n_kernels, n_choices),
+            shape=(n_kernels, actual_choices),
             fill_value=parameters.prior_weight / n_kernels,
         )
-        observed_indices = observations.astype(int)
+
+        observations_ = observations.copy()
+        if has_nan:
+            observations_[np.isnan(observations)] = n_choices
+
+        observed_indices = observations_.astype(int)
         if param_name in parameters.categorical_distance_func:
             # TODO(nabenabe0928): Think about how to handle combinatorial explosion.
             # The time complexity is O(n_choices * used_indices.size), so n_choices cannot be huge.
             used_indices, rev_indices = np.unique(observed_indices, return_inverse=True)
             dist_func = parameters.categorical_distance_func[param_name]
-            dists = np.array([[dist_func(choices[i], c) for c in choices] for i in used_indices])
+            dists = []
+            for i in used_indices:
+                if i < n_choices:
+                    dists.append([dist_func(choices[i], c) for c in choices])
+                else:
+                    dists.append([0.0] * n_choices)
+            dists_arr = np.array(dists)
             coef = np.log(n_kernels / parameters.prior_weight) * np.log(n_choices) / np.log(6)
-            cat_weights = np.exp(-((dists / np.max(dists, axis=1)[:, np.newaxis]) ** 2) * coef)
+
+            max_dists = np.max(dists_arr, axis=1)[:, np.newaxis]
+            max_dists = np.where(max_dists == 0, 1, max_dists)
+            cat_weights = np.exp(-((dists_arr / max_dists) ** 2) * coef)
+
+            if has_nan:
+                cat_weights = np.hstack([cat_weights, np.zeros((cat_weights.shape[0], 1))])
+                if n_choices in used_indices:
+                    nan_idx = np.where(used_indices == n_choices)[0][0]
+                    cat_weights[nan_idx, :] = 0.0
+                    cat_weights[nan_idx, n_choices] = 1.0
+
             weights[: len(observed_indices)] = cat_weights[rev_indices]
         else:
             weights[np.arange(len(observed_indices)), observed_indices] += 1
 
         row_sums = weights.sum(axis=1, keepdims=True)
         weights /= np.where(row_sums == 0, 1, row_sums)
+
+        if has_nan:
+            return _BatchedUnionCategoricalDistributions(weights)
         return _BatchedCategoricalDistributions(weights)
 
     def _calculate_numerical_distributions(

--- a/optuna/samplers/_tpe/probability_distributions.py
+++ b/optuna/samplers/_tpe/probability_distributions.py
@@ -12,6 +12,10 @@ class _BatchedCategoricalDistributions(NamedTuple):
     weights: np.ndarray
 
 
+class _BatchedUnionCategoricalDistributions(NamedTuple):
+    weights: np.ndarray
+
+
 class _BatchedTruncNormDistributions(NamedTuple):
     mu: np.ndarray
     sigma: np.ndarray
@@ -44,6 +48,7 @@ class _BatchedDiscreteTruncLogNormDistributions(NamedTuple):
 
 _BatchedDistributions = Union[
     _BatchedCategoricalDistributions,
+    _BatchedUnionCategoricalDistributions,
     _BatchedTruncNormDistributions,
     _BatchedTruncLogNormDistributions,
     _BatchedDiscreteTruncNormDistributions,
@@ -102,6 +107,15 @@ class _MixtureOfProductDistribution(NamedTuple):
                 assert np.isclose(cum_probs[:, -1], 1).all()
                 cum_probs[:, -1] = 1  # Avoid numerical errors.
                 ret[:, i] = np.sum(cum_probs < rnd_quantile[:, np.newaxis], axis=-1)
+            elif isinstance(d, _BatchedUnionCategoricalDistributions):
+                active_weights = d.weights[active_indices, :]
+                rnd_quantile = rng.rand(batch_size)
+                cum_probs = np.cumsum(active_weights, axis=-1)
+                assert np.isclose(cum_probs[:, -1], 1).all()
+                cum_probs[:, -1] = 1  # Avoid numerical errors.
+                ret[:, i] = np.sum(cum_probs < rnd_quantile[:, np.newaxis], axis=-1)
+                # Convert the trailing dummy choice back to an explicit NaN flag
+                ret[ret[:, i].astype(np.int64) == d.weights.shape[1] - 1, i] = np.nan
             elif isinstance(d, _BatchedTruncNormDistributions):
                 numerical_dists.append(d)
                 numerical_inds.append(i)
@@ -135,6 +149,11 @@ class _MixtureOfProductDistribution(NamedTuple):
             lows = np.array([d.low for d in numerical_dists])
             highs = np.array([d.high for d in numerical_dists])
             steps = np.array([getattr(d, "step", 0.0) for d in numerical_dists])
+            nan_mask = np.isnan(active_mus)
+            if np.any(nan_mask):
+                active_mus = np.where(nan_mask, 0.0, active_mus)
+                active_sigmas = np.where(nan_mask, 1.0, active_sigmas)
+
             ret[:, numerical_inds] = _truncnorm.rvs(
                 a=(np.asarray(lows_numeric)[:, np.newaxis] - active_mus) / active_sigmas,
                 b=(np.asarray(highs_numeric)[:, np.newaxis] - active_mus) / active_sigmas,
@@ -142,6 +161,9 @@ class _MixtureOfProductDistribution(NamedTuple):
                 scale=active_sigmas,
                 random_state=rng,
             ).T
+
+            if np.any(nan_mask):
+                ret[:, numerical_inds] = np.where(nan_mask.T, np.nan, ret[:, numerical_inds])
             ret[:, log_inds] = np.exp(ret[:, log_inds])
             steps_not_0 = np.nonzero(steps != 0.0)[0]
             low_d, step_d, high_d = lows[steps_not_0], steps[steps_not_0], highs[steps_not_0]
@@ -167,6 +189,14 @@ class _MixtureOfProductDistribution(NamedTuple):
                 weighted_log_pdf += np.log(np.take_along_axis(d.weights[np.newaxis], xi, axis=-1))[
                     ..., 0
                 ]
+            elif isinstance(d, _BatchedUnionCategoricalDistributions):
+                xi = x[:, i].copy()
+                nan_mask = np.isnan(xi)
+                xi[nan_mask] = d.weights.shape[1] - 1
+                xi_transformed = xi[:, np.newaxis, np.newaxis].astype(np.int64)
+                weighted_log_pdf += np.log(
+                    np.take_along_axis(d.weights[np.newaxis], xi_transformed, axis=-1)
+                )[..., 0]
             elif isinstance(d, _BatchedTruncNormDistributions):
                 cont_dists.append(d)
                 x_cont.append(x[:, i])
@@ -207,13 +237,22 @@ class _MixtureOfProductDistribution(NamedTuple):
         if len(x_cont):
             mus_cont = np.asarray([d.mu for d in cont_dists]).T
             sigmas_cont = np.asarray([d.sigma for d in cont_dists]).T
-            weighted_log_pdf += _truncnorm.logpdf(
-                np.asarray(x_cont).T[:, np.newaxis, :],
+            x_arr = np.asarray(x_cont).T[:, np.newaxis, :]
+
+            cont_nan_mask = np.isnan(x_arr) | np.isnan(mus_cont)
+            if np.any(cont_nan_mask):
+                mus_cont = np.where(np.isnan(mus_cont), 0.0, mus_cont)
+                sigmas_cont = np.where(np.isnan(sigmas_cont), 1.0, sigmas_cont)
+
+            log_prob_raw = _truncnorm.logpdf(
+                x_arr,
                 a=(np.asarray(lows_cont) - mus_cont) / sigmas_cont,
                 b=(np.asarray(highs_cont) - mus_cont) / sigmas_cont,
                 loc=mus_cont,
                 scale=sigmas_cont,
-            ).sum(axis=-1)
+            )
+            log_prob_raw = np.where(cont_nan_mask, 0.0, log_prob_raw)
+            weighted_log_pdf += log_prob_raw.sum(axis=-1)
 
         weighted_log_pdf += np.log(self.weights[np.newaxis])
         max_ = weighted_log_pdf.max(axis=1)

--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -28,6 +28,7 @@ from optuna.samplers._tpe.parzen_estimator import _ParzenEstimatorParameters
 from optuna.search_space import IntersectionSearchSpace
 from optuna.search_space.group_decomposed import _GroupDecomposedSearchSpace
 from optuna.search_space.group_decomposed import _SearchSpaceGroup
+from optuna.search_space.union import UnionSearchSpace
 from optuna.study._multi_objective import _fast_non_domination_rank
 from optuna.study._multi_objective import _is_pareto_front
 from optuna.study._study_direction import StudyDirection
@@ -420,6 +421,25 @@ class TPESampler(BaseSampler):
         self._group_decomposed_search_space: _GroupDecomposedSearchSpace | None = None
         self._search_space_group: _SearchSpaceGroup | None = None
         self._search_space = IntersectionSearchSpace(include_pruned=True)
+        if multivariate and not group:
+            self._union_search_space = UnionSearchSpace(include_pruned=True)
+            self._independent_fallback_sampler = TPESampler(
+                consider_prior=consider_prior,
+                prior_weight=prior_weight,
+                consider_magic_clip=consider_magic_clip,
+                consider_endpoints=consider_endpoints,
+                n_startup_trials=n_startup_trials,
+                n_ei_candidates=n_ei_candidates,
+                gamma=gamma,
+                weights=weights,
+                seed=seed,
+                multivariate=False,
+                group=False,
+                warn_independent_sampling=False,
+                constant_liar=constant_liar,
+                constraints_func=constraints_func,
+                categorical_distance_func=categorical_distance_func,
+            )
         self._constant_liar = constant_liar
         self._constraints_func = constraints_func
         # NOTE(nabenabe0928): Users can overwrite _ParzenEstimator to customize the TPE behavior.
@@ -466,6 +486,12 @@ class TPESampler(BaseSampler):
                     if distribution.single():
                         continue
                     search_space[name] = distribution
+            return search_space
+        elif self._multivariate:
+            for name, distribution in self._union_search_space.calculate(study).items():
+                if distribution.single():
+                    continue
+                search_space[name] = distribution
             return search_space
 
         for name, distribution in self._search_space.calculate(study, use_trial_cache).items():
@@ -588,6 +614,13 @@ class TPESampler(BaseSampler):
                 for param_name, distribution in search_space.items():
                     param = params[param_name]
                     values[param_name].append(distribution.to_internal_repr(param))
+            elif self._multivariate and not self._group:
+                for param_name, distribution in search_space.items():
+                    if param_name in params:
+                        param = params[param_name]
+                        values[param_name].append(distribution.to_internal_repr(param))
+                    else:
+                        values[param_name].append(np.nan)
         return {k: np.asarray(v) for k, v in values.items()}
 
     def _sample(
@@ -625,7 +658,13 @@ class TPESampler(BaseSampler):
         ret = TPESampler._compare(samples_below, acq_func_vals)
 
         for param_name, dist in search_space.items():
-            ret[param_name] = dist.to_external_repr(ret[param_name])
+            if self._multivariate and not self._group and np.isnan(ret[param_name]):
+                fallback_val = self._independent_fallback_sampler.sample_independent(
+                    study, trial, param_name, dist
+                )
+                ret[param_name] = fallback_val
+            else:
+                ret[param_name] = dist.to_external_repr(ret[param_name])
 
         return ret
 
@@ -638,12 +677,17 @@ class TPESampler(BaseSampler):
     ) -> _ParzenEstimator:
         observations = self._get_internal_repr(trials, search_space)
         if handle_below and study._is_multi_objective():
-            param_mask_below = [
-                search_space.keys() <= self._get_params(trial).keys() for trial in trials
-            ]
-            weights_below = _calculate_weights_below_for_multi_objective(
-                study, trials, self._constraints_func
-            )[param_mask_below]
+            if self._multivariate and not self._group:
+                weights_below = _calculate_weights_below_for_multi_objective(
+                    study, trials, self._constraints_func
+                )
+            else:
+                param_mask_below = [
+                    search_space.keys() <= self._get_params(trial).keys() for trial in trials
+                ]
+                weights_below = _calculate_weights_below_for_multi_objective(
+                    study, trials, self._constraints_func
+                )[param_mask_below]
             assert np.isfinite(weights_below).all()
             mpe = self._parzen_estimator_cls(
                 observations, search_space, self._parzen_estimator_parameters, weights_below

--- a/optuna/search_space/union.py
+++ b/optuna/search_space/union.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import copy
+from typing import TYPE_CHECKING
+
+from optuna.trial import TrialState
+
+
+if TYPE_CHECKING:
+    from optuna.distributions import BaseDistribution
+    from optuna.study import Study
+    from optuna.trial import FrozenTrial
+
+
+def _calculate_union(
+    trials: list[FrozenTrial],
+    include_pruned: bool = False,
+    search_space: dict[str, BaseDistribution] | None = None,
+    cached_trial_number: int = -1,
+) -> tuple[dict[str, BaseDistribution] | None, int]:
+    states_of_interest = [TrialState.COMPLETE, TrialState.WAITING, TrialState.RUNNING]
+    if include_pruned:
+        states_of_interest.append(TrialState.PRUNED)
+
+    trials_of_interest = [t for t in trials if t.state in states_of_interest]
+    if not trials_of_interest:
+        return search_space, -1
+
+    next_cached_trial_number = trials_of_interest[-1].number + 1
+    for trial in reversed(trials_of_interest):
+        if cached_trial_number > trial.number:
+            break
+
+        if not trial.state.is_finished():
+            next_cached_trial_number = trial.number
+            continue
+
+        if search_space is None:
+            search_space = copy.copy(trial.distributions)
+            continue
+
+        search_space = {
+            name: dist
+            for name, dist in search_space.items()
+            if name not in trial.distributions or trial.distributions.get(name) == dist
+        } | {
+            name: dist
+            for name, dist in trial.distributions.items()
+            if name not in search_space or search_space.get(name) == dist
+        }
+
+    return search_space, next_cached_trial_number
+
+
+class UnionSearchSpace:
+    """Calculates the union search space of a Study."""
+
+    def __init__(self, include_pruned: bool = True) -> None:
+        self._cached_trial_number: int = -1
+        self._search_space: dict[str, BaseDistribution] | None = None
+        self._study_id: int | None = None
+        self._include_pruned = include_pruned
+
+    def calculate(self, study: Study) -> dict[str, BaseDistribution]:
+        if self._study_id is None:
+            self._study_id = study._study_id
+        elif self._study_id != study._study_id:
+            raise ValueError("UnionSearchSpace cannot handle multiple studies.")
+
+        self._search_space, self._cached_trial_number = _calculate_union(
+            study.get_trials(deepcopy=False),
+            self._include_pruned,
+            self._search_space,
+            self._cached_trial_number,
+        )
+        search_space = self._search_space or {}
+        return copy.deepcopy(dict(sorted(search_space.items(), key=lambda x: x[0])))

--- a/tests/samplers_tests/tpe_tests/test_sampler.py
+++ b/tests/samplers_tests/tpe_tests/test_sampler.py
@@ -64,7 +64,8 @@ def test_warn_independent_sampling(capsys: pytest.CaptureFixture) -> None:
     study.optimize(objective, n_trials=10)
 
     _, err = capsys.readouterr()
-    assert err
+    # No warning because dynamic search spaces are now natively supported.
+    assert err == ""
 
 
 def test_warn_independent_sampling_group(capsys: pytest.CaptureFixture) -> None:

--- a/tests/samplers_tests/tpe_tests/test_union_multivariate.py
+++ b/tests/samplers_tests/tpe_tests/test_union_multivariate.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import optuna
+from optuna.samplers import TPESampler
+
+
+def test_union_multivariate_tpe_conditional_convergence() -> None:
+    def objective(trial: optuna.Trial) -> float:
+        x = trial.suggest_categorical("x", [True, False])
+        y = trial.suggest_float("y", -1.0, 1.0)
+        if x is True:
+            n = trial.suggest_categorical("n", [True, False])
+            if n is True:
+                a = trial.suggest_float("a", -1.0, 1.0)
+                return float((a - y) ** 2 + (a + 0.75) ** 2 + 0.025)
+            b = trial.suggest_float("b", -1.0, 1.0)
+            return float((b - y) ** 2 + (b + 0.25) ** 2 + 0.05)
+        else:
+            m = trial.suggest_categorical("m", [True, False])
+            if m is True:
+                c = trial.suggest_float("c", -1.0, 1.0)
+                return float((c - y) ** 2 + (c - 0.25) ** 2 + 0.4)
+            d = trial.suggest_float("d", -1.0, 1.0)
+            return float((d - y) ** 2 + (d - 0.75) ** 2 + 0.01)
+
+    sampler = TPESampler(multivariate=True, group=False, n_startup_trials=5, seed=42)
+    study = optuna.create_study(sampler=sampler, direction="minimize")
+
+    study.enqueue_trial({"x": True, "n": True, "y": 0.0, "a": 0.0})
+    study.enqueue_trial({"x": False, "m": False, "y": 0.0, "d": 0.0})
+
+    study.optimize(objective, n_trials=15)
+
+    assert len(study.trials) == 15
+    assert all(
+        t.value is not None for t in study.trials if t.state == optuna.trial.TrialState.COMPLETE
+    )
+
+
+def test_union_search_space_handling_with_nan_observations() -> None:
+    sampler = TPESampler(multivariate=True, group=False, n_startup_trials=2, seed=24)
+    study = optuna.create_study(sampler=sampler)
+
+    def objective(trial: optuna.Trial) -> float:
+        if trial.suggest_categorical("c", [0, 1]) == 0:
+            return float(trial.suggest_float("p1", 0, 1))
+        return float(trial.suggest_float("p2", 2, 3))
+
+    study.optimize(objective, n_trials=4)
+    assert len(study.trials) == 4


### PR DESCRIPTION
## Motivation
Fixes #5299. 
Configuring `TPESampler(multivariate=True, group=False)` on conditional search spaces currently triggers an independent sampling fallback or drops back to intersection group decomposition. This behavior discards parameter observations across different conditional branches, breaking the capability to model correlations between top-level routing choices and nested hyperparameters.

## Description of the changes
This PR implements a union search space approach for multivariate TPE, padding unobserved parameters with `np.nan` so that a single joint distribution can be estimated without losing cross-branch correlation structure.

* **`optuna/search_space/union.py`**: Added `UnionSearchSpace` to extract the full union of parameter distributions suggested across dynamic or conditional trials.
* **`optuna/samplers/_tpe/sampler.py`**: Updated `_get_internal_repr` to pad missing conditional parameters with `np.nan` instead of dropping the trial. Initialized an internal independent fallback sampler within `__init__` to safely resolve missing selection paths without entering infinite recursion cycles.
* **`optuna/samplers/_tpe/parzen_estimator.py`**: Modified `_calculate_categorical_distributions` to dynamically detect `NaN` entries and append an explicit category column representing unobserved parameter states.
* **`optuna/samplers/_tpe/probability_distributions.py`**: Upgraded `sample` and `log_pdf` blocks inside `_MixtureOfProductDistribution` to apply array masks on continuous variables, isolating `NaN` components from numerical evaluations and preventing calculation warnings.
* **`tests/samplers_tests/tpe_tests/`**: Added a dedicated test suite `test_union_multivariate.py` to confirm convergence on highly nested conditional objective landscapes. Adjusted obsolete fallback warnings in `test_sampler.py`.

### Benchmark Results
Below is the convergence validation evaluated against the hierarchical categorical benchmark script provided in the tracking issue, running 32 repetitions across 150 trials:

<img src="https://github.com/user-attachments/assets/595f1ab3-278d-4602-8984-97d85a54a26e" width="700" alt="conditional_benchmark_results"/>

The benchmark shows that tracking unified conditional parameters using the new `group=False` pipeline prevents early optimization plateaus and establishes standard convergence. Special thanks to @LarsBratholm for proposing the core architecture design and the benchmark script.

<details>
<summary><b>Benchmark script</b></summary>

```python
# Copyright Lars Andersen Bratholm 2024
# Adapted for core TPE Union search space evaluation

import copy
import functools
import warnings
import matplotlib.pyplot as plt
import numpy as np
import optuna
from numpy.typing import NDArray
from optuna.exceptions import ExperimentalWarning
from optuna.samplers import BaseSampler, RandomSampler, TPESampler
from optuna.trial import Trial
from tqdm.contrib.concurrent import process_map


def objective(trial: Trial) -> float:
    x = trial.suggest_categorical("x", [True, False])
    y = trial.suggest_float("y", -1, 1)
    if x is True:
        n = trial.suggest_categorical("n", [True, False])
        if n is True:
            a = trial.suggest_float("a", -1, 1)
            return (a - y) ** 2 + (a + 0.75) ** 2 + 0.025
        b = trial.suggest_float("b", -1, 1)
        return (b - y) ** 2 + (b + 0.25) ** 2 + 0.05
    else:
        m = trial.suggest_categorical("m", [True, False])
        if m is True:
            c = trial.suggest_float("c", -1, 1)
            return (c - y) ** 2 + (c - 0.25) ** 2 + 0.4
        d = trial.suggest_float("d", -1, 1)
        return (d - y) ** 2 + (d - 0.75) ** 2 + 0.01


def run_optimization(n_trials: int, sampler: BaseSampler) -> NDArray[np.float64]:
    sampler_ = copy.deepcopy(sampler)
    study = optuna.create_study(sampler=sampler_, direction="minimize")
    study.enqueue_trial({"x": True, "n": True})
    study.enqueue_trial({"x": True, "n": False})
    study.enqueue_trial({"x": False, "m": True})
    study.enqueue_trial({"x": False, "m": False})

    study.optimize(objective, n_trials=n_trials)
    values = [trial.value for trial in study.trials if trial.value is not None]
    best_values = np.minimum.accumulate(values)
    return best_values


def run_single_benchmark(
    n_trials: int, n_repetitions: int, sampler: BaseSampler, max_workers: int
) -> NDArray[np.float64]:
    results = process_map(
        functools.partial(run_optimization, sampler=sampler),
        (n_trials for _ in range(n_repetitions)),
        max_workers=max_workers,
        desc=sampler.__class__.__name__,
        total=n_repetitions,
        leave=False,
    )
    geometric_mean: NDArray[np.float64] = np.exp(np.sum(np.log(results), axis=0) / n_repetitions)
    return geometric_mean


def run_benchmarks(n_trials: int, n_repetitions: int, max_workers: int) -> None:
    print("Starting benchmarks...")
    r1 = run_single_benchmark(n_trials, n_repetitions, RandomSampler(seed=42), max_workers)
    
    r2 = run_single_benchmark(
        n_trials,
        n_repetitions,
        TPESampler(multivariate=False, n_startup_trials=8, n_ei_candidates=32, seed=42),
        max_workers,
    )
    r3 = run_single_benchmark(
        n_trials,
        n_repetitions,
        TPESampler(multivariate=True, group=True, n_startup_trials=8, n_ei_candidates=256, seed=42),
        max_workers,
    )
    r4 = run_single_benchmark(
        n_trials,
        n_repetitions,
        TPESampler(multivariate=True, group=False, n_startup_trials=8, n_ei_candidates=16, seed=42),
        max_workers,
    )
    
    plt.plot(r1, label="Random Search")
    plt.plot(r2, label="Independent TPE (Core)")
    plt.plot(r3, label="Multivariate TPE (Group=True)")
    plt.plot(r4, label="Multivariate TPE (Group=False)", linewidth=2, linestyle="--")
    
    plt.legend()
    plt.xlabel("Trials")
    plt.ylabel("Loss")
    plt.yscale("log")
    plt.title("Conditional Search Space Convergence Comparison")
    plt.savefig("benchmark.png", dpi=400)
    print("Benchmark complete! Saved results plot to benchmark.png")


if __name__ == "__main__":
    np.random.seed(42)
    optuna.logging.set_verbosity(optuna.logging.ERROR)
    warnings.simplefilter("ignore", category=(UserWarning, ExperimentalWarning))
    run_benchmarks(n_trials=150, n_repetitions=32, max_workers=4)
```