### PR TITLE
chore: consolidate instruction for external dependency

### DIFF
--- a/optuna/samplers/_cmaes.py
+++ b/optuna/samplers/_cmaes.py
@@ -52,7 +52,7 @@ class CmaEsSampler(BaseSampler):
 
     .. note::
         This sampler requires ``cmaes``.
-        You can install these dependencies with ``pip install cmaes``.
+        You can install this dependency with ``pip install cmaes``.
 
     Example:
 

--- a/optuna/samplers/_cmaes.py
+++ b/optuna/samplers/_cmaes.py
@@ -50,13 +50,13 @@ _SYSTEM_ATTR_MAX_LENGTH = 2045
 class CmaEsSampler(BaseSampler):
     """A sampler using `cmaes <https://github.com/CyberAgentAILab/cmaes>`__ as the backend.
 
+    .. note::
+        This sampler requires ``cmaes``.
+        You can install these dependencies with ``pip install cmaes``.
+
     Example:
 
         Optimize a simple quadratic function by using :class:`~optuna.samplers.CmaEsSampler`.
-
-        .. code-block:: console
-
-           $ pip install cmaes
 
         .. testcode::
 

--- a/optuna/samplers/_gp/sampler.py
+++ b/optuna/samplers/_gp/sampler.py
@@ -66,7 +66,7 @@ class GPSampler(BaseSampler):
     """Sampler using Gaussian process-based Bayesian optimization.
 
     .. note::
-        This sampler requires ``scipy`` and ``torch``.
+        This sampler requires ``scipy`` and ``torch`` (the CPU version is sufficient).
         You can install these dependencies with ``pip install scipy torch``.
 
     This sampler fits a Gaussian process (GP) to the objective function and optimizes

--- a/optuna/samplers/_gp/sampler.py
+++ b/optuna/samplers/_gp/sampler.py
@@ -65,6 +65,10 @@ def _standardize_values(values: np.ndarray) -> tuple[np.ndarray, np.ndarray, np.
 class GPSampler(BaseSampler):
     """Sampler using Gaussian process-based Bayesian optimization.
 
+    .. note::
+        This sampler requires ``scipy`` and ``torch``.
+        You can install these dependencies with ``pip install scipy torch``.
+
     This sampler fits a Gaussian process (GP) to the objective function and optimizes
     the acquisition function to suggest the next parameters.
 
@@ -139,10 +143,6 @@ class GPSampler(BaseSampler):
 
     We use line search instead of rounding the results from the continuous optimization since EI
     typically yields a high value between one grid and its adjacent grid.
-
-    .. note::
-        This sampler requires ``scipy`` and ``torch``.
-        You can install these dependencies with ``pip install scipy torch``.
 
     Args:
         seed:

--- a/optuna/samplers/_qmc.py
+++ b/optuna/samplers/_qmc.py
@@ -37,6 +37,13 @@ _threading_lock = threading.Lock()
 class QMCSampler(BaseSampler):
     """A Quasi Monte Carlo Sampler that generates low-discrepancy sequences.
 
+    .. note::
+        This sampler requires ``scipy``.
+        You can install these dependencies with ``pip install scipy``.
+
+        You can see `scipy.stats.qmc
+        <https://scipy.github.io/devdocs/reference/stats.qmc.html>`__ for the QMC algorithm detail.
+
     Quasi Monte Carlo (QMC) sequences are designed to have lower discrepancies than
     standard random sequences. They are known to perform better than the standard
     random sequences in hyperparameter optimization.
@@ -47,10 +54,6 @@ class QMCSampler(BaseSampler):
     - `Bergstra, James, and Yoshua Bengio. Random search for hyper-parameter optimization.
       Journal of machine learning research 13.2, 2012.
       <https://jmlr.org/papers/v13/bergstra12a.html>`__
-
-    We use the QMC implementations in Scipy. For the details of the QMC algorithm,
-    see the Scipy API references on `scipy.stats.qmc
-    <https://scipy.github.io/devdocs/reference/stats.qmc.html>`__.
 
     .. note::
         If your search space contains categorical parameters, it samples the categorical

--- a/optuna/samplers/_qmc.py
+++ b/optuna/samplers/_qmc.py
@@ -39,7 +39,7 @@ class QMCSampler(BaseSampler):
 
     .. note::
         This sampler requires ``scipy``.
-        You can install these dependencies with ``pip install scipy``.
+        You can install this dependency with ``pip install scipy``.
 
         You can see `scipy.stats.qmc
         <https://scipy.github.io/devdocs/reference/stats.qmc.html>`__ for the QMC algorithm detail.

--- a/optuna/samplers/_qmc.py
+++ b/optuna/samplers/_qmc.py
@@ -41,9 +41,6 @@ class QMCSampler(BaseSampler):
         This sampler requires ``scipy``.
         You can install this dependency with ``pip install scipy``.
 
-        You can see `scipy.stats.qmc
-        <https://scipy.github.io/devdocs/reference/stats.qmc.html>`__ for the QMC algorithm detail.
-
     Quasi Monte Carlo (QMC) sequences are designed to have lower discrepancies than
     standard random sequences. They are known to perform better than the standard
     random sequences in hyperparameter optimization.
@@ -54,6 +51,10 @@ class QMCSampler(BaseSampler):
     - `Bergstra, James, and Yoshua Bengio. Random search for hyper-parameter optimization.
       Journal of machine learning research 13.2, 2012.
       <https://jmlr.org/papers/v13/bergstra12a.html>`__
+
+    We use the QMC implementations in Scipy. For the details of the QMC algorithm,
+    see the Scipy API references on `scipy.stats.qmc
+    <https://scipy.github.io/devdocs/reference/stats.qmc.html>`__.
 
     .. note::
         If your search space contains categorical parameters, it samples the categorical


### PR DESCRIPTION
This PR just suggests the cosmetic thing; how about consolidating the note about external dependencies inside `optuna.samplers`?

## Motivation
To state the external dependencies explicitly in the aligned way.

## Description of the changes
Move `pip install` notes to the top of descriptions.
