### PR TITLE
DOC: add missing Raises sections to Trial.report and get_param_importances docstrings

### DIFF
--- a/optuna/importance/__init__.py
+++ b/optuna/importance/__init__.py
@@ -105,6 +105,11 @@ def get_param_importances(
     Returns:
         A :obj:`dict` where the keys are parameter names and the values are assessed importances.
 
+    Raises:
+        :exc:`TypeError`:
+            If ``evaluator`` is not a subclass of
+            :class:`~optuna.importance.BaseImportanceEvaluator`.
+
     Example:
         .. testcode::
 

--- a/optuna/trial/_trial.py
+++ b/optuna/trial/_trial.py
@@ -475,6 +475,13 @@ class Trial(BaseTrial):
                 :class:`~optuna.pruners.MedianPruner` simply checks if ``step`` is less than
                 ``n_warmup_steps`` as the warmup mechanism.
                 ``step`` must be a non-negative integer.
+
+        Raises:
+            :exc:`TypeError`:
+                If ``value`` cannot be cast to :obj:`float`, or if ``step`` cannot be cast to
+                :obj:`int`.
+            :exc:`ValueError`:
+                If ``step`` is a negative integer.
         """
 
         if len(self.study.directions) > 1:


### PR DESCRIPTION
Both `Trial.report()` and `optuna.importance.get_param_importances()` raise
`TypeError` and/or `ValueError` in documented scenarios but lack `Raises:`
sections in their docstrings, inconsistent with other functions in the codebase
(e.g. `Study.best_trial`).

Notably, `Trial.report()` already mentions in a `.. note::` block that it raises
`TypeError`, but doesn't document it in the standard `Raises:` section where
users and IDE tooling expect to find it.

Changes:
- `optuna/trial/_trial.py`: add `Raises:` to `Trial.report()` documenting
  `TypeError` (bad value/step types) and `ValueError` (negative step)
- `optuna/importance/__init__.py`: add `Raises:` to `get_param_importances()`
  documenting `TypeError` (invalid evaluator type)

No behavior change. ruff clean, 134 tests pass.