### PR TITLE
Propagate exceptions from final parallel trials in `Study.optimize`

### DIFF
--- a/optuna/study/_optimize.py
+++ b/optuna/study/_optimize.py
@@ -119,6 +119,10 @@ def _optimize(
                             progress_bar,
                         )
                     )
+
+                # Raise if an exception occurred in any remaining future.
+                for f in futures:
+                    f.result()
     finally:
         study._thread_local.in_optimize_loop = False
         progress_bar.close()

--- a/tests/study_tests/test_study.py
+++ b/tests/study_tests/test_study.py
@@ -252,6 +252,29 @@ def test_optimize_with_catch(storage_mode: str) -> None:
         assert all(trial.state == TrialState.FAIL for trial in study.trials)
 
 
+@pytest.mark.parametrize("n_trials", [1, 2, 3])
+@pytest.mark.parametrize("n_jobs", [1, 2])
+@pytest.mark.parametrize("catch", [(), (ValueError,), (ArithmeticError,)])
+def test_optimize_with_error_in_last_trial(
+    n_trials: int, n_jobs: int, catch: tuple[type[Exception], ...]
+) -> None:
+    def objective(trial: Trial) -> float:
+        if trial.number == n_trials - 1:
+            raise ValueError("error in last trial")
+        return 1.0
+
+    study = create_study()
+    if ValueError in catch:
+        study.optimize(objective, n_trials=n_trials, n_jobs=n_jobs, catch=catch)
+    else:
+        with pytest.raises(ValueError, match="error in last trial"):
+            study.optimize(objective, n_trials=n_trials, n_jobs=n_jobs, catch=catch)
+
+    assert [trial.state for trial in study.trials] == [TrialState.COMPLETE] * (n_trials - 1) + [
+        TrialState.FAIL
+    ]
+
+
 @pytest.mark.parametrize("catch", [ValueError, (ValueError,), [ValueError], {ValueError}])
 def test_optimize_with_catch_valid_type(catch: Any) -> None:
     study = create_study()


### PR DESCRIPTION
## Motivation

`Study.optimize` can return normally when an objective raises an exception that is not included in `catch` and `n_jobs` is greater than one. Exceptions from the remaining worker futures are lost when the submission loop ends, even though the affected trials are marked as failed.

For example, this returns normally before the fix, while the equivalent call with `n_jobs=1` raises `ValueError`:

```python
import optuna


def objective(trial):
    raise ValueError("objective failed")


study = optuna.create_study()
study.optimize(objective, n_trials=1, n_jobs=2)
```

## Description of the changes

- Retrieve the results of outstanding futures after the parallel submission loop ends, so their exceptions reach the caller.
- Add a parametrized regression test covering sequential and parallel execution, trial counts below/equal to/above the worker count, and matching/nonmatching `catch` settings. The test also verifies the final trial states.

Six of the eighteen regression cases failed before the fix because `ValueError` was not raised; all eighteen pass afterward.

## Checklist

* [x] I used an LLM while working on this PR.
