### PR TITLE
Fix Study.enqueue_trial treating NaN as duplicate of any numeric value

### DIFF
--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -1137,7 +1137,7 @@ class Study:
                     continue
 
                 is_repeated = (
-                    np.isnan(float(param_value))
+                    (np.isnan(float(param_value)) and np.isnan(float(existing_param)))
                     or np.isclose(float(param_value), float(existing_param), atol=0.0)
                     if isinstance(param_value, Real)
                     else param_value == existing_param

--- a/tests/study_tests/test_study.py
+++ b/tests/study_tests/test_study.py
@@ -842,6 +842,33 @@ def test_enqueue_trial_skip_existing_handles_common_types(storage_mode: str, par
         assert before_enqueue == after_enqueue
 
 
+@pytest.mark.parametrize("storage_mode", STORAGE_MODES)
+def test_enqueue_trial_skip_existing_nan_not_duplicate_of_other_value(
+    storage_mode: str,
+) -> None:
+    # https://github.com/optuna/optuna/issues/6798
+    # A NaN value should not be treated as a duplicate of a different numeric value, and
+    # vice versa, regardless of enqueue order.
+    with StorageSupplier(storage_mode) as storage:
+        study = create_study(storage=storage)
+        study.enqueue_trial({"x": 0.0})
+        study.enqueue_trial({"x": float("nan")}, skip_if_exists=True)
+        assert len(study.trials) == 2
+
+    with StorageSupplier(storage_mode) as storage:
+        reverse_study = create_study(storage=storage)
+        reverse_study.enqueue_trial({"x": float("nan")})
+        reverse_study.enqueue_trial({"x": 0.0}, skip_if_exists=True)
+        assert len(reverse_study.trials) == 2
+
+    with StorageSupplier(storage_mode) as storage:
+        # NaN should still be treated as a duplicate of an existing NaN.
+        nan_study = create_study(storage=storage)
+        nan_study.enqueue_trial({"x": float("nan")})
+        nan_study.enqueue_trial({"x": float("nan")}, skip_if_exists=True)
+        assert len(nan_study.trials) == 1
+
+
 @patch("optuna.study._optimize.gc.collect")
 def test_optimize_with_gc(collect_mock: Mock) -> None:
     study = create_study()


### PR DESCRIPTION
## Summary
Fixes #6798.

`Study._should_skip_enqueue` (used by `enqueue_trial(..., skip_if_exists=True)`) had an asymmetric NaN comparison bug:

```python
is_repeated = (
    np.isnan(float(param_value))
    or np.isclose(float(param_value), float(existing_param), atol=0.0)
    if isinstance(param_value, Real)
    else param_value == existing_param
)
```

Whenever the newly enqueued value was NaN, `is_repeated` was always `True`, regardless of the existing trial's value — so a NaN enqueue would be incorrectly skipped as a "duplicate" of any previously enqueued numeric value.

The fix only treats NaN as a duplicate when **both** the new and existing values are NaN:

```python
is_repeated = (
    (np.isnan(float(param_value)) and np.isnan(float(existing_param)))
    or np.isclose(float(param_value), float(existing_param), atol=0.0)
    if isinstance(param_value, Real)
    else param_value == existing_param
)
```

## Test plan
- [x] Reproduced the bug from the issue against `master` (forward case printed 1 trial instead of 2).
- [x] Confirmed the fix resolves both the forward and reverse enqueue-order cases from the issue, and that NaN-vs-NaN is still correctly treated as a duplicate.
- [x] Added `test_enqueue_trial_skip_existing_nan_not_duplicate_of_other_value` to `tests/study_tests/test_study.py`, parametrized over all storage modes.
- [x] Ran `pytest tests/study_tests/test_study.py -k enqueue_trial` — all pass except the pre-existing `journal_redis` storage mode, which fails identically on unmodified tests in this environment due to a `fakeredis` limitation (`unknown command 'eval'`) unrelated to this change.