### PR TITLE
Fix NaN duplicate detection in `Study.enqueue_trial`

### DIFF
--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -1137,7 +1137,7 @@ class Study:
                     continue
 
                 is_repeated = (
-                    np.isnan(float(param_value))
+                    (np.isnan(float(param_value)) and np.isnan(float(existing_param)))
                     or np.isclose(float(param_value), float(existing_param), atol=0.0)
                     if isinstance(param_value, Real)
                     else param_value == existing_param

--- a/tests/study_tests/test_study.py
+++ b/tests/study_tests/test_study.py
@@ -842,6 +842,22 @@ def test_enqueue_trial_skip_existing_handles_common_types(storage_mode: str, par
         assert before_enqueue == after_enqueue
 
 
+@pytest.mark.parametrize("storage_mode", STORAGE_MODES)
+def test_enqueue_trial_skip_existing_distinguishes_nan_from_other_values(
+    storage_mode: str,
+) -> None:
+    with StorageSupplier(storage_mode) as storage:
+        study = create_study(storage=storage)
+        study.enqueue_trial({"x": 0.0})
+        study.enqueue_trial({"x": float("nan")}, skip_if_exists=True)
+        assert len(study.trials) == 2
+
+        reverse_study = create_study(storage=storage)
+        reverse_study.enqueue_trial({"x": float("nan")})
+        reverse_study.enqueue_trial({"x": 0.0}, skip_if_exists=True)
+        assert len(reverse_study.trials) == 2
+
+
 @patch("optuna.study._optimize.gc.collect")
 def test_optimize_with_gc(collect_mock: Mock) -> None:
     study = create_study()


### PR DESCRIPTION
Fixes #6798. When skip_if_exists=True, NaN should only match an existing NaN, not an ordinary numeric value. Update the duplicate check to require both values to be NaN, and add a regression test covering both enqueue orders across all storage modes. Validation: .venv\Scripts\python -m pytest tests\study_tests\test_study.py -q; .venv\Scripts\ruff.exe format --check optuna\study\study.py tests\study_tests\test_study.py; .venv\Scripts\ruff.exe check optuna\study\study.py tests\study_tests\test_study.py; .venv\Scripts\mypy.exe .; git diff --check.