### PR TITLE
Fix NaN handling in `Study.enqueue_trial` with `skip_if_exists`

### DIFF
--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -1136,12 +1136,16 @@ class Study:
                     repeated_params.append(False)
                     continue
 
-                is_repeated = (
-                    np.isnan(float(param_value))
-                    or np.isclose(float(param_value), float(existing_param), atol=0.0)
-                    if isinstance(param_value, Real)
-                    else param_value == existing_param
-                )
+                if isinstance(param_value, Real):
+                    if np.isnan(float(param_value)):
+                        # NaN only matches another NaN
+                        is_repeated = np.isnan(float(existing_param))
+                    else:
+                        is_repeated = np.isclose(
+                            float(param_value), float(existing_param), atol=0.0
+                        )
+                else:
+                    is_repeated = param_value == existing_param
                 repeated_params.append(bool(is_repeated))
 
             if all(repeated_params):

--- a/tests/study_tests/test_study.py
+++ b/tests/study_tests/test_study.py
@@ -1930,3 +1930,35 @@ def test_after_trial_with_study_tell() -> None:
     study.tell(study.ask(), 1.0)
 
     assert n_calls == 1
+
+
+def test_enqueue_trial_nan_equality() -> None:
+    study = optuna.create_study()
+    study.enqueue_trial({"fill_value": 0.0})
+    study.enqueue_trial({"fill_value": float("nan")}, skip_if_exists=True)
+    assert len(study.trials) == 2  # Should not skip!
+
+    reverse_study = optuna.create_study()
+    reverse_study.enqueue_trial({"fill_value": float("nan")})
+    reverse_study.enqueue_trial({"fill_value": 0.0}, skip_if_exists=True)
+    assert len(reverse_study.trials) == 2  # Symmetrical behavior!
+
+
+def test_enqueue_trial_skip_if_exists_nan() -> None:
+    # Case 1: 0.0 followed by NaN (The original bug)
+    study1 = optuna.create_study()
+    study1.enqueue_trial({"x": 0.0})
+    study1.enqueue_trial({"x": float("nan")}, skip_if_exists=True)
+    assert len(study1.get_trials(deepcopy=False)) == 2
+
+    # Case 2: NaN followed by 0.0 (Symmetrical behavior)
+    study2 = optuna.create_study()
+    study2.enqueue_trial({"x": float("nan")})
+    study2.enqueue_trial({"x": 0.0}, skip_if_exists=True)
+    assert len(study2.get_trials(deepcopy=False)) == 2
+
+    # Case 3: NaN followed by NaN (Should correctly skip!)
+    study3 = optuna.create_study()
+    study3.enqueue_trial({"x": float("nan")})
+    study3.enqueue_trial({"x": float("nan")}, skip_if_exists=True)
+    assert len(study3.get_trials(deepcopy=False)) == 1


### PR DESCRIPTION
## Motivation
Resolves #6798

When `skip_if_exists=True`, `Study.enqueue_trial` incorrectly treated `NaN` as a duplicate of *any* existing numeric value. This happened because `np.isnan(float(param_value))` short-circuited to `True` in the `_should_skip_enqueue` check, bypassing the comparison with the existing parameter.

This caused asymmetrical and incorrect behavior:
- Enqueueing `0.0` then `NaN` -> Skipped (Bug!)
- Enqueueing `NaN` then `0.0` -> Added (Correct)

## Description of the changes
I updated `_should_skip_enqueue` in `optuna/study/study.py` to explicitly check if the new parameter is `NaN`. If it is, it is only considered a duplicate if the existing parameter is *also* `NaN`. This restores correct, symmetrical behavior and prevents `NaN` from silently swallowing valid numeric configurations.

I also added a regression test `test_enqueue_trial_skip_if_exists_nan` in `tests/study_tests/test_study.py` to ensure symmetrical behavior and prevent future regressions.