### PR TITLE
Use MOTPE-like split in PED-ANOVA for multi-objective studies when `target` is `None`

### DIFF
--- a/optuna/importance/_ped_anova/evaluator.py
+++ b/optuna/importance/_ped_anova/evaluator.py
@@ -273,6 +273,8 @@ class PedAnovaImportanceEvaluator(BaseImportanceEvaluator):
             return {k: 0.0 for k in params}
         target_trial_ids = set(t._trial_id for t in target_trials)
         region_trial_ids = set(t._trial_id for t in region_trials)
+        # Since HSSP is approximately implemented using a greedy algorithm, target trials
+        # are guaranteed to be included in region trials.
         assert target_trial_ids.issubset(region_trial_ids)
 
         # Theorem 4.2 and Algorithm 1 in the original paper:

--- a/optuna/importance/_ped_anova/evaluator.py
+++ b/optuna/importance/_ped_anova/evaluator.py
@@ -281,7 +281,6 @@ class PedAnovaImportanceEvaluator(BaseImportanceEvaluator):
         # https://arxiv.org/abs/2601.20800
         quantile = len(target_trials) / len(region_trials)  # gamma' / gamma
         param_importances = {k: 0.0 for k in params}
-        target_trial_ids = set(t._trial_id for t in target_trials)
         for param_name in params:
             regime_trials = _partition_by_regime(
                 param_name, region_trials, self._min_n_trials_in_regime

--- a/optuna/importance/_ped_anova/evaluator.py
+++ b/optuna/importance/_ped_anova/evaluator.py
@@ -202,6 +202,11 @@ class PedAnovaImportanceEvaluator(BaseImportanceEvaluator):
             return trials
         if study._is_multi_objective() and target is None:
             n_below = math.ceil(quantile * len(trials)) - 1
+            # NOTE(kAIto47802): Since HSSP is implemented greedily, target trials could be
+            # obtained by taking the top trials from region trials without solving HSSP again,
+            # which would improve performance by a constant factor. However,
+            # _split_complete_trials_multi_objective does not return trials in the selected
+            # order, so this optimization would require a larger refactoring.
             top_trials, _ = _split_complete_trials_multi_objective(trials, study, n_below)
             return top_trials
         is_lower_better = study.directions[0] == StudyDirection.MINIMIZE

--- a/optuna/importance/_ped_anova/evaluator.py
+++ b/optuna/importance/_ped_anova/evaluator.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 from collections import defaultdict
+import math
 from typing import cast
 from typing import TYPE_CHECKING
-import math
 
 import numpy as np
 

--- a/optuna/importance/_ped_anova/evaluator.py
+++ b/optuna/importance/_ped_anova/evaluator.py
@@ -13,8 +13,8 @@ from optuna._warnings import optuna_warn
 from optuna.importance._base import _check_evaluate_args
 from optuna.importance._base import _sort_dict_by_importance
 from optuna.importance._base import BaseImportanceEvaluator
-from optuna.samplers._tpe.sampler import _split_complete_trials_multi_objective
 from optuna.importance._ped_anova.scott_parzen_estimator import build_parzen_estimator_on_grid
+from optuna.samplers._tpe.sampler import _split_complete_trials_multi_objective
 from optuna.study import StudyDirection
 from optuna.trial import TrialState
 

--- a/optuna/importance/_ped_anova/evaluator.py
+++ b/optuna/importance/_ped_anova/evaluator.py
@@ -271,6 +271,10 @@ class PedAnovaImportanceEvaluator(BaseImportanceEvaluator):
             )
         if len(target_trials) == 0:
             return {k: 0.0 for k in params}
+        target_trial_ids = set(t._trial_id for t in target_trials)
+        region_trial_ids = set(t._trial_id for t in region_trials)
+        assert target_trial_ids.issubset(region_trial_ids)
+
         # Theorem 4.2 and Algorithm 1 in the original paper:
         # https://arxiv.org/abs/2601.20800
         quantile = len(target_trials) / len(region_trials)  # gamma' / gamma

--- a/optuna/importance/_ped_anova/evaluator.py
+++ b/optuna/importance/_ped_anova/evaluator.py
@@ -254,7 +254,7 @@ class PedAnovaImportanceEvaluator(BaseImportanceEvaluator):
 
         assert params is not None
 
-        trials = _get_filtered_trials(study, target=target)
+        trials = study.get_trials(deepcopy=False, states=(TrialState.COMPLETE,))
         # The following should be tested at _get_filtered_trials.
         assert target is not None or max([len(t.values) for t in trials], default=1) == 1
         if len(trials) <= 1:
@@ -327,16 +327,6 @@ def _partition_by_regime(
 
     return regime_trials
 
-
-def _get_filtered_trials(
-    study: Study, target: Callable[[FrozenTrial], float] | None
-) -> list[FrozenTrial]:
-    trials = study.get_trials(deepcopy=False, states=(TrialState.COMPLETE,))
-    return [
-        trial
-        for trial in trials
-        if np.isfinite(target(trial) if target is not None else cast(float, trial.value))  # TC006
-    ]
 
 
 def _get_distributions_list(

--- a/optuna/importance/_ped_anova/evaluator.py
+++ b/optuna/importance/_ped_anova/evaluator.py
@@ -211,7 +211,7 @@ class PedAnovaImportanceEvaluator(BaseImportanceEvaluator):
             is_lower_better = True
 
         top_trials = _QuantileFilter(
-            quantile, is_lower_better, self._min_n_top_trials, target
+            quantile, is_lower_better, target
         ).filter(trials)
 
         return top_trials

--- a/optuna/importance/_ped_anova/evaluator.py
+++ b/optuna/importance/_ped_anova/evaluator.py
@@ -255,8 +255,6 @@ class PedAnovaImportanceEvaluator(BaseImportanceEvaluator):
         assert params is not None
 
         trials = study.get_trials(deepcopy=False, states=(TrialState.COMPLETE,))
-        # The following should be tested at _get_filtered_trials.
-        assert target is not None or max([len(t.values) for t in trials], default=1) == 1
         if len(trials) <= 1:
             return {k: 0.0 for k in params}
 

--- a/optuna/importance/_ped_anova/evaluator.py
+++ b/optuna/importance/_ped_anova/evaluator.py
@@ -268,6 +268,40 @@ class PedAnovaImportanceEvaluator(BaseImportanceEvaluator):
         *,
         target: Callable[[FrozenTrial], float] | None = None,
     ) -> dict[str, float]:
+        """Evaluate parameter importances based on completed trials in the given study.
+
+        .. note::
+
+            This method is not meant to be called by library users.
+
+        .. seealso::
+
+            Please refer to :func:`~optuna.importance.get_param_importances` for how a concrete
+            evaluator should implement this method.
+
+        Args:
+            study:
+                An optimized study.
+            params:
+                A list of names of parameters to assess.
+                If :obj:`None`, all parameters that are present in all of the completed trials are
+                assessed.
+            target:
+                A function to specify the value to evaluate importances.
+                If it is :obj:`None` and ``study`` is being used for single-objective optimization,
+                the objective values are used. Can also be used for other trial attributes, such as
+                the duration, like ``target=lambda t: t.duration.total_seconds()``.
+
+                .. note::
+                    Specify this argument if ``study`` is being used for multi-objective
+                    optimization. For example, to get the hyperparameter importance of the first
+                    objective, use ``target=lambda t: t.values[0]`` for the target parameter.
+
+        Returns:
+            A :obj:`dict` where the keys are parameter names and the values are assessed
+            importances.
+
+        """
         dists = _get_distributions_list(study, params=params)
         if params is None:
             params = list(dict.fromkeys(k for d in dists for k in d))

--- a/optuna/importance/_ped_anova/evaluator.py
+++ b/optuna/importance/_ped_anova/evaluator.py
@@ -274,7 +274,8 @@ class PedAnovaImportanceEvaluator(BaseImportanceEvaluator):
         target_trial_ids = set(t._trial_id for t in target_trials)
         region_trial_ids = set(t._trial_id for t in region_trials)
         # Since HSSP is approximately implemented using a greedy algorithm, target trials
-        # are guaranteed to be included in region trials.
+        # are guaranteed to be included in region trials, even when target is None for
+        # multi-objective studies.
         assert target_trial_ids.issubset(region_trial_ids)
 
         # Theorem 4.2 and Algorithm 1 in the original paper:

--- a/optuna/importance/_ped_anova/evaluator.py
+++ b/optuna/importance/_ped_anova/evaluator.py
@@ -271,12 +271,10 @@ class PedAnovaImportanceEvaluator(BaseImportanceEvaluator):
         trials = _get_filtered_trials(study, target=target)
         # The following should be tested at _get_filtered_trials.
         assert target is not None or max([len(t.values) for t in trials], default=1) == 1
-        if len(trials) <= self._min_n_top_trials:
+        if len(trials) <= 1:
             return {k: 0.0 for k in params}
 
         target_trials = self._get_top_quantile_trials(study, trials, self._target_quantile, target)
-        if len(target_trials) <= self._min_n_top_trials:
-            return {k: 0.0 for k in params}
         region_trials = self._get_top_quantile_trials(study, trials, self._region_quantile, target)
         if len(target_trials) == len(region_trials):
             optuna_warn(

--- a/optuna/importance/_ped_anova/evaluator.py
+++ b/optuna/importance/_ped_anova/evaluator.py
@@ -330,7 +330,11 @@ def _get_filtered_trials(
     return [
         trial
         for trial in trials
-        if (math.isfinite(target(trial)) if target is not None else all(math.isfinite(v) for v in trial.values))
+        if (
+            math.isfinite(target(trial))
+            if target is not None
+            else all(math.isfinite(v) for v in trial.values)
+        )
     ]
 
 

--- a/optuna/importance/_ped_anova/evaluator.py
+++ b/optuna/importance/_ped_anova/evaluator.py
@@ -207,7 +207,7 @@ class PedAnovaImportanceEvaluator(BaseImportanceEvaluator):
         if quantile == 1.0:
             return trials
         if study._is_multi_objective() and target is None:
-            n_below = math.ceil(quantile * len(trials)) - 1
+            n_below = math.ceil(quantile * len(trials))
             # NOTE(kAIto47802): Since HSSP is implemented greedily, target trials could be
             # obtained by taking the top trials from region trials without solving HSSP again,
             # which would improve performance by a constant factor. However,

--- a/optuna/importance/_ped_anova/evaluator.py
+++ b/optuna/importance/_ped_anova/evaluator.py
@@ -91,6 +91,12 @@ class PedAnovaImportanceEvaluator(BaseImportanceEvaluator):
 
     .. note::
 
+        For multi-objective studies, if ``target`` is :obj:`None`, top-quantile trials are
+        selected in the same manner as MOTPE, using non-domination ranks and the hypervolume
+        subset selection problem (HSSP) for tie-breaking.
+
+    .. note::
+
         The performance of PED-ANOVA depends on how many trials to consider above
         ``target_quantile``. To stabilize the analysis, it is preferable to include at least
         5 trials above ``target_quantile``.

--- a/optuna/importance/_ped_anova/evaluator.py
+++ b/optuna/importance/_ped_anova/evaluator.py
@@ -178,8 +178,6 @@ class PedAnovaImportanceEvaluator(BaseImportanceEvaluator):
         self._n_steps: int = 50
         # Control the regularization effect by prior.
         self._prior_weight = 1.0
-        # How many `trials` must be included in `top_trials`.
-        self._min_n_top_trials = 2
         # How many `trials` must be included in each regime.
         self._min_n_trials_in_regime = 2
 

--- a/optuna/importance/_ped_anova/evaluator.py
+++ b/optuna/importance/_ped_anova/evaluator.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from collections import defaultdict
 import math
-from typing import cast
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -41,7 +40,9 @@ class _QuantileFilter:
 
     def filter(self, trials: list[FrozenTrial]) -> list[FrozenTrial]:
         sign = 1.0 if self._is_lower_better else -1.0
-        loss_values = sign * np.asarray([t.value if self._target is None else self._target(t) for t in trials])
+        loss_values = sign * np.asarray(
+            [t.value if self._target is None else self._target(t) for t in trials]
+        )
         # TODO(nabenabe0928): After dropping Python3.10, replace below with
         # np.quantile(loss_values, self._quantile, method="inverted_cdf").
         cutoff_index = int(math.ceil(self._quantile * loss_values.size)) - 1
@@ -208,9 +209,7 @@ class PedAnovaImportanceEvaluator(BaseImportanceEvaluator):
             )
             is_lower_better = True
 
-        top_trials = _QuantileFilter(
-            quantile, is_lower_better, target
-        ).filter(trials)
+        top_trials = _QuantileFilter(quantile, is_lower_better, target).filter(trials)
 
         return top_trials
 
@@ -322,7 +321,6 @@ def _partition_by_regime(
     regime_trials = {k: v for k, v in regime_trials.items() if len(v) >= min_n_trials_in_regime}
 
     return regime_trials
-
 
 
 def _get_distributions_list(

--- a/optuna/importance/_ped_anova/evaluator.py
+++ b/optuna/importance/_ped_anova/evaluator.py
@@ -93,13 +93,15 @@ class PedAnovaImportanceEvaluator(BaseImportanceEvaluator):
 
             # Objective 0 is being minimized.
             importance = get_param_importances(
-                study, evaluator=PedAnovaImportanceEvaluator(),
+                study,
+                evaluator=PedAnovaImportanceEvaluator(),
                 target=lambda t: t.values[0],
             )
 
             # Objective 0 is being maximized—negate so that "lower is better".
             importance = get_param_importances(
-                study, evaluator=PedAnovaImportanceEvaluator(),
+                study,
+                evaluator=PedAnovaImportanceEvaluator(),
                 target=lambda t: -t.values[0],
             )
 

--- a/optuna/importance/_ped_anova/evaluator.py
+++ b/optuna/importance/_ped_anova/evaluator.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections import defaultdict
 from typing import cast
 from typing import TYPE_CHECKING
+import math
 
 import numpy as np
 
@@ -13,6 +14,7 @@ from optuna.importance._base import _check_evaluate_args
 from optuna.importance._base import _sort_dict_by_importance
 from optuna.importance._base import BaseImportanceEvaluator
 from optuna.importance._ped_anova.scott_parzen_estimator import _build_parzen_estimator
+from optuna.samplers._tpe.sampler import _split_complete_trials_multi_objective
 from optuna.study import StudyDirection
 from optuna.trial import TrialState
 

--- a/optuna/importance/_ped_anova/evaluator.py
+++ b/optuna/importance/_ped_anova/evaluator.py
@@ -276,6 +276,10 @@ class PedAnovaImportanceEvaluator(BaseImportanceEvaluator):
 
         trials = _get_filtered_trials(study, target)
         if len(trials) <= 1:
+            optuna_warn(
+                "The number of trials is too small to compute importances. "
+                "Parameter importances will be equal."
+            )
             return {k: 0.0 for k in params}
 
         target_trials = self._get_top_quantile_trials(study, trials, self._target_quantile, target)

--- a/optuna/importance/_ped_anova/evaluator.py
+++ b/optuna/importance/_ped_anova/evaluator.py
@@ -198,6 +198,10 @@ class PedAnovaImportanceEvaluator(BaseImportanceEvaluator):
     ) -> list[FrozenTrial]:
         if quantile == 1.0:
             return trials
+        if study._is_multi_objective() and target is None:
+            n_below = math.ceil(quantile * len(trials)) - 1
+            top_trials, _ = _split_complete_trials_multi_objective(trials, study, n_below)
+            return top_trials
         is_lower_better = study.directions[0] == StudyDirection.MINIMIZE
         if target is not None:
             optuna_warn(

--- a/optuna/importance/_ped_anova/evaluator.py
+++ b/optuna/importance/_ped_anova/evaluator.py
@@ -275,6 +275,8 @@ class PedAnovaImportanceEvaluator(BaseImportanceEvaluator):
             return {k: 0.0 for k in params}
 
         target_trials = self._get_top_quantile_trials(study, trials, self._target_quantile, target)
+        if len(target_trials) <= self._min_n_top_trials:
+            return {k: 0.0 for k in params}
         region_trials = self._get_top_quantile_trials(study, trials, self._region_quantile, target)
         if len(target_trials) == len(region_trials):
             optuna_warn(

--- a/optuna/importance/_ped_anova/evaluator.py
+++ b/optuna/importance/_ped_anova/evaluator.py
@@ -32,34 +32,20 @@ class _QuantileFilter:
         self,
         quantile: float,
         is_lower_better: bool,
-        min_n_top_trials: int,
         target: Callable[[FrozenTrial], float] | None,
     ) -> None:
         assert 0 < quantile <= 1, "quantile must be in (0, 1]."
-        assert min_n_top_trials > 0, "min_n_top_trials must be positive."
-
         self._quantile = quantile
         self._is_lower_better = is_lower_better
-        self._min_n_top_trials = min_n_top_trials
         self._target = target
 
     def filter(self, trials: list[FrozenTrial]) -> list[FrozenTrial]:
-        target, min_n_top_trials = self._target, self._min_n_top_trials
         sign = 1.0 if self._is_lower_better else -1.0
-        loss_values = sign * np.asarray([t.value if target is None else target(t) for t in trials])
-        err_msg = "len(trials) must be larger than or equal to min_n_top_trials"
-        assert min_n_top_trials <= loss_values.size, err_msg
-
-        def _quantile(v: np.ndarray, q: float) -> float:
-            cutoff_index = int(np.ceil(q * loss_values.size)) - 1
-            return float(np.partition(loss_values, cutoff_index)[cutoff_index])
-
-        cutoff_val = max(
-            np.partition(loss_values, min_n_top_trials - 1)[min_n_top_trials - 1],
-            # TODO(nabenabe0928): After dropping Python3.10, replace below with
-            # np.quantile(loss_values, self._quantile, method="inverted_cdf").
-            _quantile(loss_values, self._quantile),
-        )
+        loss_values = sign * np.asarray([t.value if self._target is None else self._target(t) for t in trials])
+        # TODO(nabenabe0928): After dropping Python3.10, replace below with
+        # np.quantile(loss_values, self._quantile, method="inverted_cdf").
+        cutoff_index = int(math.ceil(self._quantile * loss_values.size)) - 1
+        cutoff_val = float(np.partition(loss_values, cutoff_index)[cutoff_index])
         should_keep_trials = loss_values <= cutoff_val
         return [t for t, should_keep in zip(trials, should_keep_trials) if should_keep]
 

--- a/optuna/importance/_ped_anova/evaluator.py
+++ b/optuna/importance/_ped_anova/evaluator.py
@@ -78,9 +78,30 @@ class PedAnovaImportanceEvaluator(BaseImportanceEvaluator):
 
     .. note::
 
-        For multi-objective studies, if ``target`` is :obj:`None`, top-quantile trials are
-        selected in the same manner as MOTPE, using non-domination ranks and the hypervolume
-        subset selection problem (HSSP) for tie-breaking.
+        **Behavior on multi-objective studies.**
+        If ``target`` is :obj:`None`, top-quantile trials are selected in the same
+        manner as multi-objective :class:`~optuna.samplers.TPESampler`: trials are
+        ranked by non-domination rank, with the hypervolume subset selection problem
+        (HSSP) used to break ties within a rank. The resulting importance can be
+        interpreted as how important each hyperparameter is to reach the Pareto
+        front without preference for any particular objective.
+
+        To compute the importance against a *single* objective instead, pass a
+        ``target`` callable explicitly. Note that :class:`PedAnovaImportanceEvaluator`
+        assumes **minimization** (i.e., lower ``target`` values are better); when an
+        objective is being maximized, negate it inside ``target``::
+
+            # Objective 0 is being minimized.
+            importance = get_param_importances(
+                study, evaluator=PedAnovaImportanceEvaluator(),
+                target=lambda t: t.values[0],
+            )
+
+            # Objective 0 is being maximized—negate so that "lower is better".
+            importance = get_param_importances(
+                study, evaluator=PedAnovaImportanceEvaluator(),
+                target=lambda t: -t.values[0],
+            )
 
     .. note::
 

--- a/optuna/importance/_ped_anova/evaluator.py
+++ b/optuna/importance/_ped_anova/evaluator.py
@@ -246,15 +246,6 @@ class PedAnovaImportanceEvaluator(BaseImportanceEvaluator):
         *,
         target: Callable[[FrozenTrial], float] | None = None,
     ) -> dict[str, float]:
-        if target is None and study._is_multi_objective():
-            raise ValueError(
-                "If the `study` is being used for multi-objective optimization, "
-                "please specify the `target`. For example, use "
-                "`target=lambda t: t.values[0]` for the first objective value. "
-                f"{self.__class__.__name__} computes the importances of params to achieve "
-                "low `target` values. If this is not what you want, "
-                "please modify target, e.g., by multiplying the output by -1."
-            )
         dists = _get_distributions_list(study, params=params)
         if params is None:
             params = list(dict.fromkeys(k for d in dists for k in d))

--- a/optuna/importance/_ped_anova/evaluator.py
+++ b/optuna/importance/_ped_anova/evaluator.py
@@ -289,13 +289,17 @@ class PedAnovaImportanceEvaluator(BaseImportanceEvaluator):
             target:
                 A function to specify the value to evaluate importances.
                 If it is :obj:`None` and ``study`` is being used for single-objective optimization,
-                the objective values are used. Can also be used for other trial attributes, such as
-                the duration, like ``target=lambda t: t.duration.total_seconds()``.
+                the objective values are used. If it is :obj:`None` and ``study`` is being used for
+                multi-objective optimization, the importance of reaching the Pareto front is
+                evaluated by selecting top-quantile trials without preference for any particular
+                objective, using non-domination rank and HSSP tie-breaking. To evaluate importance
+                against a single objective or another trial attribute, specify ``target``
+                explicitly, for example ``target=lambda t: t.values[0]`` or
+                ``target=lambda t: t.duration.total_seconds()``.
 
                 .. note::
-                    Specify this argument if ``study`` is being used for multi-objective
-                    optimization. For example, to get the hyperparameter importance of the first
-                    objective, use ``target=lambda t: t.values[0]`` for the target parameter.
+                    :class:`PedAnovaImportanceEvaluator` assumes lower ``target`` values are
+                    better.
 
         Returns:
             A :obj:`dict` where the keys are parameter names and the values are assessed

--- a/optuna/importance/_ped_anova/evaluator.py
+++ b/optuna/importance/_ped_anova/evaluator.py
@@ -251,7 +251,7 @@ class PedAnovaImportanceEvaluator(BaseImportanceEvaluator):
 
         assert params is not None
 
-        trials = study.get_trials(deepcopy=False, states=(TrialState.COMPLETE,))
+        trials = _get_filtered_trials(study, target)
         if len(trials) <= 1:
             return {k: 0.0 for k in params}
 
@@ -321,6 +321,17 @@ def _partition_by_regime(
     regime_trials = {k: v for k, v in regime_trials.items() if len(v) >= min_n_trials_in_regime}
 
     return regime_trials
+
+
+def _get_filtered_trials(
+    study: Study, target: Callable[[FrozenTrial], float] | None
+) -> list[FrozenTrial]:
+    trials = study.get_trials(deepcopy=False, states=(TrialState.COMPLETE,))
+    return [
+        trial
+        for trial in trials
+        if (math.isfinite(target(trial)) if target is not None else all(math.isfinite(v) for v in trial.values))
+    ]
 
 
 def _get_distributions_list(

--- a/tests/importance_tests/pedanova_tests/test_evaluator.py
+++ b/tests/importance_tests/pedanova_tests/test_evaluator.py
@@ -56,6 +56,68 @@ def test_filter(
     assert all(i == j for i, j in zip(indices, filtered_indices))
 
 
+
+def test_n_trials_equal_to_min_n_top_trials() -> None:
+    evaluator = PedAnovaImportanceEvaluator()
+    study = get_study(seed=0, n_trials=evaluator._min_n_top_trials, is_multi_obj=False)
+    param_importance = list(evaluator.evaluate(study).values())
+    n_params = len(param_importance)
+    assert np.allclose(param_importance, np.zeros(n_params))
+
+
+def test_direction() -> None:
+    study_minimize = get_study(seed=0, n_trials=20, is_multi_obj=False)
+    study_maximize = optuna.create_study(direction="maximize")
+    study_maximize.add_trials(study_minimize.trials)
+
+    evaluator = PedAnovaImportanceEvaluator()
+    assert evaluator.evaluate(study_minimize) != evaluator.evaluate(study_maximize)
+
+
+def test_target_quantile() -> None:
+    study = get_study(seed=0, n_trials=20, is_multi_obj=False)
+    default_evaluator = PedAnovaImportanceEvaluator(target_quantile=0.1)
+    evaluator = PedAnovaImportanceEvaluator(target_quantile=0.3)
+    assert evaluator.evaluate(study) != default_evaluator.evaluate(study)
+
+
+def test_region_quantile_less_than_one() -> None:
+    study = get_study(seed=0, n_trials=20, is_multi_obj=False)
+    default_evaluator = PedAnovaImportanceEvaluator(region_quantile=1.0)
+    evaluator = PedAnovaImportanceEvaluator(region_quantile=0.5)
+    assert evaluator.evaluate(study) != default_evaluator.evaluate(study)
+
+
+def test_evaluate_on_local() -> None:
+    study = get_study(seed=0, n_trials=20, is_multi_obj=False)
+    default_evaluator = PedAnovaImportanceEvaluator(evaluate_on_local=True)
+    global_evaluator = PedAnovaImportanceEvaluator(evaluate_on_local=False)
+    assert global_evaluator.evaluate(study) != default_evaluator.evaluate(study)
+
+
+def test_conditional() -> None:
+    study = optuna.study.create_study()
+    dists_cx: dict[str, BaseDistribution] = {
+        "c": FloatDistribution(0.0, 1.0),
+        "x": FloatDistribution(0.0, 2.0),
+    }
+    dists_cy: dict[str, BaseDistribution] = {
+        "c": FloatDistribution(0.0, 1.0),
+        "y": FloatDistribution(-2.0, 0.0),
+    }
+    trials = [
+        optuna.create_trial(params={"c": 1.0, "x": 1.0}, distributions=dists_cx, value=1.0),
+        optuna.create_trial(params={"c": 0.0, "y": -1.0}, distributions=dists_cy, value=-1.0),
+        optuna.create_trial(params={"c": 0.8, "x": 0.8}, distributions=dists_cx, value=0.8),
+        optuna.create_trial(params={"c": 0.2, "y": -0.2}, distributions=dists_cy, value=-0.2),
+    ]
+    study.add_trials(trials)
+    evaluator = PedAnovaImportanceEvaluator()
+    importance = evaluator.evaluate(study)
+    assert set(importance.keys()) == {"c", "x", "y"}
+    assert importance != {"c": 0.0, "x": 0.0, "y": 0.0}
+
+
 @pytest.mark.parametrize(
     (
         "directions",
@@ -125,64 +187,3 @@ def test_get_top_quantile_trials_multi_objective_target_none(
     assert len(target_trials) == expected_target_size
     assert len(region_trials) == expected_region_size
     assert {t._trial_id for t in target_trials}.issubset({t._trial_id for t in region_trials})
-
-
-def test_n_trials_equal_to_min_n_top_trials() -> None:
-    evaluator = PedAnovaImportanceEvaluator()
-    study = get_study(seed=0, n_trials=evaluator._min_n_top_trials, is_multi_obj=False)
-    param_importance = list(evaluator.evaluate(study).values())
-    n_params = len(param_importance)
-    assert np.allclose(param_importance, np.zeros(n_params))
-
-
-def test_direction() -> None:
-    study_minimize = get_study(seed=0, n_trials=20, is_multi_obj=False)
-    study_maximize = optuna.create_study(direction="maximize")
-    study_maximize.add_trials(study_minimize.trials)
-
-    evaluator = PedAnovaImportanceEvaluator()
-    assert evaluator.evaluate(study_minimize) != evaluator.evaluate(study_maximize)
-
-
-def test_target_quantile() -> None:
-    study = get_study(seed=0, n_trials=20, is_multi_obj=False)
-    default_evaluator = PedAnovaImportanceEvaluator(target_quantile=0.1)
-    evaluator = PedAnovaImportanceEvaluator(target_quantile=0.3)
-    assert evaluator.evaluate(study) != default_evaluator.evaluate(study)
-
-
-def test_region_quantile_less_than_one() -> None:
-    study = get_study(seed=0, n_trials=20, is_multi_obj=False)
-    default_evaluator = PedAnovaImportanceEvaluator(region_quantile=1.0)
-    evaluator = PedAnovaImportanceEvaluator(region_quantile=0.5)
-    assert evaluator.evaluate(study) != default_evaluator.evaluate(study)
-
-
-def test_evaluate_on_local() -> None:
-    study = get_study(seed=0, n_trials=20, is_multi_obj=False)
-    default_evaluator = PedAnovaImportanceEvaluator(evaluate_on_local=True)
-    global_evaluator = PedAnovaImportanceEvaluator(evaluate_on_local=False)
-    assert global_evaluator.evaluate(study) != default_evaluator.evaluate(study)
-
-
-def test_conditional() -> None:
-    study = optuna.study.create_study()
-    dists_cx: dict[str, BaseDistribution] = {
-        "c": FloatDistribution(0.0, 1.0),
-        "x": FloatDistribution(0.0, 2.0),
-    }
-    dists_cy: dict[str, BaseDistribution] = {
-        "c": FloatDistribution(0.0, 1.0),
-        "y": FloatDistribution(-2.0, 0.0),
-    }
-    trials = [
-        optuna.create_trial(params={"c": 1.0, "x": 1.0}, distributions=dists_cx, value=1.0),
-        optuna.create_trial(params={"c": 0.0, "y": -1.0}, distributions=dists_cy, value=-1.0),
-        optuna.create_trial(params={"c": 0.8, "x": 0.8}, distributions=dists_cx, value=0.8),
-        optuna.create_trial(params={"c": 0.2, "y": -0.2}, distributions=dists_cy, value=-0.2),
-    ]
-    study.add_trials(trials)
-    evaluator = PedAnovaImportanceEvaluator()
-    importance = evaluator.evaluate(study)
-    assert set(importance.keys()) == {"c", "x", "y"}
-    assert importance != {"c": 0.0, "x": 0.0, "y": 0.0}

--- a/tests/importance_tests/pedanova_tests/test_evaluator.py
+++ b/tests/importance_tests/pedanova_tests/test_evaluator.py
@@ -56,7 +56,6 @@ def test_filter(
     assert all(i == j for i, j in zip(indices, filtered_indices))
 
 
-
 def test_n_trials_equal_to_min_n_top_trials() -> None:
     evaluator = PedAnovaImportanceEvaluator()
     study = get_study(seed=0, n_trials=evaluator._min_n_top_trials, is_multi_obj=False)

--- a/tests/importance_tests/pedanova_tests/test_evaluator.py
+++ b/tests/importance_tests/pedanova_tests/test_evaluator.py
@@ -46,7 +46,7 @@ def test_filter(
     target: Callable[[FrozenTrial], float] | None,
     filtered_indices: list[int],
 ) -> None:
-    _filter = _QuantileFilter(quantile, is_lower_better, min_n_top_trials=2, target=target)
+    _filter = _QuantileFilter(quantile, is_lower_better, target=target)
     trials = [optuna.create_trial(values=vs) for vs in values]
     for i, t in enumerate(trials):
         t.set_user_attr("index", i)

--- a/tests/importance_tests/pedanova_tests/test_evaluator.py
+++ b/tests/importance_tests/pedanova_tests/test_evaluator.py
@@ -56,12 +56,16 @@ def test_filter(
     assert all(i == j for i, j in zip(indices, filtered_indices))
 
 
-def test_n_trials_equal_to_min_n_top_trials() -> None:
+@pytest.mark.parametrize("n_trials", [0, 1, 2])
+def test_n_trials_less_than_two(n_trials: int) -> None:
     evaluator = PedAnovaImportanceEvaluator()
-    study = get_study(seed=0, n_trials=evaluator._min_n_top_trials, is_multi_obj=False)
+    study = get_study(seed=0, n_trials=n_trials, is_multi_obj=False)
     param_importance = list(evaluator.evaluate(study).values())
     n_params = len(param_importance)
-    assert np.allclose(param_importance, np.zeros(n_params))
+    if n_trials < 2:
+        assert np.allclose(param_importance, np.zeros(n_params))
+    else:
+        assert not np.allclose(param_importance, np.zeros(n_params))
 
 
 def test_direction() -> None:

--- a/tests/importance_tests/pedanova_tests/test_evaluator.py
+++ b/tests/importance_tests/pedanova_tests/test_evaluator.py
@@ -22,7 +22,7 @@ _MULTI_VALUES = [[float(i), float(j)] for i, j in zip(range(10), reversed(range(
 @pytest.mark.parametrize(
     "quantile,is_lower_better,values,target,filtered_indices",
     [
-        (0.1, True, [[1.0], [2.0]], None, [0, 1]),  # Check min_n_trials = 2
+        (0.1, True, [[1.0], [2.0]], None, [0]),
         (0.49, True, deepcopy(_VALUES), None, list(range(10))[-5:]),
         (0.5, True, deepcopy(_VALUES), None, list(range(10))[-5:]),
         (0.51, True, deepcopy(_VALUES), None, list(range(10))[-6:]),
@@ -136,8 +136,8 @@ def test_conditional() -> None:
             [[float(i), float(i)] for i in range(6)],
             0.5,
             0.8,
-            2,
-            4,
+            3,
+            5,
             id="different-nondomination-ranks",
         ),
         pytest.param(
@@ -154,8 +154,8 @@ def test_conditional() -> None:
             ],
             0.5,
             0.75,
-            3,
-            5,
+            4,
+            6,
             id="same-rank-hssp-tie-break-after-best-rank",
         ),
         pytest.param(
@@ -163,8 +163,8 @@ def test_conditional() -> None:
             [[float(i), float(5 - i)] for i in range(6)],
             0.5,
             0.8,
-            2,
-            4,
+            3,
+            5,
             id="same-rank-hssp-tie-break-on-front",
         ),
     ],

--- a/tests/importance_tests/pedanova_tests/test_evaluator.py
+++ b/tests/importance_tests/pedanova_tests/test_evaluator.py
@@ -127,13 +127,6 @@ def test_get_top_quantile_trials_multi_objective_target_none(
     assert {t._trial_id for t in target_trials}.issubset({t._trial_id for t in region_trials})
 
 
-def test_error_in_ped_anova() -> None:
-    with pytest.raises(ValueError):
-        evaluator = PedAnovaImportanceEvaluator()
-        study = get_study(seed=0, n_trials=5, is_multi_obj=True)
-        evaluator.evaluate(study)
-
-
 def test_n_trials_equal_to_min_n_top_trials() -> None:
     evaluator = PedAnovaImportanceEvaluator()
     study = get_study(seed=0, n_trials=evaluator._min_n_top_trials, is_multi_obj=False)

--- a/tests/importance_tests/pedanova_tests/test_evaluator.py
+++ b/tests/importance_tests/pedanova_tests/test_evaluator.py
@@ -56,6 +56,77 @@ def test_filter(
     assert all(i == j for i, j in zip(indices, filtered_indices))
 
 
+@pytest.mark.parametrize(
+    (
+        "directions",
+        "values",
+        "target_quantile",
+        "region_quantile",
+        "expected_target_size",
+        "expected_region_size",
+    ),
+    [
+        pytest.param(
+            ["minimize", "minimize"],
+            [[float(i), float(i)] for i in range(6)],
+            0.5,
+            0.8,
+            2,
+            4,
+            id="different-nondomination-ranks",
+        ),
+        pytest.param(
+            ["minimize", "minimize"],
+            [
+                [0.0, 0.0],
+                [1.0, 5.0],
+                [2.0, 4.0],
+                [3.0, 3.0],
+                [4.0, 2.0],
+                [5.0, 1.0],
+                [6.0, 6.0],
+                [7.0, 7.0],
+            ],
+            0.5,
+            0.75,
+            3,
+            5,
+            id="same-rank-hssp-tie-break-after-best-rank",
+        ),
+        pytest.param(
+            ["minimize", "minimize"],
+            [[float(i), float(5 - i)] for i in range(6)],
+            0.5,
+            0.8,
+            2,
+            4,
+            id="same-rank-hssp-tie-break-on-front",
+        ),
+    ],
+)
+def test_get_top_quantile_trials_multi_objective_target_none(
+    directions: list[str],
+    values: list[list[float]],
+    target_quantile: float,
+    region_quantile: float,
+    expected_target_size: int,
+    expected_region_size: int,
+) -> None:
+    study = optuna.create_study(directions=directions)
+    study.add_trials([optuna.create_trial(values=vs) for vs in values])
+    trials = study.get_trials(deepcopy=False)
+    evaluator = PedAnovaImportanceEvaluator(
+        target_quantile=target_quantile, region_quantile=region_quantile
+    )
+
+    target_trials = evaluator._get_top_quantile_trials(study, trials, target_quantile, target=None)
+    region_trials = evaluator._get_top_quantile_trials(study, trials, region_quantile, target=None)
+
+    assert len(target_trials) == expected_target_size
+    assert len(region_trials) == expected_region_size
+    assert {t._trial_id for t in target_trials}.issubset({t._trial_id for t in region_trials})
+
+
 def test_error_in_ped_anova() -> None:
     with pytest.raises(ValueError):
         evaluator = PedAnovaImportanceEvaluator()


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. To minimize the review effort, we highly appreciate PRs only with related changes. Please note that submitted PRs may be closed if they include unrelated changes or significantly modified unit tests. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

This is the follow-up to https://github.com/optuna/optuna/pull/6716, addressing the comment suggested here:
- https://github.com/optuna/optuna/pull/6716#pullrequestreview-4494049876.

Currently, `PedAnovaImportanceEvaluator` raises a `ValueError` for multi-objective studies when `target` is `None`. On the other hand, specifying `target` emits a warning, so there is currently no way to use `PedAnovaImportanceEvaluator` for multi-objective studies without triggering either an error or a warning:

https://github.com/optuna/optuna/blob/46befbd44ff27b6077871b8e077b5c2975737dbc/optuna/importance/_ped_anova/evaluator.py#L202-L207

This PR addresses this limitation by introducing a MOTPE-like split as the default behavior when `target` is `None`. It uses non-domination ranks and HSSP for tie-breaking.

## Description of the changes
<!-- Describe the changes in this PR. -->
