### PR TITLE
Use incremental indexing for GA generation tracking

### DIFF
--- a/optuna/samplers/_ga/_base.py
+++ b/optuna/samplers/_ga/_base.py
@@ -90,10 +90,7 @@ class BaseGASampler(BaseSampler, abc.ABC):
 
     def _sync_incremental_cache(self, study: Study) -> list[FrozenTrial]:
         trials = study._get_trials(deepcopy=False, use_cache=True)
-        if (
-            self._cached_study_id != study._study_id
-            or len(trials) < self._cached_trial_cursor
-        ):
+        if self._cached_study_id != study._study_id or len(trials) < self._cached_trial_cursor:
             self._cached_study_id = study._study_id
             self._cached_generation_to_numbers.clear()
             self._cached_completed_numbers.clear()

--- a/optuna/samplers/_ga/_base.py
+++ b/optuna/samplers/_ga/_base.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import abc
+import threading
 from typing import Any
 from typing import TYPE_CHECKING
 
@@ -56,6 +57,7 @@ class BaseGASampler(BaseSampler, abc.ABC):
         self._cached_generation_to_numbers: dict[int, list[int]] = {}
         self._cached_unfinished_numbers: set[int] = set()
         self._cached_unseen_trial_start = 0
+        self._thread_lock = threading.Lock()
 
     @property
     def population_size(self) -> int | None:
@@ -88,19 +90,35 @@ class BaseGASampler(BaseSampler, abc.ABC):
         raise NotImplementedError
 
     def _sync_generation_cache(self, study: Study) -> list[FrozenTrial]:
-        trials = study._get_trials(deepcopy=False, use_cache=True)
-        if (
-            self._cached_study_id != study._study_id
-            or len(trials) < self._cached_unseen_trial_start
-        ):
-            self._cached_study_id = study._study_id
-            self._cached_generation_to_numbers.clear()
-            self._cached_unfinished_numbers.clear()
-            self._cached_unseen_trial_start = 0
+        with self._thread_lock:
+            trials = study._get_trials(deepcopy=False, use_cache=True)
+            if (
+                self._cached_study_id != study._study_id
+                or len(trials) < self._cached_unseen_trial_start
+            ):
+                self._cached_study_id = study._study_id
+                self._cached_generation_to_numbers.clear()
+                self._cached_unfinished_numbers.clear()
+                self._cached_unseen_trial_start = 0
 
-        for trial_number in tuple(self._cached_unfinished_numbers):
-            if trial_number < len(trials):
-                trial = trials[trial_number]
+            for trial_number in tuple(self._cached_unfinished_numbers):
+                if trial_number < len(trials):
+                    trial = trials[trial_number]
+                    if trial.state == TrialState.COMPLETE:
+                        self._cached_unfinished_numbers.discard(trial.number)
+                        generation = trial.system_attrs.get(self._get_generation_key())
+                        if generation is not None:
+                            self._cached_generation_to_numbers.setdefault(generation, []).append(
+                                trial.number
+                            )
+                        continue
+
+                    if trial.state.is_finished():
+                        self._cached_unfinished_numbers.discard(trial.number)
+                    else:
+                        self._cached_unfinished_numbers.add(trial.number)
+
+            for trial in trials[self._cached_unseen_trial_start :]:
                 if trial.state == TrialState.COMPLETE:
                     self._cached_unfinished_numbers.discard(trial.number)
                     generation = trial.system_attrs.get(self._get_generation_key())
@@ -115,23 +133,8 @@ class BaseGASampler(BaseSampler, abc.ABC):
                 else:
                     self._cached_unfinished_numbers.add(trial.number)
 
-        for trial in trials[self._cached_unseen_trial_start :]:
-            if trial.state == TrialState.COMPLETE:
-                self._cached_unfinished_numbers.discard(trial.number)
-                generation = trial.system_attrs.get(self._get_generation_key())
-                if generation is not None:
-                    self._cached_generation_to_numbers.setdefault(generation, []).append(
-                        trial.number
-                    )
-                continue
-
-            if trial.state.is_finished():
-                self._cached_unfinished_numbers.discard(trial.number)
-            else:
-                self._cached_unfinished_numbers.add(trial.number)
-
-        self._cached_unseen_trial_start = len(trials)
-        return trials
+            self._cached_unseen_trial_start = len(trials)
+            return trials
 
     def get_trial_generation(self, study: Study, trial: FrozenTrial) -> int:
         """Get the generation number of the given trial.

--- a/optuna/samplers/_ga/_base.py
+++ b/optuna/samplers/_ga/_base.py
@@ -98,14 +98,24 @@ class BaseGASampler(BaseSampler, abc.ABC):
             self._cached_unfinished_numbers.clear()
             self._cached_unseen_trial_start = 0
 
-        trials_to_index = [
-            trials[trial_number]
-            for trial_number in list(self._cached_unfinished_numbers)
-            if trial_number < len(trials)
-        ]
-        trials_to_index.extend(trials[self._cached_unseen_trial_start :])
+        for trial_number in tuple(self._cached_unfinished_numbers):
+            if trial_number < len(trials):
+                trial = trials[trial_number]
+                if trial.state == TrialState.COMPLETE:
+                    self._cached_unfinished_numbers.discard(trial.number)
+                    generation = trial.system_attrs.get(self._get_generation_key())
+                    if generation is not None:
+                        self._cached_generation_to_numbers.setdefault(generation, []).append(
+                            trial.number
+                        )
+                    continue
 
-        for trial in trials_to_index:
+                if trial.state.is_finished():
+                    self._cached_unfinished_numbers.discard(trial.number)
+                else:
+                    self._cached_unfinished_numbers.add(trial.number)
+
+        for trial in trials[self._cached_unseen_trial_start :]:
             if trial.state == TrialState.COMPLETE:
                 self._cached_unfinished_numbers.discard(trial.number)
                 generation = trial.system_attrs.get(self._get_generation_key())

--- a/optuna/samplers/_ga/_base.py
+++ b/optuna/samplers/_ga/_base.py
@@ -88,20 +88,17 @@ class BaseGASampler(BaseSampler, abc.ABC):
         """
         raise NotImplementedError
 
-    def _reset_incremental_cache(self, study_id: int | None = None) -> None:
-        self._cached_study_id = study_id
-        self._cached_generation_to_numbers.clear()
-        self._cached_completed_numbers.clear()
-        self._cached_unfinished_numbers.clear()
-        self._cached_trial_cursor = 0
-
     def _sync_incremental_cache(self, study: Study) -> list[FrozenTrial]:
-        if self._cached_study_id != study._study_id:
-            self._reset_incremental_cache(study._study_id)
-
         trials = study._get_trials(deepcopy=False, use_cache=True)
-        if len(trials) < self._cached_trial_cursor:
-            self._reset_incremental_cache(study._study_id)
+        if (
+            self._cached_study_id != study._study_id
+            or len(trials) < self._cached_trial_cursor
+        ):
+            self._cached_study_id = study._study_id
+            self._cached_generation_to_numbers.clear()
+            self._cached_completed_numbers.clear()
+            self._cached_unfinished_numbers.clear()
+            self._cached_trial_cursor = 0
 
         trials_to_index = [
             trials[trial_number]

--- a/optuna/samplers/_ga/_base.py
+++ b/optuna/samplers/_ga/_base.py
@@ -52,6 +52,11 @@ class BaseGASampler(BaseSampler, abc.ABC):
 
     def __init__(self, population_size: int | None):
         self._population_size = population_size
+        self._cached_study_id: int | None = None
+        self._cached_generation_to_numbers: dict[int, list[int]] = {}
+        self._cached_completed_numbers: set[int] = set()
+        self._cached_unfinished_numbers: set[int] = set()
+        self._cached_trial_cursor = 0
 
     @property
     def population_size(self) -> int | None:
@@ -83,6 +88,50 @@ class BaseGASampler(BaseSampler, abc.ABC):
         """
         raise NotImplementedError
 
+    def _reset_incremental_cache(self, study_id: int | None = None) -> None:
+        self._cached_study_id = study_id
+        self._cached_generation_to_numbers.clear()
+        self._cached_completed_numbers.clear()
+        self._cached_unfinished_numbers.clear()
+        self._cached_trial_cursor = 0
+
+    def _sync_incremental_cache(self, study: Study) -> list[FrozenTrial]:
+        if self._cached_study_id != study._study_id:
+            self._reset_incremental_cache(study._study_id)
+
+        trials = study._get_trials(deepcopy=False, use_cache=True)
+        if len(trials) < self._cached_trial_cursor:
+            self._reset_incremental_cache(study._study_id)
+
+        trials_to_index = [
+            trials[trial_number]
+            for trial_number in list(self._cached_unfinished_numbers)
+            if trial_number < len(trials)
+        ]
+        trials_to_index.extend(trials[self._cached_trial_cursor :])
+
+        for trial in trials_to_index:
+            if trial.state == TrialState.COMPLETE:
+                self._cached_unfinished_numbers.discard(trial.number)
+                if trial.number in self._cached_completed_numbers:
+                    continue
+
+                self._cached_completed_numbers.add(trial.number)
+                generation = trial.system_attrs.get(self._get_generation_key())
+                if generation is not None:
+                    self._cached_generation_to_numbers.setdefault(generation, []).append(
+                        trial.number
+                    )
+                continue
+
+            if trial.state.is_finished():
+                self._cached_unfinished_numbers.discard(trial.number)
+            else:
+                self._cached_unfinished_numbers.add(trial.number)
+
+        self._cached_trial_cursor = len(trials)
+        return trials
+
     def get_trial_generation(self, study: Study, trial: FrozenTrial) -> int:
         """Get the generation number of the given trial.
 
@@ -106,26 +155,12 @@ class BaseGASampler(BaseSampler, abc.ABC):
         if generation is not None:
             return generation
 
-        trials = study._get_trials(deepcopy=False, states=[TrialState.COMPLETE], use_cache=True)
-
-        max_generation, max_generation_count = 0, 0
-
-        for t in reversed(trials):
-            generation = t.system_attrs.get(self._get_generation_key(), -1)
-
-            if generation < max_generation:
-                continue
-            elif generation > max_generation:
-                max_generation = generation
-                max_generation_count = 1
-            else:
-                max_generation_count += 1
+        self._sync_incremental_cache(study)
 
         assert self._population_size is not None, "Population size must be set."
-        if max_generation_count < self._population_size:
-            generation = max_generation
-        else:
-            generation = max_generation + 1
+        generation = 0
+        while len(self._cached_generation_to_numbers.get(generation, ())) >= self._population_size:
+            generation += 1
         study._storage.set_trial_system_attr(
             trial._trial_id, self._get_generation_key(), generation
         )
@@ -143,12 +178,10 @@ class BaseGASampler(BaseSampler, abc.ABC):
         Returns:
             List of frozen trials in the given generation.
         """
+        trials = self._sync_incremental_cache(study)
         return [
-            trial
-            for trial in study._get_trials(
-                deepcopy=False, states=[TrialState.COMPLETE], use_cache=True
-            )
-            if trial.system_attrs.get(self._get_generation_key(), None) == generation
+            trials[trial_number]
+            for trial_number in self._cached_generation_to_numbers.get(generation, ())
         ]
 
     def get_parent_population(self, study: Study, generation: int) -> list[FrozenTrial]:

--- a/optuna/samplers/_ga/_base.py
+++ b/optuna/samplers/_ga/_base.py
@@ -54,9 +54,8 @@ class BaseGASampler(BaseSampler, abc.ABC):
         self._population_size = population_size
         self._cached_study_id: int | None = None
         self._cached_generation_to_numbers: dict[int, list[int]] = {}
-        self._cached_completed_numbers: set[int] = set()
         self._cached_unfinished_numbers: set[int] = set()
-        self._cached_trial_cursor = 0
+        self._cached_unseen_trial_start = 0
 
     @property
     def population_size(self) -> int | None:
@@ -90,27 +89,25 @@ class BaseGASampler(BaseSampler, abc.ABC):
 
     def _sync_incremental_cache(self, study: Study) -> list[FrozenTrial]:
         trials = study._get_trials(deepcopy=False, use_cache=True)
-        if self._cached_study_id != study._study_id or len(trials) < self._cached_trial_cursor:
+        if (
+            self._cached_study_id != study._study_id
+            or len(trials) < self._cached_unseen_trial_start
+        ):
             self._cached_study_id = study._study_id
             self._cached_generation_to_numbers.clear()
-            self._cached_completed_numbers.clear()
             self._cached_unfinished_numbers.clear()
-            self._cached_trial_cursor = 0
+            self._cached_unseen_trial_start = 0
 
         trials_to_index = [
             trials[trial_number]
             for trial_number in list(self._cached_unfinished_numbers)
             if trial_number < len(trials)
         ]
-        trials_to_index.extend(trials[self._cached_trial_cursor :])
+        trials_to_index.extend(trials[self._cached_unseen_trial_start :])
 
         for trial in trials_to_index:
             if trial.state == TrialState.COMPLETE:
                 self._cached_unfinished_numbers.discard(trial.number)
-                if trial.number in self._cached_completed_numbers:
-                    continue
-
-                self._cached_completed_numbers.add(trial.number)
                 generation = trial.system_attrs.get(self._get_generation_key())
                 if generation is not None:
                     self._cached_generation_to_numbers.setdefault(generation, []).append(
@@ -123,7 +120,7 @@ class BaseGASampler(BaseSampler, abc.ABC):
             else:
                 self._cached_unfinished_numbers.add(trial.number)
 
-        self._cached_trial_cursor = len(trials)
+        self._cached_unseen_trial_start = len(trials)
         return trials
 
     def get_trial_generation(self, study: Study, trial: FrozenTrial) -> int:

--- a/optuna/samplers/_ga/_base.py
+++ b/optuna/samplers/_ga/_base.py
@@ -87,7 +87,7 @@ class BaseGASampler(BaseSampler, abc.ABC):
         """
         raise NotImplementedError
 
-    def _sync_incremental_cache(self, study: Study) -> list[FrozenTrial]:
+    def _sync_generation_cache(self, study: Study) -> list[FrozenTrial]:
         trials = study._get_trials(deepcopy=False, use_cache=True)
         if (
             self._cached_study_id != study._study_id
@@ -146,7 +146,7 @@ class BaseGASampler(BaseSampler, abc.ABC):
         if generation is not None:
             return generation
 
-        self._sync_incremental_cache(study)
+        self._sync_generation_cache(study)
 
         assert self._population_size is not None, "Population size must be set."
         generation = 0
@@ -169,7 +169,7 @@ class BaseGASampler(BaseSampler, abc.ABC):
         Returns:
             List of frozen trials in the given generation.
         """
-        trials = self._sync_incremental_cache(study)
+        trials = self._sync_generation_cache(study)
         return [
             trials[trial_number]
             for trial_number in self._cached_generation_to_numbers.get(generation, ())

--- a/optuna/samplers/_ga/_base.py
+++ b/optuna/samplers/_ga/_base.py
@@ -98,38 +98,25 @@ class BaseGASampler(BaseSampler, abc.ABC):
                 self._cached_unfinished_numbers.clear()
                 self._cached_unseen_trial_start = 0
 
-            for trial_number in tuple(self._cached_unfinished_numbers):
-                if trial_number < len(trials):
-                    trial = trials[trial_number]
-                    if trial.state == TrialState.COMPLETE:
-                        self._cached_unfinished_numbers.discard(trial.number)
-                        generation = trial.system_attrs.get(self._get_generation_key())
-                        if generation is not None:
-                            self._cached_generation_to_numbers.setdefault(generation, []).append(
-                                trial.number
-                            )
-                        continue
+            next_unfinished_numbers = []
+            trial_numbers = [
+                *self._cached_unfinished_numbers,
+                *range(self._cached_unseen_trial_start, len(trials)),
+            ]
 
-                    if trial.state.is_finished():
-                        self._cached_unfinished_numbers.discard(trial.number)
-                    else:
-                        self._cached_unfinished_numbers.add(trial.number)
+            for trial_number in trial_numbers:
+                trial = trials[trial_number]
 
-            for trial in trials[self._cached_unseen_trial_start :]:
                 if trial.state == TrialState.COMPLETE:
-                    self._cached_unfinished_numbers.discard(trial.number)
                     generation = trial.system_attrs.get(self._get_generation_key())
                     if generation is not None:
                         self._cached_generation_to_numbers.setdefault(generation, []).append(
                             trial.number
                         )
-                    continue
+                elif not trial.state.is_finished():
+                    next_unfinished_numbers.append(trial.number)
 
-                if trial.state.is_finished():
-                    self._cached_unfinished_numbers.discard(trial.number)
-                else:
-                    self._cached_unfinished_numbers.add(trial.number)
-
+            self._cached_unfinished_numbers = next_unfinished_numbers
             self._cached_unseen_trial_start = len(trials)
             return trials
 

--- a/optuna/samplers/_ga/_base.py
+++ b/optuna/samplers/_ga/_base.py
@@ -53,10 +53,7 @@ class BaseGASampler(BaseSampler, abc.ABC):
 
     def __init__(self, population_size: int | None):
         self._population_size = population_size
-        self._cached_study_id: int | None = None
-        self._cached_generation_to_numbers: dict[int, list[int]] = {}
-        self._cached_unfinished_numbers: set[int] = set()
-        self._cached_unseen_trial_start = 0
+        self._cached_unfinished_numbers: list[int] = []
         self._thread_lock = threading.Lock()
 
     @property

--- a/optuna/samplers/_ga/_base.py
+++ b/optuna/samplers/_ga/_base.py
@@ -53,7 +53,10 @@ class BaseGASampler(BaseSampler, abc.ABC):
 
     def __init__(self, population_size: int | None):
         self._population_size = population_size
+        self._cached_study_id: int | None = None
+        self._cached_generation_to_numbers: dict[int, list[int]] = {}
         self._cached_unfinished_numbers: list[int] = []
+        self._cached_unseen_trial_start = 0
         self._thread_lock = threading.Lock()
 
     @property

--- a/optuna/samplers/_ga/_base.py
+++ b/optuna/samplers/_ga/_base.py
@@ -54,7 +54,8 @@ class BaseGASampler(BaseSampler, abc.ABC):
     def __init__(self, population_size: int | None):
         self._population_size = population_size
         self._cached_study_id: int | None = None
-        self._cached_generation_to_numbers: dict[int, list[int]] = {}
+        self._cached_generation = 0
+        self._cached_generation_numbers: list[int] = []
         self._cached_unfinished_numbers: list[int] = []
         self._cached_unseen_trial_start = 0
         self._thread_lock = threading.Lock()
@@ -97,7 +98,8 @@ class BaseGASampler(BaseSampler, abc.ABC):
                 or len(trials) < self._cached_unseen_trial_start
             ):
                 self._cached_study_id = study._study_id
-                self._cached_generation_to_numbers.clear()
+                self._cached_generation = 0
+                self._cached_generation_numbers.clear()
                 self._cached_unfinished_numbers.clear()
                 self._cached_unseen_trial_start = 0
 
@@ -113,15 +115,20 @@ class BaseGASampler(BaseSampler, abc.ABC):
                 if trial.state == TrialState.COMPLETE:
                     generation = trial.system_attrs.get(self._get_generation_key())
                     if generation is not None:
-                        self._cached_generation_to_numbers.setdefault(generation, []).append(
-                            trial.number
-                        )
+                        self._cache_completed_trial(generation, trial.number)
                 elif not trial.state.is_finished():
                     next_unfinished_numbers.append(trial.number)
 
             self._cached_unfinished_numbers = next_unfinished_numbers
             self._cached_unseen_trial_start = len(trials)
             return trials
+
+    def _cache_completed_trial(self, generation: int, trial_number: int) -> None:
+        if generation > self._cached_generation:
+            self._cached_generation = generation
+            self._cached_generation_numbers = [trial_number]
+        elif generation == self._cached_generation:
+            self._cached_generation_numbers.append(trial_number)
 
     def get_trial_generation(self, study: Study, trial: FrozenTrial) -> int:
         """Get the generation number of the given trial.
@@ -149,8 +156,8 @@ class BaseGASampler(BaseSampler, abc.ABC):
         self._sync_generation_cache(study)
 
         assert self._population_size is not None, "Population size must be set."
-        generation = 0
-        while len(self._cached_generation_to_numbers.get(generation, ())) >= self._population_size:
+        generation = self._cached_generation
+        if len(self._cached_generation_numbers) >= self._population_size:
             generation += 1
         study._storage.set_trial_system_attr(
             trial._trial_id, self._get_generation_key(), generation
@@ -170,9 +177,17 @@ class BaseGASampler(BaseSampler, abc.ABC):
             List of frozen trials in the given generation.
         """
         trials = self._sync_generation_cache(study)
+        if generation == self._cached_generation:
+            return [trials[trial_number] for trial_number in self._cached_generation_numbers]
+
+        # Calls made by GA samplers target the latest completed generation. Preserve the public
+        # method's behavior for an explicitly requested historical generation without retaining
+        # every generation in the sampler-side cache.
         return [
-            trials[trial_number]
-            for trial_number in self._cached_generation_to_numbers.get(generation, ())
+            trial
+            for trial in trials
+            if trial.state == TrialState.COMPLETE
+            and trial.system_attrs.get(self._get_generation_key()) == generation
         ]
 
     def get_parent_population(self, study: Study, generation: int) -> list[FrozenTrial]:

--- a/tests/samplers_tests/test_base_gasampler.py
+++ b/tests/samplers_tests/test_base_gasampler.py
@@ -86,21 +86,21 @@ def test_systemattr_keys() -> None:
 )
 def test_get_generation(args: dict[str, Any]) -> None:
     test_sampler = BaseGASamplerTestSampler(population_size=args["population_size"])
-    mock_study = Mock(
-        _get_trials=Mock(
-            return_value=[
-                Mock(system_attrs={"BaseGASamplerTestSampler:generation": i})
-                for i in args["trials"]
-            ]
+    mock_study = Mock()
+    mock_study._get_trials.return_value = [
+        Mock(
+            number=n,
+            _trial_id=n,
+            state=TrialState.COMPLETE,
+            system_attrs={"BaseGASamplerTestSampler:generation": i},
         )
-    )
+        for n, i in enumerate(args["trials"])
+    ]
     mock_trial = Mock(system_attrs={})
 
     assert test_sampler.get_trial_generation(mock_study, mock_trial) == args["generation"]
 
-    mock_study._get_trials.assert_called_once_with(
-        deepcopy=False, states=[TrialState.COMPLETE], use_cache=True
-    )
+    mock_study._get_trials.assert_called_once_with(deepcopy=False, use_cache=True)
     mock_study._storage.set_trial_system_attr.assert_called_once_with(
         mock_trial._trial_id,
         "BaseGASamplerTestSampler:generation",
@@ -156,8 +156,13 @@ def test_get_population(args: dict[str, Any]) -> None:
     mock_study = Mock(
         _get_trials=Mock(
             return_value=[
-                Mock(system_attrs={"BaseGASamplerTestSampler:generation": i})
-                for i in args["trials"]
+                Mock(
+                    number=n,
+                    _trial_id=n,
+                    state=TrialState.COMPLETE,
+                    system_attrs={"BaseGASamplerTestSampler:generation": i},
+                )
+                for n, i in enumerate(args["trials"])
             ]
         )
     )


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. To minimize the review effort, we highly appreciate PRs only with related changes. Please note that submitted PRs may be closed if they include unrelated changes or significantly modified unit tests. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
```BaseGASampler``` was repeatedly scanning study trials in hot paths:
  - ```get_trial_generation``` rescanned completed trials to decide the next generation
  - ```get_population``` rescanned completed trials to collect members of one generation

This work becomes expensive as the study grows because the same trial history is traversed over and over. The goal of this change is to introduce incremental generation indexing to prevent repeatative scanning. 

## Description of the changes
<!-- Describe the changes in this PR. -->
  - add sampler-local incremental cache state for generation bookkeeping
  - track:
      - current study ID
      - ```generation -> completed trial numbers```
      - unfinished trial numbers that need to be revisited
      - ```_cached_unseen_trial_start``` to keep track of unseen trials. 

  - add ```_sync_incremental_cache``` to update that state incrementally from the study trial list
  - change ```get_trial_generation``` to compute the next generation from cached generation membership instead of rescanning completed trials
  - change ```get_population``` to resolve generation members from the cached generation index instead of filtering all completed trials
  - keep ```get_parent_population``` behavior unchanged apart from reusing the shared sync path where needed by the narrowed implementation scope
  - update tests to use more realistic mocked trials with ```number```, ```_trial_id```, and ```state```, matching the new indexing path
