### PR TITLE
Warn when `TPESampler` does pure random search for the entire run

### DIFF
--- a/optuna/study/_optimize.py
+++ b/optuna/study/_optimize.py
@@ -36,6 +36,27 @@ if TYPE_CHECKING:
 _logger = logging.get_logger(__name__)
 
 
+def _warn_if_sampler_never_engages(
+    sampler: "optuna.samplers.BaseSampler", n_trials: int | None
+) -> None:
+    # ``TPESampler`` samples randomly for its first ``n_startup_trials`` trials before TPE engages.
+    # When ``n_trials`` does not exceed that count, every trial is random and TPE never runs, yet
+    # nothing tells the user. Warn once here, where the per-call budget is known, since the sampler
+    # itself never sees ``n_trials``. This is information-only and changes no behavior.
+    from optuna.samplers import TPESampler
+
+    if n_trials is None or not isinstance(sampler, TPESampler):
+        return
+
+    n_startup_trials = sampler._n_startup_trials
+    if n_trials <= n_startup_trials:
+        optuna_warn(
+            f"n_trials={n_trials} is at or below TPESampler's "
+            f"n_startup_trials={n_startup_trials}, so every trial will be sampled randomly "
+            "and TPE will not engage. Increase n_trials or lower n_startup_trials to use TPE."
+        )
+
+
 def _optimize(
     study: "optuna.Study",
     func: "optuna.study.study.ObjectiveFuncType",
@@ -58,6 +79,8 @@ def _optimize(
     if show_progress_bar and n_trials is None and timeout is not None and n_jobs != 1:
         optuna_warn("The timeout-based progress bar is not supported with n_jobs != 1.")
         show_progress_bar = False
+
+    _warn_if_sampler_never_engages(study.sampler, n_trials)
 
     progress_bar = pbar_module._ProgressBar(show_progress_bar, n_trials, timeout)
 

--- a/tests/samplers_tests/tpe_tests/test_sampler.py
+++ b/tests/samplers_tests/tpe_tests/test_sampler.py
@@ -93,6 +93,39 @@ def test_warn_independent_sampling_group(capsys: pytest.CaptureFixture) -> None:
     assert err == ""
 
 
+def _quadratic_objective(trial: Trial) -> float:
+    x = trial.suggest_float("x", -10, 10)
+    return x**2
+
+
+@pytest.mark.parametrize("n_trials", [1, 5, 10])
+def test_warn_when_n_trials_at_or_below_n_startup_trials(n_trials: int) -> None:
+    # All trials are random because TPE only engages after ``n_startup_trials`` (10 by default),
+    # so the user should be warned that TPE never runs.
+    sampler = TPESampler(n_startup_trials=10, seed=0)
+    study = optuna.create_study(sampler=sampler)
+    with pytest.warns(UserWarning, match="n_startup_trials"):
+        study.optimize(_quadratic_objective, n_trials=n_trials)
+
+
+def test_no_warn_when_n_trials_above_n_startup_trials() -> None:
+    sampler = TPESampler(n_startup_trials=10, seed=0)
+    study = optuna.create_study(sampler=sampler)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", UserWarning)
+        study.optimize(_quadratic_objective, n_trials=11)
+
+
+def test_no_warn_when_n_trials_is_none() -> None:
+    # ``n_trials=None`` means the run is driven by ``timeout`` (or a callback), so the warning
+    # must not fire even though the startup count would otherwise be reached.
+    sampler = TPESampler(n_startup_trials=10, seed=0)
+    study = optuna.create_study(sampler=sampler)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", UserWarning)
+        study.optimize(_quadratic_objective, n_trials=None, timeout=0.0)
+
+
 def test_infer_relative_search_space() -> None:
     sampler = TPESampler()
     search_space = {


### PR DESCRIPTION
## Motivation

The default `TPESampler` samples randomly for its first `n_startup_trials` trials (10 by default) and only then engages TPE. When a study runs with `n_trials` at or below `n_startup_trials`, **every** trial is random, TPE never runs, and `study.best_params` is just the best of N random draws — but Optuna says nothing. A user relying on the default sampler reasonably assumes they are doing Bayesian optimization when they are really doing random search. This is easy to hit with small budgets.

Reproduction (no warning today, nothing indicates TPE never ran):

```python
import optuna
optuna.logging.set_verbosity(optuna.logging.WARNING)

def objective(trial):
    x = trial.suggest_float("x", -10, 10)
    return x ** 2

study = optuna.create_study(direction="minimize")  # default: TPESampler(n_startup_trials=10)
study.optimize(objective, n_trials=5)  # all 5 trials random, TPE never engages
```

Fixes #6723

## Description of the changes

The issue raised an open question about where the check belongs: `Study.optimize` knows `n_trials` but not the sampler's startup count, while `TPESampler` knows `n_startup_trials` but never sees the total budget. Since the per-call budget is the deciding input and is only available in `Study.optimize`, the check lives there:

- Added `_warn_if_sampler_never_engages(sampler, n_trials)` in `optuna/study/_optimize.py`, called once near the start of `_optimize`.
- It emits a single, information-only `UserWarning` **only** when `n_trials is not None`, the active sampler is a `TPESampler`, and `n_trials <= n_startup_trials`.
- It is intentionally scoped to avoid false positives: it stays silent for timeout-driven runs (`n_trials=None`) and for non-`TPESampler` samplers, and does not fire on a normal long run's warm-up. No behavior, return values, or sampling change — it is purely a heads-up.

This deliberately does not touch the `BaseSampler` ABC and does not revive the deprecated `warn_independent_sampling` (that was a fallback that improved; here the chosen algorithm never runs at all).

### Tests

Added to `tests/samplers_tests/tpe_tests/test_sampler.py`:

- `test_warn_when_n_trials_at_or_below_n_startup_trials` (parametrized over `n_trials` = 1, 5, 10) — asserts the warning fires.
- `test_no_warn_when_n_trials_above_n_startup_trials` — asserts silence when `n_trials > n_startup_trials`.
- `test_no_warn_when_n_trials_is_none` — asserts silence for timeout-driven runs.

### Local verification

- `uv run ruff check` / `ruff format --check` — clean on changed files.
- `uv run mypy optuna/study/_optimize.py` — `Success: no issues found`.
- `uv run pytest tests/samplers_tests/tpe_tests/test_sampler.py` — 77 passed; `tests/study_tests/test_optimize.py` — 42 passed.
