### PR TITLE
Handle insufficient trials without raising `ValueError` in importances

### DIFF
--- a/optuna/importance/_base.py
+++ b/optuna/importance/_base.py
@@ -113,11 +113,6 @@ def _get_distributions(study: Study, params: list[str] | None) -> dict[str, Base
 
 
 def _check_evaluate_args(completed_trials: list[FrozenTrial], params: list[str] | None) -> None:
-    if len(completed_trials) == 0:
-        raise ValueError("Cannot evaluate parameter importances without completed trials.")
-    if len(completed_trials) == 1:
-        raise ValueError("Cannot evaluate parameter importances with only a single trial.")
-
     if params is not None:
         if not isinstance(params, (list, tuple)):
             raise TypeError(

--- a/optuna/importance/_fanova/_evaluator.py
+++ b/optuna/importance/_fanova/_evaluator.py
@@ -103,7 +103,7 @@ class FanovaImportanceEvaluator(BaseImportanceEvaluator):
             return {k: 0.0 for k in single_distributions}
 
         trials: list[FrozenTrial] = _get_filtered_trials(study, params=params, target=target)
-        if len(trials) <= 2:
+        if len(trials) <= 1:
             return {k: 0.0 for k in params}
 
         trans = _SearchSpaceTransform(

--- a/optuna/importance/_fanova/_evaluator.py
+++ b/optuna/importance/_fanova/_evaluator.py
@@ -103,6 +103,8 @@ class FanovaImportanceEvaluator(BaseImportanceEvaluator):
             return {k: 0.0 for k in single_distributions}
 
         trials: list[FrozenTrial] = _get_filtered_trials(study, params=params, target=target)
+        if len(trials) <= 2:
+            return {k: 0.0 for k in params}
 
         trans = _SearchSpaceTransform(
             non_single_distributions, transform_log=False, transform_step=False

--- a/optuna/importance/_mean_decrease_impurity.py
+++ b/optuna/importance/_mean_decrease_impurity.py
@@ -84,6 +84,8 @@ class MeanDecreaseImpurityImportanceEvaluator(BaseImportanceEvaluator):
             return {}
 
         trials: list[FrozenTrial] = _get_filtered_trials(study, params=params, target=target)
+        if len(trials) <= 2:
+            return {k: 0.0 for k in params}
         trans = _SearchSpaceTransform(distributions, transform_log=False, transform_step=False)
         trans_params: np.ndarray = _get_trans_params(trials, trans)
         target_values: np.ndarray = _get_target_values(trials, target)

--- a/optuna/importance/_mean_decrease_impurity.py
+++ b/optuna/importance/_mean_decrease_impurity.py
@@ -84,7 +84,7 @@ class MeanDecreaseImpurityImportanceEvaluator(BaseImportanceEvaluator):
             return {}
 
         trials: list[FrozenTrial] = _get_filtered_trials(study, params=params, target=target)
-        if len(trials) <= 2:
+        if len(trials) <= 1:
             return {k: 0.0 for k in params}
         trans = _SearchSpaceTransform(distributions, transform_log=False, transform_step=False)
         trans_params: np.ndarray = _get_trans_params(trials, trans)

--- a/tests/importance_tests/test_init.py
+++ b/tests/importance_tests/test_init.py
@@ -222,8 +222,8 @@ def test_get_param_importances_invalid_single_trial(
     study = create_study()
     study.optimize(objective, n_trials=1)
 
-    with pytest.raises(ValueError):
-        get_param_importances(study, evaluator=evaluator_init_func())
+    importance = get_param_importances(study, evaluator=evaluator_init_func())
+    assert importance == {"x1": 1.0} # becomes 1.0 after normalization
 
 
 @parametrize_evaluator

--- a/tests/importance_tests/test_init.py
+++ b/tests/importance_tests/test_init.py
@@ -223,7 +223,7 @@ def test_get_param_importances_invalid_single_trial(
     study.optimize(objective, n_trials=1)
 
     importance = get_param_importances(study, evaluator=evaluator_init_func())
-    assert importance == {"x1": 1.0} # becomes 1.0 after normalization
+    assert importance == {"x1": 1.0}  # becomes 1.0 after normalization
 
 
 @parametrize_evaluator

--- a/tests/importance_tests/test_init.py
+++ b/tests/importance_tests/test_init.py
@@ -200,13 +200,15 @@ def test_get_param_importances_invalid_empty_study(
 ) -> None:
     study = create_study()
 
-    with pytest.raises(ValueError):
-        get_param_importances(study, evaluator=evaluator_init_func())
+    importance = get_param_importances(study, evaluator=evaluator_init_func())
+    assert isinstance(importance, dict)
+    assert not importance
 
     study.optimize(pruned_objective, n_trials=3)
 
-    with pytest.raises(ValueError):
-        get_param_importances(study, evaluator=evaluator_init_func())
+    importance = get_param_importances(study, evaluator=evaluator_init_func())
+    assert isinstance(importance, dict)
+    assert not importance
 
 
 @parametrize_evaluator


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. To minimize the review effort, we highly appreciate PRs only with related changes. Please note that submitted PRs may be closed if they include unrelated changes or significantly modified unit tests. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

This PR is a follow-up to the following PR:
- https://github.com/optuna/optuna/pull/6500.


Currently, `PedAnovaImportanceEvaluator` behaves inconsistently when the number of effective trials is insufficient:

- when `<= 1`, it raises a `ValueError`;
- when `== 2`, it returns `0.0` importances for all parameters; and
- when `> 2`, it returns positive importances.

Furthermore, raising a `ValueError` is inconsistent with the existing behavior of returning `0.0` importances when all parameters have single-valued distributions.


## Description of the changes
<!-- Describe the changes in this PR. -->
