### PR TITLE
Make categorical NaN hashes consistent

### DIFF
--- a/optuna/distributions.py
+++ b/optuna/distributions.py
@@ -467,6 +467,12 @@ def _categorical_choice_equal(
     return (value1 == value2) or (value1_is_nan and value2_is_nan)
 
 
+def _categorical_choice_hash(value: CategoricalChoiceType) -> int:
+    if isinstance(value, Real) and math.isnan(float(value)):
+        return hash(("nan",))
+    return hash(value)
+
+
 class CategoricalDistribution(BaseDistribution):
     """A categorical distribution.
 
@@ -547,7 +553,8 @@ class CategoricalDistribution(BaseDistribution):
                     return False
         return True
 
-    __hash__ = BaseDistribution.__hash__
+    def __hash__(self) -> int:
+        return hash((self.__class__, tuple(map(_categorical_choice_hash, self.choices))))
 
 
 DISTRIBUTION_CLASSES = (

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -437,6 +437,12 @@ def test_eq_ne_hash() -> None:
     d2 = distributions.IntDistribution(low=1, high=2)
     assert d0 != d2
 
+    d3 = distributions.CategoricalDistribution(choices=(float("nan"), 1.0))
+    d4 = distributions.CategoricalDistribution(choices=(float("nan"), 1.0))
+    assert d3 == d4
+    assert hash(d3) == hash(d4)
+    assert {d3: "value"}[d4] == "value"
+
 
 def test_repr() -> None:
     # The following variables are needed to apply `eval` to distribution


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. To minimize the review effort, we highly appreciate PRs only with related changes. Please note that submitted PRs may be closed if they include unrelated changes or significantly modified unit tests. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

Fixes #6823.

`CategoricalDistribution` equality treats independently created NaN choices as equal, but its inherited hash used each NaN object's raw hash. This violated Python's equality/hash contract and caused equal distributions to occupy separate dictionary entries.

## Description of the changes
<!-- Describe the changes in this PR. -->

- Hash categorical choices through a NaN-aware helper so all real-valued NaNs use the same hash value.
- Add regression coverage for hash equality and dictionary lookup with independently created NaN choices.

Tests:

- `uv run pytest tests/test_distributions.py` (99 passed)
- `uv run ruff check optuna/distributions.py tests/test_distributions.py`
- `uv run ruff format --check optuna/distributions.py tests/test_distributions.py`

## Checklist
<!-- If you used an LLM while working on this PR, please check the box below. Optuna does not prohibit the use of LLMs. However, as described in CONTRIBUTING.md, PRs from first-time contributors that appear to be primarily generated by LLMs are generally not accepted unless the contributor demonstrates clear understanding, validation, and ownership of the proposed changes. Depending on the changes, a PR may be closed without review. -->

* [x] I used an LLM while working on this PR.
