### PR TITLE
Fix/tempfile pool typevar

### DIFF
--- a/optuna/testing/tempfile_pool.py
+++ b/optuna/testing/tempfile_pool.py
@@ -9,35 +9,39 @@ import os
 import tempfile
 import threading
 from typing import Any
-from typing import cast
 from typing import ClassVar
+from typing import Generic
 from typing import IO
 from typing import TYPE_CHECKING
+from typing import TypeVar
 
 
 if TYPE_CHECKING:
     from types import TracebackType
 
 
-class NamedTemporaryFilePool:
+_T = TypeVar("_T", bytes, str)
+
+
+class NamedTemporaryFilePool(Generic[_T]):
     _lock: ClassVar[threading.Lock] = threading.Lock()
     _path: ClassVar[list[str]] = []
     _registered: ClassVar[bool] = False
 
     def __init__(self, **kwargs: Any) -> None:
         self.kwargs = kwargs
-        self._file: IO[bytes] | IO[str] | None = None
+        self._file: IO[_T] | None = None
 
         with self.__class__._lock:
             if not self.__class__._registered:
                 _ = atexit.register(self.__class__.cleanup)
                 self.__class__._registered = True
 
-    def __enter__(self) -> IO[bytes] | IO[str]:
+    def __enter__(self) -> IO[_T]:
         return self.tempfile()
 
-    def tempfile(self) -> IO[bytes] | IO[str]:
-        f = cast("IO[bytes] | IO[str]", tempfile.NamedTemporaryFile(delete=False, **self.kwargs))
+    def tempfile(self) -> IO[_T]:
+        f = tempfile.NamedTemporaryFile(delete=False, **self.kwargs)
         self._file = f
         with self.__class__._lock:
             self.__class__._path.append(f.name)

--- a/tests/storages_tests/journal_tests/test_journal.py
+++ b/tests/storages_tests/journal_tests/test_journal.py
@@ -7,7 +7,6 @@ import pathlib
 import pickle
 from types import TracebackType
 from typing import Any
-from typing import cast
 from typing import IO
 from unittest import mock
 
@@ -123,8 +122,7 @@ def test_retry_an_incomplete_trailing_log() -> None:
         + b'{"op_code":0,"work'
     )
     what_to_write_2 = b'er_id":"worker-2"}\n' + b'{"op_code":0,"worker_id":"worker-3"}\n'
-    with NamedTemporaryFilePool() as file_:
-        file = cast(IO[bytes], file_)
+    with NamedTemporaryFilePool[bytes]() as file:
         file.write(what_to_write_1)
         file.flush()
 
@@ -150,8 +148,7 @@ def test_does_not_cache_an_incomplete_log_before_requested_number() -> None:
         + b'{"op_code":0,"work'
     )
     what_to_write_2 = b'er_id":"worker-2"}\n' + b'{"op_code":0,"worker_id":"worker-3"}\n'
-    with NamedTemporaryFilePool() as file_:
-        file = cast(IO[bytes], file_)
+    with NamedTemporaryFilePool[bytes]() as file:
         file.write(what_to_write_1)
         file.flush()
 


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. To minimize the review effort, we highly appreciate PRs only with related changes. Please note that submitted PRs may be closed if they include unrelated changes or significantly modified unit tests. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
NamedTemporaryFilePool was typed as returning IO[bytes] | IO[str], which made callers lose the concrete file mode and required a cast in the implementation. This change makes the pool generic over bytes/str so the return type matches the actual usage at call sites.

## Description of the changes
  - Made NamedTemporaryFilePool generic with _T = TypeVar("_T", bytes, str).
  - Updated self._file, __enter__, and tempfile() to use IO[_T].
  - Removed the cast from tempfile_pool.py and returned tempfile.NamedTemporaryFile(...) directly.
  - Verified the typed bytes use cases in journal_tests still pass.

## Checklist
<!-- If you used an LLM while working on this PR, please check the box below. Optuna does not prohibit the use of LLMs. However, as described in CONTRIBUTING.md, PRs from first-time contributors that appear to be primarily generated by LLMs are generally not accepted unless the contributor demonstrates clear understanding, validation, and ownership of the proposed changes. Depending on the changes, a PR may be closed without review. -->

* [ ] I used an LLM while working on this PR.

