### PR TITLE
Support user attrs in slice plots

### DIFF
--- a/optuna/visualization/_slice.py
+++ b/optuna/visualization/_slice.py
@@ -56,6 +56,10 @@ class _PlotValues(NamedTuple):
     trial_numbers: list[int]
 
 
+def _is_numerical_values(values: list[Any]) -> bool:
+    return all(isinstance(v, int | float) and not isinstance(v, bool) for v in values)
+
+
 def _get_slice_subplot_info(
     trials: list[FrozenTrial],
     param: str,
@@ -83,9 +87,13 @@ def _get_slice_subplot_info(
     )
 
     for t in trials:
-        if param not in t.params:
+        if param in t.params:
+            x_value = t.params[param]
+        elif param in t.user_attrs:
+            x_value = t.user_attrs[param]
+        else:
             continue
-        plot_info.x.append(t.params[param])
+        plot_info.x.append(x_value)
         plot_info.y.append(target(t))
         plot_info.trial_numbers.append(t.number)
         constraints = t.system_attrs.get(_CONSTRAINTS_KEY)
@@ -111,6 +119,11 @@ def _get_slice_plot_info(
         return _SlicePlotInfo(target_name, [])
 
     all_params = {p_name for t in trials for p_name in t.params.keys()}
+    user_attr_values = {
+        attr_name: [t.user_attrs[attr_name] for t in trials if attr_name in t.user_attrs]
+        for attr_name in {attr_name for t in trials for attr_name in t.user_attrs.keys()}
+    }
+    all_plot_attrs = all_params | set(user_attr_values)
 
     distributions = {}
     for trial in trials:
@@ -127,8 +140,10 @@ def _get_slice_plot_info(
         sorted_params = sorted(all_params)
     else:
         for input_p_name in params:
-            if input_p_name not in all_params:
-                raise ValueError(f"Parameter {input_p_name} does not exist in your study.")
+            if input_p_name not in all_plot_attrs:
+                raise ValueError(
+                    f"Parameter or user attribute {input_p_name} does not exist in your study."
+                )
         sorted_params = sorted(set(params))
 
     return _SlicePlotInfo(
@@ -138,9 +153,20 @@ def _get_slice_plot_info(
                 trials=trials,
                 param=param,
                 target=target,
-                log_scale=_is_log_scale(trials, param),
-                numerical=not isinstance(distributions[param], CategoricalDistribution),
-                x_labels=x_labels.get(param),
+                log_scale=param in all_params and _is_log_scale(trials, param),
+                numerical=(
+                    not isinstance(distributions[param], CategoricalDistribution)
+                    if param in distributions
+                    else _is_numerical_values(user_attr_values[param])
+                ),
+                x_labels=(
+                    x_labels[param]
+                    if param in x_labels
+                    else tuple(dict.fromkeys(user_attr_values[param]))
+                    if param in user_attr_values
+                    and not _is_numerical_values(user_attr_values[param])
+                    else None
+                ),
             )
             for param in sorted_params
         ],

--- a/tests/visualization_tests/test_slice.py
+++ b/tests/visualization_tests/test_slice.py
@@ -213,6 +213,45 @@ def test_get_slice_plot_info_params(params: list[str] | None) -> None:
     )
 
 
+def test_get_slice_plot_info_user_attrs() -> None:
+    study = create_study()
+    study.add_trial(create_trial(value=0.0, user_attrs={"n_estimators": 10, "stage": "warmup"}))
+    study.add_trial(create_trial(value=1.0, user_attrs={"n_estimators": 20, "stage": "train"}))
+
+    info = _get_slice_plot_info(
+        study,
+        params=["n_estimators", "stage"],
+        target=None,
+        target_name="Objective Value",
+    )
+
+    assert info == _SlicePlotInfo(
+        target_name="Objective Value",
+        subplots=[
+            _SliceSubplotInfo(
+                param_name="n_estimators",
+                x=[10, 20],
+                y=[0.0, 1.0],
+                trial_numbers=[0, 1],
+                is_log=False,
+                is_numerical=True,
+                x_labels=None,
+                constraints=[True, True],
+            ),
+            _SliceSubplotInfo(
+                param_name="stage",
+                x=["warmup", "train"],
+                y=[0.0, 1.0],
+                trial_numbers=[0, 1],
+                is_log=False,
+                is_numerical=False,
+                x_labels=("warmup", "train"),
+                constraints=[True, True],
+            ),
+        ],
+    )
+
+
 def test_get_slice_plot_info_customized_target() -> None:
     params = ["param_a"]
     study = prepare_study_with_trials()


### PR DESCRIPTION
## Motivation
Fixes #6329.

Users may record values such as the selected number of estimators with `trial.set_user_attr`, but `plot_slice(..., params=[...])` previously only accepted trial parameters. This made it difficult to inspect relationships between objective values and trial-level metadata.

## Description of the changes
Allow `plot_slice` to accept user attribute names in `params` while keeping the default behavior limited to trial parameters. Numeric user attributes are plotted on numeric axes, and non-numeric user attributes are handled categorically. Added regression coverage for numeric and categorical user attributes.
