### PR TITLE
Fix mypy errors with latest NumPy stubs

### DIFF
--- a/optuna/importance/_fanova/_tree.py
+++ b/optuna/importance/_fanova/_tree.py
@@ -306,7 +306,7 @@ def _get_cardinality(search_spaces: np.ndarray) -> float:
     return np.prod(search_spaces[:, 1] - search_spaces[:, 0])
 
 
-def _get_cardinality_batched(search_spaces_list: list[np.ndarray]) -> float:
+def _get_cardinality_batched(search_spaces_list: list[np.ndarray]) -> np.ndarray:
     search_spaces = np.asarray(search_spaces_list)
     return np.prod(search_spaces[:, :, 1] - search_spaces[:, :, 0], axis=1)
 

--- a/optuna/samplers/_tpe/_truncnorm.py
+++ b/optuna/samplers/_tpe/_truncnorm.py
@@ -36,6 +36,7 @@ from __future__ import annotations
 import functools
 import math
 import sys
+from typing import cast
 
 import numpy as np
 
@@ -102,7 +103,7 @@ def _log_ndtr_single(a: float) -> float:
 
 
 def _log_ndtr(a: np.ndarray) -> np.ndarray:
-    return np.frompyfunc(_log_ndtr_single, 1, 1)(a).astype(float)
+    return cast(np.ndarray, np.frompyfunc(_log_ndtr_single, 1, 1)(a)).astype(float)
 
 
 def _norm_logpdf(x: np.ndarray) -> np.ndarray:


### PR DESCRIPTION
## Motivation
The scheduled Checks workflow failed in the mypy step after NumPy/numpy-typing-compat updates made NumPy return types stricter.

https://github.com/optuna/optuna/actions/runs/28339666388/job/83951805121

## Description of the changes
- Update `_get_cardinality_batched` to declare that it returns an ndarray, matching the batched `np.prod(..., axis=1)` result.
- Cast the `np.frompyfunc` result to `np.ndarray` in `_log_ndtr` before calling `.astype(float)`, preserving the existing runtime behavior while helping mypy understand the return type.