### PR TITLE
Fix gRPC trial datetime serialization

### DIFF
--- a/optuna/storages/_grpc/servicer.py
+++ b/optuna/storages/_grpc/servicer.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime
+from datetime import timezone
 import json
 import threading
 from typing import TYPE_CHECKING
@@ -29,7 +30,6 @@ else:
 
 
 _logger = logging.get_logger(__name__)
-DATETIME_FORMAT = "%Y-%m-%d %H:%M:%S.%f"
 
 
 class OptunaStorageProxyService(api_pb2_grpc.StorageServiceServicer):
@@ -370,6 +370,24 @@ def _from_proto_trial_state(state: api_pb2.TrialState.ValueType) -> TrialState:
     raise ValueError(f"Unknown api_pb2.TrialState: {state}")
 
 
+def _to_proto_datetime(dt: datetime | None) -> str:
+    """Convert a datetime to a UTC-aware ISO 8601 string for gRPC, or an empty string for None."""
+    if dt is None:
+        return ""
+
+    dt_utc = dt.astimezone(timezone.utc)
+    return dt_utc.isoformat(timespec="microseconds")
+
+
+def _from_proto_datetime(proto_str: str) -> datetime | None:
+    """Convert a gRPC datetime string to a naive local datetime, or None for an empty string."""
+    if proto_str == "":
+        return None
+
+    dt = datetime.fromisoformat(proto_str)
+    return dt.astimezone().replace(tzinfo=None)
+
+
 def _to_proto_trial(trial: FrozenTrial) -> api_pb2.Trial:
     params = {}
     for key, value in trial.params.items():
@@ -380,12 +398,8 @@ def _to_proto_trial(trial: FrozenTrial) -> api_pb2.Trial:
         number=trial.number,
         state=_to_proto_trial_state(trial.state),
         values=trial.values,
-        datetime_start=(
-            trial.datetime_start.strftime(DATETIME_FORMAT) if trial.datetime_start else ""
-        ),
-        datetime_complete=(
-            trial.datetime_complete.strftime(DATETIME_FORMAT) if trial.datetime_complete else ""
-        ),
+        datetime_start=_to_proto_datetime(trial.datetime_start),
+        datetime_complete=_to_proto_datetime(trial.datetime_complete),
         distributions={
             key: distribution_to_json(distribution)
             for key, distribution in trial.distributions.items()
@@ -398,14 +412,8 @@ def _to_proto_trial(trial: FrozenTrial) -> api_pb2.Trial:
 
 
 def _from_proto_trial(trial: api_pb2.Trial) -> FrozenTrial:
-    datetime_start = (
-        datetime.strptime(trial.datetime_start, DATETIME_FORMAT) if trial.datetime_start else None
-    )
-    datetime_complete = (
-        datetime.strptime(trial.datetime_complete, DATETIME_FORMAT)
-        if trial.datetime_complete
-        else None
-    )
+    datetime_start = _from_proto_datetime(trial.datetime_start)
+    datetime_complete = _from_proto_datetime(trial.datetime_complete)
     distributions = {
         key: json_to_distribution(value) for key, value in trial.distributions.items()
     }

--- a/tests/storages_tests/test_grpc.py
+++ b/tests/storages_tests/test_grpc.py
@@ -1,29 +1,79 @@
 from __future__ import annotations
 
+from datetime import datetime
+from datetime import timedelta
+from datetime import timezone
+
 import pytest
 
 from optuna.storages import BaseStorage
 from optuna.study._study_direction import StudyDirection
 from optuna.testing.storages import STORAGE_MODES
 from optuna.testing.storages import StorageSupplier
+from optuna.trial import FrozenTrial
 from optuna.trial import TrialState
 
 
 def _test_set_and_get_compatibility(
-    storage_set: BaseStorage, storage_get: BaseStorage, values: list[float] | None
+    storage_set: BaseStorage,
+    storage_get: BaseStorage,
+    values: list[float] | None,
+    template_trial: FrozenTrial | None = None,
 ) -> None:
     study_id = storage_set.create_new_study(directions=[StudyDirection.MINIMIZE])
-    trial_id = storage_set.create_new_trial(study_id)
-    assert storage_get.get_trial(trial_id).state == TrialState.RUNNING
+    trial_id = storage_set.create_new_trial(study_id, template_trial=template_trial)
+    trial = storage_get.get_trial(trial_id)
+    assert trial.state == (
+        template_trial.state if template_trial is not None else TrialState.RUNNING
+    )
+    assert trial.datetime_start == storage_set.get_trial(trial_id).datetime_start
+    if template_trial is not None:
+        assert template_trial.datetime_start is not None
+        assert trial.datetime_start == template_trial.datetime_start.astimezone().replace(
+            tzinfo=None
+        )
     storage_set.set_trial_state_values(trial_id, state=TrialState.COMPLETE, values=values)
-    assert storage_get.get_trial(trial_id).state == TrialState.COMPLETE
-    assert storage_get.get_trial(trial_id).values == values
+    trial = storage_get.get_trial(trial_id)
+    assert trial.state == TrialState.COMPLETE
+    assert trial.values == values
+    assert trial.datetime_start == storage_set.get_trial(trial_id).datetime_start
+    assert trial.datetime_complete == storage_set.get_trial(trial_id).datetime_complete
 
 
 @pytest.mark.parametrize("storage_mode", STORAGE_MODES)
-@pytest.mark.parametrize("values", [None, [0.0]])
-def test_set_and_get_trial_state_values(storage_mode: str, values: list[float] | None) -> None:
+@pytest.mark.parametrize(
+    ("values", "template_timezone"),
+    [
+        pytest.param(None, None, id="without_template_without_values"),
+        pytest.param([0.0], None, id="without_template_with_values"),
+        pytest.param([0.0], timezone.utc, id="template_trial_utc"),
+        pytest.param([0.0], timezone(timedelta(hours=9)), id="template_trial_utc_plus_9"),
+        pytest.param([0.0], timezone(timedelta(hours=-8)), id="template_trial_utc_minus_8"),
+    ],
+)
+def test_set_and_get_trial_state_values(
+    storage_mode: str, values: list[float] | None, template_timezone: timezone | None
+) -> None:
+    template_trial: FrozenTrial | None = None
+    if template_timezone is not None:
+        datetime_start = datetime.now(template_timezone).replace(microsecond=123456)
+        template_trial = FrozenTrial(
+            number=0,
+            state=TrialState.RUNNING,
+            value=None,
+            datetime_start=datetime_start,
+            datetime_complete=None,
+            params={},
+            distributions={},
+            user_attrs={},
+            system_attrs={},
+            intermediate_values={},
+            trial_id=0,
+        )
+
     with StorageSupplier(storage_mode) as storage_direct:
         with StorageSupplier("grpc_proxy", base_storage=storage_direct) as storage_grpc_proxy:
-            _test_set_and_get_compatibility(storage_grpc_proxy, storage_direct, values)
+            _test_set_and_get_compatibility(
+                storage_grpc_proxy, storage_direct, values, template_trial
+            )
             _test_set_and_get_compatibility(storage_direct, storage_grpc_proxy, values)


### PR DESCRIPTION
## Motivation

This is the gRPC-side follow-up to #6708.

Although #6776 made timestamp handling in the storage backends consistent, gRPC still serialized trial datetimes without timezone information. As a result,
datetimes could be interpreted using the gRPC server's local timezone.

## Description of the changes

- Serialize trial datetimes as UTC-aware ISO 8601 strings.
- Deserialize them back into the naive local datetime representation expected by `FrozenTrial`.
- Preserve the empty-string representation for missing datetimes.
- Extend the existing gRPC client/server compatibility tests to cover template trials with multiple timezones.

## Checklist
  <!-- If you used an LLM while working on this PR, please check the box below. Optuna does not prohibit the use of LLMs. However, as described in CONTRIBUTING.md, PRs from first-time contributors that appear to
  be primarily generated by LLMs are generally not accepted unless the contributor demonstrates clear understanding, validation, and ownership of the proposed changes. Depending on the changes, a PR may be closed
  without review. -->

 * [x] I used an LLM while working on this PR.