### PR TITLE
Fix `get_all_study_summaries` to select `best_trial` from feasible tr…

### DIFF
--- a/optuna/study/_constrained_optimization.py
+++ b/optuna/study/_constrained_optimization.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from typing import Any
+from typing import cast
 from typing import TYPE_CHECKING
 
 from optuna._warnings import optuna_warn
+from optuna.study._study_direction import StudyDirection
 
 
 if TYPE_CHECKING:
@@ -33,6 +35,23 @@ def _get_feasible_trials(trials: Sequence[FrozenTrial]) -> list[FrozenTrial]:
         if all(x <= 0.0 for x in constraints):
             feasible_trials.append(trial)
     return feasible_trials
+
+
+def _get_best_feasible_trial(
+    trials: Sequence[FrozenTrial], direction: StudyDirection
+) -> FrozenTrial | None:
+    """Return the best feasible trial from given trials.
+
+    Returns:
+        The best feasible trial, or ``None`` if no feasible trial exists.
+    """
+
+    feasible_trials = _get_feasible_trials(trials)
+    if len(feasible_trials) == 0:
+        return None
+    if direction == StudyDirection.MAXIMIZE:
+        return max(feasible_trials, key=lambda t: cast("float", t.value))
+    return min(feasible_trials, key=lambda t: cast("float", t.value))
 
 
 def _get_constraints_from_system_attrs(system_attrs: dict[str, Any]) -> dict[str, float]:

--- a/optuna/study/_study_summary.py
+++ b/optuna/study/_study_summary.py
@@ -34,6 +34,13 @@ class StudySummary:
         best_trial:
             :class:`optuna.trial.FrozenTrial` with best objective value in the
             :class:`~optuna.study.Study`.
+
+            .. note::
+                In constrained optimization, the best trial is selected from trials that
+                satisfy all constraints. A trial is considered feasible when all of its
+                constraint values are less than or equal to 0.0. This attribute is
+                :obj:`None` if no complete feasible trials exist or if the study is
+                multi-objective.
         user_attrs:
             Dictionary that contains the attributes of the :class:`~optuna.study.Study` set with
             :func:`optuna.study.Study.set_user_attr`.

--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -9,7 +9,6 @@ import copy
 from numbers import Real
 import threading
 from typing import Any
-from typing import cast
 from typing import Literal
 from typing import TYPE_CHECKING
 from typing import Union
@@ -29,7 +28,7 @@ from optuna._warnings import optuna_warn
 from optuna.distributions import _convert_old_distribution_to_new_distribution
 from optuna.distributions import BaseDistribution
 from optuna.storages._heartbeat import is_heartbeat_enabled
-from optuna.study._constrained_optimization import _get_feasible_trials
+from optuna.study._constrained_optimization import _get_best_feasible_trial
 from optuna.study._constrained_optimization import _is_constrained_optimization
 from optuna.study._multi_objective import _get_pareto_front_trials
 from optuna.study._optimize import _optimize
@@ -337,13 +336,10 @@ class Study:
         # trials.
         if any(x > 0.0 for x in best_trial.constraints.values()):
             complete_trials = self.get_trials(deepcopy=False, states=[TrialState.COMPLETE])
-            feasible_trials = _get_feasible_trials(complete_trials)
-            if len(feasible_trials) == 0:
+            best_feasible_trial = _get_best_feasible_trial(complete_trials, self.direction)
+            if best_feasible_trial is None:
                 raise ValueError("No feasible trials are completed yet.")
-            if self.direction == StudyDirection.MAXIMIZE:
-                best_trial = max(feasible_trials, key=lambda t: cast("float", t.value))
-            else:
-                best_trial = min(feasible_trials, key=lambda t: cast("float", t.value))
+            best_trial = best_feasible_trial
 
         return copy.deepcopy(best_trial) if deepcopy else best_trial
 
@@ -1601,8 +1597,10 @@ def get_all_study_summaries(
             Database URL such as ``sqlite:///example.db``. Please see also the documentation of
             :func:`~optuna.study.create_study` for further details.
         include_best_trial:
-            Include the best trials if exist. It potentially increases the number of queries and
-            may take longer to fetch summaries depending on the storage.
+            Include the best trial if it exists. In constrained optimization, only feasible
+            trials are considered. If every complete trial is infeasible, ``best_trial`` is
+            :obj:`None`. It potentially increases the number of queries and may take longer to
+            fetch summaries depending on the storage.
 
     Returns:
         List of study history summarized as :class:`~optuna.study.StudySummary` objects.
@@ -1626,11 +1624,8 @@ def get_all_study_summaries(
         if len(s.directions) == 1:
             direction = s.direction
             directions = None
-            if include_best_trial and len(completed_trials) != 0:
-                if direction == StudyDirection.MAXIMIZE:
-                    best_trial = max(completed_trials, key=lambda t: cast("float", t.value))
-                else:
-                    best_trial = min(completed_trials, key=lambda t: cast("float", t.value))
+            if include_best_trial:
+                best_trial = _get_best_feasible_trial(completed_trials, direction)
             else:
                 best_trial = None
         else:

--- a/tests/study_tests/test_constrained_optimization.py
+++ b/tests/study_tests/test_constrained_optimization.py
@@ -1,5 +1,7 @@
 from optuna.study._constrained_optimization import _CONSTRAINTS_KEY
+from optuna.study._constrained_optimization import _get_best_feasible_trial
 from optuna.study._constrained_optimization import _get_feasible_trials
+from optuna.study._study_direction import StudyDirection
 from optuna.trial import create_trial
 
 
@@ -13,3 +15,30 @@ def test_get_feasible_trials() -> None:
     assert len(feasible_trials) == 2
     assert feasible_trials[0] == trials[0]
     assert feasible_trials[1] == trials[2]
+
+
+def test_get_best_feasible_trial() -> None:
+    infeasible = create_trial(value=10.0, system_attrs={_CONSTRAINTS_KEY: [1.0]})
+    feasible_low = create_trial(value=0.0, system_attrs={_CONSTRAINTS_KEY: [0.0]})
+    feasible_high = create_trial(value=1.0, system_attrs={_CONSTRAINTS_KEY: [-1.0]})
+    unconstrained = create_trial(value=-2.0)
+
+    assert _get_best_feasible_trial([], StudyDirection.MINIMIZE) is None
+    assert _get_best_feasible_trial([infeasible], StudyDirection.MINIMIZE) is None
+    assert (
+        _get_best_feasible_trial(
+            [infeasible, feasible_low, feasible_high], StudyDirection.MINIMIZE
+        )
+        == feasible_low
+    )
+    assert (
+        _get_best_feasible_trial(
+            [infeasible, feasible_low, feasible_high], StudyDirection.MAXIMIZE
+        )
+        == feasible_high
+    )
+    # A trial without constraint values is considered feasible.
+    assert (
+        _get_best_feasible_trial([infeasible, unconstrained], StudyDirection.MINIMIZE)
+        == unconstrained
+    )

--- a/tests/study_tests/test_study.py
+++ b/tests/study_tests/test_study.py
@@ -331,6 +331,8 @@ def test_get_all_study_summaries(storage_mode: str, include_best_trial: bool) ->
         assert summary.n_trials == NUM_MINIMAL_TRIALS
         if include_best_trial:
             assert summary.best_trial is not None
+            assert summary.best_trial.number == study.best_trial.number
+            assert summary.best_trial.value == study.best_trial.value
         else:
             assert summary.best_trial is None
 
@@ -1270,6 +1272,74 @@ def test_best_trial_constrained_optimization(direction: StudyDirection) -> None:
     storage.set_trial_system_attr(trial._trial_id, _CONSTRAINTS_KEY, [0])
     study.tell(trial, -1 if direction == StudyDirection.MINIMIZE else 1)
     assert study.best_trial.number == 3
+
+
+@pytest.mark.parametrize("direction", [StudyDirection.MINIMIZE, StudyDirection.MAXIMIZE])
+def test_get_all_study_summaries_constrained_optimization(direction: StudyDirection) -> None:
+    study = create_study(direction=direction)
+    storage = study._storage
+
+    summaries = get_all_study_summaries(storage)
+    assert summaries[0].best_trial is None
+
+    trial = study.ask()
+    storage.set_trial_system_attr(trial._trial_id, _CONSTRAINTS_KEY, [1])
+    study.tell(trial, 0)
+    summaries = get_all_study_summaries(storage)
+    assert summaries[0].best_trial is None
+
+    trial = study.ask()
+    storage.set_trial_system_attr(trial._trial_id, _CONSTRAINTS_KEY, [0])
+    study.tell(trial, 0)
+    summaries = get_all_study_summaries(storage)
+    assert summaries[0].best_trial is not None
+    assert summaries[0].best_trial.number == study.best_trial.number == 1
+
+    trial = study.ask()
+    storage.set_trial_system_attr(trial._trial_id, _CONSTRAINTS_KEY, [1])
+    study.tell(trial, -1 if direction == StudyDirection.MINIMIZE else 1)
+    summaries = get_all_study_summaries(storage)
+    assert summaries[0].best_trial is not None
+    assert summaries[0].best_trial.number == study.best_trial.number == 1
+
+    trial = study.ask()
+    storage.set_trial_system_attr(trial._trial_id, _CONSTRAINTS_KEY, [0])
+    study.tell(trial, -1 if direction == StudyDirection.MINIMIZE else 1)
+    summaries = get_all_study_summaries(storage)
+    assert summaries[0].best_trial is not None
+    assert summaries[0].best_trial.number == study.best_trial.number == 3
+
+    summaries = get_all_study_summaries(storage, include_best_trial=False)
+    assert summaries[0].best_trial is None
+
+
+def test_get_all_study_summaries_constrained_multi_objective() -> None:
+    study = create_study(directions=["minimize", "minimize"])
+    trial = study.ask()
+    trial.set_constraint("c", 0.0)
+    study.tell(trial, [0.0, 0.0])
+
+    summaries = get_all_study_summaries(study._storage, include_best_trial=True)
+    assert summaries[0].best_trial is None
+
+
+def test_get_all_study_summaries_constrained_matches_study_best_trial() -> None:
+    def objective(trial: Trial) -> float:
+        x = trial.suggest_float("x", -10, 10)
+        trial.set_constraint("c", 5 - x)  # Feasible iff x >= 5.
+        return x
+
+    study = create_study(direction="minimize")
+    study.enqueue_trial({"x": -10.0})  # Infeasible, better objective.
+    study.enqueue_trial({"x": 5.0})  # Feasible.
+    study.optimize(objective, n_trials=2)
+
+    summary = get_all_study_summaries(study._storage)[0]
+    assert summary.best_trial is not None
+    assert summary.best_trial.number == study.best_trial.number
+    assert summary.best_trial.params == {"x": 5.0}
+    assert summary.best_trial.value == 5.0
+    assert summary.best_trial.constraints == {"c": 0.0}
 
 
 def test_best_trials() -> None:


### PR DESCRIPTION
## Motivation
Fixes #6825.

`Study.best_trial` selects the best trial among feasible trials (all constraint values `<= 0`). `get_all_study_summaries` ignored constraints and used min/max over every complete trial, so `StudySummary.best_trial` could be an infeasible trial.

## Description of the changes
- Select `StudySummary.best_trial` from feasible complete trials, matching `Study.best_trial`.
- Return `None` when no complete feasible trial exists.
- Share this selection via `_get_best_feasible_trial`.
