### PR TITLE
Remove the kaleido dependency for unit tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,11 +93,8 @@ checking = [
 ]
 test = [
   "fakeredis[lua]",
-  "kaleido<0.4,!=0.2.1.post1",  # TODO(nzw0301): Remove the version constraint by installing browser separately.
   "moto",
-  # plotly>=7 dropped support for kaleido<1, which `Figure.write_image` in the tests relies on.
-  # The upper bound can be dropped together with the kaleido constraint above.
-  "plotly<7",
+  "plotly",
   "pytest",
   "pytest-xdist",
   "scipy>=1.9.2",

--- a/tests/visualization_tests/test_contour.py
+++ b/tests/visualization_tests/test_contour.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from io import BytesIO
 import math
 from typing import Any
 from typing import Literal
@@ -26,7 +25,6 @@ from optuna.visualization._plotly_imports import go
 from optuna.visualization._utils import COLOR_SCALE
 from optuna.visualization.matplotlib import plot_contour as plt_plot_contour
 from optuna.visualization.matplotlib._matplotlib_imports import Axes
-from optuna.visualization.matplotlib._matplotlib_imports import plt
 
 
 parametrize_plot_contour = pytest.mark.parametrize(
@@ -178,12 +176,7 @@ def test_plot_contour(
     params: list[str] | None,
 ) -> None:
     study = specific_create_study()
-    figure = plot_contour(study, params=params)
-    if isinstance(figure, go.Figure):
-        figure.write_image(BytesIO())
-    else:
-        plt.savefig(BytesIO())
-        plt.close()
+    plot_contour(study, params=params)
 
 
 def test_target_is_none_and_study_is_multi_obj() -> None:

--- a/tests/visualization_tests/test_edf.py
+++ b/tests/visualization_tests/test_edf.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from io import BytesIO
 from typing import Any
 from typing import Literal
 
@@ -27,18 +26,9 @@ if plotly_imports.is_successful():
 
 if plt_imports.is_successful():
     from optuna.visualization.matplotlib._matplotlib_imports import Axes
-    from optuna.visualization.matplotlib._matplotlib_imports import plt
 
 
 parametrized_plot_edf = pytest.mark.parametrize("plot_edf", [plotly_plot_edf, plt_plot_edf])
-
-
-def save_static_image(figure: go.Figure | Axes | np.ndarray) -> None:
-    if isinstance(figure, go.Figure):
-        figure.write_image(BytesIO())
-    else:
-        plt.savefig(BytesIO())
-        plt.close()
 
 
 @parametrized_plot_edf
@@ -63,8 +53,7 @@ def test_target_is_none_and_study_is_multi_obj(plot_edf: Callable[..., Any]) -> 
 def test_edf_plot_no_trials(
     plot_edf: Callable[..., Any], direction: Literal["minimize", "maximize"]
 ) -> None:
-    figure = plot_edf(create_study(direction=direction))
-    save_static_image(figure)
+    plot_edf(create_study(direction=direction))
 
 
 @parametrized_plot_edf
@@ -76,8 +65,7 @@ def test_edf_plot_no_trials_studies(
     num_studies: int,
 ) -> None:
     studies = [create_study(direction=direction) for _ in range(num_studies)]
-    figure = plot_edf(studies)
-    save_static_image(figure)
+    plot_edf(studies)
 
 
 @parametrized_plot_edf
@@ -93,8 +81,7 @@ def test_plot_edf_with_multiple_studies(
         study = create_study(direction=direction)
         study.optimize(lambda t: t.suggest_float("x", 0, 5), n_trials=10)
         studies.append(study)
-    figure = plot_edf(studies)
-    save_static_image(figure)
+    plot_edf(studies)
 
 
 @parametrized_plot_edf
@@ -102,8 +89,7 @@ def test_plot_edf_with_target(plot_edf: Callable[..., Any]) -> None:
     study = create_study()
     study.optimize(lambda t: t.suggest_float("x", 0, 5), n_trials=10)
     with pytest.warns(UserWarning):
-        figure = plot_edf(study, target=lambda t: t.params["x"])
-    save_static_image(figure)
+        plot_edf(study, target=lambda t: t.params["x"])
 
 
 @parametrized_plot_edf
@@ -121,8 +107,6 @@ def test_plot_edf_with_target_name(plot_edf: Callable[..., Any], target_name: st
         assert figure.layout.xaxis.title.text == expected
     elif isinstance(figure, Axes):
         assert figure.xaxis.label.get_text() == expected
-
-    save_static_image(figure)
 
 
 def test_empty_edf_info() -> None:

--- a/tests/visualization_tests/test_intermediate_plot.py
+++ b/tests/visualization_tests/test_intermediate_plot.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from io import BytesIO
 from typing import Any
 
 import pytest
@@ -13,9 +12,7 @@ import optuna.visualization._intermediate_values
 from optuna.visualization._intermediate_values import _get_intermediate_plot_info
 from optuna.visualization._intermediate_values import _IntermediatePlotInfo
 from optuna.visualization._intermediate_values import _TrialInfo
-from optuna.visualization._plotly_imports import go
 import optuna.visualization.matplotlib._intermediate_values
-from optuna.visualization.matplotlib._matplotlib_imports import plt
 
 
 def test_intermediate_plot_info() -> None:
@@ -120,9 +117,4 @@ def test_intermediate_plot_info() -> None:
 def test_plot_intermediate_values(
     plotter: Callable[[_IntermediatePlotInfo], Any], info: _IntermediatePlotInfo
 ) -> None:
-    figure = plotter(info)
-    if isinstance(figure, go.Figure):
-        figure.write_image(BytesIO())
-    else:
-        plt.savefig(BytesIO())
-        plt.close()
+    plotter(info)

--- a/tests/visualization_tests/test_optimization_history.py
+++ b/tests/visualization_tests/test_optimization_history.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from io import BytesIO
 import math
 from typing import Literal
 
@@ -421,4 +420,3 @@ def test_get_optimization_history_plot(
             expected_legends.append(info.best_values_info.label_name)
     legends = [scatter.name for scatter in figure.data if scatter.name is not None]
     assert sorted(legends) == sorted(expected_legends)
-    figure.write_image(BytesIO())

--- a/tests/visualization_tests/test_param_importances.py
+++ b/tests/visualization_tests/test_param_importances.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from io import BytesIO
 from typing import Any
 
 import pytest
@@ -24,7 +23,6 @@ from optuna.visualization._param_importances import _ImportancesInfo
 from optuna.visualization._plotly_imports import go
 from optuna.visualization.matplotlib import plot_param_importances as plt_plot_param_importances
 from optuna.visualization.matplotlib._matplotlib_imports import Axes
-from optuna.visualization.matplotlib._matplotlib_imports import plt
 
 
 parametrize_plot_param_importances = pytest.mark.parametrize(
@@ -108,12 +106,7 @@ def test_plot_param_importances(
     params: list[str] | None,
 ) -> None:
     study = specific_create_study()
-    figure = plot_param_importances(study, params=params)
-    if isinstance(figure, go.Figure):
-        figure.write_image(BytesIO())
-    else:
-        plt.savefig(BytesIO())
-        plt.close()
+    plot_param_importances(study, params=params)
 
 
 @pytest.mark.parametrize(

--- a/tests/visualization_tests/test_pareto_front.py
+++ b/tests/visualization_tests/test_pareto_front.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from collections.abc import Sequence
-from io import BytesIO
 from typing import Any
 from typing import Literal
 import warnings
@@ -21,9 +20,7 @@ from optuna.visualization import plot_pareto_front
 import optuna.visualization._pareto_front
 from optuna.visualization._pareto_front import _get_pareto_front_info
 from optuna.visualization._pareto_front import _ParetoFrontInfo
-from optuna.visualization._plotly_imports import go
 from optuna.visualization._utils import COLOR_SCALE
-from optuna.visualization.matplotlib._matplotlib_imports import plt
 import optuna.visualization.matplotlib._pareto_front
 
 
@@ -334,12 +331,7 @@ def test_get_pareto_front_plot(
     if not has_constraints:
         info = info._replace(has_constraints=False, infeasible_trials_with_values=[])
 
-    figure = plotter(info)
-    if isinstance(figure, go.Figure):
-        figure.write_image(BytesIO())
-    else:
-        plt.savefig(BytesIO())
-        plt.close()
+    plotter(info)
 
 
 @pytest.mark.parametrize("direction", ["minimize", "maximize"])

--- a/tests/visualization_tests/test_rank.py
+++ b/tests/visualization_tests/test_rank.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from io import BytesIO
 import math
 from typing import Any
 
@@ -18,7 +17,6 @@ from optuna.testing.objectives import fail_objective
 from optuna.testing.visualization import prepare_study_with_trials
 from optuna.trial import create_trial
 from optuna.visualization import plot_rank as plotly_plot_rank
-from optuna.visualization._plotly_imports import go
 from optuna.visualization._rank import _AxisInfo
 from optuna.visualization._rank import _convert_color_idxs_to_scaled_rgb_colors
 from optuna.visualization._rank import _get_axis_info
@@ -178,9 +176,7 @@ def test_plot_rank(
     params: list[str] | None,
 ) -> None:
     study = specific_create_study()
-    figure = plot_rank(study, params=params)
-    if isinstance(figure, go.Figure):
-        figure.write_image(BytesIO())
+    plot_rank(study, params=params)
 
 
 def test_target_is_none_and_study_is_multi_obj() -> None:

--- a/tests/visualization_tests/test_slice.py
+++ b/tests/visualization_tests/test_slice.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from collections.abc import Sequence
-from io import BytesIO
 from typing import Any
 from typing import Literal
 
@@ -25,7 +24,6 @@ from optuna.visualization._slice import _SliceSubplotInfo
 from optuna.visualization._utils import COLOR_SCALE
 from optuna.visualization.matplotlib import plot_slice as plt_plot_slice
 from optuna.visualization.matplotlib._matplotlib_imports import Axes
-from optuna.visualization.matplotlib._matplotlib_imports import plt
 
 
 parametrize_plot_slice = pytest.mark.parametrize("plot_slice", [plotly_plot_slice, plt_plot_slice])
@@ -107,12 +105,7 @@ def test_plot_slice(
     params: list[str] | None,
 ) -> None:
     study = specific_create_study()
-    figure = plot_slice(study, params=params)
-    if isinstance(figure, go.Figure):
-        figure.write_image(BytesIO())
-    else:
-        plt.savefig(BytesIO())
-        plt.close()
+    plot_slice(study, params=params)
 
 
 def test_target_is_none_and_study_is_multi_obj() -> None:

--- a/tests/visualization_tests/test_terminator_improvement.py
+++ b/tests/visualization_tests/test_terminator_improvement.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from io import BytesIO
 from typing import Any
 
 import pytest
@@ -68,8 +67,7 @@ def test_plot_terminator_improvement(
     plot_error: bool,
 ) -> None:
     study = specific_create_study()
-    figure = plot_terminator_improvement(study, plot_error)
-    figure.write_image(BytesIO())
+    plot_terminator_improvement(study, plot_error)
 
 
 @pytest.mark.parametrize(

--- a/tests/visualization_tests/test_timeline.py
+++ b/tests/visualization_tests/test_timeline.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import datetime
-from io import BytesIO
 from typing import Any
 from typing import TYPE_CHECKING
 
@@ -23,12 +22,6 @@ if TYPE_CHECKING:
     import _pytest.capture
 
     from optuna.study.study import Study
-
-if plotly_imports.is_successful():
-    from optuna.visualization._plotly_imports import go
-
-if plt_imports.is_successful():
-    from optuna.visualization.matplotlib._matplotlib_imports import plt
 
 
 parametrize_plot_timeline = pytest.mark.parametrize(
@@ -172,13 +165,7 @@ def test_get_timeline_plot(
     n_recent_trials: int | None,
 ) -> None:
     study = _create_study(trial_states)
-    figure = plot_timeline(study, n_recent_trials=n_recent_trials)
-
-    if isinstance(figure, go.Figure):
-        figure.write_image(BytesIO())
-    else:
-        plt.savefig(BytesIO())
-        plt.close()
+    plot_timeline(study, n_recent_trials=n_recent_trials)
 
 
 @parametrize_plot_timeline

--- a/tests/visualization_tests/test_timeline.py
+++ b/tests/visualization_tests/test_timeline.py
@@ -10,10 +10,8 @@ import optuna
 from optuna.study._constrained_optimization import _CONSTRAINTS_KEY
 from optuna.trial import TrialState
 from optuna.visualization import plot_timeline as plotly_plot_timeline
-from optuna.visualization._plotly_imports import _imports as plotly_imports
 from optuna.visualization._timeline import _get_timeline_info
 from optuna.visualization.matplotlib import plot_timeline as plt_plot_timeline
-from optuna.visualization.matplotlib._matplotlib_imports import _imports as plt_imports
 
 
 if TYPE_CHECKING:


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. To minimize the review effort, we highly appreciate PRs only with related changes. Please note that submitted PRs may be closed if they include unrelated changes or significantly modified unit tests. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
Follow-up #6829 

Kaleido v1.0.0 requires Chromium to be installed, which adds unnecessary environment requirements for unit tests.
https://github.com/plotly/Kaleido

## Description of the changes
<!-- Describe the changes in this PR. -->


- Remove the `kaleido` dependency from the test environment.
- Stop exporting Plotly figures with `Figure.write_image` in visualization tests.
- Stop saving Matplotlib figures with `plt.savefig` as well.
- Remove the unnecessary `plotly<7` constraint.

## Checklist
<!-- If you used an LLM while working on this PR, please check the box below. Optuna does not prohibit the use of LLMs. However, as described in CONTRIBUTING.md, PRs from first-time contributors that appear to be primarily generated by LLMs are generally not accepted unless the contributor demonstrates clear understanding, validation, and ownership of the proposed changes. Depending on the changes, a PR may be closed without review. -->

* [ ] I used an LLM while working on this PR.

