### PR TITLE
Change to treat cases without constraints as feasible

### DIFF
--- a/optuna/samplers/nsgaii/_constraints_evaluation.py
+++ b/optuna/samplers/nsgaii/_constraints_evaluation.py
@@ -31,9 +31,6 @@ def _constrained_dominates(
     constraints0 = trial0.constraints
     constraints1 = trial1.constraints
 
-    if constraints0.keys() != constraints1.keys():
-        raise ValueError("Trials with different constraint keys cannot be compared.")
-
     if trial0.state != TrialState.COMPLETE:
         return False
 
@@ -82,10 +79,7 @@ def _validate_constraints(
     if not is_constrained:
         return
 
-    num_constraints = max([len(t.constraints) for t in population], default=0)
     for _trial in population:
         _constraints = _trial.constraints
         if np.any(np.isnan(list(_constraints.values()))):
             raise ValueError("NaN is not acceptable as constraint value.")
-        elif len(_constraints) != num_constraints:
-            raise ValueError("Trials with different numbers of constraints cannot be compared.")

--- a/optuna/samplers/nsgaii/_constraints_evaluation.py
+++ b/optuna/samplers/nsgaii/_constraints_evaluation.py
@@ -62,7 +62,7 @@ def _constrained_dominates(
 
 
 def _evaluate_penalty(population: Sequence[FrozenTrial]) -> np.ndarray:
-    """Evaluate feasibility of trials in population.
+    """Evaluate penalty values of trials in population.
     Returns:
         A list of penalty values of trials in population, where a trial with constraint values of
         zero or less is feasible.

--- a/optuna/samplers/nsgaii/_constraints_evaluation.py
+++ b/optuna/samplers/nsgaii/_constraints_evaluation.py
@@ -4,7 +4,6 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
-from optuna._warnings import optuna_warn
 from optuna.study._multi_objective import _dominates
 from optuna.trial import TrialState
 
@@ -31,30 +30,6 @@ def _constrained_dominates(
 
     constraints0 = trial0.constraints
     constraints1 = trial1.constraints
-
-    if len(constraints0) == 0:
-        optuna_warn(
-            f"Trial {trial0.number} does not have constraint values."
-            " It will be dominated by the other trials."
-        )
-
-    if len(constraints1) == 0:
-        optuna_warn(
-            f"Trial {trial1.number} does not have constraint values."
-            " It will be dominated by the other trials."
-        )
-
-    if len(constraints0) == 0 and len(constraints1) == 0:
-        # Neither Trial x nor y has constraints values
-        return _dominates(trial0, trial1, directions)
-
-    if len(constraints0) > 0 and len(constraints1) == 0:
-        # Trial x has constraint values, but y doesn't.
-        return True
-
-    if len(constraints0) == 0 and len(constraints1) > 0:
-        # If Trial y has constraint values, but x doesn't.
-        return False
 
     if constraints0.keys() != constraints1.keys():
         raise ValueError("Trials with different constraint keys cannot be compared.")
@@ -89,17 +64,13 @@ def _constrained_dominates(
 def _evaluate_penalty(population: Sequence[FrozenTrial]) -> np.ndarray:
     """Evaluate feasibility of trials in population.
     Returns:
-        A list of feasibility status T/F/None of trials in population, where T/F means
-        feasible/infeasible and None means that the trial does not have constraint values.
+        A list of penalty values of trials in population, where a trial with constraint values of
+        zero or less is feasible.
     """
 
     penalty: list[float] = []
     for trial in population:
-        constraints = trial.constraints
-        if len(constraints) == 0:
-            penalty.append(np.nan)
-        else:
-            penalty.append(sum(v for v in constraints.values() if v > 0))
+        penalty.append(sum(v for v in trial.constraints.values() if v > 0))
     return np.array(penalty)
 
 
@@ -114,12 +85,6 @@ def _validate_constraints(
     num_constraints = max([len(t.constraints) for t in population], default=0)
     for _trial in population:
         _constraints = _trial.constraints
-        if len(_constraints) == 0:
-            optuna_warn(
-                f"Trial {_trial.number} does not have constraint values."
-                " It will be dominated by the other trials."
-            )
-            continue
         if np.any(np.isnan(list(_constraints.values()))):
             raise ValueError("NaN is not acceptable as constraint value.")
         elif len(_constraints) != num_constraints:

--- a/optuna/study/_constrained_optimization.py
+++ b/optuna/study/_constrained_optimization.py
@@ -20,10 +20,6 @@ def _is_constrained_optimization(trials: Sequence[FrozenTrial]) -> bool:
 def _get_feasible_trials(trials: Sequence[FrozenTrial]) -> list[FrozenTrial]:
     """Return feasible trials from given trials.
 
-    This function assumes that the trials were created in constrained optimization.
-    Therefore, if there is no violation value in the trial, it is considered infeasible.
-
-
     Returns:
         A list of feasible trials.
     """
@@ -31,6 +27,6 @@ def _get_feasible_trials(trials: Sequence[FrozenTrial]) -> list[FrozenTrial]:
     feasible_trials = []
     for trial in trials:
         constraints = trial.constraints.values()
-        if len(constraints) > 0 and all(x <= 0.0 for x in constraints):
+        if all(x <= 0.0 for x in constraints):
             feasible_trials.append(trial)
     return feasible_trials

--- a/optuna/study/_multi_objective.py
+++ b/optuna/study/_multi_objective.py
@@ -54,19 +54,14 @@ def _fast_non_domination_rank(
     The fast non-dominated sort algorithm assigns a rank to each trial based on the dominance
     relationship of the trials, determined by the objective values and the penalty values. The
     algorithm is based on `the constrained NSGA-II algorithm
-    <https://doi.org/10.1109/4235.99601>`__, but the handling of the case when penalty
-    values are None is different. The algorithm assigns the rank according to the following
-    rules:
+    <https://doi.org/10.1109/4235.99601>`__. The algorithm assigns the rank according to the
+    following rules:
 
     1. Feasible trials: First, the algorithm assigns the rank to feasible trials, whose penalty
         values are less than or equal to 0, according to unconstrained version of fast non-
         dominated sort.
     2. Infeasible trials: Next, the algorithm assigns the rank from the minimum penalty value of to
         the maximum penalty value.
-    3. Trials with no penalty information (constraints value is None): Finally, The algorithm
-        assigns the rank to trials with no penalty information according to unconstrained version
-        of fast non-dominated sort. Note that only this step is different from the original
-        constrained NSGA-II algorithm.
     Plus, the algorithm terminates whenever the number of sorted trials reaches n_below.
 
     Args:
@@ -100,9 +95,8 @@ def _fast_non_domination_rank(
         )
 
     ranks = np.full(len(loss_values), -1, dtype=int)
-    is_penalty_nan = np.isnan(penalty)
-    is_feasible = np.logical_and(~is_penalty_nan, penalty <= 0)
-    is_infeasible = np.logical_and(~is_penalty_nan, penalty > 0)
+    is_feasible = penalty <= 0
+    is_infeasible = penalty > 0
 
     # First, we calculate the domination rank for feasible trials.
     ranks[is_feasible] = _calculate_nondomination_rank(loss_values[is_feasible], n_below=n_below)
@@ -112,13 +106,6 @@ def _fast_non_domination_rank(
     top_rank_infeasible = np.max(ranks[is_feasible], initial=-1) + 1
     ranks[is_infeasible] = top_rank_infeasible + _calculate_nondomination_rank(
         penalty[is_infeasible][:, np.newaxis], n_below=n_below
-    )
-    n_below -= int(np.count_nonzero(is_infeasible))
-
-    # Third, we calculate the domination rank for trials with no penalty information.
-    top_rank_penalty_nan = np.max(ranks[~is_penalty_nan], initial=-1) + 1
-    ranks[is_penalty_nan] = top_rank_penalty_nan + _calculate_nondomination_rank(
-        loss_values[is_penalty_nan], n_below=n_below
     )
     assert np.all(ranks != -1), "All the rank must be updated."
     return ranks

--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -334,8 +334,7 @@ class Study:
         best_trial = self._storage.get_best_trial(self._study_id)
 
         # If the trial with the best value is infeasible, select the best trial from all feasible
-        # trials. Note that the behavior is undefined when constrained optimization without the
-        # violation value in the best-valued trial.
+        # trials.
         if any(x > 0.0 for x in best_trial.constraints.values()):
             complete_trials = self.get_trials(deepcopy=False, states=[TrialState.COMPLETE])
             feasible_trials = _get_feasible_trials(complete_trials)

--- a/tests/samplers_tests/test_nsgaii.py
+++ b/tests/samplers_tests/test_nsgaii.py
@@ -221,6 +221,24 @@ def test_constraints_func_nan() -> None:
     assert len(trials[0].constraints) == 0  # No constraints are set.
 
 
+def test_set_constraint_with_different_keys() -> None:
+    n_trials = 8
+
+    def objective(trial: optuna.Trial) -> Sequence[float]:
+        x = trial.suggest_float("x", 0, 1)
+        y = trial.suggest_float("y", 0, 1)
+        if trial.number % 3 == 1:
+            trial.set_constraint("a", x - 0.5)
+        elif trial.number % 3 == 2:
+            trial.set_constraint("b", y - 0.5)
+            trial.set_constraint("c", x + y - 1)
+        return x, y
+
+    sampler = NSGAIISampler(population_size=2)
+    study = optuna.create_study(directions=["minimize", "minimize"], sampler=sampler)
+    study.optimize(objective, n_trials=n_trials)
+
+
 @pytest.mark.parametrize("direction1", [StudyDirection.MINIMIZE, StudyDirection.MAXIMIZE])
 @pytest.mark.parametrize("direction2", [StudyDirection.MINIMIZE, StudyDirection.MAXIMIZE])
 @pytest.mark.parametrize(
@@ -369,6 +387,52 @@ def test_constrained_dominates_infeasible_vs_infeasible(
                 assert not _constrained_dominates(t2, t1, directions)
 
 
+def _create_frozen_trial_with_keyed_constraints(
+    number: int, values: Sequence[float], constraints: dict[str, float]
+) -> FrozenTrial:
+    trial = _create_frozen_trial(number=number, values=values)
+    for key, value in constraints.items():
+        trial.set_constraint(key, value)
+    return trial
+
+
+@pytest.mark.parametrize("direction", [StudyDirection.MINIMIZE, StudyDirection.MAXIMIZE])
+def test_constrained_dominates_different_constraint_keys(direction: StudyDirection) -> None:
+    directions = [direction]
+
+    # A feasible trial dominates an infeasible trial even if their constraint keys differ,
+    # regardless of the values.
+    for values1, values2 in [([0], [1]), ([1], [0])]:
+        t1 = _create_frozen_trial_with_keyed_constraints(0, values1, {"a": -1})
+        t2 = _create_frozen_trial_with_keyed_constraints(1, values2, {"b": 1})
+        assert _constrained_dominates(t1, t2, directions)
+        assert not _constrained_dominates(t2, t1, directions)
+
+        # A trial without constraints is treated as feasible.
+        t1 = _create_frozen_trial(number=0, values=values1)
+        t2 = _create_frozen_trial_with_keyed_constraints(1, values2, {"b": 1})
+        assert _constrained_dominates(t1, t2, directions)
+        assert not _constrained_dominates(t2, t1, directions)
+
+    # When both trials are feasible, the domination is determined by the values.
+    t1 = _create_frozen_trial_with_keyed_constraints(0, [0], {"a": -1})
+    t2 = _create_frozen_trial_with_keyed_constraints(1, [1], {"b": -1, "c": 0})
+    if direction == StudyDirection.MINIMIZE:
+        better, worse = t1, t2
+    else:
+        better, worse = t2, t1
+    assert _constrained_dominates(better, worse, directions)
+    assert not _constrained_dominates(worse, better, directions)
+
+    # When both trials are infeasible, the trial with the smaller total violation dominates
+    # the other, regardless of the values.
+    for values1, values2 in [([0], [1]), ([1], [0])]:
+        t1 = _create_frozen_trial_with_keyed_constraints(0, values1, {"a": 1})
+        t2 = _create_frozen_trial_with_keyed_constraints(1, values2, {"b": 1, "c": 1})
+        assert _constrained_dominates(t1, t2, directions)
+        assert not _constrained_dominates(t2, t1, directions)
+
+
 def _assert_population_per_rank(
     trials: list[FrozenTrial],
     direction: list[StudyDirection],
@@ -428,24 +492,6 @@ def test_validate_constraints() -> None:
     with pytest.raises(ValueError):
         _validate_constraints(
             [_create_frozen_trial(number=0, values=[1], constraints=[0, float("nan")])],
-            is_constrained=True,
-        )
-
-    # Different numbers of constraints are not allowed.
-    with pytest.raises(ValueError):
-        _validate_constraints(
-            [
-                _create_frozen_trial(number=0, values=[1], constraints=[]),
-                _create_frozen_trial(number=1, values=[1], constraints=[0]),
-            ],
-            is_constrained=True,
-        )
-    with pytest.raises(ValueError):
-        _validate_constraints(
-            [
-                _create_frozen_trial(number=0, values=[1], constraints=[0]),
-                _create_frozen_trial(number=1, values=[1], constraints=[0, 1]),
-            ],
             is_constrained=True,
         )
 

--- a/tests/samplers_tests/test_nsgaii.py
+++ b/tests/samplers_tests/test_nsgaii.py
@@ -378,21 +378,19 @@ def _assert_population_per_rank(
     flattened = [trial for rank in population_per_rank for trial in rank]
     assert len(flattened) == len(trials)
 
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", UserWarning)
-        # Check that the trials in the same rank do not dominate each other.
-        for i in range(len(population_per_rank)):
-            for trial1 in population_per_rank[i]:
-                for trial2 in population_per_rank[i]:
-                    assert not _constrained_dominates(trial1, trial2, direction)
+    # Check that the trials in the same rank do not dominate each other.
+    for i in range(len(population_per_rank)):
+        for trial1 in population_per_rank[i]:
+            for trial2 in population_per_rank[i]:
+                assert not _constrained_dominates(trial1, trial2, direction)
 
-        # Check that each trial is dominated by some trial in the rank above.
-        for i in range(len(population_per_rank) - 1):
-            for trial2 in population_per_rank[i + 1]:
-                assert any(
-                    _constrained_dominates(trial1, trial2, direction)
-                    for trial1 in population_per_rank[i]
-                )
+    # Check that each trial is dominated by some trial in the rank above.
+    for i in range(len(population_per_rank) - 1):
+        for trial2 in population_per_rank[i + 1]:
+            assert any(
+                _constrained_dominates(trial1, trial2, direction)
+                for trial1 in population_per_rank[i]
+            )
 
 
 @pytest.mark.parametrize("direction1", [StudyDirection.MINIMIZE, StudyDirection.MAXIMIZE])
@@ -437,42 +435,19 @@ def test_validate_constraints() -> None:
     with pytest.raises(ValueError):
         _validate_constraints(
             [
+                _create_frozen_trial(number=0, values=[1], constraints=[]),
+                _create_frozen_trial(number=1, values=[1], constraints=[0]),
+            ],
+            is_constrained=True,
+        )
+    with pytest.raises(ValueError):
+        _validate_constraints(
+            [
                 _create_frozen_trial(number=0, values=[1], constraints=[0]),
                 _create_frozen_trial(number=1, values=[1], constraints=[0, 1]),
             ],
             is_constrained=True,
         )
-
-
-@pytest.mark.parametrize(
-    "values_and_constraints",
-    [
-        [([10], None), ([20], None), ([20], [0]), ([20], [1]), ([30], [-1])],
-        [
-            ([50, 30], None),
-            ([30, 50], None),
-            ([20, 20], [3, 3]),
-            ([30, 10], [0, -1]),
-            ([15, 15], [4, 4]),
-        ],
-    ],
-)
-def test_rank_population_missing_constraint_values(
-    values_and_constraints: list[tuple[list[float], list[float]]],
-) -> None:
-    values_dim = len(values_and_constraints[0][0])
-    for directions in itertools.product(
-        [StudyDirection.MINIMIZE, StudyDirection.MAXIMIZE], repeat=values_dim
-    ):
-        trials = [
-            _create_frozen_trial(number=i, values=v, constraints=c)
-            for i, (v, c) in enumerate(values_and_constraints)
-        ]
-
-        with pytest.warns(UserWarning):
-            _validate_constraints(trials, is_constrained=True)
-        population_per_rank = _rank_population(trials, list(directions), is_constrained=True)
-        _assert_population_per_rank(trials, list(directions), population_per_rank)
 
 
 @pytest.mark.parametrize("n_dims", [1, 2, 3])

--- a/tests/study_tests/test_constrained_optimization.py
+++ b/tests/study_tests/test_constrained_optimization.py
@@ -7,7 +7,9 @@ def test_get_feasible_trials() -> None:
     trials = []
     trials.append(create_trial(value=0.0, system_attrs={_CONSTRAINTS_KEY: [0.0]}))
     trials.append(create_trial(value=0.0, system_attrs={_CONSTRAINTS_KEY: [1.0]}))
+    # A trial without constraint values is considered feasible.
     trials.append(create_trial(value=0.0))
     feasible_trials = _get_feasible_trials(trials)
-    assert len(feasible_trials) == 1
+    assert len(feasible_trials) == 2
     assert feasible_trials[0] == trials[0]
+    assert feasible_trials[1] == trials[2]


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. To minimize the review effort, we highly appreciate PRs only with related changes. Please note that submitted PRs may be closed if they include unrelated changes or significantly modified unit tests. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

Previously, in constrained optimization, trials without constraints were treated as infeasible. However, with the introduction of `set_constraint` in #6754, it has become possible for constrained optimization problems to include trials that intentionally do not specify any constraints. Additionally, there were existing issues such as undefined behavior in how `best_trial` handled these cases. In v5, we will modify the behavior to treat such cases as feasible when no constraints are present.

## Description of the changes
<!-- Describe the changes in this PR. -->

- Change to treat cases without constraints as feasible in `best_trial`, `best_trials`, `NSGAIISampler`, and `NSGAIIISampler`