### PR TITLE
docs: combine visualization backend examples

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -59,6 +59,7 @@ extensions = [
     "sphinx.ext.githubpages",
     "sphinx.ext.graphviz",
     "sphinx_copybutton",
+    "sphinx_design",
     "sphinx_gallery.gen_gallery"
 ]
 
@@ -197,28 +198,27 @@ autodoc_default_options = {
 copybutton_prompt_text = "$ "
 
 # Sphinx Gallery
-pio.renderers.default = "sphinx_gallery_png"
 
 sphinx_gallery_conf = {
     "doc_module": ("sphinx_gallery"),
     "examples_dirs": [
         "../../tutorial/10_key_features",
         "../../tutorial/20_recipes",
-        "../visualization_examples",
         "../visualization_matplotlib_examples",
+        "../visualization_examples",
     ],
     "gallery_dirs": [
         "tutorial/10_key_features",
         "tutorial/20_recipes",
-        "reference/visualization/generated",
         "reference/visualization/matplotlib/generated",
+        "reference/visualization/generated",
     ],
     "compress_images": ("images", "thumbnails"),
     "thumbnail_size": (400, 280),
     "within_subsection_order": "FileNameSortKey",
     "filename_pattern": r"/*\.py",
     "first_notebook_cell": None,
-    "image_scrapers": ("matplotlib", "plotly.io._sg_scraper.plotly_sg_scraper"),
+    "image_scrapers": ("matplotlib",),
 }
 
 # matplotlib plot directive
@@ -226,12 +226,6 @@ plot_include_source = True
 plot_formats = [("png", 90)]
 plot_html_show_formats = False
 plot_html_show_source_link = False
-
-# sphinx plotly directive
-plotly_include_source = True
-plotly_formats = ["html"]
-plotly_html_show_formats = False
-plotly_html_show_source_link = False
 
 # Not showing common warning messages as in
 # https://sphinx-gallery.github.io/stable/configuration.html#removing-warnings.

--- a/docs/source/docutils.conf
+++ b/docs/source/docutils.conf
@@ -1,0 +1,2 @@
+[parsers]
+line-length-limit: 100000

--- a/docs/source/reference/visualization/index.rst
+++ b/docs/source/reference/visualization/index.rst
@@ -9,50 +9,62 @@ Each example page contains tabs for the Plotly and Matplotlib implementations.
 
     .. grid-item-card:: plot_contour
         :link: plot_contour
+        :link-type: doc
         :img-top: /reference/visualization/matplotlib/generated/images/sphx_glr_optuna.visualization.matplotlib.contour_001.png
 
     .. grid-item-card:: plot_edf
         :link: plot_edf
+        :link-type: doc
         :img-top: /reference/visualization/matplotlib/generated/images/sphx_glr_optuna.visualization.matplotlib.edf_001.png
 
     .. grid-item-card:: plot_hypervolume_history
         :link: plot_hypervolume_history
+        :link-type: doc
         :img-top: /reference/visualization/matplotlib/generated/images/sphx_glr_optuna.visualization.matplotlib.hypervolume_history_001.png
 
     .. grid-item-card:: plot_intermediate_values
         :link: plot_intermediate_values
+        :link-type: doc
         :img-top: /reference/visualization/matplotlib/generated/images/sphx_glr_optuna.visualization.matplotlib.intermediate_values_001.png
 
     .. grid-item-card:: plot_optimization_history
         :link: plot_optimization_history
+        :link-type: doc
         :img-top: /reference/visualization/matplotlib/generated/images/sphx_glr_optuna.visualization.matplotlib.optimization_history_001.png
 
     .. grid-item-card:: plot_parallel_coordinate
         :link: plot_parallel_coordinate
+        :link-type: doc
         :img-top: /reference/visualization/matplotlib/generated/images/sphx_glr_optuna.visualization.matplotlib.parallel_coordinate_001.png
 
     .. grid-item-card:: plot_param_importances
         :link: plot_param_importances
+        :link-type: doc
         :img-top: /reference/visualization/matplotlib/generated/images/sphx_glr_optuna.visualization.matplotlib.param_importances_001.png
 
     .. grid-item-card:: plot_pareto_front
         :link: plot_pareto_front
+        :link-type: doc
         :img-top: /reference/visualization/matplotlib/generated/images/sphx_glr_optuna.visualization.matplotlib.pareto_front_001.png
 
     .. grid-item-card:: plot_rank
         :link: plot_rank
+        :link-type: doc
         :img-top: /reference/visualization/matplotlib/generated/images/sphx_glr_optuna.visualization.matplotlib.rank_001.png
 
     .. grid-item-card:: plot_slice
         :link: plot_slice
+        :link-type: doc
         :img-top: /reference/visualization/matplotlib/generated/images/sphx_glr_optuna.visualization.matplotlib.slice_001.png
 
     .. grid-item-card:: plot_terminator_improvement
         :link: plot_terminator_improvement
+        :link-type: doc
         :img-top: /reference/visualization/matplotlib/generated/images/sphx_glr_optuna.visualization.matplotlib.terminator_improvement_001.png
 
     .. grid-item-card:: plot_timeline
         :link: plot_timeline
+        :link-type: doc
         :img-top: /reference/visualization/matplotlib/generated/images/sphx_glr_optuna.visualization.matplotlib.timeline_001.png
 
 .. note::

--- a/docs/source/reference/visualization/index.rst
+++ b/docs/source/reference/visualization/index.rst
@@ -1,12 +1,79 @@
-.. include:: ./generated/index.rst
+optuna.visualization
+====================
+
+Optuna provides visualization functions with both Plotly and Matplotlib backends.
+Each example page contains tabs for the Plotly and Matplotlib implementations.
+
+.. grid:: 3
+    :gutter: 2
+
+    .. grid-item-card:: plot_contour
+        :link: plot_contour
+        :img-top: /reference/visualization/matplotlib/generated/images/sphx_glr_optuna.visualization.matplotlib.contour_001.png
+
+    .. grid-item-card:: plot_edf
+        :link: plot_edf
+        :img-top: /reference/visualization/matplotlib/generated/images/sphx_glr_optuna.visualization.matplotlib.edf_001.png
+
+    .. grid-item-card:: plot_hypervolume_history
+        :link: plot_hypervolume_history
+        :img-top: /reference/visualization/matplotlib/generated/images/sphx_glr_optuna.visualization.matplotlib.hypervolume_history_001.png
+
+    .. grid-item-card:: plot_intermediate_values
+        :link: plot_intermediate_values
+        :img-top: /reference/visualization/matplotlib/generated/images/sphx_glr_optuna.visualization.matplotlib.intermediate_values_001.png
+
+    .. grid-item-card:: plot_optimization_history
+        :link: plot_optimization_history
+        :img-top: /reference/visualization/matplotlib/generated/images/sphx_glr_optuna.visualization.matplotlib.optimization_history_001.png
+
+    .. grid-item-card:: plot_parallel_coordinate
+        :link: plot_parallel_coordinate
+        :img-top: /reference/visualization/matplotlib/generated/images/sphx_glr_optuna.visualization.matplotlib.parallel_coordinate_001.png
+
+    .. grid-item-card:: plot_param_importances
+        :link: plot_param_importances
+        :img-top: /reference/visualization/matplotlib/generated/images/sphx_glr_optuna.visualization.matplotlib.param_importances_001.png
+
+    .. grid-item-card:: plot_pareto_front
+        :link: plot_pareto_front
+        :img-top: /reference/visualization/matplotlib/generated/images/sphx_glr_optuna.visualization.matplotlib.pareto_front_001.png
+
+    .. grid-item-card:: plot_rank
+        :link: plot_rank
+        :img-top: /reference/visualization/matplotlib/generated/images/sphx_glr_optuna.visualization.matplotlib.rank_001.png
+
+    .. grid-item-card:: plot_slice
+        :link: plot_slice
+        :img-top: /reference/visualization/matplotlib/generated/images/sphx_glr_optuna.visualization.matplotlib.slice_001.png
+
+    .. grid-item-card:: plot_terminator_improvement
+        :link: plot_terminator_improvement
+        :img-top: /reference/visualization/matplotlib/generated/images/sphx_glr_optuna.visualization.matplotlib.terminator_improvement_001.png
+
+    .. grid-item-card:: plot_timeline
+        :link: plot_timeline
+        :img-top: /reference/visualization/matplotlib/generated/images/sphx_glr_optuna.visualization.matplotlib.timeline_001.png
 
 .. note::
-    The following :mod:`optuna.visualization.matplotlib` module uses Matplotlib as a backend.
+    The :mod:`optuna.visualization` and :mod:`optuna.visualization.matplotlib` modules
+    provide Plotly and Matplotlib backends, respectively.
 
 .. toctree::
-    :maxdepth: 1
+    :hidden:
 
-    matplotlib/index
+    plot_contour
+    plot_edf
+    plot_hypervolume_history
+    plot_intermediate_values
+    plot_optimization_history
+    plot_parallel_coordinate
+    plot_param_importances
+    plot_pareto_front
+    plot_rank
+    plot_slice
+    plot_terminator_improvement
+    plot_timeline
 
 .. seealso::
     The :ref:`visualization` tutorial provides use-cases with examples.

--- a/docs/source/reference/visualization/matplotlib/index.rst
+++ b/docs/source/reference/visualization/matplotlib/index.rst
@@ -1,1 +1,0 @@
-.. include:: ./generated/index.rst

--- a/docs/source/reference/visualization/plot_contour.rst
+++ b/docs/source/reference/visualization/plot_contour.rst
@@ -1,0 +1,22 @@
+plot_contour
+============
+
+.. tab-set::
+
+    .. tab-item:: Plotly
+
+        .. autofunction:: optuna.visualization.plot_contour
+            :no-index:
+
+        .. include:: generated/optuna.visualization.plot_contour.rst
+            :start-after: .. _visualization-plot-contour-plotly-content:
+            :end-before: .. _sphx_glr_download_reference_visualization_generated_optuna.visualization.plot_contour.py:
+
+    .. tab-item:: Matplotlib
+
+        .. autofunction:: optuna.visualization.matplotlib.plot_contour
+            :no-index:
+
+        .. include:: matplotlib/generated/optuna.visualization.matplotlib.contour.rst
+            :start-after: .. _visualization-plot-contour-matplotlib-content:
+            :end-before: .. _sphx_glr_download_reference_visualization_matplotlib_generated_optuna.visualization.matplotlib.contour.py:

--- a/docs/source/reference/visualization/plot_edf.rst
+++ b/docs/source/reference/visualization/plot_edf.rst
@@ -1,0 +1,22 @@
+plot_edf
+========
+
+.. tab-set::
+
+    .. tab-item:: Plotly
+
+        .. autofunction:: optuna.visualization.plot_edf
+            :no-index:
+
+        .. include:: generated/optuna.visualization.plot_edf.rst
+            :start-after: .. _visualization-plot-edf-plotly-content:
+            :end-before: .. _sphx_glr_download_reference_visualization_generated_optuna.visualization.plot_edf.py:
+
+    .. tab-item:: Matplotlib
+
+        .. autofunction:: optuna.visualization.matplotlib.plot_edf
+            :no-index:
+
+        .. include:: matplotlib/generated/optuna.visualization.matplotlib.edf.rst
+            :start-after: .. _visualization-plot-edf-matplotlib-content:
+            :end-before: .. _sphx_glr_download_reference_visualization_matplotlib_generated_optuna.visualization.matplotlib.edf.py:

--- a/docs/source/reference/visualization/plot_hypervolume_history.rst
+++ b/docs/source/reference/visualization/plot_hypervolume_history.rst
@@ -1,0 +1,22 @@
+plot_hypervolume_history
+========================
+
+.. tab-set::
+
+    .. tab-item:: Plotly
+
+        .. autofunction:: optuna.visualization.plot_hypervolume_history
+            :no-index:
+
+        .. include:: generated/optuna.visualization.plot_hypervolume_history.rst
+            :start-after: .. _visualization-plot-hypervolume-history-plotly-content:
+            :end-before: .. _sphx_glr_download_reference_visualization_generated_optuna.visualization.plot_hypervolume_history.py:
+
+    .. tab-item:: Matplotlib
+
+        .. autofunction:: optuna.visualization.matplotlib.plot_hypervolume_history
+            :no-index:
+
+        .. include:: matplotlib/generated/optuna.visualization.matplotlib.hypervolume_history.rst
+            :start-after: .. _visualization-plot-hypervolume-history-matplotlib-content:
+            :end-before: .. _sphx_glr_download_reference_visualization_matplotlib_generated_optuna.visualization.matplotlib.hypervolume_history.py:

--- a/docs/source/reference/visualization/plot_intermediate_values.rst
+++ b/docs/source/reference/visualization/plot_intermediate_values.rst
@@ -1,0 +1,22 @@
+plot_intermediate_values
+=========================
+
+.. tab-set::
+
+    .. tab-item:: Plotly
+
+        .. autofunction:: optuna.visualization.plot_intermediate_values
+            :no-index:
+
+        .. include:: generated/optuna.visualization.plot_intermediate_values.rst
+            :start-after: .. _visualization-plot-intermediate-values-plotly-content:
+            :end-before: .. _sphx_glr_download_reference_visualization_generated_optuna.visualization.plot_intermediate_values.py:
+
+    .. tab-item:: Matplotlib
+
+        .. autofunction:: optuna.visualization.matplotlib.plot_intermediate_values
+            :no-index:
+
+        .. include:: matplotlib/generated/optuna.visualization.matplotlib.intermediate_values.rst
+            :start-after: .. _visualization-plot-intermediate-values-matplotlib-content:
+            :end-before: .. _sphx_glr_download_reference_visualization_matplotlib_generated_optuna.visualization.matplotlib.intermediate_values.py:

--- a/docs/source/reference/visualization/plot_optimization_history.rst
+++ b/docs/source/reference/visualization/plot_optimization_history.rst
@@ -1,0 +1,22 @@
+plot_optimization_history
+=========================
+
+.. tab-set::
+
+    .. tab-item:: Plotly
+
+        .. autofunction:: optuna.visualization.plot_optimization_history
+            :no-index:
+
+        .. include:: generated/optuna.visualization.plot_optimization_history.rst
+            :start-after: .. _visualization-plot-optimization-history-plotly-content:
+            :end-before: .. _sphx_glr_download_reference_visualization_generated_optuna.visualization.plot_optimization_history.py:
+
+    .. tab-item:: Matplotlib
+
+        .. autofunction:: optuna.visualization.matplotlib.plot_optimization_history
+            :no-index:
+
+        .. include:: matplotlib/generated/optuna.visualization.matplotlib.optimization_history.rst
+            :start-after: .. _visualization-plot-optimization-history-matplotlib-content:
+            :end-before: .. _sphx_glr_download_reference_visualization_matplotlib_generated_optuna.visualization.matplotlib.optimization_history.py:

--- a/docs/source/reference/visualization/plot_parallel_coordinate.rst
+++ b/docs/source/reference/visualization/plot_parallel_coordinate.rst
@@ -1,0 +1,22 @@
+plot_parallel_coordinate
+========================
+
+.. tab-set::
+
+    .. tab-item:: Plotly
+
+        .. autofunction:: optuna.visualization.plot_parallel_coordinate
+            :no-index:
+
+        .. include:: generated/optuna.visualization.plot_parallel_coordinate.rst
+            :start-after: .. _visualization-plot-parallel-coordinate-plotly-content:
+            :end-before: .. _sphx_glr_download_reference_visualization_generated_optuna.visualization.plot_parallel_coordinate.py:
+
+    .. tab-item:: Matplotlib
+
+        .. autofunction:: optuna.visualization.matplotlib.plot_parallel_coordinate
+            :no-index:
+
+        .. include:: matplotlib/generated/optuna.visualization.matplotlib.parallel_coordinate.rst
+            :start-after: .. _visualization-plot-parallel-coordinate-matplotlib-content:
+            :end-before: .. _sphx_glr_download_reference_visualization_matplotlib_generated_optuna.visualization.matplotlib.parallel_coordinate.py:

--- a/docs/source/reference/visualization/plot_param_importances.rst
+++ b/docs/source/reference/visualization/plot_param_importances.rst
@@ -1,0 +1,22 @@
+plot_param_importances
+======================
+
+.. tab-set::
+
+    .. tab-item:: Plotly
+
+        .. autofunction:: optuna.visualization.plot_param_importances
+            :no-index:
+
+        .. include:: generated/optuna.visualization.plot_param_importances.rst
+            :start-after: .. _visualization-plot-param-importances-plotly-content:
+            :end-before: .. _sphx_glr_download_reference_visualization_generated_optuna.visualization.plot_param_importances.py:
+
+    .. tab-item:: Matplotlib
+
+        .. autofunction:: optuna.visualization.matplotlib.plot_param_importances
+            :no-index:
+
+        .. include:: matplotlib/generated/optuna.visualization.matplotlib.param_importances.rst
+            :start-after: .. _visualization-plot-param-importances-matplotlib-content:
+            :end-before: .. _sphx_glr_download_reference_visualization_matplotlib_generated_optuna.visualization.matplotlib.param_importances.py:

--- a/docs/source/reference/visualization/plot_pareto_front.rst
+++ b/docs/source/reference/visualization/plot_pareto_front.rst
@@ -1,0 +1,22 @@
+plot_pareto_front
+=================
+
+.. tab-set::
+
+    .. tab-item:: Plotly
+
+        .. autofunction:: optuna.visualization.plot_pareto_front
+            :no-index:
+
+        .. include:: generated/optuna.visualization.plot_pareto_front.rst
+            :start-after: .. _visualization-plot-pareto-front-plotly-content:
+            :end-before: .. _sphx_glr_download_reference_visualization_generated_optuna.visualization.plot_pareto_front.py:
+
+    .. tab-item:: Matplotlib
+
+        .. autofunction:: optuna.visualization.matplotlib.plot_pareto_front
+            :no-index:
+
+        .. include:: matplotlib/generated/optuna.visualization.matplotlib.pareto_front.rst
+            :start-after: .. _visualization-plot-pareto-front-matplotlib-content:
+            :end-before: .. _sphx_glr_download_reference_visualization_matplotlib_generated_optuna.visualization.matplotlib.pareto_front.py:

--- a/docs/source/reference/visualization/plot_rank.rst
+++ b/docs/source/reference/visualization/plot_rank.rst
@@ -1,0 +1,22 @@
+plot_rank
+=========
+
+.. tab-set::
+
+    .. tab-item:: Plotly
+
+        .. autofunction:: optuna.visualization.plot_rank
+            :no-index:
+
+        .. include:: generated/optuna.visualization.plot_rank.rst
+            :start-after: .. _visualization-plot-rank-plotly-content:
+            :end-before: .. _sphx_glr_download_reference_visualization_generated_optuna.visualization.plot_rank.py:
+
+    .. tab-item:: Matplotlib
+
+        .. autofunction:: optuna.visualization.matplotlib.plot_rank
+            :no-index:
+
+        .. include:: matplotlib/generated/optuna.visualization.matplotlib.rank.rst
+            :start-after: .. _visualization-plot-rank-matplotlib-content:
+            :end-before: .. _sphx_glr_download_reference_visualization_matplotlib_generated_optuna.visualization.matplotlib.rank.py:

--- a/docs/source/reference/visualization/plot_slice.rst
+++ b/docs/source/reference/visualization/plot_slice.rst
@@ -1,0 +1,22 @@
+plot_slice
+==========
+
+.. tab-set::
+
+    .. tab-item:: Plotly
+
+        .. autofunction:: optuna.visualization.plot_slice
+            :no-index:
+
+        .. include:: generated/optuna.visualization.plot_slice.rst
+            :start-after: .. _visualization-plot-slice-plotly-content:
+            :end-before: .. _sphx_glr_download_reference_visualization_generated_optuna.visualization.plot_slice.py:
+
+    .. tab-item:: Matplotlib
+
+        .. autofunction:: optuna.visualization.matplotlib.plot_slice
+            :no-index:
+
+        .. include:: matplotlib/generated/optuna.visualization.matplotlib.slice.rst
+            :start-after: .. _visualization-plot-slice-matplotlib-content:
+            :end-before: .. _sphx_glr_download_reference_visualization_matplotlib_generated_optuna.visualization.matplotlib.slice.py:

--- a/docs/source/reference/visualization/plot_terminator_improvement.rst
+++ b/docs/source/reference/visualization/plot_terminator_improvement.rst
@@ -1,0 +1,22 @@
+plot_terminator_improvement
+===========================
+
+.. tab-set::
+
+    .. tab-item:: Plotly
+
+        .. autofunction:: optuna.visualization.plot_terminator_improvement
+            :no-index:
+
+        .. include:: generated/optuna.visualization.plot_terminator_improvement.rst
+            :start-after: .. _visualization-plot-terminator-improvement-plotly-content:
+            :end-before: .. _sphx_glr_download_reference_visualization_generated_optuna.visualization.plot_terminator_improvement.py:
+
+    .. tab-item:: Matplotlib
+
+        .. autofunction:: optuna.visualization.matplotlib.plot_terminator_improvement
+            :no-index:
+
+        .. include:: matplotlib/generated/optuna.visualization.matplotlib.terminator_improvement.rst
+            :start-after: .. _visualization-plot-terminator-improvement-matplotlib-content:
+            :end-before: .. _sphx_glr_download_reference_visualization_matplotlib_generated_optuna.visualization.matplotlib.terminator_improvement.py:

--- a/docs/source/reference/visualization/plot_timeline.rst
+++ b/docs/source/reference/visualization/plot_timeline.rst
@@ -1,0 +1,22 @@
+plot_timeline
+=============
+
+.. tab-set::
+
+    .. tab-item:: Plotly
+
+        .. autofunction:: optuna.visualization.plot_timeline
+            :no-index:
+
+        .. include:: generated/optuna.visualization.plot_timeline.rst
+            :start-after: .. _visualization-plot-timeline-plotly-content:
+            :end-before: .. _sphx_glr_download_reference_visualization_generated_optuna.visualization.plot_timeline.py:
+
+    .. tab-item:: Matplotlib
+
+        .. autofunction:: optuna.visualization.matplotlib.plot_timeline
+            :no-index:
+
+        .. include:: matplotlib/generated/optuna.visualization.matplotlib.timeline.rst
+            :start-after: .. _visualization-plot-timeline-matplotlib-content:
+            :end-before: .. _sphx_glr_download_reference_visualization_matplotlib_generated_optuna.visualization.matplotlib.timeline.py:

--- a/docs/visualization_examples/optuna.visualization.plot_contour.py
+++ b/docs/visualization_examples/optuna.visualization.plot_contour.py
@@ -7,10 +7,13 @@ plot_contour
 
 The following code snippet shows how to plot the parameter relationship as contour plot.
 
+.. _visualization-plot-contour-plotly-content:
+
 """
 
+# sphinx_gallery_thumbnail_path = "reference/visualization/matplotlib/generated/images/sphx_glr_optuna.visualization.matplotlib.contour_001.png"
+
 import optuna
-from plotly.io import show
 
 
 def objective(trial):
@@ -24,4 +27,4 @@ study = optuna.create_study(sampler=sampler)
 study.optimize(objective, n_trials=30)
 
 fig = optuna.visualization.plot_contour(study, params=["x", "y"])
-show(fig)
+fig

--- a/docs/visualization_examples/optuna.visualization.plot_edf.py
+++ b/docs/visualization_examples/optuna.visualization.plot_edf.py
@@ -7,12 +7,15 @@ plot_edf
 
 The following code snippet shows how to plot EDF.
 
+.. _visualization-plot-edf-plotly-content:
+
 """
+
+# sphinx_gallery_thumbnail_path = "reference/visualization/matplotlib/generated/images/sphx_glr_optuna.visualization.matplotlib.edf_001.png"
 
 import math
 
 import optuna
-from plotly.io import show
 
 
 def ackley(x, y):
@@ -42,4 +45,4 @@ study2 = optuna.create_study(study_name="x=[1,3), y=[1,3)", sampler=sampler)
 study2.optimize(lambda t: objective(t, 1, 3), n_trials=500)
 
 fig = optuna.visualization.plot_edf([study0, study1, study2])
-show(fig)
+fig

--- a/docs/visualization_examples/optuna.visualization.plot_hypervolume_history.py
+++ b/docs/visualization_examples/optuna.visualization.plot_hypervolume_history.py
@@ -7,10 +7,13 @@ plot_hypervolume_history
 
 The following code snippet shows how to plot optimization history.
 
+.. _visualization-plot-hypervolume-history-plotly-content:
+
 """
 
+# sphinx_gallery_thumbnail_path = "reference/visualization/matplotlib/generated/images/sphx_glr_optuna.visualization.matplotlib.hypervolume_history_001.png"
+
 import optuna
-from plotly.io import show
 
 
 def objective(trial):
@@ -27,4 +30,4 @@ study.optimize(objective, n_trials=50)
 
 reference_point = [100.0, 50.0]
 fig = optuna.visualization.plot_hypervolume_history(study, reference_point)
-show(fig)
+fig

--- a/docs/visualization_examples/optuna.visualization.plot_intermediate_values.py
+++ b/docs/visualization_examples/optuna.visualization.plot_intermediate_values.py
@@ -7,10 +7,13 @@ plot_intermediate_values
 
 The following code snippet shows how to plot intermediate values.
 
+.. _visualization-plot-intermediate-values-plotly-content:
+
 """
 
+# sphinx_gallery_thumbnail_path = "reference/visualization/matplotlib/generated/images/sphx_glr_optuna.visualization.matplotlib.intermediate_values_001.png"
+
 import optuna
-from plotly.io import show
 
 
 def f(x):
@@ -43,4 +46,4 @@ study = optuna.create_study(sampler=sampler)
 study.optimize(objective, n_trials=16)
 
 fig = optuna.visualization.plot_intermediate_values(study)
-show(fig)
+fig

--- a/docs/visualization_examples/optuna.visualization.plot_optimization_history.py
+++ b/docs/visualization_examples/optuna.visualization.plot_optimization_history.py
@@ -7,10 +7,13 @@ plot_optimization_history
 
 The following code snippet shows how to plot optimization history.
 
+.. _visualization-plot-optimization-history-plotly-content:
+
 """
 
+# sphinx_gallery_thumbnail_path = "reference/visualization/matplotlib/generated/images/sphx_glr_optuna.visualization.matplotlib.optimization_history_001.png"
+
 import optuna
-from plotly.io import show
 
 
 def objective(trial):
@@ -24,4 +27,4 @@ study = optuna.create_study(sampler=sampler)
 study.optimize(objective, n_trials=10)
 
 fig = optuna.visualization.plot_optimization_history(study)
-show(fig)
+fig

--- a/docs/visualization_examples/optuna.visualization.plot_parallel_coordinate.py
+++ b/docs/visualization_examples/optuna.visualization.plot_parallel_coordinate.py
@@ -7,10 +7,13 @@ plot_parallel_coordinate
 
 The following code snippet shows how to plot the high-dimensional parameter relationships.
 
+.. _visualization-plot-parallel-coordinate-plotly-content:
+
 """
 
+# sphinx_gallery_thumbnail_path = "reference/visualization/matplotlib/generated/images/sphx_glr_optuna.visualization.matplotlib.parallel_coordinate_001.png"
+
 import optuna
-from plotly.io import show
 
 
 def objective(trial):
@@ -24,4 +27,4 @@ study = optuna.create_study(sampler=sampler)
 study.optimize(objective, n_trials=10)
 
 fig = optuna.visualization.plot_parallel_coordinate(study, params=["x", "y"])
-show(fig)
+fig

--- a/docs/visualization_examples/optuna.visualization.plot_param_importances.py
+++ b/docs/visualization_examples/optuna.visualization.plot_param_importances.py
@@ -7,10 +7,13 @@ plot_param_importances
 
 The following code snippet shows how to plot hyperparameter importances.
 
+.. _visualization-plot-param-importances-plotly-content:
+
 """
 
+# sphinx_gallery_thumbnail_path = "reference/visualization/matplotlib/generated/images/sphx_glr_optuna.visualization.matplotlib.param_importances_001.png"
+
 import optuna
-from plotly.io import show
 
 
 def objective(trial):
@@ -25,4 +28,4 @@ study = optuna.create_study(sampler=sampler)
 study.optimize(objective, n_trials=100)
 
 fig = optuna.visualization.plot_param_importances(study)
-show(fig)
+fig

--- a/docs/visualization_examples/optuna.visualization.plot_pareto_front.py
+++ b/docs/visualization_examples/optuna.visualization.plot_pareto_front.py
@@ -7,10 +7,13 @@ plot_pareto_front
 
 The following code snippet shows how to plot the Pareto front of a study.
 
+.. _visualization-plot-pareto-front-plotly-content:
+
 """
 
+# sphinx_gallery_thumbnail_path = "reference/visualization/matplotlib/generated/images/sphx_glr_optuna.visualization.matplotlib.pareto_front_001.png"
+
 import optuna
-from plotly.io import show
 
 
 def objective(trial):
@@ -26,7 +29,7 @@ study = optuna.create_study(directions=["minimize", "minimize"])
 study.optimize(objective, n_trials=50)
 
 fig = optuna.visualization.plot_pareto_front(study)
-show(fig)
+fig
 
 # %%
 # The following code snippet shows how to plot a 2-dimensional Pareto front
@@ -35,7 +38,6 @@ show(fig)
 # of a 4-dimensional study and so on.
 
 import optuna
-from plotly.io import show
 
 
 def objective(trial):
@@ -58,4 +60,4 @@ fig = optuna.visualization.plot_pareto_front(
     target_names=["Objective 0", "Objective 1"],
 )
 
-show(fig)
+fig

--- a/docs/visualization_examples/optuna.visualization.plot_rank.py
+++ b/docs/visualization_examples/optuna.visualization.plot_rank.py
@@ -7,10 +7,13 @@ plot_rank
 
 The following code snippet shows how to plot the parameter relationship as a rank plot.
 
+.. _visualization-plot-rank-plotly-content:
+
 """
 
+# sphinx_gallery_thumbnail_path = "reference/visualization/matplotlib/generated/images/sphx_glr_optuna.visualization.matplotlib.rank_001.png"
+
 import optuna
-from plotly.io import show
 
 
 def objective(trial):
@@ -28,4 +31,4 @@ study = optuna.create_study(sampler=sampler)
 study.optimize(objective, n_trials=30)
 
 fig = optuna.visualization.plot_rank(study, params=["x", "y"])
-show(fig)
+fig

--- a/docs/visualization_examples/optuna.visualization.plot_slice.py
+++ b/docs/visualization_examples/optuna.visualization.plot_slice.py
@@ -7,10 +7,13 @@ plot_slice
 
 The following code snippet shows how to plot the parameter relationship as slice plot.
 
+.. _visualization-plot-slice-plotly-content:
+
 """
 
+# sphinx_gallery_thumbnail_path = "reference/visualization/matplotlib/generated/images/sphx_glr_optuna.visualization.matplotlib.slice_001.png"
+
 import optuna
-from plotly.io import show
 
 
 def objective(trial):
@@ -24,4 +27,4 @@ study = optuna.create_study(sampler=sampler)
 study.optimize(objective, n_trials=10)
 
 fig = optuna.visualization.plot_slice(study, params=["x", "y"])
-show(fig)
+fig

--- a/docs/visualization_examples/optuna.visualization.plot_terminator_improvement.py
+++ b/docs/visualization_examples/optuna.visualization.plot_terminator_improvement.py
@@ -8,14 +8,17 @@ plot_terminator_improvement
 The following code snippet shows how to plot improvement potentials,
 together with cross-validation errors.
 
+.. _visualization-plot-terminator-improvement-plotly-content:
+
 """
+
+# sphinx_gallery_thumbnail_path = "reference/visualization/matplotlib/generated/images/sphx_glr_optuna.visualization.matplotlib.terminator_improvement_001.png"
 
 from lightgbm import LGBMClassifier
 from sklearn.datasets import load_wine
 from sklearn.model_selection import cross_val_score
 from sklearn.model_selection import KFold
 import optuna
-from plotly.io import show
 from optuna.terminator import report_cross_validation_scores
 from optuna.visualization import plot_terminator_improvement
 
@@ -40,4 +43,4 @@ study = optuna.create_study()
 study.optimize(objective, n_trials=30)
 
 fig = plot_terminator_improvement(study, plot_error=True)
-show(fig)
+fig

--- a/docs/visualization_examples/optuna.visualization.plot_timeline.py
+++ b/docs/visualization_examples/optuna.visualization.plot_timeline.py
@@ -9,12 +9,15 @@ The following code snippet shows how to plot the timeline of a study.
 Timeline plot can visualize trials with overlapping execution time
 (e.g., in distributed environments).
 
+.. _visualization-plot-timeline-plotly-content:
+
 """
+
+# sphinx_gallery_thumbnail_path = "reference/visualization/matplotlib/generated/images/sphx_glr_optuna.visualization.matplotlib.timeline_001.png"
 
 import time
 
 import optuna
-from plotly.io import show
 
 
 def objective(trial):
@@ -33,5 +36,4 @@ study.optimize(
 )
 
 fig = optuna.visualization.plot_timeline(study)
-show(fig)
-
+fig

--- a/docs/visualization_matplotlib_examples/optuna.visualization.matplotlib.contour.py
+++ b/docs/visualization_matplotlib_examples/optuna.visualization.matplotlib.contour.py
@@ -7,6 +7,8 @@ plot_contour
 
 The following code snippet shows how to plot the parameter relationship as contour plot.
 
+.. _visualization-plot-contour-matplotlib-content:
+
 """
 
 import optuna

--- a/docs/visualization_matplotlib_examples/optuna.visualization.matplotlib.edf.py
+++ b/docs/visualization_matplotlib_examples/optuna.visualization.matplotlib.edf.py
@@ -7,6 +7,8 @@ plot_edf
 
 The following code snippet shows how to plot EDF.
 
+.. _visualization-plot-edf-matplotlib-content:
+
 """
 
 import math

--- a/docs/visualization_matplotlib_examples/optuna.visualization.matplotlib.hypervolume_history.py
+++ b/docs/visualization_matplotlib_examples/optuna.visualization.matplotlib.hypervolume_history.py
@@ -7,6 +7,8 @@ plot_hypervolume_history
 
 The following code snippet shows how to plot optimization history.
 
+.. _visualization-plot-hypervolume-history-matplotlib-content:
+
 """
 
 import optuna

--- a/docs/visualization_matplotlib_examples/optuna.visualization.matplotlib.intermediate_values.py
+++ b/docs/visualization_matplotlib_examples/optuna.visualization.matplotlib.intermediate_values.py
@@ -7,6 +7,8 @@ plot_intermediate_values
 
 The following code snippet shows how to plot intermediate values.
 
+.. _visualization-plot-intermediate-values-matplotlib-content:
+
 """
 
 import optuna

--- a/docs/visualization_matplotlib_examples/optuna.visualization.matplotlib.optimization_history.py
+++ b/docs/visualization_matplotlib_examples/optuna.visualization.matplotlib.optimization_history.py
@@ -7,6 +7,8 @@ plot_optimization_history
 
 The following code snippet shows how to plot optimization history.
 
+.. _visualization-plot-optimization-history-matplotlib-content:
+
 """
 
 import optuna

--- a/docs/visualization_matplotlib_examples/optuna.visualization.matplotlib.parallel_coordinate.py
+++ b/docs/visualization_matplotlib_examples/optuna.visualization.matplotlib.parallel_coordinate.py
@@ -7,6 +7,8 @@ plot_parallel_coordinate
 
 The following code snippet shows how to plot the high-dimensional parameter relationships.
 
+.. _visualization-plot-parallel-coordinate-matplotlib-content:
+
 """
 
 import optuna

--- a/docs/visualization_matplotlib_examples/optuna.visualization.matplotlib.param_importances.py
+++ b/docs/visualization_matplotlib_examples/optuna.visualization.matplotlib.param_importances.py
@@ -7,6 +7,8 @@ plot_param_importances
 
 The following code snippet shows how to plot hyperparameter importances.
 
+.. _visualization-plot-param-importances-matplotlib-content:
+
 """
 
 import optuna

--- a/docs/visualization_matplotlib_examples/optuna.visualization.matplotlib.pareto_front.py
+++ b/docs/visualization_matplotlib_examples/optuna.visualization.matplotlib.pareto_front.py
@@ -7,6 +7,8 @@ plot_pareto_front
 
 The following code snippet shows how to plot the Pareto front of a study.
 
+.. _visualization-plot-pareto-front-matplotlib-content:
+
 """
 
 import optuna

--- a/docs/visualization_matplotlib_examples/optuna.visualization.matplotlib.rank.py
+++ b/docs/visualization_matplotlib_examples/optuna.visualization.matplotlib.rank.py
@@ -7,6 +7,8 @@ plot_rank
 
 The following code snippet shows how to plot the parameter relationship as a rank plot.
 
+.. _visualization-plot-rank-matplotlib-content:
+
 """
 
 import optuna

--- a/docs/visualization_matplotlib_examples/optuna.visualization.matplotlib.slice.py
+++ b/docs/visualization_matplotlib_examples/optuna.visualization.matplotlib.slice.py
@@ -7,6 +7,8 @@ plot_slice
 
 The following code snippet shows how to plot the parameter relationship as slice plot.
 
+.. _visualization-plot-slice-matplotlib-content:
+
 """
 
 import optuna

--- a/docs/visualization_matplotlib_examples/optuna.visualization.matplotlib.terminator_improvement.py
+++ b/docs/visualization_matplotlib_examples/optuna.visualization.matplotlib.terminator_improvement.py
@@ -8,6 +8,8 @@ plot_terminator_improvement
 The following code snippet shows how to plot improvement potentials,
 together with cross-validation errors.
 
+.. _visualization-plot-terminator-improvement-matplotlib-content:
+
 """
 
 from lightgbm import LGBMClassifier

--- a/docs/visualization_matplotlib_examples/optuna.visualization.matplotlib.timeline.py
+++ b/docs/visualization_matplotlib_examples/optuna.visualization.matplotlib.timeline.py
@@ -7,6 +7,8 @@ plot_timeline
 
 The following code snippet shows how to plot the timeline of a study.
 
+.. _visualization-plot-timeline-matplotlib-content:
+
 """
 
 import time

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,17 +46,15 @@ document = [
   "ase",
   "cmaes>=0.12.0",  # optuna/samplers/_cmaes.py.
   "fvcore",
-  "kaleido<0.4,!=0.2.1.post1",  # TODO(nzw0301): Remove the version constraint by installing browser separately.
   "lightgbm",
   "matplotlib!=3.6.0",
   "pandas",
   "pillow",
-  # plotly>=7 dropped support for kaleido<1, which the `sphinx_gallery_png` renderer relies on.
-  # The upper bound can be dropped together with the kaleido constraint above.
-  "plotly>=4.9.0,<7",  # optuna/visualization.
+  "plotly>=4.9.0",  # optuna/visualization.
   "scikit-learn",
   "sphinx",
   "sphinx-copybutton",
+  "sphinx-design",
   "sphinx-gallery",
   "sphinx-notfound-page",
   "sphinx_rtd_theme>=1.2.0",


### PR DESCRIPTION
## Motivation

The visualization documentation currently separates Plotly and Matplotlib examples and uses Kaleido-based PNG scraping for Plotly thumbnails. This makes the documentation structure harder to navigate and adds an unnecessary Kaleido dependency to the documentation build.

The screenshots below show the unified visualization page, where the Plotly and Matplotlib examples can be switched using tabs.
<img width="1474" height="1031" alt="スクリーンショット 2026-08-28 16 03 39" src="https://github.com/user-attachments/assets/43b458b5-1dc5-447d-9476-ddb1551ed7c1" />


## Description of the changes

- Added combined visualization pages for Plotly and Matplotlib.
- Added Plotly/Matplotlib tabs within each visualization page.
- Organized the sidebar under `API Reference > optuna.visualization`.
- Uses Matplotlib PNGs only for visualization thumbnails.
- Removed the Plotly/Kaleido thumbnail scraper.
- Removed Kaleido from the documentation dependencies.
- Kept Plotly HTML rendering through Sphinx Gallery.
- Added `sphinx-design` for the visualization cards.
- No files under `optuna/` were modified.

## Validation

- `ruff check` passed.
- `ruff format` passed.
- Sphinx HTML output was generated and verified to contain both Plotly and Matplotlib tabs.
- The full local build is blocked only by the environment missing `libomp.dylib`, which affects existing LightGBM examples.

## Checklist

* [x] I used an LLM while working on this PR.