### PR TITLE
Add `set_constraint` method to `Trial`

### DIFF
--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -473,8 +473,9 @@ The following example is a benchmark of Binh and Korn function, a multi-objectiv
         c0 = (x - 5) ** 2 + y ** 2 - 25
         c1 = -((x - 8) ** 2) - (y + 3) ** 2 + 7.7
 
-        # Store the constraints as user attributes so that they can be restored after optimization.
-        trial.set_user_attr("constraint", (c0, c1))
+        # Set constraints
+        trial.set_constraint("c0", c0)
+        trial.set_constraint("c1", c1)
 
         v0 = 4 * x ** 2 + 4 * y ** 2
         v1 = (x - 5) ** 2 + (y - 5) ** 2
@@ -482,11 +483,7 @@ The following example is a benchmark of Binh and Korn function, a multi-objectiv
         return v0, v1
 
 
-    def constraints(trial):
-        return trial.user_attrs["constraint"]
-
-
-    sampler = optuna.samplers.NSGAIISampler(constraints_func=constraints)
+    sampler = optuna.samplers.NSGAIISampler()
     study = optuna.create_study(
         directions=["minimize", "minimize"],
         sampler=sampler,
@@ -502,7 +499,7 @@ The following example is a benchmark of Binh and Korn function, a multi-objectiv
     for trial in trials:
         print(f"  Trial#{trial.number}")
         print(
-            f"    Values: Values={trial.values}, Constraint={trial.user_attrs['constraint'][0]}"
+            f"    Values: Values={trial.values}, Constraint={trial.constraints}"
         )
         print(f"    Params: {trial.params}")
 

--- a/docs/visualization_examples/optuna.visualization.plot_rank.py
+++ b/docs/visualization_examples/optuna.visualization.plot_rank.py
@@ -18,16 +18,12 @@ def objective(trial):
     y = trial.suggest_categorical("y", [-1, 0, 1])
 
     c0 = 400 - (x + y) ** 2
-    trial.set_user_attr("constraint", [c0])
+    trial.set_constraint("c0", c0)
 
     return x**2 + y
 
 
-def constraints(trial):
-    return trial.user_attrs["constraint"]
-
-
-sampler = optuna.samplers.TPESampler(seed=10, constraints_func=constraints)
+sampler = optuna.samplers.TPESampler(seed=10)
 study = optuna.create_study(sampler=sampler)
 study.optimize(objective, n_trials=30)
 

--- a/docs/visualization_matplotlib_examples/optuna.visualization.matplotlib.rank.py
+++ b/docs/visualization_matplotlib_examples/optuna.visualization.matplotlib.rank.py
@@ -17,16 +17,12 @@ def objective(trial):
     y = trial.suggest_categorical("y", [-1, 0, 1])
 
     c0 = 400 - (x + y) ** 2
-    trial.set_user_attr("constraint", [c0])
+    trial.set_constraint("c0", c0)
 
     return x**2 + y
 
 
-def constraints(trial):
-    return trial.user_attrs["constraint"]
-
-
-sampler = optuna.samplers.TPESampler(seed=10, constraints_func=constraints)
+sampler = optuna.samplers.TPESampler(seed=10)
 study = optuna.create_study(sampler=sampler)
 study.optimize(objective, n_trials=30)
 

--- a/optuna/samplers/_gp/sampler.py
+++ b/optuna/samplers/_gp/sampler.py
@@ -13,6 +13,7 @@ from optuna.samplers._base import _process_constraints_after_trial
 from optuna.samplers._base import BaseSampler
 from optuna.samplers._lazy_random_state import LazyRandomState
 from optuna.study import StudyDirection
+from optuna.study._constrained_optimization import _is_constrained_optimization
 from optuna.study._multi_objective import _is_pareto_front
 from optuna.trial import FrozenTrial
 from optuna.trial import TrialState
@@ -418,7 +419,7 @@ class GPSampler(BaseSampler):
 
         best_params: np.ndarray | None
         acqf: acqf_module.BaseAcquisitionFunc
-        if self._constraints_func is None:
+        if not _is_constrained_optimization(completed_trials):
             if n_objectives == 1:
                 assert len(gprs_list) == 1
                 if normalized_params_of_running_trials is None:

--- a/optuna/samplers/_nsgaiii/_elite_population_selection_strategy.py
+++ b/optuna/samplers/_nsgaiii/_elite_population_selection_strategy.py
@@ -8,6 +8,7 @@ import numpy as np
 
 from optuna.samplers.nsgaii._constraints_evaluation import _validate_constraints
 from optuna.samplers.nsgaii._elite_population_selection_strategy import _rank_population
+from optuna.study._constrained_optimization import _is_constrained_optimization
 
 
 if TYPE_CHECKING:
@@ -54,9 +55,10 @@ class NSGAIIIElitePopulationSelectionStrategy:
         Returns:
             A list of trials that are selected as elite population.
         """
-        _validate_constraints(population, is_constrained=self._constraints_func is not None)
+        is_constrained = _is_constrained_optimization(population)
+        _validate_constraints(population, is_constrained=is_constrained)
         population_per_rank = _rank_population(
-            population, study.directions, is_constrained=self._constraints_func is not None
+            population, study.directions, is_constrained=is_constrained
         )
 
         elite_population: list[FrozenTrial] = []

--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -598,7 +598,6 @@ class TPESampler(BaseSampler):
             study,
             trials,
             self._gamma(n),
-            self._constraints_func is not None,
         )
 
         mpe_below = self._build_parzen_estimator(
@@ -629,9 +628,9 @@ class TPESampler(BaseSampler):
             param_mask_below = [
                 search_space.keys() <= self._get_params(trial).keys() for trial in trials
             ]
-            weights_below = _calculate_weights_below_for_multi_objective(
-                study, trials, self._constraints_func
-            )[param_mask_below]
+            weights_below = _calculate_weights_below_for_multi_objective(study, trials)[
+                param_mask_below
+            ]
             assert np.isfinite(weights_below).all()
             mpe = self._parzen_estimator_cls(
                 observations, search_space, self._parzen_estimator_parameters, weights_below
@@ -743,7 +742,7 @@ def _get_reference_point(loss_vals: np.ndarray) -> np.ndarray:
 
 
 def _split_trials(
-    study: Study, trials: list[FrozenTrial], n_below: int, constraints_enabled: bool
+    study: Study, trials: list[FrozenTrial], n_below: int
 ) -> tuple[list[FrozenTrial], list[FrozenTrial]]:
     complete_trials = []
     pruned_trials = []
@@ -755,7 +754,7 @@ def _split_trials(
             # We should check if the trial is RUNNING before the feasibility check
             # because its constraint values have not yet been set.
             running_trials.append(trial)
-        elif constraints_enabled and _get_infeasible_trial_score(trial) > 0:
+        elif _get_infeasible_trial_score(trial) > 0:
             infeasible_trials.append(trial)
         elif trial.state == TrialState.COMPLETE:
             complete_trials.append(trial)
@@ -860,16 +859,7 @@ def _split_pruned_trials(
 
 
 def _get_infeasible_trial_score(trial: FrozenTrial) -> float:
-    constraint = trial.constraints
-    if len(constraint) == 0:
-        optuna_warn(
-            f"Trial {trial.number} does not have constraint values."
-            " It will be treated as a lower priority than other trials."
-        )
-        return float("inf")
-    else:
-        # Violation values of infeasible dimensions are summed up.
-        return sum(v for v in constraint.values() if v > 0)
+    return sum(v for v in trial.constraints.values() if v > 0)
 
 
 def _split_infeasible_trials(
@@ -883,10 +873,9 @@ def _split_infeasible_trials(
 def _calculate_weights_below_for_multi_objective(
     study: Study,
     below_trials: list[FrozenTrial],
-    constraints_func: Callable[[FrozenTrial], Sequence[float]] | None,
 ) -> np.ndarray:
     def _feasible(trial: FrozenTrial) -> bool:
-        return constraints_func is None or all(c <= 0 for c in constraints_func(trial))
+        return all(c <= 0 for c in trial.constraints.values())
 
     is_feasible = np.asarray([_feasible(t) for t in below_trials])
     weights_below = np.where(is_feasible, 1.0, EPS)  # Assign EPS to infeasible trials.

--- a/optuna/samplers/nsgaii/_child_generation_strategy.py
+++ b/optuna/samplers/nsgaii/_child_generation_strategy.py
@@ -8,6 +8,7 @@ from optuna.samplers.nsgaii._crossover import perform_crossover
 from optuna.samplers.nsgaii._crossovers._base import BaseCrossover
 from optuna.samplers.nsgaii._mutation import perform_mutation
 from optuna.samplers.nsgaii._mutations._base import BaseMutation
+from optuna.study._constrained_optimization import _is_constrained_optimization
 from optuna.study._multi_objective import _dominates
 
 
@@ -79,7 +80,10 @@ class NSGAIIChildGenerationStrategy:
         Returns:
             A dictionary containing the parameter names and parameter's values.
         """
-        dominates = _dominates if self._constraints_func is None else _constrained_dominates
+        if _is_constrained_optimization(parent_population):
+            dominates = _constrained_dominates
+        else:
+            dominates = _dominates
         # We choose a child based on the specified crossover method.
         if self._rng.rng.rand() < self._crossover_prob:
             child_params = perform_crossover(

--- a/optuna/samplers/nsgaii/_elite_population_selection_strategy.py
+++ b/optuna/samplers/nsgaii/_elite_population_selection_strategy.py
@@ -8,6 +8,7 @@ import numpy as np
 from optuna.samplers.nsgaii._constraints_evaluation import _evaluate_penalty
 from optuna.samplers.nsgaii._constraints_evaluation import _validate_constraints
 from optuna.study import StudyDirection
+from optuna.study._constrained_optimization import _is_constrained_optimization
 from optuna.study._multi_objective import _fast_non_domination_rank
 
 
@@ -44,9 +45,10 @@ class NSGAIIElitePopulationSelectionStrategy:
         Returns:
             A list of trials that are selected as elite population.
         """
-        _validate_constraints(population, is_constrained=self._constraints_func is not None)
+        is_constrained = _is_constrained_optimization(population)
+        _validate_constraints(population, is_constrained=is_constrained)
         population_per_rank = _rank_population(
-            population, study.directions, is_constrained=self._constraints_func is not None
+            population, study.directions, is_constrained=is_constrained
         )
         elite_population: list[FrozenTrial] = []
         for individuals in population_per_rank:

--- a/optuna/study/_constrained_optimization.py
+++ b/optuna/study/_constrained_optimization.py
@@ -11,6 +11,12 @@ if TYPE_CHECKING:
 _CONSTRAINTS_KEY = "constraints"
 
 
+def _is_constrained_optimization(trials: Sequence[FrozenTrial]) -> bool:
+    """Return whether the given trials are created in constrained optimization."""
+
+    return any(len(trial.constraints) > 0 for trial in trials)
+
+
 def _get_feasible_trials(trials: Sequence[FrozenTrial]) -> list[FrozenTrial]:
     """Return feasible trials from given trials.
 

--- a/optuna/study/_constrained_optimization.py
+++ b/optuna/study/_constrained_optimization.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+from typing import Any
 from typing import TYPE_CHECKING
+
+from optuna._warnings import optuna_warn
 
 
 if TYPE_CHECKING:
@@ -34,3 +37,23 @@ def _get_feasible_trials(trials: Sequence[FrozenTrial]) -> list[FrozenTrial]:
         if len(constraints) > 0 and all(x <= 0.0 for x in constraints):
             feasible_trials.append(trial)
     return feasible_trials
+
+
+def _get_constraints_from_system_attrs(system_attrs: dict[str, Any]) -> dict[str, float]:
+    constraints_dict: dict[str, float] = {}
+
+    # Load constraints from old format (list)
+    con = system_attrs.get(_CONSTRAINTS_KEY)
+    if con is not None:
+        for i, c in enumerate(con):
+            constraints_dict[str(i)] = c
+
+    # Load constraints from new format (individual keys)
+    prefix = f"{_CONSTRAINTS_KEY}:"
+    for key, value in system_attrs.items():
+        if key.startswith(prefix):
+            constraint_key = key[len(prefix) :]
+            if constraint_key in constraints_dict:
+                optuna_warn("Overwrite an old format constraint.")
+            constraints_dict[constraint_key] = value
+    return constraints_dict

--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -30,6 +30,7 @@ from optuna.distributions import _convert_old_distribution_to_new_distribution
 from optuna.distributions import BaseDistribution
 from optuna.storages._heartbeat import is_heartbeat_enabled
 from optuna.study._constrained_optimization import _get_feasible_trials
+from optuna.study._constrained_optimization import _is_constrained_optimization
 from optuna.study._multi_objective import _get_pareto_front_trials
 from optuna.study._optimize import _optimize
 from optuna.study._study_direction import StudyDirection
@@ -195,7 +196,7 @@ class Study:
 
         # Check whether the study is constrained optimization.
         trials = self.get_trials(deepcopy=False)
-        is_constrained = any(len(trial.constraints) > 0 for trial in trials)
+        is_constrained = _is_constrained_optimization(trials)
 
         return _get_pareto_front_trials(self, consider_constraint=is_constrained)
 

--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -184,8 +184,8 @@ class Study:
             When optimizing many objectives, a large fraction of trials may become non-dominated
             in general due to the curse of dimensionality in the objective space. If this makes
             post-hoc selection difficult, consider modeling some objectives as constraints.
-            Constraints can be passed via the `constraints_func` argument at the sampler
-            initialization.
+            Constraints can be set within the objective function using
+            :meth:`~optuna.trial.Trial.set_constraint` method.
 
         Returns:
             A list of :class:`~optuna.trial.FrozenTrial` objects. If no trials are

--- a/optuna/trial/_base.py
+++ b/optuna/trial/_base.py
@@ -139,3 +139,7 @@ class BaseTrial(abc.ABC):
     @property
     def constraints(self) -> dict[str, float]:
         raise NotImplementedError
+
+    @abc.abstractmethod
+    def set_constraint(self, key: str, value: float) -> None:
+        raise NotImplementedError

--- a/optuna/trial/_fixed.py
+++ b/optuna/trial/_fixed.py
@@ -229,4 +229,13 @@ class FixedTrial(BaseTrial):
                 are zero or less.
         """
 
-        self._system_attrs[f"{_CONSTRAINTS_KEY}:{key}"] = value
+        constraint_key = f"{_CONSTRAINTS_KEY}:{key}"
+
+        if constraint_key in self._system_attrs:
+            # Do nothing if already set.
+            optuna_warn(
+                f"The constraint value is ignored because this constraint `{key=}` is already set."
+            )
+            return
+
+        self._system_attrs[constraint_key] = value

--- a/optuna/trial/_fixed.py
+++ b/optuna/trial/_fixed.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import datetime
+import math
 from typing import Any
 from typing import overload
 from typing import TYPE_CHECKING
@@ -230,6 +231,18 @@ class FixedTrial(BaseTrial):
                 A constraint value. The trial is considered feasible when all constraint values
                 are zero or less.
         """
+
+        try:
+            # For convenience, we allow users to set a value that can be cast to `float`.
+            value = float(value)
+        except (TypeError, ValueError):
+            message = (
+                f"The `value` argument is of type '{type(value)}' but supposed to be a float."
+            )
+            raise TypeError(message) from None
+
+        if math.isnan(value):
+            raise ValueError(f"Attempted to set a constraint for {key!r}, but NaN is not allowed.")
 
         constraint_key = f"{_CONSTRAINTS_KEY}:{key}"
 

--- a/optuna/trial/_fixed.py
+++ b/optuna/trial/_fixed.py
@@ -201,7 +201,32 @@ class FixedTrial(BaseTrial):
             constraint values of trial.
         """
 
+        constraints_dict: dict[str, float] = {}
+
+        # Load constraints from old format (list)
         con = self.system_attrs.get(_CONSTRAINTS_KEY)
-        if con is None:
-            return {}
-        return {str(i): c for i, c in enumerate(con)}
+        if con is not None:
+            for i, c in enumerate(con):
+                constraints_dict[str(i)] = c
+
+        # Load constraints from new format (individual keys)
+        prefix = f"{_CONSTRAINTS_KEY}:"
+        for key, value in self.system_attrs.items():
+            if key.startswith(prefix):
+                constraint_key = key[len(prefix) :]
+                constraints_dict[constraint_key] = value
+
+        return constraints_dict
+
+    def set_constraint(self, key: str, value: float) -> None:
+        """Set a constraint value for the trial.
+
+        Args:
+            key:
+                A constraint name.
+            value:
+                A constraint value. The trial is considered feasible when all constraint values
+                are zero or less.
+        """
+
+        self._system_attrs[f"{_CONSTRAINTS_KEY}:{key}"] = value

--- a/optuna/trial/_fixed.py
+++ b/optuna/trial/_fixed.py
@@ -214,6 +214,8 @@ class FixedTrial(BaseTrial):
         for key, value in self.system_attrs.items():
             if key.startswith(prefix):
                 constraint_key = key[len(prefix) :]
+                if constraint_key in constraints_dict:
+                    optuna_warn("Overwrite an old format constraint.")
                 constraints_dict[constraint_key] = value
 
         return constraints_dict

--- a/optuna/trial/_fixed.py
+++ b/optuna/trial/_fixed.py
@@ -14,6 +14,7 @@ from optuna.distributions import CategoricalDistribution
 from optuna.distributions import FloatDistribution
 from optuna.distributions import IntDistribution
 from optuna.study._constrained_optimization import _CONSTRAINTS_KEY
+from optuna.study._constrained_optimization import _get_constraints_from_system_attrs
 from optuna.trial._base import _SUGGEST_INT_POSITIONAL_ARGS
 from optuna.trial._base import BaseTrial
 
@@ -202,24 +203,7 @@ class FixedTrial(BaseTrial):
             constraint values of trial.
         """
 
-        constraints_dict: dict[str, float] = {}
-
-        # Load constraints from old format (list)
-        con = self.system_attrs.get(_CONSTRAINTS_KEY)
-        if con is not None:
-            for i, c in enumerate(con):
-                constraints_dict[str(i)] = c
-
-        # Load constraints from new format (individual keys)
-        prefix = f"{_CONSTRAINTS_KEY}:"
-        for key, value in self.system_attrs.items():
-            if key.startswith(prefix):
-                constraint_key = key[len(prefix) :]
-                if constraint_key in constraints_dict:
-                    optuna_warn("Overwrite an old format constraint.")
-                constraints_dict[constraint_key] = value
-
-        return constraints_dict
+        return _get_constraints_from_system_attrs(self.system_attrs)
 
     def set_constraint(self, key: str, value: float) -> None:
         """Set a constraint value for the trial.

--- a/optuna/trial/_frozen.py
+++ b/optuna/trial/_frozen.py
@@ -518,7 +518,16 @@ class FrozenTrial(BaseTrial):
                 are zero or less.
         """
 
-        self._system_attrs[f"{_CONSTRAINTS_KEY}:{key}"] = value
+        constraint_key = f"{_CONSTRAINTS_KEY}:{key}"
+
+        if constraint_key in self._system_attrs:
+            # Do nothing if already set.
+            optuna_warn(
+                f"The constraint value is ignored because this constraint `{key=}` is already set."
+            )
+            return
+
+        self._system_attrs[constraint_key] = value
 
 
 def create_trial(

--- a/optuna/trial/_frozen.py
+++ b/optuna/trial/_frozen.py
@@ -490,10 +490,35 @@ class FrozenTrial(BaseTrial):
             constraint values of trial.
         """
 
+        constraints_dict: dict[str, float] = {}
+
+        # Load constraints from old format (list)
         con = self.system_attrs.get(_CONSTRAINTS_KEY)
-        if con is None:
-            return {}
-        return {str(i): c for i, c in enumerate(con)}
+        if con is not None:
+            for i, c in enumerate(con):
+                constraints_dict[str(i)] = c
+
+        # Load constraints from new format (individual keys)
+        prefix = f"{_CONSTRAINTS_KEY}:"
+        for key, value in self.system_attrs.items():
+            if key.startswith(prefix):
+                constraint_key = key[len(prefix) :]
+                constraints_dict[constraint_key] = value
+
+        return constraints_dict
+
+    def set_constraint(self, key: str, value: float) -> None:
+        """Set a constraint value for the trial.
+
+        Args:
+            key:
+                A constraint name.
+            value:
+                A constraint value. The trial is considered feasible when all constraint values
+                are zero or less.
+        """
+
+        self._system_attrs[f"{_CONSTRAINTS_KEY}:{key}"] = value
 
 
 def create_trial(

--- a/optuna/trial/_frozen.py
+++ b/optuna/trial/_frozen.py
@@ -520,6 +520,18 @@ class FrozenTrial(BaseTrial):
                 are zero or less.
         """
 
+        try:
+            # For convenience, we allow users to set a value that can be cast to `float`.
+            value = float(value)
+        except (TypeError, ValueError):
+            message = (
+                f"The `value` argument is of type '{type(value)}' but supposed to be a float."
+            )
+            raise TypeError(message) from None
+
+        if math.isnan(value):
+            raise ValueError(f"Attempted to set a constraint for {key!r}, but NaN is not allowed.")
+
         constraint_key = f"{_CONSTRAINTS_KEY}:{key}"
 
         if constraint_key in self._system_attrs:

--- a/optuna/trial/_frozen.py
+++ b/optuna/trial/_frozen.py
@@ -503,6 +503,8 @@ class FrozenTrial(BaseTrial):
         for key, value in self.system_attrs.items():
             if key.startswith(prefix):
                 constraint_key = key[len(prefix) :]
+                if constraint_key in constraints_dict:
+                    optuna_warn("Overwrite an old format constraint.")
                 constraints_dict[constraint_key] = value
 
         return constraints_dict

--- a/optuna/trial/_frozen.py
+++ b/optuna/trial/_frozen.py
@@ -17,6 +17,7 @@ from optuna.distributions import CategoricalDistribution
 from optuna.distributions import FloatDistribution
 from optuna.distributions import IntDistribution
 from optuna.study._constrained_optimization import _CONSTRAINTS_KEY
+from optuna.study._constrained_optimization import _get_constraints_from_system_attrs
 from optuna.trial._base import _SUGGEST_INT_POSITIONAL_ARGS
 from optuna.trial._base import BaseTrial
 from optuna.trial._state import TrialState
@@ -490,24 +491,7 @@ class FrozenTrial(BaseTrial):
             constraint values of trial.
         """
 
-        constraints_dict: dict[str, float] = {}
-
-        # Load constraints from old format (list)
-        con = self.system_attrs.get(_CONSTRAINTS_KEY)
-        if con is not None:
-            for i, c in enumerate(con):
-                constraints_dict[str(i)] = c
-
-        # Load constraints from new format (individual keys)
-        prefix = f"{_CONSTRAINTS_KEY}:"
-        for key, value in self.system_attrs.items():
-            if key.startswith(prefix):
-                constraint_key = key[len(prefix) :]
-                if constraint_key in constraints_dict:
-                    optuna_warn("Overwrite an old format constraint.")
-                constraints_dict[constraint_key] = value
-
-        return constraints_dict
+        return _get_constraints_from_system_attrs(self.system_attrs)
 
     def set_constraint(self, key: str, value: float) -> None:
         """Set a constraint value for the trial.

--- a/optuna/trial/_trial.py
+++ b/optuna/trial/_trial.py
@@ -777,10 +777,37 @@ class Trial(BaseTrial):
             constraint values of trial.
         """
 
-        con = self.storage.get_trial_system_attrs(self._trial_id).get(_CONSTRAINTS_KEY)
-        if con is None:
-            return {}
-        return {str(i): c for i, c in enumerate(con)}
+        system_attrs = self.storage.get_trial_system_attrs(self._trial_id)
+        constraints_dict: dict[str, float] = {}
+
+        # Load constraints from old format (list)
+        con = system_attrs.get(_CONSTRAINTS_KEY)
+        if con is not None:
+            for i, c in enumerate(con):
+                constraints_dict[str(i)] = c
+
+        # Load constraints from new format (individual keys)
+        prefix = f"{_CONSTRAINTS_KEY}:"
+        for key, value in system_attrs.items():
+            if key.startswith(prefix):
+                constraint_key = key[len(prefix) :]
+                constraints_dict[constraint_key] = value
+
+        return constraints_dict
+
+    def set_constraint(self, key: str, value: float) -> None:
+        """Set a constraint value for the trial.
+
+        Args:
+            key:
+                A constraint name.
+            value:
+                A constraint value. The trial is considered feasible when all constraint values
+                are zero or less.
+        """
+
+        self.storage.set_trial_system_attr(self._trial_id, f"{_CONSTRAINTS_KEY}:{key}", value)
+        self._cached_frozen_trial.system_attrs[f"{_CONSTRAINTS_KEY}:{key}"] = value
 
 
 class _LazyTrialSystemAttrs(UserDict):

--- a/optuna/trial/_trial.py
+++ b/optuna/trial/_trial.py
@@ -791,6 +791,8 @@ class Trial(BaseTrial):
         for key, value in system_attrs.items():
             if key.startswith(prefix):
                 constraint_key = key[len(prefix) :]
+                if constraint_key in constraints_dict:
+                    optuna_warn("Overwrite an old format constraint.")
                 constraints_dict[constraint_key] = value
 
         return constraints_dict

--- a/optuna/trial/_trial.py
+++ b/optuna/trial/_trial.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections import UserDict
 import copy
+import math
 from typing import Any
 from typing import overload
 from typing import TYPE_CHECKING
@@ -807,6 +808,18 @@ class Trial(BaseTrial):
                 A constraint value. The trial is considered feasible when all constraint values
                 are zero or less.
         """
+
+        try:
+            # For convenience, we allow users to set a value that can be cast to `float`.
+            value = float(value)
+        except (TypeError, ValueError):
+            message = (
+                f"The `value` argument is of type '{type(value)}' but supposed to be a float."
+            )
+            raise TypeError(message) from None
+
+        if math.isnan(value):
+            raise ValueError(f"Attempted to set a constraint for {key!r}, but NaN is not allowed.")
 
         constraint_key = f"{_CONSTRAINTS_KEY}:{key}"
 

--- a/optuna/trial/_trial.py
+++ b/optuna/trial/_trial.py
@@ -806,8 +806,18 @@ class Trial(BaseTrial):
                 are zero or less.
         """
 
-        self.storage.set_trial_system_attr(self._trial_id, f"{_CONSTRAINTS_KEY}:{key}", value)
-        self._cached_frozen_trial.system_attrs[f"{_CONSTRAINTS_KEY}:{key}"] = value
+        constraint_key = f"{_CONSTRAINTS_KEY}:{key}"
+
+        system_attrs = self.storage.get_trial_system_attrs(self._trial_id)
+        if constraint_key in system_attrs:
+            # Do nothing if already set.
+            optuna_warn(
+                f"The constraint value is ignored because this constraint `{key=}` is already set."
+            )
+            return
+
+        self.storage.set_trial_system_attr(self._trial_id, constraint_key, value)
+        self._cached_frozen_trial.system_attrs[constraint_key] = value
 
 
 class _LazyTrialSystemAttrs(UserDict):

--- a/optuna/trial/_trial.py
+++ b/optuna/trial/_trial.py
@@ -20,6 +20,7 @@ from optuna.distributions import CategoricalDistribution
 from optuna.distributions import FloatDistribution
 from optuna.distributions import IntDistribution
 from optuna.study._constrained_optimization import _CONSTRAINTS_KEY
+from optuna.study._constrained_optimization import _get_constraints_from_system_attrs
 from optuna.trial._base import _SUGGEST_INT_POSITIONAL_ARGS
 from optuna.trial._base import BaseTrial
 
@@ -779,24 +780,7 @@ class Trial(BaseTrial):
         """
 
         system_attrs = self.storage.get_trial_system_attrs(self._trial_id)
-        constraints_dict: dict[str, float] = {}
-
-        # Load constraints from old format (list)
-        con = system_attrs.get(_CONSTRAINTS_KEY)
-        if con is not None:
-            for i, c in enumerate(con):
-                constraints_dict[str(i)] = c
-
-        # Load constraints from new format (individual keys)
-        prefix = f"{_CONSTRAINTS_KEY}:"
-        for key, value in system_attrs.items():
-            if key.startswith(prefix):
-                constraint_key = key[len(prefix) :]
-                if constraint_key in constraints_dict:
-                    optuna_warn("Overwrite an old format constraint.")
-                constraints_dict[constraint_key] = value
-
-        return constraints_dict
+        return _get_constraints_from_system_attrs(system_attrs)
 
     def set_constraint(self, key: str, value: float) -> None:
         """Set a constraint value for the trial.

--- a/tests/samplers_tests/tpe_tests/test_multi_objective_sampler.py
+++ b/tests/samplers_tests/tpe_tests/test_multi_objective_sampler.py
@@ -346,16 +346,14 @@ def test_split_complete_trials_multi_objective_empty() -> None:
 def test_calculate_weights_below_for_multi_objective() -> None:
     # No sample.
     study = optuna.create_study(directions=["minimize", "minimize"])
-    weights_below = _tpe.sampler._calculate_weights_below_for_multi_objective(study, [], None)
+    weights_below = _tpe.sampler._calculate_weights_below_for_multi_objective(study, [])
     assert len(weights_below) == 0
 
     # One sample.
     study = optuna.create_study(directions=["minimize", "minimize"])
     trial0 = optuna.create_trial(values=[0.2, 0.5])
     study.add_trials([trial0])
-    weights_below = _tpe.sampler._calculate_weights_below_for_multi_objective(
-        study, [trial0], None
-    )
+    weights_below = _tpe.sampler._calculate_weights_below_for_multi_objective(study, [trial0])
     assert len(weights_below) == 1
     assert sum(weights_below) > 0
 
@@ -367,7 +365,6 @@ def test_calculate_weights_below_for_multi_objective() -> None:
     weights_below = _tpe.sampler._calculate_weights_below_for_multi_objective(
         study,
         [trial0, trial1],
-        None,
     )
     assert len(weights_below) == 2
     assert weights_below[0] > weights_below[1]
@@ -381,7 +378,6 @@ def test_calculate_weights_below_for_multi_objective() -> None:
     weights_below = _tpe.sampler._calculate_weights_below_for_multi_objective(
         study,
         [trial0, trial1],
-        None,
     )
     assert len(weights_below) == 2
     assert weights_below[0] == weights_below[1]
@@ -395,7 +391,6 @@ def test_calculate_weights_below_for_multi_objective() -> None:
     weights_below = _tpe.sampler._calculate_weights_below_for_multi_objective(
         study,
         [trial0, trial1],
-        None,
     )
     assert len(weights_below) == 2
     assert weights_below[0] == weights_below[1]
@@ -410,7 +405,6 @@ def test_calculate_weights_below_for_multi_objective() -> None:
     weights_below = _tpe.sampler._calculate_weights_below_for_multi_objective(
         study,
         [trial0, trial1, trial2],
-        None,
     )
     assert len(weights_below) == 3
     assert weights_below[0] > weights_below[1]
@@ -427,7 +421,6 @@ def test_calculate_weights_below_for_multi_objective() -> None:
     weights_below = _tpe.sampler._calculate_weights_below_for_multi_objective(
         study,
         [trial0, trial1, trial2],
-        None,
     )
     assert len(weights_below) == 3
     assert weights_below[0] > weights_below[1]
@@ -444,7 +437,6 @@ def test_calculate_weights_below_for_multi_objective() -> None:
     weights_below = _tpe.sampler._calculate_weights_below_for_multi_objective(
         study,
         [trial0, trial1, trial2],
-        None,
     )
     assert len(weights_below) == 3
     assert not any([np.isnan(w) for w in weights_below])
@@ -452,14 +444,13 @@ def test_calculate_weights_below_for_multi_objective() -> None:
 
     # Three samples with two infeasible trials.
     study = optuna.create_study(directions=["minimize", "minimize"])
-    trial0 = optuna.create_trial(values=[0.3, 0.3], system_attrs={"constraints": 2})
-    trial1 = optuna.create_trial(values=[0.2, 0.8], system_attrs={"constraints": 8})
-    trial2 = optuna.create_trial(values=[0.8, 0.2], system_attrs={"constraints": 0})
+    trial0 = optuna.create_trial(values=[0.3, 0.3], system_attrs={"constraints:c": 2})
+    trial1 = optuna.create_trial(values=[0.2, 0.8], system_attrs={"constraints:c": 8})
+    trial2 = optuna.create_trial(values=[0.8, 0.2], system_attrs={"constraints:c": 0})
     study.add_trials([trial0, trial1, trial2])
     weights_below = _tpe.sampler._calculate_weights_below_for_multi_objective(
         study,
         [trial0, trial1, trial2],
-        lambda trial: [trial.system_attrs["constraints"]],
     )
     assert len(weights_below) == 3
     assert weights_below[0] == _tpe.sampler.EPS

--- a/tests/samplers_tests/tpe_tests/test_sampler.py
+++ b/tests/samplers_tests/tpe_tests/test_sampler.py
@@ -791,7 +791,6 @@ def test_split_trials(direction: str, constant_liar: bool, constraints: bool) ->
             study,
             trials,
             n_below,
-            constraints,
         )
 
         below_trial_numbers = [trial.number for trial in below_trials]
@@ -847,9 +846,7 @@ def test_split_trials_for_multiobjective_constant_liar(directions: list[str]) ->
     # NOTE(nabenabe0928): Running trials (#16 -- #20) must come at the end.
     ground_truth += [n_completed_trials + i for i in range(n_running_trials)]
     for n_below in range(1, len(finished_trials) + 1):
-        below_trials, above_trials = _tpe.sampler._split_trials(
-            study, trials, n_below, constraints_enabled=False
-        )
+        below_trials, above_trials = _tpe.sampler._split_trials(study, trials, n_below)
         below_trial_numbers = [trial.number for trial in below_trials]
         assert below_trial_numbers == sorted(ground_truth[:n_below])
         above_trial_numbers = [trial.number for trial in above_trials]

--- a/tests/trial_tests/test_trials.py
+++ b/tests/trial_tests/test_trials.py
@@ -232,14 +232,16 @@ def test_set_constraint(trial_type: type) -> None:
     assert constraints["limit"] == 2.5
 
 
+@pytest.mark.filterwarnings("ignore::UserWarning")
 @parametrize_trial_type
 def test_set_constraint_override(trial_type: type) -> None:
     trial = _create_trial(trial_type)
     trial.set_constraint("value", 1.0)
-    trial.set_constraint("value", 2.0)  # Override
+    assert trial.constraints["value"] == 1.0
 
-    constraints = trial.constraints
-    assert constraints["value"] == 2.0
+    # set_constraint does not perform constraint overrides.
+    trial.set_constraint("value", 2.0)
+    assert trial.constraints["value"] == 1.0
 
 
 def test_constraints_old_format() -> None:

--- a/tests/trial_tests/test_trials.py
+++ b/tests/trial_tests/test_trials.py
@@ -271,6 +271,7 @@ def test_constraints_new_format() -> None:
     assert constraints == {"cost": 2.5, "limit": 10.0}
 
 
+@pytest.mark.filterwarnings("ignore::UserWarning")
 def test_constraints_mixed_format() -> None:
     trial = create_trial(
         value=1.0,
@@ -285,6 +286,20 @@ def test_constraints_mixed_format() -> None:
 
     constraints = trial.constraints
     assert constraints == {"0": 1.0, "1": 2.0, "cost": 3.0, "limit": 4.0}
+
+    trial = create_trial(
+        value=1.0,
+        params={"x": 5.0},
+        distributions={"x": FloatDistribution(-10, 10)},
+        system_attrs={
+            _CONSTRAINTS_KEY: [1.0, 2.0],  # Old format
+            "constraints:0": 3.0,  # New format
+        },
+    )
+
+    constraints = trial.constraints
+    # The new format constraint overrides the old format one.
+    assert constraints == {"0": 3.0, "1": 2.0}
 
 
 def test_constraints_empty() -> None:

--- a/tests/trial_tests/test_trials.py
+++ b/tests/trial_tests/test_trials.py
@@ -232,6 +232,13 @@ def test_set_constraint(trial_type: type) -> None:
     assert constraints["limit"] == 2.5
 
 
+@parametrize_trial_type
+def test_set_constraint_nan(trial_type: type) -> None:
+    trial = _create_trial(trial_type)
+    with pytest.raises(ValueError):
+        trial.set_constraint("constraint", float("nan"))
+
+
 @pytest.mark.filterwarnings("ignore::UserWarning")
 @parametrize_trial_type
 def test_set_constraint_override(trial_type: type) -> None:

--- a/tests/trial_tests/test_trials.py
+++ b/tests/trial_tests/test_trials.py
@@ -10,6 +10,7 @@ from optuna.distributions import BaseDistribution
 from optuna.distributions import CategoricalDistribution
 from optuna.distributions import FloatDistribution
 from optuna.distributions import IntDistribution
+from optuna.study._constrained_optimization import _CONSTRAINTS_KEY
 from optuna.study.study import create_study
 from optuna.trial import BaseTrial
 from optuna.trial import create_trial
@@ -218,3 +219,79 @@ def test_datetime_start(trial_type: type) -> None:
     old_date_time_start = trial.datetime_start
     time.sleep(0.001)  # Sleep 1ms to avoid faulty assertion on Windows OS.
     assert datetime.datetime.now() != old_date_time_start
+
+
+@parametrize_trial_type
+def test_set_constraint(trial_type: type) -> None:
+    trial = _create_trial(trial_type)
+    trial.set_constraint("cost", 1.5)
+    trial.set_constraint("limit", 2.5)
+
+    constraints = trial.constraints
+    assert constraints["cost"] == 1.5
+    assert constraints["limit"] == 2.5
+
+
+@parametrize_trial_type
+def test_set_constraint_override(trial_type: type) -> None:
+    trial = _create_trial(trial_type)
+    trial.set_constraint("value", 1.0)
+    trial.set_constraint("value", 2.0)  # Override
+
+    constraints = trial.constraints
+    assert constraints["value"] == 2.0
+
+
+def test_constraints_old_format() -> None:
+    trial = create_trial(
+        value=1.0,
+        params={"x": 5.0},
+        distributions={"x": FloatDistribution(-10, 10)},
+        system_attrs={_CONSTRAINTS_KEY: [1.5, -0.5, 2.0]},
+    )
+
+    constraints = trial.constraints
+    assert constraints == {"0": 1.5, "1": -0.5, "2": 2.0}
+
+
+def test_constraints_new_format() -> None:
+    trial = create_trial(
+        value=1.0,
+        params={"x": 5.0},
+        distributions={"x": FloatDistribution(-10, 10)},
+        system_attrs={
+            "constraints:cost": 2.5,
+            "constraints:limit": 10.0,
+        },
+    )
+
+    constraints = trial.constraints
+    assert constraints == {"cost": 2.5, "limit": 10.0}
+
+
+def test_constraints_mixed_format() -> None:
+    trial = create_trial(
+        value=1.0,
+        params={"x": 5.0},
+        distributions={"x": FloatDistribution(-10, 10)},
+        system_attrs={
+            _CONSTRAINTS_KEY: [1.0, 2.0],  # Old format
+            "constraints:cost": 3.0,  # New format
+            "constraints:limit": 4.0,  # New format
+        },
+    )
+
+    constraints = trial.constraints
+    assert constraints == {"0": 1.0, "1": 2.0, "cost": 3.0, "limit": 4.0}
+
+
+def test_constraints_empty() -> None:
+    trial = create_trial(
+        value=1.0,
+        params={"x": 5.0},
+        distributions={"x": FloatDistribution(-10, 10)},
+        system_attrs={},
+    )
+
+    constraints = trial.constraints
+    assert constraints == {}

--- a/tests/visualization_tests/test_hypervolume_history.py
+++ b/tests/visualization_tests/test_hypervolume_history.py
@@ -7,7 +7,6 @@ import pytest
 
 from optuna.samplers import NSGAIISampler
 from optuna.study import create_study
-from optuna.trial import FrozenTrial
 from optuna.trial import Trial
 from optuna.visualization._hypervolume_history import _get_hypervolume_history_info
 from optuna.visualization._hypervolume_history import _HypervolumeHistoryInfo
@@ -40,15 +39,15 @@ def test_get_optimization_history_info(directions: str) -> None:
             return 0.0, 0.0  # dominates all
 
         values = impl(trial)
+        # Set constraint: trial 2 is infeasible
+        if trial.number == 2:
+            trial.set_constraint("constraint", 1.0)
+        else:
+            trial.set_constraint("constraint", 0.0)
+
         return signs[0] * values[0], signs[1] * values[1]
 
-    def constraints(trial: FrozenTrial) -> Sequence[float]:
-        if trial.number == 2:
-            return (1,)  # infeasible
-
-        return (0,)  # feasible
-
-    sampler = NSGAIISampler(constraints_func=constraints)
+    sampler = NSGAIISampler()
     study = create_study(directions=directions, sampler=sampler)
     study.optimize(objective, n_trials=6)
 

--- a/tests/visualization_tests/test_intermediate_plot.py
+++ b/tests/visualization_tests/test_intermediate_plot.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from collections.abc import Sequence
 from io import BytesIO
 from typing import Any
 
@@ -9,7 +8,6 @@ import pytest
 
 from optuna.study import create_study
 from optuna.testing.objectives import fail_objective
-from optuna.trial import FrozenTrial
 from optuna.trial import Trial
 import optuna.visualization._intermediate_values
 from optuna.visualization._intermediate_values import _get_intermediate_plot_info
@@ -69,16 +67,13 @@ def test_intermediate_plot_info() -> None:
 
     # Test a study with constraints
     def objective_with_constraints(trial: Trial) -> float:
-        trial.set_user_attr("constraint", [trial.number % 2])
+        trial.set_constraint("constraint", trial.number % 2)
 
         trial.report(1.0, step=0)
         trial.report(2.0, step=1)
         return 0.0
 
-    def constraints(trial: FrozenTrial) -> Sequence[float]:
-        return trial.user_attrs["constraint"]
-
-    study = create_study(sampler=optuna.samplers.NSGAIIISampler(constraints_func=constraints))
+    study = create_study(sampler=optuna.samplers.NSGAIIISampler())
     study.optimize(objective_with_constraints, n_trials=2)
     assert _get_intermediate_plot_info(study) == _IntermediatePlotInfo(
         trial_infos=[

--- a/tests/visualization_tests/test_optimization_history.py
+++ b/tests/visualization_tests/test_optimization_history.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Sequence
 from io import BytesIO
 import math
 
@@ -12,7 +11,6 @@ from optuna import TrialPruned
 from optuna.study import create_study
 from optuna.testing.objectives import fail_objective
 from optuna.testing.objectives import pruned_objective
-from optuna.trial import FrozenTrial
 from optuna.trial import Trial
 from optuna.visualization._optimization_history import _get_optimization_history_info_list
 from optuna.visualization._optimization_history import _get_optimization_history_plot
@@ -196,20 +194,17 @@ def test_get_optimization_history_info_list_with_infeasible(direction: str) -> N
 
     def objective(trial: Trial) -> float:
         if trial.number == 0:
-            trial.set_user_attr("constraint", [0])
+            trial.set_constraint("constraint", 0.0)
             return 1.0
         elif trial.number == 1:
-            trial.set_user_attr("constraint", [0])
+            trial.set_constraint("constraint", 0.0)
             return 2.0
         elif trial.number == 2:
-            trial.set_user_attr("constraint", [1])
+            trial.set_constraint("constraint", 1.0)
             return 3.0
         return 0.0
 
-    def constraints_func(trial: FrozenTrial) -> Sequence[float]:
-        return trial.user_attrs["constraint"]
-
-    sampler = samplers.TPESampler(constraints_func=constraints_func)
+    sampler = samplers.TPESampler()
     study = create_study(sampler=sampler, direction=direction)
     study.optimize(objective, n_trials=3)
     info_list = _get_optimization_history_info_list(

--- a/tests/visualization_tests/test_pareto_front.py
+++ b/tests/visualization_tests/test_pareto_front.py
@@ -13,7 +13,9 @@ from optuna import create_study
 from optuna import create_trial
 from optuna.distributions import FloatDistribution
 from optuna.study.study import Study
+from optuna.trial import BaseTrial
 from optuna.trial import FrozenTrial
+from optuna.trial import Trial
 from optuna.visualization import plot_pareto_front
 import optuna.visualization._pareto_front
 from optuna.visualization._pareto_front import _get_pareto_front_info
@@ -46,16 +48,24 @@ def test_get_pareto_front_info_infer_n_targets() -> None:
 
 
 def create_study_2d(
-    constraints_func: Callable[[FrozenTrial], Sequence[float]] | None = None,
+    constraints_func: Callable[[Trial], Sequence[float]] | None = None,
 ) -> Study:
-    sampler = optuna.samplers.TPESampler(seed=0, constraints_func=constraints_func)
+    sampler = optuna.samplers.TPESampler(seed=0)
     study = optuna.create_study(directions=["minimize", "minimize"], sampler=sampler)
+
+    def objective(t: optuna.trial.Trial) -> tuple[int, int]:
+        x = t.suggest_int("x", 0, 2)
+        y = t.suggest_int("y", 0, 2)
+        if constraints_func is not None:
+            for i, c in enumerate(constraints_func(t)):
+                t.set_constraint(f"constraint_{i}", c)
+        return x, y
 
     study.enqueue_trial({"x": 1, "y": 2})
     study.enqueue_trial({"x": 1, "y": 1})
     study.enqueue_trial({"x": 0, "y": 2})
     study.enqueue_trial({"x": 1, "y": 0})
-    study.optimize(lambda t: [t.suggest_int("x", 0, 2), t.suggest_int("y", 0, 2)], n_trials=4)
+    study.optimize(objective, n_trials=4)
     return study
 
 
@@ -138,7 +148,7 @@ def test_get_pareto_front_info_constrained(
         )
 
     # (x, y) = (1, 0) is infeasible; others are feasible.
-    def constraints_func(t: FrozenTrial) -> Sequence[float]:
+    def constraints_func(t: BaseTrial) -> Sequence[float]:
         return [1.0] if t.params["x"] == 1 and t.params["y"] == 0 else [-1.0]
 
     if use_study_with_constraints:
@@ -193,7 +203,7 @@ def test_get_pareto_front_info_all_infeasible(
         )
 
     # all trials are infeasible.
-    def constraints_func(t: FrozenTrial) -> Sequence[float]:
+    def constraints_func(t: BaseTrial) -> Sequence[float]:
         return [1.0]
 
     if use_study_with_constraints:

--- a/tutorial/20_recipes/002_multi_objective.py
+++ b/tutorial/20_recipes/002_multi_objective.py
@@ -11,11 +11,11 @@ We use `fvcore <https://github.com/facebookresearch/fvcore>`__ to measure FLOPS.
 
 Note that when optimizing many objectives, a large fraction of trials may become non-dominated
 due to the curse of dimensionality in the objective space. If possible, consider modeling some
-objectives as constraints. Constraints can be passed via the `constraints_func` argument at the
-sampler initialization. Currently, `NSGAIISampler`, `NSGAIIISampler`, `TPESampler`, and `GPSampler`
-support constrained multi-objective optimization. Since Bayesian optimization is often sample
-efficient, use :class:`~optuna.samplers.TPESampler`, or :class:`~optuna.samplers.GPSampler` for
-``n_trials < 1000``.
+objectives as constraints. Constraints can be set within the objective function using
+:meth:`~optuna.trial.Trial.set_constraint` method. Currently, `NSGAIISampler`, `NSGAIIISampler`,
+`TPESampler`, and `GPSampler` support constrained multi-objective optimization.
+Since Bayesian optimization is often sample efficient, use :class:`~optuna.samplers.TPESampler`,
+or :class:`~optuna.samplers.GPSampler` for ``n_trials < 1000``.
 """
 
 import torch


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. To minimize the review effort, we highly appreciate PRs only with related changes. Please note that submitted PRs may be closed if they include unrelated changes or significantly modified unit tests. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

This represents one of a series of changes aimed at providing official support for constrained optimization, following #6736. This PR introduces the `set_constraint` method, elevating constrained optimization—previously implemented as a feature of samplers—to a core functionality within Optuna itself.

Note: Deprecating `constraints_func` will be done in the following PR.

## Description of the changes
<!-- Describe the changes in this PR. -->
- Add `set_constraint` method to `Trial`
- Replace tests and documentation to use `set_constraint` instead of `constraints_func`