### PR TITLE
FIx wording in specify params tutorial

### DIFF
--- a/tutorial/20_recipes/008_specify_params.py
+++ b/tutorial/20_recipes/008_specify_params.py
@@ -26,7 +26,7 @@ evaluated them yet and decided to use Optuna to find better sets of hyperparamet
 Optuna has :func:`optuna.study.Study.enqueue_trial` which lets you pass those sets of
 hyperparameters to Optuna and Optuna will evaluate them.
 
-This section walks you through how to use this lit API with `LightGBM <https://lightgbm.readthedocs.io/en/stable/>`__.
+This section walks you through how to use this API with `LightGBM <https://lightgbm.readthedocs.io/en/stable/>`__.
 """
 
 import lightgbm as lgb
@@ -70,7 +70,7 @@ def objective(trial):
 study = optuna.create_study(direction="maximize", pruner=optuna.pruners.MedianPruner())
 
 ###################################################################################################
-# Here, we get Optuna evaluate some sets with larger ``"bagging_fraq"`` value and
+# Here, we get Optuna evaluate some sets with larger ``"bagging_freq"`` value and
 # the default values.
 
 study.enqueue_trial(
@@ -92,7 +92,7 @@ study.enqueue_trial(
 import logging
 import sys
 
-# Add stream handler of stdout to show the messages to see Optuna works expectedly.
+# Add a stream handler of stdout to show log messages to confirm that Optuna works as expected.
 optuna.logging.get_logger("optuna").addHandler(logging.StreamHandler(sys.stdout))
 study.optimize(objective, n_trials=100, timeout=600)
 


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. To minimize the review effort, we highly appreciate PRs only with related changes. Please note that submitted PRs may be closed if they include unrelated changes or significantly modified unit tests. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
While reading and running the `008_specify_params.py` tutorial, I noticed a few minor typos and unclear comments.


## Description of the changes
<!-- Describe the changes in this PR. -->

- Fixed `lit API` to `API`.
- Fixed `bagging_fraq` to `bagging_freq`.
- Improved the wording of comments related to `enqueue_trial` and logging.

## Verification

I ran the following checks locally:

```bash
uv run ruff format tutorial/20_recipes/008_specify_params.py
uv run ruff check tutorial/20_recipes/008_specify_params.py