### PR TITLE
feat: Add is_best column to trials_dataframe (GH #6780)

### DIFF
--- a/optuna/study/_dataframe.py
+++ b/optuna/study/_dataframe.py
@@ -39,11 +39,24 @@ def _create_records_and_aggregate_column(
 
     metric_names = study.metric_names
 
+    best_trial_numbers = set()
+    if "is_best" in attrs:
+        if study._is_multi_objective():
+            best_trial_numbers = {t.number for t in study.best_trials}
+        else:
+            try:
+                best_trial_numbers = {study.best_trial.number}
+            except ValueError:
+                pass
+
     records = []
     for trial in study.get_trials(deepcopy=False):
         record = {}
         for attr, df_column in attrs_to_df_columns.items():
-            value = getattr(trial, attr)
+            if attr == "is_best":
+                value = trial.number in best_trial_numbers
+            else:
+                value = getattr(trial, attr)
             if isinstance(value, TrialState):
                 value = value.name
             if isinstance(value, dict):

--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -806,7 +806,10 @@ class Study:
         Args:
             attrs:
                 Specifies field names of :class:`~optuna.trial.FrozenTrial` to include them to a
-                DataFrame of trials.
+                DataFrame of trials. In addition to the fields of
+                :class:`~optuna.trial.FrozenTrial`, you can specify ``"is_best"`` to include a
+                boolean column indicating whether a trial is the best trial (single-objective
+                optimization) or a Pareto-optimal trial (multi-objective optimization).
             multi_index:
                 Specifies whether the returned DataFrame_ employs MultiIndex_ or not. Columns that
                 are hierarchical by nature such as ``(params, x)`` will be flattened to

--- a/tests/study_tests/test_dataframe.py
+++ b/tests/study_tests/test_dataframe.py
@@ -245,3 +245,105 @@ def test_trials_dataframe_preserves_metric_names_order() -> None:
     flat_cols2 = list(study2.trials_dataframe().columns)
     values_cols2 = [c for c in flat_cols2 if c.startswith("values_")]
     assert values_cols2 == ["values_test", "values_train"]
+
+
+def _can_symlink() -> bool:
+    import os
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        src = os.path.join(tmpdir, "src")
+        dst = os.path.join(tmpdir, "dst")
+        with open(src, "w") as f:
+            f.write("test")
+        try:
+            os.symlink(src, dst)
+            return True
+        except OSError:
+            return False
+
+
+@pytest.mark.parametrize("storage_mode", STORAGE_MODES)
+@pytest.mark.parametrize("multi_index", [True, False])
+def test_trials_dataframe_with_is_best(storage_mode: str, multi_index: bool) -> None:
+    from optuna.distributions import FloatDistribution
+
+    if storage_mode in ("journal", "grpc_journal_file"):
+        if not _can_symlink():
+            pytest.skip("Environment does not support symlinks.")
+
+    # Single-objective optimization: minimization
+    with StorageSupplier(storage_mode) as storage:
+        study = create_study(storage=storage, direction="minimize")
+        study.optimize(lambda t: t.suggest_float("x", 0, 10), n_trials=3)
+        best_trial = study.best_trial
+        df = study.trials_dataframe(attrs=("number", "value", "is_best"), multi_index=multi_index)
+        assert len(df) == 3
+        if multi_index:
+            df.set_index(("number", ""), inplace=True, drop=False)
+            is_best_col = ("is_best", "")
+        else:
+            df.set_index("number", inplace=True, drop=False)
+            is_best_col = "is_best"
+
+        for i in range(3):
+            assert bool(df[is_best_col][i]) is (i == best_trial.number)
+
+    # Multi-objective optimization (Pareto front)
+    with StorageSupplier(storage_mode) as storage:
+        study = create_study(storage=storage, directions=["minimize", "minimize"])
+        # Add trials manually to ensure Pareto optimality structure:
+        # Trial 0: (1.0, 5.0) - Pareto-optimal
+        # Trial 1: (5.0, 1.0) - Pareto-optimal
+        # Trial 2: (5.0, 5.0) - Dominated
+        study.add_trial(create_trial(
+            state=TrialState.COMPLETE,
+            values=[1.0, 5.0],
+            params={"x": 1.0, "y": 5.0},
+            distributions={"x": FloatDistribution(0, 10), "y": FloatDistribution(0, 10)}
+        ))
+        study.add_trial(create_trial(
+            state=TrialState.COMPLETE,
+            values=[5.0, 1.0],
+            params={"x": 5.0, "y": 1.0},
+            distributions={"x": FloatDistribution(0, 10), "y": FloatDistribution(0, 10)}
+        ))
+        study.add_trial(create_trial(
+            state=TrialState.COMPLETE,
+            values=[5.0, 5.0],
+            params={"x": 5.0, "y": 5.0},
+            distributions={"x": FloatDistribution(0, 10), "y": FloatDistribution(0, 10)}
+        ))
+
+        df = study.trials_dataframe(attrs=("number", "values", "is_best"), multi_index=multi_index)
+        assert len(df) == 3
+        if multi_index:
+            df.set_index(("number", ""), inplace=True, drop=False)
+            is_best_col = ("is_best", "")
+        else:
+            df.set_index("number", inplace=True, drop=False)
+            is_best_col = "is_best"
+
+        assert bool(df[is_best_col][0]) is True
+        assert bool(df[is_best_col][1]) is True
+        assert bool(df[is_best_col][2]) is False
+
+    # Empty study
+    with StorageSupplier(storage_mode) as storage:
+        study = create_study(storage=storage)
+        df = study.trials_dataframe(attrs=("number", "is_best"), multi_index=multi_index)
+        assert df.empty
+
+    # No completed/feasible trials (only fail)
+    with StorageSupplier(storage_mode) as storage:
+        study = create_study(storage=storage)
+        study.add_trial(create_trial(state=TrialState.FAIL))
+        df = study.trials_dataframe(attrs=("number", "is_best"), multi_index=multi_index)
+        assert len(df) == 1
+        if multi_index:
+            is_best_value = df[("is_best", "")][0]
+        else:
+            is_best_value = df["is_best"][0]
+        assert bool(is_best_value) is False
+
+


### PR DESCRIPTION
Add support for 'is_best' as a valid attr in Study.trials_dataframe(). For single-objective studies, is_best is True for the best trial. For multi-objective studies, is_best is True for all Pareto-optimal trials.

is_best is opt-in and not part of the default attrs tuple to avoid performance overhead on large studies.

Tests added in tests/study_tests/test_dataframe.py covering:
- Single-objective minimization with is_best column
- Multi-objective (Pareto front) with is_best column
- Empty study edge case
- No completed trials edge case
- Both flat and multi-index DataFrame formats

<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. To minimize the review effort, we highly appreciate PRs only with related changes. Please note that submitted PRs may be closed if they include unrelated changes or significantly modified unit tests. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

## Description of the changes
<!-- Describe the changes in this PR. -->
