### PR TITLE
Consider constraints when selecting best_trial in get_all_study_summaries

### DIFF
--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -1600,10 +1600,13 @@ def get_all_study_summaries(
             direction = s.direction
             directions = None
             if include_best_trial and len(completed_trials) != 0:
-                if direction == StudyDirection.MAXIMIZE:
-                    best_trial = max(completed_trials, key=lambda t: cast("float", t.value))
+                feasible_trials = _get_feasible_trials(completed_trials)
+                if len(feasible_trials) == 0:
+                    best_trial = None
+                elif direction == StudyDirection.MAXIMIZE:
+                    best_trial = max(feasible_trials, key=lambda t: cast("float", t.value))
                 else:
-                    best_trial = min(completed_trials, key=lambda t: cast("float", t.value))
+                    best_trial = min(feasible_trials, key=lambda t: cast("float", t.value))
             else:
                 best_trial = None
         else:

--- a/tests/study_tests/test_study.py
+++ b/tests/study_tests/test_study.py
@@ -336,6 +336,44 @@ def test_get_all_study_summaries(storage_mode: str, include_best_trial: bool) ->
 
 
 @pytest.mark.parametrize("storage_mode", STORAGE_MODES)
+@pytest.mark.parametrize("direction", ["minimize", "maximize"])
+def test_get_all_study_summaries_with_constraints(
+    storage_mode: str, direction: Literal["minimize", "maximize"]
+) -> None:
+    def objective(trial: Trial) -> float:
+        x = trial.suggest_float("x", -10, 10)
+        # feasible iff x >= 0
+        trial.set_constraint("c", -x)
+        return x
+
+    with StorageSupplier(storage_mode) as storage:
+        study = create_study(storage=storage, direction=direction)
+
+        # 1. Only infeasible trial completed.
+        study.enqueue_trial({"x": -5.0})
+        study.optimize(objective, n_trials=1)
+
+        summaries = get_all_study_summaries(study._storage, include_best_trial=True)
+        summary = [s for s in summaries if s._study_id == study._study_id][0]
+        assert summary.best_trial is None
+        with pytest.raises(ValueError):
+            _ = study.best_trial
+
+        # 2. Add feasible trials.
+        study.enqueue_trial({"x": 2.0})
+        study.enqueue_trial({"x": 5.0})
+        study.optimize(objective, n_trials=2)
+
+        summaries = get_all_study_summaries(study._storage, include_best_trial=True)
+        summary = [s for s in summaries if s._study_id == study._study_id][0]
+        assert summary.best_trial is not None
+        assert summary.best_trial.number == study.best_trial.number
+        assert summary.best_trial.value == study.best_trial.value
+        expected_x = 2.0 if direction == "minimize" else 5.0
+        assert summary.best_trial.params["x"] == expected_x
+
+
+@pytest.mark.parametrize("storage_mode", STORAGE_MODES)
 def test_get_all_study_summaries_with_no_trials(storage_mode: str) -> None:
     with StorageSupplier(storage_mode) as storage:
         study = create_study(storage=storage)


### PR DESCRIPTION
## Motivation
Fixes #6825.

In constrained optimization studies, \get_all_study_summaries\ was selecting \StudySummary.best_trial\ across all completed trials without filtering for feasibility. As a result, \StudySummary.best_trial\ could return an infeasible trial even when feasible trials existed, causing an inconsistency with \Study.best_trial\.

## Description of the changes
- Filtered completed trials with \_get_feasible_trials\ before selecting \est_trial\ in \get_all_study_summaries\.
- Set \est_trial = None\ if all completed trials are infeasible.
- Added \	est_get_all_study_summaries_with_constraints\ in \	ests/study_tests/test_study.py\ covering minimize/maximize directions and all storage backends.

## Checklist
* [x] I used an LLM while working on this PR.