### PR TITLE
Preserve empty study names across storage backends

### DIFF
--- a/optuna/storages/_grpc/client.py
+++ b/optuna/storages/_grpc/client.py
@@ -113,12 +113,14 @@ class GrpcStorageProxy(BaseStorage):
     def create_new_study(
         self, directions: Sequence[StudyDirection], study_name: str | None = None
     ) -> int:
+        if study_name is None:
+            study_name = DEFAULT_STUDY_NAME_PREFIX + str(uuid.uuid4())
         request = api_pb2.CreateNewStudyRequest(
             directions=[
                 api_pb2.MINIMIZE if d == StudyDirection.MINIMIZE else api_pb2.MAXIMIZE
                 for d in directions
             ],
-            study_name=study_name or DEFAULT_STUDY_NAME_PREFIX + str(uuid.uuid4()),
+            study_name=study_name,
         )
         try:
             response = self._stub.CreateNewStudy(request)

--- a/optuna/storages/journal/_storage.py
+++ b/optuna/storages/journal/_storage.py
@@ -153,7 +153,8 @@ class JournalStorage(BaseStorage):
     def create_new_study(
         self, directions: Sequence[StudyDirection], study_name: str | None = None
     ) -> int:
-        study_name = study_name or DEFAULT_STUDY_NAME_PREFIX + str(uuid.uuid4())
+        if study_name is None:
+            study_name = DEFAULT_STUDY_NAME_PREFIX + str(uuid.uuid4())
 
         with self._thread_lock:
             self._write_log(

--- a/optuna/testing/pytest_storages.py
+++ b/optuna/testing/pytest_storages.py
@@ -73,6 +73,11 @@ class StorageTestCase:
         with pytest.raises(optuna.exceptions.DuplicatedStudyError):
             storage.create_new_study(directions=[StudyDirection.MINIMIZE], study_name=study_name)
 
+    def test_create_new_study_with_empty_name(self, storage: BaseStorage) -> None:
+        study_id = storage.create_new_study(directions=[StudyDirection.MINIMIZE], study_name="")
+
+        assert storage.get_study_name_from_id(study_id) == ""
+
     def test_delete_study(self, storage: BaseStorage) -> None:
         study_id = storage.create_new_study(directions=[StudyDirection.MINIMIZE])
         storage.create_new_trial(study_id)


### PR DESCRIPTION
## Motivation

`BaseStorage.create_new_study()` generates a name only when no name is specified. `InMemoryStorage` and `RDBStorage` therefore preserve an explicitly supplied empty `study_name`, but `JournalStorage` and `GrpcStorageProxy` currently treat the empty string as if the argument were omitted and replace it with a generated `no-name-*` value.

Besides making the same public API behave differently across storage backends, this prevents callers from loading the resulting study with the explicit name they supplied.

## Description of the changes

- Distinguish `None` from an explicitly supplied empty string in `JournalStorage` and `GrpcStorageProxy`.
- Add a shared storage contract test that verifies the behavior across all seven storage configurations covered by `StorageTestCase`.

Before the production change, the regression test failed for the two Journal configurations and the two gRPC configurations while passing for the other three. After the change:

- Focused cross-storage regression: 7 passed
- Complete `tests/storages_tests/test_storages.py`: 411 passed, 5 skipped
- Ruff check and format on changed files: passed
- mypy on changed files: passed
- `git diff --check`: passed

This PR was prepared with assistance from OpenAI Codex. I reviewed and understand both condition changes and the cross-backend regression test, and verified the behavior and test results locally.
