### PR TITLE
Allow array-like `reference_points` in `NSGAIIISampler`

### DIFF
--- a/optuna/samplers/_nsgaiii/_sampler.py
+++ b/optuna/samplers/_nsgaiii/_sampler.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from typing import Any
 from typing import TYPE_CHECKING
 
+import numpy as np
+
 from optuna import _deprecated
 from optuna._experimental import experimental_class
 from optuna._warnings import optuna_warn
@@ -25,8 +27,6 @@ from optuna.trial import TrialState
 if TYPE_CHECKING:
     from collections.abc import Callable
     from collections.abc import Sequence
-
-    import numpy as np
 
     from optuna.distributions import BaseDistribution
     from optuna.study import Study
@@ -62,8 +62,10 @@ class NSGAIIISampler(BaseGASampler):
 
     Args:
         reference_points:
-            A 2 dimension ``numpy.ndarray`` with objective dimension columns. Represents
-            a list of reference points which is used to determine who to survive.
+            A 2 dimensional array-like object, e.g. ``numpy.ndarray`` or a nested list, with
+            objective dimension columns. The given object is converted to ``numpy.ndarray``
+            internally. Represents a list of reference points which is used to determine who
+            to survive.
             After non-dominated sort, who out of borderline front are going to survived is
             determined according to how sparse the closest reference point of each individual is.
             In the default setting the algorithm uses `uniformly` spread points to diversify the
@@ -93,7 +95,7 @@ class NSGAIIISampler(BaseGASampler):
         swapping_prob: float = 0.5,
         seed: int | None = None,
         constraints_func: Callable[[FrozenTrial], Sequence[float]] | None = None,
-        reference_points: np.ndarray | None = None,
+        reference_points: np.ndarray | Sequence[Sequence[float]] | None = None,
         dividing_parameter: int = 3,
         elite_population_selection_strategy: (
             Callable[[Study, list[FrozenTrial]], list[FrozenTrial]] | None
@@ -133,6 +135,9 @@ class NSGAIIISampler(BaseGASampler):
                 f" the population size should be greater than or equal to {crossover.n_parents}."
                 f" The specified `population_size` is {population_size}."
             )
+
+        if reference_points is not None:
+            reference_points = np.asarray(reference_points)
 
         super().__init__(population_size=population_size)
         self._random_sampler = RandomSampler(seed=seed)

--- a/tests/samplers_tests/test_nsgaiii.py
+++ b/tests/samplers_tests/test_nsgaiii.py
@@ -25,6 +25,9 @@ from optuna.samplers._nsgaiii._elite_population_selection_strategy import (
 from optuna.samplers._nsgaiii._elite_population_selection_strategy import (
     _preserve_niche_individuals,
 )
+from optuna.samplers._nsgaiii._elite_population_selection_strategy import (
+    NSGAIIIElitePopulationSelectionStrategy,
+)
 from optuna.samplers._nsgaiii._sampler import NSGAIIISampler
 from optuna.samplers.nsgaii import BaseCrossover
 from optuna.samplers.nsgaii import BLXAlphaCrossover
@@ -199,6 +202,27 @@ def test_child_generation_strategy_experimental_warning() -> None:
 def test_after_trial_strategy_experimental_warning() -> None:
     with pytest.warns(optuna.exceptions.ExperimentalWarning):
         NSGAIIISampler(after_trial_strategy=lambda study, trial, state, value: None)
+
+
+@pytest.mark.parametrize(
+    "reference_points",
+    [[[1.0, 0.0], [0.0, 1.0]], np.array([[1.0, 0.0], [0.0, 1.0]])],
+)
+def test_reference_points_as_array_like(
+    reference_points: Sequence[Sequence[float]] | np.ndarray,
+) -> None:
+    sampler = NSGAIIISampler(population_size=2, reference_points=reference_points)
+
+    elite_population_selection_strategy = sampler._elite_population_selection_strategy
+    assert isinstance(elite_population_selection_strategy, NSGAIIIElitePopulationSelectionStrategy)
+    assert isinstance(elite_population_selection_strategy._reference_points, np.ndarray)
+    assert np.array_equal(
+        elite_population_selection_strategy._reference_points, np.asarray(reference_points)
+    )
+
+    study = optuna.create_study(directions=["minimize", "minimize"], sampler=sampler)
+    study.optimize(lambda t: [t.suggest_float("x", 0, 9), t.suggest_float("y", 0, 9)], n_trials=10)
+    assert len(study.trials) == 10
 
 
 def test_call_after_trial_of_random_sampler() -> None:


### PR DESCRIPTION
## Motivation

Close #6836.

`reference_points` in `NSGAIIISampler` is currently annotated as `np.ndarray`, while all NumPy operations used inside the sampler implementation are array-like compatible. Relaxing it to accept any 2 dimensional array-like object (e.g. a nested Python list) makes the sampler easier to use.

## Description of the changes

- `NSGAIIISampler.__init__` now accepts `reference_points` as `np.ndarray | Sequence[Sequence[float]] | None` and converts a non-`None` input to `numpy.ndarray` with `np.asarray` before passing it to `NSGAIIIElitePopulationSelectionStrategy`.
- Updated the docstring of `reference_points` accordingly.
- Added `test_reference_points_as_array_like`, parametrized over a nested list and a `numpy.ndarray`, which verifies that the input is converted to `numpy.ndarray` and that optimization runs with user-specified reference points. The list case fails without this fix.

Verified locally with `ruff check`, `ruff format`, `mypy` on the changed files, and `pytest tests/samplers_tests/test_nsgaiii.py` (81 passed).