### PR TITLE
Extend parallel coordinate plots to conditional, multi-objective, and constrained studies

### DIFF
--- a/optuna/visualization/_parallel_coordinate.py
+++ b/optuna/visualization/_parallel_coordinate.py
@@ -107,7 +107,14 @@ def plot_parallel_coordinate(
 
 
 def _get_parallel_coordinate_plot(info: _ParallelCoordinateInfo) -> "go.Figure":
-    layout = go.Layout(title="Parallel Coordinate Plot")
+    layout = go.Layout(
+        title={
+            "text": "Parallel Coordinate Plot",
+            "y": 1,
+            "yanchor": "bottom",
+            "yref": "paper",
+        }
+    )
 
     if len(info.dims_params) == 0 or len(info.dim_objective.values) == 0:
         return go.Figure(data=[], layout=layout)
@@ -204,7 +211,7 @@ def _get_parallel_coordinate_plot(info: _ParallelCoordinateInfo) -> "go.Figure":
             "orientation": "h",
             "x": 1,
             "xanchor": "right",
-            "y": 1.08,
+            "y": 1,
             "yanchor": "bottom",
         },
     )

--- a/optuna/visualization/_parallel_coordinate.py
+++ b/optuna/visualization/_parallel_coordinate.py
@@ -383,7 +383,7 @@ def _get_parallel_coordinate_info(
                 ticktext = [str(v) for v in sorted(vocab.keys(), key=lambda x: vocab[x])]
             offset = 1 if has_missing else 0
             categorical_values = tuple(
-                0 if v is _MISSING_VALUE else vocab[cast(int | str | None, v)] + offset
+                0 if v is _MISSING_VALUE else vocab[cast("int | str | None", v)] + offset
                 for v in values
             )
             if has_missing:

--- a/optuna/visualization/_parallel_coordinate.py
+++ b/optuna/visualization/_parallel_coordinate.py
@@ -10,6 +10,8 @@ import numpy as np
 
 from optuna.distributions import CategoricalDistribution
 from optuna.logging import get_logger
+from optuna.study._multi_objective import _fast_non_domination_rank
+from optuna.study._study_direction import StudyDirection
 from optuna.trial import TrialState
 
 
@@ -23,7 +25,6 @@ if TYPE_CHECKING:
 from optuna.visualization._plotly_imports import _imports
 from optuna.visualization._utils import _check_plot_args
 from optuna.visualization._utils import _filter_nonfinite
-from optuna.visualization._utils import _get_skipped_trial_numbers
 from optuna.visualization._utils import _is_log_scale
 from optuna.visualization._utils import _is_numerical
 from optuna.visualization._utils import _is_reverse_scale
@@ -31,6 +32,7 @@ from optuna.visualization._utils import _is_reverse_scale
 
 if _imports.is_successful():
     from optuna.visualization._plotly_imports import go
+    from optuna.visualization._plotly_imports import plotly
     from optuna.visualization._utils import COLOR_SCALE
 
 _logger = get_logger(__name__)
@@ -44,13 +46,22 @@ class _DimensionInfo(NamedTuple):
     is_cat: bool
     tickvals: list[int | float]
     ticktext: list[str]
+    has_missing: bool = False
 
 
 class _ParallelCoordinateInfo(NamedTuple):
     dim_objective: _DimensionInfo
     dims_params: list[_DimensionInfo]
     reverse_scale: bool
-    target_name: str
+    colorbar_title: str
+    color_values: tuple[float, ...] | None = None
+    is_rank_color: bool = False
+    draw_order: tuple[int, ...] | None = None
+    feasibility: tuple[bool, ...] | None = None
+
+
+_MISSING_LABEL = "None"
+_MISSING_VALUE = object()
 
 
 def plot_parallel_coordinate(
@@ -62,7 +73,10 @@ def plot_parallel_coordinate(
 ) -> "go.Figure":
     """Plot the high-dimensional parameter relationships in a study.
 
-    Note that, if a parameter contains missing values, a trial with missing values is not plotted.
+    If a trial does not contain a parameter, the line is connected to a special ``None`` tick.
+    If at least one completed trial contains constraint values, feasible trials are drawn with
+    solid lines and infeasible trials with dotted lines. In this case, trials without constraint
+    values are treated as infeasible.
 
     Args:
         study:
@@ -71,10 +85,10 @@ def plot_parallel_coordinate(
             Parameter list to visualize. The default is all parameters.
         target:
             A function to specify the value to display. If it is :obj:`None` and ``study`` is being
-            used for single-objective optimization, the objective values are plotted.
-
-            .. note::
-                Specify this argument if ``study`` is being used for multi-objective optimization.
+            used for single-objective optimization, the objective values are plotted. For a
+            multi-objective study, all objective values are plotted and the lines are colored by
+            Pareto rank. Pareto ranks are computed from the objective values without considering
+            constraints.
         target_name:
             Target's name to display on the axis label and the legend.
 
@@ -83,7 +97,8 @@ def plot_parallel_coordinate(
 
     .. note::
         The colormap is reversed when the ``target`` argument isn't :obj:`None` or ``direction``
-        of :class:`~optuna.study.Study` is ``minimize``.
+        of :class:`~optuna.study.Study` is ``minimize``. The Pareto-rank colormap is always
+        reversed for multi-objective studies.
     """
 
     _imports.check()
@@ -97,28 +112,129 @@ def _get_parallel_coordinate_plot(info: _ParallelCoordinateInfo) -> "go.Figure":
     if len(info.dims_params) == 0 or len(info.dim_objective.values) == 0:
         return go.Figure(data=[], layout=layout)
 
-    dims = _get_dims_from_info(info)
-    reverse_scale = info.reverse_scale
-    target_name = info.target_name
+    dimensions = [info.dim_objective] + info.dims_params
+    draw_order = (
+        info.draw_order
+        if info.draw_order is not None
+        else tuple(range(len(info.dim_objective.values)))
+    )
+    color_values = (
+        info.color_values if info.color_values is not None else info.dim_objective.values
+    )
+    color_min, color_max = _get_color_range(color_values, info.is_rank_color)
 
-    traces = [
-        go.Parcoords(
-            dimensions=dims,
-            labelangle=30,
-            labelside="bottom",
-            line={
-                "color": dims[0]["values"],
-                "colorscale": COLOR_SCALE,
-                "colorbar": {"title": target_name},
-                "showscale": True,
-                "reversescale": reverse_scale,
-            },
+    normalized_dimensions = [_normalize_dimension(dim) for dim in dimensions]
+    colors = _get_line_colors(color_values, color_min, color_max, info.reverse_scale)
+    x_values = list(range(len(dimensions)))
+    traces: list[go.Scatter] = []
+    for trial_id in draw_order:
+        is_feasible = info.feasibility is None or info.feasibility[trial_id]
+        traces.append(
+            go.Scatter(
+                x=x_values,
+                y=[values[trial_id] for values in normalized_dimensions],
+                customdata=[
+                    [dim.label, _format_dimension_value(dim, dim.values[trial_id])]
+                    for dim in dimensions
+                ],
+                mode="lines",
+                line={
+                    "color": colors[trial_id],
+                    "dash": "solid" if is_feasible else "dot",
+                    "width": 1.2,
+                },
+                opacity=0.5,
+                showlegend=False,
+                hovertemplate="%{customdata[0]}: %{customdata[1]}<extra></extra>",
+            )
         )
+
+    colorbar: dict[str, Any] = {"title": info.colorbar_title}
+    if info.is_rank_color:
+        colorbar["tickvals"] = list(range(int(max(color_values)) + 1))
+    if info.feasibility is not None:
+        traces.extend(_get_feasibility_legend_traces())
+    traces.append(
+        go.Scatter(
+            x=[None, None],
+            y=[None, None],
+            mode="markers",
+            marker={
+                "color": [color_min, color_max],
+                "cmin": color_min,
+                "cmax": color_max,
+                "colorscale": COLOR_SCALE,
+                "reversescale": info.reverse_scale,
+                "showscale": True,
+                "colorbar": colorbar,
+            },
+            showlegend=False,
+            hoverinfo="skip",
+        )
+    )
+
+    annotations = _get_axis_annotations(dimensions)
+    shapes = [
+        {
+            "type": "line",
+            "x0": axis_id,
+            "x1": axis_id,
+            "y0": 0,
+            "y1": 1,
+            "line": {"color": "#888", "width": 1},
+            "layer": "below",
+        }
+        for axis_id in x_values
     ]
+    layout.update(
+        xaxis={
+            "tickmode": "array",
+            "tickvals": x_values,
+            "ticktext": [dim.label for dim in dimensions],
+            "range": (-0.2, len(dimensions) - 0.8),
+            "showgrid": False,
+            "zeroline": False,
+        },
+        yaxis={"range": (-0.08, 1.08), "visible": False, "fixedrange": True},
+        annotations=annotations,
+        shapes=shapes,
+        hovermode="closest",
+        plot_bgcolor="white",
+        legend={
+            "orientation": "h",
+            "x": 1,
+            "xanchor": "right",
+            "y": 1.08,
+            "yanchor": "bottom",
+        },
+    )
 
     figure = go.Figure(data=traces, layout=layout)
 
     return figure
+
+
+def _get_feasibility_legend_traces() -> list["go.Scatter"]:
+    return [
+        go.Scatter(
+            x=[None],
+            y=[None],
+            mode="lines",
+            line={"color": "#2F3B52", "dash": "solid", "width": 2},
+            name="Feasible",
+            showlegend=True,
+            hoverinfo="skip",
+        ),
+        go.Scatter(
+            x=[None],
+            y=[None],
+            mode="lines",
+            line={"color": "#2F3B52", "dash": "dot", "width": 2},
+            name="Infeasible",
+            showlegend=True,
+            hoverinfo="skip",
+        ),
+    ]
 
 
 def _get_parallel_coordinate_info(
@@ -127,13 +243,22 @@ def _get_parallel_coordinate_info(
     target: Callable[[FrozenTrial], float] | None = None,
     target_name: str = "Objective Value",
 ) -> _ParallelCoordinateInfo:
-    _check_plot_args(study, target, target_name)
+    has_custom_target = target is not None
+    is_multi_objective = target is None and study._is_multi_objective()
+    if not is_multi_objective:
+        _check_plot_args(study, target, target_name)
 
-    reverse_scale = _is_reverse_scale(study, target)
-
-    trials = _filter_nonfinite(
-        study.get_trials(deepcopy=False, states=(TrialState.COMPLETE,)), target=target
-    )
+    trials = list(study.get_trials(deepcopy=False, states=(TrialState.COMPLETE,)))
+    if is_multi_objective:
+        trials = [
+            trial
+            for trial in trials
+            if trial.values is not None
+            and len(trial.values) == len(study.directions)
+            and all(math.isfinite(value) for value in trial.values)
+        ]
+    else:
+        trials = _filter_nonfinite(trials, target=target)
 
     all_params = {p_name for t in trials for p_name in t.params.keys()}
     if params is not None:
@@ -143,26 +268,53 @@ def _get_parallel_coordinate_info(
         all_params = set(params)
     sorted_params = sorted(all_params)
 
-    if target is None:
+    if is_multi_objective:
+        metric_names = study.metric_names
+        objective_labels = metric_names or [
+            f"Objective {objective_id}" for objective_id in range(len(study.directions))
+        ]
+        objective_dims = [
+            _build_numerical_dimension(
+                label,
+                [float(cast(tuple[float, ...], trial.values)[objective_id]) for trial in trials],
+            )
+            for objective_id, label in enumerate(objective_labels)
+        ]
+        loss_values = np.asarray(
+            [
+                [
+                    -value if direction == StudyDirection.MAXIMIZE else value
+                    for value, direction in zip(
+                        cast(tuple[float, ...], trial.values), study.directions
+                    )
+                ]
+                for trial in trials
+            ],
+            dtype=np.float64,
+        )
+        ranks = _fast_non_domination_rank(loss_values)
+        color_values: tuple[float, ...] | None = tuple(float(rank) for rank in ranks)
+        draw_order: tuple[int, ...] | None = tuple(np.argsort(ranks)[::-1].tolist())
+        colorbar_title = "Pareto Rank"
+        reverse_scale = True
+    else:
+        if target is None:
 
-        def _target(t: FrozenTrial) -> float:
-            return cast(float, t.value)
+            def _target(t: FrozenTrial) -> float:
+                return cast(float, t.value)
 
-        target = _target
+            target = _target
 
-    skipped_trial_numbers = _get_skipped_trial_numbers(trials, sorted_params)
+        objectives = [target(t) for t in trials]
+        objective_dims = [_build_numerical_dimension(target_name, objectives)]
+        color_values = None
+        draw_order = None
+        colorbar_title = target_name
+        reverse_scale = _is_reverse_scale(study, target if has_custom_target else None)
 
-    objectives = tuple([target(t) for t in trials if t.number not in skipped_trial_numbers])
     # The value of (0, 0) is a dummy range. It is ignored when we plot.
-    objective_range = (min(objectives), max(objectives)) if len(objectives) > 0 else (0, 0)
-    dim_objective = _DimensionInfo(
-        label=target_name,
-        values=objectives,
-        range=objective_range,
-        is_log=False,
-        is_cat=False,
-        tickvals=[],
-        ticktext=[],
+    dim_objective = (
+        objective_dims[0] if objective_dims else _build_numerical_dimension(target_name, [])
     )
 
     if len(trials) == 0:
@@ -171,33 +323,27 @@ def _get_parallel_coordinate_info(
             dim_objective=dim_objective,
             dims_params=[],
             reverse_scale=reverse_scale,
-            target_name=target_name,
+            colorbar_title=colorbar_title,
+            color_values=color_values,
+            is_rank_color=is_multi_objective,
+            draw_order=draw_order,
         )
 
-    if len(objectives) == 0:
-        _logger.warning("Your study has only completed trials with missing parameters.")
-        return _ParallelCoordinateInfo(
-            dim_objective=dim_objective,
-            dims_params=[],
-            reverse_scale=reverse_scale,
-            target_name=target_name,
-        )
+    feasibility = _get_feasibility(trials)
 
     numeric_cat_params_indices: list[int] = []
     dims = []
-    for dim_index, p_name in enumerate(sorted_params, start=1):
-        values = []
+    for dim_index, p_name in enumerate(sorted_params, start=len(objective_dims)):
+        values = [t.params.get(p_name, _MISSING_VALUE) for t in trials]
         is_categorical = False
         for t in trials:
-            if t.number in skipped_trial_numbers:
-                continue
             if p_name in t.params:
-                values.append(t.params[p_name])
                 is_categorical |= isinstance(t.distributions[p_name], CategoricalDistribution)
+        has_missing = any(value is _MISSING_VALUE for value in values)
         if _is_log_scale(trials, p_name):
-            values = [math.log10(v) for v in values]
-            min_value = min(values)
-            max_value = max(values)
+            valid_values = [math.log10(cast(float, v)) for v in values if v is not _MISSING_VALUE]
+            min_value = min(valid_values)
+            max_value = max(valid_values)
             tickvals: list[int | float] = list(
                 range(math.ceil(min_value), math.floor(max_value) + 1)
             )
@@ -205,51 +351,89 @@ def _get_parallel_coordinate_info(
                 tickvals = [min_value] + tickvals
             if max_value not in tickvals:
                 tickvals = tickvals + [max_value]
+            missing_value = _get_missing_value(min_value, max_value) if has_missing else None
+            transformed_values = tuple(
+                cast(float, missing_value) if v is _MISSING_VALUE else math.log10(cast(float, v))
+                for v in values
+            )
+            if missing_value is not None:
+                tickvals.insert(0, missing_value)
             dim = _DimensionInfo(
                 label=_truncate_label(p_name),
-                values=tuple(values),
-                range=(min_value, max_value),
+                values=transformed_values,
+                range=(missing_value if missing_value is not None else min_value, max_value),
                 is_log=True,
                 is_cat=False,
                 tickvals=tickvals,
-                ticktext=[f"{math.pow(10, x):.3g}" for x in tickvals],
+                ticktext=([_MISSING_LABEL] if has_missing else [])
+                + [f"{math.pow(10, x):.3g}" for x in tickvals[bool(has_missing) :]],
+                has_missing=has_missing,
             )
         elif is_categorical:
-            vocab: defaultdict[int | str, int] = defaultdict(lambda: len(vocab))
+            valid_values = [v for v in values if v is not _MISSING_VALUE]
+            vocab: defaultdict[Any, int] = defaultdict(lambda: len(vocab))
 
             ticktext: list[str]
             if _is_numerical(trials, p_name):
-                _ = [vocab[v] for v in sorted(values)]
-                values = [vocab[v] for v in values]
-                ticktext = [str(v) for v in list(sorted(vocab.keys()))]
+                _ = [vocab[v] for v in sorted(valid_values)]
+                ticktext = [str(v) for v in sorted(vocab.keys())]
                 numeric_cat_params_indices.append(dim_index)
             else:
-                values = [vocab[v] for v in values]
-                ticktext = [str(v) for v in list(sorted(vocab.keys(), key=lambda x: vocab[x]))]
+                _ = [vocab[v] for v in valid_values]
+                ticktext = [str(v) for v in sorted(vocab.keys(), key=lambda x: vocab[x])]
+            offset = 1 if has_missing else 0
+            categorical_values = tuple(
+                0 if v is _MISSING_VALUE else vocab[cast(int | str | None, v)] + offset
+                for v in values
+            )
+            if has_missing:
+                ticktext = [
+                    f"{text} (value)" if text == _MISSING_LABEL else text for text in ticktext
+                ]
             dim = _DimensionInfo(
                 label=_truncate_label(p_name),
-                values=tuple(values),
-                range=(min(values), max(values)),
+                values=categorical_values,
+                range=(min(categorical_values), max(categorical_values)),
                 is_log=False,
                 is_cat=True,
-                tickvals=list(range(len(vocab))),
-                ticktext=ticktext,
+                tickvals=list(range(len(vocab) + offset)),
+                ticktext=([_MISSING_LABEL] if has_missing else []) + ticktext,
+                has_missing=has_missing,
             )
         else:
+            valid_values = [cast(float, v) for v in values if v is not _MISSING_VALUE]
+            min_value = min(valid_values)
+            max_value = max(valid_values)
+            missing_value = _get_missing_value(min_value, max_value) if has_missing else None
+            numerical_values = tuple(
+                cast(float, missing_value) if v is _MISSING_VALUE else cast(float, v)
+                for v in values
+            )
+            valid_ticks = (
+                [min_value]
+                if min_value == max_value
+                else [float(value) for value in np.linspace(min_value, max_value, num=5)]
+            )
             dim = _DimensionInfo(
                 label=_truncate_label(p_name),
-                values=tuple(values),
-                range=(min(values), max(values)),
+                values=numerical_values,
+                range=(missing_value if missing_value is not None else min_value, max_value),
                 is_log=False,
                 is_cat=False,
-                tickvals=[],
-                ticktext=[],
+                tickvals=([missing_value] + valid_ticks if missing_value is not None else []),
+                ticktext=(
+                    [_MISSING_LABEL] + [f"{value:.3g}" for value in valid_ticks]
+                    if has_missing
+                    else []
+                ),
+                has_missing=has_missing,
             )
 
         dims.append(dim)
 
+    plot_dims = dims
     if numeric_cat_params_indices:
-        dims.insert(0, dim_objective)
+        dims = objective_dims + plot_dims
         # np.lexsort consumes the sort keys the order from back to front.
         # So the values of parameters have to be reversed the order.
         idx = np.lexsort([dims[index].values for index in numeric_cat_params_indices][::-1])
@@ -266,43 +450,137 @@ def _get_parallel_coordinate_info(
                     is_cat=dim.is_cat,
                     tickvals=dim.tickvals,
                     ticktext=dim.ticktext,
+                    has_missing=dim.has_missing,
                 )
             )
-        dim_objective = updated_dims[0]
-        dims = updated_dims[1:]
+        objective_dims = updated_dims[: len(objective_dims)]
+        dim_objective = objective_dims[0]
+        plot_dims = updated_dims[len(objective_dims) :]
+        if color_values is not None:
+            color_values = tuple(np.asarray(color_values)[idx])
+        if feasibility is not None:
+            feasibility = tuple(bool(value) for value in np.asarray(feasibility)[idx])
+        if draw_order is not None:
+            assert color_values is not None
+            draw_order = tuple(
+                sorted(range(len(trials)), key=color_values.__getitem__, reverse=True)
+            )
 
     return _ParallelCoordinateInfo(
         dim_objective=dim_objective,
-        dims_params=dims,
+        dims_params=objective_dims[1:] + plot_dims,
         reverse_scale=reverse_scale,
-        target_name=target_name,
+        colorbar_title=colorbar_title,
+        color_values=color_values,
+        is_rank_color=is_multi_objective,
+        draw_order=draw_order,
+        feasibility=feasibility,
     )
 
 
-def _get_dims_from_info(info: _ParallelCoordinateInfo) -> list[dict[str, Any]]:
-    dims = [
-        {
-            "label": info.dim_objective.label,
-            "values": info.dim_objective.values,
-            "range": info.dim_objective.range,
-        }
-    ]
+def _build_numerical_dimension(label: str, values: list[float]) -> _DimensionInfo:
+    value_range = (min(values), max(values)) if values else (0, 0)
+    return _DimensionInfo(label, tuple(values), value_range, False, False, [], [])
 
-    for dim in info.dims_params:
-        if dim.is_log or dim.is_cat:
-            dims.append(
+
+def _get_feasibility(trials: list[FrozenTrial]) -> tuple[bool, ...] | None:
+    if not any(len(trial.constraints) > 0 for trial in trials):
+        return None
+
+    return tuple(
+        len(trial.constraints) > 0 and all(value <= 0.0 for value in trial.constraints.values())
+        for trial in trials
+    )
+
+
+def _get_missing_value(min_value: float, max_value: float) -> float:
+    if min_value == max_value:
+        return min_value - 1.0
+    return min_value - (max_value - min_value) * 0.12 / 0.88
+
+
+def _normalize_dimension(dim: _DimensionInfo) -> tuple[float, ...]:
+    min_value, max_value = dim.range
+    if min_value == max_value:
+        return tuple(0.5 for _ in dim.values)
+    return tuple((value - min_value) / (max_value - min_value) for value in dim.values)
+
+
+def _get_line_colors(
+    values: tuple[float, ...], min_value: float, max_value: float, reverse_scale: bool
+) -> list[str]:
+    if min_value == max_value:
+        normalized = [0.5] * len(values)
+    else:
+        normalized = [(value - min_value) / (max_value - min_value) for value in values]
+    if reverse_scale:
+        normalized = [1.0 - value for value in normalized]
+    return [_sample_colorscale(COLOR_SCALE, value) for value in normalized]
+
+
+def _sample_colorscale(colorscale: list[str], value: float) -> str:
+    scaled_value = value * (len(colorscale) - 1)
+    lower_index = min(int(scaled_value), len(colorscale) - 2)
+    return cast(
+        str,
+        plotly.colors.find_intermediate_color(
+            colorscale[lower_index],
+            colorscale[lower_index + 1],
+            scaled_value - lower_index,
+            colortype="rgb",
+        ),
+    )
+
+
+def _get_color_range(values: tuple[float, ...], is_rank_color: bool) -> tuple[float, float]:
+    if is_rank_color:
+        return -0.5, max(values) + 0.5
+
+    min_value = min(values)
+    max_value = max(values)
+    if min_value == max_value:
+        return min_value - 0.5, max_value + 0.5
+    return min_value, max_value
+
+
+def _format_dimension_value(dim: _DimensionInfo, value: float) -> str:
+    for tick_value, tick_text in zip(dim.tickvals, dim.ticktext):
+        if math.isclose(value, tick_value):
+            return tick_text
+    if dim.is_log:
+        return f"{math.pow(10, value):.3g}"
+    return f"{value:.3g}"
+
+
+def _get_axis_annotations(dimensions: list[_DimensionInfo]) -> list[dict[str, Any]]:
+    annotations: list[dict[str, Any]] = []
+    for axis_id, dim in enumerate(dimensions):
+        if dim.tickvals:
+            tick_values = dim.tickvals
+            tick_text = dim.ticktext or [f"{value:.3g}" for value in tick_values]
+        elif dim.range[0] == dim.range[1]:
+            tick_values = [dim.range[0]]
+            tick_text = [f"{dim.range[0]:.3g}"]
+        else:
+            tick_values = [float(value) for value in np.linspace(*dim.range, num=5)]
+            tick_text = [f"{value:.3g}" for value in tick_values]
+
+        normalized_ticks = _normalize_dimension(
+            dim._replace(values=tuple(float(value) for value in tick_values))
+        )
+        for value, text in zip(normalized_ticks, tick_text):
+            annotations.append(
                 {
-                    "label": dim.label,
-                    "values": dim.values,
-                    "range": dim.range,
-                    "tickvals": dim.tickvals,
-                    "ticktext": dim.ticktext,
+                    "x": axis_id,
+                    "y": value,
+                    "text": text,
+                    "showarrow": False,
+                    "xanchor": "right",
+                    "xshift": -4,
+                    "font": {"size": 10, "color": "#555"},
                 }
             )
-        else:
-            dims.append({"label": dim.label, "values": dim.values, "range": dim.range})
-
-    return dims
+    return annotations
 
 
 def _truncate_label(label: str) -> str:

--- a/optuna/visualization/_parallel_coordinate.py
+++ b/optuna/visualization/_parallel_coordinate.py
@@ -50,13 +50,13 @@ class _DimensionInfo(NamedTuple):
 
 
 class _ParallelCoordinateInfo(NamedTuple):
-    dim_objective: _DimensionInfo
+    dims_objectives: list[_DimensionInfo]
     dims_params: list[_DimensionInfo]
     reverse_scale: bool
     colorbar_title: str
-    color_values: tuple[float, ...] | None = None
+    color_values: tuple[float, ...] = ()
     is_rank_color: bool = False
-    draw_order: tuple[int, ...] | None = None
+    draw_order: tuple[int, ...] = ()
     feasibility: tuple[bool, ...] | None = None
 
 
@@ -116,25 +116,18 @@ def _get_parallel_coordinate_plot(info: _ParallelCoordinateInfo) -> "go.Figure":
         }
     )
 
-    if len(info.dims_params) == 0 or len(info.dim_objective.values) == 0:
+    # _get_parallel_coordinate_info always provides at least one objective dimension.
+    if len(info.dims_params) == 0 or len(info.dims_objectives[0].values) == 0:
         return go.Figure(data=[], layout=layout)
 
-    dimensions = [info.dim_objective] + info.dims_params
-    draw_order = (
-        info.draw_order
-        if info.draw_order is not None
-        else tuple(range(len(info.dim_objective.values)))
-    )
-    color_values = (
-        info.color_values if info.color_values is not None else info.dim_objective.values
-    )
-    color_min, color_max = _get_color_range(color_values, info.is_rank_color)
+    dimensions = info.dims_objectives + info.dims_params
+    color_min, color_max = _get_color_range(info.color_values, info.is_rank_color)
 
     normalized_dimensions = [_normalize_dimension(dim) for dim in dimensions]
-    colors = _get_line_colors(color_values, color_min, color_max, info.reverse_scale)
+    colors = _get_line_colors(info.color_values, color_min, color_max, info.reverse_scale)
     x_values = list(range(len(dimensions)))
     traces: list[go.Scatter] = []
-    for trial_id in draw_order:
+    for trial_id in info.draw_order:
         is_feasible = info.feasibility is None or info.feasibility[trial_id]
         traces.append(
             go.Scatter(
@@ -158,7 +151,7 @@ def _get_parallel_coordinate_plot(info: _ParallelCoordinateInfo) -> "go.Figure":
 
     colorbar: dict[str, Any] = {"title": info.colorbar_title}
     if info.is_rank_color:
-        colorbar["tickvals"] = list(range(int(max(color_values)) + 1))
+        colorbar["tickvals"] = list(range(int(max(info.color_values)) + 1))
     if info.feasibility is not None:
         traces.extend(_get_feasibility_legend_traces())
     traces.append(
@@ -180,7 +173,6 @@ def _get_parallel_coordinate_plot(info: _ParallelCoordinateInfo) -> "go.Figure":
         )
     )
 
-    annotations = _get_axis_annotations(dimensions)
     shapes = [
         {
             "type": "line",
@@ -203,7 +195,7 @@ def _get_parallel_coordinate_plot(info: _ParallelCoordinateInfo) -> "go.Figure":
             "zeroline": False,
         },
         yaxis={"range": (-0.08, 1.08), "visible": False, "fixedrange": True},
-        annotations=annotations,
+        annotations=_get_axis_annotations(dimensions),
         shapes=shapes,
         hovermode="closest",
         plot_bgcolor="white",
@@ -300,8 +292,8 @@ def _get_parallel_coordinate_info(
             dtype=np.float64,
         )
         ranks = _fast_non_domination_rank(loss_values)
-        color_values: tuple[float, ...] | None = tuple(float(rank) for rank in ranks)
-        draw_order: tuple[int, ...] | None = tuple(np.argsort(ranks)[::-1].tolist())
+        color_values = tuple(float(rank) for rank in ranks)
+        draw_order = tuple(np.argsort(ranks)[::-1].tolist())
         colorbar_title = "Pareto Rank"
         reverse_scale = True
     else:
@@ -314,20 +306,20 @@ def _get_parallel_coordinate_info(
 
         objectives = [target(t) for t in trials]
         objective_dims = [_build_numerical_dimension(target_name, objectives)]
-        color_values = None
-        draw_order = None
+        color_values = tuple(objectives)
+        draw_order = tuple(range(len(trials)))
         colorbar_title = target_name
         reverse_scale = _is_reverse_scale(study, target if has_custom_target else None)
 
     # The value of (0, 0) is a dummy range. It is ignored when we plot.
-    dim_objective = (
-        objective_dims[0] if objective_dims else _build_numerical_dimension(target_name, [])
+    dims_objectives = (
+        objective_dims if objective_dims else [_build_numerical_dimension(target_name, [])]
     )
 
     if len(trials) == 0:
         _logger.warning("Your study does not have any completed trials.")
         return _ParallelCoordinateInfo(
-            dim_objective=dim_objective,
+            dims_objectives=dims_objectives,
             dims_params=[],
             reverse_scale=reverse_scale,
             colorbar_title=colorbar_title,
@@ -340,7 +332,7 @@ def _get_parallel_coordinate_info(
 
     numeric_cat_params_indices: list[int] = []
     dims = []
-    for dim_index, p_name in enumerate(sorted_params, start=len(objective_dims)):
+    for dim_index, p_name in enumerate(sorted_params, start=len(dims_objectives)):
         values = [t.params.get(p_name, _MISSING_VALUE) for t in trials]
         is_categorical = False
         for t in trials:
@@ -440,7 +432,7 @@ def _get_parallel_coordinate_info(
 
     plot_dims = dims
     if numeric_cat_params_indices:
-        dims = objective_dims + plot_dims
+        dims = dims_objectives + plot_dims
         # np.lexsort consumes the sort keys the order from back to front.
         # So the values of parameters have to be reversed the order.
         idx = np.lexsort([dims[index].values for index in numeric_cat_params_indices][::-1])
@@ -460,22 +452,19 @@ def _get_parallel_coordinate_info(
                     has_missing=dim.has_missing,
                 )
             )
-        objective_dims = updated_dims[: len(objective_dims)]
-        dim_objective = objective_dims[0]
-        plot_dims = updated_dims[len(objective_dims) :]
-        if color_values is not None:
-            color_values = tuple(np.asarray(color_values)[idx])
+        dims_objectives = updated_dims[: len(dims_objectives)]
+        plot_dims = updated_dims[len(dims_objectives) :]
+        color_values = tuple(np.asarray(color_values)[idx])
         if feasibility is not None:
             feasibility = tuple(bool(value) for value in np.asarray(feasibility)[idx])
-        if draw_order is not None:
-            assert color_values is not None
+        if is_multi_objective:
             draw_order = tuple(
                 sorted(range(len(trials)), key=color_values.__getitem__, reverse=True)
             )
 
     return _ParallelCoordinateInfo(
-        dim_objective=dim_objective,
-        dims_params=objective_dims[1:] + plot_dims,
+        dims_objectives=dims_objectives,
+        dims_params=plot_dims,
         reverse_scale=reverse_scale,
         colorbar_title=colorbar_title,
         color_values=color_values,

--- a/optuna/visualization/_utils.py
+++ b/optuna/visualization/_utils.py
@@ -95,33 +95,6 @@ def _is_numerical(trials: list[FrozenTrial], param: str) -> bool:
     return True
 
 
-def _get_skipped_trial_numbers(
-    trials: list[FrozenTrial], used_param_names: Sequence[str]
-) -> set[int]:
-    """Utility function for ``plot_parallel_coordinate``.
-
-    If trial's parameters do not contain a parameter in ``used_param_names``,
-    ``plot_parallel_coordinate`` methods do not use such trials.
-
-    Args:
-        trials:
-            List of ``FrozenTrial``s.
-        used_param_names:
-            The parameter names used in ``plot_parallel_coordinate``.
-
-    Returns:
-        A set of invalid trial numbers.
-    """
-
-    skipped_trial_numbers = set()
-    for trial in trials:
-        for used_param in used_param_names:
-            if used_param not in trial.params.keys():
-                skipped_trial_numbers.add(trial.number)
-                break
-    return skipped_trial_numbers
-
-
 def _filter_nonfinite(
     trials: list[FrozenTrial],
     target: Callable[[FrozenTrial], float] | None = None,

--- a/optuna/visualization/matplotlib/_matplotlib_imports.py
+++ b/optuna/visualization/matplotlib/_matplotlib_imports.py
@@ -11,10 +11,12 @@ with try_import() as _imports:
     from matplotlib.axes._axes import Axes
     from matplotlib.collections import LineCollection
     from matplotlib.collections import PathCollection
+    from matplotlib.colors import BoundaryNorm
     from matplotlib.colors import Colormap
     from matplotlib.contour import ContourSet
     from matplotlib.dates import DateFormatter
     from matplotlib.figure import Figure
+    from matplotlib.lines import Line2D
     from mpl_toolkits.mplot3d.axes3d import Axes3D
 
     # TODO(ytknzw): Set precise version.
@@ -34,10 +36,12 @@ __all__ = [
     "plt",
     "Axes",
     "Axes3D",
+    "BoundaryNorm",
     "Colormap",
     "ContourSet",
     "DateFormatter",
     "Figure",
     "LineCollection",
+    "Line2D",
     "PathCollection",
 ]

--- a/optuna/visualization/matplotlib/_parallel_coordinate.py
+++ b/optuna/visualization/matplotlib/_parallel_coordinate.py
@@ -124,7 +124,7 @@ def _get_parallel_coordinate_plot(info: _ParallelCoordinateInfo) -> "Axes":
     segments = [np.column_stack([x, y]) for x, y in zip(xs, dims_obj_base)]
     lc = LineCollection(segments, cmap=cmap)
     if info.feasibility is not None:
-        lc.set_linestyles(
+        lc.set_linestyle(
             ["solid" if info.feasibility[trial_id] else "dotted" for trial_id in draw_order]
         )
         feasibility_legend = [

--- a/optuna/visualization/matplotlib/_parallel_coordinate.py
+++ b/optuna/visualization/matplotlib/_parallel_coordinate.py
@@ -19,6 +19,8 @@ if TYPE_CHECKING:
 
 if _imports.is_successful():
     from optuna.visualization.matplotlib._matplotlib_imports import Axes
+    from optuna.visualization.matplotlib._matplotlib_imports import BoundaryNorm
+    from optuna.visualization.matplotlib._matplotlib_imports import Line2D
     from optuna.visualization.matplotlib._matplotlib_imports import LineCollection
     from optuna.visualization.matplotlib._matplotlib_imports import plt
 
@@ -33,7 +35,10 @@ def plot_parallel_coordinate(
 ) -> "Axes":
     """Plot the high-dimensional parameter relationships in a study with Matplotlib.
 
-    Note that, if a parameter contains missing values, a trial with missing values is not plotted.
+    If a trial does not contain a parameter, the line is connected to a special ``None`` tick.
+    If at least one completed trial contains constraint values, feasible trials are drawn with
+    solid lines and infeasible trials with dotted lines. In this case, trials without constraint
+    values are treated as infeasible.
 
     .. seealso::
         Please refer to :func:`optuna.visualization.plot_parallel_coordinate` for an example.
@@ -45,10 +50,10 @@ def plot_parallel_coordinate(
             Parameter list to visualize. The default is all parameters.
         target:
             A function to specify the value to display. If it is :obj:`None` and ``study`` is being
-            used for single-objective optimization, the objective values are plotted.
-
-            .. note::
-                Specify this argument if ``study`` is being used for multi-objective optimization.
+            used for single-objective optimization, the objective values are plotted. For a
+            multi-objective study, all objective values are plotted and the lines are colored by
+            Pareto rank. Pareto ranks are computed from the objective values without considering
+            constraints.
         target_name:
             Target's name to display on the axis label and the legend.
 
@@ -57,7 +62,8 @@ def plot_parallel_coordinate(
 
     .. note::
         The colormap is reversed when the ``target`` argument isn't :obj:`None` or ``direction``
-        of :class:`~optuna.study.Study` is ``minimize``.
+        of :class:`~optuna.study.Study` is ``minimize``. The Pareto-rank colormap is always
+        reversed for multi-objective studies.
     """
 
     _imports.check()
@@ -67,12 +73,11 @@ def plot_parallel_coordinate(
 
 def _get_parallel_coordinate_plot(info: _ParallelCoordinateInfo) -> "Axes":
     reversescale = info.reverse_scale
-    target_name = info.target_name
 
     # Set up the graph style.
     fig, ax = plt.subplots()
     cmap = plt.get_cmap("Blues_r" if reversescale else "Blues")
-    ax.set_title("Parallel Coordinate Plot")
+    ax.set_title("Parallel Coordinate Plot", y=1.03)
     ax.spines["top"].set_visible(False)
     ax.spines["bottom"].set_visible(False)
 
@@ -82,8 +87,18 @@ def _get_parallel_coordinate_plot(info: _ParallelCoordinateInfo) -> "Axes":
 
     obj_min = info.dim_objective.range[0]
     obj_max = info.dim_objective.range[1]
+    objective_is_constant = obj_min == obj_max
+    if objective_is_constant:
+        padding = abs(obj_min) * 0.05 if obj_min != 0.0 else 0.5
+        obj_min -= padding
+        obj_max += padding
     obj_w = obj_max - obj_min
-    dims_obj_base = [[o] for o in info.dim_objective.values]
+    draw_order = (
+        info.draw_order
+        if info.draw_order is not None
+        else tuple(range(len(info.dim_objective.values)))
+    )
+    dims_obj_base = [[info.dim_objective.values[i]] for i in draw_order]
     for dim in info.dims_params:
         p_min = dim.range[0]
         p_max = dim.range[1]
@@ -91,29 +106,60 @@ def _get_parallel_coordinate_plot(info: _ParallelCoordinateInfo) -> "Axes":
 
         if p_w == 0.0:
             center = obj_w / 2 + obj_min
-            for i in range(len(dim.values)):
-                dims_obj_base[i].append(center)
+            for row in dims_obj_base:
+                row.append(center)
         else:
-            for i, v in enumerate(dim.values):
-                dims_obj_base[i].append((v - p_min) / p_w * obj_w + obj_min)
+            for row, trial_id in zip(dims_obj_base, draw_order):
+                value = dim.values[trial_id]
+                row.append((value - p_min) / p_w * obj_w + obj_min)
 
     # Draw multiple line plots and axes.
     # Ref: https://stackoverflow.com/a/50029441
     n_params = len(info.dims_params)
     ax.set_xlim(0, n_params)
-    ax.set_ylim(info.dim_objective.range[0], info.dim_objective.range[1])
+    ax.set_ylim(obj_min, obj_max)
+    if objective_is_constant:
+        ax.set_yticks([info.dim_objective.range[0]])
     xs = [range(n_params + 1) for _ in range(len(dims_obj_base))]
     segments = [np.column_stack([x, y]) for x, y in zip(xs, dims_obj_base)]
     lc = LineCollection(segments, cmap=cmap)
-    lc.set_array(np.asarray(info.dim_objective.values))
+    if info.feasibility is not None:
+        lc.set_linestyles(
+            ["solid" if info.feasibility[trial_id] else "dotted" for trial_id in draw_order]
+        )
+        feasibility_legend = [
+            (True, "Feasible", "solid"),
+            (False, "Infeasible", "dotted"),
+        ]
+        legend_handles = [
+            Line2D([0], [0], color="#2F3B52", linestyle=linestyle, label=label)
+            for _, label, linestyle in feasibility_legend
+        ]
+        ax.legend(
+            handles=legend_handles,
+            loc="lower right",
+            bbox_to_anchor=(1.0, 1.02),
+            ncol=len(legend_handles),
+            frameon=False,
+        )
+    color_values = (
+        info.color_values if info.color_values is not None else info.dim_objective.values
+    )
+    color_values = tuple(np.asarray(color_values)[list(draw_order)])
+    lc.set_array(np.asarray(color_values))
+    if info.is_rank_color:
+        max_rank = int(max(color_values))
+        lc.set_norm(BoundaryNorm(np.arange(-0.5, max_rank + 1.5), cmap.N))
     axcb = fig.colorbar(lc, pad=0.1, ax=ax)
-    axcb.set_label(target_name)
+    if info.is_rank_color:
+        axcb.set_ticks(list(range(int(max(color_values)) + 1)))
+    axcb.set_label(info.colorbar_title)
     var_names = [info.dim_objective.label] + [dim.label for dim in info.dims_params]
     plt.xticks(range(n_params + 1), var_names, rotation=330)
 
     for i, dim in enumerate(info.dims_params):
         ax2 = ax.twinx()
-        if dim.is_log:
+        if dim.is_log and not dim.has_missing:
             ax2.set_ylim(np.power(10, dim.range[0]), np.power(10, dim.range[1]))
             ax2.set_yscale("log")
         else:
@@ -122,7 +168,7 @@ def _get_parallel_coordinate_plot(info: _ParallelCoordinateInfo) -> "Axes":
         ax2.spines["bottom"].set_visible(False)
         ax2.xaxis.set_visible(False)
         ax2.spines["right"].set_position(("axes", (i + 1) / n_params))
-        if dim.is_cat:
+        if dim.is_cat or dim.has_missing:
             ax2.set_yticks(dim.tickvals)
             ax2.set_yticklabels(dim.ticktext)
 

--- a/optuna/visualization/matplotlib/_parallel_coordinate.py
+++ b/optuna/visualization/matplotlib/_parallel_coordinate.py
@@ -55,7 +55,9 @@ def plot_parallel_coordinate(
             Pareto rank. Pareto ranks are computed from the objective values without considering
             constraints.
         target_name:
-            Target's name to display on the axis label and the legend.
+            Target's name to display on the axis label and the legend. This is used for
+            single-objective studies or when ``target`` is specified, and ignored for
+            multi-objective studies when ``target`` is :obj:`None`.
 
     Returns:
         A :class:`matplotlib.axes.Axes` object.

--- a/optuna/visualization/matplotlib/_parallel_coordinate.py
+++ b/optuna/visualization/matplotlib/_parallel_coordinate.py
@@ -72,34 +72,33 @@ def plot_parallel_coordinate(
 
 
 def _get_parallel_coordinate_plot(info: _ParallelCoordinateInfo) -> "Axes":
-    reversescale = info.reverse_scale
+    # _get_parallel_coordinate_info always provides at least one objective dimension.
+    plot_dimensions = info.dims_objectives[1:] + info.dims_params
+    first_objective_dim = info.dims_objectives[0]
+    dimensions = info.dims_objectives + info.dims_params
 
     # Set up the graph style.
     fig, ax = plt.subplots()
-    cmap = plt.get_cmap("Blues_r" if reversescale else "Blues")
+    cmap = plt.get_cmap("Blues_r" if info.reverse_scale else "Blues")
     ax.set_title("Parallel Coordinate Plot", y=1.03)
     ax.spines["top"].set_visible(False)
     ax.spines["bottom"].set_visible(False)
 
     # Prepare data for plotting.
-    if len(info.dims_params) == 0 or len(info.dim_objective.values) == 0:
+    if len(plot_dimensions) == 0 or len(first_objective_dim.values) == 0:
         return ax
 
-    obj_min = info.dim_objective.range[0]
-    obj_max = info.dim_objective.range[1]
+    obj_min = first_objective_dim.range[0]
+    obj_max = first_objective_dim.range[1]
     objective_is_constant = obj_min == obj_max
     if objective_is_constant:
         padding = abs(obj_min) * 0.05 if obj_min != 0.0 else 0.5
         obj_min -= padding
         obj_max += padding
     obj_w = obj_max - obj_min
-    draw_order = (
-        info.draw_order
-        if info.draw_order is not None
-        else tuple(range(len(info.dim_objective.values)))
-    )
-    dims_obj_base = [[info.dim_objective.values[i]] for i in draw_order]
-    for dim in info.dims_params:
+    draw_order = info.draw_order
+    dims_obj_base = [[first_objective_dim.values[i]] for i in draw_order]
+    for dim in plot_dimensions:
         p_min = dim.range[0]
         p_max = dim.range[1]
         p_w = p_max - p_min
@@ -115,11 +114,11 @@ def _get_parallel_coordinate_plot(info: _ParallelCoordinateInfo) -> "Axes":
 
     # Draw multiple line plots and axes.
     # Ref: https://stackoverflow.com/a/50029441
-    n_params = len(info.dims_params)
+    n_params = len(plot_dimensions)
     ax.set_xlim(0, n_params)
     ax.set_ylim(obj_min, obj_max)
     if objective_is_constant:
-        ax.set_yticks([info.dim_objective.range[0]])
+        ax.set_yticks([first_objective_dim.range[0]])
     xs = [range(n_params + 1) for _ in range(len(dims_obj_base))]
     segments = [np.column_stack([x, y]) for x, y in zip(xs, dims_obj_base)]
     lc = LineCollection(segments, cmap=cmap)
@@ -142,10 +141,7 @@ def _get_parallel_coordinate_plot(info: _ParallelCoordinateInfo) -> "Axes":
             ncol=len(legend_handles),
             frameon=False,
         )
-    color_values = (
-        info.color_values if info.color_values is not None else info.dim_objective.values
-    )
-    color_values = tuple(np.asarray(color_values)[list(draw_order)])
+    color_values = tuple(np.asarray(info.color_values)[list(info.draw_order)])
     lc.set_array(np.asarray(color_values))
     if info.is_rank_color:
         max_rank = int(max(color_values))
@@ -154,10 +150,10 @@ def _get_parallel_coordinate_plot(info: _ParallelCoordinateInfo) -> "Axes":
     if info.is_rank_color:
         axcb.set_ticks(list(range(int(max(color_values)) + 1)))
     axcb.set_label(info.colorbar_title)
-    var_names = [info.dim_objective.label] + [dim.label for dim in info.dims_params]
+    var_names = [dim.label for dim in dimensions]
     plt.xticks(range(n_params + 1), var_names, rotation=330)
 
-    for i, dim in enumerate(info.dims_params):
+    for i, dim in enumerate(plot_dimensions):
         ax2 = ax.twinx()
         if dim.is_log and not dim.has_missing:
             ax2.set_ylim(np.power(10, dim.range[0]), np.power(10, dim.range[1]))

--- a/tests/visualization_tests/test_parallel_coordinate.py
+++ b/tests/visualization_tests/test_parallel_coordinate.py
@@ -11,8 +11,10 @@ import pytest
 from optuna.distributions import BaseDistribution
 from optuna.distributions import CategoricalDistribution
 from optuna.distributions import FloatDistribution
+from optuna.exceptions import ExperimentalWarning
 from optuna.study import create_study
 from optuna.study import Study
+from optuna.study._constrained_optimization import _CONSTRAINTS_KEY
 from optuna.testing.objectives import fail_objective
 from optuna.testing.visualization import prepare_study_with_trials
 from optuna.trial import create_trial
@@ -166,14 +168,15 @@ def _create_study_with_log_scale_and_str_and_numeric_category() -> Study:
 
 def test_target_is_none_and_study_is_multi_obj() -> None:
     study = create_study(directions=["minimize", "minimize"])
-    with pytest.raises(ValueError):
-        _get_parallel_coordinate_info(study)
+    info = _get_parallel_coordinate_info(study)
+    assert info.is_rank_color
+    assert info.colorbar_title == "Pareto Rank"
 
 
 def test_plot_parallel_coordinate_customized_target_name() -> None:
     study = prepare_study_with_trials()
     figure = plotly_plot_parallel_coordinate(study, target_name="Target Name")
-    assert figure.data[0]["dimensions"][0]["label"] == "Target Name"
+    assert figure.layout.xaxis.ticktext[0] == "Target Name"
 
     figure = matplotlib.plot_parallel_coordinate(study, target_name="Target Name").get_figure()
     assert figure is not None
@@ -225,7 +228,7 @@ def test_get_parallel_coordinate_info() -> None:
         ),
         dims_params=[],
         reverse_scale=True,
-        target_name="Objective Value",
+        colorbar_title="Objective Value",
     )
 
     study = prepare_study_with_trials()
@@ -244,8 +247,12 @@ def test_get_parallel_coordinate_info() -> None:
         ),
         dims_params=[],
         reverse_scale=True,
-        target_name="Objective Value",
+        colorbar_title="Objective Value",
     )
+
+    study_without_missing_params = create_study()
+    study_without_missing_params.add_trials([study.trials[0], study.trials[2]])
+    study = study_without_missing_params
 
     # Test with a trial.
     info = _get_parallel_coordinate_info(study, params=["param_a", "param_b"])
@@ -280,7 +287,7 @@ def test_get_parallel_coordinate_info() -> None:
             ),
         ],
         reverse_scale=True,
-        target_name="Objective Value",
+        colorbar_title="Objective Value",
     )
 
     # Test with a trial to select parameter.
@@ -307,7 +314,7 @@ def test_get_parallel_coordinate_info() -> None:
             ),
         ],
         reverse_scale=True,
-        target_name="Objective Value",
+        colorbar_title="Objective Value",
     )
 
     # Test with a customized target value.
@@ -337,7 +344,7 @@ def test_get_parallel_coordinate_info() -> None:
             ),
         ],
         reverse_scale=True,
-        target_name="Objective Value",
+        colorbar_title="Objective Value",
     )
 
     # Test with a customized target name.
@@ -375,7 +382,7 @@ def test_get_parallel_coordinate_info() -> None:
             ),
         ],
         reverse_scale=True,
-        target_name="Target Name",
+        colorbar_title="Target Name",
     )
 
     # Test with wrong params that do not exist in trials.
@@ -397,7 +404,7 @@ def test_get_parallel_coordinate_info() -> None:
         ),
         dims_params=[],
         reverse_scale=True,
-        target_name="Objective Value",
+        colorbar_title="Objective Value",
     )
 
 
@@ -436,7 +443,7 @@ def test_get_parallel_coordinate_info_categorical_params() -> None:
             ),
         ],
         reverse_scale=True,
-        target_name="Objective Value",
+        colorbar_title="Objective Value",
     )
 
 
@@ -477,7 +484,7 @@ def test_get_parallel_coordinate_info_categorical_numeric_params() -> None:
             ),
         ],
         reverse_scale=True,
-        target_name="Objective Value",
+        colorbar_title="Objective Value",
     )
 
 
@@ -516,7 +523,7 @@ def test_get_parallel_coordinate_info_log_params() -> None:
             ),
         ],
         reverse_scale=True,
-        target_name="Objective Value",
+        colorbar_title="Objective Value",
     )
 
 
@@ -569,7 +576,7 @@ def test_get_parallel_coordinate_info_unique_param() -> None:
             ),
         ],
         reverse_scale=True,
-        target_name="Objective Value",
+        colorbar_title="Objective Value",
     )
 
     study_categorical_params.add_trial(
@@ -613,7 +620,7 @@ def test_get_parallel_coordinate_info_unique_param() -> None:
             ),
         ],
         reverse_scale=True,
-        target_name="Objective Value",
+        colorbar_title="Objective Value",
     )
 
 
@@ -671,7 +678,7 @@ def test_get_parallel_coordinate_info_with_log_scale_and_str_and_numeric_categor
             ),
         ],
         reverse_scale=True,
-        target_name="Objective Value",
+        colorbar_title="Objective Value",
     )
 
 
@@ -691,19 +698,19 @@ def test_color_map(direction: str) -> None:
         )
 
     # `target` is `None`.
-    line = plotly_plot_parallel_coordinate(study).data[0]["line"]
-    assert COLOR_SCALE == [v[1] for v in line["colorscale"]]
+    marker = plotly_plot_parallel_coordinate(study).data[-1]["marker"]
+    assert COLOR_SCALE == [v[1] for v in marker["colorscale"]]
     if direction == "minimize":
-        assert line["reversescale"]
+        assert marker["reversescale"]
     else:
-        assert not line["reversescale"]
+        assert not marker["reversescale"]
 
     # When `target` is not `None`, `reversescale` is always `True`.
-    line = plotly_plot_parallel_coordinate(
+    marker = plotly_plot_parallel_coordinate(
         study, target=lambda t: t.number, target_name="Target Name"
-    ).data[0]["line"]
-    assert COLOR_SCALE == [v[1] for v in line["colorscale"]]
-    assert line["reversescale"]
+    ).data[-1]["marker"]
+    assert COLOR_SCALE == [v[1] for v in marker["colorscale"]]
+    assert marker["reversescale"]
 
     # Multi-objective optimization.
     study = create_study(directions=[direction, direction])
@@ -718,16 +725,15 @@ def test_color_map(direction: str) -> None:
                 },
             )
         )
-    line = plotly_plot_parallel_coordinate(
+    marker = plotly_plot_parallel_coordinate(
         study, target=lambda t: t.number, target_name="Target Name"
-    ).data[0]["line"]
-    assert COLOR_SCALE == [v[1] for v in line["colorscale"]]
-    assert line["reversescale"]
+    ).data[-1]["marker"]
+    assert COLOR_SCALE == [v[1] for v in marker["colorscale"]]
+    assert marker["reversescale"]
 
 
 def test_get_parallel_coordinate_info_only_missing_params() -> None:
-    # When all trials contain only a part of parameters,
-    # the plot returns an empty figure.
+    # Trials with conditional parameters are connected to a special "None" tick.
     study = create_study()
     study.add_trial(
         create_trial(
@@ -749,20 +755,211 @@ def test_get_parallel_coordinate_info_only_missing_params() -> None:
     )
 
     info = _get_parallel_coordinate_info(study)
-    assert info == _ParallelCoordinateInfo(
-        dim_objective=_DimensionInfo(
-            label="Objective Value",
-            values=(),
-            range=(0, 0),
-            is_log=False,
-            is_cat=False,
-            tickvals=[],
-            ticktext=[],
-        ),
-        dims_params=[],
-        reverse_scale=True,
-        target_name="Objective Value",
+    assert info.dim_objective.values == (0.0, 1.0)
+    assert len(info.dims_params) == 2
+    assert all(dim.ticktext[0] == "None" for dim in info.dims_params)
+    assert all(len(dim.values) == 2 for dim in info.dims_params)
+    assert all(dim.has_missing for dim in info.dims_params)
+
+
+@pytest.mark.parametrize("value", ["None", None])
+def test_get_parallel_coordinate_info_missing_categorical_value_label_collision(
+    value: str | None,
+) -> None:
+    study = create_study()
+    distribution = CategoricalDistribution((value, "value"))
+    study.add_trial(create_trial(value=0.0))
+    study.add_trial(
+        create_trial(
+            value=1.0,
+            params={"param": value},
+            distributions={"param": distribution},
+        )
     )
+
+    info = _get_parallel_coordinate_info(study)
+
+    assert info.dims_params[0].ticktext == ["None", "None (value)"]
+    assert info.dims_params[0].values == (0, 1)
+    assert info.dims_params[0].has_missing
+
+
+def test_get_parallel_coordinate_info_categorical_none_without_missing_value() -> None:
+    study = create_study()
+    distribution = CategoricalDistribution((None, "value"))
+    study.add_trial(
+        create_trial(
+            value=1.0,
+            params={"param": None},
+            distributions={"param": distribution},
+        )
+    )
+
+    info = _get_parallel_coordinate_info(study)
+
+    assert info.dims_params[0].ticktext == ["None"]
+    assert not info.dims_params[0].has_missing
+
+
+def test_plot_parallel_coordinate_with_constant_objective() -> None:
+    study = create_study()
+    distribution = FloatDistribution(0.0, 1.0)
+    study.add_trial(
+        create_trial(
+            value=1.0,
+            params={"param": 0.0},
+            distributions={"param": distribution},
+        )
+    )
+    study.add_trial(
+        create_trial(
+            value=1.0,
+            params={"param": 1.0},
+            distributions={"param": distribution},
+        )
+    )
+
+    figure = plotly_plot_parallel_coordinate(study)
+    assert figure.data[-1]["marker"]["cmin"] < figure.data[-1]["marker"]["cmax"]
+
+    ax = matplotlib.plot_parallel_coordinate(study)
+    segments = ax.collections[0].get_segments()
+    assert segments[0][-1, 1] != segments[1][-1, 1]
+    plt.close(ax.get_figure())
+
+
+def test_get_parallel_coordinate_info_multi_objective() -> None:
+    study = create_study(directions=["minimize", "maximize"])
+    with pytest.warns(ExperimentalWarning):
+        study.set_metric_names(["loss", "score"])
+    distribution = FloatDistribution(0.0, 10.0)
+    study.add_trial(
+        create_trial(
+            values=[1.0, 1.0],
+            params={"param": 1.0},
+            distributions={"param": distribution},
+        )
+    )
+    study.add_trial(
+        create_trial(
+            values=[2.0, 0.0],
+            params={"param": 2.0},
+            distributions={"param": distribution},
+        )
+    )
+
+    info = _get_parallel_coordinate_info(study)
+
+    assert info.dim_objective.label == "loss"
+    assert info.dims_params[0].label == "score"
+    assert info.color_values == (0.0, 1.0)
+    assert info.colorbar_title == "Pareto Rank"
+    assert info.is_rank_color
+
+    figure = plotly_plot_parallel_coordinate(study)
+    assert all(trace.type == "scatter" for trace in figure.data)
+    assert figure.layout.plot_bgcolor == "white"
+    assert figure.layout.xaxis.ticktext == ("loss", "score", "param")
+    assert figure.data[-1]["marker"]["colorbar"]["title"]["text"] == "Pareto Rank"
+    assert figure.data[-1]["marker"]["colorbar"]["tickvals"] == (0, 1)
+
+    ax = matplotlib.plot_parallel_coordinate(study)
+    assert [label.get_text() for label in ax.get_xticklabels()] == ["loss", "score", "param"]
+    assert ax.get_figure().axes[1].get_ylabel() == "Pareto Rank"
+    plt.close(ax.get_figure())
+
+
+def test_get_parallel_coordinate_info_multi_objective_with_numeric_category_and_constraints() -> (
+    None
+):
+    study = create_study(directions=["minimize", "minimize"])
+    distribution = CategoricalDistribution((1, 2, 3))
+    study.add_trial(
+        create_trial(
+            values=[0.0, 0.0],
+            params={"param": 2},
+            distributions={"param": distribution},
+            system_attrs={_CONSTRAINTS_KEY: [-1.0]},
+        )
+    )
+    study.add_trial(
+        create_trial(
+            values=[1.0, 1.0],
+            params={"param": 1},
+            distributions={"param": distribution},
+            system_attrs={_CONSTRAINTS_KEY: [1.0]},
+        )
+    )
+    study.add_trial(
+        create_trial(
+            values=[2.0, 2.0],
+            params={"param": 3},
+            distributions={"param": distribution},
+        )
+    )
+
+    info = _get_parallel_coordinate_info(study)
+
+    assert info.color_values == (1.0, 0.0, 2.0)
+    assert info.feasibility == (False, True, False)
+    assert info.draw_order == (2, 0, 1)
+
+    figure = plotly_plot_parallel_coordinate(study)
+    assert [trace["line"]["dash"] for trace in figure.data[:3]] == ["dot", "dot", "solid"]
+
+
+def test_get_parallel_coordinate_info_with_constraints() -> None:
+    study = create_study()
+    distribution = FloatDistribution(0.0, 10.0)
+    study.add_trial(
+        create_trial(
+            value=0.0,
+            params={"param": 1.0},
+            distributions={"param": distribution},
+            system_attrs={_CONSTRAINTS_KEY: [-1.0, 0.0]},
+        )
+    )
+    study.add_trial(
+        create_trial(
+            value=1.0,
+            params={"param": 2.0},
+            distributions={"param": distribution},
+            system_attrs={_CONSTRAINTS_KEY: [0.1]},
+        )
+    )
+    study.add_trial(
+        create_trial(
+            value=2.0,
+            params={"param": 3.0},
+            distributions={"param": distribution},
+        )
+    )
+
+    info = _get_parallel_coordinate_info(study)
+
+    assert info.feasibility == (True, False, False)
+    assert info.dims_params[0].label == "param"
+
+    figure = plotly_plot_parallel_coordinate(study)
+    assert all(trace.type == "scatter" for trace in figure.data)
+    assert figure.layout.xaxis.ticktext == ("Objective Value", "param")
+    assert [trace["line"]["dash"] for trace in figure.data[:3]] == [
+        "solid",
+        "dot",
+        "dot",
+    ]
+    assert [trace["mode"] for trace in figure.data[:3]] == ["lines"] * 3
+    assert [trace["opacity"] for trace in figure.data[:3]] == [0.5] * 3
+    assert [trace["name"] for trace in figure.data[3:5]] == ["Feasible", "Infeasible"]
+    figure.write_image(BytesIO())
+
+    ax = matplotlib.plot_parallel_coordinate(study)
+    assert [label.get_text() for label in ax.get_xticklabels()] == ["Objective Value", "param"]
+    legend = ax.get_legend()
+    assert legend is not None
+    assert [text.get_text() for text in legend.get_texts()] == ["Feasible", "Infeasible"]
+    plt.savefig(BytesIO())
+    plt.close(ax.get_figure())
 
 
 @pytest.mark.parametrize("value", [float("inf"), -float("inf")])

--- a/tests/visualization_tests/test_parallel_coordinate.py
+++ b/tests/visualization_tests/test_parallel_coordinate.py
@@ -34,6 +34,45 @@ parametrize_plot_parallel_coordinate = pytest.mark.parametrize(
 )
 
 
+def _create_parallel_coordinate_info(
+    *,
+    objective_dimensions: list[_DimensionInfo],
+    parameter_dimensions: list[_DimensionInfo],
+    reverse_scale: bool,
+    colorbar_title: str,
+    color_values: tuple[float, ...] = (),
+    is_rank_color: bool = False,
+    draw_order: tuple[int, ...] = (),
+    feasibility: tuple[bool, ...] | None = None,
+) -> _ParallelCoordinateInfo:
+    if color_values == () and len(objective_dimensions) == 1:
+        color_values = objective_dimensions[0].values
+    if draw_order == () and len(objective_dimensions) == 1:
+        draw_order = tuple(range(len(objective_dimensions[0].values)))
+    return _ParallelCoordinateInfo(
+        dims_objectives=objective_dimensions,
+        dims_params=parameter_dimensions,
+        reverse_scale=reverse_scale,
+        colorbar_title=colorbar_title,
+        color_values=color_values,
+        is_rank_color=is_rank_color,
+        draw_order=draw_order,
+        feasibility=feasibility,
+    )
+
+
+def _objective_dimensions(info: _ParallelCoordinateInfo) -> list[_DimensionInfo]:
+    return info.dims_objectives
+
+
+def _parameter_dimensions(info: _ParallelCoordinateInfo) -> list[_DimensionInfo]:
+    return info.dims_params
+
+
+def _assert_plotly_figure_serializable(figure: go.Figure) -> None:
+    assert figure.to_json()
+
+
 def _create_study_with_failed_trial() -> Study:
     study = create_study()
     study.optimize(fail_objective, n_trials=1, catch=(ValueError,))
@@ -206,7 +245,7 @@ def test_plot_parallel_coordinate(
     study = specific_create_study()
     figure = plot_parallel_coordinate(study, params=params)
     if isinstance(figure, go.Figure):
-        figure.write_image(BytesIO())
+        _assert_plotly_figure_serializable(figure)
     else:
         plt.savefig(BytesIO())
         plt.close()
@@ -216,17 +255,19 @@ def test_get_parallel_coordinate_info() -> None:
     # Test with no trial.
     study = create_study()
     info = _get_parallel_coordinate_info(study)
-    assert info == _ParallelCoordinateInfo(
-        dim_objective=_DimensionInfo(
-            label="Objective Value",
-            values=(),
-            range=(0, 0),
-            is_log=False,
-            is_cat=False,
-            tickvals=[],
-            ticktext=[],
-        ),
-        dims_params=[],
+    assert info == _create_parallel_coordinate_info(
+        objective_dimensions=[
+            _DimensionInfo(
+                label="Objective Value",
+                values=(),
+                range=(0, 0),
+                is_log=False,
+                is_cat=False,
+                tickvals=[],
+                ticktext=[],
+            )
+        ],
+        parameter_dimensions=[],
         reverse_scale=True,
         colorbar_title="Objective Value",
     )
@@ -235,17 +276,19 @@ def test_get_parallel_coordinate_info() -> None:
 
     # Test with no parameters.
     info = _get_parallel_coordinate_info(study, params=[])
-    assert info == _ParallelCoordinateInfo(
-        dim_objective=_DimensionInfo(
-            label="Objective Value",
-            values=(0.0, 2.0, 1.0),
-            range=(0.0, 2.0),
-            is_log=False,
-            is_cat=False,
-            tickvals=[],
-            ticktext=[],
-        ),
-        dims_params=[],
+    assert info == _create_parallel_coordinate_info(
+        objective_dimensions=[
+            _DimensionInfo(
+                label="Objective Value",
+                values=(0.0, 2.0, 1.0),
+                range=(0.0, 2.0),
+                is_log=False,
+                is_cat=False,
+                tickvals=[],
+                ticktext=[],
+            )
+        ],
+        parameter_dimensions=[],
         reverse_scale=True,
         colorbar_title="Objective Value",
     )
@@ -256,17 +299,19 @@ def test_get_parallel_coordinate_info() -> None:
 
     # Test with a trial.
     info = _get_parallel_coordinate_info(study, params=["param_a", "param_b"])
-    assert info == _ParallelCoordinateInfo(
-        dim_objective=_DimensionInfo(
-            label="Objective Value",
-            values=(0.0, 1.0),
-            range=(0.0, 1.0),
-            is_log=False,
-            is_cat=False,
-            tickvals=[],
-            ticktext=[],
-        ),
-        dims_params=[
+    assert info == _create_parallel_coordinate_info(
+        objective_dimensions=[
+            _DimensionInfo(
+                label="Objective Value",
+                values=(0.0, 1.0),
+                range=(0.0, 1.0),
+                is_log=False,
+                is_cat=False,
+                tickvals=[],
+                ticktext=[],
+            )
+        ],
+        parameter_dimensions=[
             _DimensionInfo(
                 label="param_a",
                 values=(1.0, 2.5),
@@ -292,17 +337,19 @@ def test_get_parallel_coordinate_info() -> None:
 
     # Test with a trial to select parameter.
     info = _get_parallel_coordinate_info(study, params=["param_a"])
-    assert info == _ParallelCoordinateInfo(
-        dim_objective=_DimensionInfo(
-            label="Objective Value",
-            values=(0.0, 1.0),
-            range=(0.0, 1.0),
-            is_log=False,
-            is_cat=False,
-            tickvals=[],
-            ticktext=[],
-        ),
-        dims_params=[
+    assert info == _create_parallel_coordinate_info(
+        objective_dimensions=[
+            _DimensionInfo(
+                label="Objective Value",
+                values=(0.0, 1.0),
+                range=(0.0, 1.0),
+                is_log=False,
+                is_cat=False,
+                tickvals=[],
+                ticktext=[],
+            )
+        ],
+        parameter_dimensions=[
             _DimensionInfo(
                 label="param_a",
                 values=(1.0, 2.5),
@@ -322,17 +369,19 @@ def test_get_parallel_coordinate_info() -> None:
         info = _get_parallel_coordinate_info(
             study, params=["param_a"], target=lambda t: t.params["param_b"]
         )
-    assert info == _ParallelCoordinateInfo(
-        dim_objective=_DimensionInfo(
-            label="Objective Value",
-            values=(2.0, 1.0),
-            range=(1.0, 2.0),
-            is_log=False,
-            is_cat=False,
-            tickvals=[],
-            ticktext=[],
-        ),
-        dims_params=[
+    assert info == _create_parallel_coordinate_info(
+        objective_dimensions=[
+            _DimensionInfo(
+                label="Objective Value",
+                values=(2.0, 1.0),
+                range=(1.0, 2.0),
+                is_log=False,
+                is_cat=False,
+                tickvals=[],
+                ticktext=[],
+            )
+        ],
+        parameter_dimensions=[
             _DimensionInfo(
                 label="param_a",
                 values=(1.0, 2.5),
@@ -351,17 +400,19 @@ def test_get_parallel_coordinate_info() -> None:
     info = _get_parallel_coordinate_info(
         study, params=["param_a", "param_b"], target_name="Target Name"
     )
-    assert info == _ParallelCoordinateInfo(
-        dim_objective=_DimensionInfo(
-            label="Target Name",
-            values=(0.0, 1.0),
-            range=(0.0, 1.0),
-            is_log=False,
-            is_cat=False,
-            tickvals=[],
-            ticktext=[],
-        ),
-        dims_params=[
+    assert info == _create_parallel_coordinate_info(
+        objective_dimensions=[
+            _DimensionInfo(
+                label="Target Name",
+                values=(0.0, 1.0),
+                range=(0.0, 1.0),
+                is_log=False,
+                is_cat=False,
+                tickvals=[],
+                ticktext=[],
+            )
+        ],
+        parameter_dimensions=[
             _DimensionInfo(
                 label="param_a",
                 values=(1.0, 2.5),
@@ -392,17 +443,19 @@ def test_get_parallel_coordinate_info() -> None:
     # Ignore failed trials.
     study = _create_study_with_failed_trial()
     info = _get_parallel_coordinate_info(study)
-    assert info == _ParallelCoordinateInfo(
-        dim_objective=_DimensionInfo(
-            label="Objective Value",
-            values=(),
-            range=(0, 0),
-            is_log=False,
-            is_cat=False,
-            tickvals=[],
-            ticktext=[],
-        ),
-        dims_params=[],
+    assert info == _create_parallel_coordinate_info(
+        objective_dimensions=[
+            _DimensionInfo(
+                label="Objective Value",
+                values=(),
+                range=(0, 0),
+                is_log=False,
+                is_cat=False,
+                tickvals=[],
+                ticktext=[],
+            )
+        ],
+        parameter_dimensions=[],
         reverse_scale=True,
         colorbar_title="Objective Value",
     )
@@ -412,17 +465,19 @@ def test_get_parallel_coordinate_info_categorical_params() -> None:
     # Test with categorical params that cannot be converted to numeral.
     study = _create_study_with_categorical_params()
     info = _get_parallel_coordinate_info(study)
-    assert info == _ParallelCoordinateInfo(
-        dim_objective=_DimensionInfo(
-            label="Objective Value",
-            values=(0.0, 2.0),
-            range=(0.0, 2.0),
-            is_log=False,
-            is_cat=False,
-            tickvals=[],
-            ticktext=[],
-        ),
-        dims_params=[
+    assert info == _create_parallel_coordinate_info(
+        objective_dimensions=[
+            _DimensionInfo(
+                label="Objective Value",
+                values=(0.0, 2.0),
+                range=(0.0, 2.0),
+                is_log=False,
+                is_cat=False,
+                tickvals=[],
+                ticktext=[],
+            )
+        ],
+        parameter_dimensions=[
             _DimensionInfo(
                 label="category_a",
                 values=(0, 1),
@@ -453,17 +508,19 @@ def test_get_parallel_coordinate_info_categorical_numeric_params() -> None:
 
     # Trials are sorted by using param_a and param_b, i.e., trial#1, trial#2, and trial#0.
     info = _get_parallel_coordinate_info(study)
-    assert info == _ParallelCoordinateInfo(
-        dim_objective=_DimensionInfo(
-            label="Objective Value",
-            values=(1.0, 2.0, 0.0),
-            range=(0.0, 2.0),
-            is_log=False,
-            is_cat=False,
-            tickvals=[],
-            ticktext=[],
-        ),
-        dims_params=[
+    assert info == _create_parallel_coordinate_info(
+        objective_dimensions=[
+            _DimensionInfo(
+                label="Objective Value",
+                values=(1.0, 2.0, 0.0),
+                range=(0.0, 2.0),
+                is_log=False,
+                is_cat=False,
+                tickvals=[],
+                ticktext=[],
+            )
+        ],
+        parameter_dimensions=[
             _DimensionInfo(
                 label="category_a",
                 values=(0, 1, 1),
@@ -492,17 +549,19 @@ def test_get_parallel_coordinate_info_log_params() -> None:
     # Test with log params.
     study = _create_study_with_log_params()
     info = _get_parallel_coordinate_info(study)
-    assert info == _ParallelCoordinateInfo(
-        dim_objective=_DimensionInfo(
-            label="Objective Value",
-            values=(0.0, 1.0, 0.1),
-            range=(0.0, 1.0),
-            is_log=False,
-            is_cat=False,
-            tickvals=[],
-            ticktext=[],
-        ),
-        dims_params=[
+    assert info == _create_parallel_coordinate_info(
+        objective_dimensions=[
+            _DimensionInfo(
+                label="Objective Value",
+                values=(0.0, 1.0, 0.1),
+                range=(0.0, 1.0),
+                is_log=False,
+                is_cat=False,
+                tickvals=[],
+                ticktext=[],
+            )
+        ],
+        parameter_dimensions=[
             _DimensionInfo(
                 label="param_a",
                 values=(-6, math.log10(2e-5), -4),
@@ -545,17 +604,19 @@ def test_get_parallel_coordinate_info_unique_param() -> None:
 
     # Both parameters contain unique values.
     info = _get_parallel_coordinate_info(study_categorical_params)
-    assert info == _ParallelCoordinateInfo(
-        dim_objective=_DimensionInfo(
-            label="Objective Value",
-            values=(0.0,),
-            range=(0.0, 0.0),
-            is_log=False,
-            is_cat=False,
-            tickvals=[],
-            ticktext=[],
-        ),
-        dims_params=[
+    assert info == _create_parallel_coordinate_info(
+        objective_dimensions=[
+            _DimensionInfo(
+                label="Objective Value",
+                values=(0.0,),
+                range=(0.0, 0.0),
+                is_log=False,
+                is_cat=False,
+                tickvals=[],
+                ticktext=[],
+            )
+        ],
+        parameter_dimensions=[
             _DimensionInfo(
                 label="category_a",
                 values=(0.0,),
@@ -589,17 +650,19 @@ def test_get_parallel_coordinate_info_unique_param() -> None:
 
     # Still "category_a" contains unique suggested value during the optimization.
     info = _get_parallel_coordinate_info(study_categorical_params)
-    assert info == _ParallelCoordinateInfo(
-        dim_objective=_DimensionInfo(
-            label="Objective Value",
-            values=(0.0, 2.0),
-            range=(0.0, 2.0),
-            is_log=False,
-            is_cat=False,
-            tickvals=[],
-            ticktext=[],
-        ),
-        dims_params=[
+    assert info == _create_parallel_coordinate_info(
+        objective_dimensions=[
+            _DimensionInfo(
+                label="Objective Value",
+                values=(0.0, 2.0),
+                range=(0.0, 2.0),
+                is_log=False,
+                is_cat=False,
+                tickvals=[],
+                ticktext=[],
+            )
+        ],
+        parameter_dimensions=[
             _DimensionInfo(
                 label="category_a",
                 values=(0, 0),
@@ -629,17 +692,19 @@ def test_get_parallel_coordinate_info_with_log_scale_and_str_and_numeric_categor
     # that can be interpreted as numeric params.
     study = _create_study_with_log_scale_and_str_and_numeric_category()
     info = _get_parallel_coordinate_info(study)
-    assert info == _ParallelCoordinateInfo(
-        dim_objective=_DimensionInfo(
-            label="Objective Value",
-            values=(1.0, 3.0, 0.0, 2.0),
-            range=(0.0, 3.0),
-            is_log=False,
-            is_cat=False,
-            tickvals=[],
-            ticktext=[],
-        ),
-        dims_params=[
+    assert info == _create_parallel_coordinate_info(
+        objective_dimensions=[
+            _DimensionInfo(
+                label="Objective Value",
+                values=(1.0, 3.0, 0.0, 2.0),
+                range=(0.0, 3.0),
+                is_log=False,
+                is_cat=False,
+                tickvals=[],
+                ticktext=[],
+            )
+        ],
+        parameter_dimensions=[
             _DimensionInfo(
                 label="param_a",
                 values=(1, 1, 0, 0),
@@ -755,11 +820,12 @@ def test_get_parallel_coordinate_info_only_missing_params() -> None:
     )
 
     info = _get_parallel_coordinate_info(study)
-    assert info.dim_objective.values == (0.0, 1.0)
-    assert len(info.dims_params) == 2
-    assert all(dim.ticktext[0] == "None" for dim in info.dims_params)
-    assert all(len(dim.values) == 2 for dim in info.dims_params)
-    assert all(dim.has_missing for dim in info.dims_params)
+    parameter_dimensions = _parameter_dimensions(info)
+    assert _objective_dimensions(info)[0].values == (0.0, 1.0)
+    assert len(parameter_dimensions) == 2
+    assert all(dim.ticktext[0] == "None" for dim in parameter_dimensions)
+    assert all(len(dim.values) == 2 for dim in parameter_dimensions)
+    assert all(dim.has_missing for dim in parameter_dimensions)
 
 
 @pytest.mark.parametrize("value", ["None", None])
@@ -778,10 +844,10 @@ def test_get_parallel_coordinate_info_missing_categorical_value_label_collision(
     )
 
     info = _get_parallel_coordinate_info(study)
-
-    assert info.dims_params[0].ticktext == ["None", "None (value)"]
-    assert info.dims_params[0].values == (0, 1)
-    assert info.dims_params[0].has_missing
+    parameter_dimension = _parameter_dimensions(info)[0]
+    assert parameter_dimension.ticktext == ["None", "None (value)"]
+    assert parameter_dimension.values == (0, 1)
+    assert parameter_dimension.has_missing
 
 
 def test_get_parallel_coordinate_info_categorical_none_without_missing_value() -> None:
@@ -796,9 +862,9 @@ def test_get_parallel_coordinate_info_categorical_none_without_missing_value() -
     )
 
     info = _get_parallel_coordinate_info(study)
-
-    assert info.dims_params[0].ticktext == ["None"]
-    assert not info.dims_params[0].has_missing
+    parameter_dimension = _parameter_dimensions(info)[0]
+    assert parameter_dimension.ticktext == ["None"]
+    assert not parameter_dimension.has_missing
 
 
 def test_plot_parallel_coordinate_with_constant_objective() -> None:
@@ -849,9 +915,7 @@ def test_get_parallel_coordinate_info_multi_objective() -> None:
     )
 
     info = _get_parallel_coordinate_info(study)
-
-    assert info.dim_objective.label == "loss"
-    assert info.dims_params[0].label == "score"
+    assert [dim.label for dim in _objective_dimensions(info)] == ["loss", "score"]
     assert info.color_values == (0.0, 1.0)
     assert info.colorbar_title == "Pareto Rank"
     assert info.is_rank_color
@@ -938,7 +1002,7 @@ def test_get_parallel_coordinate_info_with_constraints() -> None:
     info = _get_parallel_coordinate_info(study)
 
     assert info.feasibility == (True, False, False)
-    assert info.dims_params[0].label == "param"
+    assert _parameter_dimensions(info)[0].label == "param"
 
     figure = plotly_plot_parallel_coordinate(study)
     assert all(trace.type == "scatter" for trace in figure.data)
@@ -951,7 +1015,7 @@ def test_get_parallel_coordinate_info_with_constraints() -> None:
     assert [trace["mode"] for trace in figure.data[:3]] == ["lines"] * 3
     assert [trace["opacity"] for trace in figure.data[:3]] == [0.5] * 3
     assert [trace["name"] for trace in figure.data[3:5]] == ["Feasible", "Infeasible"]
-    figure.write_image(BytesIO())
+    _assert_plotly_figure_serializable(figure)
 
     ax = matplotlib.plot_parallel_coordinate(study)
     assert [label.get_text() for label in ax.get_xticklabels()] == ["Objective Value", "param"]
@@ -966,7 +1030,7 @@ def test_get_parallel_coordinate_info_with_constraints() -> None:
 def test_nonfinite_removed(value: float) -> None:
     study = prepare_study_with_trials(value_for_first_trial=value)
     info = _get_parallel_coordinate_info(study)
-    assert all(np.isfinite(info.dim_objective.values))
+    assert all(np.isfinite(_objective_dimensions(info)[0].values))
 
 
 @pytest.mark.parametrize("objective", (0, 1))
@@ -976,4 +1040,4 @@ def test_nonfinite_multiobjective(objective: int, value: float) -> None:
     info = _get_parallel_coordinate_info(
         study, target=lambda t: t.values[objective], target_name="Target Name"
     )
-    assert all(np.isfinite(info.dim_objective.values))
+    assert all(np.isfinite(_objective_dimensions(info)[0].values))

--- a/tests/visualization_tests/test_parallel_coordinate.py
+++ b/tests/visualization_tests/test_parallel_coordinate.py
@@ -11,7 +11,6 @@ import pytest
 from optuna.distributions import BaseDistribution
 from optuna.distributions import CategoricalDistribution
 from optuna.distributions import FloatDistribution
-from optuna.exceptions import ExperimentalWarning
 from optuna.study import create_study
 from optuna.study import Study
 from optuna.study._constrained_optimization import _CONSTRAINTS_KEY
@@ -32,45 +31,6 @@ parametrize_plot_parallel_coordinate = pytest.mark.parametrize(
     "plot_parallel_coordinate",
     [plotly_plot_parallel_coordinate, matplotlib.plot_parallel_coordinate],
 )
-
-
-def _create_parallel_coordinate_info(
-    *,
-    objective_dimensions: list[_DimensionInfo],
-    parameter_dimensions: list[_DimensionInfo],
-    reverse_scale: bool,
-    colorbar_title: str,
-    color_values: tuple[float, ...] = (),
-    is_rank_color: bool = False,
-    draw_order: tuple[int, ...] = (),
-    feasibility: tuple[bool, ...] | None = None,
-) -> _ParallelCoordinateInfo:
-    if color_values == () and len(objective_dimensions) == 1:
-        color_values = objective_dimensions[0].values
-    if draw_order == () and len(objective_dimensions) == 1:
-        draw_order = tuple(range(len(objective_dimensions[0].values)))
-    return _ParallelCoordinateInfo(
-        dims_objectives=objective_dimensions,
-        dims_params=parameter_dimensions,
-        reverse_scale=reverse_scale,
-        colorbar_title=colorbar_title,
-        color_values=color_values,
-        is_rank_color=is_rank_color,
-        draw_order=draw_order,
-        feasibility=feasibility,
-    )
-
-
-def _objective_dimensions(info: _ParallelCoordinateInfo) -> list[_DimensionInfo]:
-    return info.dims_objectives
-
-
-def _parameter_dimensions(info: _ParallelCoordinateInfo) -> list[_DimensionInfo]:
-    return info.dims_params
-
-
-def _assert_plotly_figure_serializable(figure: go.Figure) -> None:
-    assert figure.to_json()
 
 
 def _create_study_with_failed_trial() -> Study:
@@ -245,7 +205,7 @@ def test_plot_parallel_coordinate(
     study = specific_create_study()
     figure = plot_parallel_coordinate(study, params=params)
     if isinstance(figure, go.Figure):
-        _assert_plotly_figure_serializable(figure)
+        assert figure.to_json()
     else:
         plt.savefig(BytesIO())
         plt.close()
@@ -255,8 +215,8 @@ def test_get_parallel_coordinate_info() -> None:
     # Test with no trial.
     study = create_study()
     info = _get_parallel_coordinate_info(study)
-    assert info == _create_parallel_coordinate_info(
-        objective_dimensions=[
+    assert info == _ParallelCoordinateInfo(
+        dims_objectives=[
             _DimensionInfo(
                 label="Objective Value",
                 values=(),
@@ -267,17 +227,19 @@ def test_get_parallel_coordinate_info() -> None:
                 ticktext=[],
             )
         ],
-        parameter_dimensions=[],
+        dims_params=[],
         reverse_scale=True,
         colorbar_title="Objective Value",
+        color_values=(),
+        draw_order=(),
     )
 
     study = prepare_study_with_trials()
 
     # Test with no parameters.
     info = _get_parallel_coordinate_info(study, params=[])
-    assert info == _create_parallel_coordinate_info(
-        objective_dimensions=[
+    assert info == _ParallelCoordinateInfo(
+        dims_objectives=[
             _DimensionInfo(
                 label="Objective Value",
                 values=(0.0, 2.0, 1.0),
@@ -288,9 +250,11 @@ def test_get_parallel_coordinate_info() -> None:
                 ticktext=[],
             )
         ],
-        parameter_dimensions=[],
+        dims_params=[],
         reverse_scale=True,
         colorbar_title="Objective Value",
+        color_values=(0.0, 2.0, 1.0),
+        draw_order=(0, 1, 2),
     )
 
     study_without_missing_params = create_study()
@@ -299,8 +263,8 @@ def test_get_parallel_coordinate_info() -> None:
 
     # Test with a trial.
     info = _get_parallel_coordinate_info(study, params=["param_a", "param_b"])
-    assert info == _create_parallel_coordinate_info(
-        objective_dimensions=[
+    assert info == _ParallelCoordinateInfo(
+        dims_objectives=[
             _DimensionInfo(
                 label="Objective Value",
                 values=(0.0, 1.0),
@@ -311,7 +275,7 @@ def test_get_parallel_coordinate_info() -> None:
                 ticktext=[],
             )
         ],
-        parameter_dimensions=[
+        dims_params=[
             _DimensionInfo(
                 label="param_a",
                 values=(1.0, 2.5),
@@ -333,12 +297,14 @@ def test_get_parallel_coordinate_info() -> None:
         ],
         reverse_scale=True,
         colorbar_title="Objective Value",
+        color_values=(0.0, 1.0),
+        draw_order=(0, 1),
     )
 
     # Test with a trial to select parameter.
     info = _get_parallel_coordinate_info(study, params=["param_a"])
-    assert info == _create_parallel_coordinate_info(
-        objective_dimensions=[
+    assert info == _ParallelCoordinateInfo(
+        dims_objectives=[
             _DimensionInfo(
                 label="Objective Value",
                 values=(0.0, 1.0),
@@ -349,7 +315,7 @@ def test_get_parallel_coordinate_info() -> None:
                 ticktext=[],
             )
         ],
-        parameter_dimensions=[
+        dims_params=[
             _DimensionInfo(
                 label="param_a",
                 values=(1.0, 2.5),
@@ -362,6 +328,8 @@ def test_get_parallel_coordinate_info() -> None:
         ],
         reverse_scale=True,
         colorbar_title="Objective Value",
+        color_values=(0.0, 1.0),
+        draw_order=(0, 1),
     )
 
     # Test with a customized target value.
@@ -369,8 +337,8 @@ def test_get_parallel_coordinate_info() -> None:
         info = _get_parallel_coordinate_info(
             study, params=["param_a"], target=lambda t: t.params["param_b"]
         )
-    assert info == _create_parallel_coordinate_info(
-        objective_dimensions=[
+    assert info == _ParallelCoordinateInfo(
+        dims_objectives=[
             _DimensionInfo(
                 label="Objective Value",
                 values=(2.0, 1.0),
@@ -381,7 +349,7 @@ def test_get_parallel_coordinate_info() -> None:
                 ticktext=[],
             )
         ],
-        parameter_dimensions=[
+        dims_params=[
             _DimensionInfo(
                 label="param_a",
                 values=(1.0, 2.5),
@@ -394,14 +362,16 @@ def test_get_parallel_coordinate_info() -> None:
         ],
         reverse_scale=True,
         colorbar_title="Objective Value",
+        color_values=(2.0, 1.0),
+        draw_order=(0, 1),
     )
 
     # Test with a customized target name.
     info = _get_parallel_coordinate_info(
         study, params=["param_a", "param_b"], target_name="Target Name"
     )
-    assert info == _create_parallel_coordinate_info(
-        objective_dimensions=[
+    assert info == _ParallelCoordinateInfo(
+        dims_objectives=[
             _DimensionInfo(
                 label="Target Name",
                 values=(0.0, 1.0),
@@ -412,7 +382,7 @@ def test_get_parallel_coordinate_info() -> None:
                 ticktext=[],
             )
         ],
-        parameter_dimensions=[
+        dims_params=[
             _DimensionInfo(
                 label="param_a",
                 values=(1.0, 2.5),
@@ -434,6 +404,8 @@ def test_get_parallel_coordinate_info() -> None:
         ],
         reverse_scale=True,
         colorbar_title="Target Name",
+        color_values=(0.0, 1.0),
+        draw_order=(0, 1),
     )
 
     # Test with wrong params that do not exist in trials.
@@ -443,8 +415,8 @@ def test_get_parallel_coordinate_info() -> None:
     # Ignore failed trials.
     study = _create_study_with_failed_trial()
     info = _get_parallel_coordinate_info(study)
-    assert info == _create_parallel_coordinate_info(
-        objective_dimensions=[
+    assert info == _ParallelCoordinateInfo(
+        dims_objectives=[
             _DimensionInfo(
                 label="Objective Value",
                 values=(),
@@ -455,9 +427,11 @@ def test_get_parallel_coordinate_info() -> None:
                 ticktext=[],
             )
         ],
-        parameter_dimensions=[],
+        dims_params=[],
         reverse_scale=True,
         colorbar_title="Objective Value",
+        color_values=(),
+        draw_order=(),
     )
 
 
@@ -465,8 +439,8 @@ def test_get_parallel_coordinate_info_categorical_params() -> None:
     # Test with categorical params that cannot be converted to numeral.
     study = _create_study_with_categorical_params()
     info = _get_parallel_coordinate_info(study)
-    assert info == _create_parallel_coordinate_info(
-        objective_dimensions=[
+    assert info == _ParallelCoordinateInfo(
+        dims_objectives=[
             _DimensionInfo(
                 label="Objective Value",
                 values=(0.0, 2.0),
@@ -477,7 +451,7 @@ def test_get_parallel_coordinate_info_categorical_params() -> None:
                 ticktext=[],
             )
         ],
-        parameter_dimensions=[
+        dims_params=[
             _DimensionInfo(
                 label="category_a",
                 values=(0, 1),
@@ -499,6 +473,8 @@ def test_get_parallel_coordinate_info_categorical_params() -> None:
         ],
         reverse_scale=True,
         colorbar_title="Objective Value",
+        color_values=(0.0, 2.0),
+        draw_order=(0, 1),
     )
 
 
@@ -508,8 +484,8 @@ def test_get_parallel_coordinate_info_categorical_numeric_params() -> None:
 
     # Trials are sorted by using param_a and param_b, i.e., trial#1, trial#2, and trial#0.
     info = _get_parallel_coordinate_info(study)
-    assert info == _create_parallel_coordinate_info(
-        objective_dimensions=[
+    assert info == _ParallelCoordinateInfo(
+        dims_objectives=[
             _DimensionInfo(
                 label="Objective Value",
                 values=(1.0, 2.0, 0.0),
@@ -520,7 +496,7 @@ def test_get_parallel_coordinate_info_categorical_numeric_params() -> None:
                 ticktext=[],
             )
         ],
-        parameter_dimensions=[
+        dims_params=[
             _DimensionInfo(
                 label="category_a",
                 values=(0, 1, 1),
@@ -542,6 +518,8 @@ def test_get_parallel_coordinate_info_categorical_numeric_params() -> None:
         ],
         reverse_scale=True,
         colorbar_title="Objective Value",
+        color_values=(1.0, 2.0, 0.0),
+        draw_order=(0, 1, 2),
     )
 
 
@@ -549,8 +527,8 @@ def test_get_parallel_coordinate_info_log_params() -> None:
     # Test with log params.
     study = _create_study_with_log_params()
     info = _get_parallel_coordinate_info(study)
-    assert info == _create_parallel_coordinate_info(
-        objective_dimensions=[
+    assert info == _ParallelCoordinateInfo(
+        dims_objectives=[
             _DimensionInfo(
                 label="Objective Value",
                 values=(0.0, 1.0, 0.1),
@@ -561,7 +539,7 @@ def test_get_parallel_coordinate_info_log_params() -> None:
                 ticktext=[],
             )
         ],
-        parameter_dimensions=[
+        dims_params=[
             _DimensionInfo(
                 label="param_a",
                 values=(-6, math.log10(2e-5), -4),
@@ -583,6 +561,8 @@ def test_get_parallel_coordinate_info_log_params() -> None:
         ],
         reverse_scale=True,
         colorbar_title="Objective Value",
+        color_values=(0.0, 1.0, 0.1),
+        draw_order=(0, 1, 2),
     )
 
 
@@ -604,8 +584,8 @@ def test_get_parallel_coordinate_info_unique_param() -> None:
 
     # Both parameters contain unique values.
     info = _get_parallel_coordinate_info(study_categorical_params)
-    assert info == _create_parallel_coordinate_info(
-        objective_dimensions=[
+    assert info == _ParallelCoordinateInfo(
+        dims_objectives=[
             _DimensionInfo(
                 label="Objective Value",
                 values=(0.0,),
@@ -616,7 +596,7 @@ def test_get_parallel_coordinate_info_unique_param() -> None:
                 ticktext=[],
             )
         ],
-        parameter_dimensions=[
+        dims_params=[
             _DimensionInfo(
                 label="category_a",
                 values=(0.0,),
@@ -638,6 +618,8 @@ def test_get_parallel_coordinate_info_unique_param() -> None:
         ],
         reverse_scale=True,
         colorbar_title="Objective Value",
+        color_values=(0.0,),
+        draw_order=(0,),
     )
 
     study_categorical_params.add_trial(
@@ -650,8 +632,8 @@ def test_get_parallel_coordinate_info_unique_param() -> None:
 
     # Still "category_a" contains unique suggested value during the optimization.
     info = _get_parallel_coordinate_info(study_categorical_params)
-    assert info == _create_parallel_coordinate_info(
-        objective_dimensions=[
+    assert info == _ParallelCoordinateInfo(
+        dims_objectives=[
             _DimensionInfo(
                 label="Objective Value",
                 values=(0.0, 2.0),
@@ -662,7 +644,7 @@ def test_get_parallel_coordinate_info_unique_param() -> None:
                 ticktext=[],
             )
         ],
-        parameter_dimensions=[
+        dims_params=[
             _DimensionInfo(
                 label="category_a",
                 values=(0, 0),
@@ -684,6 +666,8 @@ def test_get_parallel_coordinate_info_unique_param() -> None:
         ],
         reverse_scale=True,
         colorbar_title="Objective Value",
+        color_values=(0.0, 2.0),
+        draw_order=(0, 1),
     )
 
 
@@ -692,8 +676,8 @@ def test_get_parallel_coordinate_info_with_log_scale_and_str_and_numeric_categor
     # that can be interpreted as numeric params.
     study = _create_study_with_log_scale_and_str_and_numeric_category()
     info = _get_parallel_coordinate_info(study)
-    assert info == _create_parallel_coordinate_info(
-        objective_dimensions=[
+    assert info == _ParallelCoordinateInfo(
+        dims_objectives=[
             _DimensionInfo(
                 label="Objective Value",
                 values=(1.0, 3.0, 0.0, 2.0),
@@ -704,7 +688,7 @@ def test_get_parallel_coordinate_info_with_log_scale_and_str_and_numeric_categor
                 ticktext=[],
             )
         ],
-        parameter_dimensions=[
+        dims_params=[
             _DimensionInfo(
                 label="param_a",
                 values=(1, 1, 0, 0),
@@ -744,6 +728,8 @@ def test_get_parallel_coordinate_info_with_log_scale_and_str_and_numeric_categor
         ],
         reverse_scale=True,
         colorbar_title="Objective Value",
+        color_values=(1.0, 3.0, 0.0, 2.0),
+        draw_order=(0, 1, 2, 3),
     )
 
 
@@ -820,21 +806,32 @@ def test_get_parallel_coordinate_info_only_missing_params() -> None:
     )
 
     info = _get_parallel_coordinate_info(study)
-    parameter_dimensions = _parameter_dimensions(info)
-    assert _objective_dimensions(info)[0].values == (0.0, 1.0)
+    parameter_dimensions = info.dims_params
+    assert info.dims_objectives[0].values == (0.0, 1.0)
     assert len(parameter_dimensions) == 2
     assert all(dim.ticktext[0] == "None" for dim in parameter_dimensions)
     assert all(len(dim.values) == 2 for dim in parameter_dimensions)
     assert all(dim.has_missing for dim in parameter_dimensions)
 
 
-@pytest.mark.parametrize("value", ["None", None])
+@pytest.mark.parametrize(
+    "value, include_missing, expected_ticktext, expected_has_missing",
+    [
+        ("None", True, ["None", "None (value)"], True),
+        (None, True, ["None", "None (value)"], True),
+        (None, False, ["None"], False),
+    ],
+)
 def test_get_parallel_coordinate_info_missing_categorical_value_label_collision(
     value: str | None,
+    include_missing: bool,
+    expected_ticktext: list[str],
+    expected_has_missing: bool,
 ) -> None:
     study = create_study()
     distribution = CategoricalDistribution((value, "value"))
-    study.add_trial(create_trial(value=0.0))
+    if include_missing:
+        study.add_trial(create_trial(value=0.0))
     study.add_trial(
         create_trial(
             value=1.0,
@@ -844,27 +841,10 @@ def test_get_parallel_coordinate_info_missing_categorical_value_label_collision(
     )
 
     info = _get_parallel_coordinate_info(study)
-    parameter_dimension = _parameter_dimensions(info)[0]
-    assert parameter_dimension.ticktext == ["None", "None (value)"]
-    assert parameter_dimension.values == (0, 1)
-    assert parameter_dimension.has_missing
-
-
-def test_get_parallel_coordinate_info_categorical_none_without_missing_value() -> None:
-    study = create_study()
-    distribution = CategoricalDistribution((None, "value"))
-    study.add_trial(
-        create_trial(
-            value=1.0,
-            params={"param": None},
-            distributions={"param": distribution},
-        )
-    )
-
-    info = _get_parallel_coordinate_info(study)
-    parameter_dimension = _parameter_dimensions(info)[0]
-    assert parameter_dimension.ticktext == ["None"]
-    assert not parameter_dimension.has_missing
+    parameter_dimension = info.dims_params[0]
+    assert parameter_dimension.ticktext == expected_ticktext
+    assert parameter_dimension.values == ((0, 1) if include_missing else (0,))
+    assert parameter_dimension.has_missing == expected_has_missing
 
 
 def test_plot_parallel_coordinate_with_constant_objective() -> None:
@@ -894,10 +874,10 @@ def test_plot_parallel_coordinate_with_constant_objective() -> None:
     plt.close(ax.get_figure())
 
 
+@pytest.mark.filterwarnings("ignore::optuna.exceptions.ExperimentalWarning")
 def test_get_parallel_coordinate_info_multi_objective() -> None:
     study = create_study(directions=["minimize", "maximize"])
-    with pytest.warns(ExperimentalWarning):
-        study.set_metric_names(["loss", "score"])
+    study.set_metric_names(["loss", "score"])
     distribution = FloatDistribution(0.0, 10.0)
     study.add_trial(
         create_trial(
@@ -915,7 +895,7 @@ def test_get_parallel_coordinate_info_multi_objective() -> None:
     )
 
     info = _get_parallel_coordinate_info(study)
-    assert [dim.label for dim in _objective_dimensions(info)] == ["loss", "score"]
+    assert [dim.label for dim in info.dims_objectives] == ["loss", "score"]
     assert info.color_values == (0.0, 1.0)
     assert info.colorbar_title == "Pareto Rank"
     assert info.is_rank_color
@@ -1002,7 +982,7 @@ def test_get_parallel_coordinate_info_with_constraints() -> None:
     info = _get_parallel_coordinate_info(study)
 
     assert info.feasibility == (True, False, False)
-    assert _parameter_dimensions(info)[0].label == "param"
+    assert info.dims_params[0].label == "param"
 
     figure = plotly_plot_parallel_coordinate(study)
     assert all(trace.type == "scatter" for trace in figure.data)
@@ -1015,7 +995,7 @@ def test_get_parallel_coordinate_info_with_constraints() -> None:
     assert [trace["mode"] for trace in figure.data[:3]] == ["lines"] * 3
     assert [trace["opacity"] for trace in figure.data[:3]] == [0.5] * 3
     assert [trace["name"] for trace in figure.data[3:5]] == ["Feasible", "Infeasible"]
-    _assert_plotly_figure_serializable(figure)
+    assert figure.to_json()
 
     ax = matplotlib.plot_parallel_coordinate(study)
     assert [label.get_text() for label in ax.get_xticklabels()] == ["Objective Value", "param"]
@@ -1030,7 +1010,7 @@ def test_get_parallel_coordinate_info_with_constraints() -> None:
 def test_nonfinite_removed(value: float) -> None:
     study = prepare_study_with_trials(value_for_first_trial=value)
     info = _get_parallel_coordinate_info(study)
-    assert all(np.isfinite(_objective_dimensions(info)[0].values))
+    assert all(np.isfinite(info.dims_objectives[0].values))
 
 
 @pytest.mark.parametrize("objective", (0, 1))
@@ -1040,4 +1020,4 @@ def test_nonfinite_multiobjective(objective: int, value: float) -> None:
     info = _get_parallel_coordinate_info(
         study, target=lambda t: t.values[objective], target_name="Target Name"
     )
-    assert all(np.isfinite(_objective_dimensions(info)[0].values))
+    assert all(np.isfinite(info.dims_objectives[0].values))


### PR DESCRIPTION
## Motivation & Description of the changes

The existing parallel coordinate plot has limited support for conditional search spaces, multi-objective studies, and constrained optimization.

This PR extends both the Plotly and Matplotlib implementations to visualize these studies consistently.

- Support conditional parameters.
  - Missing values are displayed using a fixed `None` label.
  - If an actual categorical value is also represented as `None`, it is displayed as `None (value)` to distinguish it from a missing value.

- Support multi-objective studies without requiring `target`.
  - All objective values are displayed as separate axes.
  - Lines are colored by Pareto rank (Pareto ranks are computed from objective values independently of constraints).

- Support constrained studies.
  - Feasible trials are drawn with solid lines.
  - Infeasible trials are drawn with dotted lines.

- Use Scatter traces for the Plotly implementation.
  - This allows each trial to have an individual line style, which is not supported by `go.Parcoords`.

Plotly
<img width="1946" height="1050" alt="image" src="https://github.com/user-attachments/assets/00cc222c-574b-4ac4-a8e3-401ce065899a" />

Matplotlib
<img width="1946" height="1050" alt="image" src="https://github.com/user-attachments/assets/b18ab5ae-89a8-4abf-952c-7d9b89bdbcd3" />
