### PR TITLE
Allow JournalStorage to read Rustuna journal files

### DIFF
--- a/optuna/storages/journal/_storage.py
+++ b/optuna/storages/journal/_storage.py
@@ -49,6 +49,7 @@ class JournalOperation(enum.IntEnum):
     SET_TRIAL_INTERMEDIATE_VALUE = 7
     SET_TRIAL_USER_ATTR = 8
     SET_TRIAL_SYSTEM_ATTR = 9
+    DISCARD_TRIALS = 10
 
 
 class JournalStorage(BaseStorage):
@@ -439,6 +440,9 @@ class JournalStorageReplayResult:
                 self._apply_set_trial_user_attr(log)
             elif op == JournalOperation.SET_TRIAL_SYSTEM_ATTR:
                 self._apply_set_trial_system_attr(log)
+            elif op == JournalOperation.DISCARD_TRIALS:
+                # This operation is only supported by Rustuna.
+                continue
             else:
                 assert False, "Should not reach."
 

--- a/tests/storages_tests/journal_tests/test_journal.py
+++ b/tests/storages_tests/journal_tests/test_journal.py
@@ -286,5 +286,5 @@ def test_ignore_discard_trial_operation() -> None:
         x = trial2.suggest_float("x", -10, 10)
         study.tell(trial2, values=x**2)
 
-        # Optuna simply ignores DISCARD_TRIALS operation.
-        assert len(storage.get_all_trials(study._study_id)) == 2
+        trials = storage.get_all_trials(study._study_id)
+        assert trial2.number in [t.number for t in trials]

--- a/tests/storages_tests/journal_tests/test_journal.py
+++ b/tests/storages_tests/journal_tests/test_journal.py
@@ -23,6 +23,7 @@ from optuna.storages import JournalFileSymlinkLock as DeprecatedJournalFileSymli
 from optuna.storages import JournalStorage
 from optuna.storages.journal._base import BaseJournalSnapshot
 from optuna.storages.journal._file import BaseJournalFileLock
+from optuna.storages.journal._storage import JournalOperation
 from optuna.storages.journal._storage import JournalStorageReplayResult
 from optuna.testing.storages import StorageSupplier
 from optuna.testing.tempfile_pool import NamedTemporaryFilePool
@@ -264,3 +265,26 @@ def test_invalid_grace_period(log_storage_type: str, grace_period: int) -> None:
     with pytest.raises(ValueError):
         with JournalLogStorageSupplier(log_storage_type, grace_period):
             pass
+
+
+def test_ignore_discard_trial_operation() -> None:
+    with NamedTemporaryFilePool() as file:
+        file_storage = journal.JournalFileBackend(file.name)
+        storage = optuna.storages.JournalStorage(file_storage)
+
+        # Create an Optuna study
+        study = optuna.create_study(storage=storage)
+        trial1 = study.ask()
+        x = trial1.suggest_float("x", -10, 10)
+        study.tell(trial1, values=x**2)
+
+        # Insert DISCARD_TRIALS operation
+        storage._write_log(JournalOperation.DISCARD_TRIALS, {"trial_ids": [trial1._trial_id]})
+
+        # Resume optimization
+        trial2 = study.ask()
+        x = trial2.suggest_float("x", -10, 10)
+        study.tell(trial2, values=x**2)
+
+        # Optuna simply ignores DISCARD_TRIALS operation.
+        assert len(storage.get_all_trials(study._study_id)) == 2


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. To minimize the review effort, we highly appreciate PRs only with related changes. Please note that submitted PRs may be closed if they include unrelated changes or significantly modified unit tests. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
Allow Optuna's `JournalStorage` to replay journal files generated by Rustuna.

## Description of the changes
<!-- Describe the changes in this PR. -->
- Add the Rustuna-specific `DISCARD_TRIALS` journal operation.
- Ignore this operation when replaying journal logs, since Optuna does not currently implement its semantics.
- Add a test to ensure that journal replay continues successfully after encountering this operation.

The corresponding Rustuna implementation is available here:

https://github.com/optuna/rustuna/blob/846f1edc26846f80fd89464c0078922258d0836e/rustuna_storage/src/journal/mod.rs#L43