### PR TITLE
Avoid to persist CMA-ES optimizer in the `trial.system_attrs`

### DIFF
--- a/optuna/cli.py
+++ b/optuna/cli.py
@@ -709,7 +709,7 @@ class _Ask(_BaseCommand):
             sampler = sampler_cls(**sampler_kwargs)
             if isinstance(sampler, optuna.samplers.CmaEsSampler):
                 # See https://github.com/optuna/optuna/pull/6752
-                raise ValueError
+                raise ValueError(
                     "`CmaEsSampler` is not supported with the `ask` command. "
                     "Please use a different sampler."
                 )

--- a/optuna/cli.py
+++ b/optuna/cli.py
@@ -709,7 +709,7 @@ class _Ask(_BaseCommand):
             sampler = sampler_cls(**sampler_kwargs)
             if isinstance(sampler, optuna.samplers.CmaEsSampler):
                 # See https://github.com/optuna/optuna/pull/6752
-                optuna_warn(
+                raise ValueError
                     "`CmaEsSampler` is not supported with the `ask` command. "
                     "Please use a different sampler."
                 )

--- a/optuna/cli.py
+++ b/optuna/cli.py
@@ -707,6 +707,12 @@ class _Ask(_BaseCommand):
                 sampler_kwargs = {}
             sampler_cls = getattr(optuna.samplers, parsed_args.sampler)
             sampler = sampler_cls(**sampler_kwargs)
+            if isinstance(sampler, optuna.samplers.CmaEsSampler):
+                # See https://github.com/optuna/optuna/pull/6752
+                optuna_warn(
+                    "`CmaEsSampler` is not supported with the `ask` command. "
+                    "Please use a different sampler."
+                )
             create_study_kwargs["sampler"] = sampler
         else:
             if parsed_args.sampler_kwargs is not None:

--- a/optuna/samplers/_cmaes.py
+++ b/optuna/samplers/_cmaes.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
 import copy
-import math
-import pickle
+import threading
 from typing import Any
 from typing import cast
 from typing import TYPE_CHECKING
@@ -43,8 +42,6 @@ else:
 _logger = logging.get_logger(__name__)
 
 _EPS = 1e-10
-# The value of system_attrs must be less than 2046 characters on RDBStorage.
-_SYSTEM_ATTR_MAX_LENGTH = 2045
 
 
 class CmaEsSampler(BaseSampler):
@@ -78,10 +75,6 @@ class CmaEsSampler(BaseSampler):
     `CatCmawmSampler <https://hub.optuna.org/samplers/catcmawm/>`__ available on
     `OptunaHub <https://hub.optuna.org/>`__.
 
-    Furthermore, there is room for performance improvements in parallel
-    optimization settings. This sampler cannot use some trials for updating
-    the parameters of multivariate normal distribution.
-
     For further information about CMA-ES algorithm, please refer to the following papers:
 
     - `N. Hansen, The CMA Evolution Strategy: A Tutorial. arXiv:1604.00772, 2016.
@@ -111,7 +104,11 @@ class CmaEsSampler(BaseSampler):
     Args:
 
         seed:
-            A random seed for CMA-ES.
+            A random seed for CMA-ES. The optimizer state is kept in memory and is not persisted
+            in storage, so each sampler instance in distributed optimization updates its own
+            optimizer independently. To avoid identical optimization trajectories, use a different
+            seed for each worker. With the default ``None``, each sampler is initialized with a
+            random seed.
 
         n_startup_trials:
             The independent sampling is used instead of the CMA-ES algorithm until the given number
@@ -319,13 +316,10 @@ class CmaEsSampler(BaseSampler):
         self._with_margin = with_margin
         self._lr_adapt = lr_adapt
         self._source_trials = source_trials
-
-        if self._use_separable_cma:
-            self._attr_prefix = "sepcma:"
-        elif self._with_margin:
-            self._attr_prefix = "cmawm:"
-        else:
-            self._attr_prefix = "cma:"
+        self._optimizer: CmaClass | None = None
+        self._search_space_transform: _SearchSpaceTransform | None = None
+        self._solution_trial_numbers: set[int] = set()
+        self._lock = threading.Lock()
 
         if self._consider_pruned_trials:
             warn_experimental_argument("consider_pruned_trials")
@@ -369,6 +363,15 @@ class CmaEsSampler(BaseSampler):
         # _cma_rng doesn't require reseeding because the relative sampling reseeds in each trial.
         self._independent_sampler.reseed_rng()
 
+    def __getstate__(self) -> dict[Any, Any]:
+        state = self.__dict__.copy()
+        state.pop("_lock", None)
+        return state
+
+    def __setstate__(self, state: dict[Any, Any]) -> None:
+        self.__dict__.update(state)
+        self._lock = threading.Lock()
+
     def infer_relative_search_space(
         self, study: "optuna.Study", trial: "optuna.trial.FrozenTrial"
     ) -> dict[str, BaseDistribution]:
@@ -402,107 +405,63 @@ class CmaEsSampler(BaseSampler):
         if len(completed_trials) < self._n_startup_trials:
             return {}
 
-        # When `with_margin=True`, bounds in discrete dimensions are handled inside `CMAwM`.
-        trans = _SearchSpaceTransform(
-            search_space, transform_step=not self._with_margin, transform_0_1=True
-        )
-
-        optimizer = self._restore_optimizer(completed_trials)
-        if optimizer is None:
-            optimizer = self._init_optimizer(trans, study.direction)
-
-        if optimizer.dim != len(trans.bounds):
-            if self._warn_independent_sampling:
-                ind_sampler_name = self._independent_sampler.__class__.__name__
-                _logger.warning(
-                    "`CmaEsSampler` does not support dynamic search space. "
-                    f"`{ind_sampler_name}` is used instead of `CmaEsSampler`."
+        with self._lock:
+            if self._search_space_transform is None:
+                # When `with_margin=True`, bounds in discrete dimensions are
+                # handled inside `CMAwM`.
+                self._search_space_transform = _SearchSpaceTransform(
+                    copy.deepcopy(search_space),
+                    transform_step=not self._with_margin,
+                    transform_0_1=True,
                 )
-                self._warn_independent_sampling = False
-            return {}
+            trans = self._search_space_transform
+            assert trans is not None
+            if self._optimizer is None:
+                self._optimizer = self._init_optimizer(
+                    self._search_space_transform, study.direction
+                )
+            optimizer = self._optimizer
+            assert optimizer is not None
 
-        # TODO(c-bata): Reduce the number of wasted trials during parallel optimization.
-        # See https://github.com/optuna/optuna/pull/920#discussion_r385114002 for details.
-        solution_trials = self._get_solution_trials(completed_trials, optimizer.generation)
+            if optimizer.dim != len(trans.bounds) or trans._search_space != search_space:
+                if self._warn_independent_sampling:
+                    ind_sampler_name = self._independent_sampler.__class__.__name__
+                    _logger.warning(
+                        "`CmaEsSampler` does not support dynamic search space. "
+                        f"`{ind_sampler_name}` is used instead of `CmaEsSampler`."
+                    )
+                    self._warn_independent_sampling = False
+                return {}
 
-        if len(solution_trials) >= optimizer.population_size:
-            solutions: list[tuple[np.ndarray, float]] = []
-            for t in solution_trials[: optimizer.population_size]:
-                assert t.value is not None, "completed trials must have a value"
-                if isinstance(optimizer, cmaes.CMAwM):
-                    x = np.array(t.system_attrs["x_for_tell"])
-                else:
-                    x = trans.transform(t.params)
-                y = t.value if study.direction == StudyDirection.MINIMIZE else -t.value
-                solutions.append((x, y))
+            solution_trials = [
+                t for t in completed_trials if t.number in self._solution_trial_numbers
+            ]
+            if len(solution_trials) >= optimizer.population_size:
+                solutions: list[tuple[np.ndarray, float]] = []
+                for t in solution_trials[: optimizer.population_size]:
+                    assert t.value is not None, "completed trials must have a value"
+                    if isinstance(optimizer, cmaes.CMAwM):
+                        x = np.array(t.system_attrs["x_for_tell"])
+                    else:
+                        x = trans.transform(t.params)
+                    y = t.value if study.direction == StudyDirection.MINIMIZE else -t.value
+                    solutions.append((x, y))
 
-            optimizer.tell(solutions)
+                optimizer.tell(solutions)
+                self._solution_trial_numbers.clear()
 
-            # Store optimizer.
-            optimizer_str = pickle.dumps(optimizer).hex()
-            optimizer_attrs = self._split_optimizer_str(optimizer_str)
-            for key in optimizer_attrs:
-                study._storage.set_trial_system_attr(trial._trial_id, key, optimizer_attrs[key])
+            if isinstance(optimizer, cmaes.CMAwM):
+                params, x_for_tell = optimizer.ask()
+                study._storage.set_trial_system_attr(
+                    trial._trial_id, "x_for_tell", x_for_tell.tolist()
+                )
+            else:
+                params = optimizer.ask()
 
-        # Caution: optimizer should update its seed value.
-        seed = self._cma_rng.rng.randint(1, 2**16) + trial.number
-        optimizer._rng.seed(seed)
-        if isinstance(optimizer, cmaes.CMAwM):
-            params, x_for_tell = optimizer.ask()
-            study._storage.set_trial_system_attr(
-                trial._trial_id, "x_for_tell", x_for_tell.tolist()
-            )
-        else:
-            params = optimizer.ask()
-
-        generation_attr_key = self._attr_key_generation
-        study._storage.set_trial_system_attr(
-            trial._trial_id, generation_attr_key, optimizer.generation
-        )
-
-        external_values = trans.untransform(params)
+            self._solution_trial_numbers.add(trial.number)
+            external_values = trans.untransform(np.asarray(params, dtype=float))
 
         return external_values
-
-    @property
-    def _attr_key_generation(self) -> str:
-        return self._attr_prefix + "generation"
-
-    @property
-    def _attr_key_optimizer(self) -> str:
-        return self._attr_prefix + "optimizer"
-
-    def _concat_optimizer_attrs(self, optimizer_attrs: dict[str, str]) -> str:
-        return "".join(
-            optimizer_attrs[f"{self._attr_key_optimizer}:{i}"] for i in range(len(optimizer_attrs))
-        )
-
-    def _split_optimizer_str(self, optimizer_str: str) -> dict[str, str]:
-        optimizer_len = len(optimizer_str)
-        attrs = {}
-        for i in range(math.ceil(optimizer_len / _SYSTEM_ATTR_MAX_LENGTH)):
-            start = i * _SYSTEM_ATTR_MAX_LENGTH
-            end = min((i + 1) * _SYSTEM_ATTR_MAX_LENGTH, optimizer_len)
-            attrs[f"{self._attr_key_optimizer}:{i}"] = optimizer_str[start:end]
-        return attrs
-
-    def _restore_optimizer(
-        self,
-        completed_trials: "list[optuna.trial.FrozenTrial]",
-    ) -> "CmaClass" | None:
-        # Restore a previous CMA object.
-        for trial in reversed(completed_trials):
-            optimizer_attrs = {
-                key: value
-                for key, value in trial.system_attrs.items()
-                if key.startswith(self._attr_key_optimizer)
-            }
-            if len(optimizer_attrs) == 0:
-                continue
-
-            optimizer_str = self._concat_optimizer_attrs(optimizer_attrs)
-            return pickle.loads(bytes.fromhex(optimizer_str))
-        return None
 
     def _init_optimizer(
         self,
@@ -649,12 +608,6 @@ class CmaEsSampler(BaseSampler):
                 copied_t.value = value
                 complete_trials.append(copied_t)
         return complete_trials
-
-    def _get_solution_trials(
-        self, trials: list[FrozenTrial], generation: int
-    ) -> list[FrozenTrial]:
-        generation_attr_key = self._attr_key_generation
-        return [t for t in trials if generation == t.system_attrs.get(generation_attr_key, -1)]
 
     def before_trial(self, study: optuna.Study, trial: FrozenTrial) -> None:
         self._independent_sampler.before_trial(study, trial)

--- a/optuna/samplers/_cmaes.py
+++ b/optuna/samplers/_cmaes.py
@@ -360,8 +360,8 @@ class CmaEsSampler(BaseSampler):
             )
 
     def reseed_rng(self) -> None:
-        # _cma_rng doesn't require reseeding because the relative sampling reseeds in each trial.
         self._independent_sampler.reseed_rng()
+        self._cma_rng.rng.seed()
 
     def __getstate__(self) -> dict[Any, Any]:
         state = self.__dict__.copy()

--- a/tests/samplers_tests/test_cmaes.py
+++ b/tests/samplers_tests/test_cmaes.py
@@ -349,87 +349,31 @@ def _create_trials() -> list[FrozenTrial]:
     return trials
 
 
-@pytest.mark.parametrize("sampler_opts", [{}, {"use_separable_cma": True}, {"with_margin": True}])
-def test_restore_optimizer_from_substrings(sampler_opts: dict[str, Any]) -> None:
-    popsize = 8
-    sampler = optuna.samplers.CmaEsSampler(popsize=popsize, **sampler_opts)
-    optimizer = sampler._restore_optimizer([])
-    assert optimizer is None
-
-    def objective(trial: optuna.Trial) -> float:
-        x1 = trial.suggest_float("x1", -10, 10, step=1)
-        x2 = trial.suggest_float("x2", -10, 10)
-        return x1**2 + x2**2
-
-    study = optuna.create_study(sampler=sampler)
-    study.optimize(objective, n_trials=popsize + 2)
-    optimizer = sampler._restore_optimizer(study.trials)
-
-    assert optimizer is not None
-    assert optimizer.generation == 1
-    if sampler._with_margin:
-        assert isinstance(optimizer, CMAwM)
-    elif sampler._use_separable_cma:
-        assert isinstance(optimizer, SepCMA)
-    else:
-        assert isinstance(optimizer, CMA)
-
-
-def test_get_solution_trials() -> None:
+@pytest.mark.parametrize(
+    "sampler_opts",
+    [
+        {},
+        {"use_separable_cma": True},
+        {"with_margin": True},
+    ],
+)
+def test_solution_trial_numbers(sampler_opts: dict[str, Any]) -> None:
     def objective(trial: optuna.Trial) -> float:
         x1 = trial.suggest_float("x1", -10, 10, step=1)
         x2 = trial.suggest_float("x2", -10, 10)
         return x1**2 + x2**2
 
     popsize = 5
-    sampler = optuna.samplers.CmaEsSampler(popsize=popsize)
+    sampler = optuna.samplers.CmaEsSampler(popsize=popsize, **sampler_opts)
     study = optuna.create_study(sampler=sampler)
-    study.optimize(objective, n_trials=popsize + 2)
+    study.optimize(objective, n_trials=popsize + 1)
 
     # The number of solutions for generation 0 equals population size.
-    assert len(sampler._get_solution_trials(study.trials, 0)) == popsize
+    assert len(sampler._solution_trial_numbers) == popsize
 
     # The number of solutions for generation 1 is 1.
-    assert len(sampler._get_solution_trials(study.trials, 1)) == 1
-
-
-@pytest.mark.parametrize(
-    "sampler_opts",
-    [
-        {"use_separable_cma": True},
-        {"with_margin": True},
-    ],
-)
-def test_get_solution_trials_with_other_options(sampler_opts: dict[str, Any]) -> None:
-    def objective(trial: optuna.Trial) -> float:
-        x1 = trial.suggest_float("x1", -10, 10, step=1)
-        x2 = trial.suggest_float("x2", -10, 10)
-        return x1**2 + x2**2
-
-    sampler = optuna.samplers.CmaEsSampler(popsize=5)
-    study = optuna.create_study(sampler=sampler)
-    study.optimize(objective, n_trials=5 + 2)
-
-    # The number of solutions is 0 after changed samplers
-    sampler = optuna.samplers.CmaEsSampler(**sampler_opts)
-    assert len(sampler._get_solution_trials(study.trials, 0)) == 0
-
-
-@pytest.mark.parametrize(
-    "dummy_optimizer_str,attr_len",
-    [
-        ("012", 1),
-        ("01234", 1),
-        ("012345", 2),
-    ],
-)
-def test_split_and_concat_optimizer_string(dummy_optimizer_str: str, attr_len: int) -> None:
-    sampler = optuna.samplers.CmaEsSampler()
-    with patch("optuna.samplers._cmaes._SYSTEM_ATTR_MAX_LENGTH", 5):
-        attrs = sampler._split_optimizer_str(dummy_optimizer_str)
-        assert len(attrs) == attr_len
-        actual = sampler._concat_optimizer_attrs(attrs)
-        assert dummy_optimizer_str == actual
+    study.optimize(objective, n_trials=1)
+    assert len(sampler._solution_trial_numbers) == 1
 
 
 def test_call_after_trial_of_base_sampler() -> None:

--- a/tests/samplers_tests/test_cmaes.py
+++ b/tests/samplers_tests/test_cmaes.py
@@ -7,9 +7,6 @@ from unittest.mock import patch
 import warnings
 
 import _pytest.capture
-from cmaes import CMA
-from cmaes import CMAwM
-from cmaes import SepCMA
 import numpy as np
 import pytest
 

--- a/tests/samplers_tests/test_samplers.py
+++ b/tests/samplers_tests/test_samplers.py
@@ -216,11 +216,7 @@ def test_sampler_reseed_rng(
         original_random_state = sampler.__dict__[rng_name].rng.get_state()
         sampler.reseed_rng()
         random_state = sampler.__dict__[rng_name].rng.get_state()
-        if not isinstance(sampler, optuna.samplers.CmaEsSampler):
-            assert str(original_random_state) != str(random_state)
-        else:
-            # CmaEsSampler has a RandomState that is not reseed by its reseed_rng method.
-            assert str(original_random_state) == str(random_state)
+        assert str(original_random_state) != str(random_state)
 
     had_sampler_name = _extract_attr_name_from_sampler_by_cls(sampler, BaseSampler)
     has_another_sampler = had_sampler_name is not None


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. To minimize the review effort, we highly appreciate PRs only with related changes. Please note that submitted PRs may be closed if they include unrelated changes or significantly modified unit tests. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

Fixes #5762

CmaEsSampler persists its optimizer object in the `trial.system_attrs` causing the issue reported in #5762. This not only consumes excessive storage but also causes several other issues:

* Inefficient distributed optimization: Because multiple workers share a single optimizer, some parameters are discarded without being used to update the distribution. In many cases, it is much more efficient for each worker to maintain its own independent distribution.
* Complex implementation: CmaEsSampler supports several variants (such as CMA-ES with Margin and sep-CMA-ES). Sharing the optimizer required complex logic to avoid loading the wrong variant, which complicated the codebase.

## Description of the changes
<!-- Describe the changes in this PR. -->

This PR updates `CmaEsSampler` to hold the optimizer object in memory. This resolves the issue reported in #5762, significantly simplifies the implementation, and eliminates the inefficiency of discarded parameters during distributed optimization.

**Notice to reviewers**

Unlike the previous implementation, because the optimizer is no longer saved in storage, using `CmaEsSampler` via the Optuna CLI will now always fall back to random sampling. To address this, I have updated `optuna/cli.py` to display a warning message when `CmaEsSampler` is specified, but raising an exception might be another option. Please let me know if you have any feedback on this or if I missed anything else!
