### PR TITLE
docs: clarify `n_warmup_steps` boundary in `MedianPruner` and `PercentilePruner`

### DIFF
--- a/optuna/pruners/_median.py
+++ b/optuna/pruners/_median.py
@@ -62,7 +62,7 @@ class MedianPruner(PercentilePruner):
         n_warmup_steps:
             Pruning is disabled while the current step is less than ``n_warmup_steps``; the
             earliest a trial can be pruned is at ``step == n_warmup_steps``. This feature
-            assumes that ``step`` starts at zero.
+            assumes that ``step`` is a non-negative integer.
         interval_steps:
             Interval in number of steps between the pruning checks, offset by the warmup steps.
             If no value has been reported at the time of a pruning check, that particular check

--- a/optuna/pruners/_median.py
+++ b/optuna/pruners/_median.py
@@ -60,9 +60,9 @@ class MedianPruner(PercentilePruner):
         n_startup_trials:
             Pruning is disabled until the given number of trials finish in the same study.
         n_warmup_steps:
-            Pruning is disabled for the first ``n_warmup_steps`` reported steps (steps ``0`` to
-            ``n_warmup_steps - 1``); the earliest a trial can be pruned is at
-            ``step == n_warmup_steps``.
+            Pruning is disabled while the current step is less than ``n_warmup_steps``; the
+            earliest a trial can be pruned is at ``step == n_warmup_steps``. This feature
+            assumes that ``step`` starts at zero.
         interval_steps:
             Interval in number of steps between the pruning checks, offset by the warmup steps.
             If no value has been reported at the time of a pruning check, that particular check

--- a/optuna/pruners/_median.py
+++ b/optuna/pruners/_median.py
@@ -60,8 +60,9 @@ class MedianPruner(PercentilePruner):
         n_startup_trials:
             Pruning is disabled until the given number of trials finish in the same study.
         n_warmup_steps:
-            Pruning is disabled until the trial exceeds the given number of step. Note that
-            this feature assumes that ``step`` starts at zero.
+            Pruning is disabled for the first ``n_warmup_steps`` reported steps (steps ``0`` to
+            ``n_warmup_steps - 1``); the earliest a trial can be pruned is at
+            ``step == n_warmup_steps``. This feature assumes that ``step`` starts at zero.
         interval_steps:
             Interval in number of steps between the pruning checks, offset by the warmup steps.
             If no value has been reported at the time of a pruning check, that particular check

--- a/optuna/pruners/_median.py
+++ b/optuna/pruners/_median.py
@@ -62,7 +62,7 @@ class MedianPruner(PercentilePruner):
         n_warmup_steps:
             Pruning is disabled for the first ``n_warmup_steps`` reported steps (steps ``0`` to
             ``n_warmup_steps - 1``); the earliest a trial can be pruned is at
-            ``step == n_warmup_steps``. This feature assumes that ``step`` starts at zero.
+            ``step == n_warmup_steps``.
         interval_steps:
             Interval in number of steps between the pruning checks, offset by the warmup steps.
             If no value has been reported at the time of a pruning check, that particular check

--- a/optuna/pruners/_percentile.py
+++ b/optuna/pruners/_percentile.py
@@ -125,9 +125,9 @@ class PercentilePruner(BasePruner):
         n_startup_trials:
             Pruning is disabled until the given number of trials finish in the same study.
         n_warmup_steps:
-            Pruning is disabled for the first ``n_warmup_steps`` reported steps (steps ``0`` to
-            ``n_warmup_steps - 1``); the earliest a trial can be pruned is at
-            ``step == n_warmup_steps``.
+            Pruning is disabled while the current step is less than ``n_warmup_steps``; the
+            earliest a trial can be pruned is at ``step == n_warmup_steps``. This feature
+            assumes that ``step`` starts at zero.
         interval_steps:
             Interval in number of steps between the pruning checks, offset by the warmup steps.
             If no value has been reported at the time of a pruning check, that particular check

--- a/optuna/pruners/_percentile.py
+++ b/optuna/pruners/_percentile.py
@@ -127,7 +127,7 @@ class PercentilePruner(BasePruner):
         n_warmup_steps:
             Pruning is disabled while the current step is less than ``n_warmup_steps``; the
             earliest a trial can be pruned is at ``step == n_warmup_steps``. This feature
-            assumes that ``step`` starts at zero.
+            assumes that ``step`` is a non-negative integer.
         interval_steps:
             Interval in number of steps between the pruning checks, offset by the warmup steps.
             If no value has been reported at the time of a pruning check, that particular check

--- a/optuna/pruners/_percentile.py
+++ b/optuna/pruners/_percentile.py
@@ -125,8 +125,9 @@ class PercentilePruner(BasePruner):
         n_startup_trials:
             Pruning is disabled until the given number of trials finish in the same study.
         n_warmup_steps:
-            Pruning is disabled until the trial exceeds the given number of step. Note that
-            this feature assumes that ``step`` starts at zero.
+            Pruning is disabled for the first ``n_warmup_steps`` reported steps (steps ``0`` to
+            ``n_warmup_steps - 1``); the earliest a trial can be pruned is at
+            ``step == n_warmup_steps``. This feature assumes that ``step`` starts at zero.
         interval_steps:
             Interval in number of steps between the pruning checks, offset by the warmup steps.
             If no value has been reported at the time of a pruning check, that particular check

--- a/optuna/pruners/_percentile.py
+++ b/optuna/pruners/_percentile.py
@@ -127,7 +127,7 @@ class PercentilePruner(BasePruner):
         n_warmup_steps:
             Pruning is disabled for the first ``n_warmup_steps`` reported steps (steps ``0`` to
             ``n_warmup_steps - 1``); the earliest a trial can be pruned is at
-            ``step == n_warmup_steps``. This feature assumes that ``step`` starts at zero.
+            ``step == n_warmup_steps``.
         interval_steps:
             Interval in number of steps between the pruning checks, offset by the warmup steps.
             If no value has been reported at the time of a pruning check, that particular check


### PR DESCRIPTION
Closes #6732

The docstring said "until the trial exceeds the given number of step" which implies 
`step > n_warmup_steps`, but the implementation uses `step < n_warmup_steps`, meaning 
pruning begins at `step == n_warmup_steps`. Updated both `_median.py` and `_percentile.py` to make the boundary explicit.