### PR TITLE
fix: raise ImportError when rank backends are unavailable

### DIFF
--- a/optuna/visualization/_rank.py
+++ b/optuna/visualization/_rank.py
@@ -400,6 +400,8 @@ def _convert_color_idxs_to_scaled_rgb_colors(color_idxs: np.ndarray) -> np.ndarr
         scaled_rgb_colors = np.array([plotly.colors.unlabel_rgb(cl) for cl in labeled_colors])
         return scaled_rgb_colors
     else:
+        if not matplotlib_imports.is_successful():
+            raise ImportError("Neither plotly nor matplotlib is available. Please install one of them to use rank plots.")
         cmap = matplotlib_plt.get_cmap(colormap)
         colors = cmap(color_idxs)[:, :3]  # Drop alpha values.
         rgb_colors = np.asarray(colors * 255, dtype=int)

--- a/tests/visualization_tests/test_rank.py
+++ b/tests/visualization_tests/test_rank.py
@@ -699,3 +699,11 @@ def test_convert_color_idxs_to_scaled_rgb_colors() -> None:
     x2 = np.array([])
     result2 = _convert_color_idxs_to_scaled_rgb_colors(x2)
     np.testing.assert_array_equal(result2, [])
+
+
+def test_convert_color_idxs_to_scaled_rgb_colors_requires_plot_backend(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("optuna.visualization._rank.plotly_is_available", False)
+    monkeypatch.setattr("optuna.visualization._rank.matplotlib_imports.is_successful", lambda: False)
+
+    with pytest.raises(ImportError, match="Neither plotly nor matplotlib is available"):
+        _convert_color_idxs_to_scaled_rgb_colors(np.array([0.1]))


### PR DESCRIPTION
## Motivation

Fixes #6702.

## Description of the changes

When both Plotly and Matplotlib are unavailable, `_convert_color_idxs_to_scaled_rgb_colors()` currently falls through to `matplotlib_plt` and raises a `NameError`. This change turns that into a clear `ImportError` and adds a regression test for the no-backend path.

Validation:
- `.venv/bin/python -m pytest tests/visualization_tests/test_rank.py -k convert_color_idxs_to_scaled_rgb_colors`