### PR TITLE
fix(gp): fix qLogEI acquisition function ignoring the threshold

### DIFF
--- a/optuna/_gp/acqf.py
+++ b/optuna/_gp/acqf.py
@@ -208,11 +208,8 @@ class qLogEI(BaseAcquisitionFunc):
         # NOTE(nabenabe): See Eq. (10) of https://arxiv.org/pdf/2310.20708
         joint_x = self._get_joint_input(x)
         y_post = self._get_posterior_samples(joint_x)
-        log_improvement = (
-            y_post.sub(self._threshold)
-            .clamp_(min=torch.tensor(_EPS, dtype=torch.float64))
-            .log()
-        )
+        eps = torch.tensor(_EPS, dtype=torch.float64)
+        log_improvement = y_post.sub(self._threshold).clamp_(min=eps).log()
         # Take the max operation along the running candidates direction (the Q-axis).
         # TODO(sawa3030): Consider using fatmax instead of max.
         max_log_improvement_in_q_batch = torch.amax(log_improvement, dim=-1)

--- a/optuna/_gp/acqf.py
+++ b/optuna/_gp/acqf.py
@@ -208,7 +208,11 @@ class qLogEI(BaseAcquisitionFunc):
         # NOTE(nabenabe): See Eq. (10) of https://arxiv.org/pdf/2310.20708
         joint_x = self._get_joint_input(x)
         y_post = self._get_posterior_samples(joint_x)
-        log_improvement = y_post.sub(self._threshold).clamp_(min=torch.tensor(_EPS, dtype=torch.float64)).log()
+        log_improvement = (
+            y_post.sub(self._threshold)
+            .clamp_(min=torch.tensor(_EPS, dtype=torch.float64))
+            .log()
+        )
         # Take the max operation along the running candidates direction (the Q-axis).
         # TODO(sawa3030): Consider using fatmax instead of max.
         max_log_improvement_in_q_batch = torch.amax(log_improvement, dim=-1)

--- a/optuna/_gp/acqf.py
+++ b/optuna/_gp/acqf.py
@@ -208,7 +208,7 @@ class qLogEI(BaseAcquisitionFunc):
         # NOTE(nabenabe): See Eq. (10) of https://arxiv.org/pdf/2310.20708
         joint_x = self._get_joint_input(x)
         y_post = self._get_posterior_samples(joint_x)
-        log_improvement = y_post.clamp_(min=torch.tensor(_EPS, dtype=torch.float64)).log()
+        log_improvement = y_post.sub(self._threshold).clamp_(min=torch.tensor(_EPS, dtype=torch.float64)).log()
         # Take the max operation along the running candidates direction (the Q-axis).
         # TODO(sawa3030): Consider using fatmax instead of max.
         max_log_improvement_in_q_batch = torch.amax(log_improvement, dim=-1)


### PR DESCRIPTION
Fixes #6758. The qLogEI acquisition function was calculating Expected Improvement using raw posterior samples y_post instead of subtracting the threshold self._threshold first. This caused it to optimize raw function values instead of improvement.