### PR TITLE
Fix FrozenTrial.__hash__ raising TypeError for every trial

### DIFF
--- a/optuna/trial/_frozen.py
+++ b/optuna/trial/_frozen.py
@@ -194,7 +194,11 @@ class FrozenTrial(BaseTrial):
         return self.number <= other.number
 
     def __hash__(self) -> int:
-        return hash(tuple(getattr(self, field) for field in self.__dict__))
+        # ``__dict__`` holds unhashable values (e.g. the ``list`` in ``values`` and the ``dict``
+        # in ``params``), so hashing over it raises ``TypeError`` for every trial. Hash on the
+        # ``number`` and ``trial_id`` identity fields instead. Equal trials share the whole
+        # ``__dict__`` and hence both fields, so the equal-implies-equal-hash invariant holds.
+        return hash((self._number, self._trial_id))
 
     def __repr__(self) -> str:
         cls = self.__class__.__name__

--- a/tests/trial_tests/test_frozen.py
+++ b/tests/trial_tests/test_frozen.py
@@ -39,6 +39,24 @@ def test_eq_ne() -> None:
     assert trial != trial_other
 
 
+def test_hash() -> None:
+    trial = _create_trial()
+
+    # A ``FrozenTrial`` defines ``__eq__``, so defining ``__hash__`` declares that instances
+    # are hashable. ``hash`` must therefore not raise, even though the trial holds list/dict
+    # fields such as ``values`` and ``params``.
+    assert isinstance(hash(trial), int)
+
+    # Objects that compare equal must have the same hash value.
+    trial_other = copy.copy(trial)
+    assert trial == trial_other
+    assert hash(trial) == hash(trial_other)
+
+    # A ``FrozenTrial`` can therefore be used as a set element and a dict key.
+    assert trial in {trial}
+    assert {trial: "value"}[trial_other] == "value"
+
+
 def test_lt() -> None:
     trial = _create_trial()
 


### PR DESCRIPTION
## Motivation

`FrozenTrial` defines both `__eq__` and `__hash__`, so instances are meant to be hashable. However, `__hash__` hashes a tuple built from `self.__dict__`, whose values include a `list` (`values`) and `dict`s (`params`, `distributions`, `user_attrs`, `system_attrs`, `intermediate_values`). As a result `hash(trial)` raises `TypeError: unhashable type: 'list'` for every trial — even one with no params — so a trial cannot be used as a set element or dict key, despite `trial == trial` being `True`.

Repro on current master:

```python
import optuna
t = optuna.trial.create_trial(value=1.0)
hash(t)   # TypeError: unhashable type: 'list'
```

## Description of the changes

Hash on the `(number, trial_id)` identity fields instead of the full `__dict__`. Equal trials share the entire `__dict__` (hence both fields), preserving the equal-implies-equal-hash invariant, and this is consistent with `__lt__`/`__le__`, which already order trials by `number`. Added a regression test (`tests/trial_tests/test_frozen.py::test_hash`) covering hashability, hash-equality of equal trials, and use as a set element / dict key.

Worth noting the alternative: `__hash__ = None`, making `FrozenTrial` explicitly unhashable. That may be the better contract given the mutating setters, and I'm happy to switch if you prefer it. This change takes the view that defining `__hash__` at all signals intent for the type to be hashable.

## Checklist

- [x] I used an LLM while working on this PR.
