### PR TITLE
Fix NaN comparison when skipping enqueued trials

### DIFF
--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -1137,8 +1137,7 @@ class Study:
                     continue
 
                 is_repeated = (
-                    np.isnan(float(param_value))
-                    or np.isclose(float(param_value), float(existing_param), atol=0.0)
+                    np.isclose(float(param_value), float(existing_param), atol=0.0, equal_nan=True)
                     if isinstance(param_value, Real)
                     else param_value == existing_param
                 )

--- a/tests/study_tests/test_study.py
+++ b/tests/study_tests/test_study.py
@@ -842,6 +842,21 @@ def test_enqueue_trial_skip_existing_handles_common_types(storage_mode: str, par
         assert before_enqueue == after_enqueue
 
 
+@pytest.mark.parametrize("storage_mode", STORAGE_MODES)
+@pytest.mark.parametrize(
+    ("first_param", "second_param"),
+    [(0.0, float("nan")), (float("nan"), 0.0)],
+)
+def test_enqueue_trial_skip_existing_distinguishes_nan_from_numeric_values(
+    storage_mode: str, first_param: float, second_param: float
+) -> None:
+    with StorageSupplier(storage_mode) as storage:
+        study = create_study(storage=storage)
+        study.enqueue_trial({"x": first_param})
+        study.enqueue_trial({"x": second_param}, skip_if_exists=True)
+        assert len(study.trials) == 2
+
+
 @patch("optuna.study._optimize.gc.collect")
 def test_optimize_with_gc(collect_mock: Mock) -> None:
     study = create_study()


### PR DESCRIPTION


## Motivation
Fixes #6798.

When `skip_if_exists=True`, `Study.enqueue_trial` incorrectly treats a newly enqueued `NaN` as a duplicate of any existing numeric value. This makes duplicate detection asymmetric: enqueueing `0.0` followed by `NaN` behaves differently from enqueueing the same values in reverse order.

## Description of the changes
Use `np.isclose(..., equal_nan=True)` when comparing numeric parameter values.

This ensures that:

- `NaN` and ordinary numeric values are distinct.
- Two `NaN` values are treated as duplicates.
- Duplicate detection is independent of enqueue order.
- Existing approximate numeric comparison behavior is preserved.

A regression test covers both `0.0` followed by `NaN` and `NaN` followed by `0.0` across all configured storage modes.

## Validation

- 77 focused tests passed across all configured storage modes.
- Ruff lint passed.
- Ruff formatting check passed.
- `git diff --check` passed.
