### PR TITLE
Fix unused mypy ignores in `optuna/visualization/matplotlib/_rank.py`

### DIFF
--- a/optuna/visualization/matplotlib/_rank.py
+++ b/optuna/visualization/matplotlib/_rank.py
@@ -103,9 +103,7 @@ def _get_rank_plot(
     pc.set_cmap(plt.get_cmap("RdYlBu_r"))
     cbar = fig.colorbar(pc, ax=axs, ticks=tick_info.coloridxs)
     cbar.ax.set_yticklabels(tick_info.text)
-    # NOTE(Alnusjaponica): The class of cbar.outline inherits matplotlib.patches.Patch,
-    # which has set_edgecolor method. However, mypy does not recognize it.
-    cbar.outline.set_edgecolor("gray")  # type: ignore[operator]
+    cbar.outline.set_edgecolor("gray")
     return axs
 
 


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. To minimize the review effort, we highly appreciate PRs only with related changes. Please note that submitted PRs may be closed if they include unrelated changes or significantly modified unit tests. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
The scheduled CI started being failed: https://github.com/optuna/optuna/actions/runs/30053065414/job/89359050090

## Description of the changes
<!-- Describe the changes in this PR. -->
* Fix unused mypy ignores in `optuna/visualization/matplotlib/_rank.py`