### PR TITLE
Validate base_path in FileSystemArtifactStore

### DIFF
--- a/optuna/artifacts/_filesystem.py
+++ b/optuna/artifacts/_filesystem.py
@@ -48,7 +48,8 @@ class FileSystemArtifactStore:
     def __init__(self, base_path: str | Path) -> None:
         if isinstance(base_path, str):
             base_path = Path(base_path)
-        # TODO(Shinichi): Check if the base_path is valid directory.
+        if base_path.exists() and not base_path.is_dir():
+            raise ValueError(f"base_path must be a directory: {base_path}")
         self._base_path = base_path
 
     def _get_filepath(self, artifact_id: str) -> Path:

--- a/tests/artifacts_tests/test_filesystem.py
+++ b/tests/artifacts_tests/test_filesystem.py
@@ -53,3 +53,12 @@ def test_path_traversal(tmp_path: Path) -> None:
 
         with pytest.raises(ValueError, match="Invalid artifact_id"):
             backend.remove(invalid_id)
+
+
+def test_invalid_base_path(tmp_path: Path) -> None:
+    file_path = tmp_path / "file.txt"
+    file_path.touch()
+
+    with pytest.raises(ValueError, match="base_path must be a directory"):
+        FileSystemArtifactStore(file_path)
+

--- a/tests/artifacts_tests/test_filesystem.py
+++ b/tests/artifacts_tests/test_filesystem.py
@@ -61,4 +61,3 @@ def test_invalid_base_path(tmp_path: Path) -> None:
 
     with pytest.raises(ValueError, match="base_path must be a directory"):
         FileSystemArtifactStore(file_path)
-


### PR DESCRIPTION
## Description
This PR resolves an existing TODO in `FileSystemArtifactStore.__init__` by validating that `base_path` is a directory if it exists, raising a `ValueError` if it points to an existing file.

## Changes
- Validate `base_path` in `FileSystemArtifactStore.__init__`
- Add unit test `test_invalid_base_path` in `tests/artifacts_tests/test_filesystem.py`