### PR TITLE
Fix unused mypy ignore in GP QMC sampling

### DIFF
--- a/optuna/_gp/qmc.py
+++ b/optuna/_gp/qmc.py
@@ -19,9 +19,9 @@ def sample_from_normal_sobol(dim: int, n_samples: int, seed: int) -> torch.Tenso
     # NOTE(nabenabe): Normal Sobol sampling based on BoTorch.
     # https://github.com/pytorch/botorch/blob/v0.13.0/botorch/sampling/qmc.py#L26-L97
     # https://github.com/pytorch/botorch/blob/v0.13.0/botorch/utils/sampling.py#L109-L138
-    sobol_samples = torch.quasirandom.SobolEngine(  # type: ignore[no-untyped-call]
-        dimension=dim, scramble=True, seed=seed
-    ).draw(n_samples, dtype=torch.float64)
+    sobol_samples = torch.quasirandom.SobolEngine(dimension=dim, scramble=True, seed=seed).draw(
+        n_samples, dtype=torch.float64
+    )
     samples = 2.0 * (sobol_samples - 0.5)  # The Sobol sequence in [-1, 1].
     # Inverse transform to standard normal (values to close to -1 or 1 result in infinity).
     return torch.erfinv(samples) * _SQRT_2


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. To minimize the review effort, we highly appreciate PRs only with related changes. Please note that submitted PRs may be closed if they include unrelated changes or significantly modified unit tests. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation

The scheduled optional-dependencies check failed because an unused mypy ignore was detected in `optuna/_gp/qmc.py`.
https://github.com/optuna/optuna/actions/runs/34169447135/job/101886800701

## Description of the changes

Remove the obsolete `no-untyped-call` ignore from the SobolEngine call and apply the required formatting.

## Checklist
<!-- If you used an LLM while working on this PR, please check the box below. Optuna does not prohibit the use of LLMs. However, as described in CONTRIBUTING.md, PRs from first-time contributors that appear to be primarily generated by LLMs are generally not accepted unless the contributor demonstrates clear understanding, validation, and ownership of the proposed changes. Depending on the changes, a PR may be closed without review. -->

* [x] I used an LLM while working on this PR.

