### PR TITLE
Support categorical parameters in QMCSampler

### DIFF
--- a/optuna/samplers/_qmc.py
+++ b/optuna/samplers/_qmc.py
@@ -54,10 +54,6 @@ class QMCSampler(BaseSampler):
     <https://scipy.github.io/devdocs/reference/stats.qmc.html>`__.
 
     .. note::
-        Categorical parameters are sampled by the QMC algorithm: each categorical parameter maps
-        to a single QMC dimension whose value is rounded to a choice index.
-
-    .. note::
         The search space of the sampler is determined by either previous trials in the study or
         the first trial that this sampler samples.
 
@@ -266,10 +262,6 @@ class QMCSampler(BaseSampler):
         if search_space == {}:
             return {}
 
-        # Each parameter, including a categorical one, occupies exactly one QMC dimension, so
-        # sample[i] is the coordinate of the i-th parameter in insertion order. A categorical
-        # parameter is mapped to a single IntDistribution dimension rather than one-hot encoded
-        # into several correlated dimensions. See https://github.com/optuna/optuna/issues/6617.
         sample = self._sample_qmc(study, search_space)[0]
         pseudo_search_space = {
             name: (

--- a/optuna/samplers/_qmc.py
+++ b/optuna/samplers/_qmc.py
@@ -266,10 +266,11 @@ class QMCSampler(BaseSampler):
         if search_space == {}:
             return {}
 
-        sample = self._sample_qmc(study, search_space)
-        # A categorical parameter is mapped to a single IntDistribution dimension so QMC draws one
-        # coordinate for it and rounds to a choice index, rather than one-hot encoding it into
-        # several correlated dimensions. See https://github.com/optuna/optuna/issues/6617.
+        # Each parameter, including a categorical one, occupies exactly one QMC dimension, so
+        # sample[i] is the coordinate of the i-th parameter in insertion order. A categorical
+        # parameter is mapped to a single IntDistribution dimension rather than one-hot encoded
+        # into several correlated dimensions. See https://github.com/optuna/optuna/issues/6617.
+        sample = self._sample_qmc(study, search_space)[0]
         pseudo_search_space = {
             name: (
                 IntDistribution(0, len(dist.choices) - 1)
@@ -279,14 +280,21 @@ class QMCSampler(BaseSampler):
             for name, dist in search_space.items()
         }
         trans = _SearchSpaceTransform(pseudo_search_space, transform_0_1=True)
-        return {
-            name: (
-                dist.to_external_repr(value)
-                if isinstance(dist := search_space[name], CategoricalDistribution)
-                else value
-            )
-            for name, value in trans.untransform(sample[0]).items()
-        }
+        untransformed = trans.untransform(sample)
+        params: dict[str, Any] = {}
+        for i, (name, dist) in enumerate(search_space.items()):
+            if isinstance(dist, CategoricalDistribution):
+                # Bin the raw coordinate with equal-width half-open bins instead of going through
+                # the transform, which ends in np.round and rounds half to even. Sobol and Halton
+                # emit dyadic values, so after scaling many coordinates land exactly on the bin
+                # boundaries and even indices get drawn systematically more often. The clamp only
+                # guards against a coordinate of exactly 1.0; the engines emit values in [0, 1).
+                n_choices = len(dist.choices)
+                index = min(int(sample[i] * n_choices), n_choices - 1)
+                params[name] = dist.to_external_repr(index)
+            else:
+                params[name] = untransformed[name]
+        return params
 
     def before_trial(self, study: Study, trial: FrozenTrial) -> None:
         self._independent_sampler.before_trial(study, trial)

--- a/optuna/samplers/_qmc.py
+++ b/optuna/samplers/_qmc.py
@@ -15,7 +15,7 @@ from optuna._imports import _LazyImport
 from optuna._transform import _SearchSpaceTransform
 from optuna.distributions import BaseDistribution
 from optuna.distributions import CategoricalDistribution
-from optuna.distributions import IntDistribution
+from optuna.distributions import FloatDistribution
 from optuna.samplers import BaseSampler
 from optuna.samplers._base import _INDEPENDENT_SAMPLING_WARNING_TEMPLATE
 from optuna.trial import TrialState
@@ -262,31 +262,29 @@ class QMCSampler(BaseSampler):
         if search_space == {}:
             return {}
 
-        sample = self._sample_qmc(study, search_space)[0]
-        pseudo_search_space = {
-            name: (
-                IntDistribution(0, len(dist.choices) - 1)
-                if isinstance(dist, CategoricalDistribution)
-                else dist
-            )
+        categorical_space = {
+            name: dist
             for name, dist in search_space.items()
+            if isinstance(dist, CategoricalDistribution)
         }
-        trans = _SearchSpaceTransform(pseudo_search_space, transform_0_1=True)
-        untransformed = trans.untransform(sample)
-        params: dict[str, Any] = {}
-        for i, (name, dist) in enumerate(search_space.items()):
-            if isinstance(dist, CategoricalDistribution):
-                # Bin the raw coordinate with equal-width half-open bins instead of going through
-                # the transform, which ends in np.round and rounds half to even. Sobol and Halton
-                # emit dyadic values, so after scaling many coordinates land exactly on the bin
-                # boundaries and even indices get drawn systematically more often. The clamp only
-                # guards against a coordinate of exactly 1.0; the engines emit values in [0, 1).
-                n_choices = len(dist.choices)
-                index = min(int(sample[i] * n_choices), n_choices - 1)
-                params[name] = dist.to_external_repr(index)
-            else:
-                params[name] = untransformed[name]
-        return params
+        # Map each categorical parameter to FloatDistribution(0, C) so it takes one QMC
+        # coordinate in [0, C). Flooring that with int() gives a uniform choice index in
+        # [0, C - 1]; it never reaches C because the engines emit values in [0, 1). Going through
+        # IntDistribution instead would round to nearest and reintroduce a bin-boundary bias.
+        pseudo_categorical_space = {
+            name: FloatDistribution(0, len(dist.choices))
+            for name, dist in categorical_space.items()
+        }
+        trans = _SearchSpaceTransform(search_space | pseudo_categorical_space, transform_0_1=True)
+        sample = trans.untransform(self._sample_qmc(study, search_space)[0])
+        return {
+            name: (
+                dist.to_external_repr(int(value))
+                if (dist := categorical_space.get(name)) is not None
+                else value
+            )
+            for name, value in sample.items()
+        }
 
     def before_trial(self, study: Study, trial: FrozenTrial) -> None:
         self._independent_sampler.before_trial(study, trial)

--- a/optuna/samplers/_qmc.py
+++ b/optuna/samplers/_qmc.py
@@ -15,6 +15,7 @@ from optuna._imports import _LazyImport
 from optuna._transform import _SearchSpaceTransform
 from optuna.distributions import BaseDistribution
 from optuna.distributions import CategoricalDistribution
+from optuna.distributions import IntDistribution
 from optuna.samplers import BaseSampler
 from optuna.samplers._base import _INDEPENDENT_SAMPLING_WARNING_TEMPLATE
 from optuna.trial import TrialState
@@ -53,8 +54,8 @@ class QMCSampler(BaseSampler):
     <https://scipy.github.io/devdocs/reference/stats.qmc.html>`__.
 
     .. note::
-        If your search space contains categorical parameters, it samples the categorical
-        parameters by its `independent_sampler` without using QMC algorithm.
+        Categorical parameters are sampled by the QMC algorithm: each categorical parameter maps
+        to a single QMC dimension whose value is rounded to a choice index.
 
     .. note::
         The search space of the sampler is determined by either previous trials in the study or
@@ -220,13 +221,7 @@ class QMCSampler(BaseSampler):
         return self._infer_initial_search_space(first_trial)
 
     def _infer_initial_search_space(self, trial: FrozenTrial) -> dict[str, BaseDistribution]:
-        search_space: dict[str, BaseDistribution] = {}
-        for param_name, distribution in trial.distributions.items():
-            if isinstance(distribution, CategoricalDistribution):
-                continue
-            search_space[param_name] = distribution
-
-        return search_space
+        return dict(trial.distributions)
 
     @staticmethod
     def _log_asynchronous_seeding() -> None:
@@ -238,20 +233,15 @@ class QMCSampler(BaseSampler):
         )
 
     def _log_independent_sampling(self, trial: FrozenTrial, param_name: str) -> None:
-        # NOTE(nabenabe): We can extend `QMCSampler` to dynamic search space and categorical dist
-        # as well. For dynamic search space, we need to use the same mechanism as `group` by TPE.
-        # For categorical, we simply need to sample from [-1/2, C+1/2] and then round the number
-        # to get a categorical index.
+        # NOTE(nabenabe): We can extend `QMCSampler` to dynamic search space as well by using the
+        # same mechanism as `group` by TPE.
         _logger.warning(
             _INDEPENDENT_SAMPLING_WARNING_TEMPLATE.format(
                 param_name=param_name,
                 trial_number=trial.number,
                 independent_sampler_name=self._independent_sampler.__class__.__name__,
                 sampler_name=self.__class__.__name__,
-                fallback_reason=(
-                    "dynamic search space and `CategoricalDistribution` are not supported "
-                    "by `QMCSampler`"
-                ),
+                fallback_reason="dynamic search space is not supported by `QMCSampler`",
             )
         )
 
@@ -277,9 +267,26 @@ class QMCSampler(BaseSampler):
             return {}
 
         sample = self._sample_qmc(study, search_space)
-        trans = _SearchSpaceTransform(search_space)
-        sample = trans.bounds[:, 0] + sample * (trans.bounds[:, 1] - trans.bounds[:, 0])
-        return trans.untransform(sample[0, :])
+        # A categorical parameter is mapped to a single IntDistribution dimension so QMC draws one
+        # coordinate for it and rounds to a choice index, rather than one-hot encoding it into
+        # several correlated dimensions. See https://github.com/optuna/optuna/issues/6617.
+        pseudo_search_space = {
+            name: (
+                IntDistribution(0, len(dist.choices) - 1)
+                if isinstance(dist, CategoricalDistribution)
+                else dist
+            )
+            for name, dist in search_space.items()
+        }
+        trans = _SearchSpaceTransform(pseudo_search_space, transform_0_1=True)
+        return {
+            name: (
+                dist.to_external_repr(value)
+                if isinstance(dist := search_space[name], CategoricalDistribution)
+                else value
+            )
+            for name, value in trans.untransform(sample[0]).items()
+        }
 
     def before_trial(self, study: Study, trial: FrozenTrial) -> None:
         self._independent_sampler.before_trial(study, trial)

--- a/optuna/samplers/_qmc.py
+++ b/optuna/samplers/_qmc.py
@@ -195,7 +195,7 @@ class QMCSampler(BaseSampler):
             union_search_space: dict[str, BaseDistribution] = {}
             intersection_keys: set[str] | None = None
             for t in pending_trials:
-                space = self._infer_initial_search_space(t)
+                space = dict(t.distributions)
                 union_search_space.update(space)
                 if intersection_keys is None:
                     intersection_keys = set(space.keys())
@@ -214,10 +214,7 @@ class QMCSampler(BaseSampler):
         # If an initial trial was already made,
         # construct search_space of this sampler from the initial trial.
         first_trial = min(past_trials, key=lambda t: t.number)
-        return self._infer_initial_search_space(first_trial)
-
-    def _infer_initial_search_space(self, trial: FrozenTrial) -> dict[str, BaseDistribution]:
-        return dict(trial.distributions)
+        return dict(first_trial.distributions)
 
     @staticmethod
     def _log_asynchronous_seeding() -> None:

--- a/tests/samplers_tests/test_qmc.py
+++ b/tests/samplers_tests/test_qmc.py
@@ -123,20 +123,6 @@ def test_infer_relative_search_space_with_ask_fixed() -> None:
     assert "b" in search_space
 
 
-def test_infer_initial_search_space() -> None:
-    trial = Mock()
-    sampler = _init_QMCSampler_without_exp_warning()
-    # Can it handle empty search space?
-    trial.distributions = {}
-    initial_search_space = sampler._infer_initial_search_space(trial)
-    assert initial_search_space == {}
-    # Does it keep every distribution, including categorical?
-    search_space = _SEARCH_SPACE.copy()
-    trial.distributions = search_space
-    initial_search_space = sampler._infer_initial_search_space(trial)
-    assert initial_search_space == search_space
-
-
 def test_sample_independent() -> None:
     def objective(t: Trial) -> float:
         return t.suggest_categorical("x", [1.0, 2.0])

--- a/tests/samplers_tests/test_qmc.py
+++ b/tests/samplers_tests/test_qmc.py
@@ -80,13 +80,13 @@ def test_infer_relative_search_space() -> None:
     running_trial.suggest_categorical("x6", [1, 4, 7, 10])
 
     speculative_space = sampler.infer_relative_search_space(study, trial)
-    assert set(speculative_space.keys()) == {"x1"}
+    assert set(speculative_space.keys()) == {"x1", "x6"}
 
     # In case there is a past trial.
     study.optimize(objective, n_trials=1)
     relative_search_space = sampler.infer_relative_search_space(study, trial)
-    assert len(relative_search_space.keys()) == 5
-    assert set(relative_search_space.keys()) == {"x1", "x2", "x3", "x4", "x5"}
+    assert len(relative_search_space.keys()) == 6
+    assert set(relative_search_space.keys()) == {"x1", "x2", "x3", "x4", "x5", "x6"}
 
 
 def test_infer_relative_search_space_without_any() -> None:
@@ -129,11 +129,10 @@ def test_infer_initial_search_space() -> None:
     trial.distributions = {}
     initial_search_space = sampler._infer_initial_search_space(trial)
     assert initial_search_space == {}
-    # Does it exclude only categorical distribution?
+    # Does it keep every distribution, including categorical?
     search_space = _SEARCH_SPACE.copy()
     trial.distributions = search_space
     initial_search_space = sampler._infer_initial_search_space(trial)
-    search_space.pop("x6")
     assert initial_search_space == search_space
 
 
@@ -151,17 +150,17 @@ def test_sample_independent() -> None:
         study.optimize(objective, n_trials=1)
         assert mock_sample_indep.call_count == 1
 
-        # Relative sampling of `QMCSampler` does not support categorical distribution.
-        # Thus, `independent_sampler.sample_independent` is called twice.
+        # Relative sampling now covers categorical distributions, so the second trial is sampled
+        # relatively and `independent_sampler.sample_independent` is not called again.
         study.optimize(objective, n_trials=1)
-        assert mock_sample_indep.call_count == 2
+        assert mock_sample_indep.call_count == 1
 
         # Unseen parameter is sampled by independent sampler.
         def new_objective(t: Trial) -> int:
             return t.suggest_int("y", 0, 10)
 
         study.optimize(new_objective, n_trials=1)
-        assert mock_sample_indep.call_count == 3
+        assert mock_sample_indep.call_count == 2
 
 
 def test_warn_asynchronous_seeding() -> None:
@@ -188,11 +187,11 @@ def test_warn_asynchronous_seeding() -> None:
 
 
 def test_warn_independent_sampling() -> None:
-    # Relative sampling of `QMCSampler` does not support categorical distribution.
-    # Thus, `independent_sampler.sample_independent` is called twice.
-    # '_log_independent_sampling is not called in the first trial so called once in total.
+    # A per-trial parameter name forces the dynamic-search-space fallback, which is what
+    # `warn_independent_sampling` gates. `_log_independent_sampling` is not called on the first
+    # trial, so it is called once in total when warning is enabled.
     def objective(t: Trial) -> float:
-        return t.suggest_categorical("x", [1.0, 2.0])
+        return t.suggest_float(f"x{t.number}", 0, 1)
 
     with patch.object(optuna.samplers.QMCSampler, "_log_independent_sampling") as mock_log_indep:
         sampler = _init_QMCSampler_without_exp_warning(warn_independent_sampling=False)
@@ -210,7 +209,6 @@ def test_warn_independent_sampling() -> None:
 
 def test_sample_relative() -> None:
     search_space = _SEARCH_SPACE.copy()
-    search_space.pop("x6")
     sampler = _init_QMCSampler_without_exp_warning()
     study = optuna.create_study(sampler=sampler)
     trial = Mock()
@@ -226,9 +224,27 @@ def test_sample_relative() -> None:
         assert isinstance(sample["x1"], int)
         assert isinstance(sample["x2"], int)
         assert sample["x5"] in (1, 4, 7, 10)
+        assert sample["x6"] in (1, 4, 7, 10)
 
     # If empty search_space, return {}.
     assert sampler.sample_relative(study, trial, {}) == {}
+
+
+def test_sample_relative_categorical() -> None:
+    # A categorical parameter is sampled by QMC rather than the independent fallback: every draw
+    # is a valid choice, and the sequence covers more than one option. See issue #6617.
+    search_space: dict[str, BaseDistribution] = {
+        "c": optuna.distributions.CategoricalDistribution(["a", "b", "c", "d"]),
+    }
+    sampler = _init_QMCSampler_without_exp_warning(qmc_type="halton", seed=0)
+    study = optuna.create_study(sampler=sampler)
+    trial = Mock()
+    seen = set()
+    for _ in range(16):
+        value = sampler.sample_relative(study, trial, search_space)["c"]
+        assert value in ("a", "b", "c", "d")
+        seen.add(value)
+    assert len(seen) > 1
 
 
 def test_sample_relative_halton() -> None:
@@ -349,12 +365,12 @@ def test_sample_qmc(qmc_type: str) -> None:
     sampler = _init_QMCSampler_without_exp_warning(qmc_type=qmc_type)
     study = Mock()
     search_space = _SEARCH_SPACE.copy()
-    search_space.pop("x6")
 
     with patch.object(sampler, "_find_sample_id", side_effect=[0, 1, 2, 4, 9]) as _:
-        # Make sure that the shape of sample is correct.
+        # Make sure that the shape of sample is correct. A categorical parameter contributes a
+        # single dimension, so the six-parameter space yields a width-six sample.
         sample = sampler._sample_qmc(study, search_space)
-        assert sample.shape == (1, 5)
+        assert sample.shape == (1, 6)
 
 
 def test_find_sample_id() -> None:

--- a/tests/samplers_tests/test_qmc.py
+++ b/tests/samplers_tests/test_qmc.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections import Counter
 from typing import Any
 from typing import TYPE_CHECKING
 from unittest.mock import Mock
@@ -245,6 +246,30 @@ def test_sample_relative_categorical() -> None:
         assert value in ("a", "b", "c", "d")
         seen.add(value)
     assert len(seen) > 1
+
+
+@pytest.mark.parametrize("n", [4, 16])
+def test_sample_relative_categorical_balanced(n: int) -> None:
+    # Unscrambled Sobol at n = 2^m must draw every choice equally often. Binning through
+    # np.round broke this structurally: Sobol values are dyadic, so many coordinates land
+    # exactly on the bin boundaries and round-half-to-even overdraws the even indices.
+    search_space: dict[str, BaseDistribution] = {
+        "c": optuna.distributions.CategoricalDistribution(["a", "b", "c", "d"]),
+    }
+    sampler = _init_QMCSampler_without_exp_warning(qmc_type="sobol", scramble=False)
+    study = optuna.create_study(sampler=sampler)
+    trial = Mock()
+    counts = Counter(sampler.sample_relative(study, trial, search_space)["c"] for _ in range(n))
+    assert counts == {"a": n // 4, "b": n // 4, "c": n // 4, "d": n // 4}
+
+
+def test_sample_relative_categorical_single_choice() -> None:
+    search_space: dict[str, BaseDistribution] = {
+        "c": optuna.distributions.CategoricalDistribution(["only"]),
+    }
+    sampler = _init_QMCSampler_without_exp_warning(qmc_type="sobol", scramble=False)
+    study = optuna.create_study(sampler=sampler)
+    assert sampler.sample_relative(study, Mock(), search_space)["c"] == "only"
 
 
 def test_sample_relative_halton() -> None:


### PR DESCRIPTION
## Motivation

`QMCSampler` dropped categorical parameters from its relative search space and sampled them with the independent sampler instead, so a study with categorical parameters lost the low-discrepancy property for those dimensions. #6617 asks for QMC to cover categoricals directly.

## Description of the changes

- `_infer_initial_search_space` now keeps categorical distributions instead of skipping them.
- `sample_relative` maps each `CategoricalDistribution` to a single `IntDistribution(0, len(choices) - 1)` so the transform yields one QMC coordinate per parameter (rather than a one-hot expansion), draws the QMC sample, then rounds each categorical coordinate back to a choice via `to_external_repr`. This follows @nabenabe0928's sketch in the issue.
- Updated the docstring note and the independent-sampling fallback message, which no longer apply to categoricals.
- Updated the existing tests that assumed categoricals fall back to independent sampling, and added `test_sample_relative_categorical` to cover QMC categorical draws.

Resolves #6617.