### PR TITLE
Fix logging tests broken by pytest 9.1.0 caplog behavior change

### DIFF
--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -27,14 +27,14 @@ def test_default_handler(capsys: _pytest.capture.CaptureFixture) -> None:
 
     # Default handler enabled
     optuna.logging.enable_default_handler()
-    assert library_root_logger.handlers
+    assert optuna.logging._default_handler in library_root_logger.handlers
     example_logger.info("hey")
     _, err = capsys.readouterr()
     assert "hey" in err
 
     # Default handler disabled
     optuna.logging.disable_default_handler()
-    assert not library_root_logger.handlers
+    assert optuna.logging._default_handler not in library_root_logger.handlers
     example_logger.info("yoyo")
     _, err = capsys.readouterr()
     assert "yoyo" not in err
@@ -70,23 +70,35 @@ def test_verbosity(capsys: _pytest.capture.CaptureFixture) -> None:
     assert "bye-debug" not in err
 
 
-def test_propagation(caplog: _pytest.logging.LogCaptureFixture) -> None:
+def test_propagation() -> None:
     optuna.logging._reset_library_root_logger()
     logger = optuna.logging.get_logger("optuna.foo")
 
-    # Propagation is disabled by default.
-    with caplog.at_level(logging.INFO, logger="optuna"):
+    # Capture the records that actually reach the root logger to verify propagation directly.
+    # We cannot rely on caplog here because, since pytest 9.1.0, caplog captures logs even from
+    # non-propagating loggers (https://github.com/pytest-dev/pytest/issues/3697).
+    records: list[logging.LogRecord] = []
+
+    class _RecordingHandler(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            records.append(record)
+
+    root_logger = logging.getLogger()
+    handler = _RecordingHandler()
+    root_logger.addHandler(handler)
+    try:
+        # Propagation is disabled by default.
         logger.info("no-propagation")
-    assert "no-propagation" not in caplog.text
+        assert not any(r.getMessage() == "no-propagation" for r in records)
 
-    # Enable propagation.
-    optuna.logging.enable_propagation()
-    with caplog.at_level(logging.INFO, logger="optuna"):
+        # Enable propagation.
+        optuna.logging.enable_propagation()
         logger.info("enable-propagate")
-    assert "enable-propagate" in caplog.text
+        assert any(r.getMessage() == "enable-propagate" for r in records)
 
-    # Disable propagation.
-    optuna.logging.disable_propagation()
-    with caplog.at_level(logging.INFO, logger="optuna"):
+        # Disable propagation.
+        optuna.logging.disable_propagation()
         logger.info("disable-propagation")
-    assert "disable-propagation" not in caplog.text
+        assert not any(r.getMessage() == "disable-propagation" for r in records)
+    finally:
+        root_logger.removeHandler(handler)

--- a/tests/visualization_tests/test_utils.py
+++ b/tests/visualization_tests/test_utils.py
@@ -159,12 +159,15 @@ def test_filter_inf_trials_message(caplog: LogCaptureFixture, with_message: bool
 
     if with_message:
         assert msg in caplog.text
-        n_filtered_as_inf = 0
+        # Since pytest 9.1.0, the same record can be captured more than once because caplog also
+        # captures logs from non-propagating loggers in addition to the propagated ones
+        # (https://github.com/pytest-dev/pytest/issues/3697). Deduplicate the records to count how
+        # many times the message was actually logged.
+        filtered_as_inf = {id(record) for record in caplog.records if record.msg == msg}
         for record in caplog.records:
             if record.msg == msg:
                 assert record.levelno == logging.WARNING
-                n_filtered_as_inf += 1
-        assert n_filtered_as_inf == 1
+        assert len(filtered_as_inf) == 1
     else:
         assert msg not in caplog.text
 


### PR DESCRIPTION
## Motivation & Changes

The scheduled CI started failing with the following 3 test failures:

- `tests/test_logging.py::test_default_handler`
- `tests/test_logging.py::test_propagation`
- `tests/visualization_tests/test_utils.py::test_filter_inf_trials_message[True]`

The root cause is pytest 9.1.0 that includes the bugfix ["Logging capture now works for non-propagating loggers"](https://github.com/pytest-dev/pytest/issues/3697):

- Before 9.1.0: `caplog` captured only logs that propagated to the root logger.
- Since 9.1.0: pytest also attaches its own handlers (`_LiveLoggingNullHandler` / `_FileHandler`) directly to non-propagating loggers and captures them.

Our logging tests relied on the old behavior, so they broke even though Optuna's logging functionality itself is unaffected. 

This PR makes the affected tests robust to the new pytest behavior (and keeps them passing on older pytest too).