### PR TITLE
Fix `IndexError` in `_is_pareto_front_for_unique_sorted` for empty input

### DIFF
--- a/optuna/study/_multi_objective.py
+++ b/optuna/study/_multi_objective.py
@@ -145,6 +145,8 @@ def _is_pareto_front_2d(unique_lexsorted_loss_values: np.ndarray) -> np.ndarray:
 
 def _is_pareto_front_for_unique_sorted(unique_lexsorted_loss_values: np.ndarray) -> np.ndarray:
     (n_trials, n_objectives) = unique_lexsorted_loss_values.shape
+    if n_trials == 0:
+        return np.zeros(0, dtype=bool)
     if n_objectives == 1:
         on_front = np.zeros(len(unique_lexsorted_loss_values), dtype=bool)
         on_front[0] = True  # Only the first element is Pareto optimal.

--- a/tests/study_tests/test_multi_objective.py
+++ b/tests/study_tests/test_multi_objective.py
@@ -6,6 +6,7 @@ import pytest
 from optuna.study import StudyDirection
 from optuna.study._multi_objective import _dominates
 from optuna.study._multi_objective import _fast_non_domination_rank
+from optuna.study._multi_objective import _is_pareto_front_for_unique_sorted
 from optuna.study._multi_objective import _normalize_value
 from optuna.trial import create_trial
 from optuna.trial import TrialState
@@ -169,3 +170,12 @@ def test_normalize_value() -> None:
     assert _normalize_value(1.0, StudyDirection.MAXIMIZE) == -1.0
     assert _normalize_value(None, StudyDirection.MINIMIZE) == float("inf")
     assert _normalize_value(None, StudyDirection.MAXIMIZE) == float("inf")
+
+
+def test_is_pareto_front_for_unique_sorted_with_empty_array() -> None:
+    """Test that an empty array returns an empty boolean array without crashing (Issue #6827)."""
+    empty_array = np.zeros((0, 1))
+    on_front = _is_pareto_front_for_unique_sorted(empty_array)
+
+    assert on_front.shape == (0,)
+    assert on_front.dtype == bool


### PR DESCRIPTION
Fixes #6827

## Motivation
When calculating the Pareto front for an empty study (0 completed trials) with 1 objective, `_is_pareto_front_for_unique_sorted` crashes with an `IndexError` because it unconditionally accesses `on_front[0]` on an empty boolean array. 

## Description of the changes
Added a guard clause at the beginning of `_is_pareto_front_for_unique_sorted` to immediately return an empty boolean array if `n_trials == 0`. 

This ensures the function safely handles the empty-input edge case before branching into the 1-objective, 2-objective, or N-objective logic paths.

## Testing
- Added a regression test `test_is_pareto_front_for_unique_sorted_with_empty_array` in `tests/study_tests/test_multi_objective.py` to verify the function gracefully returns an empty boolean array of shape `(0,)` instead of crashing.
- Verified all 36 tests in `tests/study_tests/test_multi_objective.py` pass.
- Verified `ruff check`, `ruff format`, and `mypy` all pass cleanly on the modified files.