### PR TITLE
Enable multivariate by default in TPESampler

### DIFF
--- a/optuna/samplers/_tpe/parzen_estimator.py
+++ b/optuna/samplers/_tpe/parzen_estimator.py
@@ -184,34 +184,23 @@ class _ParzenEstimator:
         mus = observations
 
         def compute_sigmas() -> np.ndarray:
-            if parameters.multivariate:
-                SIGMA0_MAGNITUDE = 0.2
-                sigma = (
-                    SIGMA0_MAGNITUDE
-                    * max(len(observations), 1) ** (-1.0 / (len(self._search_space) + 4))
-                    * (high - low)
-                )
-                sigmas = np.full(shape=(len(observations),), fill_value=sigma)
-            else:
-                sorted_indices = np.argsort(mus)
-                sorted_mus = mus[sorted_indices]
-                sorted_mus_with_endpoints = np.empty(len(mus) + 2, dtype=float)
-                sorted_mus_with_endpoints[0] = low
-                sorted_mus_with_endpoints[1:-1] = sorted_mus
-                sorted_mus_with_endpoints[-1] = high
+            sorted_indices = np.argsort(mus)
+            sorted_mus = mus[sorted_indices]
+            sorted_mus_with_endpoints = np.empty(len(mus) + 2, dtype=float)
+            sorted_mus_with_endpoints[0] = low
+            sorted_mus_with_endpoints[1:-1] = sorted_mus
+            sorted_mus_with_endpoints[-1] = high
 
-                sorted_sigmas = np.maximum(
-                    sorted_mus_with_endpoints[1:-1] - sorted_mus_with_endpoints[0:-2],
-                    sorted_mus_with_endpoints[2:] - sorted_mus_with_endpoints[1:-1],
-                )
+            sorted_sigmas = np.maximum(
+                sorted_mus_with_endpoints[1:-1] - sorted_mus_with_endpoints[0:-2],
+                sorted_mus_with_endpoints[2:] - sorted_mus_with_endpoints[1:-1],
+            )
 
-                if not parameters.consider_endpoints and sorted_mus_with_endpoints.shape[0] >= 4:
-                    sorted_sigmas[0] = sorted_mus_with_endpoints[2] - sorted_mus_with_endpoints[1]
-                    sorted_sigmas[-1] = (
-                        sorted_mus_with_endpoints[-2] - sorted_mus_with_endpoints[-3]
-                    )
+            if not parameters.consider_endpoints and sorted_mus_with_endpoints.shape[0] >= 4:
+                sorted_sigmas[0] = sorted_mus_with_endpoints[2] - sorted_mus_with_endpoints[1]
+                sorted_sigmas[-1] = sorted_mus_with_endpoints[-2] - sorted_mus_with_endpoints[-3]
 
-                sigmas = sorted_sigmas[np.argsort(sorted_indices)]
+            sigmas = sorted_sigmas[np.argsort(sorted_indices)]
 
             # We adjust the range of the 'sigmas' according to the 'consider_magic_clip' flag.
             maxsigma = high - low

--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -172,11 +172,6 @@ class TPESampler(BaseSampler):
             <http://proceedings.mlr.press/v80/falkner18a.html>`__ and `our article
             <https://medium.com/optuna/multivariate-tpe-makes-optuna-even-more-powerful-63c4bfbaebe2>`__
             for more details.
-
-            .. note::
-                Added in v2.2.0 as an experimental feature. The interface may change in newer
-                versions without prior notice. See
-                https://github.com/optuna/optuna/releases/tag/v2.2.0.
         group:
             If this and ``multivariate`` are :obj:`True`, the multivariate TPE with the group
             decomposed search space is used when suggesting parameters.
@@ -366,7 +361,7 @@ class TPESampler(BaseSampler):
         gamma: Callable[[int], int] | None = None,
         weights: Callable[[int], np.ndarray] | None = None,
         seed: int | None = None,
-        multivariate: bool = False,
+        multivariate: bool = True,
         group: bool = False,
         warn_independent_sampling: bool | None = None,
         constant_liar: bool = True,
@@ -424,9 +419,6 @@ class TPESampler(BaseSampler):
         self._constraints_func = constraints_func
         # NOTE(nabenabe0928): Users can overwrite _ParzenEstimator to customize the TPE behavior.
         self._parzen_estimator_cls = _ParzenEstimator
-
-        if multivariate:
-            warn_experimental_argument("multivariate")
 
         if group:
             if not multivariate:

--- a/tests/samplers_tests/test_partial_fixed.py
+++ b/tests/samplers_tests/test_partial_fixed.py
@@ -16,7 +16,7 @@ parametrize_sampler = pytest.mark.parametrize(
     [
         optuna.samplers.RandomSampler,
         lambda: optuna.samplers.TPESampler(n_startup_trials=0),
-        lambda: optuna.samplers.TPESampler(n_startup_trials=0, multivariate=True),
+        lambda: optuna.samplers.TPESampler(n_startup_trials=0, multivariate=False),
         lambda: optuna.samplers.TPESampler(n_startup_trials=0, multivariate=True, group=True),
         lambda: optuna.samplers.CmaEsSampler(n_startup_trials=0),
         lambda: optuna.samplers.CmaEsSampler(n_startup_trials=0, use_separable_cma=True),

--- a/tests/samplers_tests/test_samplers.py
+++ b/tests/samplers_tests/test_samplers.py
@@ -39,8 +39,8 @@ def get_gp_sampler(
 sampler_class_with_seed: dict[str, Callable[[int], BaseSampler]] = {
     "RandomSampler": lambda seed: optuna.samplers.RandomSampler(seed=seed),
     "TPESampler": lambda seed: optuna.samplers.TPESampler(seed=seed),
-    "multivariate TPESampler": lambda seed: optuna.samplers.TPESampler(
-        multivariate=True, seed=seed
+    "univariate TPESampler": lambda seed: optuna.samplers.TPESampler(
+        multivariate=False, seed=seed
     ),
     "CmaEsSampler": lambda seed: optuna.samplers.CmaEsSampler(seed=seed),
     "separable CmaEsSampler": lambda seed: optuna.samplers.CmaEsSampler(
@@ -94,7 +94,7 @@ class TestBasicSampler(BasicSamplerTestCase):
         params=[
             optuna.samplers.RandomSampler,
             lambda: optuna.samplers.TPESampler(n_startup_trials=0),
-            lambda: optuna.samplers.TPESampler(n_startup_trials=0, multivariate=True),
+            lambda: optuna.samplers.TPESampler(n_startup_trials=0, multivariate=False),
             lambda: optuna.samplers.CmaEsSampler(n_startup_trials=0),
             lambda: optuna.samplers.CmaEsSampler(n_startup_trials=0, use_separable_cma=True),
             optuna.samplers.NSGAIISampler,
@@ -176,7 +176,7 @@ def unset_seed_in_test(request: SubRequest) -> None:
         (optuna.samplers.RandomSampler, True, False),
         (lambda: optuna.samplers.TPESampler(n_startup_trials=0), True, True),
         (
-            lambda: optuna.samplers.TPESampler(n_startup_trials=0, multivariate=True),
+            lambda: optuna.samplers.TPESampler(n_startup_trials=0, multivariate=False),
             True,
             True,
         ),

--- a/tests/samplers_tests/tpe_tests/test_parzen_estimator.py
+++ b/tests/samplers_tests/tpe_tests/test_parzen_estimator.py
@@ -40,7 +40,7 @@ SEARCH_SPACE = {
     "g": distributions.CategoricalDistribution([0.0, float("inf"), float("nan"), None]),
 }
 
-MULTIVARIATE_SAMPLES = {
+SAMPLES = {
     "a": np.array([1.0]),
     "b": np.array([1.0]),
     "c": np.array([1.0]),
@@ -51,23 +51,22 @@ MULTIVARIATE_SAMPLES = {
 }
 
 
-@pytest.mark.parametrize("multivariate", [True, False])
-def test_init_parzen_estimator(multivariate: bool) -> None:
+def test_init_parzen_estimator() -> None:
     parameters = _ParzenEstimatorParameters(
         prior_weight=1.0,
         consider_magic_clip=False,
         consider_endpoints=False,
         weights=lambda x: np.arange(x) + 1.0,
-        multivariate=multivariate,
+        multivariate=True,
         categorical_distance_func={},
     )
 
-    mpe = _ParzenEstimator(MULTIVARIATE_SAMPLES, SEARCH_SPACE, parameters)
+    mpe = _ParzenEstimator(SAMPLES, SEARCH_SPACE, parameters)
 
     weights = np.array([1, 1], dtype=float)
     weights /= weights.sum()
 
-    expected_univariate = _MixtureOfProductDistribution(
+    expected = _MixtureOfProductDistribution(
         weights=weights,
         distributions=[
             _BatchedTruncNormDistributions(
@@ -116,60 +115,6 @@ def test_init_parzen_estimator(multivariate: bool) -> None:
             ),
         ],
     )
-    SIGMA0 = 0.2
-    expected_multivarite = _MixtureOfProductDistribution(
-        weights=weights,
-        distributions=[
-            _BatchedTruncNormDistributions(
-                mu=np.array([1.0, 50.5]),
-                sigma=np.array([SIGMA0 * 99.0, 99.0]),
-                low=1.0,
-                high=100.0,
-            ),
-            _BatchedTruncLogNormDistributions(
-                mu=np.array([np.log(1.0), np.log(100) / 2.0]),
-                sigma=np.array([SIGMA0 * np.log(100), np.log(100)]),
-                low=1.0,
-                high=100.0,
-            ),
-            _BatchedDiscreteTruncNormDistributions(
-                mu=np.array([1.0, 50.5]),
-                sigma=np.array([SIGMA0 * 102.0, 102.0]),
-                low=1.0,
-                high=100.0,
-                step=3.0,
-            ),
-            _BatchedDiscreteTruncNormDistributions(
-                mu=np.array([1.0, 50.5]),
-                sigma=np.array([SIGMA0 * 100.0, 100.0]),
-                low=1,
-                high=100,
-                step=1,
-            ),
-            _BatchedDiscreteTruncLogNormDistributions(
-                mu=np.array([np.log(1.0), (np.log(100.5) + np.log(0.5)) / 2.0]),
-                sigma=np.array(
-                    [SIGMA0 * (np.log(100.5) - np.log(0.5)), np.log(100.5) - np.log(0.5)]
-                ),
-                low=1,
-                high=100,
-                step=1,
-            ),
-            _BatchedCategoricalDistributions(
-                np.array([[0.2, 0.6, 0.2], [1.0 / 3.0, 1.0 / 3.0, 1.0 / 3.0]])
-            ),
-            _BatchedCategoricalDistributions(
-                np.array(
-                    [
-                        [1.0 / 6.0, 0.5, 1.0 / 6.0, 1.0 / 6.0],
-                        [1.0 / 4.0, 1.0 / 4.0, 1.0 / 4.0, 1.0 / 4.0],
-                    ]
-                )
-            ),
-        ],
-    )
-
-    expected = expected_multivarite if multivariate else expected_univariate
 
     # Test that the distribution is correct.
     assert_distribution_almost_equal(mpe._mixture_distribution, expected)
@@ -185,20 +130,18 @@ def test_init_parzen_estimator(multivariate: bool) -> None:
 @pytest.mark.parametrize("prior_weight", [1.0, 0.01, 100.0])
 @pytest.mark.parametrize("magic_clip", (True, False))
 @pytest.mark.parametrize("endpoints", (True, False))
-@pytest.mark.parametrize("multivariate", (True, False))
 def test_calculate_shape_check(
     mus: np.ndarray,
     prior_weight: float,
     magic_clip: bool,
     endpoints: bool,
-    multivariate: bool,
 ) -> None:
     parameters = _ParzenEstimatorParameters(
         prior_weight=prior_weight,
         consider_magic_clip=magic_clip,
         consider_endpoints=endpoints,
         weights=default_weights,
-        multivariate=multivariate,
+        multivariate=True,
         categorical_distance_func={},
     )
     mpe = _ParzenEstimator(
@@ -223,7 +166,7 @@ def test_calculate_shape_check_categorical(
         consider_magic_clip=True,
         consider_endpoints=False,
         weights=default_weights,
-        multivariate=False,
+        multivariate=True,
         categorical_distance_func=categorical_distance_func,
     )
     mpe = _ParzenEstimator(
@@ -239,7 +182,7 @@ def test_invalid_prior_weight(mus: np.ndarray) -> None:
         consider_magic_clip=False,
         consider_endpoints=False,
         weights=default_weights,
-        multivariate=False,
+        multivariate=True,
         categorical_distance_func={},
     )
     with pytest.raises(ValueError):
@@ -303,7 +246,7 @@ def test_calculate(
         consider_magic_clip=flags["magic_clip"],
         consider_endpoints=flags["endpoints"],
         weights=default_weights,
-        multivariate=False,
+        multivariate=True,
         categorical_distance_func={},
     )
     mpe = _ParzenEstimator(
@@ -339,7 +282,7 @@ def test_invalid_weights(weights: Callable[[int], np.ndarray]) -> None:
         consider_magic_clip=False,
         consider_endpoints=False,
         weights=weights,
-        multivariate=False,
+        multivariate=True,
         categorical_distance_func={},
     )
     with pytest.raises(ValueError):

--- a/tests/samplers_tests/tpe_tests/test_sampler.py
+++ b/tests/samplers_tests/tpe_tests/test_sampler.py
@@ -33,11 +33,6 @@ def test_hyperopt_parameters_deprecation_warning() -> None:
         TPESampler.hyperopt_parameters()
 
 
-def test_multivariate_experimental_warning() -> None:
-    with pytest.warns(optuna.exceptions.ExperimentalWarning):
-        optuna.samplers.TPESampler(multivariate=True)
-
-
 def test_constraints_func_experimental_warning() -> None:
     with pytest.warns(optuna.exceptions.ExperimentalWarning):
         optuna.samplers.TPESampler(constraints_func=lambda _: (0,))
@@ -58,7 +53,6 @@ def test_warn_independent_sampling(capsys: pytest.CaptureFixture) -> None:
 
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", FutureWarning)
-        warnings.simplefilter("ignore", optuna.exceptions.ExperimentalWarning)
         sampler = TPESampler(multivariate=True, warn_independent_sampling=True, n_startup_trials=0)
     study = optuna.create_study(sampler=sampler)
     study.optimize(objective, n_trials=10)
@@ -94,7 +88,7 @@ def test_warn_independent_sampling_group(capsys: pytest.CaptureFixture) -> None:
 
 
 def test_infer_relative_search_space() -> None:
-    sampler = TPESampler()
+    sampler = TPESampler(multivariate=False)
     search_space = {
         "a": distributions.FloatDistribution(1.0, 100.0),
         "b": distributions.FloatDistribution(1.0, 100.0, log=True),
@@ -124,9 +118,7 @@ def test_infer_relative_search_space() -> None:
     study2.optimize(obj, n_trials=1)
     assert sampler.infer_relative_search_space(study2, study2.best_trial) == {}
 
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", optuna.exceptions.ExperimentalWarning)
-        sampler = TPESampler(multivariate=True)
+    sampler = TPESampler(multivariate=True)
     study3 = optuna.create_study(sampler=sampler)
     study3.optimize(obj, n_trials=1)
     assert sampler.infer_relative_search_space(study3, study3.best_trial) == search_space
@@ -134,9 +126,7 @@ def test_infer_relative_search_space() -> None:
 
 @pytest.mark.parametrize("multivariate", [False, True])
 def test_sample_relative_empty_input(multivariate: bool) -> None:
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", optuna.exceptions.ExperimentalWarning)
-        sampler = TPESampler(multivariate=multivariate)
+    sampler = TPESampler(multivariate=multivariate)
     # A frozen-trial is not supposed to be accessed.
     study = optuna.create_study()
     frozen_trial = Mock(spec=[])
@@ -150,17 +140,21 @@ def test_sample_relative_prior() -> None:
 
     # Prepare a trial and a sample for later checks.
     trial = frozen_trial_factory(8)
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", optuna.exceptions.ExperimentalWarning)
-        sampler = TPESampler(n_startup_trials=5, seed=0, multivariate=True, constant_liar=False)
+    sampler = TPESampler(
+        n_startup_trials=5, seed=0, multivariate=True, constant_liar=False, n_ei_candidates=100
+    )
     with patch.object(study._storage, "get_all_trials", return_value=past_trials):
         suggestion = sampler.sample_relative(study, trial, {"param-a": dist})
 
     with warnings.catch_warnings():
-        warnings.simplefilter("ignore", optuna.exceptions.ExperimentalWarning)
         warnings.simplefilter("ignore", FutureWarning)
         sampler = TPESampler(
-            prior_weight=0.2, n_startup_trials=5, seed=0, multivariate=True, constant_liar=False
+            prior_weight=0.2,
+            n_startup_trials=5,
+            seed=0,
+            multivariate=True,
+            constant_liar=False,
+            n_ei_candidates=100,
         )
     with patch.object(study._storage, "get_all_trials", return_value=past_trials):
         assert sampler.sample_relative(study, trial, {"param-a": dist}) != suggestion
@@ -173,9 +167,7 @@ def test_sample_relative_n_startup_trial() -> None:
 
     trial = frozen_trial_factory(8)
     # sample_relative returns {} for only 4 observations.
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", optuna.exceptions.ExperimentalWarning)
-        sampler = TPESampler(n_startup_trials=5, seed=0, multivariate=True, constant_liar=False)
+    sampler = TPESampler(n_startup_trials=5, seed=0, multivariate=True, constant_liar=False)
     with patch.object(study._storage, "get_all_trials", return_value=past_trials[:4]):
         assert sampler.sample_relative(study, trial, {"param-a": dist}) == {}
     # sample_relative returns some value for only 7 observations.
@@ -191,23 +183,18 @@ def test_sample_relative_misc_arguments() -> None:
 
     # Prepare a trial and a sample for later checks.
     trial = frozen_trial_factory(40)
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", optuna.exceptions.ExperimentalWarning)
-        sampler = TPESampler(n_startup_trials=5, seed=0, multivariate=True, constant_liar=False)
+    sampler = TPESampler(n_startup_trials=5, seed=0, multivariate=True, constant_liar=False)
     with patch.object(study._storage, "get_all_trials", return_value=past_trials):
         suggestion = sampler.sample_relative(study, trial, {"param-a": dist})
 
     # Test misc. parameters.
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", optuna.exceptions.ExperimentalWarning)
-        sampler = TPESampler(
-            n_ei_candidates=13, n_startup_trials=5, seed=0, multivariate=True, constant_liar=False
-        )
+    sampler = TPESampler(
+        n_ei_candidates=13, n_startup_trials=5, seed=0, multivariate=True, constant_liar=False
+    )
     with patch.object(study._storage, "get_all_trials", return_value=past_trials):
         assert sampler.sample_relative(study, trial, {"param-a": dist}) != suggestion
 
     with warnings.catch_warnings():
-        warnings.simplefilter("ignore", optuna.exceptions.ExperimentalWarning)
         warnings.simplefilter("ignore", FutureWarning)
         sampler = TPESampler(
             gamma=lambda _: 5, n_startup_trials=5, seed=0, multivariate=True, constant_liar=False
@@ -216,7 +203,6 @@ def test_sample_relative_misc_arguments() -> None:
         assert sampler.sample_relative(study, trial, {"param-a": dist}) != suggestion
 
     with warnings.catch_warnings():
-        warnings.simplefilter("ignore", optuna.exceptions.ExperimentalWarning)
         warnings.simplefilter("ignore", FutureWarning)
         sampler = TPESampler(
             weights=lambda n: np.asarray([i**2 + 1 for i in range(n)]),
@@ -236,9 +222,7 @@ def test_sample_relative_uniform_distributions() -> None:
     uni_dist = optuna.distributions.FloatDistribution(1.0, 100.0)
     past_trials = [frozen_trial_factory(i, dist=uni_dist) for i in range(1, 8)]
     trial = frozen_trial_factory(8)
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", optuna.exceptions.ExperimentalWarning)
-        sampler = TPESampler(n_startup_trials=5, seed=0, multivariate=True, constant_liar=False)
+    sampler = TPESampler(n_startup_trials=5, seed=0, multivariate=True, constant_liar=False)
     with patch.object(study._storage, "get_all_trials", return_value=past_trials):
         uniform_suggestion = sampler.sample_relative(study, trial, {"param-a": uni_dist})
     assert 1.0 <= uniform_suggestion["param-a"] < 100.0
@@ -252,9 +236,7 @@ def test_sample_relative_log_uniform_distributions() -> None:
     uni_dist = optuna.distributions.FloatDistribution(1.0, 100.0)
     past_trials = [frozen_trial_factory(i, dist=uni_dist) for i in range(1, 8)]
     trial = frozen_trial_factory(8)
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", optuna.exceptions.ExperimentalWarning)
-        sampler = TPESampler(n_startup_trials=5, seed=0, multivariate=True, constant_liar=False)
+    sampler = TPESampler(n_startup_trials=5, seed=0, multivariate=True, constant_liar=False)
     with patch.object(study._storage, "get_all_trials", return_value=past_trials):
         uniform_suggestion = sampler.sample_relative(study, trial, {"param-a": uni_dist})
 
@@ -262,9 +244,7 @@ def test_sample_relative_log_uniform_distributions() -> None:
     log_dist = optuna.distributions.FloatDistribution(1.0, 100.0, log=True)
     past_trials = [frozen_trial_factory(i, dist=log_dist) for i in range(1, 8)]
     trial = frozen_trial_factory(8)
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", optuna.exceptions.ExperimentalWarning)
-        sampler = TPESampler(n_startup_trials=5, seed=0, multivariate=True, constant_liar=False)
+    sampler = TPESampler(n_startup_trials=5, seed=0, multivariate=True, constant_liar=False)
     with patch.object(study._storage, "get_all_trials", return_value=past_trials):
         loguniform_suggestion = sampler.sample_relative(study, trial, {"param-a": log_dist})
     assert 1.0 <= loguniform_suggestion["param-a"] < 100.0
@@ -283,9 +263,7 @@ def test_sample_relative_disrete_uniform_distributions() -> None:
 
     past_trials = [frozen_trial_factory(i, dist=disc_dist, value_fn=value_fn) for i in range(1, 8)]
     trial = frozen_trial_factory(8)
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", optuna.exceptions.ExperimentalWarning)
-        sampler = TPESampler(n_startup_trials=5, seed=0, multivariate=True, constant_liar=False)
+    sampler = TPESampler(n_startup_trials=5, seed=0, multivariate=True, constant_liar=False)
     with patch.object(study._storage, "get_all_trials", return_value=past_trials):
         discrete_uniform_suggestion = sampler.sample_relative(study, trial, {"param-a": disc_dist})
     assert 1.0 <= discrete_uniform_suggestion["param-a"] <= 100.0
@@ -310,9 +288,7 @@ def test_sample_relative_categorical_distributions() -> None:
         frozen_trial_factory(i, dist=cat_dist, value_fn=cat_value_fn) for i in range(1, 8)
     ]
     trial = frozen_trial_factory(8)
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", optuna.exceptions.ExperimentalWarning)
-        sampler = TPESampler(n_startup_trials=5, seed=0, multivariate=True, constant_liar=False)
+    sampler = TPESampler(n_startup_trials=5, seed=0, multivariate=True, constant_liar=False)
     with patch.object(study._storage, "get_all_trials", return_value=past_trials):
         categorical_suggestion = sampler.sample_relative(study, trial, {"param-a": cat_dist})
     assert categorical_suggestion["param-a"] in categories
@@ -333,9 +309,7 @@ def test_sample_relative_int_uniform_distributions(step: int) -> None:
         frozen_trial_factory(i, dist=int_dist, value_fn=int_value_fn) for i in range(1, 8)
     ]
     trial = frozen_trial_factory(8)
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", optuna.exceptions.ExperimentalWarning)
-        sampler = TPESampler(n_startup_trials=5, seed=0, multivariate=True, constant_liar=False)
+    sampler = TPESampler(n_startup_trials=5, seed=0, multivariate=True, constant_liar=False)
     with patch.object(study._storage, "get_all_trials", return_value=past_trials):
         int_suggestion = sampler.sample_relative(study, trial, {"param-a": int_dist})
     assert 1 <= int_suggestion["param-a"] <= 100
@@ -357,9 +331,7 @@ def test_sample_relative_int_loguniform_distributions() -> None:
         frozen_trial_factory(i, dist=intlog_dist, value_fn=int_value_fn) for i in range(1, 8)
     ]
     trial = frozen_trial_factory(8)
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", optuna.exceptions.ExperimentalWarning)
-        sampler = TPESampler(n_startup_trials=5, seed=0, multivariate=True, constant_liar=False)
+    sampler = TPESampler(n_startup_trials=5, seed=0, multivariate=True, constant_liar=False)
     with patch.object(study._storage, "get_all_trials", return_value=past_trials):
         intlog_suggestion = sampler.sample_relative(study, trial, {"param-a": intlog_dist})
     assert 1 <= intlog_suggestion["param-a"] <= 100
@@ -386,9 +358,7 @@ def test_sample_relative_handle_unsuccessful_states(
         trial = frozen_trial_factory(i, dist=dist)
         study._storage.create_new_trial(study._study_id, template_trial=trial)
     trial = frozen_trial_factory(100)
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", optuna.exceptions.ExperimentalWarning)
-        sampler = TPESampler(n_startup_trials=5, seed=0, multivariate=True, constant_liar=False)
+    sampler = TPESampler(n_startup_trials=5, seed=0, multivariate=True, constant_liar=False)
     all_success_suggestion = sampler.sample_relative(study, trial, {"param-a": dist})
 
     # Test unsuccessful trials are handled differently.
@@ -398,9 +368,7 @@ def test_sample_relative_handle_unsuccessful_states(
         trial = frozen_trial_factory(i, dist=dist, state_fn=state_fn)
         study._storage.create_new_trial(study._study_id, template_trial=trial)
     trial = frozen_trial_factory(100)
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", optuna.exceptions.ExperimentalWarning)
-        sampler = TPESampler(n_startup_trials=5, seed=0, multivariate=True, constant_liar=False)
+    sampler = TPESampler(n_startup_trials=5, seed=0, multivariate=True, constant_liar=False)
     partial_unsuccessful_suggestion = sampler.sample_relative(study, trial, {"param-a": dist})
 
     assert partial_unsuccessful_suggestion != all_success_suggestion
@@ -422,11 +390,7 @@ def test_sample_relative_ignored_states() -> None:
         for i in range(1, 30):
             trial = frozen_trial_factory(i, dist=dist, state_fn=state_fn)
             study._storage.create_new_trial(study._study_id, template_trial=trial)
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", optuna.exceptions.ExperimentalWarning)
-            sampler = TPESampler(
-                n_startup_trials=5, seed=0, multivariate=True, constant_liar=False
-            )
+        sampler = TPESampler(n_startup_trials=5, seed=0, multivariate=True, constant_liar=False)
         suggestions.append(sampler.sample_relative(study, trial, {"param-a": dist})["param-a"])
 
     assert len(set(suggestions)) == 1
@@ -449,11 +413,7 @@ def test_sample_relative_pruned_state() -> None:
             trial = frozen_trial_factory(i, dist=dist, state_fn=state_fn)
             study._storage.create_new_trial(study._study_id, template_trial=trial)
         trial = frozen_trial_factory(40)
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", optuna.exceptions.ExperimentalWarning)
-            sampler = TPESampler(
-                n_startup_trials=5, seed=0, multivariate=True, constant_liar=False
-            )
+        sampler = TPESampler(n_startup_trials=5, seed=0, multivariate=True, constant_liar=False)
         suggestions.append(sampler.sample_relative(study, trial, {"param-a": dist})["param-a"])
 
     assert len(set(suggestions)) == 3
@@ -1056,9 +1016,7 @@ def test_mixed_relative_search_space_pruned_and_completed_trials() -> None:
 
 
 def test_group() -> None:
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", optuna.exceptions.ExperimentalWarning)
-        sampler = TPESampler(multivariate=True, group=True)
+    sampler = TPESampler(multivariate=True, group=True)
     study = optuna.create_study(sampler=sampler)
 
     with patch.object(sampler, "_sample_relative", wraps=sampler._sample_relative) as mock:


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. To minimize the review effort, we highly appreciate PRs only with related changes. Please note that submitted PRs may be closed if they include unrelated changes or significantly modified unit tests. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

The multivariate `TPESampler` was introduced in Optuna v2.2 and has undergone various improvements and refactoring since then. As noted in https://arxiv.org/abs/2304.11127, this algorithm demonstrates superior optimization performance when combined with Optuna's default bandwidth selection. Our replication has confirmed this trend. Therefore, we are introducing these changes in this PR to make it Optuna's default sampling algorithm starting from version 5.
Note: Our replication results will be compiled and published before the release of version 5.

## Description of the changes
<!-- Describe the changes in this PR. -->

- Enable multivariate by default in TPESampler
- Update tests

Note: `_ParzenEstimatorParameters`' `multivariate` attribute can be removed, but since it's also used in other code, I'll leave it unchanged in this PR.