### PR TITLE
capture windows stdout

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,17 @@
+import sys
+
 import pytest
 
 
 pytest.register_assert_rewrite("optuna.testing.pytest_samplers")
 pytest.register_assert_rewrite("optuna.testing.pytest_storages")
+
+
+def pytest_runtest_setup() -> None:
+    if sys.platform != "win32":
+        return
+
+    import optuna.logging
+
+    optuna.logging._reset_library_root_logger()
+    optuna.logging._configure_library_root_logger()


### PR DESCRIPTION
## Motivation

In the current Windows tests, Optuna logging output is not properly captured by pytest. This happens because `optuna.logging` can bind its default stream before pytest redirects/captures stderr, and the logging handler then keeps that stale stream
reference throughout the test run.

As a result, the `windows-tests` CI output contains a large amount of noisy log output instead of the usual compact pytest progress output, for example:

```text
Uninstalled 1 package in 51ms
Installed 1 package in 289ms
[I 2026-05-31 12:27:03,819] A new study created in memory with name: no-name-812ffc68-2d92-405b-94bd-65af4c7c5e22
[I 2026-05-31 12:27:03,827] A new study created in memory with name: no-name-fed26276-bc8c-4739-bd64-bac6468fa548
[I 2026-05-31 12:27:03,828] Trial 0 finished with values: [1.0, 2.0] and parameters: {'x': 1, 'y': 2}.
[I 2026-05-31 12:27:03,828] Trial 1 finished with values: [1.0, 1.0] and parameters: {'x': 1, 'y': 1}.
[I 2026-05-31 12:27:03,828] Trial 2 finished with values: [0.0, 2.0] and parameters: {'x': 0, 'y': 2}.
[I 2026-05-31 12:27:03,828] Trial 3 finished with values: [1.0, 0.0] and parameters: {'x': 1, 'y': 0}.
```

This makes Windows CI logs harder to inspect compared with Linux and macOS, where pytest capture works as expected.

## Description of the changes

- Reconfigured Optuna's default logging handler during pytest setup on Windows so that it uses pytest's captured stream.
