### PR TITLE
Fix HyperbandPruner building one bracket too few

### DIFF
--- a/optuna/pruners/_hyperband.py
+++ b/optuna/pruners/_hyperband.py
@@ -204,12 +204,18 @@ class HyperbandPruner(BasePruner):
             # In this implementation, we combine this formula and that of ASHA paper
             # https://arxiv.org/abs/1502.07943 as
             # `n_brackets = floor(log_{reduction_factor}(max_resource / min_resource)) + 1`
-            self._n_brackets = (
-                math.floor(
-                    math.log(self._max_resource / self._min_resource, self._reduction_factor)
-                )
-                + 1
+            max_rung = math.floor(
+                math.log(self._max_resource / self._min_resource, self._reduction_factor)
             )
+            # `math.log` is inexact, e.g. it evaluates `log_3(243)` as 4.999999999999999, so the
+            # exponent above is corrected by exact integer comparisons.
+            while self._min_resource * self._reduction_factor**max_rung > self._max_resource:
+                max_rung -= 1
+            while (
+                self._min_resource * self._reduction_factor ** (max_rung + 1) <= self._max_resource
+            ):
+                max_rung += 1
+            self._n_brackets = max_rung + 1
 
         _logger.debug(f"Hyperband has {self._n_brackets} brackets")
 

--- a/tests/pruners_tests/test_hyperband.py
+++ b/tests/pruners_tests/test_hyperband.py
@@ -94,6 +94,32 @@ def test_hyperband_max_resource_value_error() -> None:
 
 
 @pytest.mark.parametrize(
+    "min_resource,max_resource,reduction_factor,expected_n_brackets",
+    [
+        # `math.log(243, 3)` is 4.999999999999999 and `math.log(1000, 10)` is 2.9999999999999996,
+        # so a naive `floor` of them drops the last bracket.
+        (1, 243, 3, 6),
+        (2, 486, 3, 6),
+        (1, 1000, 10, 4),
+        (1, 81, 3, 5),
+        (1, 16, 2, 5),
+        (1, 20, 3, 3),
+    ],
+)
+def test_hyperband_n_brackets(
+    min_resource: int, max_resource: int, reduction_factor: int, expected_n_brackets: int
+) -> None:
+    pruner = optuna.pruners.HyperbandPruner(
+        min_resource=min_resource, max_resource=max_resource, reduction_factor=reduction_factor
+    )
+    study = optuna.study.create_study(pruner=pruner)
+    pruner._try_initialization(study)
+
+    assert pruner._n_brackets == expected_n_brackets
+    assert len(pruner._pruners) == expected_n_brackets
+
+
+@pytest.mark.parametrize(
     "sampler_init_func",
     [
         lambda: optuna.samplers.RandomSampler(),


### PR DESCRIPTION
## Motivation

`HyperbandPruner` documents the number of brackets as `floor(log_{reduction_factor}(max_resource / min_resource)) + 1`, and `_try_initialization` computes it with `math.log`. `math.log(243, 3)` returns 4.999999999999999, so `HyperbandPruner(min_resource=1, max_resource=243, reduction_factor=3)` builds 5 brackets instead of 6. `min_resource=1, max_resource=1000, reduction_factor=10` builds 3 instead of 4, because `math.log(1000, 10)` returns 2.9999999999999996.

The bracket that goes missing is the one with the largest `min_early_stopping_rate`, so the most aggressive SHA bracket disappears and every bracket's trial allocation budget shifts. Nothing warns. Today, raising `max_resource` from 81 to 243 at `reduction_factor=3` does not change the bracket count at all.

## Description of the changes

Keep the `math.log` result as a starting point, then correct the exponent with exact integer comparisons. Values where `math.log` was already exact are unchanged, and I kept the `math.log` call so the existing errors for `min_resource=0`, `reduction_factor <= 1` and `max_resource < min_resource` behave exactly as before.

`test_hyperband_n_brackets` covers both the fixed cases and three that were already correct. Without the source change it fails with `assert 5 == 6`, `assert 5 == 6` and `assert 3 == 4`.

## Checklist

* [x] I used an LLM while working on this PR.