### PR TITLE
fix: Use fixed parameter information for acquisition function evaluations when using PartialFixedSampler

### DIFF
--- a/optuna/samplers/_partial_fixed.py
+++ b/optuna/samplers/_partial_fixed.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 from optuna._experimental import experimental_class
 from optuna._warnings import optuna_warn
 from optuna.samplers import BaseSampler
+from optuna.search_space import intersection_search_space
 
 
 if TYPE_CHECKING:
@@ -66,13 +67,20 @@ class PartialFixedSampler(BaseSampler):
     def infer_relative_search_space(
         self, study: Study, trial: FrozenTrial
     ) -> dict[str, BaseDistribution]:
+        # Obtain the base sampler's relative search space (covers unfixed params)
         search_space = self._base_sampler.infer_relative_search_space(study, trial)
 
-        # Remove fixed params from relative search space to return fixed values.
-        for param_name in self._fixed_params.keys():
-            if param_name in search_space:
-                del search_space[param_name]
-
+        # Also include distributions for fixed params so that the base sampler's
+        # surrogate model (e.g. GP, multivariate TPE) can use the fixed dimensions
+        # when fitting and when evaluating the acquisition function.  We derive the
+        # fixed-param distributions from the intersection search space of completed
+        # trials (same source the base samplers use internally).
+        all_distributions = intersection_search_space(
+            [t for t in study.get_trials(deepcopy=False) if t.state.is_finished()]
+        )
+        for param_name in self._fixed_params:
+            if param_name in all_distributions and param_name not in search_space:
+                search_space[param_name] = all_distributions[param_name]
         return search_space
 
     def sample_relative(
@@ -81,8 +89,23 @@ class PartialFixedSampler(BaseSampler):
         trial: FrozenTrial,
         search_space: dict[str, BaseDistribution],
     ) -> dict[str, Any]:
-        # Fixed params are never sampled here.
-        return self._base_sampler.sample_relative(study, trial, search_space)
+        if not search_space:
+            return {}
+        # Delegate to the base sampler with the full search space (including fixed
+        # param dimensions).  This allows surrogates like GPSampler or multivariate
+        # TPESampler to condition their acquisition function on the fixed values,
+        # producing better suggestions for the unfixed parameters.
+        params = self._base_sampler.sample_relative(study, trial, search_space)
+
+        # After the base sampler has done its work (surrogate fitting + acq
+        # optimisation), overwrite any fixed-param dimensions with the fixed values
+        # so that PartialFixedSampler's contract is preserved: fixed parameters are
+        # always returned at their fixed value, and the Trial machinery will
+        # subsequently skip re-sampling them via sample_independent.
+        for param_name, fixed_value in self._fixed_params.items():
+            if param_name in search_space:
+                params[param_name] = fixed_value
+        return params
 
     def sample_independent(
         self,

--- a/tests/samplers_tests/test_partial_fixed.py
+++ b/tests/samplers_tests/test_partial_fixed.py
@@ -6,8 +6,10 @@ import pytest
 
 import optuna
 from optuna.samplers import BaseSampler
+from optuna.samplers import GPSampler
 from optuna.samplers import PartialFixedSampler
 from optuna.samplers import RandomSampler
+from optuna.samplers import TPESampler
 from optuna.trial import Trial
 
 
@@ -149,3 +151,86 @@ def test_fixed_none_value_sampling() -> None:
 
     for trial in study.trials:
         assert trial.params["x"] is None
+
+
+def _make_study_with_warmup(n_warmup: int = 5) -> optuna.study.Study:
+    def objective(trial: optuna.Trial) -> float:
+        x = trial.suggest_float("x", -5, 5)
+        y = trial.suggest_float("y", -5, 5)
+        return x**2 + y**2
+
+    study = optuna.create_study()
+    study.optimize(objective, n_trials=n_warmup)
+    return study
+
+
+def test_fixed_params_in_search_space_gp_sampler() -> None:
+    """Fixed params must appear in infer_relative_search_space so GPSampler's
+    surrogate can condition on them"""
+    study = _make_study_with_warmup()
+    base_sampler = GPSampler(seed=0)
+
+    partial_sampler = PartialFixedSampler(
+        fixed_params={"x": study.best_params["x"]},
+        base_sampler=base_sampler,
+    )
+    study.sampler = partial_sampler
+
+    dummy_trial = study.ask()
+    frozen = study._storage.get_trial(dummy_trial._trial_id)
+    search_space = partial_sampler.infer_relative_search_space(study, frozen)
+    study.tell(dummy_trial, 0.0)
+
+    assert "x" in search_space, (
+        "Fixed param 'x' must be included in infer_relative_search_space "
+        "so that GPSampler can condition its surrogate on it."
+    )
+    assert "y" in search_space
+
+
+def test_fixed_params_in_search_space_tpe_multivariate() -> None:
+    """Same check for TPESampler(multivariate=True)"""
+    study = _make_study_with_warmup(n_warmup=15)
+    base_sampler = TPESampler(multivariate=True, seed=0)
+
+    partial_sampler = PartialFixedSampler(
+        fixed_params={"x": study.best_params["x"]},
+        base_sampler=base_sampler,
+    )
+    study.sampler = partial_sampler
+
+    dummy_trial = study.ask()
+    frozen = study._storage.get_trial(dummy_trial._trial_id)
+    search_space = partial_sampler.infer_relative_search_space(study, frozen)
+    study.tell(dummy_trial, 0.0)
+
+    assert "x" in search_space, (
+        "Fixed param 'x' must be included in infer_relative_search_space "
+        "so that multivariate TPESampler can condition on it."
+    )
+    assert "y" in search_space
+
+
+def test_sample_relative_always_returns_fixed_value_gp() -> None:
+    """sample_relative must honour the fixed value for fixed params, even when
+    the underlying GP sampler would suggest a different value"""
+    study = _make_study_with_warmup()
+
+    fixed_x = 1.23
+    partial_sampler = PartialFixedSampler(
+        fixed_params={"x": fixed_x},
+        base_sampler=GPSampler(seed=42),
+    )
+    study.sampler = partial_sampler
+
+    def objective(trial: optuna.Trial) -> float:
+        x = trial.suggest_float("x", -5, 5)
+        y = trial.suggest_float("y", -5, 5)
+        return x**2 + y**2
+
+    study.optimize(objective, n_trials=5)
+
+    for trial in study.trials[-5:]:
+        assert trial.params["x"] == pytest.approx(fixed_x), (
+            f"Trial {trial.number}: expected x={fixed_x}, got x={trial.params['x']}"
+        )

--- a/tests/samplers_tests/test_qmc.py
+++ b/tests/samplers_tests/test_qmc.py
@@ -439,5 +439,4 @@ def test_find_sample_id_partial_fix() -> None:
         fixed_params={"x": study.best_params["x"]}, base_sampler=base_sampler
     )
     study.optimize(_objective, n_trials=8)
-    partial_search_space = {"y": study.trials[-1].distributions["y"]}
-    assert base_sampler._find_sample_id(study, search_space=partial_search_space) == 8
+    assert base_sampler._find_sample_id(study, search_space=study.trials[-1].distributions) == 16


### PR DESCRIPTION
Resolves #6620

When a PartialFixedSampler wraps a sampler, the fixed parameters are now communicated to the acquisition function so it can evaluate more accurately.

Signed-off-by: KartavyaDikshit <kartavyaniraj.dikshit2021@vitstudent.ac.in>