### PR TITLE
Use UTC consistently for trial datetimes in storages

### DIFF
--- a/optuna/storages/_grpc/servicer.py
+++ b/optuna/storages/_grpc/servicer.py
@@ -29,7 +29,6 @@ else:
 
 
 _logger = logging.get_logger(__name__)
-DATETIME_FORMAT = "%Y-%m-%d %H:%M:%S.%f"
 
 
 class OptunaStorageProxyService(api_pb2_grpc.StorageServiceServicer):
@@ -381,10 +380,14 @@ def _to_proto_trial(trial: FrozenTrial) -> api_pb2.Trial:
         state=_to_proto_trial_state(trial.state),
         values=trial.values,
         datetime_start=(
-            trial.datetime_start.strftime(DATETIME_FORMAT) if trial.datetime_start else ""
+            trial._datetime_start_utc.isoformat(timespec="microseconds")
+            if trial._datetime_start_utc
+            else ""
         ),
         datetime_complete=(
-            trial.datetime_complete.strftime(DATETIME_FORMAT) if trial.datetime_complete else ""
+            trial._datetime_complete_utc.isoformat(timespec="microseconds")
+            if trial._datetime_complete_utc
+            else ""
         ),
         distributions={
             key: distribution_to_json(distribution)
@@ -398,13 +401,9 @@ def _to_proto_trial(trial: FrozenTrial) -> api_pb2.Trial:
 
 
 def _from_proto_trial(trial: api_pb2.Trial) -> FrozenTrial:
-    datetime_start = (
-        datetime.strptime(trial.datetime_start, DATETIME_FORMAT) if trial.datetime_start else None
-    )
+    datetime_start = datetime.fromisoformat(trial.datetime_start) if trial.datetime_start else None
     datetime_complete = (
-        datetime.strptime(trial.datetime_complete, DATETIME_FORMAT)
-        if trial.datetime_complete
-        else None
+        datetime.fromisoformat(trial.datetime_complete) if trial.datetime_complete else None
     )
     distributions = {
         key: json_to_distribution(value) for key, value in trial.distributions.items()

--- a/optuna/storages/_rdb/models.py
+++ b/optuna/storages/_rdb/models.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import datetime
 import enum
 import math
 from typing import Any
@@ -178,8 +179,48 @@ class TrialModel(BaseModel):
     number = _Column(Integer)
     study_id = _Column(Integer, ForeignKey("studies.study_id"), index=True)
     state = _Column(Enum(TrialState), nullable=False)
-    datetime_start = _Column(DateTime)
-    datetime_complete = _Column(DateTime)
+
+    # `datetime_start` and `datetime_complete` are stored in UTC without timezone information.
+    # When assigning timezone-aware datetime objects, they are converted to UTC and stored without
+    # timezone information. When assigning timezone-naive datetime objects, they are interpreted as
+    # local time, converted to UTC, and stored without timezone information.
+    # Thus, we need to convert stored datetime objects to UTC timezone-aware datetime objects when
+    # they are accessed.
+    #
+    # Before datetime values were normalized to UTC, they were stored in local time without
+    # timezone information. Since such datetime objects lack timezone information, we treat them
+    # as UTC timezone-aware datetime objects when they are accessed. Previously stored datetime
+    # values may therefore be shifted by the local UTC offset when they are read.
+    _datetime_start_utc = _Column("datetime_start", DateTime)
+    _datetime_complete_utc = _Column("datetime_complete", DateTime)
+
+    @property
+    def datetime_start(self) -> datetime.datetime | None:
+        if self._datetime_start_utc is None:
+            return None
+        return self._datetime_start_utc.replace(tzinfo=datetime.timezone.utc)
+
+    @datetime_start.setter
+    def datetime_start(self, value: datetime.datetime | None) -> None:
+        if value is None:
+            self._datetime_start_utc = None
+        else:
+            self._datetime_start_utc = value.astimezone(datetime.timezone.utc).replace(tzinfo=None)
+
+    @property
+    def datetime_complete(self) -> datetime.datetime | None:
+        if self._datetime_complete_utc is None:
+            return None
+        return self._datetime_complete_utc.replace(tzinfo=datetime.timezone.utc)
+
+    @datetime_complete.setter
+    def datetime_complete(self, value: datetime.datetime | None) -> None:
+        if value is None:
+            self._datetime_complete_utc = None
+        else:
+            self._datetime_complete_utc = value.astimezone(datetime.timezone.utc).replace(
+                tzinfo=None
+            )
 
     study = orm.relationship(
         StudyModel, backref=orm.backref("trials", cascade="all, delete-orphan")

--- a/optuna/storages/_rdb/storage.py
+++ b/optuna/storages/_rdb/storage.py
@@ -544,8 +544,8 @@ class RDBStorage(BaseStorage, BaseHeartbeat):
                 study_id=study_id,
                 number=None,
                 state=temp_state,
-                datetime_start=template_trial.datetime_start,
-                datetime_complete=template_trial.datetime_complete,
+                datetime_start=template_trial._datetime_start_utc,
+                datetime_complete=template_trial._datetime_complete_utc,
             )
 
         session.add(trial)

--- a/optuna/storages/journal/_storage.py
+++ b/optuna/storages/journal/_storage.py
@@ -4,7 +4,8 @@ from collections.abc import Container
 from collections.abc import Iterable
 from collections.abc import Sequence
 import copy
-import datetime
+from datetime import datetime
+from datetime import timezone
 import enum
 import pickle
 import threading
@@ -231,7 +232,7 @@ class JournalStorage(BaseStorage):
     def create_new_trial(self, study_id: int, template_trial: FrozenTrial | None = None) -> int:
         log: dict[str, Any] = {
             "study_id": study_id,
-            "datetime_start": datetime.datetime.now().isoformat(timespec="microseconds"),
+            "datetime_start": datetime.now(timezone.utc).isoformat(timespec="microseconds"),
         }
 
         if template_trial:
@@ -242,14 +243,14 @@ class JournalStorage(BaseStorage):
             else:
                 log["value"] = template_trial.value
                 log["values"] = None
-            if template_trial.datetime_start:
-                log["datetime_start"] = template_trial.datetime_start.isoformat(
+            if template_trial._datetime_start_utc:
+                log["datetime_start"] = template_trial._datetime_start_utc.isoformat(
                     timespec="microseconds"
                 )
             else:
                 log["datetime_start"] = None
-            if template_trial.datetime_complete:
-                log["datetime_complete"] = template_trial.datetime_complete.isoformat(
+            if template_trial._datetime_complete_utc:
+                log["datetime_complete"] = template_trial._datetime_complete_utc.isoformat(
                     timespec="microseconds"
                 )
 
@@ -313,9 +314,11 @@ class JournalStorage(BaseStorage):
         }
 
         if state == TrialState.RUNNING:
-            log["datetime_start"] = datetime.datetime.now().isoformat(timespec="microseconds")
+            log["datetime_start"] = datetime.now(timezone.utc).isoformat(timespec="microseconds")
         elif state.is_finished():
-            log["datetime_complete"] = datetime.datetime.now().isoformat(timespec="microseconds")
+            log["datetime_complete"] = datetime.now(timezone.utc).isoformat(
+                timespec="microseconds"
+            )
 
         with self._thread_lock:
             if state == TrialState.RUNNING:
@@ -538,12 +541,15 @@ class JournalStorageReplayResult:
         params = {}
         if "params" in log:
             params = {k: distributions[k].to_external_repr(p) for k, p in log["params"].items()}
+        # New logs contain UTC-aware datetimes. Datetimes in legacy logs are timezone-naive and
+        # are interpreted as local time in the environment where the log is replayed by the
+        # FrozenTrial setters.
         if log["datetime_start"] is not None:
-            datetime_start = datetime.datetime.fromisoformat(log["datetime_start"])
+            datetime_start = datetime.fromisoformat(log["datetime_start"])
         else:
             datetime_start = None
         if "datetime_complete" in log:
-            datetime_complete = datetime.datetime.fromisoformat(log["datetime_complete"])
+            datetime_complete = datetime.fromisoformat(log["datetime_complete"])
         else:
             datetime_complete = None
 
@@ -615,12 +621,15 @@ class JournalStorageReplayResult:
             return
 
         trial = copy.copy(self._trials[trial_id])
+        # New logs contain UTC-aware datetimes. Datetimes in legacy logs are timezone-naive and
+        # are interpreted as local time in the environment where the log is replayed by the
+        # FrozenTrial setters.
         if state == TrialState.RUNNING:
-            trial.datetime_start = datetime.datetime.fromisoformat(log["datetime_start"])
+            trial.datetime_start = datetime.fromisoformat(log["datetime_start"])
             if self._is_issued_by_this_worker(log):
                 self._worker_id_to_owned_trial_id[self.worker_id] = trial_id
         if state.is_finished():
-            trial.datetime_complete = datetime.datetime.fromisoformat(log["datetime_complete"])
+            trial.datetime_complete = datetime.fromisoformat(log["datetime_complete"])
         trial.state = state
         if log["values"] is not None:
             trial.values = log["values"]

--- a/optuna/trial/_frozen.py
+++ b/optuna/trial/_frozen.py
@@ -168,7 +168,10 @@ class FrozenTrial(BaseTrial):
             self._values = [value]
         elif values is not None:
             self._values = list(values)
-        self._datetime_start = datetime_start
+
+        # Datetime values are normalized to UTC internally and converted to local time by the
+        # public properties.
+        self.datetime_start = datetime_start
         self.datetime_complete = datetime_complete
         self._params = params
         self._user_attrs = user_attrs
@@ -199,13 +202,19 @@ class FrozenTrial(BaseTrial):
 
     def __repr__(self) -> str:
         cls = self.__class__.__name__
-        kwargs = (
-            ", ".join(
-                f"{field if not field.startswith('_') else field[1:]}={repr(getattr(self, field))}"
-                for field in self.__dict__
-            )
-            + ", value=None"
-        )
+        fields = []
+        for field in self.__dict__:
+            if field == "_datetime_start_utc":
+                name = "datetime_start"
+                value = self.datetime_start
+            elif field == "_datetime_complete_utc":
+                name = "datetime_complete"
+                value = self.datetime_complete
+            else:
+                name = field if not field.startswith("_") else field[1:]
+                value = getattr(self, field)
+            fields.append(f"{name}={value!r}")
+        kwargs = ", ".join(fields) + ", value=None"
         return f"{cls}({kwargs})"
 
     def suggest_float(
@@ -416,11 +425,31 @@ class FrozenTrial(BaseTrial):
 
     @property
     def datetime_start(self) -> datetime.datetime | None:
-        return self._datetime_start
+        return (
+            self._datetime_start_utc.astimezone().replace(tzinfo=None)
+            if self._datetime_start_utc is not None
+            else None
+        )
 
     @datetime_start.setter
     def datetime_start(self, value: datetime.datetime | None) -> None:
-        self._datetime_start = value
+        self._datetime_start_utc = (
+            value.astimezone(datetime.timezone.utc) if value is not None else None
+        )
+
+    @property
+    def datetime_complete(self) -> datetime.datetime | None:
+        return (
+            self._datetime_complete_utc.astimezone().replace(tzinfo=None)
+            if self._datetime_complete_utc is not None
+            else None
+        )
+
+    @datetime_complete.setter
+    def datetime_complete(self, value: datetime.datetime | None) -> None:
+        self._datetime_complete_utc = (
+            value.astimezone(datetime.timezone.utc) if value is not None else None
+        )
 
     @property
     def params(self) -> dict[str, Any]:

--- a/tests/storages_tests/test_storages.py
+++ b/tests/storages_tests/test_storages.py
@@ -1,7 +1,13 @@
 from __future__ import annotations
 
 from collections.abc import Generator
+from contextlib import contextmanager
+from datetime import datetime
+from datetime import timedelta
+from datetime import timezone
+from datetime import tzinfo
 import pickle
+from unittest.mock import patch
 
 import pytest
 from pytest import FixtureRequest
@@ -24,6 +30,48 @@ from optuna.testing.storages import StorageSupplier
 def storage(request: FixtureRequest) -> Generator[BaseStorage, None, None]:
     with StorageSupplier(request.param) as storage:
         yield storage
+
+
+@contextmanager
+def _mock_storage_datetime(value: datetime) -> Generator[None, None, None]:
+    class MockDatetime(datetime):
+        @classmethod
+        def now(cls, tz: tzinfo | None = None) -> MockDatetime:
+            return cls.fromtimestamp(value.timestamp(), tz)
+
+    with (
+        patch("optuna.storages._in_memory.datetime", MockDatetime),
+        patch("optuna.storages._rdb.storage.datetime", MockDatetime),
+        patch("optuna.storages.journal._storage.datetime", MockDatetime),
+    ):
+        yield
+
+
+def test_ask_and_tell_store_utc_and_return_local_time_without_timezone(
+    storage: BaseStorage,
+) -> None:
+    datetime_start = datetime(2020, 1, 2, 3, 4, 5, tzinfo=timezone(timedelta(hours=9)))
+    datetime_complete = datetime(2020, 1, 2, 1, 2, 3, tzinfo=timezone(timedelta(hours=-5)))
+    study = optuna.create_study(storage=storage)
+
+    with _mock_storage_datetime(datetime_start):
+        trial = study.ask()
+
+    stored_running_trial = storage.get_trial(trial._trial_id)
+    assert stored_running_trial._datetime_start_utc == datetime_start.astimezone(timezone.utc)
+    assert trial.datetime_start == datetime_start.astimezone().replace(tzinfo=None)
+    assert trial.datetime_start.tzinfo is None
+
+    with _mock_storage_datetime(datetime_complete):
+        study.tell(trial, 1.0)
+
+    frozen_trial = study.trials[0]
+    assert frozen_trial._datetime_start_utc == datetime_start.astimezone(timezone.utc)
+    assert frozen_trial._datetime_complete_utc == datetime_complete.astimezone(timezone.utc)
+    assert frozen_trial.datetime_start == datetime_start.astimezone().replace(tzinfo=None)
+    assert frozen_trial.datetime_complete == datetime_complete.astimezone().replace(tzinfo=None)
+    assert frozen_trial.datetime_start.tzinfo is None
+    assert frozen_trial.datetime_complete.tzinfo is None
 
 
 class TestStorage(StorageTestCase):

--- a/tests/trial_tests/test_frozen.py
+++ b/tests/trial_tests/test_frozen.py
@@ -40,6 +40,47 @@ def test_eq_ne() -> None:
     assert trial != trial_other
 
 
+def test_datetime_is_normalized_on_initialization() -> None:
+    datetime_start = datetime.datetime.fromisoformat("2020-01-02T03:04:05+09:00")
+    datetime_complete = datetime.datetime.fromisoformat("2020-01-02T01:02:03-05:00")
+    trial = FrozenTrial(
+        number=0,
+        state=TrialState.COMPLETE,
+        value=1.0,
+        datetime_start=datetime_start,
+        datetime_complete=datetime_complete,
+        params={},
+        distributions={},
+        user_attrs={},
+        system_attrs={},
+        intermediate_values={},
+        trial_id=0,
+    )
+
+    assert trial._datetime_start_utc == datetime_start.astimezone(datetime.timezone.utc)
+    assert trial._datetime_complete_utc == datetime_complete.astimezone(datetime.timezone.utc)
+    assert trial.datetime_start == datetime_start.astimezone().replace(tzinfo=None)
+    assert trial.datetime_complete == datetime_complete.astimezone().replace(tzinfo=None)
+    assert trial.datetime_start.tzinfo is None
+    assert trial.datetime_complete.tzinfo is None
+
+
+def test_datetime_is_normalized_on_assignment() -> None:
+    datetime_start = datetime.datetime.fromisoformat("2020-01-02T03:04:05+09:00")
+    datetime_complete = datetime.datetime.fromisoformat("2020-01-02T01:02:03-05:00")
+    trial = _create_trial()
+
+    trial.datetime_start = datetime_start
+    trial.datetime_complete = datetime_complete
+
+    assert trial._datetime_start_utc == datetime_start.astimezone(datetime.timezone.utc)
+    assert trial._datetime_complete_utc == datetime_complete.astimezone(datetime.timezone.utc)
+    assert trial.datetime_start == datetime_start.astimezone().replace(tzinfo=None)
+    assert trial.datetime_complete == datetime_complete.astimezone().replace(tzinfo=None)
+    assert trial.datetime_start.tzinfo is None
+    assert trial.datetime_complete.tzinfo is None
+
+
 def test_lt() -> None:
     trial = _create_trial()
 


### PR DESCRIPTION
fix #6708

## Motivation

Trial datetimes were handled as timezone-naive local times in storages. This could produce inconsistent timestamps when a storage is accessed from environments using different local timezones.

This PR standardizes the internal datetime representation across storages while preserving the existing user-facing behavior.

## Description of the changes

- Standardize storage-internal trial datetimes to UTC. RDB storage drops `tzinfo` explicitly to avoid a schema migration.
- Convert datetimes to timezone-naive local time when exposed to users for backward compatibility.
- Preserve UTC datetime information across JournalStorage and gRPC.
- Add tests covering the behavior across all storage implementations.