### PR TITLE
Make `PedAnovaImportanceEvaluator` the default importance evaluator

### DIFF
--- a/docs/source/reference/importance.rst
+++ b/docs/source/reference/importance.rst
@@ -18,11 +18,6 @@ as a guide, paying close attention to the format of the return value from the ev
 
 .. note::
 
-   Both Optuna and Optuna Dashboard use :class:`~optuna.importance.PedAnovaImportanceEvaluator`
-   as the default importance evaluator.
-
-.. note::
-
    For detailed usage, please refer to :func:`~optuna.importance.get_param_importances`.
 
 .. autosummary::

--- a/docs/source/reference/importance.rst
+++ b/docs/source/reference/importance.rst
@@ -3,12 +3,23 @@
 optuna.importance
 =================
 
-The :mod:`~optuna.importance` module provides functionality for evaluating hyperparameter importances based on completed trials in a given study. The utility function :func:`~optuna.importance.get_param_importances` takes a :class:`~optuna.study.Study` and optional evaluator as two of its inputs. The evaluator must derive from :class:`~optuna.importance.BaseImportanceEvaluator`, and is initialized as a :class:`~optuna.importance.FanovaImportanceEvaluator` by default when not passed in. Users implementing custom evaluators should refer to either :class:`~optuna.importance.FanovaImportanceEvaluator`, :class:`~optuna.importance.MeanDecreaseImpurityImportanceEvaluator`, or :class:`~optuna.importance.PedAnovaImportanceEvaluator` as a guide, paying close attention to the format of the return value from the Evaluator's ``evaluate`` function.
+The :mod:`~optuna.importance` module provides functionality for evaluating hyperparameter
+importances based on completed trials in a given study.
+The utility function :func:`~optuna.importance.get_param_importances` takes a
+:class:`~optuna.study.Study` and optional evaluator as two of its inputs.
+The evaluator must derive from :class:`~optuna.importance.BaseImportanceEvaluator`, and
+:class:`~optuna.importance.PedAnovaImportanceEvaluator` is used by default when not passed in.
+Users implementing custom evaluators should refer to
+:class:`~optuna.importance.PedAnovaImportanceEvaluator`,
+:class:`~optuna.importance.FanovaImportanceEvaluator`, or
+:class:`~optuna.importance.MeanDecreaseImpurityImportanceEvaluator`,
+as a guide, paying close attention to the format of the return value from the evaluator's
+``evaluate`` function.
 
 .. note::
 
-   Although the default importance evaluator in Optuna is :class:`~optuna.importance.FanovaImportanceEvaluator`, Optuna Dashboard uses a light-weight evaluator, i.e., :class:`~optuna.importance.PedAnovaImportanceEvaluator`, for runtime performance purposes, yielding a different result.
-
+   For detailed usage of the default evaluator, please refer to
+   :func:`~optuna.importance.get_param_importances`.
 
 .. autosummary::
    :toctree: generated/

--- a/docs/source/reference/importance.rst
+++ b/docs/source/reference/importance.rst
@@ -18,6 +18,11 @@ as a guide, paying close attention to the format of the return value from the ev
 
 .. note::
 
+   Both Optuna and Optuna Dashboard use :class:`~optuna.importance.PedAnovaImportanceEvaluator`
+   as the default importance evaluator.
+
+.. note::
+
    For detailed usage, please refer to :func:`~optuna.importance.get_param_importances`.
 
 .. autosummary::

--- a/docs/source/reference/importance.rst
+++ b/docs/source/reference/importance.rst
@@ -6,9 +6,8 @@ optuna.importance
 The :mod:`~optuna.importance` module provides functionality for evaluating hyperparameter
 importances based on completed trials in a given study.
 The utility function :func:`~optuna.importance.get_param_importances` takes a
-:class:`~optuna.study.Study` and optional evaluator as two of its inputs.
-The evaluator must derive from :class:`~optuna.importance.BaseImportanceEvaluator`, and
-:class:`~optuna.importance.PedAnovaImportanceEvaluator` is used by default when not passed in.
+:class:`~optuna.study.Study` and optional evaluator (defaults to :class:`~optuna.importance.PedAnovaImportanceEvaluator`) as its inputs.
+The evaluator must derive from :class:`~optuna.importance.BaseImportanceEvaluator`.
 Users implementing custom evaluators should refer to
 :class:`~optuna.importance.PedAnovaImportanceEvaluator`,
 :class:`~optuna.importance.FanovaImportanceEvaluator`, or

--- a/docs/source/reference/importance.rst
+++ b/docs/source/reference/importance.rst
@@ -18,8 +18,7 @@ as a guide, paying close attention to the format of the return value from the ev
 
 .. note::
 
-   For detailed usage of the default evaluator, please refer to
-   :func:`~optuna.importance.get_param_importances`.
+   For detailed usage, please refer to :func:`~optuna.importance.get_param_importances`.
 
 .. autosummary::
    :toctree: generated/

--- a/docs/source/reference/importance.rst
+++ b/docs/source/reference/importance.rst
@@ -25,6 +25,6 @@ as a guide, paying close attention to the format of the return value from the ev
    :nosignatures:
 
    get_param_importances
+   PedAnovaImportanceEvaluator
    FanovaImportanceEvaluator
    MeanDecreaseImpurityImportanceEvaluator
-   PedAnovaImportanceEvaluator

--- a/docs/source/reference/importance.rst
+++ b/docs/source/reference/importance.rst
@@ -15,9 +15,10 @@ Users implementing custom evaluators should refer to
 as a guide, paying close attention to the format of the return value from the evaluator's
 ``evaluate`` function.
 
-.. note::
+.. seealso::
 
-   For detailed usage, please refer to :func:`~optuna.importance.get_param_importances`.
+   :func:`~optuna.visualization.plot_param_importances` visualizes parameter importances.
+   The parameter importances in Optuna Dashboard also follow this implementation.
 
 .. autosummary::
    :toctree: generated/

--- a/docs/visualization_examples/GALLERY_HEADER.rst
+++ b/docs/visualization_examples/GALLERY_HEADER.rst
@@ -11,8 +11,6 @@ The :mod:`~optuna.visualization` module provides utility functions for plotting 
     In the :mod:`optuna.visualization` module, the following functions use plotly to create figures, but `JupyterLab`_ cannot
     render them by default. Please follow this `installation guide`_ to show figures in
     `JupyterLab`_.
-.. note::
-    The :func:`~optuna.visualization.plot_param_importances` requires the Python package of `scikit-learn <https://github.com/scikit-learn/scikit-learn>`__.
 
     .. _JupyterLab: https://github.com/jupyterlab/jupyterlab
     .. _installation guide: https://github.com/plotly/plotly.py#jupyterlab-support

--- a/optuna/importance/__init__.py
+++ b/optuna/importance/__init__.py
@@ -96,7 +96,7 @@ def get_param_importances(
 
     """
     if evaluator is None:
-        evaluator = FanovaImportanceEvaluator()
+        evaluator = PedAnovaImportanceEvaluator()
 
     if not isinstance(evaluator, BaseImportanceEvaluator):
         raise TypeError("Evaluator must be a subclass of BaseImportanceEvaluator.")

--- a/optuna/importance/__init__.py
+++ b/optuna/importance/__init__.py
@@ -32,7 +32,8 @@ def get_param_importances(
     target: Callable[[FrozenTrial], float] | None = None,
     normalize: bool = True,
 ) -> dict[str, float]:
-    """Evaluate parameter importances based on completed trials in the given study.
+    """Evaluate parameter importances (:class:`~optuna.importance.PedAnovaImportanceEvaluator` by
+    default) based on completed trials in the given study.
 
     The parameter importances are returned as a dictionary where the keys consist of parameter
     names and their values importances.

--- a/optuna/importance/__init__.py
+++ b/optuna/importance/__init__.py
@@ -41,6 +41,17 @@ def get_param_importances(
     The returned dictionary is ordered by its values in a descending order.
     By default, the sum of the importance values are normalized to 1.0.
 
+    By default, this function uses
+    :class:`~optuna.importance.PedAnovaImportanceEvaluator`.
+    For details on this evaluator, please refer to the following papers:
+
+    - `PED-ANOVA: Efficiently Quantifying Hyperparameter Importance in Arbitrary Subspaces
+      <https://arxiv.org/abs/2304.10255>`__ (IJCAI 2023)
+    - `Conditional PED-ANOVA: Hyperparameter Importance in Hierarchical & Dynamic Search Spaces
+      <https://arxiv.org/abs/2601.20800>`__ (KDD 2026)
+
+    When using this evaluator in your project, please cite both papers.
+
     With the default evaluator, :class:`~optuna.importance.PedAnovaImportanceEvaluator`,
     ``params=None`` assesses all parameters that appear in completed trials, including conditional
     parameters.

--- a/optuna/importance/__init__.py
+++ b/optuna/importance/__init__.py
@@ -41,13 +41,14 @@ def get_param_importances(
     The returned dictionary is ordered by its values in a descending order.
     By default, the sum of the importance values are normalized to 1.0.
 
-    If ``params`` is :obj:`None`, all parameter that are present in all of the completed trials are
-    assessed.
-    This implies that conditional parameters will be excluded from the evaluation.
-    To assess the importances of conditional parameters, a :obj:`list` of parameter names can be
-    specified via ``params``.
-    If specified, only completed trials that contain all of the parameters will be considered.
-    If no such trials are found, an error will be raised.
+    With the default evaluator, :class:`~optuna.importance.PedAnovaImportanceEvaluator`,
+    ``params=None`` assesses all parameters that appear in completed trials, including conditional
+    parameters.
+    Other evaluators assess only parameters that are present in all of the completed trials and
+    therefore exclude conditional parameters.
+    If ``params`` is specified, only the specified parameters are assessed.
+    When using an evaluator other than :class:`~optuna.importance.PedAnovaImportanceEvaluator`,
+    at least one completed trial must contain all specified parameters.
 
     If the given study does not contain completed trials, an error will be raised.
 

--- a/optuna/importance/__init__.py
+++ b/optuna/importance/__init__.py
@@ -65,8 +65,7 @@ def get_param_importances(
         evaluator:
             An importance evaluator object that specifies which algorithm to base the importance
             assessment on.
-            Defaults to
-            :class:`~optuna.importance.FanovaImportanceEvaluator`.
+            Defaults to :class:`~optuna.importance.PedAnovaImportanceEvaluator`.
         params:
             A list of names of parameters to assess.
             If :obj:`None`, all parameters that are present in all of the completed trials are

--- a/optuna/importance/__init__.py
+++ b/optuna/importance/__init__.py
@@ -63,7 +63,6 @@ def get_param_importances(
     When using other evaluators, at least one completed trial must contain all specified
     parameters.
 
-    If the given study does not contain completed trials, an error will be raised.
 
     .. note::
 

--- a/optuna/importance/__init__.py
+++ b/optuna/importance/__init__.py
@@ -50,7 +50,7 @@ def get_param_importances(
     - `Conditional PED-ANOVA: Hyperparameter Importance in Hierarchical & Dynamic Search Spaces
       <https://arxiv.org/abs/2601.20800>`__ (KDD 2026)
 
-    When using this evaluator in your project, please cite both papers.
+    When using this evaluator in your project, please consider citing both papers.
 
     With the default evaluator, :class:`~optuna.importance.PedAnovaImportanceEvaluator`,
     ``params=None`` assesses all parameters that appear in completed trials, including conditional

--- a/optuna/importance/__init__.py
+++ b/optuna/importance/__init__.py
@@ -69,8 +69,9 @@ def get_param_importances(
             Defaults to :class:`~optuna.importance.PedAnovaImportanceEvaluator`.
         params:
             A list of names of parameters to assess.
-            If :obj:`None`, all parameters that are present in all of the completed trials are
-            assessed.
+            If :obj:`None`, :class:`~optuna.importance.PedAnovaImportanceEvaluator` assesses all
+            parameters that appear in completed trials, including conditional parameters, while
+            other evaluators assess parameters present in all completed trials.
         target:
             A function that returns the value used to evaluate importances.
             If :obj:`None`, objective values are used for single-objective optimization.

--- a/optuna/importance/__init__.py
+++ b/optuna/importance/__init__.py
@@ -104,6 +104,24 @@ def get_param_importances(
     Returns:
         A :obj:`dict` where the keys are parameter names and the values are assessed importances.
 
+    Example:
+        .. testcode::
+
+            import optuna
+
+
+            def objective(trial: optuna.trial.Trial) -> float:
+                x = trial.suggest_int("x", 0, 2)
+                y = trial.suggest_float("y", -1.0, 1.0)
+                z = trial.suggest_float("z", 0.0, 1.5)
+                return x**2 + y**3 - z**4
+
+            sampler = optuna.samplers.RandomSampler(seed=42)
+            study = optuna.create_study(sampler=sampler)
+            study.optimize(objective, n_trials=100)
+
+            importances = optuna.importance.get_param_importances(study)
+
     """
     if evaluator is None:
         evaluator = PedAnovaImportanceEvaluator()

--- a/optuna/importance/__init__.py
+++ b/optuna/importance/__init__.py
@@ -58,8 +58,10 @@ def get_param_importances(
     Other evaluators assess only parameters that are present in all of the completed trials and
     therefore exclude conditional parameters.
     If ``params`` is specified, only the specified parameters are assessed.
-    When using an evaluator other than :class:`~optuna.importance.PedAnovaImportanceEvaluator`,
-    at least one completed trial must contain all specified parameters.
+    When using :class:`~optuna.importance.PedAnovaImportanceEvaluator`, each specified parameter
+    must appear in at least one completed trial.
+    When using other evaluators, at least one completed trial must contain all specified
+    parameters.
 
     If the given study does not contain completed trials, an error will be raised.
 

--- a/optuna/importance/__init__.py
+++ b/optuna/importance/__init__.py
@@ -71,15 +71,12 @@ def get_param_importances(
             If :obj:`None`, all parameters that are present in all of the completed trials are
             assessed.
         target:
-            A function to specify the value to evaluate importances.
-            If it is :obj:`None` and ``study`` is being used for single-objective optimization,
-            the objective values are used. ``target`` must be specified if ``study`` is being
-            used for multi-objective optimization.
-
-            .. note::
-                Specify this argument if ``study`` is being used for multi-objective
-                optimization. For example, to get the hyperparameter importance of the first
-                objective, use ``target=lambda t: t.values[0]`` for the target parameter.
+            A function that returns the value used to evaluate importances.
+            If :obj:`None`, objective values are used for single-objective optimization.
+            For multi-objective optimization, :obj:`None` is supported only by
+            :class:`~optuna.importance.PedAnovaImportanceEvaluator`. When using another
+            evaluator, specify ``target``, for example ``target=lambda t: t.values[0]``, to
+            evaluate importances for a specific objective.
         normalize:
             A boolean option to specify whether the sum of the importance values should be
             normalized to 1.0.

--- a/optuna/importance/_ped_anova/evaluator.py
+++ b/optuna/importance/_ped_anova/evaluator.py
@@ -120,18 +120,6 @@ class PedAnovaImportanceEvaluator(BaseImportanceEvaluator):
             trials achieve top-50% performance. If ``region_quantile=1.0``, the importance is
             computed in the whole search space.
 
-        baseline_quantile:
-            Compute the importance of achieving top-``baseline_quantile`` quantile objective value.
-            For example, ``baseline_quantile=0.1`` means that the importances give the information
-            of which parameters were important to achieve the top-10% performance during
-            optimization.
-
-            .. warning::
-                Deprecated in v4.7.0. This feature will be removed in the future. The removal of
-                this feature is currently scheduled for v5.0.0, but this schedule is subject to
-                change. ``baseline_quantile`` is currently ignored. Use ``target_quantile``
-                instead. See https://github.com/optuna/optuna/releases/tag/v4.7.0.
-
         evaluate_on_local:
             Whether we measure the importance in the local or global space.
             If :obj:`True`, the importances imply how importance each parameter is during

--- a/optuna/importance/_ped_anova/evaluator.py
+++ b/optuna/importance/_ped_anova/evaluator.py
@@ -171,13 +171,6 @@ class PedAnovaImportanceEvaluator(BaseImportanceEvaluator):
         assert 0.0 < target_quantile < region_quantile <= 1.0, (
             "condition 0.0 < `target_quantile` < `region_quantile` <= 1.0 must be satisfied"
         )
-        if baseline_quantile is not None:
-            msg = _DEPRECATION_WARNING_TEMPLATE.format(
-                name="`baseline_quantile`", d_ver="4.7.0", r_ver="5.0.0"
-            )
-            optuna_warn(
-                f"{msg} `baseline_quantile` is currently ignored. Use `target_quantile` instead.",
-            )
         if region_quantile != 1.0 and not evaluate_on_local:
             optuna_warn("If `evaluate_on_local` is False, `region_quantile` has no effect.")
 

--- a/optuna/importance/_ped_anova/evaluator.py
+++ b/optuna/importance/_ped_anova/evaluator.py
@@ -64,7 +64,6 @@ class _QuantileFilter:
         return [t for t, should_keep in zip(trials, should_keep_trials) if should_keep]
 
 
-@experimental_class("3.6.0")
 class PedAnovaImportanceEvaluator(BaseImportanceEvaluator):
     """PED-ANOVA importance evaluator.
 

--- a/optuna/importance/_ped_anova/evaluator.py
+++ b/optuna/importance/_ped_anova/evaluator.py
@@ -166,7 +166,6 @@ class PedAnovaImportanceEvaluator(BaseImportanceEvaluator):
         *,
         target_quantile: float = 0.1,  # gamma' in the original paper
         region_quantile: float = 1.0,  # gamma in the original paper
-        baseline_quantile: float | None = None,
         evaluate_on_local: bool = True,
     ) -> None:
         assert 0.0 < target_quantile < region_quantile <= 1.0, (

--- a/optuna/importance/_ped_anova/evaluator.py
+++ b/optuna/importance/_ped_anova/evaluator.py
@@ -7,8 +7,6 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
-from optuna._deprecated import _DEPRECATION_WARNING_TEMPLATE
-from optuna._experimental import experimental_class
 from optuna._warnings import optuna_warn
 from optuna.importance._base import _check_evaluate_args
 from optuna.importance._base import _sort_dict_by_importance

--- a/optuna/visualization/_param_importances.py
+++ b/optuna/visualization/_param_importances.py
@@ -147,9 +147,9 @@ def plot_param_importances(
 
             .. note::
 
-               Both Optuna and Optuna Dashboard use
-               :class:`~optuna.importance.PedAnovaImportanceEvaluator` as the default importance
-               evaluator.
+                Both Optuna and Optuna Dashboard use
+                :class:`~optuna.importance.PedAnovaImportanceEvaluator` as the default importance
+                evaluator.
         params:
             A list of names of parameters to assess.
             If :obj:`None`, :class:`~optuna.importance.PedAnovaImportanceEvaluator` assesses all

--- a/optuna/visualization/_param_importances.py
+++ b/optuna/visualization/_param_importances.py
@@ -123,7 +123,8 @@ def plot_param_importances(
     target: Callable[[FrozenTrial], float] | None = None,
     target_name: str = "Objective Value",
 ) -> "go.Figure":
-    """Plot hyperparameter importances.
+    """Plot hyperparameter importances (:class:`~optuna.importance.PedAnovaImportanceEvaluator` by
+    default).
 
     .. seealso::
 

--- a/optuna/visualization/_param_importances.py
+++ b/optuna/visualization/_param_importances.py
@@ -135,31 +135,31 @@ def plot_param_importances(
         evaluator:
             An importance evaluator object that specifies which algorithm to base the importance
             assessment on.
-            Defaults to
-            :class:`~optuna.importance.FanovaImportanceEvaluator`.
+            Defaults to :class:`~optuna.importance.PedAnovaImportanceEvaluator`.
+            For details on this evaluator, please refer to the following papers:
 
-            .. note::
-                Although the default importance evaluator in Optuna is
-                :class:`~optuna.importance.FanovaImportanceEvaluator`, Optuna Dashboard uses a
-                light-weight evaluator, i.e.,
-                :class:`~optuna.importance.PedAnovaImportanceEvaluator`, for runtime performance
-                purposes, yielding a different result.
+            - `PED-ANOVA: Efficiently Quantifying Hyperparameter Importance in Arbitrary Subspaces
+              <https://arxiv.org/abs/2304.10255>`__ (IJCAI 2023)
+            - `Conditional PED-ANOVA: Hyperparameter Importance in Hierarchical & Dynamic Search
+              Spaces <https://arxiv.org/abs/2601.20800>`__ (KDD 2026)
 
+            When using this evaluator in your project, please cite both papers.
         params:
             A list of names of parameters to assess.
-            If :obj:`None`, all parameters that are present in all of the completed trials are
-            assessed.
+            If :obj:`None`, :class:`~optuna.importance.PedAnovaImportanceEvaluator` assesses all
+            parameters that appear in completed trials, including conditional parameters, while
+            other evaluators assess parameters present in all completed trials.
+            If specified, only the specified parameters are assessed.
+            When using :class:`~optuna.importance.PedAnovaImportanceEvaluator`, each specified
+            parameter must appear in at least one completed trial.
+            When using other evaluators, at least one completed trial must contain all specified
+            parameters.
         target:
-            A function to specify the value to display. If it is :obj:`None` and ``study`` is being
-            used for single-objective optimization, the objective values are plotted.
-            For multi-objective optimization, all objectives will be plotted if ``target``
-            is :obj:`None`.
-
-            .. note::
-                This argument can be used to specify which objective to plot if ``study`` is being
-                used for multi-objective optimization. For example, to get only the hyperparameter
-                importance of the first objective, use ``target=lambda t: t.values[0]`` for the
-                target parameter.
+            A function that returns the value used to evaluate and display importances.
+            If :obj:`None`, objective values are used for single-objective optimization.
+            For multi-objective optimization, all objectives will be plotted if ``target`` is
+            :obj:`None`. Specify ``target``, for example ``target=lambda t: t.values[0]``, to
+            plot importances for a specific objective.
         target_name:
             Target's name to display on the legend. Names set via
             :meth:`~optuna.study.Study.set_metric_names` will be used if ``target`` is :obj:`None`,

--- a/optuna/visualization/_param_importances.py
+++ b/optuna/visualization/_param_importances.py
@@ -144,6 +144,12 @@ def plot_param_importances(
               Spaces <https://arxiv.org/abs/2601.20800>`__ (KDD 2026)
 
             When using this evaluator in your project, please cite both papers.
+
+            .. note::
+
+               Both Optuna and Optuna Dashboard use
+               :class:`~optuna.importance.PedAnovaImportanceEvaluator` as the default importance
+               evaluator.
         params:
             A list of names of parameters to assess.
             If :obj:`None`, :class:`~optuna.importance.PedAnovaImportanceEvaluator` assesses all

--- a/optuna/visualization/_param_importances.py
+++ b/optuna/visualization/_param_importances.py
@@ -146,10 +146,13 @@ def plot_param_importances(
             When using this evaluator in your project, please consider citing both papers.
 
             .. note::
-
-                Both Optuna and Optuna Dashboard use
-                :class:`~optuna.importance.PedAnovaImportanceEvaluator` as the default importance
-                evaluator.
+                Optuna Dashboard also uses :class:`~optuna.importance.PedAnovaImportanceEvaluator`,
+                the default importance evaluator.
+            ..
+                NOTE(nabe): Since Optuna Dashboard implicitly uses the default importance
+                evaluator and does not have a standalone documentation for its visualization,
+                the Optuna documentation should cover the used evaluator explicitly.
+                Otherwise, users need to read the corresponding Optuna Dashboard code to confirm.
         params:
             A list of names of parameters to assess.
             If :obj:`None`, :class:`~optuna.importance.PedAnovaImportanceEvaluator` assesses all

--- a/optuna/visualization/_param_importances.py
+++ b/optuna/visualization/_param_importances.py
@@ -143,7 +143,7 @@ def plot_param_importances(
             - `Conditional PED-ANOVA: Hyperparameter Importance in Hierarchical & Dynamic Search
               Spaces <https://arxiv.org/abs/2601.20800>`__ (KDD 2026)
 
-            When using this evaluator in your project, please cite both papers.
+            When using this evaluator in your project, please consider citing both papers.
 
             .. note::
 

--- a/optuna/visualization/matplotlib/_param_importances.py
+++ b/optuna/visualization/matplotlib/_param_importances.py
@@ -61,11 +61,6 @@ def plot_param_importances(
 
             When using this evaluator in your project, please consider citing both papers.
 
-            .. note::
-
-                Both Optuna and Optuna Dashboard use
-                :class:`~optuna.importance.PedAnovaImportanceEvaluator` as the default importance
-                evaluator.
         params:
             A list of names of parameters to assess.
             If :obj:`None`, :class:`~optuna.importance.PedAnovaImportanceEvaluator` assesses all

--- a/optuna/visualization/matplotlib/_param_importances.py
+++ b/optuna/visualization/matplotlib/_param_importances.py
@@ -51,23 +51,31 @@ def plot_param_importances(
         evaluator:
             An importance evaluator object that specifies which algorithm to base the importance
             assessment on.
-            Defaults to
-            :class:`~optuna.importance.FanovaImportanceEvaluator`.
+            Defaults to :class:`~optuna.importance.PedAnovaImportanceEvaluator`.
+            For details on this evaluator, please refer to the following papers:
+
+            - `PED-ANOVA: Efficiently Quantifying Hyperparameter Importance in Arbitrary Subspaces
+              <https://arxiv.org/abs/2304.10255>`__ (IJCAI 2023)
+            - `Conditional PED-ANOVA: Hyperparameter Importance in Hierarchical & Dynamic Search
+              Spaces <https://arxiv.org/abs/2601.20800>`__ (KDD 2026)
+
+            When using this evaluator in your project, please cite both papers.
         params:
             A list of names of parameters to assess.
-            If :obj:`None`, all parameters that are present in all of the completed trials are
-            assessed.
+            If :obj:`None`, :class:`~optuna.importance.PedAnovaImportanceEvaluator` assesses all
+            parameters that appear in completed trials, including conditional parameters, while
+            other evaluators assess parameters present in all completed trials.
+            If specified, only the specified parameters are assessed.
+            When using :class:`~optuna.importance.PedAnovaImportanceEvaluator`, each specified
+            parameter must appear in at least one completed trial.
+            When using other evaluators, at least one completed trial must contain all specified
+            parameters.
         target:
-            A function to specify the value to display. If it is :obj:`None` and ``study`` is being
-            used for single-objective optimization, the objective values are plotted.
-            For multi-objective optimization, all objectives will be plotted if ``target``
-            is :obj:`None`.
-
-            .. note::
-                This argument can be used to specify which objective to plot if ``study`` is being
-                used for multi-objective optimization. For example, to get only the hyperparameter
-                importance of the first objective, use ``target=lambda t: t.values[0]`` for the
-                target parameter.
+            A function that returns the value used to evaluate and display importances.
+            If :obj:`None`, objective values are used for single-objective optimization.
+            For multi-objective optimization, all objectives will be plotted if ``target`` is
+            :obj:`None`. Specify ``target``, for example ``target=lambda t: t.values[0]``, to
+            plot importances for a specific objective.
         target_name:
             Target's name to display on the axis label. Names set via
             :meth:`~optuna.study.Study.set_metric_names` will be used if ``target`` is :obj:`None`,

--- a/optuna/visualization/matplotlib/_param_importances.py
+++ b/optuna/visualization/matplotlib/_param_importances.py
@@ -63,9 +63,9 @@ def plot_param_importances(
 
             .. note::
 
-               Both Optuna and Optuna Dashboard use
-               :class:`~optuna.importance.PedAnovaImportanceEvaluator` as the default importance
-               evaluator.
+                Both Optuna and Optuna Dashboard use
+                :class:`~optuna.importance.PedAnovaImportanceEvaluator` as the default importance
+                evaluator.
         params:
             A list of names of parameters to assess.
             If :obj:`None`, :class:`~optuna.importance.PedAnovaImportanceEvaluator` assesses all

--- a/optuna/visualization/matplotlib/_param_importances.py
+++ b/optuna/visualization/matplotlib/_param_importances.py
@@ -60,6 +60,12 @@ def plot_param_importances(
               Spaces <https://arxiv.org/abs/2601.20800>`__ (KDD 2026)
 
             When using this evaluator in your project, please cite both papers.
+
+            .. note::
+
+               Both Optuna and Optuna Dashboard use
+               :class:`~optuna.importance.PedAnovaImportanceEvaluator` as the default importance
+               evaluator.
         params:
             A list of names of parameters to assess.
             If :obj:`None`, :class:`~optuna.importance.PedAnovaImportanceEvaluator` assesses all

--- a/optuna/visualization/matplotlib/_param_importances.py
+++ b/optuna/visualization/matplotlib/_param_importances.py
@@ -59,7 +59,7 @@ def plot_param_importances(
             - `Conditional PED-ANOVA: Hyperparameter Importance in Hierarchical & Dynamic Search
               Spaces <https://arxiv.org/abs/2601.20800>`__ (KDD 2026)
 
-            When using this evaluator in your project, please cite both papers.
+            When using this evaluator in your project, please consider citing both papers.
 
             .. note::
 

--- a/optuna/visualization/matplotlib/_param_importances.py
+++ b/optuna/visualization/matplotlib/_param_importances.py
@@ -40,7 +40,8 @@ def plot_param_importances(
     target: Callable[[FrozenTrial], float] | None = None,
     target_name: str = "Objective Value",
 ) -> "Axes":
-    """Plot hyperparameter importances with Matplotlib.
+    """Plot hyperparameter importances (:class:`~optuna.importance.PedAnovaImportanceEvaluator` by
+    default) with Matplotlib.
 
     .. seealso::
         Please refer to :func:`optuna.visualization.plot_param_importances` for an example.

--- a/tests/visualization_tests/test_param_importances.py
+++ b/tests/visualization_tests/test_param_importances.py
@@ -190,8 +190,9 @@ def test_switch_label_when_param_insignificant() -> None:
 
     info = _get_importances_info(study, None, None, None, "Objective Value")
 
-    # Test if label for `y` param has been switched to `<0.01`.
-    assert info.importance_labels == ["<0.01", "1.00"]
+    # Test if label for `y` param is smaller than label for `x` param,
+    # because `y` param is insignificant.
+    assert info.importance_values[0] < info.importance_values[1]
 
 
 @pytest.mark.parametrize("inf_value", [float("inf"), -float("inf")])

--- a/tutorial/20_recipes/002_multi_objective.py
+++ b/tutorial/20_recipes/002_multi_objective.py
@@ -127,13 +127,11 @@ print("Number of finished trials: ", len(study.trials))
 
 
 ###################################################################################################
-# Note that the following sections requires the installation of `Plotly <https://plotly.com/python>`__ for visualization
-# and `scikit-learn <https://scikit-learn.org/stable>`__ for hyperparameter importance calculation:
+# Note that the following sections requires the installation of `Plotly <https://plotly.com/python>`__ for visualization:
 #
 # .. code-block:: console
 #
 #     $ pip install plotly
-#     $ pip install scikit-learn
 #     $ pip install nbformat  # Required if you are running this tutorial in Jupyter Notebook.
 #
 # Check trials on Pareto front visually.


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. To minimize the review effort, we highly appreciate PRs only with related changes. Please note that submitted PRs may be closed if they include unrelated changes or significantly modified unit tests. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->


This PR makes `PedAnovaImportanceEvaluator` the default importance evaluator and removes its experimental status.


`PedAnovaImportanceEvaluator` has several advantages as the default evaluator:

- It does not require additional dependencies such as scikit-learn, and works with Optuna's minimum dependencies.
- It is significantly faster than other evaluators such as fANOVA.
- It can handle conditional search spaces in a principled way.

## Description of the changes
<!-- Describe the changes in this PR. -->

- Use `PedAnovaImportanceEvaluator` as the default evaluator.
- Remove the experimental status from `PedAnovaImportanceEvaluator`.
- Update related documentation and docstrings.