### PR TITLE
Fix outdated failure and NaN reporting examples in FAQ

### DIFF
--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -230,8 +230,9 @@ You can find the failed trials in log messages.
 
 .. code-block:: sh
 
-    [W 2018-12-07 16:38:36,889] Setting status of trial#0 as TrialState.FAIL because of \
-    the following error: ValueError('A sample error in objective.')
+    [W 2018-12-07 16:38:36,889] Trial 0 failed with parameters: {'x': 7} because of the \
+    following error: ValueError('A sample error in objective.').
+    [W 2018-12-07 16:38:36,889] Trial 0 failed with value None.
 
 You can also find the failed trials by checking the trial states as follows:
 
@@ -241,9 +242,9 @@ You can also find the failed trials by checking the trial states as follows:
 
 .. csv-table::
 
-    number,state,value,...,params,system_attrs
-    0,TrialState.FAIL,,...,0,Setting status of trial#0 as TrialState.FAIL because of the following error: ValueError('A test error in objective.')
-    1,TrialState.COMPLETE,1269,...,1,
+    number,value,...,params_x,state
+    0,,...,7,FAIL
+    1,1269.0,...,5,COMPLETE
 
 .. seealso::
 
@@ -259,8 +260,9 @@ Trials which return NaN are shown as follows:
 
 .. code-block:: sh
 
-    [W 2018-12-07 16:41:59,000] Setting status of trial#2 as TrialState.FAIL because the \
-    objective function returned nan.
+    [W 2018-12-07 16:41:59,000] Trial 2 failed with parameters: {'x': 3} because of the \
+    following error: The value nan is not acceptable.
+    [W 2018-12-07 16:41:59,000] Trial 2 failed with value nan.
 
 
 What happens when I dynamically alter a search space?

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -230,8 +230,7 @@ You can find the failed trials in log messages.
 
 .. code-block:: sh
 
-    [W 2018-12-07 16:38:36,889] Trial 0 failed with parameters: {'x': 7} because of the \
-    following error: ValueError('A sample error in objective.').
+    [W 2018-12-07 16:38:36,889] Trial 0 failed with parameters: {'x': 7} because of the following error: ValueError('A sample error in objective.').
     [W 2018-12-07 16:38:36,889] Trial 0 failed with value None.
 
 You can also find the failed trials by checking the trial states as follows:
@@ -260,8 +259,7 @@ Trials which return NaN are shown as follows:
 
 .. code-block:: sh
 
-    [W 2018-12-07 16:41:59,000] Trial 2 failed with parameters: {'x': 3} because of the \
-    following error: The value nan is not acceptable.
+    [W 2018-12-07 16:41:59,000] Trial 2 failed with parameters: {'x': 3} because of the following error: The value nan is not acceptable.
     [W 2018-12-07 16:41:59,000] Trial 2 failed with value nan.
 
 


### PR DESCRIPTION
## Motivation

The FAQ sections "How are exceptions from trials handled?" and "How are NaNs
returned by trials handled?" show examples that no longer match Optuna's current
behavior. The snippets have been unchanged since 2018-2019:

- The log-message snippets use the old wording
  `Setting status of trial#0 as TrialState.FAIL because of the following error: ...`.
  Current Optuna logs
  `Trial 0 failed with parameters: {...} because of the following error: ...`
  followed by `Trial 0 failed with value None`.
- The `study.trials_dataframe()` example shows a `system_attrs` column holding the
  failure reason. That column is not in the default output, and the failure reason
  is not stored in the DataFrame at all. The table also uses `TrialState.FAIL` /
  `TrialState.COMPLETE` labels and a column order that do not match the real output.

A reader following the current FAQ looks for an error-message column that does not exist.

## Description of the changes

- Update the two log-message snippets to the current format.
- Replace the `trials_dataframe()` CSV table with the actual columns
  (`number,value,...,params_x,state`) and state labels (`FAIL`, `COMPLETE`).

Verified on `master` (5.1.0.dev):

```python
import optuna

def objective(trial):
    x = trial.suggest_int("x", 0, 10)
    if trial.number == 0:
        raise ValueError("A test error in objective.")
    return 1269

study = optuna.create_study()
study.optimize(objective, n_trials=2, catch=(ValueError,))
print(study.trials_dataframe())
```

Output:

```
[W ...] Trial 0 failed with parameters: {'x': 7} because of the following error: ValueError('A test error in objective.').
[W ...] Trial 0 failed with value None.
   number   value  ...  params_x     state
0       0     NaN  ...         7      FAIL
1       1  1269.0  ...         5  COMPLETE
```

## Checklist

* [x] I used an LLM while working on this PR.
