### PR TITLE
Fix `GridSampler` crashing on enqueued trials with one grid remaining

### DIFF
--- a/optuna/samplers/_grid.py
+++ b/optuna/samplers/_grid.py
@@ -222,7 +222,8 @@ class GridSampler(BaseSampler):
         if len(target_grids) == 0:
             study.stop()
         elif len(target_grids) == 1:
-            grid_id = study._storage.get_trial_system_attrs(trial._trial_id)["grid_id"]
+            # Enqueued trials have no grid_id and must not stop the remaining grid.
+            grid_id = study._storage.get_trial_system_attrs(trial._trial_id).get("grid_id")
             if grid_id == target_grids[0]:
                 study.stop()
 

--- a/tests/samplers_tests/test_grid.py
+++ b/tests/samplers_tests/test_grid.py
@@ -209,16 +209,22 @@ def test_retried_trial() -> None:
     assert study.trials[0].system_attrs["grid_id"] == study.trials[1].system_attrs["grid_id"]
 
 
-def test_enqueued_trial() -> None:
-    sampler = samplers.GridSampler({"a": [0, 50]})
+@pytest.mark.parametrize(
+    ("grid_values", "n_initial_trials"), [([0], 0), ([0, 50], 0), ([0, 50], 1)]
+)
+def test_enqueued_trial(grid_values: list[int], n_initial_trials: int) -> None:
+    sampler = samplers.GridSampler({"a": grid_values})
     study = optuna.create_study(sampler=sampler)
+    study.optimize(lambda trial: trial.suggest_int("a", 0, 100), n_trials=n_initial_trials)
     study.enqueue_trial({"a": 100})
 
     study.optimize(lambda trial: trial.suggest_int("a", 0, 100))
 
-    assert len(study.trials) == 3
-    assert study.trials[0].params["a"] == 100
-    assert sorted([study.trials[1].params["a"], study.trials[2].params["a"]]) == [0, 50]
+    trials = study.trials
+    assert len(trials) == len(grid_values) + 1
+    assert trials[n_initial_trials].params["a"] == 100
+    grid_trials = trials[:n_initial_trials] + trials[n_initial_trials + 1 :]
+    assert sorted(trial.params["a"] for trial in grid_trials) == grid_values
 
 
 def test_same_seed_trials() -> None:


### PR DESCRIPTION
## Motivation

`GridSampler` raises `KeyError("grid_id")` after an enqueued trial when exactly one grid point remains. Enqueued trials intentionally have no grid ID, but `after_trial` assumes the ID exists when deciding whether to stop optimization.

This interrupts optimization before the remaining grid point is evaluated:

```python
import optuna


study = optuna.create_study(sampler=optuna.samplers.GridSampler({"a": [0]}))
study.enqueue_trial({"a": 100})
study.optimize(lambda trial: trial.suggest_int("a", 0, 100))
```

The expected evaluations are `a=100` followed by `a=0`, after which optimization stops. The same error occurs when an enqueued trial follows a normal trial in a two-point grid.

## Description of the changes

- Use an optional lookup for the trial's grid ID when checking the last remaining grid.
- Extend the existing enqueued-trial test to cover a single-point grid and a partly completed two-point grid, while retaining the original case. Verify the queued value, complete grid coverage, and termination.

Both added cases failed before the fix; all three cases pass afterward.

## Checklist

* [x] I used an LLM while working on this PR.
