### PR TITLE
DOC: add missing Raises sections to set_constraint and distribution utility functions

### DIFF
--- a/optuna/distributions.py
+++ b/optuna/distributions.py
@@ -571,6 +571,9 @@ def json_to_distribution(json_str: str) -> BaseDistribution:
     Returns:
         A deserialized distribution.
 
+    Raises:
+        :exc:`ValueError`:
+            If the JSON string does not contain a known distribution class or type.
     """
 
     json_dict = json.loads(json_str)
@@ -636,6 +639,10 @@ def check_distribution_compatibility(
         dist_new:
             A distribution newly added to storage.
 
+    Raises:
+        :exc:`ValueError`:
+            If ``dist_old`` and ``dist_new`` are of different distribution kinds,
+            different ``choices`` (for categorical), or different log/step configurations.
     """
 
     if dist_old.__class__ != dist_new.__class__:

--- a/optuna/importance/__init__.py
+++ b/optuna/importance/__init__.py
@@ -105,6 +105,11 @@ def get_param_importances(
     Returns:
         A :obj:`dict` where the keys are parameter names and the values are assessed importances.
 
+    Raises:
+        :exc:`TypeError`:
+            If ``evaluator`` is not a subclass of
+            :class:`~optuna.importance.BaseImportanceEvaluator`.
+
     Example:
         .. testcode::
 

--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -914,6 +914,10 @@ class Study:
 
             Please refer to :ref:`enqueue_trial_tutorial` for the tutorial of specifying
             hyperparameters manually.
+
+        Raises:
+            :exc:`TypeError`:
+                If ``params`` is not a dictionary.
         """
 
         if not isinstance(params, dict):
@@ -990,6 +994,10 @@ class Study:
         Args:
             trial: Trial to add.
 
+        Raises:
+            :exc:`ValueError`:
+                If the number of values in the trial does not match the number of objectives
+                in the study.
         """
 
         trial._validate()
@@ -1078,6 +1086,10 @@ class Study:
 
         Args:
             metric_names: A list of metric names for the objective function.
+
+        Raises:
+            :exc:`ValueError`:
+                If the length of ``metric_names`` does not match the number of objectives.
         """
         if len(self.directions) != len(metric_names):
             raise ValueError("The number of objectives must match the length of the metric names.")
@@ -1271,6 +1283,12 @@ def create_study(
         The :ref:`rdb` tutorial provides concrete examples to save and resume optimization using
         RDB.
 
+    Raises:
+        :exc:`ValueError`:
+            If both ``direction`` and ``directions`` are specified, or if neither is specified,
+            or if an invalid direction string is provided, or if the number of objectives is
+            not greater than 0.
+
     """
 
     if direction is None and directions is None:
@@ -1388,6 +1406,10 @@ def load_study(
 
     See also:
         :func:`optuna.load_study` is an alias of :func:`optuna.study.load_study`.
+
+    Raises:
+        :exc:`ValueError`:
+            If ``study_name`` is :obj:`None` and cannot be determined from the storage.
 
     """
     if study_name is None:

--- a/optuna/trial/_fixed.py
+++ b/optuna/trial/_fixed.py
@@ -207,6 +207,12 @@ class FixedTrial(BaseTrial):
             value:
                 A constraint value. The trial is considered feasible when all constraint values
                 are zero or less.
+
+        Raises:
+            :exc:`TypeError`:
+                If ``value`` cannot be cast to :obj:`float`.
+            :exc:`ValueError`:
+                If ``value`` is NaN.
         """
 
         try:

--- a/optuna/trial/_frozen.py
+++ b/optuna/trial/_frozen.py
@@ -495,6 +495,12 @@ class FrozenTrial(BaseTrial):
             value:
                 A constraint value. The trial is considered feasible when all constraint values
                 are zero or less.
+
+        Raises:
+            :exc:`TypeError`:
+                If ``value`` cannot be cast to :obj:`float`.
+            :exc:`ValueError`:
+                If ``value`` is NaN.
         """
 
         try:

--- a/optuna/trial/_trial.py
+++ b/optuna/trial/_trial.py
@@ -791,6 +791,12 @@ class Trial(BaseTrial):
             value:
                 A constraint value. The trial is considered feasible when all constraint values
                 are zero or less.
+
+        Raises:
+            :exc:`TypeError`:
+                If ``value`` cannot be cast to :obj:`float`.
+            :exc:`ValueError`:
+                If ``value`` is NaN.
         """
 
         try:

--- a/optuna/trial/_trial.py
+++ b/optuna/trial/_trial.py
@@ -475,6 +475,13 @@ class Trial(BaseTrial):
                 :class:`~optuna.pruners.MedianPruner` simply checks if ``step`` is less than
                 ``n_warmup_steps`` as the warmup mechanism.
                 ``step`` must be a non-negative integer.
+
+        Raises:
+            :exc:`TypeError`:
+                If ``value`` cannot be cast to :obj:`float`, or if ``step`` cannot be cast to
+                :obj:`int`.
+            :exc:`ValueError`:
+                If ``step`` is a negative integer.
         """
 
         if len(self.study.directions) > 1:


### PR DESCRIPTION
Five public functions raise `TypeError` or `ValueError` but are missing
`Raises:` sections in their docstrings, inconsistent with other functions
like `Study.best_trial` which document their exceptions properly.

- `Trial.set_constraint()` in `_trial.py`, `_frozen.py`, `_fixed.py`:
  raises `TypeError` if value cannot be cast to float, `ValueError` if NaN
- `check_distribution_compatibility()` in `distributions.py`:
  raises `ValueError` for incompatible distributions
- `json_to_distribution()` in `distributions.py`:
  raises `ValueError` for unknown distribution class/type

No behavior change. ruff clean, 220 tests pass.