### PR TITLE
Expose gRPC proxy server lifecycle

### DIFF
--- a/docs/source/reference/storages.rst
+++ b/docs/source/reference/storages.rst
@@ -14,6 +14,7 @@ The :mod:`~optuna.storages` module defines a :class:`~optuna.storages.BaseStorag
    fail_stale_trials
    JournalStorage
    InMemoryStorage
+   create_grpc_proxy_server
    run_grpc_proxy_server
    GrpcStorageProxy
 

--- a/optuna/storages/__init__.py
+++ b/optuna/storages/__init__.py
@@ -5,6 +5,7 @@ from optuna.storages._cached_storage import _CachedStorage
 from optuna.storages._callbacks import RetryFailedTrialCallback
 from optuna.storages._callbacks import RetryHeartbeatStaleTrialCallback
 from optuna.storages._grpc import GrpcStorageProxy
+from optuna.storages._grpc import create_grpc_proxy_server
 from optuna.storages._grpc import run_grpc_proxy_server
 from optuna.storages._heartbeat import fail_stale_trials
 from optuna.storages._in_memory import InMemoryStorage
@@ -34,6 +35,7 @@ __all__ = [
     "_CachedStorage",
     "fail_stale_trials",
     "GrpcStorageProxy",
+    "create_grpc_proxy_server",
     "run_grpc_proxy_server",
 ]
 

--- a/optuna/storages/_grpc/__init__.py
+++ b/optuna/storages/_grpc/__init__.py
@@ -1,8 +1,10 @@
 from optuna.storages._grpc.client import GrpcStorageProxy
+from optuna.storages._grpc.server import create_grpc_proxy_server
 from optuna.storages._grpc.server import run_grpc_proxy_server
 
 
 __all__ = [
+    "create_grpc_proxy_server",
     "run_grpc_proxy_server",
     "GrpcStorageProxy",
 ]

--- a/optuna/storages/_grpc/server.py
+++ b/optuna/storages/_grpc/server.py
@@ -35,6 +35,24 @@ def make_server(
     return server
 
 
+@experimental_func("4.6.0")
+def create_grpc_proxy_server(
+    storage: BaseStorage,
+    *,
+    host: str = "localhost",
+    port: int = 13000,
+    thread_pool: ThreadPoolExecutor | None = None,
+) -> grpc.Server:
+    """Create a gRPC server for the given storage without starting it.
+
+    Use this function when embedding the gRPC proxy in another process and
+    explicit control over ``start()``, ``stop()``, or ``wait_for_termination()``
+    is needed. For a standalone blocking server, use
+    :func:`~optuna.storages.run_grpc_proxy_server`.
+    """
+    return make_server(storage, host, port, thread_pool)
+
+
 @experimental_func("4.2.0")
 def run_grpc_proxy_server(
     storage: BaseStorage,
@@ -77,7 +95,9 @@ def run_grpc_proxy_server(
         https://github.com/optuna/optuna/issues/6084. Please use
         :class:`~optuna.storages.RDBStorage` instead.
     """
-    server = make_server(storage, host, port, thread_pool)
+    server = create_grpc_proxy_server(
+        storage, host=host, port=port, thread_pool=thread_pool
+    )
     server.start()
     _logger.info(f"Server started at {host}:{port}")
     _logger.info("Listening...")

--- a/tests/storages_tests/test_grpc.py
+++ b/tests/storages_tests/test_grpc.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import pytest
 
+import optuna
 from optuna.storages import BaseStorage
 from optuna.study._study_direction import StudyDirection
 from optuna.testing.storages import STORAGE_MODES
@@ -27,3 +28,11 @@ def test_set_and_get_trial_state_values(storage_mode: str, values: list[float] |
         with StorageSupplier("grpc_proxy", base_storage=storage_direct) as storage_grpc_proxy:
             _test_set_and_get_compatibility(storage_grpc_proxy, storage_direct, values)
             _test_set_and_get_compatibility(storage_direct, storage_grpc_proxy, values)
+
+
+def test_create_grpc_proxy_server_controls_lifecycle() -> None:
+    storage = optuna.storages.InMemoryStorage()
+    server = optuna.storages.create_grpc_proxy_server(storage, port=0)
+
+    server.start()
+    server.stop(grace=0).wait()


### PR DESCRIPTION
## Motivation

Closes #6678.

The gRPC proxy server currently exposes only `run_grpc_proxy_server`, which starts the server and blocks. Embedding the proxy in a larger process needs explicit access to the server lifecycle.

## Description of the changes

- Add `create_grpc_proxy_server` as a public helper that returns an unstarted `grpc.Server`.
- Reuse the new helper from `run_grpc_proxy_server`.
- Export the helper from `optuna.storages` and include it in the storage reference docs.
- Add a focused lifecycle test for creating, starting, and stopping the server.

Tests:

```text
python3 -m compileall optuna/storages/_grpc/server.py optuna/storages/__init__.py optuna/storages/_grpc/__init__.py tests/storages_tests/test_grpc.py
python3 - <<'PY'
import optuna
storage = optuna.storages.InMemoryStorage()
server = optuna.storages.create_grpc_proxy_server(storage, port=0)
server.start()
server.stop(grace=0).wait()
print('ok')
PY
```

`python3 -m pytest tests/storages_tests/test_grpc.py::test_create_grpc_proxy_server_controls_lifecycle -q` could not run in this environment because `fakeredis` is not installed.