### PR TITLE
Raise `ValueError` in `PedAnovaImportanceEvaluator` for multi-objective studies without `target`

### DIFF
--- a/optuna/importance/_ped_anova/evaluator.py
+++ b/optuna/importance/_ped_anova/evaluator.py
@@ -235,7 +235,10 @@ class PedAnovaImportanceEvaluator(BaseImportanceEvaluator):
             raise ValueError(
                 "If the `study` is being used for multi-objective optimization, "
                 "please specify the `target`. For example, use "
-                "`target=lambda t: t.values[0]` for the first objective value."
+                "`target=lambda t: t.values[0]` for the first objective value. "
+                f"{self.__class__.__name__} computes the importances of params to achieve "
+                "low `target` values. If this is not what you want, "
+                "please modify target, e.g., by multiplying the output by -1."
             )
         dists = _get_distributions(study, params=params)
         if params is None:

--- a/optuna/importance/_ped_anova/evaluator.py
+++ b/optuna/importance/_ped_anova/evaluator.py
@@ -231,6 +231,12 @@ class PedAnovaImportanceEvaluator(BaseImportanceEvaluator):
         *,
         target: Callable[[FrozenTrial], float] | None = None,
     ) -> dict[str, float]:
+        if target is None and study._is_multi_objective():
+            raise ValueError(
+                "If the `study` is being used for multi-objective optimization, "
+                "please specify the `target`. For example, use "
+                "`target=lambda t: t.values[0]` for the first objective value."
+            )
         dists = _get_distributions(study, params=params)
         if params is None:
             params = list(dists.keys())

--- a/tests/importance_tests/pedanova_tests/test_evaluator.py
+++ b/tests/importance_tests/pedanova_tests/test_evaluator.py
@@ -55,7 +55,7 @@ def test_filter(
 
 
 def test_error_in_ped_anova() -> None:
-    with pytest.raises(RuntimeError):
+    with pytest.raises(ValueError):
         evaluator = PedAnovaImportanceEvaluator()
         study = get_study(seed=0, n_trials=5, is_multi_obj=True)
         evaluator.evaluate(study)


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. To minimize the review effort, we highly appreciate PRs only with related changes. Please note that submitted PRs may be closed if they include unrelated changes or significantly modified unit tests. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->


Currently, `FanovaImportanceEvaluator` and `MeanDecreaseImpurityImportanceEvaluator` explicitly raise a `ValueError` when `target` is `None` for a multi-objective study, but `PedAnovaImportanceEvaluator` does not.

https://github.com/optuna/optuna/blob/13c8d36021c07f3477b8174d54d3b4c079c98fe5/optuna/importance/_fanova/_evaluator.py#L80-L85

https://github.com/optuna/optuna/blob/13c8d36021c07f3477b8174d54d3b4c079c98fe5/optuna/importance/_mean_decrease_impurity.py#L72-L77

As a result, this case is not caught early and instead leads to a `RuntimeError` when the implementation internally accesses `trial.value`.

https://github.com/optuna/optuna/blob/13c8d36021c07f3477b8174d54d3b4c079c98fe5/optuna/importance/_base.py#L154

https://github.com/optuna/optuna/blob/13c8d36021c07f3477b8174d54d3b4c079c98fe5/optuna/trial/_frozen.py#L383

This behavior is not user-friendly because the error message does not explain that `target` should be specified. This PR adds the same `ValueError` check to `PedAnovaImportanceEvaluator` as in `FanovaImportanceEvaluator` and `MeanDecreaseImpurityImportanceEvaluator`.

## Description of the changes
<!-- Describe the changes in this PR. -->
