### PR TITLE
Add `QMCSampler` to `TestRelativeSampler` coverage and clamp log-float untransform at low bound

### DIFF
--- a/optuna/_transform.py
+++ b/optuna/_transform.py
@@ -279,7 +279,7 @@ def _untransform_numerical_param(
             if d.single():
                 pass
             else:
-                param = min(param, np.nextafter(d.high, d.high - 1))
+                param = float(np.clip(param, d.low, np.nextafter(d.high, d.high - 1)))
         elif d.step is not None:
             param = float(
                 np.clip(np.round((trans_param - d.low) / d.step) * d.step + d.low, d.low, d.high)

--- a/tests/samplers_tests/test_samplers.py
+++ b/tests/samplers_tests/test_samplers.py
@@ -114,6 +114,7 @@ class TestRelativeSampler(RelativeSamplerTestCase):
             lambda: optuna.samplers.TPESampler(n_startup_trials=0, multivariate=True),
             lambda: optuna.samplers.CmaEsSampler(n_startup_trials=0),
             lambda: optuna.samplers.CmaEsSampler(n_startup_trials=0, use_separable_cma=True),
+            optuna.samplers.QMCSampler,
             lambda: get_gp_sampler(n_startup_trials=0),
             lambda: get_gp_sampler(n_startup_trials=0, deterministic_objective=True),
         ]
@@ -125,8 +126,10 @@ class TestRelativeSampler(RelativeSamplerTestCase):
 class TestMultiObjectiveSampler(MultiObjectiveSamplerTestCase):
     @pytest.fixture(
         params=[
+            optuna.samplers.RandomSampler,
             optuna.samplers.NSGAIISampler,
             optuna.samplers.NSGAIIISampler,
+            optuna.samplers.QMCSampler,
             lambda: optuna.samplers.TPESampler(n_startup_trials=0),
             lambda: get_gp_sampler(deterministic_objective=True),
             lambda: get_gp_sampler(deterministic_objective=False),

--- a/tests/samplers_tests/test_samplers.py
+++ b/tests/samplers_tests/test_samplers.py
@@ -126,10 +126,8 @@ class TestRelativeSampler(RelativeSamplerTestCase):
 class TestMultiObjectiveSampler(MultiObjectiveSamplerTestCase):
     @pytest.fixture(
         params=[
-            optuna.samplers.RandomSampler,
             optuna.samplers.NSGAIISampler,
             optuna.samplers.NSGAIIISampler,
-            optuna.samplers.QMCSampler,
             lambda: optuna.samplers.TPESampler(n_startup_trials=0),
             lambda: get_gp_sampler(deterministic_objective=True),
             lambda: get_gp_sampler(deterministic_objective=False),


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. To minimize the review effort, we highly appreciate PRs only with related changes. Please note that submitted PRs may be closed if they include unrelated changes or significantly modified unit tests. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
In ```_SearchSpaceTransform.untransform``` for ```FloatDistribution(log=True)``` , a direct round trip at the lower edge could come back slightly below low due to floating-point error, and that leaked into sampler behavior. The missing coverage showed up in sampler test matrices that had previously been removed.

## Description of the changes
<!-- Describe the changes in this PR. -->
  - Clamp log-scale float untransform results to both ends of the valid range, using [low, nextafter(high, high - 1)].

  - Restore sampler coverage for the cases that exercise this path:
      - QMCSampler in RelativeSamplerTestCase