### PR TITLE
Remove `axis_order` argument from `plot_pareto_front`

### DIFF
--- a/optuna/visualization/_pareto_front.py
+++ b/optuna/visualization/_pareto_front.py
@@ -42,7 +42,6 @@ def plot_pareto_front(
     *,
     target_names: list[str] | None = None,
     include_dominated_trials: bool = True,
-    axis_order: list[int] | None = None,
     constraints_func: Callable[[FrozenTrial], Sequence[float]] | None = None,
     targets: Callable[[FrozenTrial], Sequence[float]] | None = None,
 ) -> "go.Figure":
@@ -62,14 +61,6 @@ def plot_pareto_front(
             ``target_name`` must be specified.
         include_dominated_trials:
             A flag to include all dominated trial's objective values.
-        axis_order:
-            A list of indices indicating the axis order. If :obj:`None` is specified,
-            default order is used. ``axis_order`` and ``targets`` cannot be used at the same time.
-
-            .. warning::
-                Deprecated in v3.0.0. This feature will be removed in the future. The removal of
-                this feature is currently scheduled for v5.0.0, but this schedule is subject to
-                change. See https://github.com/optuna/optuna/releases/tag/v3.0.0.
         constraints_func:
             An optional function that computes the objective constraints. It must take a
             :class:`~optuna.trial.FrozenTrial` and return the constraints. The return value must
@@ -89,7 +80,6 @@ def plot_pareto_front(
         targets:
             A function that returns targets values to display.
             The argument to this function is :class:`~optuna.trial.FrozenTrial`.
-            ``axis_order`` and ``targets`` cannot be used at the same time.
             If ``study.n_objectives`` is neither 2 nor 3, ``targets`` must be specified.
 
             .. note::
@@ -104,7 +94,7 @@ def plot_pareto_front(
     _imports.check()
 
     info = _get_pareto_front_info(
-        study, target_names, include_dominated_trials, axis_order, constraints_func, targets
+        study, target_names, include_dominated_trials, constraints_func, targets
     )
     return _get_pareto_front_plot(info)
 
@@ -181,27 +171,14 @@ def _get_pareto_front_info(
     study: Study,
     target_names: list[str] | None = None,
     include_dominated_trials: bool = True,
-    axis_order: list[int] | None = None,
     constraints_func: Callable[[FrozenTrial], Sequence[float]] | None = None,
     targets: Callable[[FrozenTrial], Sequence[float]] | None = None,
 ) -> _ParetoFrontInfo:
-    if axis_order is not None:
-        msg = _deprecated._DEPRECATION_WARNING_TEMPLATE.format(
-            name="`axis_order`", d_ver="3.0.0", r_ver="5.0.0"
-        )
-        optuna_warn(msg, FutureWarning)
-
     if constraints_func is not None:
         msg = _deprecated._DEPRECATION_WARNING_TEMPLATE.format(
             name="`constraints_func`", d_ver="4.0.0", r_ver="6.0.0"
         )
         optuna_warn(msg, FutureWarning)
-
-    if targets is not None and axis_order is not None:
-        raise ValueError(
-            "Using both `targets` and `axis_order` is not supported. "
-            "Use either `targets` or `axis_order`."
-        )
 
     feasible_trials = []
     infeasible_trials = []
@@ -298,27 +275,7 @@ def _get_pareto_front_info(
     elif len(target_names) != n_targets:
         raise ValueError(f"The length of `target_names` is supposed to be {n_targets}.")
 
-    if axis_order is None:
-        axis_order = list(range(n_targets))
-    else:
-        if len(axis_order) != n_targets:
-            raise ValueError(
-                f"Size of `axis_order` {axis_order}. Expect: {n_targets}, "
-                f"Actual: {len(axis_order)}."
-            )
-        if len(set(axis_order)) != n_targets:
-            raise ValueError(f"Elements of given `axis_order` {axis_order} are not unique!.")
-        if max(axis_order) > n_targets - 1:
-            raise ValueError(
-                f"Given `axis_order` {axis_order} contains invalid index {max(axis_order)} "
-                f"higher than {n_targets - 1}."
-            )
-        if min(axis_order) < 0:
-            raise ValueError(
-                f"Given `axis_order` {axis_order} contains invalid index {min(axis_order)} "
-                "lower than 0."
-            )
-
+    axis_order = list(range(n_targets))
     return _ParetoFrontInfo(
         n_targets=n_targets,
         target_names=target_names,

--- a/optuna/visualization/matplotlib/_pareto_front.py
+++ b/optuna/visualization/matplotlib/_pareto_front.py
@@ -28,7 +28,6 @@ def plot_pareto_front(
     *,
     target_names: list[str] | None = None,
     include_dominated_trials: bool = True,
-    axis_order: list[int] | None = None,
     constraints_func: Callable[[FrozenTrial], Sequence[float]] | None = None,
     targets: Callable[[FrozenTrial], Sequence[float]] | None = None,
 ) -> "Axes":
@@ -48,14 +47,6 @@ def plot_pareto_front(
             ``target_name`` must be specified.
         include_dominated_trials:
             A flag to include all dominated trial's objective values.
-        axis_order:
-            A list of indices indicating the axis order. If :obj:`None` is specified,
-            default order is used. ``axis_order`` and ``targets`` cannot be used at the same time.
-
-            .. warning::
-                Deprecated in v3.0.0. This feature will be removed in the future. The removal of
-                this feature is currently scheduled for v5.0.0, but this schedule is subject to
-                change. See https://github.com/optuna/optuna/releases/tag/v3.0.0.
         constraints_func:
             An optional function that computes the objective constraints. It must take a
             :class:`~optuna.trial.FrozenTrial` and return the constraints. The return value must
@@ -76,7 +67,6 @@ def plot_pareto_front(
             A function that returns a tuple of target values to display.
             The argument to this function is :class:`~optuna.trial.FrozenTrial`.
             ``targets`` must be :obj:`None` or return 2 or 3 values.
-            ``axis_order`` and ``targets`` cannot be used at the same time.
             If the number of objectives is neither 2 nor 3, ``targets`` must be specified.
 
             .. note::
@@ -91,7 +81,7 @@ def plot_pareto_front(
     _imports.check()
 
     info = _get_pareto_front_info(
-        study, target_names, include_dominated_trials, axis_order, constraints_func, targets
+        study, target_names, include_dominated_trials, constraints_func, targets
     )
     return _get_pareto_front_plot(info)
 

--- a/tests/visualization_tests/test_pareto_front.py
+++ b/tests/visualization_tests/test_pareto_front.py
@@ -85,22 +85,15 @@ def create_study_3d() -> Study:
 
 
 @pytest.mark.parametrize("include_dominated_trials", [False, True])
-@pytest.mark.parametrize("axis_order", [None, [0, 1], [1, 0]])
 @pytest.mark.parametrize("targets", [None, lambda t: (t.values[0], t.values[1])])
 @pytest.mark.parametrize("target_names", [None, ["Foo", "Bar"]])
 @pytest.mark.parametrize("metric_names", [None, ["v0", "v1"]])
 def test_get_pareto_front_info_unconstrained(
     include_dominated_trials: bool,
-    axis_order: list[int] | None,
     targets: Callable[[FrozenTrial], Sequence[float]] | None,
     target_names: list[str] | None,
     metric_names: list[str] | None,
 ) -> None:
-    if axis_order is not None and targets is not None:
-        pytest.skip(
-            "skip using both axis_order and targets because they cannot be used at the same time."
-        )
-
     study = create_study_2d()
     if metric_names is not None:
         study.set_metric_names(metric_names)
@@ -110,7 +103,6 @@ def test_get_pareto_front_info_unconstrained(
         info = _get_pareto_front_info(
             study=study,
             include_dominated_trials=include_dominated_trials,
-            axis_order=axis_order,
             targets=targets,
             target_names=target_names,
         )
@@ -123,31 +115,24 @@ def test_get_pareto_front_info_unconstrained(
             [(trials[0], [1, 2]), (trials[1], [1, 1])] if include_dominated_trials else []
         ),
         infeasible_trials_with_values=[],
-        axis_order=axis_order or [0, 1],
+        axis_order=[0, 1],
         include_dominated_trials=include_dominated_trials,
         has_constraints=False,
     )
 
 
 @pytest.mark.parametrize("include_dominated_trials", [False, True])
-@pytest.mark.parametrize("axis_order", [None, [0, 1], [1, 0]])
 @pytest.mark.parametrize("targets", [None, lambda t: (t.values[0], t.values[1])])
 @pytest.mark.parametrize("target_names", [None, ["Foo", "Bar"]])
 @pytest.mark.parametrize("metric_names", [None, ["v0", "v1"]])
 @pytest.mark.parametrize("use_study_with_constraints", [True, False])
 def test_get_pareto_front_info_constrained(
     include_dominated_trials: bool,
-    axis_order: list[int] | None,
     targets: Callable[[FrozenTrial], Sequence[float]] | None,
     target_names: list[str] | None,
     metric_names: list[str] | None,
     use_study_with_constraints: bool,
 ) -> None:
-    if axis_order is not None and targets is not None:
-        pytest.skip(
-            "skip using both axis_order and targets because they cannot be used at the same time."
-        )
-
     # (x, y) = (1, 0) is infeasible; others are feasible.
     def constraints_func(t: BaseTrial) -> Sequence[float]:
         return [1.0] if t.params["x"] == 1 and t.params["y"] == 0 else [-1.0]
@@ -166,7 +151,6 @@ def test_get_pareto_front_info_constrained(
         info = _get_pareto_front_info(
             study=study,
             include_dominated_trials=include_dominated_trials,
-            axis_order=axis_order,
             targets=targets,
             target_names=target_names,
             constraints_func=None if use_study_with_constraints else constraints_func,
@@ -178,31 +162,24 @@ def test_get_pareto_front_info_constrained(
         best_trials_with_values=[(trials[1], [1, 1]), (trials[2], [0, 2])],
         non_best_trials_with_values=[(trials[0], [1, 2])] if include_dominated_trials else [],
         infeasible_trials_with_values=[(trials[3], [1, 0])],
-        axis_order=axis_order or [0, 1],
+        axis_order=[0, 1],
         include_dominated_trials=include_dominated_trials,
         has_constraints=True,
     )
 
 
 @pytest.mark.parametrize("include_dominated_trials", [False, True])
-@pytest.mark.parametrize("axis_order", [None, [0, 1], [1, 0]])
 @pytest.mark.parametrize("targets", [None, lambda t: (t.values[0], t.values[1])])
 @pytest.mark.parametrize("target_names", [None, ["Foo", "Bar"]])
 @pytest.mark.parametrize("metric_names", [None, ["v0", "v1"]])
 @pytest.mark.parametrize("use_study_with_constraints", [True, False])
 def test_get_pareto_front_info_all_infeasible(
     include_dominated_trials: bool,
-    axis_order: list[int] | None,
     targets: Callable[[FrozenTrial], Sequence[float]] | None,
     target_names: list[str] | None,
     metric_names: list[str] | None,
     use_study_with_constraints: bool,
 ) -> None:
-    if axis_order is not None and targets is not None:
-        pytest.skip(
-            "skip using both axis_order and targets because they cannot be used at the same time."
-        )
-
     # all trials are infeasible.
     def constraints_func(t: BaseTrial) -> Sequence[float]:
         return [1.0]
@@ -221,7 +198,6 @@ def test_get_pareto_front_info_all_infeasible(
         info = _get_pareto_front_info(
             study=study,
             include_dominated_trials=include_dominated_trials,
-            axis_order=axis_order,
             targets=targets,
             target_names=target_names,
             constraints_func=None if use_study_with_constraints else constraints_func,
@@ -238,27 +214,20 @@ def test_get_pareto_front_info_all_infeasible(
             (trials[2], [0, 2]),
             (trials[3], [1, 0]),
         ],
-        axis_order=axis_order or [0, 1],
+        axis_order=[0, 1],
         include_dominated_trials=include_dominated_trials,
         has_constraints=True,
     )
 
 
 @pytest.mark.parametrize("include_dominated_trials", [False, True])
-@pytest.mark.parametrize("axis_order", [None, [0, 1, 2], [2, 1, 0]])
 @pytest.mark.parametrize("targets", [None, lambda t: (t.values[0], t.values[1], t.values[2])])
 @pytest.mark.parametrize("target_names", [None, ["Foo", "Bar", "Baz"]])
 def test_get_pareto_front_info_3d(
     include_dominated_trials: bool,
-    axis_order: list[int] | None,
     targets: Callable[[FrozenTrial], Sequence[float]] | None,
     target_names: list[str] | None,
 ) -> None:
-    if axis_order is not None and targets is not None:
-        pytest.skip(
-            "skip using both axis_order and targets because they cannot be used at the same time."
-        )
-
     study = create_study_3d()
     trials = study.get_trials(deepcopy=False)
 
@@ -267,7 +236,6 @@ def test_get_pareto_front_info_3d(
         info = _get_pareto_front_info(
             study=study,
             include_dominated_trials=include_dominated_trials,
-            axis_order=axis_order,
             targets=targets,
             target_names=target_names,
         )
@@ -280,7 +248,7 @@ def test_get_pareto_front_info_3d(
             [(trials[0], [1, 2, 1]), (trials[1], [1, 1, 1])] if include_dominated_trials else []
         ),
         infeasible_trials_with_values=[],
-        axis_order=axis_order or [0, 1, 2],
+        axis_order=[0, 1, 2],
         include_dominated_trials=include_dominated_trials,
         has_constraints=False,
     )
@@ -311,25 +279,6 @@ def test_get_pareto_front_info_unsupported_dimensions(
 
 
 @pytest.mark.filterwarnings("ignore::FutureWarning")
-@pytest.mark.parametrize("axis_order", [[0, 1, 1], [0, 0], [0, 2], [-1, 1]])
-@pytest.mark.parametrize("include_dominated_trials", [False, True])
-@pytest.mark.parametrize("constraints_func", [None, lambda _: [-1.0]])
-def test_get_pareto_front_info_invalid_axis_order(
-    axis_order: list[int],
-    include_dominated_trials: bool,
-    constraints_func: Callable[[FrozenTrial], Sequence[float]] | None,
-) -> None:
-    study = optuna.create_study(directions=["minimize", "minimize"])
-    with pytest.raises(ValueError):
-        _get_pareto_front_info(
-            study=study,
-            include_dominated_trials=include_dominated_trials,
-            axis_order=axis_order,
-            constraints_func=constraints_func,
-        )
-
-
-@pytest.mark.filterwarnings("ignore::FutureWarning")
 @pytest.mark.parametrize("include_dominated_trials", [False, True])
 @pytest.mark.parametrize("constraints_func", [None, lambda _: [-1.0]])
 def test_get_pareto_front_info_invalid_target_values(
@@ -342,24 +291,6 @@ def test_get_pareto_front_info_invalid_target_values(
         _get_pareto_front_info(
             study=study,
             targets=lambda t: t.values[0],
-            include_dominated_trials=include_dominated_trials,
-            constraints_func=constraints_func,
-        )
-
-
-@pytest.mark.filterwarnings("ignore::FutureWarning")
-@pytest.mark.parametrize("include_dominated_trials", [False, True])
-@pytest.mark.parametrize("constraints_func", [None, lambda _: [-1.0]])
-def test_get_pareto_front_info_using_axis_order_and_targets(
-    include_dominated_trials: bool,
-    constraints_func: Callable[[FrozenTrial], Sequence[float]] | None,
-) -> None:
-    study = optuna.create_study(directions=["minimize", "minimize", "minimize"])
-    with pytest.raises(ValueError):
-        _get_pareto_front_info(
-            study=study,
-            axis_order=[0, 1, 2],
-            targets=lambda t: (t.values[0], t.values[1], t.values[2]),
             include_dominated_trials=include_dominated_trials,
             constraints_func=constraints_func,
         )


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. To minimize the review effort, we highly appreciate PRs only with related changes. Please note that submitted PRs may be closed if they include unrelated changes or significantly modified unit tests. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
`axis_order` argument is deprecated in v3.0.0 and the removal is scheduled for v5.0.0.


## Description of the changes
<!-- Describe the changes in this PR. -->
- Remove `axis_order` argument from `Plot_pareto_front`