### PR TITLE
fix: preserve metric_names order in trials_dataframe columns

### DIFF
--- a/optuna/study/_dataframe.py
+++ b/optuna/study/_dataframe.py
@@ -76,9 +76,18 @@ def _create_records_and_aggregate_column(
 
         records.append(record)
 
-    columns: list[tuple[str, str]] = sum(
-        (sorted(column_agg[k]) for k in attrs if k in column_agg), []
-    )
+    # Build column list preserving the order of `attrs` and, for multi-objective
+    # studies with metric names set, the order of `metric_names` instead of
+    # alphabetical sorting (GH #6785).
+    columns: list[tuple[str, str]] = []
+    for k in attrs:
+        if k not in column_agg:
+            continue
+        if k == "values" and metric_names is not None:
+            df_col = attrs_to_df_columns[k]
+            columns.extend((df_col, name) for name in metric_names)
+        else:
+            columns.extend(sorted(column_agg[k]))
 
     return records, columns
 

--- a/tests/study_tests/test_dataframe.py
+++ b/tests/study_tests/test_dataframe.py
@@ -213,3 +213,35 @@ def test_trials_dataframe_with_multi_objective_optimization_with_fail_and_pruned
     else:
         assert df.get("values_v0")[0] is None
         assert df.get("values_v1")[0] is None
+
+
+def test_trials_dataframe_preserves_metric_names_order() -> None:
+    # GH #6785: trials_dataframe() sorted value columns alphabetically instead
+    # of preserving the order set by set_metric_names().
+    study = create_study(directions=["minimize", "minimize"])
+    study.set_metric_names(["train", "test"])
+
+    def objective(trial: Trial) -> tuple[float, float]:
+        x0 = trial.suggest_int("x0", 0, 10)
+        x1 = trial.suggest_int("x1", 0, 10)
+        return x0, x1
+
+    study.optimize(objective, n_trials=3)
+
+    # Flat columns
+    flat_cols = list(study.trials_dataframe().columns)
+    values_cols = [c for c in flat_cols if c.startswith("values_")]
+    assert values_cols == ["values_train", "values_test"]
+
+    # Multi-index columns
+    multi_cols = list(study.trials_dataframe(multi_index=True).columns)
+    values_multi = [c for c in multi_cols if c[0] == "values"]
+    assert values_multi == [("values", "train"), ("values", "test")]
+
+    # Reverse order should also be preserved
+    study2 = create_study(directions=["minimize", "minimize"])
+    study2.set_metric_names(["test", "train"])
+    study2.optimize(objective, n_trials=1)
+    flat_cols2 = list(study2.trials_dataframe().columns)
+    values_cols2 = [c for c in flat_cols2 if c.startswith("values_")]
+    assert values_cols2 == ["values_test", "values_train"]


### PR DESCRIPTION
## Problem

`Study.trials_dataframe()` sorted value columns alphabetically instead of preserving the order set by `Study.set_metric_names()`. For metric names like `[train, test]`, the columns came out as `[values_test, values_train]` instead of `[values_train, values_test]`.

## Root cause

`_create_records_and_aggregate_column()` in `optuna/study/_dataframe.py` used `sorted()` on all column sets including the `values` attribute. When `metric_names` is set, the column tuples are `(df_column, metric_name)`, and `sorted()` orders by `metric_name` alphabetically — not by the user-defined order.

## Fix

When `metric_names` is set, the `values` columns are emitted in `metric_names` order instead of being sorted. All other column sets (params, attrs, etc.) and the `metric_names is None` case (integer indices) still use `sorted()` as before.

## Verification

```python
study = optuna.create_study(directions=[minimize, minimize])
study.set_metric_names([train, test])
study.optimize(objective, n_trials=3)
list(study.trials_dataframe().columns)
# Before: [..., values_test, values_train, ...]
# After:  [..., values_train, values_test, ...]
```

Also tested with reversed order (`[test, train]` → `[values_test, values_train]`) and without metric names (unchanged: `[values_0, values_1]`).

Fixes #6785