### PR TITLE
fix(visualization): raise ImportError in _rank when no plotting backend is available

### DIFF
--- a/optuna/visualization/_rank.py
+++ b/optuna/visualization/_rank.py
@@ -405,6 +405,11 @@ def _convert_color_idxs_to_scaled_rgb_colors(color_idxs: np.ndarray) -> np.ndarr
         scaled_rgb_colors = np.array([plotly.colors.unlabel_rgb(cl) for cl in labeled_colors])
         return scaled_rgb_colors
     else:
+        if not matplotlib_imports.is_successful():
+            raise ImportError(
+                "Neither plotly nor matplotlib is installed. "
+                "Please install one of them to use plot_rank."
+            )
         cmap = matplotlib_plt.get_cmap(colormap)
         colors = cmap(color_idxs)[:, :3]  # Drop alpha values.
         rgb_colors = np.asarray(colors * 255, dtype=int)

--- a/tests/visualization_tests/matplotlib_tests/test_rank.py
+++ b/tests/visualization_tests/matplotlib_tests/test_rank.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+
+from optuna.visualization._rank import _convert_color_idxs_to_scaled_rgb_colors
+
+
+def test_convert_color_idxs_raises_when_no_backend_available() -> None:
+    with patch("optuna.visualization._rank.plotly_is_available", False), patch(
+        "optuna.visualization._rank.matplotlib_imports.is_successful", return_value=False
+    ):
+        with pytest.raises(ImportError, match="Neither plotly nor matplotlib"):
+            _convert_color_idxs_to_scaled_rgb_colors(np.array([0.1, 0.5]))


### PR DESCRIPTION
## What's broken

When `_get_rank_info` is called without plotly or matplotlib installed, it crashes inside `_convert_color_idxs_to_scaled_rgb_colors` with `NameError: name 'matplotlib_plt' is not defined`. This happens because `matplotlib_plt` is only imported at module level when matplotlib is available, but the plotly-unavailable fallback branch uses `matplotlib_plt` unconditionally.

## Why it happens

The `else` branch at line 407 of `optuna/visualization/_rank.py` assumes `matplotlib_plt` is always defined when plotly is not available, but that name only exists in the module scope when `matplotlib_imports.is_successful()` is true.

## Fix

Added an explicit `if not matplotlib_imports.is_successful()` guard in the `else` branch. When neither plotly nor matplotlib is installed, the function now raises `ImportError` with a clear message instead of crashing with `NameError`.

## Test

Added `test_convert_color_idxs_raises_when_no_backend_available` in `tests/visualization_tests/matplotlib_tests/test_rank.py`. It patches both `plotly_is_available` and `matplotlib_imports.is_successful` to simulate the no-backend state and asserts that `ImportError` is raised with the expected message.

Fixes #6702