### PR TITLE
Fix typos in docstrings and duplicated author names in SPXCrossover citation

### DIFF
--- a/optuna/_gp/gp.py
+++ b/optuna/_gp/gp.py
@@ -297,7 +297,7 @@ class GPRegressor:
         n_params = self._X_train.shape[1]
 
         # We apply log transform to enforce the positivity of the kernel parameters.
-        # Note that we cannot just use the constraint because of the numerical unstability
+        # Note that we cannot just use the constraint because of the numerical instability
         # of the marginal log likelihood.
         # We also enforce the noise parameter to be greater than `minimum_noise` to avoid
         # pathological behavior of maximum likelihood estimation.

--- a/optuna/logging.py
+++ b/optuna/logging.py
@@ -280,7 +280,7 @@ def disable_propagation() -> None:
             logger.info("Logs from first optimize call")  # The logs are saved in the logs file.
             study.optimize(objective, n_trials=10)
 
-            optuna.logging.disable_propagation()  # Stop propogating logs to the root logger.
+            optuna.logging.disable_propagation()  # Stop propagating logs to the root logger.
 
             logger.info("Logs from second optimize call")
             # The new logs for second optimize call are not saved.

--- a/optuna/samplers/_base.py
+++ b/optuna/samplers/_base.py
@@ -104,7 +104,7 @@ class BaseSampler(abc.ABC):
         that use relationship between parameters such as Gaussian Process and CMA-ES.
 
         .. note::
-                The failed trials are ignored by any build-in samplers when they sample new
+                The failed trials are ignored by any built-in samplers when they sample new
                 parameters. Thus, failed trials are regarded as deleted in the samplers'
                 perspective.
 
@@ -141,7 +141,7 @@ class BaseSampler(abc.ABC):
         sampling and TPE.
 
         .. note::
-                The failed trials are ignored by any build-in samplers when they sample new
+                The failed trials are ignored by any built-in samplers when they sample new
                 parameters. Thus, failed trials are regarded as deleted in the samplers'
                 perspective.
 

--- a/optuna/samplers/nsgaii/_crossovers/_spx.py
+++ b/optuna/samplers/nsgaii/_crossovers/_spx.py
@@ -20,8 +20,7 @@ class SPXCrossover(BaseCrossover):
     that is similar to the simplex produced by the parent individual.
     For further information about SPX crossover, please refer to the following paper:
 
-    - `Shigeyoshi Tsutsui and Shigeyoshi Tsutsui and David E. Goldberg and
-      David E. Goldberg and Kumara Sastry and Kumara Sastry
+    - `Shigeyoshi Tsutsui, David E. Goldberg, and Kumara Sastry.
       Progress Toward Linkage Learning in Real-Coded GAs with Simplex Crossover.
       IlliGAL Report. 2000.
       <https://www.researchgate.net/publication/2388486_Progress_Toward_Linkage_Learning_in_Real-Coded_GAs_with_Simplex_Crossover>`__

--- a/optuna/testing/tempfile_pool.py
+++ b/optuna/testing/tempfile_pool.py
@@ -1,4 +1,4 @@
-# On Windows, temporary file shold delete "after" storage was deleted
+# On Windows, temporary file should delete "after" storage was deleted
 # NamedTemporaryFilePool ensures tempfile delete after tests.
 
 from __future__ import annotations


### PR DESCRIPTION
…itation

<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. To minimize the review effort, we highly appreciate PRs only with related changes. Please note that submitted PRs may be closed if they include unrelated changes or significantly modified unit tests. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
Long-standing typos in docstrings and comments make user-facing documentation look unpolished, and a citation in `SPXCrossover` had each author name duplicated, making the reference confusing.

## Description of the changes
These typos were surfaced by running [codespell](https://github.com/codespell-project/codespell) on the `optuna/` and `docs/` directories. Six hits were returned; `IlliGAL` is the correct name of the Illinois Genetic Algorithms Laboratory's technical report series and has been left unchanged.

While reviewing the SPX file in context, I noticed each author name in the citation was duplicated (e.g. "Shigeyoshi Tsutsui and Shigeyoshi Tsutsui and David E. Goldberg and David E. Goldberg and Kumara Sastry and Kumara Sastry"). All other crossover docstrings in `optuna/samplers/nsgaii/_crossovers/` list each author exactly once, so I deduplicated this list to match the project convention.

Changes:
- `optuna/logging.py`: "propogating" → "propagating"
- `optuna/_gp/gp.py`: "unstability" → "instability"
- `optuna/testing/tempfile_pool.py`: "shold" → "should"
- `optuna/samplers/_base.py`: "build-in samplers" → "built-in samplers" (two occurrences)
- `optuna/samplers/nsgaii/_crossovers/_spx.py`: deduplicated author list in citation

No behavior changes, comments and docstrings only.
