### PR TITLE
Fix enqueue_trial(skip_if_exists=True) failing to dedupe equal int/float params

### DIFF
--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -1128,7 +1128,8 @@ class Study:
             repeated_params: list[bool] = []
             for param_name, param_value in params.items():
                 existing_param = trial_params[param_name]
-                if not isinstance(param_value, type(existing_param)):
+                both_numeric = isinstance(param_value, Real) and isinstance(existing_param, Real)
+                if not both_numeric and not isinstance(param_value, type(existing_param)):
                     # Enqueued param has distribution that does not match existing param
                     # (e.g. trying to enqueue categorical to float param).
                     # We are not doing anything about it here, since sanitization should
@@ -1139,7 +1140,7 @@ class Study:
                 is_repeated = (
                     np.isnan(float(param_value))
                     or np.isclose(float(param_value), float(existing_param), atol=0.0)
-                    if isinstance(param_value, Real)
+                    if both_numeric
                     else param_value == existing_param
                 )
                 repeated_params.append(bool(is_repeated))

--- a/tests/study_tests/test_study.py
+++ b/tests/study_tests/test_study.py
@@ -842,6 +842,26 @@ def test_enqueue_trial_skip_existing_handles_common_types(storage_mode: str, par
         assert before_enqueue == after_enqueue
 
 
+@pytest.mark.parametrize("storage_mode", STORAGE_MODES)
+@pytest.mark.parametrize(
+    ("first_param", "second_param"),
+    [(5, 5.0), (5.0, 5)],
+)
+def test_enqueue_trial_skip_existing_handles_mixed_int_float(
+    storage_mode: str, first_param: Any, second_param: Any
+) -> None:
+    # Numerically equal `int` and `float` values for the same parameter should be
+    # recognized as duplicates even though their Python types differ.
+    with StorageSupplier(storage_mode) as storage:
+        study = create_study(storage=storage)
+        study.enqueue_trial({"x": first_param})
+        study.enqueue_trial({"x": second_param}, skip_if_exists=True)
+        assert len(study.trials) == 1
+
+        study.enqueue_trial({"x": second_param + 1}, skip_if_exists=True)
+        assert len(study.trials) == 2
+
+
 @patch("optuna.study._optimize.gc.collect")
 def test_optimize_with_gc(collect_mock: Mock) -> None:
     study = create_study()


### PR DESCRIPTION
`Study._should_skip_enqueue()` used `isinstance(param_value, type(existing_param))` to gate its duplicate check, so an `int` and a numerically-equal `float` for the same param (e.g. `5` vs `5.0`) were treated as different "types" and never deduplicated. Reproducible: `enqueue_trial({"x": 5})` followed by `enqueue_trial({"x": 5.0}, skip_if_exists=True)` produces 2 trials instead of 1, in both orderings.

**Fix:** replace the strict same-type check with one that treats any pair of `numbers.Real` values (int/float/bool) as comparable, while still rejecting genuinely incompatible types.

Added `test_enqueue_trial_skip_existing_handles_mixed_int_float`, parametrized over both int->float and float->int orderings and multiple storage backends (367 passed in the affected suite, no new failures).
