### PR TITLE
Fix `NameError` when visualization backends are missing in `_rank.py` (closes #6702)

### DIFF
--- a/optuna/visualization/_rank.py
+++ b/optuna/visualization/_rank.py
@@ -404,8 +404,13 @@ def _convert_color_idxs_to_scaled_rgb_colors(color_idxs: np.ndarray) -> np.ndarr
         labeled_colors = plotly.colors.sample_colorscale(colormap, color_idxs)
         scaled_rgb_colors = np.array([plotly.colors.unlabel_rgb(cl) for cl in labeled_colors])
         return scaled_rgb_colors
-    else:
+    elif matplotlib_imports.is_successful():
         cmap = matplotlib_plt.get_cmap(colormap)
         colors = cmap(color_idxs)[:, :3]  # Drop alpha values.
         rgb_colors = np.asarray(colors * 255, dtype=int)
         return rgb_colors
+    else:
+        raise ImportError(
+            "Neither plotly nor matplotlib is available. Please install either of them "
+            "to use this feature."
+        )


### PR DESCRIPTION
## Motivation

Addresses #6702.

When `optuna.visualization._rank._get_rank_info` is called without either `plotly` or `matplotlib` installed, it crashes with a `NameError: name 'matplotlib_plt' is not defined`. This occurs because `matplotlib_plt` is used in the `else` fallback branch without first verifying if the import was successful at the module level.

## Description of the changes

- **`optuna/visualization/_rank.py`**: Updated `_convert_color_idxs_to_scaled_rgb_colors` to explicitly check `matplotlib_imports.is_successful()` in an `elif` branch. If both backends are unavailable, it now falls back to a final `else` block that raises a clear `ImportError`, mirroring the behavior in other visualization modules.
