### PR TITLE
Fix undefined variable in GCSArtifactStore docstring example

### DIFF
--- a/optuna/artifacts/_gcs.py
+++ b/optuna/artifacts/_gcs.py
@@ -34,7 +34,7 @@ class GCSArtifactStore:
             from optuna.artifacts import GCSArtifactStore, upload_artifact
 
 
-            artifact_backend = GCSArtifactStore("my-bucket")
+            artifact_store = GCSArtifactStore("my-bucket")
 
 
             def objective(trial: optuna.Trial) -> float:


### PR DESCRIPTION
The `GCSArtifactStore` docstring example defines the store as `artifact_backend`, but the `upload_artifact()` call below it passes `artifact_store=artifact_store` — a name that is never defined — so running the example raises `NameError: name 'artifact_store' is not defined`.

The other three artifact-store examples (`Boto3ArtifactStore`, `FileSystemArtifactStore`, `Backoff`) all define the variable as `artifact_store`, so this renames the GCS example to match and makes the snippet runnable.

Documentation-only; single-line change, no behavior change.