### PR TITLE
Normalize trial timestamps to UTC in RDBStorage and JournalStorage

### DIFF
--- a/optuna/storages/_rdb/models.py
+++ b/optuna/storages/_rdb/models.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import datetime
 import enum
 import math
 from typing import Any
@@ -178,8 +179,43 @@ class TrialModel(BaseModel):
     number = _Column(Integer)
     study_id = _Column(Integer, ForeignKey("studies.study_id"), index=True)
     state = _Column(Enum(TrialState), nullable=False)
-    datetime_start = _Column(DateTime)
-    datetime_complete = _Column(DateTime)
+
+    # Trial datetimes are stored as naive UTC and converted to naive local time when constructing
+    # FrozenTrial objects.
+    #
+    # Unlike JournalStorage, which stores aware UTC datetimes, RDBStorage intentionally uses naive
+    # UTC. Timezone-aware column types would require a schema migration where supported and are not
+    # portable across all supported database backends.
+    _datetime_start_utc = _Column("datetime_start", DateTime)
+    _datetime_complete_utc = _Column("datetime_complete", DateTime)
+
+    @property
+    def datetime_start(self) -> datetime.datetime | None:
+        if self._datetime_start_utc is None:
+            return None
+        return self._datetime_start_utc.replace(tzinfo=datetime.timezone.utc)
+
+    @datetime_start.setter
+    def datetime_start(self, value: datetime.datetime | None) -> None:
+        if value is None:
+            self._datetime_start_utc = None
+        else:
+            self._datetime_start_utc = value.astimezone(datetime.timezone.utc).replace(tzinfo=None)
+
+    @property
+    def datetime_complete(self) -> datetime.datetime | None:
+        if self._datetime_complete_utc is None:
+            return None
+        return self._datetime_complete_utc.replace(tzinfo=datetime.timezone.utc)
+
+    @datetime_complete.setter
+    def datetime_complete(self, value: datetime.datetime | None) -> None:
+        if value is None:
+            self._datetime_complete_utc = None
+        else:
+            self._datetime_complete_utc = value.astimezone(datetime.timezone.utc).replace(
+                tzinfo=None
+            )
 
     study = orm.relationship(
         StudyModel, backref=orm.backref("trials", cascade="all, delete-orphan")

--- a/optuna/storages/_rdb/models.py
+++ b/optuna/storages/_rdb/models.py
@@ -193,7 +193,12 @@ class TrialModel(BaseModel):
     def datetime_start(self) -> datetime.datetime | None:
         if self._datetime_start_utc is None:
             return None
-        return self._datetime_start_utc.replace(tzinfo=datetime.timezone.utc)
+
+        return (
+            self._datetime_start_utc.replace(tzinfo=datetime.timezone.utc)
+            .astimezone()
+            .replace(tzinfo=None)
+        )
 
     @datetime_start.setter
     def datetime_start(self, value: datetime.datetime | None) -> None:
@@ -206,7 +211,11 @@ class TrialModel(BaseModel):
     def datetime_complete(self) -> datetime.datetime | None:
         if self._datetime_complete_utc is None:
             return None
-        return self._datetime_complete_utc.replace(tzinfo=datetime.timezone.utc)
+        return (
+            self._datetime_complete_utc.replace(tzinfo=datetime.timezone.utc)
+            .astimezone()
+            .replace(tzinfo=None)
+        )
 
     @datetime_complete.setter
     def datetime_complete(self, value: datetime.datetime | None) -> None:

--- a/optuna/storages/_rdb/storage.py
+++ b/optuna/storages/_rdb/storage.py
@@ -478,7 +478,7 @@ class RDBStorage(BaseStorage, BaseHeartbeat):
             if template_trial:
                 frozen = copy.deepcopy(template_trial)
                 frozen.number = trial.number
-                frozen.datetime_start = _utc_to_local_naive_datetime(trial.datetime_start)
+                frozen.datetime_start = _naive_utc_to_naive_local(trial.datetime_start)
                 frozen._trial_id = trial.trial_id
                 return frozen
             return FrozenTrial(
@@ -486,7 +486,7 @@ class RDBStorage(BaseStorage, BaseHeartbeat):
                 state=trial.state,
                 value=None,
                 values=None,
-                datetime_start=_utc_to_local_naive_datetime(trial.datetime_start),
+                datetime_start=_naive_utc_to_naive_local(trial.datetime_start),
                 datetime_complete=None,
                 params={},
                 distributions={},
@@ -544,8 +544,8 @@ class RDBStorage(BaseStorage, BaseHeartbeat):
                 study_id=study_id,
                 number=None,
                 state=temp_state,
-                datetime_start=_utc_to_local_naive_datetime(template_trial.datetime_start),
-                datetime_complete=_utc_to_local_naive_datetime(template_trial.datetime_complete),
+                datetime_start=_naive_utc_to_naive_local(template_trial.datetime_start),
+                datetime_complete=_naive_utc_to_naive_local(template_trial.datetime_complete),
             )
 
         session.add(trial)
@@ -940,8 +940,8 @@ class RDBStorage(BaseStorage, BaseHeartbeat):
             state=trial.state,
             value=None,
             values=values,
-            datetime_start=_utc_to_local_naive_datetime(trial.datetime_start),
-            datetime_complete=_utc_to_local_naive_datetime(trial.datetime_complete),
+            datetime_start=_naive_utc_to_naive_local(trial.datetime_start),
+            datetime_complete=_naive_utc_to_naive_local(trial.datetime_complete),
             params={
                 p.param_name: distributions.json_to_distribution(
                     p.distribution_json
@@ -1241,7 +1241,7 @@ def escape_alembic_config_value(value: str) -> str:
     return value.replace("%", "%%")
 
 
-def _utc_to_local_naive_datetime(dt: datetime | None) -> datetime | None:
+def _naive_utc_to_naive_local(dt: datetime | None) -> datetime | None:
     if dt is None:
         return None
     return dt.astimezone().replace(tzinfo=None)

--- a/optuna/storages/_rdb/storage.py
+++ b/optuna/storages/_rdb/storage.py
@@ -478,7 +478,7 @@ class RDBStorage(BaseStorage, BaseHeartbeat):
             if template_trial:
                 frozen = copy.deepcopy(template_trial)
                 frozen.number = trial.number
-                frozen.datetime_start = trial.datetime_start
+                frozen.datetime_start = _utc_to_local_naive_datetime(trial.datetime_start)
                 frozen._trial_id = trial.trial_id
                 return frozen
             return FrozenTrial(
@@ -486,7 +486,7 @@ class RDBStorage(BaseStorage, BaseHeartbeat):
                 state=trial.state,
                 value=None,
                 values=None,
-                datetime_start=trial.datetime_start,
+                datetime_start=_utc_to_local_naive_datetime(trial.datetime_start),
                 datetime_complete=None,
                 params={},
                 distributions={},
@@ -544,8 +544,8 @@ class RDBStorage(BaseStorage, BaseHeartbeat):
                 study_id=study_id,
                 number=None,
                 state=temp_state,
-                datetime_start=template_trial.datetime_start,
-                datetime_complete=template_trial.datetime_complete,
+                datetime_start=_utc_to_local_naive_datetime(template_trial.datetime_start),
+                datetime_complete=_utc_to_local_naive_datetime(template_trial.datetime_complete),
             )
 
         session.add(trial)
@@ -940,8 +940,8 @@ class RDBStorage(BaseStorage, BaseHeartbeat):
             state=trial.state,
             value=None,
             values=values,
-            datetime_start=trial.datetime_start,
-            datetime_complete=trial.datetime_complete,
+            datetime_start=_utc_to_local_naive_datetime(trial.datetime_start),
+            datetime_complete=_utc_to_local_naive_datetime(trial.datetime_complete),
             params={
                 p.param_name: distributions.json_to_distribution(
                     p.distribution_json
@@ -1239,3 +1239,9 @@ def escape_alembic_config_value(value: str) -> str:
     # is regarded as the trigger of variable expansion.
     # Please see the documentation of `configparser.BasicInterpolation` for more details.
     return value.replace("%", "%%")
+
+
+def _utc_to_local_naive_datetime(dt: datetime | None) -> datetime | None:
+    if dt is None:
+        return None
+    return dt.astimezone().replace(tzinfo=None)

--- a/optuna/storages/_rdb/storage.py
+++ b/optuna/storages/_rdb/storage.py
@@ -478,7 +478,7 @@ class RDBStorage(BaseStorage, BaseHeartbeat):
             if template_trial:
                 frozen = copy.deepcopy(template_trial)
                 frozen.number = trial.number
-                frozen.datetime_start = _naive_utc_to_naive_local(trial.datetime_start)
+                frozen.datetime_start = trial.datetime_start
                 frozen._trial_id = trial.trial_id
                 return frozen
             return FrozenTrial(
@@ -486,7 +486,7 @@ class RDBStorage(BaseStorage, BaseHeartbeat):
                 state=trial.state,
                 value=None,
                 values=None,
-                datetime_start=_naive_utc_to_naive_local(trial.datetime_start),
+                datetime_start=trial.datetime_start,
                 datetime_complete=None,
                 params={},
                 distributions={},
@@ -544,8 +544,8 @@ class RDBStorage(BaseStorage, BaseHeartbeat):
                 study_id=study_id,
                 number=None,
                 state=temp_state,
-                datetime_start=_naive_utc_to_naive_local(template_trial.datetime_start),
-                datetime_complete=_naive_utc_to_naive_local(template_trial.datetime_complete),
+                datetime_start=template_trial.datetime_start,
+                datetime_complete=template_trial.datetime_complete,
             )
 
         session.add(trial)
@@ -940,8 +940,8 @@ class RDBStorage(BaseStorage, BaseHeartbeat):
             state=trial.state,
             value=None,
             values=values,
-            datetime_start=_naive_utc_to_naive_local(trial.datetime_start),
-            datetime_complete=_naive_utc_to_naive_local(trial.datetime_complete),
+            datetime_start=trial.datetime_start,
+            datetime_complete=trial.datetime_complete,
             params={
                 p.param_name: distributions.json_to_distribution(
                     p.distribution_json
@@ -1239,9 +1239,3 @@ def escape_alembic_config_value(value: str) -> str:
     # is regarded as the trigger of variable expansion.
     # Please see the documentation of `configparser.BasicInterpolation` for more details.
     return value.replace("%", "%%")
-
-
-def _naive_utc_to_naive_local(dt: datetime | None) -> datetime | None:
-    if dt is None:
-        return None
-    return dt.astimezone().replace(tzinfo=None)

--- a/optuna/storages/journal/_storage.py
+++ b/optuna/storages/journal/_storage.py
@@ -4,7 +4,8 @@ from collections.abc import Container
 from collections.abc import Iterable
 from collections.abc import Sequence
 import copy
-import datetime
+from datetime import datetime
+from datetime import timezone
 import enum
 import pickle
 import threading
@@ -229,9 +230,10 @@ class JournalStorage(BaseStorage):
 
     # Basic trial manipulation
     def create_new_trial(self, study_id: int, template_trial: FrozenTrial | None = None) -> int:
+        datetime_start = datetime.now(tz=timezone.utc)
         log: dict[str, Any] = {
             "study_id": study_id,
-            "datetime_start": datetime.datetime.now().isoformat(timespec="microseconds"),
+            "datetime_start": datetime_start.isoformat(timespec="microseconds"),
         }
 
         if template_trial:
@@ -243,15 +245,13 @@ class JournalStorage(BaseStorage):
                 log["value"] = template_trial.value
                 log["values"] = None
             if template_trial.datetime_start:
-                log["datetime_start"] = template_trial.datetime_start.isoformat(
-                    timespec="microseconds"
-                )
+                datetime_start = template_trial.datetime_start.astimezone(timezone.utc)
+                log["datetime_start"] = datetime_start.isoformat(timespec="microseconds")
             else:
                 log["datetime_start"] = None
             if template_trial.datetime_complete:
-                log["datetime_complete"] = template_trial.datetime_complete.isoformat(
-                    timespec="microseconds"
-                )
+                datetime_complete = template_trial.datetime_complete.astimezone(timezone.utc)
+                log["datetime_complete"] = datetime_complete.isoformat(timespec="microseconds")
 
             log["distributions"] = {
                 k: distribution_to_json(dist) for k, dist in template_trial.distributions.items()
@@ -313,9 +313,9 @@ class JournalStorage(BaseStorage):
         }
 
         if state == TrialState.RUNNING:
-            log["datetime_start"] = datetime.datetime.now().isoformat(timespec="microseconds")
+            log["datetime_start"] = datetime.now(tz=timezone.utc).isoformat(timespec="microseconds")
         elif state.is_finished():
-            log["datetime_complete"] = datetime.datetime.now().isoformat(timespec="microseconds")
+            log["datetime_complete"] = datetime.now(tz=timezone.utc).isoformat(timespec="microseconds")
 
         with self._thread_lock:
             if state == TrialState.RUNNING:
@@ -543,11 +543,11 @@ class JournalStorageReplayResult:
         if "params" in log:
             params = {k: distributions[k].to_external_repr(p) for k, p in log["params"].items()}
         if log["datetime_start"] is not None:
-            datetime_start = datetime.datetime.fromisoformat(log["datetime_start"])
+            datetime_start = datetime.fromisoformat(log["datetime_start"]).astimezone().replace(tzinfo=None)
         else:
             datetime_start = None
         if "datetime_complete" in log:
-            datetime_complete = datetime.datetime.fromisoformat(log["datetime_complete"])
+            datetime_complete = datetime.fromisoformat(log["datetime_complete"]).astimezone().replace(tzinfo=None)
         else:
             datetime_complete = None
 
@@ -620,11 +620,11 @@ class JournalStorageReplayResult:
 
         trial = copy.copy(self._trials[trial_id])
         if state == TrialState.RUNNING:
-            trial.datetime_start = datetime.datetime.fromisoformat(log["datetime_start"])
+            trial.datetime_start = datetime.fromisoformat(log["datetime_start"]).astimezone().replace(tzinfo=None)
             if self._is_issued_by_this_worker(log):
                 self._worker_id_to_owned_trial_id[self.worker_id] = trial_id
         if state.is_finished():
-            trial.datetime_complete = datetime.datetime.fromisoformat(log["datetime_complete"])
+            trial.datetime_complete = datetime.fromisoformat(log["datetime_complete"]).astimezone().replace(tzinfo=None)
         trial.state = state
         if log["values"] is not None:
             trial.values = log["values"]

--- a/optuna/storages/journal/_storage.py
+++ b/optuna/storages/journal/_storage.py
@@ -313,9 +313,13 @@ class JournalStorage(BaseStorage):
         }
 
         if state == TrialState.RUNNING:
-            log["datetime_start"] = datetime.now(tz=timezone.utc).isoformat(timespec="microseconds")
+            log["datetime_start"] = datetime.now(tz=timezone.utc).isoformat(
+                timespec="microseconds"
+            )
         elif state.is_finished():
-            log["datetime_complete"] = datetime.now(tz=timezone.utc).isoformat(timespec="microseconds")
+            log["datetime_complete"] = datetime.now(tz=timezone.utc).isoformat(
+                timespec="microseconds"
+            )
 
         with self._thread_lock:
             if state == TrialState.RUNNING:
@@ -543,11 +547,15 @@ class JournalStorageReplayResult:
         if "params" in log:
             params = {k: distributions[k].to_external_repr(p) for k, p in log["params"].items()}
         if log["datetime_start"] is not None:
-            datetime_start = datetime.fromisoformat(log["datetime_start"]).astimezone().replace(tzinfo=None)
+            datetime_start = (
+                datetime.fromisoformat(log["datetime_start"]).astimezone().replace(tzinfo=None)
+            )
         else:
             datetime_start = None
         if "datetime_complete" in log:
-            datetime_complete = datetime.fromisoformat(log["datetime_complete"]).astimezone().replace(tzinfo=None)
+            datetime_complete = (
+                datetime.fromisoformat(log["datetime_complete"]).astimezone().replace(tzinfo=None)
+            )
         else:
             datetime_complete = None
 
@@ -620,11 +628,15 @@ class JournalStorageReplayResult:
 
         trial = copy.copy(self._trials[trial_id])
         if state == TrialState.RUNNING:
-            trial.datetime_start = datetime.fromisoformat(log["datetime_start"]).astimezone().replace(tzinfo=None)
+            trial.datetime_start = (
+                datetime.fromisoformat(log["datetime_start"]).astimezone().replace(tzinfo=None)
+            )
             if self._is_issued_by_this_worker(log):
                 self._worker_id_to_owned_trial_id[self.worker_id] = trial_id
         if state.is_finished():
-            trial.datetime_complete = datetime.fromisoformat(log["datetime_complete"]).astimezone().replace(tzinfo=None)
+            trial.datetime_complete = (
+                datetime.fromisoformat(log["datetime_complete"]).astimezone().replace(tzinfo=None)
+            )
         trial.state = state
         if log["values"] is not None:
             trial.values = log["values"]


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. To minimize the review effort, we highly appreciate PRs only with related changes. Please note that submitted PRs may be closed if they include unrelated changes or significantly modified unit tests. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation

Refs #6755

RDBStorage and JournalStorage currently create trial timestamps using timezone-naive datetime.now().
As a result, the persisted values represent the local wall-clock time of the process writing to the storage.

This makes datetime_start and datetime_complete dependent on the writer's local timezone. In particular, when using the gRPC storage proxy, changing the timezone of the proxy process changes the timestamps written to the database, even if the workers and database remain unchanged.

This PR normalizes newly stored trial timestamps to UTC while preserving the existing public representation of trial datetimes.

## Description of the changes

The datetime representations after this change are:

| Layer | Representation |
| --- | --- |
| RDBStorage database columns | Timezone-naive UTC |
| JournalStorage logs | Timezone-aware UTC |
| FrozenTrial.datetime_start and datetime_complete | Timezone-naive local time |

The representations used by RDBStorage and JournalStorage intentionally differ.

* RDBStorage continues to use timezone-naive database columns because timezone-aware column types are not portable across all supported database backends. Using them would also require a schema migration on backends that support them. 
* JournalStorage stores JSON-compatible strings and can preserve the UTC offset without a schema migration, so new Journal entries use timezone-aware ISO 8601 values such as `2026-07-28T10:00:00.000000+00:00`.

The public `FrozenTrial` representation remains timezone-naive local time for backward compatibility.
Changing it to a timezone-aware datetime would break existing code that compares or subtracts it from a timezone-naive `datetime.now()`, including existing Optuna functionality such as `plot_timeline()`.

