### PR TITLE
Remove `categorical_distance_func` from `TPESampler`

### DIFF
--- a/optuna/importance/_ped_anova/scott_parzen_estimator.py
+++ b/optuna/importance/_ped_anova/scott_parzen_estimator.py
@@ -129,7 +129,6 @@ def build_parzen_estimator_on_grid(
         consider_endpoints=False,
         weights=lambda x: np.empty(0),
         multivariate=True,
-        categorical_distance_func={},
     )
     pe = ScottParzenEstimator(
         {param_name: observations},

--- a/optuna/samplers/_tpe/parzen_estimator.py
+++ b/optuna/samplers/_tpe/parzen_estimator.py
@@ -30,9 +30,6 @@ class _ParzenEstimatorParameters(NamedTuple):
     consider_endpoints: bool
     weights: Callable[[int], np.ndarray]
     multivariate: bool
-    categorical_distance_func: dict[
-        str, Callable[[CategoricalChoiceType, CategoricalChoiceType], float]
-    ]
 
 
 class _ParzenEstimator:
@@ -149,17 +146,7 @@ class _ParzenEstimator:
             fill_value=parameters.prior_weight / n_kernels,
         )
         observed_indices = observations.astype(int)
-        if param_name in parameters.categorical_distance_func:
-            # TODO(nabenabe0928): Think about how to handle combinatorial explosion.
-            # The time complexity is O(n_choices * used_indices.size), so n_choices cannot be huge.
-            used_indices, rev_indices = np.unique(observed_indices, return_inverse=True)
-            dist_func = parameters.categorical_distance_func[param_name]
-            dists = np.array([[dist_func(choices[i], c) for c in choices] for i in used_indices])
-            coef = np.log(n_kernels / parameters.prior_weight) * np.log(n_choices) / np.log(6)
-            cat_weights = np.exp(-((dists / np.max(dists, axis=1)[:, np.newaxis]) ** 2) * coef)
-            weights[: len(observed_indices)] = cat_weights[rev_indices]
-        else:
-            weights[np.arange(len(observed_indices)), observed_indices] += 1
+        weights[np.arange(len(observed_indices)), observed_indices] += 1
 
         row_sums = weights.sum(axis=1, keepdims=True)
         weights /= np.where(row_sums == 0, 1, row_sums)

--- a/optuna/samplers/_tpe/parzen_estimator.py
+++ b/optuna/samplers/_tpe/parzen_estimator.py
@@ -6,7 +6,6 @@ from typing import NamedTuple
 import numpy as np
 
 from optuna.distributions import BaseDistribution
-from optuna.distributions import CategoricalChoiceType
 from optuna.distributions import CategoricalDistribution
 from optuna.distributions import FloatDistribution
 from optuna.distributions import IntDistribution

--- a/optuna/samplers/_tpe/sampler.py
+++ b/optuna/samplers/_tpe/sampler.py
@@ -37,7 +37,6 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
 
     from optuna.distributions import BaseDistribution
-    from optuna.distributions import CategoricalChoiceType
     from optuna.study import Study
 
 
@@ -119,11 +118,6 @@ class TPESampler(BaseSampler):
     background of constrained optimization for TPE in general. Notably, the Optuna algorithm
     differs from the one proposed in the second paper. OptunaHub provides
     `c-TPE proposed by the second paper <https://hub.optuna.org/samplers/ctpe/>`__.
-
-    For the `categorical_distance_func`, please refer to the following paper:
-
-    - `Tree-Structured Parzen Estimator Can Solve Black-Box Combinatorial Optimization More
-      Efficiently <https://arxiv.org/abs/2507.08053>`__
 
     Please also check our articles:
 
@@ -315,21 +309,6 @@ class TPESampler(BaseSampler):
                 the future. The removal of this feature is currently scheduled for v6.0.0,
                 but this schedule is subject to change.
                 See https://github.com/optuna/optuna/releases/tag/v4.9.0.
-        categorical_distance_func:
-            A dictionary of distance functions for categorical parameters. The key is the name of
-            the categorical parameter and the value is a distance function that takes two
-            :class:`~optuna.distributions.CategoricalChoiceType` s and returns a :obj:`float`
-            value. The distance function must return a non-negative value.
-
-            While categorical choices are handled equally by default, this option allows users to
-            specify prior knowledge on the structure of categorical parameters. When specified,
-            categorical choices closer to current best choices are more likely to be sampled.
-
-            .. warning::
-                Deprecated in v4.9.0. ``categorical_distance_func`` argument will be removed in
-                the future. The removal of this feature is currently scheduled for v5.0.0,
-                but this schedule is subject to change.
-                See https://github.com/optuna/optuna/releases/tag/v4.9.0.
     """
 
     @convert_positional_args(
@@ -365,9 +344,6 @@ class TPESampler(BaseSampler):
         warn_independent_sampling: bool | None = None,
         constant_liar: bool = True,
         constraints_func: Callable[[FrozenTrial], Sequence[float]] | None = None,
-        categorical_distance_func: (
-            dict[str, Callable[[CategoricalChoiceType, CategoricalChoiceType], float]] | None
-        ) = None,
     ) -> None:
         consider_prior = _warn_if_deprecated_argument(
             "`consider_prior`", consider_prior, True, "4.3.0", "6.0.0"
@@ -388,9 +364,6 @@ class TPESampler(BaseSampler):
         warn_independent_sampling = _warn_if_deprecated_argument(
             "`warn_independent_sampling`", warn_independent_sampling, False, "4.9.0", "6.0.0"
         )
-        categorical_distance_func = _warn_if_deprecated_argument(
-            "`categorical_distance_func`", categorical_distance_func, None, "4.9.0", "5.0.0"
-        )
 
         self._parzen_estimator_parameters = _ParzenEstimatorParameters(
             prior_weight=prior_weight,
@@ -400,7 +373,6 @@ class TPESampler(BaseSampler):
             # The ``multivariate`` field remains only for historical reasons and is unused,
             # so any value is fine here.
             multivariate=True,
-            categorical_distance_func=categorical_distance_func or {},
         )
 
         self._n_startup_trials = n_startup_trials

--- a/tests/importance_tests/pedanova_tests/test_scott_parzen_estimator.py
+++ b/tests/importance_tests/pedanova_tests/test_scott_parzen_estimator.py
@@ -27,7 +27,6 @@ pe_parameters = _ParzenEstimatorParameters(
     consider_endpoints=False,
     weights=lambda x: np.empty(0),
     multivariate=True,
-    categorical_distance_func={},
 )
 
 

--- a/tests/samplers_tests/tpe_tests/test_parzen_estimator.py
+++ b/tests/samplers_tests/tpe_tests/test_parzen_estimator.py
@@ -58,7 +58,6 @@ def test_init_parzen_estimator() -> None:
         consider_endpoints=False,
         weights=lambda x: np.arange(x) + 1.0,
         multivariate=True,
-        categorical_distance_func={},
     )
 
     mpe = _ParzenEstimator(SAMPLES, SEARCH_SPACE, parameters)
@@ -142,7 +141,6 @@ def test_calculate_shape_check(
         consider_endpoints=endpoints,
         weights=default_weights,
         multivariate=True,
-        categorical_distance_func={},
     )
     mpe = _ParzenEstimator(
         {"a": mus}, {"a": distributions.FloatDistribution(-1.0, 1.0)}, parameters
@@ -152,14 +150,9 @@ def test_calculate_shape_check(
 
 @pytest.mark.parametrize("mus", (np.asarray([]), np.asarray([0.4]), np.asarray([-0.4, 0.4])))
 @pytest.mark.parametrize("prior_weight", [1.0, 0.01, 100.0])
-@pytest.mark.parametrize("categorical_distance_func", ({}, {"c": lambda x, y: abs(x - y)}))
 def test_calculate_shape_check_categorical(
     mus: np.ndarray,
     prior_weight: float,
-    categorical_distance_func: dict[
-        str,
-        Callable[[CategoricalChoiceType, CategoricalChoiceType], float],
-    ],
 ) -> None:
     parameters = _ParzenEstimatorParameters(
         prior_weight=prior_weight,
@@ -167,7 +160,6 @@ def test_calculate_shape_check_categorical(
         consider_endpoints=False,
         weights=default_weights,
         multivariate=True,
-        categorical_distance_func=categorical_distance_func,
     )
     mpe = _ParzenEstimator(
         {"c": mus}, {"c": distributions.CategoricalDistribution([0.0, 1.0, 2.0])}, parameters
@@ -183,7 +175,6 @@ def test_invalid_prior_weight(mus: np.ndarray) -> None:
         consider_endpoints=False,
         weights=default_weights,
         multivariate=True,
-        categorical_distance_func={},
     )
     with pytest.raises(ValueError):
         _ParzenEstimator({"a": mus}, {"a": distributions.FloatDistribution(-1.0, 1.0)}, parameters)
@@ -247,7 +238,6 @@ def test_calculate(
         consider_endpoints=flags["endpoints"],
         weights=default_weights,
         multivariate=True,
-        categorical_distance_func={},
     )
     mpe = _ParzenEstimator(
         {"a": mus}, {"a": distributions.FloatDistribution(-1.0, 1.0)}, parameters
@@ -283,7 +273,6 @@ def test_invalid_weights(weights: Callable[[int], np.ndarray]) -> None:
         consider_endpoints=False,
         weights=weights,
         multivariate=True,
-        categorical_distance_func={},
     )
     with pytest.raises(ValueError):
         _ParzenEstimator(

--- a/tests/samplers_tests/tpe_tests/test_parzen_estimator.py
+++ b/tests/samplers_tests/tpe_tests/test_parzen_estimator.py
@@ -6,7 +6,6 @@ import numpy as np
 import pytest
 
 from optuna import distributions
-from optuna.distributions import CategoricalChoiceType
 from optuna.samplers._tpe.parzen_estimator import _ParzenEstimator
 from optuna.samplers._tpe.parzen_estimator import _ParzenEstimatorParameters
 from optuna.samplers._tpe.probability_distributions import _BatchedCategoricalDistributions


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. To minimize the review effort, we highly appreciate PRs only with related changes. Please note that submitted PRs may be closed if they include unrelated changes or significantly modified unit tests. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
TPESampler's `categorical_distance_func` was introduced at Optuna 3.4 as an experimental feature, and deprecated in v4.9.0.

## Description of the changes
<!-- Describe the changes in this PR. -->
This PR removes `categorical_distance_func` from `TPESampler`. Since this feature is still valuable for certain use cases, we plan to publish an alternative implementation in optunahub-registry.