### PR TITLE
add log cache offset tests and fixed logic

### DIFF
--- a/optuna/storages/journal/_file.py
+++ b/optuna/storages/journal/_file.py
@@ -82,17 +82,16 @@ class JournalFileBackend(BaseJournalBackend):
                     break
                 if last_decode_error is not None:
                     raise last_decode_error
+
+                # Ensure that each line ends with line separators (\n, \r\n).
+                if not line.endswith(b"\n"):
+                    last_decode_error = ValueError("Invalid log format.")
+                    continue
                 if log_number + 1 not in self._log_number_offset:
                     self._log_number_offset[log_number + 1] = (
                         self._log_number_offset[log_number] + byte_len
                     )
                 if log_number < log_number_from:
-                    continue
-
-                # Ensure that each line ends with line separators (\n, \r\n).
-                if not line.endswith(b"\n"):
-                    last_decode_error = ValueError("Invalid log format.")
-                    del self._log_number_offset[log_number + 1]
                     continue
                 try:
                     yield json.loads(line)

--- a/tests/storages_tests/journal_tests/test_journal.py
+++ b/tests/storages_tests/journal_tests/test_journal.py
@@ -143,7 +143,7 @@ def test_read_logs_caches_offset_after_incomplete_skipped_log_1() -> None:
         ]
 
 
-def test_read_logs_caches_offset_after_incomplete_skipped_log_2() -> None:
+def test_does_not_cache_an_incomplete_log_before_requested_number() -> None:
     what_to_write_1 = (
         b'{"op_code":0,"worker_id":"worker-0"}\n'
         + b'{"op_code":0,"worker_id":"worker-1"}\n'

--- a/tests/storages_tests/journal_tests/test_journal.py
+++ b/tests/storages_tests/journal_tests/test_journal.py
@@ -7,6 +7,7 @@ import pathlib
 import pickle
 from types import TracebackType
 from typing import Any
+from typing import cast
 from typing import IO
 from unittest import mock
 
@@ -112,6 +113,58 @@ def test_concurrent_append_logs_for_multi_threads(
 
         assert len(list(storage.read_logs(0))) == num_records
         assert all(record == r for r in storage.read_logs(0))
+
+
+def test_read_logs_caches_offset_after_incomplete_skipped_log_1() -> None:
+    what_to_write_1 = (
+        b'{"op_code":0,"worker_id":"worker-0"}\n'
+        + b'{"op_code":0,"worker_id":"worker-1"}\n'
+        + b'{"op_code":0,"work'
+    )
+    what_to_write_2 = b'er_id":"worker-2"}\n' + b'{"op_code":0,"worker_id":"worker-3"}\n'
+    with NamedTemporaryFilePool() as file:
+        file = cast(IO[bytes], file)
+        file.write(what_to_write_1)
+        file.flush()
+        file.close()
+
+        file_backend = journal.JournalFileBackend(file.name)
+        assert list(file_backend.read_logs(0)) == [
+            {"op_code": 0, "worker_id": "worker-0"},
+            {"op_code": 0, "worker_id": "worker-1"},
+        ]
+
+        with open(file.name, "ab") as f:
+            f.write(what_to_write_2)
+
+        assert list(file_backend.read_logs(2)) == [
+            {"op_code": 0, "worker_id": "worker-2"},
+            {"op_code": 0, "worker_id": "worker-3"},
+        ]
+
+
+def test_read_logs_caches_offset_after_incomplete_skipped_log_2() -> None:
+    what_to_write_1 = (
+        b'{"op_code":0,"worker_id":"worker-0"}\n'
+        + b'{"op_code":0,"worker_id":"worker-1"}\n'
+        + b'{"op_code":0,"work'
+    )
+    what_to_write_2 = b'er_id":"worker-2"}\n' + b'{"op_code":0,"worker_id":"worker-3"}\n'
+    with NamedTemporaryFilePool() as file:
+        file = cast(IO[bytes], file)
+        file.write(what_to_write_1)
+        file.flush()
+        file.close()
+
+        file_backend = journal.JournalFileBackend(file.name)
+        assert list(file_backend.read_logs(3)) == []
+
+        with open(file.name, "ab") as f:
+            f.write(what_to_write_2)
+
+        assert list(file_backend.read_logs(3)) == [
+            {"op_code": 0, "worker_id": "worker-3"},
+        ]
 
 
 def pop_waiting_trial(file_path: str, study_name: str) -> int | None:

--- a/tests/storages_tests/journal_tests/test_journal.py
+++ b/tests/storages_tests/journal_tests/test_journal.py
@@ -7,7 +7,6 @@ import pathlib
 import pickle
 from types import TracebackType
 from typing import Any
-from typing import cast
 from typing import IO
 from unittest import mock
 
@@ -123,10 +122,8 @@ def test_retry_an_incomplete_trailing_log() -> None:
     )
     what_to_write_2 = b'er_id":"worker-2"}\n' + b'{"op_code":0,"worker_id":"worker-3"}\n'
     with NamedTemporaryFilePool() as file:
-        file = cast(IO[bytes], file)
-        file.write(what_to_write_1)
-        file.flush()
-        file.close()
+        with open(file.name, "wb") as f:
+            f.write(what_to_write_1)
 
         file_backend = journal.JournalFileBackend(file.name)
         assert list(file_backend.read_logs(0)) == [
@@ -151,10 +148,8 @@ def test_does_not_cache_an_incomplete_log_before_requested_number() -> None:
     )
     what_to_write_2 = b'er_id":"worker-2"}\n' + b'{"op_code":0,"worker_id":"worker-3"}\n'
     with NamedTemporaryFilePool() as file:
-        file = cast(IO[bytes], file)
-        file.write(what_to_write_1)
-        file.flush()
-        file.close()
+        with open(file.name, "wb") as f:
+            f.write(what_to_write_1)
 
         file_backend = journal.JournalFileBackend(file.name)
         assert list(file_backend.read_logs(3)) == []

--- a/tests/storages_tests/journal_tests/test_journal.py
+++ b/tests/storages_tests/journal_tests/test_journal.py
@@ -121,9 +121,10 @@ def test_retry_an_incomplete_trailing_log() -> None:
         + b'{"op_code":0,"work'
     )
     what_to_write_2 = b'er_id":"worker-2"}\n' + b'{"op_code":0,"worker_id":"worker-3"}\n'
-    with NamedTemporaryFilePool() as file:
-        with open(file.name, "wb") as f:
-            f.write(what_to_write_1)
+    with NamedTemporaryFilePool() as file_:
+        file: IO[bytes] = file_
+        file.write(what_to_write_1)
+        file.flush()
 
         file_backend = journal.JournalFileBackend(file.name)
         assert list(file_backend.read_logs(0)) == [
@@ -131,8 +132,8 @@ def test_retry_an_incomplete_trailing_log() -> None:
             {"op_code": 0, "worker_id": "worker-1"},
         ]
 
-        with open(file.name, "ab") as f:
-            f.write(what_to_write_2)
+        file.write(what_to_write_2)
+        file.flush()
 
         assert list(file_backend.read_logs(2)) == [
             {"op_code": 0, "worker_id": "worker-2"},
@@ -147,15 +148,16 @@ def test_does_not_cache_an_incomplete_log_before_requested_number() -> None:
         + b'{"op_code":0,"work'
     )
     what_to_write_2 = b'er_id":"worker-2"}\n' + b'{"op_code":0,"worker_id":"worker-3"}\n'
-    with NamedTemporaryFilePool() as file:
-        with open(file.name, "wb") as f:
-            f.write(what_to_write_1)
+    with NamedTemporaryFilePool() as file_:
+        file: IO[bytes] = file_
+        file.write(what_to_write_1)
+        file.flush()
 
         file_backend = journal.JournalFileBackend(file.name)
         assert list(file_backend.read_logs(3)) == []
 
-        with open(file.name, "ab") as f:
-            f.write(what_to_write_2)
+        file.write(what_to_write_2)
+        file.flush()
 
         assert list(file_backend.read_logs(3)) == [
             {"op_code": 0, "worker_id": "worker-3"},

--- a/tests/storages_tests/journal_tests/test_journal.py
+++ b/tests/storages_tests/journal_tests/test_journal.py
@@ -115,7 +115,7 @@ def test_concurrent_append_logs_for_multi_threads(
         assert all(record == r for r in storage.read_logs(0))
 
 
-def test_read_logs_caches_offset_after_incomplete_skipped_log_1() -> None:
+def test_retry_an_incomplete_trailing_log() -> None:
     what_to_write_1 = (
         b'{"op_code":0,"worker_id":"worker-0"}\n'
         + b'{"op_code":0,"worker_id":"worker-1"}\n'

--- a/tests/storages_tests/journal_tests/test_journal.py
+++ b/tests/storages_tests/journal_tests/test_journal.py
@@ -7,6 +7,7 @@ import pathlib
 import pickle
 from types import TracebackType
 from typing import Any
+from typing import cast
 from typing import IO
 from unittest import mock
 
@@ -122,7 +123,7 @@ def test_retry_an_incomplete_trailing_log() -> None:
     )
     what_to_write_2 = b'er_id":"worker-2"}\n' + b'{"op_code":0,"worker_id":"worker-3"}\n'
     with NamedTemporaryFilePool() as file_:
-        file: IO[bytes] = file_
+        file = cast(IO[bytes], file_)
         file.write(what_to_write_1)
         file.flush()
 
@@ -149,7 +150,7 @@ def test_does_not_cache_an_incomplete_log_before_requested_number() -> None:
     )
     what_to_write_2 = b'er_id":"worker-2"}\n' + b'{"op_code":0,"worker_id":"worker-3"}\n'
     with NamedTemporaryFilePool() as file_:
-        file: IO[bytes] = file_
+        file = cast(IO[bytes], file_)
         file.write(what_to_write_1)
         file.flush()
 


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. To minimize the review effort, we highly appreciate PRs only with related changes. Please note that submitted PRs may be closed if they include unrelated changes or significantly modified unit tests. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
```JournalFileBackend.read_logs()``` caches byte offsets so later reads can seek directly to a requested log number. There was a bug when the file ended with an incomplete log line and the caller read from a later ```log_number_from```.

  In that case, ```read_logs()``` cached the offset for the next log before validating that the current line was complete. If the incomplete line was skipped because ```log_number < log_number_from```, the invalid cached offset remained. A later read could then seek into the middle of the completed log line and fail with ```JSONDecodeError```.


## Description of the changes
<!-- Describe the changes in this PR. -->
  - Fix ```JournalFileBackend.read_logs()``` so it validates line completeness before caching the offset for the next log entry.
  - This prevents _log_number_offset from recording offsets derived from incomplete log lines.
  - Add regression tests covering:
      - the case where an incomplete final log is detected while reading from 0
      - the case where an incomplete final log is skipped due to ```log_number_from```, then later completed