### PR TITLE
Fix RDBStorage trial timestamp timezone

### DIFF
--- a/optuna/storages/_rdb/storage.py
+++ b/optuna/storages/_rdb/storage.py
@@ -10,6 +10,7 @@ from contextlib import contextmanager
 import copy
 from datetime import datetime
 from datetime import timedelta
+from datetime import timezone
 import json
 import logging
 import os
@@ -67,6 +68,10 @@ else:
 
 
 _logger = optuna.logging.get_logger(__name__)
+
+
+def _get_current_datetime() -> datetime:
+    return datetime.now(timezone.utc).replace(tzinfo=None)
 
 
 @contextmanager
@@ -514,7 +519,7 @@ class RDBStorage(BaseStorage, BaseHeartbeat):
                 study_id=study_id,
                 number=None,
                 state=TrialState.RUNNING,
-                datetime_start=datetime.now(),
+                datetime_start=_get_current_datetime(),
             )
         else:
             # Because only `RUNNING` trials can be updated,
@@ -668,10 +673,10 @@ class RDBStorage(BaseStorage, BaseHeartbeat):
                 trial.state = state
 
                 if state == TrialState.RUNNING:
-                    trial.datetime_start = datetime.now()
+                    trial.datetime_start = _get_current_datetime()
 
                 if state.is_finished():
-                    trial.datetime_complete = datetime.now()
+                    trial.datetime_complete = _get_current_datetime()
         except sqlalchemy_exc.IntegrityError:
             return False
         return True

--- a/tests/storages_tests/rdb_tests/test_storage.py
+++ b/tests/storages_tests/rdb_tests/test_storage.py
@@ -3,11 +3,13 @@ from __future__ import annotations
 from collections.abc import Generator
 from contextlib import contextmanager
 from datetime import datetime
+from datetime import timezone
 import os
 import platform
 import shutil
 import sys
 import tempfile
+import time
 from typing import Any
 from unittest.mock import Mock
 from unittest.mock import patch
@@ -335,6 +337,35 @@ def test_upgrade_distributions(optuna_version: str) -> None:
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore", category=UserWarning)
                 new_study.optimize(objective_test_upgrade_distributions, n_trials=1)
+
+
+@pytest.mark.skipif(not hasattr(time, "tzset"), reason="requires time.tzset")
+def test_trial_timestamps_are_recorded_as_utc_naive() -> None:
+    original_tz = os.environ.get("TZ")
+    os.environ["TZ"] = "Asia/Tokyo"
+    time.tzset()
+
+    try:
+        with create_test_storage("sqlite:///:memory:") as storage:
+            study_id = storage.create_new_study(directions=[StudyDirection.MINIMIZE])
+
+            before_utc = datetime.now(timezone.utc).replace(tzinfo=None)
+            trial_id = storage.create_new_trial(study_id)
+            storage.set_trial_state_values(trial_id, TrialState.COMPLETE, [1.0])
+            after_utc = datetime.now(timezone.utc).replace(tzinfo=None)
+
+            trial = storage.get_trial(trial_id)
+
+        assert trial.datetime_start is not None
+        assert trial.datetime_complete is not None
+        assert before_utc <= trial.datetime_start <= after_utc
+        assert before_utc <= trial.datetime_complete <= after_utc
+    finally:
+        if original_tz is None:
+            os.environ.pop("TZ", None)
+        else:
+            os.environ["TZ"] = original_tz
+        time.tzset()
 
 
 def test_create_new_trial_with_retries() -> None:


### PR DESCRIPTION
## Motivation
Fixes #6708. RDBStorage currently records naive trial timestamps using the process-local timezone, so identical runs can be stored with shifted timestamps depending on where the storage process runs.

## Description of the changes
Use naive UTC datetimes for RDBStorage-created trial start/completion timestamps while preserving the existing naive datetime API shape. Added a regression test that sets a non-UTC local timezone and verifies stored timestamps fall within the UTC execution window.