### PR TITLE
Pin `plotly<7` where `kaleido<1` is required

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,9 @@ document = [
   "matplotlib!=3.6.0",
   "pandas",
   "pillow",
-  "plotly>=4.9.0",  # optuna/visualization.
+  # plotly>=7 dropped support for kaleido<1, which the `sphinx_gallery_png` renderer relies on.
+  # The upper bound can be dropped together with the kaleido constraint above.
+  "plotly>=4.9.0,<7",  # optuna/visualization.
   "scikit-learn",
   "sphinx",
   "sphinx-copybutton",
@@ -93,6 +95,9 @@ test = [
   "fakeredis[lua]",
   "kaleido<0.4,!=0.2.1.post1",  # TODO(nzw0301): Remove the version constraint by installing browser separately.
   "moto",
+  # plotly>=7 dropped support for kaleido<1, which `Figure.write_image` in the tests relies on.
+  # The upper bound can be dropped together with the kaleido constraint above.
+  "plotly<7",
   "pytest",
   "pytest-xdist",
   "scipy>=1.9.2",


### PR DESCRIPTION
## Motivation & Description of the changes

plotly v7.0.0 (released 2026-08-25) dropped support for kaleido v0, so static image export now needs kaleido>=1 (plus a Chrome installation). Optuna still pins kaleido<0.4, which makes the Read the Docs build fail. This PR fixes the issue.

## Checklist
<!-- If you used an LLM while working on this PR, please check the box below. Optuna does not prohibit the use of LLMs. However, as described in CONTRIBUTING.md, PRs from first-time contributors that appear to be primarily generated by LLMs are generally not accepted unless the contributor demonstrates clear understanding, validation, and ownership of the proposed changes. Depending on the changes, a PR may be closed without review. -->

* [x] I used an LLM while working on this PR.

