### PR TITLE
Fix repeated artifact removal in `Backoff`

### DIFF
--- a/optuna/artifacts/_backoff.py
+++ b/optuna/artifacts/_backoff.py
@@ -99,6 +99,7 @@ class Backoff:
         for i in range(self._max_retries):
             try:
                 self._backend.remove(artifact_id)
+                return
             except ArtifactNotFound:
                 raise
             except Exception as e:

--- a/tests/artifacts_tests/test_backoff.py
+++ b/tests/artifacts_tests/test_backoff.py
@@ -1,7 +1,11 @@
 import io
+from unittest.mock import patch
 import uuid
 
+import pytest
+
 from optuna.artifacts import Backoff
+from optuna.artifacts.exceptions import ArtifactNotFound
 
 from .stubs import FailArtifactStore
 from .stubs import InMemoryArtifactStore
@@ -33,3 +37,18 @@ def test_read_and_write() -> None:
     with backend.open_reader(artifact_id) as f:
         actual = f.read()
     assert actual == dummy_content
+
+
+def test_remove() -> None:
+    artifact_id = f"test-{uuid.uuid4()}"
+    artifact_store = InMemoryArtifactStore()
+    backend = Backoff(backend=artifact_store, max_retries=3)
+    backend.write(artifact_id, io.BytesIO(b"content"))
+
+    with patch.object(artifact_store, "remove", wraps=artifact_store.remove) as remove_mock:
+        backend.remove(artifact_id)
+
+    remove_mock.assert_called_once_with(artifact_id)
+
+    with pytest.raises(ArtifactNotFound):
+        backend.open_reader(artifact_id)


### PR DESCRIPTION
## Motivation

`Backoff.remove()` continues its retry loop after the underlying artifact store successfully deletes an artifact. For stores such as `FileSystemArtifactStore`, the next attempt raises `ArtifactNotFound` because the first attempt already removed the artifact. As a result, callers receive an error even though deletion succeeded. Idempotent backends also perform unnecessary delete requests and backoff delays.

The issue can be reproduced by writing an artifact to `InMemoryArtifactStore`, wrapping the store in `Backoff` with multiple attempts, and calling `remove()`. Before this change, the first backend call deletes the artifact and the second call raises `ArtifactNotFound`.

## Description of the changes

- Return from `Backoff.remove()` immediately after a successful backend deletion.
- Add a regression test that makes multiple attempts available, verifies that the backend is called exactly once after success, and confirms that the artifact was removed.

This preserves retries for ordinary exceptions and immediate propagation of `ArtifactNotFound`.

Validation performed locally:

- `pytest tests/artifacts_tests/test_backoff.py`: 3 passed
- Artifact tests excluding optional Boto3 and Google Cloud SDK modules: 18 passed
- Ruff lint and formatting checks passed
- Mypy passed for both changed files

## Checklist

* [x] I used an LLM while working on this PR.
