### PR TITLE
Fix a concurrency issue when setting study attributes

### DIFF
--- a/optuna/storages/_in_memory.py
+++ b/optuna/storages/_in_memory.py
@@ -103,13 +103,17 @@ class InMemoryStorage(BaseStorage):
         with self._lock:
             self._check_study_id(study_id)
 
-            self._studies[study_id].user_attrs[key] = value
+            user_attrs = copy.copy(self._studies[study_id].user_attrs)
+            user_attrs[key] = value
+            self._studies[study_id].user_attrs = user_attrs
 
     def set_study_system_attr(self, study_id: int, key: str, value: JSONSerializable) -> None:
         with self._lock:
             self._check_study_id(study_id)
 
-            self._studies[study_id].system_attrs[key] = value
+            system_attrs = copy.copy(self._studies[study_id].system_attrs)
+            system_attrs[key] = value
+            self._studies[study_id].system_attrs = system_attrs
 
     def get_study_id_from_name(self, study_name: str) -> int:
         with self._lock:

--- a/optuna/storages/journal/_storage.py
+++ b/optuna/storages/journal/_storage.py
@@ -521,14 +521,18 @@ class JournalStorageReplayResult:
 
         if self._study_exists(study_id, log):
             assert len(log["user_attr"]) == 1
-            self._studies[study_id].user_attrs.update(log["user_attr"])
+            user_attrs = copy.copy(self._studies[study_id].user_attrs)
+            user_attrs.update(log["user_attr"])
+            self._studies[study_id].user_attrs = user_attrs
 
     def _apply_set_study_system_attr(self, log: dict[str, Any]) -> None:
         study_id = log["study_id"]
 
         if self._study_exists(study_id, log):
             assert len(log["system_attr"]) == 1
-            self._studies[study_id].system_attrs.update(log["system_attr"])
+            system_attrs = copy.copy(self._studies[study_id].system_attrs)
+            system_attrs.update(log["system_attr"])
+            self._studies[study_id].system_attrs = system_attrs
 
     def _apply_create_trial(self, log: dict[str, Any]) -> None:
         study_id = log["study_id"]

--- a/optuna/testing/pytest_storages.py
+++ b/optuna/testing/pytest_storages.py
@@ -930,6 +930,28 @@ class StorageTestCase:
         with pytest.raises(UpdateFinishedTrialError):
             storage.check_trial_is_updatable(trial_id, TrialState.COMPLETE)
 
+    def test_study_user_attrs_concurrent_write(self, storage: BaseStorage) -> None:
+        study_id = storage.create_new_study([StudyDirection.MINIMIZE], study_name=None)
+        storage.set_study_user_attr(study_id, "key", "value")
+        attrs = storage.get_study_user_attrs(study_id)
+        attrs_iter = iter(attrs)
+        next(attrs_iter)
+
+        # Simulate a reader iterating over the attributes while another worker updates them.
+        storage.set_study_user_attr(study_id, "key2", "value2")
+        list(attrs_iter)
+
+    def test_study_system_attrs_concurrent_write(self, storage: BaseStorage) -> None:
+        study_id = storage.create_new_study([StudyDirection.MINIMIZE], study_name=None)
+        storage.set_study_system_attr(study_id, "key", "value")
+        attrs = storage.get_study_system_attrs(study_id)
+        attrs_iter = iter(attrs)
+        next(attrs_iter)
+
+        # Simulate a reader iterating over the attributes while another worker updates them.
+        storage.set_study_system_attr(study_id, "key2", "value2")
+        list(attrs_iter)
+
 
 ALL_STATES = list(TrialState)
 


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. To minimize the review effort, we highly appreciate PRs only with related changes. Please note that submitted PRs may be closed if they include unrelated changes or significantly modified unit tests. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

`Study.user_attrs` and `Study.system_attrs` can read an internal attribute dictionary after the storage lock has been released. When another thread updates the same study attribute dictionary concurrently, the reader may fail with:

```text
RuntimeError: dictionary changed size during iteration
```

## Description of the changes
<!-- Describe the changes in this PR. -->

This PR updates study attributes using copy-on-write in:

- InMemoryStorage
- JournalStorageReplayResult

As a result, readers keep observing the previous immutable dictionary while the writer replaces it with an updated dictionary.

## Steps to reproduce

The following script reproduces the issue on master:

```python
import threading
import optuna
from optuna.storages import InMemoryStorage

storage = InMemoryStorage()
study = optuna.create_study(storage=storage)
study.set_user_attr("key1", "value1")
study.set_user_attr("key2", "value2")

ready = threading.Event()
updated = threading.Event()


def writer() -> None:
    ready.wait()
    study.set_user_attr("key3", "value3")
    updated.set()


def reader() -> None:
    attrs = storage.get_study_user_attrs(study._study_id)
    for i, attr in enumerate(attrs):
        if i == 0:
            ready.set()
            updated.wait()
        print(attr)


tw = threading.Thread(target=writer)
tr = threading.Thread(target=reader)

tw.start()
tr.start()
tw.join()
tr.join()
```