### PR TITLE
Deprecate `constraints_func`

### DIFF
--- a/optuna/samplers/_gp/sampler.py
+++ b/optuna/samplers/_gp/sampler.py
@@ -7,7 +7,9 @@ from typing import TYPE_CHECKING
 import numpy as np
 
 import optuna
+from optuna import _deprecated
 from optuna._experimental import warn_experimental_argument
+from optuna._warnings import optuna_warn
 from optuna.samplers._base import _INDEPENDENT_SAMPLING_WARNING_TEMPLATE
 from optuna.samplers._base import _process_constraints_after_trial
 from optuna.samplers._base import BaseSampler
@@ -202,10 +204,11 @@ class GPSampler(BaseSampler):
             The function won't be called when trials fail or are pruned, but this behavior is
             subject to change in future releases.
 
-            .. note::
-                Added in v4.2.0 as an experimental feature. The interface may change in newer
-                versions without prior notice. See
-                https://github.com/optuna/optuna/releases/tag/v4.2.0.
+            .. warning::
+                Deprecated in v5.0.0. This feature will be removed in the future. The removal of
+                this feature is currently scheduled for v7.0.0, but this schedule is subject to
+                change. Use :meth:`~optuna.trial.Trial.set_constraint` instead.
+                See https://github.com/optuna/optuna/releases/tag/v5.0.0.
         warn_independent_sampling:
             If this is :obj:`True`, a warning message is emitted when
             the value of a parameter is sampled by using an independent sampler,
@@ -248,7 +251,10 @@ class GPSampler(BaseSampler):
         self._warn_independent_sampling = warn_independent_sampling
 
         if constraints_func is not None:
-            warn_experimental_argument("constraints_func")
+            msg = _deprecated._DEPRECATION_WARNING_TEMPLATE.format(
+                name="`constraints_func`", d_ver="5.0.0", r_ver="7.0.0"
+            )
+            optuna_warn(f"{msg} Use `optuna.trial.Trial.set_constraint` instead.", FutureWarning)
         if deterministic_objective:
             warn_experimental_argument("deterministic_objective")
 

--- a/optuna/samplers/_nsgaiii/_sampler.py
+++ b/optuna/samplers/_nsgaiii/_sampler.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 from typing import Any
 from typing import TYPE_CHECKING
 
+from optuna import _deprecated
 from optuna._experimental import experimental_class
+from optuna._warnings import optuna_warn
 from optuna.samplers._ga import BaseGASampler
 from optuna.samplers._lazy_random_state import LazyRandomState
 from optuna.samplers._nsgaiii._elite_population_selection_strategy import (
@@ -40,8 +42,8 @@ class NSGAIIISampler(BaseGASampler):
     .. note::
         When optimizing many objectives, a large fraction of trials may become non-dominated
         in general due to the curse of dimensionality in the objective space. If possible, consider
-        modeling some objectives as constraints. Constraints can be passed via the
-        `constraints_func` argument at the sampler initialization.
+        modeling some objectives as constraints. Constraints can be set within the objective
+        function using the :meth:`~optuna.trial.Trial.set_constraint` method.
         :class:`~optuna.samplers.NSGAIISampler`, :class:`~optuna.samplers.TPESampler`, and
         :class:`~optuna.samplers.GPSampler` also support constrained multi-objective optimization.
         Since Bayesian optimization is often sample efficient, it is worth considering
@@ -108,6 +110,12 @@ class NSGAIIISampler(BaseGASampler):
 
         if population_size < 2:
             raise ValueError("`population_size` must be greater than or equal to 2.")
+
+        if constraints_func is not None:
+            msg = _deprecated._DEPRECATION_WARNING_TEMPLATE.format(
+                name="`constraints_func`", d_ver="5.0.0", r_ver="7.0.0"
+            )
+            optuna_warn(f"{msg} Use `optuna.trial.Trial.set_constraint` instead.", FutureWarning)
 
         if crossover is None:
             crossover = UniformCrossover(swapping_prob)

--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -230,10 +230,11 @@ class TPESampler(BaseSampler):
             The function won't be called when trials fail or they are pruned, but this behavior is
             subject to change in the future releases.
 
-            .. note::
-                Added in v3.0.0 as an experimental feature. The interface may change in newer
-                versions without prior notice.
-                See https://github.com/optuna/optuna/releases/tag/v3.0.0.
+            .. warning::
+                Deprecated in v5.0.0. This feature will be removed in the future. The removal of
+                this feature is currently scheduled for v7.0.0, but this schedule is subject to
+                change. Use :meth:`~optuna.trial.Trial.set_constraint` instead.
+                See https://github.com/optuna/optuna/releases/tag/v5.0.0.
         consider_prior:
             Enhance the stability of Parzen estimator by imposing a Gaussian prior when
             :obj:`True`. The prior is only effective if the sampling distribution is
@@ -428,7 +429,10 @@ class TPESampler(BaseSampler):
             self._group_decomposed_search_space = _GroupDecomposedSearchSpace(True)
 
         if constraints_func is not None:
-            warn_experimental_argument("constraints_func")
+            msg = _deprecated._DEPRECATION_WARNING_TEMPLATE.format(
+                name="`constraints_func`", d_ver="5.0.0", r_ver="7.0.0"
+            )
+            optuna_warn(f"{msg} Use `optuna.trial.Trial.set_constraint` instead.", FutureWarning)
 
     def reseed_rng(self) -> None:
         self._rng.rng.seed()

--- a/optuna/samplers/nsgaii/_sampler.py
+++ b/optuna/samplers/nsgaii/_sampler.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 from typing import Any
 from typing import TYPE_CHECKING
 
+from optuna import _deprecated
 from optuna._experimental import warn_experimental_argument
+from optuna._warnings import optuna_warn
 from optuna.samplers._ga import BaseGASampler
 from optuna.samplers._lazy_random_state import LazyRandomState
 from optuna.samplers._random import RandomSampler
@@ -130,10 +132,11 @@ class NSGAIISampler(BaseGASampler):
             2. Trial x and y are both infeasible, but trial x has a smaller overall violation.
             3. Trial x and y are feasible and trial x dominates trial y.
 
-            .. note::
-                Added in v2.5.0 as an experimental feature. The interface may change in newer
-                versions without prior notice. See
-                https://github.com/optuna/optuna/releases/tag/v2.5.0.
+            .. warning::
+                Deprecated in v5.0.0. This feature will be removed in the future. The removal of
+                this feature is currently scheduled for v7.0.0, but this schedule is subject to
+                change. Use :meth:`~optuna.trial.Trial.set_constraint` instead.
+                See https://github.com/optuna/optuna/releases/tag/v5.0.0.
 
         elite_population_selection_strategy:
             The selection strategy for determining the individuals to survive from the current
@@ -191,7 +194,10 @@ class NSGAIISampler(BaseGASampler):
             raise ValueError("`population_size` must be greater than or equal to 2.")
 
         if constraints_func is not None:
-            warn_experimental_argument("constraints_func")
+            msg = _deprecated._DEPRECATION_WARNING_TEMPLATE.format(
+                name="`constraints_func`", d_ver="5.0.0", r_ver="7.0.0"
+            )
+            optuna_warn(f"{msg} Use `optuna.trial.Trial.set_constraint` instead.", FutureWarning)
         if after_trial_strategy is not None:
             warn_experimental_argument("after_trial_strategy")
 

--- a/tests/samplers_tests/test_gp.py
+++ b/tests/samplers_tests/test_gp.py
@@ -62,7 +62,7 @@ def test_constraints_func(constraint_value: float, n_objectives: int) -> None:
         return (constraint_value + trial.number,)
 
     with warnings.catch_warnings():
-        warnings.simplefilter("ignore", optuna.exceptions.ExperimentalWarning)
+        warnings.simplefilter("ignore", FutureWarning)
         sampler = GPSampler(n_startup_trials=2, constraints_func=constraints_func)
 
     def objective(trial: optuna.Trial) -> float | tuple[float, float]:
@@ -90,7 +90,7 @@ def test_constraints_func_nan(n_objectives: int) -> None:
         return (float("nan"),)
 
     with warnings.catch_warnings():
-        warnings.simplefilter("ignore", optuna.exceptions.ExperimentalWarning)
+        warnings.simplefilter("ignore", FutureWarning)
         sampler = GPSampler(n_startup_trials=2, constraints_func=constraints_func)
 
     def objective(

--- a/tests/samplers_tests/test_nsgaii.py
+++ b/tests/samplers_tests/test_nsgaii.py
@@ -180,7 +180,7 @@ def test_constraints_func(constraint_value: float) -> None:
         return (constraint_value + trial.number,)
 
     with warnings.catch_warnings():
-        warnings.simplefilter("ignore", optuna.exceptions.ExperimentalWarning)
+        warnings.simplefilter("ignore", FutureWarning)
         sampler = NSGAIISampler(population_size=2, constraints_func=constraints_func)
 
     study = optuna.create_study(directions=["minimize"] * n_objectives, sampler=sampler)
@@ -204,7 +204,7 @@ def test_constraints_func_nan() -> None:
         return (float("nan"),)
 
     with warnings.catch_warnings():
-        warnings.simplefilter("ignore", optuna.exceptions.ExperimentalWarning)
+        warnings.simplefilter("ignore", FutureWarning)
         sampler = NSGAIISampler(population_size=2, constraints_func=constraints_func)
 
     study = optuna.create_study(directions=["minimize"] * n_objectives, sampler=sampler)
@@ -547,8 +547,8 @@ def test_crowding_distance_sort(values: list[list[float]]) -> None:
     assert sorted_dist == sorted(sorted_dist, reverse=True)
 
 
-def test_constraints_func_experimental_warning() -> None:
-    with pytest.warns(optuna.exceptions.ExperimentalWarning):
+def test_constraints_func_deprecation_warning() -> None:
+    with pytest.warns(FutureWarning):
         NSGAIISampler(constraints_func=lambda _: [0])
 
 

--- a/tests/samplers_tests/test_nsgaiii.py
+++ b/tests/samplers_tests/test_nsgaiii.py
@@ -144,6 +144,7 @@ def test_constraints_func(constraint_value: float) -> None:
 
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", optuna.exceptions.ExperimentalWarning)
+        warnings.simplefilter("ignore", FutureWarning)
         sampler = NSGAIIISampler(population_size=2, constraints_func=constraints_func)
 
     study = optuna.create_study(directions=["minimize"] * n_objectives, sampler=sampler)
@@ -168,6 +169,7 @@ def test_constraints_func_nan() -> None:
 
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", optuna.exceptions.ExperimentalWarning)
+        warnings.simplefilter("ignore", FutureWarning)
         sampler = NSGAIIISampler(population_size=2, constraints_func=constraints_func)
 
     study = optuna.create_study(directions=["minimize"] * n_objectives, sampler=sampler)
@@ -184,8 +186,8 @@ def test_constraints_func_nan() -> None:
     assert len(trials[0].constraints) == 0  # No constraints are set.
 
 
-def test_constraints_func_experimental_warning() -> None:
-    with pytest.warns(optuna.exceptions.ExperimentalWarning):
+def test_constraints_func_deprecation_warning() -> None:
+    with pytest.warns(FutureWarning):
         NSGAIIISampler(constraints_func=lambda _: [0])
 
 

--- a/tests/samplers_tests/tpe_tests/test_sampler.py
+++ b/tests/samplers_tests/tpe_tests/test_sampler.py
@@ -33,8 +33,8 @@ def test_hyperopt_parameters_deprecation_warning() -> None:
         TPESampler.hyperopt_parameters()
 
 
-def test_constraints_func_experimental_warning() -> None:
-    with pytest.warns(optuna.exceptions.ExperimentalWarning):
+def test_constraints_func_deprecation_warning() -> None:
+    with pytest.warns(FutureWarning):
         optuna.samplers.TPESampler(constraints_func=lambda _: (0,))
 
 
@@ -699,7 +699,9 @@ def test_constrained_sample_independent_zero_startup() -> None:
     study = optuna.create_study()
     dist = optuna.distributions.FloatDistribution(1.0, 100.0)
     trial = frozen_trial_factory(30)
-    sampler = TPESampler(n_startup_trials=0, seed=2, constraints_func=lambda _: (0,))
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", FutureWarning)
+        sampler = TPESampler(n_startup_trials=0, seed=2, constraints_func=lambda _: (0,))
     sampler.sample_independent(study, trial, "param-a", dist)
 
 


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. To minimize the review effort, we highly appreciate PRs only with related changes. Please note that submitted PRs may be closed if they include unrelated changes or significantly modified unit tests. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

#6754 introduced `set_constraint`, so `constraints_func` is being deprecated.

## Description of the changes
<!-- Describe the changes in this PR. -->
- Deprecate `constraints_func` in `TPESampler`, `NSGAIISampler`, `NSGAIIISampler`, and `GPSampler`