### PR TITLE
Add a private attribute to BruteForceSampler for advanced usage

### DIFF
--- a/optuna/samplers/_brute_force.py
+++ b/optuna/samplers/_brute_force.py
@@ -206,12 +206,11 @@ class _TreeNode:
 
 
 def _get_non_waiting_trials_and_current_trial_index(
-    study: Study, current_trial_number: int
+    study: Study, current_trial_number: int, states: list[TrialState]
 ) -> tuple[list[FrozenTrial], int]:
     # We directly query the storage to get trials here instead of `study.get_trials`,
     # since some pruners such as `HyperbandPruner` use the study transformed
     # to filter trials. See https://github.com/optuna/optuna/issues/2327 for details.
-    states = (TrialState.COMPLETE, TrialState.PRUNED, TrialState.RUNNING, TrialState.FAIL)
     trials = study._storage.get_all_trials(study._study_id, deepcopy=False, states=states)
     # `trials` is fetched by shallow copy, so pop() or element replacement are safe operations.
     for i in range(1, len(trials) + 1):
@@ -274,6 +273,20 @@ class BruteForceSampler(BaseSampler):
     def __init__(self, seed: int | None = None, avoid_premature_stop: bool = False) -> None:
         self._rng = LazyRandomState(seed)
         self._avoid_premature_stop = avoid_premature_stop
+        # region (Private attribute for advanced users)
+        # NOTE(nabenabe): Defining this in global scope lets advanced users customize the target
+        # states externally (e.g., excluding FAIL). See
+        # https://github.com/optuna/optuna/issues/6654 for the motivation. Additionally, setting
+        # `None` skips state filtering in the storage layer, speeding up `BruteForceSampler`,
+        # though this is valid only for non-parallel setups. Please note that this is not an
+        # official API, so we do not guarantee any correctness.
+        # endregion
+        self._trial_states_in_tree = (
+            TrialState.COMPLETE,
+            TrialState.PRUNED,
+            TrialState.RUNNING,
+            TrialState.FAIL,
+        )
 
     def infer_relative_search_space(
         self, study: Study, trial: FrozenTrial
@@ -337,7 +350,9 @@ class BruteForceSampler(BaseSampler):
         param_distribution: BaseDistribution,
     ) -> Any:
         exclude_running = not self._avoid_premature_stop
-        trials, current_idx = _get_non_waiting_trials_and_current_trial_index(study, trial.number)
+        trials, current_idx = _get_non_waiting_trials_and_current_trial_index(
+            study, trial.number, states=self._trial_states_in_tree
+        )
         trials.pop(current_idx)
         tree = _TreeNode()
         if isinstance(param_distribution, CategoricalDistribution):
@@ -363,7 +378,9 @@ class BruteForceSampler(BaseSampler):
         self, study: Study, trial: FrozenTrial, state: TrialState, values: Sequence[float] | None
     ) -> None:
         exclude_running = not self._avoid_premature_stop
-        trials, current_idx = _get_non_waiting_trials_and_current_trial_index(study, trial.number)
+        trials, current_idx = _get_non_waiting_trials_and_current_trial_index(
+            study, trial.number, states=self._trial_states_in_tree
+        )
         # Set current trial as complete.
         trials[current_idx] = create_trial(
             state=state, values=values, params=trial.params, distributions=trial.distributions

--- a/optuna/samplers/_brute_force.py
+++ b/optuna/samplers/_brute_force.py
@@ -206,7 +206,7 @@ class _TreeNode:
 
 
 def _get_non_waiting_trials_and_current_trial_index(
-    study: Study, current_trial_number: int, states: list[TrialState]
+    study: Study, current_trial_number: int, states: tuple[TrialState, ...]
 ) -> tuple[list[FrozenTrial], int]:
     # We directly query the storage to get trials here instead of `study.get_trials`,
     # since some pruners such as `HyperbandPruner` use the study transformed


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. To minimize the review effort, we highly appreciate PRs only with related changes. Please note that submitted PRs may be closed if they include unrelated changes or significantly modified unit tests. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

Essentially, it is painful to manually kill preempted trials when I use BruteForceSampler on cluster.
Since adding a new argument was rejected but this is indeed annoying, I added a private attribute for this purpose.
Users can modify this attribute to control the tree build protocol externally.

As this is a hidden feature, Optuna does not guarantee any expected behavior for this modification.

No side effect by this change, some users can simply enjoy this.

> [!NOTE]
> If this PR should be moved to OptunaHub, please tell me.
> I'm open to transfer there as well, though I'd appreciate master merge more.

## Description of the changes
<!-- Describe the changes in this PR. -->
- Add a private attribute to change the filtering level for tree build