### PR TITLE
DOC: add missing Raises sections to 5 public Study functions

### DIFF
--- a/optuna/importance/__init__.py
+++ b/optuna/importance/__init__.py
@@ -105,6 +105,11 @@ def get_param_importances(
     Returns:
         A :obj:`dict` where the keys are parameter names and the values are assessed importances.
 
+    Raises:
+        :exc:`TypeError`:
+            If ``evaluator`` is not a subclass of
+            :class:`~optuna.importance.BaseImportanceEvaluator`.
+
     Example:
         .. testcode::
 

--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -914,6 +914,10 @@ class Study:
 
             Please refer to :ref:`enqueue_trial_tutorial` for the tutorial of specifying
             hyperparameters manually.
+
+        Raises:
+            :exc:`TypeError`:
+                If ``params`` is not a dictionary.
         """
 
         if not isinstance(params, dict):
@@ -990,6 +994,10 @@ class Study:
         Args:
             trial: Trial to add.
 
+        Raises:
+            :exc:`ValueError`:
+                If the number of values in the trial does not match the number of objectives
+                in the study.
         """
 
         trial._validate()
@@ -1078,6 +1086,10 @@ class Study:
 
         Args:
             metric_names: A list of metric names for the objective function.
+
+        Raises:
+            :exc:`ValueError`:
+                If the length of ``metric_names`` does not match the number of objectives.
         """
         if len(self.directions) != len(metric_names):
             raise ValueError("The number of objectives must match the length of the metric names.")
@@ -1271,6 +1283,12 @@ def create_study(
         The :ref:`rdb` tutorial provides concrete examples to save and resume optimization using
         RDB.
 
+    Raises:
+        :exc:`ValueError`:
+            If both ``direction`` and ``directions`` are specified, or if neither is specified,
+            or if an invalid direction string is provided, or if the number of objectives is
+            not greater than 0.
+
     """
 
     if direction is None and directions is None:
@@ -1388,6 +1406,10 @@ def load_study(
 
     See also:
         :func:`optuna.load_study` is an alias of :func:`optuna.study.load_study`.
+
+    Raises:
+        :exc:`ValueError`:
+            If ``study_name`` is :obj:`None` and cannot be determined from the storage.
 
     """
     if study_name is None:

--- a/optuna/trial/_trial.py
+++ b/optuna/trial/_trial.py
@@ -475,6 +475,13 @@ class Trial(BaseTrial):
                 :class:`~optuna.pruners.MedianPruner` simply checks if ``step`` is less than
                 ``n_warmup_steps`` as the warmup mechanism.
                 ``step`` must be a non-negative integer.
+
+        Raises:
+            :exc:`TypeError`:
+                If ``value`` cannot be cast to :obj:`float`, or if ``step`` cannot be cast to
+                :obj:`int`.
+            :exc:`ValueError`:
+                If ``step`` is a negative integer.
         """
 
         if len(self.study.directions) > 1:


### PR DESCRIPTION
`create_study()`, `load_study()`, `enqueue_trial()`, `add_trial()`, and
`set_metric_names()` all raise `ValueError` or `TypeError` in documented
scenarios, but unlike other functions in the same file (e.g. `Study.best_trial`),
they are missing `Raises:` sections in their docstrings.

This patch adds the missing sections, consistent with the existing style in
`optuna/study/study.py` and the Google-style docstring convention used
throughout Optuna.

No behavior change. ruff clean, tests pass.