### PR TITLE
FIX: validate min_resource and reduction_factor in HyperbandPruner.__init__

### DIFF
--- a/optuna/distributions.py
+++ b/optuna/distributions.py
@@ -571,6 +571,9 @@ def json_to_distribution(json_str: str) -> BaseDistribution:
     Returns:
         A deserialized distribution.
 
+    Raises:
+        :exc:`ValueError`:
+            If the JSON string does not contain a known distribution class or type.
     """
 
     json_dict = json.loads(json_str)
@@ -636,6 +639,10 @@ def check_distribution_compatibility(
         dist_new:
             A distribution newly added to storage.
 
+    Raises:
+        :exc:`ValueError`:
+            If ``dist_old`` and ``dist_new`` are of different distribution kinds,
+            different ``choices`` (for categorical), or different log/step configurations.
     """
 
     if dist_old.__class__ != dist_new.__class__:

--- a/optuna/importance/__init__.py
+++ b/optuna/importance/__init__.py
@@ -105,6 +105,11 @@ def get_param_importances(
     Returns:
         A :obj:`dict` where the keys are parameter names and the values are assessed importances.
 
+    Raises:
+        :exc:`TypeError`:
+            If ``evaluator`` is not a subclass of
+            :class:`~optuna.importance.BaseImportanceEvaluator`.
+
     Example:
         .. testcode::
 

--- a/optuna/pruners/_hyperband.py
+++ b/optuna/pruners/_hyperband.py
@@ -161,6 +161,18 @@ class HyperbandPruner(BasePruner):
         self._trial_allocation_budgets: list[int] = []
         self._n_brackets: int | None = None
 
+        if self._min_resource < 1:
+            raise ValueError(
+                "The `min_resource` should be a positive integer, "
+                f"but got min_resource={self._min_resource}."
+            )
+
+        if self._reduction_factor < 2:
+            raise ValueError(
+                "The `reduction_factor` should be an integer no less than 2, "
+                f"but got reduction_factor={self._reduction_factor}."
+            )
+
         if not isinstance(self._max_resource, int) and self._max_resource != "auto":
             raise ValueError(
                 "The 'max_resource' should be integer or 'auto'. "

--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -914,6 +914,10 @@ class Study:
 
             Please refer to :ref:`enqueue_trial_tutorial` for the tutorial of specifying
             hyperparameters manually.
+
+        Raises:
+            :exc:`TypeError`:
+                If ``params`` is not a dictionary.
         """
 
         if not isinstance(params, dict):
@@ -990,6 +994,10 @@ class Study:
         Args:
             trial: Trial to add.
 
+        Raises:
+            :exc:`ValueError`:
+                If the number of values in the trial does not match the number of objectives
+                in the study.
         """
 
         trial._validate()
@@ -1078,6 +1086,10 @@ class Study:
 
         Args:
             metric_names: A list of metric names for the objective function.
+
+        Raises:
+            :exc:`ValueError`:
+                If the length of ``metric_names`` does not match the number of objectives.
         """
         if len(self.directions) != len(metric_names):
             raise ValueError("The number of objectives must match the length of the metric names.")
@@ -1271,6 +1283,12 @@ def create_study(
         The :ref:`rdb` tutorial provides concrete examples to save and resume optimization using
         RDB.
 
+    Raises:
+        :exc:`ValueError`:
+            If both ``direction`` and ``directions`` are specified, or if neither is specified,
+            or if an invalid direction string is provided, or if the number of objectives is
+            not greater than 0.
+
     """
 
     if direction is None and directions is None:
@@ -1388,6 +1406,10 @@ def load_study(
 
     See also:
         :func:`optuna.load_study` is an alias of :func:`optuna.study.load_study`.
+
+    Raises:
+        :exc:`ValueError`:
+            If ``study_name`` is :obj:`None` and cannot be determined from the storage.
 
     """
     if study_name is None:

--- a/optuna/trial/_fixed.py
+++ b/optuna/trial/_fixed.py
@@ -207,6 +207,12 @@ class FixedTrial(BaseTrial):
             value:
                 A constraint value. The trial is considered feasible when all constraint values
                 are zero or less.
+
+        Raises:
+            :exc:`TypeError`:
+                If ``value`` cannot be cast to :obj:`float`.
+            :exc:`ValueError`:
+                If ``value`` is NaN.
         """
 
         try:

--- a/optuna/trial/_frozen.py
+++ b/optuna/trial/_frozen.py
@@ -495,6 +495,12 @@ class FrozenTrial(BaseTrial):
             value:
                 A constraint value. The trial is considered feasible when all constraint values
                 are zero or less.
+
+        Raises:
+            :exc:`TypeError`:
+                If ``value`` cannot be cast to :obj:`float`.
+            :exc:`ValueError`:
+                If ``value`` is NaN.
         """
 
         try:

--- a/optuna/trial/_trial.py
+++ b/optuna/trial/_trial.py
@@ -791,6 +791,12 @@ class Trial(BaseTrial):
             value:
                 A constraint value. The trial is considered feasible when all constraint values
                 are zero or less.
+
+        Raises:
+            :exc:`TypeError`:
+                If ``value`` cannot be cast to :obj:`float`.
+            :exc:`ValueError`:
+                If ``value`` is NaN.
         """
 
         try:

--- a/optuna/trial/_trial.py
+++ b/optuna/trial/_trial.py
@@ -475,6 +475,13 @@ class Trial(BaseTrial):
                 :class:`~optuna.pruners.MedianPruner` simply checks if ``step`` is less than
                 ``n_warmup_steps`` as the warmup mechanism.
                 ``step`` must be a non-negative integer.
+
+        Raises:
+            :exc:`TypeError`:
+                If ``value`` cannot be cast to :obj:`float`, or if ``step`` cannot be cast to
+                :obj:`int`.
+            :exc:`ValueError`:
+                If ``step`` is a negative integer.
         """
 
         if len(self.study.directions) > 1:


### PR DESCRIPTION
`HyperbandPruner` computes `math.log(max_resource / min_resource, reduction_factor)`
inside `_try_initialization` (called lazily from `should_prune()`). If the user
passes `min_resource=0` or `reduction_factor=1`, this raises a `ZeroDivisionError`
deep inside the pruner instead of a clear `ValueError` at construction time.

Reproducible with:

```python
pruner = optuna.pruners.HyperbandPruner(min_resource=0)
study = optuna.create_study(pruner=pruner)
study.optimize(objective, n_trials=5)
# ZeroDivisionError: division by zero  (inside _try_initialization)
```

This fix adds two `ValueError` checks to `__init__`, consistent with how
`MedianPruner` and `SuccessiveHalvingPruner` validate their parameters
at construction time.

- `min_resource` must be >= 1 (used as denominator in log calculation)
- `reduction_factor` must be >= 2 (log(1) = 0, used as log base)

Existing hyperband tests pass. The one pre-existing failure
(`test_hyperband_filter_study[<lambda>3]`) is unrelated — it requires
the optional `cmaes` package which is not installed.