### PR TITLE
Warn when `step` decreases in `Trial.report` (closes #6734)

### DIFF
--- a/optuna/trial/_trial.py
+++ b/optuna/trial/_trial.py
@@ -504,6 +504,26 @@ class Trial(BaseTrial):
         if step < 0:
             raise ValueError(f"`{step=}` must be non-negative.")
 
+        # Warn if the step is smaller than the previously reported maximum step.
+        # Most pruners (MedianPruner, SuccessiveHalvingPruner, etc.) assume that
+        # steps are reported in monotonically increasing order. Reporting a
+        # decreasing step typically indicates a bug in the objective function.
+        # WilcoxonPruner is the exception: it explicitly supports non-monotonic
+        # step ordering (steps represent instance IDs, not epochs).
+        if self._cached_frozen_trial.intermediate_values:
+            max_reported_step = max(self._cached_frozen_trial.intermediate_values.keys())
+            if step < max_reported_step:
+                from optuna.pruners._wilcoxon import WilcoxonPruner
+
+                if not isinstance(self.study.pruner, WilcoxonPruner):
+                    optuna_warn(
+                        f"The step {step} is smaller than the previously reported "
+                        f"maximum step {max_reported_step}. Most pruners assume that "
+                        f"`step` is monotonically increasing. If you intend to report "
+                        f"values in a non-monotonic order, consider using "
+                        f"`WilcoxonPruner`."
+                    )
+
         if step in self._cached_frozen_trial.intermediate_values:
             # Do nothing if already reported.
             optuna_warn(

--- a/tests/trial_tests/test_trial.py
+++ b/tests/trial_tests/test_trial.py
@@ -652,6 +652,33 @@ def test_report_warning() -> None:
         trial.report(1, 1)
 
 
+def test_report_decreasing_step_warning() -> None:
+    """Test that a warning is emitted when step decreases with standard pruners."""
+    study = create_study()
+    trial = study.ask()
+
+    trial.report(1.0, 5)
+    trial.report(2.0, 10)
+
+    # Reporting a step smaller than the current maximum (10) should warn.
+    with pytest.warns(UserWarning, match="smaller than the previously reported maximum step"):
+        trial.report(3.0, 3)
+
+
+def test_report_decreasing_step_no_warning_with_wilcoxon() -> None:
+    """Test that no warning is emitted when step decreases with WilcoxonPruner."""
+    study = create_study(pruner=optuna.pruners.WilcoxonPruner())
+    trial = study.ask()
+
+    trial.report(1.0, 5)
+    trial.report(2.0, 10)
+
+    # WilcoxonPruner supports non-monotonic steps, so no warning should be emitted.
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        trial.report(3.0, 3)
+
+
 def test_suggest_with_multi_objectives() -> None:
     study = create_study(directions=["maximize", "maximize"])
 


### PR DESCRIPTION
## Motivation

Addresses #6734.

Most pruners (`MedianPruner`, `SuccessiveHalvingPruner`, `HyperbandPruner`, etc.) assume that `step` values reported via `Trial.report(value, step)` are monotonically increasing, representing training epochs or iterations. When a user accidentally reports decreasing steps (e.g., `step=200 - 2*t`), pruner logic silently produces incorrect results — the trial may never be pruned or may be pruned at the wrong time.

Currently, `Trial.report` only validates that `step >= 0`, but does not warn about non-monotonic step sequences.

## Description of the changes

- **`optuna/trial/_trial.py`**: Added a check in `Trial.report()` that emits a `UserWarning` when the reported `step` is smaller than the maximum previously reported step. The warning message explains the issue and suggests using `WilcoxonPruner` if non-monotonic steps are intentional.
  - `WilcoxonPruner` is explicitly exempted from this warning, since it documents that "The instance id (step) may not be in ascending order."
  - The import of `WilcoxonPruner` is deferred (inside the `if` branch) to avoid circular imports and minimize overhead on the normal code path.

- **`tests/trial_tests/test_trial.py`**: Added two tests:
  - `test_report_decreasing_step_warning`: Verifies that a `UserWarning` is emitted when steps decrease with a standard pruner.
  - `test_report_decreasing_step_no_warning_with_wilcoxon`: Verifies that no warning is emitted when using `WilcoxonPruner`.
