### PR TITLE
Add opt-in `is_best` column to `Study.trials_dataframe`

### DIFF
--- a/docs/source/reference/study.rst
+++ b/docs/source/reference/study.rst
@@ -19,3 +19,15 @@ The :mod:`~optuna.study` module implements the :class:`~optuna.study.Study` obje
    MaxTrialsCallback
    StudyDirection
    StudySummary
+
+Trial dataframes
+----------------
+
+Use the ``is_best`` attribute with :meth:`~optuna.study.Study.trials_dataframe` to add an
+opt-in boolean column identifying the best trials. For single-objective studies, the column
+marks the best feasible trial. For multi-objective studies, it marks trials on the Pareto front.
+The default columns are unchanged.
+
+.. code-block:: python
+
+   df = study.trials_dataframe(attrs=("number", "value", "is_best"))

--- a/optuna/study/_dataframe.py
+++ b/optuna/study/_dataframe.py
@@ -21,7 +21,7 @@ __all__ = ["pd"]
 
 def _create_records_and_aggregate_column(
     study: "optuna.Study", attrs: tuple[str, ...]
-) -> tuple[list[dict[tuple[str, str], Any]], list[tuple[str, str]]]:
+) -> tuple[list[dict[tuple[str, Any], Any]], list[tuple[str, str]]]:
     attrs_to_df_columns: dict[str, str] = {}
     for attr in attrs:
         if attr.startswith("_"):
@@ -39,10 +39,25 @@ def _create_records_and_aggregate_column(
 
     metric_names = study.metric_names
 
-    records = []
+    records: list[dict[tuple[str, Any], Any]] = []
+    best_trial_numbers: set[int] = set()
+    if "is_best" in attrs:
+        if study._is_multi_objective():
+            best_trial_numbers = {trial.number for trial in study.best_trials}
+        else:
+            try:
+                best_trial_numbers.add(study.best_trial.number)
+            except ValueError:
+                pass
+
     for trial in study.get_trials(deepcopy=False):
-        record = {}
+        record: dict[tuple[str, Any], Any] = {}
         for attr, df_column in attrs_to_df_columns.items():
+            if attr == "is_best":
+                record[(df_column, non_nested_attr)] = trial.number in best_trial_numbers
+                column_agg[attr].add((df_column, non_nested_attr))
+                continue
+
             value = getattr(trial, attr)
             if isinstance(value, TrialState):
                 value = value.name

--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -806,7 +806,10 @@ class Study:
         Args:
             attrs:
                 Specifies field names of :class:`~optuna.trial.FrozenTrial` to include them to a
-                DataFrame of trials.
+                DataFrame of trials. The special attribute ``is_best`` can be used to include a
+                boolean column indicating whether each trial is among the best trials. It is not
+                included by default. For single-objective studies, only the best trial is marked.
+                For multi-objective studies, trials on the Pareto front are marked.
             multi_index:
                 Specifies whether the returned DataFrame_ employs MultiIndex_ or not. Columns that
                 are hierarchical by nature such as ``(params, x)`` will be flattened to

--- a/tests/study_tests/test_dataframe.py
+++ b/tests/study_tests/test_dataframe.py
@@ -6,6 +6,7 @@ import pytest
 from optuna import create_study
 from optuna import create_trial
 from optuna import Trial
+from optuna.study._constrained_optimization import _CONSTRAINTS_KEY
 from optuna.testing.storages import STORAGE_MODES
 from optuna.testing.storages import StorageSupplier
 from optuna.trial import TrialState
@@ -15,6 +16,72 @@ def test_study_trials_dataframe_with_no_trials() -> None:
     study_with_no_trials = create_study()
     trials_df = study_with_no_trials.trials_dataframe()
     assert trials_df.empty
+
+
+@pytest.mark.parametrize("multi_index", [True, False])
+def test_trials_dataframe_with_is_best(multi_index: bool) -> None:
+    study = create_study(direction="minimize")
+    study.add_trial(create_trial(value=2.0))
+    study.add_trial(create_trial(value=1.0))
+    study.add_trial(create_trial(value=3.0))
+
+    assert "is_best" not in study.trials_dataframe().columns
+
+    df = study.trials_dataframe(attrs=("number", "is_best"), multi_index=multi_index)
+
+    if multi_index:
+        assert list(df.columns) == [("number", ""), ("is_best", "")]
+        assert df[("is_best", "")].tolist() == [False, True, False]
+    else:
+        assert list(df.columns) == ["number", "is_best"]
+        assert df["is_best"].tolist() == [False, True, False]
+
+
+@pytest.mark.parametrize("multi_index", [True, False])
+def test_trials_dataframe_with_is_best_for_multi_objective(multi_index: bool) -> None:
+    study = create_study(directions=["minimize", "minimize"])
+    study.add_trial(create_trial(values=[1.0, 3.0]))
+    study.add_trial(create_trial(values=[2.0, 2.0]))
+    study.add_trial(create_trial(values=[3.0, 1.0]))
+    study.add_trial(create_trial(values=[4.0, 4.0]))
+
+    df = study.trials_dataframe(attrs=("number", "is_best"), multi_index=multi_index)
+
+    if multi_index:
+        assert df[("is_best", "")].tolist() == [True, True, True, False]
+    else:
+        assert df["is_best"].tolist() == [True, True, True, False]
+
+
+def test_trials_dataframe_with_is_best_when_no_trials_are_complete() -> None:
+    study = create_study()
+    study.add_trial(create_trial(state=TrialState.FAIL))
+    study.add_trial(create_trial(state=TrialState.PRUNED))
+
+    df = study.trials_dataframe(attrs=("number", "is_best"))
+
+    assert df["is_best"].tolist() == [False, False]
+
+
+def test_trials_dataframe_with_is_best_for_constrained_optimization() -> None:
+    study = create_study(direction="minimize")
+    storage = study._storage
+
+    trial = study.ask()
+    storage.set_trial_system_attr(trial._trial_id, _CONSTRAINTS_KEY, [1])
+    study.tell(trial, 0)
+
+    trial = study.ask()
+    storage.set_trial_system_attr(trial._trial_id, _CONSTRAINTS_KEY, [0])
+    study.tell(trial, 1)
+
+    trial = study.ask()
+    storage.set_trial_system_attr(trial._trial_id, _CONSTRAINTS_KEY, [0])
+    study.tell(trial, 2)
+
+    df = study.trials_dataframe(attrs=("number", "is_best"))
+
+    assert df["is_best"].tolist() == [False, True, False]
 
 
 @pytest.mark.parametrize("storage_mode", STORAGE_MODES)


### PR DESCRIPTION
## Motivation

It is currently difficult to identify the trials that produced the best results when analyzing the DataFrame returned by `Study.trials_dataframe()`. This is especially useful for multi-objective studies, where `Study.best_trials` contains the Pareto front.

## Description of the changes

- Add `is_best` as an opt-in `attrs` value for `Study.trials_dataframe()`.
- Mark the best feasible trial for single-objective studies.
- Mark Pareto-front trials for multi-objective studies.
- Keep the existing default columns unchanged.
- Return `False` for all rows when no completed or feasible best trial exists.
- Add coverage for flat and MultiIndex columns, multi-objective studies, constrained studies, and studies without completed trials.
- Document the new opt-in attribute in the Study reference.

The implementation reuses the existing `Study.best_trial` and `Study.best_trials` semantics, so constrained studies follow the same feasibility rules as the public Study properties.

## Validation

- `pytest tests/study_tests/test_dataframe.py -q -k is_best` (6 passed)
- `ruff check` on the changed files (passed)
- `ruff format --check` on the changed files (passed)
- `git diff --check` (passed)
- GitHub Actions checks passed for Python 3.9, 3.13, and 3.14, minimum versions, RDB storage, macOS, Windows, documentation, doctest, and reviewdog.
- The Read the Docs build for this head is still in progress.

The local mypy invocation is currently blocked by an existing error in `optuna/storages/_rdb/models.py` unrelated to this change.

AI assistance was used for research, implementation, and test drafting. I reviewed the resulting diff, understand the behavior, and ran the validation listed above.