### PR TITLE
Enable `constant_liar` by default

### DIFF
--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -214,7 +214,7 @@ class TPESampler(BaseSampler):
                 study.optimize(objective, n_trials=10)
         constant_liar:
             If :obj:`True`, penalize running trials to avoid suggesting parameter configurations
-            nearby.
+            nearby. Defaults to :obj:`True`.
 
             .. note::
                 Abnormally terminated trials often leave behind a record with a state of
@@ -226,16 +226,12 @@ class TPESampler(BaseSampler):
                 ``FAIL``.
 
             .. note::
-                It is recommended to set this value to :obj:`True` during distributed
-                optimization to avoid having multiple workers evaluating similar parameter
-                configurations. In particular, if each objective function evaluation is costly
-                and the durations of the running states are significant, and/or the number of
-                workers is high.
-
-            .. note::
-                Added in v2.8.0 as an experimental feature. The interface may change in newer
-                versions without prior notice. See
-                https://github.com/optuna/optuna/releases/tag/v2.8.0.
+                Enabling this option is especially beneficial during distributed optimization to
+                avoid having multiple workers evaluating similar parameter configurations. In
+                particular, if each objective function evaluation is costly and the durations of
+                the running states are significant, and/or the number of workers is high. For
+                sequential (single-worker) optimization, this option does not affect the sampling
+                results because there are no other running trials.
         constraints_func:
             An optional function that computes the objective constraints. It must take a
             :class:`~optuna.trial.FrozenTrial` and return the constraints. The return value must
@@ -381,7 +377,7 @@ class TPESampler(BaseSampler):
         multivariate: bool = False,
         group: bool = False,
         warn_independent_sampling: bool | None = None,
-        constant_liar: bool = False,
+        constant_liar: bool = True,
         constraints_func: Callable[[FrozenTrial], Sequence[float]] | None = None,
         categorical_distance_func: (
             dict[str, Callable[[CategoricalChoiceType, CategoricalChoiceType], float]] | None
@@ -447,9 +443,6 @@ class TPESampler(BaseSampler):
                 )
             warn_experimental_argument("group")
             self._group_decomposed_search_space = _GroupDecomposedSearchSpace(True)
-
-        if constant_liar:
-            warn_experimental_argument("constant_liar")
 
         if constraints_func is not None:
             warn_experimental_argument("constraints_func")

--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -224,14 +224,6 @@ class TPESampler(BaseSampler):
                 When using an :class:`~optuna.storages.RDBStorage`, it is possible to enable the
                 ``heartbeat_interval`` to change the records for abnormally terminated trials to
                 ``FAIL``.
-
-            .. note::
-                Enabling this option is especially beneficial during distributed optimization to
-                avoid having multiple workers evaluating similar parameter configurations. In
-                particular, if each objective function evaluation is costly and the durations of
-                the running states are significant, and/or the number of workers is high. For
-                sequential (single-worker) optimization, this option does not affect the sampling
-                results because there are no other running trials.
         constraints_func:
             An optional function that computes the objective constraints. It must take a
             :class:`~optuna.trial.FrozenTrial` and return the constraints. The return value must

--- a/tests/samplers_tests/tpe_tests/test_multi_objective_sampler.py
+++ b/tests/samplers_tests/tpe_tests/test_multi_objective_sampler.py
@@ -134,16 +134,16 @@ def test_multi_objective_sample_independent_misc_arguments() -> None:
 
     # Prepare a trial and a sample for later checks.
     trial = frozen_trial_factory(16, [0, 0])
-    sampler = TPESampler(seed=0)
+    sampler = TPESampler(seed=0, constant_liar=False)
     suggestion = suggest(sampler, study, trial, dist, past_trials)
 
     # Test misc. parameters.
-    sampler = TPESampler(n_ei_candidates=13, seed=0)
+    sampler = TPESampler(n_ei_candidates=13, seed=0, constant_liar=False)
     assert suggest(sampler, study, trial, dist, past_trials) != suggestion
 
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", FutureWarning)
-        sampler = TPESampler(gamma=lambda _: 1, seed=0)
+        sampler = TPESampler(gamma=lambda _: 1, seed=0, constant_liar=False)
     assert suggest(sampler, study, trial, dist, past_trials) != suggestion
 
 

--- a/tests/samplers_tests/tpe_tests/test_sampler.py
+++ b/tests/samplers_tests/tpe_tests/test_sampler.py
@@ -152,14 +152,16 @@ def test_sample_relative_prior() -> None:
     trial = frozen_trial_factory(8)
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", optuna.exceptions.ExperimentalWarning)
-        sampler = TPESampler(n_startup_trials=5, seed=0, multivariate=True)
+        sampler = TPESampler(n_startup_trials=5, seed=0, multivariate=True, constant_liar=False)
     with patch.object(study._storage, "get_all_trials", return_value=past_trials):
         suggestion = sampler.sample_relative(study, trial, {"param-a": dist})
 
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", optuna.exceptions.ExperimentalWarning)
         warnings.simplefilter("ignore", FutureWarning)
-        sampler = TPESampler(prior_weight=0.2, n_startup_trials=5, seed=0, multivariate=True)
+        sampler = TPESampler(
+            prior_weight=0.2, n_startup_trials=5, seed=0, multivariate=True, constant_liar=False
+        )
     with patch.object(study._storage, "get_all_trials", return_value=past_trials):
         assert sampler.sample_relative(study, trial, {"param-a": dist}) != suggestion
 
@@ -173,7 +175,7 @@ def test_sample_relative_n_startup_trial() -> None:
     # sample_relative returns {} for only 4 observations.
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", optuna.exceptions.ExperimentalWarning)
-        sampler = TPESampler(n_startup_trials=5, seed=0, multivariate=True)
+        sampler = TPESampler(n_startup_trials=5, seed=0, multivariate=True, constant_liar=False)
     with patch.object(study._storage, "get_all_trials", return_value=past_trials[:4]):
         assert sampler.sample_relative(study, trial, {"param-a": dist}) == {}
     # sample_relative returns some value for only 7 observations.
@@ -191,21 +193,25 @@ def test_sample_relative_misc_arguments() -> None:
     trial = frozen_trial_factory(40)
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", optuna.exceptions.ExperimentalWarning)
-        sampler = TPESampler(n_startup_trials=5, seed=0, multivariate=True)
+        sampler = TPESampler(n_startup_trials=5, seed=0, multivariate=True, constant_liar=False)
     with patch.object(study._storage, "get_all_trials", return_value=past_trials):
         suggestion = sampler.sample_relative(study, trial, {"param-a": dist})
 
     # Test misc. parameters.
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", optuna.exceptions.ExperimentalWarning)
-        sampler = TPESampler(n_ei_candidates=13, n_startup_trials=5, seed=0, multivariate=True)
+        sampler = TPESampler(
+            n_ei_candidates=13, n_startup_trials=5, seed=0, multivariate=True, constant_liar=False
+        )
     with patch.object(study._storage, "get_all_trials", return_value=past_trials):
         assert sampler.sample_relative(study, trial, {"param-a": dist}) != suggestion
 
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", optuna.exceptions.ExperimentalWarning)
         warnings.simplefilter("ignore", FutureWarning)
-        sampler = TPESampler(gamma=lambda _: 5, n_startup_trials=5, seed=0, multivariate=True)
+        sampler = TPESampler(
+            gamma=lambda _: 5, n_startup_trials=5, seed=0, multivariate=True, constant_liar=False
+        )
     with patch.object(study._storage, "get_all_trials", return_value=past_trials):
         assert sampler.sample_relative(study, trial, {"param-a": dist}) != suggestion
 
@@ -217,6 +223,7 @@ def test_sample_relative_misc_arguments() -> None:
             n_startup_trials=5,
             seed=0,
             multivariate=True,
+            constant_liar=False,
         )
     with patch.object(study._storage, "get_all_trials", return_value=past_trials):
         assert sampler.sample_relative(study, trial, {"param-a": dist}) != suggestion
@@ -231,7 +238,7 @@ def test_sample_relative_uniform_distributions() -> None:
     trial = frozen_trial_factory(8)
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", optuna.exceptions.ExperimentalWarning)
-        sampler = TPESampler(n_startup_trials=5, seed=0, multivariate=True)
+        sampler = TPESampler(n_startup_trials=5, seed=0, multivariate=True, constant_liar=False)
     with patch.object(study._storage, "get_all_trials", return_value=past_trials):
         uniform_suggestion = sampler.sample_relative(study, trial, {"param-a": uni_dist})
     assert 1.0 <= uniform_suggestion["param-a"] < 100.0
@@ -247,7 +254,7 @@ def test_sample_relative_log_uniform_distributions() -> None:
     trial = frozen_trial_factory(8)
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", optuna.exceptions.ExperimentalWarning)
-        sampler = TPESampler(n_startup_trials=5, seed=0, multivariate=True)
+        sampler = TPESampler(n_startup_trials=5, seed=0, multivariate=True, constant_liar=False)
     with patch.object(study._storage, "get_all_trials", return_value=past_trials):
         uniform_suggestion = sampler.sample_relative(study, trial, {"param-a": uni_dist})
 
@@ -257,7 +264,7 @@ def test_sample_relative_log_uniform_distributions() -> None:
     trial = frozen_trial_factory(8)
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", optuna.exceptions.ExperimentalWarning)
-        sampler = TPESampler(n_startup_trials=5, seed=0, multivariate=True)
+        sampler = TPESampler(n_startup_trials=5, seed=0, multivariate=True, constant_liar=False)
     with patch.object(study._storage, "get_all_trials", return_value=past_trials):
         loguniform_suggestion = sampler.sample_relative(study, trial, {"param-a": log_dist})
     assert 1.0 <= loguniform_suggestion["param-a"] < 100.0
@@ -278,7 +285,7 @@ def test_sample_relative_disrete_uniform_distributions() -> None:
     trial = frozen_trial_factory(8)
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", optuna.exceptions.ExperimentalWarning)
-        sampler = TPESampler(n_startup_trials=5, seed=0, multivariate=True)
+        sampler = TPESampler(n_startup_trials=5, seed=0, multivariate=True, constant_liar=False)
     with patch.object(study._storage, "get_all_trials", return_value=past_trials):
         discrete_uniform_suggestion = sampler.sample_relative(study, trial, {"param-a": disc_dist})
     assert 1.0 <= discrete_uniform_suggestion["param-a"] <= 100.0
@@ -305,7 +312,7 @@ def test_sample_relative_categorical_distributions() -> None:
     trial = frozen_trial_factory(8)
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", optuna.exceptions.ExperimentalWarning)
-        sampler = TPESampler(n_startup_trials=5, seed=0, multivariate=True)
+        sampler = TPESampler(n_startup_trials=5, seed=0, multivariate=True, constant_liar=False)
     with patch.object(study._storage, "get_all_trials", return_value=past_trials):
         categorical_suggestion = sampler.sample_relative(study, trial, {"param-a": cat_dist})
     assert categorical_suggestion["param-a"] in categories
@@ -328,7 +335,7 @@ def test_sample_relative_int_uniform_distributions(step: int) -> None:
     trial = frozen_trial_factory(8)
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", optuna.exceptions.ExperimentalWarning)
-        sampler = TPESampler(n_startup_trials=5, seed=0, multivariate=True)
+        sampler = TPESampler(n_startup_trials=5, seed=0, multivariate=True, constant_liar=False)
     with patch.object(study._storage, "get_all_trials", return_value=past_trials):
         int_suggestion = sampler.sample_relative(study, trial, {"param-a": int_dist})
     assert 1 <= int_suggestion["param-a"] <= 100
@@ -352,7 +359,7 @@ def test_sample_relative_int_loguniform_distributions() -> None:
     trial = frozen_trial_factory(8)
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", optuna.exceptions.ExperimentalWarning)
-        sampler = TPESampler(n_startup_trials=5, seed=0, multivariate=True)
+        sampler = TPESampler(n_startup_trials=5, seed=0, multivariate=True, constant_liar=False)
     with patch.object(study._storage, "get_all_trials", return_value=past_trials):
         intlog_suggestion = sampler.sample_relative(study, trial, {"param-a": intlog_dist})
     assert 1 <= intlog_suggestion["param-a"] <= 100
@@ -381,7 +388,7 @@ def test_sample_relative_handle_unsuccessful_states(
     trial = frozen_trial_factory(100)
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", optuna.exceptions.ExperimentalWarning)
-        sampler = TPESampler(n_startup_trials=5, seed=0, multivariate=True)
+        sampler = TPESampler(n_startup_trials=5, seed=0, multivariate=True, constant_liar=False)
     all_success_suggestion = sampler.sample_relative(study, trial, {"param-a": dist})
 
     # Test unsuccessful trials are handled differently.
@@ -393,7 +400,7 @@ def test_sample_relative_handle_unsuccessful_states(
     trial = frozen_trial_factory(100)
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", optuna.exceptions.ExperimentalWarning)
-        sampler = TPESampler(n_startup_trials=5, seed=0, multivariate=True)
+        sampler = TPESampler(n_startup_trials=5, seed=0, multivariate=True, constant_liar=False)
     partial_unsuccessful_suggestion = sampler.sample_relative(study, trial, {"param-a": dist})
 
     assert partial_unsuccessful_suggestion != all_success_suggestion
@@ -417,7 +424,9 @@ def test_sample_relative_ignored_states() -> None:
             study._storage.create_new_trial(study._study_id, template_trial=trial)
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", optuna.exceptions.ExperimentalWarning)
-            sampler = TPESampler(n_startup_trials=5, seed=0, multivariate=True)
+            sampler = TPESampler(
+                n_startup_trials=5, seed=0, multivariate=True, constant_liar=False
+            )
         suggestions.append(sampler.sample_relative(study, trial, {"param-a": dist})["param-a"])
 
     assert len(set(suggestions)) == 1
@@ -442,7 +451,9 @@ def test_sample_relative_pruned_state() -> None:
         trial = frozen_trial_factory(40)
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", optuna.exceptions.ExperimentalWarning)
-            sampler = TPESampler(n_startup_trials=5, seed=0, multivariate=True)
+            sampler = TPESampler(
+                n_startup_trials=5, seed=0, multivariate=True, constant_liar=False
+            )
         suggestions.append(sampler.sample_relative(study, trial, {"param-a": dist})["param-a"])
 
     assert len(set(suggestions)) == 3
@@ -1116,17 +1127,10 @@ def test_group_experimental_warning() -> None:
         _ = TPESampler(multivariate=True, group=True)
 
 
-def test_constant_liar_experimental_warning() -> None:
-    with pytest.warns(optuna.exceptions.ExperimentalWarning):
-        _ = TPESampler(constant_liar=True)
-
-
 @pytest.mark.parametrize("multivariate", [True, False])
 @pytest.mark.parametrize("multiobjective", [True, False])
 def test_constant_liar_with_running_trial(multivariate: bool, multiobjective: bool) -> None:
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", optuna.exceptions.ExperimentalWarning)
-        sampler = TPESampler(multivariate=multivariate, constant_liar=True, n_startup_trials=0)
+    sampler = TPESampler(multivariate=multivariate, constant_liar=True, n_startup_trials=0)
 
     directions = ["minimize"] * 2 if multiobjective else ["minimize"]
     study = optuna.create_study(sampler=sampler, directions=directions)

--- a/tutorial/20_recipes/009_ask_and_tell.py
+++ b/tutorial/20_recipes/009_ask_and_tell.py
@@ -238,11 +238,11 @@ for _ in range(3):
 ###################################################################################################
 # .. tip::
 #
-#     :class:`optuna.samplers.TPESampler` class can take a boolean parameter ``constant_liar``. It
-#     is recommended to set this value to ``True`` during batched optimization to avoid having
-#     multiple workers evaluating similar parameter configurations. In particular, if each
-#     objective function evaluation is costly and the durations of the running states are
-#     significant, and/or the number of workers is high.
+#     :class:`optuna.samplers.TPESampler` class can take a boolean parameter ``constant_liar``,
+#     which is enabled by default. It penalizes running trials to avoid having multiple workers
+#     evaluating similar parameter configurations during batched optimization. This is especially
+#     beneficial if each objective function evaluation is costly and the durations of the running
+#     states are significant, and/or the number of workers is high.
 
 ###################################################################################################
 # .. tip::


### PR DESCRIPTION
## Motivation

`TPESampler`'s `constant_liar` option penalizes running trials so that concurrent workers avoid evaluating similar parameter configurations. It is highly beneficial for batched / distributed optimization, and we have long recommended enabling it in that setting (e.g., in the ask-and-tell tutorial). However, it has been disabled by default and kept as an experimental feature.

This PR makes `constant_liar` enabled by default and promotes it to a stable feature, so that users benefit from it out of the box during parallel optimization without extra configuration.

Note that this option has **no effect on sequential (single-worker) optimization**, because there are no other running trials to penalize (the current trial is filtered out). Therefore the change only affects the sampling results in parallel / distributed settings.

## Description of the changes

- `optuna/samplers/_tpe/sampler.py`
  - Change the default of `constant_liar` from `False` to `True`.
  - Remove the `ExperimentalWarning` emitted when `constant_liar=True` (promote to stable).
  - Update the docstring: note the new default and that it does not affect sequential optimization; drop the "Added in v2.8.0 as an experimental feature" note.
- `tests/samplers_tests/tpe_tests/`
  - Remove `test_constant_liar_experimental_warning` (no warning is emitted anymore).
  - Set `constant_liar=False` explicitly in the mock-based `sample_relative` / multi-objective `sample_independent` unit tests. These tests fabricate a current trial that is not registered in the storage and mock the trial set to test the sampling math; the constant-liar behavior (writing system attrs to / filtering the current trial) is orthogonal to what they verify.
- `tutorial/20_recipes/009_ask_and_tell.py`
  - Update the tip to state that `constant_liar` is now enabled by default.
